### PR TITLE
fix(tools): block rm targeting .git/worktrees regardless of flag order

### DIFF
--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -6,6 +6,22 @@ use crate::provider::ImageData;
 use crate::provider::MessageMetadata;
 use tokio_stream::StreamExt;
 
+#[test]
+fn completion_tokens_details_reasoning_tokens_deserialized() {
+    let json = r#"{
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "completion_tokens_details": {
+            "reasoning_tokens": 5
+        }
+    }"#;
+    let usage: OpenAiUsage = serde_json::from_str(json).expect("deserialization failed");
+    assert_eq!(usage.prompt_tokens, 10);
+    assert_eq!(usage.completion_tokens, 20);
+    let details = usage.completion_tokens_details.expect("details missing");
+    assert_eq!(details.reasoning_tokens, 5);
+}
+
 fn test_provider() -> OpenAiProvider {
     OpenAiProvider::new(OpenAiConfig {
         api_key: "sk-test-key".into(),

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -153,7 +153,7 @@ pub use shell::background::{BackgroundCompletion, BackgroundRunSnapshot, RunId};
 pub use shell::{
     DEFAULT_BLOCKED_COMMANDS, SHELL_INTERPRETERS, SafeFixSuggestion, ShellExecutor,
     ShellOutputEnvelope, ShellPolicyHandle, check_blocklist, deobfuscate_command,
-    effective_shell_command,
+    effective_shell_command, is_blocked_rm_worktrees,
 };
 pub use tool_filter::ToolFilter;
 pub use trust_gate::TrustGateExecutor;

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -63,22 +63,65 @@ use transaction::{TransactionSnapshot, affected_paths, build_scope_matchers, is_
 use crate::risk_chain::RiskChainAccumulator;
 
 const DEFAULT_BLOCKED: &[&str] = &[
-    "rm -rf /",
-    "sudo",
-    "mkfs",
-    "dd if=",
-    "curl",
-    "wget",
-    "nc ",
-    "ncat",
-    "netcat",
-    "shutdown",
-    "reboot",
-    "halt",
-    // Prevent rm -rf/-fr fallback on git worktree directories; use `git worktree remove --force` instead.
-    "rm -rf .git/worktrees",
-    "rm -fr .git/worktrees",
+    "rm -rf /", "sudo", "mkfs", "dd if=", "curl", "wget", "nc ", "ncat", "netcat", "shutdown",
+    "reboot", "halt",
 ];
+
+/// Returns `true` if `cmd` is an `rm` invocation with both recursive and force flags
+/// that targets `.git/worktrees`, regardless of flag ordering or bundling style.
+///
+/// Blocks variants like `-rf`, `-fr`, `-rfd`, `-rfv`, `--recursive --force`, etc.
+/// A plain `rm -r .git/worktrees` (no force) is intentionally allowed.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_tools::shell::is_blocked_rm_worktrees;
+/// assert!(is_blocked_rm_worktrees("rm -rf .git/worktrees"));
+/// assert!(is_blocked_rm_worktrees("rm -fr .git/worktrees"));
+/// assert!(is_blocked_rm_worktrees("rm -rfd .git/worktrees"));
+/// assert!(is_blocked_rm_worktrees("rm --recursive --force .git/worktrees"));
+/// assert!(!is_blocked_rm_worktrees("rm -r .git/worktrees")); // no force
+/// assert!(!is_blocked_rm_worktrees("rm -rf /tmp/other")); // no worktrees path
+/// ```
+#[must_use]
+pub fn is_blocked_rm_worktrees(cmd: &str) -> bool {
+    let lower = cmd.to_lowercase();
+    let tokens: Vec<&str> = lower.split_whitespace().collect();
+
+    // First token must be `rm` (or path-qualified, e.g. `/usr/bin/rm`).
+    let Some(first) = tokens.first() else {
+        return false;
+    };
+    if first.rsplit('/').next().unwrap_or(first) != "rm" {
+        return false;
+    }
+
+    if !lower.contains(".git/worktrees") {
+        return false;
+    }
+
+    let mut has_recursive = false;
+    let mut has_force = false;
+
+    for token in &tokens[1..] {
+        if *token == "--recursive" {
+            has_recursive = true;
+        } else if *token == "--force" {
+            has_force = true;
+        } else if let Some(flags) = token.strip_prefix('-').filter(|f| !f.starts_with('-')) {
+            // Short flag bundle like `-rfd` or `-fr`.
+            if flags.contains('r') || flags.contains('R') {
+                has_recursive = true;
+            }
+            if flags.contains('f') {
+                has_force = true;
+            }
+        }
+    }
+
+    has_recursive && has_force
+}
 
 /// Graceful period between SIGTERM and SIGKILL during process escalation.
 #[cfg(unix)]
@@ -87,9 +130,12 @@ const GRACEFUL_TERM_MS: Duration = Duration::from_millis(250);
 /// The default list of blocked command patterns used by [`ShellExecutor`].
 ///
 /// Includes highly destructive commands (`rm -rf /`, `mkfs`, `dd if=`), privilege
-/// escalation (`sudo`), network egress tools (`curl`, `wget`, `nc`, `netcat`), and
-/// `rm -rf` targeting `.git/worktrees` paths to prevent unsafe worktree teardown fallbacks.
+/// escalation (`sudo`), and network egress tools (`curl`, `wget`, `nc`, `netcat`).
 /// Network commands can be re-enabled via [`ShellConfig::allow_network`].
+///
+/// `rm` commands targeting `.git/worktrees` with recursive+force flags are blocked
+/// semantically via [`is_blocked_rm_worktrees`] regardless of flag ordering or bundling,
+/// so they do not appear as literal entries in this list.
 ///
 /// Exposed so other executors (e.g. `AcpShellExecutor`) can reuse the same
 /// blocklist without duplicating it.
@@ -126,6 +172,12 @@ pub fn check_blocklist(command: &str, blocklist: &[String]) -> Option<String> {
     }
     let cleaned = strip_shell_escapes(&lower);
     let commands = tokenize_commands(&cleaned);
+    for cmd_tokens in &commands {
+        let joined = cmd_tokens.join(" ");
+        if is_blocked_rm_worktrees(&joined) {
+            return Some("rm --recursive --force .git/worktrees".to_owned());
+        }
+    }
     for blocked in blocklist {
         for cmd_tokens in &commands {
             if tokens_match_pattern(cmd_tokens, blocked) {
@@ -1405,6 +1457,12 @@ impl ShellExecutor {
         let snapshot = self.policy.load_full();
         let cleaned = strip_shell_escapes(&code.to_lowercase());
         let commands = tokenize_commands(&cleaned);
+        for cmd_tokens in &commands {
+            let joined = cmd_tokens.join(" ");
+            if is_blocked_rm_worktrees(&joined) {
+                return Some("rm --recursive --force .git/worktrees".to_owned());
+            }
+        }
         for blocked in &snapshot.blocked_commands {
             for cmd_tokens in &commands {
                 if tokens_match_pattern(cmd_tokens, blocked) {
@@ -1415,6 +1473,12 @@ impl ShellExecutor {
         // Also check commands embedded inside subshell constructs.
         for inner in extract_subshell_contents(&cleaned) {
             let inner_commands = tokenize_commands(&inner);
+            for cmd_tokens in &inner_commands {
+                let joined = cmd_tokens.join(" ");
+                if is_blocked_rm_worktrees(&joined) {
+                    return Some("rm --recursive --force .git/worktrees".to_owned());
+                }
+            }
             for blocked in &snapshot.blocked_commands {
                 for cmd_tokens in &inner_commands {
                     if tokens_match_pattern(cmd_tokens, blocked) {

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -1507,6 +1507,94 @@ fn check_blocklist_blocks_shutdown() {
     assert!(check_blocklist("shutdown -h now", &bl).is_some());
 }
 
+// --- is_blocked_rm_worktrees tests ---
+
+#[test]
+fn rm_worktrees_blocked_rf() {
+    assert!(is_blocked_rm_worktrees("rm -rf .git/worktrees"));
+}
+
+#[test]
+fn rm_worktrees_blocked_fr() {
+    assert!(is_blocked_rm_worktrees("rm -fr .git/worktrees"));
+}
+
+#[test]
+fn rm_worktrees_blocked_rfd() {
+    assert!(is_blocked_rm_worktrees("rm -rfd .git/worktrees"));
+}
+
+#[test]
+fn rm_worktrees_blocked_frd() {
+    assert!(is_blocked_rm_worktrees("rm -frd .git/worktrees"));
+}
+
+#[test]
+fn rm_worktrees_blocked_rfv() {
+    assert!(is_blocked_rm_worktrees("rm -rfv .git/worktrees"));
+}
+
+#[test]
+fn rm_worktrees_blocked_long_flags() {
+    assert!(is_blocked_rm_worktrees(
+        "rm --recursive --force .git/worktrees"
+    ));
+}
+
+#[test]
+fn rm_worktrees_blocked_long_flags_reversed() {
+    assert!(is_blocked_rm_worktrees(
+        "rm --force --recursive .git/worktrees"
+    ));
+}
+
+#[test]
+fn rm_worktrees_blocked_uppercase_r() {
+    assert!(is_blocked_rm_worktrees("rm -Rf .git/worktrees"));
+}
+
+#[test]
+fn rm_worktrees_not_blocked_without_force() {
+    // recursive but no force — should NOT be blocked
+    assert!(!is_blocked_rm_worktrees("rm -r .git/worktrees"));
+    assert!(!is_blocked_rm_worktrees("rm --recursive .git/worktrees"));
+}
+
+#[test]
+fn rm_worktrees_not_blocked_without_recursive() {
+    // force but no recursive — should NOT be blocked
+    assert!(!is_blocked_rm_worktrees("rm -f .git/worktrees"));
+}
+
+#[test]
+fn rm_worktrees_not_blocked_other_path() {
+    // recursive+force but target is not .git/worktrees
+    assert!(!is_blocked_rm_worktrees("rm -rf /tmp/something"));
+    assert!(!is_blocked_rm_worktrees("rm -rf .git/config"));
+}
+
+#[test]
+fn rm_worktrees_not_blocked_non_rm_command() {
+    assert!(!is_blocked_rm_worktrees(
+        "git worktree remove --force .git/worktrees/foo"
+    ));
+}
+
+#[test]
+fn check_blocklist_blocks_rm_worktrees_extra_flags() {
+    let bl = default_blocklist();
+    assert!(check_blocklist("rm -rfd .git/worktrees", &bl).is_some());
+    assert!(check_blocklist("rm -frd .git/worktrees", &bl).is_some());
+    assert!(check_blocklist("rm -rfv .git/worktrees", &bl).is_some());
+    assert!(check_blocklist("rm --recursive --force .git/worktrees", &bl).is_some());
+}
+
+#[test]
+fn check_blocklist_allows_rm_worktrees_no_force() {
+    let bl = default_blocklist();
+    assert!(check_blocklist("rm -r .git/worktrees", &bl).is_none());
+}
+
 // --- effective_shell_command tests ---
 
 #[test]

--- a/crates/zeph-tui/src/widgets/fleet.rs
+++ b/crates/zeph-tui/src/widgets/fleet.rs
@@ -122,3 +122,33 @@ pub fn render(snapshot: &FleetSnapshot, frame: &mut Frame, area: Rect, list_stat
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
     frame.render_stateful_widget(list, area, list_state);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::format_tokens_short;
+
+    #[test]
+    fn format_tokens_short_zero() {
+        assert_eq!(format_tokens_short(0), "0");
+    }
+
+    #[test]
+    fn format_tokens_short_below_1k() {
+        assert_eq!(format_tokens_short(999), "999");
+    }
+
+    #[test]
+    fn format_tokens_short_exactly_1k() {
+        assert_eq!(format_tokens_short(1_000), "1.0k");
+    }
+
+    #[test]
+    fn format_tokens_short_below_1m() {
+        assert_eq!(format_tokens_short(999_999), "1000.0k");
+    }
+
+    #[test]
+    fn format_tokens_short_exactly_1m() {
+        assert_eq!(format_tokens_short(1_000_000), "1.0M");
+    }
+}


### PR DESCRIPTION
## Summary

- **#4352** — Replace exact-string blocklist entries for `.git/worktrees` with `is_blocked_rm_worktrees()`, a semantic check that blocks any `rm` combining recursive+force flags (`-rf`, `-fr`, `-rfd`, `-frd`, `-rfv`, `--recursive --force`, etc.) targeting `.git/worktrees`, regardless of flag ordering or bundling style. Adds 15 unit tests.
- **#4347** — Add 5 boundary unit tests for `format_tokens_short` (0, 999, 1_000, 999_999, 1_000_000) in `zeph-tui`.
- **#4346** — Add deserialization unit test for `OpenAiUsage.completion_tokens_details.reasoning_tokens` in `zeph-llm`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — no warnings
- [x] `cargo nextest run --workspace --lib --bins` — 9869 passed, 0 failed
- [x] Code review approved (no changes requested)

Closes #4352
Closes #4347
Closes #4346