### PR TITLE
fix(memory): correct ephemeral message in bare mode and deduplicate audit types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-core`: `memory_save` tool now returns "Saved to session memory (ephemeral — not
+  available after session ends)." in `--bare` mode instead of the persistent-mode message that
+  incorrectly implied data would survive the session (closes #4394).
+
+### Changed
+
+- `zeph-common`: canonical `AuditSignalType`, `Severity`, and `AuditSignal` types moved here
+  from `zeph-sanitizer` and `zeph-memory`; both crates re-export from `zeph_common::audit` for
+  backward compatibility (closes #4395).
+
 ### Added
 
 - `zeph-memory`, `zeph-config`: Five-signal SYNAPSE retrieval (#4374). Extends the recall

--- a/crates/zeph-common/src/audit.rs
+++ b/crates/zeph-common/src/audit.rs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared audit signal types used by both the sanitizer and memory subsystems.
+//!
+//! Defined here in `zeph-common` to eliminate the duplicate definitions that previously
+//! existed in `zeph-sanitizer::audit` and `zeph-memory::shadow`. Both crates re-export
+//! from this module.
+
+/// Signal type emitted by a sanitizer subsystem.
+///
+/// Variants correspond to the four signal classes defined in spec 004-16, FR-007.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AuditSignalType {
+    /// A policy gate denied or flagged an operation.
+    PolicyViolation,
+    /// A prompt-injection pattern was detected in untrusted content.
+    PromptInjectionPattern,
+    /// An anomalous tool-call chain was observed (e.g., rapid multi-tool escalation).
+    ToolChainAnomaly,
+    /// LLM response confidence dropped significantly between turns.
+    ConfidenceDrop,
+}
+
+/// Severity level for an [`AuditSignalType`].
+///
+/// Mapped to a numeric multiplier by `TrajectorySeverityMultipliers`:
+/// `Low → 0.5`, `Medium → 1.0`, `High → 2.0` (defaults).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Severity {
+    /// Minor or likely-benign signal.
+    Low,
+    /// Moderate concern; warrants accumulation.
+    Medium,
+    /// Strong indicator; highest multiplier.
+    High,
+}
+
+/// A single audit event emitted by a sanitizer subsystem.
+///
+/// Carries the minimum information needed by `TrajectoryRiskAccumulator::ingest`.
+/// No heap allocation — both fields are `Copy`.
+#[derive(Debug, Clone, Copy)]
+pub struct AuditSignal {
+    /// Category of the detected signal.
+    pub signal_type: AuditSignalType,
+    /// Severity of the detected signal.
+    pub severity: Severity,
+}
+
+impl AuditSignal {
+    /// Construct a new audit signal.
+    #[must_use]
+    pub const fn new(signal_type: AuditSignalType, severity: Severity) -> Self {
+        Self {
+            signal_type,
+            severity,
+        }
+    }
+}

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -9,6 +9,7 @@
 //! It has no `zeph-*` dependencies. The optional `treesitter` feature adds tree-sitter
 //! query constants and helpers.
 
+pub mod audit;
 pub mod config;
 pub mod error_taxonomy;
 pub mod fs_secure;

--- a/crates/zeph-core/src/memory_tools.rs
+++ b/crates/zeph-core/src/memory_tools.rs
@@ -38,13 +38,17 @@ fn default_role() -> String {
     "assistant".into()
 }
 
+/// Executes `memory_search` and `memory_save` tool calls on behalf of the agent.
 pub struct MemoryToolExecutor {
     memory: Arc<SemanticMemory>,
     conversation_id: ConversationId,
     validator: MemoryWriteValidator,
+    /// When `true` the backing store is in-memory (bare mode) and saves do not persist across sessions.
+    ephemeral: bool,
 }
 
 impl MemoryToolExecutor {
+    /// Create with default validator and persistent (non-ephemeral) semantics.
     #[must_use]
     pub fn new(memory: Arc<SemanticMemory>, conversation_id: ConversationId) -> Self {
         Self {
@@ -53,6 +57,7 @@ impl MemoryToolExecutor {
             validator: MemoryWriteValidator::new(
                 zeph_sanitizer::memory_validation::MemoryWriteValidationConfig::default(),
             ),
+            ephemeral: false,
         }
     }
 
@@ -67,7 +72,18 @@ impl MemoryToolExecutor {
             memory,
             conversation_id,
             validator,
+            ephemeral: false,
         }
+    }
+
+    /// Mark this executor as ephemeral (bare mode).
+    ///
+    /// When set, `memory_save` reports that the content is session-only and will not be
+    /// available after the session ends.
+    #[must_use]
+    pub fn ephemeral(mut self) -> Self {
+        self.ephemeral = true;
+        self
     }
 }
 
@@ -199,10 +215,19 @@ impl ToolExecutor for MemoryToolExecutor {
                     .map_err(|e| ToolError::Execution(std::io::Error::other(e.to_string())))?;
 
                 let summary = match message_id_opt {
-                    Some(message_id) => format!(
-                        "Saved to memory (message_id: {message_id}, conversation: {}). Content will be available for future recall.",
-                        self.conversation_id
-                    ),
+                    Some(message_id) => {
+                        if self.ephemeral {
+                            format!(
+                                "Saved to session memory (message_id: {message_id}, conversation: {}). Ephemeral — not available after session ends.",
+                                self.conversation_id
+                            )
+                        } else {
+                            format!(
+                                "Saved to memory (message_id: {message_id}, conversation: {}). Content will be available for future recall.",
+                                self.conversation_id
+                            )
+                        }
+                    }
                     None => "Memory admission rejected: message did not meet quality threshold."
                         .to_owned(),
                 };
@@ -373,6 +398,38 @@ mod tests {
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn memory_save_ephemeral_returns_session_only_message() {
+        let memory = make_memory().await;
+        let sqlite = memory.sqlite().clone();
+        let cid = sqlite.create_conversation().await.unwrap();
+        let executor = MemoryToolExecutor::new(Arc::new(memory), cid).ephemeral();
+
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "content".into(),
+            serde_json::Value::String("temp fact".into()),
+        );
+        let call = ToolCall {
+            tool_id: zeph_common::ToolName::new("memory_save"),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+        };
+        let output = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        assert!(
+            output.summary.contains("Ephemeral"),
+            "bare-mode save must mention ephemeral semantics; got: {}",
+            output.summary
+        );
+        assert!(
+            !output.summary.contains("available for future recall"),
+            "bare-mode save must not claim cross-session persistence; got: {}",
+            output.summary
+        );
     }
 
     /// `memory_search` description must mention user-provided facts so the model

--- a/crates/zeph-memory/src/shadow/mod.rs
+++ b/crates/zeph-memory/src/shadow/mod.rs
@@ -26,35 +26,7 @@ use std::collections::VecDeque;
 use tracing::info_span;
 use zeph_config::TrajectoryRiskAccumulatorConfig;
 
-/// Signal type for a safety event ingested by [`TrajectoryRiskAccumulator`].
-///
-/// Maps to the four signal classes defined in spec 004-16, FR-007.
-/// Callers in `zeph-core` convert from `zeph_sanitizer::audit::AuditSignalType` to this type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum AuditSignalType {
-    /// A policy gate denied or flagged an operation.
-    PolicyViolation,
-    /// A prompt-injection pattern was detected in untrusted content.
-    PromptInjectionPattern,
-    /// An anomalous tool-call chain was observed.
-    ToolChainAnomaly,
-    /// LLM response confidence dropped significantly between turns.
-    ConfidenceDrop,
-}
-
-/// Severity level for an [`AuditSignalType`] ingested by [`TrajectoryRiskAccumulator`].
-///
-/// Mapped to a numeric multiplier by `TrajectorySeverityMultipliers`:
-/// `Low → 0.5`, `Medium → 1.0`, `High → 2.0` (defaults).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Severity {
-    /// Minor or likely-benign signal.
-    Low,
-    /// Moderate concern; warrants accumulation.
-    Medium,
-    /// Strong indicator; highest multiplier.
-    High,
-}
+pub use zeph_common::audit::{AuditSignalType, Severity};
 
 /// A recorded safety signal ingested during a specific turn.
 #[derive(Debug, Clone)]

--- a/crates/zeph-sanitizer/src/audit.rs
+++ b/crates/zeph-sanitizer/src/audit.rs
@@ -5,55 +5,8 @@
 //!
 //! These types are consumed by `TrajectoryRiskAccumulator` in `zeph-memory` to maintain
 //! a rolling per-session risk score without coupling the sanitizer to the memory crate.
+//!
+//! The canonical definitions live in [`zeph_common::audit`]; this module re-exports them
+//! for backward compatibility with existing `zeph_sanitizer::audit` import paths.
 
-/// Signal type emitted by a sanitizer subsystem.
-///
-/// Variants correspond to the four signal classes defined in spec 004-16, FR-007.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum AuditSignalType {
-    /// A policy gate denied or flagged an operation.
-    PolicyViolation,
-    /// A prompt-injection pattern was detected in untrusted content.
-    PromptInjectionPattern,
-    /// An anomalous tool-call chain was observed (e.g., rapid multi-tool escalation).
-    ToolChainAnomaly,
-    /// LLM response confidence dropped significantly between turns.
-    ConfidenceDrop,
-}
-
-/// Severity level for an [`AuditSignalType`].
-///
-/// Mapped to a numeric multiplier by `TrajectorySeverityMultipliers`:
-/// `Low → 0.5`, `Medium → 1.0`, `High → 2.0` (defaults).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Severity {
-    /// Minor or likely-benign signal.
-    Low,
-    /// Moderate concern; warrants accumulation.
-    Medium,
-    /// Strong indicator; highest multiplier.
-    High,
-}
-
-/// A single audit event emitted by a sanitizer subsystem.
-///
-/// Carry the minimum information needed by `TrajectoryRiskAccumulator::ingest`.
-/// No heap allocation — both fields are `Copy`.
-#[derive(Debug, Clone, Copy)]
-pub struct AuditSignal {
-    /// Category of the detected signal.
-    pub signal_type: AuditSignalType,
-    /// Severity of the detected signal.
-    pub severity: Severity,
-}
-
-impl AuditSignal {
-    /// Construct a new audit signal.
-    #[must_use]
-    pub const fn new(signal_type: AuditSignalType, severity: Severity) -> Self {
-        Self {
-            signal_type,
-            severity,
-        }
-    }
-}
+pub use zeph_common::audit::{AuditSignal, AuditSignalType, Severity};

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1753,13 +1753,16 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let skill_paths_for_features = skill_paths.clone();
     let plugin_dirs_supplier = app.plugin_dirs_supplier();
 
-    let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::with_validator(
-        std::sync::Arc::clone(&memory),
-        conversation_id,
-        zeph_sanitizer::memory_validation::MemoryWriteValidator::new(
-            config.security.memory_validation.clone(),
-        ),
-    );
+    let memory_executor = {
+        let e = zeph_core::memory_tools::MemoryToolExecutor::with_validator(
+            std::sync::Arc::clone(&memory),
+            conversation_id,
+            zeph_sanitizer::memory_validation::MemoryWriteValidator::new(
+                config.security.memory_validation.clone(),
+            ),
+        );
+        if exec_mode.bare { e.ephemeral() } else { e }
+    };
     let overflow_executor = zeph_core::overflow_tools::OverflowToolExecutor::new(
         std::sync::Arc::new(memory.sqlite().clone()),
     )


### PR DESCRIPTION
## Summary

- **#4394**: `memory_save` in `--bare` mode now returns "Saved to session memory (ephemeral — not available after session ends)." instead of the persistent-mode message that incorrectly implied data would survive the session. Added `ephemeral: bool` field with a `#[must_use]` builder to `MemoryToolExecutor`; wired from `runner.rs` when `exec_mode.bare` is set.
- **#4395**: Moved canonical `AuditSignalType`, `Severity`, and `AuditSignal` from `zeph-sanitizer` and `zeph-memory` into `zeph-common::audit`. Both crates re-export the types for backward compatibility, eliminating duplicate definitions and the manual conversion match arms they required.

Closes #4394
Closes #4395

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 9905 passed, 21 skipped
- [ ] New regression test `memory_save_ephemeral_returns_session_only_message` covers the ephemeral branch
- [ ] Doc-tests pass: `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean