### PR TITLE
refactor(llm,commands,plugins,sanitizer,skills): add #[non_exhaustive] to extensible pub enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   propagated through `parse_frontmatter`, `load_skill_meta_from_str`, and `load_skill_meta`.
 - CLI: `zeph skills promote-heuristics [--skill <name>]` subcommand for manual promotion dry-run.
 
+### Changed
+
+- `zeph-llm`: mark `StreamChunk`, `ThinkingBlock`, `ChatResponse`, `MessagePart`, and `LlmError`
+  as `#[non_exhaustive]` — adding new variants in the future will not be a breaking change for
+  downstream crates (closes #4515, #4517).
+- `zeph-commands`: mark `CommandOutput` and `GoalStatusView` as `#[non_exhaustive]` (closes #4517).
+- `zeph-plugins`: mark `PluginError` as `#[non_exhaustive]` (closes #4517).
+- `zeph-sanitizer`: mark `ExfiltrationEvent` as `#[non_exhaustive]` (closes #4517).
+- `zeph-skills`: mark `MatchResult` and `SkillMatcherBackend` as `#[non_exhaustive]` (closes #4520).
+
 ### Fixed
 
 - `zeph-tools`: convert remaining 6 `FileExecutor` handlers from blocking `std::fs` to non-blocking

--- a/crates/zeph-commands/src/lib.rs
+++ b/crates/zeph-commands/src/lib.rs
@@ -40,6 +40,7 @@ pub use traits::agent::{AgentAccess, NullAgent};
 ///
 /// Mirrors `zeph_core::goal::GoalStatus`. Defined here to avoid a dependency cycle
 /// (`zeph-commands` cannot depend on `zeph-core`).
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GoalStatusView {
@@ -93,6 +94,7 @@ use std::pin::Pin;
 ///
 /// Replaces the heterogeneous return types of earlier command dispatch with a unified,
 /// exhaustive enum.
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum CommandOutput {
     /// Send a message to the user via the channel.

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -572,8 +572,8 @@ impl<C: Channel> Agent<C> {
                 )
                 .await;
             let (mut scored, infra_error) = match match_result {
-                zeph_skills::MatchResult::InfraError => (Vec::new(), true),
                 zeph_skills::MatchResult::Scored(v) => (v, false),
+                _ => (Vec::new(), true),
             };
 
             if !scored.is_empty() {

--- a/crates/zeph-core/src/agent/learning/skill_commands.rs
+++ b/crates/zeph-core/src/agent/learning/skill_commands.rs
@@ -204,7 +204,7 @@ impl<C: Channel> Agent<C> {
             .await
         {
             zeph_skills::MatchResult::Scored(v) => v,
-            zeph_skills::MatchResult::InfraError => Vec::new(),
+            _ => Vec::new(),
         };
         if let Some(best) = scored.first()
             && best.score > 0.85

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1231,18 +1231,16 @@ impl<C: Channel> Agent<C> {
                 let _ = self.channel.flush_chunks().await;
                 DispatchFlow::Break
             }
-            Some(Ok(
-                zeph_commands::CommandOutput::Continue | zeph_commands::CommandOutput::Silent,
-            )) => {
-                let _ = self.channel.flush_chunks().await;
-                DispatchFlow::Continue
-            }
             Some(Ok(zeph_commands::CommandOutput::Message(msg))) => {
                 let _ = self.channel.send(&msg).await;
                 let _ = self.channel.flush_chunks().await;
                 if with_learning {
                     self.maybe_trigger_post_command_learning(command).await;
                 }
+                DispatchFlow::Continue
+            }
+            Some(Ok(_)) => {
+                let _ = self.channel.flush_chunks().await;
                 DispatchFlow::Continue
             }
             Some(Err(e)) => {
@@ -3774,6 +3772,7 @@ pub(crate) fn estimate_parts_size(m: &zeph_llm::provider::Message) -> usize {
             } => 50 + thinking.len() + signature.len(),
             MessagePart::RedactedThinkingBlock { data } => data.len(),
             MessagePart::Compaction { summary } => summary.len(),
+            _ => 0,
         })
         .sum()
 }

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -696,6 +696,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                     }
                     messages.push(Message::from_parts(Role::User, result_parts));
                 }
+                _ => {}
             }
         }
 

--- a/crates/zeph-core/src/agent/speculative/stream_drainer.rs
+++ b/crates/zeph-core/src/agent/speculative/stream_drainer.rs
@@ -390,7 +390,7 @@ mod tests {
                 assert_eq!(tool_calls[0].id, "toolu_01");
                 assert_eq!(tool_calls[0].name, "bash");
             }
-            other @ ChatResponse::Text(_) => panic!("expected ToolUse, got {other:?}"),
+            other => panic!("expected ToolUse, got {other:?}"),
         }
     }
 

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -946,6 +946,7 @@ impl DebugState {
                     text.as_deref().unwrap_or("")
                 )
             }
