### PR TITLE
refactor(common,core): tracing spans for http_middleware; replace custom date math with chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,12 +226,11 @@ discord = ["zeph-channels/discord"]
 slack = ["zeph-channels/slack"]
 gateway = ["dep:zeph-gateway"]
 prometheus = ["gateway", "dep:prometheus-client", "zeph-gateway/prometheus"]
-scheduler = ["dep:zeph-scheduler", "dep:blake3", "dep:cron", "dep:schemars", "dep:chrono", "zeph-core/scheduler", "zeph-scheduler/daemon", "zeph-memory/scheduler"]
+scheduler = ["dep:zeph-scheduler", "dep:blake3", "dep:cron", "dep:schemars", "zeph-core/scheduler", "zeph-scheduler/daemon", "zeph-memory/scheduler"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
 pdf = ["zeph-memory/pdf"]
 profiling = [
     "dep:tracing-chrome",
-    "dep:chrono",
     "dep:sysinfo",
     "zeph-core/profiling",
     "zeph-core/sysinfo",
@@ -276,7 +275,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 axum = { workspace = true, optional = true }
 blake3 = { workspace = true, optional = true }
-chrono = { workspace = true, optional = true, features = ["clock"] }
+chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true, features = ["derive", "env"] }
 cron = { workspace = true, optional = true }
 dialoguer.workspace = true

--- a/crates/zeph-common/src/http_middleware.rs
+++ b/crates/zeph-common/src/http_middleware.rs
@@ -272,6 +272,7 @@ impl RateLimitState {
 /// # Errors
 ///
 /// Returns `401 Unauthorized` on authentication failure.
+#[tracing::instrument(skip_all, name = "common.http_middleware.auth")]
 pub async fn auth_middleware(
     axum::extract::State(cfg): axum::extract::State<AuthConfig>,
     mut req: Request<Body>,
@@ -339,6 +340,7 @@ pub async fn auth_middleware(
 ///
 /// Returns `429 Too Many Requests` when the rate limit is exceeded or the rate-limit
 /// table is full and cannot accommodate a new IP after eviction.
+#[tracing::instrument(skip_all, name = "common.http_middleware.rate_limit")]
 pub async fn rate_limit_middleware(
     axum::extract::State(state): axum::extract::State<RateLimitState>,
     req: Request<Body>,

--- a/src/fleet_session.rs
+++ b/src/fleet_session.rs
@@ -9,6 +9,8 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
+use chrono::Utc;
+
 use zeph_memory::store::SqliteStore;
 use zeph_memory::store::agent_sessions::{
     AgentSessionRow, SessionChannel, SessionKind, SessionStatus,
@@ -106,8 +108,8 @@ pub(crate) async fn start_session(
         status: SessionStatus::Active,
         channel,
         model: model.to_owned(),
-        created_at: utc_now(),
-        last_active_at: utc_now(),
+        created_at: Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+        last_active_at: Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
         turns: 0,
         prompt_tokens: 0,
         completion_tokens: 0,
@@ -157,66 +159,4 @@ fn parse_channel(name: &str) -> SessionChannel {
         "slack" => SessionChannel::Slack,
         _ => SessionChannel::Cli,
     }
-}
-
-fn utc_now() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    // Format as SQLite-compatible ISO-8601 UTC string (no sub-second precision needed).
-    let (year, month, day, hour, min, sec) = epoch_to_datetime(secs);
-    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}")
-}
-
-fn epoch_to_datetime(epoch: u64) -> (u64, u64, u64, u64, u64, u64) {
-    let sec = epoch % 60;
-    let epoch = epoch / 60;
-    let min = epoch % 60;
-    let epoch = epoch / 60;
-    let hour = epoch % 24;
-    let mut days = epoch / 24;
-
-    // Days since 1970-01-01.
-    let mut year = 1970u64;
-    loop {
-        let leap = is_leap(year);
-        let days_in_year = if leap { 366 } else { 365 };
-        if days < days_in_year {
-            break;
-        }
-        days -= days_in_year;
-        year += 1;
-    }
-
-    let leap = is_leap(year);
-    let months = [
-        31u64,
-        if leap { 29 } else { 28 },
-        31,
-        30,
-        31,
-        30,
-        31,
-        31,
-        30,
-        31,
-        30,
-        31,
-    ];
-    let mut month = 1u64;
-    for &m in &months {
-        if days < m {
-            break;
-        }
-        days -= m;
-        month += 1;
-    }
-
-    (year, month, days + 1, hour, min, sec)
-}
-
-fn is_leap(year: u64) -> bool {
-    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
 }


### PR DESCRIPTION
## Summary

- **#4413**: add `#[tracing::instrument(skip_all)]` to `auth_middleware` and `rate_limit_middleware` in `crates/zeph-common/src/http_middleware.rs` with span names `common.http_middleware.auth` / `common.http_middleware.rate_limit` per project instrumentation convention.
- **#4367**: remove ~60 lines of hand-rolled date math (`epoch_to_datetime`, `utc_now`, `is_leap`) from `src/fleet_session.rs`; replace both call sites with `chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string()` — same output format as before. Corrected `chrono` in root `Cargo.toml` from `optional = true` to unconditional (it was already used without a feature gate).

## Changes

| File | Change |
|---|---|
| `crates/zeph-common/src/http_middleware.rs` | +2 lines: `#[tracing::instrument]` on both middleware fns |
| `src/fleet_session.rs` | −60 lines: removed dead date math, replaced call sites |
| `Cargo.toml` | chrono `optional = true` removed, dropped from feature lists |

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 9981 passed, 0 failed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings

Closes #4413
Closes #4367