### PR TITLE
refactor(llm,orchestration,vault): AtomicU32 confidence, PlanSlug newtype, vault error-path tests

### DIFF
--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -399,7 +399,10 @@ impl RouterProvider {
     /// Must be called before `chat` / `chat_stream` to influence bandit provider selection.
     /// Pass `None` to disable MAR for this turn.
     pub fn set_memory_confidence(&self, confidence: Option<f32>) {
-        *self.state.last_memory_confidence.lock() = confidence;
+        let raw = confidence.map_or(u32::MAX, f32::to_bits);
+        self.state
+            .last_memory_confidence
+            .store(raw, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Enable EMA-based adaptive provider ordering.
@@ -899,7 +902,15 @@ impl RouterProvider {
 
         // Try LinUCB selection with feature vector.
         if let Some(features) = self.bandit_features(query).await {
-            let memory_confidence = self.state.last_memory_confidence.lock().as_ref().copied();
+            let raw = self
+                .state
+                .last_memory_confidence
+                .load(std::sync::atomic::Ordering::Relaxed);
+            let memory_confidence = if raw == u32::MAX {
+                None
+            } else {
+                Some(f32::from_bits(raw))
+            };
             let selected = {
                 let state = bandit_arc.lock();
                 state.select(

--- a/crates/zeph-llm/src/router/state.rs
+++ b/crates/zeph-llm/src/router/state.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 
 use parking_lot::Mutex;
 
@@ -64,7 +64,10 @@ pub struct RouterState {
     /// Set by the agent via `RouterProvider::set_memory_confidence` before each
     /// `chat` / `chat_stream` call. Read by `bandit_select_provider` to bias toward
     /// cheaper providers when memory recall confidence is high.
-    pub last_memory_confidence: Arc<Mutex<Option<f32>>>,
+    ///
+    /// `u32::MAX` is the sentinel for "no confidence value set" — it maps to a NaN
+    /// bit pattern in IEEE 754, which is never a valid confidence value.
+    pub last_memory_confidence: Arc<AtomicU32>,
 
     /// Monotonically increasing per-turn counter.
     ///
@@ -105,7 +108,7 @@ impl RouterState {
             provider_models: Arc::new(provider_models),
             provider_order: Arc::new(Mutex::new((0..n).collect())),
             last_active_provider: Arc::new(Mutex::new(None)),
-            last_memory_confidence: Arc::new(Mutex::new(None)),
+            last_memory_confidence: Arc::new(AtomicU32::new(u32::MAX)),
             turn_counter: Arc::new(AtomicU64::new(0)),
             asi_last_turn: Arc::new(AtomicU64::new(u64::MAX)),
             embed_semaphore: None,

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -51,7 +51,7 @@ impl fmt::Display for TaskId {
     }
 }
 
-/// Stable kebab-case identifier assigned to a task in a [`PlanTemplate`] or LLM planner response.
+/// Stable kebab-case identifier assigned to a task in a plan template or LLM planner response.
 ///
 /// A `PlanSlug` is a human-readable string of the form `[a-z0-9]([a-z0-9-]*[a-z0-9])?`
 /// (e.g. `"fetch-data"`, `"deploy-service"`). It is distinct from [`TaskId`], which is a

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -51,6 +51,55 @@ impl fmt::Display for TaskId {
     }
 }
 
+/// Stable kebab-case identifier assigned to a task in a [`PlanTemplate`] or LLM planner response.
+///
+/// A `PlanSlug` is a human-readable string of the form `[a-z0-9]([a-z0-9-]*[a-z0-9])?`
+/// (e.g. `"fetch-data"`, `"deploy-service"`). It is distinct from [`TaskId`], which is a
+/// dense numeric index used for in-memory graph traversal. `PlanSlug` values appear in LLM
+/// JSON responses and cached plan templates; they are resolved to `TaskId` during graph
+/// construction.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_orchestration::PlanSlug;
+///
+/// let slug = PlanSlug::from("fetch-data");
+/// assert_eq!(slug.to_string(), "fetch-data");
+/// assert_eq!(slug.as_str(), "fetch-data");
+/// ```
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
+)]
+#[schemars(transparent)]
+pub struct PlanSlug(pub String);
+
+impl PlanSlug {
+    /// Returns the inner string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for PlanSlug {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for PlanSlug {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl fmt::Display for PlanSlug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Unique identifier for a [`TaskGraph`].
 ///
 /// Backed by a UUID v4. Implements `FromStr` / `Display` for serialization and

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -93,8 +93,8 @@ pub use cascade::{AbortDecision, CascadeConfig, CascadeDetector, RegionHealth};
 pub use command::PlanCommand;
 pub use error::OrchestrationError;
 pub use graph::{
-    ExecutionMode, FailureStrategy, GraphId, GraphPersistence, GraphStatus, TaskGraph, TaskId,
-    TaskNode, TaskResult, TaskStatus,
+    ExecutionMode, FailureStrategy, GraphId, GraphPersistence, GraphStatus, PlanSlug, TaskGraph,
+    TaskId, TaskNode, TaskResult, TaskStatus,
 };
 pub use lineage::{ErrorLineage, LineageEntry, LineageKind, classify_error};
 pub use plan_cache::{

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -19,7 +19,7 @@ use zeph_llm::provider::{LlmProvider, Message, Role};
 
 use super::dag;
 use super::error::OrchestrationError;
-use super::graph::{FailureStrategy, TaskGraph};
+use super::graph::{FailureStrategy, PlanSlug, TaskGraph};
 use super::planner::{PlannerResponse, convert_response_pub};
 use zeph_subagent::SubAgentDef;
 
@@ -35,14 +35,14 @@ pub struct TemplateTask {
     /// Preferred agent name, if specified by the original planner.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_hint: Option<String>,
-    /// Kebab-case `task_id` strings of tasks this task depends on.
+    /// Kebab-case slugs of tasks this task depends on.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub depends_on: Vec<String>,
+    pub depends_on: Vec<PlanSlug>,
     /// Failure strategy override for this task, if set by the original planner.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_strategy: Option<FailureStrategy>,
-    /// Stable kebab-case `task_id` assigned during template extraction.
-    pub task_id: String,
+    /// Stable kebab-case slug assigned during template extraction.
+    pub task_id: PlanSlug,
 }
 
 /// Reusable plan skeleton extracted from a successfully completed [`TaskGraph`].
@@ -83,11 +83,11 @@ impl PlanTemplate {
             ));
         }
 
-        // Build task_id strings indexed by position for depends_on reconstruction.
-        let id_to_slug: Vec<String> = graph
+        // Build PlanSlug indexed by position for depends_on reconstruction.
+        let id_to_slug: Vec<PlanSlug> = graph
             .tasks
             .iter()
-            .map(|n| slugify_title(&n.title, n.id.as_u32()))
+            .map(|n| PlanSlug::from(slugify_title(&n.title, n.id.as_u32())))
             .collect();
 
         let tasks = graph

--- a/crates/zeph-orchestration/src/planner.rs
+++ b/crates/zeph-orchestration/src/planner.rs
@@ -12,7 +12,7 @@ use zeph_llm::provider::{LlmProvider, Message, Role}; // Role needed for plan_wi
 use super::adaptorch::TopologyHint;
 use super::dag;
 use super::error::OrchestrationError;
-use super::graph::{ExecutionMode, FailureStrategy, TaskGraph, TaskId, TaskNode};
+use super::graph::{ExecutionMode, FailureStrategy, PlanSlug, TaskGraph, TaskId, TaskNode};
 use super::verify_predicate::VerifyPredicate;
 use zeph_config::OrchestrationConfig;
 use zeph_subagent::{SubAgentDef, ToolPolicy};
@@ -138,13 +138,13 @@ pub(crate) struct PlannerResponse {
 /// A single task in the raw LLM planner response. Internal parsing type.
 #[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
 pub(crate) struct PlannedTask {
-    pub task_id: String,
+    pub task_id: PlanSlug,
     pub title: String,
     pub description: String,
     #[serde(default)]
     pub agent_hint: Option<String>,
     #[serde(default)]
-    pub depends_on: Vec<String>,
+    pub depends_on: Vec<PlanSlug>,
     #[serde(default, deserialize_with = "failure_strategy_opt::deserialize")]
     pub failure_strategy: Option<FailureStrategy>,
     /// LLM-annotated execution mode. Absent or `null` defaults to `Parallel`.
@@ -344,7 +344,7 @@ fn convert_response(
 
     // Validate task_id format and build string -> index map
     for pt in &planned {
-        if !is_valid_task_id(&pt.task_id) {
+        if !is_valid_task_id(pt.task_id.as_str()) {
             return Err(OrchestrationError::PlanningFailed(format!(
                 "invalid task_id '{}': must match ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
                 pt.task_id
@@ -464,11 +464,11 @@ mod tests {
         agent_hint: Option<&str>,
     ) -> PlannedTask {
         PlannedTask {
-            task_id: task_id.to_string(),
+            task_id: PlanSlug::from(task_id),
             title: title.to_string(),
             description: format!("do {title}"),
             agent_hint: agent_hint.map(std::string::ToString::to_string),
-            depends_on: deps.iter().map(std::string::ToString::to_string).collect(),
+            depends_on: deps.iter().map(|s| PlanSlug::from(*s)).collect(),
             failure_strategy: None,
             execution_mode: None,
             verify_criteria: None,
@@ -603,7 +603,7 @@ mod tests {
         for bad_id in cases {
             let response = PlannerResponse {
                 tasks: vec![PlannedTask {
-                    task_id: bad_id.to_string(),
+                    task_id: PlanSlug::from(bad_id),
                     title: "T".to_string(),
                     description: "d".to_string(),
                     agent_hint: None,
@@ -788,7 +788,7 @@ mod tests {
     fn convert_execution_mode_parallel() {
         let response = PlannerResponse {
             tasks: vec![PlannedTask {
-                task_id: "t1".to_string(),
+                task_id: PlanSlug::from("t1"),
                 title: "T1".to_string(),
                 description: "d".to_string(),
                 agent_hint: None,
@@ -806,7 +806,7 @@ mod tests {
     fn convert_execution_mode_sequential() {
         let response = PlannerResponse {
             tasks: vec![PlannedTask {
-                task_id: "t1".to_string(),
+                task_id: PlanSlug::from("t1"),
                 title: "T1".to_string(),
                 description: "d".to_string(),
                 agent_hint: None,

--- a/crates/zeph-vault/src/age.rs
+++ b/crates/zeph-vault/src/age.rs
@@ -512,4 +512,66 @@ mod tests {
         let result = AgeVaultProvider::load(&key_path, &vault_path);
         assert!(result.is_err());
     }
+
+    #[test]
+    #[cfg(unix)]
+    fn key_file_has_restricted_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempdir().unwrap();
+        let (key_path, _) = init_temp_vault(dir.path());
+
+        let mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "vault-key.txt must have mode 0600, got {mode:o}"
+        );
+    }
+
+    #[test]
+    fn load_blank_key_returns_key_parse_error() {
+        let dir = tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+
+        // Key file with only comments and blank lines — no valid identity line.
+        std::fs::write(&key_path, "# comment\n\n# another comment\n").unwrap();
+        // Vault file must exist so the error comes from key parsing, not vault read.
+        std::fs::write(&vault_path, b"").unwrap();
+
+        let result = AgeVaultProvider::load(&key_path, &vault_path);
+        assert!(
+            matches!(result, Err(AgeVaultError::KeyParse(_))),
+            "expected KeyParse, got {result:?}",
+        );
+    }
+
+    #[test]
+    fn decrypt_corrupted_ciphertext_returns_decrypt_error() {
+        let dir = tempdir().unwrap();
+        let (key_path, vault_path) = init_temp_vault(dir.path());
+
+        // Overwrite the encrypted vault with random garbage.
+        std::fs::write(&vault_path, b"not valid age ciphertext at all").unwrap();
+
+        let result = AgeVaultProvider::load(&key_path, &vault_path);
+        assert!(
+            matches!(result, Err(AgeVaultError::Decrypt(_))),
+            "expected Decrypt, got {result:?}",
+        );
+    }
+
+    #[test]
+    fn save_leaves_no_tmp_file() {
+        let dir = tempdir().unwrap();
+        let (key_path, vault_path) = init_temp_vault(dir.path());
+
+        let mut vault = AgeVaultProvider::new(&key_path, &vault_path).unwrap();
+        vault.set_secret_mut("TMP_TEST".into(), "value".into());
+        vault.save().unwrap();
+
+        let tmp_path = vault_path.with_added_extension("tmp");
+        assert!(!tmp_path.exists(), ".age.tmp must not exist after save()");
+        assert!(vault_path.exists(), "secrets.age must exist after save()");
+    }
 }


### PR DESCRIPTION
## Summary

- **#4484** (`zeph-llm`): replace `Arc<parking_lot::Mutex<Option<f32>>>` with `Arc<AtomicU32>` for `RouterState.last_memory_confidence`; uses `u32::MAX` as `None` sentinel (IEEE 754 NaN, not a valid confidence value); `Relaxed` ordering on both write and read sites
- **#4485** (`zeph-orchestration`): introduce `PlanSlug(String)` newtype for kebab-case LLM-facing task identifiers; migrate `TemplateTask.task_id`, `PlannedTask.task_id`, and their `depends_on` fields; `TaskId(u32)` for numeric runtime IDs is unchanged; the two types are now non-interchangeable at compile time
- **#4518** (`zeph-vault`): add four unit tests for `AgeVaultProvider` error paths — key file permission 0600, `KeyParse` on blank key file, `Decrypt` on corrupted ciphertext, atomic write cleanup (`.age.tmp` absent after `save()`)

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — zero warnings
- [ ] `cargo nextest run --workspace --lib --bins` — 10119 passed, 0 failed
- [ ] zeph-vault: 47/47 (all 4 new tests pass)
- [ ] zeph-llm router: 219/219
- [ ] zeph-orchestration: 367/367

Closes #4484, #4485, #4518.