+            _ => String::new(),
         };
         let text = if pii_filter.is_enabled() {
             pii_filter.scrub(&raw).into_owned()

--- a/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
+++ b/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
@@ -322,15 +322,18 @@ impl<C: Channel> Agent<C> {
         {
             let mut thinking_parts: Vec<MessagePart> = blocks
                 .into_iter()
-                .map(|b| match b {
+                .filter_map(|b| match b {
                     ThinkingBlock::Thinking {
                         thinking,
                         signature,
-                    } => MessagePart::ThinkingBlock {
+                    } => Some(MessagePart::ThinkingBlock {
                         thinking,
                         signature,
-                    },
-                    ThinkingBlock::Redacted { data } => MessagePart::RedactedThinkingBlock { data },
+                    }),
+                    ThinkingBlock::Redacted { data } => {
+                        Some(MessagePart::RedactedThinkingBlock { data })
+                    }
+                    _ => None,
                 })
                 .collect();
             // Thinking blocks must appear before text/tool_use in the assistant message.

--- a/crates/zeph-core/src/agent/tool_execution/metrics_compact.rs
+++ b/crates/zeph-core/src/agent/tool_execution/metrics_compact.rs
@@ -57,6 +57,7 @@ impl<C: Channel> Agent<C> {
                     .sum();
                 (text_tokens + calls_tokens) as u64
             }
+            _ => 0,
         };
         let (final_prompt, final_completion) = self
             .provider

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -581,7 +581,6 @@ fn part_to_block(part: &MessagePart, is_assistant: bool) -> Option<serde_json::V
         {
             None
         }
-        MessagePart::ThinkingBlock { .. } | MessagePart::RedactedThinkingBlock { .. } => None,
         MessagePart::Compaction { summary } => {
             Some(serde_json::json!({ "type": "compaction", "summary": summary }))
         }
@@ -593,6 +592,7 @@ fn part_to_block(part: &MessagePart, is_assistant: bool) -> Option<serde_json::V
                 "data": base64::engine::general_purpose::STANDARD.encode(&img.data),
             },
         })),
+        _ => None,
     }
 }
 

