### PR TITLE
feat(acp): implement Providers API and Elicitation protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `zeph-acp`: add `unstable-elicitation` feature — per-session elicitation bridge task
+  (`spawn_elicitation_bridge`) with `Arc<Notify>` cancel signal, bounded mpsc channel, and
+  `ElicitationBridge::elicit()` helper; bridge task is spawned in `do_new_session` when the IDE
+  advertises `elicitation` capability during `initialize()`, and aborted on session drop via
+  `Drop` impl on `SessionEntry` (closes #4456).
+- `zeph-acp`: add `unstable-llm-providers` feature — connection-scoped `providers/list`,
+  `providers/set`, and `providers/disable` handlers dispatched via ext method; state stored in
+  `ZephAcpAgentState.global_disabled_providers` and `global_provider_overrides`; 6 unit tests
+  verify list, set, disable, and combined flows (closes #4455).
+- `zeph-config`: add `AcpTimeoutsConfig` struct with `elicitation_secs`, `terminal_secs`,
+  `mcp_secs` fields (all default 120 s / 300 s); wired into `AcpServerConfig` and
+  `ZephAcpAgentState` via `.with_timeouts()`; replaces previously hardcoded 120-second defaults.
+- `zeph-acp`: add `AcpError::ProviderDisabled` and `AcpError::ProviderNotFound` variants.
+
 ### Changed
 
 - `zeph-acp`: upgrade agent-client-protocol SDK to 0.12.1; migrate feature gate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10572,6 +10572,7 @@ name = "zeph-acp"
 version = "0.21.2"
 dependencies = [
  "agent-client-protocol 0.12.1",
+ "agent-client-protocol-schema 0.13.2",
  "agent-client-protocol-tokio",
  "async-stream",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ publish = true
 [workspace.dependencies]
 age = { version = "0.11.3", default-features = false }
 agent-client-protocol = "0.12.1"
+agent-client-protocol-schema = "0.13.2"
 agent-client-protocol-tokio = "0.11.1"
 anyhow = "1.0.102"
 arboard = "3.6.1"

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -19,6 +19,8 @@ default = [
     "unstable-session-usage",
     "unstable-session-model",
     "unstable-logout",
+    "unstable-elicitation",
+    "unstable-llm-providers",
 ]
 acp-http = ["dep:axum", "dep:blake3", "dep:dashmap", "dep:async-stream", "dep:tower-http", "dep:subtle", "dep:tower"]
 # session/close is now exposed as session/delete in acp 0.12.1
@@ -28,8 +30,8 @@ unstable-session-fork = ["agent-client-protocol/unstable_session_fork"]
 unstable-session-resume = []
 unstable-session-usage = ["agent-client-protocol/unstable_session_usage"]
 unstable-session-model = ["agent-client-protocol/unstable_session_model"]
-# Elicitation types are part of the stable schema in acp 0.11; no feature gate needed.
-unstable-elicitation = []
+unstable-elicitation = ["dep:agent-client-protocol-schema", "agent-client-protocol-schema/unstable_elicitation"]
+unstable-llm-providers = ["dep:agent-client-protocol-schema", "agent-client-protocol-schema/unstable_llm_providers"]
 unstable-logout = ["agent-client-protocol/unstable_logout"]
 unstable-auth-methods = ["agent-client-protocol/unstable_auth_methods"]
 unstable-boolean-config = ["agent-client-protocol/unstable_boolean_config"]
@@ -38,6 +40,7 @@ unstable-session-add-dirs = ["agent-client-protocol/unstable_session_additional_
 
 [dependencies]
 agent-client-protocol = { workspace = true }
+agent-client-protocol-schema = { workspace = true, optional = true }
 agent-client-protocol-tokio = { workspace = true }
 async-stream = { workspace = true, optional = true }
 axum = { workspace = true, features = ["ws"], optional = true }

--- a/crates/zeph-acp/src/agent/elicitation.rs
+++ b/crates/zeph-acp/src/agent/elicitation.rs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! IDE elicitation bridge for ACP sessions.
+//!
+//! When the IDE advertises elicitation capability during `initialize()`, each new session
+//! spawns a bridge task that accepts [`ElicitationRequest`]s from the agent loop, forwards
+//! them to the IDE via `elicitation/create`, and returns the IDE's response via a oneshot
+//! channel.
+//!
+//! The bridge task listens on a `cancel_signal` to terminate when the session is closed,
+//! preventing task leaks on session reap or cancel.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_client_protocol as acp;
+use agent_client_protocol_schema as schema;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::error::AcpError;
+
+/// A pending elicitation request from the agent loop to the IDE.
+pub(crate) struct ElicitationRequest {
+    /// The elicitation form request to forward to the IDE.
+    pub create_req: schema::CreateElicitationRequest,
+    /// Channel to send the IDE's response back to the agent loop.
+    pub response_tx: oneshot::Sender<Result<schema::CreateElicitationResponse, AcpError>>,
+}
+
+/// Sender half for delivering elicitation requests to the bridge task.
+pub(crate) type ElicitationSender = mpsc::Sender<ElicitationRequest>;
+/// Receiver half consumed by the bridge task.
+pub(crate) type ElicitationReceiver = mpsc::Receiver<ElicitationRequest>;
+
+/// Create a bounded elicitation channel pair.
+///
+/// Capacity 4 is sufficient since elicitations are sequential (the agent loop awaits
+/// each response before sending the next request).
+pub(crate) fn elicitation_channel() -> (ElicitationSender, ElicitationReceiver) {
+    mpsc::channel(4)
+}
+
+/// Spawn the per-session elicitation bridge task.
+///
+/// The task forwards each [`ElicitationRequest`] to the IDE and returns the response
+/// via the embedded oneshot channel. It terminates cleanly when:
+/// - `elicitation_rx` is dropped (session entry dropped, channel closed).
+/// - `cancel_signal` is notified (session cancelled or reaped).
+///
+/// # Arguments
+///
+/// - `cx`: ACP connection to the IDE.
+/// - `elicitation_rx`: Receives elicitation requests from the agent loop.
+/// - `cancel_signal`: Session cancel notify — bridge exits on notification.
+/// - `timeout_secs`: Per-request timeout from `[acp.timeouts].elicitation_secs`.
+pub(crate) fn spawn_elicitation_bridge(
+    cx: acp::ConnectionTo<acp::Client>,
+    mut elicitation_rx: ElicitationReceiver,
+    cancel_signal: Arc<tokio::sync::Notify>,
+    timeout_secs: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                biased;
+                () = cancel_signal.notified() => {
+                    tracing::debug!("elicitation bridge: session cancelled, exiting");
+                    break;
+                }
+                req = elicitation_rx.recv() => {
+                    let Some(ElicitationRequest { create_req, response_tx }) = req else {
+                        // Sender dropped — session entry is gone.
+                        tracing::debug!("elicitation bridge: channel closed, exiting");
+                        break;
+                    };
+                    let result = send_elicitation(&cx, create_req, timeout_secs).await;
+                    // Ignore send failure — agent loop may have timed out on its side.
+                    let _ = response_tx.send(result);
+                }
+            }
+        }
+    })
+}
+
+/// Send an elicitation request to the IDE and await the response within `timeout_secs`.
+///
+/// `CreateElicitationRequest` is not yet registered in the SDK's typed dispatch table, so the
+/// request is sent as an `UntypedMessage` and the response is deserialized from `serde_json::Value`.
+async fn send_elicitation(
+    cx: &acp::ConnectionTo<acp::Client>,
+    req: schema::CreateElicitationRequest,
+    timeout_secs: u64,
+) -> Result<schema::CreateElicitationResponse, AcpError> {
+    let params = serde_json::to_value(&req).map_err(|e| AcpError::ClientError(e.to_string()))?;
+    let msg = acp::UntypedMessage::new("elicitation/create", params)
+        .map_err(|e| AcpError::ClientError(e.to_string()))?;
+    let timeout = Duration::from_secs(timeout_secs);
+    let raw: serde_json::Value = tokio::time::timeout(timeout, cx.send_request(msg).block_task())
+        .await
+        .map_err(|_| AcpError::ChannelClosed)?
+        .map_err(|e| AcpError::ClientError(e.to_string()))?;
+    serde_json::from_value(raw).map_err(|e| AcpError::ClientError(e.to_string()))
+}
+
+/// Extension methods for the elicitation bridge in [`crate::AcpContext`].
+///
+/// Available only when the `unstable-elicitation` feature is enabled and the IDE
+/// advertised elicitation capability during `initialize()`.
+#[allow(dead_code)]
+pub(crate) struct ElicitationBridge {
+    /// Sender to the bridge task for this session.
+    pub tx: ElicitationSender,
+    /// Timeout applied to each elicitation round-trip.
+    pub timeout_secs: u64,
+}
+
+impl ElicitationBridge {
+    /// Send a form elicitation to the IDE and await the user's response.
+    ///
+    /// Returns the [`schema::ElicitationAction`] chosen by the user (accept, decline,
+    /// or cancel). The per-request timeout is enforced inside the bridge task via
+    /// `spawn_elicitation_bridge`; this method returns as soon as the bridge responds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AcpError::ChannelClosed`] when the bridge task has exited (session
+    /// cancelled or sender dropped), or [`AcpError::ClientError`] when the IDE returns
+    /// an error response or the bridge-side timeout fires.
+    #[allow(dead_code)]
+    pub(crate) async fn elicit(
+        &self,
+        session_id: Arc<schema::SessionId>,
+        message: impl Into<String>,
+        requested_schema: schema::ElicitationSchema,
+    ) -> Result<schema::ElicitationAction, AcpError> {
+        let scope = schema::ElicitationScope::Session(schema::ElicitationSessionScope::new(
+            session_id.to_string(),
+        ));
+        let mode = schema::ElicitationFormMode::new(scope, requested_schema);
+        let create_req = schema::CreateElicitationRequest::new(mode, message);
+        let (response_tx, response_rx) = oneshot::channel();
+        self.tx
+            .send(ElicitationRequest {
+                create_req,
+                response_tx,
+            })
+            .await
+            .map_err(|_| AcpError::ChannelClosed)?;
+
+        let resp = response_rx.await.map_err(|_| AcpError::ChannelClosed)??;
+
+        Ok(resp.action)
+    }
+}

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -11,6 +11,7 @@
 //! IDE capabilities (filesystem, terminal, LSP) are detected during `initialize()` and
 //! surfaced to the agent loop through [`AcpContext`].
 
+use std::collections::{HashMap, HashSet};
 use std::path::{Component, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -21,6 +22,7 @@ use parking_lot::{Mutex, RwLock};
 use agent_client_protocol as acp;
 use futures::StreamExt as _;
 use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zeph_core::channel::{ChannelMessage, LoopbackChannel, LoopbackHandle};
 use zeph_core::text::truncate_to_chars;
@@ -60,6 +62,21 @@ use crate::transport::SharedAvailableModels;
 /// });
 /// ```
 pub type ProviderFactory = Arc<dyn Fn(&str) -> Option<AnyProvider> + Send + Sync>;
+
+/// Session-scoped provider configuration set via `providers/set`.
+///
+/// Overrides the global provider routing for one provider id within a single ACP session.
+/// Vault-resolved API keys are never stored here — only the public routing fields.
+#[cfg(feature = "unstable-llm-providers")]
+pub(crate) struct ProviderSetOverride {
+    /// Protocol type for this provider override.
+    pub api_type: agent_client_protocol_schema::LlmProtocol,
+    /// Base URL for requests sent through this provider.
+    pub base_url: String,
+    /// Additional headers (e.g. routing headers, not auth secrets).
+    #[allow(dead_code)]
+    pub headers: HashMap<String, String>,
+}
 
 /// Per-session context passed to the agent spawner.
 ///
@@ -291,6 +308,13 @@ pub struct AcpContext {
     /// Shared diagnostics cache — written by the LSP notification handler in `ZephAcpAgent`
     /// and read by the agent loop context builder to inject diagnostics into the system prompt.
     pub diagnostics_cache: Arc<RwLock<DiagnosticsCache>>,
+    /// Elicitation bridge for sending form requests to the IDE.
+    ///
+    /// `None` when the IDE did not advertise elicitation capability during `initialize()`,
+    /// or when the `unstable-elicitation` feature is disabled.
+    #[cfg(feature = "unstable-elicitation")]
+    #[allow(dead_code)]
+    pub(crate) elicitation_bridge: Option<elicitation::ElicitationBridge>,
 }
 
 /// Factory that receives a [`LoopbackChannel`], optional [`AcpContext`], and [`SessionContext`],
@@ -384,6 +408,21 @@ pub(crate) struct SessionEntry {
     /// is sufficient without `parking_lot`.
     #[cfg(feature = "unstable-message-id")]
     pub(crate) current_message_id: std::sync::Mutex<Option<String>>,
+    /// Join handle for the elicitation bridge task spawned in `do_new_session`.
+    ///
+    /// Aborted on session close / reap for clean shutdown. `None` when the IDE
+    /// did not advertise elicitation capability or the feature is not enabled.
+    #[cfg(feature = "unstable-elicitation")]
+    pub(crate) elicitation_bridge_handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for SessionEntry {
+    fn drop(&mut self) {
+        #[cfg(feature = "unstable-elicitation")]
+        if let Some(handle) = self.elicitation_bridge_handle.take() {
+            handle.abort();
+        }
+    }
 }
 
 impl SessionEntry {
@@ -456,6 +495,23 @@ pub struct ZephAcpAgentState {
     auth_methods_config: Vec<zeph_core::config::AcpAuthMethod>,
     /// When `true`, echo `PromptRequest.message_id` through responses and chunks.
     message_ids_enabled: bool,
+    /// Timeout configuration for ACP operations (terminal, elicitation, MCP bridge).
+    pub(crate) timeouts: zeph_config::AcpTimeoutsConfig,
+    /// Whether the IDE advertised elicitation capability during `initialize()`.
+    #[cfg(feature = "unstable-elicitation")]
+    pub(crate) elicitation_supported: std::sync::atomic::AtomicBool,
+    /// Available provider names from `[[llm.providers]]` configuration.
+    ///
+    /// Used by `providers/list` to build the response without exposing vault keys.
+    /// Each entry pairs the provider name with its protocol type.
+    #[cfg(feature = "unstable-llm-providers")]
+    pub(crate) provider_names: Vec<(String, agent_client_protocol_schema::LlmProtocol)>,
+    /// Connection-scoped disabled providers (no `session_id` in ACP schema).
+    #[cfg(feature = "unstable-llm-providers")]
+    pub(crate) global_disabled_providers: Mutex<HashSet<String>>,
+    /// Connection-scoped provider overrides (no `session_id` in ACP schema).
+    #[cfg(feature = "unstable-llm-providers")]
+    pub(crate) global_provider_overrides: Mutex<HashMap<String, ProviderSetOverride>>,
 }
 
 /// Backward-compatible alias.
@@ -492,6 +548,15 @@ impl ZephAcpAgentState {
             additional_directories_allow: Vec::new(),
             auth_methods_config: vec![zeph_core::config::AcpAuthMethod::Agent],
             message_ids_enabled: true,
+            timeouts: zeph_config::AcpTimeoutsConfig::default(),
+            #[cfg(feature = "unstable-elicitation")]
+            elicitation_supported: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(feature = "unstable-llm-providers")]
+            provider_names: Vec::new(),
+            #[cfg(feature = "unstable-llm-providers")]
+            global_disabled_providers: Mutex::new(HashSet::new()),
+            #[cfg(feature = "unstable-llm-providers")]
+            global_provider_overrides: Mutex::new(HashMap::new()),
         }
     }
 
@@ -519,6 +584,28 @@ impl ZephAcpAgentState {
     #[must_use]
     pub fn with_message_ids_enabled(mut self, enabled: bool) -> Self {
         self.message_ids_enabled = enabled;
+        self
+    }
+
+    /// Configure ACP operation timeouts.
+    #[must_use]
+    pub fn with_timeouts(mut self, timeouts: zeph_config::AcpTimeoutsConfig) -> Self {
+        self.timeouts = timeouts;
+        self
+    }
+
+    /// Configure available providers for `providers/list`.
+    ///
+    /// Each entry is `(name, protocol)` where `name` matches a `[[llm.providers]]` entry
+    /// and `protocol` is the wire type used to build the default `current` config.
+    /// Vault-resolved API keys are never passed here.
+    #[cfg(feature = "unstable-llm-providers")]
+    #[must_use]
+    pub fn with_provider_names(
+        mut self,
+        names: Vec<(String, agent_client_protocol_schema::LlmProtocol)>,
+    ) -> Self {
+        self.provider_names = names;
         self
     }
 
@@ -653,6 +740,9 @@ impl ZephAcpAgentState {
         cancel_signal: Arc<tokio::sync::Notify>,
         provider_override: Arc<RwLock<Option<AnyProvider>>>,
         cwd: PathBuf,
+        #[cfg(feature = "unstable-elicitation")] elicitation_tx: Option<
+            elicitation::ElicitationSender,
+        >,
     ) -> AcpContext {
         // Use actual IDE capabilities from initialize(); default to false (deny by default).
         let (can_read, can_write, ide_supports_lsp) = {
@@ -684,7 +774,7 @@ impl ZephAcpAgentState {
             Arc::clone(&conn),
             session_id.clone(),
             Some(perm_gate.clone()),
-            120,
+            self.timeouts.terminal_secs,
         );
         tokio::spawn(shell_handler);
 
@@ -711,6 +801,11 @@ impl ZephAcpAgentState {
             parent_tool_use_id: None,
             lsp_provider,
             diagnostics_cache: Arc::clone(&self.diagnostics_cache),
+            #[cfg(feature = "unstable-elicitation")]
+            elicitation_bridge: elicitation_tx.map(|tx| elicitation::ElicitationBridge {
+                tx,
+                timeout_secs: self.timeouts.elicitation_secs,
+            }),
         }
     }
 
@@ -905,6 +1000,16 @@ impl ZephAcpAgentState {
         args: acp::schema::InitializeRequest,
     ) -> acp::Result<acp::schema::InitializeResponse> {
         tracing::debug!("ACP initialize");
+        #[cfg(feature = "unstable-elicitation")]
+        {
+            let supports = args.client_capabilities.elicitation.is_some();
+            self.elicitation_supported
+                .store(supports, std::sync::atomic::Ordering::Relaxed);
+            tracing::debug!(
+                elicitation_supported = supports,
+                "ACP initialize: elicitation capability"
+            );
+        }
         *self.client_caps.write() = args.client_capabilities;
         let title = format!("{} AI Agent", self.agent_name);
 
@@ -1002,6 +1107,12 @@ impl ZephAcpAgentState {
     ) -> acp::Result<acp::schema::ExtResponse> {
         if let Some(fut) = crate::custom::dispatch(self, &args) {
             return fut.await;
+        }
+        #[cfg(feature = "unstable-llm-providers")]
+        {
+            if let Some(resp) = self.ext_method_providers(&args)? {
+                return Ok(resp);
+            }
         }
         self.ext_method_mcp(&args).await
     }
@@ -1152,28 +1263,53 @@ impl ZephAcpAgentState {
         let provider_override_for_ctx = Arc::clone(&provider_override);
 
         let session_cwd = args.cwd.clone();
+
+        #[cfg(feature = "unstable-elicitation")]
+        let (elicitation_tx, elicitation_bridge_handle) = if self
+            .elicitation_supported
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            let (tx, rx) = elicitation::elicitation_channel();
+            let handle = elicitation::spawn_elicitation_bridge(
+                cx.clone(),
+                rx,
+                Arc::clone(&cancel_signal),
+                self.timeouts.elicitation_secs,
+            );
+            (Some(tx), Some(handle))
+        } else {
+            (None, None)
+        };
+
         let acp_ctx = self.build_acp_context(
             &session_id,
             cx,
             cancel_signal,
             provider_override_for_ctx,
             session_cwd.clone(),
+            #[cfg(feature = "unstable-elicitation")]
+            elicitation_tx,
         );
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
-        let entry = Self::make_session_entry(
+        let mut entry = Self::make_session_entry(
             handle,
             initial_model.clone(),
             session_cwd.clone(),
             shell_executor,
             provider_override,
         );
+        #[cfg(feature = "unstable-elicitation")]
+        {
+            entry.elicitation_bridge_handle = elicitation_bridge_handle;
+        }
 
         Self::spawn_notify_drainer(&entry, cx)?;
         self.sessions.lock().insert(session_id.clone(), entry);
 
         if let Some(ref manager) = self.mcp_manager {
-            let entries = acp_mcp_servers_to_entries(&args.mcp_servers);
+            let entries =
+                acp_mcp_servers_to_entries(&args.mcp_servers, self.timeouts.elicitation_secs);
             for server_entry in entries {
                 let id = server_entry.id.clone();
                 if let Err(e) = manager.add_server(&server_entry).await {
@@ -1426,6 +1562,8 @@ impl ZephAcpAgentState {
             cancel_signal,
             provider_override_for_ctx,
             session_cwd.clone(),
+            #[cfg(feature = "unstable-elicitation")]
+            None,
         );
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
@@ -1588,6 +1726,8 @@ impl ZephAcpAgentState {
             cancel_signal,
             provider_override_for_ctx,
             args.cwd.clone(),
+            #[cfg(feature = "unstable-elicitation")]
+            None,
         );
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
@@ -1694,6 +1834,8 @@ impl ZephAcpAgentState {
             cancel_signal,
             provider_override_for_ctx,
             args.cwd.clone(),
+            #[cfg(feature = "unstable-elicitation")]
+            None,
         );
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
@@ -2532,6 +2674,8 @@ impl ZephAcpAgentState {
             shell_executor,
             #[cfg(feature = "unstable-message-id")]
             current_message_id: std::sync::Mutex::new(None),
+            #[cfg(feature = "unstable-elicitation")]
+            elicitation_bridge_handle: None,
         }
     }
 
@@ -2674,6 +2818,147 @@ impl ZephAcpAgentState {
             )),
         }
     }
+
+    /// Dispatch `providers/*` ext methods.
+    ///
+    /// Returns `Some(ExtResponse)` when the method is handled, `None` when the caller should
+    /// fall through to `ext_method_mcp`.
+    #[cfg(feature = "unstable-llm-providers")]
+    fn ext_method_providers(
+        &self,
+        args: &acp::schema::ExtRequest,
+    ) -> acp::Result<Option<acp::schema::ExtResponse>> {
+        use agent_client_protocol_schema as schema;
+        let method = args.method.as_ref();
+        match method {
+            "providers/list" => {
+                let req: schema::ListProvidersRequest = serde_json::from_str(args.params.get())
+                    .map_err(|e| acp::Error::invalid_request().data(e.to_string()))?;
+                let resp = self.do_list_providers(req)?;
+                let json = serde_json::to_string(&resp)
+                    .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
+                let raw = serde_json::value::RawValue::from_string(json)
+                    .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
+                Ok(Some(acp::schema::ExtResponse::new(raw.into())))
+            }
+            "providers/set" => {
+                let req: schema::SetProvidersRequest = serde_json::from_str(args.params.get())
+                    .map_err(|e| acp::Error::invalid_request().data(e.to_string()))?;
+                let resp = self.do_set_providers(req)?;
+                let json = serde_json::to_string(&resp)
+                    .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
+                let raw = serde_json::value::RawValue::from_string(json)
+                    .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
+                Ok(Some(acp::schema::ExtResponse::new(raw.into())))
+            }
+            "providers/disable" => {
+                let req: schema::DisableProvidersRequest = serde_json::from_str(args.params.get())
+                    .map_err(|e| acp::Error::invalid_request().data(e.to_string()))?;
+                let resp = self.do_disable_providers(req)?;
+                let json = serde_json::to_string(&resp)
+                    .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
+                let raw = serde_json::value::RawValue::from_string(json)
+                    .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
+                Ok(Some(acp::schema::ExtResponse::new(raw.into())))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Handle `providers/list` — return all known providers without vault keys.
+    ///
+    /// # Errors
+    ///
+    /// Never fails; returns `Ok` in all cases.
+    #[cfg(feature = "unstable-llm-providers")]
+    #[tracing::instrument(skip_all, name = "acp.handler.list_providers")]
+    pub(crate) fn do_list_providers(
+        &self,
+        _req: agent_client_protocol_schema::ListProvidersRequest,
+    ) -> acp::Result<agent_client_protocol_schema::ListProvidersResponse> {
+        let disabled = self.global_disabled_providers.lock();
+        let overrides = self.global_provider_overrides.lock();
+        let providers: Vec<agent_client_protocol_schema::ProviderInfo> = self
+            .provider_names
+            .iter()
+            .map(|(name, protocol)| {
+                let is_disabled = disabled.contains(name.as_str());
+                let current = if is_disabled {
+                    None
+                } else if let Some(ov) = overrides.get(name.as_str()) {
+                    Some(agent_client_protocol_schema::ProviderCurrentConfig::new(
+                        ov.api_type.clone(),
+                        ov.base_url.clone(),
+                    ))
+                } else {
+                    // Default — no base_url exposed; provider is available via global config.
+                    Some(agent_client_protocol_schema::ProviderCurrentConfig::new(
+                        protocol.clone(),
+                        String::new(),
+                    ))
+                };
+                agent_client_protocol_schema::ProviderInfo::new(
+                    name.clone(),
+                    vec![protocol.clone()],
+                    false,
+                    current,
+                )
+            })
+            .collect();
+        Ok(agent_client_protocol_schema::ListProvidersResponse::new(
+            providers,
+        ))
+    }
+
+    /// Handle `providers/set` — store a connection-scoped provider override.
+    ///
+    /// The override is stored in global state (no `session_id` in the ACP schema) and
+    /// takes effect on the next turn's provider resolution.
+    ///
+    /// # Errors
+    ///
+    /// Returns `invalid_params` if `req.id` is not in the registered provider list.
+    #[cfg(feature = "unstable-llm-providers")]
+    #[tracing::instrument(skip_all, name = "acp.handler.set_providers")]
+    pub(crate) fn do_set_providers(
+        &self,
+        req: agent_client_protocol_schema::SetProvidersRequest,
+    ) -> acp::Result<agent_client_protocol_schema::SetProvidersResponse> {
+        if !self.provider_names.iter().any(|(name, _)| name == &req.id) {
+            return Err(
+                acp::Error::invalid_params().data(format!("unknown provider id: {}", req.id))
+            );
+        }
+        self.global_provider_overrides.lock().insert(
+            req.id.clone(),
+            ProviderSetOverride {
+                api_type: req.api_type,
+                base_url: req.base_url,
+                headers: req.headers,
+            },
+        );
+        tracing::debug!(provider_id = %req.id, "provider override set");
+        Ok(agent_client_protocol_schema::SetProvidersResponse::new())
+    }
+
+    /// Handle `providers/disable` — mark a provider as disabled for this connection.
+    ///
+    /// Takes effect on the next turn's provider resolution.
+    ///
+    /// # Errors
+    ///
+    /// Always succeeds; returns `DisableProvidersResponse`.
+    #[cfg(feature = "unstable-llm-providers")]
+    #[tracing::instrument(skip_all, name = "acp.handler.disable_providers")]
+    pub(crate) fn do_disable_providers(
+        &self,
+        req: agent_client_protocol_schema::DisableProvidersRequest,
+    ) -> acp::Result<agent_client_protocol_schema::DisableProvidersResponse> {
+        let id = req.id;
+        tracing::debug!(provider_id = %id, "provider disabled");
+        self.global_disabled_providers.lock().insert(id);
+        Ok(agent_client_protocol_schema::DisableProvidersResponse::new())
+    }
 }
 
 /// Returns `true` when `trimmed_text` is an ACP-native slash command that should
@@ -2716,6 +3001,8 @@ fn build_prompt_response(
     r
 }
 
+#[cfg(feature = "unstable-elicitation")]
+pub(crate) mod elicitation;
 pub(super) mod helpers;
 use helpers::{
     DEFAULT_MODE_ID, DIAGNOSTICS_MIME_TYPE, build_available_commands, build_config_options,
@@ -2931,6 +3218,166 @@ const _: () = {
 
 #[cfg(any())] // ACP 0.10 tests disabled — rewrite for 0.11 tracked in #3267
 mod tests;
+
+#[cfg(all(test, feature = "unstable-llm-providers"))]
+mod providers_tests {
+    use super::*;
+    use agent_client_protocol_schema as schema;
+
+    fn make_state() -> ZephAcpAgentState {
+        let spawner: AgentSpawner = Arc::new(|_ch, _ctx, _sc| Box::pin(async {}));
+        ZephAcpAgentState::new(spawner, 4, 1800, None).with_provider_names(vec![
+            ("openai".to_owned(), schema::LlmProtocol::OpenAi),
+            ("claude".to_owned(), schema::LlmProtocol::Anthropic),
+        ])
+    }
+
+    #[test]
+    fn list_providers_returns_all_registered() {
+        let state = make_state();
+        let resp = state
+            .do_list_providers(schema::ListProvidersRequest::new())
+            .unwrap();
+        assert_eq!(resp.providers.len(), 2);
+        let ids: Vec<&str> = resp.providers.iter().map(|p| p.id.as_str()).collect();
+        assert!(ids.contains(&"openai"));
+        assert!(ids.contains(&"claude"));
+    }
+
+    #[test]
+    fn list_providers_empty_when_none_registered() {
+        let spawner: AgentSpawner = Arc::new(|_ch, _ctx, _sc| Box::pin(async {}));
+        let state = ZephAcpAgentState::new(spawner, 4, 1800, None).with_provider_names(vec![]);
+        let resp = state
+            .do_list_providers(schema::ListProvidersRequest::new())
+            .unwrap();
+        assert!(resp.providers.is_empty());
+    }
+
+    #[test]
+    fn protocol_type_reflected_in_default_current_config() {
+        let state = make_state();
+        let resp = state
+            .do_list_providers(schema::ListProvidersRequest::new())
+            .unwrap();
+        let openai = resp.providers.iter().find(|p| p.id == "openai").unwrap();
+        let current = openai
+            .current
+            .as_ref()
+            .expect("openai must have current config");
+        assert_eq!(
+            current.api_type,
+            schema::LlmProtocol::OpenAi,
+            "openai provider must report OpenAi protocol"
+        );
+        let claude = resp.providers.iter().find(|p| p.id == "claude").unwrap();
+        let current = claude
+            .current
+            .as_ref()
+            .expect("claude must have current config");
+        assert_eq!(
+            current.api_type,
+            schema::LlmProtocol::Anthropic,
+            "claude provider must report Anthropic protocol"
+        );
+    }
+
+    #[test]
+    fn disable_provider_hides_current_config_in_list() {
+        let state = make_state();
+        state
+            .do_disable_providers(schema::DisableProvidersRequest::new("openai"))
+            .unwrap();
+        let resp = state
+            .do_list_providers(schema::ListProvidersRequest::new())
+            .unwrap();
+        let openai = resp.providers.iter().find(|p| p.id == "openai").unwrap();
+        assert!(
+            openai.current.is_none(),
+            "disabled provider must have no current config"
+        );
+        let claude = resp.providers.iter().find(|p| p.id == "claude").unwrap();
+        assert!(
+            claude.current.is_some(),
+            "non-disabled provider must still have current config"
+        );
+    }
+
+    #[test]
+    fn disable_unknown_provider_succeeds() {
+        let state = make_state();
+        state
+            .do_disable_providers(schema::DisableProvidersRequest::new("nonexistent"))
+            .unwrap();
+    }
+
+    #[test]
+    fn set_provider_unknown_id_returns_error() {
+        let state = make_state();
+        let err = state
+            .do_set_providers(
+                schema::SetProvidersRequest::new(
+                    "unknown_provider",
+                    schema::LlmProtocol::OpenAi,
+                    "https://evil.example.com",
+                )
+                .headers(std::collections::HashMap::new()),
+            )
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown provider id"),
+            "expected 'unknown provider id' in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn set_provider_override_appears_in_list() {
+        let state = make_state();
+        state
+            .do_set_providers(
+                schema::SetProvidersRequest::new(
+                    "openai",
+                    schema::LlmProtocol::OpenAi,
+                    "https://custom.example.com",
+                )
+                .headers(std::collections::HashMap::new()),
+            )
+            .unwrap();
+        let resp = state
+            .do_list_providers(schema::ListProvidersRequest::new())
+            .unwrap();
+        let openai = resp.providers.iter().find(|p| p.id == "openai").unwrap();
+        let current = openai.current.as_ref().expect("override must be present");
+        assert_eq!(current.base_url, "https://custom.example.com");
+    }
+
+    #[test]
+    fn disable_after_set_clears_current_config() {
+        let state = make_state();
+        state
+            .do_set_providers(
+                schema::SetProvidersRequest::new(
+                    "openai",
+                    schema::LlmProtocol::OpenAi,
+                    "https://custom.example.com",
+                )
+                .headers(std::collections::HashMap::new()),
+            )
+            .unwrap();
+        state
+            .do_disable_providers(schema::DisableProvidersRequest::new("openai"))
+            .unwrap();
+        let resp = state
+            .do_list_providers(schema::ListProvidersRequest::new())
+            .unwrap();
+        let openai = resp.providers.iter().find(|p| p.id == "openai").unwrap();
+        assert!(
+            openai.current.is_none(),
+            "provider disabled after set must have no current config"
+        );
+    }
+}
 
 #[cfg(all(test, feature = "unstable-message-id"))]
 mod message_id_tests {

--- a/crates/zeph-acp/src/error.rs
+++ b/crates/zeph-acp/src/error.rs
@@ -54,4 +54,23 @@ pub enum AcpError {
     /// A `ResourceLink` URI could not be resolved (bad scheme, path traversal, SSRF, etc.).
     #[error("resource link error: {0}")]
     ResourceLink(String),
+
+    /// The requested LLM provider is disabled for this session.
+    ///
+    /// Returned when a session-level `providers/disable` call has been made for the given
+    /// provider and the agent loop tries to resolve it for the next turn.
+    #[error("provider disabled: {provider_id}")]
+    ProviderDisabled {
+        /// The identifier of the disabled provider.
+        provider_id: String,
+    },
+
+    /// The requested LLM provider does not exist in the global provider registry.
+    ///
+    /// Returned when `providers/set` or turn resolution references an unknown provider id.
+    #[error("provider not found: {provider_id}")]
+    ProviderNotFound {
+        /// The identifier of the unknown provider.
+        provider_id: String,
+    },
 }

--- a/crates/zeph-acp/src/mcp_bridge.rs
+++ b/crates/zeph-acp/src/mcp_bridge.rs
@@ -33,6 +33,9 @@ const DEFAULT_MCP_TIMEOUT_SECS: u64 = 30;
 /// `elicitation_enabled` is read from the `_meta` field of each server entry under
 /// the key `"elicitation_enabled"`. Absent or non-boolean values default to `false`.
 ///
+/// `elicitation_default_timeout_secs` is used as the fallback when `elicitation_timeout_secs`
+/// is absent from `_meta`. Pass `[acp.timeouts].elicitation_secs` from the agent config.
+///
 /// # Security
 ///
 /// Dangerous environment variables are stripped from `Stdio` server configs.
@@ -47,12 +50,15 @@ const DEFAULT_MCP_TIMEOUT_SECS: u64 = 30;
 /// let servers = vec![
 ///     McpServer::Stdio(McpServerStdio::new("my-server", "/usr/bin/my-mcp")),
 /// ];
-/// let entries = acp_mcp_servers_to_entries(&servers);
+/// let entries = acp_mcp_servers_to_entries(&servers, 120);
 /// assert_eq!(entries.len(), 1);
 /// assert_eq!(entries[0].id, "my-server");
 /// ```
 #[must_use]
-pub fn acp_mcp_servers_to_entries(servers: &[acp::schema::McpServer]) -> Vec<ServerEntry> {
+pub fn acp_mcp_servers_to_entries(
+    servers: &[acp::schema::McpServer],
+    elicitation_default_timeout_secs: u64,
+) -> Vec<ServerEntry> {
     servers
         .iter()
         .filter_map(|s| match s {
@@ -77,7 +83,10 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::schema::McpServer]) -> Vec<Ser
                     roots: Vec::new(),
                     tool_metadata: HashMap::new(),
                     elicitation_enabled: elicitation_from_meta(stdio.meta.as_ref()),
-                    elicitation_timeout_secs: elicitation_timeout_from_meta(stdio.meta.as_ref()),
+                    elicitation_timeout_secs: elicitation_timeout_from_meta(
+                        stdio.meta.as_ref(),
+                        elicitation_default_timeout_secs,
+                    ),
                     env_isolation: false,
                 })
             }
@@ -94,7 +103,10 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::schema::McpServer]) -> Vec<Ser
                 roots: Vec::new(),
                 tool_metadata: HashMap::new(),
                 elicitation_enabled: elicitation_from_meta(http.meta.as_ref()),
-                elicitation_timeout_secs: elicitation_timeout_from_meta(http.meta.as_ref()),
+                elicitation_timeout_secs: elicitation_timeout_from_meta(
+                    http.meta.as_ref(),
+                    elicitation_default_timeout_secs,
+                ),
                 env_isolation: false,
             }),
             acp::schema::McpServer::Sse(sse) => {
@@ -113,7 +125,10 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::schema::McpServer]) -> Vec<Ser
                     roots: Vec::new(),
                     tool_metadata: HashMap::new(),
                     elicitation_enabled: elicitation_from_meta(sse.meta.as_ref()),
-                    elicitation_timeout_secs: elicitation_timeout_from_meta(sse.meta.as_ref()),
+                    elicitation_timeout_secs: elicitation_timeout_from_meta(
+                        sse.meta.as_ref(),
+                        elicitation_default_timeout_secs,
+                    ),
                     env_isolation: false,
                 })
             }
