### PR TITLE
feat(observability): add telemetry.trace_metadata config field for OTEL span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `zeph-config`: Added `telemetry.trace_metadata` config field (`HashMap<String, String>`)
+  that propagates user-defined key/value pairs as OpenTelemetry resource attributes. Attributes
+  appear on every exported OTLP span and in Chrome JSON `resourceSpans[].resource.attributes`.
+  The reserved key `service.name` is silently ignored — `service_name` takes precedence.
+  Values are stored in plaintext; do not use for secrets (closes #4160).
+- `zeph-config`: Added migration step 47 (`migrate_trace_metadata`) that injects a
+  commented-out `[telemetry.trace_metadata]` example into existing configs that have a
+  `[telemetry]` section (closes #4160).
+
 ### Security
 
 - `zeph-core`, `zeph-config`: Parent messages passed to spawned sub-agents are now sanitized

--- a/config/default.toml
+++ b/config/default.toml
@@ -1333,6 +1333,11 @@ sweep_batch_size = 100
 # sample_rate = 1.0
 # # Interval between system-metrics snapshots in seconds (Phase 3)
 # system_metrics_interval_secs = 5
+# # Custom key/value pairs attached as OpenTelemetry resource attributes.
+# # Appear on every exported span. Values are plaintext — do not store secrets here.
+# [telemetry.trace_metadata]
+# "deployment.environment" = "production"
+# "vcs.revision" = "abc1234"
 
 # [session] — session-scoped user experience settings
 # ── Goals ─────────────────────────────────────────────────────────────────────

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3322,7 +3322,8 @@ use steps::{
     MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter,
     MigrateSchedulerDaemon, MigrateSessionProviderPersistence, MigrateSessionRecapConfig,
     MigrateShellTransactional, MigrateSttToProvider, MigrateSupervisorConfig,
-    MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateVigilConfig,
+    MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateTraceMetadata,
+    MigrateVigilConfig,
 };
 
 /// Step 45: add an advisory comment above `GonkaGate` provider entries pointing users to
@@ -3410,7 +3411,47 @@ pub fn migrate_cocoon_provider_notice(toml_src: &str) -> Result<MigrationResult,
     })
 }
 
-/// Ordered registry of all sequential migration steps (steps 1–46).
+/// Adds a commented-out `[telemetry.trace_metadata]` example to configs that have a
+/// `[telemetry]` section but no `trace_metadata` key (#4160).
+///
+/// # Errors
+///
+/// Returns [`MigrateError`] if the TOML source cannot be parsed.
+pub fn migrate_trace_metadata(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("trace_metadata") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+
+    if !doc.contains_key("telemetry") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Custom key/value pairs attached as OpenTelemetry resource attributes (#4160).\n\
+        # Appear on every exported span. Values are plaintext — do not store secrets here.\n\
+        # [telemetry.trace_metadata]\n\
+        # \"deployment.environment\" = \"production\"\n\
+        # \"vcs.revision\" = \"abc1234\"\n";
+    let raw = doc.to_string();
+    let output = insert_after_section(&raw, "telemetry", comment);
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["telemetry.trace_metadata".to_owned()],
+    })
+}
+
+/// Ordered registry of all sequential migration steps (steps 1–47).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -3485,6 +3526,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateGonkagateToGonka),
             // Step 46 — advisory notice for Cocoon decentralized inference provider (#3671)
             Box::new(MigrateCocoonProviderNotice),
+            // Step 47 — telemetry.trace_metadata OTEL resource attributes (#4160)
+            Box::new(MigrateTraceMetadata),
         ]
     });
 
@@ -3503,8 +3546,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            46,
-            "MIGRATIONS registry must contain all 46 sequential steps"
+            47,
+            "MIGRATIONS registry must contain all 47 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -5090,8 +5133,8 @@ prompt_cache_ttl = "1h"
     // ── Migration registry ────────────────────────────────────────────────────
 
     #[test]
