### PR TITLE
fix(skills,common): sync matched_indices with active_skills after allowlist filter; consolidate xml_escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `zeph-core`: rename `ShadowEvent` → `SentinelEvent` in `shadow_sentinel` module to eliminate
   naming collision with `zeph_sanitizer::ShadowMemory`; `ShadowEventStore` and `ShadowEventRow`
-  retain their names (closes #4379).### Fixed
+  retain their names (closes #4379).
+
+### Fixed
+
+- `zeph-core`: GoSkills `active_skills` and `matched_indices` are now filtered in lockstep during
+  channel allowlist pruning; previously the allowlist filter removed skills from `active_skills`
+  but left stale indices in `matched_indices`, causing `group_skills` to look up the wrong
+  embedding vectors and produce incorrect groupings (closes #4430).
+- `zeph-common`: extract shared `xml_escape` utility into `zeph_common::text::xml_escape`;
+  remove three duplicate private copies from `zeph-experiments`, `zeph-orchestration`, and
+  `zeph-skills` (closes #4431). The canonical implementation escapes `&`, `<`, `>`, `"`, and
+  `'` — a superset of the most permissive prior copy.
 
 - `zeph` (binary): `ConsolidationHandler` is now registered with `zeph-scheduler` at bootstrap
   under `TaskKind::Custom("five_signal_consolidation")` when

--- a/crates/zeph-acp/src/agent/helpers.rs
+++ b/crates/zeph-acp/src/agent/helpers.rs
@@ -4,6 +4,7 @@
 #[allow(clippy::wildcard_imports)]
 use acp::schema::*;
 use agent_client_protocol as acp;
+use zeph_common::text::xml_escape;
 
 use zeph_core::LoopbackEvent;
 
@@ -94,13 +95,6 @@ pub(super) const DIAGNOSTICS_MIME_TYPE: &str = "application/vnd.zed.diagnostics+
 
 /// Deserialize Zed LSP diagnostics JSON and append a formatted `<diagnostics>` block to `out`.
 ///
-pub(super) fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
-
 /// Each entry is rendered as `file:line: [SEVERITY] message`.
 /// On parse error the block is emitted empty to avoid injecting untrusted raw JSON into the prompt.
 pub(super) fn format_diagnostics_block(json: &str, out: &mut String) {

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -2695,8 +2695,9 @@ pub(super) mod helpers;
 use helpers::{
     DEFAULT_MODE_ID, DIAGNOSTICS_MIME_TYPE, build_available_commands, build_config_options,
     build_mode_state, format_diagnostics_block, loopback_event_to_updates, mime_to_ext, model_meta,
-    session_update_to_event, xml_escape,
+    session_update_to_event,
 };
+use zeph_common::text::xml_escape;
 
 pub(crate) mod handlers;
 

--- a/crates/zeph-common/src/text.rs
+++ b/crates/zeph-common/src/text.rs
@@ -113,6 +113,37 @@ pub fn truncate_to_chars(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Escape XML special characters in a string.
+///
+/// Replaces `&`, `<`, `>`, `"`, and `'` with their XML entity equivalents.
+/// Use this when embedding arbitrary text into XML attributes or text nodes to
+/// prevent tag injection.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::text::xml_escape;
+///
+/// assert_eq!(xml_escape("a < b && b > c"), "a &lt; b &amp;&amp; b &gt; c");
+/// assert_eq!(xml_escape(r#"say "hi""#), "say &quot;hi&quot;");
+/// assert_eq!(xml_escape("it's"), "it&#39;s");
+/// ```
+#[must_use]
+pub fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -745,7 +745,7 @@ impl<C: Channel> Agent<C> {
         }
         self.update_skill_confidence_metrics().await;
 
-        let (all_skills, active_skills): (Vec<Skill>, Vec<Skill>) = {
+        let (all_skills, active_skills, matched_indices): (Vec<Skill>, Vec<Skill>, Vec<usize>) = {
             let reg = self.services.skill.registry.read();
             let all: Vec<Skill> = reg
                 .all_meta()
@@ -762,13 +762,14 @@ impl<C: Channel> Agent<C> {
                     allowed
                 })
                 .collect();
-            let active: Vec<Skill> = self
-                .services
-                .skill
-                .active_skill_names
+            // Zip matched_indices with active_skill_names so that the allowlist filter
+            // keeps both in sync. Without this, active_skills[i] and matched_indices[i]
+            // would refer to different skills after allowlist pruning.
+            let (active, filtered_indices): (Vec<Skill>, Vec<usize>) = matched_indices
                 .iter()
-                .filter_map(|name| reg.skill(name).ok())
-                .filter(|s| {
+                .zip(self.services.skill.active_skill_names.iter())
+                .filter_map(|(&idx, name)| reg.skill(name).ok().map(|s| (s, idx)))
+                .filter(|(s, _idx)| {
                     let allowed = zeph_config::is_skill_allowed(
                         s.name(),
                         &self.runtime.config.channel_skills,
@@ -781,8 +782,8 @@ impl<C: Channel> Agent<C> {
                     }
                     allowed
                 })
-                .collect();
-            (all, active)
+                .unzip();
+            (all, active, filtered_indices)
         };
 
         // Rebuild matched_indices to stay 1:1 with active_skills after the channel-allowlist

--- a/crates/zeph-experiments/src/evaluator.rs
+++ b/crates/zeph-experiments/src/evaluator.rs
@@ -557,12 +557,7 @@ fn build_judge_messages(case: &BenchmarkCase, response: &str) -> Vec<Message> {
     ]
 }
 
-/// Escape XML metacharacters in a string to prevent prompt injection.
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-}
+use zeph_common::text::xml_escape;
 
 /// Compute aggregate report from collected scores.
 fn build_report(

--- a/crates/zeph-orchestration/src/scheduler/router.rs
+++ b/crates/zeph-orchestration/src/scheduler/router.rs
@@ -7,6 +7,7 @@ use std::fmt::Write as _;
 
 use super::DagScheduler;
 use crate::graph::{TaskNode, TaskStatus};
+use zeph_common::text::xml_escape;
 use zeph_sanitizer::{ContentSource, ContentSourceKind};
 
 impl DagScheduler {
@@ -93,22 +94,6 @@ impl DagScheduler {
         context_block.push_str("</completed-dependencies>\n\n");
         format!("{context_block}Your task: {}", task.description)
     }
-}
-
-/// Escape XML special characters in a string to prevent tag injection.
-fn xml_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '&' => out.push_str("&amp;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&#39;"),
-            other => out.push(other),
-        }
-    }
-    out
 }
 
 #[cfg(test)]

--- a/crates/zeph-skills/src/prompt.rs
+++ b/crates/zeph-skills/src/prompt.rs
@@ -34,6 +34,8 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 
+use zeph_common::text::xml_escape;
+
 use crate::group::SkillGroup;
 use crate::loader::Skill;
 use crate::resource::discover_resources;
@@ -81,21 +83,6 @@ pub fn sanitize_skill_body(body: &str) -> String {
     let mut out = body.to_string();
     for (pattern, replacement) in SANITIZE_PATTERNS {
         out = replace_case_insensitive(&out, pattern, replacement);
-    }
-    out
-}
-
-/// Escape XML special characters in attribute values and text content.
-fn xml_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        match ch {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            other => out.push(other),
-        }
     }
     out
 }


### PR DESCRIPTION
## Summary

- **#4430**: In `assembly.rs`, the channel allowlist filter rebuilt `active_skills` but left `matched_indices` unfiltered, causing a positional desync — `active_skills[i]` could refer to a different skill than `matched_indices[i]` after allowlist removal. Fixed by zipping the two slices before filtering and unzipping after.
- **#4431**: `xml_escape` was duplicated as a private function in four crates (`zeph-acp`, `zeph-experiments`, `zeph-orchestration`, `zeph-skills`). Moved to `zeph-common::text` as a documented public function; all callers updated.

## Changes

- `crates/zeph-core/src/agent/context/assembly.rs` — zip-filter-unzip fix + regression test
- `crates/zeph-common/src/text.rs` — `pub fn xml_escape` with doctest
- `crates/zeph-acp/src/agent/helpers.rs` + `mod.rs` — remove private copy, import from zeph-common
- `crates/zeph-experiments/src/evaluator.rs` — remove private copy
- `crates/zeph-orchestration/src/scheduler/router.rs` — remove private copy
- `crates/zeph-skills/src/prompt.rs` — remove private copy

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9981 passed, 21 skipped
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `cargo test --doc -p zeph-common` — doctests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Regression test `allowlist_filter_keeps_active_skills_and_matched_indices_in_sync` covers the desync scenario

Closes #4430
Closes #4431