### PR TITLE
refactor(core,common): rename ShadowEvent to SentinelEvent; extract HTTP middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `zeph-core`: rename `ShadowEvent` → `SentinelEvent` in `shadow_sentinel` module to eliminate
+  naming collision with `zeph_sanitizer::ShadowMemory`; `ShadowEventStore` and `ShadowEventRow`
+  retain their names (closes #4379).
+
 ### Added
 
+- `zeph-common`: new `http_middleware` module (feature `http-middleware`) — shared bearer-token
+  auth and per-IP rate-limit axum middleware extracted from `zeph-gateway` and `zeph-a2a`;
+  eliminates duplicated `AuthConfig`, `RateLimitState`, `Cidr`, `auth_middleware`,
+  `rate_limit_middleware` implementations; gateway's pre-hashing + `subtle::ConstantTimeEq`
+  approach is canonical (closes #4387).
 - `zeph-memory`: `MAX_GRAPH_NODES` constant (500) added to A* graph retrieval; `node_map` is
   truncated to the highest-scored 500 nodes before the inner loop, bounding worst-case complexity
   from O(n²) per seed to O(n log n) (closes #4368).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10364,7 +10364,6 @@ version = "0.21.2"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
- "blake3",
  "eventsource-stream",
  "futures",
  "futures-core",
@@ -10375,7 +10374,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -10571,6 +10569,7 @@ dependencies = [
 name = "zeph-common"
 version = "0.21.2"
 dependencies = [
+ "axum 0.8.9",
  "blake3",
  "cpu-time",
  "metrics",
@@ -10580,6 +10579,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -10746,12 +10746,10 @@ name = "zeph-gateway"
 version = "0.21.2"
 dependencies = [
  "axum 0.8.9",
- "blake3",
  "http-body-util",
  "prometheus-client",
  "serde",
  "serde_json",
- "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",

--- a/crates/zeph-a2a/Cargo.toml
+++ b/crates/zeph-a2a/Cargo.toml
@@ -14,12 +14,11 @@ readme = "README.md"
 
 [features]
 ibct = ["dep:hmac", "dep:sha2"]
-server = ["dep:axum", "dep:blake3", "dep:subtle", "dep:tower", "dep:tower-http"]
+server = ["dep:axum", "dep:tower", "dep:tower-http", "zeph-common/http-middleware"]
 
 [dependencies]
 axum = { workspace = true, optional = true }
 base64.workspace = true
-blake3 = { workspace = true, optional = true }
 eventsource-stream.workspace = true
 futures.workspace = true
 futures-core.workspace = true
@@ -29,7 +28,6 @@ reqwest = { workspace = true, features = ["json", "stream"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2 = { workspace = true, optional = true }
-subtle = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["net", "sync"] }
 tokio-stream.workspace = true

--- a/crates/zeph-a2a/src/server/handlers.rs
+++ b/crates/zeph-a2a/src/server/handlers.rs
@@ -50,8 +50,8 @@ use crate::jsonrpc::{
 };
 use crate::types::{TaskArtifactUpdateEvent, TaskState, TaskStatusUpdateEvent};
 
-use super::router::AuthIdentity;
 use super::state::{AppState, CancelError, ProcessorEvent, now_rfc3339};
+use zeph_common::http_middleware::AuthIdentity;
 
 const ERR_METHOD_NOT_FOUND: i32 = -32601;
 const ERR_INVALID_PARAMS: i32 = -32602;

--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -221,7 +221,7 @@ impl A2aServer {
 
         let router = build_router_with_full_config(
             self.state,
-            self.auth_token,
+            self.auth_token.as_deref(),
             self.require_auth,
             self.rate_limit,
             self.max_body_size,

--- a/crates/zeph-a2a/src/server/router.rs
+++ b/crates/zeph-a2a/src/server/router.rs
@@ -7,21 +7,13 @@
 //! The test-only [`build_router_with_config`] omits `require_auth` and `max_body_size`
 //! for convenience.
 
-use std::collections::HashMap;
-use std::net::IpAddr;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-
 use axum::Router;
-use axum::body::Body;
-use axum::extract::ConnectInfo;
-use axum::http::{Request, StatusCode};
-use axum::middleware::{self, Next};
-use axum::response::{IntoResponse, Response};
+use axum::middleware;
 use axum::routing::{get, post};
-use subtle::ConstantTimeEq;
-use tokio::sync::Mutex;
 use tower_http::limit::RequestBodyLimitLayer;
+use zeph_common::http_middleware::{
+    AuthConfig, RateLimitState, auth_middleware, rate_limit_middleware,
+};
 
 use super::handlers::{agent_card_handler, jsonrpc_handler, stream_handler};
 use super::state::AppState;
@@ -29,76 +21,24 @@ use super::state::AppState;
 #[cfg(test)]
 const DEFAULT_MAX_BODY_SIZE: usize = 1024 * 1024; // 1 MiB
 
-/// Identity extracted from a validated bearer token.
-/// Inserted into request extensions by `auth_middleware` for every request.
-#[derive(Clone, Debug)]
-pub struct AuthIdentity {
-    /// Whether the request was authenticated via a valid bearer token.
-    pub authenticated: bool,
-}
-
-#[derive(Clone)]
-struct AuthConfig {
-    token: Option<String>,
-    require_auth: bool,
-}
-
-const MAX_RATE_LIMIT_ENTRIES: usize = 10_000;
-const EVICTION_INTERVAL: Duration = Duration::from_mins(1);
-const RATE_WINDOW: Duration = Duration::from_mins(1);
-
-#[derive(Clone)]
-struct RateLimitState {
-    limit: u32,
-    counters: Arc<Mutex<HashMap<IpAddr, (u32, Instant)>>>,
-}
-
-fn spawn_eviction_task(
-    counters: Arc<Mutex<HashMap<IpAddr, (u32, Instant)>>>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(EVICTION_INTERVAL);
-        interval.tick().await;
-        loop {
-            interval.tick().await;
-            let now = Instant::now();
-            let mut map = counters.lock().await;
-            map.retain(|_, (_, ts)| now.duration_since(*ts) < RATE_WINDOW);
-        }
-    })
-}
-
 #[cfg(test)]
 pub fn build_router_with_config(
     state: AppState,
-    auth_token: Option<String>,
+    auth_token: Option<&str>,
     rate_limit: u32,
 ) -> Router {
     build_router_with_full_config(state, auth_token, false, rate_limit, DEFAULT_MAX_BODY_SIZE)
 }
 
 pub fn build_router_with_full_config(
-    mut state: AppState,
-    auth_token: Option<String>,
+    state: AppState,
+    auth_token: Option<&str>,
     require_auth: bool,
     rate_limit: u32,
     max_body_size: usize,
 ) -> Router {
-    let auth_cfg = AuthConfig {
-        token: auth_token,
-        require_auth,
-    };
-    let counters = Arc::new(Mutex::new(HashMap::new()));
-    let eviction_handle = if rate_limit > 0 {
-        Some(Arc::new(spawn_eviction_task(Arc::clone(&counters))))
-    } else {
-        None
-    };
-    state.eviction_task = eviction_handle;
-    let rate_state = RateLimitState {
-        limit: rate_limit,
-        counters,
-    };
+    let auth_cfg = AuthConfig::new(auth_token, require_auth);
+    let rate_state = RateLimitState::new(rate_limit, &[]);
 
     let protected = Router::new()
         .route("/a2a", post(jsonrpc_handler))
@@ -116,111 +56,24 @@ pub fn build_router_with_full_config(
         .with_state(state)
 }
 
-async fn auth_middleware(
-    axum::extract::State(cfg): axum::extract::State<AuthConfig>,
-    mut req: Request<Body>,
-    next: Next,
-) -> Response {
-    if let Some(ref expected) = cfg.token {
-        let auth_header = req
-            .headers()
-            .get("authorization")
-            .and_then(|v| v.to_str().ok());
-
-        let token = auth_header
-            .and_then(|v| v.strip_prefix("Bearer "))
-            .unwrap_or("");
-
-        // Hash both sides so ct_eq compares fixed-length digests, avoiding the
-        // length side-channel that an explicit len() check or direct ct_eq would expose.
-        let h_token = blake3::hash(token.as_bytes());
-        let h_expected = blake3::hash(expected.as_bytes());
-        if !bool::from(h_token.as_bytes().ct_eq(h_expected.as_bytes())) {
-            req.extensions_mut().insert(AuthIdentity {
-                authenticated: false,
-            });
-            return StatusCode::UNAUTHORIZED.into_response();
-        }
-        req.extensions_mut().insert(AuthIdentity {
-            authenticated: true,
-        });
-    } else {
-        if cfg.require_auth {
-            tracing::warn!("a2a require_auth=true but no auth_token configured, rejecting request");
-            req.extensions_mut().insert(AuthIdentity {
-                authenticated: false,
-            });
-            return StatusCode::UNAUTHORIZED.into_response();
-        }
-        req.extensions_mut().insert(AuthIdentity {
-            authenticated: false,
-        });
-    }
-
-    next.run(req).await
-}
-
-async fn rate_limit_middleware(
-    axum::extract::State(state): axum::extract::State<RateLimitState>,
-    req: Request<Body>,
-    next: Next,
-) -> Response {
-    if state.limit == 0 {
-        return next.run(req).await;
-    }
-
-    // Extract IP from ConnectInfo if available, fall back to 0.0.0.0
-    let ip = req
-        .extensions()
-        .get::<ConnectInfo<std::net::SocketAddr>>()
-        .map_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), |ci| ci.0.ip());
-
-    let now = Instant::now();
-
-    let mut counters = state.counters.lock().await;
-
-    if counters.len() >= MAX_RATE_LIMIT_ENTRIES && !counters.contains_key(&ip) {
-        let before_eviction = counters.len();
-        counters.retain(|_, (_, ts)| now.duration_since(*ts) < RATE_WINDOW);
-        let after_eviction = counters.len();
-
-        if after_eviction >= MAX_RATE_LIMIT_ENTRIES {
-            tracing::warn!(
-                before = before_eviction,
-                after = after_eviction,
-                limit = MAX_RATE_LIMIT_ENTRIES,
-                "rate limiter at capacity after stale entry eviction, rejecting new IP"
-            );
-            return StatusCode::TOO_MANY_REQUESTS.into_response();
-        }
-    }
-
-    let entry = counters.entry(ip).or_insert((0, now));
-
-    if now.duration_since(entry.1) >= RATE_WINDOW {
-        *entry = (1, now);
-    } else {
-        entry.0 += 1;
-        if entry.0 > state.limit {
-            return StatusCode::TOO_MANY_REQUESTS.into_response();
-        }
-    }
-    drop(counters);
-
-    next.run(req).await
-}
-
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::net::IpAddr;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
     use axum::body::Body;
+    use tokio::sync::Mutex;
     use tower::ServiceExt;
+    use zeph_common::http_middleware::{MAX_RATE_LIMIT_ENTRIES, RATE_WINDOW};
 
     use super::*;
     use crate::server::testing::test_state;
 
     #[tokio::test]
     async fn auth_allows_valid_token() {
-        let app = build_router_with_config(test_state(), Some("secret-token".into()), 0);
+        let app = build_router_with_config(test_state(), Some("secret-token"), 0);
 
         let body = serde_json::json!({
             "jsonrpc": "2.0",
@@ -243,7 +96,7 @@ mod tests {
 
     #[tokio::test]
     async fn auth_rejects_missing_token() {
-        let app = build_router_with_config(test_state(), Some("secret-token".into()), 0);
+        let app = build_router_with_config(test_state(), Some("secret-token"), 0);
 
         let body = serde_json::json!({
             "jsonrpc": "2.0",
@@ -265,7 +118,7 @@ mod tests {
 
     #[tokio::test]
     async fn auth_rejects_wrong_token() {
-        let app = build_router_with_config(test_state(), Some("secret-token".into()), 0);
+        let app = build_router_with_config(test_state(), Some("secret-token"), 0);
 
         let body = serde_json::json!({
             "jsonrpc": "2.0",
@@ -288,7 +141,7 @@ mod tests {
 
     #[tokio::test]
     async fn agent_card_skips_auth() {
-        let app = build_router_with_config(test_state(), Some("secret-token".into()), 0);
+        let app = build_router_with_config(test_state(), Some("secret-token"), 0);
 
         let req = axum::http::Request::builder()
             .uri("/.well-known/agent.json")
@@ -339,7 +192,7 @@ mod tests {
 
     #[tokio::test]
     async fn auth_rejects_bearer_prefix_only() {
-        let app = build_router_with_config(test_state(), Some("secret".into()), 0);
+        let app = build_router_with_config(test_state(), Some("secret"), 0);
 
         let body = serde_json::json!({
             "jsonrpc": "2.0", "id": "1",
@@ -360,7 +213,7 @@ mod tests {
 
     #[tokio::test]
     async fn auth_rejects_non_bearer_scheme() {
-        let app = build_router_with_config(test_state(), Some("secret".into()), 0);
+        let app = build_router_with_config(test_state(), Some("secret"), 0);
 
         let body = serde_json::json!({
             "jsonrpc": "2.0", "id": "1",
@@ -520,57 +373,12 @@ mod tests {
         assert_eq!(resp.status(), 401);
     }
 
-    // --- Regression: #4044 — eviction JoinHandle stored in AppState ---
-
-    /// When `rate_limit` > 0, `build_router_with_full_config` must store the eviction
-    /// task handle in `AppState.eviction_task`.  Before #4044 the handle was dropped
-    /// immediately, making it impossible to abort the task on server shutdown.
+    /// Verify that `build_router_with_full_config` with `rate_limit` > 0 constructs a valid
+    /// router using inline GC eviction (shared middleware, no background task required).
     #[tokio::test]
-    async fn eviction_task_stored_in_state_when_rate_limit_enabled() {
-        // build_router_with_full_config takes AppState by value and sets eviction_task
-        // on it, so we can't inspect the state after the call.  Instead we verify the
-        // field via the router builder for the test-only helper which passes rate_limit.
-        //
-        // We construct AppState directly with rate_limit > 0 by calling the internal
-        // spawn_eviction_task path through build_router_with_full_config, then verify
-        // the handle lifecycle by checking the tokio runtime still has an active task.
-        //
-        // Since AppState is moved into the router we inspect the precondition: a state
-        // built without rate_limit has eviction_task = None.
-        let state_no_rl = test_state();
-        assert!(
-            state_no_rl.eviction_task.is_none(),
-            "eviction_task must be None when rate_limit = 0 (base state)"
-        );
-
-        // For rate_limit > 0 we cannot inspect AppState after build_router_with_config
-        // consumes it.  Instead verify that build_router_with_full_config accepts the
-        // call and produces a valid router (implying eviction_task was set without
-        // panicking).
+    async fn build_router_with_rate_limit_succeeds() {
         let _router = build_router_with_full_config(test_state(), None, false, 5, 1024 * 1024);
-        // Reaching here means spawn_eviction_task ran and the handle was stored.
-    }
-
-    /// Verifies that `AppState.eviction_task` is `None` when `rate_limit` is 0, and that
-    /// `build_router_with_full_config` sets it to `Some` when `rate_limit` > 0 by checking
-    /// that the spawned task is still running shortly after construction.
-    #[tokio::test]
-    async fn eviction_task_is_alive_after_build_with_rate_limit() {
-        // build_router_with_full_config stores the JoinHandle via Arc — the task must
-        // still be running immediately after construction (not yet finished).
-        // We cannot extract AppState after it is moved into the router, so we verify
-        // indirectly: spawn a task, hold an Arc to its handle via the same pattern
-        // used in spawn_eviction_task, and confirm it is not yet finished.
-        let counters: Arc<
-            Mutex<std::collections::HashMap<std::net::IpAddr, (u32, std::time::Instant)>>,
-        > = Arc::new(Mutex::new(std::collections::HashMap::new()));
-        let handle = Arc::new(spawn_eviction_task(Arc::clone(&counters)));
-        // Immediately after spawning the eviction loop should still be running.
-        assert!(
-            !handle.is_finished(),
-            "#4044 regression: eviction task must be alive after spawn"
-        );
-        handle.abort();
+        // Reaching here confirms inline-GC-based router builds without panic.
     }
 
     #[tokio::test]

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -13,6 +13,7 @@ description = "Shared utility functions and security primitives for Zeph crates"
 readme = "README.md"
 
 [features]
+http-middleware = ["dep:axum", "dep:subtle"]
 jsonschema = ["dep:schemars"]
 treesitter = [
     "dep:tree-sitter",
@@ -24,12 +25,14 @@ treesitter = [
 ]
 
 [dependencies]
+axum = { workspace = true, optional = true }
 blake3.workspace = true
 cpu-time.workspace = true
 metrics.workspace = true
 parking_lot.workspace = true
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "rc"] }
+subtle = { workspace = true, optional = true }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }

--- a/crates/zeph-common/src/http_middleware.rs
+++ b/crates/zeph-common/src/http_middleware.rs
@@ -1,0 +1,512 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared HTTP middleware for Zeph HTTP server crates.
+//!
+//! This module provides re-usable [`axum`] middleware for bearer-token authentication
+//! and per-IP rate limiting.  Both `zeph-gateway` and `zeph-a2a` activate this module
+//! via the `http-middleware` feature flag — no implementation is duplicated.
+//!
+//! # Feature gate
+//!
+//! Enable with `zeph-common = { …, features = ["http-middleware"] }`.
+//!
+//! # Authentication
+//!
+//! [`AuthConfig`] stores a pre-computed BLAKE3 hash of the expected bearer token.
+//! Per-request comparison operates on two 32-byte digests using [`subtle::ConstantTimeEq`],
+//! preventing timing-oracle attacks.  Set [`AuthConfig::require_auth`] to `true` to reject
+//! requests even when no token is configured (useful for strict enforcement in A2A servers).
+//!
+//! # Rate limiting
+//!
+//! [`RateLimitState`] implements a per-IP fixed-window counter with optional CIDR-based
+//! trusted-proxy support.  When the TCP peer falls within a trusted CIDR the middleware
+//! applies the XFF rightmost-untrusted algorithm to identify the real client IP.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use subtle::ConstantTimeEq;
+use tokio::sync::Mutex;
+
+/// Maximum number of IP entries retained in the rate-limit map before a GC pass.
+///
+/// When the map reaches this size and a new, unseen IP arrives, expired entries
+/// (older than [`RATE_WINDOW`]) are evicted before inserting the new one.  This
+/// bounds memory usage to roughly `MAX_RATE_LIMIT_ENTRIES × ~56 bytes`.
+pub const MAX_RATE_LIMIT_ENTRIES: usize = 10_000;
+
+/// Fixed window duration for the per-IP request counter.
+pub const RATE_WINDOW: Duration = Duration::from_mins(1);
+
+/// Pre-computed authentication configuration for the bearer-token middleware.
+///
+/// The expected token is hashed once at startup so that the per-request comparison
+/// always operates on two 32-byte BLAKE3 digests, keeping comparison both O(1) and
+/// constant-time.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_common::http_middleware::AuthConfig;
+///
+/// let cfg = AuthConfig::new(Some("my-secret-token"), false);
+/// // token_hash is pre-computed; raw string never stored
+/// ```
+#[derive(Clone)]
+pub struct AuthConfig {
+    /// BLAKE3 hash of the configured bearer token, or `None` when no token is set.
+    pub token_hash: Option<blake3::Hash>,
+    /// When `true`, requests are rejected even if no token is configured.
+    ///
+    /// Useful for A2A servers that must enforce authentication at the config level.
+    pub require_auth: bool,
+}
+
+impl AuthConfig {
+    /// Construct an [`AuthConfig`], hashing `token` once at startup.
+    ///
+    /// If `token` is `None` and `require_auth` is `false`, all requests pass through.
+    /// If `token` is `None` and `require_auth` is `true`, all requests are rejected with 401.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_common::http_middleware::AuthConfig;
+    ///
+    /// // Auth enabled with a token
+    /// let cfg = AuthConfig::new(Some("secret"), false);
+    ///
+    /// // Require auth even without a configured token (rejects all requests)
+    /// let cfg_strict = AuthConfig::new(None, true);
+    /// ```
+    #[must_use]
+    pub fn new(token: Option<&str>, require_auth: bool) -> Self {
+        Self {
+            token_hash: token.map(|t| blake3::hash(t.as_bytes())),
+            require_auth,
+        }
+    }
+}
+
+/// Identity extracted from a validated bearer token, inserted into request extensions.
+///
+/// Downstream handlers may read this extension to check whether the request was
+/// authenticated without re-examining the `Authorization` header.
+///
+/// # Examples
+///
+/// ```no_run
+/// use axum::extract::Extension;
+/// use zeph_common::http_middleware::AuthIdentity;
+///
+/// async fn my_handler(Extension(id): Extension<AuthIdentity>) {
+///     if id.authenticated {
+///         // handle authenticated request
+///     }
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct AuthIdentity {
+    /// `true` when the request carried a valid bearer token.
+    pub authenticated: bool,
+}
+
+/// A parsed CIDR block used for trusted-proxy matching.
+///
+/// Used by [`RateLimitState`] to decide whether to trust `X-Forwarded-For` headers.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_common::http_middleware::Cidr;
+///
+/// let cidr = Cidr::parse("10.0.0.0/8").unwrap();
+/// assert!(cidr.contains("10.1.2.3".parse().unwrap()));
+/// assert!(!cidr.contains("11.0.0.0".parse().unwrap()));
+/// ```
+#[derive(Clone, Debug)]
+pub struct Cidr {
+    addr: IpAddr,
+    prefix_len: u8,
+}
+
+impl Cidr {
+    /// Parse `"a.b.c.d/n"` or `"addr/n"`.  Returns `None` on any parse error.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_common::http_middleware::Cidr;
+    ///
+    /// assert!(Cidr::parse("192.168.0.0/16").is_some());
+    /// assert!(Cidr::parse("not-a-cidr").is_none());
+    /// assert!(Cidr::parse("10.0.0.0/33").is_none());
+    /// ```
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        let (addr_str, prefix_str) = s.split_once('/')?;
+        let addr: IpAddr = addr_str.parse().ok()?;
+        let prefix_len: u8 = prefix_str.parse().ok()?;
+        let max = match addr {
+            IpAddr::V4(_) => 32,
+            IpAddr::V6(_) => 128,
+        };
+        if prefix_len > max {
+            return None;
+        }
+        Some(Self { addr, prefix_len })
+    }
+
+    /// Returns `true` when `ip` falls within this CIDR block.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_common::http_middleware::Cidr;
+    ///
+    /// let cidr = Cidr::parse("10.0.0.0/8").unwrap();
+    /// assert!(cidr.contains("10.255.255.255".parse().unwrap()));
+    /// assert!(!cidr.contains("11.0.0.0".parse().unwrap()));
+    /// ```
+    #[must_use]
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        match (self.addr, ip) {
+            (IpAddr::V4(net), IpAddr::V4(candidate)) => {
+                if self.prefix_len == 0 {
+                    return true;
+                }
+                let shift = 32 - u32::from(self.prefix_len);
+                u32::from(net) >> shift == u32::from(candidate) >> shift
+            }
+            (IpAddr::V6(net), IpAddr::V6(candidate)) => {
+                if self.prefix_len == 0 {
+                    return true;
+                }
+                let shift = 128 - u32::from(self.prefix_len);
+                u128::from(net) >> shift == u128::from(candidate) >> shift
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Shared state threaded through the rate-limiting middleware.
+///
+/// Construct via [`RateLimitState::new`].  Pass to axum via
+/// `middleware::from_fn_with_state(rate_state, rate_limit_middleware)`.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_common::http_middleware::RateLimitState;
+///
+/// // 100 req/min, trust the loopback as a proxy
+/// let state = RateLimitState::new(100, &["127.0.0.1/32".to_string()]);
+/// ```
+#[derive(Clone)]
+pub struct RateLimitState {
+    /// Maximum requests per IP per [`RATE_WINDOW`].  `0` disables rate limiting.
+    pub limit: u32,
+    /// Map from remote IP to `(request_count, window_start)`.
+    pub counters: Arc<Mutex<HashMap<IpAddr, (u32, Instant)>>>,
+    /// Parsed CIDR blocks for trusted reverse proxies.
+    pub trusted_cidrs: Arc<Vec<Cidr>>,
+}
+
+impl RateLimitState {
+    /// Construct a [`RateLimitState`], parsing `trusted_proxy_cidrs` at startup.
+    ///
+    /// Invalid CIDR strings are logged as warnings and silently ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_common::http_middleware::RateLimitState;
+    ///
+    /// let state = RateLimitState::new(60, &["10.0.0.0/8".to_string()]);
+    /// ```
+    #[must_use]
+    pub fn new(limit: u32, trusted_proxy_cidrs: &[String]) -> Self {
+        let parsed_cidrs: Vec<Cidr> = trusted_proxy_cidrs
+            .iter()
+            .filter_map(|s| {
+                let c = Cidr::parse(s);
+                if c.is_none() {
+                    tracing::warn!(cidr = %s, "http-middleware: invalid trusted_proxy_cidr, ignoring");
+                }
+                c
+            })
+            .collect();
+        Self {
+            limit,
+            counters: Arc::new(Mutex::new(HashMap::new())),
+            trusted_cidrs: Arc::new(parsed_cidrs),
+        }
+    }
+}
+
+/// Axum middleware that enforces bearer-token authentication.
+///
+/// When [`AuthConfig::token_hash`] is `Some`, the request must carry
+/// `Authorization: Bearer <token>` whose BLAKE3 hash matches the pre-computed digest.
+/// Comparison uses [`ConstantTimeEq`] on two 32-byte arrays — constant time regardless
+/// of token content, preventing timing-oracle attacks.
+///
+/// The middleware always inserts an [`AuthIdentity`] extension into the request so that
+/// downstream handlers can inspect authentication status without re-reading the header.
+///
+/// - Token present and valid → passes through, `AuthIdentity { authenticated: true }`
+/// - Token present but wrong → 401, `AuthIdentity { authenticated: false }`
+/// - No token, `require_auth = true` → 401 with a warning log
+/// - No token, `require_auth = false` → passes through, `AuthIdentity { authenticated: false }`
+///
+/// # Errors
+///
+/// Returns `401 Unauthorized` on authentication failure.
+pub async fn auth_middleware(
+    axum::extract::State(cfg): axum::extract::State<AuthConfig>,
+    mut req: Request<Body>,
+    next: Next,
+) -> Response {
+    if let Some(expected_hash) = cfg.token_hash {
+        let auth_header = req
+            .headers()
+            .get("authorization")
+            .and_then(|v| v.to_str().ok());
+
+        let token = auth_header
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .unwrap_or("");
+
+        // Hash the submitted token to a fixed-length digest before comparing.
+        // Expected hash is pre-computed at startup (stored in AuthConfig).
+        // ct_eq operates on two 32-byte arrays — constant time regardless of content.
+        let token_hash = blake3::hash(token.as_bytes());
+        if !bool::from(token_hash.as_bytes().ct_eq(expected_hash.as_bytes())) {
+            req.extensions_mut().insert(AuthIdentity {
+                authenticated: false,
+            });
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+        req.extensions_mut().insert(AuthIdentity {
+            authenticated: true,
+        });
+    } else {
+        if cfg.require_auth {
+            tracing::warn!(
+                "http-middleware: require_auth=true but no auth_token configured, rejecting request"
+            );
+            req.extensions_mut().insert(AuthIdentity {
+                authenticated: false,
+            });
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+        req.extensions_mut().insert(AuthIdentity {
+            authenticated: false,
+        });
+    }
+
+    next.run(req).await
+}
+
+/// Axum middleware that enforces a per-IP fixed-window rate limit.
+///
+/// Each remote IP is tracked independently.  A counter is incremented on every request
+/// within the current window.  When the counter exceeds [`RateLimitState::limit`] the
+/// request receives `429 Too Many Requests`.
+///
+/// When [`RateLimitState::trusted_cidrs`] is non-empty and the TCP peer falls within
+/// a trusted CIDR, the middleware applies the XFF rightmost-untrusted algorithm on
+/// `X-Forwarded-For` to identify the real client IP.
+///
+/// To prevent unbounded memory growth, expired entries are evicted via inline GC when
+/// the counters map reaches [`MAX_RATE_LIMIT_ENTRIES`] and a new IP is encountered.
+/// When the map is still at capacity after eviction (all entries fresh), the request
+/// receives `429 Too Many Requests`.
+///
+/// Setting [`RateLimitState::limit`] to `0` disables rate limiting entirely.
+///
+/// # Errors
+///
+/// Returns `429 Too Many Requests` when the rate limit is exceeded or the rate-limit
+/// table is full and cannot accommodate a new IP after eviction.
+pub async fn rate_limit_middleware(
+    axum::extract::State(state): axum::extract::State<RateLimitState>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    if state.limit == 0 {
+        return next.run(req).await;
+    }
+
+    let peer_ip = req
+        .extensions()
+        .get::<ConnectInfo<std::net::SocketAddr>>()
+        .map_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), |ci| ci.0.ip());
+
+    // When trusted proxy CIDRs are configured and the TCP peer falls within one of them,
+    // apply the rightmost-untrusted algorithm on X-Forwarded-For: walk the header values
+    // from right to left and pick the first IP that is not in any trusted CIDR.
+    let ip = if !state.trusted_cidrs.is_empty()
+        && state.trusted_cidrs.iter().any(|c| c.contains(peer_ip))
+    {
+        let xff_ip = req
+            .headers()
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| {
+                v.split(',')
+                    .map(str::trim)
+                    .filter_map(|s| s.parse::<IpAddr>().ok())
+                    .rev()
+                    .find(|ip| !state.trusted_cidrs.iter().any(|c| c.contains(*ip)))
+            });
+        xff_ip.unwrap_or(peer_ip)
+    } else {
+        peer_ip
+    };
+
+    let now = Instant::now();
+    let mut counters = state.counters.lock().await;
+
+    if counters.len() >= MAX_RATE_LIMIT_ENTRIES && !counters.contains_key(&ip) {
+        let before_eviction = counters.len();
+        counters.retain(|_, (_, ts)| now.duration_since(*ts) < RATE_WINDOW);
+        let after_eviction = counters.len();
+
+        if after_eviction >= MAX_RATE_LIMIT_ENTRIES {
+            tracing::warn!(
+                before = before_eviction,
+                after = after_eviction,
+                limit = MAX_RATE_LIMIT_ENTRIES,
+                "rate limiter at capacity after stale entry eviction, rejecting new IP"
+            );
+            return StatusCode::TOO_MANY_REQUESTS.into_response();
+        }
+    }
+
+    let entry = counters.entry(ip).or_insert((0, now));
+    if now.duration_since(entry.1) >= RATE_WINDOW {
+        *entry = (1, now);
+    } else {
+        entry.0 += 1;
+        if entry.0 > state.limit {
+            return StatusCode::TOO_MANY_REQUESTS.into_response();
+        }
+    }
+    drop(counters);
+
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cidr_ipv4_contains_in_range() {
+        let cidr = Cidr::parse("10.0.0.0/8").unwrap();
+        assert!(cidr.contains("10.1.2.3".parse().unwrap()));
+        assert!(cidr.contains("10.255.255.255".parse().unwrap()));
+        assert!(!cidr.contains("11.0.0.0".parse().unwrap()));
+        assert!(!cidr.contains("9.255.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_ipv4_slash32_exact_host() {
+        let cidr = Cidr::parse("192.168.1.100/32").unwrap();
+        assert!(cidr.contains("192.168.1.100".parse().unwrap()));
+        assert!(!cidr.contains("192.168.1.101".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_ipv4_slash0_matches_all() {
+        let cidr = Cidr::parse("0.0.0.0/0").unwrap();
+        assert!(cidr.contains("1.2.3.4".parse().unwrap()));
+        assert!(cidr.contains("255.255.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_ipv6_contains_in_range() {
+        let cidr = Cidr::parse("::1/128").unwrap();
+        assert!(cidr.contains("::1".parse().unwrap()));
+        assert!(!cidr.contains("::2".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_ipv4_v6_mismatch_returns_false() {
+        let cidr = Cidr::parse("10.0.0.0/8").unwrap();
+        assert!(!cidr.contains("::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_parse_rejects_invalid() {
+        assert!(Cidr::parse("not-a-cidr").is_none());
+        assert!(Cidr::parse("10.0.0.0/33").is_none());
+        assert!(Cidr::parse("::1/129").is_none());
+        assert!(Cidr::parse("10.0.0.0/").is_none());
+    }
+
+    #[test]
+    fn auth_config_new_hashes_token() {
+        let cfg = AuthConfig::new(Some("secret"), false);
+        assert!(cfg.token_hash.is_some());
+        assert!(!cfg.require_auth);
+        let expected = blake3::hash(b"secret");
+        assert_eq!(cfg.token_hash.unwrap(), expected);
+    }
+
+    #[test]
+    fn auth_config_new_none_token() {
+        let cfg = AuthConfig::new(None, true);
+        assert!(cfg.token_hash.is_none());
+        assert!(cfg.require_auth);
+    }
+
+    #[test]
+    fn rate_limit_state_new_parses_cidrs() {
+        let state = RateLimitState::new(10, &["10.0.0.0/8".to_string(), "invalid".to_string()]);
+        assert_eq!(state.limit, 10);
+        assert_eq!(state.trusted_cidrs.len(), 1);
+    }
+
+    #[test]
+    fn bearer_ct_eq_is_constant_time() {
+        use std::time::Instant;
+
+        const ITERS: u32 = 100_000;
+        const MAX_RATIO: u128 = 10;
+
+        let expected_hash = blake3::hash(b"super-secret-gateway-token");
+        let candidates: &[&[u8]] = &[b"x", b"wrong_token_123", &[b'z'; 512]];
+        let mut times_ns: Vec<u128> = Vec::with_capacity(candidates.len());
+
+        for candidate in candidates {
+            let h = blake3::hash(candidate);
+            for _ in 0..1_000 {
+                let _ = h.as_bytes().ct_eq(expected_hash.as_bytes());
+            }
+            let start = Instant::now();
+            for _ in 0..ITERS {
+                let _ = h.as_bytes().ct_eq(expected_hash.as_bytes());
+            }
+            times_ns.push(start.elapsed().as_nanos() / u128::from(ITERS));
+        }
+
+        let min = *times_ns.iter().min().unwrap();
+        let max = *times_ns.iter().max().unwrap();
+        assert!(
+            min > 0 && max / min < MAX_RATIO,
+            "ct_eq timing ratio {max}/{min} exceeds {MAX_RATIO}×; times per iter: {times_ns:?} ns"
+        );
+    }
+}

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -9,6 +9,9 @@
 //! It has no `zeph-*` dependencies. The optional `treesitter` feature adds tree-sitter
 //! query constants and helpers.
 
+#[cfg(feature = "http-middleware")]
+pub mod http_middleware;
+
 pub mod config;
 pub mod error_taxonomy;
 pub mod fs_secure;

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2895,7 +2895,7 @@ mod tests {
     #[tokio::test]
     async fn with_shadow_sentinel_sets_field() {
         use crate::agent::shadow_sentinel::{
-            SafetyProbe, ShadowEvent, ShadowEventStore, ShadowSentinel,
+            SafetyProbe, SentinelEvent, ShadowEventStore, ShadowSentinel,
         };
 
         struct NoopProbe;
@@ -2904,7 +2904,7 @@ mod tests {
                 &'a self,
                 _: &'a str,
                 _: &'a serde_json::Value,
-                _: &'a [ShadowEvent],
+                _: &'a [SentinelEvent],
             ) -> std::pin::Pin<
                 Box<
                     dyn std::future::Future<Output = crate::agent::shadow_sentinel::ProbeVerdict>

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -79,13 +79,13 @@ pub enum ProbeVerdict {
     Skip,
 }
 
-// ── Shadow event ─────────────────────────────────────────────────────────────
+// ── Sentinel event ───────────────────────────────────────────────────────────
 
-/// A single event in the persistent safety shadow stream.
+/// A single probe trajectory record in the persistent safety sentinel stream.
 ///
 /// Stored in `safety_shadow_events` and retrieved for cross-session probe context.
 #[derive(Debug, Clone)]
-pub struct ShadowEvent {
+pub struct SentinelEvent {
     /// Database row id (0 for unsaved records).
     pub id: i64,
     /// Agent session identifier.
@@ -135,7 +135,7 @@ pub trait SafetyProbe: Send + Sync {
         &'a self,
         tool_id: &'a str,
         tool_args: &'a JsonValue,
-        trajectory: &'a [ShadowEvent],
+        trajectory: &'a [SentinelEvent],
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>;
 }
 
@@ -172,7 +172,7 @@ impl LlmSafetyProbe {
     fn build_prompt(
         tool_id: &str,
         tool_args: &JsonValue,
-        trajectory: &[ShadowEvent],
+        trajectory: &[SentinelEvent],
     ) -> Vec<Message> {
         let context = if trajectory.is_empty() {
             "No prior events in this session.".to_owned()
@@ -247,7 +247,7 @@ impl SafetyProbe for LlmSafetyProbe {
         &'a self,
         tool_id: &'a str,
         tool_args: &'a JsonValue,
-        trajectory: &'a [ShadowEvent],
+        trajectory: &'a [SentinelEvent],
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>> {
         let span = info_span!("security.shadow.probe", tool_id = %tool_id);
         Box::pin(
@@ -313,7 +313,7 @@ impl ShadowEventStore {
     ///
     /// Returns `AgentError` on database failure.
     #[tracing::instrument(name = "security.shadow.record", skip_all, fields(event_type = %event.event_type))]
-    pub async fn record(&self, event: &ShadowEvent) -> Result<(), AgentError> {
+    pub async fn record(&self, event: &SentinelEvent) -> Result<(), AgentError> {
         sqlx::query(
             "INSERT INTO safety_shadow_events \
              (session_id, turn_number, event_type, tool_id, risk_signal, risk_level, \
@@ -348,7 +348,7 @@ impl ShadowEventStore {
         &self,
         session_id: &str,
         limit: usize,
-    ) -> Result<Vec<ShadowEvent>, AgentError> {
+    ) -> Result<Vec<SentinelEvent>, AgentError> {
         let rows = sqlx::query_as::<_, ShadowEventRow>(
             "SELECT id, session_id, turn_number, event_type, tool_id, risk_signal, \
              risk_level, probe_verdict, context_summary, created_at \
@@ -364,7 +364,7 @@ impl ShadowEventStore {
         .map_err(|e| AgentError::Db(e.to_string()))?;
 
         // DB returns DESC (newest first); reverse once to get ASC (oldest first) for LLM context.
-        let mut events: Vec<ShadowEvent> = rows.into_iter().map(ShadowEvent::from).collect();
+        let mut events: Vec<SentinelEvent> = rows.into_iter().map(SentinelEvent::from).collect();
         events.reverse();
         Ok(events)
     }
@@ -381,7 +381,7 @@ impl ShadowEventStore {
         &self,
         tool_id: &str,
         limit: usize,
-    ) -> Result<Vec<ShadowEvent>, AgentError> {
+    ) -> Result<Vec<SentinelEvent>, AgentError> {
         let rows = sqlx::query_as::<_, ShadowEventRow>(
             "SELECT id, session_id, turn_number, event_type, tool_id, risk_signal, \
              risk_level, probe_verdict, context_summary, created_at \
@@ -396,7 +396,7 @@ impl ShadowEventStore {
         .await
         .map_err(|e| AgentError::Db(e.to_string()))?;
 
-        Ok(rows.into_iter().map(ShadowEvent::from).collect())
+        Ok(rows.into_iter().map(SentinelEvent::from).collect())
     }
 }
 
@@ -415,7 +415,7 @@ struct ShadowEventRow {
     created_at: i64,
 }
 
-impl From<ShadowEventRow> for ShadowEvent {
+impl From<ShadowEventRow> for SentinelEvent {
     fn from(r: ShadowEventRow) -> Self {
         Self {
             id: r.id,
@@ -612,7 +612,7 @@ impl ShadowSentinel {
             ProbeVerdict::Allow => format!("probe allowed {qualified_tool_id}"),
             ProbeVerdict::Skip => format!("probe skipped {qualified_tool_id}"),
         };
-        let event = ShadowEvent {
+        let event = SentinelEvent {
             id: 0,
             session_id: self.session_id.clone(),
             turn_number,
@@ -647,7 +647,7 @@ impl ShadowSentinel {
         if !self.config.enabled {
             return;
         }
-        let event = ShadowEvent {
+        let event = SentinelEvent {
             id: 0,
             session_id: self.session_id.clone(),
             turn_number,
@@ -896,7 +896,7 @@ mod tests {
                 &'a self,
                 _: &'a str,
                 _: &'a JsonValue,
-                _: &'a [ShadowEvent],
+                _: &'a [SentinelEvent],
             ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>
             {
                 Box::pin(async { ProbeVerdict::Allow })

--- a/crates/zeph-gateway/Cargo.toml
+++ b/crates/zeph-gateway/Cargo.toml
@@ -17,17 +17,15 @@ prometheus = ["dep:prometheus-client"]
 
 [dependencies]
 axum.workspace = true
-blake3.workspace = true
 prometheus-client = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-subtle.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["net", "sync", "time"] }
 tower.workspace = true
 tower-http = { workspace = true, features = ["limit", "trace"] }
 tracing.workspace = true
-zeph-common.workspace = true
+zeph-common = { workspace = true, features = ["http-middleware"] }
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [dev-dependencies]

--- a/crates/zeph-gateway/src/router.rs
+++ b/crates/zeph-gateway/src/router.rs
@@ -1,102 +1,16 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::HashMap;
-use std::net::IpAddr;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-
 use axum::Router;
-use axum::body::Body;
-use axum::extract::ConnectInfo;
-use axum::http::{Request, StatusCode};
-use axum::middleware::{self, Next};
-use axum::response::{IntoResponse, Response};
+use axum::middleware;
 use axum::routing::{get, post};
-use subtle::ConstantTimeEq;
-use tokio::sync::Mutex;
 use tower_http::limit::RequestBodyLimitLayer;
+use zeph_common::http_middleware::{
+    AuthConfig, RateLimitState, auth_middleware, rate_limit_middleware,
+};
 
 use super::handlers::{health_handler, webhook_handler};
 use super::server::AppState;
-
-/// Pre-computed authentication configuration for the bearer-token middleware.
-///
-/// The expected token is hashed once at startup so that the per-request
-/// comparison always operates on two 32-byte BLAKE3 digests, keeping the
-/// comparison both O(1) and constant-time.
-#[derive(Clone)]
-struct AuthConfig {
-    /// BLAKE3 hash of the configured bearer token, or `None` when auth is disabled.
-    token_hash: Option<blake3::Hash>,
-}
-
-/// Maximum number of IP entries retained in the rate-limit map before a GC pass.
-///
-/// When the map reaches this size and a new, unseen IP arrives, expired entries
-/// (older than [`RATE_WINDOW`]) are evicted before inserting the new one.  This
-/// bounds memory usage to roughly `MAX_RATE_LIMIT_ENTRIES * ~56 bytes`.
-const MAX_RATE_LIMIT_ENTRIES: usize = 10_000;
-
-/// Fixed window duration for the per-IP request counter.
-const RATE_WINDOW: Duration = Duration::from_mins(1);
-
-/// A parsed CIDR block used for trusted-proxy matching.
-#[derive(Clone, Debug)]
-struct Cidr {
-    addr: IpAddr,
-    prefix_len: u8,
-}
-
-impl Cidr {
-    /// Parse `"a.b.c.d/n"` or `"addr/n"`.  Returns `None` on any parse error.
-    fn parse(s: &str) -> Option<Self> {
-        let (addr_str, prefix_str) = s.split_once('/')?;
-        let addr: IpAddr = addr_str.parse().ok()?;
-        let prefix_len: u8 = prefix_str.parse().ok()?;
-        let max = match addr {
-            IpAddr::V4(_) => 32,
-            IpAddr::V6(_) => 128,
-        };
-        if prefix_len > max {
-            return None;
-        }
-        Some(Self { addr, prefix_len })
-    }
-
-    /// Returns `true` when `ip` falls within this CIDR block.
-    fn contains(&self, ip: IpAddr) -> bool {
-        match (self.addr, ip) {
-            (IpAddr::V4(net), IpAddr::V4(candidate)) => {
-                if self.prefix_len == 0 {
-                    return true;
-                }
-                let shift = 32 - u32::from(self.prefix_len);
-                u32::from(net) >> shift == u32::from(candidate) >> shift
-            }
-            (IpAddr::V6(net), IpAddr::V6(candidate)) => {
-                if self.prefix_len == 0 {
-                    return true;
-                }
-                let shift = 128 - u32::from(self.prefix_len);
-                u128::from(net) >> shift == u128::from(candidate) >> shift
-            }
-            _ => false,
-        }
-    }
-}
-
-/// Shared state threaded through the rate-limiting middleware.
-#[derive(Clone)]
-struct RateLimitState {
-    /// Maximum number of requests allowed per IP in one [`RATE_WINDOW`].
-    /// `0` means rate limiting is disabled.
-    limit: u32,
-    /// Map from remote IP to `(request_count, window_start)`.
-    counters: Arc<Mutex<HashMap<IpAddr, (u32, Instant)>>>,
-    /// Parsed CIDR blocks for trusted reverse proxies.
-    trusted_cidrs: Arc<Vec<Cidr>>,
-}
 
 /// Build the complete axum [`Router`] for the gateway.
 ///
@@ -116,24 +30,8 @@ pub(crate) fn build_router(
     max_body_size: usize,
     trusted_proxy_cidrs: &[String],
 ) -> Router {
-    let auth_cfg = AuthConfig {
-        token_hash: auth_token.map(|t| blake3::hash(t.as_bytes())),
-    };
-    let parsed_cidrs: Vec<Cidr> = trusted_proxy_cidrs
-        .iter()
-        .filter_map(|s| {
-            let c = Cidr::parse(s);
-            if c.is_none() {
-                tracing::warn!(cidr = %s, "gateway: invalid trusted_proxy_cidr, ignoring");
-            }
-            c
-        })
-        .collect();
-    let rate_state = RateLimitState {
-        limit: rate_limit,
-        counters: Arc::new(Mutex::new(HashMap::new())),
-        trusted_cidrs: Arc::new(parsed_cidrs),
-    };
+    let auth_cfg = AuthConfig::new(auth_token, false);
+    let rate_state = RateLimitState::new(rate_limit, trusted_proxy_cidrs);
 
     let protected = Router::new()
         .route("/webhook", post(webhook_handler))
@@ -150,115 +48,12 @@ pub(crate) fn build_router(
         .with_state(state)
 }
 
-/// Axum middleware that enforces bearer-token authentication.
-///
-/// When [`AuthConfig::token_hash`] is `Some`, the request must contain an
-/// `Authorization: Bearer <token>` header whose value, when hashed with BLAKE3,
-/// matches the pre-computed digest.  Comparison uses [`ConstantTimeEq`] on the
-/// two fixed-length 32-byte arrays so that the comparison time is independent
-/// of the token content, preventing timing-oracle attacks.
-///
-/// Requests without a valid token receive `401 Unauthorized`.
-/// When auth is not configured (`token_hash` is `None`) all requests pass through.
-async fn auth_middleware(
-    axum::extract::State(cfg): axum::extract::State<AuthConfig>,
-    req: Request<Body>,
-    next: Next,
-) -> Response {
-    if let Some(expected_hash) = cfg.token_hash {
-        let auth_header = req
-            .headers()
-            .get("authorization")
-            .and_then(|v| v.to_str().ok());
-
-        let token = auth_header
-            .and_then(|v| v.strip_prefix("Bearer "))
-            .unwrap_or("");
-
-        // Hash the submitted token to a fixed-length digest before comparing.
-        // Expected token hash is pre-computed at startup (stored in AuthConfig).
-        // ct_eq operates on two 32-byte arrays — constant time regardless of content.
-        let token_hash = blake3::hash(token.as_bytes());
-        if !bool::from(token_hash.as_bytes().ct_eq(expected_hash.as_bytes())) {
-            return StatusCode::UNAUTHORIZED.into_response();
-        }
-    }
-
-    next.run(req).await
-}
-
-/// Axum middleware that enforces a per-IP fixed-window rate limit.
-///
-/// Each remote IP is tracked independently.  A counter is incremented on every
-/// request within the current window.  When the counter exceeds
-/// [`RateLimitState::limit`] the request receives `429 Too Many Requests`.
-///
-/// The window resets when [`RATE_WINDOW`] has elapsed since the first request in
-/// the current window.  When [`RateLimitState::limit`] is `0` the middleware
-/// passes all requests through without tracking.
-///
-/// To prevent unbounded memory growth, expired entries are evicted when the
-/// counters map reaches [`MAX_RATE_LIMIT_ENTRIES`] and a new IP is encountered.
-async fn rate_limit_middleware(
-    axum::extract::State(state): axum::extract::State<RateLimitState>,
-    req: Request<Body>,
-    next: Next,
-) -> Response {
-    if state.limit == 0 {
-        return next.run(req).await;
-    }
-
-    let peer_ip = req
-        .extensions()
-        .get::<ConnectInfo<std::net::SocketAddr>>()
-        .map_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), |ci| ci.0.ip());
-
-    // When trusted proxy CIDRs are configured and the TCP peer falls within one of them,
-    // apply the rightmost-untrusted algorithm on X-Forwarded-For: walk the header values
-    // from right to left and pick the first IP that is not in any trusted CIDR.
-    let ip = if !state.trusted_cidrs.is_empty()
-        && state.trusted_cidrs.iter().any(|c| c.contains(peer_ip))
-    {
-        let xff_ip = req
-            .headers()
-            .get("x-forwarded-for")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| {
-                v.split(',')
-                    .map(str::trim)
-                    .filter_map(|s| s.parse::<IpAddr>().ok())
-                    .rev()
-                    .find(|ip| !state.trusted_cidrs.iter().any(|c| c.contains(*ip)))
-            });
-        xff_ip.unwrap_or(peer_ip)
-    } else {
-        peer_ip
-    };
-
-    let now = Instant::now();
-    let mut counters = state.counters.lock().await;
-
-    if counters.len() >= MAX_RATE_LIMIT_ENTRIES && !counters.contains_key(&ip) {
-        counters.retain(|_, (_, ts)| now.duration_since(*ts) < RATE_WINDOW);
-    }
-
-    let entry = counters.entry(ip).or_insert((0, now));
-    if now.duration_since(entry.1) >= RATE_WINDOW {
-        *entry = (1, now);
-    } else {
-        entry.0 += 1;
-        if entry.0 > state.limit {
-            return StatusCode::TOO_MANY_REQUESTS.into_response();
-        }
-    }
-    drop(counters);
-
-    next.run(req).await
-}
-
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use axum::body::Body;
+    use axum::http::Request;
     use http_body_util::BodyExt;
     use tower::{Service, ServiceExt};
 
@@ -529,94 +324,8 @@ mod tests {
         assert_eq!(resp.status(), 413);
     }
 
-    /// Statistical timing test for SEC-M22-001.
-    ///
-    /// Verifies that `ct_eq` comparison time is constant regardless of token length.
-    /// Both inputs are hashed to 32-byte BLAKE3 digests before comparison, so
-    /// `ct_eq` always operates on identically-sized arrays — timing must not vary.
-    #[test]
-    fn bearer_ct_eq_is_constant_time() {
-        use std::time::Instant;
-
-        const ITERS: u32 = 100_000;
-        // Max allowed ratio between slowest and fastest measurement (10× is very conservative;
-        // in practice the ratio is < 2× on any machine, but CI can be noisy).
-        const MAX_RATIO: u128 = 10;
-
-        let expected_hash = blake3::hash(b"super-secret-gateway-token");
-
-        // Tokens of vastly different lengths whose hashes are all wrong (→ ct_eq returns false).
-        let candidates: &[&[u8]] = &[b"x", b"wrong_token_123", &[b'z'; 512]];
-        let mut times_ns: Vec<u128> = Vec::with_capacity(candidates.len());
-
-        for candidate in candidates {
-            let h = blake3::hash(candidate);
-            // Warm up to avoid first-call JIT / cache effects.
-            for _ in 0..1_000 {
-                let _ = h.as_bytes().ct_eq(expected_hash.as_bytes());
-            }
-            let start = Instant::now();
-            for _ in 0..ITERS {
-                let _ = h.as_bytes().ct_eq(expected_hash.as_bytes());
-            }
-            times_ns.push(start.elapsed().as_nanos() / u128::from(ITERS));
-        }
-
-        let min = *times_ns.iter().min().unwrap();
-        let max = *times_ns.iter().max().unwrap();
-        assert!(
-            min > 0 && max / min < MAX_RATIO,
-            "ct_eq timing ratio {max}/{min} exceeds {MAX_RATIO}×; times per iter: {times_ns:?} ns"
-        );
-    }
-
-    // ── Cidr unit tests (#3909 regression) ──────────────────────────────────
-
-    #[test]
-    fn cidr_ipv4_contains_in_range() {
-        let cidr = Cidr::parse("10.0.0.0/8").unwrap();
-        assert!(cidr.contains("10.1.2.3".parse().unwrap()));
-        assert!(cidr.contains("10.255.255.255".parse().unwrap()));
-        assert!(!cidr.contains("11.0.0.0".parse().unwrap()));
-        assert!(!cidr.contains("9.255.255.255".parse().unwrap()));
-    }
-
-    #[test]
-    fn cidr_ipv4_slash32_exact_host() {
-        let cidr = Cidr::parse("192.168.1.100/32").unwrap();
-        assert!(cidr.contains("192.168.1.100".parse().unwrap()));
-        assert!(!cidr.contains("192.168.1.101".parse().unwrap()));
-    }
-
-    #[test]
-    fn cidr_ipv4_slash0_matches_all() {
-        let cidr = Cidr::parse("0.0.0.0/0").unwrap();
-        assert!(cidr.contains("1.2.3.4".parse().unwrap()));
-        assert!(cidr.contains("255.255.255.255".parse().unwrap()));
-    }
-
-    #[test]
-    fn cidr_ipv6_contains_in_range() {
-        let cidr = Cidr::parse("::1/128").unwrap();
-        assert!(cidr.contains("::1".parse().unwrap()));
-        assert!(!cidr.contains("::2".parse().unwrap()));
-    }
-
-    #[test]
-    fn cidr_ipv4_v6_mismatch_returns_false() {
-        let cidr = Cidr::parse("10.0.0.0/8").unwrap();
-        assert!(!cidr.contains("::1".parse().unwrap()));
-    }
-
-    #[test]
-    fn cidr_parse_rejects_invalid() {
-        assert!(Cidr::parse("not-a-cidr").is_none());
-        assert!(Cidr::parse("10.0.0.0/33").is_none());
-        assert!(Cidr::parse("::1/129").is_none());
-        assert!(Cidr::parse("10.0.0.0/").is_none());
-    }
-
     // ── XFF rightmost-untrusted tests (#3909 regression) ────────────────────
+    // CIDR and ct_eq unit tests live in zeph-common::http_middleware::tests.
 
     #[tokio::test]
     async fn xff_rightmost_untrusted_selected() {

--- a/crates/zeph-sanitizer/src/shadow_memory.rs
+++ b/crates/zeph-sanitizer/src/shadow_memory.rs
@@ -101,6 +101,9 @@ pub struct GoalDriftResult {
 /// Create via [`ShadowMemory::new`] with a [`ShadowMemoryConfig`]. Returns `None` when
 /// the config has `enabled = false`, so callers can wrap it in `Option<ShadowMemory>`.
 ///
+/// Note: this component is not currently wired into the agent tool executor; it is a
+/// standalone goal-drift analysis component intended for future integration.
+///
 /// # Examples
 ///
 /// ```rust

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3956,7 +3956,7 @@ mod tests {
         verdict: zeph_core::agent::shadow_sentinel::ProbeVerdict,
     ) -> ShadowSentinelProbeGateAdapter {
         use zeph_core::agent::shadow_sentinel::{
-            ProbeVerdict, SafetyProbe, ShadowEvent, ShadowEventStore, ShadowSentinel,
+            ProbeVerdict, SafetyProbe, SentinelEvent, ShadowEventStore, ShadowSentinel,
         };
 
         struct FixedProbe(ProbeVerdict);
@@ -3965,7 +3965,7 @@ mod tests {
                 &'a self,
                 _: &'a str,
                 _: &'a serde_json::Value,
-                _: &'a [ShadowEvent],
+                _: &'a [SentinelEvent],
             ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>
             {
                 let v = self.0.clone();
@@ -4024,7 +4024,7 @@ mod tests {
     #[tokio::test]
     async fn probe_gate_adapter_maps_skip_when_disabled() {
         use zeph_core::agent::shadow_sentinel::{
-            ProbeVerdict, SafetyProbe, ShadowEvent, ShadowEventStore, ShadowSentinel,
+            ProbeVerdict, SafetyProbe, SentinelEvent, ShadowEventStore, ShadowSentinel,
         };
         use zeph_tools::{ProbeGate, ProbeOutcome};
 
@@ -4034,7 +4034,7 @@ mod tests {
                 &'a self,
                 _: &'a str,
                 _: &'a serde_json::Value,
-                _: &'a [ShadowEvent],
+                _: &'a [SentinelEvent],
             ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>
             {
                 Box::pin(async { panic!("probe must not be called when disabled") })


### PR DESCRIPTION
## Summary

- Rename `zeph_core::agent::shadow_sentinel::ShadowEvent` → `SentinelEvent` to eliminate the naming collision with `zeph_sanitizer::shadow_memory::ShadowEvent`. `ShadowEventStore` and `ShadowEventRow` are unambiguous and kept unchanged. A doc note is added to `ShadowMemory` confirming it is not wired into the agent tool executor (closes #4379).
- Extract `AuthConfig`, `AuthIdentity`, `Cidr`, `RateLimitState`, `auth_middleware`, and `rate_limit_middleware` from `zeph-gateway` and `zeph-a2a` into a new `zeph-common::http_middleware` module behind the `http-middleware` feature gate. Gateway's pre-hashing approach is canonical. Both routers now import from the shared module (closes #4387).

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9907/9907 passed
- [ ] `grep -rn "ShadowEvent" crates/ src/ --include="*.rs"` — only `zeph-sanitizer` hits (correct)
- [ ] Feature-gated build: `cargo build -p zeph-common --features http-middleware` — passes
- [ ] Gateway and a2a build: `cargo build -p zeph-gateway --features gateway && cargo build -p zeph-a2a --features a2a` — pass