### PR TITLE
fix(scheduler): adversarial policy bypass for list_tasks + #[non_exhaustive] on 17 enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-config`: add `list_tasks` to `AdversarialPolicyConfig::default_exempt_tools()` so the
+  `/scheduler list` slash command is never blocked by the adversarial probe gate when the embed
+  provider is unavailable and `fail_open = false`; read-only scheduler intrinsics now bypass the
+  policy check unconditionally (closes #4529).
+- `zeph-orchestration`, `zeph-subagent`, `zeph-scheduler`: add `#[non_exhaustive]` to 17 extensible
+  pub enums (`TaskStatus`, `GraphStatus`, `ExecutionMode`, `TaskClass`, `TopologyHint`, `Topology`,
+  `DispatchStrategy`, `LineageKind`, `SubAgentState`, `AgentsCommand`, `AgentCommand`,
+  `FleetSessionStatus`, `GrantKind`, `HookError`, `SchedulerMessage`, `TaskKind`, `TaskMode`);
+  prevents downstream exhaustive `match` breakage when new variants are added (closes #4527).
+
 - `zeph-tools`: convert remaining 6 `FileExecutor` handlers from blocking `std::fs` to non-blocking
   `tokio::fs` (`handle_create_directory`, `handle_delete_path`, `handle_move_path`,
   `handle_copy_path`) and wrap recursive helpers (`grep_recursive`, `copy_dir_recursive`) in

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -784,6 +784,9 @@ impl AdversarialPolicyConfig {
             "load_skill".into(),
             "invoke_skill".into(),
             "schedule_deferred".into(),
+            // Read-only scheduler intrinsic must never be blocked by the adversarial
+            // probe: it carries no side-effects and the embed provider may be unavailable.
+            "list_tasks".into(),
         ]
     }
 }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2537,6 +2537,7 @@ impl<C: Channel> Agent<C> {
             AgentCommand::Approve { id } => self.handle_agent_approve(&id),
             AgentCommand::Deny { id } => self.handle_agent_deny(&id),
             AgentCommand::Resume { id, prompt } => self.handle_agent_resume(&id, &prompt).await,
+            _ => None,
         }
     }
 
@@ -2611,6 +2612,7 @@ impl<C: Channel> Agent<C> {
             AgentsCommand::Delete { name } => {
                 format!("To delete '{name}', remove the file `.zeph/agents/{name}.md`.")
             }
+            _ => "Unknown agents command.".to_owned(),
         }
     }
 

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -892,6 +892,7 @@ impl<C: crate::channel::Channel> Agent<C> {
             }
             GraphStatus::Completed => "Plan completed successfully.",
             GraphStatus::Canceled => "Plan was canceled.",
+            _ => "Plan is in an unknown state.",
         }
         .to_owned()
     }
@@ -998,6 +999,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                 self.services.orchestration.pending_graph = Some(loaded);
                 msg
             }
+            _ => format!("Plan '{id_str}' is in an unrecognised state and cannot be resumed."),
         }
     }
 

--- a/crates/zeph-orchestration/src/adaptorch.rs
+++ b/crates/zeph-orchestration/src/adaptorch.rs
@@ -29,6 +29,7 @@ use zeph_llm::provider::{LlmProvider, Message, Role};
 /// Task decomposition shape inferred from the user goal text.
 ///
 /// `Unknown` absorbs all unclassified cases and defaults the hint to [`TopologyHint::Hybrid`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskClass {
