### PR TITLE
fix(context,plugins): deterministic compression order and async fs (#4558, #4560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-core`: `select_messages_for_compression` now sorts indices before building `to_compress`,
+  ensuring messages are passed to the compression LLM in chronological (ascending index) order.
+  Previously, iterating a raw `HashSet<usize>` produced non-deterministic ordering (closes #4558).
+- `zeph-plugins`: replaced blocking `std::fs::write` / `std::fs::read_to_string` calls in the
+  async `update_one_plugin` with `tokio::fs` equivalents, preventing Tokio thread starvation
+  during concurrent auto-update checks (closes #4560).
+
 ### Added
 
 - `specs/062-context-adaptive-memory/`: formal specification package for Context-Adaptive Memory (CAM)

--- a/crates/zeph-core/src/agent/tool_execution/focus.rs
+++ b/crates/zeph-core/src/agent/tool_execution/focus.rs
@@ -290,7 +290,7 @@ impl<C: Channel> Agent<C> {
     /// Returns `None` (with the compressible count) when the history is too short (fewer than
     /// `preserve_tail + 4` compressible messages). Returns `Some` with the removal set and
     /// the messages to summarize when compression can proceed.
-    fn select_messages_for_compression(
+    pub(crate) fn select_messages_for_compression(
         &self,
         preserve_tail: usize,
     ) -> Result<
@@ -320,7 +320,9 @@ impl<C: Channel> Agent<C> {
             .copied()
             .collect();
 
-        let to_compress: Vec<zeph_llm::provider::Message> = to_remove_indices
+        let mut sorted_indices: Vec<usize> = to_remove_indices.iter().copied().collect();
+        sorted_indices.sort_unstable();
+        let to_compress: Vec<zeph_llm::provider::Message> = sorted_indices
             .iter()
             .map(|&i| self.msg.messages[i].clone())
             .collect();

--- a/crates/zeph-core/src/agent/tool_execution/tests/focus_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/focus_tests.rs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use zeph_llm::provider::{Message, Role};
+
+use crate::agent::Agent;
+use crate::agent::tests::agent_tests::{
+    MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+};
+
+fn make_agent() -> Agent<MockChannel> {
+    let mut agent = Agent::new(
+        mock_provider(vec![]),
+        MockChannel::new(vec![]),
+        create_test_registry(),
+        None,
+        5,
+        MockToolExecutor::no_tools(),
+    );
+    agent
+        .msg
+        .messages
+        .push(Message::from_legacy(Role::System, "system"));
+    agent
+}
+
+/// Regression test for #4558: `select_messages_for_compression` must return `to_compress`
+/// in ascending chronological index order regardless of `HashSet` iteration order.
+///
+/// Before the fix, indices were collected from a raw `HashSet` into `to_compress` without
+/// sorting, producing non-deterministic message ordering in the compression prompt.
+#[test]
+fn select_messages_for_compression_returns_chronological_order() {
+    let mut agent = make_agent();
+
+    // Build a history: system (idx 0) + 10 user/assistant messages (idx 1..=10).
+    // system is at idx 0 and is filtered out by the role guard, so all 10 are compressible.
+    for i in 1..=10u32 {
+        let role = if i % 2 == 0 {
+            Role::User
+        } else {
+            Role::Assistant
+        };
+        agent
+            .msg
+            .messages
+            .push(Message::from_legacy(role, format!("message {i}")));
+    }
+
+    // preserve_tail = 2 means the last 2 compressible messages are kept; the rest (8) are compressed.
+    let preserve_tail = 2;
+    let result = agent.select_messages_for_compression(preserve_tail);
+
+    let (_, to_compress) = result.expect("enough messages to compress");
+
+    // The content of each message encodes its original position ("message N").
+    // Extract the numeric suffix and verify strict ascending order.
+    let positions: Vec<u32> = to_compress
+        .iter()
+        .map(|m| {
+            m.content
+                .strip_prefix("message ")
+                .and_then(|s| s.parse::<u32>().ok())
+                .expect("message content must be 'message N'")
+        })
+        .collect();
+
+    let mut sorted = positions.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        positions, sorted,
+        "to_compress must be in ascending chronological order (regression for #4558); \
+         got: {positions:?}"
+    );
+}
+
+/// Verify that `select_messages_for_compression` excludes focus-pinned messages.
+#[test]
+fn select_messages_for_compression_excludes_pinned() {
+    let mut agent = make_agent();
+
+    for i in 1..=8u32 {
+        let mut msg = Message::from_legacy(Role::User, format!("msg {i}"));
+        if i == 3 || i == 5 {
+            msg.metadata.focus_pinned = true;
+        }
+        agent.msg.messages.push(msg);
+    }
+
+    let result = agent.select_messages_for_compression(1);
+    let (to_remove, to_compress) = result.expect("enough messages to compress");
+
+    // Pinned messages must not appear in the removal set or the compression slice.
+    let msg_at = |idx: usize| agent.msg.messages[idx].content.clone();
+    for idx in &to_remove {
+        let content = msg_at(*idx);
+        assert!(
+            !agent.msg.messages[*idx].metadata.focus_pinned,
+            "pinned message '{content}' must not be in to_remove"
+        );
+    }
+    for m in &to_compress {
+        assert!(
+            !m.metadata.focus_pinned,
+            "pinned message '{}' must not appear in to_compress",
+            m.content
+        );
+    }
+}

--- a/crates/zeph-core/src/agent/tool_execution/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod boundary_and_classifier_tests;
+mod focus_tests;
 mod hook_block_cap_tests;
 mod native_tests;
 mod parallel_and_handle_tests;

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -840,11 +840,12 @@ impl PluginManager {
         };
         let source_dest = plugin.path.join(".plugin-source.toml");
         if let Ok(toml_str) = toml::to_string(&new_source) {
-            let _ = std::fs::write(&source_dest, toml_str);
+            let _ = tokio::fs::write(&source_dest, toml_str).await;
         }
 
         // Read the new version from the updated manifest.
-        let new_version = std::fs::read_to_string(plugin.path.join(".plugin.toml"))
+        let new_version = tokio::fs::read_to_string(plugin.path.join(".plugin.toml"))
+            .await
             .ok()
             .and_then(|s| toml::from_str::<crate::manifest::PluginManifest>(&s).ok())
             .map_or_else(|| old_version.clone(), |m| m.plugin.version);


### PR DESCRIPTION
## Summary

- **#4558 (zeph-core):** `select_messages_for_compression` iterated a raw `HashSet<usize>` to build `to_compress`, producing non-deterministic message order in the LLM compression prompt. Fixed by sorting indices before mapping to messages — mirrors the existing pattern in `apply_compression_removals`.
- **#4560 (zeph-plugins):** `update_one_plugin` called `std::fs::write` and `std::fs::read_to_string` directly on the Tokio executor after the main `spawn_blocking` block, risking thread pool starvation under concurrent auto-update checks. Replaced with `tokio::fs::write(...).await` and `tokio::fs::read_to_string(...).await`.

Both fixes are minimal and targeted — no surrounding code was refactored.

## Test plan

- [x] Two regression tests added for #4558: `select_messages_for_compression_returns_chronological_order` and `select_messages_for_compression_excludes_pinned`
- [x] `select_messages_for_compression` visibility bumped to `pub(crate)` to enable unit testing
- [x] `cargo nextest run -p zeph-core -p zeph-plugins --lib` — 1617 tests passed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core -p zeph-plugins -- -D warnings` — clean
- [x] Rebased onto `origin/main`

Closes #4558
Closes #4560