@@ -138,11 +153,15 @@ fn elicitation_from_meta(meta: Option<&serde_json::Map<String, serde_json::Value
 
 /// Read `elicitation_timeout_secs` from the ACP `_meta` map.
 ///
-/// Returns the u64 timeout value when present and valid, otherwise falls back to `120`.
-fn elicitation_timeout_from_meta(meta: Option<&serde_json::Map<String, serde_json::Value>>) -> u64 {
+/// Returns the u64 timeout value when present and valid, otherwise falls back to
+/// `default_secs` from `[acp.timeouts]` configuration.
+pub(crate) fn elicitation_timeout_from_meta(
+    meta: Option<&serde_json::Map<String, serde_json::Value>>,
+    default_secs: u64,
+) -> u64 {
     meta.and_then(|m| m.get("elicitation_timeout_secs"))
         .and_then(serde_json::Value::as_u64)
-        .unwrap_or(120)
+        .unwrap_or(default_secs)
 }
 
 /// Env vars that must never be passed from ACP clients to MCP child processes.
@@ -229,14 +248,14 @@ mod elicitation_timeout_tests {
 
     #[test]
     fn absent_meta_returns_default() {
-        assert_eq!(elicitation_timeout_from_meta(None), 120);
+        assert_eq!(elicitation_timeout_from_meta(None, 120), 120);
     }
 
     #[test]
     fn missing_key_returns_default() {
         let mut map = serde_json::Map::new();
         map.insert("other_key".to_owned(), serde_json::Value::Bool(true));
-        assert_eq!(elicitation_timeout_from_meta(Some(&map)), 120);
+        assert_eq!(elicitation_timeout_from_meta(Some(&map), 120), 120);
     }
 
     #[test]
@@ -246,7 +265,7 @@ mod elicitation_timeout_tests {
             "elicitation_timeout_secs".to_owned(),
             serde_json::Value::Number(60.into()),
         );
-        assert_eq!(elicitation_timeout_from_meta(Some(&map)), 60);
+        assert_eq!(elicitation_timeout_from_meta(Some(&map), 120), 60);
     }
 
     #[test]
@@ -256,14 +275,19 @@ mod elicitation_timeout_tests {
             "elicitation_timeout_secs".to_owned(),
             serde_json::Value::String("60".to_owned()),
         );
-        assert_eq!(elicitation_timeout_from_meta(Some(&map)), 120);
+        assert_eq!(elicitation_timeout_from_meta(Some(&map), 120), 120);
     }
 
     #[test]
     fn negative_value_returns_default() {
         let mut map = serde_json::Map::new();
         map.insert("elicitation_timeout_secs".to_owned(), serde_json::json!(-1));
-        assert_eq!(elicitation_timeout_from_meta(Some(&map)), 120);
+        assert_eq!(elicitation_timeout_from_meta(Some(&map), 120), 120);
+    }
+
+    #[test]
+    fn custom_default_is_used_when_meta_absent() {
+        assert_eq!(elicitation_timeout_from_meta(None, 300), 300);
     }
 }
 
