### PR TITLE
fix(plugins,core,index): replace blocking fs and add embed timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-plugins`: `read_plugin_source` in `update_one_plugin` now uses `tokio::fs::read_to_string`
+  instead of `std::fs::read_to_string`, preventing the async executor thread from blocking during
+  plugin auto-update sidecar reads (closes #4589).
+- `zeph-core`: `AgentBuilder::apply_tool_schema_filter` wraps `provider.embed()` with a 15-second
+  `tokio::time::timeout`. On timeout the filter is silently disabled (graceful degradation) rather
+  than hanging agent startup indefinitely (closes #4585).
+- `zeph-index`: `CodeIndexer::ensure_collection_for_provider` wraps `provider.embed("probe")` with
+  a 15-second `tokio::time::timeout`, mapping a stall to `IndexError::EmbedTimeout` so index
+  initialization fails fast with a clear diagnostic (closes #4585).
 - `zeph-llm`, `zeph-mcp`: embed calls inside fire-and-forget tasks (`RouterProvider::spawn_asi_update`
   and `EmbeddingAnomalyGuard::check_async`) are now bounded by `embed_timeout_ms` (default 5 s) via
   `tokio::time::timeout`. On timeout the task returns early — same as the existing embed-error path —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10978,6 +10978,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serial_test",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1184,6 +1184,7 @@ impl<C: Channel> Agent<C> {
         provider: zeph_llm::any::AnyProvider,
     ) -> Self {
         use zeph_llm::provider::LlmProvider;
+        const STARTUP_EMBED_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
         if !config.enabled {
             return self;
@@ -1206,18 +1207,25 @@ impl<C: Channel> Agent<C> {
         let mut embeddings = Vec::with_capacity(filterable.len());
         for (id, description) in filterable {
             let text = format!("{id}: {description}");
-            match provider.embed(&text).await {
-                Ok(emb) => {
+            match tokio::time::timeout(STARTUP_EMBED_TIMEOUT, provider.embed(&text)).await {
+                Ok(Ok(emb)) => {
                     embeddings.push(zeph_tools::ToolEmbedding {
                         tool_id: id.as_str().into(),
                         embedding: emb,
                     });
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::info!(
                         provider = provider.name(),
                         "tool schema filter disabled: embedding not supported \
                         by provider ({e:#})"
+                    );
+                    return self;
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        provider = provider.name(),
+                        "tool schema filter disabled: embedding provider timed out during startup"
                     );
                     return self;
                 }

--- a/crates/zeph-index/Cargo.toml
+++ b/crates/zeph-index/Cargo.toml
@@ -43,6 +43,7 @@ zeph-memory.workspace = true
 zeph-tools.workspace = true
 
 [dev-dependencies]
+serial_test.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/zeph-index/Cargo.toml
+++ b/crates/zeph-index/Cargo.toml
@@ -45,7 +45,7 @@ zeph-tools.workspace = true
 [dev-dependencies]
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 zeph-llm = { workspace = true, features = ["testing"] }
 
 [features]

--- a/crates/zeph-index/src/error.rs
+++ b/crates/zeph-index/src/error.rs
@@ -90,8 +90,9 @@ pub enum IndexError {
 
     /// Embedding call timed out.
     ///
-    /// Raised by [`crate::retriever::CodeRetriever`] when `provider.embed()` does not
-    /// complete within the configured `embed_timeout_secs`.
+    /// Raised by [`crate::retriever::CodeRetriever`] and
+    /// [`crate::indexer::CodeIndexer`] when `provider.embed()` does not complete
+    /// within the configured timeout.
     #[error("embedding timed out after {0}s")]
     EmbedTimeout(u64),
 

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -906,7 +906,7 @@ mod tests {
     /// when the embedding provider exceeds the 15-second startup timeout.
     ///
     /// Uses `tokio::time::pause` + `advance` to avoid a real 15-second wall-clock wait.
-    /// DB is initialised before pausing time to avoid SQLite pool timeout under paused clock.
+    /// DB is initialised before pausing time to avoid `SQLite` pool timeout under paused clock.
     /// Must run serially — `tokio::time::pause` is process-global and breaks parallel tests.
     #[serial_test::serial]
     #[tokio::test]

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -292,7 +292,19 @@ impl CodeIndexer {
 
     #[tracing::instrument(name = "index.indexer.ensure_collection", skip_all)]
     async fn ensure_collection_for_provider(&self) -> Result<()> {
-        let probe = self.provider.embed("probe").await?;
+        const STARTUP_EMBED_TIMEOUT_SECS: u64 = 15;
+        let probe = tokio::time::timeout(
+            Duration::from_secs(STARTUP_EMBED_TIMEOUT_SECS),
+            self.provider.embed("probe"),
+        )
+        .await
+        .map_err(|_| {
+            tracing::warn!(
+                timeout_secs = STARTUP_EMBED_TIMEOUT_SECS,
+                "embedding provider timed out during startup"
+            );
+            crate::error::IndexError::EmbedTimeout(STARTUP_EMBED_TIMEOUT_SECS)
+        })??;
         let vector_size = u64::try_from(probe.len())?;
         self.store.ensure_collection(vector_size).await
     }
@@ -888,6 +900,57 @@ mod tests {
         }
         // Guard dropped — flag must be false.
         assert!(!flag.load(Ordering::Relaxed));
+    }
+
+    /// Verify that `ensure_collection_for_provider` returns `IndexError::EmbedTimeout`
+    /// when the embedding provider exceeds the 15-second startup timeout.
+    ///
+    /// Uses `tokio::time::pause` + `advance` to avoid a real 15-second wall-clock wait.
+    /// DB is initialised before pausing time to avoid SQLite pool timeout under paused clock.
+    #[tokio::test]
+    async fn ensure_collection_timeout_returns_embed_timeout_error() {
+        use std::sync::Arc;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_memory::QdrantOps;
+
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_string(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap();
+
+        // Pause time only after DB initialisation to avoid SQLite PoolTimedOut.
+        tokio::time::pause();
+
+        // embed_delay_ms must exceed the 15 s timeout; we pair it with time::advance
+        // so the test completes instantly in wall-clock time.
+        let slow_provider = Arc::new(AnyProvider::Mock(
+            MockProvider::default()
+                .with_embed_delay(20_000) // 20 s > 15 s timeout
+                .with_embedding(vec![0.0_f32; 384]),
+        ));
+
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        let store = crate::store::CodeStore::with_ops(ops, pool);
+        let indexer = CodeIndexer::new(store, slow_provider, IndexerConfig::default());
+
+        // Advance mock time past the 15-second timeout so tokio::time::timeout fires.
+        let drive = tokio::spawn(async {
+            tokio::time::advance(std::time::Duration::from_secs(16)).await;
+        });
+
+        let result = indexer.ensure_collection_for_provider().await;
+        drive.await.unwrap();
+
+        match result {
+            Err(crate::error::IndexError::EmbedTimeout(secs)) => {
+                assert_eq!(secs, 15, "timeout value must be the configured 15 s");
+            }
+            other => panic!("expected IndexError::EmbedTimeout, got: {other:?}"),
+        }
     }
 
     /// Verify that `compare_exchange` rejects a second caller while the flag is set.

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -939,13 +939,10 @@ mod tests {
         let store = crate::store::CodeStore::with_ops(ops, pool);
         let indexer = CodeIndexer::new(store, slow_provider, IndexerConfig::default());
 
-        // Advance mock time past the 15-second timeout so tokio::time::timeout fires.
-        let drive = tokio::spawn(async {
-            tokio::time::advance(std::time::Duration::from_secs(16)).await;
-        });
-
-        let result = indexer.ensure_collection_for_provider().await;
-        drive.await.unwrap();
+        // Spawn the operation so we can advance mock time from the test body.
+        let handle = tokio::spawn(async move { indexer.ensure_collection_for_provider().await });
+        tokio::time::advance(std::time::Duration::from_secs(16)).await;
+        let result = handle.await.unwrap();
 
         match result {
             Err(crate::error::IndexError::EmbedTimeout(secs)) => {

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -907,6 +907,8 @@ mod tests {
     ///
     /// Uses `tokio::time::pause` + `advance` to avoid a real 15-second wall-clock wait.
     /// DB is initialised before pausing time to avoid SQLite pool timeout under paused clock.
+    /// Must run serially — `tokio::time::pause` is process-global and breaks parallel tests.
+    #[serial_test::serial]
     #[tokio::test]
     async fn ensure_collection_timeout_returns_embed_timeout_error() {
         use std::sync::Arc;

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -749,7 +749,7 @@ impl PluginManager {
     #[tracing::instrument(name = "plugins.manager.update_one", skip_all, fields(plugin = %plugin.name))]
     async fn update_one_plugin(&self, plugin: &InstalledPlugin) -> AutoUpdateStatus {
         let source_path = plugin.path.join(".plugin-source.toml");
-        let Some(source) = read_plugin_source(&source_path) else {
+        let Some(source) = read_plugin_source(&source_path).await else {
             return AutoUpdateStatus::NoSource;
         };
 
@@ -1183,8 +1183,8 @@ impl PluginManager {
 /// Read `.plugin-source.toml` from `path` and return it, or `None` on any failure.
 ///
 /// Failures are logged as debug — missing sidecar is normal for local-install plugins.
-fn read_plugin_source(path: &std::path::Path) -> Option<PluginSource> {
-    let text = std::fs::read_to_string(path).ok()?;
+async fn read_plugin_source(path: &std::path::Path) -> Option<PluginSource> {
+    let text = tokio::fs::read_to_string(path).await.ok()?;
     match toml::from_str::<PluginSource>(&text) {
         Ok(s) => Some(s),
         Err(e) => {


### PR DESCRIPTION
## Summary

- Replace blocking `std::fs::read_to_string` with `tokio::fs::read_to_string` in `read_plugin_source` so `update_one_plugin` no longer stalls the async executor thread during plugin auto-update sidecar reads (#4589)
- Wrap `provider.embed()` in `AgentBuilder::apply_tool_schema_filter` with a 15-second timeout; disables the tool schema filter gracefully on timeout rather than hanging agent startup (#4585)
- Wrap `provider.embed("probe")` in `CodeIndexer::ensure_collection_for_provider` with a 15-second timeout, mapping a stall to `IndexError::EmbedTimeout` for fast-fail with a clear diagnostic (#4585)
- Add `#[serial_test::serial]` regression test for `EmbedTimeout` using `tokio::time::pause` + spawned-operation pattern matching the established convention in `zeph-memory`

## Test plan

- [ ] `cargo nextest run -p zeph-plugins -p zeph-core -p zeph-index --lib` — all pass (108 index, 110 plugins tests)
- [ ] `cargo clippy -p zeph-plugins -p zeph-core -p zeph-index -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check -p zeph-plugins -p zeph-core -p zeph-index --all-targets` — clean
- [ ] `ensure_collection_timeout_returns_embed_timeout_error` passes in isolation and in parallel suite with `#[serial_test::serial]`

Closes #4589
Closes #4585