### PR TITLE
refactor(common,memory,tui): deduplicate token format helpers and add tracing spans

### DIFF
--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -42,6 +42,7 @@ pub use task_supervisor::{
     BlockingError, BlockingHandle, MAX_RESTART_DELAY, RestartPolicy, TaskDescriptor, TaskHandle,
     TaskSnapshot, TaskStatus, TaskSupervisor,
 };
+pub use text::format_tokens;
 pub use trust_level::SkillTrustLevel;
 pub use types::{ProviderName, SessionId, SkillName, ToolDefinition, ToolName};
 

--- a/crates/zeph-common/src/text.rs
+++ b/crates/zeph-common/src/text.rs
@@ -3,6 +3,34 @@
 
 //! String utility functions for Unicode-safe text manipulation.
 
+/// Format a token count as a short human-readable string.
+///
+/// - `>= 1_000_000` → `"{:.1}M"`
+/// - `>= 1_000`     → `"{:.1}k"`
+/// - otherwise      → decimal digits
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::text::format_tokens;
+///
+/// assert_eq!(format_tokens(0), "0");
+/// assert_eq!(format_tokens(999), "999");
+/// assert_eq!(format_tokens(1_500), "1.5k");
+/// assert_eq!(format_tokens(2_000_000), "2.0M");
+/// ```
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
 /// Truncate `s` to at most `max_bytes` bytes, preserving UTF-8 char boundaries.
 ///
 /// Returns an owned `String`. If `s` fits within `max_bytes`, returns a copy

--- a/crates/zeph-memory/src/store/agent_sessions.rs
+++ b/crates/zeph-memory/src/store/agent_sessions.rs
@@ -232,6 +232,12 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns an error if the database write fails.
+    #[tracing::instrument(
+        name = "memory.fleet.update_agent_session_status",
+        skip_all,
+        level = "debug",
+        err
+    )]
     pub async fn update_agent_session_status(
         &self,
         id: &str,
@@ -255,6 +261,12 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns an error if the database write fails.
+    #[tracing::instrument(
+        name = "memory.fleet.reconcile_stale_sessions",
+        skip_all,
+        level = "debug",
+        err
+    )]
     pub async fn reconcile_stale_sessions(
         &self,
         current_session_id: &str,

--- a/crates/zeph-tui/src/widgets/fleet.rs
+++ b/crates/zeph-tui/src/widgets/fleet.rs
@@ -8,6 +8,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+use zeph_common::format_tokens;
 use zeph_memory::store::agent_sessions::{AgentSessionRow, SessionStatus};
 
 use crate::theme::Theme;
@@ -29,17 +30,6 @@ fn status_color(status: SessionStatus) -> Color {
     }
 }
 