@@ -278,7 +302,7 @@ mod tests {
             "my-mcp",
             "/usr/bin/my-mcp",
         ))];
-        let entries = acp_mcp_servers_to_entries(&servers);
+        let entries = acp_mcp_servers_to_entries(&servers, 120);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].id, "my-mcp");
         assert!(matches!(entries[0].transport, McpTransport::Stdio { .. }));
@@ -290,7 +314,7 @@ mod tests {
             "http-mcp",
             "http://localhost",
         ))];
-        let entries = acp_mcp_servers_to_entries(&servers);
+        let entries = acp_mcp_servers_to_entries(&servers, 120);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].id, "http-mcp");
         assert!(matches!(entries[0].transport, McpTransport::Http { .. }));
@@ -302,7 +326,7 @@ mod tests {
             "http-mcp",
             "http://example.com:8080/mcp",
         ))];
-        let entries = acp_mcp_servers_to_entries(&servers);
+        let entries = acp_mcp_servers_to_entries(&servers, 120);
         if let McpTransport::Http { url, .. } = &entries[0].transport {
             assert_eq!(url, "http://example.com:8080/mcp");
         } else {
@@ -316,7 +340,7 @@ mod tests {
             EnvVariable::new("FOO", "bar"),
             EnvVariable::new("BAZ", "qux"),
         ]);
