### PR TITLE
refactor(types): replace raw String session_id fields with SessionId newtype

### DIFF
--- a/crates/zeph-acp/src/custom.rs
+++ b/crates/zeph-acp/src/custom.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use agent_client_protocol as acp;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
+use zeph_common::SessionId;
 
 use crate::agent::ZephAcpAgent;
 
@@ -23,7 +24,7 @@ pub(crate) struct SessionListParams {}
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct SessionListEntry {
-    pub session_id: String,
+    pub session_id: SessionId,
     pub created_at: String,
     pub busy: bool,
 }
@@ -35,7 +36,7 @@ pub(crate) struct SessionListResponse {
 
 #[derive(Deserialize)]
 pub(crate) struct SessionGetParams {
-    pub session_id: String,
+    pub session_id: SessionId,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -46,7 +47,7 @@ pub(crate) struct SessionEventEntry {
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct SessionGetResponse {
-    pub session_id: String,
+    pub session_id: SessionId,
     pub created_at: String,
     pub busy: bool,
     pub events: Vec<SessionEventEntry>,
@@ -54,7 +55,7 @@ pub(crate) struct SessionGetResponse {
 
 #[derive(Deserialize)]
 pub(crate) struct SessionDeleteParams {
-    pub session_id: String,
+    pub session_id: SessionId,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -64,12 +65,12 @@ pub(crate) struct SessionDeleteResponse {
 
 #[derive(Deserialize)]
 pub(crate) struct SessionExportParams {
-    pub session_id: String,
+    pub session_id: SessionId,
 }
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct SessionExportResponse {
-    pub session_id: String,
+    pub session_id: SessionId,
     pub events: Vec<SessionEventEntry>,
     pub exported_at: String,
 }
@@ -81,7 +82,7 @@ pub(crate) struct SessionImportParams {
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct SessionImportResponse {
-    pub session_id: String,
+    pub session_id: SessionId,
 }
 
 #[derive(Deserialize)]
@@ -90,7 +91,7 @@ pub(crate) struct AgentToolsParams {
         dead_code,
         reason = "required for JSON deserialization of the ACP ext method params"
     )]
-    pub session_id: String,
+    pub session_id: SessionId,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -106,7 +107,7 @@ pub(crate) struct AgentToolsResponse {
 
 #[derive(Deserialize)]
 pub(crate) struct WorkingDirUpdateParams {
-    pub session_id: String,
+    pub session_id: SessionId,
     pub path: String,
 }
 
@@ -212,10 +213,11 @@ async fn handle_session_list(
             Ok(rows) => {
                 sessions.reserve(rows.len());
                 for row in rows {
+                    let sid = String::from(&*row.id);
                     sessions.insert(
-                        row.id.clone(),
+                        sid.clone(),
                         SessionListEntry {
-                            session_id: row.id,
+                            session_id: SessionId::new(sid),
                             created_at: row.created_at,
                             busy: false,
                         },
@@ -231,7 +233,7 @@ async fn handle_session_list(
         sessions.insert(
             sid.clone(),
             SessionListEntry {
-                session_id: sid,
+                session_id: SessionId::new(sid),
                 created_at,
                 busy,
             },
@@ -297,7 +299,7 @@ async fn handle_session_get(
     };
 
     let resp = SessionGetResponse {
-        session_id: sid.to_owned(),
+        session_id: SessionId::new(sid),
         created_at,
         busy,
         events,
@@ -394,7 +396,9 @@ async fn handle_session_import(
             .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
     }
 
-    to_ext_response(&SessionImportResponse { session_id: new_id })
+    to_ext_response(&SessionImportResponse {
+        session_id: SessionId::new(new_id),
+    })
 }
 
 #[allow(clippy::unused_async)]

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -41,6 +41,8 @@ use zeph_llm::LlmProvider;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{Message, Role};
 
+use zeph_common::SessionId;
+
 use crate::agent::error::AgentError;
 
 // ── Risk category ────────────────────────────────────────────────────────────
@@ -89,7 +91,7 @@ pub struct SentinelEvent {
     /// Database row id (0 for unsaved records).
     pub id: i64,
     /// Agent session identifier.
-    pub session_id: String,
+    pub session_id: SessionId,
     /// Turn number within the session.
     pub turn_number: u64,
     /// Event category: `"tool_call"`, `"tool_result"`, `"risk_signal"`, `"probe_result"`.
@@ -320,7 +322,7 @@ impl ShadowEventStore {
               probe_verdict, context_summary, created_at) \
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
-        .bind(&event.session_id)
+        .bind(event.session_id.as_str())
         .bind(i64::try_from(event.turn_number).unwrap_or(i64::MAX))
         .bind(&event.event_type)
         .bind(&event.tool_id)
@@ -419,7 +421,7 @@ impl From<ShadowEventRow> for SentinelEvent {
     fn from(r: ShadowEventRow) -> Self {
         Self {
             id: r.id,
-            session_id: r.session_id,
+            session_id: SessionId::new(r.session_id),
             turn_number: u64::try_from(r.turn_number).unwrap_or(0),
             event_type: r.event_type,
             tool_id: r.tool_id,
@@ -457,7 +459,7 @@ pub struct ShadowSentinel {
     /// Counter of probe calls made in the current turn. Uses `AtomicU32` so all
     /// probe-checking methods can take `&self` even under parallel tool execution.
     probes_this_turn: AtomicU32,
-    session_id: String,
+    session_id: SessionId,
 }
 
 impl ShadowSentinel {
@@ -474,7 +476,7 @@ impl ShadowSentinel {
         store: ShadowEventStore,
         probe: Box<dyn SafetyProbe>,
         config: zeph_config::ShadowSentinelConfig,
-        session_id: impl Into<String>,
+        session_id: impl Into<SessionId>,
     ) -> Self {
         Self {
             store,

--- a/crates/zeph-memory/src/episodic_graph.rs
+++ b/crates/zeph-memory/src/episodic_graph.rs
@@ -35,6 +35,7 @@ use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
 
 pub use zeph_config::memory::EmGraphConfig;
 
+use zeph_common::SessionId;
 use zeph_db::ActiveDialect;
 
 use crate::error::MemoryError;
@@ -53,7 +54,7 @@ pub struct EpisodicEvent {
     /// `SQLite` row ID (`0` when not yet persisted).
     pub id: i64,
     /// Session identifier this event belongs to.
-    pub session_id: String,
+    pub session_id: SessionId,
     /// The message that triggered this event.
     pub message_id: MessageId,
     /// Short event category (e.g. `"decision"`, `"discovery"`, `"error"`, `"tool_use"`).
@@ -173,7 +174,7 @@ fn parse_events_response(raw: &str, session_id: &str, message_id: MessageId) -> 
             }
             Some(EpisodicEvent {
                 id: 0,
-                session_id: session_id.to_owned(),
+                session_id: SessionId::new(session_id),
                 message_id,
                 event_type,
                 summary,
@@ -338,7 +339,7 @@ pub async fn store_events(
         );
         let sql = zeph_db::rewrite_placeholders(&raw);
         let id = sqlx::query_scalar::<_, i64>(&sql)
-            .bind(&event.session_id)
+            .bind(event.session_id.as_str())
             .bind(event.message_id.0)
             .bind(&event.event_type)
             .bind(&event.summary)
@@ -416,7 +417,7 @@ pub async fn fetch_recent_events(
         .map(
             |(id, session_id, message_id, event_type, summary, created_at)| EpisodicEvent {
                 id,
-                session_id,
+                session_id: SessionId::new(session_id),
                 message_id: MessageId(message_id),
                 event_type,
                 summary,
@@ -503,7 +504,7 @@ pub async fn recall_episodic_causal(
         for &id in &visited {
             q = q.bind(id);
         }
-        q = q.bind(session_id);
+        q = q.bind(session_id.as_str());
 
         let rows = q.fetch_all(&pool).await?;
 
@@ -512,7 +513,7 @@ pub async fn recall_episodic_causal(
             .map(
                 |(id, session_id, message_id, event_type, summary, created_at)| EpisodicEvent {
                     id,
-                    session_id,
+                    session_id: SessionId::new(session_id),
                     message_id: MessageId(message_id),
                     event_type,
                     summary,
@@ -611,7 +612,7 @@ mod tests {
 
         let mut events = vec![EpisodicEvent {
             id: 0,
-            session_id: "test-session".to_owned(),
+            session_id: SessionId::new("test-session"),
             message_id: mid,
             event_type: "decision".to_owned(),
             summary: "User decided to use approach A".to_owned(),
@@ -647,7 +648,7 @@ mod tests {
         let mut events = vec![
             EpisodicEvent {
                 id: 0,
-                session_id: "sess".to_owned(),
+                session_id: SessionId::new("sess"),
                 message_id: mid,
                 event_type: "discovery".to_owned(),
                 summary: "Found a bug".to_owned(),
@@ -656,7 +657,7 @@ mod tests {
             },
             EpisodicEvent {
                 id: 0,
-                session_id: "sess".to_owned(),
+                session_id: SessionId::new("sess"),
                 message_id: mid,
                 event_type: "decision".to_owned(),
                 summary: "Decided to fix it".to_owned(),
@@ -742,7 +743,7 @@ mod tests {
         let mut events = vec![
             EpisodicEvent {
                 id: 0,
-                session_id: "sess".to_owned(),
+                session_id: SessionId::new("sess"),
                 message_id: mid,
                 event_type: "decision".to_owned(),
                 summary: "A".to_owned(),
@@ -751,7 +752,7 @@ mod tests {
             },
             EpisodicEvent {
                 id: 0,
-                session_id: "sess".to_owned(),
+                session_id: SessionId::new("sess"),
                 message_id: mid,
                 event_type: "discovery".to_owned(),
                 summary: "B".to_owned(),

--- a/crates/zeph-memory/src/five_signal/mod.rs
+++ b/crates/zeph-memory/src/five_signal/mod.rs
@@ -23,6 +23,7 @@ pub mod weights;
 
 use std::sync::Arc;
 
+use zeph_common::SessionId;
 use zeph_config::memory::FiveSignalConfig;
 use zeph_db::DbPool;
 
@@ -58,7 +59,7 @@ pub struct FiveSignalRuntime {
     ///
     /// Set at bootstrap from a per-process UUID so access counts are isolated
     /// per session and do not bleed across process restarts.
-    pub session_id: String,
+    pub session_id: SessionId,
     /// Config snapshot (used by the consolidation daemon).
     pub config: FiveSignalConfig,
 }
@@ -92,7 +93,7 @@ impl FiveSignalRuntime {
         graph_store: Arc<crate::graph::GraphStore>,
         qdrant: Option<Arc<EmbeddingStore>>,
         session_start: i64,
-        session_id: String,
+        session_id: impl Into<SessionId>,
     ) -> Self {
         let weights = FiveSignalWeights::normalized(&config);
 
@@ -119,7 +120,7 @@ impl FiveSignalRuntime {
             pool,
             qdrant,
             session_start,
-            session_id,
+            session_id: session_id.into(),
             config,
         }
     }

--- a/crates/zeph-skills/src/loader.rs
+++ b/crates/zeph-skills/src/loader.rs
@@ -55,6 +55,8 @@
 
 use std::path::{Path, PathBuf};
 
+use zeph_common::SessionId;
+
 use crate::error::SkillError;
 
 /// Parsed frontmatter metadata for a single skill.
@@ -80,7 +82,7 @@ pub struct SkillMeta {
     /// Session identifier from which this skill was extracted (`session_id` frontmatter field).
     ///
     /// Only present for skills created by the trace extraction pipeline (spec 056).
-    pub session_id: Option<String>,
+    pub session_id: Option<SessionId>,
     /// Optional agent version or runtime compatibility constraint.
     pub compatibility: Option<String>,
     /// SPDX license identifier.
@@ -662,7 +664,7 @@ pub fn load_skill_meta_from_str(content: &str) -> Result<(SkillMeta, String), Sk
         description,
         version: raw.version,
         source: raw.source,
-        session_id: raw.session_id,
+        session_id: raw.session_id.map(SessionId::new),
         compatibility: raw.compatibility,
         license: raw.license,
         metadata: raw.metadata,
@@ -743,7 +745,7 @@ pub fn load_skill_meta(path: &Path) -> Result<SkillMeta, SkillError> {
         description,
         version: raw.version,
         source: raw.source,
-        session_id: raw.session_id,
+        session_id: raw.session_id.map(SessionId::new),
         compatibility: raw.compatibility,
         license: raw.license,
         metadata: raw.metadata,

--- a/crates/zeph-skills/src/trace_extractor.rs
+++ b/crates/zeph-skills/src/trace_extractor.rs
@@ -592,12 +592,6 @@ fn ensure_closed_frontmatter(content: String) -> String {
     result
 }
 
-/// Check whether a session has already been extracted (idempotency guard).
-///
-/// Callers are responsible for implementing the DB check against `skill_trace_sessions`.
-/// This type is the `session_id` string used as the primary key.
-pub type SessionId = String;
-
 /// Build the content for a `skill_trace_sessions` insert.
 ///
 /// Returns `(session_id, processed_at_unix, proposed, saved, merged)`.

--- a/specs/056-autoskill-trace-extraction/spec.md
+++ b/specs/056-autoskill-trace-extraction/spec.md
@@ -136,12 +136,16 @@ All fields live under `[skills.learning]`:
 # A1: Conversation trace extraction
 trace_extraction_enabled = false               # opt-in; default off
 trace_extraction_provider = ""                 # named [[llm.providers]] name; empty = primary
+trace_extraction_embed_provider = ""           # embed provider for dedup; empty = primary embed provider
 trace_extraction_max_turns = 200               # max user messages sent per session
 trace_extraction_max_sessions_queued = 10      # max concurrent background extraction tasks
 ```
 
 - `trace_extraction_provider`: resolves via `ProviderRegistry::get_by_name()`. Empty string
   falls back to the default provider. Unknown name emits a warning and falls back — never panics.
+- `trace_extraction_embed_provider`: embed provider for dedup; empty = primary embed provider.
+  Resolves via `ProviderRegistry::get_by_name()`. Empty string falls back to the default provider.
+  Unknown name emits a warning and falls back — never panics.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces `session_id: String` with the canonical `SessionId` newtype in 6 crates, closing a type-system gap where bare `String` values could be passed in place of `SessionId` without a compile error
- Removes the `pub type SessionId = String` transparent alias from `zeph-skills/src/trace_extractor.rs` that was shadowing the canonical newtype for local callers
- Updates spec 056 (`specs/056-autoskill-trace-extraction/spec.md`) to document the `trace_extraction_embed_provider` config field that was missing from the Config Fields section

## Changed files

| File | Change |
|------|--------|
| `crates/zeph-memory/src/episodic_graph.rs` | `EpisodicGraphEntry.session_id: String` → `SessionId` |
| `crates/zeph-memory/src/five_signal/mod.rs` | `FiveSignalRuntime.session_id: String` → `SessionId` |
| `crates/zeph-core/src/agent/shadow_sentinel.rs` | `ShadowEvent.session_id` + `ShadowSentinel.session_id` |
| `crates/zeph-acp/src/custom.rs` | 9 custom protocol notification structs |
| `crates/zeph-skills/src/loader.rs` | `SkillMeta.session_id: Option<String>` → `Option<SessionId>` |
| `crates/zeph-skills/src/trace_extractor.rs` | Remove `pub type SessionId = String` alias |
| `specs/056-autoskill-trace-extraction/spec.md` | Add `trace_extraction_embed_provider` to Config Fields |

**Note:** remaining `session_id: String` fields are intentional DB/serde boundaries (sqlx `FromRow` structs, YAML deserializers, HTTP path extractors). `SessionId` is `#[serde(transparent)]` — JSON wire format is unchanged.

## Test plan

- [x] `cargo build --workspace --features desktop,ide,server,chat,pdf,scheduler` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10115 passed, 21 skipped
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 19 passed
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace` — no errors

Closes #4481
Closes #4505