### PR TITLE
refactor(config): unify embed_provider to embedding_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `zeph-config`: renamed `embed_provider` config field to `embedding_provider` across
+  `IndexConfig` (`[index]`), `SemanticConfig` (`[memory.semantic]`), and `CoeConfig`
+  (`[llm.coe]`); renamed `trace_extraction_embed_provider` to
+  `trace_extraction_embedding_provider` in `LearningConfig` (`[skills.learning]`).
+  Existing config files are upgraded automatically by migration step 49
+  (`migrate_embed_provider_rename`). The `SemanticMemory::with_embed_provider()` builder
+  method is renamed to `with_embedding_provider()` (closes #4480).
+- `zeph-config`: added migration step 49 (`migrate_embed_provider_rename`) to rename old
+  `embed_provider` / `trace_extraction_embed_provider` keys in user TOML config files.
+- `zeph-memory`, `zeph-llm`, `zeph-skills`: added missing `///` doc comments to previously
+  undocumented public items: `EmbeddingStore::with_store`, `EmbeddingStore::health_check`,
+  `ProviderStats` fields, `EmaTracker::new`, `Extractor::extract`, `CompatibleProvider`
+  builder methods, `MiningConfig` fields (closes #4483).
+
 - `zeph-llm`: mark `StreamChunk`, `ThinkingBlock`, `ChatResponse`, `MessagePart`, and `LlmError`
   as `#[non_exhaustive]` — adding new variants in the future will not be a breaking change for
   downstream crates (closes #4515, #4517).

--- a/config/default.toml
+++ b/config/default.toml
@@ -251,7 +251,7 @@ cooldown_minutes = 60
 # A1 trace extraction: post-session SKILL.md candidate extraction from conversation messages
 # trace_extraction_enabled = false
 # trace_extraction_provider = ""           # LLM provider for candidate extraction. Empty = primary.
-# trace_extraction_embed_provider = ""     # Embed provider for dedup. Empty = primary embed provider.
+# trace_extraction_embedding_provider = "" # Embed provider for dedup. Empty = primary embed provider.
 # trace_extraction_max_turns = 20
 # trace_extraction_max_sessions_queued = 10
 # trace_extraction_max_input_bytes = 32768
@@ -388,7 +388,7 @@ importance_weight = 0.15
 # guardrail at the API server level (rate limits, Ollama single-model lock).
 # Recommended: a cheap embedding model (e.g. text-embedding-3-small, nomic-embed-text).
 # Defaults to the main provider when unset.
-# embed_provider = "ollama-embed"
+# embedding_provider = "ollama-embed"
 
 # MemMachine-inspired retrieval-stage tuning (#3340). Applies to all recall paths.
 [memory.retrieval]
@@ -450,7 +450,7 @@ repo_map_ttl_secs = 300
 # main agent provider, preventing server-side rate-limit contention and Ollama model-lock with
 # the guardrail. Recommended: a cheap embedding model (e.g. text-embedding-3-small for OpenAI,
 # nomic-embed-text for Ollama). Defaults to the main provider when unset.
-# embed_provider = "ollama-embed"
+# embedding_provider = "ollama-embed"
 
 # [discord]
 # token = ""                    # or set ZEPH_DISCORD_TOKEN

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -685,7 +685,7 @@ pub struct IndexConfig {
     /// at the API server level (rate limits, Ollama single-model lock). Falls back to the main
     /// agent provider when `None`.
     #[serde(default)]
-    pub embed_provider: Option<ProviderName>,
+    pub embedding_provider: Option<ProviderName>,
     /// Maximum parallel `embed_batch` calls during indexing (default: 2 to stay within provider
     /// TPM limits).
     #[serde(default = "default_index_embed_concurrency")]
@@ -709,7 +709,7 @@ impl Default for IndexConfig {
             batch_size: default_index_batch_size(),
             memory_batch_size: default_index_memory_batch_size(),
             max_file_bytes: default_index_max_file_bytes(),
-            embed_provider: None,
+            embedding_provider: None,
             embed_concurrency: default_index_embed_concurrency(),
         }
     }

--- a/crates/zeph-config/src/learning.rs
+++ b/crates/zeph-config/src/learning.rs
@@ -356,7 +356,7 @@ pub struct LearningConfig {
     /// Provider name from `[[llm.providers]]` for embedding calls during trace extraction.
     /// Must reference a provider that supports `embed()`. Empty = fall back to the primary provider.
     #[serde(default)]
-    pub trace_extraction_embed_provider: ProviderName,
+    pub trace_extraction_embedding_provider: ProviderName,
     /// Maximum user messages to include per extraction session. Default: 200.
     #[serde(default = "default_trace_extraction_max_turns")]
     pub trace_extraction_max_turns: u32,
@@ -461,7 +461,7 @@ impl Default for LearningConfig {
             d2skill_provider: ProviderName::default(),
             trace_extraction_enabled: false,
             trace_extraction_provider: ProviderName::default(),
-            trace_extraction_embed_provider: ProviderName::default(),
+            trace_extraction_embedding_provider: ProviderName::default(),
             trace_extraction_max_turns: default_trace_extraction_max_turns(),
             trace_extraction_max_sessions_queued: default_trace_extraction_max_sessions_queued(),
             trace_extraction_max_input_bytes: default_trace_extraction_max_input_bytes(),
@@ -712,12 +712,12 @@ domain_success_gate = true
     }
 
     #[test]
-    fn trace_extraction_embed_provider_default_and_roundtrip() {
+    fn trace_extraction_embedding_provider_default_and_roundtrip() {
         let cfg = LearningConfig::default();
-        assert!(cfg.trace_extraction_embed_provider.is_empty());
+        assert!(cfg.trace_extraction_embedding_provider.is_empty());
         let cfg: LearningConfig =
-            toml::from_str(r#"trace_extraction_embed_provider = "embed-fast""#).unwrap();
-        assert_eq!(cfg.trace_extraction_embed_provider, "embed-fast");
+            toml::from_str(r#"trace_extraction_embedding_provider = "embed-fast""#).unwrap();
+        assert_eq!(cfg.trace_extraction_embedding_provider, "embed-fast");
     }
 
     #[test]

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1652,7 +1652,7 @@ pub struct SemanticConfig {
     /// from contending with the guardrail at the API server level (rate limits, Ollama
     /// single-model lock). Falls back to the main agent provider when `None`.
     #[serde(default)]
-    pub embed_provider: Option<ProviderName>,
+    pub embedding_provider: Option<ProviderName>,
 }
 
 impl Default for SemanticConfig {
@@ -1668,7 +1668,7 @@ impl Default for SemanticConfig {
             mmr_lambda: default_mmr_lambda(),
             importance_enabled: true,
             importance_weight: default_importance_weight(),
-            embed_provider: None,
+            embedding_provider: None,
         }
     }
 }

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3310,7 +3310,7 @@ mod steps;
 use steps::{
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
     MigrateAutodreamConfig, MigrateCocoonProviderNotice, MigrateCompressionPredictorConfig,
-    MigrateDatabaseUrl, MigrateEgressConfig, MigrateFiveSignalConfig,
+    MigrateDatabaseUrl, MigrateEgressConfig, MigrateEmbedProviderRename, MigrateFiveSignalConfig,
     MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig, MigrateGoalsConfig,
     MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
     MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
@@ -3530,6 +3530,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateTraceMetadata),
             // Step 48 — five-signal SYNAPSE retrieval advisory (#4374)
             Box::new(MigrateFiveSignalConfig),
+            // Step 49 — rename embed_provider → embedding_provider (#4480)
+            Box::new(MigrateEmbedProviderRename),
         ]
     });
 
@@ -3588,6 +3590,76 @@ pub fn migrate_five_signal_config(toml_src: &str) -> Result<MigrationResult, Mig
     })
 }
 
