### PR TITLE
refactor(config): replace stringly-typed provider and failure-strategy fields

### DIFF
--- a/crates/zeph-config/src/agent.rs
+++ b/crates/zeph-config/src/agent.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::providers::ProviderName;
 use crate::subagent::{HookDef, MemoryScope, PermissionMode};
 
 /// Specifies which LLM provider a sub-agent should use.
@@ -390,7 +391,7 @@ pub struct GoalConfig {
     pub autonomous_max_turns: u32,
     /// Provider name for the supervisor verifier LLM call (references `[[llm.providers]] name`).
     /// Falls back to the main provider when `None`.
-    pub supervisor_provider: Option<String>,
+    pub supervisor_provider: Option<ProviderName>,
     /// How many turns to execute between supervisor verification checks. Default: `5`.
     #[serde(default = "default_verify_interval")]
     pub verify_interval: u32,

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -1,8 +1,69 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::fmt;
+use std::str::FromStr;
+
 use crate::providers::ProviderName;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+/// Strategy applied when a task in the orchestration graph fails.
+///
+/// Set at the graph level via [`OrchestrationConfig::default_failure_strategy`] and overridden
+/// per-task in the task node. Variants map directly to the `serde` lowercase string form used in
+/// TOML config and LLM-produced JSON plans.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_config::FailureStrategy;
+///
+/// assert_eq!(FailureStrategy::default(), FailureStrategy::Abort);
+///
+/// let s: FailureStrategy = serde_json::from_str("\"skip\"").unwrap();
+/// assert_eq!(s, FailureStrategy::Skip);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureStrategy {
+    /// Abort the entire graph and cancel all running tasks.
+    #[default]
+    Abort,
+    /// Retry the task up to the configured `max_retries` limit, then abort.
+    Retry,
+    /// Skip the failed task and transitively skip all its dependents.
+    Skip,
+    /// Pause the graph and wait for user intervention.
+    Ask,
+}
+
+impl fmt::Display for FailureStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Abort => write!(f, "abort"),
+            Self::Retry => write!(f, "retry"),
+            Self::Skip => write!(f, "skip"),
+            Self::Ask => write!(f, "ask"),
+        }
+    }
+}
+
+impl FromStr for FailureStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "abort" => Ok(Self::Abort),
+            "retry" => Ok(Self::Retry),
+            "skip" => Ok(Self::Skip),
+            "ask" => Ok(Self::Ask),
+            other => Err(format!(
+                "unknown failure strategy '{other}': expected one of abort, retry, skip, ask"
+            )),
+        }
+    }
+}
 
 fn default_planner_max_tokens() -> u32 {
     4096
@@ -173,12 +234,8 @@ pub struct OrchestrationConfig {
     /// Maximum number of tasks that can run in parallel.
     pub max_parallel: u32,
     /// Default failure strategy applied to every task graph unless overridden per-task.
-    ///
-    /// Accepted values: `"abort"` (cancel the whole graph), `"retry"` (retry up to
-    /// `default_max_retries` times then abort), `"skip"` (skip the failed task and its
-    /// transitive dependents), `"ask"` (pause and wait for user input).
-    /// Unrecognised values fall back to `"abort"` with a warning log at runtime.
-    pub default_failure_strategy: String,
+    #[serde(default)]
+    pub default_failure_strategy: FailureStrategy,
     /// Default number of retries for the `retry` failure strategy.
     pub default_max_retries: u32,
     /// Timeout in seconds for a single task. `0` means no timeout.
@@ -364,7 +421,7 @@ impl Default for OrchestrationConfig {
             enabled: false,
             max_tasks: 20,
             max_parallel: 4,
-            default_failure_strategy: "abort".to_string(),
+            default_failure_strategy: FailureStrategy::default(),
             default_max_retries: 3,
             task_timeout_secs: 300,
             planner_provider: ProviderName::default(),

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -123,7 +123,8 @@ pub use defaults::{
 pub use dump_format::DumpFormat;
 pub use execution::{EnvironmentConfig, ExecutionConfig};
 pub use experiment::{
-    AdaptOrchConfig, ExperimentConfig, ExperimentSchedule, OrchestrationConfig, PlanCacheConfig,
+    AdaptOrchConfig, ExperimentConfig, ExperimentSchedule, FailureStrategy, OrchestrationConfig,
+    PlanCacheConfig,
 };
 pub use features::{
     CompressionSpectrumConfig, CostConfig, DaemonConfig, DebugConfig, GatewayConfig, IndexConfig,

--- a/crates/zeph-core/src/agent/autonomous_turn.rs
+++ b/crates/zeph-core/src/agent/autonomous_turn.rs
@@ -229,7 +229,13 @@ impl<C: Channel> Agent<C> {
     /// Resolve the configured supervisor provider and build a [`GoalSupervisor`].
     fn build_supervisor(&self) -> GoalSupervisor {
         let provider = {
-            let name = self.runtime.config.goals.supervisor_provider.as_deref();
+            let name = self
+                .runtime
+                .config
+                .goals
+                .supervisor_provider
+                .as_ref()
+                .map(zeph_config::ProviderName::as_str);
             let snapshot = self.runtime.providers.provider_config_snapshot.as_ref();
             match (name, snapshot) {
                 (Some(n), Some(snap)) => self

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -1016,7 +1016,7 @@ pub(crate) struct GoalRuntimeConfig {
     /// Maximum turns per autonomous session.
     pub(crate) autonomous_max_turns: u32,
     /// Provider name for the supervisor LLM call (`None` = use main provider).
-    pub(crate) supervisor_provider: Option<String>,
+    pub(crate) supervisor_provider: Option<zeph_config::ProviderName>,
     /// Turns between supervisor verification checks.
     pub(crate) verify_interval: u32,
     /// Timeout for a single supervisor call in seconds.

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+pub use zeph_config::FailureStrategy;
 use zeph_memory::store::graph_store::{GraphSummary, RawGraphStore};
 
 use super::error::OrchestrationError;
@@ -203,64 +204,6 @@ impl fmt::Display for GraphStatus {
             GraphStatus::Failed => write!(f, "failed"),
             GraphStatus::Canceled => write!(f, "canceled"),
             GraphStatus::Paused => write!(f, "paused"),
-        }
-    }
-}
-
-/// What to do when a task fails.
-///
-/// Set at the graph level via [`TaskGraph::default_failure_strategy`] and
-/// optionally overridden per task via [`TaskNode::failure_strategy`].
-///
-/// # Examples
-///
-/// ```rust
-/// use std::str::FromStr;
-/// use zeph_orchestration::FailureStrategy;
-///
-/// assert_eq!(FailureStrategy::default(), FailureStrategy::Abort);
-/// assert_eq!("skip".parse::<FailureStrategy>().unwrap(), FailureStrategy::Skip);
-/// assert_eq!(FailureStrategy::Retry.to_string(), "retry");
-/// ```
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
-)]
-#[serde(rename_all = "snake_case")]
-pub enum FailureStrategy {
-    /// Abort the entire graph and cancel all running tasks.
-    #[default]
-    Abort,
-    /// Retry the task up to [`TaskNode::max_retries`] times, then abort.
-    Retry,
-    /// Skip the failed task and transitively skip all its dependents.
-    Skip,
-    /// Pause the graph ([`GraphStatus::Paused`]) and wait for user intervention.
-    Ask,
-}
-
-impl fmt::Display for FailureStrategy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FailureStrategy::Abort => write!(f, "abort"),
-            FailureStrategy::Retry => write!(f, "retry"),
-            FailureStrategy::Skip => write!(f, "skip"),
-            FailureStrategy::Ask => write!(f, "ask"),
-        }
-    }
-}
-
-impl FromStr for FailureStrategy {
-    type Err = OrchestrationError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "abort" => Ok(FailureStrategy::Abort),
-            "retry" => Ok(FailureStrategy::Retry),
-            "skip" => Ok(FailureStrategy::Skip),
-            "ask" => Ok(FailureStrategy::Ask),
-            other => Err(OrchestrationError::InvalidGraph(format!(
-                "unknown failure strategy '{other}': expected one of abort, retry, skip, ask"
-            ))),
         }
     }
 }

--- a/crates/zeph-orchestration/src/planner.rs
+++ b/crates/zeph-orchestration/src/planner.rs
@@ -102,25 +102,13 @@ impl<P: LlmProvider> LlmPlanner<P> {
     /// it here. `LlmPlanner` uses whatever provider it receives without further
     /// provider resolution. The timeout is taken from `config.planner_timeout_secs`.
     ///
-    /// `config.default_failure_strategy` is parsed once here; an unrecognised value
-    /// falls back to [`FailureStrategy::Abort`] with a warning log.
     #[must_use]
     pub fn new(provider: P, config: &OrchestrationConfig) -> Self {
-        let default_failure_strategy = config
-            .default_failure_strategy
-            .parse::<FailureStrategy>()
-            .unwrap_or_else(|_| {
-                tracing::warn!(
-                    value = %config.default_failure_strategy,
-                    "unrecognised orchestration.default_failure_strategy; falling back to 'abort'"
-                );
-                FailureStrategy::Abort
-            });
         Self {
             provider,
             max_tasks: config.max_tasks,
             timeout: Duration::from_secs(config.planner_timeout_secs),
-            default_failure_strategy,
+            default_failure_strategy: config.default_failure_strategy,
         }
     }
 }
@@ -706,7 +694,7 @@ mod tests {
         .to_string();
         let provider = MockProvider::with_responses(vec![json]);
         let config = OrchestrationConfig {
-            default_failure_strategy: "skip".to_string(),
+            default_failure_strategy: FailureStrategy::Skip,
             ..Default::default()
         };
         let planner = LlmPlanner::new(provider, &config);
@@ -715,27 +703,6 @@ mod tests {
             graph.default_failure_strategy,
             FailureStrategy::Skip,
             "planner must apply OrchestrationConfig.default_failure_strategy to the produced graph"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_llm_planner_unknown_failure_strategy_falls_back_to_abort() {
-        use zeph_llm::mock::MockProvider;
-        let json = r#"{"tasks":[
-            {"task_id":"t1","title":"T1","description":"desc","depends_on":[]}
-        ]}"#
-        .to_string();
-        let provider = MockProvider::with_responses(vec![json]);
-        let config = OrchestrationConfig {
-            default_failure_strategy: "bogus_value".to_string(),
-            ..Default::default()
-        };
-        let planner = LlmPlanner::new(provider, &config);
-        let (graph, _) = planner.plan("goal", &agents()).await.unwrap();
-        assert_eq!(
-            graph.default_failure_strategy,
-            FailureStrategy::Abort,
-            "unrecognised strategy must fall back to Abort"
         );
     }
 
@@ -749,7 +716,7 @@ mod tests {
         .to_string();
         let provider = MockProvider::with_responses(vec![json]);
         let config = OrchestrationConfig {
-            default_failure_strategy: "retry".to_string(),
+            default_failure_strategy: FailureStrategy::Retry,
             ..Default::default()
         };
         let planner = LlmPlanner::new(provider, &config);

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -743,7 +743,7 @@ mod tests {
             enabled: true,
             max_tasks: 20,
             max_parallel: 4,
-            default_failure_strategy: "abort".to_string(),
+            default_failure_strategy: zeph_config::FailureStrategy::Abort,
             default_max_retries: 3,
             task_timeout_secs: 300,
             planner_provider: Default::default(),

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -890,7 +890,10 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
         max_tasks: state.orchestration_max_tasks,
         max_parallel: state.orchestration_max_parallel,
         confirm_before_execute: state.orchestration_confirm_before_execute,
-        default_failure_strategy: state.orchestration_failure_strategy.clone(),
+        default_failure_strategy: state
+            .orchestration_failure_strategy
+            .parse::<zeph_config::FailureStrategy>()
+            .unwrap_or_default(),
         planner_provider: ProviderName::new(
             state
                 .orchestration_planner_provider

--- a/tests/orchestration_integration.rs
+++ b/tests/orchestration_integration.rs
@@ -44,7 +44,7 @@ mod orchestration_integration {
             max_parallel: 4,
             // task_timeout_secs = 0 uses the internal 600s fallback; fine for unit tests.
             task_timeout_secs: 0,
-            default_failure_strategy: "abort".to_string(),
+            default_failure_strategy: FailureStrategy::Abort,
             default_max_retries: 3,
             planner_provider: ProviderName::default(),
             planner_max_tokens: 4096,


### PR DESCRIPTION
## Summary

- **#4343**: `GoalConfig.supervisor_provider: Option<String>` → `Option<ProviderName>`, consistent with all other `*_provider` fields migrated by #4295
- **#4344**: `OrchestrationConfig.default_failure_strategy: String` → `FailureStrategy` enum (`Abort | Retry | Skip | Ask`) with `serde(rename_all = "lowercase")`; invalid config values now produce a deserialisation error at startup instead of silently falling back to `"abort"` with a warning

`FailureStrategy` is defined in `zeph-config` and re-exported from `zeph-orchestration::graph`, preserving the existing public API for downstream consumers.

## Changes

| File | Change |
|---|---|
| `crates/zeph-config/src/agent.rs` | `supervisor_provider`: `Option<String>` → `Option<ProviderName>` |
| `crates/zeph-config/src/experiment.rs` | Define `FailureStrategy` enum; change field type |
| `crates/zeph-config/src/lib.rs` | Re-export `FailureStrategy` |
| `crates/zeph-core/src/agent/state/mod.rs` | Update `GoalRuntimeConfig.supervisor_provider` type |
| `crates/zeph-core/src/agent/autonomous_turn.rs` | Update `.as_deref()` usage |
| `crates/zeph-orchestration/src/graph.rs` | Remove own `FailureStrategy` definition; `pub use zeph_config::FailureStrategy` |
| `crates/zeph-orchestration/src/planner.rs` | Remove string-parse fallback; use typed value; update tests |
| `crates/zeph-orchestration/src/scheduler/mod.rs` | Update test fixture |
| `src/init/mod.rs` | Wizard boundary: `String` → `.parse().unwrap_or_default()` on build |
| `tests/orchestration_integration.rs` | Update fixture to `FailureStrategy::Abort` |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9839 passed, 0 failed
- [x] `cargo check --test orchestration_integration --features full` — clean

Closes #4343
Closes #4344