### PR TITLE
fix(plugins): replace blocking std::fs in async add_remote + update A-MAC spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-plugins`: `add_remote` now uses `tokio::fs::write` instead of `std::fs::write` when
+  persisting the `.plugin-source.toml` sidecar, preventing the async executor thread from blocking
+  during remote plugin installation (closes #4606).
+
+### Docs
+
+- `specs/004-memory/004-3-admission-control.md`: updated to document the actual 5-factor A-MAC
+  scoring model (`future_utility`, `factual_confidence`, `semantic_novelty`, `temporal_recency`,
+  `content_type_prior`; optional `goal_utility`) with correct default weights and config fields.
+  The original 6-factor design is preserved as historical context with a reference to arXiv:2603.04549
+  and issue #4141 (closes #4605).
+
 - `zeph-plugins`: `read_plugin_source` in `update_one_plugin` now uses `tokio::fs::read_to_string`
   instead of `std::fs::read_to_string`, preventing the async executor thread from blocking during
   plugin auto-update sidecar reads (closes #4589).

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -506,7 +506,7 @@ impl PluginManager {
             .join(".plugin-source.toml");
         match toml::to_string(&source) {
             Ok(toml_str) => {
-                if let Err(e) = std::fs::write(&source_path, toml_str) {
+                if let Err(e) = tokio::fs::write(&source_path, toml_str).await {
                     tracing::warn!(
                         plugin = %result.name,
                         error = %e,

--- a/specs/004-memory/004-3-admission-control.md
+++ b/specs/004-memory/004-3-admission-control.md
@@ -20,13 +20,15 @@ related:
 # Spec: Memory Admission Control (A-MAC & Importance Scoring)
 
 > [!info]
-> Adaptive Memory Admission Control (A-MAC): six-factor importance scoring,
+> Adaptive Memory Admission Control (A-MAC): five-factor importance scoring
+> based on the A-MAC paper (arXiv:2603.04549), with optional goal-conditioned extension,
 > admission gates, and graceful degradation.
 
 ## Overview
 
 Not all messages should be stored in memory. A-MAC scores importance and decides
-whether to admit messages based on recency, relevance, and utility.
+whether to admit messages based on future utility, factual confidence, semantic novelty,
+recency, and content-type prior.
 
 ### Goal
 
@@ -40,7 +42,8 @@ Implement adaptive admission control that filters noise while preserving critica
 |----|------------|----------|
 | FR-001 | WHEN remember() called, THE SYSTEM SHALL score message importance | must |
 | FR-002 | WHEN score < admission_threshold, message rejected (returns None) | must |
-| FR-003 | Scoring SHALL consider 6 factors: recency, relevance, tool_use, unique_entities, length, frequency | must |
+| FR-003 | Scoring SHALL consider 5 core factors: future_utility, factual_confidence, semantic_novelty, temporal_recency, content_type_prior | must |
+| FR-004 | OPTIONALLY extend with goal-conditioned utility factor when goal_conditioned_write enabled | should |
 
 ---
 
@@ -60,26 +63,36 @@ Implement adaptive admission control that filters noise while preserving critica
 
 ---
 
-## Six-Factor Scoring Model
+## Five-Factor Scoring Model (A-MAC)
 
-| Factor | Weight | Calculation |
-|--------|--------|-------------|
-| Recency | 0.1667 | exponential decay from now |
-| Relevance | 0.1667 | embedding similarity to context |
-| Tool Use | 0.1667 | 1.0 if contains tool output, 0.0 else |
-| Entity Density | 0.1667 | unique named entities / message length |
-| Message Length | 0.1667 | normalized (longer = higher, cap at threshold) |
-| Frequency | 0.1667 | entity mention count with exponential decay |
+The core A-MAC model uses five factors normalized to [0.0, 1.0] range:
 
-Final score = sum of weighted factors, range [0.0, 1.0].
+| Factor | Default Weight | Calculation |
+|--------|---------|-------------|
+| `future_utility` | 0.30 | LLM-estimated reuse probability; defaults to 0.5 on fast path or failure |
+| `factual_confidence` | 0.15 | Inverse hedging heuristic: high confidence → high score |
+| `semantic_novelty` | 0.30 | 1.0 minus max similarity to top-3 neighbors; 1.0 when memory is empty |
+| `temporal_recency` | 0.10 | Always 1.0 at write time (decay applied at recall, not admission) |
+| `content_type_prior` | 0.15 | Prior based on message role (e.g., user/assistant/tool) |
 
-### Frequency Factor
+**Composite score** = Σ (factor × weight), normalized so weights sum to 1.0. Range: [0.0, 1.0].
 
-The frequency factor tracks how often entities mentioned in the message have been referenced in recent sessions. Calculation:
-- Query entity graph for each unique entity in the message
-- Count mentions in last N sessions (configurable, default: 10 sessions)
-- Apply exponential decay: `count × exp(-λ × days_since_last_mention)` where λ = 0.01
-- Normalize to [0, 1] by dividing by threshold (default: 5 mentions)
+### Future Utility Factor
+
+Evaluates whether a message is likely to be reused in future interactions:
+- **Fast path**: heuristic score computed; if score ≥ threshold + fast_path_margin, LLM call skipped (fast admission)
+- **Slow path**: LLM provider queries estimated reuse probability (provider specified by `admission_provider` config)
+- **Failure**: defaults to 0.5 (neutral) on LLM error
+
+### Optional Goal-Conditioned Extension (Feature #2408)
+
+When `goal_conditioned_write = true`, an optional sixth factor can extend the model:
+
+| Factor | Purpose |
+|--------|---------|
+| `goal_utility` | Cosine similarity between goal embedding and candidate memory |
+
+This factor is applied only when a goal is active; zero when goal text is absent/trivial. If enabled, its weight is redistributed from `future_utility`.
 
 ---
 
@@ -87,15 +100,20 @@ The frequency factor tracks how often entities mentioned in the message have bee
 
 ```toml
 [memory.admission]
