### PR TITLE
refactor(orchestration,scheduler,tui): architecture cleanup group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `zeph-orchestration`: cache reverse-adjacency list in `TopologyAnalysis.rev_adj`; `propagate_failure`
+  and `reset_for_retry` now accept `rev_adj: &[Vec<TaskId>]` and no longer allocate on every failure
+  event (closes #4384).
+- `zeph-scheduler`: extract private `run_loop(interval, grace_secs)` from three near-identical public
+  run-loop methods (`run`, `run_with_interval`, `run_with_interval_and_grace`); public methods are now
+  thin wrappers (closes #4382).
+- `zeph-tui`: remove duplicate `format_token_count` helper in `widgets/input.rs`; call site delegates
+  to `zeph_common::text::format_tokens` (closes #4378).
+
 - `zeph-core`: rename `ShadowEvent` → `SentinelEvent` in `shadow_sentinel` module to eliminate
   naming collision with `zeph_sanitizer::ShadowMemory`; `ShadowEventStore` and `ShadowEventRow`
   retain their names (closes #4379).

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -1064,7 +1064,7 @@ impl<C: crate::channel::Channel> Agent<C> {
         &mut self,
         graph_id: Option<&str>,
     ) -> Result<String, error::AgentError> {
-        use zeph_orchestration::{GraphStatus, dag};
+        use zeph_orchestration::{GraphStatus, dag, topology::build_rev_adj};
 
         let Some(ref graph) = self.services.orchestration.pending_graph else {
             return Ok(
@@ -1105,7 +1105,8 @@ impl<C: crate::channel::Channel> Agent<C> {
             .filter(|t| t.status == zeph_orchestration::TaskStatus::Failed)
             .count();
 
-        dag::reset_for_retry(&mut graph)
+        let rev_adj = build_rev_adj(&graph.tasks);
+        dag::reset_for_retry(&mut graph, &rev_adj)
             .map_err(|e| error::OrchestrationFailure::RetryReset(e.to_string()))?;
 
         for task in &mut graph.tasks {

--- a/crates/zeph-orchestration/src/dag.rs
+++ b/crates/zeph-orchestration/src/dag.rs
@@ -214,9 +214,14 @@ pub fn ready_tasks(graph: &TaskGraph) -> Vec<TaskId> {
 /// - `Retry`: if `retry_count < max_retries`, increments counter and resets task to `Ready`.
 ///   Otherwise falls through to `Abort`.
 /// - `Ask`: sets `graph.status = Paused`.
-pub fn propagate_failure(graph: &mut TaskGraph, failed_id: TaskId) -> Vec<TaskId> {
-    let task_count = graph.tasks.len();
-
+///
+/// `rev_adj[i]` must contain the IDs of all tasks that depend on task `i` (pre-built by the
+/// caller from `TopologyAnalysis::rev_adj` to avoid repeated allocation on the hot path).
+pub fn propagate_failure(
+    graph: &mut TaskGraph,
+    failed_id: TaskId,
+    rev_adj: &[Vec<TaskId>],
+) -> Vec<TaskId> {
     // If the task is already terminal (not Failed), this is a no-op
     if graph.tasks[failed_id.index()].status != TaskStatus::Failed {
         return Vec::new();
@@ -247,14 +252,6 @@ pub fn propagate_failure(graph: &mut TaskGraph, failed_id: TaskId) -> Vec<TaskId
             // Mark the failed task as Skipped
             graph.tasks[failed_id.index()].status = TaskStatus::Skipped;
 
-            // Build reverse adjacency list
-            let mut dependents: Vec<Vec<TaskId>> = vec![Vec::new(); task_count];
-            for task in &graph.tasks {
-                for dep in &task.depends_on {
-                    dependents[dep.index()].push(task.id);
-                }
-            }
-
             // BFS to transitively skip all non-terminal dependents.
             // Collect Running tasks that are being skipped — the caller must cancel them,
             // because marking a task Skipped in the data structure does not stop execution.
@@ -263,7 +260,8 @@ pub fn propagate_failure(graph: &mut TaskGraph, failed_id: TaskId) -> Vec<TaskId
             queue.push_back(failed_id);
 
             while let Some(current) = queue.pop_front() {
-                for &dep_id in &dependents[current.index()] {
+                let dependents = rev_adj.get(current.index()).map_or(&[] as &[TaskId], |v| v);
+                for &dep_id in dependents {
                     if !graph.tasks[dep_id.index()].status.is_terminal() {
                         if graph.tasks[dep_id.index()].status == TaskStatus::Running {
                             to_cancel.push(dep_id);
@@ -311,11 +309,17 @@ pub fn propagate_failure(graph: &mut TaskGraph, failed_id: TaskId) -> Vec<TaskId
 ///   `Pending`, allowing `ready_tasks()` to re-evaluate them on the next tick.
 /// - Sets `graph.status = Running` so the scheduler can continue.
 ///
+/// `rev_adj[i]` must contain the IDs of all tasks that depend on task `i` (pre-built by the
+/// caller from `TopologyAnalysis::rev_adj` to avoid repeated allocation on the hot path).
+///
 /// # Errors
 ///
 /// Returns `OrchestrationError::InvalidGraph` if the graph is not in `Failed`
 /// or `Paused` status (the only states that make sense to retry from).
-pub fn reset_for_retry(graph: &mut TaskGraph) -> Result<(), OrchestrationError> {
+pub fn reset_for_retry(
+    graph: &mut TaskGraph,
+    rev_adj: &[Vec<TaskId>],
+) -> Result<(), OrchestrationError> {
     use super::graph::GraphStatus;
 
     if graph.status != GraphStatus::Failed && graph.status != GraphStatus::Paused {
@@ -324,8 +328,6 @@ pub fn reset_for_retry(graph: &mut TaskGraph) -> Result<(), OrchestrationError> 
             graph.status
         )));
     }
-
-    let task_count = graph.tasks.len();
 
     // First pass: reset Failed -> Ready and collect their IDs as BFS seeds.
     let mut seeds: Vec<TaskId> = Vec::new();
@@ -352,18 +354,11 @@ pub fn reset_for_retry(graph: &mut TaskGraph) -> Result<(), OrchestrationError> 
         return Ok(());
     }
 
-    // Build reverse adjacency: dependents[i] = tasks that depend on task i.
-    let mut dependents: Vec<Vec<TaskId>> = vec![Vec::new(); task_count];
-    for task in &graph.tasks {
-        for dep in &task.depends_on {
-            dependents[dep.index()].push(task.id);
-        }
-    }
-
     // BFS from seeds: reset Skipped dependents back to Pending.
     let mut queue: std::collections::VecDeque<TaskId> = seeds.into_iter().collect();
     while let Some(current) = queue.pop_front() {
-        for &dep_id in &dependents[current.index()] {
+        let dependents = rev_adj.get(current.index()).map_or(&[] as &[TaskId], |v| v);
+        for &dep_id in dependents {
             if graph.tasks[dep_id.index()].status == TaskStatus::Skipped {
                 graph.tasks[dep_id.index()].status = TaskStatus::Pending;
                 queue.push_back(dep_id);
@@ -379,6 +374,7 @@ pub fn reset_for_retry(graph: &mut TaskGraph) -> Result<(), OrchestrationError> 
 mod tests {
     use super::*;
     use crate::graph::{FailureStrategy, GraphStatus, TaskGraph, TaskNode, TaskStatus};
+    use crate::topology::build_rev_adj;
 
     fn make_node(id: u32, deps: &[u32]) -> TaskNode {
         let mut n = TaskNode::new(id, format!("task-{id}"), "desc");
@@ -390,6 +386,10 @@ mod tests {
         let mut g = TaskGraph::new("test");
         g.tasks = nodes;
         g
+    }
+
+    fn make_rev_adj(graph: &TaskGraph) -> Vec<Vec<TaskId>> {
+        build_rev_adj(&graph.tasks)
     }
 
     // --- validate tests ---
@@ -667,7 +667,9 @@ mod tests {
         graph.tasks[2].status = TaskStatus::Pending;
         graph.default_failure_strategy = FailureStrategy::Abort;
 
-        let to_cancel = propagate_failure(&mut graph, TaskId(0));
+        let __ra = make_rev_adj(&graph);
+
+        let to_cancel = propagate_failure(&mut graph, TaskId(0), &__ra);
         assert_eq!(graph.status, GraphStatus::Failed);
         assert!(to_cancel.contains(&TaskId(1)));
         assert!(!to_cancel.contains(&TaskId(2)));
@@ -680,7 +682,9 @@ mod tests {
         graph.tasks[0].failure_strategy = Some(FailureStrategy::Skip);
         graph.tasks[1].status = TaskStatus::Pending;
 
-        let to_cancel = propagate_failure(&mut graph, TaskId(0));
+        let __ra = make_rev_adj(&graph);
+
+        let to_cancel = propagate_failure(&mut graph, TaskId(0), &__ra);
         assert!(to_cancel.is_empty());
         assert_eq!(graph.tasks[0].status, TaskStatus::Skipped);
         assert_eq!(graph.tasks[1].status, TaskStatus::Skipped);
@@ -699,7 +703,9 @@ mod tests {
         graph.tasks[1].status = TaskStatus::Pending;
         graph.tasks[2].status = TaskStatus::Pending;
 
-        propagate_failure(&mut graph, TaskId(0));
+        let __ra = make_rev_adj(&graph);
+
+        propagate_failure(&mut graph, TaskId(0), &__ra);
         assert_eq!(graph.tasks[0].status, TaskStatus::Skipped);
         assert_eq!(graph.tasks[1].status, TaskStatus::Skipped);
         assert_eq!(graph.tasks[2].status, TaskStatus::Skipped);
@@ -714,7 +720,9 @@ mod tests {
         graph.tasks[0].failure_strategy = Some(FailureStrategy::Skip);
         graph.tasks[1].status = TaskStatus::Running;
 
-        let to_cancel = propagate_failure(&mut graph, TaskId(0));
+        let __ra = make_rev_adj(&graph);
+
+        let to_cancel = propagate_failure(&mut graph, TaskId(0), &__ra);
         assert!(
             to_cancel.contains(&TaskId(1)),
             "Running dependent must be returned for cancellation"
@@ -730,7 +738,9 @@ mod tests {
         graph.tasks[0].max_retries = Some(3);
         graph.tasks[0].retry_count = 1;
 
-        let to_cancel = propagate_failure(&mut graph, TaskId(0));
+        let __ra = make_rev_adj(&graph);
+
+        let to_cancel = propagate_failure(&mut graph, TaskId(0), &__ra);
         assert!(to_cancel.is_empty());
         assert_eq!(graph.tasks[0].status, TaskStatus::Ready);
         assert_eq!(graph.tasks[0].retry_count, 2);
@@ -744,7 +754,9 @@ mod tests {
         graph.tasks[0].max_retries = Some(3);
         graph.tasks[0].retry_count = 3; // at max
 
-        propagate_failure(&mut graph, TaskId(0));
+        let __ra = make_rev_adj(&graph);
+
+        propagate_failure(&mut graph, TaskId(0), &__ra);
         assert_eq!(graph.status, GraphStatus::Failed);
     }
 
@@ -754,7 +766,9 @@ mod tests {
         graph.tasks[0].status = TaskStatus::Failed;
         graph.tasks[0].failure_strategy = Some(FailureStrategy::Ask);
 
-        let to_cancel = propagate_failure(&mut graph, TaskId(0));
+        let __ra = make_rev_adj(&graph);
+
+        let to_cancel = propagate_failure(&mut graph, TaskId(0), &__ra);
         assert!(to_cancel.is_empty());
         assert_eq!(graph.status, GraphStatus::Paused);
     }
@@ -768,7 +782,9 @@ mod tests {
         graph.tasks[0].failure_strategy = Some(FailureStrategy::Skip);
         graph.tasks[1].status = TaskStatus::Pending;
 
-        propagate_failure(&mut graph, TaskId(0));
+        let __ra = make_rev_adj(&graph);
+
+        propagate_failure(&mut graph, TaskId(0), &__ra);
         // Should use Skip, not Abort
         assert_eq!(graph.tasks[0].status, TaskStatus::Skipped);
         assert_ne!(graph.status, GraphStatus::Failed);
@@ -780,7 +796,9 @@ mod tests {
         let mut graph = graph_from_nodes(vec![make_node(0, &[])]);
         graph.tasks[0].status = TaskStatus::Completed;
 
-        let to_cancel = propagate_failure(&mut graph, TaskId(0));
+        let __ra = make_rev_adj(&graph);
+
+        let to_cancel = propagate_failure(&mut graph, TaskId(0), &__ra);
         assert!(to_cancel.is_empty());
         assert_eq!(graph.status, GraphStatus::Created);
     }
@@ -793,7 +811,9 @@ mod tests {
         graph.tasks[0].status = TaskStatus::Failed;
         graph.status = GraphStatus::Failed;
 
-        reset_for_retry(&mut graph).unwrap();
+        let __ra = make_rev_adj(&graph);
+
+        reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.tasks[0].status, TaskStatus::Ready);
         assert_eq!(graph.status, GraphStatus::Running);
     }
@@ -806,7 +826,9 @@ mod tests {
         graph.tasks[1].status = TaskStatus::Skipped;
         graph.status = GraphStatus::Failed;
 
-        reset_for_retry(&mut graph).unwrap();
+        let __ra = make_rev_adj(&graph);
+
+        reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.tasks[0].status, TaskStatus::Ready);
         assert_eq!(graph.tasks[1].status, TaskStatus::Pending);
     }
@@ -824,7 +846,9 @@ mod tests {
         graph.tasks[2].status = TaskStatus::Skipped;
         graph.status = GraphStatus::Failed;
 
-        reset_for_retry(&mut graph).unwrap();
+        let __ra = make_rev_adj(&graph);
+
+        reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.tasks[0].status, TaskStatus::Ready);
         assert_eq!(graph.tasks[1].status, TaskStatus::Pending);
         assert_eq!(graph.tasks[2].status, TaskStatus::Pending);
@@ -838,7 +862,9 @@ mod tests {
         graph.tasks[1].status = TaskStatus::Failed;
         graph.status = GraphStatus::Failed;
 
-        reset_for_retry(&mut graph).unwrap();
+        let __ra = make_rev_adj(&graph);
+
+        reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.tasks[0].status, TaskStatus::Completed);
         assert_eq!(graph.tasks[1].status, TaskStatus::Ready);
     }
@@ -849,7 +875,9 @@ mod tests {
         graph.tasks[0].status = TaskStatus::Running;
         graph.status = GraphStatus::Running;
 
-        let err = reset_for_retry(&mut graph).unwrap_err();
+        let __ra = make_rev_adj(&graph);
+
+        let err = reset_for_retry(&mut graph, &__ra).unwrap_err();
         assert!(matches!(err, OrchestrationError::InvalidGraph(_)));
     }
 
@@ -860,7 +888,9 @@ mod tests {
         graph.tasks[1].status = TaskStatus::Skipped;
         graph.status = GraphStatus::Paused;
 
-        reset_for_retry(&mut graph).unwrap();
+        let __ra = make_rev_adj(&graph);
+
+        reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.status, GraphStatus::Running);
     }
 
@@ -871,7 +901,9 @@ mod tests {
         graph.tasks[0].retry_count = 5;
         graph.status = GraphStatus::Failed;
 
-        reset_for_retry(&mut graph).unwrap();
+        let __ra = make_rev_adj(&graph);
+
+        reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.tasks[0].retry_count, 0);
     }
 
@@ -882,7 +914,9 @@ mod tests {
         graph.tasks[0].status = TaskStatus::Completed;
         graph.status = GraphStatus::Paused;
 
-        reset_for_retry(&mut graph).unwrap();
+        let __ra = make_rev_adj(&graph);
+
+        reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.status, GraphStatus::Running);
         assert_eq!(graph.tasks[0].status, TaskStatus::Completed);
     }
@@ -901,7 +935,9 @@ mod tests {
         graph.tasks[2].status = TaskStatus::Pending;
         graph.status = GraphStatus::Failed;
 
-        reset_for_retry(&mut graph).unwrap();
+        let __ra = make_rev_adj(&graph);
+
+        reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.tasks[0].status, TaskStatus::Ready);
         assert_eq!(
             graph.tasks[1].status,
@@ -920,7 +956,9 @@ mod tests {
         graph.tasks[1].status = TaskStatus::Canceled;
         graph.status = GraphStatus::Failed;
 
-        reset_for_retry(&mut graph).unwrap();
+        let __ra = make_rev_adj(&graph);
+
+        reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.tasks[0].status, TaskStatus::Ready);
         assert_eq!(graph.tasks[1].status, TaskStatus::Pending);
     }

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -103,6 +103,8 @@ pub use plan_cache::{
 pub use planner::{LlmPlanner, Planner};
 pub use router::{AgentRouter, RuleBasedRouter};
 pub use scheduler::{DagScheduler, SchedulerAction, TaskEvent, TaskOutcome};
-pub use topology::{DispatchStrategy, Topology, TopologyAnalysis, TopologyClassifier};
+pub use topology::{
+    DispatchStrategy, Topology, TopologyAnalysis, TopologyClassifier, build_rev_adj,
+};
 pub use verifier::{Gap, GapSeverity, PlanVerifier, VerificationResult};
 pub use verify_predicate::{PredicateEvaluator, PredicateOutcome, VerifyPredicate};

--- a/crates/zeph-orchestration/src/scheduler/planner.rs
+++ b/crates/zeph-orchestration/src/scheduler/planner.rs
@@ -7,7 +7,9 @@
 use super::{DagScheduler, SchedulerAction};
 use crate::dag;
 use crate::graph::{GraphStatus, TaskStatus};
-use crate::topology::{DispatchStrategy, Topology, TopologyAnalysis, TopologyClassifier};
+use crate::topology::{
+    DispatchStrategy, Topology, TopologyAnalysis, TopologyClassifier, build_rev_adj,
+};
 
 impl DagScheduler {
     /// Re-analyze topology when marked dirty by `inject_tasks`.
@@ -24,6 +26,7 @@ impl DagScheduler {
                     max_parallel: self.config_max_parallel,
                     depth: 0,
                     depths: std::collections::HashMap::new(),
+                    rev_adj: Vec::new(),
                 }
             } else {
                 let (depth, depths) = crate::topology::compute_depths_for_scheduler(&self.graph);
@@ -36,12 +39,14 @@ impl DagScheduler {
                 let strategy = TopologyClassifier::strategy(topo, &strategy_config);
                 let max_parallel =
                     TopologyClassifier::compute_max_parallel(topo, self.config_max_parallel);
+                let rev_adj = build_rev_adj(&self.graph.tasks);
                 TopologyAnalysis {
                     topology: topo,
                     strategy,
                     max_parallel,
                     depth,
                     depths,
+                    rev_adj,
                 }
             }
         };

--- a/crates/zeph-orchestration/src/scheduler/tick.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick.rs
@@ -367,7 +367,7 @@ impl DagScheduler {
             "spawn failed, marking task failed"
         );
         self.graph.tasks[task_id.index()].status = TaskStatus::Failed;
-        let cancel_ids = dag::propagate_failure(&mut self.graph, task_id);
+        let cancel_ids = dag::propagate_failure(&mut self.graph, task_id, &self.topology.rev_adj);
         let mut actions = Vec::new();
         for cancel_task_id in cancel_ids {
             if let Some(running) = self.running.remove(&cancel_task_id) {
@@ -657,7 +657,7 @@ impl DagScheduler {
             return self.abort_dag_with_lineage(root_id, chain.entries());
         }
 
-        let cancel_ids = dag::propagate_failure(&mut self.graph, task_id);
+        let cancel_ids = dag::propagate_failure(&mut self.graph, task_id, &self.topology.rev_adj);
         let mut actions = Vec::new();
 
         for cancel_task_id in cancel_ids {
@@ -740,7 +740,8 @@ impl DagScheduler {
 
             actions.push(SchedulerAction::Cancel { agent_handle_id });
 
-            let cancel_ids = dag::propagate_failure(&mut self.graph, task_id);
+            let cancel_ids =
+                dag::propagate_failure(&mut self.graph, task_id, &self.topology.rev_adj);
             for cancel_task_id in cancel_ids {
                 if let Some(running) = self.running.remove(&cancel_task_id) {
                     actions.push(SchedulerAction::Cancel {

--- a/crates/zeph-orchestration/src/topology.rs
+++ b/crates/zeph-orchestration/src/topology.rs
@@ -93,6 +93,12 @@ pub struct TopologyAnalysis {
     /// Uses `HashMap` so new tasks injected via `inject_tasks()` can be
     /// added without index-out-of-bounds on `Vec` access (critic S3).
     pub depths: HashMap<TaskId, usize>,
+    /// Reverse adjacency list: `rev_adj[i]` = IDs of tasks that depend on task `i`.
+    ///
+    /// Built once from the static graph topology and cached here so that
+    /// `propagate_failure` and `reset_for_retry` can avoid rebuilding it on
+    /// every call. Invalidated and rebuilt by `inject_tasks()` via `topology_dirty`.
+    pub rev_adj: Vec<Vec<TaskId>>,
 }
 
 /// Stateless DAG topology classifier.
@@ -267,6 +273,7 @@ impl TopologyClassifier {
                 max_parallel: config.max_parallel as usize,
                 depth: 0,
                 depths: HashMap::new(),
+                rev_adj: build_rev_adj(tasks),
             };
         }
 
@@ -275,6 +282,7 @@ impl TopologyClassifier {
         let strategy = Self::strategy(topology, config);
         let base = config.max_parallel as usize;
         let max_parallel = Self::compute_max_parallel(topology, base);
+        let rev_adj = build_rev_adj(tasks);
 
         TopologyAnalysis {
             topology,
@@ -282,6 +290,7 @@ impl TopologyClassifier {
             max_parallel,
             depth: longest,
             depths,
+            rev_adj,
         }
     }
 }
@@ -294,6 +303,21 @@ pub(crate) fn compute_depths_for_scheduler(
     graph: &TaskGraph,
 ) -> (usize, std::collections::HashMap<TaskId, usize>) {
     compute_longest_path_and_depths(&graph.tasks)
+}
+
+/// Build a reverse-adjacency list from a task slice.
+///
+/// `rev_adj[i]` contains the IDs of all tasks that list task `i` in their
+/// `depends_on`. Assumes tasks are validated (no out-of-bounds deps).
+#[must_use]
+pub fn build_rev_adj(tasks: &[TaskNode]) -> Vec<Vec<TaskId>> {
+    let mut rev_adj = vec![Vec::new(); tasks.len()];
+    for task in tasks {
+        for dep in &task.depends_on {
+            rev_adj[dep.index()].push(task.id);
+        }
+    }
+    rev_adj
 }
 
 /// Compute the longest path and per-task depth map using Kahn's toposort.

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -433,13 +433,48 @@ impl Scheduler {
     /// The `grace_secs` parameter corresponds to `scheduler.daemon.shutdown_grace_secs`
     /// in config (default 30). Pass 0 for immediate exit after shutdown signal.
     pub async fn run_with_interval_and_grace(&mut self, tick_secs: u64, grace_secs: u64) {
-        let secs = tick_secs.clamp(5, 3600);
-        let mut interval = tokio::time::interval(Duration::from_secs(secs));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        self.run_loop(
+            Duration::from_secs(tick_secs.clamp(5, 3600)),
+            Some(grace_secs),
+        )
+        .await;
+    }
+
+    /// Run the scheduler loop with a configurable tick interval.
+    ///
+    /// The interval is clamped to a minimum of 1 second. Missed ticks (caused by a
+    /// slow `tick()` call) are skipped instead of burst-replayed, preventing runaway
+    /// execution storms on slow hosts.
+    ///
+    /// This method runs until `true` is sent on the shutdown channel.
+    pub async fn run_with_interval(&mut self, tick_secs: u64) {
+        self.run_loop(Duration::from_secs(tick_secs.max(1)), None)
+            .await;
+    }
+
+    /// Run the scheduler loop, checking for due tasks every 60 seconds.
+    ///
+    /// This is a convenience wrapper around [`Scheduler::run_with_interval`] with a
+    /// 60-second tick. It runs until `true` is sent on the shutdown channel.
+    pub async fn run(&mut self) {
+        self.run_loop(Duration::from_mins(1), None).await;
+    }
+
+    /// Core scheduler event loop.
+    ///
+    /// Ticks on `interval`, processes the shutdown signal, and optionally waits for
+    /// in-flight handlers during the grace window before returning. `grace_secs = None`
+    /// means exit immediately on shutdown with no grace wait.
+    async fn run_loop(&mut self, interval: Duration, grace_secs: Option<u64>) {
+        let mut ticker = tokio::time::interval(interval);
+        // Skip missed ticks instead of bursting to catch up. Without this, a slow `tick()`
+        // call causes tokio to fire the interval in a tight loop to "catch up", producing
+        // hundreds of executions per second (#2737 leak 4).
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
             tokio::select! {
-                _ = interval.tick() => {
+                _ = ticker.tick() => {
                     {
                         use tracing::Instrument as _;
                         let span = tracing::info_span!(
@@ -456,10 +491,11 @@ impl Scheduler {
                 }
                 _ = self.shutdown_rx.changed() => {
                     if *self.shutdown_rx.borrow() {
-                        tracing::info!("scheduler shutting down (grace {}s)", grace_secs);
-                        if grace_secs > 0 {
+                        let grace = grace_secs.unwrap_or(0);
+                        tracing::info!("scheduler shutting down (grace {}s)", grace);
+                        if grace > 0 {
                             let deadline = tokio::time::Instant::now()
-                                + Duration::from_secs(grace_secs.min(60));
+                                + Duration::from_secs(grace.min(60));
                             loop {
                                 if self.in_flight.lock().await.is_empty() {
                                     tracing::debug!("scheduler: no in-flight tasks, exiting immediately");
@@ -472,81 +508,6 @@ impl Scheduler {
                                 tokio::time::sleep(Duration::from_millis(100)).await;
                             }
                         }
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    /// Run the scheduler loop with a configurable tick interval.
-    ///
-    /// The interval is clamped to a minimum of 1 second. Missed ticks (caused by a
-    /// slow `tick()` call) are skipped instead of burst-replayed, preventing runaway
-    /// execution storms on slow hosts.
-    ///
-    /// This method runs until `true` is sent on the shutdown channel.
-    pub async fn run_with_interval(&mut self, tick_secs: u64) {
-        let secs = tick_secs.max(1);
-        let mut interval = tokio::time::interval(Duration::from_secs(secs));
-        // Skip missed ticks instead of bursting to catch up. Without this, a slow `tick()`
-        // call causes tokio to fire the interval in a tight loop to "catch up", producing
-        // hundreds of executions per second (#2737 leak 4).
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            tokio::select! {
-                _ = interval.tick() => {
-                    {
-                        use tracing::Instrument as _;
-                        let span = tracing::info_span!(
-                            "scheduler.daemon.tick",
-                            tasks = self.tasks.len()
-                        );
-                        async {
-                            self.drain_channel().await;
-                            self.tick().await;
-                        }
-                        .instrument(span)
-                        .await;
-                    }
-                }
-                _ = self.shutdown_rx.changed() => {
-                    if *self.shutdown_rx.borrow() {
-                        tracing::info!("scheduler shutting down");
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    /// Run the scheduler loop, checking for due tasks every 60 seconds.
-    ///
-    /// This is a convenience wrapper around [`Scheduler::run_with_interval`] with a
-    /// 60-second tick. It runs until `true` is sent on the shutdown channel.
-    pub async fn run(&mut self) {
-        let mut interval = tokio::time::interval(Duration::from_mins(1));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            tokio::select! {
-                _ = interval.tick() => {
-                    {
-                        use tracing::Instrument as _;
-                        let span = tracing::info_span!(
-                            "scheduler.daemon.tick",
-                            tasks = self.tasks.len()
-                        );
-                        async {
-                            self.drain_channel().await;
-                            self.tick().await;
-                        }
-                        .instrument(span)
-                        .await;
-                    }
-                }
-                _ = self.shutdown_rx.changed() => {
-                    if *self.shutdown_rx.borrow() {
-                        tracing::info!("scheduler shutting down");
                         break;
                     }
                 }

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -10,6 +10,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, InputMode};
 use crate::theme::Theme;
+use zeph_common::text::format_tokens;
 
 pub fn render(
     app: &App,
@@ -28,7 +29,7 @@ pub fn render(
     let estimate = app.context_token_estimate();
     let title_buf;
     let title = if estimate > 0 {
-        let count_str = format_token_count(estimate);
+        let count_str = format!("~{}", format_tokens(estimate as u64));
         title_buf = format!("{base_title} | {count_str} tokens ");
         title_buf.as_str()
     } else {
@@ -119,21 +120,6 @@ pub fn render(
         #[allow(clippy::cast_possible_truncation)]
         let cursor_y = area.y + 1 + line_count.saturating_sub(scroll);
         frame.set_cursor_position((cursor_x, cursor_y));
-    }
-}
-
-/// Format a token count for display in the input block title.
-///
-/// Returns `"~{n}"` for counts below 1000, or `"~{n:.1}k"` for larger values.
-fn format_token_count(tokens: usize) -> String {
-    if tokens < 1000 {
-        format!("~{tokens}")
-    } else {
-        // Integer division keeps precision adequate for display; max representable value
-        // is u64::MAX / 1000 ≈ 1.8 × 10^16, which fits safely in f64 mantissa at this scale.
-        let whole = tokens / 1000;
-        let frac = (tokens % 1000) / 100;
-        format!("~{whole}.{frac}k")
     }
 }
 
@@ -249,16 +235,34 @@ mod tests {
 
     #[test]
     fn format_token_count_below_1000() {
-        assert_eq!(super::format_token_count(0), "~0");
-        assert_eq!(super::format_token_count(512), "~512");
-        assert_eq!(super::format_token_count(999), "~999");
+        assert_eq!(format!("~{}", zeph_common::text::format_tokens(0)), "~0");
+        assert_eq!(
+            format!("~{}", zeph_common::text::format_tokens(512)),
+            "~512"
+        );
+        assert_eq!(
+            format!("~{}", zeph_common::text::format_tokens(999)),
+            "~999"
+        );
     }
 
     #[test]
     fn format_token_count_1000_and_above() {
-        assert_eq!(super::format_token_count(1000), "~1.0k");
-        assert_eq!(super::format_token_count(1500), "~1.5k");
-        assert_eq!(super::format_token_count(14_200), "~14.2k");
-        assert_eq!(super::format_token_count(100_000), "~100.0k");
+        assert_eq!(
+            format!("~{}", zeph_common::text::format_tokens(1000)),
+            "~1.0k"
+        );
+        assert_eq!(
+            format!("~{}", zeph_common::text::format_tokens(1500)),
+            "~1.5k"
+        );
+        assert_eq!(
+            format!("~{}", zeph_common::text::format_tokens(14_200)),
+            "~14.2k"
+        );
+        assert_eq!(
+            format!("~{}", zeph_common::text::format_tokens(100_000)),
+            "~100.0k"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **#4384**: Cache reverse-adjacency list in `TopologyAnalysis.rev_adj`; `propagate_failure` and `reset_for_retry` no longer rebuild it on every call — eliminates O(N) allocation per failure event in large DAGs.
- **#4382**: Extract private `run_loop(interval, grace_secs)` from three near-identical `tokio::select!` bodies in `Scheduler`; public methods become thin wrappers — any future fix lands in one place.
- **#4378**: Remove duplicate `format_token_count` in `zeph-tui/widgets/input.rs`; call site delegates to `zeph_common::text::format_tokens`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9980/9980 passed

Closes #4384
Closes #4382
Closes #4378