### PR TITLE
fix(subagent): sanitize parent messages before passing to spawned subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- `zeph-core`, `zeph-config`: Parent messages passed to spawned sub-agents are now sanitized
+  through the IPI pipeline by default (`parent_context_policy = "inherit_sanitized"`), stripping
+  prompt-injection payloads that may have entered the parent history via tool results, web scrapes,
+  or A2A messages (closes #3942, #3936).
+- `zeph-config`: Added `max_parent_messages` config cap (default 20) for sub-agent spawn context
+  to limit the blast radius of poisoned histories (closes #3936).
+- `zeph-config`: Added `ParentContextPolicy` enum (`inherit` / `inherit_sanitized` / `none`)
+  giving operators explicit control over cross-agent context propagation trust (closes #3936).
+
 ### Fixed
 
 - `zeph-core`: `AutonomousRegistry::upsert`, `remove`, and `list` now log a `tracing::error!`

--- a/crates/zeph-config/src/agent.rs
+++ b/crates/zeph-config/src/agent.rs
@@ -54,7 +54,7 @@ impl<'de> Deserialize<'de> for ModelSpec {
 ///
 /// Prompt injection is a documented attack vector when the parent history contains untrusted
 /// content from web scrapes, tool results, or A2A messages.  `InheritSanitized` is the safe
-/// default: messages pass through [`zeph_sanitizer::ContentSanitizer`] before injection.
+/// default: messages pass through `ContentSanitizer` (in `zeph-sanitizer`) before injection.
 ///
 /// # Examples
 ///

--- a/crates/zeph-config/src/agent.rs
+++ b/crates/zeph-config/src/agent.rs
@@ -49,6 +49,31 @@ impl<'de> Deserialize<'de> for ModelSpec {
     }
 }
 
+/// Controls how the parent agent's conversation history is sanitized before passing to a
+/// spawned sub-agent.
+///
+/// Prompt injection is a documented attack vector when the parent history contains untrusted
+/// content from web scrapes, tool results, or A2A messages.  `InheritSanitized` is the safe
+/// default: messages pass through [`zeph_sanitizer::ContentSanitizer`] before injection.
+///
+/// # Examples
+///
+/// ```toml
+/// [subagent]
+/// parent_context_policy = "inherit_sanitized"   # default
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParentContextPolicy {
+    /// Pass the parent history verbatim — legacy behaviour, no sanitization.
+    Inherit,
+    /// Sanitize text parts of each message through the IPI pipeline before injection.
+    #[default]
+    InheritSanitized,
+    /// Do not inject any parent history into the sub-agent context.
+    None,
+}
+
 /// Controls how parent agent context is injected into a spawned sub-agent's task prompt.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -60,6 +85,10 @@ pub enum ContextInjectionMode {
     LastAssistantTurn,
     /// LLM-generated summary of parent context (not yet implemented in Phase 1).
     Summary,
+}
+
+fn default_max_parent_messages() -> usize {
+    20
 }
 
 fn default_max_tool_iterations() -> usize {
@@ -508,6 +537,21 @@ pub struct SubAgentConfig {
     /// How parent context is injected into the sub-agent's task prompt.
     #[serde(default)]
     pub context_injection_mode: ContextInjectionMode,
+    /// Whether to sanitize parent conversation history before passing to a spawned sub-agent.
+    ///
+    /// Defaults to [`ParentContextPolicy::InheritSanitized`] which runs each text message part
+    /// through the IPI sanitizer, stripping prompt-injection payloads that may have entered the
+    /// parent history via tool results, web scrapes, or A2A messages.
+    #[serde(default)]
+    pub parent_context_policy: ParentContextPolicy,
+    /// Maximum number of parent messages to inject, independent of `context_window_turns`.
+    ///
+    /// Acts as a hard upper bound on context propagation volume to limit the blast radius
+    /// of poisoned histories.  When `max_parent_messages < context_window_turns * 2` this cap
+    /// wins and fewer messages are passed; otherwise `context_window_turns * 2` is the binding
+    /// limit.  The tighter of the two limits always applies.
+    #[serde(default = "default_max_parent_messages")]
+    pub max_parent_messages: usize,
 }
 
 impl Default for SubAgentConfig {
@@ -528,6 +572,8 @@ impl Default for SubAgentConfig {
             context_window_turns: default_context_window_turns(),
             max_spawn_depth: default_max_spawn_depth(),
             context_injection_mode: ContextInjectionMode::default(),
+            parent_context_policy: ParentContextPolicy::default(),
+            max_parent_messages: default_max_parent_messages(),
         }
     }
 }
@@ -555,6 +601,11 @@ mod tests {
             cfg.context_injection_mode,
             ContextInjectionMode::LastAssistantTurn
         );
+        assert_eq!(
+            cfg.parent_context_policy,
+            ParentContextPolicy::InheritSanitized
+        );
+        assert_eq!(cfg.max_parent_messages, 20);
     }
 
     #[test]
@@ -569,6 +620,29 @@ mod tests {
         assert_eq!(cfg.context_window_turns, 5);
         assert_eq!(cfg.max_spawn_depth, 2);
         assert_eq!(cfg.context_injection_mode, ContextInjectionMode::None);
+    }
+
+    #[test]
+    fn subagent_config_deserialize_parent_context_policy() {
+        let toml_str = r#"
+            parent_context_policy = "none"
+            max_parent_messages = 10
+        "#;
+        let cfg: SubAgentConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.parent_context_policy, ParentContextPolicy::None);
+        assert_eq!(cfg.max_parent_messages, 10);
+    }
+
+    #[test]
+    fn subagent_config_deserialize_parent_context_policy_inherit_sanitized() {
+        let toml_str = r#"
+            parent_context_policy = "inherit_sanitized"
+        "#;
+        let cfg: SubAgentConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            cfg.parent_context_policy,
+            ParentContextPolicy::InheritSanitized
+        );
     }
 
     #[test]

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -103,8 +103,8 @@ pub mod ui;
 pub mod vigil;
 
 pub use agent::{
-    AgentConfig, ContextInjectionMode, FocusConfig, GoalConfig, ModelSpec, SubAgentConfig,
-    SubAgentLifecycleHooks, TaskSupervisorConfig, ToolFilterConfig,
+    AgentConfig, ContextInjectionMode, FocusConfig, GoalConfig, ModelSpec, ParentContextPolicy,
+    SubAgentConfig, SubAgentLifecycleHooks, TaskSupervisorConfig, ToolFilterConfig,
 };
 pub use channels::{
     A2aServerConfig, ChannelSkillsConfig, DiscordConfig, IbctKeyConfig, McpConfig, McpOAuthConfig,

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2751,17 +2751,23 @@ impl<C: Channel> Agent<C> {
 
     /// Extract recent parent messages for history propagation (Section 5.7 in spec).
     ///
-    /// Filters system messages, takes last `context_window_turns * 2` messages,
-    /// applies a 25% context window cap using a 4-chars-per-token heuristic, and
-    /// prunes orphaned `ToolUse`/`ToolResult` pairs at the slice boundary.
+    /// Filters system messages, applies `context_window_turns` and `max_parent_messages` caps,
+    /// applies a 25% context window cap using a 4-chars-per-token heuristic, prunes orphaned
+    /// `ToolUse`/`ToolResult` pairs at the slice boundary, and optionally sanitizes text parts
+    /// through the IPI pipeline according to `parent_context_policy`.
     fn extract_parent_messages(
         &self,
         config: &zeph_config::SubAgentConfig,
     ) -> Vec<zeph_llm::provider::Message> {
+        use zeph_config::ParentContextPolicy;
         use zeph_llm::provider::Role;
-        if config.context_window_turns == 0 {
+
+        if config.parent_context_policy == ParentContextPolicy::None
+            || config.context_window_turns == 0
+        {
             return Vec::new();
         }
+
         let non_system: Vec<_> = self
             .msg
             .messages
@@ -2769,7 +2775,11 @@ impl<C: Channel> Agent<C> {
             .filter(|m| m.role != Role::System)
             .cloned()
             .collect();
-        let take_count = config.context_window_turns * 2;
+
+        let take_count = config
+            .context_window_turns
+            .saturating_mul(2)
+            .min(config.max_parent_messages);
         let start = non_system.len().saturating_sub(take_count);
         let mut msgs = non_system[start..].to_vec();
 
@@ -2784,6 +2794,14 @@ impl<C: Channel> Agent<C> {
                 "[subagent] truncated parent history due to token budget or orphan pruning"
             );
         }
+
+        if config.parent_context_policy == ParentContextPolicy::InheritSanitized {
+            use zeph_sanitizer::{ContentSource, ContentSourceKind};
+            let source =
+                ContentSource::new(ContentSourceKind::A2aMessage).with_identifier("parent_history");
+            msgs = sanitize_parent_messages(msgs, &self.services.security.sanitizer, &source);
+        }
+
         msgs
     }
 
@@ -3822,6 +3840,35 @@ pub(crate) fn trim_parent_messages(msgs: &mut Vec<zeph_llm::provider::Message>, 
             "[subagent] pruned orphaned ToolUse/ToolResult parts from parent context boundary"
         );
     }
+}
+
+/// Sanitize text parts of `msgs` through the IPI pipeline.
+///
+/// Only [`MessagePart::Text`] parts are passed through the sanitizer; structured parts
+/// (`ToolUse`, `ToolResult`, `Recall`, `CodeContext`) are left untouched.  After sanitization
+/// the message `content` field is rebuilt to stay consistent with the updated parts.
+fn sanitize_parent_messages(
+    mut msgs: Vec<zeph_llm::provider::Message>,
+    sanitizer: &zeph_sanitizer::ContentSanitizer,
+    source: &zeph_sanitizer::ContentSource,
+) -> Vec<zeph_llm::provider::Message> {
+    use zeph_llm::provider::MessagePart;
+    for msg in &mut msgs {
+        let mut changed = false;
+        for part in &mut msg.parts {
+            if let MessagePart::Text { text } = part {
+                let clean = sanitizer.sanitize(text, source.clone());
+                if clean.body != *text {
+                    *text = clean.body;
+                    changed = true;
+                }
+            }
+        }
+        if changed {
+            msg.rebuild_content();
+        }
+    }
+    msgs
 }
 
 /// Thin wrapper that implements [`zeph_subagent::McpDispatch`] over an [`Arc<zeph_mcp::McpManager>`].


### PR DESCRIPTION
## Summary

- Add `ParentContextPolicy` enum (`inherit` / `inherit_sanitized` / `none`) to `SubAgentConfig` controlling how parent conversation history is passed to spawned subagents
- Add `max_parent_messages` config cap (default 20) to bound inherited context size
- Route text parts through `ContentSanitizer` with `A2aMessage` trust level when policy is `inherit_sanitized` (new default), stripping prompt injection payloads and PII before they reach child agent context
- Structured parts (`ToolUse`/`ToolResult`) are not sanitized to preserve tool call integrity
- `ShadowSentinel` gap documented: it does not inspect `parent_messages`; this PR closes the primary injection vector

Fixes the P1 vulnerability confirmed in CI-791: `extract_parent_messages` was passing all user/assistant message content verbatim to subagents with no sanitization.

Closes #3942, #3936

## Test plan

- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` passes
- [ ] `cargo nextest run --workspace --lib --bins` passes (9773 tests)
- [ ] `ParentContextPolicy` TOML deserialization tests added (`subagent_config_deserialize_parent_context_policy`, `subagent_config_deserialize_parent_context_policy_inherit_sanitized`)
- [ ] Sanitization scenarios SC-1..SC-4 documented in `.local/testing/playbooks/subagent-context.md` for live validation