### PR TITLE
test(vault): add AgeVault unit tests and deduplicate sanitizer regex patterns

### DIFF
--- a/crates/zeph-sanitizer/src/memory_validation.rs
+++ b/crates/zeph-sanitizer/src/memory_validation.rs
@@ -16,27 +16,12 @@
 //!    after `GraphExtractor::extract()` returns. Checks entity count, edge count,
 //!    entity name length, fact text length, and PII in entity names.
 
-use std::sync::LazyLock;
-
-use regex::Regex;
 use thiserror::Error;
 use zeph_memory::graph::extractor::ExtractionResult;
 
 pub use zeph_config::MemoryWriteValidationConfig;
 
-// ---------------------------------------------------------------------------
-// PII patterns for entity name scanning (subset — email and SSN only)
-// ---------------------------------------------------------------------------
-
-/// Email pattern kept in sync with `pii.rs`: domain labels must be purely alphabetic.
-static ENTITY_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"[a-zA-Z0-9._%+\-]{2,}@(?:[a-zA-Z]+\.)+[a-zA-Z]{2,6}")
-        .expect("valid ENTITY_EMAIL_RE")
-});
-
-/// SSN pattern for entity name scanning.
-static ENTITY_SSN_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").expect("valid ENTITY_SSN_RE"));
+use crate::pii::{EMAIL_RE, SSN_RE};
 
 // ---------------------------------------------------------------------------
 // Error
@@ -206,7 +191,7 @@ impl MemoryWriteValidator {
                 });
             }
             // Guard against PII leaking into entity names (email and SSN).
-            if ENTITY_EMAIL_RE.is_match(&entity.name) || ENTITY_SSN_RE.is_match(&entity.name) {
+            if EMAIL_RE.is_match(&entity.name) || SSN_RE.is_match(&entity.name) {
                 return Err(MemoryValidationError::SuspiciousPiiInEntityName {
                     entity: entity.name.clone(),
                 });

--- a/crates/zeph-sanitizer/src/pii.rs
+++ b/crates/zeph-sanitizer/src/pii.rs
@@ -49,7 +49,7 @@ pub use zeph_config::{CustomPiiPattern, PiiFilterConfig};
 /// Known limitation: purely-alphabetic code-style patterns such as
 /// `decorator@factory.method` are not rejected because they are
 /// indistinguishable from a real hostname without a TLD allowlist.
-static EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+pub(crate) static EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"[a-zA-Z0-9._%+\-]{2,}@(?:[a-zA-Z]+\.)+[a-zA-Z]{2,6}").expect("valid EMAIL_RE")
 });
 
@@ -59,7 +59,7 @@ static PHONE_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 /// US Social Security Number (NNN-NN-NNNN).
-static SSN_RE: LazyLock<Regex> =
+pub(crate) static SSN_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").expect("valid SSN_RE"));
 
 /// Credit card number: 16 digits in groups of 4 (space or dash separated, or bare).

--- a/crates/zeph-vault/src/age.rs
+++ b/crates/zeph-vault/src/age.rs
@@ -457,3 +457,59 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AgeVaultError
 pub(crate) fn write_private_file(path: &Path, data: &[u8]) -> Result<(), AgeVaultError> {
     zeph_common::fs_secure::write_private(path, data).map_err(AgeVaultError::KeyWrite)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn init_temp_vault(dir: &Path) -> (PathBuf, PathBuf) {
+        AgeVaultProvider::init_vault(dir).expect("init_vault failed");
+        (dir.join("vault-key.txt"), dir.join("secrets.age"))
+    }
+
+    #[test]
+    fn round_trip() {
+        let dir = tempdir().unwrap();
+        let (key_path, vault_path) = init_temp_vault(dir.path());
+
+        let mut vault = AgeVaultProvider::new(&key_path, &vault_path).unwrap();
+        vault.set_secret_mut("KEY".into(), "val".into());
+        vault.save().unwrap();
+
+        let loaded = AgeVaultProvider::load(&key_path, &vault_path).unwrap();
+        assert_eq!(loaded.get("KEY"), Some("val"));
+    }
+
+    #[test]
+    fn remove_secret() {
+        let dir = tempdir().unwrap();
+        let (key_path, vault_path) = init_temp_vault(dir.path());
+
+        let mut vault = AgeVaultProvider::new(&key_path, &vault_path).unwrap();
+        vault.set_secret_mut("KEY".into(), "val".into());
+
+        assert!(vault.remove_secret_mut("KEY"));
+        assert!(!vault.remove_secret_mut("KEY"));
+        assert_eq!(vault.get("KEY"), None);
+    }
+
+    #[test]
+    fn init_vault_creates_files() {
+        let dir = tempdir().unwrap();
+        AgeVaultProvider::init_vault(dir.path()).unwrap();
+
+        assert!(dir.path().join("vault-key.txt").exists());
+        assert!(dir.path().join("secrets.age").exists());
+    }
+
+    #[test]
+    fn load_missing_vault_errors() {
+        let dir = tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+
+        let result = AgeVaultProvider::load(&key_path, &vault_path);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Add 4 inline unit tests to `crates/zeph-vault/src/age.rs` covering all core `AgeVaultBackend` operations: round-trip encrypt/decrypt, `remove_secret_mut` return values, `init_vault` file layout, and `load` error on missing vault file (closes #4498)
- Make `EMAIL_RE` and `SSN_RE` `pub(crate)` in `crates/zeph-sanitizer/src/pii.rs`; remove the duplicate `ENTITY_EMAIL_RE` / `ENTITY_SSN_RE` from `memory_validation.rs` and update call sites to use the imported names, eliminating the "kept in sync" maintenance smell (closes #4491)

## Test plan

- [ ] `cargo nextest run -p zeph-vault` — 43 tests pass (4 new)
- [ ] `cargo nextest run -p zeph-sanitizer` — all sanitizer tests pass, no regressions
- [ ] Full workspace: 10054 tests pass, zero failures
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean

Closes #4498
Closes #4491