### PR TITLE
refactor(skills,memory): replace stringly-typed trust_level with SkillTrustLevel enum

### DIFF
--- a/crates/zeph-common/src/trust_level.rs
+++ b/crates/zeph-common/src/trust_level.rs
@@ -80,6 +80,17 @@ impl SkillTrustLevel {
         }
     }
 
+    /// Returns the string representation used for database storage.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Trusted => "trusted",
+            Self::Verified => "verified",
+            Self::Quarantined => "quarantined",
+            Self::Blocked => "blocked",
+        }
+    }
+
     /// Returns `true` if the level is not `Blocked`.
     ///
     /// # Examples

--- a/crates/zeph-core/src/agent/learning/mod.rs
+++ b/crates/zeph-core/src/agent/learning/mod.rs
@@ -37,7 +37,10 @@ impl<C: Channel> Agent<C> {
         let Ok(Some(row)) = memory.sqlite().load_skill_trust(skill_name).await else {
             return true; // no trust record = local skill = trusted
         };
-        matches!(row.trust_level.as_str(), "trusted" | "verified")
+        matches!(
+            row.trust_level,
+            zeph_common::SkillTrustLevel::Trusted | zeph_common::SkillTrustLevel::Verified
+        )
     }
 
     pub(crate) async fn record_skill_outcomes(

--- a/crates/zeph-core/src/agent/learning/skill_commands.rs
+++ b/crates/zeph-core/src/agent/learning/skill_commands.rs
@@ -233,7 +233,10 @@ impl<C: Channel> Agent<C> {
                 if let Some(ref memory) = memory {
                     let _ = memory
                         .sqlite()
-                        .set_skill_trust_level(&generated.name, "quarantined")
+                        .set_skill_trust_level(
+                            &generated.name,
+                            zeph_common::SkillTrustLevel::Quarantined,
+                        )
                         .await;
                 }
                 let _ = write!(

--- a/crates/zeph-core/src/agent/learning/tests.rs
+++ b/crates/zeph-core/src/agent/learning/tests.rs
@@ -879,7 +879,7 @@ async fn setup_skill_with_outcomes(
     skill_name: &str,
     successes: u32,
     failures: u32,
-    initial_trust: &str,
+    initial_trust: zeph_common::SkillTrustLevel,
 ) {
     use zeph_memory::store::SourceKind;
     memory
@@ -921,7 +921,14 @@ async fn check_trust_transition_auto_promotes_to_trusted() {
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     // 50 successes, 0 failures → posterior > 0.95 threshold
-    setup_skill_with_outcomes(&memory, "test-skill", 50, 0, "local").await;
+    setup_skill_with_outcomes(
+        &memory,
+        "test-skill",
+        50,
+        0,
+        zeph_common::SkillTrustLevel::Quarantined,
+    )
+    .await;
 
     let mut config = learning_config_enabled();
     config.auto_promote_min_uses = 50;
@@ -941,7 +948,8 @@ async fn check_trust_transition_auto_promotes_to_trusted() {
         .unwrap()
         .unwrap();
     assert_eq!(
-        row.trust_level, "trusted",
+        row.trust_level,
+        zeph_common::SkillTrustLevel::Trusted,
         "should auto-promote to trusted, got: {}",
         row.trust_level
     );
@@ -958,7 +966,14 @@ async fn check_trust_transition_auto_demotes_to_quarantined() {
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     // 5 successes, 30 failures → posterior < 0.40 threshold, starting as "trusted"
-    setup_skill_with_outcomes(&memory, "test-skill", 5, 30, "trusted").await;
+    setup_skill_with_outcomes(
+        &memory,
+        "test-skill",
+        5,
+        30,
+        zeph_common::SkillTrustLevel::Trusted,
+    )
+    .await;
 
     let mut config = learning_config_enabled();
     config.auto_demote_min_uses = 30;
@@ -978,7 +993,8 @@ async fn check_trust_transition_auto_demotes_to_quarantined() {
         .unwrap()
         .unwrap();
     assert_eq!(
-        row.trust_level, "quarantined",
+        row.trust_level,
+        zeph_common::SkillTrustLevel::Quarantined,
         "should auto-demote to quarantined, got: {}",
         row.trust_level
     );
@@ -995,7 +1011,14 @@ async fn check_trust_transition_does_not_promote_blocked() {
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     // High success rate but "blocked" — should NOT be promoted
-    setup_skill_with_outcomes(&memory, "test-skill", 100, 0, "blocked").await;
+    setup_skill_with_outcomes(
+        &memory,
+        "test-skill",
+        100,
+        0,
+        zeph_common::SkillTrustLevel::Blocked,
+    )
+    .await;
 
     let mut config = learning_config_enabled();
     config.auto_promote_min_uses = 50;
@@ -1015,7 +1038,8 @@ async fn check_trust_transition_does_not_promote_blocked() {
         .unwrap()
         .unwrap();
     assert_eq!(
-        row.trust_level, "blocked",
+        row.trust_level,
+        zeph_common::SkillTrustLevel::Blocked,
         "blocked skill should never be auto-promoted, got: {}",
         row.trust_level
     );

--- a/crates/zeph-core/src/agent/learning/trust.rs
+++ b/crates/zeph-core/src/agent/learning/trust.rs
@@ -118,7 +118,9 @@ async fn try_auto_promote(
         .flatten()
         .map(|r| r.trust_level);
     // Skip promotion only if explicitly blocked; promote even if no record exists.
-    if trust_level.as_deref() != Some("trusted") && trust_level.as_deref() != Some("blocked") {
+    if trust_level != Some(zeph_common::SkillTrustLevel::Trusted)
+        && trust_level != Some(zeph_common::SkillTrustLevel::Blocked)
+    {
         tracing::info!(
             skill = skill_name,
             posterior = format!("{posterior:.3}"),
@@ -131,7 +133,7 @@ async fn try_auto_promote(
                 .sqlite()
                 .upsert_skill_trust(
                     skill_name,
-                    "trusted",
+                    zeph_common::SkillTrustLevel::Trusted,
                     zeph_memory::store::SourceKind::Local,
                     None,
                     None,
@@ -141,7 +143,7 @@ async fn try_auto_promote(
         } else {
             let _ = memory
                 .sqlite()
-                .set_skill_trust_level(skill_name, "trusted")
+                .set_skill_trust_level(skill_name, zeph_common::SkillTrustLevel::Trusted)
                 .await;
         }
     }
@@ -157,7 +159,9 @@ async fn try_auto_demote(
     let Ok(Some(trust_row)) = memory.sqlite().load_skill_trust(skill_name).await else {
         return;
     };
-    if trust_row.trust_level == "trusted" || trust_row.trust_level == "verified" {
+    if trust_row.trust_level == zeph_common::SkillTrustLevel::Trusted
+        || trust_row.trust_level == zeph_common::SkillTrustLevel::Verified
+    {
         tracing::warn!(
             skill = skill_name,
             posterior = format!("{posterior:.3}"),
@@ -166,7 +170,7 @@ async fn try_auto_demote(
         );
         let _ = memory
             .sqlite()
-            .set_skill_trust_level(skill_name, "quarantined")
+            .set_skill_trust_level(skill_name, zeph_common::SkillTrustLevel::Quarantined)
             .await;
     }
 }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2770,41 +2770,31 @@ impl<C: Channel> Agent<C> {
                 .await
                 .ok()
                 .flatten();
-            let trust_level_str = if let Some(ref row) = existing {
+            let trust_level = if let Some(ref row) = existing {
                 if row.blake3_hash != current_hash {
-                    trust_cfg.hash_mismatch_level.to_string()
+                    trust_cfg.hash_mismatch_level
                 } else if row.source_kind != source_kind {
                     // source_kind changed (e.g., hub → bundled on upgrade).
                     // Never override an explicit operator block. For active trust levels,
                     // adopt the source-kind initial level when it grants more trust.
-                    let stored = row
-                        .trust_level
-                        .parse::<zeph_common::SkillTrustLevel>()
-                        .unwrap_or_else(|_| {
-                            tracing::warn!(
-                                skill = %meta.name,
-                                raw = %row.trust_level,
-                                "unrecognised trust_level in DB, treating as quarantined"
-                            );
-                            zeph_common::SkillTrustLevel::Quarantined
-                        });
+                    let stored = row.trust_level;
                     if !stored.is_active() || stored.severity() <= initial_level.severity() {
-                        row.trust_level.clone()
+                        stored
                     } else {
-                        initial_level.to_string()
+                        *initial_level
                     }
                 } else {
-                    row.trust_level.clone()
+                    row.trust_level
                 }
             } else {
-                initial_level.to_string()
+                *initial_level
             };
             let source_path = meta.skill_dir.to_str();
             if let Err(e) = memory
                 .sqlite()
                 .upsert_skill_trust(
                     &meta.name,
-                    &trust_level_str,
+                    trust_level,
                     source_kind,
                     None,
                     source_path,

--- a/crates/zeph-core/src/agent/skill_management.rs
+++ b/crates/zeph-core/src/agent/skill_management.rs
@@ -56,7 +56,7 @@ impl<C: Channel> Agent<C> {
                         .sqlite()
                         .upsert_skill_trust(
                             &installed.name,
-                            "quarantined",
+                            zeph_common::SkillTrustLevel::Quarantined,
                             source_kind,
                             source_url,
                             source_path.as_deref(),

--- a/crates/zeph-core/src/agent/trust_commands.rs
+++ b/crates/zeph-core/src/agent/trust_commands.rs
@@ -42,22 +42,13 @@ impl<C: Channel> Agent<C> {
             }
             Some(name) => {
                 if let Some(level_str) = args.get(1).copied() {
-                    let level = match level_str {
-                        "trusted" => SkillTrustLevel::Trusted,
-                        "verified" => SkillTrustLevel::Verified,
-                        "quarantined" => SkillTrustLevel::Quarantined,
-                        "blocked" => SkillTrustLevel::Blocked,
-                        _ => {
-                            return Ok(
-                                "Invalid trust level. Use: trusted, verified, quarantined, blocked"
-                                    .to_owned(),
-                            );
-                        }
+                    let Ok(level) = level_str.parse::<SkillTrustLevel>() else {
+                        return Ok(
+                            "Invalid trust level. Use: trusted, verified, quarantined, blocked"
+                                .to_owned(),
+                        );
                     };
-                    let updated = memory
-                        .sqlite()
-                        .set_skill_trust_level(name, &level.to_string())
-                        .await?;
+                    let updated = memory.sqlite().set_skill_trust_level(name, level).await?;
                     if updated {
                         Ok(format!("Trust level for \"{name}\" set to {level}."))
                     } else {
@@ -90,7 +81,7 @@ impl<C: Channel> Agent<C> {
         };
         let updated = memory
             .sqlite()
-            .set_skill_trust_level(name, "blocked")
+            .set_skill_trust_level(name, SkillTrustLevel::Blocked)
             .await?;
         if updated {
             Ok(format!("Skill \"{name}\" blocked."))
@@ -112,7 +103,7 @@ impl<C: Channel> Agent<C> {
         };
         let updated = memory
             .sqlite()
-            .set_skill_trust_level(name, "quarantined")
+            .set_skill_trust_level(name, SkillTrustLevel::Quarantined)
             .await?;
         if updated {
             Ok(format!("Skill \"{name}\" unblocked (set to quarantined)."))
@@ -162,22 +153,15 @@ impl<C: Channel> Agent<C> {
             return HashMap::new();
         };
         rows.into_iter()
-            .filter_map(|r| {
-                let trust_level = match r.trust_level.as_str() {
-                    "trusted" => SkillTrustLevel::Trusted,
-                    "verified" => SkillTrustLevel::Verified,
-                    "quarantined" => SkillTrustLevel::Quarantined,
-                    "blocked" => SkillTrustLevel::Blocked,
-                    _ => return None,
-                };
-                Some((
+            .map(|r| {
+                (
                     r.skill_name,
                     SkillTrustSnapshot {
-                        trust_level,
+                        trust_level: r.trust_level,
                         requires_trust_check: r.requires_trust_check,
                         blake3_hash: r.blake3_hash,
                     },
-                ))
+                )
             })
             .collect()
     }

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -186,12 +186,15 @@ impl ToolExecutor for SkillInvokeExecutor {
         }]
     }
 
+    #[tracing::instrument(name = "core.skill_invoke.execute", skip_all, fields(skill = tracing::field::Empty))]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         if call.tool_id != "invoke_skill" {
             return Ok(None);
         }
         let params: InvokeSkillParams = deserialize_params(&call.params)?;
         let skill_name: String = params.skill_name.chars().take(128).collect();
+
+        tracing::Span::current().record("skill", skill_name.as_str());
 
         let snapshot = self.resolve_snapshot(&skill_name);
         let trust = snapshot.as_ref().map(|s| s.trust_level).unwrap_or_default();

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -155,7 +155,7 @@ pub async fn link_memory_notes(
         return stats;
     }
 
-    let valid = embed_work_items(&work_items, &provider).await;
+    let valid = embed_work_items(&work_items, &provider, cfg).await;
 
     let search_limit = cfg.top_k + 1; // +1 to account for self-match
     let search_results = search_similar_for_items(&valid, &embedding_store, search_limit).await;
@@ -214,11 +214,12 @@ async fn collect_note_link_work_items(
 async fn embed_work_items(
     work_items: &[EntityWorkItem],
     provider: &AnyProvider,
+    cfg: &NoteLinkingConfig,
 ) -> Vec<(usize, Vec<f32>)> {
     use futures::future;
 
     let Ok(embed_results) = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
+        std::time::Duration::from_secs(cfg.timeout_secs),
         future::join_all(work_items.iter().map(|w| provider.embed(&w.embed_text))),
     )
     .await
@@ -864,7 +865,7 @@ mod tests {
 
     use zeph_llm::any::AnyProvider;
 
-    use super::extract_and_store;
+    use super::{NoteLinkingConfig, extract_and_store};
     use crate::embedding_store::EmbeddingStore;
     use crate::graph::GraphStore;
     use crate::in_memory_store::InMemoryVectorStore;
@@ -1154,7 +1155,11 @@ mod tests {
             self_point_id: None,
         }];
 
-        let result = super::embed_work_items(&work_items, &provider).await;
+        let cfg = NoteLinkingConfig {
+            timeout_secs: 30,
+            ..NoteLinkingConfig::default()
+        };
+        let result = super::embed_work_items(&work_items, &provider, &cfg).await;
         assert!(
             result.is_empty(),
             "embed_work_items must return empty Vec on 30 s timeout (fail-open)"

--- a/crates/zeph-memory/src/store/trust.rs
+++ b/crates/zeph-memory/src/store/trust.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use serde::{Deserialize, Serialize};
+use zeph_common::SkillTrustLevel;
 #[allow(unused_imports)]
 use zeph_db::sql;
 
@@ -53,7 +54,7 @@ impl std::str::FromStr for SourceKind {
 #[derive(Debug, Clone)]
 pub struct SkillTrustRow {
     pub skill_name: String,
-    pub trust_level: String,
+    pub trust_level: SkillTrustLevel,
     pub source_kind: SourceKind,
     pub source_url: Option<String>,
     pub source_path: Option<String>,
@@ -81,9 +82,10 @@ type TrustTuple = (
 
 fn row_from_tuple(t: TrustTuple) -> SkillTrustRow {
     let source_kind = t.2.parse::<SourceKind>().unwrap_or(SourceKind::Local);
+    let trust_level = t.1.parse::<SkillTrustLevel>().unwrap_or_default();
     SkillTrustRow {
         skill_name: t.0,
-        trust_level: t.1,
+        trust_level,
         source_kind,
         source_url: t.3,
         source_path: t.4,
@@ -103,7 +105,7 @@ impl SqliteStore {
     pub async fn upsert_skill_trust(
         &self,
         skill_name: &str,
-        trust_level: &str,
+        trust_level: SkillTrustLevel,
         source_kind: SourceKind,
         source_url: Option<&str>,
         source_path: Option<&str>,
@@ -134,7 +136,7 @@ impl SqliteStore {
     pub async fn upsert_skill_trust_with_git_hash(
         &self,
         skill_name: &str,
-        trust_level: &str,
+        trust_level: SkillTrustLevel,
         source_kind: SourceKind,
         source_url: Option<&str>,
         source_path: Option<&str>,
@@ -155,7 +157,7 @@ impl SqliteStore {
              updated_at = CURRENT_TIMESTAMP"),
         )
         .bind(skill_name)
-        .bind(trust_level)
+        .bind(trust_level.as_str())
         .bind(source_kind.as_str())
         .bind(source_url)
         .bind(source_path)
@@ -210,12 +212,12 @@ impl SqliteStore {
     pub async fn set_skill_trust_level(
         &self,
         skill_name: &str,
-        trust_level: &str,
+        trust_level: SkillTrustLevel,
     ) -> Result<bool, MemoryError> {
         let result = zeph_db::query(
             sql!("UPDATE skill_trust SET trust_level = ?, updated_at = CURRENT_TIMESTAMP WHERE skill_name = ?"),
         )
-        .bind(trust_level)
+        .bind(trust_level.as_str())
         .bind(skill_name)
         .execute(&self.pool)
         .await?;
@@ -293,13 +295,20 @@ mod tests {
         let store = test_store().await;
 
         store
-            .upsert_skill_trust("git", "trusted", SourceKind::Local, None, None, "abc123")
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Trusted,
+                SourceKind::Local,
+                None,
+                None,
+                "abc123",
+            )
             .await
             .unwrap();
 
         let row = store.load_skill_trust("git").await.unwrap().unwrap();
         assert_eq!(row.skill_name, "git");
-        assert_eq!(row.trust_level, "trusted");
+        assert_eq!(row.trust_level, SkillTrustLevel::Trusted);
         assert_eq!(row.source_kind, SourceKind::Local);
         assert_eq!(row.blake3_hash, "abc123");
     }
@@ -309,16 +318,30 @@ mod tests {
         let store = test_store().await;
 
         store
-            .upsert_skill_trust("git", "quarantined", SourceKind::Local, None, None, "hash1")
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Quarantined,
+                SourceKind::Local,
+                None,
+                None,
+                "hash1",
+            )
             .await
             .unwrap();
         store
-            .upsert_skill_trust("git", "trusted", SourceKind::Local, None, None, "hash2")
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Trusted,
+                SourceKind::Local,
+                None,
+                None,
+                "hash2",
+            )
             .await
             .unwrap();
 
         let row = store.load_skill_trust("git").await.unwrap().unwrap();
-        assert_eq!(row.trust_level, "trusted");
+        assert_eq!(row.trust_level, SkillTrustLevel::Trusted);
         assert_eq!(row.blake3_hash, "hash2");
     }
 
@@ -334,13 +357,20 @@ mod tests {
         let store = test_store().await;
 
         store
-            .upsert_skill_trust("alpha", "trusted", SourceKind::Local, None, None, "h1")
+            .upsert_skill_trust(
+                "alpha",
+                SkillTrustLevel::Trusted,
+                SourceKind::Local,
+                None,
+                None,
+                "h1",
+            )
             .await
             .unwrap();
         store
             .upsert_skill_trust(
                 "beta",
-                "quarantined",
+                SkillTrustLevel::Quarantined,
                 SourceKind::Hub,
                 Some("https://hub.example.com"),
                 None,
@@ -360,22 +390,32 @@ mod tests {
         let store = test_store().await;
 
         store
-            .upsert_skill_trust("git", "quarantined", SourceKind::Local, None, None, "h1")
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Quarantined,
+                SourceKind::Local,
+                None,
+                None,
+                "h1",
+            )
             .await
             .unwrap();
 
-        let updated = store.set_skill_trust_level("git", "blocked").await.unwrap();
+        let updated = store
+            .set_skill_trust_level("git", SkillTrustLevel::Blocked)
+            .await
+            .unwrap();
         assert!(updated);
 
         let row = store.load_skill_trust("git").await.unwrap().unwrap();
-        assert_eq!(row.trust_level, "blocked");
+        assert_eq!(row.trust_level, SkillTrustLevel::Blocked);
     }
 
     #[tokio::test]
     async fn set_trust_level_nonexistent() {
         let store = test_store().await;
         let updated = store
-            .set_skill_trust_level("nope", "blocked")
+            .set_skill_trust_level("nope", SkillTrustLevel::Blocked)
             .await
             .unwrap();
         assert!(!updated);
@@ -386,7 +426,14 @@ mod tests {
         let store = test_store().await;
 
         store
-            .upsert_skill_trust("git", "trusted", SourceKind::Local, None, None, "h1")
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Trusted,
+                SourceKind::Local,
+                None,
+                None,
+                "h1",
+            )
             .await
             .unwrap();
 
@@ -409,7 +456,14 @@ mod tests {
         let store = test_store().await;
 
         store
-            .upsert_skill_trust("git", "verified", SourceKind::Local, None, None, "old_hash")
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Verified,
+                SourceKind::Local,
+                None,
+                None,
+                "old_hash",
+            )
             .await
             .unwrap();
 
@@ -427,7 +481,7 @@ mod tests {
         store
             .upsert_skill_trust(
                 "remote-skill",
-                "quarantined",
+                SkillTrustLevel::Quarantined,
                 SourceKind::Hub,
                 Some("https://hub.example.com/skill"),
                 None,
@@ -455,7 +509,7 @@ mod tests {
         store
             .upsert_skill_trust(
                 "file-skill",
-                "quarantined",
+                SkillTrustLevel::Quarantined,
                 SourceKind::File,
                 None,
                 Some("/tmp/skill.tar.gz"),
@@ -549,7 +603,7 @@ mod tests {
         store
             .upsert_skill_trust_with_git_hash(
                 "versioned-skill",
-                "trusted",
+                SkillTrustLevel::Trusted,
                 SourceKind::Hub,
                 Some("https://hub.example.com/skill"),
                 None,
@@ -573,7 +627,14 @@ mod tests {
         let store = test_store().await;
 
         store
-            .upsert_skill_trust("git", "trusted", SourceKind::Local, None, None, "hash1")
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Trusted,
+                SourceKind::Local,
+                None,
+                None,
+                "hash1",
+            )
             .await
             .unwrap();
 
@@ -592,7 +653,14 @@ mod tests {
         ];
         for (name, kind) in &variants {
             store
-                .upsert_skill_trust(name, "trusted", kind.clone(), None, None, "hash")
+                .upsert_skill_trust(
+                    name,
+                    SkillTrustLevel::Trusted,
+                    kind.clone(),
+                    None,
+                    None,
+                    "hash",
+                )
                 .await
                 .unwrap();
             let row = store.load_skill_trust(name).await.unwrap().unwrap();
@@ -640,7 +708,7 @@ mod tests {
         store
             .upsert_skill_trust(
                 "web-search",
-                "trusted",
+                SkillTrustLevel::Trusted,
                 SourceKind::Bundled,
                 None,
                 None,
@@ -653,7 +721,7 @@ mod tests {
         store
             .upsert_skill_trust(
                 "web-search",
-                "trusted",
+                SkillTrustLevel::Trusted,
                 SourceKind::Bundled,
                 None,
                 None,
@@ -664,7 +732,7 @@ mod tests {
 
         let row = store.load_skill_trust("web-search").await.unwrap().unwrap();
         assert_eq!(row.source_kind, SourceKind::Bundled);
-        assert_eq!(row.trust_level, "trusted");
+        assert_eq!(row.trust_level, SkillTrustLevel::Trusted);
     }
 
     // Scenario 3: Migration from hub/quarantined to bundled/trusted when .bundled marker appears.
@@ -675,23 +743,37 @@ mod tests {
 
         // Initial state: existing install has hub/quarantined.
         store
-            .upsert_skill_trust("git", "quarantined", SourceKind::Hub, None, None, "hash1")
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Quarantined,
+                SourceKind::Hub,
+                None,
+                None,
+                "hash1",
+            )
             .await
             .unwrap();
 
         let row = store.load_skill_trust("git").await.unwrap().unwrap();
         assert_eq!(row.source_kind, SourceKind::Hub);
-        assert_eq!(row.trust_level, "quarantined");
+        assert_eq!(row.trust_level, SkillTrustLevel::Quarantined);
 
         // After runner detects .bundled marker: upsert with Bundled/trusted (initial_level from bundled_level).
         store
-            .upsert_skill_trust("git", "trusted", SourceKind::Bundled, None, None, "hash1")
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Trusted,
+                SourceKind::Bundled,
+                None,
+                None,
+                "hash1",
+            )
             .await
             .unwrap();
 
         let row = store.load_skill_trust("git").await.unwrap().unwrap();
         assert_eq!(row.source_kind, SourceKind::Bundled);
-        assert_eq!(row.trust_level, "trusted");
+        assert_eq!(row.trust_level, SkillTrustLevel::Trusted);
     }
 
     // Regression test for C1: operator-blocked bundled skills must not be unblocked by migration.
@@ -704,7 +786,7 @@ mod tests {
         store
             .upsert_skill_trust(
                 "web-search",
-                "blocked",
+                SkillTrustLevel::Blocked,
                 SourceKind::Hub,
                 None,
                 None,
@@ -717,7 +799,7 @@ mod tests {
         store
             .upsert_skill_trust(
                 "web-search",
-                "blocked",
+                SkillTrustLevel::Blocked,
                 SourceKind::Bundled,
                 None,
                 None,
@@ -729,21 +811,22 @@ mod tests {
         let row = store.load_skill_trust("web-search").await.unwrap().unwrap();
         assert_eq!(row.source_kind, SourceKind::Bundled);
         assert_eq!(
-            row.trust_level, "blocked",
+            row.trust_level,
+            SkillTrustLevel::Blocked,
             "operator block must survive source_kind migration"
         );
     }
 
-    // Scenario 4: Configurable bundled_level (e.g., "supervised") is applied during classification.
-    // This tests that the store persists any trust level string correctly for non-default configs.
+    // Scenario 4: Configurable bundled_level (e.g., "quarantined" for strict configs) is applied during classification.
+    // This tests that the store persists any trust level correctly for non-default configs.
     #[tokio::test]
-    async fn bundled_skill_with_configured_supervised_level() {
+    async fn bundled_skill_with_configured_quarantined_level() {
         let store = test_store().await;
 
         store
             .upsert_skill_trust(
                 "git",
-                "supervised",
+                SkillTrustLevel::Quarantined,
                 SourceKind::Bundled,
                 None,
                 None,
@@ -754,6 +837,6 @@ mod tests {
 
         let row = store.load_skill_trust("git").await.unwrap().unwrap();
         assert_eq!(row.source_kind, SourceKind::Bundled);
-        assert_eq!(row.trust_level, "supervised");
+        assert_eq!(row.trust_level, SkillTrustLevel::Quarantined);
     }
 }

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -56,7 +56,7 @@ pub(crate) async fn handle_skill_command(
             store
                 .upsert_skill_trust(
                     &result.name,
-                    "quarantined",
+                    zeph_common::SkillTrustLevel::Quarantined,
                     source_kind,
                     source_url,
                     source_path.as_deref(),
@@ -112,7 +112,10 @@ pub(crate) async fn handle_skill_command(
                     .await
                     .ok()
                     .flatten()
-                    .map_or_else(|| "no trust record".to_owned(), |r| r.trust_level);
+                    .map_or_else(
+                        || "no trust record".to_owned(),
+                        |r| r.trust_level.to_string(),
+                    );
                 if skill.requires_secrets.is_empty() {
                     println!("  {} — {} [{}]", skill.name, skill.description, trust);
                 } else {
@@ -147,7 +150,7 @@ pub(crate) async fn handle_skill_command(
                     Some(_) => {
                         println!("{name}: MISMATCH (hash changed, setting to quarantined)");
                         store
-                            .set_skill_trust_level(&name, "quarantined")
+                            .set_skill_trust_level(&name, zeph_common::SkillTrustLevel::Quarantined)
                             .await
                             .map_err(|e| anyhow::anyhow!("trust update failed: {e}"))?;
                         store
@@ -178,7 +181,10 @@ pub(crate) async fn handle_skill_command(
                         Some(false) => {
                             println!("{}: MISMATCH (setting to quarantined)", r.name);
                             store
-                                .set_skill_trust_level(&r.name, "quarantined")
+                                .set_skill_trust_level(
+                                    &r.name,
+                                    zeph_common::SkillTrustLevel::Quarantined,
+                                )
                                 .await
                                 .map_err(|e| anyhow::anyhow!("trust update failed: {e}"))?;
                             store
@@ -193,18 +199,17 @@ pub(crate) async fn handle_skill_command(
         }
 
         SkillCommand::Trust { name, level } => {
-            let valid = matches!(
-                level.as_str(),
-                "trusted" | "verified" | "quarantined" | "blocked"
-            );
-            if !valid {
-                anyhow::bail!(
+            let trust_level = level.parse::<zeph_common::SkillTrustLevel>().map_err(|_| {
+                anyhow::anyhow!(
                     "invalid trust level: {level}. Use: trusted, verified, quarantined, blocked"
-                );
-            }
+                )
+            })?;
 
             // REV-003: re-verify hash before promoting to trusted/verified.
-            if matches!(level.as_str(), "trusted" | "verified") {
+            if matches!(
+                trust_level,
+                zeph_common::SkillTrustLevel::Trusted | zeph_common::SkillTrustLevel::Verified
+            ) {
                 let managed_dir = crate::bootstrap::managed_skills_dir();
                 let mgr = zeph_skills::manager::SkillManager::new(managed_dir.clone());
                 let name_clone = name.clone();
@@ -230,11 +235,11 @@ pub(crate) async fn handle_skill_command(
                 }
 
                 let updated = store
-                    .set_skill_trust_level(&name, &level)
+                    .set_skill_trust_level(&name, trust_level)
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
                 if updated {
-                    println!("Trust level for \"{name}\" set to {level}.");
+                    println!("Trust level for \"{name}\" set to {trust_level}.");
                 } else {
                     anyhow::bail!("skill \"{name}\" not found in trust database");
                 }
@@ -243,11 +248,11 @@ pub(crate) async fn handle_skill_command(
                     .await
                     .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
                 let updated = store
-                    .set_skill_trust_level(&name, &level)
+                    .set_skill_trust_level(&name, trust_level)
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
                 if updated {
-                    println!("Trust level for \"{name}\" set to {level}.");
+                    println!("Trust level for \"{name}\" set to {trust_level}.");
                 } else {
                     anyhow::bail!("skill \"{name}\" not found in trust database");
                 }
@@ -259,7 +264,7 @@ pub(crate) async fn handle_skill_command(
                 .await
                 .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
             let updated = store
-                .set_skill_trust_level(&name, "blocked")
+                .set_skill_trust_level(&name, zeph_common::SkillTrustLevel::Blocked)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             if updated {
@@ -274,7 +279,7 @@ pub(crate) async fn handle_skill_command(
                 .await
                 .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
             let updated = store
-                .set_skill_trust_level(&name, "quarantined")
+                .set_skill_trust_level(&name, zeph_common::SkillTrustLevel::Quarantined)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             if updated {
@@ -285,8 +290,6 @@ pub(crate) async fn handle_skill_command(
         }
 
         SkillCommand::Invoke { name, args } => {
-            use std::str::FromStr;
-
             use zeph_common::SkillTrustLevel;
             use zeph_skills::prompt::{sanitize_skill_text, wrap_quarantined};
 
@@ -302,7 +305,7 @@ pub(crate) async fn handle_skill_command(
                     .load_skill_trust(&name)
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?
-                    .and_then(|r| SkillTrustLevel::from_str(&r.trust_level).ok())
+                    .map(|r| r.trust_level)
                     .unwrap_or_default()
             };
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1109,41 +1109,31 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                 .await
                 .ok()
                 .flatten();
-            let trust_level_str = if let Some(ref row) = existing {
+            let trust_level = if let Some(ref row) = existing {
                 if row.blake3_hash != *current_hash {
-                    trust_cfg.hash_mismatch_level.to_string()
+                    trust_cfg.hash_mismatch_level
                 } else if row.source_kind != source_kind {
                     // source_kind changed (e.g., hub → bundled on upgrade).
                     // Never override an explicit operator block. For active trust levels,
                     // adopt the source-kind initial level when it grants more trust.
-                    let stored = row
-                        .trust_level
-                        .parse::<zeph_common::SkillTrustLevel>()
-                        .unwrap_or_else(|_| {
-                            tracing::warn!(
-                                skill = %meta.name,
-                                raw = %row.trust_level,
-                                "unrecognised trust_level in DB, treating as quarantined"
-                            );
-                            zeph_common::SkillTrustLevel::Quarantined
-                        });
+                    let stored = row.trust_level;
                     if !stored.is_active() || stored.severity() <= initial_level.severity() {
-                        row.trust_level.clone()
+                        stored
                     } else {
-                        initial_level.to_string()
+                        *initial_level
                     }
                 } else {
-                    row.trust_level.clone()
+                    row.trust_level
                 }
             } else {
-                initial_level.to_string()
+                *initial_level
             };
             let source_path = meta.skill_dir.to_str();
             if let Err(e) = memory
                 .sqlite()
                 .upsert_skill_trust(
                     &meta.name,
-                    &trust_level_str,
+                    trust_level,
                     source_kind,
                     None,
                     source_path,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3865,6 +3865,7 @@ mod self_learning {
 mod trust_commands {
     use std::sync::{Arc, Mutex};
 
+    use zeph_common::SkillTrustLevel;
     use zeph_core::agent::Agent;
     use zeph_llm::any::AnyProvider;
     use zeph_llm::mock::MockProvider;
@@ -3931,7 +3932,7 @@ mod trust_commands {
             .sqlite()
             .upsert_skill_trust(
                 "my-skill",
-                "trusted",
+                SkillTrustLevel::Trusted,
                 SourceKind::Local,
                 None,
                 None,
@@ -3969,7 +3970,7 @@ mod trust_commands {
             .sqlite()
             .upsert_skill_trust(
                 "my-skill",
-                "trusted",
+                SkillTrustLevel::Trusted,
                 SourceKind::Local,
                 None,
                 None,
@@ -4007,7 +4008,7 @@ mod trust_commands {
             .sqlite()
             .upsert_skill_trust(
                 "my-skill",
-                "trusted",
+                SkillTrustLevel::Trusted,
                 SourceKind::Local,
                 None,
                 None,


### PR DESCRIPTION
## Summary

- **#4308**: `SkillTrustRow.trust_level` changed from `String` to `SkillTrustLevel`; store API methods now accept the enum and call `.as_str()` for SQLite binding, eliminating 10+ scattered string-literal comparisons across `zeph-core` and the binary
- **#4309**: Added `#[tracing::instrument(name = "core.skill_invoke.execute", ...)]` with lazy `skill` field to `SkillInvokeExecutor::execute_tool_call` so invocations appear in Perfetto/Chrome traces
- **#4310**: `embed_work_items` in `semantic/graph.rs` now reads `cfg.timeout_secs` from `NoteLinkingConfig` instead of a hardcoded `Duration::from_secs(30)`

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9766 passed, 21 skipped
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — 0 errors
- [ ] `cargo +nightly fmt --check` — clean
- [ ] SQLite round-trip for all 4 `SkillTrustLevel` variants covered by in-memory tests in `zeph-memory`
- [ ] Integration tests updated: `tests/integration.rs` uses `SkillTrustLevel::Trusted` instead of string literals

Closes #4308
Closes #4309
Closes #4310