### PR TITLE
fix(sanitizer): add wildcard arms to non-exhaustive InjectionEnforcementMode match

### DIFF
--- a/crates/zeph-sanitizer/src/sanitizer.rs
+++ b/crates/zeph-sanitizer/src/sanitizer.rs
@@ -544,7 +544,7 @@ impl ContentSanitizer {
     fn regex_verdict(&self) -> InjectionVerdict {
         match self.enforcement_mode {
             zeph_config::InjectionEnforcementMode::Block => InjectionVerdict::Blocked,
-            zeph_config::InjectionEnforcementMode::Warn => InjectionVerdict::Suspicious,
+            _ => InjectionVerdict::Suspicious,
         }
     }
 
@@ -584,7 +584,7 @@ impl ContentSanitizer {
             // enforcement_mode determines whether hard threshold blocks or just warns
             match self.enforcement_mode {
                 zeph_config::InjectionEnforcementMode::Block => InjectionVerdict::Blocked,
-                zeph_config::InjectionEnforcementMode::Warn => InjectionVerdict::Suspicious,
+                _ => InjectionVerdict::Suspicious,
             }
         } else if is_positive && score >= self.injection_threshold_soft {
             tracing::warn!(score = score, "injection_classifier soft_signal");


### PR DESCRIPTION
## Summary

- `InjectionEnforcementMode` in `zeph-config` is `#[non_exhaustive]`, requiring a wildcard arm in all external match expressions
- Two match sites in `crates/zeph-sanitizer/src/sanitizer.rs` (`regex_verdict`, `binary_score_to_verdict`) lacked `_` arms, causing `E0004` when building with `--features classifiers`
- Replace the explicit `Warn => Suspicious` + `_ => Suspicious` duplicate pattern with a single `_ => Suspicious` arm in both sites

## Test plan

- [ ] `cargo build -p zeph-sanitizer --features classifiers,zeph-memory/sqlite` — `Finished` with no errors
- [ ] `cargo clippy -p zeph-sanitizer --features classifiers,zeph-memory/sqlite -- -D warnings` — clean
- [ ] `cargo nextest run -p zeph-sanitizer --features classifiers,zeph-memory/sqlite` — 343 passed, 2 skipped
- [ ] `cargo +nightly fmt --check` — clean

Closes #4557