-enabled = true
-threshold = 0.5
-weights = { recency = 0.1667, relevance = 0.1667, tool = 0.1667, entities = 0.1667, length = 0.1667, frequency = 0.1667 }
+enabled = false
+threshold = 0.40
+fast_path_margin = 0.15
+admission_provider = ""  # falls back to primary provider if unset
+goal_conditioned_write = false
 
-[memory.admission.frequency]
-# Frequency factor configuration
-mention_lookback_sessions = 10
-mention_decay_rate = 0.01
-mention_normalization_cap = 5.0
+[memory.admission.weights]
+# Per-factor weights; normalized at runtime to sum to 1.0
+future_utility = 0.30
+factual_confidence = 0.15
+semantic_novelty = 0.30
+temporal_recency = 0.10
+content_type_prior = 0.15
+goal_utility = 0.0  # only non-zero when goal_conditioned_write is true
 ```
 
 ---
@@ -104,7 +122,13 @@ mention_normalization_cap = 5.0
 
 - [[004-1-architecture]] — called in remember() method
 - [[004-2-compaction]] — scores before compaction decision
-- [[004-4-embeddings]] — uses embeddings for relevance factor
+- [[004-4-embeddings]] — uses embeddings for semantic novelty factor
+
+---
+
+## Historical Note
+
+The A-MAC model was refined from an earlier six-factor design (recency, relevance, tool_use, unique_entities, length, frequency) to the current five-factor model based on the A-MAC paper (arXiv:2603.04549, tracked in issue #4141). The paper model emphasizes LLM-based future utility and semantic novelty (via embedding similarity) as primary signals, with temporal recency and content-type prior as supporting factors. This shift reflects advances in learned importance signals over hand-engineered entity and frequency heuristics.
 
 ---
 
@@ -112,3 +136,4 @@ mention_normalization_cap = 5.0
 
 - [[004-memory/spec]] — Parent
 - [[004-1-architecture]] — Core pipeline where admission is checked
+- A-MAC paper: arXiv:2603.04549 (#4141)


### PR DESCRIPTION
## Summary

- **#4606**: Replace `std::fs::write` with `tokio::fs::write(...).await` in `pub async fn add_remote` (`crates/zeph-plugins/src/manager.rs:509`). The blocking call stalled the Tokio executor thread on every remote plugin install. This was the remaining std::fs call after the #4589 partial fix.

- **#4605**: Rewrite `specs/004-memory/004-3-admission-control.md` to document the actual 5-factor A-MAC scoring model (`future_utility`, `factual_confidence`, `semantic_novelty`, `temporal_recency`, `content_type_prior`, optional `goal_utility`). The spec previously described a stale 6-factor model. Default weights and config fields verified against `AdmissionWeights` in `zeph-config`. Historical 6-factor design preserved as footnote with reference to arXiv:2603.04549 and #4141.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10215 passed, 21 skipped
- [x] Existing `add_remote_persists_plugin_source_sidecar` test covers the fixed path end-to-end (wiremock + tempfile)
- [x] Spec factors and weights cross-verified against `AdmissionWeights::default()` in `zeph-config/src/memory.rs`

Closes #4606
Closes #4605