--- a/crates/zeph-llm/src/error.rs
+++ b/crates/zeph-llm/src/error.rs
@@ -10,6 +10,7 @@
 /// [`is_invalid_input`](Self::is_invalid_input),
 /// [`is_beta_header_rejected`](Self::is_beta_header_rejected)) to classify errors
 /// before deciding whether to retry, fall back, or propagate.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum LlmError {
     /// Underlying HTTP transport error (connection refused, TLS failure, etc.).

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -109,6 +109,7 @@ impl ChatExtras {
 ///
 /// Consumers should match all variants: future providers may emit non-`Content` chunks
 /// that callers must not silently drop (e.g. thinking blocks that must be echoed back).
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum StreamChunk {
     /// Regular response text.
@@ -148,6 +149,7 @@ pub struct ToolUseRequest {
 /// Both variants must be echoed verbatim in the next turn's `assistant` message so
 /// the API can correctly attribute reasoning across turns. Never modify or discard
 /// these blocks between turns.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum ThinkingBlock {
     /// Visible reasoning token with its cryptographic signature.
@@ -167,6 +169,7 @@ pub const MAX_TOKENS_TRUNCATION_MARKER: &str = "max_tokens limit reached";
 /// 2. Append an `assistant` message with the original `tool_calls` and any `thinking_blocks`.
 /// 3. Append a `user` message containing [`MessagePart::ToolResult`] entries.
 /// 4. Call `chat_with_tools` again to continue the conversation.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum ChatResponse {
     /// Model produced text output only.
@@ -265,6 +268,7 @@ pub enum Role {
 ///   multi-turn requests so the API can correctly attribute reasoning.
 /// - `Compaction` parts must be preserved verbatim; the API uses them to prune
 ///   prior history on subsequent turns (Claude compact-2026-01-12 beta).
+#[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MessagePart {

--- a/crates/zeph-memory/src/token_counter.rs
+++ b/crates/zeph-memory/src/token_counter.rs
@@ -191,6 +191,9 @@ impl TokenCounter {
 
             // Compaction summary is sent back verbatim to the API.
             MessagePart::Compaction { summary } => self.count_tokens(summary),
+
+            // Forward-compatibility: unknown future variants have no known token count.
+            _ => 0,
         }
     }
 

--- a/crates/zeph-plugins/src/error.rs
+++ b/crates/zeph-plugins/src/error.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 /// Errors that can occur during plugin install, remove, or list operations.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum PluginError {
     /// The plugin manifest (`plugin.toml`) is missing or cannot be parsed.

--- a/crates/zeph-sanitizer/src/exfiltration.rs
+++ b/crates/zeph-sanitizer/src/exfiltration.rs
@@ -99,6 +99,7 @@ static UNICODE_BYPASS_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// assert_eq!(events.len(), 1);
 /// assert!(matches!(&events[0], ExfiltrationEvent::MarkdownImageBlocked { url } if url.contains("evil.com")));
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExfiltrationEvent {
     /// A markdown image with an external URL was stripped from LLM output.

--- a/crates/zeph-skills/src/matcher.rs
+++ b/crates/zeph-skills/src/matcher.rs
@@ -77,6 +77,7 @@ pub struct ScoredMatch {
 /// - [`MatchResult::Scored`] — matcher produced candidates (the vec may be empty when no skills
 ///   are loaded or all fall below the caller's threshold); the `min_injection_score` gate must be
 ///   respected.
+#[non_exhaustive]
 #[must_use]
 pub enum MatchResult {
     /// Infrastructure failure — embedding call timed out or backend returned an error.
@@ -559,6 +560,7 @@ impl SkillMatcher {
 ///
 /// `InMemory` uses a pre-computed in-process embedding index; `Qdrant` delegates to a
 /// remote Qdrant vector store and requires the `qdrant` feature to be enabled.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum SkillMatcherBackend {
     /// In-process embedding index built at startup from skill descriptions.

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -387,6 +387,7 @@ async fn run_turn(
     let response_text = match &response {
         ChatResponse::Text(t) => t.clone(),
         ChatResponse::ToolUse { text, .. } => text.as_deref().unwrap_or_default().to_owned(),
+        _ => String::new(),
     };
 
     *turns += 1;
@@ -601,6 +602,7 @@ async fn handle_tool_step(
             messages.push(Message::from_parts(Role::User, result_parts));
             false
         }
+        _ => true,
     }
 }
 


### PR DESCRIPTION
## Summary

- Mark 11 extensible pub enums across 6 crates with `#[non_exhaustive]`: `StreamChunk`, `ThinkingBlock`, `ChatResponse`, `MessagePart`, `LlmError` (zeph-llm), `CommandOutput`, `GoalStatusView` (zeph-commands), `PluginError` (zeph-plugins), `ExfiltrationEvent` (zeph-sanitizer), `MatchResult`, `SkillMatcherBackend` (zeph-skills)
- Fix 14 exhaustive match arms in `zeph-core`, `zeph-memory`, `zeph-subagent` that became non-exhaustive after the attribute was applied
- `Role` and `MessageVisibility` in zeph-llm intentionally left exhaustive (stable 3-value enums); `ChatExtras` already had the attribute

## Motivation

Without `#[non_exhaustive]`, adding a new variant to these enums is a semver-breaking change for any downstream crate that pattern-matches on them. All 11 enums are explicitly expected to grow (new LLM providers, new content part types, new tool result shapes).

## Test plan

- [ ] `cargo build --workspace` — clean
- [ ] `cargo clippy --features desktop,ide,server,chat,pdf,scheduler --workspace -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10077 passed
- [ ] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 19 passed

Closes #4515, #4517, #4520