### PR TITLE
spec(004-memory): shadow memory safety, implicit conflict detection, five-signal retrieval

### DIFF
--- a/specs/004-memory/004-16-shadow-memory-safety.md
+++ b/specs/004-memory/004-16-shadow-memory-safety.md
@@ -1,0 +1,372 @@
+---
+aliases:
+  - MAGE Shadow Memory
+  - Trajectory Risk Accumulator
+  - Shadow Memory Defense
+tags:
+  - sdd
+  - spec
+  - memory
+  - security
+  - experimental
+created: 2026-05-18
+status: draft
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[004-memory/spec]]"
+  - "[[004-7-memory-apex-magma]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[010-security/010-7-shadow-memory-guardrail]]"
+---
+
+# Spec: Shadow Memory Safety — Trajectory-Level Attack Defense (MAGE)
+
+> [!info]
+> Implements a parallel shadow memory stream that accumulates safety-critical
+> signals across an agent's full execution trajectory, enabling detection and
+> blocking of multi-turn attacks that evade per-turn controls.
+> Resolves GitHub issue [#3695](https://github.com/rabax/zeph/issues/3695).
+
+## Sources
+
+### External
+- **MAGE: Multi-turn Agent Guard with Extended memory** (arXiv:2605.03228, 2026) —
+  shadow memory for trajectory-level threat detection; reduces tool-attack chaining
+  from 100% → 8.3% success rate; eliminates persistent indirect prompt injection
+
+### Internal
+
+| File | Contents |
+|------|----------|
+| `crates/zeph-sanitizer/src/lib.rs` | `ContentSanitizer`, `PolicyGate`, per-turn audit events |
+| `crates/zeph-agent-tools/src/executor.rs` | Tool execution gate; pre-execution policy check |
+| `crates/zeph-memory/src/semantic/mod.rs` | `SemanticMemory`; shadow memory is a sibling stream |
+| `crates/zeph-core/src/agent/mod.rs` | Agent turn loop; `MemoryState` lifecycle |
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+Zeph's current safety controls in `zeph-sanitizer` operate per-turn: `ContentSanitizer`
+filters individual messages and `PolicyGate` enforces policies on individual tool
+invocations. These mechanisms cannot detect cumulative threats that unfold gradually
+across multiple turns — a class of attack where no single turn triggers a policy
+violation but the trajectory as a whole enacts adversarial behavior.
+
+Three concrete threat classes are undetected today:
+
+1. **Sequential tool-attack chaining**: an adversary plants a goal across 3–5 turns
+   (each plausible in isolation), then triggers execution in a later turn. Per-turn
+   controls see only individual turns and admit all of them.
+2. **Persistent indirect prompt injection**: malicious instructions injected via tool
+   output (e.g., a web-scrape result) persist in episodic memory and are recalled in
+   future turns, re-injecting the adversarial directive.
+3. **Multi-turn poisoning**: repeated low-severity signals accumulate into a high-risk
+   trajectory. Each signal alone falls below the per-turn policy threshold.
+
+MAGMA [[004-7-memory-apex-magma]] tracks semantic entity relationships but does not
+accumulate trajectory-level safety signals. SafeAgent (#3570) addresses trajectory-
+stateful mediation conceptually but remains unimplemented.
+
+### Goal
+
+Implement `TrajectoryRiskAccumulator` — a lightweight shadow memory attached to each
+agent session — that ingests per-turn audit events from `zeph-sanitizer`, maintains
+a rolling trajectory risk score, and gates tool execution when cumulative risk exceeds
+a configured threshold. No changes to the primary memory pipeline are required; shadow
+memory is an orthogonal stream.
+
+### Out of Scope
+
+- Replacing or modifying the per-turn `ContentSanitizer` or `PolicyGate` (shadow memory
+  is additive, not a substitute)
+- Cross-session risk propagation (risk resets when the session ends)
+- LLM-based intent classification of each turn (signal detection is rule-based to keep
+  overhead low; LLM escalation is a separate optional path)
+- Changes to the MAGMA semantic graph schema
+- Modifying `zeph-sanitizer` internals beyond adding audit event emission
+
+---
+
+## 2. User Stories
+
+### US-001: Multi-turn attack detection
+AS AN operator running long-lived Zeph agents in production
+I WANT the agent to detect and block tool-attack chains that develop over multiple turns
+SO THAT an adversary who plants context incrementally cannot reach tool execution
+
+**Acceptance criteria:**
+```
+GIVEN a session where turns 1–4 each emit one low-severity policy warning
+  AND turn 5 requests a tool execution
+WHEN the cumulative trajectory risk exceeds the configured threshold
+THEN the tool execution is denied
+AND the agent returns a rationale explaining the denial
+AND the incident is logged in the sanitizer audit trail
+```
+
+### US-002: Persistent prompt injection blocking
+AS AN operator
+I WANT recalled tool output that contains injection patterns to be flagged at the
+trajectory level
+SO THAT injected instructions planted via episodic memory do not execute silently
+
+**Acceptance criteria:**
+```
+GIVEN a tool result containing a prompt-injection pattern was stored in episodic memory
+  AND the injected instruction is recalled in a later turn
+WHEN the recall surface triggers a prompt-injection signal
+THEN the TrajectoryRiskAccumulator records a high-severity injection signal
+AND if the trajectory risk exceeds the threshold, the current tool call is blocked
+AND the event is emitted to the audit log
+```
+
+### US-003: Benign session pass-through
+AS A regular user running normal agent tasks
+I WANT safety checks to add no observable latency on clean sessions
+SO THAT the security mechanism does not degrade normal operations
+
+**Acceptance criteria:**
+```
+GIVEN a session with no policy violations, no anomalous tool patterns, and
+  no injection signals across 50 turns
+WHEN the agent processes each turn
+THEN no tool calls are denied by the TrajectoryRiskAccumulator
+AND per-turn overhead from shadow memory is < 1 ms at p95
+```
+
+---
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL maintain one `TrajectoryRiskAccumulator` per agent session, created at session start and dropped at session end | must |
+| FR-002 | WHEN `zeph-sanitizer` emits an `AuditEvent` THE SYSTEM SHALL ingest it into the session's `TrajectoryRiskAccumulator` within the same turn | must |
+| FR-003 | `TrajectoryRiskAccumulator` SHALL accumulate a `trajectory_risk` score in `[0.0, 1.0]` via a weighted sum of ingested signals with exponential temporal decay per `risk_halflife_turns` | must |
+| FR-004 | WHEN `zeph-agent-tools` prepares a tool execution THE SYSTEM SHALL query the session's `TrajectoryRiskAccumulator` for the current `trajectory_risk` | must |
+| FR-005 | WHEN `trajectory_risk` ≥ `risk_threshold` (default `0.75`) THE SYSTEM SHALL block the tool execution and return a `ToolError::TrajectoryRiskExceeded { score, signals }` to the agent loop | must |
+| FR-006 | WHEN `trajectory_risk` is in `[escalation_threshold, risk_threshold)` (default `[0.5, 0.75)`) THE SYSTEM SHALL escalate to human confirmation before allowing tool execution | should |
+| FR-007 | Signal types ingested from `AuditEvent` SHALL include at minimum: `policy_violation`, `prompt_injection_pattern`, `tool_chain_anomaly`, `confidence_drop` | must |
+| FR-008 | Each signal type SHALL carry a configurable `base_weight` in `(0.0, 1.0]` and a configurable `severity_multiplier` in `{low=0.5, medium=1.0, high=2.0}` | must |
+| FR-009 | `TrajectoryRiskAccumulator` SHALL apply temporal decay: at each new turn, all accumulated signal contributions are multiplied by `exp(-ln(2) / risk_halflife_turns)` before the new turn's signals are added | must |
+| FR-010 | WHEN a tool execution is blocked THE SYSTEM SHALL emit an `AuditEvent::TrajectoryBlock { trajectory_risk, top_signals, turn_count }` to the sanitizer audit log | must |
+| FR-011 | The TUI SHALL display the current session `trajectory_risk` as a gauge in the security panel when `[memory.shadow_memory] enabled = true` and `tui_show_risk_gauge = true` | should |
+| FR-012 | Config flag `[memory.shadow_memory] enabled` SHALL gate all shadow memory code paths; when `false`, `TrajectoryRiskAccumulator` is a no-op struct that always returns `trajectory_risk = 0.0` | must |
+| FR-013 | WHEN shadow memory is enabled THE SYSTEM SHALL emit Prometheus counters: `shadow_memory_signals_total{type}`, `shadow_memory_blocks_total`, `shadow_memory_escalations_total` | should |
+| FR-014 | Every new code path introduced by this spec SHALL be instrumented with `tracing::info_span!` per the naming convention `memory.shadow.<operation>` | must |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | `TrajectoryRiskAccumulator::ingest` SHALL complete in < 0.5 ms at p99 (in-memory accumulation only; no I/O on the hot path) |
+| NFR-002 | Performance | `TrajectoryRiskAccumulator::current_risk` query (called before each tool execution) SHALL complete in < 0.1 ms at p99 |
+| NFR-003 | Performance | When `enabled = false`, shadow memory code contributes zero overhead — all calls are dispatched through a zero-cost no-op implementation |
+| NFR-004 | Reliability | `TrajectoryRiskAccumulator` is session-scoped; a session crash or reset creates a fresh accumulator with `trajectory_risk = 0.0`. No persistence is required |
+| NFR-005 | Reliability | Shadow memory NEVER blocks the agent loop on I/O. Signal ingestion is synchronous and in-memory only |
+| NFR-006 | Security | The shadow memory stream is separate from the primary `SemanticMemory` pipeline; signals from shadow memory are NEVER written to SQLite or Qdrant as user-visible memory |
+| NFR-007 | Observability | Prometheus counters export `shadow_memory_signals_total{type,severity}`, `shadow_memory_blocks_total`, `shadow_memory_escalations_total` |
+| NFR-008 | Maintainability | Signal type registry is a configurable TOML section; operators can add new signal types and adjust weights without code changes |
+
+---
+
+## 5. Data Model
+
+Shadow memory is entirely in-process and session-scoped. No new database tables are
+required.
+
+### `TrajectoryRiskAccumulator` struct
+
+```
+TrajectoryRiskAccumulator {
+    session_id: SessionId,
+    turn_count: u32,
+    trajectory_risk: f64,           // current accumulated score ∈ [0.0, 1.0]
+    signal_history: Vec<SignalEvent>, // capped ring buffer (last N signals)
+    config: ShadowMemoryConfig,
+}
+```
+
+### `SignalEvent`
+
+```
+SignalEvent {
+    turn_id: u32,
+    signal_type: SignalType,
+    severity: Severity,       // Low | Medium | High
+    raw_score: f64,           // base_weight × severity_multiplier
+    timestamp: Instant,
+}
+```
+
+### `SignalType` (extensible enum)
+
+| Variant | Source | Default base_weight |
+|---------|--------|---------------------|
+| `PolicyViolation` | `AuditEvent::PolicyViolation` | 0.30 |
+| `PromptInjectionPattern` | `AuditEvent::InjectionDetected` | 0.50 |
+| `ToolChainAnomaly` | `AuditEvent::ToolChainPattern` | 0.25 |
+| `ConfidenceDrop` | `AuditEvent::ConfidenceDrop` | 0.15 |
+
+### `AuditEvent` additions (in `zeph-sanitizer`)
+
+Two new variants emitted by existing per-turn checks:
+
+```
+AuditEvent::ToolChainPattern { turn_id, tool_sequence, anomaly_score }
+AuditEvent::TrajectoryBlock { trajectory_risk, top_signals, turn_count }
+```
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `trajectory_risk` overflows 1.0 from accumulated signals | Clamp to 1.0; do not error |
+| `AuditEvent` ingestion panics (bug in signal parsing) | Catch unwind; log `WARN`; treat as zero-signal; never crash the agent loop |
+| Session resets mid-turn (e.g., context compaction) | `TrajectoryRiskAccumulator` is tied to the session; compaction does not reset it unless `reset_on_compaction = true` (config opt-in) |
+| Tool execution denied; agent loop retries with a different tool | Each retry re-queries `current_risk`; if risk has not decayed below threshold, retry is also blocked |
+| Human escalation response is "deny" | Block recorded as a block event; risk score unchanged (escalation itself does not affect score) |
+| `risk_halflife_turns = 0` (misconfiguration) | Treat as `risk_halflife_turns = 1`; log `WARN` at startup |
+| Shadow memory disabled at runtime | All paths return no-op immediately; no signals accumulated; no blocks issued |
+| Injection pattern detected in recalled (not fresh) content | Signals are emitted by recall surface checks in `zeph-sanitizer`; ingested by accumulator identically to fresh-content signals |
+
+---
+
+## 7. Config
+
+```toml
+[memory.shadow_memory]
+enabled = false                        # opt-in; default off
+
+risk_threshold = 0.75                  # block tool execution at or above this score
+escalation_threshold = 0.50            # escalate to human confirmation above this score
+risk_halflife_turns = 10               # decay half-life in agent turns
+signal_history_cap = 200              # ring buffer max capacity
+tui_show_risk_gauge = true             # show trajectory_risk gauge in TUI security panel
+reset_on_compaction = false           # reset accumulator on context compaction
+
+[memory.shadow_memory.signal_weights]
+policy_violation     = 0.30
+prompt_injection     = 0.50
+tool_chain_anomaly   = 0.25
+confidence_drop      = 0.15
+
+[memory.shadow_memory.severity_multipliers]
+low    = 0.5
+medium = 1.0
+high   = 2.0
+```
+
+---
+
+## 8. Key Invariants
+
+### Always (without asking)
+- One `TrajectoryRiskAccumulator` per session; created at session start, dropped at session end
+- Signal ingestion is synchronous, in-memory, and completes before the turn continues
+- `trajectory_risk` is clamped to `[0.0, 1.0]` at all times
+- Shadow memory signals are never written to primary `SemanticMemory` stores (SQLite, Qdrant)
+- Temporal decay is applied at the start of each turn before new signals are added
+- `enabled = false` is a zero-overhead no-op — no allocations, no checks
+
+### Ask First
+- Changing `risk_threshold` below 0.5 (increases false-positive rate significantly)
+- Adding new `SignalType` variants (requires validation of base_weight calibration)
+- Enabling cross-session risk accumulation (introduces session-state persistence complexity)
+- Exposing `trajectory_risk` in user-visible agent output (privacy and gaming concerns)
+
+### Never
+- Block the agent turn thread on I/O from within shadow memory
+- Write shadow memory signals to `graph_edges`, `messages`, or any primary store
+- Return shadow memory state in default recall paths
+- Allow `TrajectoryRiskAccumulator` to survive session reset without explicit opt-in
+
+---
+
+## 9. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Sequential tool-attack chaining success rate (lab scenario) | ≤ 10% with default config |
+| SC-002 | Persistent indirect prompt injection success rate | 0% — blocked by injection signal weight |
+| SC-003 | False-positive block rate on benign 50-turn sessions | < 1% |
+| SC-004 | Per-turn shadow memory overhead (ingest + query) | < 1 ms at p95 |
+| SC-005 | Prometheus counters exported when enabled | All 3 counter families present |
+
+---
+
+## 10. Acceptance Criteria
+
+```
+GIVEN shadow_memory.enabled = true
+  AND a session accumulates 5 turns each emitting one PolicyViolation (medium severity)
+WHEN the agent attempts a tool call on turn 6
+THEN trajectory_risk = f(5 × 0.30 × 1.0 × decay_factor) is computed correctly
+AND IF trajectory_risk ≥ 0.75 the tool is blocked with ToolError::TrajectoryRiskExceeded
+AND shadow_memory_blocks_total increments
+AND AuditEvent::TrajectoryBlock is emitted to the audit log
+
+GIVEN shadow_memory.enabled = false
+WHEN the agent processes any number of turns
+THEN TrajectoryRiskAccumulator::current_risk always returns 0.0
+AND no Prometheus counters are updated
+AND no audit events of type TrajectoryBlock are emitted
+
+GIVEN a session with 50 clean turns (no AuditEvents of tracked signal types)
+WHEN the agent processes turn 51
+THEN trajectory_risk = 0.0
+AND no tool call is blocked by shadow memory
+```
+
+---
+
+## 11. Implementation Notes
+
+- New module: `crates/zeph-memory/src/shadow/mod.rs` — owns `TrajectoryRiskAccumulator`
+  and `SignalEvent`. No dependency on graph or semantic memory modules.
+- `zeph-sanitizer` gains two new `AuditEvent` variants (`ToolChainPattern`,
+  `TrajectoryBlock`) — additive change, no existing variant modified.
+- `zeph-agent-tools` wires the accumulator into the pre-tool-execution gate; receives it
+  as an `Arc<Mutex<TrajectoryRiskAccumulator>>` from the session context.
+- Signal weight calibration: start with the MAGE paper's reported thresholds; adjust via
+  integration tests against known-attack scenarios.
+- The in-memory ring buffer for `signal_history` is sized by `signal_history_cap` (default
+  200 entries); oldest entries evicted when capacity is reached. The risk score itself is
+  not affected by eviction — it is a running accumulator, not recomputed from history.
+- Temporal decay formula: at each turn boundary, `trajectory_risk *= exp(-ln(2) / halflife)`.
+  This ensures the score halves every `risk_halflife_turns` turns without any signals.
+- No database migration is required for this feature.
+- TUI gauge integration uses the existing security panel widget added in `zeph-tui`.
+
+---
+
+## 12. Open Questions
+
+> [!question]
+> - **Escalation UX**: when `trajectory_risk` is in the escalation band, the agent
+>   pauses for human confirmation. The confirmation channel in CLI mode is a blocking
+>   prompt; in Telegram/Discord modes it is an async message-reply. The exact API for
+>   channel-agnostic human confirmation is not yet defined. This must be resolved before
+>   the escalation path (FR-006) can be implemented.
+> - **Signal calibration**: the default `base_weight` values are derived from the MAGE
+>   paper's scenario descriptions but have not been validated against Zeph's specific
+>   attack surface. Calibration experiments should be run before enabling this feature
+>   in production configs.
+
+---
+
+## 13. See Also
+
+- [[constitution]] — project principles
+- [[004-memory/spec]] — memory system parent index
+- [[004-7-memory-apex-magma]] — APEX-MEM (orthogonal: semantic graph, not safety signals)
+- [[001-system-invariants/spec]] — system-wide invariants
+- [[MOC-specs]] — all specifications

--- a/specs/004-memory/004-17-implicit-conflict-detection.md
+++ b/specs/004-memory/004-17-implicit-conflict-detection.md
@@ -1,0 +1,393 @@
+---
+aliases:
+  - CUPMem
+  - Implicit Conflict Detection
+  - STALE Conflict Resolution
+tags:
+  - sdd
+  - spec
+  - memory
+  - graph
+  - experimental
+created: 2026-05-18
+status: draft
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[004-memory/spec]]"
+  - "[[004-7-memory-apex-magma]]"
+  - "[[004-6-graph-memory]]"
+  - "[[001-system-invariants/spec]]"
+---
+
+# Spec: Implicit Conflict Detection in SYNAPSE Recall (STALE / CUPMem)
+
+> [!info]
+> Extends APEX-MEM [[004-7-memory-apex-magma]] with write-time implicit conflict
+> detection via fuzzy predicate matching and propagation-aware SYNAPSE recall that
+> resolves conflicting beliefs before returning fact sets to the agent.
+> Addresses the gap identified in STALE benchmark (arXiv:2605.06527) and tracked
+> in GitHub issue [#3702](https://github.com/rabax/zeph/issues/3702).
+
+## Sources
+
+### External
+- **STALE: Benchmarking Implicit Memory Conflicts in Long-Context Agents**
+  (arXiv:2605.06527, 2026) — evaluates three failure dimensions: State Resolution,
+  Premise Resistance, Implicit Policy Adaptation; frontier models achieve only 55.2%
+  accuracy on implicit conflict detection
+- **CUPMem: Conflict-Unaware Propagation Memory** (arXiv:2605.06527 companion) —
+  write-time structured state consolidation with propagation-aware search
+
+### Internal
+
+| File | Contents |
+|------|----------|
+| `crates/zeph-memory/src/graph/store.rs` | Edge CRUD, `insert_or_supersede` (APEX-MEM) |
+| `crates/zeph-memory/src/graph/extractor.rs` | LLM extraction → predicate strings |
+| `crates/zeph-memory/src/semantic/graph.rs` | SYNAPSE spreading activation recall |
+| `crates/zeph-memory/src/graph/types.rs` | `Edge`, `EdgeType`, temporal fields |
+| `crates/zeph-memory/src/graph/ontology.rs` | Ontology normalization (APEX-MEM) |
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+APEX-MEM [[004-7-memory-apex-magma]] resolves conflicts between edges that share an
+**identical `canonical_relation`** — this covers explicit supersession (e.g.,
+`works_at` written twice with different targets). However, a large class of real
+conflicts is **implicit**: later observations invalidate earlier beliefs without the
+predicate strings being equal or near-equal.
+
+Three concrete failure dimensions from the STALE benchmark:
+
+1. **State Resolution**: the agent asserts a later observation (`Alice switched to
+   Provider B`) but recall returns both the old belief (`uses Provider A`) and the new
+   fact without resolving the conflict, because `uses` ≠ `switched_to` at the string
+   level.
+2. **Premise Resistance**: the agent is queried with a stale presupposition
+   (`"Given that Alice uses Provider A, ..."`) and fails to reject the premise because
+   the contradicting newer fact is not surfaced during recall.
+3. **Implicit Policy Adaptation**: a policy fact changes (e.g., `max_retries = 3` →
+   `max_retries = 5`) but the predicates differ semantically and the policy update is
+   not propagated to downstream reasoning.
+
+Existing MAGMA issue #2441 documents the symptom: SYNAPSE returns both stale and
+current facts for semantically related predicates without resolution.
+
+### Goal
+
+Two complementary mechanisms:
+
+1. **`ImplicitConflictDetector`** at write time: when a new edge is extracted, compare
+   its predicate against existing active edges on the same source entity using both
+   string-distance (Levenshtein) and semantic similarity (embedding cosine). When a
+   likely conflict is detected, mark the old edge for resolution and apply the
+   configured strategy.
+2. **Propagation-aware SYNAPSE recall**: after assembling the candidate fact set, follow
+   causal-link neighbors transitively to surface facts that may supersede the retrieved
+   candidates, then apply conflict resolution before returning results to the agent.
+
+### Out of Scope
+
+- Replacing the APEX-MEM explicit-supersession mechanism (this spec adds implicit
+  detection on top; explicit detection remains unchanged)
+- Changing the `EdgeType` taxonomy or the MAGMA four-subgraph model
+- Cross-entity coreference resolution beyond the existing `EntityResolver`
+- New database migrations beyond adding an `implicit_conflict_candidates` staging table
+
+---
+
+## 2. User Stories
+
+### US-001: Implicit fact supersession at write time
+AS AN agent that processes information spanning days or weeks
+I WANT the memory system to recognize when a new extracted fact semantically
+supersedes an older one — even when predicates differ in wording
+SO THAT the primary recall path returns only current beliefs
+
+**Acceptance criteria:**
+```
+GIVEN an active edge (Agent-X, uses, Provider-A) in the graph
+  AND a new edge (Agent-X, switched_to, Provider-B) is extracted
+  AND "uses" and "switched_to" have embedding cosine similarity ≥ 0.82
+WHEN insert_or_supersede runs for the new edge
+THEN the ImplicitConflictDetector identifies (Agent-X, uses, Provider-A) as a candidate
+AND the configured resolution strategy is applied (default: flag for LLM mediation)
+AND SYNAPSE no longer returns Provider-A as the active provider for Agent-X
+```
+
+### US-002: Stale premise rejection in recall
+AS AN agent processing a user query with a stale presupposition
+I WANT recall to surface the superseding fact alongside the stale one
+SO THAT the agent can reject the stale premise in its response
+
+**Acceptance criteria:**
+```
+GIVEN the graph contains (Policy, max_retries, 3) [older]
+  AND (Policy, retry_limit, 5) [newer, different predicate]
+  AND embedding similarity between "max_retries" and "retry_limit" ≥ 0.80
+WHEN SYNAPSE recalls facts about Policy
+THEN both edges are returned with conflict metadata
+AND the conflict metadata indicates which edge is the authoritative head
+AND the result is annotated with is_implicit_conflict = true
+```
+
+### US-003: Async write-time consolidation
+AS AN operator running long-lived agents
+I WANT an optional background pass to review the episodic edge log for implicit conflicts
+  and promote resolved facts to MAGMA
+SO THAT conflicts accumulated over long windows are periodically resolved without
+blocking the agent turn loop
+
+**Acceptance criteria:**
+```
+GIVEN implicit_consolidation_daemon.enabled = true
+  AND the daemon runs on its configured schedule (default: every 2 hours)
+WHEN the daemon reviews the edge log
+THEN for each implicit conflict candidate pair, it applies the configured strategy
+AND resolved facts are committed to the committed edge store via insert_or_supersede
+AND a log entry records: pair_ids, resolution_strategy, resolved_at, outcome
+```
+
+---
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN a new edge is extracted AND `implicit_conflict_detection.enabled = true` THE SYSTEM SHALL compare the new edge's `canonical_relation` against all active edge predicates on the same source entity using the configured similarity method | must |
+| FR-002 | Similarity methods SHALL include: `levenshtein` (normalized edit distance), `embedding` (cosine on predicate embedding), `both` (either match triggers detection) | must |
+| FR-003 | WHEN similarity ≥ `conflict_similarity_threshold` (default 0.80) AND the existing edge has a different `canonical_relation` than the new edge THE SYSTEM SHALL mark the pair as an implicit conflict candidate in `implicit_conflict_candidates` | must |
+| FR-004 | The resolution strategy for detected implicit conflicts SHALL be one of: `recency` (mark older edge superseded), `confidence` (pick higher confidence), `llm` (call `implicit_conflict_provider`), `flag_only` (mark without resolving; default) | must |
+| FR-005 | WHEN strategy is `flag_only` THE SYSTEM SHALL insert the candidate pair into `implicit_conflict_candidates` but NOT supersede either edge; SYNAPSE recall annotates flagged conflicts in the result | must |
+| FR-006 | WHEN strategy is `recency` or `confidence` THE SYSTEM SHALL call `insert_or_supersede` on the older or lower-confidence edge within the same write transaction | must |
+| FR-007 | WHEN strategy is `llm` THE SYSTEM SHALL call `implicit_conflict_provider` asynchronously with both edge facts as context; on timeout (default 800 ms) fall back to `flag_only` | must |
+| FR-008 | SYNAPSE recall SHALL, after assembling the candidate set, optionally follow causal-link edges up to `propagation_depth` hops (default 2) to surface potential superseding facts | should |
+| FR-009 | WHEN SYNAPSE returns an edge that has a pending entry in `implicit_conflict_candidates` THE SYSTEM SHALL annotate the result with `is_implicit_conflict = true` and include the conflicting candidate in a `conflict_metadata` field | must |
+| FR-010 | `implicit_conflict_candidates` entries SHALL be cleaned up when: (a) a resolution is applied, (b) either edge is explicitly superseded via APEX-MEM, or (c) `candidate_ttl_days` (default 30) expires | should |
+| FR-011 | THE SYSTEM SHALL NOT run implicit conflict detection for edges with `cardinality = n` (multi-valued predicates) — only cardinality-1 predicates are candidates for implicit supersession | must |
+| FR-012 | WHEN `implicit_consolidation_daemon.enabled = true` THE SYSTEM SHALL schedule an async task (via `zeph-scheduler`) that periodically reviews `implicit_conflict_candidates` and applies the configured strategy to unresolved pairs | should |
+| FR-013 | Config flag `[memory.graph.implicit_conflict] enabled` SHALL gate all new code paths; when `false`, write-time detection and SYNAPSE annotation are skipped entirely | must |
+| FR-014 | Every new code path introduced by this spec SHALL be instrumented with `tracing::info_span!` per the naming convention `memory.graph.implicit_conflict.<operation>` | must |
+| FR-015 | THE SYSTEM SHALL export Prometheus counters: `implicit_conflict_candidates_total`, `implicit_conflict_resolved_total{strategy}`, `implicit_conflict_llm_timeouts_total` | should |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Write-time implicit conflict detection (Levenshtein method) SHALL complete in < 5 ms at p95 for source entities with ≤ 100 active edges |
+| NFR-002 | Performance | Write-time detection using the embedding method requires a pre-computed predicate embedding; embedding computation is NEVER on the synchronous write path — embeddings are computed in the background queue and the similarity check is deferred until the embedding is available |
+| NFR-003 | Performance | SYNAPSE propagation-aware recall overhead (2-hop causal traversal) SHALL add < 10 ms at p95 on graphs with ≤ 10k edges |
+| NFR-004 | Performance | When `enabled = false`, write-time detection contributes zero overhead |
+| NFR-005 | Reliability | LLM-mediated resolution has an 800 ms timeout; on timeout the strategy falls back to `flag_only` — no write operation blocks on an LLM call |
+| NFR-006 | Reliability | Implicit conflict detection is additive on top of APEX-MEM; disabling it (`enabled = false`) must reproduce exactly pre-spec APEX-MEM behavior |
+| NFR-007 | Accuracy | On the STALE benchmark's State Resolution sub-task, the `embedding` similarity method SHALL achieve ≥ 70% detection rate at ≤ 15% false-positive rate with the default threshold of 0.80 (validated against synthetic benchmark fixtures) |
+| NFR-008 | Maintainability | `conflict_similarity_threshold` and the similarity method are runtime-configurable; no rebuild required to tune detection sensitivity |
+
+---
+
+## 5. Data Model Changes
+
+### New Table: `implicit_conflict_candidates`
+
+```sql
+CREATE TABLE IF NOT EXISTS implicit_conflict_candidates (
+    id              INTEGER PRIMARY KEY,
+    edge_a_id       INTEGER NOT NULL REFERENCES edges(id),
+    edge_b_id       INTEGER NOT NULL REFERENCES edges(id),
+    similarity      REAL    NOT NULL,
+    method          TEXT    NOT NULL,  -- "levenshtein" | "embedding" | "both"
+    status          TEXT    NOT NULL DEFAULT 'pending',
+                                       -- "pending" | "resolved" | "expired"
+    resolution      TEXT,              -- NULL | "recency" | "confidence" | "llm" | "flag_only"
+    created_at      INTEGER NOT NULL,
+    resolved_at     INTEGER,
+    expires_at      INTEGER NOT NULL
+);
+
+CREATE INDEX idx_icc_edge_a ON implicit_conflict_candidates(edge_a_id);
+CREATE INDEX idx_icc_edge_b ON implicit_conflict_candidates(edge_b_id);
+CREATE INDEX idx_icc_status  ON implicit_conflict_candidates(status, expires_at);
+```
+
+### `Edge` struct additions (extends APEX-MEM `Edge`)
+
+No schema changes to the `edges` table are required. Implicit conflict metadata is
+stored in `implicit_conflict_candidates` with foreign keys to edge ids.
+
+### Database migration
+
+Migration `047_implicit_conflict_candidates.sql` — creates the staging table above.
+Wrapped in `BEGIN IMMEDIATE; ... COMMIT;` per constitution.
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Source entity has 0 active edges (first write) | Skip detection; no candidates possible |
+| Two edges match above threshold but both are cardinality-n | Skip detection; no implicit conflict for multi-valued predicates (FR-011) |
+| Embedding for a predicate is not yet computed | Defer embedding-based detection until embedding is available; if deferred and LLM fallback is `flag_only`, no candidate is created for that pair until embedding arrives |
+| LLM resolution provider times out | Fall back to `flag_only`; increment `implicit_conflict_llm_timeouts_total` |
+| Both edges in a pair are superseded before resolution | Mark candidate as `expired`; no resolution needed |
+| Consolidation daemon runs while write-time detection is in progress | Per-entity lock in APEX-MEM serializes; daemon's `insert_or_supersede` call will observe the latest head |
+| Detection identifies a false positive (predicates similar in form but semantically unrelated) | With `flag_only` strategy, the flag is present in results but no edge is superseded; LLM resolution will reject the conflict on review; false positives are a calibration concern, not a correctness issue |
+| `candidate_ttl_days` expires for an unresolved pair | Set `status = expired`; pair is excluded from future SYNAPSE annotations; original edges unchanged |
+
+---
+
+## 7. Config
+
+```toml
+[memory.graph.implicit_conflict]
+enabled = false                        # opt-in; default off
+
+# Similarity method: "levenshtein" | "embedding" | "both"
+similarity_method = "levenshtein"
+
+# Similarity threshold above which a pair is a conflict candidate [0.0, 1.0]
+conflict_similarity_threshold = 0.80
+
+# Resolution strategy: "flag_only" | "recency" | "confidence" | "llm"
+resolution_strategy = "flag_only"
+
+# Provider name from [[llm.providers]] for LLM-mediated resolution (required for strategy = "llm")
+implicit_conflict_provider = ""
+
+# Timeout for LLM resolution call
+conflict_llm_timeout_ms = 800
+
+# Days before an unresolved candidate entry expires
+candidate_ttl_days = 30
+
+# SYNAPSE propagation depth for surfacing potential superseding facts
+propagation_depth = 2
+
+[memory.graph.implicit_conflict.consolidation_daemon]
+enabled = false
+# Schedule: cron expression or interval (seconds)
+interval_seconds = 7200               # 2 hours
+# Max candidates processed per daemon run
+batch_size = 100
+```
+
+---
+
+## 8. Key Invariants
+
+### Always (without asking)
+- Implicit conflict detection is additive over APEX-MEM; no existing write or recall paths are modified when `enabled = false`
+- Cardinality-n predicates are never flagged as implicit conflicts
+- The write-time detection path never blocks on an LLM call; LLM resolution is async-only
+- `implicit_conflict_candidates` entries are cleaned up when either edge is superseded, resolved, or expired
+- `propagation_depth = 0` disables SYNAPSE propagation-aware recall; default is 2 hops
+
+### Ask First
+- Raising `conflict_similarity_threshold` below 0.70 (significantly increases false positives)
+- Switching `resolution_strategy` from `flag_only` to `recency` or `confidence` in production without running calibration tests
+- Enabling `similarity_method = "embedding"` before predicate embedding backfill is complete
+
+### Never
+- Apply implicit conflict resolution to cardinality-n predicates
+- Block the synchronous write path on embedding computation or LLM calls
+- Supersede an edge via implicit detection without following the APEX-MEM `insert_or_supersede` contract (FR-006)
+- Return `implicit_conflict_candidates` entries directly to the LLM as part of the main context
+
+---
+
+## 9. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | STALE State Resolution sub-task detection rate (embedding method, default threshold) | ≥ 70% |
+| SC-002 | False-positive rate on a benign 100-edge graph with no implicit conflicts | ≤ 15% |
+| SC-003 | Write-time detection latency (Levenshtein method, 100 active edges) | < 5 ms at p95 |
+| SC-004 | SYNAPSE propagation-aware recall overhead (2-hop causal, 10k edges) | < 10 ms at p95 |
+| SC-005 | Implicit conflict detection disabled (`enabled = false`) reproduces pre-spec APEX-MEM behavior | 100% |
+
+---
+
+## 10. Acceptance Criteria
+
+```
+GIVEN implicit_conflict.enabled = true
+  AND similarity_method = "levenshtein"
+  AND an active edge (X, uses, Provider-A)
+  AND a new edge (X, switched_to, Provider-B) with Levenshtein similarity < 0.80
+WHEN insert_or_supersede runs for the new edge
+THEN no conflict candidate is created (similarity below threshold)
+AND both edges remain active
+
+GIVEN an active edge (X, uses, Provider-A)
+  AND a new edge (X, employs, Provider-B) with Levenshtein similarity ≥ 0.80
+  AND resolution_strategy = "flag_only"
+WHEN insert_or_supersede runs for the new edge
+THEN one row is inserted into implicit_conflict_candidates with status = "pending"
+AND both edges remain in the committed edge store (neither superseded)
+AND SYNAPSE recall annotates both edges with is_implicit_conflict = true
+
+GIVEN a candidate pair in implicit_conflict_candidates with status = "pending"
+  AND resolution_strategy = "recency"
+  AND the consolidation daemon runs
+WHEN the daemon processes the pair
+THEN the older edge is superseded via insert_or_supersede
+AND the candidate row is updated to status = "resolved", resolution = "recency"
+AND implicit_conflict_resolved_total{strategy="recency"} increments
+
+GIVEN implicit_conflict.enabled = false
+WHEN any number of edges are written or recalled
+THEN implicit_conflict_candidates remains empty
+AND SYNAPSE results contain no is_implicit_conflict annotations
+```
+
+---
+
+## 11. Implementation Notes
+
+- New module: `crates/zeph-memory/src/graph/implicit_conflict.rs` — owns
+  `ImplicitConflictDetector`, candidate staging, and the Levenshtein check.
+- Embedding-based similarity reuses the existing embedding infrastructure from
+  `zeph-memory/src/embeddings/` — predicate strings are embedded the same way as
+  message content; the embedding queue is shared.
+- SYNAPSE propagation-aware recall is an opt-in post-processing pass added to
+  `graph_recall_activated` in `crates/zeph-memory/src/semantic/graph.rs`; it queries
+  the `edges` table for causal-edge neighbors of the retrieved node set and re-runs
+  head-of-chain filtering on the expanded set.
+- The consolidation daemon is a `zeph-scheduler` task registered at startup when both
+  `graph.implicit_conflict.enabled = true` and `consolidation_daemon.enabled = true`.
+  It shares the `ConsolidationTask` infrastructure introduced by HeLa-Mem
+  [[004-11-memory-hela-mem]] to avoid duplicating scheduler registration boilerplate.
+- Migration 047 is separate from APEX-MEM migration 042; both can be applied independently.
+
+---
+
+## 12. Open Questions
+
+> [!question]
+> - **Embedding-based predicate similarity at write time**: computing predicate embeddings
+>   on every write introduces latency unless pre-computed. The proposed approach (defer
+>   detection until embedding is available) means a conflict candidate may not be created
+>   until the next batch embedding cycle. This lag needs to be bounded and communicated
+>   to operators. Exact deferral semantics must be defined before FR-002 (embedding method)
+>   is implemented.
+> - **STALE benchmark integration**: validation of the 70% detection rate target (SC-001)
+>   requires adapting the STALE evaluation suite to Zeph's edge schema. A benchmark
+>   adapter must be written in `zeph-bench` before the success criterion can be measured.
+
+---
+
+## 13. See Also
+
+- [[constitution]] — project principles
+- [[004-memory/spec]] — memory system parent index
+- [[004-7-memory-apex-magma]] — APEX-MEM (explicit supersession; this spec adds implicit detection on top)
+- [[004-6-graph-memory]] — MAGMA typed edges, SYNAPSE recall
+- [[004-11-memory-hela-mem]] — HeLa-Mem consolidation daemon (shared scheduler infrastructure)
+- [[001-system-invariants/spec]] — system-wide invariants
+- [[MOC-specs]] — all specifications

--- a/specs/004-memory/004-18-five-signal-retrieval.md
+++ b/specs/004-memory/004-18-five-signal-retrieval.md
@@ -1,0 +1,403 @@
+---
+aliases:
+  - MemTier Five-Signal Retrieval
+  - Five-Signal SYNAPSE
+  - Async Consolidation Daemon
+tags:
+  - sdd
+  - spec
+  - memory
+  - retrieval
+  - experimental
+created: 2026-05-18
+status: draft
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[004-memory/spec]]"
+  - "[[004-6-graph-memory]]"
+  - "[[004-5-temporal-decay]]"
+  - "[[004-11-memory-hela-mem]]"
+  - "[[001-system-invariants/spec]]"
+---
+
+# Spec: Five-Signal Retrieval and Async Consolidation Daemon (MemTier)
+
+> [!info]
+> Extends SYNAPSE recall with three additional retrieval signals (access frequency,
+> causal distance, novelty) beyond the current two-signal baseline (recency +
+> semantic relevance), and introduces an async consolidation daemon that promotes
+> high-utility episodic facts to the semantic layer.
+> Based on MemTier analysis (arXiv:2605.03675). Tracked in GitHub issue
+> [#3703](https://github.com/rabax/zeph/issues/3703).
+
+## Sources
+
+### External
+- **MemTier: Tiered Memory Architecture for Long-Horizon Agent Tasks**
+  (arXiv:2605.03675, 2026) — identifies four failure modes in flat-file memory over
+  72-hour windows; five-signal weighted retrieval achieves +33pp on LongMemEval-S;
+  async consolidation daemon reduces tool-execution success degradation from 14pp → 0pp
+
+### Internal
+
+| File | Contents |
+|------|----------|
+| `crates/zeph-memory/src/semantic/mod.rs` | SYNAPSE recall, `SemanticMemory` |
+| `crates/zeph-memory/src/semantic/graph.rs` | `graph_recall_activated`, spreading activation |
+| `crates/zeph-memory/src/graph/store.rs` | MAGMA graph traversal (causal edges) |
+| `crates/zeph-scheduler/src/lib.rs` | Background task scheduler |
+| `crates/zeph-experiments/src/lib.rs` | Self-learning / hyperparameter tuning framework |
+| `crates/zeph-memory/src/sleepgate/mod.rs` | SleepGate importance-score forgetting |
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+Zeph's current SYNAPSE recall weights two signals: **temporal recency** and **semantic
+relevance** (Qdrant vector similarity). Over 72-hour agent windows, three failure modes
+emerge that these two signals cannot address:
+
+1. **Retrieval interference**: frequently-queried but semantically distant facts are
+   ranked below rarely-accessed but semantically close facts. An access frequency signal
+   corrects this.
+2. **Goal-disconnected recall**: facts far removed from the current agent goal are
+   ranked equally with directly causally connected facts. A causal distance signal
+   (graph hops from the current goal node) corrects this.
+3. **Stale-episodic interference**: facts old relative to agent initialization but still
+   semantically similar to current queries pollute results. A novelty signal (decay from
+   agent initialization) corrects this.
+
+Additionally, SleepGate performs synchronous single-pass forgetting. For long-running
+agents, a continuously running async consolidation daemon that promotes hot episodic
+facts to the semantic (Qdrant) layer and deprioritizes cold facts prevents the
+14-percentage-point tool-execution success degradation observed by MemTier over
+72-hour windows.
+
+### Goal
+
+Two complementary changes:
+
+1. **Five-signal SYNAPSE retrieval**: add `access_frequency`, `causal_distance`, and
+   `novelty` signals to the SYNAPSE recall scoring function, with configurable per-signal
+   weights.
+2. **Async consolidation daemon**: background scheduler task (via `zeph-scheduler`) that
+   periodically reviews the episodic log, computes five-signal scores, promotes top-K
+   facts to Qdrant, and demotes cold facts below a retention threshold.
+
+### Out of Scope
+
+- Replacing the existing two-signal SYNAPSE baseline (new signals are additive with
+  weight 0.0 by default, preserving backward compatibility)
+- Modifying SleepGate's synchronous forgetting pass (the daemon is a companion, not a
+  replacement)
+- PPO-based weight adaptation (tracked as a follow-on task in `zeph-experiments`; not
+  part of this spec's must-have scope)
+- Changes to the Qdrant index schema beyond adding new payload metadata fields
+- New memory tiers beyond the existing SQLite episodic / Qdrant semantic split
+
+---
+
+## 2. User Stories
+
+### US-001: Access-frequency-boosted recall
+AS AN agent in a long-running session
+I WANT frequently-queried facts to rank higher in retrieval
+SO THAT facts I have used repeatedly remain accessible even when semantic similarity
+is not the highest
+
+**Acceptance criteria:**
+```
+GIVEN fact F1 has been queried 20 times (high access_frequency)
+  AND fact F2 has never been queried (access_frequency = 0)
+  AND F2 has marginally higher semantic similarity to the current query than F1
+WHEN SYNAPSE retrieves top-K facts with access_frequency weight > 0
+THEN F1 ranks above F2 in the weighted score
+```
+
+### US-002: Causal-distance-gated recall
+AS AN agent executing a multi-step goal
+I WANT facts causally connected to my current goal to rank higher than
+semantically similar but causally distant facts
+SO THAT recall stays focused on the active task trajectory
+
+**Acceptance criteria:**
+```
+GIVEN the current goal node G
+  AND fact F1 is 1 causal hop from G (causal_distance = 1)
+  AND fact F2 is 5 causal hops from G (causal_distance = 5)
+  AND F2 has higher semantic similarity than F1
+WHEN SYNAPSE retrieves with causal_distance weight > 0
+THEN F1 ranks above F2 after signal weighting
+```
+
+### US-003: Async promotion of hot episodic facts
+AS AN operator running Zeph for multi-day sessions
+I WANT the consolidation daemon to automatically promote high-utility episodic facts
+to the semantic layer
+SO THAT SYNAPSE vector search can surface them without scanning the full SQLite log
+
+**Acceptance criteria:**
+```
+GIVEN the daemon is enabled with interval_seconds = 7200
+  AND fact F has five-signal score above promotion_score_threshold after 2 hours
+WHEN the daemon runs
+THEN F is upserted into Qdrant with five-signal metadata in its payload
+AND the episodic store records F.qdrant_promoted = true
+AND the daemon run is logged with: facts_promoted, facts_demoted, run_duration_ms
+```
+
+---
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN SYNAPSE computes the retrieval score for a candidate fact THE SYSTEM SHALL compute: `score = w_recency × recency + w_relevance × relevance + w_frequency × access_frequency + w_causal × (1 / causal_distance) + w_novelty × novelty` where each weight is sourced from config | must |
+| FR-002 | When `w_frequency = 0`, `w_causal = 0`, `w_novelty = 0` (the defaults), the five-signal formula MUST be algebraically equivalent to the current two-signal baseline | must |
+| FR-003 | `access_frequency` for a fact SHALL be tracked in a new `fact_access_log` SQLite table: one row per (fact_id, turn_id) access event; the signal value is `log(1 + access_count)` normalized to `[0.0, 1.0]` across the candidate set | must |
+| FR-004 | WHEN a fact is returned to the agent loop (included in the context window) THE SYSTEM SHALL insert one row into `fact_access_log(fact_id, accessed_at, session_id)` | must |
+| FR-005 | `causal_distance` for a fact SHALL be computed as the minimum number of causal-type edges in the MAGMA graph between the fact's source entity and the current goal entity; if no goal entity is set, `causal_distance` defaults to a neutral value `neutral_causal_distance` (default 5) | must |
+| FR-006 | Goal entity resolution SHALL use the most recently mentioned goal node from the agent's active context (sourced from `TurnContext.current_goal_entity_id`); if absent, the causal distance signal contribution is zero regardless of weight | must |
+| FR-007 | `novelty` SHALL be computed as `exp(-λ_novelty × days_since_agent_init)` where `days_since_agent_init` is the fact's `created_at` minus the session start timestamp | must |
+| FR-008 | Signal weights SHALL be normalized to sum to 1.0 at startup; if the configured weights do not sum to 1.0, the system SHALL normalize them and log a `WARN` | must |
+| FR-009 | Config flag `[memory.five_signal] enabled` SHALL gate all five-signal code paths; when `false`, SYNAPSE uses the existing two-signal formula unchanged | must |
+| FR-010 | WHEN `consolidation_daemon.enabled = true` THE SYSTEM SHALL schedule an async task via `zeph-scheduler` that runs at `interval_seconds` intervals and (a) queries the top-K episodic facts by five-signal score, (b) upserts them to Qdrant with signal metadata in payload, (c) marks demoted facts in SQLite | should |
+| FR-011 | The consolidation daemon SHALL process at most `batch_size` facts per run to bound runtime; remaining facts are processed in the next run | should |
+| FR-012 | WHEN a fact is demoted by the daemon (five-signal score below `demotion_score_threshold`) THE SYSTEM SHALL set `memory_tier = episodic_only` in the episodic store; subsequent Qdrant searches WILL NOT return demoted facts until their score recovers above the promotion threshold | should |
+| FR-013 | THE SYSTEM SHALL export Prometheus counters: `five_signal_recall_total`, `consolidation_daemon_runs_total`, `consolidation_promoted_total`, `consolidation_demoted_total` | should |
+| FR-014 | Every new code path SHALL be instrumented with `tracing::info_span!` per the naming convention `memory.five_signal.<operation>` | must |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Five-signal SYNAPSE scoring overhead SHALL add < 5 ms at p95 per retrieval call for candidate sets ≤ 200 facts |
+| NFR-002 | Performance | `fact_access_log` insert (FR-004) is fire-and-forget (non-blocking); it SHALL complete in < 1 ms at p99 |
+| NFR-003 | Performance | Causal distance computation (BFS on MAGMA causal edges) SHALL be bounded by `causal_bfs_max_depth` (default 10 hops); facts beyond this depth receive `neutral_causal_distance` |
+| NFR-004 | Performance | Consolidation daemon runs in the background on the scheduler thread; it SHALL not block agent turns. Daemon runtime per batch SHALL be ≤ `daemon_max_runtime_ms` (default 30000 ms); excess facts are deferred to the next run |
+| NFR-005 | Reliability | When `enabled = false`, the five-signal code paths contribute zero overhead — all new code branches are behind the feature flag |
+| NFR-006 | Reliability | Consolidation daemon failures (Qdrant unavailable, SQLite write error) SHALL be logged and retried on the next scheduled run; agent operation is not interrupted |
+| NFR-007 | Reliability | Weight normalization (FR-008) is applied once at startup and cached; it does not occur on the hot retrieval path |
+| NFR-008 | Accuracy | On MemTier's LongMemEval-S benchmark, the five-signal retrieval with default weights SHALL improve retrieval accuracy vs. two-signal baseline by ≥ 15pp (validated on synthetic benchmark fixtures in `zeph-bench`) |
+
+---
+
+## 5. Data Model Changes
+
+### New Table: `fact_access_log`
+
+```sql
+CREATE TABLE IF NOT EXISTS fact_access_log (
+    id          INTEGER PRIMARY KEY,
+    fact_id     INTEGER NOT NULL,      -- references messages.id or graph edge id
+    fact_type   TEXT    NOT NULL,      -- "message" | "edge"
+    session_id  TEXT    NOT NULL,
+    accessed_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_fact_access_fact ON fact_access_log(fact_id, accessed_at DESC);
+CREATE INDEX idx_fact_access_session ON fact_access_log(session_id, accessed_at DESC);
+```
+
+### Qdrant payload additions (no schema migration required)
+
+Promoted facts gain additional metadata fields in the Qdrant point payload:
+
+```json
+{
+  "access_count": 15,
+  "causal_distance_at_promotion": 2,
+  "novelty_at_promotion": 0.87,
+  "five_signal_score": 0.91,
+  "promoted_at": 1747600000,
+  "memory_tier": "semantic"
+}
+```
+
+### SQLite `messages` table additions
+
+```sql
+ALTER TABLE messages ADD COLUMN memory_tier TEXT DEFAULT 'episodic';
+ALTER TABLE messages ADD COLUMN qdrant_promoted INTEGER DEFAULT 0;  -- boolean
+```
+
+Database migration: `048_five_signal_retrieval.sql` — adds `fact_access_log` table,
+alters `messages` table. Wrapped in `BEGIN IMMEDIATE; ... COMMIT;`.
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `TurnContext.current_goal_entity_id` is not set | Causal distance signal contribution = 0 regardless of `w_causal`; no BFS is run |
+| MAGMA graph has no causal-type edges | All facts receive `neutral_causal_distance`; causal signal is uniform and has no discriminating effect |
+| `fact_access_log` insert fails (SQLite I/O error) | Log `WARN`; continue agent turn; access count tracking is best-effort |
+| Consolidation daemon runs while agent turn is in progress | Qdrant upserts are atomic per-point; concurrent reads from SYNAPSE see either the old or new version — both are valid. No lock is held across the full batch |
+| Qdrant is unavailable during daemon promotion | Skip the promotion phase; log `WARN`; try again on the next scheduled run |
+| Five-signal weights do not sum to 1.0 in config | Normalize at startup; log `WARN` with original and normalized values |
+| `access_count` for a fact overflows the normalized range | `log(1 + access_count)` is bounded by `log(1 + max_access_count)` where `max_access_count` is capped at 10000; normalize against the cap |
+| Agent session shorter than `interval_seconds` | Consolidation daemon may not fire; episodic facts remain un-promoted. This is acceptable for short sessions |
+| Demoted fact's score recovers above promotion threshold | On the next daemon run, the fact is re-promoted to Qdrant; `qdrant_promoted` flipped back to 1 |
+
+---
+
+## 7. Config
+
+```toml
+[memory.five_signal]
+enabled = false                        # opt-in; default off
+
+# Signal weights (must sum to 1.0; normalized at startup if they do not)
+w_recency    = 0.35
+w_relevance  = 0.35
+w_frequency  = 0.15
+w_causal     = 0.10
+w_novelty    = 0.05
+
+# Causal distance BFS bounds
+causal_bfs_max_depth   = 10
+neutral_causal_distance = 5            # used when no goal entity or goal is beyond max depth
+
+# Novelty decay rate (λ in exp(-λ × days))
+novelty_decay_rate = 0.1
+
+[memory.five_signal.consolidation_daemon]
+enabled = false
+interval_seconds = 7200               # 2 hours
+batch_size = 500                      # max facts processed per run
+daemon_max_runtime_ms = 30000         # safety cap per run
+promotion_score_threshold = 0.70      # five-signal score above which a fact is promoted
+demotion_score_threshold = 0.20       # score below which a fact is demoted
+top_k_per_run = 500                   # number of top-scoring facts evaluated per run
+```
+
+---
+
+## 8. Key Invariants
+
+### Always (without asking)
+- When `w_frequency = 0`, `w_causal = 0`, `w_novelty = 0`, the five-signal formula is identical to the current two-signal baseline
+- Signal weights are normalized to sum to 1.0 exactly once at startup; the normalized values are used for all retrieval calls in the session
+- `fact_access_log` inserts are fire-and-forget; a failure does not interrupt the agent turn
+- Causal BFS is bounded by `causal_bfs_max_depth`; unbounded graph traversal is prohibited on the retrieval hot path
+- The consolidation daemon runs only on the scheduler thread and never blocks the agent turn thread
+- `enabled = false` is a zero-overhead no-op for all five-signal code paths
+
+### Ask First
+- Changing default signal weights (affects retrieval behavior for all sessions)
+- Enabling the consolidation daemon in production without running benchmark validation (SC-003)
+- Setting `demotion_score_threshold` above 0.30 (may demote facts that are still useful)
+
+### Never
+- Block the agent turn thread on causal BFS computation (BFS must be bounded and fast)
+- Allow the consolidation daemon to acquire a session-level lock that delays agent turns
+- Perform Qdrant writes on the synchronous SYNAPSE recall path (promotion is daemon-only)
+- Allow `w_recency + w_relevance + w_frequency + w_causal + w_novelty ≠ 1.0` after normalization
+
+---
+
+## 9. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Two-signal equivalence: five-signal with `w_frequency = w_causal = w_novelty = 0` produces identical ranking to current baseline | 100% on unit test fixtures |
+| SC-002 | LongMemEval-S retrieval accuracy (five-signal vs. two-signal baseline) | ≥ 15pp improvement |
+| SC-003 | Tool-execution success degradation over 72-hour synthetic session (with daemon enabled) | ≤ 3pp degradation (vs. 14pp baseline) |
+| SC-004 | Five-signal scoring overhead per retrieval call (200-fact candidate set) | < 5 ms at p95 |
+| SC-005 | Consolidation daemon batch runtime (500 facts) | < 30 s |
+
+---
+
+## 10. Acceptance Criteria
+
+```
+GIVEN five_signal.enabled = true
+  AND w_frequency = 0, w_causal = 0, w_novelty = 0
+WHEN SYNAPSE retrieves facts
+THEN the result ranking is identical to the two-signal baseline
+AND no new Prometheus counters are incremented beyond the existing ones
+
+GIVEN five_signal.enabled = true
+  AND w_frequency = 0.15
+  AND fact F1 has access_count = 50, F2 has access_count = 0
+  AND F2 has marginally higher semantic similarity (Δ = 0.02)
+WHEN SYNAPSE retrieves top-5 facts
+THEN F1 ranks above F2 (access_frequency contribution outweighs Δ similarity)
+AND five_signal_recall_total increments
+
+GIVEN consolidation_daemon.enabled = true
+  AND fact F has five_signal_score = 0.85 > promotion_score_threshold
+WHEN the daemon runs
+THEN F is upserted to Qdrant with five_signal_score in payload
+AND messages.qdrant_promoted = 1 for F
+AND consolidation_promoted_total increments
+
+GIVEN five_signal.enabled = false
+WHEN SYNAPSE retrieves any facts
+THEN no fact_access_log rows are written
+AND no five-signal weights are applied
+AND SYNAPSE latency is indistinguishable from the pre-spec baseline
+```
+
+---
+
+## 11. Implementation Notes
+
+- Five-signal scoring is a post-processing step applied to the candidate set returned
+  by Qdrant and the SQLite episodic search. The existing recall pipeline returns
+  `(fact_id, recency_score, relevance_score)` tuples; this spec adds three more score
+  fields hydrated from `fact_access_log` (frequency) and the MAGMA graph (causal
+  distance). The final weighted sum replaces the current linear combination.
+- `fact_access_log` counters are pre-aggregated at query time via a single SQL
+  `COUNT(*) GROUP BY fact_id` over the session's access log — no per-fact hot-path
+  lookup. The aggregation is cached per turn boundary.
+- Causal distance BFS reuses the existing `bfs_typed` infrastructure in
+  `graph/store.rs`, filtered to `EdgeType::Causal`. The BFS result is cached per turn
+  (keyed on goal entity id and source entity set) to avoid re-traversal within a turn.
+- Novelty is a pure arithmetic computation (`exp(-λ × days)`); no I/O required.
+- Consolidation daemon registration uses the `ConsolidationTask` pattern established by
+  HeLa-Mem [[004-11-memory-hela-mem]]. The five-signal daemon is a distinct task
+  registered under the `zeph-scheduler` feature gate.
+- PPO-based weight adaptation (MemTier §5) is deferred to `zeph-experiments` as a
+  follow-on enhancement. The weight config section is designed to accept automated
+  updates from the experiments framework without schema changes.
+- Database migration 048 is independent of APEX-MEM migration 042 and CUPMem migration
+  047; all three can be applied in any order.
+
+---
+
+## 12. Open Questions
+
+> [!question]
+> - **Goal entity sourcing**: FR-006 requires `TurnContext.current_goal_entity_id`.
+>   This field does not currently exist in `TurnContext`. It must be defined — either
+>   extracted from the current task description via a lightweight NER pass, or set
+>   explicitly by the orchestration layer. The mechanism for goal entity resolution
+>   must be agreed before FR-005 and FR-006 can be implemented.
+> - **LongMemEval-S benchmark adapter**: the ≥ 15pp improvement target (SC-002) requires
+>   an adapter in `zeph-bench` that replicates the LongMemEval-S evaluation protocol
+>   against Zeph's retrieval stack. This adapter does not yet exist and must be built
+>   as part of the implementation work.
+> - **PPO weight adaptation scope**: the MemTier paper's PPO agent learns per-agent-profile
+>   weights (e.g., code-generation agents weight causal distance higher). Integrating
+>   this into `zeph-experiments` is a P4 follow-on. The question of whether weights
+>   should be global (per deployment) or per-session should be resolved before
+>   implementing the experiments integration.
+
+---
+
+## 13. See Also
+
+- [[constitution]] — project principles
+- [[004-memory/spec]] — memory system parent index
+- [[004-5-temporal-decay]] — SleepGate forgetting (complementary, not replaced)
+- [[004-6-graph-memory]] — MAGMA graph and SYNAPSE recall (extended by this spec)
+- [[004-11-memory-hela-mem]] — HeLa-Mem consolidation (shared daemon infrastructure)
+- [[001-system-invariants/spec]] — system-wide invariants
+- [[MOC-specs]] — all specifications

--- a/specs/004-memory/spec.md
+++ b/specs/004-memory/spec.md
@@ -16,6 +16,9 @@ related:
   - "[[001-system-invariants/spec#6. Memory Pipeline Contract]]"
   - "[[002-agent-loop/spec]]"
   - "[[004-6-graph-memory]]"
+  - "[[004-16-shadow-memory-safety]]"
+  - "[[004-17-implicit-conflict-detection]]"
+  - "[[004-18-five-signal-retrieval]]"
   - "[[012-graph-memory/spec]]"
   - "[[031-database-abstraction/spec]]"
 ---
@@ -167,6 +170,9 @@ with zero overhead when disabled (#3318, #3349).
 | [[004-10-memory-memmachine-retrieval]] | MemMachine retrieval depth, query bias correction, episode preservation |
 | [[004-11-memory-hela-mem]] | HeLa-Mem Hebbian edge weights, consolidation, spreading activation |
 | [[004-12-memory-reasoning-bank]] | ReasoningBank distilled strategy memory, self-judge pipeline |
+| [[004-16-shadow-memory-safety]] | Shadow Memory Safety — trajectory-level attack defense (MAGE, issue #3695) |
+| [[004-17-implicit-conflict-detection]] | Implicit Conflict Detection — STALE/CUPMem fuzzy predicate matching and propagation-aware SYNAPSE recall (issue #3702) |
+| [[004-18-five-signal-retrieval]] | Five-Signal Retrieval — access frequency, causal distance, novelty signals + async consolidation daemon (MemTier, issue #3703) |
 
 ## Integration Points
 


### PR DESCRIPTION
## Summary

Three new memory subsystem specifications derived from arXiv research papers (issues #3695, #3702, #3703):

- `004-16-shadow-memory-safety.md` — `TrajectoryRiskAccumulator` for multi-turn attack defense (MAGE, arXiv:2605.03228)
- `004-17-implicit-conflict-detection.md` — `ImplicitConflictDetector` extending APEX-MEM write path (STALE, arXiv:2605.06527)
- `004-18-five-signal-retrieval.md` — Five-signal SYNAPSE retrieval + async consolidation daemon (MemTier, arXiv:2605.03675)

Implementation tracked in follow-up issues: #4372 (P2), #4373 (P2), #4374 (P3).

## Test plan

- [ ] Spec files build without broken intra-doc links (markdown only, no Rust changes)
- [ ] `specs/004-memory/spec.md` index updated with all three new entries
- [ ] Follow-up implementation issues #4372, #4373, #4374 created and labeled