### PR TITLE
refactor(mcp,core): add #[non_exhaustive] to extensible pub enums in zeph-mcp

### DIFF
--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1143,6 +1143,10 @@ impl<C: Channel> Agent<C> {
                     // Pass all tools through without filtering.
                     self.services.mcp.sync_executor_tools();
                 }
+                _ => {
+                    // Unknown future variant: fall back to passing all tools through.
+                    self.services.mcp.sync_executor_tools();
+                }
             }
         }
 

--- a/crates/zeph-mcp/src/attestation.rs
+++ b/crates/zeph-mcp/src/attestation.rs
@@ -23,6 +23,7 @@ pub type ToolFingerprint = String;
 ///
 /// Produced by [`attest_tools`] at connect time. Stored in [`ServerTrustBoundary`] and used
 /// to decide whether unexpected tools should be filtered or surfaced as warnings.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum AttestationResult {
     /// All actual tools are in the operator-declared expected set.

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -325,6 +325,7 @@ impl rmcp::ClientHandler for ToolListChangedHandler {
 }
 
 /// Result of an OAuth connection attempt.
+#[non_exhaustive]
 pub enum OAuthConnectResult {
     /// Connection established using cached or freshly obtained tokens.
     Connected(McpClient),

--- a/crates/zeph-mcp/src/embedding_guard.rs
+++ b/crates/zeph-mcp/src/embedding_guard.rs
@@ -32,6 +32,7 @@ static INJECTION_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
 });
 
 /// Result of an embedding anomaly check.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum EmbeddingGuardResult {
     /// Output is within the expected distribution.

--- a/crates/zeph-mcp/src/error.rs
+++ b/crates/zeph-mcp/src/error.rs
@@ -7,6 +7,7 @@ use zeph_common::ToolName;
 ///
 /// Used by [`McpError::code`] and callers such as the agent retry loop to decide
 /// whether an operation should be retried, backed off, or abandoned.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum McpErrorCode {
@@ -56,6 +57,7 @@ impl McpErrorCode {
 /// assert_eq!(err.code(), Some(McpErrorCode::Transient));
 /// assert!(err.code().unwrap().is_retryable());
 /// ```
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum McpError {
     #[error("connection failed for server '{server_id}': {message}")]

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -48,6 +48,7 @@ pub(crate) use zeph_config::McpTrustLevel;
 const MAX_INJECTION_PENALTIES_PER_REGISTRATION: usize = 3;
 
 /// Transport type for MCP server connections.
+#[non_exhaustive]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum McpTransport {
     /// Stdio: spawn child process with command + args.

--- a/crates/zeph-mcp/src/policy.rs
+++ b/crates/zeph-mcp/src/policy.rs
@@ -23,6 +23,7 @@ use crate::tool::{DataSensitivity, McpTool};
 // ── Data-flow policy ─────────────────────────────────────────────────────────
 
 /// Data-flow policy violation.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum DataFlowViolation {
     #[error(
@@ -81,6 +82,7 @@ pub(crate) use zeph_config::McpPolicy;
 ///
 /// Returned by [`PolicyEnforcer::check`]. The outer [`McpError`](crate::error::McpError)
 /// wraps this as `McpError::PolicyViolation`.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum PolicyViolation {
     #[error("tool '{tool_name}' is denied on server '{server_id}'")]

--- a/crates/zeph-mcp/src/pruning.rs
+++ b/crates/zeph-mcp/src/pruning.rs
@@ -220,6 +220,7 @@ pub async fn prune_tools_cached<P: LlmProvider>(
 }
 
 /// Errors that can occur during tool pruning.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum PruningError {
     /// LLM call failed.

--- a/crates/zeph-mcp/src/sanitize.rs
+++ b/crates/zeph-mcp/src/sanitize.rs
@@ -212,6 +212,7 @@ fn sanitize_server_id(id: &str) -> String {
 /// Used in [`CrossToolReference::severity`] to distinguish a plain cross-reference
 /// (suspicious, but may be legitimate) from one that accompanies an injection pattern
 /// (high-confidence attack surface indicator).
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CrossRefSeverity {
     /// Cross-reference only — no injection pattern on the same source tool.

--- a/crates/zeph-mcp/src/semantic_index.rs
+++ b/crates/zeph-mcp/src/semantic_index.rs
@@ -23,6 +23,7 @@ use crate::tool::McpTool;
 // ── Errors ────────────────────────────────────────────────────────────────────
 
 /// Errors produced by [`SemanticToolIndex::build`].
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum SemanticIndexError {
     /// Every tool in the input list failed to embed.
@@ -254,6 +255,7 @@ impl SemanticToolIndex {
 /// Mirrors `ToolDiscoveryStrategyConfig` in `zeph-config` but lives in `zeph-mcp`
 /// to avoid a circular crate dependency.  Callers in `zeph-core` convert between
 /// the two representations.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ToolDiscoveryStrategy {
     /// Embedding-based cosine similarity retrieval.  Fast, no LLM call per turn.


### PR DESCRIPTION
## Summary

- Add `#[non_exhaustive]` to 12 extensible `pub enum`s in `crates/zeph-mcp/` missed by the #4545 sweep
- Add wildcard arm to the `ToolDiscoveryStrategy` match in `zeph-core` `assembly.rs` to handle future variants

## Affected enums (zeph-mcp)

| File | Enum |
|------|------|
| `attestation.rs` | `AttestationResult` |
| `error.rs` | `McpErrorCode`, `McpError` |
| `policy.rs` | `DataFlowViolation`, `PolicyViolation` |
| `client.rs` | `OAuthConnectResult` |
| `embedding_guard.rs` | `EmbeddingGuardResult` |
| `manager.rs` | `McpTransport` |
| `sanitize.rs` | `CrossRefSeverity` |
| `pruning.rs` | `PruningError` |
| `semantic_index.rs` | `SemanticIndexError`, `ToolDiscoveryStrategy` |

## Cross-crate impact (zeph-core)

`ToolDiscoveryStrategy` is matched exhaustively in `assembly.rs`. Added a wildcard `_ =>` arm that falls back to `sync_executor_tools()` (same behavior as `None`), ensuring future variants do not break compilation in downstream crates.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-mcp -p zeph-core -- -D warnings` — zero warnings
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10208/10208 passed
- [x] `cargo doc --no-deps -p zeph-mcp -p zeph-core` — no broken intra-doc links

Closes #4564
Closes #4575