### PR TITLE
fix(memory,skills): mark Docker integration tests as ignored and track trace extraction handle

### DIFF
--- a/crates/zeph-core/src/agent/learning_engine.rs
+++ b/crates/zeph-core/src/agent/learning_engine.rs
@@ -39,6 +39,11 @@ pub(crate) struct LearningEngine {
     /// Capped at `MAX_LEARNING_TASKS`. New spawns are skipped (not aborted) when the
     /// cap is reached. The set is detached via `detach_all` at each turn boundary.
     pub(crate) learning_tasks: tokio::task::JoinSet<()>,
+    /// Handle for the post-session `AutoSkill` trace extraction task (spec 056).
+    ///
+    /// Set by `maybe_extract_skills_from_trace`; awaited at shutdown so the extraction
+    /// task is not silently dropped if the agent exits before it completes.
+    pub(crate) trace_extraction_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl LearningEngine {
@@ -53,6 +58,7 @@ impl LearningEngine {
             analysis_interval: DEFAULT_ANALYSIS_INTERVAL,
             last_analyzed_correction_id: 0,
             learning_tasks: tokio::task::JoinSet::new(),
+            trace_extraction_handle: None,
         }
     }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -751,6 +751,11 @@ impl<C: Channel> Agent<C> {
         // Abort learning tasks (JoinSet detached at turn boundaries but not on shutdown).
         self.services.learning_engine.learning_tasks.abort_all();
 
+        // Await the AutoSkill trace extraction task so it is not silently dropped.
+        if let Some(h) = self.services.learning_engine.trace_extraction_handle.take() {
+            let _ = h.await;
+        }
+
         // Allow cancelled tasks to release their HTTP connections before the summary LLM call.
         // abort_all() posts cancellation signals but does not drain tasks; aborted futures only
         // observe cancellation at their next .await point. Without yielding here the summary

--- a/crates/zeph-core/src/agent/trace_extraction.rs
+++ b/crates/zeph-core/src/agent/trace_extraction.rs
@@ -96,9 +96,7 @@ impl<C: Channel> super::Agent<C> {
             .as_ref()
             .map(|tx| tx.send("Extracting skills from session…".into()));
 
-        // Intentionally fire-and-forget: extraction runs after the session ends.
-        // _handle makes the drop explicit rather than silent.
-        let _handle = tokio::spawn(run_extraction(
+        self.services.learning_engine.trace_extraction_handle = Some(tokio::spawn(run_extraction(
             extract_provider,
             embed_provider,
             output_dir,
@@ -112,7 +110,7 @@ impl<C: Channel> super::Agent<C> {
             conversation_id,
             db_pool,
             status_tx,
-        ));
+        )));
     }
 
     /// Check whether `session_id` already exists in `skill_trace_sessions`.

--- a/crates/zeph-memory/tests/document_integration.rs
+++ b/crates/zeph-memory/tests/document_integration.rs
@@ -41,6 +41,7 @@ fn make_doc(content: &str) -> Document {
     }
 }
 
+#[ignore = "requires Docker"]
 #[tokio::test]
 async fn ingest_single_document() {
     let container = qdrant_image().start().await.unwrap();
@@ -69,6 +70,7 @@ async fn ingest_single_document() {
     assert_eq!(results.len(), 1);
 }
 
+#[ignore = "requires Docker"]
 #[tokio::test]
 async fn ingest_empty_document_returns_zero() {
     let container = qdrant_image().start().await.unwrap();
@@ -90,6 +92,7 @@ async fn ingest_empty_document_returns_zero() {
     assert_eq!(count, 0);
 }
 
+#[ignore = "requires Docker"]
 #[tokio::test]
 async fn ingest_multi_chunk_document() {
     let container = qdrant_image().start().await.unwrap();
@@ -122,6 +125,7 @@ async fn ingest_multi_chunk_document() {
     assert_eq!(results.len(), count);
 }
 
+#[ignore = "requires Docker"]
 #[tokio::test]
 async fn load_and_ingest_text_file() {
     let container = qdrant_image().start().await.unwrap();
@@ -154,6 +158,7 @@ async fn load_and_ingest_text_file() {
     assert_eq!(results.len(), 1);
 }
 
+#[ignore = "requires Docker"]
 #[tokio::test]
 async fn ingested_chunks_have_correct_payload() {
     let container = qdrant_image().start().await.unwrap();


### PR DESCRIPTION
## Summary

- Mark all 5 testcontainer-backed tests in `zeph-memory` with `#[ignore = "requires Docker"]` so they are skipped in standard CI runs and only executed via `--ignored` (Closes #4487)
- Track the AutoSkill A1 trace extraction `JoinHandle` in `LearningEngine` and await it during `Agent::shutdown()` so the LLM extraction task is not silently cancelled at shutdown (Closes #4486)

## Changes

| File | Change |
|------|--------|
| `crates/zeph-memory/tests/document_integration.rs` | Added `#[ignore = "requires Docker"]` to 5 tokio::test functions |
| `crates/zeph-core/src/agent/learning_engine.rs` | Added `trace_extraction_handle: Option<JoinHandle<()>>` field |
| `crates/zeph-core/src/agent/trace_extraction.rs` | Store handle in `LearningEngine` instead of dropping it |
| `crates/zeph-core/src/agent/mod.rs` | Await handle in `Agent::shutdown()` before service teardown |

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 10037 passed, 21 skipped, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] Docker-backed tests confirmed skipped (not failed) in standard run
- [x] JoinHandle await placed before service drops in shutdown sequence