### PR TITLE
fix(tools,agent-context): replace sync fs with tokio in FileExecutor, dedup box_err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-tools`: convert remaining 6 `FileExecutor` handlers from blocking `std::fs` to non-blocking
+  `tokio::fs` (`handle_create_directory`, `handle_delete_path`, `handle_move_path`,
+  `handle_copy_path`) and wrap recursive helpers (`grep_recursive`, `copy_dir_recursive`) in
+  `tokio::task::spawn_blocking`; eliminates tokio worker thread starvation on directory operations
+  (closes #4507).
 - `zeph-tools`: convert `FileExecutor` file I/O from blocking `std::fs` to non-blocking `tokio::fs`
   in `handle_read`, `handle_write`, `handle_edit`, and `handle_list_directory`; `symlink_metadata`
   wrapped in `tokio::task::spawn_blocking`; prevents tokio worker thread starvation on large file
@@ -41,6 +46,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   observability (closes #4496).
 - `zeph-acp`, `zeph-gateway`: add `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` annotations to
   all feature-gated public items so docs.rs renders them with the correct feature badge (closes #4497).
+
+### Changed
+
+- `zeph-agent-context`: extract private `box_err` helper in `memory_backend.rs` and replace 12
+  identical `map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)` closures; no behavior
+  change (closes #4511).
 
 ### Added
 

--- a/crates/zeph-agent-context/src/memory_backend.rs
+++ b/crates/zeph-agent-context/src/memory_backend.rs
@@ -19,6 +19,12 @@ use zeph_common::memory::{
 use zeph_memory::semantic::SemanticMemory;
 use zeph_memory::{ConversationId, RecallView as MemRecallView, RecalledFact};
 
+fn box_err<E: std::error::Error + Send + Sync + 'static>(
+    e: E,
+) -> Box<dyn std::error::Error + Send + Sync> {
+    Box::new(e)
+}
+
 fn map_persona_fact(r: zeph_memory::PersonaFactRow) -> MemPersonaFact {
     MemPersonaFact {
         category: r.category,
@@ -128,7 +134,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
                 .sqlite()
                 .load_persona_facts(min_confidence)
                 .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                .map_err(box_err)?;
             Ok(rows.into_iter().map(map_persona_fact).collect())
         })
     }
@@ -144,7 +150,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
                 .sqlite()
                 .load_trajectory_entries(tier, top_k)
                 .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                .map_err(box_err)?;
             Ok(rows.into_iter().map(map_trajectory_entry).collect())
         })
     }
@@ -156,7 +162,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
                 .sqlite()
                 .load_tree_level(level.into(), top_k)
                 .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                .map_err(box_err)?;
             Ok(rows.into_iter().map(map_tree_node).collect())
         })
     }
@@ -164,11 +170,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
     fn load_summaries(&self, conversation_id: i64) -> BoxFut<'_, Vec<MemSummary>> {
         Box::pin(async move {
             let cid = ConversationId(conversation_id);
-            let rows = self
-                .inner
-                .load_summaries(cid)
-                .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+            let rows = self.inner.load_summaries(cid).await.map_err(box_err)?;
             Ok(rows.into_iter().map(map_summary).collect())
         })
     }
@@ -183,7 +185,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
                 .inner
                 .retrieve_reasoning_strategies(query, top_k)
                 .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                .map_err(box_err)?;
             Ok(strategies.into_iter().map(map_reasoning_strategy).collect())
         })
     }
@@ -191,10 +193,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
     fn mark_reasoning_used<'a>(&'a self, ids: &'a [String]) -> BoxFut<'a, ()> {
         Box::pin(async move {
             if let Some(ref reasoning) = self.inner.reasoning {
-                reasoning
-                    .mark_used(ids)
-                    .await
-                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                reasoning.mark_used(ids).await.map_err(box_err)?;
             }
             Ok(())
         })
@@ -211,7 +210,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
                 .inner
                 .retrieve_similar_corrections(query, limit, min_score)
                 .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                .map_err(box_err)?;
             Ok(corrections.into_iter().map(map_correction).collect())
         })
     }
@@ -227,12 +226,12 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
                 self.inner
                     .recall_routed_async(query, limit, None, r, None)
                     .await
-                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                    .map_err(box_err)?
             } else {
                 self.inner
                     .recall(query, limit, None)
                     .await
-                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                    .map_err(box_err)?
             };
             Ok(recalled.into_iter().map(map_recalled_message).collect())
         })
@@ -288,7 +287,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
                     sa_params,
                 )
                 .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                .map_err(box_err)?;
             Ok(recalled.into_iter().map(map_graph_fact).collect())
         })
     }
@@ -305,7 +304,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
                 .inner
                 .search_session_summaries(query, limit, cid)
                 .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                .map_err(box_err)?;
             Ok(results.into_iter().map(map_session_summary).collect())
         })
     }
@@ -321,7 +320,7 @@ impl ContextMemoryBackend for SemanticMemoryBackend {
                 .inner
                 .search_document_collection(collection, query, top_k)
                 .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                .map_err(box_err)?;
             Ok(points
                 .into_iter()
                 .map(|p| {

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -231,7 +231,7 @@ impl FileExecutor {
             }
             "grep" => {
                 let p: GrepParams = deserialize_params(params)?;
-                self.handle_grep(&p)
+                self.handle_grep(&p).await
             }
             "list_directory" => {
                 let p: ListDirectoryParams = deserialize_params(params)?;
@@ -239,19 +239,19 @@ impl FileExecutor {
             }
             "create_directory" => {
                 let p: CreateDirectoryParams = deserialize_params(params)?;
-                self.handle_create_directory(&p)
+                self.handle_create_directory(&p).await
             }
             "delete_path" => {
                 let p: DeletePathParams = deserialize_params(params)?;
-                self.handle_delete_path(&p)
+                self.handle_delete_path(&p).await
             }
             "move_path" => {
                 let p: MovePathParams = deserialize_params(params)?;
-                self.handle_move_path(&p)
+                self.handle_move_path(&p).await
             }
             "copy_path" => {
                 let p: CopyPathParams = deserialize_params(params)?;
-                self.handle_copy_path(&p)
+                self.handle_copy_path(&p).await
             }
             _ => Ok(None),
         }
@@ -392,7 +392,7 @@ impl FileExecutor {
         }))
     }
 
-    fn handle_grep(&self, params: &GrepParams) -> Result<Option<ToolOutput>, ToolError> {
+    async fn handle_grep(&self, params: &GrepParams) -> Result<Option<ToolOutput>, ToolError> {
         let search_path = params.path.as_deref().unwrap_or(".");
         let case_sensitive = params.case_sensitive.unwrap_or(true);
         let path = self.validate_path(Path::new(search_path))?;
@@ -411,9 +411,38 @@ impl FileExecutor {
             ))
         })?;
 
-        let sandbox = |p: &Path| self.check_read_sandbox(p);
-        let mut results = Vec::new();
-        grep_recursive(&path, &regex, &mut results, 100, &sandbox)?;
+        let allowed_paths = self.allowed_paths.clone();
+        let read_deny_globs = self.read_deny_globs.clone();
+        let read_allow_globs = self.read_allow_globs.clone();
+        let results = tokio::task::spawn_blocking(move || {
+            let sandbox = |p: &Path| {
+                let Some(ref deny) = read_deny_globs else {
+                    return Ok(());
+                };
+                if deny.is_match(p)
+                    && !read_allow_globs
+                        .as_ref()
+                        .is_some_and(|allow| allow.is_match(p))
+                {
+                    return Err(ToolError::SandboxViolation {
+                        path: p.display().to_string(),
+                    });
+                }
+                Ok(())
+            };
+            // Validate path is within sandbox before grepping.
+            let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
+            if !allowed_paths.iter().any(|a| canonical.starts_with(a)) {
+                return Err(ToolError::SandboxViolation {
+                    path: path.display().to_string(),
+                });
+            }
+            let mut results = Vec::new();
+            grep_recursive(&path, &regex, &mut results, 100, &sandbox)?;
+            Ok(results)
+        })
+        .await
+        .map_err(|e| ToolError::Execution(std::io::Error::other(e.to_string())))??;
 
         Ok(Some(ToolOutput {
             tool_name: ToolName::new("grep"),
@@ -494,12 +523,12 @@ impl FileExecutor {
         }))
     }
 
-    fn handle_create_directory(
+    async fn handle_create_directory(
         &self,
         params: &CreateDirectoryParams,
     ) -> Result<Option<ToolOutput>, ToolError> {
         let path = self.validate_path(Path::new(&params.path))?;
-        std::fs::create_dir_all(&path)?;
+        tokio::fs::create_dir_all(&path).await?;
 
         Ok(Some(ToolOutput {
             tool_name: ToolName::new("create_directory"),
@@ -515,7 +544,7 @@ impl FileExecutor {
         }))
     }
 
-    fn handle_delete_path(
+    async fn handle_delete_path(
         &self,
         params: &DeletePathParams,
     ) -> Result<Option<ToolOutput>, ToolError> {
@@ -532,13 +561,13 @@ impl FileExecutor {
             if params.recursive {
                 // Accepted risk: remove_dir_all has no depth/size guard within the sandbox.
                 // Resource exhaustion is bounded by the filesystem and OS limits.
-                std::fs::remove_dir_all(&path)?;
+                tokio::fs::remove_dir_all(&path).await?;
             } else {
                 // remove_dir only succeeds on empty dirs
-                std::fs::remove_dir(&path)?;
+                tokio::fs::remove_dir(&path).await?;
             }
         } else {
-            std::fs::remove_file(&path)?;
+            tokio::fs::remove_file(&path).await?;
         }
 
         Ok(Some(ToolOutput {
@@ -555,10 +584,13 @@ impl FileExecutor {
         }))
     }
 
-    fn handle_move_path(&self, params: &MovePathParams) -> Result<Option<ToolOutput>, ToolError> {
+    async fn handle_move_path(
+        &self,
+        params: &MovePathParams,
+    ) -> Result<Option<ToolOutput>, ToolError> {
         let src = self.validate_path(Path::new(&params.source))?;
         let dst = self.validate_path(Path::new(&params.destination))?;
-        std::fs::rename(&src, &dst)?;
+        tokio::fs::rename(&src, &dst).await?;
 
         Ok(Some(ToolOutput {
             tool_name: ToolName::new("move_path"),
@@ -574,17 +606,24 @@ impl FileExecutor {
         }))
     }
 
-    fn handle_copy_path(&self, params: &CopyPathParams) -> Result<Option<ToolOutput>, ToolError> {
+    async fn handle_copy_path(
+        &self,
+        params: &CopyPathParams,
+    ) -> Result<Option<ToolOutput>, ToolError> {
         let src = self.validate_path(Path::new(&params.source))?;
         let dst = self.validate_path(Path::new(&params.destination))?;
 
         if src.is_dir() {
-            copy_dir_recursive(&src, &dst)?;
+            let src2 = src.clone();
+            let dst2 = dst.clone();
+            tokio::task::spawn_blocking(move || copy_dir_recursive(&src2, &dst2))
+                .await
+                .map_err(|e| ToolError::Execution(std::io::Error::other(e.to_string())))??;
         } else {
             if let Some(parent) = dst.parent() {
-                std::fs::create_dir_all(parent)?;
+                tokio::fs::create_dir_all(parent).await?;
             }
-            std::fs::copy(&src, &dst)?;
+            tokio::fs::copy(&src, &dst).await?;
         }
 
         Ok(Some(ToolOutput {


### PR DESCRIPTION
## Summary

- **#4507**: Replace 6 remaining `std::fs` blocking call sites in `FileExecutor` that were missed in the partial fix (#4502). Simple handlers (`handle_create_directory`, `handle_delete_path`, `handle_move_path`, `handle_copy_path`) are converted to `tokio::fs` equivalents. Recursive helpers (`grep_recursive`, `copy_dir_recursive`) are wrapped in `tokio::task::spawn_blocking` since the traversal loop cannot be trivially made async.
- **#4511**: Extract a private `box_err` helper in `memory_backend.rs` and replace 12 identical `map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)` closures — no behavior change.

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace --lib --bins` — 10054 tests passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` passes
- [x] Reviewer verified all 6 blocking call sites eliminated; `spawn_blocking` closures satisfy `'static + Send`; `box_err` bounds correct for all 12 call sites

Closes #4507, #4511