### PR TITLE
refactor(a2a,index): pre-hash auth token at startup; add NodeKind and Lang newtypes

### DIFF
--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -154,9 +154,9 @@ impl A2aServer {
     /// string is not retained. Passing `None` disables bearer auth. A `WARN` log is emitted
     /// if no token is set, as a reminder that the server is open to unauthenticated requests.
     #[must_use]
-    pub fn with_auth(mut self, token: Option<String>) -> Self {
+    pub fn with_auth(mut self, token: Option<impl Into<String>>) -> Self {
         let require_auth = self.auth_cfg.require_auth;
-        self.auth_cfg = AuthConfig::new(token.as_deref(), require_auth);
+        self.auth_cfg = AuthConfig::new(token.map(Into::into).as_deref(), require_auth);
         self
     }
 

--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -88,7 +88,7 @@ pub use state::{AppState, ProcessorEvent, TaskManager, TaskProcessor};
 /// let (_shutdown_tx, shutdown_rx) = watch::channel(false);
 ///
 /// A2aServer::new(card, Arc::new(MyProcessor), "0.0.0.0", 9090, shutdown_rx)
-///     .with_auth(Some("my-secret-token".into()))
+///     .with_auth(Some("my-secret-token"))
 ///     .serve()
 ///     .await?;
 /// # Ok(())

--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -37,6 +37,8 @@ use std::time::Duration;
 
 use tokio::sync::watch;
 
+use zeph_common::http_middleware::AuthConfig;
+
 use crate::error::A2aError;
 use crate::types::AgentCard;
 use router::build_router_with_full_config;
@@ -97,8 +99,7 @@ pub struct A2aServer {
     state: AppState,
     addr: SocketAddr,
     shutdown_rx: watch::Receiver<bool>,
-    auth_token: Option<String>,
-    require_auth: bool,
+    auth_cfg: AuthConfig,
     rate_limit: u32,
     max_body_size: usize,
 }
@@ -137,8 +138,7 @@ impl A2aServer {
             state,
             addr,
             shutdown_rx,
-            auth_token: None,
-            require_auth: false,
+            auth_cfg: AuthConfig::new(None, false),
             rate_limit: 0,
             max_body_size: 1_048_576,
         }
@@ -150,11 +150,13 @@ impl A2aServer {
     /// include an `Authorization: Bearer <token>` header. The comparison is constant-time
     /// (blake3 hash of both sides) to prevent timing attacks.
     ///
-    /// Passing `None` disables bearer auth. A `WARN` log is emitted if no token is set,
-    /// as a reminder that the server is open to unauthenticated requests.
+    /// The token is hashed once here at construction time via `AuthConfig::new`; the raw
+    /// string is not retained. Passing `None` disables bearer auth. A `WARN` log is emitted
+    /// if no token is set, as a reminder that the server is open to unauthenticated requests.
     #[must_use]
     pub fn with_auth(mut self, token: Option<String>) -> Self {
-        self.auth_token = token;
+        let require_auth = self.auth_cfg.require_auth;
+        self.auth_cfg = AuthConfig::new(token.as_deref(), require_auth);
         self
     }
 
@@ -164,7 +166,7 @@ impl A2aServer {
     /// [`with_auth`](Self::with_auth), every request returns `401 Unauthorized`.
     #[must_use]
     pub fn with_require_auth(mut self, require: bool) -> Self {
-        self.require_auth = require;
+        self.auth_cfg.require_auth = require;
         self
     }
 
@@ -213,7 +215,7 @@ impl A2aServer {
     /// Returns [`A2aError::Server`] if the TCP listener fails to
     /// bind or if the axum server encounters a fatal I/O error during operation.
     pub async fn serve(self) -> Result<(), A2aError> {
-        if self.auth_token.is_none() {
+        if self.auth_cfg.token_hash.is_none() {
             tracing::warn!(
                 "A2A server running without bearer auth — ensure this is a trusted-network-only deployment"
             );
@@ -221,8 +223,7 @@ impl A2aServer {
 
         let router = build_router_with_full_config(
             self.state,
-            self.auth_token.as_deref(),
-            self.require_auth,
+            self.auth_cfg,
             self.rate_limit,
             self.max_body_size,
         );

--- a/crates/zeph-a2a/src/server/router.rs
+++ b/crates/zeph-a2a/src/server/router.rs
@@ -27,17 +27,20 @@ pub fn build_router_with_config(
     auth_token: Option<&str>,
     rate_limit: u32,
 ) -> Router {
-    build_router_with_full_config(state, auth_token, false, rate_limit, DEFAULT_MAX_BODY_SIZE)
+    build_router_with_full_config(
+        state,
+        AuthConfig::new(auth_token, false),
+        rate_limit,
+        DEFAULT_MAX_BODY_SIZE,
+    )
 }
 
 pub fn build_router_with_full_config(
     state: AppState,
-    auth_token: Option<&str>,
-    require_auth: bool,
+    auth_cfg: AuthConfig,
     rate_limit: u32,
     max_body_size: usize,
 ) -> Router {
-    let auth_cfg = AuthConfig::new(auth_token, require_auth);
     let rate_state = RateLimitState::new(rate_limit, &[]);
 
     let protected = Router::new()
@@ -355,7 +358,12 @@ mod tests {
 
     #[tokio::test]
     async fn require_auth_rejects_when_no_token_configured() {
-        let app = build_router_with_full_config(test_state(), None, true, 0, DEFAULT_MAX_BODY_SIZE);
+        let app = build_router_with_full_config(
+            test_state(),
+            AuthConfig::new(None, true),
+            0,
+            DEFAULT_MAX_BODY_SIZE,
+        );
 
         let body = serde_json::json!({
             "jsonrpc": "2.0", "id": "1",
@@ -377,14 +385,23 @@ mod tests {
     /// router using inline GC eviction (shared middleware, no background task required).
     #[tokio::test]
     async fn build_router_with_rate_limit_succeeds() {
-        let _router = build_router_with_full_config(test_state(), None, false, 5, 1024 * 1024);
+        let _router = build_router_with_full_config(
+            test_state(),
+            AuthConfig::new(None, false),
+            5,
+            1024 * 1024,
+        );
         // Reaching here confirms inline-GC-based router builds without panic.
     }
 
     #[tokio::test]
     async fn require_auth_false_allows_unauthenticated() {
-        let app =
-            build_router_with_full_config(test_state(), None, false, 0, DEFAULT_MAX_BODY_SIZE);
+        let app = build_router_with_full_config(
+            test_state(),
+            AuthConfig::new(None, false),
+            0,
+            DEFAULT_MAX_BODY_SIZE,
+        );
 
         let body = serde_json::json!({
             "jsonrpc": "2.0", "id": "1",

--- a/crates/zeph-index/src/languages.rs
+++ b/crates/zeph-index/src/languages.rs
@@ -83,6 +83,35 @@ pub enum Lang {
 }
 
 impl Lang {
+    /// Parse a [`Lang`] from the short lowercase identifier used in Qdrant payloads.
+    ///
+    /// Returns `None` when the string does not match any known language id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_index::languages::Lang;
+    ///
+    /// assert_eq!(Lang::from_id("rust"), Some(Lang::Rust));
+    /// assert_eq!(Lang::from_id("typescript"), Some(Lang::TypeScript));
+    /// assert_eq!(Lang::from_id("unknown"), None);
+    /// ```
+    #[must_use]
+    pub fn from_id(s: &str) -> Option<Self> {
+        match s {
+            "rust" => Some(Self::Rust),
+            "python" => Some(Self::Python),
+            "javascript" => Some(Self::JavaScript),
+            "typescript" => Some(Self::TypeScript),
+            "go" => Some(Self::Go),
+            "bash" => Some(Self::Bash),
+            "toml" => Some(Self::Toml),
+            "json" => Some(Self::Json),
+            "markdown" => Some(Self::Markdown),
+            _ => None,
+        }
+    }
+
     /// Short lowercase identifier stored in Qdrant payload and config fields.
     ///
     /// # Examples

--- a/crates/zeph-index/src/retriever.rs
+++ b/crates/zeph-index/src/retriever.rs
@@ -307,7 +307,8 @@ impl CodeRetriever {
 ///         file_path: "src/lib.rs".to_string(),
 ///         line_range: (1, 1),
 ///         score: 0.9,
-///         node_type: "function_item".to_string(),
+///         node_type: zeph_index::store::NodeKind::from("function_item"),
+///         language: zeph_index::languages::Lang::Rust,
 ///         entity_name: Some("hello".to_string()),
 ///         scope_chain: String::new(),
 ///     }],
@@ -329,7 +330,10 @@ pub fn format_as_context(result: &RetrievedCode) -> String {
     let mut out = String::from("<code_context>\n");
 
     for chunk in &result.chunks {
-        let name = chunk.entity_name.as_deref().unwrap_or(&chunk.node_type);
+        let name = chunk
+            .entity_name
+            .as_deref()
+            .unwrap_or(chunk.node_type.as_ref());
         let _ = writeln!(
             out,
             "  <chunk file=\"{}\" lines=\"{}-{}\" name=\"{}\" score=\"{:.2}\">",
@@ -422,7 +426,7 @@ fn budget_tokens(available: usize, ratio: f32) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::store::SearchHit;
+    use crate::store::{NodeKind, SearchHit};
 
     #[test]
     fn classify_symbol_query_rust() {
@@ -493,7 +497,8 @@ mod tests {
                 file_path: "src/lib.rs".to_string(),
                 line_range: (1, 3),
                 score: 0.85,
-                node_type: "function_item".to_string(),
+                node_type: NodeKind::from("function_item"),
+                language: crate::languages::Lang::Rust,
                 entity_name: Some("hello".to_string()),
                 scope_chain: String::new(),
             }],
@@ -542,7 +547,8 @@ mod tests {
                 file_path: "src/foo.rs".to_string(),
                 line_range: (1, 2),
                 score: 0.75,
-                node_type: "struct_item".to_string(),
+                node_type: NodeKind::from("struct_item"),
+                language: crate::languages::Lang::Rust,
                 entity_name: None,
                 scope_chain: String::new(),
             }],

--- a/crates/zeph-index/src/store.rs
+++ b/crates/zeph-index/src/store.rs
@@ -75,6 +75,47 @@ pub struct ChunkInsert<'a> {
     pub content_hash: &'a str,
 }
 
+/// Tree-sitter node kind stored in Qdrant payload (e.g. `"function_item"`, `"struct_item"`).
+///
+/// A thin newtype over `String` that provides `Display`, `AsRef<str>`, `From<String>`,
+/// and `From<&str>` for ergonomic use in format strings and comparisons.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_index::store::NodeKind;
+///
+/// let kind = NodeKind::from("function_item");
+/// assert_eq!(kind.as_ref(), "function_item");
+/// assert_eq!(kind.to_string(), "function_item");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeKind(pub String);
+
+impl std::fmt::Display for NodeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for NodeKind {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for NodeKind {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for NodeKind {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
 /// A single search result returned by [`CodeStore::search`].
 ///
 /// Decoded from the Qdrant vector point payload by `SearchHit::from_payload`.
@@ -90,7 +131,9 @@ pub struct SearchHit {
     /// Cosine similarity score returned by Qdrant (higher is more similar).
     pub score: f32,
     /// Tree-sitter node kind of the primary AST node.
-    pub node_type: String,
+    pub node_type: NodeKind,
+    /// Programming language of the chunk.
+    pub language: crate::languages::Lang,
     /// Symbol name, if available.
     pub entity_name: Option<String>,
     /// `">"` separated scope chain.
@@ -451,12 +494,15 @@ impl SearchHit {
                 .and_then(|v| usize::try_from(v).ok())
         };
 
+        let language_str = get_str("language")?;
+        let language = crate::languages::Lang::from_id(&language_str)?;
         Some(Self {
             code: get_str("code")?,
             file_path: get_str("file_path")?,
             line_range: (get_usize("line_start")?, get_usize("line_end")?),
             score: point.score,
-            node_type: get_str("node_type")?,
+            node_type: NodeKind::from(get_str("node_type")?),
+            language,
             entity_name: get_str("entity_name"),
             scope_chain: get_str("scope_chain").unwrap_or_default(),
         })
@@ -488,6 +534,7 @@ mod tests {
                 "file_path": "src/lib.rs",
                 "line_start": 10,
                 "line_end": 12,
+                "language": "rust",
                 "node_type": "function_item",
                 "entity_name": "foo",
                 "scope_chain": "mod::foo"
@@ -499,7 +546,8 @@ mod tests {
         assert_eq!(hit.file_path, "src/lib.rs");
         assert_eq!(hit.line_range, (10, 12));
         assert!((hit.score - 0.9).abs() < f32::EPSILON);
-        assert_eq!(hit.node_type, "function_item");
+        assert_eq!(hit.node_type.as_ref(), "function_item");
+        assert_eq!(hit.language, crate::languages::Lang::Rust);
         assert_eq!(hit.entity_name, Some("foo".to_string()));
         assert_eq!(hit.scope_chain, "mod::foo");
     }
@@ -512,6 +560,7 @@ mod tests {
                 "file_path": "src/bar.rs",
                 "line_start": 1,
                 "line_end": 3,
+                "language": "rust",
                 "node_type": "struct_item",
                 "scope_chain": ""
             }),
@@ -519,7 +568,7 @@ mod tests {
         );
         let hit = SearchHit::from_payload(&point).unwrap();
         assert!(hit.entity_name.is_none());
-        assert_eq!(hit.node_type, "struct_item");
+        assert_eq!(hit.node_type.as_ref(), "struct_item");
     }
 
     #[test]
@@ -530,6 +579,7 @@ mod tests {
                 "file_path": "src/lib.rs",
                 "line_start": 1,
                 "line_end": 2,
+                "language": "rust",
                 "node_type": "function_item"
             }),
             0.5,


### PR DESCRIPTION
## Summary

- **#4389 (zeph-a2a):** `AuthConfig` now pre-hashes the bearer token once at construction using BLAKE3. `auth_middleware` compares 32-byte digests via `subtle::ConstantTimeEq`. The raw token string is not retained in memory after startup — consistent with `zeph-gateway`.
- **#4390 (zeph-index):** Added `NodeKind(pub String)` newtype for tree-sitter node kinds (with `Display`, `AsRef<str>`, `From<String>`, `From<&str>`). Added `Lang::from_id` for parsing language from stored `&str`. `SearchHit::node_type` is now `NodeKind` and `SearchHit::language` is now `Lang`, making invalid states unrepresentable at the type level.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run -p zeph-a2a -p zeph-index --lib` — 204/204 pass

Closes #4389
Closes #4390