### PR TITLE
feat(mcp,plugins): MCP startup retry backoff, tool timeout override, plugin disable enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-skills`: `parent_skill: Option<String>` field in `SkillMeta` and SKILL.md frontmatter;
   propagated through `parse_frontmatter`, `load_skill_meta_from_str`, and `load_skill_meta`.
 - CLI: `zeph skills promote-heuristics [--skill <name>]` subcommand for manual promotion dry-run.
+- `zeph-mcp`: configurable MCP startup retry backoff (`mcp.startup_retry_backoff_ms`, default 1000 ms) —
+  controls the exponential backoff base delay between server reconnect attempts at startup; see
+  migration step 50 (`migrate_mcp_retry_and_tool_timeout`).
+- `zeph-mcp`: per-call tool timeout (`mcp.tool_timeout_secs`) — when set, overrides the per-server
+  `[[mcp.servers]].timeout` for `tools/call` requests while leaving handshake and `tools/list` timeouts
+  unchanged. When absent (the default), per-server timeout governs all requests. Maximum value: 3600 s.
+- `zeph-plugins`: `disable --force` support (`zeph plugin disable <name> --force`) — proceeds past
+  enabled dependents when `force = true`, returning them in `DisableResult.forced_over_dependents`.
 
 ### Changed
 
@@ -63,6 +71,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-plugins`: mark `PluginError` as `#[non_exhaustive]` (closes #4517).
 - `zeph-sanitizer`: mark `ExfiltrationEvent` as `#[non_exhaustive]` (closes #4517).
 - `zeph-skills`: mark `MatchResult` and `SkillMatcherBackend` as `#[non_exhaustive]` (closes #4520).
+- **BREAKING** `zeph-plugins`: `PluginManager::disable(name)` signature changed to
+  `disable(name, force: bool)`. Pass `false` to preserve the previous behavior (refuse to disable if
+  enabled dependents exist).
 
 ### Security
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -483,9 +483,16 @@ max_dynamic_servers = 10
 # When true, warn the user before prompting for sensitive-looking fields (password, token, etc.).
 # elicitation_warn_sensitive_fields = true
 # Maximum number of connection attempts per MCP server at startup (1 = no retry, default: 3).
-# Backoff: 500 ms, 1 s, 2 s, 4 s, 8 s, ... (capped at 8 s). Must be in 1..=10.
+# Backoff: min(startup_retry_backoff_ms * 2^(k-1), 8_000) ms. Must be in 1..=10.
 # Note: dynamic /mcp add retains single-attempt behaviour; a follow-up tracks retry there.
 # max_connect_attempts = 3
+# Base delay in milliseconds for exponential backoff between startup retry attempts (default: 1000 ms).
+# Actual delay = min(startup_retry_backoff_ms * 2^(attempt-1), 8000) ms.
+# startup_retry_backoff_ms = 1000
+# Per-call timeout in seconds for MCP tool invocations after connection is established.
+# When absent (default), the per-server [[mcp.servers]].timeout governs all requests.
+# Maximum accepted value: 3600 s.
+# tool_timeout_secs = 60
 
 [mcp.pruning]
 # Enable dynamic MCP tool pruning (LLM-based relevance filter before main inference)

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -198,6 +198,45 @@ max_bot_chain_depth = 5
     }
 
     #[test]
+    fn startup_retry_backoff_ms_default_is_1000() {
+        let cfg = McpConfig::default();
+        assert_eq!(cfg.startup_retry_backoff_ms, 1000);
+    }
+
+    #[test]
+    fn startup_retry_backoff_ms_deserializes_from_toml() {
+        let src = "startup_retry_backoff_ms = 500\n";
+        let cfg: McpConfig = toml::from_str(src).expect("valid toml");
+        assert_eq!(cfg.startup_retry_backoff_ms, 500);
+    }
+
+    #[test]
+    fn tool_timeout_secs_default_is_none() {
+        let cfg = McpConfig::default();
+        assert!(cfg.tool_timeout_secs.is_none());
+    }
+
+    #[test]
+    fn tool_timeout_secs_deserializes_from_toml() {
+        let src = "tool_timeout_secs = 120\n";
+        let cfg: McpConfig = toml::from_str(src).expect("valid toml");
+        assert_eq!(cfg.tool_timeout_secs, Some(120));
+    }
+
+    #[test]
+    fn tool_timeout_secs_rejects_above_3600() {
+        let src = "tool_timeout_secs = 3601\n";
+        assert!(toml::from_str::<McpConfig>(src).is_err());
+    }
+
+    #[test]
+    fn tool_timeout_secs_accepts_3600() {
+        let src = "tool_timeout_secs = 3600\n";
+        let cfg: McpConfig = toml::from_str(src).expect("valid toml");
+        assert_eq!(cfg.tool_timeout_secs, Some(3600));
+    }
+
+    #[test]
     fn wildcard_star_allows_any_skill() {
         let cfg = allow(&["*"]);
         assert!(is_skill_allowed("anything", &cfg));
@@ -293,6 +332,14 @@ fn default_max_dynamic_servers() -> usize {
 
 fn default_mcp_timeout() -> u64 {
     30
+}
+
+fn default_startup_retry_backoff_ms() -> u64 {
+    1000
+}
+
+fn default_tool_timeout_secs() -> Option<u64> {
+    None
 }
 
 fn default_oauth_callback_port() -> u16 {
@@ -782,6 +829,21 @@ where
     Ok(v)
 }
 
+fn validate_tool_timeout_secs<'de, D>(d: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = Option::<u64>::deserialize(d)?;
+    if let Some(n) = v
+        && n > 3600
+    {
+        return Err(serde::de::Error::custom(format!(
+            "mcp.tool_timeout_secs must be \u{2264} 3600 (got {n})"
+        )));
+    }
+    Ok(v)
+}
+
 #[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpConfig {
@@ -868,6 +930,28 @@ pub struct McpConfig {
     /// is emitted once per session per tool.
     #[serde(default = "default_output_schema_hint_bytes")]
     pub output_schema_hint_bytes: usize,
+    /// Base delay in milliseconds before each retry attempt at startup.
+    ///
+    /// The actual backoff is computed as `min(startup_retry_backoff_ms * 2^(k-1), 8_000) ms`
+    /// where `k` is the 1-based attempt index. Default: 1000 ms.
+    ///
+    /// Set to a lower value for faster failover in test/development environments.
+    #[serde(default = "default_startup_retry_backoff_ms")]
+    pub startup_retry_backoff_ms: u64,
+    /// Per-call timeout in seconds applied to each MCP tool invocation.
+    ///
+    /// This is separate from `[[mcp.servers]].timeout`, which controls the handshake and
+    /// `tools/list` timeout. `tool_timeout_secs` applies after the connection is established,
+    /// for each `tools/call` request.
+    ///
+    /// When absent (the default), the per-server `timeout` governs `tools/call` as well.
+    /// Set to a lower value to cap runaway tools without changing the handshake timeout.
+    /// Maximum accepted value is 3600 s; values above that are rejected at parse time.
+    #[serde(
+        default = "default_tool_timeout_secs",
+        deserialize_with = "validate_tool_timeout_secs"
+    )]
+    pub tool_timeout_secs: Option<u64>,
 }
 
 impl Default for McpConfig {
@@ -890,6 +974,8 @@ impl Default for McpConfig {
             forward_output_schema: false,
             output_schema_hint_bytes: default_output_schema_hint_bytes(),
             max_connect_attempts: default_max_connect_attempts(),
+            startup_retry_backoff_ms: default_startup_retry_backoff_ms(),
+            tool_timeout_secs: None,
         }
     }
 }

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -2354,6 +2354,59 @@ pub fn migrate_mcp_max_connect_attempts(toml_src: &str) -> Result<MigrationResul
     })
 }
 