@@ -45,6 +46,7 @@ pub enum TaskClass {
 /// Soft topology hint injected into the planner system prompt.
 ///
 /// Advisory only — `TopologyClassifier::analyze` still runs on the produced graph.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TopologyHint {

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -124,6 +124,7 @@ impl FromStr for GraphId {
 /// assert!(!TaskStatus::Running.is_terminal());
 /// assert_eq!(TaskStatus::Pending.to_string(), "pending");
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
@@ -178,6 +179,7 @@ impl fmt::Display for TaskStatus {
 /// assert_eq!(GraphStatus::Running.to_string(), "running");
 /// assert_eq!(GraphStatus::Failed.to_string(), "failed");
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GraphStatus {
@@ -245,6 +247,7 @@ pub struct TaskResult {
 /// let mode: ExecutionMode = serde_json::from_str("\"sequential\"").unwrap();
 /// assert_eq!(mode, ExecutionMode::Sequential);
 /// ```
+#[non_exhaustive]
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
 )]

--- a/crates/zeph-orchestration/src/lineage.rs
+++ b/crates/zeph-orchestration/src/lineage.rs
@@ -31,6 +31,7 @@ pub fn now_ms() -> u64 {
 ///
 /// Only `Failed` is constructible in v1. `WeakOutput` is reserved for
 /// future use once predicate confidence distribution is calibrated.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LineageKind {
     /// Task failed with the given error class (e.g., `"timeout"`, `"llm_error"`).

--- a/crates/zeph-orchestration/src/topology.rs
+++ b/crates/zeph-orchestration/src/topology.rs
@@ -26,6 +26,7 @@ use zeph_config::OrchestrationConfig;
 use super::graph::{TaskGraph, TaskId, TaskNode};
 
 /// Structural classification of a `TaskGraph`.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Topology {
@@ -49,6 +50,7 @@ pub enum Topology {
 }
 
 /// How the scheduler should dispatch tasks based on topology analysis.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DispatchStrategy {

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -46,6 +46,7 @@ use crate::task::{ScheduledTask, TaskDescriptor, TaskHandler, TaskKind, TaskMode
 /// # Ok(())
 /// # }
 /// ```
+#[non_exhaustive]
 pub enum SchedulerMessage {
     /// Register a new task (or replace an existing one with the same name).
     Add(Box<TaskDescriptor>),

--- a/crates/zeph-scheduler/src/task.rs
+++ b/crates/zeph-scheduler/src/task.rs
@@ -59,6 +59,7 @@ pub fn normalize_cron_expr(expr: &str) -> Cow<'_, str> {
 /// assert_eq!(TaskKind::from_str_kind("memory_cleanup"), TaskKind::MemoryCleanup);
 /// assert_eq!(TaskKind::from_str_kind("my_custom"), TaskKind::Custom("my_custom".into()));
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskKind {
     /// Triggers the memory subsystem's cleanup / compaction routine.
@@ -134,6 +135,7 @@ impl TaskKind {
 ///   each successful execution and never removes the task from memory.
 /// - [`TaskMode::OneShot`] fires once when `now >= run_at` and then removes the
 ///   task from the in-memory task list and marks it `done` in the store.
+#[non_exhaustive]
 pub enum TaskMode {
     /// Run on a repeating cron schedule.
     Periodic {

--- a/crates/zeph-subagent/src/command.rs
+++ b/crates/zeph-subagent/src/command.rs
@@ -26,6 +26,7 @@ use super::error::SubAgentError;
 /// let cmd = AgentsCommand::parse("/agents show reviewer").unwrap();
 /// assert_eq!(cmd, AgentsCommand::Show { name: "reviewer".to_owned() });
 /// ```
+#[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum AgentsCommand {
     /// List all discovered sub-agent definitions.
@@ -132,6 +133,7 @@ impl AgentsCommand {
 ///     prompt: "check the PR".to_owned(),
 /// });
 /// ```
+#[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum AgentCommand {
     /// List all running sub-agent tasks.

--- a/crates/zeph-subagent/src/fleet.rs
+++ b/crates/zeph-subagent/src/fleet.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 ///
 /// Mirrors the terminal variants of `zeph_memory::SessionStatus` without creating a
 /// dependency on that crate.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FleetSessionStatus {
     /// Session ended normally.

--- a/crates/zeph-subagent/src/grants.rs
+++ b/crates/zeph-subagent/src/grants.rs
@@ -62,6 +62,7 @@ pub struct SecretRequest {
 /// let tool = GrantKind::Tool("shell".to_owned());
 /// assert_eq!(tool.to_string(), "Tool(shell)");
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GrantKind {
     /// A vault secret key granted for in-memory access.

--- a/crates/zeph-subagent/src/hooks.rs
+++ b/crates/zeph-subagent/src/hooks.rs
@@ -164,6 +164,7 @@ pub trait McpDispatch: Send + Sync {
 // ── Error ─────────────────────────────────────────────────────────────────────
 
 /// Errors that can occur when executing a lifecycle hook.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum HookError {
     /// The shell command exited with a non-zero status code.

--- a/crates/zeph-subagent/src/state.rs
+++ b/crates/zeph-subagent/src/state.rs
@@ -16,6 +16,7 @@
 /// let state = SubAgentState::Working;
 /// assert_ne!(state, SubAgentState::Completed);
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SubAgentState {
     /// The agent has been enqueued but the tokio task has not started yet.

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -371,6 +371,15 @@ mod tests {
     }
 
     #[test]
+    fn adversarial_policy_default_exempt_tools_contains_scheduler_read_only() {
+        let exempt = AdversarialPolicyConfig::default_exempt_tools();
+        assert!(
+            exempt.contains(&"list_tasks".to_string()),
+            "default exempt_tools must contain list_tasks (read-only scheduler intrinsic)"
+        );
+    }
+
+    #[test]
     fn utility_scoring_default_exempt_tools_contains_skill_ops() {
         let cfg = UtilityScoringConfig::default();
         assert!(

--- a/src/fleet_session.rs
+++ b/src/fleet_session.rs
@@ -67,8 +67,8 @@ impl FleetRegistry for SqliteFleetRegistry {
         Box::pin(async move {
             let s = match status {
                 FleetSessionStatus::Completed => SessionStatus::Completed,
-                FleetSessionStatus::Failed => SessionStatus::Failed,
                 FleetSessionStatus::Cancelled => SessionStatus::Cancelled,
+                _ => SessionStatus::Failed,
             };
             self.0
                 .update_agent_session_status(session_id, s)


### PR DESCRIPTION
## Summary

- Add `list_tasks` to `AdversarialPolicyConfig::default_exempt_tools()` so `/scheduler list` is never blocked by the adversarial probe gate when the embed provider is unavailable and `fail_open=false`
- Add `#[non_exhaustive]` to 17 extensible pub enums across `zeph-orchestration`, `zeph-subagent`, and `zeph-scheduler` to prevent downstream exhaustive `match` breakage on future variant additions

## Changes

**Fix #4529 — adversarial policy bypass:**
- `crates/zeph-config/src/tools.rs`: `list_tasks` added to `default_exempt_tools()`; read-only scheduler intrinsics bypass the `ShadowProbeExecutor` unconditionally
- `crates/zeph-tools/src/config.rs`: regression test asserting `list_tasks` is in the exempt list

**Fix #4527 — `#[non_exhaustive]` on 17 enums:**
- `zeph-orchestration`: `TaskStatus`, `GraphStatus`, `ExecutionMode`, `TaskClass`, `TopologyHint`, `Topology`, `DispatchStrategy`, `LineageKind`
- `zeph-subagent`: `SubAgentState`, `AgentsCommand`, `AgentCommand`, `FleetSessionStatus`, `GrantKind`, `HookError`
- `zeph-scheduler`: `SchedulerMessage`, `TaskKind`, `TaskMode`
- Wildcard arms added at 5 match sites in `zeph-core` and the binary

## Test plan

- [x] `cargo +nightly fmt --check` — OK
- [x] `cargo clippy` (affected crates) — 0 errors, 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 10108 passed, 21 skipped

Closes #4529
Closes #4527