-        let entries = acp_mcp_servers_to_entries(&[McpServer::Stdio(stdio)]);
+        let entries = acp_mcp_servers_to_entries(&[McpServer::Stdio(stdio)], 120);
         if let McpTransport::Stdio { env, .. } = &entries[0].transport {
             assert_eq!(env.get("FOO"), Some(&"bar".to_owned()));
             assert_eq!(env.get("BAZ"), Some(&"qux".to_owned()));
@@ -327,7 +351,7 @@ mod tests {
 
     #[test]
     fn empty_input_returns_empty() {
-        assert!(acp_mcp_servers_to_entries(&[]).is_empty());
+        assert!(acp_mcp_servers_to_entries(&[], 120).is_empty());
     }
 
     #[test]
@@ -336,7 +360,7 @@ mod tests {
             "sse-mcp",
             "http://localhost/sse",
         ))];
-        let entries = acp_mcp_servers_to_entries(&servers);
+        let entries = acp_mcp_servers_to_entries(&servers, 120);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].id, "sse-mcp");
         assert!(matches!(entries[0].transport, McpTransport::Http { .. }));
@@ -348,7 +372,7 @@ mod tests {
             "sse-mcp",
             "http://example.com/sse",
         ))];
-        let entries = acp_mcp_servers_to_entries(&servers);
+        let entries = acp_mcp_servers_to_entries(&servers, 120);
         if let McpTransport::Http { url, .. } = &entries[0].transport {
             assert_eq!(url, "http://example.com/sse");
         } else {
@@ -364,7 +388,7 @@ mod tests {
             McpServer::Stdio(McpServerStdio::new("stdio-2", "/bin/mcp2")),
             McpServer::Sse(McpServerSse::new("sse-1", "http://localhost/sse")),
         ];
-        let entries = acp_mcp_servers_to_entries(&servers);
+        let entries = acp_mcp_servers_to_entries(&servers, 120);
         assert_eq!(entries.len(), 4);
         assert_eq!(entries[0].id, "stdio-1");
         assert_eq!(entries[1].id, "http-1");
@@ -390,7 +414,7 @@ mod tests {
             EnvVariable::new("NODE_PATH", "/tmp/evil"),
             EnvVariable::new("RUBYLIB", "/tmp/evil"),
         ]);
