### PR TITLE
spec(context): add Context-Adaptive Memory specification (CAM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `specs/062-context-adaptive-memory/`: formal specification package for Context-Adaptive Memory (CAM)
+  subsystem — three-level fidelity (Full/Compressed/Placeholder) via `ContextFidelity` enum in
+  `zeph-common`, heuristic `FidelityScorer` combining temporal decay + role importance + keyword
+  overlap + plan-tool relevance, proactive AgeMem regrade trigger before context fills,
+  `PlannedToolHint` struct for PAACE plan-aware context retention. Covers GitHub #4016, #4017, #4018.
+  MVP (v0.21): heuristic scoring only; RL training pipeline and orchestration wiring deferred.
+
 - `zeph-skills`: `promoter` module — pure-logic helpers for `AutoSkill A6` heuristic promotion:
   `compute_batch_hash` (BLAKE3, order-independent), `build_promotion_prompt`, `parse_promotion_response`,
   `PromotionRecommendation` enum (`BodyEnrichment`, `NewSkill`, `None`). No async/DB/LLM dependencies.

--- a/specs/062-context-adaptive-memory/brd.md
+++ b/specs/062-context-adaptive-memory/brd.md
@@ -1,0 +1,59 @@
+---
+aliases:
+  - CAM BRD
+tags:
+  - brd
+  - context
+  - memory
+created: 2026-05-28
+status: approved
+related:
+  - "[[062-context-adaptive-memory/spec]]"
+---
+
+# Context-Adaptive Memory — Business Requirements Document
+
+## 1. Problem Statement
+
+Zeph's context window management currently operates reactively: compaction fires only after the budget is nearly exhausted (typically >90% full). At that point, the system has no choice but to discard or summarize large portions of conversation history without regard to their relevance to the current task.
+
+This leads to three documented failure modes in long sessions:
+
+1. **Context blowout mid-task** — the agent loses essential context (tool outputs, intermediate reasoning, correction messages) precisely when it needs them most.
+2. **Uniform discard** — all non-recent messages are treated identically regardless of whether they contain a critical file path established three turns ago or a generic greeting from the start of the session.
+3. **Wasted recovery overhead** — after compaction, the agent spends 1–3 additional turns re-establishing context that should have been preserved.
+
+## 2. Business Value
+
+| Benefit | Target Metric |
+|---|---|
+| Token reduction | 40–60% reduction in context window usage for sessions > 20 turns |
+| Fewer context reloads | Eliminate reactive compaction mid-task in > 80% of long sessions |
+| Preserved structural history | Tool-use/tool-result pairs and correction messages survive context pressure |
+| No behavioral regression | Existing sessions unaffected when feature disabled (`enabled = false`) |
+
+## 3. Stakeholders
+
+| Stakeholder | Role | Interest |
+|---|---|---|
+| Zeph end users (long session) | Primary beneficiary | Coherent multi-turn sessions without context amnesia |
+| Agent loop (`zeph-core`) | Consumer | Receives a better-managed context window |
+| Context manager (`zeph-context`) | Owner | Hosts the fidelity scorer and regrade trigger |
+| Orchestration (`zeph-orchestration`) | Data source | Provides DAG lookahead hints (deferred in MVP) |
+
+## 4. Business Constraints
+
+- **No external infrastructure required** for MVP: heuristic scoring uses keyword overlap, not embeddings.
+- **Off by default** (`enabled = false`) — the feature must not affect existing users until opted in via config.
+- **No breaking API changes** to `MessageMetadata` serialization format that would corrupt existing session databases.
+- **Latency budget**: context scoring must add < 2ms per turn to the context preparation path.
+- **Pre-v1.0**: no backward-compatibility shims required; clean implementation preferred over incremental migration.
+
+## 5. Success Criteria
+
+The initiative is considered successful when:
+
+1. All 12 acceptance criteria in `spec.md §11` pass.
+2. A live test session of 30+ turns shows no mid-task context blowout.
+3. Token usage per turn is measurably reduced compared to a baseline session without CAM.
+4. No regression in existing unit test suite (`cargo nextest run --workspace --lib --bins`).

--- a/specs/062-context-adaptive-memory/plan.md
+++ b/specs/062-context-adaptive-memory/plan.md
@@ -1,0 +1,173 @@
+---
+aliases:
+  - CAM Implementation Plan
+tags:
+  - plan
+  - context
+  - memory
+created: 2026-05-28
+status: approved
+related:
+  - "[[062-context-adaptive-memory/spec]]"
+  - "[[062-context-adaptive-memory/tasks]]"
+---
+
+# Context-Adaptive Memory — Implementation Plan
+
+## Phase 1: MVP (v0.21)
+
+All Phase 1 work targets issues #4016, #4017, #4018.
+
+### Step 1 — Foundation types in zeph-common
+
+**Crate**: `zeph-common`
+**Module**: `src/fidelity.rs` (new file)
+**Exports**: `ContextFidelity`, `PlannedToolHint`
+
+Deliverables:
+- `ContextFidelity` enum (`#[repr(u8)]`, `Default = Full`, `Copy + Clone + PartialEq + Eq + Hash`)
+- `PlannedToolHint` struct with `tool_name`, `keywords`, `distance_from_current`
+- Public re-export from `zeph_common::prelude` (if the crate uses one)
+- Full doc comments with `# Examples` and doc-tests
+
+No dependencies on other `zeph-*` crates.
+
+### Step 2 — MessageMetadata extension in zeph-llm
+
+**Crate**: `zeph-llm`
+**Module**: wherever `MessageMetadata` is defined
+
+Deliverables:
+- Add `pub fidelity_tag: Option<ContextFidelity>` with `#[serde(default)]`
+- Import `ContextFidelity` from `zeph-common`
+- Verify `zeph-llm` Cargo.toml already has `zeph-common.workspace = true`
+
+No behavior change — this field starts as `None` everywhere.
+
+### Step 3 — FidelityConfig and FidelityScorer in zeph-context
+
+**Crate**: `zeph-context`
+**Module**: `src/fidelity.rs` (new file)
+
+Deliverables:
+- `FidelityConfig` struct with all fields from spec.md §8.1 + `#[serde(default)]`
+- `FidelityScorer` struct (stateless, takes config reference)
+- `FidelityScorer::score_and_apply()` — the main entry point
+- Internal helpers: `score_message()`, `resolve_fidelity()`, `apply_rendering()`, `merge_same_role_placeholders()`, `identify_tool_pairs()`
+- Tracing spans: `context.fidelity.score`, `context.fidelity.apply`, `context.fidelity.merge`
+- Unit test module with ≥ 10 test cases (see AC-01)
+
+Scoring algorithm must implement:
+- Weight normalization (INV-05, FR-008 through FR-010)
+- Short query fallback (FR-009)
+- Tool pair atomicity (FR-020 through FR-022)
+- Consecutive same-role merge (FR-023 through FR-025)
+- All exempt message rules (FR-015 through FR-018)
+
+Performance constraint: must pass AC-11 benchmark.
+
+### Step 4 — ContextAssemblyInput extension in zeph-context
+
+**Crate**: `zeph-context`
+**Module**: `src/input.rs`
+
+Deliverables:
+- Add `planned_next_tools: &'a [PlannedToolHint]` with `#[serde(skip)]` / lifetime-bound
+- Add `fidelity_config: Option<&'a FidelityConfig>`
+- Update all `ContextAssemblyInput` construction sites to pass defaults
+
+### Step 5 — ContextManager extensions in zeph-context
+
+**Crate**: `zeph-context`
+**Module**: `src/manager.rs`
+
+Deliverables:
+- Add `pub(crate) regraded_this_turn: bool` field (initialized `false`)
+- Implement `should_proactively_regrade(&self, cached_tokens: u64) -> bool` (guard chain from spec.md §5.1)
+- Update `advance_turn()` to reset `regraded_this_turn = false`
+- Tracing span: `context.fidelity.regrade`
+
+### Step 6 — Wire fidelity scoring in zeph-agent-context
+
+**Crate**: `zeph-agent-context`
+**Module**: `src/service.rs`
+
+Deliverables:
+- Change `apply_prepared_context()` return type to `(ContextDelta, usize)` where `usize` is `inserted_count`
+- Implement incremental insertion counting across all message insertion paths
+- After `apply_prepared_context()` returns, call `FidelityScorer::score_and_apply()` when guards are satisfied
+- TUI spinner: emit `send_status("Scoring context fidelity…")` before scorer call
+
+### Step 7 — Proactive regrade call site in zeph-agent-context
+
+**Crate**: `zeph-agent-context`
+**Module**: `src/summarization/scheduling.rs`
+
+Deliverables:
+- In `maybe_compact()` (or equivalent), before tier dispatch, call `should_proactively_regrade()`
+- When trigger fires, re-run `FidelityScorer::score_and_apply()` and set `regraded_this_turn = true`
+
+### Step 8 — Placeholder exclusion in hard compaction
+
+**Crate**: `zeph-agent-context`
+**Module**: `src/summarization/compaction.rs`
+
+Deliverables:
+- In the message selection loop, add: `if msg.metadata.fidelity_tag == Some(ContextFidelity::Placeholder) { continue; }`
+- Unit test: verify no Placeholder messages appear in summarizer input
+
+### Step 9 — Config integration
+
+**Crate**: `zeph-config`
+
+Deliverables:
+- Add `FidelityConfigToml` (or equivalent) to the `[context]` section
+- Default: `enabled = false`, all weights/thresholds at spec defaults
+- Wire through `--migrate-config` if any existing `[context]` fields are renamed
+- Add `[context.fidelity]` section to config documentation and `--init` wizard branch
+- Update `config.toml` examples / `.local/config/testing.toml` with the new section
+
+### Step 10 — Testing and observability
+
+Deliverables:
+- Unit tests for all 12 AC from spec.md §11
+- Integration test: full context assembly round-trip with `enabled = true`
+- Benchmark in `zeph-bench` for AC-11 (< 2ms for 500 messages)
+- Update `.local/testing/playbooks/context-adaptive-memory.md` with test scenarios
+- Update `.local/testing/coverage-status.md` with new rows (status: Untested)
+
+---
+
+## Phase 2: Deferred Implementation
+
+These items are spec'd but NOT implemented in v0.21.
+
+### P2-A — Orchestration DAG live wiring (PAACE full)
+
+**Crate**: `zeph-orchestration`
+**Prerequisite**: `zeph-orchestration` exposes a `lookahead_tools(depth: u8) -> Vec<PlannedToolHint>` method.
+
+Implementation: populate `planned_next_tools` in `ContextAssemblyInput` from the active DAG at turn start.
+
+### P2-B — Fidelity persistence to SQLite
+
+Store the resolved `ContextFidelity` per-message in the session database. Allows cross-turn fidelity stability (a message that was Compressed stays Compressed unless explicitly regraded).
+
+### P2-C — LLM-assisted Compressed rendering
+
+When `deferred_summary` is absent, use a fast LLM provider to generate a high-quality summary of the message content instead of simple truncation. Requires `fidelity_compress_provider` config field.
+
+### P2-D — Embedding-based semantic scoring
+
+Replace `keyword_overlap()` with cosine similarity against a cached embedding of the current query. Requires the scorer to accept an `EmbeddingProvider` and become async.
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `inserted_count` hardcoded incorrectly | Medium | High (wrong exempt set) | Unit test asserting all insertion paths are counted |
+| `compressed_max_tokens = 50` too aggressive for tool results | High | Medium (loss of useful context) | Post-merge live testing; easy config adjustment |
+| Tool pair detection by `tool_call_id` mismatches | Low | High (API 400 errors) | Unit test with malformed pair IDs |
+| Scoring overhead exceeds 2ms for large windows | Low | Medium | `max_scored_messages` cap + benchmark in AC-11 |

--- a/specs/062-context-adaptive-memory/spec.md
+++ b/specs/062-context-adaptive-memory/spec.md
@@ -1,0 +1,523 @@
+---
+aliases:
+  - CAM Spec
+  - Context-Adaptive Memory
+  - AFM
+  - AgeMem
+  - PAACE
+tags:
+  - context
+  - memory
+  - compaction
+  - fidelity
+created: 2026-05-28
+status: approved
+related:
+  - "[[022-zeph-context]]"
+  - "[[004-memory]]"
+  - "[[009-orchestration]]"
+  - "[[044-zeph-common]]"
+issues:
+  - "#4016"
+  - "#4017"
+  - "#4018"
+---
+
+# Context-Adaptive Memory (CAM) — Specification
+
+## 1. Purpose and Scope
+
+Context-Adaptive Memory (CAM) addresses a fundamental limitation in Zeph's current context management: reactive compaction triggers only after the context window is nearly exhausted, causing context blowouts mid-task and discarding all non-recent messages uniformly.
+
+CAM introduces three coordinated mechanisms across a single cohesive subsystem:
+
+- **AFM (#4017)** — Adaptive Fidelity Management: three-level representation (`Full / Compressed / Placeholder`) replacing binary keep/discard.
+- **AgeMem (#4016)** — Proactive age-triggered regrading: fires before the compaction threshold using heuristic budget monitoring.
+- **PAACE (#4018)** — Plan-Aware Adaptive Context Engineering: plan-hint scoring bias from orchestration DAG lookahead (data structure only in MVP; wiring deferred).
+
+### Out of Scope (v0.21 MVP)
+
+- RL-based trigger threshold learning
+- Per-message embedding-based scoring
+- Orchestration DAG live wiring for PAACE
+- Fidelity state persistence to SQLite
+- Dynamic weight adaptation
+- LLM-assisted compression for `Compressed` rendering
+
+---
+
+## 2. System Invariants
+
+These constraints are **NEVER** to be violated. Violation requires an explicit architectural decision reviewed by the team lead.
+
+| ID | Invariant |
+|---|---|
+| INV-01 | Fidelity scoring MUST run AFTER `apply_prepared_context()` returns. Never score before all insertions, sanitization, trimming, and token recomputation are final. |
+| INV-02 | Placeholder messages MUST NOT be included in hard compaction summarizer input. They contain no semantic content. |
+| INV-03 | A tool-use message and its matching tool-result message MUST downgrade together to the same fidelity level, or not at all. |
+| INV-04 | Consecutive same-role Placeholder messages MUST be merged into a single merged placeholder before returning the context window to the LLM. |
+| INV-05 | Fidelity scores MUST be normalized by the sum of active weights (not a fixed constant). |
+| INV-06 | `regraded_this_turn` MUST be checked before triggering a proactive regrade within a single turn. |
+| INV-07 | System prompt (index 0) MUST always be exempt from fidelity downgrade. |
+| INV-08 | Messages with `focus_pinned == true` MUST be exempt from fidelity downgrade. |
+| INV-09 | Correction messages (content starts with `CORRECTIONS_PREFIX`) MUST be exempt from fidelity downgrade. |
+| INV-10 | Freshly injected memory context messages (inserted by `apply_prepared_context`) MUST be exempt from fidelity downgrade within the same turn. |
+| INV-11 | Fidelity scoring MUST be skipped entirely when `memory_first == true`. |
+| INV-12 | Both Compressed and Placeholder rendering MUST clear `msg.parts` (no orphaned structured parts). |
+
+---
+
+## 3. Subsystem Boundaries
+
+### Modified Crates
+
+| Crate | Module | Change |
+|---|---|---|
+| `zeph-common` | `fidelity.rs` (new) | `ContextFidelity` enum, `PlannedToolHint` struct |
+| `zeph-context` | `fidelity.rs` (new) | `FidelityScorer`, `FidelityConfig`, scoring logic, `apply_fidelity_to_messages()` |
+| `zeph-context` | `manager.rs` | `should_proactively_regrade()` + `regraded_this_turn: bool` field |
+| `zeph-context` | `input.rs` | Add `planned_next_tools` and `fidelity_config` to `ContextAssemblyInput` |
+| `zeph-agent-context` | `service.rs` | Wire fidelity scoring after `apply_prepared_context()`, gated on `!memory_first` |
+| `zeph-agent-context` | `summarization/scheduling.rs` | Proactive regrade trigger call site |
+| `zeph-agent-context` | `summarization/compaction.rs` | Skip Placeholder messages in summarizer input |
+| `zeph-llm` | `MessageMetadata` | Add `fidelity_tag: Option<ContextFidelity>` |
+| `zeph-config` | config types | `[context.fidelity]` section |
+
+### Read-Only Crates
+
+- `zeph-orchestration` — DAG read only (lookahead in deferred phase)
+- `zeph-memory` — no changes (`CompressionLevel` remains independent)
+
+### Dependency Note
+
+`zeph-llm` already depends on `zeph-common` (`zeph-common.workspace = true`), so `Option<ContextFidelity>` is used directly in `MessageMetadata` — no raw `u8` indirection required.
+
+---
+
+## 4. Data Model
+
+### 4.1 ContextFidelity (zeph-common/src/fidelity.rs)
+
+```rust
+/// Fidelity level assigned to a message in the context window.
+///
+/// Determines how a historical message is rendered before sending to the LLM.
+/// Assigned by `FidelityScorer` based on relevance signals; stored in
+/// `MessageMetadata.fidelity_tag` for debug tracing and compaction filtering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[repr(u8)]
+pub enum ContextFidelity {
+    /// Original message content, unchanged.
+    #[default]
+    Full = 0,
+    /// Content truncated to `compressed_max_tokens` tokens (or replaced by
+    /// `deferred_summary` when available).
+    Compressed = 1,
+    /// Content replaced by a compact placeholder tag; no semantic content
+    /// survives.
+    Placeholder = 2,
+}
+```
+
+### 4.2 PlannedToolHint (zeph-common/src/fidelity.rs)
+
+```rust
+/// Hint about an upcoming tool call derived from the orchestration DAG.
+///
+/// Used by `FidelityScorer` to bias relevance scores toward messages that
+/// contain context useful for the next planned operations.
+#[derive(Debug, Clone)]
+pub struct PlannedToolHint {
+    /// Name of the planned tool.
+    pub tool_name: String,
+    /// Keywords extracted from the tool's planned arguments (best-effort).
+    pub keywords: Vec<String>,
+    /// Steps until this tool is scheduled. 1 = immediately next, capped at 5.
+    pub distance_from_current: u8,
+}
+```
+
+### 4.3 FidelityConfig (zeph-context/src/fidelity.rs)
+
+```rust
+/// Configuration for the heuristic fidelity scorer.
+///
+/// All weight fields must be positive. Weights are normalized at runtime by
+/// the sum of active weights (INV-05).
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct FidelityConfig {
+    /// Master switch. When false, no fidelity scoring occurs.
+    pub enabled: bool,
+    /// Cosine/keyword semantic relevance weight.
+    pub w_semantic: f32,
+    /// Recency weight.
+    pub w_temporal: f32,
+    /// Role-based importance weight.
+    pub w_importance: f32,
+    /// Plan-hint relevance weight (active only when `planned_tools` non-empty).
+    pub w_plan: f32,
+    /// Score threshold above which a message retains Full fidelity.
+    pub full_threshold: f32,
+    /// Score threshold above which a message is Compressed (not Placeholder).
+    pub compressed_threshold: f32,
+    /// Maximum tokens kept when rendering a Compressed message.
+    pub compressed_max_tokens: usize,
+    /// Budget ratio at which AgeMem triggers a proactive regrade.
+    pub regrade_threshold: f32,
+    /// Minimum query length for semantic signal to be active.
+    pub min_query_length: usize,
+    /// Maximum number of messages scored per turn (performance cap).
+    pub max_scored_messages: usize,
+}
+```
+
+### 4.4 FidelityScore (internal, zeph-context/src/fidelity.rs)
+
+Internal struct, not exposed outside `zeph-context`:
+
+```rust
+struct FidelityScore {
+    /// Normalized composite score in [0.0, 1.0].
+    score: f32,
+    /// Resolved fidelity level after threshold comparison.
+    level: ContextFidelity,
+    /// Original token count (before rendering).
+    original_tokens: u32,
+}
+```
+
+---
+
+## 5. Data Flow
+
+```
+User message arrives
+        |
+        v
+ContextService::prepare_context()   [zeph-agent-context/service.rs]
+  │
+  ├─ 1. Remove stale injected messages (existing)
+  │
+  ├─ 2. Build ContextAssemblyInput
+  │      ├─ existing fields
+  │      ├─ NEW: planned_next_tools: &[PlannedToolHint]   (empty slice if no DAG)
+  │      └─ NEW: fidelity_config: Option<&FidelityConfig> (None if disabled)
+  │
+  ├─ 3. ContextAssembler::gather(&input) -> PreparedContext (existing)
+  │
+  ├─ 4. apply_prepared_context() (existing)           ← returns (ContextDelta, usize)
+  │      ├─ inserts memory messages at position 1      │
+  │      ├─ sanitizes each via sanitize_memory_message │
+  │      ├─ runs trim_messages_to_budget()             │
+  │      ├─ runs credential scrubbing                  │
+  │      └─ calls recompute_prompt_tokens()            │
+  │                                                    └─ inserted_count (computed
+  │                                                       incrementally, not hardcoded)
+  │
+  └─ 5. [NEW] Fidelity scoring (AFTER apply_prepared_context)
+         │
+         ├─ Guard: skip if memory_first == true         (INV-11)
+         ├─ Guard: skip if fidelity_config is None
+         │
+         └─ FidelityScorer::score_and_apply(
+               messages: &mut [Message],
+               query: &str,
+               planned_tools: &[PlannedToolHint],
+               config: &FidelityConfig,
+               tc: &dyn TokenCounting,
+               inserted_count: usize,          ← exempt range [1..1+inserted_count]
+             )
+               │
+               ├─ a. Build exempt set (INV-07 through INV-10)
+               │
+               ├─ b. Score each non-exempt message
+               │      ├─ temporal = 1.0 - distance_from_end / max_dist
+               │      ├─ importance = role_weight(role)
+               │      │   [System=1.0, User=0.8, Assistant=0.6, ToolResult=0.4]
+               │      ├─ semantic = keyword_overlap(content, query)
+               │      │   (set 0.0 when query.len() < min_query_length — INV-05/D7)
+               │      └─ plan = plan_relevance(content, planned_tools)
+               │              (0.0 when hints empty)
+               │
+               ├─ c. Normalize by active weight sum (INV-05)
+               │
+               ├─ d. Resolve fidelity level from thresholds
+               │
+               ├─ e. Apply tool pair atomicity (INV-03)
+               │      └─ Assign MINIMUM fidelity of each tool-use/tool-result pair
+               │
+               ├─ f. Apply fidelity rendering (INV-12)
+               │      ├─ Compressed: truncate to compressed_max_tokens (primary)
+               │      │              OR replace with deferred_summary (if Some)
+               │      │              THEN clear msg.parts
+               │      └─ Placeholder: replace content with placeholder tag
+               │                      THEN clear msg.parts
+               │                      Token count: tc.count_tokens() on rendered string
+               │
+               ├─ g. Consecutive same-role Placeholder merge (INV-04)
+               │
+               └─ h. recompute_prompt_tokens()
+
+        Return ContextDelta (existing)
+```
+
+### 5.1 AgeMem Proactive Regrade Trigger
+
+```
+ContextService::maybe_compact()   [called from agent loop]
+  │
+  ├─ Guard 1: if regraded_this_turn → skip          (INV-06)
+  ├─ Guard 2: if compaction_state.is_exhausted() → skip
+  ├─ Guard 3: if server_compaction_active && budget_used < 95% → skip
+  │
+  ├─ Trigger: budget_used_ratio > regrade_threshold (default 0.6)
+  │           task_horizon_estimate = 1.0 (constant in MVP, see §7)
+  │
+  ├─ Action: re-run FidelityScorer on current window
+  │          set regraded_this_turn = true
+  │          recompute_prompt_tokens()
+  │          emit tracing::info! with fidelity distribution
+  │
+  └─ advance_turn(): regraded_this_turn = false
+```
+
+---
+
+## 6. Scoring Rules
+
+### 6.1 Weight Normalization (INV-05)
+
+```
+active_weights = [w_semantic, w_temporal, w_importance]
+if !planned_tools.is_empty():
+    active_weights.push(w_plan)
+if query.len() < min_query_length:
+    remove w_semantic from active_weights
+
+raw_score = Σ(weight_i × signal_i for each active signal)
+normalized_score = raw_score / Σ(active_weights)
+```
+
+Scores always range `[0.0, 1.0]` regardless of which signals are active.
+
+### 6.2 Role Weights
+
+| Role | Weight |
+|---|---|
+| System | 1.0 |
+| User | 0.8 |
+| Assistant | 0.6 |
+| ToolResult | 0.4 |
+
+### 6.3 Performance Invariant
+
+Heuristic scoring MUST complete in `<2ms` for windows up to `max_scored_messages` (default 500) messages. For windows exceeding `max_scored_messages`, score only the oldest `window_len - 250` messages; the newest 250 default to `Full`. This caps O(N) work at `max_scored_messages` regardless of window size.
+
+---
+
+## 7. Fidelity Application Rules
+
+### 7.1 Compressed Rendering
+
+1. **Primary path**: truncate `msg.content` to first `compressed_max_tokens` tokens using `tc.count_tokens()`.
+2. **Optimization path**: if `msg.metadata.deferred_summary` is `Some(summary)`, replace content with `summary` instead of truncating.
+3. Clear `msg.parts` (INV-12).
+4. Set `msg.metadata.fidelity_tag = Some(ContextFidelity::Compressed)`.
+
+### 7.2 Placeholder Rendering
+
+1. Replace `msg.content` with `[placeholder: role={role}, original_tokens={n}, importance={score:.2}]`.
+2. Clear `msg.parts` (INV-12).
+3. Set `msg.metadata.fidelity_tag = Some(ContextFidelity::Placeholder)`.
+4. Token count: call `tc.count_tokens()` on the rendered string (not a constant).
+
+### 7.3 Tool Pair Atomicity (INV-03)
+
+Identify tool-use/tool-result pairs by matching `tool_call_id`. Both messages in a pair receive the **minimum** fidelity of their two individual scores. This is an O(N) backward scan. Both downgrade together or neither does.
+
+### 7.4 Consecutive Same-Role Placeholder Merge (INV-04)
+
+After fidelity application, scan for adjacent same-role Placeholder messages (excluding `Role::System`). Merge them into a single message:
+
+```
+[placeholder: {count} messages, role={role}, total_tokens={sum}, avg_importance={avg:.2}]
+```
+
+This pass applies ONLY to Placeholder messages. Full and Compressed messages retain their individual identity even if consecutive same-role.
+
+### 7.5 Exempt Message Set
+
+Never downgraded (INV-07 through INV-10):
+
+1. System prompt at index 0.
+2. Messages with `metadata.focus_pinned == true`.
+3. Correction messages (content starts with `CORRECTIONS_PREFIX`).
+4. Messages at indices `1..1+inserted_count` (freshly injected memory context).
+
+---
+
+## 8. Configuration
+
+### 8.1 Config Section ([context.fidelity])
+
+```toml
+[context.fidelity]
+enabled = false                 # off by default for v0.21
+w_semantic = 0.3
+w_temporal = 0.3
+w_importance = 0.2
+w_plan = 0.2
+full_threshold = 0.7
+compressed_threshold = 0.3
+compressed_max_tokens = 50      # tokens kept for Compressed rendering
+regrade_threshold = 0.6         # AgeMem proactive trigger budget ratio
+min_query_length = 8            # below this, semantic signal is zeroed
+max_scored_messages = 500       # performance cap
+```
+
+### 8.2 Tuning Note
+
+`compressed_max_tokens = 50` may be aggressive for tool-result messages that commonly exceed 1000 tokens. This default is deliberately conservative for the MVP; adjustment based on live testing is expected post-merge. (Critic note N3.)
+
+---
+
+## 9. Integration Points
+
+### 9.1 ContextAssemblyInput (zeph-context/src/input.rs)
+
+```rust
+pub planned_next_tools: &'a [PlannedToolHint],
+pub fidelity_config: Option<&'a FidelityConfig>,
+```
+
+Default (empty): `planned_next_tools = &[]`, `fidelity_config = None`.
+
+### 9.2 ContextManager (zeph-context/src/manager.rs)
+
+```rust
+pub(crate) regraded_this_turn: bool   // reset in advance_turn()
+
+pub fn should_proactively_regrade(&self, cached_tokens: u64) -> bool
+```
+
+`advance_turn()` must set `self.regraded_this_turn = false`.
+
+### 9.3 apply_prepared_context Return Value
+
+```rust
+async fn apply_prepared_context(...) -> (ContextDelta, usize)
+//                                                    ^^^^^
+//                                          inserted_count — computed
+//                                          incrementally across all
+//                                          insertion paths (graph_facts,
+//                                          doc_rag, corrections, recall,
+//                                          cross_session, summaries,
+//                                          persona, trajectory, tree,
+//                                          reasoning, code_context,
+//                                          session_digest)
+```
+
+The count MUST be computed incrementally per insertion, not hardcoded as a constant.
+
+### 9.4 CompactionState (unchanged)
+
+No new variants. Regrade uses `regraded_this_turn: bool`, not the compaction FSM. This keeps the state machine clean.
+
+### 9.5 compact_context (zeph-agent-context/summarization/compaction.rs)
+
+The message selection loop building summarization input MUST skip messages where `metadata.fidelity_tag == Some(ContextFidelity::Placeholder)`. These messages carry no semantic content (INV-02). Compressed messages (`fidelity_tag == Some(Compressed)`) MAY be summarized.
+
+### 9.6 MessageMetadata (zeph-llm)
+
+```rust
+pub fidelity_tag: Option<ContextFidelity>
+```
+
+Used for: debug tracing, compaction input filtering. NOT used for rendering decisions at the LLM layer.
+
+### 9.7 Tracing Spans
+
+| Span | Location | Captures |
+|---|---|---|
+| `context.fidelity.score` | `FidelityScorer::score_and_apply` | `{message_count, query_len}` |
+| `context.fidelity.apply` | Rendering pass | `{full_count, compressed_count, placeholder_count, tokens_saved}` |
+| `context.fidelity.regrade` | Proactive regrade trigger | `{budget_ratio, fidelity_distribution}` |
+| `context.fidelity.merge` | Same-role merge pass | `{merged_count}` |
+
+All spans follow the `<crate_short>.<subsystem>.<operation>` naming convention (per continuous-improvement spec).
+
+### 9.8 TUI
+
+A spinner MUST be displayed during fidelity scoring (per TUI rule: any background operation must have a visible system status indicator). Message: `Scoring context fidelity…`
+
+---
+
+## 10. MVP Scope vs. Deferred
+
+### v0.21 MVP (implement)
+
+| Feature | Issue | Deliverable |
+|---|---|---|
+| `ContextFidelity` enum | #4017 | 3 variants in `zeph-common/src/fidelity.rs` |
+| `PlannedToolHint` struct | #4018 | Data struct in `zeph-common/src/fidelity.rs` |
+| `FidelityConfig` | #4017 | Config struct in `zeph-context/src/fidelity.rs` |
+| `FidelityScorer` | #4017 | Heuristic scorer with weight normalization |
+| Tool pair atomic downgrade | #4017 | Paired scoring in `FidelityScorer` (INV-03) |
+| Consecutive same-role merger | #4017 | Post-fidelity pass (INV-04) |
+| Fidelity-aware assembly | #4017 | `score_and_apply()` after `apply_prepared_context()` (INV-01) |
+| Proactive regrade trigger | #4016 | `should_proactively_regrade()` with `regraded_this_turn` guard (INV-06) |
+| Hard compaction Placeholder exclusion | #4016 | Skip Placeholder in summarizer input (INV-02) |
+| Config section | all | `[context.fidelity]` with all weights, thresholds, feature gate |
+| Short query fallback | #4017 | `min_query_length` gate on semantic signal |
+| Tracing instrumentation | all | 4 spans per §9.7 |
+| `fidelity_tag` in MessageMetadata | #4017 | `Option<ContextFidelity>` field |
+| TUI spinner | all | Spinner during scoring |
+
+### Spec-Only (Deferred Implementation)
+
+| Feature | Reason | Expected Phase |
+|---|---|---|
+| RL-based trigger threshold | No training infrastructure | post-v1.0 |
+| Embedding-based scoring | Per-message embedding too expensive for hot path | post-v1.0 |
+| Orchestration DAG live wiring | Requires `zeph-orchestration` API changes | P2 |
+| Fidelity state persistence to SQLite | Per-turn recompute sufficient for MVP | P2 |
+| Dynamic weight adaptation | Post-v1.0 | post-v1.0 |
+| LLM-compressed fidelity | MVP uses truncation | P2 |
+
+---
+
+## 11. Acceptance Criteria
+
+| AC | Criterion | Verifiable By |
+|---|---|---|
+| AC-01 | `cargo nextest run -p zeph-context -E 'test(fidelity)'` passes with ≥ 10 test cases covering: empty window, all-exempt window, tool pair atomicity, same-role merge, score normalization, short query fallback, MemoryFirst bypass | Unit tests |
+| AC-02 | Fidelity scoring does not run before `apply_prepared_context()` completes | Code inspection (call site ordering) |
+| AC-03 | Score for any message is always in `[0.0, 1.0]` regardless of active signal subset | Unit test: property test with all combinations of empty query, empty tool hints, zero weights |
+| AC-04 | Tool-use message and its tool-result always share the same fidelity level | Unit test: construct paired messages with divergent raw scores, verify min(a, b) applied |
+| AC-05 | No consecutive same-role Placeholder messages in the final window | Unit test: input with 5 consecutive assistant messages all scoring below threshold |
+| AC-06 | `compact_context` input never contains Placeholder-tagged messages | Unit test: seed window with Placeholder messages, assert none in summarizer input |
+| AC-07 | `regraded_this_turn` resets to `false` after `advance_turn()` | Unit test |
+| AC-08 | Proactive regrade does not fire twice in the same turn | Unit test: call `maybe_compact()` twice at 70% budget, assert regrade fires once |
+| AC-09 | Fidelity scoring skipped when `memory_first == true` | Unit test |
+| AC-10 | `enabled = false` in config disables all fidelity scoring without panics | Integration test with default config |
+| AC-11 | Scoring ≤ 500 messages completes in < 2ms (measured via tracing span) | Benchmark in `zeph-bench` |
+| AC-12 | `inserted_count` includes all message types inserted by `apply_prepared_context` (not hardcoded) | Code inspection + unit test with mock insertion counting |
+
+---
+
+## 12. Open Questions
+
+All open questions from the architect review are resolved. No remaining open questions.
+
+| Question | Resolution |
+|---|---|
+| Dependency cycle for ContextFidelity | Placed in `zeph-common` (both `zeph-llm` and `zeph-context` already depend on it) |
+| Token count for Placeholder | `tc.count_tokens()` on rendered string, not a constant |
+| task_horizon_estimate source | Always `1.0` in MVP; RL pipeline deferred |
+| MemoryFirst interaction | Skip scoring entirely when `memory_first == true` |
+| Short query handling | Set `w_semantic = 0.0`, exclude from active_weight_sum |
+| CompactionState changes | None — regrade uses a simple `bool` field |
+| Deferred summary availability | Truncation is primary path; deferred_summary is optimization |
+| `focus_pinned` vs. `pinned` | Use existing `metadata.focus_pinned` field |
+| `compressed_max_tokens` for tool results | Post-merge tuning concern; default 50 is conservative |
+| `inserted_count` computation | Incremental across all insertion paths in `apply_prepared_context` |

--- a/specs/062-context-adaptive-memory/srs.md
+++ b/specs/062-context-adaptive-memory/srs.md
@@ -1,0 +1,162 @@
+---
+aliases:
+  - CAM SRS
+tags:
+  - srs
+  - context
+  - memory
+created: 2026-05-28
+status: approved
+related:
+  - "[[062-context-adaptive-memory/spec]]"
+  - "[[062-context-adaptive-memory/brd]]"
+standard: "ISO/IEC/IEEE 29148:2018"
+---
+
+# Context-Adaptive Memory — Software Requirements Specification
+
+## 1. Functional Requirements
+
+Requirements use EARS notation: `WHEN <condition>, THE SYSTEM SHALL <action>`.
+
+### 1.1 Fidelity Levels (AFM #4017)
+
+**FR-001** — The system SHALL provide a `ContextFidelity` enum with exactly three variants: `Full`, `Compressed`, `Placeholder`.
+
+**FR-002** — WHEN a message receives `Compressed` fidelity, the system SHALL replace its content with at most `compressed_max_tokens` tokens from the original content (primary path), OR with the value of `metadata.deferred_summary` when that field is `Some` (optimization path).
+
+**FR-003** — WHEN a message receives `Placeholder` fidelity, the system SHALL replace its content with the string `[placeholder: role={role}, original_tokens={n}, importance={score:.2}]`.
+
+**FR-004** — WHEN either `Compressed` or `Placeholder` fidelity is applied, the system SHALL clear `msg.parts` on the affected message.
+
+**FR-005** — The system SHALL set `msg.metadata.fidelity_tag` to the resolved `ContextFidelity` value after rendering, for tracing and compaction input filtering.
+
+### 1.2 Fidelity Scorer (AFM #4017)
+
+**FR-006** — WHEN `fidelity_config.enabled == true` AND `memory_first == false`, the system SHALL run `FidelityScorer::score_and_apply()` on the context window AFTER `apply_prepared_context()` returns.
+
+**FR-007** — The scorer SHALL compute a relevance score for each non-exempt message using up to four signals: `temporal`, `importance`, `semantic`, `plan`.
+
+**FR-008** — WHEN `planned_tools` is empty, the system SHALL exclude the `w_plan` weight from both the numerator and denominator of the score computation.
+
+**FR-009** — WHEN `query.len() < min_query_length`, the system SHALL set `semantic = 0.0` and exclude `w_semantic` from the active weight sum.
+
+**FR-010** — The system SHALL normalize the composite score by the sum of active weights, ensuring all scores fall in `[0.0, 1.0]`.
+
+**FR-011** — WHEN a message's normalized score is ≥ `full_threshold`, the system SHALL assign it `Full` fidelity.
+
+**FR-012** — WHEN a message's normalized score is ≥ `compressed_threshold` AND < `full_threshold`, the system SHALL assign it `Compressed` fidelity.
+
+**FR-013** — WHEN a message's normalized score is < `compressed_threshold`, the system SHALL assign it `Placeholder` fidelity.
+
+**FR-014** — WHEN `fidelity_config.enabled == false` OR `fidelity_config` is absent, the system SHALL NOT perform any fidelity scoring or modification.
+
+### 1.3 Exempt Message Set (AFM #4017)
+
+**FR-015** — The system SHALL NEVER apply fidelity downgrade to the system prompt at index 0.
+
+**FR-016** — The system SHALL NEVER apply fidelity downgrade to messages where `metadata.focus_pinned == true`.
+
+**FR-017** — The system SHALL NEVER apply fidelity downgrade to correction messages (messages whose content starts with `CORRECTIONS_PREFIX`).
+
+**FR-018** — The system SHALL NEVER apply fidelity downgrade to messages inserted by `apply_prepared_context()` in the current turn. The boundary is defined by `inserted_count` returned from that function.
+
+**FR-019** — `inserted_count` SHALL be computed incrementally across all message insertion paths within `apply_prepared_context()`, not hardcoded as a constant.
+
+### 1.4 Tool Pair Atomicity (AFM #4017)
+
+**FR-020** — WHEN scoring a tool-use message, the system SHALL identify its matching tool-result message by `tool_call_id`.
+
+**FR-021** — The system SHALL assign both the tool-use and its tool-result the MINIMUM fidelity level of their two individual scores.
+
+**FR-022** — Tool-use and tool-result messages SHALL downgrade together or not at all.
+
+### 1.5 Consecutive Same-Role Merge (AFM #4017)
+
+**FR-023** — AFTER fidelity rendering, the system SHALL scan for adjacent Placeholder messages with the same role (excluding `Role::System`).
+
+**FR-024** — WHEN two or more adjacent same-role Placeholder messages are found, the system SHALL merge them into a single message with content: `[placeholder: {count} messages, role={role}, total_tokens={sum}, avg_importance={avg:.2}]`.
+
+**FR-025** — Full and Compressed messages SHALL NOT be merged even if they share the same role in adjacent positions.
+
+### 1.6 Proactive Regrade Trigger (AgeMem #4016)
+
+**FR-026** — WHEN `budget_used_ratio > regrade_threshold` AND `regraded_this_turn == false` AND `compaction_state.is_exhausted() == false`, the system SHALL run a proactive fidelity regrade on the current context window.
+
+**FR-027** — WHEN a proactive regrade fires, the system SHALL set `regraded_this_turn = true` and emit a `tracing::info!` event with fidelity distribution counters.
+
+**FR-028** — The system SHALL reset `regraded_this_turn = false` in `advance_turn()`.
+
+**FR-029** — WHEN `server_compaction_active == true` AND `budget_used < 95%`, the system SHALL skip the proactive regrade.
+
+**FR-030** — A proactive regrade SHALL NOT set `CompactedThisTurn`. Soft and hard compaction MAY still fire after a regrade.
+
+### 1.7 Hard Compaction Placeholder Exclusion (AgeMem #4016)
+
+**FR-031** — WHEN `compact_context()` builds its summarizer input, the system SHALL skip all messages where `metadata.fidelity_tag == Some(ContextFidelity::Placeholder)`.
+
+**FR-032** — Messages with `metadata.fidelity_tag == Some(ContextFidelity::Compressed)` MAY be included in summarizer input.
+
+### 1.8 Plan-Aware Hints (PAACE #4018)
+
+**FR-033** — The system SHALL provide a `PlannedToolHint` struct with fields: `tool_name: String`, `keywords: Vec<String>`, `distance_from_current: u8` (capped at 5).
+
+**FR-034** — WHEN `planned_next_tools` is non-empty, the system SHALL compute `plan_relevance` as a keyword overlap score between message content and the tool hints, weighted by inverse distance.
+
+**FR-035** — `ContextAssemblyInput` SHALL include a `planned_next_tools: &[PlannedToolHint]` field. When no orchestration DAG is active, this field SHALL default to an empty slice.
+
+---
+
+## 2. Non-Functional Requirements
+
+### 2.1 Performance
+
+**NFR-P01** — Fidelity scoring for ≤ 500 messages SHALL complete in < 2ms wall time (measured via `context.fidelity.score` tracing span).
+
+**NFR-P02** — WHEN the context window exceeds `max_scored_messages` (default 500) messages, the system SHALL score only the oldest `window_len - 250` messages; the newest 250 default to `Full`. This bounds scoring work at O(`max_scored_messages`).
+
+**NFR-P03** — Fidelity scoring SHALL NOT make any I/O calls, LLM calls, or embedding lookups. It is a pure CPU-bound operation.
+
+### 2.2 Backward Compatibility
+
+**NFR-B01** — WHEN `context.fidelity.enabled = false` (default), the system SHALL produce identical behavior to the pre-CAM implementation. No existing session, test, or integration SHALL be affected.
+
+**NFR-B02** — Adding `fidelity_tag: Option<ContextFidelity>` to `MessageMetadata` SHALL default to `None`. Existing serialized sessions SHALL deserialize without error (serde `default` attribute required).
+
+### 2.3 Observability
+
+**NFR-O01** — The system SHALL emit four tracing spans per turn when fidelity scoring is active: `context.fidelity.score`, `context.fidelity.apply`, `context.fidelity.regrade`, `context.fidelity.merge`.
+
+**NFR-O02** — Each `context.fidelity.apply` span SHALL record: `full_count`, `compressed_count`, `placeholder_count`, `tokens_saved`.
+
+### 2.4 Maintainability
+
+**NFR-M01** — `FidelityScorer` SHALL have ≥ 10 unit tests covering the cases listed in AC-01 (spec.md §11).
+
+**NFR-M02** — All public types in `zeph-common/src/fidelity.rs` and `zeph-context/src/fidelity.rs` SHALL have doc comments with `# Examples` sections per project API documentation rules.
+
+### 2.5 Dependency Constraint
+
+**NFR-D01** — `ContextFidelity` and `PlannedToolHint` SHALL be defined in `zeph-common` to avoid a dependency cycle between `zeph-context` and `zeph-llm`.
+
+**NFR-D02** — `MessageMetadata.fidelity_tag` SHALL use `Option<ContextFidelity>` directly (not `Option<u8>`) since `zeph-llm` already depends on `zeph-common`.
+
+---
+
+## 3. Traceability
+
+| FR / NFR | BRD Requirement | Spec Section |
+|---|---|---|
+| FR-001 through FR-013 | Token reduction; preserved structural history | spec.md §4, §6, §7 |
+| FR-014 | No behavioral regression | spec.md §10 |
+| FR-015 through FR-019 | Preserved structural history | spec.md §7.5 |
+| FR-020 through FR-022 | No LLM API contract breakage | spec.md INV-03, §7.3 |
+| FR-023 through FR-025 | No LLM API contract breakage | spec.md INV-04, §7.4 |
+| FR-026 through FR-030 | Fewer context reloads | spec.md §5.1 |
+| FR-031 through FR-032 | Quality of compaction summaries | spec.md INV-02 |
+| FR-033 through FR-035 | Foundation for PAACE scoring | spec.md §4.2 |
+| NFR-P01 through NFR-P03 | Latency constraint < 2ms | spec.md §6.3, AC-11 |
+| NFR-B01 through NFR-B02 | No behavioral regression | spec.md §10 |
+| NFR-O01 through NFR-O02 | Observability requirement | spec.md §9.7 |
+| NFR-M01 through NFR-M02 | Quality gates | spec.md §11 |
+| NFR-D01 through NFR-D02 | Clean architecture | spec.md §3 |

--- a/specs/062-context-adaptive-memory/tasks.md
+++ b/specs/062-context-adaptive-memory/tasks.md
@@ -1,0 +1,257 @@
+---
+aliases:
+  - CAM Tasks
+tags:
+  - tasks
+  - context
+  - memory
+created: 2026-05-28
+status: approved
+related:
+  - "[[062-context-adaptive-memory/plan]]"
+  - "[[062-context-adaptive-memory/spec]]"
+---
+
+# Context-Adaptive Memory — Implementation Tasks
+
+Tasks follow plan.md step order. Each task is self-contained and assignable to a single developer session.
+
+---
+
+## T-01 — Add ContextFidelity and PlannedToolHint to zeph-common
+
+**Crate**: `zeph-common`
+**Files**: `crates/zeph-common/src/fidelity.rs` (new), `crates/zeph-common/src/lib.rs`
+
+**Specification reference**: spec.md §4.1, §4.2; srs.md FR-001, FR-033; NFR-D01
+
+**Acceptance**:
+- `ContextFidelity` enum with `Full=0`, `Compressed=1`, `Placeholder=2`, `#[repr(u8)]`, `Default=Full`
+- `PlannedToolHint` struct with `tool_name: String`, `keywords: Vec<String>`, `distance_from_current: u8`
+- Both types: `Debug`, `Clone`, `PartialEq` (Eq for ContextFidelity), `serde::Serialize + Deserialize`
+- Public re-export from `crates/zeph-common/src/lib.rs`
+- Doc comments with `/// # Examples` and passing doc-tests
+- `cargo nextest run -p zeph-common --doc` passes
+- `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-common` passes
+
+**Blocked by**: nothing
+
+---
+
+## T-02 — Add fidelity_tag to MessageMetadata in zeph-llm
+
+**Crate**: `zeph-llm`
+**Files**: wherever `MessageMetadata` is defined (find with `grep -r "MessageMetadata" crates/zeph-llm/`)
+
+**Specification reference**: spec.md §9.6; srs.md NFR-D02, NFR-B02
+
+**Acceptance**:
+- `pub fidelity_tag: Option<ContextFidelity>` field added
+- `#[serde(default)]` attribute present so existing sessions deserialize without error
+- Verify `zeph-llm/Cargo.toml` has `zeph-common.workspace = true`; add if missing
+- No behavior change — field starts as `None` in all construction sites
+- `cargo nextest run -p zeph-llm` passes
+
+**Blocked by**: T-01
+
+---
+
+## T-03 — Implement FidelityConfig and FidelityScorer in zeph-context
+
+**Crate**: `zeph-context`
+**Files**: `crates/zeph-context/src/fidelity.rs` (new), `crates/zeph-context/src/lib.rs`
+
+**Specification reference**: spec.md §4.3, §4.4, §5, §6, §7; srs.md FR-002 through FR-025, FR-034; AC-01 through AC-05
+
+**Acceptance**:
+- `FidelityConfig` struct with all fields from spec.md §8.1, `serde::Deserialize`, `#[serde(default)]` on all fields
+- `FidelityScorer` (stateless struct) with method:
+  ```rust
+  pub fn score_and_apply(
+      &self,
+      messages: &mut Vec<Message>,
+      query: &str,
+      planned_tools: &[PlannedToolHint],
+      config: &FidelityConfig,
+      tc: &dyn TokenCounting,
+      inserted_count: usize,
+  )
+  ```
+- Implements: weight normalization (INV-05), short query fallback (FR-009), tool pair atomicity (INV-03), consecutive same-role merge (INV-04), exempt message set (FR-015 through FR-018)
+- Tracing spans: `context.fidelity.score`, `context.fidelity.apply`, `context.fidelity.merge`
+- All scores in `[0.0, 1.0]` (property: tested with extreme inputs)
+- Unit test module with ≥ 10 tests covering AC-01 cases:
+  - Empty window → no change
+  - All-exempt window → no downgrade
+  - Tool pair atomicity (divergent scores → min applied)
+  - Same-role merge (5 consecutive assistant Placeholder → merged to 1)
+  - Score normalization (all signal subsets)
+  - Short query fallback (`query.len() < 8`)
+  - MemoryFirst bypass (guard tested)
+  - `enabled = false` guard
+  - Token count uses `tc.count_tokens()` for Placeholder rendering
+  - Compressed rendering: truncation primary, `deferred_summary` optimization
+- `cargo nextest run -p zeph-context -E 'test(fidelity)'` passes
+
+**Blocked by**: T-01, T-02
+
+---
+
+## T-04 — Extend ContextAssemblyInput in zeph-context
+
+**Crate**: `zeph-context`
+**Files**: `crates/zeph-context/src/input.rs`
+
+**Specification reference**: spec.md §9.1; srs.md FR-035
+
+**Acceptance**:
+- Two new fields added to `ContextAssemblyInput`:
+  ```rust
+  pub planned_next_tools: &'a [PlannedToolHint],
+  pub fidelity_config: Option<&'a FidelityConfig>,
+  ```
+- All existing construction sites updated to pass `planned_next_tools: &[]` and `fidelity_config: None`
+- No functional change when both fields are at their defaults
+- `cargo nextest run --workspace --lib --bins` passes
+
+**Blocked by**: T-01, T-03
+
+---
+
+## T-05 — Add proactive regrade support to ContextManager
+
+**Crate**: `zeph-context`
+**Files**: `crates/zeph-context/src/manager.rs`
+
+**Specification reference**: spec.md §5.1, §9.2; srs.md FR-026 through FR-030; AC-07, AC-08
+
+**Acceptance**:
+- Field `pub(crate) regraded_this_turn: bool` added, initialized to `false`
+- Method implemented:
+  ```rust
+  pub fn should_proactively_regrade(&self, cached_tokens: u64) -> bool
+  ```
+  Implements full guard chain: `regraded_this_turn`, `is_exhausted()`, `server_compaction_active` at 95%
+- `advance_turn()` resets `regraded_this_turn = false`
+- Unit tests for AC-07 and AC-08
+- `cargo nextest run -p zeph-context` passes
+
+**Blocked by**: T-01
+
+---
+
+## T-06 — Wire fidelity scoring in zeph-agent-context service
+
+**Crate**: `zeph-agent-context`
+**Files**: `crates/zeph-agent-context/src/service.rs`
+
+**Specification reference**: spec.md §5, §9.3; srs.md FR-006, FR-014, FR-019; INV-01; AC-02
+
+**Acceptance**:
+- `apply_prepared_context()` return type changed to `(ContextDelta, usize)`
+- `inserted_count` computed incrementally across ALL insertion paths (graph_facts, doc_rag, corrections, recall, cross_session, summaries, persona, trajectory, tree, reasoning, code_context, session_digest) — not hardcoded
+- After `apply_prepared_context()` returns, call `FidelityScorer::score_and_apply()` when:
+  - `fidelity_config.enabled == true`
+  - `memory_first == false`
+- TUI status emitted before scorer: `send_status("Scoring context fidelity…")`
+- Unit test: mock `apply_prepared_context` with known insertion count, verify exempt set built correctly (AC-12)
+- `cargo nextest run -p zeph-agent-context` passes
+
+**Blocked by**: T-03, T-04, T-05
+
+---
+
+## T-07 — Wire proactive regrade trigger in summarization scheduling
+
+**Crate**: `zeph-agent-context`
+**Files**: `crates/zeph-agent-context/src/summarization/scheduling.rs`
+
+**Specification reference**: spec.md §5.1; srs.md FR-026 through FR-030; INV-06; AC-08
+
+**Acceptance**:
+- In `maybe_compact()` (or equivalent), BEFORE tier dispatch, call `should_proactively_regrade()`
+- When trigger fires: re-run `FidelityScorer::score_and_apply()`, set `regraded_this_turn = true`, call `recompute_prompt_tokens()`
+- Does NOT set `CompactedThisTurn`
+- Tracing span: `context.fidelity.regrade` emitted with `{budget_ratio, full_count, compressed_count, placeholder_count}`
+- Unit test: AC-08 (double-regrade prevention)
+- `cargo nextest run -p zeph-agent-context` passes
+
+**Blocked by**: T-05, T-06
+
+---
+
+## T-08 — Exclude Placeholder messages from hard compaction
+
+**Crate**: `zeph-agent-context`
+**Files**: `crates/zeph-agent-context/src/summarization/compaction.rs`
+
+**Specification reference**: spec.md §9.5; srs.md FR-031, FR-032; INV-02; AC-06
+
+**Acceptance**:
+- Message selection loop skips messages where `metadata.fidelity_tag == Some(ContextFidelity::Placeholder)`
+- Compressed messages are NOT skipped
+- Unit test: AC-06 (seed window with Placeholder messages, assert none in summarizer input)
+- `cargo nextest run -p zeph-agent-context` passes
+
+**Blocked by**: T-02, T-06
+
+---
+
+## T-09 — Config integration
+
+**Crates**: `zeph-config`, `zeph-core`
+**Files**: config type definitions, `--init` wizard, `--migrate-config`
+
+**Specification reference**: spec.md §8; plan.md Step 9
+
+**Acceptance**:
+- `[context.fidelity]` config section accepted by `zeph-config`
+- All fields default to spec.md §8.1 values
+- `enabled = false` by default
+- `--init` wizard includes `context.fidelity.enabled` prompt
+- `.local/config/testing.toml` updated with commented-out `[context.fidelity]` example
+- `cargo nextest run -p zeph-config` passes
+
+**Blocked by**: T-03
+
+---
+
+## T-10 — Testing, benchmark, and playbook
+
+**Crates**: `zeph-bench`, documentation
+**Files**: `.local/testing/playbooks/context-adaptive-memory.md`, `.local/testing/coverage-status.md`
+
+**Specification reference**: spec.md §11 AC-01 through AC-12; plan.md Step 10; NFR-P01 (AC-11)
+
+**Acceptance**:
+- Benchmark in `zeph-bench` for AC-11: scoring 500 messages < 2ms
+- Live test playbook created at `.local/testing/playbooks/context-adaptive-memory.md`:
+  - Test scenario 1: enable CAM, run 30-turn session, verify no mid-task blowout
+  - Test scenario 2: verify token reduction vs. baseline without CAM
+  - Test scenario 3: verify `enabled = false` produces identical behavior
+  - Edge cases: tool-heavy sessions, very short queries, MemoryFirst mode
+- Integration test verifies correct behavior when `enabled = false` (feature disabled path, AC-10)
+- Coverage status rows added to `.local/testing/coverage-status.md` with status `Untested` for:
+  - `FidelityScorer` (zeph-context)
+  - `AgeMem proactive regrade` (zeph-agent-context)
+  - `Placeholder exclusion in compaction` (zeph-agent-context)
+  - `PAACE plan hints` (zeph-context)
+
+**Blocked by**: T-06, T-07, T-08
+
+---
+
+## Summary Table
+
+| Task | Description | Blocked by | Crate |
+|---|---|---|---|
+| T-01 | ContextFidelity + PlannedToolHint types | — | zeph-common |
+| T-02 | MessageMetadata.fidelity_tag | T-01 | zeph-llm |
+| T-03 | FidelityConfig + FidelityScorer | T-01, T-02 | zeph-context |
+| T-04 | ContextAssemblyInput extension | T-01, T-03 | zeph-context |
+| T-05 | ContextManager regrade support | T-01 | zeph-context |
+| T-06 | Wire scoring in service.rs | T-03, T-04, T-05 | zeph-agent-context |
+| T-07 | Proactive regrade trigger | T-05, T-06 | zeph-agent-context |
+| T-08 | Placeholder exclusion in compaction | T-02, T-06 | zeph-agent-context |
+| T-09 | Config integration | T-03 | zeph-config |
+| T-10 | Benchmark + playbook | T-06, T-07, T-08 | zeph-bench + docs |

--- a/specs/README.md
+++ b/specs/README.md
@@ -44,6 +44,7 @@ Spec IDs (001–044) follow a logical grouping:
 - **052**: Gonka.ai Phase 2 — native network transport (GonkaProvider, ECDSA signing, EndpointPool, chat_with_tools, chat_typed) [implemented]
 - **053**: SpeculationEngine — speculative tool execution (SSE decoding path, PASTE skill activation, ToolStartEvent{speculative:true})
 - **055**: Cocoon distributed compute integration — CocoonProvider, CocoonClient, `zeph cocoon doctor`, TUI palette entries, vault key ZEPH_COCOON_ACCESS_HASH
+- **062**: Context-Adaptive Memory (CAM) — three-level fidelity (Full/Compressed/Placeholder), heuristic FidelityScorer, proactive AgeMem regrade, PlannedToolHint for PAACE; GitHub #4016, #4017, #4018
 
 ---
 
@@ -142,3 +143,4 @@ Spec IDs (001–044) follow a logical grouping:
 | `059-autoskill-bm25-hybrid/spec.md` | AutoSkill A4: wire existing `bm25.rs` into `SkillMatcher` with alpha-weighted fusion (`score = hybrid_alpha * cosine + (1-hybrid_alpha) * bm25_normalized`); BM25 index built at construction and rebuilt on hot-reload; `hybrid_alpha` config field; GitHub #4450 | `zeph-skills` |
 | `060-autoskill-trigger-sets/spec.md` | AutoSkill A5: embed `triggers` SKILL.md frontmatter entries as additional retrieval vectors; max-cosine aggregation across triggers; `trigger_weight` blends trigger and description scores; `max_triggers_per_skill` cap; in-memory only (v1); GitHub #4451 | `zeph-skills` |
 | `061-autoskill-heuristic-promotion/spec.md` | AutoSkill A6: periodic background job promotes ERL heuristics to quarantined SKILL.md drafts when heuristic count ≥ `heuristic_promotion_threshold`; LLM evaluates body-enrichment vs. new-skill vs. none; idempotency via `skill_heuristic_promotions` table; `heuristic_promotion_provider` config field; GitHub #4452 | `zeph-skills` |
+| `062-context-adaptive-memory/spec.md` | Context-Adaptive Memory (CAM): three-level fidelity (Full/Compressed/Placeholder), heuristic FidelityScorer, proactive AgeMem regrade trigger, PlannedToolHint struct for PAACE DAG lookahead; MVP: heuristic scoring only; GitHub #4016, #4017, #4018 | `zeph-common`, `zeph-context`, `zeph-agent-context` |


### PR DESCRIPTION
## Summary

Formal specification package for the Context-Adaptive Memory (CAM) subsystem, covering three research issues:

- **#4016** — AgeMem: RL-trained proactive summarization before context fills
- **#4017** — Adaptive Focus Memory: three-level fidelity (Full/Compressed/Placeholder)
- **#4018** — PAACE: plan-aware context engineering with next-k-task relevance modeling

The three approaches are unified into a single coherent subsystem. Spec produced via the spec-driven team-develop workflow (architect → critic → SDD → reviewer), with architect plan revised after SIGNIFICANT critic findings (S1-S4: index invalidation race, CompactionState underspec, LLM API contract violation, weight normalization).

## Spec package

`specs/062-context-adaptive-memory/`:
- `spec.md` — 12 invariants (INV-01..12), full data flow, scoring rules, fidelity application rules, 12 ACs
- `brd.md` — problem statement, 40–60% token reduction target, stakeholders
- `srs.md` — 35 FRs (EARS notation), 10 measurable NFRs
- `plan.md` — Phase 1 MVP + Phase 2 deferred + risk register
- `tasks.md` — 10 granular developer tasks (T-01..T-10)

## MVP scope (Phase 1, v0.21)

- `ContextFidelity { Full, Compressed, Placeholder }` enum in `zeph-common`
- Heuristic `FidelityScorer` in `zeph-context` (temporal decay + role importance + keyword overlap + plan relevance)
- Proactive regrade trigger at configurable budget threshold (`regraded_this_turn` re-entry guard)
- `PlannedToolHint` type in `ContextBuildRequest`
- Fidelity application in `assembler.rs` (AFTER `apply_prepared_context()`)

## Deferred (Phase 2)

- RL training pipeline (AgeMem full GRPO)
- Orchestration DAG wiring for PAACE lookahead
- Embedding-based semantic scoring
- Fidelity persistence across sessions

## Critical invariants

- **INV-01**: Fidelity scoring only after `apply_prepared_context()` returns (index invalidation prevention)
- **INV-02**: Placeholder messages excluded from hard compaction summarizer input
- **INV-03**: Tool-use/tool-result pairs downgrade atomically
- **INV-04**: No consecutive same-role Placeholder messages in final window
- **INV-05**: Fidelity scores normalized by sum of active weights
- **INV-06**: `regraded_this_turn` guard prevents double-regrade

## Test plan

- [ ] Spec files build without broken links
- [ ] Follow-up implementation issue created with spec reference
- [ ] Playbook added at `.local/testing/playbooks/context-adaptive-memory.md`
- [ ] Coverage-status rows added (5 new Untested rows)

Closes #4016
Closes #4017
Closes #4018