### PR TITLE
feat(acp): session/usage reporting and doc(cfg) annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-core`: `AgentError::Db` now wraps `zeph_db::DbError` via `#[from]` instead of
   erasing it to `String`, preserving the full error chain for structured handling and
   observability (closes #4496).
+- `zeph-acp`, `zeph-gateway`: add `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` annotations to
+  all feature-gated public items so docs.rs renders them with the correct feature badge (closes #4497).
 
 ### Added
+
+- `zeph-acp`: implement `session/usage` ACP message — `UsageUpdate` notifications are now sent after
+  each LLM call with per-turn input/output/cache token counts and cost estimate; a cumulative session
+  summary is sent on `session/close`. Feature-gated behind `unstable-session-usage`. Reuses existing
+  internal cost tracker and `LoopbackEvent::Usage` — no duplicate counters (closes #4457).
 
 - `zeph-config`: add `dedup_threshold: f32` field to `LearningConfig` (AutoSkill A2, spec 057)
   with default 0.90, startup validation that `merge_threshold < dedup_threshold` via

--- a/crates/zeph-acp/src/agent/helpers.rs
+++ b/crates/zeph-acp/src/agent/helpers.rs
@@ -530,12 +530,15 @@ pub(super) fn loopback_event_to_updates(event: LoopbackEvent) -> Vec<SessionUpda
             input_tokens,
             output_tokens,
             context_window,
+            cost_cents,
+            ..
         } => {
             let used = input_tokens.saturating_add(output_tokens);
-            vec![SessionUpdate::UsageUpdate(UsageUpdate::new(
-                used,
-                context_window,
-            ))]
+            let mut update = UsageUpdate::new(used, context_window);
+            if cost_cents > 0.0 {
+                update = update.cost(Cost::new(cost_cents / 100.0, "USD"));
+            }
+            vec![SessionUpdate::UsageUpdate(update)]
         }
         #[cfg(not(feature = "unstable-session-usage"))]
         LoopbackEvent::Usage { .. } => vec![],

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -358,6 +358,7 @@ pub type AgentSpawner = Arc<
 /// `axum::State` requirements (`Send + Sync`). In practice this is the same type
 /// alias — the distinction exists to make the intent clear at call sites.
 #[cfg(feature = "acp-http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "acp-http")))]
 pub type SendAgentSpawner = AgentSpawner;
 
 /// Sender half for delivering session notifications to the per-session drainer.
@@ -367,6 +368,75 @@ pub(crate) type NotifySender =
 /// Receiver half paired with [`NotifySender`].
 pub(crate) type NotifyReceiver =
     mpsc::Receiver<(acp::schema::SessionNotification, oneshot::Sender<()>)>;
+
+/// Per-turn token totals accumulated inside `drain_agent_events` for `PromptResponse.usage`.
+///
+/// Holds the sum of all `LoopbackEvent::Usage` events received within a single prompt turn.
+#[cfg(feature = "unstable-session-usage")]
+#[allow(clippy::struct_field_names)] // all fields intentionally share `_tokens` postfix for clarity
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct TurnUsage {
+    pub(crate) input_tokens: u64,
+    pub(crate) output_tokens: u64,
+    pub(crate) cache_read_tokens: u64,
+    pub(crate) cache_write_tokens: u64,
+}
+
+/// Return value of [`ZephAcpAgentState::drain_agent_events`].
+///
+/// Bundles cancelled flag, stop hint, recycled receiver, and per-turn usage totals.
+/// The `turn_usage` field is only present when `unstable-session-usage` is enabled.
+struct DrainResult {
+    cancelled: bool,
+    stop_hint: Option<StopHint>,
+    rx: tokio::sync::mpsc::Receiver<LoopbackEvent>,
+    #[cfg(feature = "unstable-session-usage")]
+    turn_usage: TurnUsage,
+}
+
+/// Per-session token and cost totals used to populate the session-close usage summary.
+///
+/// Token fields accumulate per-call deltas. `last_cost_cents` and `last_context_window`
+/// are overwritten on each update (already-cumulative / most-recent-valid values from
+/// `LoopbackEvent::Usage`).
+#[cfg(feature = "unstable-session-usage")]
+#[derive(Debug, Default, Clone)]
+pub(crate) struct SessionUsageAccumulator {
+    pub(crate) total_input_tokens: u64,
+    pub(crate) total_output_tokens: u64,
+    pub(crate) total_cache_read_tokens: u64,
+    pub(crate) total_cache_write_tokens: u64,
+    /// Cumulative cost in USD cents — overwrite on each update, do not sum.
+    pub(crate) last_cost_cents: f64,
+    /// Most recent context window size in tokens — overwrite on each update.
+    pub(crate) last_context_window: u64,
+}
+
+#[cfg(feature = "unstable-session-usage")]
+impl SessionUsageAccumulator {
+    /// Record one LLM call's token deltas, latest cumulative cost, and context window size.
+    pub(crate) fn record(
+        &mut self,
+        input_tokens: u64,
+        output_tokens: u64,
+        cache_read_tokens: u64,
+        cache_write_tokens: u64,
+        cost_cents: f64,
+        context_window: u64,
+    ) {
+        self.total_input_tokens = self.total_input_tokens.saturating_add(input_tokens);
+        self.total_output_tokens = self.total_output_tokens.saturating_add(output_tokens);
+        self.total_cache_read_tokens = self
+            .total_cache_read_tokens
+            .saturating_add(cache_read_tokens);
+        self.total_cache_write_tokens = self
+            .total_cache_write_tokens
+            .saturating_add(cache_write_tokens);
+        // cost_cents and context_window are snapshot values — overwrite, do not accumulate.
+        self.last_cost_cents = cost_cents;
+        self.last_context_window = context_window;
+    }
+}
 
 pub(crate) struct SessionEntry {
     pub(crate) input_tx: mpsc::Sender<ChannelMessage>,
@@ -414,6 +484,9 @@ pub(crate) struct SessionEntry {
     /// did not advertise elicitation capability or the feature is not enabled.
     #[cfg(feature = "unstable-elicitation")]
     pub(crate) elicitation_bridge_handle: Option<JoinHandle<()>>,
+    /// Lifetime token and cost totals for the session-close usage summary.
+    #[cfg(feature = "unstable-session-usage")]
+    pub(crate) usage_accumulator: Mutex<SessionUsageAccumulator>,
 }
 
 impl Drop for SessionEntry {
@@ -600,6 +673,7 @@ impl ZephAcpAgentState {
     /// and `protocol` is the wire type used to build the default `current` config.
     /// Vault-resolved API keys are never passed here.
     #[cfg(feature = "unstable-llm-providers")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-llm-providers")))]
     #[must_use]
     pub fn with_provider_names(
         mut self,
@@ -682,6 +756,9 @@ impl ZephAcpAgentState {
     /// The task runs until the agent's `reaper_cancel` token is cancelled.
     /// Tracked via a `tokio::spawn` (not `cx.spawn`) because it must survive
     /// individual connection teardowns in HTTP/WS mode.
+    ///
+    /// Note: sessions evicted by the idle reaper are forcibly removed without sending a
+    /// cumulative usage summary. Only graceful `do_close_session` emits a final `UsageUpdate`.
     pub fn start_idle_reaper(&self) {
         let sessions = Arc::clone(&self.sessions);
         let idle_timeout = self.idle_timeout;
@@ -1443,19 +1520,19 @@ impl ZephAcpAgentState {
             .map(|e| Arc::clone(&e.cancel_signal));
 
         // Block until the agent finishes this turn (signals via Flush or channel close).
-        let (cancelled, stop_hint, rx) = self
+        let drain = self
             .drain_agent_events(&args.session_id, output_rx, cancel_signal)
             .await;
 
         // Return the receiver so future prompt() calls on this session can proceed.
         if let Some(entry) = self.sessions.lock().get(&args.session_id) {
-            *entry.output_rx.lock() = Some(rx);
+            *entry.output_rx.lock() = Some(drain.rx);
         }
 
-        let stop_reason = compute_stop_reason(cancelled, stop_hint);
+        let stop_reason = compute_stop_reason(drain.cancelled, drain.stop_hint);
 
         // Generate session title after first successful agent response (fire-and-forget).
-        if !cancelled {
+        if !drain.cancelled {
             self.maybe_generate_session_title(&args.session_id, &text);
         }
 
@@ -1472,6 +1549,8 @@ impl ZephAcpAgentState {
             #[cfg(feature = "unstable-message-id")]
             turn_message_id.as_deref(),
             stop_reason,
+            #[cfg(feature = "unstable-session-usage")]
+            drain.turn_usage,
         ))
     }
 
@@ -1486,13 +1565,39 @@ impl ZephAcpAgentState {
     }
 
     #[cfg(feature = "unstable-session-delete")]
-    #[allow(clippy::unused_async, dead_code)]
+    #[allow(dead_code)]
     #[tracing::instrument(skip_all, name = "acp.handler.close_session", fields(session_id = %args.session_id))]
     pub(crate) async fn do_close_session(
         &self,
         args: acp::schema::CloseSessionRequest,
     ) -> acp::Result<acp::schema::CloseSessionResponse> {
         tracing::debug!(session_id = %args.session_id, "ACP session closed");
+        // Send cumulative usage summary BEFORE removing the session so the notify_tx is still live.
+        #[cfg(feature = "unstable-session-usage")]
+        {
+            use acp::schema::{Cost, SessionNotification, SessionUpdate, UsageUpdate};
+            let snapshot = self
+                .sessions
+                .lock()
+                .get(&args.session_id)
+                .map(|e| e.usage_accumulator.lock().clone());
+            if let Some(acc) = snapshot {
+                let used = acc
+                    .total_input_tokens
+                    .saturating_add(acc.total_output_tokens);
+                let mut update = UsageUpdate::new(used, acc.last_context_window);
+                if acc.last_cost_cents > 0.0 {
+                    update = update.cost(Cost::new(acc.last_cost_cents / 100.0, "USD"));
+                }
+                let notification = SessionNotification::new(
+                    args.session_id.clone(),
+                    SessionUpdate::UsageUpdate(update),
+                );
+                if let Err(e) = self.send_notification(&args.session_id, notification).await {
+                    tracing::warn!(error = %e, "failed to send session-close usage notification");
+                }
+            }
+        }
         if let Some(entry) = self.sessions.lock().remove(&args.session_id) {
             entry.cancel_signal.notify_one();
         }
@@ -1507,6 +1612,8 @@ impl ZephAcpAgentState {
         args: acp::schema::DeleteSessionRequest,
     ) -> acp::Result<acp::schema::DeleteSessionResponse> {
         tracing::debug!(session_id = %args.session_id, "ACP session deleted");
+        // Permanent deletion — no usage summary is sent. See do_close_session for graceful
+        // close that emits a cumulative UsageUpdate before removing the session.
         if let Some(entry) = self.sessions.lock().remove(&args.session_id) {
             entry.cancel_signal.notify_one();
         }
@@ -2417,20 +2524,21 @@ impl ZephAcpAgentState {
     }
 
     /// Drain events from `rx` until `Flush` or channel close, forwarding each as an ACP
-    /// notification. Returns `(cancelled, stop_hint, rx)`.
+    /// notification. Returns a [`DrainResult`] with cancelled flag, stop hint, recycled
+    /// receiver, and per-turn token totals for `PromptResponse.usage`.
+    #[allow(clippy::too_many_lines)] // dispatcher with multiple cfg-gated feature branches
     async fn drain_agent_events(
         &self,
         session_id: &acp::schema::SessionId,
         output_rx: tokio::sync::mpsc::Receiver<LoopbackEvent>,
         cancel_signal: Option<std::sync::Arc<tokio::sync::Notify>>,
-    ) -> (
-        bool,
-        Option<StopHint>,
-        tokio::sync::mpsc::Receiver<LoopbackEvent>,
-    ) {
+    ) -> DrainResult {
         let mut rx = output_rx;
         let mut cancelled = false;
         let mut stop_hint: Option<StopHint> = None;
+        // Per-turn token totals for PromptResponse.usage (separate from session accumulator).
+        #[cfg(feature = "unstable-session-usage")]
+        let mut turn_usage = TurnUsage::default();
         // Capture turn message_id once per drain to avoid re-locking sessions per event.
         #[cfg(feature = "unstable-message-id")]
         let turn_mid: Option<String> = self
@@ -2451,6 +2559,59 @@ impl ZephAcpAgentState {
             let Some(event) = event else { break };
             if let LoopbackEvent::Stop(hint) = event {
                 stop_hint = Some(hint);
+                continue;
+            }
+            // Before converting to ACP updates, capture token/cost data for accumulators.
+            #[cfg(feature = "unstable-session-usage")]
+            if let LoopbackEvent::Usage {
+                input_tokens,
+                output_tokens,
+                context_window,
+                cache_read_tokens,
+                cache_write_tokens,
+                cost_cents,
+            } = event
+            {
+                turn_usage.input_tokens = turn_usage.input_tokens.saturating_add(input_tokens);
+                turn_usage.output_tokens = turn_usage.output_tokens.saturating_add(output_tokens);
+                turn_usage.cache_read_tokens = turn_usage
+                    .cache_read_tokens
+                    .saturating_add(cache_read_tokens);
+                turn_usage.cache_write_tokens = turn_usage
+                    .cache_write_tokens
+                    .saturating_add(cache_write_tokens);
+                // Update session-lifetime accumulator (cost/context_window: overwrite, tokens: sum).
+                if let Some(entry) = self.sessions.lock().get(session_id) {
+                    entry.usage_accumulator.lock().record(
+                        input_tokens,
+                        output_tokens,
+                        cache_read_tokens,
+                        cache_write_tokens,
+                        cost_cents,
+                        context_window,
+                    );
+                }
+                // Reconstruct the event so loopback_event_to_updates can forward it as
+                // a UsageUpdate notification (with cost and context window) to the IDE.
+                let event = LoopbackEvent::Usage {
+                    input_tokens,
+                    output_tokens,
+                    context_window,
+                    cache_read_tokens,
+                    cache_write_tokens,
+                    cost_cents,
+                };
+                for update in loopback_event_to_updates(event) {
+                    #[cfg(feature = "unstable-message-id")]
+                    let update = apply_message_id_to_chunk(update, turn_mid.as_deref());
+                    #[cfg(not(feature = "unstable-message-id"))]
+                    let update = update;
+                    let notification =
+                        acp::schema::SessionNotification::new(session_id.clone(), update);
+                    if let Err(e) = self.send_notification(session_id, notification).await {
+                        tracing::warn!(error = %e, "failed to send usage notification");
+                    }
+                }
                 continue;
             }
             let is_flush = matches!(event, LoopbackEvent::Flush);
@@ -2497,7 +2658,13 @@ impl ZephAcpAgentState {
                 break;
             }
         }
-        (cancelled, stop_hint, rx)
+        DrainResult {
+            cancelled,
+            stop_hint,
+            rx,
+            #[cfg(feature = "unstable-session-usage")]
+            turn_usage,
+        }
     }
 
     /// Create a forked conversation for `new_id` from `source_id`.
@@ -2676,6 +2843,8 @@ impl ZephAcpAgentState {
             current_message_id: std::sync::Mutex::new(None),
             #[cfg(feature = "unstable-elicitation")]
             elicitation_bridge_handle: None,
+            #[cfg(feature = "unstable-session-usage")]
+            usage_accumulator: Mutex::new(SessionUsageAccumulator::default()),
         }
     }
 
@@ -2988,16 +3157,36 @@ fn compute_stop_reason(cancelled: bool, stop_hint: Option<StopHint>) -> acp::sch
     }
 }
 
-/// Construct the `PromptResponse`, optionally echoing `turn_message_id`.
+/// Construct the `PromptResponse`, optionally echoing `turn_message_id` and attaching
+/// per-turn token usage when the `unstable-session-usage` feature is enabled.
 fn build_prompt_response(
     #[cfg(feature = "unstable-message-id")] turn_message_id: Option<&str>,
     stop_reason: acp::schema::StopReason,
+    #[cfg(feature = "unstable-session-usage")] turn_usage: TurnUsage,
 ) -> acp::schema::PromptResponse {
     let r = acp::schema::PromptResponse::new(stop_reason);
     #[cfg(feature = "unstable-message-id")]
-    if let Some(mid) = turn_message_id {
-        return r.user_message_id(mid.to_owned());
-    }
+    let r = if let Some(mid) = turn_message_id {
+        r.user_message_id(mid.to_owned())
+    } else {
+        r
+    };
+    #[cfg(feature = "unstable-session-usage")]
+    let r = {
+        let total = turn_usage
+            .input_tokens
+            .saturating_add(turn_usage.output_tokens);
+        let usage =
+            acp::schema::Usage::new(total, turn_usage.input_tokens, turn_usage.output_tokens)
+                // thought_tokens: not tracked for MVP — provider may fold them into output_tokens
+                .cached_read_tokens(
+                    (turn_usage.cache_read_tokens > 0).then_some(turn_usage.cache_read_tokens),
+                )
+                .cached_write_tokens(
+                    (turn_usage.cache_write_tokens > 0).then_some(turn_usage.cache_write_tokens),
+                );
+        r.usage(usage)
+    };
     r
 }
 
@@ -3426,5 +3615,74 @@ mod message_id_tests {
         } else {
             panic!("expected AgentMessageChunk");
         }
+    }
+}
+
+#[cfg(all(test, feature = "unstable-session-usage"))]
+mod usage_tests {
+    use super::*;
+
+    #[test]
+    fn session_accumulator_sums_tokens_and_overwrites_cost_and_context_window() {
+        let mut acc = SessionUsageAccumulator::default();
+        acc.record(100, 50, 10, 5, 1.5, 128_000);
+        acc.record(200, 80, 0, 0, 3.0, 64_000); // cost and context_window must overwrite
+        assert_eq!(acc.total_input_tokens, 300);
+        assert_eq!(acc.total_output_tokens, 130);
+        assert_eq!(acc.total_cache_read_tokens, 10);
+        assert_eq!(acc.total_cache_write_tokens, 5);
+        assert!((acc.last_cost_cents - 3.0).abs() < f64::EPSILON);
+        assert_eq!(acc.last_context_window, 64_000);
+    }
+
+    #[test]
+    fn session_accumulator_default_is_zero() {
+        let acc = SessionUsageAccumulator::default();
+        assert_eq!(acc.total_input_tokens, 0);
+        assert_eq!(acc.last_cost_cents, 0.0);
+        assert_eq!(acc.last_context_window, 0);
+    }
+
+    #[test]
+    fn build_prompt_response_attaches_usage() {
+        let turn_usage = TurnUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_tokens: 10,
+            cache_write_tokens: 0,
+        };
+        let resp = build_prompt_response(
+            #[cfg(feature = "unstable-message-id")]
+            None,
+            acp::schema::StopReason::EndTurn,
+            turn_usage,
+        );
+        let u = resp.usage.expect("usage should be set");
+        assert_eq!(u.total_tokens, 150);
+        assert_eq!(u.input_tokens, 100);
+        assert_eq!(u.output_tokens, 50);
+        // cache_read_tokens > 0 → field should be set
+        assert_eq!(u.cached_read_tokens, Some(10));
+        // cache_write_tokens == 0 → field should be None
+        assert_eq!(u.cached_write_tokens, None);
+        // thought_tokens not tracked for MVP
+        assert_eq!(u.thought_tokens, None);
+    }
+
+    #[test]
+    fn build_prompt_response_zero_usage_still_attaches() {
+        let turn_usage = TurnUsage::default();
+        let resp = build_prompt_response(
+            #[cfg(feature = "unstable-message-id")]
+            None,
+            acp::schema::StopReason::EndTurn,
+            turn_usage,
+        );
+        let u = resp
+            .usage
+            .expect("usage should be set even for zero tokens");
+        assert_eq!(u.total_tokens, 0);
+        assert_eq!(u.cached_read_tokens, None);
+        assert_eq!(u.cached_write_tokens, None);
     }
 }

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -3639,7 +3639,7 @@ mod usage_tests {
     fn session_accumulator_default_is_zero() {
         let acc = SessionUsageAccumulator::default();
         assert_eq!(acc.total_input_tokens, 0);
-        assert_eq!(acc.last_cost_cents, 0.0);
+        assert!(acc.last_cost_cents.abs() < f64::EPSILON);
         assert_eq!(acc.last_context_window, 0);
     }
 

--- a/crates/zeph-acp/src/agent/tests.rs
+++ b/crates/zeph-acp/src/agent/tests.rs
@@ -2195,6 +2195,9 @@ fn loopback_usage_maps_to_usage_update() {
         input_tokens: 100,
         output_tokens: 50,
         context_window: 200_000,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        cost_cents: 0.0,
     };
     let updates = loopback_event_to_updates(event);
     assert_eq!(updates.len(), 1);

--- a/crates/zeph-acp/src/transport/http.rs
+++ b/crates/zeph-acp/src/transport/http.rs
@@ -98,6 +98,7 @@ impl ConnectionHandle {
 
 /// Serializable session metadata returned by `GET /sessions`.
 #[cfg(feature = "acp-http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "acp-http")))]
 #[derive(Serialize)]
 pub struct SessionSummary {
     /// ACP session UUID.
@@ -127,6 +128,7 @@ impl From<AcpSessionInfo> for SessionSummary {
 
 /// A single persisted ACP event returned by `GET /sessions/{id}/messages`.
 #[cfg(feature = "acp-http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "acp-http")))]
 #[derive(Serialize)]
 pub struct SessionEventDto {
     /// Event type tag (e.g. `"user_message"`, `"agent_message"`, `"tool_call"`).
@@ -139,6 +141,7 @@ pub struct SessionEventDto {
 
 /// Liveness payload returned by `GET /health`.
 #[cfg(feature = "acp-http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "acp-http")))]
 #[derive(Serialize)]
 pub struct HealthStatus {
     /// `"ok"` when the server is ready, `"starting"` otherwise.
@@ -172,6 +175,7 @@ pub struct HealthStatus {
 /// # }
 /// ```
 #[cfg(feature = "acp-http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "acp-http")))]
 #[derive(Clone)]
 pub struct AcpHttpState {
     pub(crate) connections: Arc<DashMap<String, Arc<ConnectionHandle>>>,

--- a/crates/zeph-acp/src/transport/router.rs
+++ b/crates/zeph-acp/src/transport/router.rs
@@ -84,6 +84,7 @@ const MAX_BODY_BYTES: usize = 1_048_576;
 /// # }
 /// ```
 #[cfg(feature = "acp-http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "acp-http")))]
 pub fn acp_router(state: AcpHttpState) -> Router {
     let acp_routes = Router::new()
         .route("/acp", post(post_handler).get(get_handler))

--- a/crates/zeph-bench/src/channel.rs
+++ b/crates/zeph-bench/src/channel.rs
@@ -340,6 +340,9 @@ impl zeph_core::channel::Channel for BenchmarkChannel {
         input_tokens: u64,
         output_tokens: u64,
         context_window: u64,
+        _cache_read_tokens: u64,
+        _cache_write_tokens: u64,
+        _cost_cents: f64,
     ) -> Result<(), ChannelError> {
         self.pending_input_tokens = input_tokens;
         self.pending_output_tokens = output_tokens;
@@ -427,7 +430,7 @@ mod tests {
     async fn send_usage_captured_on_send() {
         let mut ch = BenchmarkChannel::new(vec!["p".into()]);
         let _ = ch.recv().await.unwrap();
-        ch.send_usage(10, 20, 128_000).await.unwrap();
+        ch.send_usage(10, 20, 128_000, 0, 0, 0.0).await.unwrap();
         ch.send("answer").await.unwrap();
         let r = &ch.responses()[0];
         assert_eq!(r.input_tokens, 10);

--- a/crates/zeph-channels/src/any.rs
+++ b/crates/zeph-channels/src/any.rs
@@ -164,13 +164,19 @@ impl Channel for AnyChannel {
         input_tokens: u64,
         output_tokens: u64,
         context_window: u64,
+        cache_read_tokens: u64,
+        cache_write_tokens: u64,
+        cost_cents: f64,
     ) -> Result<(), ChannelError> {
         dispatch_channel!(
             self,
             send_usage,
             input_tokens,
             output_tokens,
-            context_window
+            context_window,
+            cache_read_tokens,
+            cache_write_tokens,
+            cost_cents
         )
     }
 
@@ -254,7 +260,7 @@ mod tests {
     #[tokio::test]
     async fn any_channel_sends_usage() {
         let mut ch = AnyChannel::Cli(CliChannel::new());
-        assert!(ch.send_usage(100, 50, 200_000).await.is_ok());
+        assert!(ch.send_usage(100, 50, 200_000, 0, 0, 0.0).await.is_ok());
     }
 
     #[tokio::test]
@@ -307,7 +313,7 @@ mod tests {
         // 10. send_queue_count
         ch.send_queue_count(3).await.unwrap();
         // 11. send_usage
-        ch.send_usage(10, 5, 8192).await.unwrap();
+        ch.send_usage(10, 5, 8192, 0, 0, 0.0).await.unwrap();
         // 12. send_diff
         ch.send_diff(
             zeph_core::DiffData {

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -225,6 +225,9 @@ impl Channel for JsonCliChannel {
         _input_tokens: u64,
         _output_tokens: u64,
         _context_window: u64,
+        _cache_read_tokens: u64,
+        _cache_write_tokens: u64,
+        _cost_cents: f64,
     ) -> Result<(), ChannelError> {
         Ok(())
     }
@@ -410,7 +413,7 @@ mod tests {
             .await
             .is_ok()
         );
-        assert!(ch.send_usage(100, 50, 200_000).await.is_ok());
+        assert!(ch.send_usage(100, 50, 200_000, 0, 0, 0.0).await.is_ok());
         assert!(ch.send_stop_hint(StopHint::MaxTokens).await.is_ok());
     }
 

--- a/crates/zeph-core/src/agent/tool_execution/metrics_compact.rs
+++ b/crates/zeph-core/src/agent/tool_execution/metrics_compact.rs
@@ -86,14 +86,7 @@ impl<C: Channel> Agent<C> {
             recorder.observe_llm_latency(elapsed);
         }
 
-        if let Some((input_tokens, output_tokens)) = self.provider.last_usage() {
-            let context_window =
-                u64::try_from(self.provider.context_window().unwrap_or(0)).unwrap_or(0);
-            let _ = self
-                .channel
-                .send_usage(input_tokens, output_tokens, context_window)
-                .await;
-        }
+        self.emit_usage_event().await;
 
         // C2: server-side compaction — prune old messages and insert synthetic compaction message.
         if let Some(raw_summary) = self.provider.take_compaction_summary() {
@@ -136,5 +129,34 @@ impl<C: Channel> Agent<C> {
         }
 
         Ok(())
+    }
+
+    /// Emit `send_usage` with token counts and cumulative cost from the last LLM call.
+    async fn emit_usage_event(&mut self) {
+        let Some((input_tokens, output_tokens)) = self.provider.last_usage() else {
+            return;
+        };
+        let context_window =
+            u64::try_from(self.provider.context_window().unwrap_or(0)).unwrap_or(0);
+        let (cache_read_tokens, cache_write_tokens) =
+            self.provider.last_cache_usage().unwrap_or((0, 0));
+        // Read cumulative cost after record_cost_and_cache updated the metrics snapshot.
+        let cost_cents = self
+            .runtime
+            .metrics
+            .metrics_tx
+            .as_ref()
+            .map_or(0.0, |tx| tx.borrow().cost_spent_cents);
+        let _ = self
+            .channel
+            .send_usage(
+                input_tokens,
+                output_tokens,
+                context_window,
+                cache_read_tokens,
+                cache_write_tokens,
+                cost_cents,
+            )
+            .await;
     }
 }

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -321,6 +321,9 @@ pub trait Channel: Send {
 
     /// Send token usage after an LLM call. No-op by default.
     ///
+    /// `cost_cents` is the **cumulative** session cost in USD cents as tracked by the
+    /// internal cost tracker (already-cumulative value — do not sum across calls).
+    ///
     /// # Errors
     ///
     /// Returns an error if the underlying I/O fails.
@@ -329,6 +332,9 @@ pub trait Channel: Send {
         _input_tokens: u64,
         _output_tokens: u64,
         _context_window: u64,
+        _cache_read_tokens: u64,
+        _cache_write_tokens: u64,
+        _cost_cents: f64,
     ) -> impl Future<Output = Result<(), ChannelError>> + Send {
         async { Ok(()) }
     }
@@ -552,11 +558,23 @@ pub enum LoopbackEvent {
     /// Emitted immediately before tool execution begins.
     ToolStart(Box<ToolStartEvent>),
     ToolOutput(Box<ToolOutputEvent>),
-    /// Token usage from the last LLM turn.
+    /// Token usage from the last LLM call.
+    ///
+    /// `cost_cents` is the **cumulative** session cost in USD cents at the time of emission;
+    /// receivers should overwrite (not sum) their stored cost field.
+    ///
+    /// This variant is only produced by `Agent::emit_usage_event` in `metrics_compact.rs`
+    /// after a verified LLM response — it is never constructed from external input.
     Usage {
         input_tokens: u64,
         output_tokens: u64,
         context_window: u64,
+        /// Cache read tokens for this LLM call.
+        cache_read_tokens: u64,
+        /// Cache write tokens for this LLM call.
+        cache_write_tokens: u64,
+        /// Cumulative session cost in USD cents (overwrite, do not sum).
+        cost_cents: f64,
     },
     /// Generated session title (emitted after the first agent response).
     SessionTitle(String),
@@ -687,12 +705,18 @@ impl Channel for LoopbackChannel {
         input_tokens: u64,
         output_tokens: u64,
         context_window: u64,
+        cache_read_tokens: u64,
+        cache_write_tokens: u64,
+        cost_cents: f64,
     ) -> Result<(), ChannelError> {
         self.output_tx
             .send(LoopbackEvent::Usage {
                 input_tokens,
                 output_tokens,
                 context_window,
+                cache_read_tokens,
+                cache_write_tokens,
+                cost_cents,
             })
             .await
             .map_err(|_| ChannelError::ChannelClosed)
@@ -1052,17 +1076,26 @@ mod tests {
     #[tokio::test]
     async fn loopback_send_usage_produces_usage_event() {
         let (mut channel, mut handle) = LoopbackChannel::pair(8);
-        channel.send_usage(100, 50, 200_000).await.unwrap();
+        channel
+            .send_usage(100, 50, 200_000, 10, 5, 1.5)
+            .await
+            .unwrap();
         let event = handle.output_rx.recv().await.unwrap();
         match event {
             LoopbackEvent::Usage {
                 input_tokens,
                 output_tokens,
                 context_window,
+                cache_read_tokens,
+                cache_write_tokens,
+                cost_cents,
             } => {
                 assert_eq!(input_tokens, 100);
                 assert_eq!(output_tokens, 50);
                 assert_eq!(context_window, 200_000);
+                assert_eq!(cache_read_tokens, 10);
+                assert_eq!(cache_write_tokens, 5);
+                assert!((cost_cents - 1.5).abs() < f64::EPSILON);
             }
             _ => panic!("expected Usage event"),
         }
@@ -1072,7 +1105,7 @@ mod tests {
     async fn loopback_send_usage_error_when_closed() {
         let (mut channel, handle) = LoopbackChannel::pair(8);
         drop(handle);
-        let result = channel.send_usage(1, 2, 3).await;
+        let result = channel.send_usage(1, 2, 3, 0, 0, 0.0).await;
         assert!(matches!(result, Err(ChannelError::ChannelClosed)));
     }
 

--- a/crates/zeph-gateway/src/server.rs
+++ b/crates/zeph-gateway/src/server.rs
@@ -276,6 +276,7 @@ impl GatewayServer {
     /// # }
     /// ```
     #[cfg(feature = "prometheus")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "prometheus")))]
     #[must_use]
     pub fn with_metrics_registry(
         mut self,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -104,13 +104,19 @@ impl Channel for AppChannel {
         input_tokens: u64,
         output_tokens: u64,
         context_window: u64,
+        cache_read_tokens: u64,
+        cache_write_tokens: u64,
+        cost_cents: f64,
     ) -> Result<(), ChannelError> {
         dispatch_app_channel!(
             self,
             send_usage,
             input_tokens,
             output_tokens,
-            context_window
+            context_window,
+            cache_read_tokens,
+            cache_write_tokens,
+            cost_cents
         )
     }
 
@@ -281,7 +287,7 @@ mod tests {
     #[tokio::test]
     async fn app_channel_sends_usage() {
         let mut ch = make_app_channel();
-        assert!(ch.send_usage(100, 50, 200_000).await.is_ok());
+        assert!(ch.send_usage(100, 50, 200_000, 0, 0, 0.0).await.is_ok());
     }
 
     #[tokio::test]
@@ -332,7 +338,7 @@ mod tests {
         // 10. send_queue_count
         ch.send_queue_count(3).await.unwrap();
         // 11. send_usage
-        ch.send_usage(10, 5, 8192).await.unwrap();
+        ch.send_usage(10, 5, 8192, 0, 0, 0.0).await.unwrap();
         // 12. send_diff
         ch.send_diff(
             zeph_core::DiffData {

--- a/src/gateway_spawn.rs
+++ b/src/gateway_spawn.rs
@@ -87,9 +87,19 @@ impl<C: zeph_core::channel::Channel> zeph_core::channel::Channel for GatewayChan
         input_tokens: u64,
         output_tokens: u64,
         context_window: u64,
+        cache_read_tokens: u64,
+        cache_write_tokens: u64,
+        cost_cents: f64,
     ) -> Result<(), zeph_core::channel::ChannelError> {
         self.inner
-            .send_usage(input_tokens, output_tokens, context_window)
+            .send_usage(
+                input_tokens,
+                output_tokens,
+                context_window,
+                cache_read_tokens,
+                cache_write_tokens,
+                cost_cents,
+            )
             .await
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -475,6 +475,9 @@ async fn a2a_response_shift_drain_until_flush_prevents_leak() {
                 input_tokens: 10,
                 output_tokens: 5,
                 context_window: 8192,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                cost_cents: 0.0,
             })
             .await;
         let _ = tx2.send(LoopbackEvent::Flush).await;
@@ -533,6 +536,9 @@ async fn a2a_drain_completes_on_flush_within_timeout() {
                 input_tokens: 10,
                 output_tokens: 5,
                 context_window: 8192,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                cost_cents: 0.0,
             })
             .await;
         let _ = tx2.send(LoopbackEvent::Flush).await;


### PR DESCRIPTION
## Summary

- Implements `session/usage` ACP message (#4457) — wires existing cost/token metrics into per-turn `UsageUpdate` notifications and session-close cumulative summary, feature-gated behind `unstable-session-usage`
- Adds missing `#[cfg_attr(docsrs, doc(cfg(...)))]` annotations to all feature-gated pub items in `zeph-acp` and `zeph-gateway` (#4497)

## Changes

**zeph-core** (`channel.rs`, `metrics_compact.rs`):
- `LoopbackEvent::Usage` extended with `cache_read_tokens`, `cache_write_tokens`, `cost_cents`
- `Channel::send_usage` trait updated with the three new parameters (all call-sites updated)
- `emit_usage_event()` helper consolidates usage emission after each LLM call

**zeph-acp** (`agent/mod.rs`, `agent/helpers.rs`, `transport/http.rs`, `transport/router.rs`):
- `TurnUsage` accumulates per-call token counts within a single prompt turn
- `SessionUsageAccumulator` tracks session-lifetime totals; `last_cost_cents` and `last_context_window` use overwrite semantics (not summation) because `CostTracker` already provides cumulative values
- `drain_agent_events` dual-accumulates: per-turn for `PromptResponse.usage`, session-lifetime for the close summary
- `build_prompt_response` attaches `acp::schema::Usage`; `thought_tokens = None` (unsupported providers)
- `do_close_session` sends cumulative `UsageUpdate` before removing the session entry from the map
- All feature-gated pub items now carry `#[cfg_attr(docsrs, doc(cfg(...)))]`

**zeph-gateway** (`server.rs`): `with_metrics_registry` annotated with `doc(cfg(feature = "prometheus"))`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10053 passed (+4 new tests)
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-acp` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-gateway` — clean
- [x] New unit tests: `session_accumulator_sums_tokens_and_overwrites_cost_and_context_window`, `session_accumulator_default_is_zero`, `build_prompt_response_attaches_usage`, `build_prompt_response_zero_usage_still_attaches`

## Notes

- `do_delete_session` and the idle reaper intentionally do not send a usage summary — `session/close` is the canonical path (documented with inline comments)
- Cost exposure to IDE clients is gated behind `unstable-session-usage`; a `session_usage.expose_cost` config knob is tracked as a pre-GA concern (SECURITY-1 from audit)

Closes #4457
Closes #4497