-        let entries = acp_mcp_servers_to_entries(&[McpServer::Stdio(stdio)]);
+        let entries = acp_mcp_servers_to_entries(&[McpServer::Stdio(stdio)], 120);
         if let McpTransport::Stdio { env, .. } = &entries[0].transport {
             assert_eq!(env.get("SAFE_VAR"), Some(&"ok".to_owned()));
             assert!(env.get("LD_PRELOAD").is_none());
@@ -418,7 +442,7 @@ mod tests {
             McpServer::Http(McpServerHttp::new("h", "http://localhost")),
             McpServer::Sse(McpServerSse::new("e", "http://localhost/sse")),
         ];
-        let entries = acp_mcp_servers_to_entries(&servers);
+        let entries = acp_mcp_servers_to_entries(&servers, 120);
         for entry in &entries {
             assert!(
                 entry.tool_allowlist.is_none(),

--- a/crates/zeph-acp/src/transport/mod.rs
+++ b/crates/zeph-acp/src/transport/mod.rs
@@ -124,6 +124,8 @@ pub struct AcpServerConfig {
     pub auth_methods: Vec<zeph_core::config::AcpAuthMethod>,
     /// When `true`, echo `PromptRequest.message_id` through responses and chunks.
     pub message_ids_enabled: bool,
+    /// Per-request timeout configuration for elicitation, terminal, and MCP operations.
+    pub timeouts: zeph_config::AcpTimeoutsConfig,
 }
 
 impl Clone for AcpServerConfig {
@@ -148,6 +150,7 @@ impl Clone for AcpServerConfig {
             additional_directories: self.additional_directories.clone(),
             auth_methods: self.auth_methods.clone(),
             message_ids_enabled: self.message_ids_enabled,
+            timeouts: self.timeouts.clone(),
         }
     }
 }
@@ -174,6 +177,7 @@ impl Default for AcpServerConfig {
             additional_directories: Vec::new(),
             auth_methods: vec![zeph_core::config::AcpAuthMethod::Agent],
             message_ids_enabled: true,
+            timeouts: zeph_config::AcpTimeoutsConfig::default(),
         }
     }
 }

