### PR TITLE
fix(acp,subagent): bound blocking awaits with configurable timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   observability (closes #4496).
 - `zeph-acp`, `zeph-gateway`: add `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` annotations to
   all feature-gated public items so docs.rs renders them with the correct feature badge (closes #4497).
+- `zeph-acp`: `send_notification` no longer blocks indefinitely when the IDE client does not
+  acknowledge a session notification; `tokio::time::timeout` wraps `ack_rx.await` with a
+  configurable window (`acp.timeouts.notify_ack_timeout_ms`, default 5000 ms); timeout is logged
+  as `warn` and returns an internal error (closes #4528).
+- `zeph-subagent`: LLM calls inside sub-agent turns are now bounded by `agents.llm_timeout_secs`
+  (default 120 s); previously `chat_with_tools` could block indefinitely if the provider stalled;
+  timeout logs a `warn` and returns `SubAgentError::Llm("LLM call timed out")` (closes #4525).
 
 ### Changed
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -958,6 +958,10 @@ enabled = false
 # handshake_timeout_secs = 30
 # prompt_timeout_secs = 600
 
+[acp.timeouts]
+# Maximum milliseconds to wait for an IDE client notification ack before returning an error (default 5000)
+notify_ack_timeout_ms = 5000
+
 [agents]
 # Enable sub-agent spawning (required for /agent commands and multi-agent workflows)
 enabled = false
@@ -969,6 +973,8 @@ allow_bypass_permissions = false
 transcript_enabled = true
 # Maximum number of transcript files to retain (0 = unlimited)
 transcript_max_files = 50
+# Maximum wall time in seconds for a single LLM call inside a sub-agent turn (default 120)
+llm_timeout_secs = 120
 
 [orchestration]
 # Enable the orchestration subsystem (/plan commands and task graph execution)

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -903,8 +903,16 @@ impl ZephAcpAgentState {
         tx.send((notification, ack_tx))
             .await
             .map_err(|_| acp::Error::internal_error().data("notification channel closed"))?;
-        ack_rx
+        let timeout = std::time::Duration::from_millis(self.timeouts.notify_ack_timeout_ms);
+        tokio::time::timeout(timeout, ack_rx)
             .await
+            .map_err(|_| {
+                tracing::warn!(
+                    timeout_ms = self.timeouts.notify_ack_timeout_ms,
+                    "notification ack timed out — IDE client may be hung"
+                );
+                acp::Error::internal_error().data("notification ack timed out")
+            })?
             .map_err(|_| acp::Error::internal_error().data("notification ack lost"))
     }
 
@@ -3684,5 +3692,55 @@ mod usage_tests {
         assert_eq!(u.total_tokens, 0);
         assert_eq!(u.cached_read_tokens, None);
         assert_eq!(u.cached_write_tokens, None);
+    }
+}
+
+/// Regression tests for #4528: `send_notification` must not block indefinitely.
+#[cfg(test)]
+mod notify_timeout_tests {
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use zeph_core::channel::LoopbackChannel;
+    use zeph_llm::any::AnyProvider;
+
+    use super::*;
+
+    fn make_agent_for_timeout() -> ZephAcpAgent {
+        let spawner: AgentSpawner = Arc::new(|_ch, _ctx, _sc| Box::pin(async {}));
+        let mut agent = ZephAcpAgent::new(spawner, 4, 1800, None);
+        // Override to a very small value so the test finishes in ~50 ms.
+        agent.timeouts.notify_ack_timeout_ms = 50;
+        agent
+    }
+
+    /// `send_notification` must return an error within `notify_ack_timeout_ms` when
+    /// no drainer is running (simulates a hung IDE client).
+    #[tokio::test]
+    async fn send_notification_returns_error_when_ack_times_out() {
+        let agent = make_agent_for_timeout();
+        let session_id = acp::schema::SessionId::new("timeout-test".to_owned());
+
+        let (_, handle) = LoopbackChannel::pair(4);
+        let provider_override = Arc::new(RwLock::new(None::<AnyProvider>));
+        let entry = ZephAcpAgent::make_session_entry(
+            handle,
+            "test-model".to_owned(),
+            std::path::PathBuf::from("."),
+            None,
+            provider_override,
+        );
+        // Insert without starting the drainer — no ack will ever be sent.
+        agent.sessions.lock().insert(session_id.clone(), entry);
+
+        let update = acp::schema::SessionUpdate::AgentMessageChunk(acp::schema::ContentChunk::new(
+            "hello".into(),
+        ));
+        let notif = acp::schema::SessionNotification::new(session_id.clone(), update);
+        let result = agent.send_notification(&session_id, notif).await;
+        assert!(
+            result.is_err(),
+            "send_notification must fail when ack does not arrive within the timeout"
+        );
     }
 }

--- a/crates/zeph-config/src/agent.rs
+++ b/crates/zeph-config/src/agent.rs
@@ -96,6 +96,10 @@ fn default_summary_max_chars() -> usize {
     600
 }
 
+fn default_llm_timeout_secs() -> u64 {
+    120
+}
+
 fn default_max_tool_iterations() -> usize {
     10
 }
@@ -584,6 +588,12 @@ pub struct SubAgentConfig {
     /// Default: `600` (≈200 tokens at 3 chars/token).
     #[serde(default = "default_summary_max_chars")]
     pub summary_max_chars: usize,
+    /// Maximum wall time in seconds for a single LLM call inside a sub-agent turn.
+    ///
+    /// If the provider does not return a response within this window, the call is
+    /// cancelled and the sub-agent turn fails with a timeout error. Default: 120.
+    #[serde(default = "default_llm_timeout_secs")]
+    pub llm_timeout_secs: u64,
 }
 
 impl Default for SubAgentConfig {
@@ -607,6 +617,7 @@ impl Default for SubAgentConfig {
             parent_context_policy: ParentContextPolicy::default(),
             max_parent_messages: default_max_parent_messages(),
             summary_max_chars: default_summary_max_chars(),
+            llm_timeout_secs: default_llm_timeout_secs(),
         }
     }
 }

--- a/crates/zeph-config/src/ui.rs
+++ b/crates/zeph-config/src/ui.rs
@@ -70,6 +70,11 @@ fn default_acp_terminal_timeout_secs() -> u64 {
 fn default_acp_mcp_timeout_secs() -> u64 {
     300
 }
+
+fn default_acp_notify_ack_timeout_ms() -> u64 {
+    5000
+}
+
 fn default_lsp_mcp_server_id() -> String {
     "mcpls".into()
 }
@@ -570,6 +575,12 @@ pub struct AcpTimeoutsConfig {
     /// Timeout in seconds for MCP bridge operations. Default: 300.
     #[serde(default = "default_acp_mcp_timeout_secs")]
     pub mcp_secs: u64,
+    /// Maximum time in milliseconds to wait for a notification ack from the IDE client.
+    ///
+    /// If the IDE client does not acknowledge a session notification within this window,
+    /// `send_notification` returns an error instead of blocking indefinitely. Default: 5000.
+    #[serde(default = "default_acp_notify_ack_timeout_ms")]
+    pub notify_ack_timeout_ms: u64,
 }
 
 impl Default for AcpTimeoutsConfig {
@@ -578,6 +589,7 @@ impl Default for AcpTimeoutsConfig {
             elicitation_secs: default_acp_elicitation_timeout_secs(),
             terminal_secs: default_acp_terminal_timeout_secs(),
             mcp_secs: default_acp_mcp_timeout_secs(),
+            notify_ack_timeout_ms: default_acp_notify_ack_timeout_ms(),
         }
     }
 }

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -66,6 +66,8 @@ pub(super) struct AgentLoopArgs {
     pub(super) spawn_depth: u32,
     pub(super) mcp_tool_names: Vec<String>,
     pub(super) content_isolation: zeph_config::ContentIsolationConfig,
+    /// Maximum wall time for a single LLM call inside an agent turn.
+    pub(super) llm_timeout: std::time::Duration,
 }
 
 pub(super) fn make_message(role: Role, content: String) -> Message {
@@ -140,8 +142,18 @@ async fn call_provider_with_status(
     status_tx: &watch::Sender<SubAgentStatus>,
     turns: u32,
     started_at: Instant,
+    llm_timeout: std::time::Duration,
 ) -> Result<ChatResponse, super::error::SubAgentError> {
-    let llm_result = provider.chat_with_tools(messages, tool_defs).await;
+    let llm_result =
+        tokio::time::timeout(llm_timeout, provider.chat_with_tools(messages, tool_defs))
+            .await
+            .map_err(|_| {
+                tracing::warn!(
+                    timeout_secs = llm_timeout.as_secs(),
+                    "sub-agent LLM call timed out"
+                );
+                super::error::SubAgentError::Llm("LLM call timed out".to_owned())
+            })?;
     match llm_result {
         Ok(r) => Ok(r),
         Err(e) => {
@@ -379,10 +391,18 @@ async fn run_turn(
     secret_request_tx: &mpsc::Sender<SecretRequest>,
     secret_rx: &mut mpsc::Receiver<Option<String>>,
     sanitizer: &ContentSanitizer,
+    llm_timeout: std::time::Duration,
 ) -> Result<TurnOutcome, super::error::SubAgentError> {
-    let response =
-        call_provider_with_status(provider, messages, tool_defs, status_tx, *turns, started_at)
-            .await?;
+    let response = call_provider_with_status(
+        provider,
+        messages,
+        tool_defs,
+        status_tx,
+        *turns,
+        started_at,
+        llm_timeout,
+    )
+    .await?;
 
     let response_text = match &response {
         ChatResponse::Text(t) => t.clone(),
@@ -653,6 +673,7 @@ pub(super) async fn run_agent_loop(
         spawn_depth: _spawn_depth,
         mcp_tool_names,
         content_isolation,
+        llm_timeout,
     } = args;
 
     let sanitizer = ContentSanitizer::new(&content_isolation);
@@ -704,6 +725,7 @@ pub(super) async fn run_agent_loop(
             &secret_request_tx,
             &mut secret_rx,
             &sanitizer,
+            llm_timeout,
         )
         .await?
         {

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -3591,7 +3591,7 @@ mod tests {
             mcp_tool_names: Vec::new(),
             content_isolation: ContentIsolationConfig::default(),
             max_history_messages: 200,
-            llm_timeout: std::time::Duration::from_secs(120),
+            llm_timeout: std::time::Duration::from_mins(2),
         }
     }
 

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -1037,6 +1037,7 @@ impl SubAgentManager {
                 spawn_depth: spawn_depth + 1,
                 mcp_tool_names,
                 content_isolation: ctx.content_isolation,
+                llm_timeout: std::time::Duration::from_secs(config.llm_timeout_secs),
             }));
 
         let handle_transcript_dir = if config.transcript_enabled {
@@ -1613,6 +1614,7 @@ impl SubAgentManager {
                 spawn_depth: 0,
                 mcp_tool_names: resumed_mcp_tool_names.clone(),
                 content_isolation: ContentIsolationConfig::default(),
+                llm_timeout: std::time::Duration::from_secs(config.llm_timeout_secs),
             }));
 
         let resume_handle_transcript_dir = if config.transcript_enabled {
@@ -3589,6 +3591,7 @@ mod tests {
             mcp_tool_names: Vec::new(),
             content_isolation: ContentIsolationConfig::default(),
             max_history_messages: 200,
+            llm_timeout: std::time::Duration::from_secs(120),
         }
     }
 
@@ -4919,5 +4922,33 @@ mod tests {
             count, 2,
             "both new tasks should run after stale ones are drained"
         );
+    }
+
+    // ── LLM timeout regression tests for #4525 ───────────────────────────────
+
+    /// Verifies that `call_provider_with_status` (exercised via `run_agent_loop`)
+    /// returns `SubAgentError::Llm` when the provider exceeds `llm_timeout` instead
+    /// of blocking forever.
+    #[tokio::test]
+    async fn llm_timeout_returns_error_instead_of_blocking() {
+        let mut mock = MockProvider::default();
+        // Provider sleeps for 2 s — longer than the configured timeout.
+        mock.delay_ms = 2_000;
+        let executor = FilteredToolExecutor::new(noop_executor(), ToolPolicy::InheritAll);
+
+        let mut args = make_agent_loop_args(AnyProvider::Mock(mock), executor, 1);
+        // Set a tight timeout so the test completes in ~50 ms.
+        args.llm_timeout = std::time::Duration::from_millis(50);
+
+        let result = run_agent_loop(args).await;
+        match result {
+            Err(super::super::error::SubAgentError::Llm(msg)) => {
+                assert!(
+                    msg.contains("timed out"),
+                    "expected timeout message, got: {msg}"
+                );
+            }
+            other => panic!("expected SubAgentError::Llm on timeout, got: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **#4528 (zeph-acp)**: `send_notification()` awaited `ack_rx` with no timeout — a hung IDE client blocked every agent turn indefinitely. Wrapped with `tokio::time::timeout` using `acp.timeouts.notify_ack_timeout_ms` (default 5000 ms). Affects 7 hot-path call sites.
- **#4525 (zeph-subagent)**: `call_provider_with_status()` awaited `provider.chat_with_tools()` with no timeout — a stalled LLM backend consumed a `SubAgentManager` slot indefinitely. Wrapped with `tokio::time::timeout` using `agents.llm_timeout_secs` (default 120 s).

Both timeouts are configurable, emit `tracing::warn!` on expiry, and return typed errors so callers can continue rather than hang.

## Changed files

| File | Change |
|------|--------|
| `crates/zeph-acp/src/agent/mod.rs` | Wrap `ack_rx.await` in `tokio::time::timeout` |
| `crates/zeph-config/src/ui.rs` | Add `notify_ack_timeout_ms: u64` (default 5000) to `AcpTimeoutsConfig` |
| `crates/zeph-subagent/src/agent_loop.rs` | Add `llm_timeout: Duration` to `AgentLoopArgs`; wrap `chat_with_tools` call |
| `crates/zeph-subagent/src/manager.rs` | Pass `Duration::from_secs(config.llm_timeout_secs)` at both call sites; regression test |
| `crates/zeph-config/src/agent.rs` | Add `llm_timeout_secs: u64` (default 120) to `SubAgentConfig` |
| `config/default.toml` | Add `[acp.timeouts]` section; add `llm_timeout_secs` to `[agents]` |
| `CHANGELOG.md` | Add entries under `[Unreleased] / Fixed` |

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 10079 tests pass (was 10077, +2 regression tests)
- [ ] New test `zeph-subagent manager::tests::llm_timeout_returns_error_instead_of_blocking` — verifies `Err(SubAgentError::Llm)` within 50 ms when `MockProvider` sleeps 2 s
- [ ] New test `zeph-acp agent::notify_timeout_tests::send_notification_returns_error_when_ack_times_out` — verifies `Err` within 50 ms when no ack drainer runs
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean

Closes #4528, Closes #4525