### PR TITLE
refactor(agents): replace FleetEntry.state String with AutonomousState enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10564,6 +10564,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "zeph-config",
 ]
 
 [[package]]

--- a/crates/zeph-commands/Cargo.toml
+++ b/crates/zeph-commands/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
+zeph-config.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/zeph-commands/src/handlers/agents_fleet.rs
+++ b/crates/zeph-commands/src/handlers/agents_fleet.rs
@@ -8,6 +8,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
+use zeph_config::autonomous::AutonomousState;
+
 use crate::context::CommandContext;
 use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
 
@@ -21,8 +23,8 @@ pub struct FleetEntry {
     pub goal_id: String,
     /// First 80 characters of goal text (may be followed by `…`).
     pub goal_text_short: String,
-    /// Current autonomous state as a lowercase string (e.g. `"running"`, `"verifying"`).
-    pub state: String,
+    /// Current autonomous state.
+    pub state: AutonomousState,
     /// Number of turns executed so far in this session.
     pub turns_executed: u32,
     /// Maximum turns allowed for this session.
@@ -41,11 +43,12 @@ pub struct FleetEntry {
 /// ```rust
 /// use std::time::Duration;
 /// use zeph_commands::handlers::agents_fleet::{FleetEntry, format_fleet_section};
+/// use zeph_config::autonomous::AutonomousState;
 ///
 /// let entries = vec![FleetEntry {
 ///     goal_id: "a1b2c3d4".to_owned(),
 ///     goal_text_short: "Deploy the new API".to_owned(),
-///     state: "running".to_owned(),
+///     state: AutonomousState::Running,
 ///     turns_executed: 12,
 ///     max_turns: 20,
 ///     elapsed: Duration::from_secs(272),
@@ -78,7 +81,7 @@ pub fn format_fleet_section(entries: &[FleetEntry]) -> String {
             "  {:<8}  {:<30}  {:<10}  {:<8}  {}",
             short_id,
             truncate_display(&e.goal_text_short, 30),
-            e.state,
+            e.state.to_string(),
             format!("{}/{}", e.turns_executed, e.max_turns),
             elapsed,
         );
@@ -156,11 +159,18 @@ impl CommandHandler<CommandContext<'_>> for AgentsFleetCommand {
 mod tests {
     use super::*;
 
-    fn entry(id: &str, text: &str, state: &str, turns: u32, max: u32, secs: u64) -> FleetEntry {
+    fn entry(
+        id: &str,
+        text: &str,
+        state: AutonomousState,
+        turns: u32,
+        max: u32,
+        secs: u64,
+    ) -> FleetEntry {
         FleetEntry {
             goal_id: id.to_owned(),
             goal_text_short: text.to_owned(),
-            state: state.to_owned(),
+            state,
             turns_executed: turns,
             max_turns: max,
             elapsed: Duration::from_secs(secs),
@@ -177,7 +187,7 @@ mod tests {
         let entries = vec![entry(
             "a1b2c3d4e5",
             "Deploy the new API",
-            "running",
+            AutonomousState::Running,
             12,
             20,
             272,
@@ -193,8 +203,22 @@ mod tests {
     #[test]
     fn two_entries_both_appear() {
         let entries = vec![
-            entry("aaaa1111", "First goal", "running", 3, 20, 60),
-            entry("bbbb2222", "Second goal", "verifying", 5, 10, 75),
+            entry(
+                "aaaa1111",
+                "First goal",
+                AutonomousState::Running,
+                3,
+                20,
+                60,
+            ),
+            entry(
+                "bbbb2222",
+                "Second goal",
+                AutonomousState::Verifying,
+                5,
+                10,
+                75,
+            ),
         ];
         let out = format_fleet_section(&entries);
         assert!(out.contains("aaaa1111"), "first id missing");
@@ -207,7 +231,7 @@ mod tests {
         let entries = vec![entry(
             "cccc3333",
             "Long running goal",
-            "running",
+            AutonomousState::Running,
             1,
             5,
             3665,
@@ -219,7 +243,14 @@ mod tests {
 
     #[test]
     fn elapsed_seconds_only() {
-        let entries = vec![entry("dddd4444", "Short goal", "achieved", 1, 5, 45)];
+        let entries = vec![entry(
+            "dddd4444",
+            "Short goal",
+            AutonomousState::Achieved,
+            1,
+            5,
+            45,
+        )];
         let out = format_fleet_section(&entries);
         assert!(out.contains("45s"), "seconds missing");
     }
@@ -227,7 +258,7 @@ mod tests {
     #[test]
     fn long_goal_text_truncated() {
         let long = "a".repeat(80);
-        let entries = vec![entry("eeee5555", &long, "running", 0, 5, 0)];
+        let entries = vec![entry("eeee5555", &long, AutonomousState::Running, 0, 5, 0)];
         let out = format_fleet_section(&entries);
         assert!(out.contains('…'), "truncation indicator missing");
     }

--- a/crates/zeph-config/src/autonomous.rs
+++ b/crates/zeph-config/src/autonomous.rs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! State types shared between the autonomous goal subsystem and command handlers.
+
+use serde::{Deserialize, Serialize};
+
+/// FSM states for an autonomous goal session.
+///
+/// Valid transitions:
+/// - `Running` → `Verifying` (supervisor check triggered)
+/// - `Verifying` → `Running` (supervisor: not yet achieved)
+/// - `Verifying` → `Achieved` (supervisor: goal met)
+/// - `Running` / `Verifying` → `Stuck` (stuck counter exhausted or supervisor failures)
+/// - `Running` / `Verifying` → `Aborted` (user cancel or turn limit reached)
+/// - `Running` / `Verifying` → `Failed` (unrecoverable error)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousState {
+    /// The agent is actively running multi-turn execution.
+    Running,
+    /// The supervisor is verifying whether the goal condition is satisfied.
+    Verifying,
+    /// Goal achieved and confirmed by the supervisor.
+    Achieved,
+    /// No progress detected across the configured number of consecutive turns.
+    Stuck,
+    /// Session aborted by the user or turn limit reached.
+    Aborted,
+    /// Unrecoverable error during execution.
+    Failed,
+}
+
+impl std::fmt::Display for AutonomousState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Running => f.write_str("running"),
+            Self::Verifying => f.write_str("verifying"),
+            Self::Achieved => f.write_str("achieved"),
+            Self::Stuck => f.write_str("stuck"),
+            Self::Aborted => f.write_str("aborted"),
+            Self::Failed => f.write_str("failed"),
+        }
+    }
+}

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -70,6 +70,7 @@
 // TODO(critic): post-v1.0 — re-evaluate ConfigSection derive macro for the 131 config structs.
 
 pub mod agent;
+pub mod autonomous;
 pub mod channels;
 pub mod classifiers;
 pub mod cli;

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1207,7 +1207,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     .map(|s| FleetEntry {
                         goal_id: s.goal_id,
                         goal_text_short: s.goal_text_short,
-                        state: s.state.to_string(),
+                        state: s.state,
                         turns_executed: s.turns_executed,
                         max_turns: s.max_turns,
                         elapsed: s.elapsed,

--- a/crates/zeph-core/src/goal/autonomous.rs
+++ b/crates/zeph-core/src/goal/autonomous.rs
@@ -14,44 +14,7 @@ use parking_lot::Mutex;
 use tokio::time::{Duration, Instant as TokioInstant, Interval};
 use tokio_util::sync::CancellationToken;
 
-/// FSM states for an autonomous goal session.
-///
-/// Valid transitions:
-/// - `Running` → `Verifying` (supervisor check triggered)
-/// - `Verifying` → `Running` (supervisor: not yet achieved)
-/// - `Verifying` → `Achieved` (supervisor: goal met)
-/// - `Running` / `Verifying` → `Stuck` (stuck counter exhausted or supervisor failures)
-/// - `Running` / `Verifying` → `Aborted` (user cancel or turn limit reached)
-/// - `Running` / `Verifying` → `Failed` (unrecoverable error)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AutonomousState {
-    /// The agent is actively running multi-turn execution.
-    Running,
-    /// The supervisor is verifying whether the goal condition is satisfied.
-    Verifying,
-    /// Goal achieved and confirmed by the supervisor.
-    Achieved,
-    /// No progress detected across the configured number of consecutive turns.
-    Stuck,
-    /// Session aborted by the user or turn limit reached.
-    Aborted,
-    /// Unrecoverable error during execution.
-    Failed,
-}
-
-impl std::fmt::Display for AutonomousState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Running => f.write_str("running"),
-            Self::Verifying => f.write_str("verifying"),
-            Self::Achieved => f.write_str("achieved"),
-            Self::Stuck => f.write_str("stuck"),
-            Self::Aborted => f.write_str("aborted"),
-            Self::Failed => f.write_str("failed"),
-        }
-    }
-}
+pub use zeph_config::autonomous::AutonomousState;
 
 /// Structured verdict returned by the supervisor verifier after a single LLM call.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/zeph-core/src/goal/supervisor.rs
+++ b/crates/zeph-core/src/goal/supervisor.rs
@@ -96,6 +96,85 @@ fn supervisor_user(
     )
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quality::parser::ChatJsonError;
+    use zeph_llm::LlmError;
+
+    #[test]
+    fn supervisor_user_contains_all_sections() {
+        let msg = supervisor_user(
+            "the build must pass",
+            "agent ran cargo build",
+            &[
+                "ran cargo build".to_owned(),
+                "no errors reported".to_owned(),
+            ],
+        );
+        assert!(msg.contains("Goal condition:"), "goal section missing");
+        assert!(msg.contains("the build must pass"), "goal text missing");
+        assert!(
+            msg.contains("Conversation summary:"),
+            "summary section missing"
+        );
+        assert!(
+            msg.contains("agent ran cargo build"),
+            "summary text missing"
+        );
+        assert!(msg.contains("Recent actions:"), "actions section missing");
+        assert!(msg.contains("- ran cargo build"), "first action missing");
+        assert!(
+            msg.contains("- no errors reported"),
+            "second action missing"
+        );
+    }
+
+    #[test]
+    fn supervisor_user_empty_actions_shows_none() {
+        let msg = supervisor_user("goal", "summary", &[]);
+        assert!(msg.contains("(none)"), "empty actions should show (none)");
+    }
+
+    #[test]
+    fn supervisor_error_from_chat_json_error_llm_preserved() {
+        let llm_err = ChatJsonError::Llm(LlmError::Other("backend failure".into()));
+        let sup_err = SupervisorError::from(llm_err);
+        assert!(
+            matches!(sup_err, SupervisorError::Llm(ref msg) if msg.contains("backend failure")),
+            "Llm variant must preserve the error message"
+        );
+    }
+
+    #[test]
+    fn supervisor_error_from_chat_json_error_llm_429_becomes_rate_limited() {
+        let llm_err = ChatJsonError::Llm(LlmError::Other("HTTP 429 rate limit".into()));
+        let sup_err = SupervisorError::from(llm_err);
+        assert!(
+            matches!(sup_err, SupervisorError::RateLimited),
+            "429 in message must become RateLimited"
+        );
+    }
+
+    #[test]
+    fn supervisor_error_from_chat_json_error_timeout() {
+        let err = SupervisorError::from(ChatJsonError::Timeout(5000));
+        assert!(
+            matches!(err, SupervisorError::Timeout(5000)),
+            "Timeout variant must preserve milliseconds"
+        );
+    }
+
+    #[test]
+    fn supervisor_error_from_chat_json_error_parse() {
+        let err = SupervisorError::from(ChatJsonError::Parse("bad json".to_owned()));
+        assert!(
+            matches!(err, SupervisorError::Parse(ref s) if s == "bad json"),
+            "Parse variant must preserve the raw string"
+        );
+    }
+}
+
 /// Single-call supervisor verifier for autonomous goal sessions.
 ///
 /// Uses a configurable LLM provider (ideally different from the main agent provider to avoid

--- a/crates/zeph-core/src/goal/supervisor.rs
+++ b/crates/zeph-core/src/goal/supervisor.rs
@@ -96,6 +96,59 @@ fn supervisor_user(
     )
 }
 
+/// Single-call supervisor verifier for autonomous goal sessions.
+///
+/// Uses a configurable LLM provider (ideally different from the main agent provider to avoid
+/// self-confirmation bias). On HTTP 429 the caller should wait and retry once before counting
+/// the failure toward the consecutive failure limit.
+pub struct GoalSupervisor {
+    provider: AnyProvider,
+    timeout: Duration,
+}
+
+impl GoalSupervisor {
+    /// Create a new supervisor with the given provider and per-call timeout.
+    #[must_use]
+    pub fn new(provider: AnyProvider, timeout: Duration) -> Self {
+        Self { provider, timeout }
+    }
+
+    /// Verify whether `goal_condition` has been achieved.
+    ///
+    /// Makes at most **two** LLM calls (initial + one retry on JSON parse failure via
+    /// [`chat_json`]). Rate-limit (429) errors are surfaced as [`SupervisorError::RateLimited`]
+    /// so the caller can apply backoff before counting the failure.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SupervisorError`] on provider error, timeout, or unrecoverable parse failure.
+    #[tracing::instrument(name = "goal.supervisor.verify", skip_all, level = "debug", err)]
+    pub async fn verify(
+        &self,
+        goal_condition: &str,
+        conversation_summary: &str,
+        recent_actions: &[String],
+    ) -> Result<SupervisorVerdict, SupervisorError> {
+        let user = supervisor_user(goal_condition, conversation_summary, recent_actions);
+        tracing::debug!("goal.supervisor.verify: calling provider");
+        let (raw, _tokens, _attempt): (RawVerdict, _, _) =
+            chat_json(&self.provider, SUPERVISOR_SYSTEM, &user, self.timeout)
+                .await
+                .map_err(SupervisorError::from)?;
+        tracing::debug!(
+            achieved = raw.achieved,
+            confidence = raw.confidence,
+            "goal.supervisor.verify: done"
+        );
+        Ok(SupervisorVerdict {
+            achieved: raw.achieved,
+            reasoning: raw.reasoning,
+            confidence: raw.confidence.clamp(0.0, 1.0),
+            suggestions: raw.suggestions,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -172,58 +225,5 @@ mod tests {
             matches!(err, SupervisorError::Parse(ref s) if s == "bad json"),
             "Parse variant must preserve the raw string"
         );
-    }
-}
-
-/// Single-call supervisor verifier for autonomous goal sessions.
-///
-/// Uses a configurable LLM provider (ideally different from the main agent provider to avoid
-/// self-confirmation bias). On HTTP 429 the caller should wait and retry once before counting
-/// the failure toward the consecutive failure limit.
-pub struct GoalSupervisor {
-    provider: AnyProvider,
-    timeout: Duration,
-}
-
-impl GoalSupervisor {
-    /// Create a new supervisor with the given provider and per-call timeout.
-    #[must_use]
-    pub fn new(provider: AnyProvider, timeout: Duration) -> Self {
-        Self { provider, timeout }
-    }
-
-    /// Verify whether `goal_condition` has been achieved.
-    ///
-    /// Makes at most **two** LLM calls (initial + one retry on JSON parse failure via
-    /// [`chat_json`]). Rate-limit (429) errors are surfaced as [`SupervisorError::RateLimited`]
-    /// so the caller can apply backoff before counting the failure.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SupervisorError`] on provider error, timeout, or unrecoverable parse failure.
-    #[tracing::instrument(name = "goal.supervisor.verify", skip_all, level = "debug", err)]
-    pub async fn verify(
-        &self,
-        goal_condition: &str,
-        conversation_summary: &str,
-        recent_actions: &[String],
-    ) -> Result<SupervisorVerdict, SupervisorError> {
-        let user = supervisor_user(goal_condition, conversation_summary, recent_actions);
-        tracing::debug!("goal.supervisor.verify: calling provider");
-        let (raw, _tokens, _attempt): (RawVerdict, _, _) =
-            chat_json(&self.provider, SUPERVISOR_SYSTEM, &user, self.timeout)
-                .await
-                .map_err(SupervisorError::from)?;
-        tracing::debug!(
-            achieved = raw.achieved,
-            confidence = raw.confidence,
-            "goal.supervisor.verify: done"
-        );
-        Ok(SupervisorVerdict {
-            achieved: raw.achieved,
-            reasoning: raw.reasoning,
-            confidence: raw.confidence.clamp(0.0, 1.0),
-            suggestions: raw.suggestions,
-        })
     }
 }


### PR DESCRIPTION
## Summary

- Replace `FleetEntry.state: String` with `AutonomousState` enum to restore type safety across the `zeph-commands` / `zeph-core` boundary (#4332)
- Move `AutonomousState` to `zeph-config` to avoid a circular dependency; `zeph-core` re-exports via `pub use`
- Add 6 unit tests for `supervisor_user()` and `SupervisorError::from(ChatJsonError)` in `zeph-core::goal::supervisor` (#4331)

## Changes

- `crates/zeph-config/src/autonomous.rs` — new module with `AutonomousState` enum (moved from `zeph-core`)
- `crates/zeph-core/src/goal/autonomous.rs` — removed duplicate definition, added re-export
- `crates/zeph-core/src/agent/agent_access_impl.rs` — `s.state.to_string()` → `s.state`
- `crates/zeph-commands/src/handlers/agents_fleet.rs` — `FleetEntry.state: String` → `AutonomousState`
- `crates/zeph-commands/Cargo.toml` — added `zeph-config.workspace = true`
- `crates/zeph-core/src/goal/supervisor.rs` — 6 unit tests added

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 9818 tests pass
- [ ] `cargo nextest run -p zeph-core -E 'test(supervisor)'` — 6 new tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --lib --bins -- -D warnings` — 0 warnings
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean

Closes #4332
Closes #4331