### PR TITLE
feat(plugins,tui): plugin dependency enforcement and projected context cost

### DIFF
--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1576,6 +1576,13 @@ impl<C: Channel> Agent<C> {
             ms = turn.metrics_snapshot().timings.prepare_context_ms,
             "turn timing: prepare_context done"
         );
+        // Emit projected token count so TUI can display it before the LLM call.
+        let _ = self
+            .channel
+            .send_context_estimate(
+                usize::try_from(self.runtime.providers.cached_prompt_tokens).unwrap_or(usize::MAX),
+            )
+            .await;
 
         let image_parts = std::mem::take(&mut turn.input.image_parts);
         // Prepend any background completion blocks to the user text. All completions and the

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -305,6 +305,20 @@ pub trait Channel: Send {
         async { Ok(()) }
     }
 
+    /// Send the projected context token count to the channel after context assembly.
+    ///
+    /// The value is an approximation; non-TUI channels may ignore it. No-op by default.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying I/O fails.
+    fn send_context_estimate(
+        &mut self,
+        _tokens: usize,
+    ) -> impl Future<Output = Result<(), ChannelError>> + Send {
+        async { Ok(()) }
+    }
+
     /// Send token usage after an LLM call. No-op by default.
     ///
     /// # Errors

--- a/crates/zeph-plugins/src/error.rs
+++ b/crates/zeph-plugins/src/error.rs
@@ -89,4 +89,33 @@ pub enum PluginError {
     /// HTTP download of a remote plugin archive failed.
     #[error("failed to download plugin from {url}: {reason}")]
     DownloadFailed { url: String, reason: String },
+
+    /// Attempted to remove or disable a plugin that other enabled plugins depend on.
+    #[error("Plugin '{name}' is required by: {dependents}. Disable them first:\n{hints}")]
+    DependencyRequired {
+        /// The plugin that was requested to be removed or disabled.
+        name: String,
+        /// Comma-separated list of dependent plugin names.
+        dependents: String,
+        /// Newline-separated disable hints, one per dependent.
+        hints: String,
+    },
+
+    /// A dependency cycle was detected while enabling a plugin.
+    #[error("dependency cycle detected while enabling plugin '{name}': {cycle}")]
+    DependencyCycle {
+        /// The plugin being enabled when the cycle was found.
+        name: String,
+        /// Human-readable description of the cycle path.
+        cycle: String,
+    },
+
+    /// A declared dependency plugin is not installed.
+    #[error("plugin '{name}' requires dependency '{dependency}' which is not installed")]
+    MissingDependency {
+        /// The plugin declaring the dependency.
+        name: String,
+        /// The missing dependency name.
+        dependency: String,
+    },
 }

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -14,6 +14,12 @@ use zeph_skills::scanner::scan_skill_body;
 use crate::PluginError;
 use crate::manifest::{PluginManifest, PluginMcpServer};
 