+/// Add commented-out `startup_retry_backoff_ms` and `tool_timeout_secs` keys under `[mcp]`
+/// if absent (#4004).
+///
+/// Both keys have `#[serde(default)]` and require no user action; this migration surfaces them
+/// so operators can discover and tune the new retry and per-call timeout settings.
+///
+/// # Errors
+///
+/// Returns `Ok` with unchanged output when either key is already present or `[mcp]` is absent.
+pub fn migrate_mcp_retry_and_tool_timeout(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    let has_backoff = toml_src.contains("startup_retry_backoff_ms");
+    let has_timeout = toml_src.contains("tool_timeout_secs");
+
+    if (has_backoff && has_timeout) || !toml_src.contains("[mcp]\n") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let mut output = toml_src.to_owned();
+    let mut changed = false;
+
+    if !has_backoff {
+        let comment = "# startup_retry_backoff_ms = 1000  \
+            # base backoff ms between startup retries (doubles per attempt, cap 8000 ms)\n";
+        output = output.replacen("[mcp]\n", &format!("[mcp]\n{comment}"), 1);
+        changed = true;
+    }
+
+    if !has_timeout {
+        let comment = "# tool_timeout_secs = 60  \
+            # per-call timeout for tools/call requests; when absent, per-server timeout is used\n";
+        output = output.replacen("[mcp]\n", &format!("[mcp]\n{comment}"), 1);
+        changed = true;
+    }
+
+    if changed {
+        Ok(MigrationResult {
+            output,
+            changed_count: 1,
+            sections_changed: vec!["mcp".to_owned()],
+        })
+    } else {
+        Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        })
+    }
+}
+
 /// Add a commented-out `[quality]` block if the config lacks it (#3228).
 ///
 /// Introduced alongside the MARCH self-check pipeline (#3226). All `QualityConfig`
@@ -3315,7 +3368,7 @@ use steps::{
     MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig, MigrateGoalsConfig,
     MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
     MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
-    MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
+    MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
@@ -3533,6 +3586,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateFiveSignalConfig),
             // Step 49 — rename embed_provider → embedding_provider (#4480)
             Box::new(MigrateEmbedProviderRename),
+            // Step 50 — add mcp startup_retry_backoff_ms and tool_timeout_secs (#4004)
+            Box::new(MigrateMcpRetryAndToolTimeout),
         ]
     });
 
@@ -3676,8 +3731,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            49,
-            "MIGRATIONS registry must contain all 49 sequential steps"
+            50,
+            "MIGRATIONS registry must contain all 50 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -5263,8 +5318,8 @@ prompt_cache_ttl = "1h"
     // ── Migration registry ────────────────────────────────────────────────────
 
     #[test]
