### PR TITLE
fix(core,memory): add tokio timeout guards to all unprotected embed() call sites

### DIFF
--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -562,6 +562,7 @@ impl<C: Channel> Agent<C> {
 
         let matched_indices: Vec<usize> = if let Some(matcher) = &self.services.skill.matcher {
             let provider = self.embedding_provider.clone();
+            let embed_timeout_secs = self.runtime.config.timeouts.embedding_seconds;
             let _ = self.channel.send_status("matching skills...").await;
             let match_result = matcher
                 .match_skills(
@@ -572,7 +573,20 @@ impl<C: Channel> Agent<C> {
                     |text| {
                         let owned = text.to_owned();
                         let p = provider.clone();
-                        Box::pin(async move { p.embed(&owned).await })
+                        Box::pin(async move {
+                            match tokio::time::timeout(
+                                std::time::Duration::from_secs(embed_timeout_secs),
+                                p.embed(&owned),
+                            )
+                            .await
+                            {
+                                Ok(r) => r,
+                                Err(_elapsed) => {
+                                    tracing::warn!("skill matcher: embed() timed out");
+                                    Err(zeph_llm::error::LlmError::Timeout)
+                                }
+                            }
+                        })
                     },
                 )
                 .await;
@@ -627,8 +641,30 @@ impl<C: Channel> Agent<C> {
                 );
 
                 // SkillOrchestra: RL routing head re-rank (past warmup only).
+                let rl_query_embed = if self.services.skill.rl_head.is_some() {
+                    let rl_embed_timeout = std::time::Duration::from_secs(
+                        self.runtime.config.timeouts.embedding_seconds,
+                    );
+                    match tokio::time::timeout(
+                        rl_embed_timeout,
+                        self.embedding_provider.embed(query),
+                    )
+                    .await
+                    {
+                        Ok(Ok(v)) => Some(v),
+                        Ok(Err(_)) => None,
+                        Err(_elapsed) => {
+                            tracing::warn!(
+                                "rl_head: embed() timed out, skipping RL re-rank this turn"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
                 if let Some(rl_head) = &self.services.skill.rl_head
-                    && let Ok(query_embed) = self.embedding_provider.embed(query).await
+                    && let Some(query_embed) = rl_query_embed
                     && {
                         let ok = query_embed.len() == rl_head.embed_dim();
                         if !ok {
@@ -1018,8 +1054,21 @@ impl<C: Channel> Agent<C> {
                             .clone()
                             .unwrap_or_else(|| self.embedding_provider.clone());
                         let _ = self.channel.send_status("selecting tools...").await;
-                        match embed_provider.embed(query).await {
-                            Ok(query_emb) => {
+                        let embed_timeout = std::time::Duration::from_secs(
+                            self.runtime.config.timeouts.embedding_seconds,
+                        );
+                        let embed_outcome =
+                            tokio::time::timeout(embed_timeout, embed_provider.embed(query)).await;
+                        match embed_outcome {
+                            Err(_elapsed) => {
+                                tracing::warn!(
+                                    "semantic tool discovery: embed() timed out, falling back to all tools"
+                                );
+                                if !params.strict {
+                                    self.services.mcp.sync_executor_tools();
+                                }
+                            }
+                            Ok(Ok(query_emb)) => {
                                 let selected = index.select(
                                     &query_emb,
                                     params.top_k,
@@ -1033,7 +1082,7 @@ impl<C: Channel> Agent<C> {
                                 );
                                 self.services.mcp.apply_pruned_tools(selected);
                             }
-                            Err(e) => {
+                            Ok(Err(e)) => {
                                 tracing::warn!(
                                     strict = params.strict,
                                     "semantic tool discovery: query embed failed, falling back to all tools: {e:#}"
@@ -1110,8 +1159,15 @@ impl<C: Channel> Agent<C> {
                 .collect();
 
             let _ = self.channel.send_status("filtering tools...").await;
-            match self.embedding_provider.embed(query).await {
-                Ok(query_emb) => {
+            let schema_embed_timeout =
+                std::time::Duration::from_secs(self.runtime.config.timeouts.embedding_seconds);
+            match tokio::time::timeout(schema_embed_timeout, self.embedding_provider.embed(query))
+                .await
+            {
+                Err(_elapsed) => {
+                    tracing::warn!("tool filter: embed() timed out, using all tools");
+                }
+                Ok(Ok(query_emb)) => {
                     let mut result = filter.filter(&all_ids, &descriptions, query, &query_emb);
 
                     // Apply dependency graph AFTER schema filter (and after any TAFC
@@ -1156,7 +1212,7 @@ impl<C: Channel> Agent<C> {
                     }
                     self.services.tool_state.cached_filtered_tool_ids = Some(result.included);
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::warn!("tool filter: query embed failed, using all tools: {e:#}");
                 }
             }

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -457,8 +457,14 @@ impl<C: Channel> Agent<C> {
                 threshold,
                 "semantic cache lookup: examining up to {max_candidates} candidates",
             );
-            match self.embedding_provider.embed(&content).await {
-                Ok(embedding) => {
+            let embed_timeout =
+                std::time::Duration::from_secs(self.runtime.config.timeouts.embedding_seconds);
+            match tokio::time::timeout(embed_timeout, self.embedding_provider.embed(&content)).await
+            {
+                Err(_elapsed) => {
+                    tracing::warn!("semantic cache: embed() timed out, skipping semantic cache");
+                }
+                Ok(Ok(embedding)) => {
                     let embed_model = self.services.skill.embedding_model.clone();
                     match cache
                         .get_semantic(&embedding, &embed_model, threshold, max_candidates)
@@ -489,7 +495,7 @@ impl<C: Channel> Agent<C> {
                         }
                     }
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::warn!("embedding generation failed, skipping semantic cache: {e:#}");
                 }
             }

--- a/crates/zeph-memory/src/semantic/corrections.rs
+++ b/crates/zeph-memory/src/semantic/corrections.rs
@@ -74,11 +74,19 @@ impl SemanticMemory {
             tracing::debug!("corrections: skipped, no embedding support");
             return Ok(vec![]);
         }
-        let embedding = self
-            .effective_embed_provider()
-            .embed(query)
-            .await
-            .map_err(MemoryError::Llm)?;
+        let embedding = match tokio::time::timeout(
+            Duration::from_secs(5),
+            self.effective_embed_provider().embed(query),
+        )
+        .await
+        {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => return Err(MemoryError::Llm(e)),
+            Err(_) => {
+                tracing::warn!("search_corrections: embed() timed out, returning empty");
+                return Ok(vec![]);
+            }
+        };
         let vector_size = u64::try_from(embedding.len()).unwrap_or(896);
         store
             .ensure_named_collection(CORRECTIONS_COLLECTION, vector_size)
@@ -166,5 +174,26 @@ mod tests {
             result.is_ok(),
             "embed timeout must return Ok(()) (fail-open, skip write), got {result:?}"
         );
+    }
+
+    /// `embed()` timeout in `retrieve_similar_corrections` → returns `Ok(vec![])` (fail-open).
+    #[tokio::test]
+    async fn retrieve_similar_corrections_embed_timeout_returns_empty() {
+        let mem = mem_with_slow_embed(10_000).await;
+
+        tokio::time::pause();
+
+        let fut = mem.retrieve_similar_corrections("prefer concise answers", 5, 0.7);
+        let (result, ()) = tokio::join!(fut, async {
+            tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        });
+
+        match result {
+            Ok(rows) => assert!(
+                rows.is_empty(),
+                "embed timeout must return empty vec (fail-open), got {rows:?}"
+            ),
+            Err(e) => panic!("embed timeout must not propagate error, got {e:?}"),
+        }
     }
 }

--- a/crates/zeph-memory/src/semantic/tree_consolidation.rs
+++ b/crates/zeph-memory/src/semantic/tree_consolidation.rs
@@ -226,7 +226,24 @@ async fn embed_candidates(
             .map(|row| {
                 let id = row.id;
                 let content = row.content.clone();
-                async move { (id, content.clone(), provider.embed(&content).await) }
+                async move {
+                    let result = tokio::time::timeout(
+                        std::time::Duration::from_secs(5),
+                        provider.embed(&content),
+                    )
+                    .await;
+                    let result = match result {
+                        Ok(r) => r,
+                        Err(_elapsed) => {
+                            tracing::warn!(
+                                node_id = id,
+                                "tree consolidation: embed() timed out, skipping node"
+                            );
+                            return (id, content, Err(zeph_llm::error::LlmError::Timeout));
+                        }
+                    };
+                    (id, content, result)
+                }
             })
             .collect();
 
@@ -308,6 +325,51 @@ async fn merge_via_llm(provider: &AnyProvider, contents: &[&str]) -> Result<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `embed()` timeout in `embed_candidates` → timed-out nodes are dropped, function returns
+    /// only successfully embedded entries (fail-open: the sweep can still proceed with fewer nodes).
+    #[tokio::test]
+    async fn embed_candidates_timeout_drops_timed_out_nodes() {
+        let slow = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default().with_embed_delay(10_000),
+        );
+
+        let candidates = vec![
+            MemoryTreeRow {
+                id: 1,
+                level: 0,
+                parent_id: None,
+                content: "Alice prefers Rust".to_owned(),
+                source_ids: "[]".to_owned(),
+                token_count: 3,
+                consolidated_at: None,
+                created_at: "2026-01-01T00:00:00".to_owned(),
+            },
+            MemoryTreeRow {
+                id: 2,
+                level: 0,
+                parent_id: None,
+                content: "Alice likes async code".to_owned(),
+                source_ids: "[]".to_owned(),
+                token_count: 4,
+                consolidated_at: None,
+                created_at: "2026-01-01T00:00:01".to_owned(),
+            },
+        ];
+
+        tokio::time::pause();
+
+        let fut = embed_candidates(&slow, &candidates);
+        let (result, ()) = tokio::join!(fut, async {
+            tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        });
+
+        assert!(
+            result.is_empty(),
+            "all nodes must be dropped on embed timeout, got {} entries",
+            result.len()
+        );
+    }
 
     #[test]
     fn cluster_by_similarity_groups_identical_vectors() {


### PR DESCRIPTION
## Summary

Closes #4582, Closes #4583

Wraps 7 bare `.embed().await` call sites across `zeph-core` and `zeph-memory` that had no `tokio::time::timeout` guard. Without these guards a stalled embedding provider (slow network, overloaded Ollama) blocks the agent turn or memory operations for up to 600 seconds with no diagnostic feedback.

**Note:** `RouterProvider::embed_timeout_ms` already defaults to 5000 ms in `router/mod.rs::new()`, so #4584 required no code change.

### Changes

**`zeph-core`** (closes #4582):
- `assembly.rs` — 4 sites (semantic cache check, RL head rerank, MCP tool discovery, tool schema filter) wrapped with `RuntimeConfig::timeouts.embedding_seconds`; all fail open on `Elapsed` (skip operation, log `warn`)
- `tool_execution/mod.rs` — 1 site (semantic cache check), same pattern

**`zeph-memory`** (closes #4583):
- `corrections.rs` — `retrieve_similar_corrections()` guarded with 5 s timeout matching the existing `store_correction_embedding()` pattern; returns `Ok(vec![])` on `Elapsed`
- `tree_consolidation.rs` — each `provider.embed()` in `embed_candidates()` join_all batch guarded with 5 s per-item timeout; returns `Err(LlmError::Timeout)` per item on `Elapsed` (outer caller skips timed-out nodes)

### Tests added
- `corrections::retrieve_similar_corrections_embed_timeout_returns_empty`
- `tree_consolidation::embed_candidates_timeout_drops_timed_out_nodes`

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --lib --bins` — 10178 passed
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean