### PR TITLE
refactor(context,llm): remove dead field and deduplicate build_tool_description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Refactored
+
+- `zeph-llm`: deduplicated `build_tool_description` into `crates/zeph-llm/src/tool_desc.rs`; both
+  `claude` and `openai` backends now share a single implementation with a common `static WARNED`
+  guard for once-per-session schema-overflow warnings (closes #4577).
+
 ### Fixed
 
+- `zeph-context`: removed dead `fidelity_config: Option<&'a FidelityConfig>` field from
+  `ContextAssemblyInput`; the field was always `None` and never read after the CAM Phase 1
+  refactor (closes #4595).
 - `zeph-plugins`: `add_remote` now uses `tokio::fs::write` instead of `std::fs::write` when
   persisting the `.plugin-source.toml` sidecar, preventing the async executor thread from blocking
   during remote plugin installation (closes #4606).

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -634,7 +634,6 @@ impl ContextService {
             active_levels,
             router,
             planned_next_tools: &[],
-            fidelity_config: None,
         };
 
         let mut prepared = zeph_context::assembler::ContextAssembler::gather(&input).await?;

--- a/crates/zeph-context/src/input.rs
+++ b/crates/zeph-context/src/input.rs
@@ -17,8 +17,6 @@ use zeph_config::{
     DocumentConfig, GraphConfig, PersonaConfig, ReasoningConfig, TrajectoryConfig, TreeConfig,
 };
 
-use crate::fidelity::FidelityConfig;
-
 use crate::manager::ContextManager;
 
 /// All borrowed data needed to assemble context for one agent turn.
@@ -66,8 +64,6 @@ pub struct ContextAssemblyInput<'a> {
     ///
     /// Pass `&[]` when no DAG context is available (PAACE data structure only in MVP).
     pub planned_next_tools: &'a [PlannedToolHint],
-    /// Fidelity scorer configuration. `None` disables all fidelity scoring for this turn.
-    pub fidelity_config: Option<&'a FidelityConfig>,
 }
 
 /// Configuration extracted from `LearningEngine` needed by correction recall.

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -51,6 +51,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use parking_lot::Mutex;
 
 use crate::error::LlmError;
+use crate::tool_desc::build_tool_description;
 use crate::usage::UsageTracker;
 
 use crate::provider::{
@@ -1416,62 +1417,5 @@ impl LlmProvider for ClaudeProvider {
             tracing::debug!(?parsed, "parsed ChatResponse");
             return Ok(parsed);
         }
-    }
-}
-
-/// Build the tool description string, optionally appending an output schema hint.
-///
-/// When `forward` is `true` and `output_schema` is `Some`, appends a compact JSON hint
-/// capped at `hint_bytes`. If the schema exceeds the budget, a stub is used and a WARN
-/// is emitted once per session per tool (guarded by a global `OnceLock<Mutex<HashSet>>`).
-pub(crate) fn build_tool_description(
-    base: &str,
-    output_schema: Option<&serde_json::Value>,
-    forward: bool,
-    hint_bytes: usize,
-    max_combined_bytes: usize,
-    tool_name: &str,
-) -> String {
-    if !forward {
-        return base.to_owned();
-    }
-    let Some(schema) = output_schema else {
-        return base.to_owned();
-    };
-    let compact = serde_json::to_string(schema).unwrap_or_default();
-    let hint = if compact.len() > hint_bytes {
-        use std::collections::HashSet;
-        use std::sync::{Mutex, OnceLock};
-        static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-        let guard = WARNED.get_or_init(|| Mutex::new(HashSet::new()));
-        let mut warned = guard
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if warned.insert(tool_name.to_owned()) {
-            tracing::warn!(
-                tool = tool_name,
-                schema_bytes = compact.len(),
-                cap = hint_bytes,
-                event = "mcp.output_schema.stub_used",
-                "MCP output_schema hint exceeds budget — using stub"
-            );
-        }
-        format!(
-            "Output schema too large ({} bytes); details omitted.",
-            compact.len()
-        )
-    } else {
-        tracing::debug!(
-            tool = tool_name,
-            event = "mcp.output_schema.forwarded_to_llm",
-            "MCP tool output schema forwarded to LLM description"
-        );
-        compact
-    };
-    let combined = format!("{base}\n\nExpected output schema (JSON):\n{hint}");
-    if max_combined_bytes < usize::MAX && combined.len() > max_combined_bytes {
-        zeph_common::text::truncate_to_bytes(&combined, max_combined_bytes).clone()
-    } else {
-        combined
     }
 }

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -105,6 +105,7 @@ pub mod sse;
 pub mod stt;
 #[cfg(test)]
 pub mod testing;
+pub(crate) mod tool_desc;
 pub(crate) mod usage;
 pub mod whisper;
 

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -31,6 +31,7 @@
 use std::fmt;
 
 use crate::error::LlmError;
+use crate::tool_desc::build_tool_description;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
 
@@ -1644,60 +1645,3 @@ fn normalize_for_openai_strict(schema: &mut serde_json::Value, depth: u8) {
 
 #[cfg(test)]
 mod tests;
-
-/// Build the tool description string, optionally appending an output schema hint.
-///
-/// When `forward` is `true` and `output_schema` is `Some`, appends a compact JSON hint
-/// capped at `hint_bytes`. If the schema exceeds the budget, a stub is used and a WARN
-/// is emitted once per session per tool.
-pub(crate) fn build_tool_description(
-    base: &str,
-    output_schema: Option<&serde_json::Value>,
-    forward: bool,
-    hint_bytes: usize,
-    max_combined_bytes: usize,
-    tool_name: &str,
-) -> String {
-    if !forward {
-        return base.to_owned();
-    }
-    let Some(schema) = output_schema else {
-        return base.to_owned();
-    };
-    let compact = serde_json::to_string(schema).unwrap_or_default();
-    let hint = if compact.len() > hint_bytes {
-        use std::collections::HashSet;
-        use std::sync::{Mutex, OnceLock};
-        static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-        let guard = WARNED.get_or_init(|| Mutex::new(HashSet::new()));
-        let mut warned = guard
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if warned.insert(tool_name.to_owned()) {
-            tracing::warn!(
-                tool = tool_name,
-                schema_bytes = compact.len(),
-                cap = hint_bytes,
-                event = "mcp.output_schema.stub_used",
-                "MCP output_schema hint exceeds budget — using stub"
-            );
-        }
-        format!(
-            "Output schema too large ({} bytes); details omitted.",
-            compact.len()
-        )
-    } else {
-        tracing::debug!(
-            tool = tool_name,
-            event = "mcp.output_schema.forwarded_to_llm",
-            "MCP tool output schema forwarded to LLM description"
-        );
-        compact
-    };
-    let combined = format!("{base}\n\nExpected output schema (JSON):\n{hint}");
-    if max_combined_bytes < usize::MAX && combined.len() > max_combined_bytes {
-        zeph_common::text::truncate_to_bytes(&combined, max_combined_bytes).clone()
-    } else {
-        combined
-    }
-}

--- a/crates/zeph-llm/src/tool_desc.rs
+++ b/crates/zeph-llm/src/tool_desc.rs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared helper for building MCP tool description strings with optional
+//! output-schema hints.
+//!
+//! Both the Claude and `OpenAI` backends use the same logic for appending a
+//! compact JSON schema hint to a tool's description field before sending it
+//! to the LLM. This module houses the single implementation so neither
+//! backend carries a duplicate.
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+/// Build the tool description string, optionally appending an output schema hint.
+///
+/// When `forward` is `true` and `output_schema` is `Some`, appends a compact JSON hint
+/// capped at `hint_bytes`. If the schema exceeds the budget, a stub is used and a WARN
+/// is emitted once per session per tool (guarded by a global `OnceLock<Mutex<HashSet>>`).
+///
+/// # Arguments
+///
+/// - `base` — the tool's original description text.
+/// - `output_schema` — optional MCP output schema to forward.
+/// - `forward` — whether schema forwarding is enabled for this provider.
+/// - `hint_bytes` — maximum byte length of the inlined schema JSON.
+/// - `max_combined_bytes` — overall cap on the returned string; pass
+///   `usize::MAX` to disable.
+/// - `tool_name` — used only in warning/debug log fields.
+///
+/// # Note
+///
+/// This is a `pub(crate)` function — it is not part of the public API and cannot
+/// be called from outside the `zeph-llm` crate.
+pub(crate) fn build_tool_description(
+    base: &str,
+    output_schema: Option<&serde_json::Value>,
+    forward: bool,
+    hint_bytes: usize,
+    max_combined_bytes: usize,
+    tool_name: &str,
+) -> String {
+    if !forward {
+        return base.to_owned();
+    }
+    let Some(schema) = output_schema else {
+        return base.to_owned();
+    };
+    let compact = serde_json::to_string(schema).unwrap_or_default();
+    let hint = if compact.len() > hint_bytes {
+        static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+        let guard = WARNED.get_or_init(|| Mutex::new(HashSet::new()));
+        let mut warned = guard
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if warned.insert(tool_name.to_owned()) {
+            tracing::warn!(
+                tool = tool_name,
+                schema_bytes = compact.len(),
+                cap = hint_bytes,
+                event = "mcp.output_schema.stub_used",
+                "MCP output_schema hint exceeds budget — using stub"
+            );
+        }
+        format!(
+            "Output schema too large ({} bytes); details omitted.",
+            compact.len()
+        )
+    } else {
+        tracing::debug!(
+            tool = tool_name,
+            event = "mcp.output_schema.forwarded_to_llm",
+            "MCP tool output schema forwarded to LLM description"
+        );
+        compact
+    };
+    let combined = format!("{base}\n\nExpected output schema (JSON):\n{hint}");
+    if max_combined_bytes < usize::MAX && combined.len() > max_combined_bytes {
+        zeph_common::text::truncate_to_bytes(&combined, max_combined_bytes).clone()
+    } else {
+        combined
+    }
+}


### PR DESCRIPTION
## Summary

- **#4595**: Remove dead `fidelity_config: Option<&'a FidelityConfig>` field from `ContextAssemblyInput` in `crates/zeph-context/src/input.rs`. The field was always `None` at every call site and never read by `assembler.rs` — fidelity scoring happens after `gather()` returns in the `prepare_context` pipeline. The field added misleading API surface implying the assembler performed scoring.
- **#4577**: Deduplicate `build_tool_description` from `crates/zeph-llm/src/claude/mod.rs` and `crates/zeph-llm/src/openai/mod.rs` into a new shared module `crates/zeph-llm/src/tool_desc.rs`. Both backends now share a single implementation with a common `static WARNED` guard for once-per-session schema-overflow warnings. Removes ~110 LOC of duplicated code.

## Changes

| File | Change |
|---|---|
| `crates/zeph-context/src/input.rs` | Remove `fidelity_config` field and unused `FidelityConfig` import |
| `crates/zeph-agent-context/src/service.rs` | Remove `fidelity_config: None` from the single `ContextAssemblyInput` construction site |
| `crates/zeph-llm/src/tool_desc.rs` | New shared module with `pub(crate) fn build_tool_description` |
| `crates/zeph-llm/src/lib.rs` | Add `pub(crate) mod tool_desc` |
| `crates/zeph-llm/src/claude/mod.rs` | Remove ~55-line duplicate fn, add `use crate::tool_desc::build_tool_description` |
| `crates/zeph-llm/src/openai/mod.rs` | Same |

## LLM Serialization Gate

This PR touches `claude/mod.rs` and `openai/mod.rs` but does **not** modify any serialization structs (`Message`, `MessagePart`, `ToolDefinition`, etc.). The change is purely a function extraction — the callers and call sites are unchanged. No live API session test required.

## Test Plan

- [x] `cargo nextest run --workspace --lib --bins` — 10217 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo test --doc -p zeph-llm` — 15 passed, 0 failed

Closes #4595
Closes #4577