-fn format_tokens_short(n: u64) -> String {
-    #[allow(clippy::cast_precision_loss)]
-    if n >= 1_000_000 {
-        format!("{:.1}M", n as f64 / 1_000_000.0)
-    } else if n >= 1_000 {
-        format!("{:.1}k", n as f64 / 1_000.0)
-    } else {
-        n.to_string()
-    }
-}
-
 fn build_session_item(row: &AgentSessionRow, selected: bool) -> ListItem<'static> {
     let color = status_color(row.status);
     let base = if selected {
@@ -58,8 +48,8 @@ fn build_session_item(row: &AgentSessionRow, selected: bool) -> ListItem<'static
 
     let tokens = format!(
         "{}/{}",
-        format_tokens_short(row.prompt_tokens),
-        format_tokens_short(row.completion_tokens)
+        format_tokens(row.prompt_tokens),
+        format_tokens(row.completion_tokens)
     );
     let cost = if row.cost_cents > 0.0 {
         format!("${:.4}", row.cost_cents / 100.0)
@@ -125,30 +115,30 @@ pub fn render(snapshot: &FleetSnapshot, frame: &mut Frame, area: Rect, list_stat
 
 #[cfg(test)]
 mod tests {
-    use super::format_tokens_short;
+    use super::format_tokens;
 
     #[test]
-    fn format_tokens_short_zero() {
-        assert_eq!(format_tokens_short(0), "0");
+    fn format_tokens_zero() {
+        assert_eq!(format_tokens(0), "0");
     }
 
     #[test]
-    fn format_tokens_short_below_1k() {
-        assert_eq!(format_tokens_short(999), "999");
+    fn format_tokens_below_1k() {
+        assert_eq!(format_tokens(999), "999");
     }
 
     #[test]
-    fn format_tokens_short_exactly_1k() {
-        assert_eq!(format_tokens_short(1_000), "1.0k");
+    fn format_tokens_exactly_1k() {
+        assert_eq!(format_tokens(1_000), "1.0k");
     }
 
     #[test]
-    fn format_tokens_short_below_1m() {
-        assert_eq!(format_tokens_short(999_999), "1000.0k");
+    fn format_tokens_below_1m() {
+        assert_eq!(format_tokens(999_999), "1000.0k");
     }
 
     #[test]
-    fn format_tokens_short_exactly_1m() {
-        assert_eq!(format_tokens_short(1_000_000), "1.0M");
+    fn format_tokens_exactly_1m() {
+        assert_eq!(format_tokens(1_000_000), "1.0M");
     }
 }

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -8,6 +8,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
+use zeph_common::format_tokens;
 
 use crate::app::{App, InputMode};
 use crate::metrics::MetricsSnapshot;
@@ -444,17 +445,6 @@ fn build_filter_text(metrics: &MetricsSnapshot) -> String {
         " | Filters: {}/{} ({savings:.0}% saved)",
         metrics.filter_filtered_commands, metrics.filter_total_commands,
     )
-}
-
-#[allow(clippy::cast_precision_loss)]
-fn format_tokens(n: u64) -> String {
-    if n >= 1_000_000 {
-        format!("{:.1}M", n as f64 / 1_000_000.0)
-    } else if n >= 1_000 {
-        format!("{:.1}k", n as f64 / 1_000.0)
-    } else {
-        n.to_string()
-    }
 }
 
 fn format_uptime(secs: u64) -> String {

--- a/src/commands/agents.rs
+++ b/src/commands/agents.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 
 use crate::bootstrap::resolve_config_path;
 use anyhow::{Context as _, bail};
+use zeph_common::format_tokens;
 use zeph_memory::store::agent_sessions::{AgentSessionRow, SessionStatus};
 use zeph_subagent::error::SubAgentError;
 use zeph_subagent::{SubAgentDef, ToolPolicy, is_valid_agent_name, resolve_agent_paths};
@@ -282,8 +283,8 @@ fn print_fleet_table(sessions: &[AgentSessionRow]) {
         let model = truncate(&s.model, w_model);
         let tokens = format!(
             "{}/{}",
-            fmt_tokens(s.prompt_tokens),
-            fmt_tokens(s.completion_tokens)
+            format_tokens(s.prompt_tokens),
+            format_tokens(s.completion_tokens)
         );
         let cost = if s.cost_cents > 0.0 {
             format!("${:.4}", s.cost_cents / 100.0)
@@ -301,17 +302,6 @@ fn print_fleet_table(sessions: &[AgentSessionRow]) {
             tokens,
             cost,
         );
-    }
-}
-
-fn fmt_tokens(n: u64) -> String {
-    #[allow(clippy::cast_precision_loss)]
-    if n >= 1_000_000 {
-        format!("{:.1}M", n as f64 / 1_000_000.0)
-    } else if n >= 1_000 {
-        format!("{:.1}k", n as f64 / 1_000.0)
-    } else {
-        n.to_string()
     }
 }
 


### PR DESCRIPTION
## Summary

- Extract `format_tokens(n: u64) -> String` into `zeph-common/src/text.rs`, replacing three identical local helpers (`format_tokens_short` in `fleet.rs`, `format_tokens` in `status.rs`, `fmt_tokens` in `agents.rs`). All three implemented the same `>=1M → X.XM / >=1k → X.Xk / else n` pattern.
- Add `#[tracing::instrument(name = "memory.fleet.*", skip_all, level = "debug", err)]` to `reconcile_stale_sessions` and `update_agent_session_status` in `agent_sessions.rs`, matching the existing convention of `upsert_agent_session`.

Closes #4348
Closes #4359

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 9879 passed, 0 failed
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all doc-tests pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — 0 warnings