### PR TITLE
fix(core): bound trace_extraction shutdown await and preserve DbError type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   now resolves the embed provider by name from `[[llm.providers]]` instead of passing
   `embedding_model` (a model-ID string) as a provider name, which always triggered a fallback
   warning and used the primary text provider for embeddings (closes #4494).
+- `zeph-core`: `trace_extraction_handle.await` at shutdown is now wrapped in
+  `tokio::time::timeout(2 min)` — prevents agent exit from stalling when the LLM inside
+  the trace extraction task is slow or unresponsive; timeout and task panic are logged
+  separately (closes #4500).
+- `zeph-core`: `AgentError::Db` now wraps `zeph_db::DbError` via `#[from]` instead of
+  erasing it to `String`, preserving the full error chain for structured handling and
+  observability (closes #4496).
 
 ### Added
 

--- a/crates/zeph-core/src/agent/error.rs
+++ b/crates/zeph-core/src/agent/error.rs
@@ -111,8 +111,8 @@ pub enum AgentError {
     ContextError(String),
 
     /// A database operation in the agent subsystem failed.
-    #[error("database error: {0}")]
-    Db(String),
+    #[error(transparent)]
+    Db(#[from] zeph_db::DbError),
 }
 
 impl AgentError {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -752,8 +752,17 @@ impl<C: Channel> Agent<C> {
         self.services.learning_engine.learning_tasks.abort_all();
 
         // Await the AutoSkill trace extraction task so it is not silently dropped.
+        // Bounded to avoid hanging shutdown when the LLM call inside the task stalls.
         if let Some(h) = self.services.learning_engine.trace_extraction_handle.take() {
-            let _ = h.await;
+            let deadline = std::time::Duration::from_mins(2);
+            match tokio::time::timeout(deadline, h).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!("trace_extraction: task panicked at shutdown: {e}"),
+                Err(_) => tracing::warn!(
+                    "trace_extraction: timed out at shutdown ({}s), aborting",
+                    deadline.as_secs()
+                ),
+            }
         }
 
         // Allow cancelled tasks to release their HTTP connections before the summary LLM call.

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -331,7 +331,7 @@ impl ShadowEventStore {
         .bind(event.created_at)
         .execute(&self.pool)
         .await
-        .map_err(|e| AgentError::Db(e.to_string()))?;
+        .map_err(|e| AgentError::Db(e.into()))?;
 
         Ok(())
     }
@@ -361,7 +361,7 @@ impl ShadowEventStore {
         .bind(i64::try_from(limit).unwrap_or(i64::MAX))
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| AgentError::Db(e.to_string()))?;
+        .map_err(|e| AgentError::Db(e.into()))?;
 
         // DB returns DESC (newest first); reverse once to get ASC (oldest first) for LLM context.
         let mut events: Vec<SentinelEvent> = rows.into_iter().map(SentinelEvent::from).collect();
@@ -394,7 +394,7 @@ impl ShadowEventStore {
         .bind(i64::try_from(limit).unwrap_or(i64::MAX))
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| AgentError::Db(e.to_string()))?;
+        .map_err(|e| AgentError::Db(e.into()))?;
 
         Ok(rows.into_iter().map(SentinelEvent::from).collect())
     }


### PR DESCRIPTION
## Summary

- Wrap `trace_extraction_handle.await` in `tokio::time::timeout(2 min)` at shutdown so a slow or hung LLM call inside the trace extraction task cannot stall agent exit. Timeout and task panic are logged with separate `tracing::warn!` messages (#4500).
- Change `AgentError::Db(String)` to `Db(#[from] zeph_db::DbError)` — preserves the full `DbError` structure instead of collapsing it to a string; callers in `shadow_sentinel.rs` updated to use `.into()` (#4496).

## Changed files

- `crates/zeph-core/src/agent/mod.rs` — timeout block in shutdown
- `crates/zeph-core/src/agent/error.rs` — `AgentError::Db` variant
- `crates/zeph-core/src/agent/shadow_sentinel.rs` — 3 call sites

## Test plan

- [x] `cargo nextest run -p zeph-core` — 1496/1496 passed
- [x] `cargo build --workspace` — clean, no warnings
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean
- [x] Full workspace: 10043 tests passed

Closes #4500, closes #4496