### PR TITLE
fix(agent,context): fix heuristic_promotion lifecycle and validate_query_rewrite placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`: `maybe_start_heuristic_promotion()` moved from post-loop cleanup to agent startup
+  so the background task spawns unconditionally — previously, an early `Err` return from
+  `process_user_message` (e.g. LLM 429) skipped the cleanup block entirely and the task never
+  started. Added `is_some()` guard to make idempotency structurally enforced rather than claimed
+  (closes #4537).
+- `zeph-core`: `validate_query_rewrite` in `assembly.rs` relocated before the test-only
+  integration bridges section — it was accidentally placed inside the split comment block,
+  making it appear to be a test helper when it is a production function (closes #4521).
 - `zeph-memory`: `count_heuristics_by_skill` now filters `skill_name IS NOT NULL` before grouping,
   preventing sqlx from attempting to decode a NULL row into `String` and excluding general heuristics
   (NULL skill_name) from AutoSkill A6 promotion scans (closes #4531).

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1433,10 +1433,6 @@ impl<C: Channel> Agent<C> {
     }
 }
 
-// ── Test-only integration bridges ─────────────────────────────────────────────
-//
-// These shim methods expose individual context-service operations directly on
-// `Agent<C>` so that Category 2 integration tests can drive them in isolation
 /// Validate the result of a query rewrite and return it if acceptable.
 ///
 /// Returns `None` (fall back to original) when the rewritten text is empty, too short,
@@ -1463,6 +1459,10 @@ fn validate_query_rewrite(original: &str, rewritten: &str) -> Option<String> {
     }
 }
 
+// ── Test-only integration bridges ─────────────────────────────────────────────
+//
+// These shim methods expose individual context-service operations directly on
+// `Agent<C>` so that Category 2 integration tests can drive them in isolation
 // without going through the full `prepare_context` pipeline. They are not part
 // of the production call path — production code uses `ContextService` methods
 // directly via `prepare_context`.

--- a/crates/zeph-core/src/agent/heuristic_promotion.rs
+++ b/crates/zeph-core/src/agent/heuristic_promotion.rs
@@ -42,9 +42,19 @@ const LLM_TIMEOUT_SECS: u64 = 120;
 impl<C: Channel> super::Agent<C> {
     /// Spawn the periodic heuristic promotion background task if configured.
     ///
-    /// Called once at agent startup (after learning config is loaded). When
-    /// `heuristic_promotion_enabled = false`, this is a no-op.
+    /// Called once at agent startup (after learning config is loaded). No-ops when
+    /// `heuristic_promotion_enabled = false`, when `managed_dir` is unset, or when
+    /// the task is already running (idempotent via `heuristic_promotion_handle` guard).
     pub(super) fn maybe_start_heuristic_promotion(&mut self) {
+        if self
+            .services
+            .learning_engine
+            .heuristic_promotion_handle
+            .is_some()
+        {
+            return;
+        }
+
         let Some(ref learning_cfg) = self.services.learning_engine.config else {
             return;
         };

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -876,6 +876,11 @@ impl<C: Channel> Agent<C> {
         self.load_and_cache_session_digest().await;
         self.maybe_send_resume_recap().await;
 
+        // AutoSkill A6: start periodic heuristic promotion task at session startup so it runs
+        // even when the main loop exits early due to an error (spec 061). The function guards
+        // against double-spawn via a heuristic_promotion_handle.is_some() check.
+        self.maybe_start_heuristic_promotion();
+
         loop {
             self.apply_provider_override();
             self.check_tool_refresh().await;
@@ -1195,17 +1200,6 @@ impl<C: Channel> Agent<C> {
 
         // AutoSkill A1: extract skill candidates from the completed session trace (spec 056).
         self.maybe_extract_skills_from_trace().await;
-
-        // AutoSkill A6: start periodic heuristic promotion task if not yet running (spec 061).
-        // Idempotent: re-calling after first run is a no-op because the handle is already set.
-        if self
-            .services
-            .learning_engine
-            .heuristic_promotion_handle
-            .is_none()
-        {
-            self.maybe_start_heuristic_promotion();
-        }
 
         // Flush trace collector on normal exit (C-04: Drop handles error/panic paths).
         if let Some(ref mut tc) = self.runtime.debug.trace_collector {

--- a/crates/zeph-core/src/agent/tests/agent_tests/lifecycle_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/lifecycle_tests.rs
@@ -5,6 +5,7 @@
 
 #[allow(unused_imports)]
 use super::*;
+use zeph_config::LearningConfig;
 
 #[tokio::test]
 async fn agent_new_initializes_with_system_prompt() {
@@ -845,4 +846,82 @@ async fn agent_metrics_skills_updated_on_prompt_rebuild() {
     let snapshot = rx.borrow().clone();
     assert_eq!(snapshot.total_skills, 1);
     assert!(!snapshot.active_skills.is_empty());
+}
+
+/// Regression test for #4537: `maybe_start_heuristic_promotion` must run at session
+/// startup (before `loop {}`), not in the post-loop cleanup block.
+///
+/// Previously the call was placed after the main loop, so an early `?` return from
+/// `process_user_message` would skip it entirely. The fix moves it to startup so the
+/// background task is always spawned when enabled.
+///
+/// This test directly calls `maybe_start_heuristic_promotion` and asserts the handle
+/// is set — mirroring what `Agent::run` does at startup in a real session.
+#[tokio::test]
+async fn heuristic_promotion_handle_set_at_startup_when_enabled() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    // Configure heuristic promotion as enabled with a real managed_dir.
+    agent.services.learning_engine.config = Some(LearningConfig {
+        heuristic_promotion_enabled: true,
+        ..LearningConfig::default()
+    });
+    agent.services.skill.managed_dir = Some(tmp.path().to_path_buf());
+
+    // Before the fix, this call only happened in the post-loop cleanup block.
+    // With the fix it is called at session startup, unconditionally before `loop {}`.
+    agent.maybe_start_heuristic_promotion();
+
+    assert!(
+        agent
+            .services
+            .learning_engine
+            .heuristic_promotion_handle
+            .is_some(),
+        "heuristic_promotion_handle must be set immediately after maybe_start_heuristic_promotion() \
+         is called, regardless of whether the main loop runs"
+    );
+
+    // Clean up the background task so tokio doesn't warn about leaked tasks.
+    if let Some(h) = agent
+        .services
+        .learning_engine
+        .heuristic_promotion_handle
+        .take()
+    {
+        h.abort();
+    }
+}
+
+/// Complementary to the regression above: when `heuristic_promotion_enabled = false`
+/// the method must remain a no-op and leave the handle as `None`.
+#[tokio::test]
+async fn heuristic_promotion_handle_not_set_when_disabled() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    // Provide config but leave heuristic_promotion_enabled = false (default).
+    agent.services.learning_engine.config = Some(LearningConfig::default());
+
+    agent.maybe_start_heuristic_promotion();
+
+    assert!(
+        agent
+            .services
+            .learning_engine
+            .heuristic_promotion_handle
+            .is_none(),
+        "no handle should be spawned when heuristic_promotion_enabled = false"
+    );
 }


### PR DESCRIPTION
## Summary

- **#4537**: `maybe_start_heuristic_promotion()` moved from post-loop cleanup to agent startup, so the background task spawns unconditionally even when `process_user_message` returns `Err` (e.g., OpenAI 429 mid-session).
- **#4521**: `validate_query_rewrite` relocated before the `// ── Test-only integration bridges` block in `assembly.rs` — was accidentally split across the test-only comment, making it appear to be a test helper.
- **Idempotency guard**: added `is_some()` check at the top of `maybe_start_heuristic_promotion` so re-calling the function is a no-op without leaking a JoinHandle.

## LLM serialization gate

`assembly.rs` is in `crates/zeph-core/src/agent/context/`, which normally triggers the live API session test requirement. This change is a **pure code placement fix** — `validate_query_rewrite` is only moved within the file; its signature, logic, and callers are unchanged. No serialization structs, `MessagePart`, `Message`, or LLM request/response paths were modified. Live session test is not required.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — 0 warnings
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10363 passed
- [ ] New regression tests: `heuristic_promotion_handle_set_at_startup_when_enabled`, `heuristic_promotion_handle_not_set_when_disabled`
- [ ] `validate_query_rewrite` covered by 6 existing `validate_rewrite_*` tests

Closes #4537
Closes #4521