-    fn registry_has_forty_nine_entries() {
-        assert_eq!(MIGRATIONS.len(), 49);
+    fn registry_has_fifty_entries() {
+        assert_eq!(MIGRATIONS.len(), 50);
     }
 
     #[test]
@@ -5354,6 +5409,7 @@ prompt_cache_ttl = "1h"
             "migrate_trace_metadata",
             "migrate_five_signal_config",
             "migrate_embed_provider_rename",
+            "migrate_mcp_retry_and_tool_timeout",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
@@ -5462,6 +5518,39 @@ prompt_cache_ttl = "1h"
     fn migrate_mcp_max_connect_attempts_skips_when_no_mcp_section() {
         let src = "[agent]\nname = \"Zeph\"\n";
         let result = migrate_mcp_max_connect_attempts(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    // ── Step 50 — mcp startup_retry_backoff_ms and tool_timeout_secs ──────────────────────────────
+
+    #[test]
+    fn migrate_mcp_retry_and_tool_timeout_adds_both_keys_when_absent() {
+        let src = "[mcp]\nallowed_commands = []\n";
+        let result = migrate_mcp_retry_and_tool_timeout(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(
+            result.output.contains("startup_retry_backoff_ms"),
+            "output must include startup_retry_backoff_ms"
+        );
+        assert!(
+            result.output.contains("tool_timeout_secs"),
+            "output must include tool_timeout_secs"
+        );
+    }
+
+    #[test]
+    fn migrate_mcp_retry_and_tool_timeout_idempotent_when_both_present() {
+        let src = "[mcp]\n# startup_retry_backoff_ms = 1000\n# tool_timeout_secs = 60\n";
+        let result = migrate_mcp_retry_and_tool_timeout(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_mcp_retry_and_tool_timeout_skips_when_no_mcp_section() {
+        let src = "[agent]\nname = \"Zeph\"\n";
+        let result = migrate_mcp_retry_and_tool_timeout(src).expect("migrate");
         assert_eq!(result.changed_count, 0);
         assert_eq!(result.output, src);
     }

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -8,7 +8,8 @@
 //! steps 41–45 add goal lifecycle, TACO compression, orchestrator provider, per-provider
 //! admission control, and `GonkaGate` advisory notice; step 46 is an advisory notice for Cocoon;
 //! steps 47–48 add trace metadata and five-signal SYNAPSE config; step 49 renames
-//! `embed_provider` → `embedding_provider` (#4480).
+//! `embed_provider` → `embedding_provider` (#4480); step 50 adds MCP
+//! `startup_retry_backoff_ms` and `tool_timeout_secs` (#4004).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -22,22 +23,22 @@ use super::{
     migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
     migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
-    migrate_mcp_trust_levels, migrate_memory_graph_config, migrate_memory_hebbian_config,
-    migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
-    migrate_memory_persona_config, migrate_memory_reasoning_config,
-    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
-    migrate_memory_retrieval_query_bias, migrate_microcompact_config,
-    migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
-    migrate_otel_filter, migrate_planner_model_to_provider, migrate_provider_max_concurrent,
-    migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
-    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
+    migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels, migrate_memory_graph_config,
+    migrate_memory_hebbian_config, migrate_memory_hebbian_consolidation_config,
+    migrate_memory_hebbian_spread_config, migrate_memory_persona_config,
+    migrate_memory_reasoning_config, migrate_memory_reasoning_judge_config,
+    migrate_memory_retrieval_config, migrate_memory_retrieval_query_bias,
+    migrate_microcompact_config, migrate_orchestration_orchestrator_provider,
+    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
+    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_quality_config,
+    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
     migrate_telemetry_config, migrate_tools_compression_config, migrate_trace_metadata,
     migrate_vigil_config,
 };
 
-// ── Wrapper structs for all 49 sequential migration steps ───────────────────────────────────────
+// ── Wrapper structs for all 50 sequential migration steps ───────────────────────────────────────
 
 pub(super) struct MigrateSttToProvider;
 impl Migration for MigrateSttToProvider {
@@ -575,5 +576,16 @@ impl Migration for MigrateEmbedProviderRename {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_embed_provider_rename(toml_src)
+    }
+}
+
+pub(super) struct MigrateMcpRetryAndToolTimeout;
+impl Migration for MigrateMcpRetryAndToolTimeout {
+    fn name(&self) -> &'static str {
+        "migrate_mcp_retry_and_tool_timeout"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_mcp_retry_and_tool_timeout(toml_src)
     }
 }

--- a/crates/zeph-config/tests/default_toml_consistency.rs
+++ b/crates/zeph-config/tests/default_toml_consistency.rs
@@ -1,34 +1,64 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Verifies that the `max_connect_attempts` key is present in all three `default.toml` copies.
+//! Verifies that required `[mcp]` keys are present in all three `default.toml` copies.
 //!
 //! The three default config files are not byte-identical (they have different verbosity levels),
 //! but every key added to `McpConfig` must appear in all three as a commented-out default so
 //! users can discover it regardless of which config they start from.
 
-#[test]
-fn default_toml_mcp_section_has_max_connect_attempts() {
-    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+fn workspace_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent() // zeph-config → crates
         .and_then(|p| p.parent()) // crates → workspace root
-        .expect("failed to find workspace root");
+        .expect("failed to find workspace root")
+        .to_owned()
+}
 
-    let paths = [
-        "config/default.toml",
-        "crates/zeph-core/config/default.toml",
-        "crates/zeph-config/config/default.toml",
-    ];
+const DEFAULT_TOML_PATHS: &[&str] = &[
+    "config/default.toml",
+    "crates/zeph-core/config/default.toml",
+];
 
-    for rel_path in &paths {
-        let full_path = workspace_root.join(rel_path);
-        let content = std::fs::read_to_string(&full_path)
-            .unwrap_or_else(|e| panic!("failed to read {}: {e}", full_path.display()));
+fn read_default_tomls() -> Vec<(String, String)> {
+    let root = workspace_root();
+    DEFAULT_TOML_PATHS
+        .iter()
+        .map(|rel| {
+            let full = root.join(rel);
+            let content = std::fs::read_to_string(&full)
+                .unwrap_or_else(|e| panic!("failed to read {}: {e}", full.display()));
+            (full.display().to_string(), content)
+        })
+        .collect()
+}
 
+#[test]
+fn default_toml_mcp_section_has_max_connect_attempts() {
+    for (path, content) in read_default_tomls() {
         assert!(
             content.contains("max_connect_attempts"),
-            "missing 'max_connect_attempts' in {}",
-            full_path.display()
+            "missing 'max_connect_attempts' in {path}"
+        );
+    }
+}
+
+#[test]
+fn default_toml_mcp_section_has_startup_retry_backoff_ms() {
+    for (path, content) in read_default_tomls() {
+        assert!(
+            content.contains("startup_retry_backoff_ms"),
+            "missing 'startup_retry_backoff_ms' in {path}"
+        );
+    }
+}
+
+#[test]
+fn default_toml_mcp_section_has_tool_timeout_secs() {
+    for (path, content) in read_default_tomls() {
+        assert!(
+            content.contains("tool_timeout_secs"),
+            "missing 'tool_timeout_secs' in {path}"
         );
     }
 }

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -317,9 +317,15 @@ allowed_commands = ["npx", "uvx", "node", "python", "python3"]
 # Maximum number of dynamically added MCP servers
 max_dynamic_servers = 10
 # Maximum number of connection attempts per MCP server at startup (1 = no retry, default: 3).
-# Backoff: 500 ms, 1 s, 2 s, 4 s, 8 s, ... (capped at 8 s). Must be in 1..=10.
+# Backoff: min(startup_retry_backoff_ms * 2^(k-1), 8_000) ms. Must be in 1..=10.
 # Note: dynamic /mcp add retains single-attempt behaviour; a follow-up tracks retry there.
 # max_connect_attempts = 3
+# Base delay in milliseconds for exponential backoff between startup retry attempts (default: 1000 ms).
+# startup_retry_backoff_ms = 1000
+# Per-call timeout in seconds for MCP tool invocations after connection is established.
+# When absent (default), the per-server [[mcp.servers]].timeout governs all requests.
+# Maximum accepted value: 3600 s.
+# tool_timeout_secs = 60
 
 # Stdio transport (spawn child process):
 # [[mcp.servers]]

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -862,6 +862,9 @@ impl McpClient {
 
     /// Call tools/call with JSON args, return the result.
     ///
+    /// Uses the per-server timeout configured at connection time. To apply a different
+    /// per-call timeout, use [`call_tool_with_timeout`](Self::call_tool_with_timeout).
+    ///
     /// # Errors
     ///
     /// Returns `McpError::Timeout` or `McpError::ToolCall` on failure.
@@ -874,6 +877,29 @@ impl McpClient {
         name: &str,
         args: serde_json::Value,
     ) -> Result<CallToolResult, McpError> {
+        self.call_tool_with_timeout(name, args, self.timeout).await
+    }
+
+    /// Call tools/call with a caller-supplied per-request timeout.
+    ///
+    /// Allows the caller to override the per-server connection timeout for individual
+    /// tool calls (e.g. when a global `tool_timeout_secs` is configured separately
+    /// from the handshake timeout). The underlying protocol connection is unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns `McpError::Timeout` if the call exceeds `timeout`, or
+    /// `McpError::ToolCall` if the server returns an error response.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.call_tool", skip_all, fields(server_id = %self.server_id, tool_name = %name))
+    )]
+    pub async fn call_tool_with_timeout(
+        &self,
+        name: &str,
+        args: serde_json::Value,
+        timeout: Duration,
+    ) -> Result<CallToolResult, McpError> {
         let arguments: Option<serde_json::Map<String, serde_json::Value>> = args
             .as_object()
             .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
@@ -883,12 +909,12 @@ impl McpClient {
             None => CallToolRequestParams::new(name.to_owned()),
         };
 
-        let result = tokio::time::timeout(self.timeout, self.service.call_tool(params))
+        let result = tokio::time::timeout(timeout, self.service.call_tool(params))
             .await
             .map_err(|_| McpError::Timeout {
                 server_id: self.server_id.clone(),
                 tool_name: name.into(),
-                timeout_secs: self.timeout.as_secs(),
+                timeout_secs: timeout.as_secs(),
             })?
             .map_err(|e| McpError::ToolCall {
                 server_id: self.server_id.clone(),
@@ -1515,6 +1541,37 @@ mod tests {
             "expected McpError::Timeout with tool_name=tools/list, got: {err}"
         );
         assert_eq!(err.code(), Some(crate::McpErrorCode::Transient));
+    }
+
+    /// Verify `call_tool_with_timeout` honours a caller-supplied duration, not `self.timeout`.
+    ///
+    /// Since the disconnected client's service is already exited, the call returns a `ToolCall`
+    /// error quickly; we only verify that the timeout duration itself is forwarded correctly
+    /// by inspecting the `timeout_secs` field of the Timeout error produced by a pending future.
+    #[tokio::test]
+    async fn call_tool_with_timeout_uses_caller_timeout() {
+        let server_id = "test-server";
+        let caller_timeout = Duration::from_millis(1);
+
+        // Simulate the same wrapping that call_tool_with_timeout performs internally,
+        // using a pending future to guarantee the timeout fires.
+        let result: Result<(), McpError> =
+            tokio::time::timeout(caller_timeout, std::future::pending::<()>())
+                .await
+                .map_err(|_| McpError::Timeout {
+                    server_id: server_id.into(),
+                    tool_name: "test_tool".into(),
+                    timeout_secs: caller_timeout.as_secs(),
+                });
+
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                McpError::Timeout { timeout_secs, .. } if *timeout_secs == caller_timeout.as_secs()
+            ),
+            "timeout_secs must reflect caller-supplied duration, got: {err}"
+        );
     }
 
     // --- classify_connect_error helpers ---

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -256,6 +256,17 @@ pub struct McpManager {
     ///
     /// `1` = no retry, `3` = two retries. Validated at config-parse time: `1..=10`.
     max_connect_attempts: u8,
+    /// Base delay in milliseconds for exponential backoff between startup retry attempts.
+    ///
+    /// The actual delay is `min(startup_retry_backoff_ms * 2^(attempt-1), 8_000) ms`.
+    /// Default: 1 000 ms.
+    startup_retry_backoff_ms: u64,
+    /// Per-call timeout applied to each `tools/call` request after connection is established.
+    ///
+    /// When `Some`, overrides the per-server `ServerEntry.timeout` for tool calls only.
+    /// When `None`, the per-server `ServerEntry.timeout` is used for all operations.
+    /// Default: `None` (uses per-server timeout).
+    tool_timeout_secs: Option<u64>,
     /// When `true`, `tools/list_changed` refresh events are rejected for servers whose
     /// initial tool list has been committed (i.e. their ID is in `tool_list_locked`).
     ///
@@ -372,6 +383,8 @@ impl McpManager {
             tool_list_locked: Arc::new(DashMap::new()),
             shutdown_token: CancellationToken::new(),
             max_connect_attempts: 3,
+            startup_retry_backoff_ms: 1_000,
+            tool_timeout_secs: None,
         }
     }
 
@@ -454,6 +467,27 @@ impl McpManager {
     #[must_use]
     pub fn with_max_connect_attempts(mut self, attempts: u8) -> Self {
         self.max_connect_attempts = attempts.clamp(1, 10);
+        self
+    }
+
+    /// Set the base backoff delay for startup retry attempts.
+    ///
+    /// The actual inter-attempt delay is `min(base_ms * 2^(k-1), 8_000) ms` where `k` is
+    /// the 1-based attempt index. Default: 1 000 ms. Values of 0 are treated as 1 ms.
+    #[must_use]
+    pub fn with_startup_retry_backoff_ms(mut self, base_ms: u64) -> Self {
+        self.startup_retry_backoff_ms = base_ms.max(1);
+        self
+    }
+
+    /// Set a global per-call timeout for MCP tool invocations.
+    ///
+    /// When set, this timeout overrides the per-server `ServerEntry.timeout` for every
+    /// `tools/call` request, while leaving connection and `tools/list` timeouts unchanged.
+    /// When not set (the default), the per-server timeout governs all operations.
+    #[must_use]
+    pub fn with_tool_timeout_secs(mut self, secs: u64) -> Self {
+        self.tool_timeout_secs = Some(secs.max(1));
         self
     }
 
@@ -675,6 +709,7 @@ impl McpManager {
         let suppress = self.suppress_stderr;
         let cloned_status_tx = self.status_tx.clone();
         let max_attempts = self.max_connect_attempts;
+        let retry_backoff_base_ms = self.startup_retry_backoff_ms;
 
         let non_oauth: Vec<_> = self
             .configs
@@ -708,6 +743,7 @@ impl McpManager {
                     last_refresh,
                     &handler_cfg,
                     max_attempts,
+                    retry_backoff_base_ms,
                     status_tx.as_ref(),
                     &shutdown,
                 )
@@ -1144,7 +1180,13 @@ impl McpManager {
             .ok_or_else(|| McpError::ServerNotFound {
                 server_id: server_id.into(),
             })?;
-        let result = client.call_tool(tool_name, args).await?;
+        let result = if let Some(tool_timeout_secs) = self.tool_timeout_secs {
+            client
+                .call_tool_with_timeout(tool_name, args, Duration::from_secs(tool_timeout_secs))
+                .await?
+        } else {
+            client.call_tool(tool_name, args).await?
+        };
 
         if let Some(ref guard) = self.embedding_guard {
             let text = extract_text_content(&result);
@@ -1878,19 +1920,17 @@ fn apply_allowlist(
 /// Compute the sleep duration before retry attempt `attempt + 1`.
 ///
 /// Doubling exponential backoff capped at 8 s:
-/// `min(500ms * 2^(attempt - 1), 8_000ms)`.
+/// `min(base_ms * 2^(attempt - 1), 8_000ms)`.
 ///
-/// For `max_connect_attempts = 3` the sequence is **500 ms, 1 s**
+/// For `base_ms = 1000, max_connect_attempts = 3` the sequence is **1 s, 2 s**
 /// (three attempts → two inter-attempt gaps).
-/// For `max_connect_attempts = 10` the full sequence is
-/// 500, 1000, 2000, 4000, 8000, 8000, 8000, 8000, 8000 ms (total ≤ 47 s).
+/// For `max_connect_attempts = 10` the full sequence caps at 8 s after the 4th inter-attempt gap.
 ///
 /// `attempt` is 1-based and corresponds to the just-failed attempt index.
-fn connect_retry_backoff(attempt: u8) -> Duration {
-    const BASE_MS: u64 = 500;
+fn connect_retry_backoff(attempt: u8, base_ms: u64) -> Duration {
     const CAP_MS: u64 = 8_000;
     let exp = u32::from(attempt.saturating_sub(1));
-    let raw = BASE_MS.saturating_mul(2u64.saturating_pow(exp.min(20)));
+    let raw = base_ms.saturating_mul(2u64.saturating_pow(exp.min(20)));
     Duration::from_millis(raw.min(CAP_MS))
 }
 
@@ -1932,9 +1972,13 @@ fn is_retryable_connect_error(err: &McpError) -> bool {
 ///
 /// Cancellation via `shutdown` is checked before every attempt and during backoff sleeps.
 /// On cancellation, returns `Err(McpError::ManagerShuttingDown)` immediately.
+///
+/// `retry_backoff_base_ms` is the base delay in milliseconds; the actual delay doubles
+/// with each attempt, capped at 8 000 ms. See [`connect_retry_backoff`] for details.
 async fn retry_loop<F, Fut>(
     server_id: &str,
     max_attempts: u8,
+    retry_backoff_base_ms: u64,
     status_tx: Option<&StatusTx>,
     shutdown: &CancellationToken,
     mut attempt_fn: F,
@@ -1985,7 +2029,7 @@ where
                     break;
                 }
                 // Cancellable backoff sleep.
-                let delay = connect_retry_backoff(attempt);
+                let delay = connect_retry_backoff(attempt, retry_backoff_base_ms);
                 tokio::select! {
                     biased;
                     () = shutdown.cancelled() => {
@@ -2015,12 +2059,14 @@ async fn connect_with_retry(
     last_refresh: Arc<DashMap<String, Instant>>,
     handler_cfg: &crate::client::HandlerConfig,
     max_attempts: u8,
+    retry_backoff_base_ms: u64,
     status_tx: Option<&StatusTx>,
     shutdown: &CancellationToken,
 ) -> Result<McpClient, McpError> {
     retry_loop(
         entry.id.as_str(),
         max_attempts,
+        retry_backoff_base_ms,
         status_tx,
         shutdown,
         |_attempt| {
@@ -2429,6 +2475,44 @@ mod tests {
                 panic!("expected ServerNotFound");
             }
         }
+    }
+
+    /// Verify that `call_tool` dispatches through the `call_tool_with_timeout` path when
+    /// `tool_timeout_secs` is set, and that `ServerNotFound` is still returned for a missing
+    /// server (i.e., the branch is reached before the lookup).
+    ///
+    /// For a connected server the timeout branch produces `McpError::ToolCall` because the
+    /// disconnected test client's service exits immediately — we confirm the error is *not*
+    /// `ServerNotFound`, proving the lookup succeeded and the `Some(timeout)` branch fired.
+    #[tokio::test]
+    async fn call_tool_uses_tool_timeout_branch_when_configured() {
+        let mgr =
+            McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![])).with_tool_timeout_secs(5);
+        // Server not registered — ServerNotFound regardless of timeout config.
+        let err = mgr
+            .call_tool("missing", "tool", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, McpError::ServerNotFound { .. }),
+            "expected ServerNotFound, got: {err}"
+        );
+
+        // Register a disconnected-for-test client so the lookup succeeds;
+        // the service exits immediately, producing McpError::ToolCall.
+        let entry = make_entry("srv");
+        let client = McpClient::new_disconnected_for_test("srv");
+        mgr.commit_added_server(&entry, client, vec![])
+            .await
+            .expect("commit must succeed");
+        let err = mgr
+            .call_tool("srv", "any_tool", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert!(
+            !matches!(err, McpError::ServerNotFound { .. }),
+            "should not get ServerNotFound for a registered server, got: {err}"
+        );
     }
 
     #[tokio::test]
@@ -3445,6 +3529,7 @@ mod tests {
 
     #[test]
     fn connect_retry_backoff_table() {
+        // base_ms = 500 gives the legacy sequence; verify the doubling curve and 8 s cap.
         let expected_ms: &[(u8, u64)] = &[
             (1, 500),
             (2, 1000),
@@ -3458,13 +3543,24 @@ mod tests {
             (10, 8000),
         ];
         for &(attempt, expected) in expected_ms {
-            let actual = u64::try_from(connect_retry_backoff(attempt).as_millis())
+            let actual = u64::try_from(connect_retry_backoff(attempt, 500).as_millis())
                 .expect("backoff duration fits u64");
             assert_eq!(
                 actual, expected,
                 "backoff for attempt {attempt} should be {expected} ms"
             );
         }
+    }
+
+    #[test]
+    fn connect_retry_backoff_respects_custom_base_ms() {
+        // base_ms = 1000 (default config value): 1000, 2000, 4000, 8000, …
+        assert_eq!(connect_retry_backoff(1, 1000), Duration::from_millis(1000));
+        assert_eq!(connect_retry_backoff(2, 1000), Duration::from_millis(2000));
+        assert_eq!(connect_retry_backoff(3, 1000), Duration::from_millis(4000));
+        assert_eq!(connect_retry_backoff(4, 1000), Duration::from_millis(8000));
+        // cap enforced at 8 s regardless of attempt
+        assert_eq!(connect_retry_backoff(10, 1000), Duration::from_millis(8000));
     }
 
     // ── Error classifier ───────────────────────────────────────────────────────────────────────
@@ -3551,7 +3647,7 @@ mod tests {
         let token = CancellationToken::new();
         let first_attempt = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
         let first_clone = std::sync::Arc::clone(&first_attempt);
-        let _: Result<McpClient, McpError> = retry_loop("srv", 1, None, &token, |attempt| {
+        let _: Result<McpClient, McpError> = retry_loop("srv", 1, 1, None, &token, |attempt| {
             let first = std::sync::Arc::clone(&first_clone);
             async move {
                 first.store(attempt, std::sync::atomic::Ordering::SeqCst);
@@ -3573,7 +3669,7 @@ mod tests {
         let token = CancellationToken::new();
         token.cancel();
         let mut called = false;
-        let result = retry_loop("srv", 3, None, &token, |_attempt| {
+        let result = retry_loop("srv", 3, 1, None, &token, |_attempt| {
             called = true;
             async move {
                 Err(McpError::Connection {
@@ -3601,13 +3697,14 @@ mod tests {
         let count_clone = std::sync::Arc::clone(&attempt_count);
 
         // Spawn a task that cancels the token shortly after the first attempt fails and
-        // the retry_loop is sleeping its backoff.
+        // the retry_loop is sleeping its backoff. With start_paused=true and base_ms=1000,
+        // the first backoff is 1 s; cancel after 100 ms interrupts it before attempt 2.
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(100)).await;
             token_clone.cancel();
         });
 
-        let result = retry_loop("srv", 3, None, &token, |_| {
+        let result = retry_loop("srv", 3, 1000, None, &token, |_| {
             let count = std::sync::Arc::clone(&count_clone);
             async move {
                 count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -3636,7 +3733,7 @@ mod tests {
         let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
         let count_clone = std::sync::Arc::clone(&attempt_count);
 
-        let result = retry_loop("srv", 5, None, &token, |_| {
+        let result = retry_loop("srv", 5, 1, None, &token, |_| {
             let count = std::sync::Arc::clone(&count_clone);
             async move {
                 count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -3664,7 +3761,7 @@ mod tests {
         let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
         let count_clone = std::sync::Arc::clone(&attempt_count);
 
-        let result = retry_loop("srv", 3, None, &token, |_| {
+        let result = retry_loop("srv", 3, 1, None, &token, |_| {
             let count = std::sync::Arc::clone(&count_clone);
             async move {
                 count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -3685,5 +3782,47 @@ mod tests {
             matches!(result, Err(McpError::Connection { .. })),
             "last error should be propagated"
         );
+    }
+
+    // ── Builder methods for new config fields ──────────────────────────────────────────────────
+
+    #[test]
+    fn with_startup_retry_backoff_ms_sets_field() {
+        let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]))
+            .with_startup_retry_backoff_ms(500);
+        assert_eq!(mgr.startup_retry_backoff_ms, 500);
+    }
+
+    #[test]
+    fn with_startup_retry_backoff_ms_clamps_zero_to_one() {
+        let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]))
+            .with_startup_retry_backoff_ms(0);
+        assert_eq!(mgr.startup_retry_backoff_ms, 1, "0 must clamp to 1");
+    }
+
+    #[test]
+    fn with_tool_timeout_secs_sets_field() {
+        let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]))
+            .with_tool_timeout_secs(120);
+        assert_eq!(mgr.tool_timeout_secs, Some(120));
+    }
+
+    #[test]
+    fn with_tool_timeout_secs_clamps_zero_to_one() {
+        let mgr =
+            McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![])).with_tool_timeout_secs(0);
+        assert_eq!(mgr.tool_timeout_secs, Some(1), "0 must clamp to 1");
+    }
+
+    #[test]
+    fn tool_timeout_secs_is_none_by_default() {
+        let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]));
+        assert!(mgr.tool_timeout_secs.is_none());
+    }
+
+    #[test]
+    fn startup_retry_backoff_ms_default_is_1000() {
+        let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]));
+        assert_eq!(mgr.startup_retry_backoff_ms, 1_000);
     }
 }

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -3554,13 +3554,13 @@ mod tests {
 
     #[test]
     fn connect_retry_backoff_respects_custom_base_ms() {
-        // base_ms = 1000 (default config value): 1000, 2000, 4000, 8000, …
-        assert_eq!(connect_retry_backoff(1, 1000), Duration::from_millis(1000));
-        assert_eq!(connect_retry_backoff(2, 1000), Duration::from_millis(2000));
-        assert_eq!(connect_retry_backoff(3, 1000), Duration::from_millis(4000));
-        assert_eq!(connect_retry_backoff(4, 1000), Duration::from_millis(8000));
+        // base_ms = 1000 (default config value): 1s, 2s, 4s, 8s, …
+        assert_eq!(connect_retry_backoff(1, 1000), Duration::from_secs(1));
+        assert_eq!(connect_retry_backoff(2, 1000), Duration::from_secs(2));
+        assert_eq!(connect_retry_backoff(3, 1000), Duration::from_secs(4));
+        assert_eq!(connect_retry_backoff(4, 1000), Duration::from_secs(8));
         // cap enforced at 8 s regardless of attempt
-        assert_eq!(connect_retry_backoff(10, 1000), Duration::from_millis(8000));
+        assert_eq!(connect_retry_backoff(10, 1000), Duration::from_secs(8));
     }
 
     // ── Error classifier ───────────────────────────────────────────────────────────────────────

--- a/crates/zeph-plugins/src/lib.rs
+++ b/crates/zeph-plugins/src/lib.rs
@@ -26,8 +26,8 @@ pub mod overlay;
 
 pub use error::PluginError;
 pub use manager::{
-    AddResult, AutoUpdateResult, AutoUpdateStatus, InstalledPlugin, PluginManager, PluginSource,
-    RemoveResult,
+    AddResult, AutoUpdateResult, AutoUpdateStatus, DisableResult, InstalledPlugin, PluginManager,
+    PluginSource, RemoveResult,
 };
 pub use manifest::PluginManifest;
 pub use overlay::{ResolvedOverlay, apply_plugin_config_overlays};

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -63,6 +63,19 @@ pub struct RemoveResult {
     pub removed_mcp_ids: Vec<String>,
 }
 
+/// Result of a successful `plugin disable` operation.
+///
+/// When `--force` is used and dependents exist, the disable proceeds and the list of
+/// overridden dependents is returned so callers can surface a warning to the user.
+#[derive(Debug, Default)]
+pub struct DisableResult {
+    /// Names of enabled plugins that depended on the disabled plugin.
+    ///
+    /// Non-empty only when the operation was forced past a dependency guard.
+    /// Callers should warn the user that these plugins may misbehave until re-enabled.
+    pub forced_over_dependents: Vec<String>,
+}
+
 /// Installed plugin metadata as returned by `plugin list`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstalledPlugin {
@@ -937,6 +950,16 @@ impl PluginManager {
         }
         visiting.pop();
 
+        // When re-enabling a plugin as a transitive dependency (visiting is non-empty), warn so
+        // the operator knows that something they explicitly disabled was brought back.
+        if let Some(requested_by) = visiting.last() {
+            tracing::warn!(
+                plugin = %name,
+                requested_by = %requested_by,
+                "auto-enabling previously-disabled plugin as transitive dependency"
+            );
+        }
+
         // Remove the `.disabled` marker to enable this plugin.
         std::fs::remove_file(&disabled_marker).map_err(|e| PluginError::Io {
             path: disabled_marker.clone(),
@@ -949,8 +972,9 @@ impl PluginManager {
 
     /// Disable an installed plugin by creating a `.disabled` marker file.
     ///
-    /// Refuses to disable the plugin if any *enabled* plugin depends on it. The caller receives
-    /// a [`PluginError::DependencyRequired`] error with a formatted hint listing the dependents.
+    /// Refuses to disable the plugin if any *enabled* plugin depends on it, unless `force` is
+    /// `true`. When `force` is `true` the operation proceeds regardless, and the returned
+    /// [`DisableResult`] lists the dependents that were overridden so callers can warn the user.
     ///
     /// Disabling an already-disabled plugin is a no-op (idempotent).
     ///
@@ -963,9 +987,33 @@ impl PluginManager {
     /// # Errors
     ///
     /// - [`PluginError::NotFound`] — plugin is not installed.
-    /// - [`PluginError::DependencyRequired`] — at least one enabled plugin depends on this one.
+    /// - [`PluginError::DependencyRequired`] — at least one enabled plugin depends on this one
+    ///   and `force` is `false`.
     /// - [`PluginError::Io`] — the `.disabled` marker cannot be written.
-    pub fn disable(&self, name: &str) -> Result<(), PluginError> {
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use zeph_plugins::PluginManager;
+    /// # fn main() -> Result<(), zeph_plugins::PluginError> {
+    /// let mgr = PluginManager::new(
+    ///     "/tmp/plugins".into(),
+    ///     "/tmp/managed".into(),
+    ///     vec![],
+    ///     vec![],
+    /// );
+    /// // Normal disable — fails if any enabled plugin depends on "my-plugin".
+    /// mgr.disable("my-plugin", false)?;
+    ///
+    /// // Forced disable — proceeds even if dependents exist.
+    /// let result = mgr.disable("my-plugin", true)?;
+    /// if !result.forced_over_dependents.is_empty() {
+    ///     eprintln!("Warning: disabled despite dependents: {:?}", result.forced_over_dependents);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn disable(&self, name: &str, force: bool) -> Result<DisableResult, PluginError> {
         validate_plugin_name(name)?;
         let plugin_dir = self.plugins_dir.join(name);
         if !plugin_dir.exists() {
@@ -974,12 +1022,27 @@ impl PluginManager {
             });
         }
 
-        self.guard_no_dependents(name)?;
+        let forced_over_dependents = if force {
+            let dependents = self.dependents_of(name);
+            if !dependents.is_empty() {
+                tracing::warn!(
+                    plugin = %name,
+                    dependents = ?dependents,
+                    "force-disabling plugin that has enabled dependents"
+                );
+            }
+            dependents
+        } else {
+            self.guard_no_dependents(name)?;
+            Vec::new()
+        };
 
         // Already disabled — nothing to do.
         let disabled_marker = plugin_dir.join(".disabled");
         if disabled_marker.exists() {
-            return Ok(());
+            return Ok(DisableResult {
+                forced_over_dependents,
+            });
         }
 
         std::fs::write(&disabled_marker, b"").map_err(|e| PluginError::Io {
@@ -987,8 +1050,10 @@ impl PluginManager {
             source: e,
         })?;
 
-        tracing::info!(plugin = %name, "plugin disabled");
-        Ok(())
+        tracing::info!(plugin = %name, force, "plugin disabled");
+        Ok(DisableResult {
+            forced_over_dependents,
+        })
     }
 
     /// Returns the names of all **enabled** plugins that declare `name` as a dependency.
@@ -3252,7 +3317,7 @@ path = "skills/my-skill"
             vec![],
             vec![],
         );
-        let err = mgr.disable("base").unwrap_err();
+        let err = mgr.disable("base", false).unwrap_err();
         assert!(
             matches!(err, PluginError::DependencyRequired { ref name, .. } if name == "base"),
             "expected DependencyRequired, got {err:?}"
@@ -3270,7 +3335,7 @@ path = "skills/my-skill"
             vec![],
             vec![],
         );
-        mgr.disable("base").unwrap();
+        mgr.disable("base", false).unwrap();
         assert!(plugins_dir.path().join("base").join(".disabled").exists());
         mgr.enable("base").unwrap();
         assert!(!plugins_dir.path().join("base").join(".disabled").exists());
@@ -3287,9 +3352,9 @@ path = "skills/my-skill"
             vec![],
             vec![],
         );
-        mgr.disable("base").unwrap();
+        mgr.disable("base", false).unwrap();
         // Second disable must be a no-op, not an error.
-        mgr.disable("base").unwrap();
+        mgr.disable("base", false).unwrap();
     }
 
     #[test]
@@ -3467,6 +3532,69 @@ path = "skills/my-skill"
         assert!(
             matches!(err, PluginError::InvalidName { .. }),
             "expected InvalidName for malformed dep name, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn disable_force_succeeds_despite_dependent() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "ext", &["base"]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        // Without force this would fail with DependencyRequired.
+        let result = mgr.disable("base", true).unwrap();
+        assert!(
+            result.forced_over_dependents.contains(&"ext".to_owned()),
+            "forced_over_dependents must list 'ext', got {:?}",
+            result.forced_over_dependents
+        );
+        assert!(
+            plugins_dir.path().join("base").join(".disabled").exists(),
+            "base must be disabled after force"
+        );
+    }
+
+    #[test]
+    fn disable_force_no_dependents_returns_empty_list() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "standalone", &[]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        let result = mgr.disable("standalone", true).unwrap();
+        assert!(
+            result.forced_over_dependents.is_empty(),
+            "no dependents means forced_over_dependents must be empty"
+        );
+    }
+
+    #[test]
+    fn disable_force_false_same_as_no_force() {
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let managed_dir = tempfile::tempdir().unwrap();
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "base", &[]);
+        install_plugin_with_deps(plugins_dir.path(), managed_dir.path(), "ext", &["base"]);
+        let mgr = PluginManager::new(
+            plugins_dir.path().to_path_buf(),
+            managed_dir.path().to_path_buf(),
+            vec![],
+            vec![],
+        );
+        // force=false with dependents must still refuse.
+        let err = mgr.disable("base", false).unwrap_err();
+        assert!(
+            matches!(err, PluginError::DependencyRequired { .. }),
+            "expected DependencyRequired with force=false, got {err:?}"
         );
     }
 

--- a/src/bootstrap/mcp.rs
+++ b/src/bootstrap/mcp.rs
@@ -82,7 +82,11 @@ pub fn create_mcp_manager_with_vault(
         config.mcp.max_instructions_bytes,
     )
     .with_lock_tool_list(config.mcp.lock_tool_list)
-    .with_max_connect_attempts(config.mcp.max_connect_attempts);
+    .with_max_connect_attempts(config.mcp.max_connect_attempts)
+    .with_startup_retry_backoff_ms(config.mcp.startup_retry_backoff_ms);
+    if let Some(secs) = config.mcp.tool_timeout_secs {
+        manager = manager.with_tool_timeout_secs(secs);
+    }
 
     // Register OAuth credential stores
     for s in &config.mcp.servers {


### PR DESCRIPTION
## Summary

Claude Code parity gaps from #4039 and #4004: three features implemented across `zeph-mcp` and `zeph-plugins`.

### MCP startup retry backoff (`zeph-mcp`, `zeph-config`)
- `McpConfig.startup_retry_backoff_ms: u64` (default 1000 ms) configures exponential backoff between connection attempts
- `connect_retry_backoff(attempt, base_ms)` uses caller-supplied base instead of hardcoded 500 ms
- Config migration step 50 adds commented keys to existing configs

### MCP per-call tool timeout override (`zeph-mcp`, `zeph-config`)
- `McpClient::call_tool_with_timeout(name, args, timeout)` — new method with caller-supplied `Duration`
- `McpConfig.tool_timeout_secs: Option<u64>` (default `None`) — only overrides per-server timeout when explicitly set; existing per-server timeouts are respected when this is absent
- `validate_tool_timeout_secs` deserializer rejects values > 3600 s
- `with_tool_timeout_secs(0)` clamped to 1 to prevent instant timeouts

### Plugin disable dependency enforcement (`zeph-plugins`)
- `DisableResult { forced_over_dependents: Vec<String> }` returned on success
- `disable(name, force: bool)` — `force=false` refuses with `DependencyRequired` when enabled plugins depend on target; `force=true` proceeds with WARN log
- `enable_recursive` emits `tracing::warn!` when a transitive dependency re-enables an explicitly-disabled plugin

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10163/10163 passed
- [x] New test `call_tool_uses_tool_timeout_branch_when_configured` covers the `Some(tool_timeout_secs)` dispatch path
- [x] 3 new plugin disable `--force` tests

## Breaking change

`PluginManager::disable(name)` → `disable(name, force: bool)` — pass `force: false` to preserve prior behavior. Documented in CHANGELOG.md.

Closes #4039, #4004