### PR TITLE
feat(acp): upgrade agent-client-protocol to 0.12.1 and add standard session/delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `zeph-acp`: upgrade agent-client-protocol SDK to 0.12.1; migrate feature gate
+  `unstable-session-close` → `unstable-session-delete`; `session/resume` is now stable in SDK
+  0.12.1 and no longer requires a feature gate (closes #4454).
+- `zeph-acp`: add standard `session/delete` handler; deprecate `_session/delete` ext method
+  (closes #4458).
 - `zeph-orchestration`: cache reverse-adjacency list in `TopologyAnalysis.rev_adj`; `propagate_failure`
   and `reset_for_retry` now accept `rev_adj: &[Vec<TaskId>]` and no longer allocate on every failure
   event (closes #4384).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
 dependencies = [
  "agent-client-protocol-derive",
- "agent-client-protocol-schema",
+ "agent-client-protocol-schema 0.12.0",
  "anyhow",
  "futures",
  "futures-concurrency",
@@ -115,12 +115,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "agent-client-protocol-derive"
-version = "0.11.0"
+name = "agent-client-protocol"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
+checksum = "4361ba6627e51de955b10f3c77fb9eb959c85191a236c1c2c84e32f4ff240faf"
 dependencies = [
- "proc-macro2",
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema 0.13.2",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash 2.1.2",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
+dependencies = [
  "quote",
  "syn 2.0.117",
 ]
@@ -142,12 +166,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-client-protocol-schema"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b957d8391ac3933e2a940446171c508d2b8ffc386d8fa7d0b9c936a2575b463e"
+dependencies = [
+ "anyhow",
+ "derive_more 2.1.1",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
+]
+
+[[package]]
 name = "agent-client-protocol-tokio"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1572b219f22c4b3be0f20f934c8b6f1d1457126ce72923c4f6608f96153b65"
 dependencies = [
- "agent-client-protocol",
+ "agent-client-protocol 0.11.1",
  "futures",
  "serde",
  "serde_json",
@@ -365,6 +405,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +502,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -762,6 +885,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bollard"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +969,15 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "time",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -2294,6 +2439,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -5335,6 +5490,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5406,6 +5572,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7048,11 +7228,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -7067,9 +7248,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -10390,7 +10571,7 @@ dependencies = [
 name = "zeph-acp"
 version = "0.21.2"
 dependencies = [
- "agent-client-protocol",
+ "agent-client-protocol 0.12.1",
  "agent-client-protocol-tokio",
  "async-stream",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 
 [workspace.dependencies]
 age = { version = "0.11.3", default-features = false }
-agent-client-protocol = "0.11.1"
+agent-client-protocol = "0.12.1"
 agent-client-protocol-tokio = "0.11.1"
 anyhow = "1.0.102"
 arboard = "3.6.1"
@@ -215,7 +215,7 @@ bench      = ["dep:zeph-bench"]
 
 # === Individual feature flags ===
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server", "zeph-a2a?/ibct"]
-acp = ["dep:zeph-acp", "zeph-acp/unstable-session-close", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-logout", "zeph-acp/unstable-auth-methods", "zeph-acp/unstable-message-id", "zeph-acp/unstable-session-add-dirs"]
+acp = ["dep:zeph-acp", "zeph-acp/unstable-session-delete", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-logout", "zeph-acp/unstable-auth-methods", "zeph-acp/unstable-message-id", "zeph-acp/unstable-session-add-dirs"]
 acp-http = ["acp", "dep:axum", "zeph-acp/acp-http"]
 candle = ["zeph-llm/candle", "zeph-core/candle"]
 classifiers = ["candle", "zeph-llm/classifiers", "zeph-sanitizer/classifiers", "zeph-core/classifiers"]

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -14,17 +14,18 @@ readme = "README.md"
 
 [features]
 default = [
-    "unstable-session-close",
+    "unstable-session-delete",
     "unstable-session-fork",
-    "unstable-session-resume",
     "unstable-session-usage",
     "unstable-session-model",
     "unstable-logout",
 ]
 acp-http = ["dep:axum", "dep:blake3", "dep:dashmap", "dep:async-stream", "dep:tower-http", "dep:subtle", "dep:tower"]
-unstable-session-close = ["agent-client-protocol/unstable_session_close"]
+# session/close is now exposed as session/delete in acp 0.12.1
+unstable-session-delete = ["agent-client-protocol/unstable_session_delete"]
 unstable-session-fork = ["agent-client-protocol/unstable_session_fork"]
-unstable-session-resume = ["agent-client-protocol/unstable_session_resume"]
+# session/resume is stable in acp 0.12.1; no feature gate needed
+unstable-session-resume = []
 unstable-session-usage = ["agent-client-protocol/unstable_session_usage"]
 unstable-session-model = ["agent-client-protocol/unstable_session_model"]
 # Elicitation types are part of the stable schema in acp 0.11; no feature gate needed.

--- a/crates/zeph-acp/src/agent/handlers/delete_session.rs
+++ b/crates/zeph-acp/src/agent/handlers/delete_session.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Handler for `session/close` (feature `unstable-session-delete`).
+//! Handler for `session/delete` (feature `unstable-session-delete`).
 
 use std::sync::Arc;
 
@@ -9,13 +9,13 @@ use agent_client_protocol as acp;
 
 use crate::agent::ZephAcpAgentState;
 
-/// Handle an ACP `session/close` request.
-pub(crate) async fn handle_close_session(
-    req: acp::schema::CloseSessionRequest,
-    responder: acp::Responder<acp::schema::CloseSessionResponse>,
+/// Handle an ACP `session/delete` request.
+pub(crate) async fn handle_delete_session(
+    req: acp::schema::DeleteSessionRequest,
+    responder: acp::Responder<acp::schema::DeleteSessionResponse>,
     _cx: acp::ConnectionTo<acp::Client>,
     state: Arc<ZephAcpAgentState>,
 ) -> acp::Result<()> {
-    let resp = state.do_close_session(req).await?;
+    let resp = state.do_delete_session(req).await?;
     responder.respond(resp)
 }

--- a/crates/zeph-acp/src/agent/handlers/mod.rs
+++ b/crates/zeph-acp/src/agent/handlers/mod.rs
@@ -6,8 +6,10 @@
 
 pub(crate) mod authenticate;
 pub(crate) mod cancel;
-#[cfg(feature = "unstable-session-close")]
+#[cfg(feature = "unstable-session-delete")]
 pub(crate) mod close_session;
+#[cfg(feature = "unstable-session-delete")]
+pub(crate) mod delete_session;
 pub(crate) mod dispatch;
 #[cfg(feature = "unstable-session-fork")]
 pub(crate) mod fork_session;

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -944,14 +944,14 @@ impl ZephAcpAgentState {
             caps = caps.mcp_capabilities(acp::schema::McpCapabilities::new().http(true).sse(false));
         }
         #[cfg(any(
-            feature = "unstable-session-close",
+            feature = "unstable-session-delete",
             feature = "unstable-session-fork",
             feature = "unstable-session-resume",
         ))]
         let caps = {
             let mut session_caps = acp::schema::SessionCapabilities::new();
             session_caps = session_caps.list(acp::schema::SessionListCapabilities::default());
-            #[cfg(feature = "unstable-session-close")]
+            #[cfg(feature = "unstable-session-delete")]
             {
                 session_caps = session_caps.close(acp::schema::SessionCloseCapabilities::default());
             }
@@ -1349,7 +1349,7 @@ impl ZephAcpAgentState {
         Ok(())
     }
 
-    #[cfg(feature = "unstable-session-close")]
+    #[cfg(feature = "unstable-session-delete")]
     #[allow(clippy::unused_async, dead_code)]
     #[tracing::instrument(skip_all, name = "acp.handler.close_session", fields(session_id = %args.session_id))]
     pub(crate) async fn do_close_session(
@@ -1361,6 +1361,20 @@ impl ZephAcpAgentState {
             entry.cancel_signal.notify_one();
         }
         Ok(acp::schema::CloseSessionResponse::default())
+    }
+
+    #[cfg(feature = "unstable-session-delete")]
+    #[allow(clippy::unused_async, dead_code)]
+    #[tracing::instrument(skip_all, name = "acp.handler.delete_session", fields(session_id = %args.session_id))]
+    pub(crate) async fn do_delete_session(
+        &self,
+        args: acp::schema::DeleteSessionRequest,
+    ) -> acp::Result<acp::schema::DeleteSessionResponse> {
+        tracing::debug!(session_id = %args.session_id, "ACP session deleted");
+        if let Some(entry) = self.sessions.lock().remove(&args.session_id) {
+            entry.cancel_signal.notify_one();
+        }
+        Ok(acp::schema::DeleteSessionResponse::default())
     }
 
     #[tracing::instrument(skip_all, name = "acp.handler.load_session", fields(session_id = %args.session_id))]
@@ -2768,12 +2782,15 @@ macro_rules! notif_handler {
 /// ).await
 /// # }
 /// ```
+#[allow(clippy::too_many_lines)]
 pub async fn run_agent(
     state: Arc<ZephAcpAgentState>,
     transport: impl acp::ConnectTo<acp::Agent>,
 ) -> acp::Result<()> {
-    #[cfg(feature = "unstable-session-close")]
+    #[cfg(feature = "unstable-session-delete")]
     use handlers::close_session;
+    #[cfg(feature = "unstable-session-delete")]
+    use handlers::delete_session;
     #[cfg(feature = "unstable-session-fork")]
     use handlers::fork_session;
     #[cfg(feature = "unstable-logout")]
@@ -2829,9 +2846,14 @@ pub async fn run_agent(
             acp::on_receive_notification!(),
         );
 
-    #[cfg(feature = "unstable-session-close")]
+    #[cfg(feature = "unstable-session-delete")]
     let builder = builder.on_receive_request(
         req_handler!(state, close_session::handle_close_session),
+        acp::on_receive_request!(),
+    );
+    #[cfg(feature = "unstable-session-delete")]
+    let builder = builder.on_receive_request(
+        req_handler!(state, delete_session::handle_delete_session),
         acp::on_receive_request!(),
     );
     #[cfg(feature = "unstable-session-fork")]

--- a/crates/zeph-acp/src/agent/tests.rs
+++ b/crates/zeph-acp/src/agent/tests.rs
@@ -1468,7 +1468,7 @@ async fn initialize_advertises_session_capabilities() {
                 session_caps.resume.is_some(),
                 "resume capability must be advertised"
             );
-            #[cfg(feature = "unstable-session-close")]
+            #[cfg(feature = "unstable-session-delete")]
             assert!(
                 session_caps.close.is_some(),
                 "close capability must be advertised"
@@ -3786,7 +3786,7 @@ async fn non_llm_slash_commands_all_complete_without_hanging() {
         .await;
 }
 
-#[cfg(feature = "unstable-session-close")]
+#[cfg(feature = "unstable-session-delete")]
 #[tokio::test]
 async fn close_session_removes_entry() {
     let local = tokio::task::LocalSet::new();
@@ -3816,7 +3816,7 @@ async fn close_session_removes_entry() {
         .await;
 }
 
-#[cfg(feature = "unstable-session-close")]
+#[cfg(feature = "unstable-session-delete")]
 #[tokio::test]
 async fn close_session_unknown_id_is_ok() {
     let local = tokio::task::LocalSet::new();
@@ -3945,7 +3945,7 @@ async fn set_config_option_model_emits_session_info_update() {
         .await;
 }
 
-#[cfg(feature = "unstable-session-close")]
+#[cfg(feature = "unstable-session-delete")]
 #[tokio::test]
 async fn close_session_signals_cancel() {
     let local = tokio::task::LocalSet::new();

--- a/crates/zeph-acp/src/custom.rs
+++ b/crates/zeph-acp/src/custom.rs
@@ -309,6 +309,7 @@ async fn handle_session_delete(
     agent: &ZephAcpAgent,
     raw: &Arc<RawValue>,
 ) -> acp::Result<acp::schema::ExtResponse> {
+    tracing::warn!("_session/delete is deprecated, use session/delete instead");
     let params: SessionDeleteParams = parse_params(raw)?;
     validate_session_id(&params.session_id)?;
 

--- a/crates/zeph-acp/src/lib.rs
+++ b/crates/zeph-acp/src/lib.rs
@@ -34,9 +34,9 @@
 //! | Flag | Description |
 //! |------|-------------|
 //! | `acp-http` | HTTP/SSE and WebSocket transports via axum |
-//! | `unstable-session-close` | ACP session close extension |
+//! | `unstable-session-delete` | ACP `session/close` and `session/delete` handlers |
 //! | `unstable-session-fork` | ACP session fork extension |
-//! | `unstable-session-resume` | ACP session resume extension |
+//! | `unstable-session-resume` | ACP session resume (stable since acp 0.12.1; no SDK gate needed) |
 //! | `unstable-session-usage` | ACP session token-usage extension |
 //! | `unstable-session-model` | ACP session model-switching extension |
 //! | `unstable-elicitation` | ACP elicitation schema types |


### PR DESCRIPTION
## Summary

- Bumps `agent-client-protocol` from `0.11.1` to `0.12.1`; `agent-client-protocol-tokio` stays at `0.11.1` (no 0.12.x release published yet)
- Renames feature gate `unstable-session-close` → `unstable-session-delete` across `Cargo.toml`, `lib.rs`, and all `cfg(feature)` guards in `zeph-acp`
- Adds standard `session/delete` handler (`delete_session.rs`) under the `unstable-session-delete` feature gate using the SDK's `DeleteSessionRequest`/`DeleteSessionResponse` types
- Keeps `_session/delete` ext method with a `tracing::warn!` deprecation notice

## Breaking changes

None for downstream consumers. The feature gate rename (`unstable-session-close` → `unstable-session-delete`) only affects `zeph-acp` internal feature composition.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10003 passed, 0 failed
- [x] `cargo deny check advisories` — only pre-existing RUSTSEC-2025-0134 (tracked in #3772), nothing new from this bump
- [x] `session/delete` covered by 3 tests in `transport/crud.rs`
- [x] `_session/delete` deprecation covered by 4 tests in `custom.rs`

Closes #4454
Closes #4458