### PR TITLE
fix(llm): retry after BetaHeaderRejected and add o-series max_completion_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   handles are reaped non-blockingly with `try_join_next()` before each spawn; if the set is still at
   capacity the new task is skipped with a debug log. `drain_pending()` awaits all remaining writes at
   session shutdown via `Agent::shutdown()` (closes #4570).
+- `zeph-llm`: `ClaudeProvider::send_request` and `send_stream_request` now retry the request
+  transparently after receiving a `BetaHeaderRejected` error for the `compact-2026-01-12` beta
+  header. Previously, the first request in a session with server compaction enabled would always
+  fail when the API rejects the header; the flag is now set and the call retried in the same path
+  without surfacing an error to the caller (closes #4580).
+- `zeph-llm`: `CompletionTokens::for_model` now returns `max_completion_tokens` for OpenAI
+  o-series models (`o1`, `o1-mini`, `o1-pro`, `o3`, `o3-mini`, `o4-mini`). Previously only
+  `gpt-5*` models used this field; o-series models fell through to the legacy `max_tokens` field,
+  causing 400 Bad Request errors from the API (closes #4579).
 - `zeph-core`: `select_messages_for_compression` now sorts indices before building `to_compress`,
   ensuring messages are passed to the compression LLM in chronological (ascending index) order.
   Previously, iterating a raw `HashSet<usize>` produced non-deterministic ordering (closes #4558).

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -815,70 +815,73 @@ impl ClaudeProvider {
     }
 
     async fn send_request(&self, messages: &[Message]) -> Result<String, LlmError> {
-        let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
-            self.build_request(messages, false).send()
-        })
-        .await?;
+        let mut retried = false;
+        loop {
+            let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
+                self.build_request(messages, false).send()
+            })
+            .await?;
 
-        let status = response.status();
-        let text = response.text().await.map_err(LlmError::Http)?;
+            let status = response.status();
+            let text = response.text().await.map_err(LlmError::Http)?;
 
-        if !status.is_success() {
-            if Self::is_compact_beta_rejection(status, &text) {
-                self.server_compaction_rejected
-                    .store(true, Ordering::Relaxed);
-                tracing::warn!(
-                    "compact-2026-01-12 beta header rejected by Claude API; \
-                    disabling server-side compaction for this session. \
-                    Update your config to set `server_compaction = false`."
-                );
-                return Err(LlmError::BetaHeaderRejected {
-                    header: ANTHROPIC_BETA_COMPACT.into(),
+            if !status.is_success() {
+                if !retried && Self::is_compact_beta_rejection(status, &text) {
+                    self.server_compaction_rejected
+                        .store(true, Ordering::Relaxed);
+                    tracing::warn!(
+                        "compact-2026-01-12 beta header rejected by Claude API; \
+                        disabling server-side compaction for this session. \
+                        Update your config to set `server_compaction = false`."
+                    );
+                    retried = true;
+                    continue;
+                }
+                tracing::error!("Claude API error {status}: {text}");
+                if status == reqwest::StatusCode::BAD_REQUEST
+                    && crate::error::body_is_context_length_error(&text)
+                {
+                    return Err(LlmError::ContextLengthExceeded);
+                }
+                return Err(LlmError::ApiError {
+                    provider: "claude".into(),
+                    status: status.as_u16(),
                 });
             }
-            tracing::error!("Claude API error {status}: {text}");
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
-            }
-            return Err(LlmError::ApiError {
-                provider: "claude".into(),
-                status: status.as_u16(),
-            });
-        }
 
-        if Self::has_image_parts(messages) {
-            let resp: ToolApiResponse = serde_json::from_str(&text)?;
+            if Self::has_image_parts(messages) {
+                let resp: ToolApiResponse = serde_json::from_str(&text)?;
+                if let Some(ref usage) = resp.usage {
+                    log_cache_usage(usage);
+                    self.store_cache_usage(usage);
+                }
+                let extracted = resp.content.into_iter().find_map(|b| {
+                    if let AnthropicContentBlock::Text { text, .. } = b {
+                        Some(text)
+                    } else {
+                        None
+                    }
+                });
+                return extracted.ok_or(LlmError::EmptyResponse {
+                    provider: "claude".into(),
+                });
+            }
+
+            let resp: types::ApiResponse = serde_json::from_str(&text)?;
+
             if let Some(ref usage) = resp.usage {
                 log_cache_usage(usage);
                 self.store_cache_usage(usage);
             }
-            let extracted = resp.content.into_iter().find_map(|b| {
-                if let AnthropicContentBlock::Text { text, .. } = b {
-                    Some(text)
-                } else {
-                    None
-                }
-            });
-            return extracted.ok_or(LlmError::EmptyResponse {
-                provider: "claude".into(),
-            });
+
+            return resp
+                .content
+                .first()
+                .map(|c| c.text.clone())
+                .ok_or(LlmError::EmptyResponse {
+                    provider: "claude".into(),
+                });
         }
-
-        let resp: types::ApiResponse = serde_json::from_str(&text)?;
-
-        if let Some(ref usage) = resp.usage {
-            log_cache_usage(usage);
-            self.store_cache_usage(usage);
-        }
-
-        resp.content
-            .first()
-            .map(|c| c.text.clone())
-            .ok_or(LlmError::EmptyResponse {
-                provider: "claude".into(),
-            })
     }
 
     /// Send a streaming tool-use request and return a [`crate::sse::ToolSseStream`].
@@ -978,39 +981,41 @@ impl ClaudeProvider {
         &self,
         messages: &[Message],
     ) -> Result<reqwest::Response, LlmError> {
-        let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
-            self.build_request(messages, true).send()
-        })
-        .await?;
+        let mut retried = false;
+        loop {
+            let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
+                self.build_request(messages, true).send()
+            })
+            .await?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let text = response.text().await.map_err(LlmError::Http)?;
-            if Self::is_compact_beta_rejection(status, &text) {
-                self.server_compaction_rejected
-                    .store(true, Ordering::Relaxed);
-                tracing::warn!(
-                    "compact-2026-01-12 beta header rejected by Claude API (streaming); \
-                    disabling server-side compaction for this session. \
-                    Update your config to set `server_compaction = false`."
-                );
-                return Err(LlmError::BetaHeaderRejected {
-                    header: ANTHROPIC_BETA_COMPACT.into(),
+            let status = response.status();
+            if !status.is_success() {
+                let text = response.text().await.map_err(LlmError::Http)?;
+                if !retried && Self::is_compact_beta_rejection(status, &text) {
+                    self.server_compaction_rejected
+                        .store(true, Ordering::Relaxed);
+                    tracing::warn!(
+                        "compact-2026-01-12 beta header rejected by Claude API (streaming); \
+                        disabling server-side compaction for this session. \
+                        Update your config to set `server_compaction = false`."
+                    );
+                    retried = true;
+                    continue;
+                }
+                tracing::error!("Claude API streaming request error {status}: {text}");
+                if status == reqwest::StatusCode::BAD_REQUEST
+                    && crate::error::body_is_context_length_error(&text)
+                {
+                    return Err(LlmError::ContextLengthExceeded);
+                }
+                return Err(LlmError::ApiError {
+                    provider: "claude".into(),
+                    status: status.as_u16(),
                 });
             }
-            tracing::error!("Claude API streaming request error {status}: {text}");
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
-            }
-            return Err(LlmError::ApiError {
-                provider: "claude".into(),
-                status: status.as_u16(),
-            });
-        }
 
-        Ok(response)
+            return Ok(response);
+        }
     }
 }
 

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -1488,7 +1488,13 @@ enum CompletionTokens {
 
 impl CompletionTokens {
     fn for_model(model: &str, max_tokens: u32) -> Self {
-        if model.starts_with("gpt-5") {
+        // o-series models (o1, o3, o4-mini, …) and gpt-5 require max_completion_tokens;
+        // all other models use the legacy max_tokens field.
+        if model.starts_with("gpt-5")
+            || model.starts_with("o1")
+            || model.starts_with("o3")
+            || model.starts_with("o4")
+        {
             Self::MaxCompletionTokens {
                 max_completion_tokens: max_tokens,
             }

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -1592,3 +1592,35 @@ fn test_openai_stub_used_when_schema_exceeds_1024_bytes() {
         "schema exceeding 1024 bytes must use stub with default budget"
     );
 }
+
+#[test]
+fn completion_tokens_o_series_uses_max_completion_tokens() {
+    for model in &["o1", "o1-mini", "o1-pro", "o3", "o3-mini", "o4-mini"] {
+        let ct = CompletionTokens::for_model(model, 512);
+        let json = serde_json::to_string(&ct).unwrap();
+        assert!(
+            json.contains("\"max_completion_tokens\":512"),
+            "{model} must use max_completion_tokens"
+        );
+        assert!(
+            !json.contains("\"max_tokens\""),
+            "{model} must not use max_tokens"
+        );
+    }
+}
+
+#[test]
+fn completion_tokens_legacy_models_use_max_tokens() {
+    for model in &["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo"] {
+        let ct = CompletionTokens::for_model(model, 256);
+        let json = serde_json::to_string(&ct).unwrap();
+        assert!(
+            json.contains("\"max_tokens\":256"),
+            "{model} must use max_tokens"
+        );
+        assert!(
+            !json.contains("\"max_completion_tokens\""),
+            "{model} must not use max_completion_tokens"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **#4580** — `ClaudeProvider::send_request` and `send_stream_request` now automatically retry after the `compact-2026-01-12` beta header is rejected by the API. The rejection flag is set and the request is immediately retried in the same call path without surfacing an error to the agent loop.
- **#4579** — `CompletionTokens::for_model` now returns `max_completion_tokens` for o-series models (`o1`, `o1-mini`, `o1-pro`, `o3`, `o3-mini`, `o4-mini`). Previously these fell through to the legacy `max_tokens` field, causing 400 Bad Request errors.

## Changes

- `crates/zeph-llm/src/claude/mod.rs`: wrap `send_request` and `send_stream_request` in a one-shot retry loop; `build_request` already reads `server_compaction_rejected` dynamically so the rebuilt request omits the beta header automatically
- `crates/zeph-llm/src/openai/mod.rs`: extend `CompletionTokens::for_model` condition to cover `o1*`, `o3*`, `o4*` prefixes
- `crates/zeph-llm/src/openai/tests.rs`: add `completion_tokens_o_series_uses_max_completion_tokens` and `completion_tokens_legacy_models_use_max_tokens` tests

## Test plan

- [ ] 10178 unit tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo +nightly fmt --check` clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` clean
- [ ] LLM serialization gate: live API session test required before merge (touches `claude/mod.rs` and `openai/mod.rs`)

Closes #4580
Closes #4579