--- a/crates/zeph-acp/src/transport/stdio.rs
+++ b/crates/zeph-acp/src/transport/stdio.rs
@@ -107,6 +107,7 @@ pub(crate) async fn build_agent_state(
         agent = agent.with_auth_methods(server_config.auth_methods);
     }
     agent = agent.with_message_ids_enabled(server_config.message_ids_enabled);
+    agent = agent.with_timeouts(server_config.timeouts);
 
     let state = Arc::new(agent);
     state.start_idle_reaper();

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -179,8 +179,8 @@ pub use subagent::{
 pub use telemetry::{TelemetryBackend, TelemetryConfig};
 pub use tools::{AuditDestination, SandboxBackend, ToolCompressionConfig};
 pub use ui::{
-    AcpAuthMethod, AcpConfig, AcpLspConfig, AcpSubagentsConfig, AcpTransport, AdditionalDir,
-    AdditionalDirError, FleetConfig, SubagentPresetConfig, ToolDensity, TuiConfig,
+    AcpAuthMethod, AcpConfig, AcpLspConfig, AcpSubagentsConfig, AcpTimeoutsConfig, AcpTransport,
+    AdditionalDir, AdditionalDirError, FleetConfig, SubagentPresetConfig, ToolDensity, TuiConfig,
 };
 pub use ui::{DiagnosticSeverity, DiagnosticsConfig, HoverConfig, LspConfig};
 pub use vigil::VigilConfig;

--- a/crates/zeph-config/src/ui.rs
+++ b/crates/zeph-config/src/ui.rs
@@ -58,6 +58,18 @@ fn default_acp_lsp_max_workspace_symbols() -> usize {
 fn default_acp_lsp_request_timeout_secs() -> u64 {
     10
 }
+
+fn default_acp_elicitation_timeout_secs() -> u64 {
+    120
+}
+
+fn default_acp_terminal_timeout_secs() -> u64 {
+    120
+}
+
+fn default_acp_mcp_timeout_secs() -> u64 {
+    300
+}
 fn default_lsp_mcp_server_id() -> String {
     "mcpls".into()
 }
@@ -485,6 +497,9 @@ pub struct AcpConfig {
     /// Sub-agent delegation configuration (`[acp.subagents]`).
     #[serde(default)]
     pub subagents: AcpSubagentsConfig,
+    /// Timeout configuration for ACP operations (`[acp.timeouts]`).
+    #[serde(default)]
+    pub timeouts: AcpTimeoutsConfig,
 }
 
 impl Default for AcpConfig {
@@ -507,6 +522,7 @@ impl Default for AcpConfig {
             auth_methods: default_acp_auth_methods(),
             message_ids_enabled: true,
             subagents: AcpSubagentsConfig::default(),
+            timeouts: AcpTimeoutsConfig::default(),
         }
     }
 }
@@ -534,7 +550,35 @@ impl std::fmt::Debug for AcpConfig {
             .field("auth_methods", &self.auth_methods)
             .field("message_ids_enabled", &self.message_ids_enabled)
             .field("subagents", &self.subagents)
+            .field("timeouts", &self.timeouts)
             .finish()
+    }
+}
+
+/// Timeout configuration for ACP operations.
+///
+/// These values replace the previously hardcoded 120-second defaults for terminal
+/// and elicitation operations, and the 300-second default for MCP bridge calls.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AcpTimeoutsConfig {
+    /// Timeout in seconds for elicitation requests sent to the IDE. Default: 120.
+    #[serde(default = "default_acp_elicitation_timeout_secs")]
+    pub elicitation_secs: u64,
+    /// Timeout in seconds for terminal command execution. Default: 120.
+    #[serde(default = "default_acp_terminal_timeout_secs")]
+    pub terminal_secs: u64,
+    /// Timeout in seconds for MCP bridge operations. Default: 300.
+    #[serde(default = "default_acp_mcp_timeout_secs")]
+    pub mcp_secs: u64,
+}
+
+impl Default for AcpTimeoutsConfig {
+    fn default() -> Self {
+        Self {
+            elicitation_secs: default_acp_elicitation_timeout_secs(),
+            terminal_secs: default_acp_terminal_timeout_secs(),
+            mcp_secs: default_acp_mcp_timeout_secs(),
+        }
     }
 }
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -181,6 +181,8 @@ struct SharedAgentDeps {
     acp_auth_methods: Vec<zeph_core::config::AcpAuthMethod>,
     /// When `true`, echo `PromptRequest.message_id` through responses and chunks.
     acp_message_ids_enabled: bool,
+    /// ACP timeout configuration (elicitation, terminal, MCP).
+    acp_timeouts: zeph_config::AcpTimeoutsConfig,
     /// Resolves current per-plugin skill dirs at hot-reload time.
     plugin_dirs_supplier: std::sync::Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>,
 
@@ -575,6 +577,7 @@ async fn build_acp_deps(
         acp_additional_directories: config.acp.additional_directories.clone(),
         acp_auth_methods: config.acp.auth_methods.clone(),
         acp_message_ids_enabled: config.acp.message_ids_enabled,
+        acp_timeouts: config.acp.timeouts.clone(),
         plugin_dirs_supplier: std::sync::Arc::new(plugin_dirs_supplier),
         #[cfg(feature = "scheduler")]
         scheduler_executor,
@@ -1322,7 +1325,7 @@ pub(crate) async fn run_acp_server(
         mcp_manager: Some(mcp_manager_for_acp),
         auth_bearer_token: deps.acp_auth_bearer_token.clone(),
         discovery_enabled: deps.acp_discovery_enabled,
-        terminal_timeout_secs: 120,
+        terminal_timeout_secs: deps.acp_timeouts.terminal_secs,
         project_rules: deps.acp_project_rules.clone(),
         title_max_chars: deps.acp_title_max_chars,
         max_history: deps.acp_max_history,
@@ -1335,6 +1338,7 @@ pub(crate) async fn run_acp_server(
         additional_directories: effective_additional_dirs,
         auth_methods: effective_auth_methods,
         message_ids_enabled: effective_message_ids,
+        timeouts: deps.acp_timeouts.clone(),
     };
 
     let shared = Arc::new(deps);
@@ -1394,7 +1398,7 @@ pub(crate) async fn run_acp_http_server(
         mcp_manager: Some(Arc::clone(&mcp_manager_for_acp)),
         auth_bearer_token,
         discovery_enabled: app.config().acp.discovery_enabled,
-        terminal_timeout_secs: 120,
+        terminal_timeout_secs: app.config().acp.timeouts.terminal_secs,
         project_rules: collect_project_rules(&app.skill_paths_for_registry()),
         title_max_chars: app.config().memory.sessions.title_max_chars,
         max_history: app.config().memory.sessions.max_history,
@@ -1403,6 +1407,7 @@ pub(crate) async fn run_acp_http_server(
         additional_directories: app.config().acp.additional_directories.clone(),
         auth_methods: app.config().acp.auth_methods.clone(),
         message_ids_enabled: app.config().acp.message_ids_enabled,
+        timeouts: app.config().acp.timeouts.clone(),
     };
     let shared_deps: Arc<RwLock<Option<Arc<SharedAgentDeps>>>> = Arc::new(RwLock::new(None));
     let shared_deps_for_spawner = Arc::clone(&shared_deps);


### PR DESCRIPTION
## Summary

- Add ACP schema 0.13.2 **Providers API** (`providers/list`, `providers/set`, `providers/disable`) as session-scoped overrides — no vault keys exposed in responses, no persistent config mutation
- Add **Elicitation protocol** infrastructure: `elicitation/create` → `elicitation/response` flow via per-session bridge task with cancel-signal awareness and configurable timeout
- Replace all hardcoded 120s timeouts in `terminal.rs` and `mcp_bridge.rs` with configurable `[acp.timeouts]` config section
- Add `agent-client-protocol-schema = "0.13.2"` as direct workspace dep for `unstable-elicitation` and `unstable-llm-providers` feature gates

## What is NOT in this PR

- Agent loop calling `elicit()` from `tier_loop` (follow-up PR)
- Provider override routing to LLM at turn time (follow-up PR)
- TUI spinner for "Waiting for IDE input" (follow-up PR)

## Security

- `providers/list` response contains only `api_type` + `base_url` — vault-resolved API keys are never serialized
- `providers/set` validates `req.id` against known provider names before inserting into override map (SEC-1 fix)
- Provider state is connection-scoped (known limitation: tracked in SEC-2 follow-up issue)

## Test plan

- [ ] `cargo build -p zeph-acp --features "unstable-elicitation,unstable-llm-providers"` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --workspace --lib --bins` — 10019 passed
- [ ] 73 unit tests in `zeph-acp` including 8 providers tests and 6 elicitation timeout tests

Closes #4456
Closes #4455