+/// Maximum number of entries allowed in `plugin.dependencies`.
+///
+/// Prevents a malicious manifest from triggering a fan-out `DoS` via recursive `enable()` calls
+/// across an unbounded dependency graph.
+const MAX_DEPENDENCIES: usize = 64;
+
 /// The tighten-only config overlay safelist. Any key outside this list causes
 /// [`PluginError::UnsafeOverlay`] at install time.
 const CONFIG_SAFELIST: &[&str] = &[
@@ -233,6 +239,17 @@ impl PluginManager {
 
         // Validate plugin name.
         validate_plugin_name(&manifest.plugin.name)?;
+
+        // Validate dependency list: enforce count limit and name format.
+        if manifest.plugin.dependencies.len() > MAX_DEPENDENCIES {
+            return Err(PluginError::InvalidManifest(format!(
+                "plugin declares {} dependencies; maximum allowed is {MAX_DEPENDENCIES}",
+                manifest.plugin.dependencies.len()
+            )));
+        }
+        for dep in &manifest.plugin.dependencies {
+            validate_plugin_name(dep)?;
+        }
 
         // Validate each [[skills]] entry: path must stay within source root and SKILL.md must exist.
         for entry in &manifest.skills {
@@ -474,9 +491,20 @@ impl PluginManager {
 
     /// Remove an installed plugin by name.
     ///
+    /// Refuses to remove the plugin if any enabled plugin depends on it. The caller receives a
+    /// [`PluginError::DependencyRequired`] error with a formatted hint listing the dependents.
+    ///
+    /// # Note on TOCTOU
+    ///
+    /// The dependent check and directory removal are not atomic. In a multi-process environment a
+    /// concurrent enable of a dependent could race with this remove. This is acceptable for a
+    /// single-user CLI tool where plugin operations are manual.
+    ///
     /// # Errors
     ///
-    /// Returns [`PluginError::NotFound`] if the plugin is not installed.
+    /// - [`PluginError::NotFound`] — plugin is not installed.
+    /// - [`PluginError::DependencyRequired`] — at least one enabled plugin depends on this one.
+    /// - [`PluginError::Io`] — the plugin directory cannot be removed.
     pub fn remove(&self, name: &str) -> Result<RemoveResult, PluginError> {
         validate_plugin_name(name)?;
         let plugin_dir = self.plugins_dir.join(name);
@@ -485,6 +513,8 @@ impl PluginManager {
                 name: name.to_owned(),
             });
         }
+
+        self.guard_no_dependents(name)?;
 
         let manifest_path = plugin_dir.join(".plugin.toml");
         let (removed_skills, removed_mcp_ids) = if manifest_path.exists() {
@@ -587,6 +617,10 @@ impl PluginManager {
         let mut dirs = Vec::new();
         let plugins = self.list_installed()?;
         for plugin in &plugins {
+            // Skip disabled plugins — their skills must not be loaded.
+            if plugin.path.join(".disabled").exists() {
+                continue;
+            }
             let manifest_path = plugin.path.join(".plugin.toml");
             if let Ok(bytes) = std::fs::read(&manifest_path)
                 && let Ok(text) = String::from_utf8(bytes)
@@ -810,6 +844,182 @@ impl PluginManager {
             .map_err(|e| format!("failed to read body: {e}"))?;
 
         Ok(raw.to_vec())
+    }
+
+    /// Enable an installed plugin by removing its `.disabled` marker file.
+    ///
+    /// Before enabling the target, all plugins listed in `plugin.dependencies` are enabled
+    /// recursively (depth-first). The method detects dependency cycles and returns
+    /// [`PluginError::DependencyCycle`] before touching the filesystem.
+    ///
+    /// A plugin with no `.disabled` marker is considered already enabled; this method is a no-op
+    /// for such plugins (idempotent).
+    ///
+    /// # Errors
+    ///
+    /// - [`PluginError::NotFound`] — plugin is not installed.
+    /// - [`PluginError::MissingDependency`] — a declared dependency is not installed.
+    /// - [`PluginError::DependencyCycle`] — the dependency graph contains a cycle.
+    /// - [`PluginError::Io`] — the `.disabled` marker cannot be removed.
+    pub fn enable(&self, name: &str) -> Result<(), PluginError> {
+        validate_plugin_name(name)?;
+        let mut visiting: Vec<String> = Vec::new();
+        self.enable_recursive(name, &mut visiting)
+    }
+
+    /// Recursive implementation of [`Self::enable`]; `visiting` tracks the DFS path for cycle
+    /// detection.
+    fn enable_recursive(&self, name: &str, visiting: &mut Vec<String>) -> Result<(), PluginError> {
+        if visiting.iter().any(|v| v == name) {
+            // Build a readable cycle description: A → B → A
+            let mut path = visiting.clone();
+            path.push(name.to_owned());
+            return Err(PluginError::DependencyCycle {
+                name: name.to_owned(),
+                cycle: path.join(" → "),
+            });
+        }
+
+        let plugin_dir = self.plugins_dir.join(name);
+        if !plugin_dir.exists() {
+            return Err(PluginError::NotFound {
+                name: name.to_owned(),
+            });
+        }
+
+        // Already enabled — nothing to do.
+        let disabled_marker = plugin_dir.join(".disabled");
+        if !disabled_marker.exists() {
+            return Ok(());
+        }
+
+        // Load manifest to discover dependencies.
+        let manifest = load_installed_manifest(&plugin_dir)?;
+
+        visiting.push(name.to_owned());
+        for dep in &manifest.plugin.dependencies {
+            let dep_dir = self.plugins_dir.join(dep);
+            if !dep_dir.exists() {
+                visiting.pop();
+                return Err(PluginError::MissingDependency {
+                    name: name.to_owned(),
+                    dependency: dep.clone(),
+                });
+            }
+            self.enable_recursive(dep, visiting)?;
+        }
+        visiting.pop();
+
+        // Remove the `.disabled` marker to enable this plugin.
+        std::fs::remove_file(&disabled_marker).map_err(|e| PluginError::Io {
+            path: disabled_marker.clone(),
+            source: e,
+        })?;
+
+        tracing::info!(plugin = %name, "plugin enabled");
+        Ok(())
+    }
+
+    /// Disable an installed plugin by creating a `.disabled` marker file.
+    ///
+    /// Refuses to disable the plugin if any *enabled* plugin depends on it. The caller receives
+    /// a [`PluginError::DependencyRequired`] error with a formatted hint listing the dependents.
+    ///
+    /// Disabling an already-disabled plugin is a no-op (idempotent).
+    ///
+    /// # Note on TOCTOU
+    ///
+    /// The dependent check and marker creation are not atomic. In a multi-process
+    /// environment a concurrent enable of a dependent could race with this disable. This is
+    /// acceptable for a single-user CLI tool where plugin operations are manual.
+    ///
+    /// # Errors
+    ///
+    /// - [`PluginError::NotFound`] — plugin is not installed.
+    /// - [`PluginError::DependencyRequired`] — at least one enabled plugin depends on this one.
+    /// - [`PluginError::Io`] — the `.disabled` marker cannot be written.
+    pub fn disable(&self, name: &str) -> Result<(), PluginError> {
+        validate_plugin_name(name)?;
+        let plugin_dir = self.plugins_dir.join(name);
+        if !plugin_dir.exists() {
+            return Err(PluginError::NotFound {
+                name: name.to_owned(),
+            });
+        }
+
+        self.guard_no_dependents(name)?;
+
+        // Already disabled — nothing to do.
+        let disabled_marker = plugin_dir.join(".disabled");
+        if disabled_marker.exists() {
+            return Ok(());
+        }
+
+        std::fs::write(&disabled_marker, b"").map_err(|e| PluginError::Io {
+            path: disabled_marker.clone(),
+            source: e,
+        })?;
+
+        tracing::info!(plugin = %name, "plugin disabled");
+        Ok(())
+    }
+
+    /// Returns the names of all **enabled** plugins that declare `name` as a dependency.
+    ///
+    /// Scans every installed plugin's manifest; a plugin is considered enabled if it has no
+    /// `.disabled` marker file in its directory. The check is O(N) in the number of installed
+    /// plugins and performs one filesystem read per plugin. For typical plugin counts (<50) this
+    /// is negligible.
+    fn dependents_of(&self, name: &str) -> Vec<String> {
+        if !self.plugins_dir.exists() {
+            return Vec::new();
+        }
+
+        let Ok(entries) = std::fs::read_dir(&self.plugins_dir) else {
+            return Vec::new();
+        };
+
+        let mut dependents = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            // Skip disabled plugins.
+            if path.join(".disabled").exists() {
+                continue;
+            }
+            let Ok(manifest) = load_installed_manifest(&path) else {
+                continue;
+            };
+            if manifest.plugin.name == name {
+                continue;
+            }
+            if manifest.plugin.dependencies.iter().any(|d| d == name) {
+                dependents.push(manifest.plugin.name);
+            }
+        }
+        dependents.sort();
+        dependents
+    }
+
+    /// Check that no enabled plugin depends on `name`; return [`PluginError::DependencyRequired`]
+    /// if any do.
+    fn guard_no_dependents(&self, name: &str) -> Result<(), PluginError> {
+        let dependents = self.dependents_of(name);
+        if dependents.is_empty() {
+            return Ok(());
+        }
+        let hints = dependents
+            .iter()
+            .map(|d| format!("  zeph plugin disable {d}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Err(PluginError::DependencyRequired {
+            name: name.to_owned(),
+            dependents: dependents.join(", "),
+            hints,
+        })
     }
 
     /// Like [`Self::check_skill_conflicts`] but skips the plugin currently being updated.
@@ -1384,6 +1594,22 @@ fn extract_archive_safe(bytes: &[u8], dest: &Path, url: &str) -> Result<(), Plug
 
 /// Walk the plugin tree and delete every `.bundled` marker file.
 ///
+/// Read the installed manifest (`.plugin.toml`) from `plugin_dir`.
+///
+/// # Errors
+///
+/// Returns [`PluginError`] if the file cannot be read or parsed.
+fn load_installed_manifest(plugin_dir: &Path) -> Result<PluginManifest, PluginError> {
+    let manifest_path = plugin_dir.join(".plugin.toml");
+    let bytes = std::fs::read(&manifest_path).map_err(|e| PluginError::Io {
+        path: manifest_path.clone(),
+        source: e,
+    })?;
+    let text = String::from_utf8(bytes)
+        .map_err(|_| PluginError::InvalidManifest(".plugin.toml is not valid UTF-8".to_owned()))?;
+    toml::from_str(&text).map_err(|e| PluginError::InvalidManifest(format!("{e}")))
+}
+
 /// Plugin skills are third-party and must never be treated as bundled by the scanner.
 fn strip_bundled_markers(root: &Path) {
     for entry in WalkDir::new(root).into_iter().flatten() {
@@ -2903,5 +3129,342 @@ path = "skills/my-skill"
             .components()
             .all(|c| c != std::path::Component::ParentDir);
         assert!(safe_ok, "safe relative path must pass traversal check");
+    }
+
+    // --- dependency enforcement tests ---
+
+    fn install_plugin_with_deps(plugins_dir: &Path, managed_dir: &Path, name: &str, deps: &[&str]) {
+        // Use a canonicalized tmp dir so the path-prefix check in collect_skill_dirs works on
+        // macOS where /tmp is a symlink to /private/tmp.
+        let plugin_src_raw = tempfile::tempdir().unwrap();
+        let plugin_src = plugin_src_raw.path().canonicalize().unwrap();
+        let deps_toml = deps
+            .iter()
+            .map(|d| format!("\"{d}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let skill_name = format!("skill-{name}");
+        let manifest = format!(
+            "[plugin]\nname = \"{name}\"\nversion = \"0.1.0\"\ndependencies = [{deps_toml}]\n\n[[skills]]\npath = \"skills/{skill_name}\"\n"
+        );
+        write_plugin(&plugin_src, name, &manifest, &[(&skill_name, "test skill")]);
+        let mgr = PluginManager::new(
+            plugins_dir.to_path_buf(),
+            managed_dir.to_path_buf(),
+            vec![],
+            vec![],
+        );
+        mgr.add(plugin_src.to_str().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn dependencies_field_defaults_to_empty() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        let installed = mgr.list_installed().unwrap();
+        assert_eq!(installed.len(), 1);
+        // Manifest with no dependencies field must deserialize with empty Vec.
+        let manifest_path = plugins_dir.path().join("base").join(".plugin.toml");
+        let text = std::fs::read_to_string(manifest_path).unwrap();
+        let manifest: crate::manifest::PluginManifest = toml::from_str(&text).unwrap();
+        assert!(manifest.plugin.dependencies.is_empty());
+    }
+
+    #[test]
+    fn remove_refused_when_dependent_enabled() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "ext", &["base"]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        let err = mgr.remove("base").unwrap_err();
+        assert!(
+            matches!(err, PluginError::DependencyRequired { ref name, .. } if name == "base"),
+            "expected DependencyRequired, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn remove_succeeds_after_dependent_removed() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "ext", &["base"]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        mgr.remove("ext").unwrap();
+        mgr.remove("base").unwrap();
+        assert!(mgr.list_installed().unwrap().is_empty());
+    }
+
+    #[test]
+    fn disable_refused_when_dependent_enabled() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "ext", &["base"]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        let err = mgr.disable("base").unwrap_err();
+        assert!(
+            matches!(err, PluginError::DependencyRequired { ref name, .. } if name == "base"),
+            "expected DependencyRequired, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn disable_and_enable_roundtrip() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        mgr.disable("base").unwrap();
+        assert!(plugins_dir.path().join("base").join(".disabled").exists());
+        mgr.enable("base").unwrap();
+        assert!(!plugins_dir.path().join("base").join(".disabled").exists());
+    }
+
+    #[test]
+    fn disable_idempotent() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        mgr.disable("base").unwrap();
+        // Second disable must be a no-op, not an error.
+        mgr.disable("base").unwrap();
+    }
+
+    #[test]
+    fn enable_idempotent() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        // Plugin is already enabled — second enable is a no-op.
+        mgr.enable("base").unwrap();
+        mgr.enable("base").unwrap();
+    }
+
+    #[test]
+    fn enable_transitively_enables_dependencies() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "ext", &["base"]);
+        // Disable both.
+        std::fs::write(plugins_dir.path().join("base").join(".disabled"), b"").unwrap();
+        std::fs::write(plugins_dir.path().join("ext").join(".disabled"), b"").unwrap();
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        // Enabling ext must also enable base.
+        mgr.enable("ext").unwrap();
+        assert!(
+            !plugins_dir.path().join("base").join(".disabled").exists(),
+            "base must be enabled"
+        );
+        assert!(
+            !plugins_dir.path().join("ext").join(".disabled").exists(),
+            "ext must be enabled"
+        );
+    }
+
+    #[test]
+    fn enable_detects_dependency_cycle() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        // Install alpha → beta, beta → alpha (cycle).
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "alpha", &["beta"]);
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "beta", &["alpha"]);
+        // Disable both to force the enable path.
+        std::fs::write(plugins_dir.path().join("alpha").join(".disabled"), b"").unwrap();
+        std::fs::write(plugins_dir.path().join("beta").join(".disabled"), b"").unwrap();
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        let err = mgr.enable("alpha").unwrap_err();
+        assert!(
+            matches!(err, PluginError::DependencyCycle { .. }),
+            "expected DependencyCycle, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn disable_ignored_by_dependents_of() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "ext", &["base"]);
+        // Disable ext — it should no longer block removing base.
+        std::fs::write(plugins_dir.path().join("ext").join(".disabled"), b"").unwrap();
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        // base has no enabled dependents now.
+        mgr.remove("base").unwrap();
+    }
+
+    #[test]
+    fn enable_returns_missing_dependency_when_dep_not_installed() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(
+            plugins_dir.path(),
+            managed_dir.path(),
+            "needs-ghost",
+            &["nonexistent"],
+        );
+        // Disable the plugin so enable() actually tries to traverse deps.
+        std::fs::write(
+            plugins_dir.path().join("needs-ghost").join(".disabled"),
+            b"",
+        )
+        .unwrap();
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        let err = mgr.enable("needs-ghost").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PluginError::MissingDependency {
+                    ref dependency,
+                    ..
+                } if dependency == "nonexistent"
+            ),
+            "expected MissingDependency, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn add_rejects_too_many_dependencies() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        let deps: Vec<String> = (0..=64).map(|i| format!("dep-{i:02}")).collect();
+        let deps_toml = deps
+            .iter()
+            .map(|d| format!("\"{d}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let manifest = format!(
+            "[plugin]\nname = \"bloated\"\nversion = \"0.1.0\"\ndependencies = [{deps_toml}]\n"
+        );
+        let plugin_src = tempfile::tempdir().unwrap();
+        write_plugin(
+            plugin_src.path(),
+            "bloated",
+            &manifest,
+            &[("skill-a", "test")],
+        );
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        let err = mgr.add(plugin_src.path().to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, PluginError::InvalidManifest(_)),
+            "expected InvalidManifest for too many dependencies, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn add_rejects_invalid_dependency_name() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        let manifest =
+            "[plugin]\nname = \"myplugin\"\nversion = \"0.1.0\"\ndependencies = [\"../evil\"]\n";
+        let plugin_src = tempfile::tempdir().unwrap();
+        write_plugin(
+            plugin_src.path(),
+            "myplugin",
+            manifest,
+            &[("skill-a", "test")],
+        );
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        let err = mgr.add(plugin_src.path().to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, PluginError::InvalidName { .. }),
+            "expected InvalidName for malformed dep name, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn collect_skill_dirs_excludes_disabled_plugin() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Canonicalize so the path-prefix check inside collect_skill_dirs works on macOS.
+        let real = tmp.path().canonicalize().unwrap();
+        let plugins_dir = real.join("plugins");
+        let managed_dir = real.join("managed");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+        std::fs::create_dir_all(&managed_dir).unwrap();
+        install_plugin_with_deps(&plugins_dir, &managed_dir, "active", &[]);
+        install_plugin_with_deps(&plugins_dir, &managed_dir, "sleeping", &[]);
+        // Disable sleeping.
+        std::fs::write(plugins_dir.join("sleeping").join(".disabled"), b"").unwrap();
+        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![], vec![]);
+        let dirs = mgr.collect_skill_dirs().unwrap();
+        // Only the active plugin's skill dirs should appear.
+        for dir in &dirs {
+            assert!(
+                !dir.to_string_lossy().contains("sleeping"),
+                "disabled plugin skill dir must not appear: {dir:?}"
+            );
+        }
+        assert!(!dirs.is_empty(), "active plugin skills must be present");
     }
 }

