### PR TITLE
fix(goal): log mutex poison in AutonomousRegistry; extract supervisor backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`: `AutonomousRegistry::upsert`, `remove`, and `list` now log a `tracing::error!`
+  and recover the guard via `into_inner()` instead of silently discarding poisoned-mutex errors
+  (closes #4323).
+- `zeph-core`: Extracted `apply_supervisor_backoff` as a pure free function operating on
+  `&mut AutonomousSession`; `increment_supervisor_fail_count` is now testable without a full
+  agent mock, and three unit tests cover the backoff boundary conditions (closes #4321).
+  `build_conversation_summary` was already a private helper method; no source duplication
+  remained (closes #4322).
+
 - `zeph-llm`: `BanditState::load`, `ReputationTracker::load`, and `ThompsonState::load` in
   `RouterProvider` builder methods were calling `std::fs::read` directly on the Tokio executor
   thread; wrapped in a `blocking_load()` helper using `tokio::task::block_in_place` to avoid

--- a/crates/zeph-core/src/agent/autonomous_turn.rs
+++ b/crates/zeph-core/src/agent/autonomous_turn.rs
@@ -310,20 +310,14 @@ impl<C: Channel> Agent<C> {
 
     /// Increment the supervisor failure counter; pause the session after reaching the limit.
     async fn increment_supervisor_fail_count(&mut self, goal_id: &str, limit: u32) {
-        let fail_count = {
+        let reached_limit = {
             let Some(s) = self.services.autonomous.session.as_mut() else {
                 return;
             };
-            s.supervisor_fail_count += 1;
-            let count = s.supervisor_fail_count;
-            // Return to Running if not yet at limit.
-            if count < limit {
-                s.state = AutonomousState::Running;
-            }
-            count
+            apply_supervisor_backoff(s, limit)
         };
 
-        if fail_count >= limit {
+        if reached_limit {
             let msg = format!(
                 "Supervisor verification unavailable after {limit} consecutive failures (goal {goal_id}). \
                  Session paused. Use `/goal resume --auto` to retry."
@@ -373,6 +367,26 @@ impl<C: Channel> Agent<C> {
             s.started_at,
             s.last_verdict.clone(),
         );
+    }
+}
+
+/// Increment the supervisor failure counter on `session` and update its FSM state.
+///
+/// Returns `true` when `limit` is reached and the caller should pause/terminate the session.
+/// Returns `false` when the counter is below `limit`; `session.state` is reset to `Running`.
+///
+/// Pure function — does not touch the channel or the registry; those are handled by the caller.
+pub(super) fn apply_supervisor_backoff(
+    session: &mut crate::goal::autonomous::AutonomousSession,
+    limit: u32,
+) -> bool {
+    session.supervisor_fail_count += 1;
+    let count = session.supervisor_fail_count;
+    if count < limit {
+        session.state = AutonomousState::Running;
+        false
+    } else {
+        true
     }
 }
 
@@ -485,5 +499,34 @@ mod tests {
     #[test]
     fn sanitize_goal_text_empty() {
         assert_eq!(sanitize_goal_text(""), "");
+    }
+
+    #[test]
+    fn backoff_increments_and_returns_false_below_limit() {
+        let mut s = crate::goal::autonomous::AutonomousSession::new("id", "text", 10);
+        let limit = 3;
+        assert!(!apply_supervisor_backoff(&mut s, limit));
+        assert_eq!(s.supervisor_fail_count, 1);
+        assert_eq!(s.state, AutonomousState::Running);
+
+        assert!(!apply_supervisor_backoff(&mut s, limit));
+        assert_eq!(s.supervisor_fail_count, 2);
+        assert_eq!(s.state, AutonomousState::Running);
+    }
+
+    #[test]
+    fn backoff_returns_true_at_limit() {
+        let mut s = crate::goal::autonomous::AutonomousSession::new("id", "text", 10);
+        let limit = 2;
+        apply_supervisor_backoff(&mut s, limit);
+        let reached = apply_supervisor_backoff(&mut s, limit);
+        assert!(reached);
+        assert_eq!(s.supervisor_fail_count, 2);
+    }
+
+    #[test]
+    fn backoff_limit_one_fires_immediately() {
+        let mut s = crate::goal::autonomous::AutonomousSession::new("id", "text", 10);
+        assert!(apply_supervisor_backoff(&mut s, 1));
     }
 }

--- a/crates/zeph-core/src/goal/registry.rs
+++ b/crates/zeph-core/src/goal/registry.rs
@@ -12,6 +12,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use tracing::error;
+
 use super::autonomous::{AutonomousState, SupervisorVerdict};
 
 /// Snapshot of one autonomous session suitable for cross-crate display.
@@ -95,16 +97,20 @@ impl AutonomousRegistry {
             started_at,
             last_verdict,
         };
-        if let Ok(mut map) = self.inner.lock() {
-            map.insert(goal_id, entry);
-        }
+        let mut map = self.inner.lock().unwrap_or_else(|e| {
+            error!("AutonomousRegistry::upsert: mutex poisoned, recovering guard");
+            e.into_inner()
+        });
+        map.insert(goal_id, entry);
     }
 
     /// Remove a session entry.
     pub fn remove(&self, goal_id: &str) {
-        if let Ok(mut map) = self.inner.lock() {
-            map.remove(goal_id);
-        }
+        let mut map = self.inner.lock().unwrap_or_else(|e| {
+            error!("AutonomousRegistry::remove: mutex poisoned, recovering guard");
+            e.into_inner()
+        });
+        map.remove(goal_id);
     }
 
     /// Return snapshots for all sessions currently in the registry.
@@ -112,9 +118,10 @@ impl AutonomousRegistry {
     /// In practice this is 0 or 1 entries (invariant A1).
     #[must_use]
     pub fn list(&self) -> Vec<SessionSnapshot> {
-        let Ok(map) = self.inner.lock() else {
-            return Vec::new();
-        };
+        let map = self.inner.lock().unwrap_or_else(|e| {
+            error!("AutonomousRegistry::list: mutex poisoned, recovering guard");
+            e.into_inner()
+        });
         map.iter()
             .map(|(id, e)| {
                 let short = if e.goal_text.len() > 80 {


### PR DESCRIPTION
## Summary

Follow-up fixes for the autonomous `/goal` feature landed in #4320.

- `AutonomousRegistry::upsert`, `remove`, and `list` now log `tracing::error!` and recover the guard via `into_inner()` instead of silently discarding poisoned-mutex errors (closes #4323)
- Extracted `apply_supervisor_backoff()` as a pure free function on `&mut AutonomousSession`; `increment_supervisor_fail_count` delegates to it, enabling unit testing without a full `Agent` mock; three boundary tests added (closes #4321)
- `build_conversation_summary` was already a private helper method — no source code duplication remained in `autonomous_turn.rs` (closes #4322)

## Test plan

- [x] `cargo nextest run -p zeph-core --lib` — 1472 tests pass (3 new backoff unit tests)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core --all-targets -- -D warnings` — clean