### PR TITLE
feat(memory,core): wire TrajectoryRiskAccumulator and add shadow memory metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   auth and per-IP rate-limit axum middleware extracted from `zeph-gateway` and `zeph-a2a`;
   eliminates duplicated `AuthConfig`, `RateLimitState`, `Cidr`, `auth_middleware`,
   `rate_limit_middleware` implementations; gateway's pre-hashing + `subtle::ConstantTimeEq`
-  approach is canonical (closes #4387).- `zeph-memory`, `zeph-config`: Five-signal SYNAPSE retrieval (#4374). Extends the recall
+  approach is canonical (closes #4387).
+- `zeph-core`, `zeph-memory`: Wire `TrajectoryRiskAccumulator` (MAGE spec 004-16) into the
+  tool execution gate (#4380). When `memory.shadow_memory.enabled = true` and the accumulated
+  trajectory risk reaches `risk_threshold`, all tool calls in the current turn are blocked with
+  `ToolError::TrajectoryRiskExceeded`. Signal ingestion bridges the existing `trajectory_signal_queue`
+  codes (PolicyDeny, VigilMedium/High, ExfiltrationRedaction) to MAGE `AuditSignalType` variants;
+  exponential temporal decay is applied once per turn via `advance_turn()` in `begin_turn()`.
+  Blocked dispatches bypass the tier-execution loop and produce structured error results.
+- `zeph-memory`: Prometheus counters for shadow memory (spec 004-16 NFR-007, #4396).
+  `shadow_memory_signals_total{type,severity}` increments on every `ingest()` call;
+  `shadow_memory_blocks_total` and `shadow_memory_escalations_total` are incremented via new
+  `record_block()` / `record_escalation()` methods called from the gate.
+
+### Fixed
+
+- `zeph-memory`: Remove `info_span!` from `TrajectoryRiskAccumulator::current_risk()` (#4397).
+  The method is a pure getter with no I/O; creating a span on every call added ~1 µs overhead
+  and polluted traces with noise. Spans remain on `advance_turn()` and `ingest()`.
+
+- `zeph-memory`, `zeph-config`: Five-signal SYNAPSE retrieval (#4374). Extends the recall
   pipeline with three signals beyond the two-signal baseline (recency + relevance): access
   frequency (facts queried more often rank higher), causal distance (facts closer to the current
   goal entity in the MAGMA graph rank higher), and novelty (facts created earlier in the session

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10885,6 +10885,7 @@ dependencies = [
  "futures",
  "insta",
  "lru 0.18.0",
+ "metrics",
  "parking_lot",
  "pdf-extract",
  "petgraph 0.8.3",

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1404,16 +1404,31 @@ impl<C: Channel> Agent<C> {
         self.runtime.lifecycle.turn_llm_requests = 0;
 
         // Spec 050 §2: drain pending risk signals from executor layers before advancing.
+        // Also advance MAGE accumulator (spec 004-16 FR-009) and ingest mapped signals.
         {
+            use zeph_memory::shadow::{AuditSignalType as MageSignal, Severity as MageSev};
             let pending: Vec<u8> = {
                 let mut q = self.services.security.trajectory_signal_queue.lock();
                 std::mem::take(&mut *q)
             };
+            self.services.security.mage_accumulator.advance_turn();
             for code in pending {
                 self.services
                     .security
                     .trajectory
                     .record(crate::agent::trajectory::RiskSignal::from_code(code));
+                // Map signal codes to MAGE AuditSignalType + Severity (spec 004-16 FR-002, FR-007).
+                // Code 1=PolicyDeny, 6=VigilMedium, 7=VigilHigh, 2=ExfiltrationRedaction.
+                let mage_signal: Option<(MageSignal, MageSev)> = match code {
+                    1 => Some((MageSignal::PolicyViolation, MageSev::Medium)),
+                    2 => Some((MageSignal::ToolChainAnomaly, MageSev::Medium)),
+                    6 => Some((MageSignal::PromptInjectionPattern, MageSev::Medium)),
+                    7 => Some((MageSignal::PromptInjectionPattern, MageSev::High)),
+                    _ => None,
+                };
+                if let Some((sig, sev)) = mage_signal {
+                    self.services.security.mage_accumulator.ingest(sig, sev);
+                }
             }
         }
         // Spec 050 Invariant 2: advance trajectory sentinel BEFORE any gate evaluation.

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -376,6 +376,13 @@ pub(crate) struct SecurityState {
     /// `None` by default. When `Some`, `begin_turn()` calls `reset()` to clear per-turn state.
     /// The same `Arc` must be passed to `ShellExecutor::with_risk_chain` at build time.
     pub(crate) risk_chain_accumulator: Option<std::sync::Arc<zeph_tools::RiskChainAccumulator>>,
+    /// MAGE trajectory risk accumulator (spec 004-16).
+    ///
+    /// Per-session in-memory accumulator that ingests sanitizer audit signals with exponential
+    /// temporal decay and gates tool execution when cumulative risk exceeds `risk_threshold`.
+    /// Initialized as noop when `memory.shadow_memory.enabled = false` (default).
+    /// `begin_turn()` calls `advance_turn()` then ingests pending signal codes.
+    pub(crate) mage_accumulator: zeph_memory::shadow::TrajectoryRiskAccumulator,
 }
 
 /// Groups debug/diagnostics subsystems (dumper, trace collector, anomaly detector, logging config).

--- a/crates/zeph-core/src/agent/state/security.rs
+++ b/crates/zeph-core/src/agent/state/security.rs
@@ -56,6 +56,7 @@ impl Default for SecurityState {
             trajectory_signal_queue: std::sync::Arc::new(parking_lot::Mutex::new(Vec::new())),
             shadow_sentinel: None,
             risk_chain_accumulator: None,
+            mage_accumulator: zeph_memory::shadow::TrajectoryRiskAccumulator::new_noop(),
         }
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -50,6 +50,11 @@ struct ToolDispatchContext {
     args_hashes: Vec<u64>,
     repeat_blocked: Vec<bool>,
     cache_hits: Vec<Option<zeph_tools::ToolOutput>>,
+    /// MAGE trajectory risk gate (spec 004-16 FR-005).
+    ///
+    /// When `Some((score, top_signals))`, all tool calls in this batch are blocked with
+    /// `ToolError::TrajectoryRiskExceeded`. Set when `mage_accumulator.is_blocked()` at dispatch time.
+    mage_blocked: Option<(f64, Vec<String>)>,
 }
 
 /// Output of `Agent::classify_tool_result`: all fields derived from the raw `ToolResult`.

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -510,6 +510,7 @@ impl<C: Channel> Agent<C> {
             args_hashes,
             repeat_blocked,
             cache_hits,
+            mage_blocked,
         } = self.prepare_tool_dispatch(tool_calls);
 
         let max_retries = self.tool_orchestrator.max_tool_retries;
@@ -523,8 +524,24 @@ impl<C: Channel> Agent<C> {
         // Phase 1: Tiered parallel execution bounded by a shared semaphore.
         // Extracted to run_tier_execution_loop to satisfy the line-count limit.
         // Returns None when the user cancelled (caller must return Ok(())).
-        let tier_data = self
-            .run_tier_execution_loop(
+        // MAGE override: if trajectory risk is exceeded, bypass the tier loop and build
+        // blocked results directly so process_tool_result_batch renders them normally.
+        let tier_data: TierLoopOutput = if let Some((score, top_signals)) = mage_blocked {
+            Some(TierLoopData {
+                tool_results: calls
+                    .iter()
+                    .map(|_| {
+                        Err(zeph_tools::ToolError::TrajectoryRiskExceeded {
+                            score,
+                            top_signals: top_signals.clone(),
+                        })
+                    })
+                    .collect(),
+                pending_focus_checkpoint: None,
+                pending_system_hints: Vec::new(),
+            })
+        } else {
+            self.run_tier_execution_loop(
                 tool_calls,
                 &calls,
                 &pre_exec_blocked,
@@ -538,7 +555,8 @@ impl<C: Channel> Agent<C> {
                 &tool_call_ids,
                 &mut tool_started_ats,
             )
-            .await?;
+            .await?
+        };
 
         // Unpack tier execution output. None means the user cancelled — return early.
         let Some(TierLoopData {
@@ -759,6 +777,10 @@ impl<C: Channel> Agent<C> {
         // Inject active skill secrets before tool execution.
         self.inject_active_skill_env();
 
+        // MAGE trajectory risk gate (spec 004-16 FR-004, FR-005).
+        // Extracted to keep prepare_tool_dispatch under the line limit.
+        let mage_blocked = self.check_mage_block();
+
         ToolDispatchContext {
             calls,
             tool_call_ids,
@@ -769,7 +791,40 @@ impl<C: Channel> Agent<C> {
             args_hashes,
             repeat_blocked,
             cache_hits,
+            mage_blocked,
         }
+    }
+
+    /// Check MAGE trajectory risk gate (spec 004-16 FR-004, FR-005).
+    ///
+    /// Returns `Some((score, top_signals))` when the accumulator is blocked. Emits a security
+    /// event, increments `pre_execution_blocks`, and calls `record_block()` on the accumulator.
+    fn check_mage_block(&mut self) -> Option<(f64, Vec<String>)> {
+        if !self.services.security.mage_accumulator.is_blocked() {
+            return None;
+        }
+        let score = self.services.security.mage_accumulator.current_risk();
+        let top: Vec<String> = self
+            .services
+            .security
+            .mage_accumulator
+            .top_signals(3)
+            .iter()
+            .map(|s| format!("{:?}({:?})", s.signal_type, s.severity))
+            .collect();
+        tracing::warn!(
+            score,
+            signals = ?top,
+            "MAGE trajectory risk accumulator blocked tool dispatch"
+        );
+        self.update_metrics(|m| m.pre_execution_blocks += 1);
+        self.push_security_event(
+            zeph_common::SecurityEventCategory::PreExecutionBlock,
+            "<mage>",
+            format!("trajectory risk {score:.3} exceeds threshold"),
+        );
+        self.services.security.mage_accumulator.record_block();
+        Some((score, top))
     }
 
     fn check_exfiltration_urls(&mut self, tool_calls: &[zeph_llm::provider::ToolUseRequest]) {

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { workspace = true, features = ["std", "clock"] }
 dashmap.workspace = true
 futures.workspace = true
 lru.workspace = true
+metrics.workspace = true
 parking_lot.workspace = true
 pdf-extract = { workspace = true, optional = true }
 petgraph.workspace = true

--- a/crates/zeph-memory/src/shadow/mod.rs
+++ b/crates/zeph-memory/src/shadow/mod.rs
@@ -28,6 +28,23 @@ use zeph_config::TrajectoryRiskAccumulatorConfig;
 
 pub use zeph_common::audit::{AuditSignalType, Severity};
 
+fn signal_type_label(t: AuditSignalType) -> &'static str {
+    match t {
+        AuditSignalType::PolicyViolation => "policy_violation",
+        AuditSignalType::PromptInjectionPattern => "prompt_injection",
+        AuditSignalType::ToolChainAnomaly => "tool_chain_anomaly",
+        AuditSignalType::ConfidenceDrop => "confidence_drop",
+    }
+}
+
+fn severity_label(s: Severity) -> &'static str {
+    match s {
+        Severity::Low => "low",
+        Severity::Medium => "medium",
+        Severity::High => "high",
+    }
+}
+
 /// A recorded safety signal ingested during a specific turn.
 #[derive(Debug, Clone)]
 pub struct SignalEvent {
@@ -121,6 +138,8 @@ impl TrajectoryRiskAccumulator {
     /// appended to the signal history ring buffer; the oldest entry is evicted when
     /// the buffer is full.
     ///
+    /// Emits `shadow_memory_signals_total{type, severity}` counter (NFR-007).
+    ///
     /// No-op when disabled.
     pub fn ingest(&mut self, signal_type: AuditSignalType, severity: Severity) {
         let _span = info_span!("memory.shadow.ingest").entered();
@@ -151,6 +170,28 @@ impl TrajectoryRiskAccumulator {
             severity,
             raw_score,
         });
+
+        metrics::counter!(
+            "shadow_memory_signals_total",
+            "type" => signal_type_label(signal_type),
+            "severity" => severity_label(severity),
+        )
+        .increment(1);
+    }
+
+    /// Increment `shadow_memory_blocks_total` counter (NFR-007).
+    ///
+    /// Call this once when a tool execution is actually blocked due to trajectory risk.
+    /// Do **not** call on every `is_blocked()` query — only when a block action fires.
+    pub fn record_block(&self) {
+        metrics::counter!("shadow_memory_blocks_total").increment(1);
+    }
+
+    /// Increment `shadow_memory_escalations_total` counter (NFR-007).
+    ///
+    /// Call this once when an escalation-to-human-confirmation is triggered.
+    pub fn record_escalation(&self) {
+        metrics::counter!("shadow_memory_escalations_total").increment(1);
     }
 
     /// Returns the current accumulated risk score in `[0.0, 1.0]`.
@@ -158,7 +199,6 @@ impl TrajectoryRiskAccumulator {
     /// Always returns `0.0` when disabled.
     #[must_use]
     pub fn current_risk(&self) -> f64 {
-        let _span = info_span!("memory.shadow.current_risk").entered();
         if self.config.is_none() {
             return 0.0;
         }


### PR DESCRIPTION
## Summary

- Wires `TrajectoryRiskAccumulator` (MAGE spec 004-16) into the tool execution gate in `zeph-core` (#4380). When `memory.shadow_memory.enabled = true` and trajectory risk reaches `risk_threshold`, all tool calls in the current turn are blocked with `ToolError::TrajectoryRiskExceeded`.
- Adds Prometheus counters to shadow memory: `shadow_memory_signals_total{type,severity}`, `shadow_memory_blocks_total`, `shadow_memory_escalations_total` (NFR-007, #4396).
- Removes `info_span!` from `current_risk()` — pure getter, span polluted traces and added ~1 µs per hot-path call (#4397).

## Changes

**`zeph-memory/src/shadow/mod.rs`**
- Add `metrics` crate dependency; emit `shadow_memory_signals_total` counter in `ingest()`
- Add `record_block()` / `record_escalation()` methods for gate call sites
- Remove `info_span!("memory.shadow.current_risk")` from `current_risk()`
- Add `signal_type_label()` / `severity_label()` helpers for counter labels

**`zeph-core/src/agent/mod.rs`** (`begin_turn`)
- Call `mage_accumulator.advance_turn()` before draining the signal queue
- Map existing `trajectory_signal_queue` codes (1/2/6/7) to `MageSignal`+`MageSev` and call `ingest()`

**`zeph-core/src/agent/state/mod.rs`** / **`security.rs`**
- Add `mage_accumulator: zeph_memory::shadow::TrajectoryRiskAccumulator` to `SecurityState`; default-initialized as noop

**`zeph-core/src/agent/tool_execution/`**
- Add `mage_blocked: Option<(f64, Vec<String>)>` to `ToolDispatchContext`
- Extract `check_mage_block()` method (called from `prepare_tool_dispatch()`)
- Bypass tier-execution loop when MAGE-blocked; produce `ToolError::TrajectoryRiskExceeded` for each call in the batch

## Test plan

- [ ] `cargo nextest run -p zeph-memory -p zeph-core --lib --bins` — 2887 tests pass
- [ ] `cargo clippy -p zeph-memory -p zeph-core -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Live test with `memory.shadow_memory.enabled = true` and a multi-turn session emitting PolicyViolation signals should eventually block tool calls at `risk_threshold = 0.75`

Closes #4380
Closes #4396
Closes #4397