### PR TITLE
fix(runner): restore five_signal_metrics in spawn_metrics_sync_with_five_signal

### DIFF
--- a/src/metrics_export.rs
+++ b/src/metrics_export.rs
@@ -1140,6 +1140,32 @@ mod tests {
         );
     }
 
+    // Regression test for #4427: spawn_metrics_sync_with_five_signal must receive Some when
+    // five_signal is configured; previously runner.rs passed None unconditionally.
+    #[tokio::test]
+    async fn test_spawn_metrics_sync_receives_five_signal() {
+        use zeph_memory::five_signal::metrics::FiveSignalMetrics;
+
+        let pm = Arc::new(PrometheusMetrics::new());
+        let (tx, rx) = watch::channel(MetricsSnapshot::default());
+        let fs = Arc::new(FiveSignalMetrics::default());
+        fs.inc_recall();
+
+        let handle = spawn_metrics_sync_with_five_signal(pm.clone(), rx, 0, Some(Arc::clone(&fs)));
+        // Give the spawned task one iteration to run.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        drop(tx);
+        handle.abort();
+
+        // If five_signal was wired (Some), sync_five_signal will have exported the counter.
+        let mut buf = String::new();
+        prometheus_client::encoding::text::encode(&mut buf, &pm.registry).unwrap();
+        assert!(
+            buf.contains("zeph_five_signal_recall_total 1"),
+            "five_signal metrics must be exported when Some is passed; got:\n{buf}"
+        );
+    }
+
     // Regression test for #4404: sync_five_signal does not double-count on second call.
     #[test]
     fn sync_five_signal_no_double_count() {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3213,11 +3213,14 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let _prometheus_sync_handle = if exec_mode.bare {
         None
     } else if let Some(prom) = prom_arc {
+        let five_signal_metrics = memory
+            .five_signal_runtime()
+            .map(|rt| std::sync::Arc::clone(&rt.metrics));
         let handle = crate::metrics_export::spawn_metrics_sync_with_five_signal(
             std::sync::Arc::clone(&prom),
             prometheus_metrics_rx,
             config.metrics.sync_interval_secs,
-            None,
+            five_signal_metrics,
         );
         let effective_path = {
             let p = &config.metrics.path;


### PR DESCRIPTION
## Summary

- Commit 2a105e93 accidentally passed `None` to `spawn_metrics_sync_with_five_signal`, silently disabling the four five_signal Prometheus counters (`zeph_five_signal_recall_total`, `zeph_five_signal_consolidation_*`).
- Restores `memory.five_signal_runtime().map(|rt| Arc::clone(&rt.metrics))` and passes it instead of `None`.
- Adds regression test `test_spawn_metrics_sync_receives_five_signal` in `src/metrics_export.rs`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9969 passed, 21 skipped
- [x] New regression test added and passes
- [x] Reviewed and approved by code reviewer

Closes #4427