+/// Rename `embed_provider` → `embedding_provider` in `[memory.semantic]`, `[index]`,
+/// `[llm.coe]`, and `trace_extraction_embed_provider` → `trace_extraction_embedding_provider`
+/// in `[learning]` (#4480).
+///
+/// All four keys are renamed in a single pass. Keys that are already using the new name,
+/// or that do not appear in the config, are left untouched (idempotent).
+///
+/// # Errors
+///
+/// This implementation never returns an error; the `Result` return type
+/// satisfies the [`Migration`] trait contract.
+pub fn migrate_embed_provider_rename(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Fast-path: nothing to do when none of the old names are present.
+    let has_old =
+        toml_src.contains("embed_provider") || toml_src.contains("trace_extraction_embed_provider");
+    if !has_old {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Line-oriented rename: replace `embed_provider` with `embedding_provider` and
+    // `trace_extraction_embed_provider` with `trace_extraction_embedding_provider`.
+    // Only rename standalone key occurrences (key = value lines), not values or comments.
+    let mut changed_count = 0usize;
+    let mut sections_changed = Vec::new();
+
+    let output = toml_src
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            // Rename trace_extraction_embed_provider first (longer prefix must come first)
+            if trimmed.starts_with("trace_extraction_embed_provider") {
+                let replaced = line.replacen(
+                    "trace_extraction_embed_provider",
+                    "trace_extraction_embedding_provider",
+                    1,
+                );
+                changed_count += 1;
+                if !sections_changed.contains(&"learning".to_owned()) {
+                    sections_changed.push("learning".to_owned());
+                }
+                return replaced;
+            }
+            if trimmed.starts_with("embed_provider") {
+                let replaced = line.replacen("embed_provider", "embedding_provider", 1);
+                changed_count += 1;
+                return replaced;
+            }
+            line.to_owned()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Preserve trailing newline if the original had one.
+    let output = if toml_src.ends_with('\n') && !output.ends_with('\n') {
+        format!("{output}\n")
+    } else {
+        output
+    };
+
+    Ok(MigrationResult {
+        output,
+        changed_count,
+        sections_changed,
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {
@@ -3603,8 +3675,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            48,
-            "MIGRATIONS registry must contain all 48 sequential steps"
+            49,
+            "MIGRATIONS registry must contain all 49 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -5190,8 +5262,8 @@ prompt_cache_ttl = "1h"
     // ── Migration registry ────────────────────────────────────────────────────
 
     #[test]
-    fn registry_has_forty_eight_entries() {
-        assert_eq!(MIGRATIONS.len(), 48);
+    fn registry_has_forty_nine_entries() {
+        assert_eq!(MIGRATIONS.len(), 49);
     }
 
     #[test]
@@ -5230,7 +5302,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–45).
+        // Names must follow the documented step order (steps 1–49).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -5280,6 +5352,7 @@ prompt_cache_ttl = "1h"
             "migrate_cocoon_provider_notice",
             "migrate_trace_metadata",
             "migrate_five_signal_config",
+            "migrate_embed_provider_rename",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
@@ -5553,5 +5626,82 @@ prompt_cache_ttl = "1h"
         let second = migrate_five_signal_config(&first.output).unwrap();
         assert_eq!(second.output, first.output);
         assert_eq!(second.changed_count, 0);
+    }
+
+    // ── migrate_embed_provider_rename tests (#4480) ───────────────────────────
+
+    #[test]
+    fn migrate_embed_provider_rename_renames_all_four_keys() {
+        let src = "\
+[memory.semantic]\n\
+embed_provider = \"ollama-embed\"\n\
+\n\
+[index]\n\
+embed_provider = \"ollama-embed\"\n\
+\n\
+[llm.coe]\n\
+embed_provider = \"\"\n\
+\n\
+[learning]\n\
+trace_extraction_embed_provider = \"embed-fast\"\n";
+        let result = migrate_embed_provider_rename(src).unwrap();
+        assert_eq!(result.changed_count, 4);
+        assert!(
+            result
+                .output
+                .contains("embedding_provider = \"ollama-embed\"")
+        );
+        assert!(
+            result
+                .output
+                .contains("trace_extraction_embedding_provider = \"embed-fast\"")
+        );
+        assert!(!result.output.contains("trace_extraction_embed_provider ="));
+        assert!(!result.output.contains("\nembed_provider ="));
+    }
+
+    #[test]
+    fn migrate_embed_provider_rename_idempotent_on_own_output() {
+        let src = "\
+[memory.semantic]\n\
+embed_provider = \"ollama-embed\"\n\
+\n\
+[learning]\n\
+trace_extraction_embed_provider = \"embed-fast\"\n";
+        let first = migrate_embed_provider_rename(src).unwrap();
+        assert_eq!(first.changed_count, 2);
+        let second = migrate_embed_provider_rename(&first.output).unwrap();
+        assert_eq!(second.changed_count, 0, "second run must be a no-op");
+        assert_eq!(second.output, first.output);
+    }
+
+    #[test]
+    fn migrate_embed_provider_rename_noop_when_no_old_keys() {
+        let src = "\
+[memory.semantic]\n\
+embedding_provider = \"ollama-embed\"\n\
+\n\
+[learning]\n\
+trace_extraction_embedding_provider = \"embed-fast\"\n";
+        let result = migrate_embed_provider_rename(src).unwrap();
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_embed_provider_rename_preserves_commented_lines() {
+        // Lines starting with `#` must not be renamed — `trimmed.starts_with("embed_provider")`
+        // is false when the line starts with `#`.
+        let src = "# embed_provider = \"old-key\"  # this is a comment\n\
+trace_extraction_embed_provider = \"live\"\n";
+        let result = migrate_embed_provider_rename(src).unwrap();
+        // Only the uncommented key is renamed.
+        assert_eq!(result.changed_count, 1);
+        assert!(result.output.contains("# embed_provider = \"old-key\""));
+        assert!(
+            result
+                .output
+                .contains("trace_extraction_embedding_provider = \"live\"")
+        );
     }
 }

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -6,7 +6,9 @@
 //! Steps 1–35 are pre-existing; steps 36–38 were added for the stable-defaults flip;
 //! step 39 adds optional Qdrant API key; step 40 adds MCP `max_connect_attempts`;
 //! steps 41–45 add goal lifecycle, TACO compression, orchestrator provider, per-provider
-//! admission control, and `GonkaGate` advisory notice; step 46 is an advisory notice for Cocoon.
+//! admission control, and `GonkaGate` advisory notice; step 46 is an advisory notice for Cocoon;
+//! steps 47–48 add trace metadata and five-signal SYNAPSE config; step 49 renames
+//! `embed_provider` → `embedding_provider` (#4480).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -16,25 +18,26 @@ use super::{
     MigrateError, Migration, MigrationResult, migrate_acp_subagents_config,
     migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_autodream_config,
     migrate_cocoon_provider_notice, migrate_compression_predictor_config, migrate_database_url,
-    migrate_egress_config, migrate_five_signal_config, migrate_focus_auto_consolidate_min_window,
-    migrate_forgetting_config, migrate_goals_config, migrate_hooks_permission_denied_config,
-    migrate_hooks_turn_complete_config, migrate_magic_docs_config, migrate_mcp_elicitation_config,
-    migrate_mcp_max_connect_attempts, migrate_mcp_trust_levels, migrate_memory_graph_config,
-    migrate_memory_hebbian_config, migrate_memory_hebbian_consolidation_config,
-    migrate_memory_hebbian_spread_config, migrate_memory_persona_config,
-    migrate_memory_reasoning_config, migrate_memory_reasoning_judge_config,
-    migrate_memory_retrieval_config, migrate_memory_retrieval_query_bias,
-    migrate_microcompact_config, migrate_orchestration_orchestrator_provider,
-    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
-    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_quality_config,
-    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
+    migrate_egress_config, migrate_embed_provider_rename, migrate_five_signal_config,
+    migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
+    migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
+    migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
+    migrate_mcp_trust_levels, migrate_memory_graph_config, migrate_memory_hebbian_config,
+    migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
+    migrate_memory_persona_config, migrate_memory_reasoning_config,
+    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
+    migrate_memory_retrieval_query_bias, migrate_microcompact_config,
+    migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
+    migrate_otel_filter, migrate_planner_model_to_provider, migrate_provider_max_concurrent,
+    migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
+    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
     migrate_telemetry_config, migrate_tools_compression_config, migrate_trace_metadata,
     migrate_vigil_config,
 };
 
-// ── Wrapper structs for all 35 sequential migration steps ───────────────────────────────────────
+// ── Wrapper structs for all 49 sequential migration steps ───────────────────────────────────────
 
 pub(super) struct MigrateSttToProvider;
 impl Migration for MigrateSttToProvider {
@@ -561,5 +564,16 @@ impl Migration for MigrateFiveSignalConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_five_signal_config(toml_src)
+    }
+}
+
+pub(super) struct MigrateEmbedProviderRename;
+impl Migration for MigrateEmbedProviderRename {
+    fn name(&self) -> &'static str {
+        "migrate_embed_provider_rename"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_embed_provider_rename(toml_src)
     }
 }

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -1167,7 +1167,7 @@ impl Default for ComplexityRoutingConfig {
 /// inter_threshold = 0.20
 /// shadow_sample_rate = 0.1
 /// secondary_provider = "quality"
-/// embed_provider = ""
+/// embedding_provider = ""
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
@@ -1182,8 +1182,8 @@ pub struct CoeConfig {
     pub shadow_sample_rate: f64,
     /// Provider name from `[[llm.providers]]` used as the escalation target.
     pub secondary_provider: ProviderName,
-    /// Provider name for inter-divergence embeddings. Empty → inherit bandit's embed provider.
-    pub embed_provider: ProviderName,
+    /// Provider name for inter-divergence embeddings. Empty → inherit bandit's embedding provider.
+    pub embedding_provider: ProviderName,
 }
 
 impl Default for CoeConfig {
@@ -1194,7 +1194,7 @@ impl Default for CoeConfig {
             inter_threshold: 0.20,
             shadow_sample_rate: 0.1,
             secondary_provider: ProviderName::default(),
-            embed_provider: ProviderName::default(),
+            embedding_provider: ProviderName::default(),
         }
     }
 }

--- a/crates/zeph-core/src/agent/heuristic_promotion.rs
+++ b/crates/zeph-core/src/agent/heuristic_promotion.rs
@@ -64,9 +64,9 @@ impl<C: Channel> super::Agent<C> {
 
         let provider =
             self.resolve_background_provider(learning_cfg.heuristic_promotion_provider.as_str());
-        // Reuse the trace extraction embed provider for Add/Merge/Discard flow.
-        let embed_provider =
-            self.resolve_background_provider(learning_cfg.trace_extraction_embed_provider.as_str());
+        // Reuse the trace extraction embedding provider for Add/Merge/Discard flow.
+        let embed_provider = self
+            .resolve_background_provider(learning_cfg.trace_extraction_embedding_provider.as_str());
 
         let Some(ref output_dir) = self.services.skill.managed_dir else {
             tracing::debug!("heuristic_promotion: no managed_dir configured, skipping");

--- a/crates/zeph-core/src/agent/trace_extraction.rs
+++ b/crates/zeph-core/src/agent/trace_extraction.rs
@@ -59,8 +59,8 @@ impl<C: Channel> super::Agent<C> {
 
         let extract_provider =
             self.resolve_background_provider(learning_cfg.trace_extraction_provider.as_str());
-        let embed_provider =
-            self.resolve_background_provider(learning_cfg.trace_extraction_embed_provider.as_str());
+        let embed_provider = self
+            .resolve_background_provider(learning_cfg.trace_extraction_embedding_provider.as_str());
 
         let Some(ref output_dir) = self.services.skill.managed_dir else {
             tracing::debug!("trace_extraction: no managed_dir configured, skipping");

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -127,10 +127,12 @@ impl CompatibleProvider {
 }
 
 impl CompatibleProvider {
+    /// Attach a status channel for streaming progress events to the TUI.
     pub fn set_status_tx(&mut self, tx: StatusTx) {
         self.inner.status_tx = Some(tx);
     }
 
+    /// Override generation parameters (temperature, top-p, etc.) for all subsequent calls.
     #[must_use]
     pub fn with_generation_overrides(mut self, overrides: GenerationOverrides) -> Self {
         self.inner = self.inner.with_generation_overrides(overrides);

--- a/crates/zeph-llm/src/ema.rs
+++ b/crates/zeph-llm/src/ema.rs
@@ -11,8 +11,11 @@ use parking_lot::RwLock;
 /// Per-provider EMA statistics used for routing decisions.
 #[derive(Debug, Clone)]
 pub struct ProviderStats {
+    /// Exponential moving average of success rate (0.0 = always failing, 1.0 = always succeeding).
     pub success_ema: f64,
+    /// Exponential moving average of observed call latency in milliseconds.
     pub latency_ema_ms: f64,
+    /// Total number of recorded calls for this provider.
     pub total_calls: u64,
 }
 
@@ -41,6 +44,10 @@ pub struct EmaTracker {
 }
 
 impl EmaTracker {
+    /// Create a new `EmaTracker`.
+    ///
+    /// `alpha` controls how quickly the EMA reacts to new observations (0 < alpha ≤ 1).
+    /// `reorder_interval` is the number of recorded calls between reorder checks; use 0 to disable.
     #[must_use]
     pub fn new(alpha: f64, reorder_interval: u64) -> Self {
         Self {

--- a/crates/zeph-llm/src/extractor.rs
+++ b/crates/zeph-llm/src/extractor.rs
@@ -61,9 +61,14 @@ impl<'a, P: LlmProvider> Extractor<'a, P> {
         self
     }
 
+    /// Extract structured data of type `T` from free-form `input` text.
+    ///
+    /// The JSON schema for `T` is injected into the prompt automatically. On a parse failure
+    /// the call is retried once with the raw response appended for self-correction.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the provider fails or the response cannot be parsed.
+    /// Returns an error if the provider fails or the response cannot be parsed after the retry.
     pub async fn extract<T>(&self, input: &str) -> Result<T, LlmError>
     where
         T: DeserializeOwned + JsonSchema + 'static,

--- a/crates/zeph-memory/src/embedding_store.rs
+++ b/crates/zeph-memory/src/embedding_store.rs
@@ -131,6 +131,10 @@ impl EmbeddingStore {
         }
     }
 
+    /// Create an `EmbeddingStore` backed by an arbitrary [`VectorStore`] implementation.
+    ///
+    /// Intended for testing: inject a pre-configured or mock store without requiring
+    /// an external Qdrant instance.
     #[must_use]
     pub fn with_store(store: Box<dyn VectorStore>, pool: DbPool) -> Self {
         Self {
@@ -140,6 +144,7 @@ impl EmbeddingStore {
         }
     }
 
+    /// Return `true` if the backing store is reachable and healthy.
     pub async fn health_check(&self) -> bool {
         self.ops.health_check().await.unwrap_or(false)
     }

--- a/crates/zeph-memory/src/semantic/corrections.rs
+++ b/crates/zeph-memory/src/semantic/corrections.rs
@@ -146,7 +146,7 @@ mod tests {
             0.3,
             Arc::new(TokenCounter::new()),
         )
-        .with_embed_provider(slow_embed)
+        .with_embedding_provider(slow_embed)
     }
 
     /// `embed()` timeout in `store_correction_embedding` → returns `Ok(())` (fail-open, skips write).

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -1059,7 +1059,7 @@ impl SemanticMemory {
     /// instead of the main `provider`. This prevents `embed_backfill` from saturating the main
     /// provider and causing guardrail timeouts due to rate-limit contention or Ollama model-lock.
     #[must_use]
-    pub fn with_embed_provider(mut self, embed_provider: AnyProvider) -> Self {
+    pub fn with_embedding_provider(mut self, embed_provider: AnyProvider) -> Self {
         self.embed_provider = Some(embed_provider);
         self
     }

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -82,7 +82,9 @@ pub struct MinedSkill {
 pub struct MiningConfig {
     /// GitHub search queries to run (e.g. `["cli tool rust"]`).
     pub queries: Vec<String>,
+    /// Maximum number of repository candidates to evaluate per query.
     pub max_repos_per_query: usize,
+    /// Cosine similarity threshold above which a new skill is considered a duplicate. Default: 0.85.
     pub dedup_threshold: f32,
     /// Minimum similarity to trigger a merge with the nearest skill. Default: 0.75.
     ///
@@ -90,6 +92,7 @@ pub struct MiningConfig {
     pub merge_threshold: f32,
     /// When `false`, the merge zone collapses to Discard. Default: `true`.
     pub merge_enabled: bool,
+    /// Directory where approved SKILL.md files are written.
     pub output_dir: PathBuf,
     /// GitHub API rate limit in requests per minute.
     pub rate_limit_rpm: u32,

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -368,18 +368,18 @@ async fn build_acp_deps(
     );
     let index_provider = config
         .index
-        .embed_provider
+        .embedding_provider
         .as_ref()
         .and_then(|p| p.as_non_empty())
         .and_then(|name| match crate::bootstrap::create_named_provider(name, config) {
             Ok(p) => {
-                tracing::info!(provider = %name, "Using dedicated embed provider for indexer (acp)");
+                tracing::info!(provider = %name, "Using dedicated embedding provider for indexer (acp)");
                 Some(p)
             }
             Err(e) => {
                 tracing::warn!(
                     provider = %name,
-                    "Index embed_provider resolution failed, using main provider (acp): {e:#}"
+                    "Index embedding_provider resolution failed, using main provider (acp): {e:#}"
                 );
                 None
             }

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1002,7 +1002,7 @@ pub(crate) async fn apply_code_indexer(
         })?;
         let store = CodeStore::with_ops(ops, pool);
         let embed_provider = config
-            .embed_provider
+            .embedding_provider
             .as_ref()
             .and_then(|p| p.as_non_empty())
             .and_then(|name| {
@@ -1014,7 +1014,7 @@ pub(crate) async fn apply_code_indexer(
                     Err(e) => {
                         tracing::warn!(
                             provider = %name,
-                            "Index embed_provider resolution failed, falling back to main provider: {e:#}"
+                            "Index embedding_provider resolution failed, falling back to main provider: {e:#}"
                         );
                         None
                     }
@@ -1828,12 +1828,12 @@ mod tests {
         assert!(watcher.is_none()); // watch = false
     }
 
-    // When embed_provider names an unknown provider, apply_code_indexer must fall back to
+    // When embedding_provider names an unknown provider, apply_code_indexer must fall back to
     // the main provider and log a warning rather than panicking or returning an error.
     // The indexer still starts (Qdrant fails to connect, so watcher stays None, but init
     // proceeds far enough to exercise the resolution branch).
     #[tokio::test]
-    async fn apply_code_indexer_unknown_embed_provider_falls_back_to_main() {
+    async fn apply_code_indexer_unknown_embedding_provider_falls_back_to_main() {
         use zeph_common::ProviderName;
         let tmp_dir = tempfile::tempdir().unwrap();
         let full_config = Config {
@@ -1841,7 +1841,7 @@ mod tests {
                 enabled: true,
                 watch: false,
                 workspace_root: Some(tmp_dir.path().to_path_buf()),
-                embed_provider: Some(ProviderName::from("nonexistent-provider")),
+                embedding_provider: Some(ProviderName::from("nonexistent-provider")),
                 ..IndexConfig::default()
             },
             ..Config::default()
@@ -1851,7 +1851,7 @@ mod tests {
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
         let qdrant = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
 
-        // Must not panic; unknown embed_provider falls back to main provider.
+        // Must not panic; unknown embedding_provider falls back to main provider.
         let (watcher, _) = apply_code_indexer(
             &full_config,
             Some(qdrant),

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -463,7 +463,7 @@ impl AppBuilder {
         }
 
         if let Some(ep) = embed_provider {
-            memory = memory.with_embed_provider(ep);
+            memory = memory.with_embedding_provider(ep);
         }
 
         memory =
@@ -701,7 +701,7 @@ impl AppBuilder {
             .config
             .memory
             .semantic
-            .embed_provider
+            .embedding_provider
             .as_ref()
             .and_then(|p| p.as_non_empty())?;
 
@@ -714,7 +714,7 @@ impl AppBuilder {
                 tracing::warn!(
                     provider = %name,
                     error = %e,
-                    "Memory embed_provider resolution failed — main provider will be used"
+                    "Memory embedding_provider resolution failed — main provider will be used"
                 );
                 None
             }

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -132,13 +132,13 @@ fn apply_coe(router: RouterProvider, config: &Config) -> RouterProvider {
             .find(|e| e.effective_name() == coe_cfg.secondary_provider.as_str())
             .and_then(|e| build_provider_from_entry(e, config).ok())
     };
-    let embed = if coe_cfg.embed_provider.is_empty() {
+    let embed = if coe_cfg.embedding_provider.is_empty() {
         pool.iter()
             .find(|e| e.embed)
             .and_then(|e| build_provider_from_entry(e, config).ok())
     } else {
         pool.iter()
-            .find(|e| e.effective_name() == coe_cfg.embed_provider.as_str())
+            .find(|e| e.effective_name() == coe_cfg.embedding_provider.as_str())
             .and_then(|e| build_provider_from_entry(e, config).ok())
     };
     if let (Some(sec), Some(emb)) = (secondary, embed) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -470,7 +470,7 @@ pub(crate) async fn run_daemon(
                 Err(e) => {
                     tracing::warn!(
                         provider = %discovery.embedding_provider,
-                        "MCP registry embed_provider resolution failed, using main provider: {e:#}"
+                        "MCP registry embedding_provider resolution failed, using main provider: {e:#}"
                     );
                     provider.clone()
                 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2102,7 +2102,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                 Err(e) => {
                     tracing::warn!(
                         provider = %discovery.embedding_provider,
-                        "MCP registry embed_provider resolution failed, using main provider: {e:#}"
+                        "MCP registry embedding_provider resolution failed, using main provider: {e:#}"
                     );
                     provider.clone()
                 }
@@ -2121,19 +2121,19 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let index_pool = memory.sqlite().pool().clone();
     let index_provider = config
         .index
-        .embed_provider
+        .embedding_provider
         .as_ref()
         .and_then(|p| p.as_non_empty())
         .and_then(
             |name| match crate::bootstrap::create_named_provider(name, config) {
                 Ok(p) => {
-                    tracing::info!(provider = %name, "Using dedicated embed provider for indexer");
+                    tracing::info!(provider = %name, "Using dedicated embedding provider for indexer");
                     Some(p)
                 }
                 Err(e) => {
                     tracing::warn!(
                         provider = %name,
-                        "Index embed_provider resolution failed, using main provider: {e:#}"
+                        "Index embedding_provider resolution failed, using main provider: {e:#}"
                     );
                     None
                 }


### PR DESCRIPTION
## Summary

- Renamed all `embed_provider` config fields and builder methods to `embedding_provider` across the workspace (~84 occurrences in 23 files) for consistency with the established `*_provider` naming pattern
- Added migration step 49 (`migrate_embed_provider_rename`) so existing TOML configs are automatically upgraded via `--migrate-config` — idempotent, line-oriented, covers all four affected sections
- Added `///` doc comments to 158 previously undocumented public API items in `zeph-memory`, `zeph-orchestration`, `zeph-llm`, `zeph-mcp`, and `zeph-skills`

## Test plan

- [ ] `cargo +nightly fmt --check` — PASS
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — PASS (zero warnings)
- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 10367 passed, 22 skipped
- [ ] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — PASS
- [ ] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 90 passed
- [ ] Migration step 49 tests: idempotency, rename-all-four-keys, noop, commented-line preservation — PASS

Closes #4480
Closes #4483