### PR TITLE
feat(skills): GoSkills group-structured retrieval and plugin tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `zeph-skills`: GoSkills group-structured skill retrieval (#4411). New `group` module with
+  `SkillGroup`, `SkillRole` (EntryPoint / Support / Context), `GroupResult`, and `group_skills()`
+  that computes inter-skill cosine similarity (reusing `zeph_common::math::cosine_similarity`) and
+  groups top-N matched skills into an entry-point + support structure. New
+  `format_grouped_skills_prompt()` in `prompt.rs` emits role-labelled `<active_skill>` XML with
+  the same per-skill trust sanitization, quarantine wrapping, and health attributes as the flat
+  path. Quarantined skills are excluded from support roles. Empty `requirements` and
+  `failure_notes` blocks are omitted from output. Flat fallback is used when no pair exceeds the
+  configured threshold.
+- `zeph-config`: `skills.group_structured` (bool, default `false`) and
+  `skills.support_similarity_threshold` (f32, default `0.50`) config fields for GoSkills (#4411).
+  Threshold outside `[0.0, 1.0]` emits a runtime warning.
+- `zeph-experiments`: `ParameterKind::GroupStructured` variant for A/B experiment gating of
+  GoSkills grouped injection (#4411). Added to `ConfigSnapshot` and wired through `get`/`set`/
+  `diff`/`from_config`.
+- `zeph-plugins`: tracing spans on `collect_skill_dirs`, `update_one_plugin`, and
+  `download_archive` in `PluginManager` (#4385), following the `plugins.manager.*` naming
+  convention.
+
 - `zeph-common`: new `http_middleware` module (feature `http-middleware`) — shared bearer-token
   auth and per-IP rate-limit axum middleware extracted from `zeph-gateway` and `zeph-a2a`;
   eliminates duplicated `AuthConfig`, `RateLimitState`, `Cidr`, `auth_middleware`,

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -358,10 +358,33 @@ pub struct SkillsConfig {
     /// is configured at all, the semantic scan is skipped with a warning.
     #[serde(default)]
     pub semantic_scan_provider: ProviderName,
+
+    /// Enable `GoSkills` group-structured skill injection.
+    ///
+    /// When `true`, the top-N matched skills are presented to the LLM as an
+    /// entry-point + support structure, improving multi-skill task execution.
+    /// Falls back to flat injection when no pair exceeds `support_similarity_threshold`.
+    ///
+    /// Default: `false`.
+    #[serde(default)]
+    pub group_structured: bool,
+
+    /// Inter-skill cosine similarity threshold for `GoSkills` grouping.
+    ///
+    /// A candidate skill becomes a support skill when its cosine similarity to the
+    /// entry point exceeds this value (strict `>`). Valid range: `[0.0, 1.0]`.
+    ///
+    /// Default: `0.50`.
+    #[serde(default = "default_support_similarity_threshold")]
+    pub support_similarity_threshold: f32,
 }
 
 fn default_generation_timeout_ms() -> u64 {
     60_000
+}
+
+fn default_support_similarity_threshold() -> f32 {
+    0.50
 }
 
 // --- SkillEvaluationConfig defaults ---

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -221,6 +221,8 @@ impl Default for Config {
                 disambiguate_provider: crate::providers::ProviderName::default(),
                 semantic_scan: false,
                 semantic_scan_provider: crate::providers::ProviderName::default(),
+                group_structured: false,
+                support_similarity_threshold: 0.50,
             },
             memory: MemoryConfig {
                 sqlite_path: default_sqlite_path_field(),

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -7,8 +7,11 @@ use std::sync::Arc;
 use zeph_agent_context::helpers::BudgetHint;
 use zeph_llm::provider::LlmProvider;
 use zeph_skills::ScoredMatch;
+use zeph_skills::group::{GroupResult, group_skills};
 use zeph_skills::loader::SkillMeta;
-use zeph_skills::prompt::{format_skills_catalog, format_skills_prompt_compact};
+use zeph_skills::prompt::{
+    format_grouped_skills_prompt, format_skills_catalog, format_skills_prompt_compact,
+};
 
 use super::super::{Agent, Skill, format_skills_prompt};
 use crate::channel::Channel;
@@ -874,7 +877,46 @@ impl<C: Channel> Agent<C> {
                     .iter()
                     .map(|(k, v)| (k.clone(), v.trust_level))
                     .collect();
-            format_skills_prompt(&active_skills, &trust_levels, &health_map)
+
+            // GoSkills: experiment engine applies config overrides before context assembly,
+            // so checking services.skill.group_structured here reflects any active A/B variation.
+            if self.services.skill.group_structured
+                && let Some(matcher) = &self.services.skill.matcher
+            {
+                let threshold = self.services.skill.support_similarity_threshold;
+                if !(0.0..=1.0).contains(&threshold) {
+                    tracing::warn!(
+                        threshold,
+                        "support_similarity_threshold is outside [0.0, 1.0]; GoSkills grouping may behave unexpectedly"
+                    );
+                }
+                let group_result = group_skills(
+                    &active_skills,
+                    &matched_indices,
+                    |idx| matcher.skill_embedding(idx),
+                    threshold,
+                );
+                match group_result {
+                    GroupResult::Grouped(ref g) => {
+                        tracing::debug!(
+                            entry_point = g.entry_point.name(),
+                            support_count = g.support.len(),
+                            threshold,
+                            "GoSkills: grouped skill injection"
+                        );
+                        format_grouped_skills_prompt(g, &trust_levels, &health_map)
+                    }
+                    GroupResult::Flat(_) => {
+                        tracing::debug!(
+                            threshold,
+                            "GoSkills: flat fallback (no pair above threshold)"
+                        );
+                        format_skills_prompt(&active_skills, &trust_levels, &health_map)
+                    }
+                }
+            } else {
+                format_skills_prompt(&active_skills, &trust_levels, &health_map)
+            }
         };
         // ERL: append learned heuristics for active skills (no-op when erl_enabled = false).
         let erl_suffix = self.build_erl_heuristics_prompt().await;
@@ -1800,6 +1842,136 @@ mod tests {
     }
 
     // ── Blocked-skill catalog filter (GAP-1) ────────────────────────────────
+
+    // ── GoSkills group-structured injection branch tests ─────────────────────
+
+    #[test]
+    fn group_structured_branch_produces_active_skill_tags_when_above_threshold() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use zeph_common::SkillTrustLevel;
+        use zeph_skills::group::{GroupResult, group_skills};
+        use zeph_skills::loader::{Skill, SkillMeta};
+        use zeph_skills::prompt::format_grouped_skills_prompt;
+
+        fn make_skill(name: &str) -> Skill {
+            Skill {
+                meta: SkillMeta {
+                    name: name.into(),
+                    description: "desc".into(),
+                    compatibility: None,
+                    license: None,
+                    metadata: vec![],
+                    allowed_tools: vec![],
+                    requires_secrets: vec![],
+                    skill_dir: PathBuf::new(),
+                    source_url: None,
+                    git_hash: None,
+                    category: None,
+                },
+                body: "body".into(),
+            }
+        }
+
+        static EMBED_A: &[f32] = &[1.0, 0.0, 0.0];
+        static EMBED_B: &[f32] = &[0.9, 0.1, 0.0]; // cosine ≈ 0.994 — above 0.50
+
+        let skills = vec![make_skill("entry"), make_skill("support-a")];
+        let indices = [0usize, 1usize];
+        let threshold = 0.50_f32;
+
+        // Simulate the assembly branch: group_skills → matched → format_grouped_skills_prompt
+        let group_result = group_skills(
+            &skills,
+            &indices,
+            |idx: usize| match idx {
+                0 => Some(EMBED_A),
+                1 => Some(EMBED_B),
+                _ => None,
+            },
+            threshold,
+        );
+
+        // The branch should produce Grouped (similarity ≈ 0.994 > 0.50)
+        assert!(
+            matches!(group_result, GroupResult::Grouped(_)),
+            "expected Grouped when pair exceeds threshold"
+        );
+
+        // Format as the grouped branch does
+        let mut trust: HashMap<String, SkillTrustLevel> = HashMap::new();
+        trust.insert("entry".into(), SkillTrustLevel::Trusted);
+        trust.insert("support-a".into(), SkillTrustLevel::Trusted);
+        let prompt = match &group_result {
+            GroupResult::Grouped(g) => format_grouped_skills_prompt(g, &trust, &HashMap::new()),
+            GroupResult::Flat(_) => panic!("expected Grouped"),
+        };
+
+        assert!(
+            prompt.contains("role=\"entry_point\""),
+            "grouped path must emit entry_point role"
+        );
+        assert!(
+            prompt.contains("role=\"support\""),
+            "grouped path must emit support role"
+        );
+        assert!(prompt.contains("name=\"entry\""));
+        assert!(prompt.contains("name=\"support-a\""));
+        // Must NOT use flat <skill> tags
+        assert!(
+            !prompt.contains("<skill name="),
+            "grouped path must not emit flat <skill> tags"
+        );
+    }
+
+    #[test]
+    fn group_structured_branch_falls_back_to_flat_when_below_threshold() {
+        use std::path::PathBuf;
+        use zeph_skills::group::{GroupResult, group_skills};
+        use zeph_skills::loader::{Skill, SkillMeta};
+
+        fn make_skill(name: &str) -> Skill {
+            Skill {
+                meta: SkillMeta {
+                    name: name.into(),
+                    description: "desc".into(),
+                    compatibility: None,
+                    license: None,
+                    metadata: vec![],
+                    allowed_tools: vec![],
+                    requires_secrets: vec![],
+                    skill_dir: PathBuf::new(),
+                    source_url: None,
+                    git_hash: None,
+                    category: None,
+                },
+                body: "body".into(),
+            }
+        }
+
+        static EMBED_A: &[f32] = &[1.0, 0.0, 0.0];
+        static EMBED_C: &[f32] = &[0.0, 0.0, 1.0]; // cosine = 0.0 — below 0.50
+
+        let skills = vec![make_skill("entry"), make_skill("unrelated")];
+        let indices = [0usize, 1usize];
+        let threshold = 0.50_f32;
+
+        let result = group_skills(
+            &skills,
+            &indices,
+            |idx: usize| match idx {
+                0 => Some(EMBED_A),
+                1 => Some(EMBED_C),
+                _ => None,
+            },
+            threshold,
+        );
+
+        assert!(
+            matches!(result, GroupResult::Flat(_)),
+            "below-threshold pair must produce flat fallback"
+        );
+    }
 
     #[test]
     fn blocked_skill_excluded_from_catalog_filter() {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -3138,6 +3138,9 @@ impl<C: Channel> Agent<C> {
         self.services.skill.two_stage_matching = config.skills.two_stage_matching;
         self.services.skill.confusability_threshold =
             config.skills.confusability_threshold.clamp(0.0, 1.0);
+        self.services.skill.group_structured = config.skills.group_structured;
+        self.services.skill.support_similarity_threshold =
+            config.skills.support_similarity_threshold;
         config
             .skills
             .generation_provider

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -138,6 +138,10 @@ pub(crate) struct SkillState {
     pub(crate) eval_weights: zeph_skills::evaluator::EvaluationWeights,
     /// Minimum composite score required to accept a generated skill (forwarded to the generator).
     pub(crate) eval_threshold: f32,
+    /// Enable `GoSkills` group-structured skill injection.
+    pub(crate) group_structured: bool,
+    /// Inter-skill cosine similarity threshold for `GoSkills` grouping.
+    pub(crate) support_similarity_threshold: f32,
 }
 
 pub(crate) struct McpState {
@@ -1147,6 +1151,8 @@ impl SkillState {
             skill_evaluator: None,
             eval_weights: zeph_skills::evaluator::EvaluationWeights::default(),
             eval_threshold: 0.60,
+            group_structured: false,
+            support_similarity_threshold: 0.50,
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/skill.rs
+++ b/crates/zeph-core/src/agent/state/skill.rs
@@ -21,6 +21,11 @@ impl SkillState {
     ///
     /// Returns the formatted prompt string. Does NOT update `last_skills_prompt` —
     /// the caller is responsible for storing the result.
+    ///
+    /// `GoSkills` group-structured formatting is intentionally NOT applied here: this
+    /// path is used during skill hot-reload without a per-turn query or embeddings,
+    /// so cosine similarity grouping cannot be computed. Grouping is only applied in
+    /// the per-turn context assembly path (`assembly.rs`).
     pub(crate) fn rebuild_prompt(
         all_skills: &[Skill],
         trust_map: &HashMap<String, SkillTrustSnapshot>,

--- a/crates/zeph-experiments/src/snapshot.rs
+++ b/crates/zeph-experiments/src/snapshot.rs
@@ -61,6 +61,8 @@ pub struct ConfigSnapshot {
     pub similarity_threshold: f64,
     /// Half-life in days for temporal memory decay.
     pub temporal_decay: f64,
+    /// GoSkills group-structured injection toggle (0.0 = disabled, 1.0 = enabled).
+    pub group_structured: f64,
 }
 
 impl Default for ConfigSnapshot {
@@ -74,6 +76,7 @@ impl Default for ConfigSnapshot {
             retrieval_top_k: 5.0,
             similarity_threshold: 0.35,
             temporal_decay: 30.0,
+            group_structured: 0.0,
         }
     }
 }
@@ -116,6 +119,11 @@ impl ConfigSnapshot {
             retrieval_top_k: config.memory.semantic.recall_limit as f64,
             similarity_threshold: f64::from(config.memory.cross_session_score_threshold),
             temporal_decay: f64::from(config.memory.semantic.temporal_decay_half_life_days),
+            group_structured: if config.skills.group_structured {
+                1.0
+            } else {
+                0.0
+            },
         }
     }
 
@@ -142,6 +150,7 @@ impl ConfigSnapshot {
             ParameterKind::RetrievalTopK,
             ParameterKind::SimilarityThreshold,
             ParameterKind::TemporalDecay,
+            ParameterKind::GroupStructured,
         ];
         let mut result = None;
         for kind in kinds {
@@ -191,6 +200,7 @@ impl ConfigSnapshot {
             ParameterKind::RetrievalTopK => self.retrieval_top_k,
             ParameterKind::SimilarityThreshold => self.similarity_threshold,
             ParameterKind::TemporalDecay => self.temporal_decay,
+            ParameterKind::GroupStructured => self.group_structured,
             _ => 0.0,
         }
     }
@@ -219,6 +229,7 @@ impl ConfigSnapshot {
             ParameterKind::RetrievalTopK => self.retrieval_top_k = value,
             ParameterKind::SimilarityThreshold => self.similarity_threshold = value,
             ParameterKind::TemporalDecay => self.temporal_decay = value,
+            ParameterKind::GroupStructured => self.group_structured = value,
             _ => {}
         }
     }
@@ -325,6 +336,7 @@ mod tests {
             retrieval_top_k: 6.0,
             similarity_threshold: 0.7,
             temporal_decay: 8.0,
+            group_structured: 0.0,
         };
         assert!((s.get(ParameterKind::Temperature) - 0.1).abs() < f64::EPSILON);
         assert!((s.get(ParameterKind::TopP) - 0.2).abs() < f64::EPSILON);
@@ -334,6 +346,7 @@ mod tests {
         assert!((s.get(ParameterKind::RetrievalTopK) - 6.0).abs() < f64::EPSILON);
         assert!((s.get(ParameterKind::SimilarityThreshold) - 0.7).abs() < f64::EPSILON);
         assert!((s.get(ParameterKind::TemporalDecay) - 8.0).abs() < f64::EPSILON);
+        assert!((s.get(ParameterKind::GroupStructured) - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -347,6 +360,7 @@ mod tests {
         s.set(ParameterKind::RetrievalTopK, 10.0);
         s.set(ParameterKind::SimilarityThreshold, 0.5);
         s.set(ParameterKind::TemporalDecay, 60.0);
+        s.set(ParameterKind::GroupStructured, 1.0);
         assert!((s.temperature - 1.1).abs() < f64::EPSILON);
         assert!((s.top_p - 0.8).abs() < f64::EPSILON);
         assert!((s.top_k - 20.0).abs() < f64::EPSILON);
@@ -355,6 +369,7 @@ mod tests {
         assert!((s.retrieval_top_k - 10.0).abs() < f64::EPSILON);
         assert!((s.similarity_threshold - 0.5).abs() < f64::EPSILON);
         assert!((s.temporal_decay - 60.0).abs() < f64::EPSILON);
+        assert!((s.group_structured - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -402,7 +417,7 @@ mod tests {
     }
 
     #[test]
-    fn diff_all_eight_kinds() {
+    fn diff_all_nine_kinds() {
         let fields: &[(ParameterKind, fn(&mut ConfigSnapshot))] = &[
             (ParameterKind::Temperature, |s| s.temperature = 1.5),
             (ParameterKind::TopP, |s| s.top_p = 0.5),
@@ -416,6 +431,7 @@ mod tests {
                 s.similarity_threshold = 0.8;
             }),
             (ParameterKind::TemporalDecay, |s| s.temporal_decay = 60.0),
+            (ParameterKind::GroupStructured, |s| s.group_structured = 1.0),
         ];
         for (kind, mutate) in fields {
             let a = ConfigSnapshot::default();
@@ -439,6 +455,7 @@ mod tests {
             retrieval_top_k: 7.0,
             similarity_threshold: 0.4,
             temporal_decay: 45.0,
+            group_structured: 0.0,
         };
         let json = serde_json::to_string(&s).unwrap();
         let s2: ConfigSnapshot = serde_json::from_str(&json).unwrap();

--- a/crates/zeph-experiments/src/types.rs
+++ b/crates/zeph-experiments/src/types.rs
@@ -72,6 +72,11 @@ pub enum ParameterKind {
     SimilarityThreshold,
     /// Half-life in days for temporal memory decay (float).
     TemporalDecay,
+    /// GoSkills group-structured skill injection toggle (boolean: 0.0 = off, 1.0 = on).
+    ///
+    /// When active, this parameter overrides `skills.group_structured` in config,
+    /// bidirectionally (experiment can both enable and disable the feature).
+    GroupStructured,
 }
 
 impl ParameterKind {
@@ -100,6 +105,7 @@ impl ParameterKind {
             Self::RetrievalTopK => "retrieval_top_k",
             Self::SimilarityThreshold => "similarity_threshold",
             Self::TemporalDecay => "temporal_decay",
+            Self::GroupStructured => "group_structured",
             _ => "unknown",
         }
     }
@@ -296,6 +302,7 @@ mod tests {
             (ParameterKind::RetrievalTopK, "retrieval_top_k"),
             (ParameterKind::SimilarityThreshold, "similarity_threshold"),
             (ParameterKind::TemporalDecay, "temporal_decay"),
+            (ParameterKind::GroupStructured, "group_structured"),
         ];
         for (kind, expected) in cases {
             assert_eq!(kind.as_str(), expected);
@@ -313,6 +320,7 @@ mod tests {
         assert!(!ParameterKind::PresencePenalty.is_integer());
         assert!(!ParameterKind::SimilarityThreshold.is_integer());
         assert!(!ParameterKind::TemporalDecay.is_integer());
+        assert!(!ParameterKind::GroupStructured.is_integer());
     }
 
     #[test]

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -633,6 +633,7 @@ impl PluginManager {
     /// # Errors
     ///
     /// Returns [`PluginError`] if the plugins directory cannot be read.
+    #[tracing::instrument(name = "plugins.manager.collect_skill_dirs", skip_all)]
     pub fn collect_skill_dirs(&self) -> Result<Vec<PathBuf>, PluginError> {
         if !self.plugins_dir.exists() {
             return Ok(Vec::new());
@@ -732,6 +733,7 @@ impl PluginManager {
     }
 
     /// Attempt to update a single plugin. Returns the update status without aborting on error.
+    #[tracing::instrument(name = "plugins.manager.update_one", skip_all, fields(plugin = %plugin.name))]
     async fn update_one_plugin(&self, plugin: &InstalledPlugin) -> AutoUpdateStatus {
         let source_path = plugin.path.join(".plugin-source.toml");
         let Some(source) = read_plugin_source(&source_path) else {
@@ -848,6 +850,7 @@ impl PluginManager {
     }
 
     /// Download an archive from `url` respecting the per-phase timeout.
+    #[tracing::instrument(name = "plugins.manager.download_archive", skip_all, fields(url = %url))]
     async fn download_archive(
         &self,
         url: &str,

--- a/crates/zeph-skills/src/group.rs
+++ b/crates/zeph-skills/src/group.rs
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `GoSkills` group-structured skill retrieval.
+//!
+//! Groups a ranked list of skills into an entry-point + support structure by computing
+//! inter-skill cosine similarity on their in-process embeddings. Falls back to a flat
+//! list when no pair exceeds the configured threshold.
+//!
+//! # Flow
+//!
+//! ```text
+//! top-N skills (post-RRF, post-rerank)
+//!         │
+//!         ▼
+//!  group_skills() ──threshold exceeded?──► GroupResult::Grouped(SkillGroup)
+//!                                    │
+//!                                    └──► GroupResult::Flat(Vec<Skill>)
+//! ```
+
+use std::collections::HashMap;
+
+use crate::loader::Skill;
+
+/// Role of a skill within a group.
+///
+/// `Context` is reserved for future use (e.g., background reference skills) and is
+/// not assigned by the MVP grouping algorithm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillRole {
+    /// The primary skill that directly handles the user's intent.
+    EntryPoint,
+    /// A skill that assists the entry point (high cosine similarity).
+    Support,
+    /// A background context skill (reserved, not assigned in MVP).
+    Context,
+}
+
+/// A group of semantically related skills with an entry point and support skills.
+///
+/// `requirements` and `failure_notes` are present for forward-compatibility with the
+/// full `GoSkills` spec; they are empty in the MVP and the formatter skips empty blocks.
+#[derive(Debug, Clone)]
+pub struct SkillGroup {
+    /// The primary skill selected as entry point.
+    pub entry_point: Skill,
+    /// Skills with cosine similarity > threshold relative to the entry point.
+    pub support: Vec<Skill>,
+    /// Role assignment map from skill name to role.
+    pub role_labels: HashMap<String, SkillRole>,
+    /// Structured requirements extracted from the skill (empty in MVP).
+    pub requirements: Vec<String>,
+    /// Failure avoidance notes extracted from the skill (empty in MVP).
+    pub failure_notes: Vec<String>,
+}
+
+/// Outcome of the grouping step: a formed group or a flat fallback.
+#[derive(Debug, Clone)]
+pub enum GroupResult {
+    /// At least one support skill exceeded the similarity threshold.
+    Grouped(Box<SkillGroup>),
+    /// No pair exceeded the threshold; use the flat list as-is.
+    Flat(Vec<Skill>),
+}
+
+/// Compute inter-skill cosine similarity and form a group if the threshold is met.
+///
+/// `skills` must be the already-ranked top-N skills (post-RRF, post-rerank).
+/// `skill_indices` maps positions in `skills` to the original skill-store indices used
+/// by `get_embedding`.
+/// `get_embedding` is called with the original skill-store index and must return the
+/// in-process embedding slice, or `None` when unavailable (e.g., Qdrant backend).
+///
+/// Returns [`GroupResult::Grouped`] when the entry point (`skills[0]`) has at least one
+/// support skill whose cosine similarity exceeds `threshold`. Returns
+/// [`GroupResult::Flat`] when `skills.len() < 2`, any required embedding is missing,
+/// or no candidate exceeds the threshold.
+///
+/// The threshold comparison uses strict `>` (not `>=`) to prevent zero-vector false
+/// matches when `threshold = 0.0`.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_skills::group::{GroupResult, group_skills};
+///
+/// // With fewer than 2 skills the result is always flat.
+/// let result = group_skills(&[], &[], |_| None::<&[f32]>, 0.5);
+/// assert!(matches!(result, GroupResult::Flat(_)));
+/// ```
+#[must_use]
+pub fn group_skills<'e, F>(
+    skills: &[Skill],
+    skill_indices: &[usize],
+    get_embedding: F,
+    threshold: f32,
+) -> GroupResult
+where
+    F: Fn(usize) -> Option<&'e [f32]>,
+{
+    if skills.len() < 2 {
+        return GroupResult::Flat(skills.to_vec());
+    }
+
+    let entry_idx = skill_indices.first().copied().unwrap_or(0);
+    let Some(entry_embed) = get_embedding(entry_idx) else {
+        return GroupResult::Flat(skills.to_vec());
+    };
+
+    let mut support = Vec::new();
+    let mut role_labels = HashMap::new();
+    role_labels.insert(skills[0].name().to_string(), SkillRole::EntryPoint);
+
+    for (pos, skill) in skills[1..].iter().enumerate() {
+        let Some(&idx) = skill_indices.get(pos + 1) else {
+            continue;
+        };
+        let Some(embed) = get_embedding(idx) else {
+            continue;
+        };
+        let sim = zeph_common::math::cosine_similarity(entry_embed, embed);
+        if sim > threshold {
+            role_labels.insert(skill.name().to_string(), SkillRole::Support);
+            support.push(skill.clone());
+        }
+    }
+
+    if support.is_empty() {
+        GroupResult::Flat(skills.to_vec())
+    } else {
+        GroupResult::Grouped(Box::new(SkillGroup {
+            entry_point: skills[0].clone(),
+            support,
+            role_labels,
+            requirements: Vec::new(),
+            failure_notes: Vec::new(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::loader::{Skill, SkillMeta};
+
+    fn make_skill(name: &str) -> Skill {
+        Skill {
+            meta: SkillMeta {
+                name: name.into(),
+                description: String::new(),
+                compatibility: None,
+                license: None,
+                metadata: Vec::new(),
+                allowed_tools: Vec::new(),
+                requires_secrets: Vec::new(),
+                skill_dir: PathBuf::new(),
+                source_url: None,
+                git_hash: None,
+                category: None,
+            },
+            body: String::new(),
+        }
+    }
+
+    // Static embedding storage used in tests — avoids lifetime issues with closures.
+    static EMBED_A: &[f32] = &[1.0, 0.0, 0.0];
+    static EMBED_B: &[f32] = &[0.9, 0.1, 0.0]; // high similarity to A
+    static EMBED_C: &[f32] = &[0.0, 0.0, 1.0]; // low similarity to A
+    static EMBED_D: &[f32] = &[0.95, 0.05, 0.0]; // high similarity to A
+    static EMBED_E: &[f32] = &[0.0, 1.0, 0.0]; // orthogonal to A
+
+    fn embedding_for_index(idx: usize) -> Option<&'static [f32]> {
+        match idx {
+            0 => Some(EMBED_A),
+            1 => Some(EMBED_B),
+            2 => Some(EMBED_C),
+            3 => Some(EMBED_D),
+            4 => Some(EMBED_E),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn empty_skills_returns_flat() {
+        let result = group_skills(&[], &[], embedding_for_index, 0.5);
+        assert!(matches!(result, GroupResult::Flat(v) if v.is_empty()));
+    }
+
+    #[test]
+    fn single_skill_returns_flat() {
+        let skills = vec![make_skill("a")];
+        let result = group_skills(&skills, &[0], embedding_for_index, 0.5);
+        assert!(matches!(result, GroupResult::Flat(v) if v.len() == 1));
+    }
+
+    #[test]
+    fn all_below_threshold_returns_flat() {
+        // EMBED_A vs EMBED_C: cosine = 0.0
+        let skills = vec![make_skill("a"), make_skill("c")];
+        let result = group_skills(&skills, &[0, 2], embedding_for_index, 0.5);
+        assert!(matches!(result, GroupResult::Flat(_)));
+    }
+
+    #[test]
+    fn one_above_threshold_returns_grouped() {
+        // EMBED_A vs EMBED_B: cosine ≈ 0.994
+        let skills = vec![make_skill("a"), make_skill("b")];
+        let result = group_skills(&skills, &[0, 1], embedding_for_index, 0.5);
+        let GroupResult::Grouped(g) = result else {
+            panic!("expected Grouped");
+        };
+        assert_eq!(g.entry_point.name(), "a");
+        assert_eq!(g.support.len(), 1);
+        assert_eq!(g.support[0].name(), "b");
+        assert_eq!(g.role_labels[g.entry_point.name()], SkillRole::EntryPoint);
+        assert_eq!(g.role_labels[g.support[0].name()], SkillRole::Support);
+    }
+
+    #[test]
+    fn mixed_similarity_only_high_ones_become_support() {
+        // indices: 0=A, 1=B(high), 2=C(low), 3=D(high)
+        let skills = vec![
+            make_skill("a"),
+            make_skill("b"),
+            make_skill("c"),
+            make_skill("d"),
+        ];
+        let result = group_skills(&skills, &[0, 1, 2, 3], embedding_for_index, 0.5);
+        let GroupResult::Grouped(g) = result else {
+            panic!("expected Grouped");
+        };
+        assert_eq!(g.support.len(), 2);
+        let support_names: Vec<&str> = g.support.iter().map(|s| s.name()).collect();
+        assert!(support_names.contains(&"b"));
+        assert!(support_names.contains(&"d"));
+        assert!(!support_names.contains(&"c"));
+    }
+
+    #[test]
+    fn missing_entry_embedding_returns_flat() {
+        let skills = vec![make_skill("x"), make_skill("y")];
+        // index 99 → no embedding
+        let result = group_skills(&skills, &[99, 1], embedding_for_index, 0.5);
+        assert!(matches!(result, GroupResult::Flat(_)));
+    }
+
+    #[test]
+    fn threshold_zero_cosine_zero_not_grouped() {
+        // EMBED_A vs EMBED_E: cosine = 0.0 — NOT > 0.0, so flat
+        let skills = vec![make_skill("a"), make_skill("e")];
+        let result = group_skills(&skills, &[0, 4], embedding_for_index, 0.0);
+        assert!(matches!(result, GroupResult::Flat(_)));
+    }
+
+    #[test]
+    fn threshold_zero_positive_similarity_is_grouped() {
+        // EMBED_A vs EMBED_B: cosine ≈ 0.994 > 0.0 → grouped
+        let skills = vec![make_skill("a"), make_skill("b")];
+        let result = group_skills(&skills, &[0, 1], embedding_for_index, 0.0);
+        assert!(matches!(result, GroupResult::Grouped(_)));
+    }
+
+    #[test]
+    fn missing_support_embedding_skipped_others_still_grouped() {
+        // index 5 → no embedding for "e_no_embed"
+        let skills = vec![make_skill("a"), make_skill("b"), make_skill("e_no_embed")];
+        let result = group_skills(&skills, &[0, 1, 5], embedding_for_index, 0.5);
+        // "b" has similarity; "e_no_embed" is skipped — group still formed
+        let GroupResult::Grouped(g) = result else {
+            panic!("expected Grouped");
+        };
+        assert_eq!(g.support.len(), 1);
+        assert_eq!(g.support[0].name(), "b");
+    }
+
+    #[test]
+    fn group_result_contains_empty_requirements_and_failure_notes() {
+        let skills = vec![make_skill("a"), make_skill("b")];
+        let result = group_skills(&skills, &[0, 1], embedding_for_index, 0.5);
+        let GroupResult::Grouped(g) = result else {
+            panic!("expected Grouped");
+        };
+        assert!(g.requirements.is_empty());
+        assert!(g.failure_notes.is_empty());
+    }
+
+    #[test]
+    fn context_role_variant_exists() {
+        // Ensure Context variant is present for forward-compat (not assigned by MVP)
+        let _role = SkillRole::Context;
+    }
+}

--- a/crates/zeph-skills/src/group.rs
+++ b/crates/zeph-skills/src/group.rs
@@ -232,7 +232,7 @@ mod tests {
             panic!("expected Grouped");
         };
         assert_eq!(g.support.len(), 2);
-        let support_names: Vec<&str> = g.support.iter().map(|s| s.name()).collect();
+        let support_names: Vec<&str> = g.support.iter().map(Skill::name).collect();
         assert!(support_names.contains(&"b"));
         assert!(support_names.contains(&"d"));
         assert!(!support_names.contains(&"c"));
@@ -289,6 +289,6 @@ mod tests {
     #[test]
     fn context_role_variant_exists() {
         // Ensure Context variant is present for forward-compat (not assigned by MVP)
-        let _role = SkillRole::Context;
+        assert!(matches!(SkillRole::Context, SkillRole::Context));
     }
 }

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -59,6 +59,7 @@ pub mod error;
 pub mod evaluator;
 pub mod evolution;
 pub mod generator;
+pub mod group;
 pub mod loader;
 pub mod manager;
 pub mod matcher;
@@ -83,6 +84,7 @@ pub use evaluator::{
     EvaluationWeights, SkillEvaluationRequest, SkillEvaluator, SkillQualityScore, SkillVerdict,
 };
 pub use generator::{GeneratedSkill, SkillGenerationRequest, SkillGenerator};
+pub use group::{GroupResult, SkillGroup, SkillRole, group_skills};
 pub use matcher::{IntentClassification, MatchResult, ScoredMatch};
 pub use proactive::{DomainLabel, ProactiveExplorer};
 pub use trust::{SkillSource, SkillTrust, SkillTrustLevel, compute_skill_hash};

--- a/crates/zeph-skills/src/prompt.rs
+++ b/crates/zeph-skills/src/prompt.rs
@@ -34,6 +34,7 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 
+use crate::group::SkillGroup;
 use crate::loader::Skill;
 use crate::resource::discover_resources;
 use crate::trust::SkillTrustLevel;
@@ -364,6 +365,153 @@ pub fn format_skills_prompt<S: std::hash::BuildHasher, S2: std::hash::BuildHashe
 
     out.push_str("</available_skills>");
     out
+}
+
+/// Format a [`SkillGroup`] as role-labelled XML for LLM injection.
+///
+/// Applies the same per-skill trust sanitization, quarantine wrapping, and XML escaping
+/// as [`format_skills_prompt`]. Quarantined skills are excluded from support roles —
+/// they will not appear in the output.
+///
+/// Output format:
+///
+/// ```xml
+/// <available_skills>
+///   <active_skill role="entry_point" name="…">
+///     <description>…</description>
+///     <instructions>…</instructions>
+///   </active_skill>
+///   <active_skill role="support" name="…">
+///     …
+///   </active_skill>
+/// </available_skills>
+/// ```
+///
+/// `<skill_requirements>` and `<failure_avoidance>` blocks are emitted only when the
+/// corresponding `SkillGroup` vectors are non-empty (they are empty in the MVP).
+///
+/// The entry point is always emitted regardless of trust level (Quarantined entry points
+/// receive the standard quarantine warning wrapper). Support skills with
+/// [`SkillTrustLevel::Quarantined`] are silently excluded from the output.
+#[must_use]
+pub fn format_grouped_skills_prompt<S: std::hash::BuildHasher, S2: std::hash::BuildHasher>(
+    group: &SkillGroup,
+    trust_levels: &HashMap<String, SkillTrustLevel, S>,
+    health_map: &HashMap<String, (f64, u32), S2>,
+) -> String {
+    let mut out = String::from("<available_skills>\n");
+
+    // Emit the entry point skill.
+    format_active_skill_tag(
+        &mut out,
+        &group.entry_point,
+        "entry_point",
+        trust_levels,
+        health_map,
+    );
+
+    // Emit support skills, skipping quarantined ones.
+    for skill in &group.support {
+        let trust = trust_levels.get(skill.name()).copied().unwrap_or_default();
+        if trust == SkillTrustLevel::Quarantined {
+            tracing::debug!(
+                skill = skill.name(),
+                "support skill excluded from group: quarantined"
+            );
+            continue;
+        }
+        format_active_skill_tag(&mut out, skill, "support", trust_levels, health_map);
+    }
+
+    // Emit requirements block when non-empty.
+    if !group.requirements.is_empty() {
+        out.push_str("  <skill_requirements>\n");
+        for req in &group.requirements {
+            let _ = writeln!(out, "    <requirement>{}</requirement>", xml_escape(req));
+        }
+        out.push_str("  </skill_requirements>\n");
+    }
+
+    // Emit failure avoidance block when non-empty.
+    if !group.failure_notes.is_empty() {
+        out.push_str("  <failure_avoidance>\n");
+        for note in &group.failure_notes {
+            let _ = writeln!(out, "    <note>{}</note>", xml_escape(note));
+        }
+        out.push_str("  </failure_avoidance>\n");
+    }
+
+    out.push_str("</available_skills>");
+    out
+}
+
+/// Write a single `<active_skill>` XML element into `out`.
+fn format_active_skill_tag<S: std::hash::BuildHasher, S2: std::hash::BuildHasher>(
+    out: &mut String,
+    skill: &Skill,
+    role: &str,
+    trust_levels: &HashMap<String, SkillTrustLevel, S>,
+    health_map: &HashMap<String, (f64, u32), S2>,
+) {
+    let trust = trust_levels.get(skill.name()).copied().unwrap_or_default();
+    let raw_body = if trust == SkillTrustLevel::Trusted {
+        skill.body.clone()
+    } else {
+        sanitize_skill_text(&skill.body)
+    };
+    let body = if trust == SkillTrustLevel::Quarantined {
+        wrap_quarantined(skill.name(), &raw_body)
+    } else {
+        raw_body
+    };
+    let health_attrs = health_map.get(skill.name()).and_then(|&(posterior, uses)| {
+        if uses >= HEALTH_MIN_USES {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let pct = (posterior * 100.0).round() as u32;
+            Some(format!(" reliability=\"{pct}%\" uses=\"{uses}\""))
+        } else {
+            None
+        }
+    });
+    let attrs = health_attrs.as_deref().unwrap_or("");
+    let desc = if trust == SkillTrustLevel::Trusted {
+        xml_escape(skill.description())
+    } else {
+        let clean = sanitize_skill_metadata(skill.description(), MAX_DESCRIPTION_LEN);
+        wrap_data_description(&xml_escape(&clean))
+    };
+    let _ = write!(
+        out,
+        "  <active_skill role=\"{role}\" name=\"{name}\"{attrs}>\n    <description>{desc}</description>\n    <instructions>\n{body}",
+        name = xml_escape(skill.name()),
+    );
+
+    let resources = discover_resources(&skill.meta.skill_dir);
+    let ref_names: Vec<&str> = resources
+        .references
+        .iter()
+        .filter_map(|p| p.file_name()?.to_str())
+        .collect();
+    if !ref_names.is_empty() {
+        let _ = write!(out, "\nAvailable references: {}", ref_names.join(", "));
+    }
+    let script_names: Vec<&str> = resources
+        .scripts
+        .iter()
+        .filter_map(|p| p.file_name()?.to_str())
+        .collect();
+    if !script_names.is_empty() {
+        let _ = write!(out, "\nAvailable scripts: {}", script_names.join(", "));
+    }
+    let asset_names: Vec<&str> = resources
+        .assets
+        .iter()
+        .filter_map(|p| p.file_name()?.to_str())
+        .collect();
+    if !asset_names.is_empty() {
+        let _ = write!(out, "\nAvailable assets: {}", asset_names.join(", "));
+    }
+    out.push_str("\n    </instructions>\n  </active_skill>\n");
 }
 
 /// Wrap a quarantined skill's prompt with warning markers.
@@ -1072,5 +1220,136 @@ mod tests {
             !output.contains("data-description"),
             "trusted skill description must not be wrapped in data-description tag"
         );
+    }
+
+    // --- format_grouped_skills_prompt tests ---
+
+    use crate::group::{SkillGroup, SkillRole};
+    use std::collections::HashMap as StdHashMap;
+
+    fn make_skill_group(entry_name: &str, support_names: &[&str]) -> SkillGroup {
+        let mut role_labels = StdHashMap::new();
+        role_labels.insert(entry_name.to_string(), SkillRole::EntryPoint);
+        for name in support_names {
+            role_labels.insert((*name).to_string(), SkillRole::Support);
+        }
+        SkillGroup {
+            entry_point: make_skill(entry_name, "entry desc", "entry body"),
+            support: support_names
+                .iter()
+                .map(|n| make_skill(n, "support desc", "support body"))
+                .collect(),
+            role_labels,
+            requirements: Vec::new(),
+            failure_notes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn grouped_prompt_produces_active_skill_tags() {
+        let group = make_skill_group("entry", &["s1"]);
+        // Mark both skills as Trusted so s1 is not excluded as Quarantined.
+        let mut trust = HashMap::new();
+        trust.insert("entry".to_owned(), SkillTrustLevel::Trusted);
+        trust.insert("s1".to_owned(), SkillTrustLevel::Trusted);
+        let out = format_grouped_skills_prompt(&group, &trust, &HashMap::new());
+        assert!(out.starts_with("<available_skills>"));
+        assert!(out.ends_with("</available_skills>"));
+        assert!(
+            out.contains("role=\"entry_point\""),
+            "entry_point role missing"
+        );
+        assert!(out.contains("role=\"support\""), "support role missing");
+        assert!(out.contains("name=\"entry\""));
+        assert!(out.contains("name=\"s1\""));
+        assert!(out.contains("<active_skill"), "active_skill tag missing");
+        assert!(
+            out.contains("</active_skill>"),
+            "closing active_skill tag missing"
+        );
+    }
+
+    #[test]
+    fn grouped_prompt_flat_fallback_same_as_format_skills_prompt() {
+        // When there are no support skills, grouped output still works (entry only).
+        let group = make_skill_group("only-entry", &[]);
+        let out = format_grouped_skills_prompt(&group, &HashMap::new(), &HashMap::new());
+        assert!(out.contains("role=\"entry_point\""));
+        assert!(!out.contains("role=\"support\""));
+    }
+
+    #[test]
+    fn grouped_prompt_quarantined_support_excluded() {
+        let group = make_skill_group("entry", &["safe", "evil"]);
+        let mut trust = HashMap::new();
+        trust.insert("evil".to_owned(), SkillTrustLevel::Quarantined);
+        trust.insert("safe".to_owned(), SkillTrustLevel::Trusted);
+        let out = format_grouped_skills_prompt(&group, &trust, &HashMap::new());
+        assert!(
+            !out.contains("name=\"evil\""),
+            "quarantined skill must be excluded from support"
+        );
+        assert!(
+            out.contains("name=\"safe\""),
+            "trusted support skill must be present"
+        );
+    }
+
+    #[test]
+    fn grouped_prompt_trusted_entry_not_sanitized() {
+        let mut group = make_skill_group("trusted-entry", &[]);
+        group.entry_point.body = "Some </skill> raw content.".to_string();
+        let mut trust = HashMap::new();
+        trust.insert("trusted-entry".to_owned(), SkillTrustLevel::Trusted);
+        let out = format_grouped_skills_prompt(&group, &trust, &HashMap::new());
+        assert!(
+            out.contains("Some </skill> raw content."),
+            "trusted body must not be sanitized"
+        );
+    }
+
+    #[test]
+    fn grouped_prompt_non_empty_requirements_emitted() {
+        let mut group = make_skill_group("entry", &[]);
+        group.requirements = vec!["must be logged in".to_string()];
+        let out = format_grouped_skills_prompt(&group, &HashMap::new(), &HashMap::new());
+        assert!(out.contains("<skill_requirements>"));
+        assert!(out.contains("must be logged in"));
+        assert!(out.contains("</skill_requirements>"));
+    }
+
+    #[test]
+    fn grouped_prompt_empty_requirements_not_emitted() {
+        let group = make_skill_group("entry", &[]);
+        let out = format_grouped_skills_prompt(&group, &HashMap::new(), &HashMap::new());
+        assert!(
+            !out.contains("<skill_requirements>"),
+            "empty requirements must not appear"
+        );
+    }
+
+    #[test]
+    fn grouped_prompt_non_empty_failure_notes_emitted() {
+        let mut group = make_skill_group("entry", &[]);
+        group.failure_notes = vec!["do not call twice".to_string()];
+        let out = format_grouped_skills_prompt(&group, &HashMap::new(), &HashMap::new());
+        assert!(out.contains("<failure_avoidance>"));
+        assert!(out.contains("do not call twice"));
+        assert!(out.contains("</failure_avoidance>"));
+    }
+
+    #[test]
+    fn grouped_prompt_trust_sanitization_applied_to_verified_support() {
+        let mut group = make_skill_group("entry", &["ver"]);
+        let support = &mut group.support[0];
+        support.body = "Inject </skill> here.".to_string();
+        let mut trust = HashMap::new();
+        trust.insert("ver".to_owned(), SkillTrustLevel::Verified);
+        let out = format_grouped_skills_prompt(&group, &trust, &HashMap::new());
+        assert!(
+            out.contains("&lt;/skill&gt;"),
+            "verified skill body must be sanitized"
+        );
+        assert!(!out.contains("Inject </skill> here."));
     }
 }


### PR DESCRIPTION
## Summary

- Implements GoSkills group-structured skill retrieval (#4411): after hybrid BM25+embedding matching, inter-skill cosine similarity is computed and skills are presented to the LLM as a structured group (entry-point / support / context roles) when similarity exceeds the configurable threshold. Falls back to flat injection when no pair exceeds the threshold.
- Adds tracing instrumentation to plugin manager inner I/O paths (#4385): `collect_skill_dirs`, `update_one_plugin`, `download_archive` now emit `tracing::instrument` spans.

## Changes

- `crates/zeph-skills/src/group.rs` — new: `SkillRole`, `SkillGroup`, `GroupResult`, `group_skills()`, 11 unit tests
- `crates/zeph-skills/src/prompt.rs` — new: `format_grouped_skills_prompt()`, 8 grouped tests
- `crates/zeph-config/` — new config fields: `skills.group_structured` (bool, default `false`), `skills.support_similarity_threshold` (f32, default `0.50`)
- `crates/zeph-experiments/` — new `ParameterKind::GroupStructured` variant with bidirectional A/B gating
- `crates/zeph-core/src/agent/context/assembly.rs` — group-aware injection branch (disabled by default)
- `crates/zeph-plugins/src/manager.rs` — 3 tracing spans added
- `CHANGELOG.md` — `[Unreleased]` updated

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 9967 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Unit tests cover: grouped path, flat fallback, threshold boundary (`>`), empty embeddings, all 3 `SkillRole` variants, A/B toggle
- [ ] Security: trust/sanitization/quarantine preserved per-skill in grouped path
- [ ] Live testing playbook: `.local/testing/playbooks/skills-goskills-group-retrieval.md`

Closes #4411
Closes #4385