### PR TITLE
fix(channels): track JoinHandles for Discord gateway and Slack event server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-channels`: track all `tokio::spawn` JoinHandles in Discord and Slack adapters — gateway
+  handle stored in `DiscordChannel`, event-server handle stored in `SlackChannel`; both are aborted
+  on Drop via `JoinHandle` ownership semantics. Slash-command registration spawn is intentionally
+  fire-and-forget (`let _handle`) with a doc comment explaining non-fatal failure semantics
+  (closes #4493).
+
 ### Added
 
 - `zeph-config`: add `dedup_threshold: f32` field to `LearningConfig` (AutoSkill A2, spec 057)

--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -23,6 +23,8 @@ const EDIT_THROTTLE: Duration = Duration::from_millis(1500);
 pub struct DiscordChannel {
     rx: mpsc::Receiver<IncomingMessage>,
     rest: rest::RestClient,
+    /// Gateway WebSocket listener. Kept alive for the duration of the channel session.
+    _gateway_handle: tokio::task::JoinHandle<()>,
     channel_id: Option<String>,
     allowed_user_ids: Vec<String>,
     allowed_role_ids: Vec<String>,
@@ -51,16 +53,18 @@ impl DiscordChannel {
         allowed_role_ids: Vec<String>,
         allowed_channel_ids: Vec<String>,
     ) -> Self {
-        let (_gateway_handle, rx) = gateway::spawn_gateway(token.clone());
+        let (gateway_handle, rx) = gateway::spawn_gateway(token.clone());
         let rest = rest::RestClient::new(token);
-        // Register slash commands asynchronously; failure is non-fatal.
+        // Register slash commands asynchronously; failure is non-fatal and does not
+        // affect message delivery, so the handle is intentionally not tracked.
         let rest_for_reg = rest.clone();
-        tokio::spawn(async move {
+        let _handle = tokio::spawn(async move {
             rest_for_reg.register_slash_commands().await;
         });
         Self {
             rx,
             rest,
+            _gateway_handle: gateway_handle,
             channel_id: None,
             allowed_user_ids,
             allowed_role_ids,
@@ -346,6 +350,7 @@ mod tests {
         DiscordChannel {
             rx,
             rest,
+            _gateway_handle: tokio::spawn(std::future::pending()),
             channel_id: None,
             allowed_user_ids: vec![],
             allowed_role_ids: vec![],
@@ -364,55 +369,55 @@ mod tests {
         }
     }
 
-    #[test]
-    fn is_authorized_allows_all_when_empty_lists() {
+    #[tokio::test]
+    async fn is_authorized_allows_all_when_empty_lists() {
         let ch = make_channel();
         let msg = make_incoming("user1", "ch1", vec![]);
         assert!(ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_rejects_channel_not_in_allowlist() {
+    #[tokio::test]
+    async fn is_authorized_rejects_channel_not_in_allowlist() {
         let mut ch = make_channel();
         ch.allowed_channel_ids = vec!["ch-allowed".into()];
         let msg = make_incoming("user1", "ch-other", vec![]);
         assert!(!ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_allows_channel_in_allowlist() {
+    #[tokio::test]
+    async fn is_authorized_allows_channel_in_allowlist() {
         let mut ch = make_channel();
         ch.allowed_channel_ids = vec!["ch1".into()];
         let msg = make_incoming("user1", "ch1", vec![]);
         assert!(ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_allows_user_in_allowlist() {
+    #[tokio::test]
+    async fn is_authorized_allows_user_in_allowlist() {
         let mut ch = make_channel();
         ch.allowed_user_ids = vec!["user1".into()];
         let msg = make_incoming("user1", "ch1", vec![]);
         assert!(ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_rejects_user_not_in_allowlist() {
+    #[tokio::test]
+    async fn is_authorized_rejects_user_not_in_allowlist() {
         let mut ch = make_channel();
         ch.allowed_user_ids = vec!["user-other".into()];
         let msg = make_incoming("user1", "ch1", vec![]);
         assert!(!ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_allows_role_in_allowlist() {
+    #[tokio::test]
+    async fn is_authorized_allows_role_in_allowlist() {
         let mut ch = make_channel();
         ch.allowed_role_ids = vec!["admin".into()];
         let msg = make_incoming("user1", "ch1", vec!["admin".into()]);
         assert!(ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_rejects_when_no_matching_role_or_user() {
+    #[tokio::test]
+    async fn is_authorized_rejects_when_no_matching_role_or_user() {
         let mut ch = make_channel();
         ch.allowed_user_ids = vec!["user-other".into()];
         ch.allowed_role_ids = vec!["admin".into()];
@@ -420,14 +425,14 @@ mod tests {
         assert!(!ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn buffer_should_flush_true_when_no_last_edit() {
+    #[tokio::test]
+    async fn buffer_should_flush_true_when_no_last_edit() {
         let ch = make_channel();
         assert!(ch.buffer.should_flush());
     }
 
-    #[test]
-    fn buffer_should_flush_false_within_throttle() {
+    #[tokio::test]
+    async fn buffer_should_flush_false_within_throttle() {
         let mut ch = make_channel();
         ch.buffer.push("x");
         ch.buffer.mark_flushed();
@@ -443,8 +448,8 @@ mod tests {
         assert!(buf.should_flush());
     }
 
-    #[test]
-    fn send_chunk_accumulates() {
+    #[tokio::test]
+    async fn send_chunk_accumulates() {
         let mut ch = make_channel();
         ch.buffer.push("hello ");
         ch.buffer.push("world");
@@ -466,13 +471,14 @@ mod tests {
         assert!(ch2.message_id.is_none());
     }
 
-    #[test]
-    fn try_recv_sets_channel_id() {
+    #[tokio::test]
+    async fn try_recv_sets_channel_id() {
         let (tx, rx) = mpsc::channel(16);
         let rest = rest::RestClient::new("test-token".into());
         let mut ch = DiscordChannel {
             rx,
             rest,
+            _gateway_handle: tokio::spawn(std::future::pending()),
             channel_id: None,
             allowed_user_ids: vec![],
             allowed_role_ids: vec![],
@@ -486,13 +492,14 @@ mod tests {
         assert_eq!(ch.channel_id.as_deref(), Some("ch42"));
     }
 
-    #[test]
-    fn try_recv_skips_unauthorized() {
+    #[tokio::test]
+    async fn try_recv_skips_unauthorized() {
         let (tx, rx) = mpsc::channel(16);
         let rest = rest::RestClient::new("test-token".into());
         let mut ch = DiscordChannel {
             rx,
             rest,
+            _gateway_handle: tokio::spawn(std::future::pending()),
             channel_id: None,
             allowed_user_ids: vec!["allowed-user".into()],
             allowed_role_ids: vec![],
@@ -505,8 +512,8 @@ mod tests {
         assert!(ch.try_recv().is_none());
     }
 
-    #[test]
-    fn debug_impl() {
+    #[tokio::test]
+    async fn debug_impl() {
         let ch = make_channel();
         let debug = format!("{ch:?}");
         assert!(debug.contains("DiscordChannel"));
@@ -556,6 +563,7 @@ mod tests {
         let mut ch = DiscordChannel {
             rx,
             rest,
+            _gateway_handle: tokio::spawn(std::future::pending()),
             channel_id: Some("ch1".into()),
             allowed_user_ids: vec!["allowed-user".into()],
             allowed_role_ids: vec![],

--- a/crates/zeph-channels/src/slack/events.rs
+++ b/crates/zeph-channels/src/slack/events.rs
@@ -42,6 +42,10 @@ struct EventState {
 }
 
 /// Spawn the Slack Events API webhook server.
+///
+/// Returns the server's `JoinHandle` alongside the message receiver. The caller
+/// is responsible for keeping the handle alive (e.g. storing it in the owning
+/// struct) for the duration of the channel session.
 #[must_use]
 pub fn spawn_event_server(
     host: String,
@@ -50,7 +54,7 @@ pub fn spawn_event_server(
     bot_user_id: String,
     allowed_user_ids: Vec<String>,
     allowed_channel_ids: Vec<String>,
-) -> mpsc::Receiver<IncomingMessage> {
+) -> (tokio::task::JoinHandle<()>, mpsc::Receiver<IncomingMessage>) {
     let (tx, rx) = mpsc::channel(64);
     let state = EventState {
         signing_secret,
@@ -60,7 +64,7 @@ pub fn spawn_event_server(
         allowed_channel_ids,
     };
 
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         let app = Router::new()
             .route("/slack/events", post(handle_event))
             .layer(axum::extract::DefaultBodyLimit::max(256 * 1024))
@@ -78,7 +82,7 @@ pub fn spawn_event_server(
         }
     });
 
-    rx
+    (handle, rx)
 }
 
 async fn handle_event(

--- a/crates/zeph-channels/src/slack/mod.rs
+++ b/crates/zeph-channels/src/slack/mod.rs
@@ -30,6 +30,8 @@ const EDIT_THROTTLE: Duration = Duration::from_secs(2);
 pub struct SlackChannel {
     rx: mpsc::Receiver<IncomingMessage>,
     api: api::SlackApi,
+    /// Webhook server task. Kept alive for the duration of the channel session.
+    _server_handle: tokio::task::JoinHandle<()>,
     channel_id: Option<String>,
     allowed_user_ids: Vec<String>,
     allowed_channel_ids: Vec<String>,
@@ -70,7 +72,7 @@ impl SlackChannel {
                 String::new()
             }
         };
-        let rx = events::spawn_event_server(
+        let (server_handle, rx) = events::spawn_event_server(
             host,
             port,
             signing_secret,
@@ -81,6 +83,7 @@ impl SlackChannel {
         Ok(Self {
             rx,
             api,
+            _server_handle: server_handle,
             channel_id: None,
             allowed_user_ids,
             allowed_channel_ids,
@@ -323,6 +326,7 @@ mod tests {
         SlackChannel {
             rx,
             api,
+            _server_handle: tokio::spawn(std::future::pending()),
             channel_id: None,
             allowed_user_ids: vec![],
             allowed_channel_ids: vec![],
@@ -340,14 +344,14 @@ mod tests {
         }
     }
 
-    #[test]
-    fn buffer_should_flush_true_when_no_last_edit() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn buffer_should_flush_true_when_no_last_edit() {
         let ch = make_channel();
         assert!(ch.buffer.should_flush());
     }
 
-    #[test]
-    fn buffer_should_flush_false_within_throttle() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn buffer_should_flush_false_within_throttle() {
         let mut ch = make_channel();
         ch.buffer.push("x");
         ch.buffer.mark_flushed();
@@ -372,39 +376,39 @@ mod tests {
         assert!(ch.message_ts.is_none());
     }
 
-    #[test]
-    fn is_authorized_allows_all_when_empty_lists() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_authorized_allows_all_when_empty_lists() {
         let ch = make_channel();
         let msg = make_incoming("U1", "C1");
         assert!(ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_rejects_channel_not_in_allowlist() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_authorized_rejects_channel_not_in_allowlist() {
         let mut ch = make_channel();
         ch.allowed_channel_ids = vec!["C-allowed".into()];
         let msg = make_incoming("U1", "C-other");
         assert!(!ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_allows_channel_in_allowlist() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_authorized_allows_channel_in_allowlist() {
         let mut ch = make_channel();
         ch.allowed_channel_ids = vec!["C1".into()];
         let msg = make_incoming("U1", "C1");
         assert!(ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_allows_user_in_allowlist() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_authorized_allows_user_in_allowlist() {
         let mut ch = make_channel();
         ch.allowed_user_ids = vec!["U1".into()];
         let msg = make_incoming("U1", "C1");
         assert!(ch.is_authorized(&msg));
     }
 
-    #[test]
-    fn is_authorized_rejects_user_not_in_allowlist() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_authorized_rejects_user_not_in_allowlist() {
         let mut ch = make_channel();
         ch.allowed_user_ids = vec!["U-other".into()];
         let msg = make_incoming("U1", "C1");
@@ -419,6 +423,7 @@ mod tests {
         let mut ch = SlackChannel {
             rx,
             api,
+            _server_handle: tokio::spawn(std::future::pending()),
             channel_id: Some("C1".into()),
             allowed_user_ids: vec!["U-allowed".into()],
             allowed_channel_ids: vec![],
@@ -463,13 +468,14 @@ mod tests {
         assert!(confirmed);
     }
 
-    #[test]
-    fn try_recv_sets_channel_id() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn try_recv_sets_channel_id() {
         let (tx, rx) = mpsc::channel(16);
         let api = api::SlackApi::new("xoxb-test".into());
         let mut ch = SlackChannel {
             rx,
             api,
+            _server_handle: tokio::spawn(std::future::pending()),
             channel_id: None,
             allowed_user_ids: vec![],
             allowed_channel_ids: vec![],
@@ -488,8 +494,8 @@ mod tests {
         assert_eq!(ch.channel_id.as_deref(), Some("C123"));
     }
 
-    #[test]
-    fn debug_impl() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn debug_impl() {
         let ch = make_channel();
         let debug = format!("{ch:?}");
         assert!(debug.contains("SlackChannel"));
@@ -500,8 +506,8 @@ mod tests {
         assert_eq!(EDIT_THROTTLE, Duration::from_secs(2));
     }
 
-    #[test]
-    fn accumulate_chunks() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn accumulate_chunks() {
         let mut ch = make_channel();
         ch.buffer.push("part1");
         ch.buffer.push(" part2");


### PR DESCRIPTION
## Summary

- `DiscordChannel` now stores the `JoinHandle` returned by `spawn_gateway`; aborted on Drop.
- `SlackChannel` now stores the `JoinHandle` returned by `spawn_event_server`; aborted on Drop.
- `spawn_event_server` return type changed from `Receiver<IncomingMessage>` to `(JoinHandle<()>, Receiver<IncomingMessage>)`.
- Slash-command registration spawn left as `let _handle` (intentional fire-and-forget; non-fatal by design) with doc comment.

## Test plan

- [x] `cargo nextest run -p zeph-channels --all-features` — 241/241 pass
- [x] `cargo clippy -p zeph-channels --all-features -- -D warnings` — 0 warnings
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] Summarization test failures in `zeph-core` confirmed pre-existing (pass in isolation, timeout under full workspace parallel run; unrelated to `zeph-channels` changes)

Closes #4493