-    fn registry_has_forty_six_entries() {
-        assert_eq!(MIGRATIONS.len(), 46);
+    fn registry_has_forty_seven_entries() {
+        assert_eq!(MIGRATIONS.len(), 47);
     }
 
     #[test]
@@ -5178,9 +5221,44 @@ prompt_cache_ttl = "1h"
             "migrate_provider_max_concurrent",
             "migrate_gonkagate_to_gonka",
             "migrate_cocoon_provider_notice",
+            "migrate_trace_metadata",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
+    }
+
+    // ── migrate_trace_metadata tests (#4160) ─────────────────────────────────
+
+    #[test]
+    fn migrate_trace_metadata_noop_when_already_present() {
+        let src = "[telemetry]\nenabled = true\n\n[telemetry.trace_metadata]\n\"env\" = \"prod\"\n";
+        let result = migrate_trace_metadata(src).unwrap();
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_trace_metadata_noop_when_no_telemetry_section() {
+        let src = "[agent]\nmax_turns = 10\n";
+        let result = migrate_trace_metadata(src).unwrap();
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_trace_metadata_injects_comment_when_telemetry_present() {
+        let src = "[telemetry]\nenabled = true\nservice_name = \"zeph\"\n";
+        let result = migrate_trace_metadata(src).unwrap();
+        assert_eq!(result.changed_count, 1);
+        assert!(result.output.contains("trace_metadata"));
+        assert!(
+            result
+                .sections_changed
+                .contains(&"telemetry.trace_metadata".to_owned())
+        );
+        // Idempotent: running again is a no-op.
+        let result2 = migrate_trace_metadata(&result.output).unwrap();
+        assert_eq!(result2.changed_count, 0);
     }
 
     // ── migrate_qdrant_api_key tests (#3543) ─────────────────────────────────

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -30,7 +30,8 @@ use super::{
     migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
-    migrate_telemetry_config, migrate_tools_compression_config, migrate_vigil_config,
+    migrate_telemetry_config, migrate_tools_compression_config, migrate_trace_metadata,
+    migrate_vigil_config,
 };
 
 // ── Wrapper structs for all 35 sequential migration steps ───────────────────────────────────────
@@ -538,5 +539,16 @@ impl Migration for MigrateCocoonProviderNotice {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_cocoon_provider_notice(toml_src)
+    }
+}
+
+pub(super) struct MigrateTraceMetadata;
+impl Migration for MigrateTraceMetadata {
+    fn name(&self) -> &'static str {
+        "migrate_trace_metadata"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_trace_metadata(toml_src)
     }
 }

--- a/crates/zeph-config/src/telemetry.rs
+++ b/crates/zeph-config/src/telemetry.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -146,6 +147,30 @@ pub struct TelemetryConfig {
     /// Interval in seconds between system-metrics snapshots (Phase 3). Default: `5`.
     #[serde(default = "default_system_metrics_interval_secs")]
     pub system_metrics_interval_secs: u64,
+    /// User-defined key/value pairs attached as OpenTelemetry resource attributes.
+    ///
+    /// These appear on every span exported via OTLP and in Chrome JSON trace
+    /// `resourceSpans[].resource.attributes`. Useful for tagging traces with deployment
+    /// environment, team, git revision, etc.
+    ///
+    /// Keys follow the [OpenTelemetry attribute naming convention](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/)
+    /// (dot-separated, lowercase). The reserved key `service.name` is silently ignored —
+    /// the `service_name` config field takes precedence.
+    ///
+    /// Values appear in plaintext in exported traces. The `RedactingSpanProcessor` does
+    /// **not** scrub resource attributes (they are set once at init, not per-span). Do not
+    /// store secrets here.
+    ///
+    /// # Example (TOML)
+    ///
+    /// ```toml
+    /// [telemetry.trace_metadata]
+    /// "deployment.environment" = "staging"
+    /// "team.name" = "platform"
+    /// "vcs.revision" = "abc1234"
+    /// ```
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub trace_metadata: HashMap<String, String>,
 }
 
 impl Default for TelemetryConfig {
@@ -162,6 +187,7 @@ impl Default for TelemetryConfig {
             sample_rate: default_sample_rate(),
             otel_filter: None,
             system_metrics_interval_secs: default_system_metrics_interval_secs(),
+            trace_metadata: HashMap::new(),
         }
     }
 }
@@ -212,5 +238,50 @@ mod tests {
         let cfg: TelemetryConfig = toml::from_str("").unwrap();
         assert!(!cfg.enabled);
         assert_eq!(cfg.backend, TelemetryBackend::Local);
+    }
+
+    #[test]
+    fn trace_metadata_parses_and_roundtrips() {
+        let toml = r#"
+            enabled = true
+            backend = "otlp"
+            service_name = "my-agent"
+
+            [trace_metadata]
+            "deployment.environment" = "staging"
+            "team.name" = "platform"
+        "#;
+        let cfg: TelemetryConfig = toml::from_str(toml).unwrap();
+        assert_eq!(
+            cfg.trace_metadata
+                .get("deployment.environment")
+                .map(String::as_str),
+            Some("staging")
+        );
+        assert_eq!(
+            cfg.trace_metadata.get("team.name").map(String::as_str),
+            Some("platform")
+        );
+
+        // Roundtrip: serialize then deserialize preserves values.
+        let serialized = toml::to_string(&cfg).unwrap();
+        let cfg2: TelemetryConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(cfg2.trace_metadata, cfg.trace_metadata);
+    }
+
+    #[test]
+    fn trace_metadata_empty_by_default() {
+        let cfg = TelemetryConfig::default();
+        assert!(cfg.trace_metadata.is_empty());
+    }
+
+    #[test]
+    fn trace_metadata_omitted_when_empty_on_serialize() {
+        let cfg = TelemetryConfig::default();
+        let serialized = toml::to_string(&cfg).unwrap();
+        assert!(
+            !serialized.contains("trace_metadata"),
+            "empty trace_metadata must be omitted from serialized TOML"
+        );
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1298,10 +1298,12 @@ impl<C: Channel> Agent<C> {
         mut self,
         dump_dir: std::path::PathBuf,
         service_name: impl Into<String>,
+        trace_metadata: std::collections::HashMap<String, String>,
         redact: bool,
     ) -> Self {
         self.runtime.debug.dump_dir = Some(dump_dir);
         self.runtime.debug.trace_service_name = service_name.into();
+        self.runtime.debug.trace_metadata = trace_metadata;
         self.runtime.debug.trace_redact = redact;
         self
     }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -397,6 +397,8 @@ pub(crate) struct DebugState {
     pub(crate) trace_service_name: String,
     /// Whether to redact in `TracingCollector` created via runtime format switch (CR-04).
     pub(crate) trace_redact: bool,
+    /// User-defined resource attributes forwarded to `TracingCollector` (from `telemetry.trace_metadata`).
+    pub(crate) trace_metadata: std::collections::HashMap<String, String>,
     /// Span ID of the currently executing iteration — used by LLM/tool span wiring (CR-01).
     /// Set to `Some` at the start of `process_user_message`, cleared at end.
     pub(crate) current_iteration_span_id: Option<[u8; 8]>,
@@ -876,9 +878,11 @@ impl DebugState {
         {
             let service_name = self.trace_service_name.clone();
             let redact = self.trace_redact;
+            let trace_metadata = self.trace_metadata.clone();
             match crate::debug_dump::trace::TracingCollector::new(
                 dump_dir.as_path(),
                 &service_name,
+                trace_metadata,
                 redact,
                 None,
             ) {
@@ -980,6 +984,7 @@ impl Default for DebugState {
             dump_dir: None,
             trace_service_name: String::new(),
             trace_redact: true,
+            trace_metadata: std::collections::HashMap::new(),
             current_iteration_span_id: None,
         }
     }

--- a/crates/zeph-core/src/debug_dump/trace.rs
+++ b/crates/zeph-core/src/debug_dump/trace.rs
@@ -160,6 +160,9 @@ pub struct TracingCollector {
     session_span_id: [u8; 8],
     session_start: u64,
     service_name: String,
+    /// User-defined resource attributes from `telemetry.trace_metadata`, included in
+    /// `resourceSpans[].resource.attributes` when serializing to OTLP JSON.
+    trace_metadata: HashMap<String, String>,
     output_dir: PathBuf,
     /// Active (open) iterations keyed by iteration index (I-03).
     active_iterations: HashMap<usize, IterationEntry>,
@@ -178,12 +181,16 @@ pub struct TracingCollector {
 impl TracingCollector {
     /// Create a new collector.
     ///
+    /// `trace_metadata` is included as additional resource attributes in the OTLP JSON output.
+    /// The reserved key `service.name` in `trace_metadata` is silently skipped.
+    ///
     /// # Errors
     ///
     /// Returns an error if `output_dir` cannot be created.
     pub fn new(
         output_dir: &Path,
         service_name: impl Into<String>,
+        trace_metadata: HashMap<String, String>,
         redact: bool,
         trace_tx: Option<tokio::sync::mpsc::UnboundedSender<TraceEvent>>,
     ) -> std::io::Result<Self> {
@@ -193,6 +200,7 @@ impl TracingCollector {
             session_span_id: new_span_id(),
             session_start: now_unix_nanos(),
             service_name: service_name.into(),
+            trace_metadata,
             output_dir: output_dir.to_owned(),
             active_iterations: HashMap::new(),
             completed_spans: Vec::new(),
@@ -497,7 +505,7 @@ impl TracingCollector {
         let mut all_spans = vec![session_span];
         all_spans.append(&mut self.completed_spans);
 
-        let json = serialize_otlp_json(&all_spans, &self.service_name);
+        let json = serialize_otlp_json(&all_spans, &self.service_name, &self.trace_metadata);
         let path = self.output_dir.join("trace.json");
         if let Err(e) = write_trace_file(&path, json.as_bytes()) {
             tracing::warn!(path = %path.display(), error = %e, "trace.json write failed");
@@ -537,9 +545,16 @@ fn span_status_code(status: &SpanStatus) -> u8 {
 
 /// Serialize spans to OTLP JSON Protobuf encoding.
 ///
+/// `trace_metadata` entries are appended as additional resource attributes after `service.name`.
+/// The reserved key `service.name` in `trace_metadata` is skipped to avoid duplication.
+///
 /// Format: <https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding>
 #[must_use]
-pub fn serialize_otlp_json(spans: &[SpanData], service_name: &str) -> String {
+pub fn serialize_otlp_json<S: std::hash::BuildHasher>(
+    spans: &[SpanData],
+    service_name: &str,
+    trace_metadata: &HashMap<String, String, S>,
+) -> String {
     let otlp_spans: Vec<serde_json::Value> = spans
         .iter()
         .map(|s| {
@@ -579,13 +594,24 @@ pub fn serialize_otlp_json(spans: &[SpanData], service_name: &str) -> String {
         })
         .collect();
 
+    let mut resource_attrs = vec![serde_json::json!({
+        "key": "service.name",
+        "value": { "stringValue": service_name }
+    })];
+    for (k, v) in trace_metadata {
+        if k == "service.name" {
+            continue;
+        }
+        resource_attrs.push(serde_json::json!({
+            "key": k,
+            "value": { "stringValue": v }
+        }));
+    }
+
     let payload = serde_json::json!({
         "resourceSpans": [{
             "resource": {
-                "attributes": [{
-                    "key": "service.name",
-                    "value": { "stringValue": service_name }
-                }]
+                "attributes": resource_attrs
             },
             "scopeSpans": [{
                 "scope": {
@@ -644,7 +670,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn make_collector(dir: &Path) -> TracingCollector {
-        TracingCollector::new(dir, "zeph-test", false, None).unwrap()
+        TracingCollector::new(dir, "zeph-test", HashMap::new(), false, None).unwrap()
     }
 
     #[test]
@@ -735,7 +761,7 @@ mod tests {
     #[test]
     fn redaction_applied_to_text_attributes() {
         let tmp = tempdir().unwrap();
-        let mut c = TracingCollector::new(tmp.path(), "test", true, None).unwrap();
+        let mut c = TracingCollector::new(tmp.path(), "test", HashMap::new(), true, None).unwrap();
         let iter_id = c.session_span_id();
         let guard = c.begin_memory_search(iter_id);
         c.end_memory_search(
@@ -770,7 +796,7 @@ mod tests {
             status: SpanStatus::Ok,
         }];
 
-        let json = serialize_otlp_json(&spans, "zeph");
+        let json = serialize_otlp_json(&spans, "zeph", &HashMap::new());
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
 
         let span = &v["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
@@ -797,6 +823,37 @@ mod tests {
             tmp.path().join("trace.json").exists(),
             "Drop must flush trace.json"
         );
+    }
+
+    #[test]
+    fn trace_metadata_included_in_resource_attributes() {
+        let tmp = tempdir().unwrap();
+        let mut meta = HashMap::new();
+        meta.insert("deployment.environment".to_owned(), "staging".to_owned());
+        meta.insert("service.name".to_owned(), "should-be-skipped".to_owned());
+        let mut c = TracingCollector::new(tmp.path(), "zeph-test", meta, false, None).unwrap();
+        c.finish();
+
+        let content = std::fs::read_to_string(tmp.path().join("trace.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let attrs = v["resourceSpans"][0]["resource"]["attributes"]
+            .as_array()
+            .unwrap();
+
+        // service.name must appear with the collector's service_name, not the skipped value.
+        let svc = attrs
+            .iter()
+            .find(|a| a["key"] == "service.name")
+            .expect("service.name must be in resource attributes");
+        assert_eq!(svc["value"]["stringValue"], "zeph-test");
+
+        // Custom metadata attribute must be present.
+        let env_attr = attrs.iter().find(|a| a["key"] == "deployment.environment");
+        assert!(
+            env_attr.is_some(),
+            "deployment.environment must be in resource attributes"
+        );
+        assert_eq!(env_attr.unwrap()["value"]["stringValue"], "staging");
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2795,6 +2795,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             let agent = agent.with_trace_config(
                 dir.clone(),
                 config.debug.traces.service_name.clone(),
+                config.telemetry.trace_metadata.clone(),
                 config.debug.traces.redact,
             );
             // When format=Trace, also wire a TracingCollector (C-03: independent of legacy dumper).
@@ -2803,6 +2804,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                 match zeph_core::debug_dump::trace::TracingCollector::new(
                     &session_dir,
                     &config.debug.traces.service_name,
+                    config.telemetry.trace_metadata.clone(),
                     config.debug.traces.redact,
                     None,
                 ) {

--- a/src/tracing_init.rs
+++ b/src/tracing_init.rs
@@ -347,10 +347,41 @@ fn build_chrome_layer(
 /// The `redact_secrets` parameter controls whether a `RedactingSpanProcessor` wrapper is
 /// inserted between the BSP and the exporter to scrub string attribute values before export.
 ///
+// RESERVED_KEYS lists resource attribute keys managed by the builder itself.
+// Only "service.name" is listed because Resource::builder_empty() (not builder()) does not
+// attach SDK-detected attributes. If the project later switches to Resource::builder(),
+// this list must be extended with "service.version", "telemetry.sdk.*", etc.
+#[cfg(feature = "otel")]
+const RESERVED_KEYS: &[&str] = &["service.name"];
+
+/// Returns the subset of `metadata` whose keys are not in `RESERVED_KEYS`.
+///
+/// Keys in `RESERVED_KEYS` are printed via `eprintln!` and excluded.
+/// Used by `build_otlp_layer` to build OTLP resource attributes.
+#[cfg(feature = "otel")]
+fn filter_trace_metadata(
+    metadata: &std::collections::HashMap<String, String>,
+) -> Vec<(String, String)> {
+    metadata
+        .iter()
+        .filter_map(|(k, v)| {
+            if RESERVED_KEYS.contains(&k.as_str()) {
+                eprintln!(
+                    "[zeph] warning: telemetry.trace_metadata key '{k}' is reserved and will be ignored"
+                );
+                None
+            } else {
+                Some((k.clone(), v.clone()))
+            }
+        })
+        .collect()
+}
+
 /// # Panics
 ///
 /// Does not panic. OTLP pipeline errors are logged via `tracing::warn!` and `None` is returned.
 #[cfg(feature = "otel")]
+#[allow(clippy::too_many_lines)]
 fn build_otlp_layer(
     telemetry: &TelemetryConfig,
     layers: &mut Vec<
@@ -432,9 +463,12 @@ fn build_otlp_layer(
 
     // "service.name" is the canonical OTel semconv key (opentelemetry_semantic_conventions::resource::SERVICE_NAME).
     // We inline the string to avoid a new dependency on that crate.
-    let resource = opentelemetry_sdk::Resource::builder_empty()
-        .with_service_name(telemetry.service_name.clone())
-        .build();
+    let mut resource_builder = opentelemetry_sdk::Resource::builder_empty()
+        .with_service_name(telemetry.service_name.clone());
+    for (k, v) in filter_trace_metadata(&telemetry.trace_metadata) {
+        resource_builder = resource_builder.with_attribute(opentelemetry::KeyValue::new(k, v));
+    }
+    let resource = resource_builder.build();
 
     // #2998: raise BSP queue size from the default 2048 to 4096 to absorb bursts during
     // high-throughput agent turns without dropping spans. This directly addresses the
@@ -822,5 +856,52 @@ mod tests {
             !json_files.is_empty(),
             "expected at least one .json trace file"
         );
+    }
+
+    /// Verify that `filter_trace_metadata` excludes reserved keys and passes through valid ones.
+    ///
+    /// Tests the filtering logic used in `build_otlp_layer` without requiring a live OTLP
+    /// collector. Confirms that `service.name` is dropped and that other keys are preserved.
+    #[cfg(feature = "otel")]
+    #[test]
+    fn filter_trace_metadata_excludes_reserved_keys() {
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("service.name".to_owned(), "should-be-dropped".to_owned());
+        meta.insert("deployment.environment".to_owned(), "staging".to_owned());
+        meta.insert("team.name".to_owned(), "platform".to_owned());
+
+        let result = filter_trace_metadata(&meta);
+
+        // Reserved key must not appear in result.
+        assert!(
+            result.iter().all(|(k, _)| *k != "service.name"),
+            "service.name must be excluded from filtered metadata"
+        );
+        // Valid keys must be present.
+        assert!(
+            result
+                .iter()
+                .any(|(k, v)| *k == "deployment.environment" && *v == "staging"),
+            "deployment.environment must be preserved"
+        );
+        assert!(
+            result
+                .iter()
+                .any(|(k, v)| *k == "team.name" && *v == "platform"),
+            "team.name must be preserved"
+        );
+        // Total: 2 valid keys, 1 reserved → 2 entries.
+        assert_eq!(result.len(), 2);
+    }
+
+    /// Verify that `filter_trace_metadata` returns all entries when no reserved keys are present.
+    #[cfg(feature = "otel")]
+    #[test]
+    fn filter_trace_metadata_passes_all_non_reserved() {
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("vcs.revision".to_owned(), "abc1234".to_owned());
+        let result = filter_trace_metadata(&meta);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], ("vcs.revision".to_owned(), "abc1234".to_owned()));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `telemetry.trace_metadata: HashMap<String, String>` to `TelemetryConfig` — a TOML table of arbitrary key/value labels attached to all OpenTelemetry spans at agent startup
- Propagated as OTEL resource attributes on `SdkTracerProvider` (zero per-span overhead)
- Also included in local Chrome JSON traces (`TracingCollector`) via constructor injection (required for the `Drop` path)
- Reserved key `service.name` is silently filtered out via `filter_trace_metadata()` with a stderr warning — `service_name` config field takes precedence
- Config migration step 47 (`migrate_trace_metadata`) adds a commented example block to existing configs

Parity with Codex v0.130.0 PR #21556.

Closes #4160

## Changed files

| File | Change |
|---|---|
| `crates/zeph-config/src/telemetry.rs` | Add `trace_metadata` field to `TelemetryConfig` |
| `src/tracing_init.rs` | Add `filter_trace_metadata()` helper; inject into OTLP resource |
| `crates/zeph-core/src/debug_dump/trace.rs` | Store and emit metadata in `TracingCollector` |
| `crates/zeph-core/src/agent/builder.rs` | Thread `trace_metadata` through agent builder |
| `crates/zeph-core/src/agent/state/mod.rs` | Add `trace_metadata` to `AgentState` |
| `src/runner.rs` | Pass metadata at startup |
| `crates/zeph-config/src/migrate/mod.rs` | Migration step 47 + 3 unit tests |
| `crates/zeph-config/src/migrate/steps.rs` | Register migration step 47 |
| `config/default.toml` | Add commented `[telemetry.trace_metadata]` example |
| `CHANGELOG.md` | Document feature in `[Unreleased]` |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10073 passed, 0 failed (+5 new tests)
- [x] `filter_trace_metadata` — reserved key exclusion, non-reserved pass-through
- [x] `migrate_trace_metadata` — all 3 branches (already-present, no-section, injection + idempotency)