### PR TITLE
fix(sanitizer): add LLM timeout to QuarantinedSummarizer::extract_facts

### DIFF
--- a/crates/zeph-config/src/sanitizer.rs
+++ b/crates/zeph-config/src/sanitizer.rs
@@ -260,6 +260,14 @@ pub struct QuarantineConfig {
     /// Provider name passed to `create_named_provider`.
     #[serde(default = "default_quarantine_model")]
     pub model: String,
+
+    /// Maximum time in milliseconds to wait for the quarantine LLM to respond.
+    ///
+    /// When the LLM does not respond within this window, `extract_facts` returns a timeout
+    /// error so the agent can recover rather than stalling indefinitely.
+    /// Defaults to 30 000 ms (30 s).
+    #[serde(default = "default_quarantine_timeout_ms")]
+    pub timeout_ms: u64,
 }
 
 fn default_quarantine_sources() -> Vec<String> {
@@ -270,12 +278,17 @@ fn default_quarantine_model() -> String {
     "claude".to_owned()
 }
 
+fn default_quarantine_timeout_ms() -> u64 {
+    30_000
+}
+
 impl Default for QuarantineConfig {
     fn default() -> Self {
         Self {
             enabled: false,
             sources: default_quarantine_sources(),
             model: default_quarantine_model(),
+            timeout_ms: default_quarantine_timeout_ms(),
         }
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -314,6 +314,7 @@ async fn sanitize_tool_output_cross_boundary_acp_mcp_quarantines() {
         enabled: true,
         sources: vec![],
         model: "mock".to_owned(),
+        timeout_ms: 30_000,
     };
     let qs = QuarantinedSummarizer::new(quarantine_provider, &qcfg);
 
@@ -373,6 +374,7 @@ async fn sanitize_tool_output_cross_boundary_disabled_skips_quarantine() {
         enabled: true,
         sources: vec![],
         model: "mock".to_owned(),
+        timeout_ms: 30_000,
     };
     let qs = QuarantinedSummarizer::new(quarantine_provider, &qcfg);
 

--- a/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
@@ -186,6 +186,7 @@ async fn sanitize_tool_output_quarantine_web_scrape_invoked() {
         enabled: true,
         sources: vec!["web_scrape".to_owned()],
         model: "claude".to_owned(),
+        timeout_ms: 30_000,
     };
     let qs = QuarantinedSummarizer::new(quarantine_provider, &qcfg);
 
@@ -243,6 +244,7 @@ async fn sanitize_tool_output_quarantine_fallback_on_error() {
         enabled: true,
         sources: vec!["web_scrape".to_owned()],
         model: "claude".to_owned(),
+        timeout_ms: 30_000,
     };
     let qs = QuarantinedSummarizer::new(quarantine_provider, &qcfg);
 
@@ -300,6 +302,7 @@ async fn sanitize_tool_output_quarantine_skips_shell_tool() {
         enabled: true,
         sources: vec!["web_scrape".to_owned()], // only web_scrape, NOT shell
         model: "claude".to_owned(),
+        timeout_ms: 30_000,
     };
     let qs = QuarantinedSummarizer::new(quarantine_provider, &qcfg);
 

--- a/crates/zeph-sanitizer/src/quarantine.rs
+++ b/crates/zeph-sanitizer/src/quarantine.rs
@@ -20,6 +20,7 @@
 //! 4. Insert the summary (not the raw content) into message history.
 
 use std::collections::HashSet;
+use std::time::Duration;
 
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
@@ -51,7 +52,10 @@ Do not include any preamble, explanations, or meta-commentary — only the extra
 pub enum QuarantineError {
     /// The quarantine LLM call failed (network error, provider error, etc.).
     #[error("quarantine LLM call failed: {0}")]
-    LlmError(#[from] zeph_llm::LlmError),
+    LlmError(zeph_llm::LlmError),
+    /// The quarantine LLM did not respond within the configured `timeout_ms`.
+    #[error("quarantine LLM call timed out")]
+    Timeout,
     /// The quarantine LLM returned an empty or whitespace-only response.
     #[error("quarantine response was empty")]
     EmptyResponse,
@@ -86,6 +90,7 @@ pub enum QuarantineError {
 pub struct QuarantinedSummarizer {
     provider: AnyProvider,
     enabled_sources: HashSet<ContentSourceKind>,
+    timeout: Duration,
 }
 
 impl QuarantinedSummarizer {
@@ -120,6 +125,7 @@ impl QuarantinedSummarizer {
         Self {
             provider,
             enabled_sources,
+            timeout: Duration::from_millis(config.timeout_ms),
         }
     }
 
@@ -147,10 +153,15 @@ impl QuarantinedSummarizer {
     /// If injection patterns are found in the quarantine output, they are recorded as
     /// flags in the re-spotlighted result.
     ///
+    /// The call is bounded by the `timeout_ms` field from [`QuarantineConfig`].  When
+    /// the LLM provider does not respond within that window the method returns
+    /// [`QuarantineError::Timeout`] so the agent can recover rather than stalling.
+    ///
     /// # Errors
     ///
-    /// Returns `QuarantineError::LlmError` if the provider call fails, or
-    /// `QuarantineError::EmptyResponse` if the provider returns an empty string.
+    /// - [`QuarantineError::Timeout`] — the provider did not respond within `timeout_ms`.
+    /// - [`QuarantineError::LlmError`] — the provider call failed (network error, etc.).
+    /// - [`QuarantineError::EmptyResponse`] — the provider returned an empty string.
     pub async fn extract_facts(
         &self,
         input: &SanitizedContent,
@@ -164,7 +175,16 @@ impl QuarantinedSummarizer {
             Message::from_legacy(Role::User, raw),
         ];
 
-        let response = self.provider.chat(&messages).await?;
+        let response = tokio::time::timeout(self.timeout, self.provider.chat(&messages))
+            .await
+            .map_err(|_| {
+                tracing::warn!(
+                    timeout_ms = self.timeout.as_millis(),
+                    "quarantine LLM call timed out"
+                );
+                QuarantineError::Timeout
+            })?
+            .map_err(QuarantineError::LlmError)?;
         let facts = response.trim().to_owned();
 
         if facts.is_empty() {
@@ -255,6 +275,7 @@ mod tests {
         assert!(!cfg.enabled);
         assert_eq!(cfg.sources, vec!["web_scrape", "a2a_message"]);
         assert_eq!(cfg.model, "claude");
+        assert_eq!(cfg.timeout_ms, 30_000);
     }
 
     #[test]
@@ -263,6 +284,7 @@ mod tests {
             enabled: true,
             sources: vec!["web_scrape".to_owned(), "mcp_response".to_owned()],
             model: "ollama".to_owned(),
+            timeout_ms: 15_000,
         };
         let toml_str = toml::to_string(&cfg).expect("serialize");
         let back: QuarantineConfig = toml::from_str(&toml_str).expect("deserialize");
@@ -474,6 +496,32 @@ spotlight_untrusted = true
         assert!(qs.should_quarantine(ContentSourceKind::WebScrape));
         // bogus_source was skipped — nothing else should match
         assert!(!qs.should_quarantine(ContentSourceKind::A2aMessage));
+    }
+
+    // --- timeout ---
+
+    #[tokio::test]
+    async fn extract_facts_returns_timeout_on_stalled_provider() {
+        use zeph_llm::mock::MockProvider;
+
+        // Provider delays 2 s; quarantine timeout is 50 ms — must return Timeout.
+        let provider = AnyProvider::Mock(MockProvider::default().with_delay(2_000));
+        let cfg = QuarantineConfig {
+            timeout_ms: 50,
+            ..Default::default()
+        };
+        let qs = QuarantinedSummarizer::new(provider, &cfg);
+        let sanitized = default_sanitizer()
+            .sanitize("content", ContentSource::new(ContentSourceKind::WebScrape));
+        let content_sanitizer = default_sanitizer();
+        let err = qs
+            .extract_facts(&sanitized, &content_sanitizer)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, QuarantineError::Timeout),
+            "expected Timeout, got {err:?}"
+        );
     }
 
     // --- from_str_opt ---


### PR DESCRIPTION
## Summary

- `QuarantinedSummarizer::extract_facts` called `provider.chat()` with no timeout guard, blocking the agent indefinitely when the LLM provider stalled
- Added `timeout_ms: u64` to `QuarantineConfig` (default 30 000 ms, backward-compatible via serde default)
- Added `QuarantineError::Timeout` variant with `tracing::warn!` on expiry
- Wrapped `provider.chat()` in `tokio::time::timeout` following the existing `GuardrailFilter::check_inner` pattern
- Added regression test `extract_facts_returns_timeout_on_stalled_provider`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --lib --bins` — clean
- [x] `cargo nextest run -p zeph-sanitizer -p zeph-config -p zeph-core` — 2256 passed
- [x] Regression test covers the timeout path with 50 ms config vs 2 s mock delay

Closes #4516