### PR TITLE
fix(fleet): wire session lifecycle and TUI background poll

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,6 @@ pdf = ["zeph-memory/pdf"]
 profiling = [
     "dep:tracing-chrome",
     "dep:chrono",
-    "dep:uuid",
     "dep:sysinfo",
     "zeph-core/profiling",
     "zeph-core/sysinfo",
@@ -310,7 +309,7 @@ tracing-chrome = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url.workspace = true
-uuid = { workspace = true, optional = true, features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }
 zeph-a2a = { workspace = true, optional = true }
 zeph-acp = { workspace = true, optional = true }
 zeph-bench = { workspace = true, optional = true }

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -177,7 +177,7 @@ pub use telemetry::{TelemetryBackend, TelemetryConfig};
 pub use tools::{AuditDestination, SandboxBackend, ToolCompressionConfig};
 pub use ui::{
     AcpAuthMethod, AcpConfig, AcpLspConfig, AcpSubagentsConfig, AcpTransport, AdditionalDir,
-    AdditionalDirError, SubagentPresetConfig, ToolDensity, TuiConfig,
+    AdditionalDirError, FleetConfig, SubagentPresetConfig, ToolDensity, TuiConfig,
 };
 pub use ui::{DiagnosticSeverity, DiagnosticsConfig, HoverConfig, LspConfig};
 pub use vigil::VigilConfig;

--- a/src/commands/cocoon.rs
+++ b/src/commands/cocoon.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use zeph_config::ProviderKind;
+use zeph_config::features::VaultBackend;
 use zeph_core::vault::{AgeVaultProvider, ArcAgeVaultProvider, VaultProvider};
 use zeph_llm::cocoon::CocoonClient;
 
@@ -247,7 +248,6 @@ async fn check_vault_key(
     let _span = tracing::info_span!("cli.cocoon.doctor.vault").entered();
     let vault_args = crate::bootstrap::parse_vault_args(config, None, None, None);
 
-    use zeph_config::features::VaultBackend;
     let vault: Box<dyn VaultProvider> = match vault_args.backend {
         VaultBackend::Age => {
             let (Some(key), Some(path)) = (

--- a/src/commands/gonka.rs
+++ b/src/commands/gonka.rs
@@ -16,6 +16,7 @@ use tokio::sync::RwLock;
 use tokio::task::JoinSet;
 use tracing::Instrument as _;
 use zeph_config::ProviderKind;
+use zeph_config::features::VaultBackend;
 use zeph_core::redact::scrub_content;
 use zeph_core::vault::{AgeVaultProvider, ArcAgeVaultProvider, VaultProvider};
 use zeph_llm::gonka::RequestSigner;
@@ -47,7 +48,6 @@ async fn resolve_vault_secrets(
     let _span = tracing::info_span!("cli.gonka.doctor.vault").entered();
     let vault_args = crate::bootstrap::parse_vault_args(config, None, None, None);
 
-    use zeph_config::features::VaultBackend;
     let vault: Box<dyn VaultProvider> = match vault_args.backend {
         VaultBackend::Age => {
             let (Some(key), Some(path)) = (

--- a/src/fleet_session.rs
+++ b/src/fleet_session.rs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Fleet session lifecycle management (#4356).
+//!
+//! Provides helpers for registering, updating, and reconciling agent sessions
+//! in the `agent_sessions` table so the fleet dashboard has accurate data.
+
+use zeph_memory::store::SqliteStore;
+use zeph_memory::store::agent_sessions::{
+    AgentSessionRow, SessionChannel, SessionKind, SessionStatus,
+};
+
+/// Register a new session in the fleet table and reconcile any stale sessions.
+///
+/// Call this once at agent startup, after the `SqliteStore` is available and the
+/// channel name is known. On unclean shutdown of a previous instance any
+/// sessions that were still marked `active` are transitioned to `unknown`.
+///
+/// # Errors
+///
+/// Returns an error if the database writes fail. Non-fatal: callers should log
+/// and continue — the fleet panel will simply lack data for this session.
+pub(crate) async fn start_session(
+    sqlite: &SqliteStore,
+    session_id: &str,
+    channel_name: &str,
+    model: &str,
+) -> anyhow::Result<()> {
+    match sqlite.reconcile_stale_sessions(session_id).await {
+        Ok(0) => {}
+        Ok(n) => tracing::info!(count = n, "fleet: reconciled stale sessions"),
+        Err(e) => tracing::warn!(error = %e, "fleet: reconcile_stale_sessions failed"),
+    }
+
+    let channel = parse_channel(channel_name);
+    let row = AgentSessionRow {
+        id: session_id.to_owned(),
+        kind: SessionKind::Interactive,
+        status: SessionStatus::Active,
+        channel,
+        model: model.to_owned(),
+        created_at: utc_now(),
+        last_active_at: utc_now(),
+        turns: 0,
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        reasoning_tokens: 0,
+        cost_cents: 0.0,
+        goal_text: None,
+    };
+    sqlite
+        .upsert_agent_session(&row)
+        .await
+        .map_err(|e| anyhow::anyhow!("fleet: upsert_agent_session failed: {e}"))?;
+
+    tracing::debug!(
+        session_id,
+        channel = channel_name,
+        model,
+        "fleet: session registered"
+    );
+    Ok(())
+}
+
+/// Update the fleet session status on agent exit.
+///
+/// Call this after `agent.run()` returns, passing the result to derive the
+/// appropriate terminal status.
+pub(crate) async fn end_session(
+    sqlite: &SqliteStore,
+    session_id: &str,
+    run_result: &anyhow::Result<()>,
+) {
+    let status = if run_result.is_ok() {
+        SessionStatus::Completed
+    } else {
+        SessionStatus::Failed
+    };
+    if let Err(e) = sqlite.update_agent_session_status(session_id, status).await {
+        tracing::warn!(error = %e, session_id, "fleet: update_agent_session_status failed");
+    }
+}
+
+fn parse_channel(name: &str) -> SessionChannel {
+    match name {
+        "tui" => SessionChannel::Tui,
+        "telegram" => SessionChannel::Telegram,
+        "discord" => SessionChannel::Discord,
+        "slack" => SessionChannel::Slack,
+        _ => SessionChannel::Cli,
+    }
+}
+
+fn utc_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Format as SQLite-compatible ISO-8601 UTC string (no sub-second precision needed).
+    let (year, month, day, hour, min, sec) = epoch_to_datetime(secs);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}")
+}
+
+fn epoch_to_datetime(epoch: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let sec = epoch % 60;
+    let epoch = epoch / 60;
+    let min = epoch % 60;
+    let epoch = epoch / 60;
+    let hour = epoch % 24;
+    let mut days = epoch / 24;
+
+    // Days since 1970-01-01.
+    let mut year = 1970u64;
+    loop {
+        let leap = is_leap(year);
+        let days_in_year = if leap { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+
+    let leap = is_leap(year);
+    let months = [
+        31u64,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut month = 1u64;
+    for &m in &months {
+        if days < m {
+            break;
+        }
+        days -= m;
+        month += 1;
+    }
+
+    (year, month, days + 1, hour, min, sec)
+}
+
+fn is_leap(year: u64) -> bool {
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,7 @@ mod commands;
 mod daemon;
 mod db_url;
 mod execution_mode;
+mod fleet_session;
 mod gateway_spawn;
 mod init;
 #[cfg(feature = "prometheus")]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1466,6 +1466,18 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         });
     }
 
+    let fleet_session_id = uuid::Uuid::new_v4().to_string();
+    if let Err(e) = crate::fleet_session::start_session(
+        memory.sqlite(),
+        &fleet_session_id,
+        &active_channel_name,
+        config.llm.effective_model(),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "fleet session init failed; continuing without fleet tracking");
+    }
+
     if !exec_mode.bare {
         let store = std::sync::Arc::new(memory.sqlite().clone());
         let embedding = memory.embedding_store().cloned();
@@ -3278,6 +3290,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                 early_tui,
                 backfill_rx,
                 task_supervisor: Some((*supervisor).clone()),
+                fleet_session_id: fleet_session_id.clone(),
             },
         ))
         .await;
@@ -3297,6 +3310,13 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         .expect("status_rx must be Some in CLI mode: early forwarder only runs on TUI path");
     tokio::spawn(forward_status_to_stderr(status_rx));
     let result = Box::pin(agent.run()).await;
+    {
+        let fleet_result: anyhow::Result<()> = match &result {
+            Ok(()) => Ok(()),
+            Err(e) => Err(anyhow::anyhow!("{e}")),
+        };
+        crate::fleet_session::end_session(memory.sqlite(), &fleet_session_id, &fleet_result).await;
+    }
     // Explicitly shut down MCP connections before agent.shutdown() so that child processes
     // are killed while the tokio runtime is still active (#2693).
     shutdown_mcp_manager.shutdown_all_shared().await;

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -34,6 +34,8 @@ pub(crate) struct TuiRunParams<'a> {
         tokio::sync::watch::Receiver<Option<zeph_memory::semantic::BackfillProgress>>,
     /// Optional supervisor passed to the TUI task registry panel (#2962).
     pub(crate) task_supervisor: Option<zeph_common::task_supervisor::TaskSupervisor>,
+    /// Fleet session ID to mark completed/failed when the TUI session exits.
+    pub(crate) fleet_session_id: String,
 }
 
 /// Phase-1 TUI handle: TUI is rendering but the agent hasn't started yet.
@@ -303,6 +305,12 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
         tui_command_context(params.config, params.cli_tafc),
     ));
 
+    {
+        let fleet_cfg = params.config.tui.fleet;
+        let db_path = params.config.memory.sqlite_path.clone();
+        forwarders.spawn(fleet_poll_task(db_path, fleet_cfg, agent_tx.clone()));
+    }
+
     if let Some(tool_rx) = params.tool_rx {
         forwarders.spawn(forward_tool_events_to_tui(tool_rx, agent_tx.clone()));
     }
@@ -318,11 +326,11 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
     let mut agent = agent.with_warmup_ready(warmup_rx);
     let agent_future = agent.run();
 
-    tokio::select! {
+    let run_result: anyhow::Result<()> = tokio::select! {
         result = tui_done => {
             forwarders.abort_all();
             agent.shutdown().await;
-            result.map_err(|_| anyhow::anyhow!("TUI thread exited without sending result"))??;
+            result.map_err(|_| anyhow::anyhow!("TUI thread exited without sending result"))?
         }
         result = agent_future => {
             // Abort all forwarding tasks first, then drop our agent_tx clone.
@@ -331,11 +339,21 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
             forwarders.abort_all();
             drop(agent_tx);
             agent.shutdown().await;
-            result?;
+            result.map_err(anyhow::Error::from)
+        }
+    };
+
+    let db_path = params.config.memory.sqlite_path.clone();
+    match zeph_memory::store::SqliteStore::new(&db_path).await {
+        Ok(store) => {
+            crate::fleet_session::end_session(&store, &params.fleet_session_id, &run_result).await;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "fleet: failed to open DB for end_session on TUI exit");
         }
     }
 
-    Ok(())
+    run_result
 }
 
 pub(crate) async fn forward_status_to_stderr(mut rx: tokio::sync::mpsc::UnboundedReceiver<String>) {
@@ -625,4 +643,50 @@ pub(crate) async fn forward_index_progress_to_tui(
     };
     tokio::time::sleep(delay).await;
     let _ = tx.send(zeph_tui::AgentEvent::Status(String::new())).await;
+}
+
+/// Periodically poll the database for fleet session data and forward snapshots to the TUI.
+///
+/// Runs until the `agent_tx` channel closes (agent exited). The interval is controlled by
+/// [`zeph_config::FleetConfig::refresh_interval_secs`].
+#[cfg(feature = "tui")]
+pub(crate) async fn fleet_poll_task(
+    db_path: String,
+    cfg: zeph_config::FleetConfig,
+    tx: tokio::sync::mpsc::Sender<zeph_tui::AgentEvent>,
+) {
+    let interval_secs = cfg.refresh_interval_secs.max(1);
+    let limit = cfg.max_sessions;
+
+    let store = match zeph_memory::store::SqliteStore::new(&db_path).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "fleet poll: failed to open DB; fleet panel will be empty");
+            return;
+        }
+    };
+
+    let mut ticker = tokio::time::interval(Duration::from_secs(interval_secs));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+
+        let sessions = match store.list_agent_sessions(limit, None).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(error = %e, "fleet poll: list_agent_sessions failed");
+                continue;
+            }
+        };
+
+        let snapshot = zeph_tui::widgets::fleet::FleetSnapshot { sessions };
+        if tx
+            .send(zeph_tui::AgentEvent::FleetSnapshot(snapshot))
+            .await
+            .is_err()
+        {
+            break;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Call `upsert_agent_session` on session start and `update_agent_session_status` on session end — both CLI and TUI paths now correctly close the session row.
- Call `reconcile_stale_sessions` at startup to mark any lingering `active` rows from prior crashes as `unknown`.
- Spawn a `fleet_poll_task` (tokio interval) in the TUI that periodically calls `list_agent_sessions` and sends `AgentEvent::FleetSnapshot`, so the Fleet panel shows live data instead of always being empty.

New file `src/fleet_session.rs` encapsulates `start_session` / `end_session` helpers used by both `runner.rs` and `tui_bridge.rs`.

## Test plan

- [ ] `cargo nextest run -p zeph-memory -E 'test(agent_session)'` — 8 tests pass (upsert, update, reconcile, list, filter, roundtrips)
- [ ] `cargo nextest run --workspace --lib --bins` — 9849 tests pass
- [ ] Run TUI session: `cargo run --features full -- --tui`; navigate to Fleet panel (`f`); confirm current session row appears
- [ ] Exit TUI; restart; confirm previous session shows `Completed` not `Unknown`

Closes #4356
Closes #4349