### PR TITLE
fix(llm): extend BetaHeaderRejected retry to all claude call paths and cover o2-* models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `runner`: TUI early-status-forwarder `JoinHandle` annotated as intentionally dropped at block
   end (self-terminating when the channel closes). Removes misleading bare `let _` and satisfies
   `clippy::let_underscore_future`. Closes #4571.
+- `zeph-llm`: `ClaudeProvider::chat_with_tools_stream`, `chat_typed`, and `chat_with_tools` now
+  apply the same `BetaHeaderRejected` retry loop that `send_request` and `send_stream_request`
+  already use. Previously these three paths returned `BetaHeaderRejected` to the caller without
+  retrying, meaning any session that started with server compaction enabled would always fail on
+  the first tool-stream, typed, or non-streaming tool call (closes #4598).
+- `zeph-llm`: `CompletionTokens::for_model` now uses a general `o`+digit prefix check instead of
+  enumerating `o1`/`o3`/`o4`. This covers all current and future o-series models (`o2`, `o5`, …)
+  without requiring per-model additions (closes #4600, #4602).
 
 ### Added
 

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -919,8 +919,8 @@ impl ClaudeProvider {
         let system_blocks =
             system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
         Self::cap_block_cache_controls(1, system_blocks.as_deref(), Some(&mut chat_messages));
-        let beta = self.beta_header(!tools.is_empty());
-        let body = ToolRequestBody {
+        let has_tools = !tools.is_empty();
+        let mut body = ToolRequestBody {
             model: &self.model,
             max_tokens: self.max_tokens,
             system: system_blocks,
@@ -933,48 +933,53 @@ impl ClaudeProvider {
             context_management: self.context_management(),
         };
 
-        let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
-            let mut req = self
-                .client
-                .post(API_URL)
-                .header("x-api-key", &self.api_key)
-                .header("anthropic-version", ANTHROPIC_VERSION);
-            if let Some(ref b) = beta {
-                req = req.header("anthropic-beta", b);
-            }
-            req.header("content-type", "application/json")
-                .json(&body)
-                .send()
-        })
-        .await?;
+        let mut retried = false;
+        loop {
+            body.context_management = self.context_management();
+            let beta = self.beta_header(has_tools);
+            let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
+                let mut req = self
+                    .client
+                    .post(API_URL)
+                    .header("x-api-key", &self.api_key)
+                    .header("anthropic-version", ANTHROPIC_VERSION);
+                if let Some(ref b) = beta {
+                    req = req.header("anthropic-beta", b);
+                }
+                req.header("content-type", "application/json")
+                    .json(&body)
+                    .send()
+            })
+            .await?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let text = response.text().await.map_err(LlmError::Http)?;
-            if Self::is_compact_beta_rejection(status, &text) {
-                self.server_compaction_rejected
-                    .store(true, Ordering::Relaxed);
-                tracing::warn!(
-                    "compact-2026-01-12 beta header rejected by Claude API (tool stream); \
-                    disabling server-side compaction for this session."
-                );
-                return Err(LlmError::BetaHeaderRejected {
-                    header: ANTHROPIC_BETA_COMPACT.into(),
+            let status = response.status();
+            if !status.is_success() {
+                let text = response.text().await.map_err(LlmError::Http)?;
+                if !retried && Self::is_compact_beta_rejection(status, &text) {
+                    self.server_compaction_rejected
+                        .store(true, Ordering::Relaxed);
+                    tracing::warn!(
+                        "compact-2026-01-12 beta header rejected by Claude API (tool stream); \
+                        disabling server-side compaction for this session. \
+                        Update your config to set `server_compaction = false`."
+                    );
+                    retried = true;
+                    continue;
+                }
+                tracing::error!("Claude API error {status}: {text}");
+                if status == reqwest::StatusCode::BAD_REQUEST
+                    && crate::error::body_is_context_length_error(&text)
+                {
+                    return Err(LlmError::ContextLengthExceeded);
+                }
+                return Err(LlmError::ApiError {
+                    provider: "claude".into(),
+                    status: status.as_u16(),
                 });
             }
-            tracing::error!("Claude API error {status}: {text}");
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
-            }
-            return Err(LlmError::ApiError {
-                provider: "claude".into(),
-                status: status.as_u16(),
-            });
-        }
 
-        Ok(claude_sse_to_tool_stream(response))
+            return Ok(claude_sse_to_tool_stream(response));
+        }
     }
 
     async fn send_stream_request(
@@ -1105,6 +1110,7 @@ impl LlmProvider for ClaudeProvider {
         true
     }
 
+    #[allow(clippy::too_many_lines)] // retry loop + body construction are tightly coupled; extracting would obscure control flow
     async fn chat_typed<T>(&self, messages: &[Message]) -> Result<T, LlmError>
     where
         T: serde::de::DeserializeOwned + schemars::JsonSchema + 'static,
@@ -1112,7 +1118,6 @@ impl LlmProvider for ClaudeProvider {
     {
         let (schema_value, _) = crate::provider::cached_schema::<T>()?;
         let type_name = crate::provider::short_type_name::<T>();
-
         let tool_name = format!("submit_{type_name}");
         let tool = ToolDefinition {
             name: tool_name.clone().into(),
@@ -1120,7 +1125,6 @@ impl LlmProvider for ClaudeProvider {
             parameters: schema_value,
             output_schema: None,
         };
-
         let (system, mut chat_messages) =
             split_messages_structured(messages, self.cache_user_messages, self.prompt_cache_ttl);
         let api_tool = AnthropicTool {
@@ -1128,7 +1132,6 @@ impl LlmProvider for ClaudeProvider {
             description: &tool.description,
             input_schema: &tool.parameters,
         };
-
         let (thinking_param, mut temperature, effort) = self.build_thinking_param();
         if thinking_param.is_none()
             && let Some(Some(t)) = self.generation_overrides.as_ref().map(|ov| ov.temperature)
@@ -1139,81 +1142,80 @@ impl LlmProvider for ClaudeProvider {
         let system_blocks =
             system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
         Self::cap_block_cache_controls(0, system_blocks.as_deref(), Some(&mut chat_messages));
-        let beta = self.beta_header(true);
-        let body = TypedToolRequestBody {
+        let tool_choice = ToolChoice {
+            r#type: "tool",
+            name: &tool_name,
+        };
+        let mut body = TypedToolRequestBody {
             model: &self.model,
             max_tokens: self.max_tokens,
             system: system_blocks,
             messages: &chat_messages,
             tools: &[api_tool],
-            tool_choice: ToolChoice {
-                r#type: "tool",
-                name: &tool_name,
-            },
+            tool_choice,
             thinking: thinking_param,
             output_config,
             temperature,
-            context_management: self.context_management(),
+            context_management: None,
         };
-
-        let mut req = self
-            .client
-            .post(API_URL)
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", ANTHROPIC_VERSION);
-        if let Some(b) = beta {
-            req = req.header("anthropic-beta", b);
-        }
-        let response = req
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
+        let mut retried = false;
+        loop {
+            body.context_management = self.context_management();
+            let beta = self.beta_header(true);
+            let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
+                let mut req = self
+                    .client
+                    .post(API_URL)
+                    .header("x-api-key", &self.api_key)
+                    .header("anthropic-version", ANTHROPIC_VERSION);
+                if let Some(ref b) = beta {
+                    req = req.header("anthropic-beta", b);
+                }
+                req.header("content-type", "application/json")
+                    .json(&body)
+                    .send()
+            })
             .await?;
-
-        let status = response.status();
-        let text = response.text().await.map_err(LlmError::Http)?;
-
-        if !status.is_success() {
-            if Self::is_compact_beta_rejection(status, &text) {
-                self.server_compaction_rejected
-                    .store(true, Ordering::Relaxed);
-                tracing::warn!(
-                    "compact-2026-01-12 beta header rejected by Claude API (typed); \
-                    disabling server-side compaction for this session. \
-                    Update your config to set `server_compaction = false`."
-                );
-                return Err(LlmError::BetaHeaderRejected {
-                    header: ANTHROPIC_BETA_COMPACT.into(),
+            let status = response.status();
+            let text = response.text().await.map_err(LlmError::Http)?;
+            if !status.is_success() {
+                if !retried && Self::is_compact_beta_rejection(status, &text) {
+                    self.server_compaction_rejected
+                        .store(true, Ordering::Relaxed);
+                    tracing::warn!(
+                        "compact-2026-01-12 beta header rejected by Claude API (typed); \
+                        disabling server-side compaction for this session. \
+                        Update your config to set `server_compaction = false`."
+                    );
+                    retried = true;
+                    continue;
+                }
+                tracing::error!("Claude API error {status}: {text}");
+                if status == reqwest::StatusCode::BAD_REQUEST
+                    && crate::error::body_is_context_length_error(&text)
+                {
+                    return Err(LlmError::ContextLengthExceeded);
+                }
+                return Err(LlmError::ApiError {
+                    provider: "claude".into(),
+                    status: status.as_u16(),
                 });
             }
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
+            let resp: ToolApiResponse = serde_json::from_str(&text)?;
+            if let Some(ref usage) = resp.usage {
+                log_cache_usage(usage);
+                self.store_cache_usage(usage);
             }
-            return Err(LlmError::ApiError {
-                provider: "claude".into(),
-                status: status.as_u16(),
-            });
-        }
-
-        let resp: ToolApiResponse = serde_json::from_str(&text)?;
-
-        if let Some(ref usage) = resp.usage {
-            log_cache_usage(usage);
-            self.store_cache_usage(usage);
-        }
-
-        for block in resp.content {
-            if let AnthropicContentBlock::ToolUse { input, .. } = block {
-                return serde_json::from_value::<T>(input)
-                    .map_err(|e| LlmError::StructuredParse(e.to_string()));
+            for block in resp.content {
+                if let AnthropicContentBlock::ToolUse { input, .. } = block {
+                    return serde_json::from_value::<T>(input)
+                        .map_err(|e| LlmError::StructuredParse(e.to_string()));
+                }
             }
+            return Err(LlmError::StructuredParse(
+                "no tool_use block in response".into(),
+            ));
         }
-
-        Err(LlmError::StructuredParse(
-            "no tool_use block in response".into(),
-        ))
     }
 
     fn supports_vision(&self) -> bool {
@@ -1333,8 +1335,8 @@ impl LlmProvider for ClaudeProvider {
         let system_blocks =
             system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
         Self::cap_block_cache_controls(1, system_blocks.as_deref(), Some(&mut chat_messages));
-        let beta = self.beta_header(!tools.is_empty());
-        let body = ToolRequestBody {
+        let has_tools = !tools.is_empty();
+        let mut body = ToolRequestBody {
             model: &self.model,
             max_tokens: self.max_tokens,
             system: system_blocks,
@@ -1347,69 +1349,73 @@ impl LlmProvider for ClaudeProvider {
             context_management: self.context_management(),
         };
 
-        let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
-            let mut req = self
-                .client
-                .post(API_URL)
-                .header("x-api-key", &self.api_key)
-                .header("anthropic-version", ANTHROPIC_VERSION);
-            if let Some(ref b) = beta {
-                req = req.header("anthropic-beta", b);
-            }
-            req.header("content-type", "application/json")
-                .json(&body)
-                .send()
-        })
-        .await?;
+        let mut retried = false;
+        loop {
+            body.context_management = self.context_management();
+            let beta = self.beta_header(has_tools);
+            let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
+                let mut req = self
+                    .client
+                    .post(API_URL)
+                    .header("x-api-key", &self.api_key)
+                    .header("anthropic-version", ANTHROPIC_VERSION);
+                if let Some(ref b) = beta {
+                    req = req.header("anthropic-beta", b);
+                }
+                req.header("content-type", "application/json")
+                    .json(&body)
+                    .send()
+            })
+            .await?;
 
-        let status = response.status();
-        let text = response.text().await.map_err(LlmError::Http)?;
+            let status = response.status();
+            let text = response.text().await.map_err(LlmError::Http)?;
 
-        if !status.is_success() {
-            if Self::is_compact_beta_rejection(status, &text) {
-                self.server_compaction_rejected
-                    .store(true, Ordering::Relaxed);
-                tracing::warn!(
-                    "compact-2026-01-12 beta header rejected by Claude API (tool use); \
-                    disabling server-side compaction for this session. \
-                    Update your config to set `server_compaction = false`."
-                );
-                return Err(LlmError::BetaHeaderRejected {
-                    header: ANTHROPIC_BETA_COMPACT.into(),
+            if !status.is_success() {
+                if !retried && Self::is_compact_beta_rejection(status, &text) {
+                    self.server_compaction_rejected
+                        .store(true, Ordering::Relaxed);
+                    tracing::warn!(
+                        "compact-2026-01-12 beta header rejected by Claude API (tool use); \
+                        disabling server-side compaction for this session. \
+                        Update your config to set `server_compaction = false`."
+                    );
+                    retried = true;
+                    continue;
+                }
+                tracing::error!("Claude API error {status}: {text}");
+                if status == reqwest::StatusCode::BAD_REQUEST
+                    && crate::error::body_is_context_length_error(&text)
+                {
+                    return Err(LlmError::ContextLengthExceeded);
+                }
+                return Err(LlmError::ApiError {
+                    provider: "claude".into(),
+                    status: status.as_u16(),
                 });
             }
-            tracing::error!("Claude API error {status}: {text}");
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
-            }
-            return Err(LlmError::ApiError {
-                provider: "claude".into(),
-                status: status.as_u16(),
-            });
-        }
 
-        let resp: ToolApiResponse = serde_json::from_str(&text)?;
-        tracing::debug!(
-            stop_reason = ?resp.stop_reason,
-            content_blocks = resp.content.len(),
-            "Claude chat_with_tools response"
-        );
-        if let Some(ref usage) = resp.usage {
-            log_cache_usage(usage);
-            self.store_cache_usage(usage);
-        }
-        let (parsed, compaction_summary) = parse_tool_response(resp);
-        if let Some(ref summary) = compaction_summary {
-            tracing::info!(
-                summary_len = summary.len(),
-                "storing server compaction summary"
+            let resp: ToolApiResponse = serde_json::from_str(&text)?;
+            tracing::debug!(
+                stop_reason = ?resp.stop_reason,
+                content_blocks = resp.content.len(),
+                "Claude chat_with_tools response"
             );
-            *self.last_compaction.lock() = compaction_summary;
+            if let Some(ref usage) = resp.usage {
+                log_cache_usage(usage);
+                self.store_cache_usage(usage);
+            }
+            let (parsed, compaction_summary) = parse_tool_response(resp);
+            if let Some(ref summary) = compaction_summary {
+                tracing::info!(
+                    summary_len = summary.len(),
+                    "storing server compaction summary"
+                );
+                *self.last_compaction.lock() = compaction_summary;
+            }
+            tracing::debug!(?parsed, "parsed ChatResponse");
+            return Ok(parsed);
         }
-        tracing::debug!(?parsed, "parsed ChatResponse");
-        Ok(parsed)
     }
 }
 

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -1488,13 +1488,9 @@ enum CompletionTokens {
 
 impl CompletionTokens {
     fn for_model(model: &str, max_tokens: u32) -> Self {
-        // o-series models (o1, o3, o4-mini, …) and gpt-5 require max_completion_tokens;
+        // o-series models (o1, o2, o3, o4-mini, …) and gpt-5 require max_completion_tokens;
         // all other models use the legacy max_tokens field.
-        if model.starts_with("gpt-5")
-            || model.starts_with("o1")
-            || model.starts_with("o3")
-            || model.starts_with("o4")
-        {
+        if model.starts_with("gpt-5") || starts_with_o_digit(model) {
             Self::MaxCompletionTokens {
                 max_completion_tokens: max_tokens,
             }
@@ -1502,6 +1498,11 @@ impl CompletionTokens {
             Self::MaxTokens { max_tokens }
         }
     }
+}
+
+fn starts_with_o_digit(model: &str) -> bool {
+    let mut chars = model.chars();
+    chars.next() == Some('o') && chars.next().is_some_and(|c| c.is_ascii_digit())
 }
 
 #[derive(Serialize)]

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -1595,7 +1595,10 @@ fn test_openai_stub_used_when_schema_exceeds_1024_bytes() {
 
 #[test]
 fn completion_tokens_o_series_uses_max_completion_tokens() {
-    for model in &["o1", "o1-mini", "o1-pro", "o3", "o3-mini", "o4-mini"] {
+    // Covers o1, o2, o3, o4 families including sub-variants — regression for #4598/#4600/#4602.
+    for model in &[
+        "o1", "o1-mini", "o1-pro", "o2", "o2-mini", "o3", "o3-mini", "o4-mini",
+    ] {
         let ct = CompletionTokens::for_model(model, 512);
         let json = serde_json::to_string(&ct).unwrap();
         assert!(
@@ -1611,7 +1614,7 @@ fn completion_tokens_o_series_uses_max_completion_tokens() {
 
 #[test]
 fn completion_tokens_legacy_models_use_max_tokens() {
-    for model in &["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo"] {
+    for model in &["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo", "claude-3-opus"] {
         let ct = CompletionTokens::for_model(model, 256);
         let json = serde_json::to_string(&ct).unwrap();
         assert!(
@@ -1621,6 +1624,35 @@ fn completion_tokens_legacy_models_use_max_tokens() {
         assert!(
             !json.contains("\"max_completion_tokens\""),
             "{model} must not use max_completion_tokens"
+        );
+    }
+}
+
+#[test]
+fn starts_with_o_digit_accepts_o_followed_by_digit() {
+    // Regression: o2 and o2-* were not matched before the starts_with_o_digit helper was added.
+    for model in &[
+        "o1",
+        "o2",
+        "o3",
+        "o4",
+        "o2-mini",
+        "o3-mini-deep",
+        "o9-future",
+    ] {
+        assert!(
+            starts_with_o_digit(model),
+            "{model} must be detected as o-series by starts_with_o_digit"
+        );
+    }
+}
+
+#[test]
+fn starts_with_o_digit_rejects_non_o_series() {
+    for model in &["gpt-4o", "ollama-llama3", "openai-gpt", "o-one", "oX", "o"] {
+        assert!(
+            !starts_with_o_digit(model),
+            "{model} must not be detected as o-series by starts_with_o_digit"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `chat_with_tools_stream`, `chat_typed`, and `chat_with_tools` in `crates/zeph-llm/src/claude/mod.rs` now retry transparently when the Claude API rejects the `compact-2026-01-12` beta header, using the same `retried=false; loop` pattern as `send_request`/`send_stream_request`. On each iteration `beta_header()` and `context_management()` are re-evaluated so the retry omits the rejected header.
- `CompletionTokens::for_model` in `crates/zeph-llm/src/openai/mod.rs` now uses `starts_with_o_digit()` to match any o-series model (o1, o2, o3, o4, …) instead of an explicit list, covering the missing `o2-*` case.
- 4 regression tests added: `starts_with_o_digit` unit tests + `CompletionTokens` boundary cases including `o2` and `o2-mini`.

## Test plan

- [x] `cargo clippy -p zeph-llm -- -D warnings` — 0 warnings
- [x] `cargo nextest run -p zeph-llm --lib` — 870 passed, 10 skipped
- [x] `cargo +nightly fmt --check` — clean
- [ ] Live API test required per LLM serialization gate (`.claude/rules/branching.md`) — `chat_with_tools` and `chat_typed` retry path is not unit-testable (hardcoded `API_URL`); requires a live session with `server_compaction = true` against a Claude endpoint that rejects the beta header before merge.

## Closes

Closes #4598, #4600, #4602