### PR TITLE
fix(skills,memory): AutoSkill A6 — NULL skill_name in promotion scan + blocking I/O in async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-memory`: `count_heuristics_by_skill` now filters `skill_name IS NOT NULL` before grouping,
+  preventing sqlx from attempting to decode a NULL row into `String` and excluding general heuristics
+  (NULL skill_name) from AutoSkill A6 promotion scans (closes #4531).
+- `zeph-core`: wrap `SkillRegistry::load` call in `add_merge_discard_decision` with
+  `tokio::task::spawn_blocking` to avoid blocking a Tokio worker thread with synchronous filesystem
+  I/O; falls back to empty registry on JoinError (closes #4530).
 - `zeph-config`: add `list_tasks` to `AdversarialPolicyConfig::default_exempt_tools()` so the
   `/scheduler list` slash command is never blocked by the adversarial probe gate when the embed
   provider is unavailable and `fail_open = false`; read-only scheduler intrinsics now bypass the
@@ -48,7 +54,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `DispatchStrategy`, `LineageKind`, `SubAgentState`, `AgentsCommand`, `AgentCommand`,
   `FleetSessionStatus`, `GrantKind`, `HookError`, `SchedulerMessage`, `TaskKind`, `TaskMode`);
   prevents downstream exhaustive `match` breakage when new variants are added (closes #4527).
-
 - `zeph-tools`: convert remaining 6 `FileExecutor` handlers from blocking `std::fs` to non-blocking
   `tokio::fs` (`handle_create_directory`, `handle_delete_path`, `handle_move_path`,
   `handle_copy_path`) and wrap recursive helpers (`grep_recursive`, `copy_dir_recursive`) in

--- a/crates/zeph-core/src/agent/heuristic_promotion.rs
+++ b/crates/zeph-core/src/agent/heuristic_promotion.rs
@@ -493,7 +493,16 @@ async fn add_merge_discard_decision(
         };
 
         // Load and embed existing skills from the managed directory.
-        let registry = zeph_skills::registry::SkillRegistry::load(&[output_dir.to_path_buf()]);
+        // SkillRegistry::load uses std::fs blocking I/O; run it off the async thread.
+        let output_dir_clone = output_dir.to_path_buf();
+        let registry = tokio::task::spawn_blocking(move || {
+            zeph_skills::registry::SkillRegistry::load(&[output_dir_clone])
+        })
+        .await
+        .unwrap_or_else(|_| {
+            tracing::warn!("heuristic_promotion: spawn_blocking for SkillRegistry::load panicked, using empty registry");
+            zeph_skills::registry::SkillRegistry::default()
+        });
         let existing_meta: Vec<_> = registry.all_meta().into_iter().cloned().collect();
 
         let mut existing_embeddings: Vec<(zeph_skills::loader::SkillMeta, SkillEmbedding)> =
@@ -635,7 +644,57 @@ fn patch_version(skill_md: &str, new_version: u32) -> String {
 
 #[cfg(test)]
 mod tests {
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+    use zeph_skills::generator::GeneratedSkill;
+    use zeph_skills::loader::SkillMeta;
+    use zeph_skills::merger::MergeDecision;
+
     use super::*;
+
+    fn mock_embed_provider() -> AnyProvider {
+        AnyProvider::Mock(MockProvider::default().with_embedding(vec![0.1_f32; 384]))
+    }
+
+    fn dummy_candidate(name: &str) -> GeneratedSkill {
+        GeneratedSkill {
+            name: name.to_string(),
+            content: format!("---\nname: {name}\ndescription: Test skill.\n---\n\n# Body\n"),
+            meta: SkillMeta {
+                name: name.to_string(),
+                description: "Test skill.".to_string(),
+                ..SkillMeta::default()
+            },
+            warnings: vec![],
+            has_injection_patterns: false,
+        }
+    }
+
+    /// Regression test for #4530: `add_merge_discard_decision` must call
+    /// `spawn_blocking` for `SkillRegistry::load` without panicking.
+    /// With an empty managed directory there are no existing skills, so the
+    /// function should return `MergeDecision::Add`.
+    #[tokio::test]
+    async fn add_merge_discard_decision_empty_dir_returns_add() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = mock_embed_provider();
+        let candidate = dummy_candidate("new-skill");
+
+        let decision = add_merge_discard_decision(
+            &provider,
+            tmp.path(),
+            &candidate,
+            0.9,  // merge_threshold
+            0.98, // dedup_threshold
+            true, // merge_enabled
+        )
+        .await;
+
+        assert!(
+            matches!(decision, MergeDecision::Add),
+            "expected MergeDecision::Add for empty directory, got {decision:?}"
+        );
+    }
 
     #[test]
     fn patch_version_replaces_existing() {

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -1196,7 +1196,7 @@ impl SqliteStore {
         let rows: Vec<(String, i64)> = zeph_db::query_as(sql!(
             "SELECT skill_name, COUNT(*) AS cnt \
              FROM skill_heuristics \
-             WHERE confidence >= ? \
+             WHERE confidence >= ? AND skill_name IS NOT NULL \
              GROUP BY skill_name \
              HAVING cnt >= ?"
         ))
@@ -2156,6 +2156,43 @@ mod tests {
         .execute(store.pool())
         .await
         .unwrap();
+    }
+
+    /// Regression test for #4531: NULL skill_name heuristics must be excluded from
+    /// `count_heuristics_by_skill` so sqlx does not encounter a non-null column mismatch.
+    #[tokio::test]
+    async fn count_heuristics_by_skill_excludes_null_skill_name() {
+        let store = test_store().await;
+
+        // Insert heuristics with NULL skill_name (general/unattributed).
+        store
+            .insert_skill_heuristic(None, "general tip 1", 0.9)
+            .await
+            .unwrap();
+        store
+            .insert_skill_heuristic(None, "general tip 2", 0.8)
+            .await
+            .unwrap();
+        store
+            .insert_skill_heuristic(None, "general tip 3", 0.7)
+            .await
+            .unwrap();
+
+        // NULL rows alone must not produce any results (no skill_name to group by).
+        let results = store.count_heuristics_by_skill(0.5, 2).await.unwrap();
+        assert!(
+            results.is_empty(),
+            "NULL skill_name heuristics must be excluded from count_heuristics_by_skill results"
+        );
+
+        // Verify that named skills are still counted correctly alongside NULL rows.
+        insert_heuristic(&store, "git", "use --no-pager", 0.8).await;
+        insert_heuristic(&store, "git", "check status first", 0.9).await;
+
+        let results = store.count_heuristics_by_skill(0.5, 2).await.unwrap();
+        assert_eq!(results.len(), 1, "only git should qualify");
+        assert_eq!(results[0].0, "git");
+        assert_eq!(results[0].1, 2, "git has exactly 2 qualifying heuristics");
     }
 
     #[tokio::test]

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -2158,7 +2158,7 @@ mod tests {
         .unwrap();
     }
 
-    /// Regression test for #4531: NULL skill_name heuristics must be excluded from
+    /// Regression test for #4531: `NULL` `skill_name` heuristics must be excluded from
     /// `count_heuristics_by_skill` so sqlx does not encounter a non-null column mismatch.
     #[tokio::test]
     async fn count_heuristics_by_skill_excludes_null_skill_name() {


### PR DESCRIPTION
## Summary

- **#4531**: `count_heuristics_by_skill` added `AND skill_name IS NOT NULL` to WHERE clause — prevents sqlx from failing to decode a `(NULL, i64)` row into `(String, i64)` and stops general heuristics from being treated as promotion candidates
- **#4530**: `SkillRegistry::load` in `add_merge_discard_decision` wrapped in `tokio::task::spawn_blocking` — removes blocking `std::fs` I/O from the async worker thread; falls back to empty registry on JoinError

## Test plan

- [ ] `count_heuristics_by_skill_excludes_null_skill_name` — inserts 3 NULL-skill_name heuristics above threshold, verifies query returns empty; inserts named skills alongside NULLs, verifies correct count
- [ ] `add_merge_discard_decision_empty_dir_returns_add` — uses MockProvider + tempfile, calls `add_merge_discard_decision` directly, exercises spawn_blocking path, asserts `MergeDecision::Add` for empty dir
- [ ] `cargo nextest run --workspace --lib --bins` — 10110 passed, 21 skipped
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `cargo +nightly fmt --check` — clean

Closes #4531
Closes #4530