### PR TITLE
fix(runner,llm): track JoinHandle for connect_oauth_deferred + debug log for unknown ThinkingBlock

### DIFF
--- a/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
+++ b/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
@@ -333,7 +333,10 @@ impl<C: Channel> Agent<C> {
                     ThinkingBlock::Redacted { data } => {
                         Some(MessagePart::RedactedThinkingBlock { data })
                     }
-                    _ => None,
+                    unknown => {
+                        tracing::debug!(variant = ?unknown, "discarding unknown ThinkingBlock variant");
+                        None
+                    }
                 })
                 .collect();
             // Thinking blocks must appear before text/tool_use in the assistant message.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1261,15 +1261,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         }
     }
 
-    // Spawn deferred OAuth connections now that the UI channel is ready and can
-    // display the authorization URL. Non-OAuth tools are already available from
-    // connect_all(); OAuth tools arrive via tools_watch_tx when authorized.
-    if !exec_mode.bare && tool_setup.mcp_manager.has_oauth_servers() {
-        let mgr = std::sync::Arc::clone(&tool_setup.mcp_manager);
-        tokio::spawn(async move {
-            mgr.connect_oauth_deferred().await;
-        });
-    }
+    // oauth_deferred_handle is initialised below, after shutdown_rx is created, so it can
+    // be aborted on shutdown. Declared here to keep scope visible at the abort site.
+    let oauth_deferred_handle: Option<tokio::task::JoinHandle<()>>;
 
     #[cfg(feature = "tui")]
     let is_cli =
@@ -1447,6 +1441,25 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             cancel.cancel();
         });
     }
+
+    // Spawn deferred OAuth connections now that the UI channel is ready and can display the
+    // authorization URL. Non-OAuth tools are already available from connect_all(); OAuth tools
+    // arrive via tools_watch_tx when authorized. The handle is stored so it can be aborted
+    // when the shutdown signal fires (prevents the task from outliving the runtime).
+    oauth_deferred_handle = if !exec_mode.bare && tool_setup.mcp_manager.has_oauth_servers() {
+        let mgr = std::sync::Arc::clone(&tool_setup.mcp_manager);
+        let mut shutdown = shutdown_rx.clone();
+        Some(tokio::spawn(async move {
+            tokio::select! {
+                () = mgr.connect_oauth_deferred() => {}
+                _ = shutdown.changed() => {
+                    tracing::debug!("oauth deferred connect aborted: shutdown signal received");
+                }
+            }
+        }))
+    } else {
+        None
+    };
 
     #[cfg(feature = "profiling")]
     let _sysinfo_handle = zeph_core::system_metrics::spawn_system_metrics_task(
@@ -3334,6 +3347,11 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             Err(e) => Err(anyhow::anyhow!("{e}")),
         };
         crate::fleet_session::end_session(memory.sqlite(), &fleet_session_id, &fleet_result).await;
+    }
+    // Abort the OAuth deferred connect task before shutting down MCP connections so that the
+    // task does not race with McpManager teardown (which closes the underlying transports).
+    if let Some(h) = oauth_deferred_handle {
+        h.abort();
     }
     // Explicitly shut down MCP connections before agent.shutdown() so that child processes
     // are killed while the tokio runtime is still active (#2693).


### PR DESCRIPTION
## Summary

- **#4519**: The `tokio::spawn` for `connect_oauth_deferred` in `src/runner.rs` dropped its `JoinHandle` immediately, making the background OAuth connection task unabortable on shutdown. The spawn is now moved to after `shutdown_rx` is created and uses `tokio::select!` to race the connection against the shutdown signal. The handle is aborted before `McpManager::shutdown_all_shared()` to prevent a race with transport teardown.

- **#4534**: The `_ => None` wildcard arm in `preserve_thinking_blocks` (`llm_dispatch.rs`) silently discarded unknown `ThinkingBlock` variants introduced after `#[non_exhaustive]`. The arm now emits `tracing::debug!` so discarded variants are observable in traces without blocking compilation.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10111 passed, 0 failures

Closes #4519
Closes #4534