--- a/crates/zeph-plugins/src/manifest.rs
+++ b/crates/zeph-plugins/src/manifest.rs
@@ -60,6 +60,13 @@ pub struct PluginMeta {
     /// Defaults to `false` — updates are opt-in to avoid unintended breaking changes.
     #[serde(default)]
     pub auto_update: bool,
+    /// Names of other plugins this plugin depends on.
+    ///
+    /// The plugin manager ensures all listed plugins are enabled before enabling this one.
+    /// Removing or disabling a plugin that other enabled plugins depend on is refused with
+    /// a clear error listing the dependents.
+    #[serde(default)]
+    pub dependencies: Vec<String>,
     // zeph-version field intentionally omitted: version-gating is deferred to a future release
     // when the semver crate is added as a workspace dependency.
 }

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -238,6 +238,9 @@ impl App {
                 self.trim_messages();
                 self.auto_scroll();
             }
+            AgentEvent::ContextEstimate(tokens) => {
+                self.context_token_estimate = tokens;
+            }
         }
     }
 
@@ -694,5 +697,25 @@ mod tests {
         });
 
         assert!(app.sessions.current().view_target.is_main());
+    }
+
+    #[test]
+    fn context_estimate_updates_cached_value() {
+        let mut app = make_app();
+        assert_eq!(
+            app.context_token_estimate(),
+            0,
+            "initial estimate must be 0"
+        );
+
+        app.handle_agent_event(AgentEvent::ContextEstimate(14_200));
+        assert_eq!(app.context_token_estimate(), 14_200);
+
+        app.handle_agent_event(AgentEvent::ContextEstimate(512));
+        assert_eq!(
+            app.context_token_estimate(),
+            512,
+            "estimate must update on each event"
+        );
     }
 }

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -388,6 +388,8 @@ pub struct App {
     // GLOBAL — single shared agent queue counters (stays global per arch v2 §7)
     queued_count: usize,
     pending_count: usize,
+    /// Projected context token count from the last context assembly, or 0 if not yet known.
+    context_token_estimate: usize,
     editing_queued: bool,
     hyperlinks: Vec<HyperlinkSpan>,
     cancel_signal: Option<Arc<Notify>>,
@@ -458,6 +460,7 @@ impl App {
             agent_event_rx,
             queued_count: 0,
             pending_count: 0,
+            context_token_estimate: 0,
             editing_queued: false,
             hyperlinks: Vec::new(),
             cancel_signal: None,
@@ -1064,6 +1067,26 @@ impl App {
     #[must_use]
     pub fn queued_count(&self) -> usize {
         self.queued_count.max(self.pending_count)
+    }
+
+    /// Return the projected context token count from the last assembly, or 0 if not yet known.
+    ///
+    /// The value is approximate (character-level heuristic) and is updated once per agent turn.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tokio::sync::mpsc;
+    /// use zeph_tui::App;
+    ///
+    /// let (tx, _) = mpsc::channel(1);
+    /// let (_, rx) = mpsc::channel(1);
+    /// let app = App::new(tx, rx);
+    /// assert_eq!(app.context_token_estimate(), 0);
+    /// ```
+    #[must_use]
+    pub fn context_token_estimate(&self) -> usize {
+        self.context_token_estimate
     }
 
     /// Return `true` when the user is currently editing a queued message.

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -202,6 +202,14 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
+    async fn send_context_estimate(&mut self, tokens: usize) -> Result<(), ChannelError> {
+        // Non-critical: informational estimate shown in the input block title.
+        let _ = self
+            .agent_event_tx
+            .try_send(AgentEvent::ContextEstimate(tokens));
+        Ok(())
+    }
+
     async fn send_diff(
         &mut self,
         diff: zeph_core::DiffData,

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -230,6 +230,12 @@ pub enum AgentEvent {
         /// `true` if Completed state, `false` if Failed/Canceled.
         success: bool,
     },
+    /// Current context token count estimate, updated after each context assembly.
+    ///
+    /// The value is an approximation based on character-level heuristics and may
+    /// diverge slightly from the actual token count sent to the LLM. Stale between
+    /// turns (the previous turn's estimate remains displayed until the next assembly).
+    ContextEstimate(usize),
 }
 
 /// Blocking event pump that forwards terminal events to the async [`AppEvent`] channel.

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -21,9 +21,19 @@ pub fn render(
 ) {
     let theme = Theme::default();
 
-    let title = match app.input_mode() {
-        InputMode::Normal => " Press 'i' to type ",
-        InputMode::Insert => " Input (Esc to cancel) ",
+    let base_title = match app.input_mode() {
+        InputMode::Normal => " Press 'i' to type",
+        InputMode::Insert => " Input (Esc to cancel)",
+    };
+    let estimate = app.context_token_estimate();
+    let title_buf;
+    let title = if estimate > 0 {
+        let count_str = format_token_count(estimate);
+        title_buf = format!("{base_title} | {count_str} tokens ");
+        title_buf.as_str()
+    } else {
+        title_buf = format!("{base_title} ");
+        title_buf.as_str()
     };
 
     let mut block = Block::default()
@@ -112,6 +122,21 @@ pub fn render(
     }
 }
 
+/// Format a token count for display in the input block title.
+///
+/// Returns `"~{n}"` for counts below 1000, or `"~{n:.1}k"` for larger values.
+fn format_token_count(tokens: usize) -> String {
+    if tokens < 1000 {
+        format!("~{tokens}")
+    } else {
+        // Integer division keeps precision adequate for display; max representable value
+        // is u64::MAX / 1000 ≈ 1.8 × 10^16, which fits safely in f64 mantissa at this scale.
+        let whole = tokens / 1000;
+        let frac = (tokens % 1000) / 100;
+        format!("~{whole}.{frac}k")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
@@ -193,5 +218,47 @@ mod tests {
             output.contains("Esc to interrupt"),
             "spinner hint must appear on wide terminal"
         );
+    }
+
+    #[test]
+    fn input_shows_token_estimate_when_nonzero() {
+        let mut app = make_app();
+        app.handle_event(crate::event::AppEvent::Agent(
+            crate::event::AgentEvent::ContextEstimate(14_200),
+        ));
+        let output = render_to_string(80, 5, |frame, area| {
+            super::render(&app, frame, area, false, None, 0);
+        });
+        assert!(
+            output.contains("14.2k tokens"),
+            "token estimate must appear in input block title when estimate is nonzero"
+        );
+    }
+
+    #[test]
+    fn input_hides_token_estimate_when_zero() {
+        let app = make_app();
+        let output = render_to_string(80, 5, |frame, area| {
+            super::render(&app, frame, area, false, None, 0);
+        });
+        assert!(
+            !output.contains("tokens"),
+            "token estimate must not appear when estimate is 0"
+        );
+    }
+
+    #[test]
+    fn format_token_count_below_1000() {
+        assert_eq!(super::format_token_count(0), "~0");
+        assert_eq!(super::format_token_count(512), "~512");
+        assert_eq!(super::format_token_count(999), "~999");
+    }
+
+    #[test]
+    fn format_token_count_1000_and_above() {
+        assert_eq!(super::format_token_count(1000), "~1.0k");
+        assert_eq!(super::format_token_count(1500), "~1.5k");
+        assert_eq!(super::format_token_count(14_200), "~14.2k");
+        assert_eq!(super::format_token_count(100_000), "~100.0k");
     }
 }


### PR DESCRIPTION
## Summary

- **Plugin dependency enforcement** (`zeph-plugins`): `disable`/`remove` refuse when another enabled plugin depends on the target, with a copy-pasteable disable-chain hint. `enable` transitively enables declared dependencies with cycle detection. Dependency names are validated and capped at 64 per plugin to prevent DoS. `collect_skill_dirs` now skips disabled plugins.
- **Projected context cost** (`zeph-tui`): TUI input block shows a `~Nk tokens` estimate updated after each context assembly, so the user always sees current context size before sending.

## Changes

- `crates/zeph-plugins/src/manifest.rs` — `dependencies: Vec<String>` field (serde default)
- `crates/zeph-plugins/src/error.rs` — `DependencyRequired`, `DependencyCycle`, `MissingDependency`
- `crates/zeph-plugins/src/manager.rs` — `dependents_of`, `guard_no_dependents`, `enable_recursive`, `MAX_DEPENDENCIES`, dep name validation, `collect_skill_dirs` fix
- `crates/zeph-core/src/channel.rs` — `Channel::send_context_estimate` (default no-op)
- `crates/zeph-core/src/agent/mod.rs` — emit `ContextEstimate` after context assembly
- `crates/zeph-tui/src/event.rs` — `AgentEvent::ContextEstimate(usize)`
- `crates/zeph-tui/src/channel.rs`, `app/events.rs`, `app/mod.rs`, `widgets/input.rs` — handle and render estimate

## Test plan

- [ ] `cargo nextest run -p zeph-plugins --lib` — 107 tests pass (10 new)
- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 10005 tests pass
- [ ] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Manual: `zeph plugin disable <plugin>` when dependent exists → error with hint
- [ ] Manual: `zeph plugin enable <plugin>` with dep → dep auto-enabled
- [ ] Manual: TUI input block shows `~Nk tokens` updating each turn

## Follow-up

- #4311 — `send_context_estimate` passes `cached_prompt_tokens` instead of total context count (semantic, non-blocking)

Closes #3903