### PR TITLE
feat(memory,config): make embed timeout configurable in zeph-memory (#4601, #4603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `zeph-memory`: embed timeout is now configurable via `memory.semantic.embed_timeout_secs` (default
+  `5` s, preserving existing behavior). All ~30 hardcoded `Duration::from_secs(5)` call sites across
+  `AdmissionControl`, `QualityGate`, `EntityResolver`, `TreeConsolidationConfig`,
+  `TierPromotionConfig`, `GraphExtractionConfig`, `ProcessTurnConfig`, `ConsolidationConfig`, and
+  all graph recall variants now read the value from config. `SemanticMemory::with_embed_timeout`
+  propagates the timeout to `hebbian_spread` as well (closes #4601).
+
+### Docs
+
+- `zeph-memory`: `TreeConsolidationConfig` pub fields (`enabled`, `sweep_interval_secs`,
+  `batch_size`, `similarity_threshold`, `max_level`, `min_cluster_size`) now have `///` doc
+  comments describing their semantic and valid range (closes #4603).
+
 ### Refactored
 
 - `zeph-llm`: deduplicated `build_tool_description` into `crates/zeph-llm/src/tool_desc.rs`; both

--- a/config/default.toml
+++ b/config/default.toml
@@ -405,6 +405,9 @@ importance_weight = 0.15
 # Recommended: a cheap embedding model (e.g. text-embedding-3-small, nomic-embed-text).
 # Defaults to the main provider when unset.
 # embedding_provider = "ollama-embed"
+# Timeout for a single embedding call in the memory subsystem (seconds).
+# Increase if your embedding provider is slow or overloaded.
+# embed_timeout_secs = 5
 
 # MemMachine-inspired retrieval-stage tuning (#3340). Applies to all recall paths.
 [memory.retrieval]

--- a/crates/zeph-agent-persistence/src/graph.rs
+++ b/crates/zeph-agent-persistence/src/graph.rs
@@ -19,13 +19,14 @@ use zeph_llm::provider::{Message, MessagePart, Role};
 /// use zeph_config::memory::GraphConfig;
 ///
 /// let cfg = GraphConfig::default();
-/// let extraction_cfg = build_graph_extraction_config(&cfg, Some(42));
+/// let extraction_cfg = build_graph_extraction_config(&cfg, Some(42), 5);
 /// assert_eq!(extraction_cfg.conversation_id, Some(42));
 /// ```
 #[must_use]
 pub fn build_graph_extraction_config(
     cfg: &zeph_config::memory::GraphConfig,
     conversation_id: Option<i64>,
+    embed_timeout_secs: u64,
 ) -> zeph_memory::semantic::GraphExtractionConfig {
     zeph_memory::semantic::GraphExtractionConfig {
         max_entities: cfg.max_entities_per_message,
@@ -50,6 +51,7 @@ pub fn build_graph_extraction_config(
         conversation_id,
         apex_mem_enabled: cfg.apex_mem.enabled,
         llm_timeout_secs: cfg.llm_timeout_secs,
+        embed_timeout_secs,
     }
 }
 

--- a/crates/zeph-common/src/config/memory.rs
+++ b/crates/zeph-common/src/config/memory.rs
@@ -75,6 +75,8 @@ pub struct ConsolidationConfig {
     pub similarity_threshold: f32,
     /// LLM call timeout per `propose_merge_op` invocation, in seconds.
     pub llm_timeout_secs: u64,
+    /// Per-call timeout for every `embed()` invocation, in seconds. Default: `5`.
+    pub embed_timeout_secs: u64,
 }
 
 /// Runtime config for the forgetting sweep (#2397).

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1679,6 +1679,14 @@ pub struct SemanticConfig {
     /// single-model lock). Falls back to the main agent provider when `None`.
     #[serde(default)]
     pub embedding_provider: Option<ProviderName>,
+    /// Timeout in seconds applied to every `embed()` call inside `zeph-memory`.
+    ///
+    /// Applies to all embedding call sites: admission control, quality gate, recall,
+    /// summarization, graph retrieval, consolidation, and tree consolidation.
+    /// Set to a higher value when using slow remote embedding providers.
+    /// Default: `5`.
+    #[serde(default = "default_embed_timeout_secs")]
+    pub embed_timeout_secs: u64,
 }
 
 impl Default for SemanticConfig {
@@ -1695,8 +1703,13 @@ impl Default for SemanticConfig {
             importance_enabled: true,
             importance_weight: default_importance_weight(),
             embedding_provider: None,
+            embed_timeout_secs: default_embed_timeout_secs(),
         }
     }
+}
+
+fn default_embed_timeout_secs() -> u64 {
+    5
 }
 
 /// Memory snippet rendering format injected into agent context (MM-F5, #3340).
@@ -3034,6 +3047,10 @@ pub struct ConsolidationConfig {
     /// LLM call timeout per `propose_merge_op` invocation, in seconds. Default: `30`.
     #[serde(default = "default_consolidation_llm_timeout_secs")]
     pub llm_timeout_secs: u64,
+    /// Per-call timeout for every `embed()` invocation in the consolidation sweep, in seconds.
+    /// Default: `5`.
+    #[serde(default = "default_embed_timeout_secs")]
+    pub embed_timeout_secs: u64,
 }
 
 impl Default for ConsolidationConfig {
@@ -3046,6 +3063,7 @@ impl Default for ConsolidationConfig {
             sweep_batch_size: default_consolidation_sweep_batch_size(),
             similarity_threshold: default_consolidation_similarity_threshold(),
             llm_timeout_secs: default_consolidation_llm_timeout_secs(),
+            embed_timeout_secs: default_embed_timeout_secs(),
         }
     }
 }

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -456,6 +456,13 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
             Err(msg) => return Box::pin(async move { Ok(msg) }),
         };
         let graph_cfg = self.services.memory.extraction.graph_config.clone();
+        let embed_timeout_secs = self
+            .services
+            .memory
+            .persistence
+            .memory
+            .as_ref()
+            .map_or(5, |m| m.embed_timeout().as_secs());
         let provider = if graph_cfg.extract_provider.as_str().is_empty() {
             self.provider.clone()
         } else {
@@ -518,6 +525,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                             conversation_id: None,
                             apex_mem_enabled: graph_cfg.apex_mem.enabled,
                             llm_timeout_secs: graph_cfg.llm_timeout_secs,
+                            embed_timeout_secs,
                         };
                         let pool = store.pool().clone();
                         match extract_and_store(

--- a/crates/zeph-core/src/agent/autodream.rs
+++ b/crates/zeph-core/src/agent/autodream.rs
@@ -116,6 +116,7 @@ impl<C: Channel> super::Agent<C> {
             similarity_threshold: 0.85,
             sweep_interval_secs: 0,
             llm_timeout_secs: cfg.llm_timeout_secs,
+            embed_timeout_secs: memory.embed_timeout().as_secs(),
         };
 
         // Run with a timeout bounded by max_iterations * ~30s per call as a rough limit.

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -323,6 +323,13 @@ impl<C: Channel> Agent<C> {
         if !cfg.enabled {
             return;
         }
+        let embed_timeout_secs = self
+            .services
+            .memory
+            .persistence
+            .memory
+            .as_ref()
+            .map_or(5, |m| m.embed_timeout().as_secs());
         let extraction_cfg = build_graph_extraction_config(
             cfg,
             self.services
@@ -330,6 +337,7 @@ impl<C: Channel> Agent<C> {
                 .persistence
                 .conversation_id
                 .map(|c| c.0),
+            embed_timeout_secs,
         );
         // Resolve a clean provider that bypasses quality_gate for JSON extraction tasks.
         // When extract_provider is empty, falls back to the primary provider (existing behavior).
@@ -702,6 +710,7 @@ impl<C: Channel> Agent<C> {
         let store_limit = cfg.store_limit;
         let extraction_timeout = std::time::Duration::from_secs(cfg.extraction_timeout_secs);
         let distill_timeout = std::time::Duration::from_secs(cfg.distill_timeout_secs);
+        let embed_timeout = memory.embed_timeout();
         let self_judge_window = cfg.self_judge_window;
         let min_assistant_chars = cfg.min_assistant_chars;
 
@@ -719,6 +728,7 @@ impl<C: Channel> Agent<C> {
                         store_limit,
                         extraction_timeout,
                         distill_timeout,
+                        embed_timeout,
                         self_judge_window,
                         min_assistant_chars,
                     },

--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -133,6 +133,8 @@ pub struct AdmissionControl {
     provider: Option<AnyProvider>,
     /// Goal-conditioned write gate. `None` when `goal_conditioned_write = false`.
     goal_gate: Option<GoalGateConfig>,
+    /// Per-call timeout for every `embed()` invocation. Default: 5 s.
+    embed_timeout: Duration,
 }
 
 impl AdmissionControl {
@@ -150,7 +152,17 @@ impl AdmissionControl {
             weights: weights.normalized(),
             provider: None,
             goal_gate: None,
+            embed_timeout: Duration::from_secs(5),
         }
+    }
+
+    /// Set the per-call timeout for every `embed()` invocation.
+    ///
+    /// Default: 5 s. Must be non-zero; the minimum effective value is 1 s.
+    #[must_use]
+    pub fn with_embed_timeout(mut self, timeout_secs: u64) -> Self {
+        self.embed_timeout = Duration::from_secs(timeout_secs.max(1));
+        self
     }
 
     /// Attach a dedicated LLM provider for `future_utility` evaluation.
@@ -209,14 +221,23 @@ impl AdmissionControl {
         let content_type_prior = compute_content_type_prior(role);
 
         // Semantic novelty requires an async embedding search.
-        let semantic_novelty = compute_semantic_novelty(content, effective_provider, qdrant).await;
+        let semantic_novelty =
+            compute_semantic_novelty(content, effective_provider, qdrant, self.embed_timeout).await;
 
         // Goal-conditioned utility (W3.1 fix: skip trivial goal text < 10 chars).
         let goal_utility = match &self.goal_gate {
             Some(gate) => {
                 let effective_goal = goal_text.filter(|t| t.trim().len() >= 10);
                 if let Some(goal) = effective_goal {
-                    compute_goal_utility(content, goal, gate, effective_provider, qdrant).await
+                    compute_goal_utility(
+                        content,
+                        goal,
+                        gate,
+                        effective_provider,
+                        qdrant,
+                        self.embed_timeout,
+                    )
+                    .await
                 } else {
                     0.0
                 }
@@ -341,6 +362,7 @@ async fn compute_semantic_novelty(
     content: &str,
     provider: &AnyProvider,
     qdrant: Option<&Arc<EmbeddingStore>>,
+    embed_timeout: Duration,
 ) -> f32 {
     let Some(store) = qdrant else {
         return 1.0;
@@ -348,7 +370,7 @@ async fn compute_semantic_novelty(
     if !provider.supports_embeddings() {
         return 1.0;
     }
-    let vector = match tokio::time::timeout(Duration::from_secs(5), provider.embed(content)).await {
+    let vector = match tokio::time::timeout(embed_timeout, provider.embed(content)).await {
         Ok(Ok(v)) => v,
         Ok(Err(e)) => {
             tracing::debug!(error = %e, "A-MAC: failed to embed for novelty, using 1.0");
@@ -440,6 +462,7 @@ async fn compute_goal_utility(
     gate: &GoalGateConfig,
     provider: &AnyProvider,
     qdrant: Option<&Arc<EmbeddingStore>>,
+    embed_timeout: Duration,
 ) -> f32 {
     use zeph_llm::provider::LlmProvider as _;
 
@@ -447,30 +470,28 @@ async fn compute_goal_utility(
         return 0.0;
     }
 
-    let goal_emb =
-        match tokio::time::timeout(Duration::from_secs(5), provider.embed(goal_text)).await {
-            Ok(Ok(v)) => v,
-            Ok(Err(e)) => {
-                tracing::debug!(error = %e, "goal_utility: failed to embed goal text, using 0.0");
-                return 0.0;
-            }
-            Err(_) => {
-                tracing::warn!("A-MAC: embed timed out in goal_utility (goal text), using 0.0");
-                return 0.0;
-            }
-        };
-    let content_emb =
-        match tokio::time::timeout(Duration::from_secs(5), provider.embed(content)).await {
-            Ok(Ok(v)) => v,
-            Ok(Err(e)) => {
-                tracing::debug!(error = %e, "goal_utility: failed to embed content, using 0.0");
-                return 0.0;
-            }
-            Err(_) => {
-                tracing::warn!("A-MAC: embed timed out in goal_utility (content), using 0.0");
-                return 0.0;
-            }
-        };
+    let goal_emb = match tokio::time::timeout(embed_timeout, provider.embed(goal_text)).await {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, "goal_utility: failed to embed goal text, using 0.0");
+            return 0.0;
+        }
+        Err(_) => {
+            tracing::warn!("A-MAC: embed timed out in goal_utility (goal text), using 0.0");
+            return 0.0;
+        }
+    };
+    let content_emb = match tokio::time::timeout(embed_timeout, provider.embed(content)).await {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, "goal_utility: failed to embed content, using 0.0");
+            return 0.0;
+        }
+        Err(_) => {
+            tracing::warn!("A-MAC: embed timed out in goal_utility (content), using 0.0");
+            return 0.0;
+        }
+    };
 
     // Qdrant is used for novelty search, not for goal utility — we compute cosine directly.
     let _ = qdrant; // unused here; kept for API symmetry
@@ -886,8 +907,9 @@ mod tests {
             .with_embed_delay(10_000)
             .with_embedding(vec![0.0; 4]);
         let provider = zeph_llm::any::AnyProvider::Mock(mock);
-        let handle =
-            tokio::spawn(async move { compute_semantic_novelty("hello", &provider, None).await });
+        let handle = tokio::spawn(async move {
+            compute_semantic_novelty("hello", &provider, None, Duration::from_secs(5)).await
+        });
         tokio::time::advance(std::time::Duration::from_secs(6)).await;
         let result = handle.await.expect("task panicked");
         assert!(
@@ -909,7 +931,15 @@ mod tests {
             provider: None,
         };
         let handle = tokio::spawn(async move {
-            compute_goal_utility("content", "goal", &gate, &provider, None).await
+            compute_goal_utility(
+                "content",
+                "goal",
+                &gate,
+                &provider,
+                None,
+                Duration::from_secs(5),
+            )
+            .await
         });
         tokio::time::advance(std::time::Duration::from_secs(6)).await;
         let result = handle.await.expect("task panicked");

--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -184,7 +184,12 @@ async fn process_conversation(
         return Ok(());
     }
 
-    let embedded = embed_candidates(provider, &candidates).await;
+    let embedded = embed_candidates(
+        provider,
+        &candidates,
+        Duration::from_secs(config.embed_timeout_secs),
+    )
+    .await;
 
     if embedded.len() < 2 {
         return Ok(());
@@ -210,6 +215,7 @@ async fn process_conversation(
 async fn embed_candidates(
     provider: &AnyProvider,
     candidates: &[(crate::types::MessageId, String)],
+    embed_timeout: Duration,
 ) -> Vec<(i64, String, Vec<f32>)> {
     let futures: Vec<_> = candidates
         .iter()
@@ -218,7 +224,7 @@ async fn embed_candidates(
             let content = content.clone();
             async move {
                 let timeout_result =
-                    tokio::time::timeout(Duration::from_secs(5), provider.embed(&content)).await;
+                    tokio::time::timeout(embed_timeout, provider.embed(&content)).await;
                 let embed_result = if let Ok(r) = timeout_result {
                     r
                 } else {
@@ -639,6 +645,7 @@ mod tests {
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
             llm_timeout_secs: 99,
+            embed_timeout_secs: 5,
         };
         assert_eq!(cfg.llm_timeout_secs, 99);
     }
@@ -660,6 +667,7 @@ mod tests {
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
             llm_timeout_secs: 30,
+            embed_timeout_secs: 5,
         };
 
         let result = run_consolidation_sweep(&store, &provider, &config).await;
@@ -699,6 +707,7 @@ mod tests {
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
             llm_timeout_secs: 30,
+            embed_timeout_secs: 5,
         };
 
         let result = run_consolidation_sweep(&store, &provider, &config)
@@ -828,6 +837,7 @@ mod tests {
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
             llm_timeout_secs: 30,
+            embed_timeout_secs: 5,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)
@@ -871,6 +881,7 @@ mod tests {
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
             llm_timeout_secs: 30,
+            embed_timeout_secs: 5,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)
@@ -914,6 +925,7 @@ mod tests {
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
             llm_timeout_secs: 30,
+            embed_timeout_secs: 5,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)
@@ -958,6 +970,7 @@ mod tests {
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
             llm_timeout_secs: 30,
+            embed_timeout_secs: 5,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)
@@ -1003,6 +1016,7 @@ mod tests {
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
             llm_timeout_secs: 30,
+            embed_timeout_secs: 5,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)
@@ -1056,7 +1070,7 @@ mod tests {
             (crate::types::MessageId(2), "Alice loves Rust".to_owned()),
         ];
 
-        let fut = embed_candidates(&slow, &candidates);
+        let fut = embed_candidates(&slow, &candidates, Duration::from_secs(5));
         let (result, ()) = tokio::join!(fut, async {
             tokio::time::advance(std::time::Duration::from_secs(6)).await;
         });

--- a/crates/zeph-memory/src/graph/belief_revision.rs
+++ b/crates/zeph-memory/src/graph/belief_revision.rs
@@ -76,9 +76,13 @@ fn edit_distance(a: &str, b: &str) -> usize {
 
 /// Embed a fact string with the given provider.
 ///
-/// Returns `None` on timeout (5 s) or provider error.
-async fn embed_fact(provider: &AnyProvider, fact: &str) -> Option<Vec<f32>> {
-    match tokio::time::timeout(std::time::Duration::from_secs(5), provider.embed(fact)).await {
+/// Returns `None` on timeout or provider error.
+async fn embed_fact(
+    provider: &AnyProvider,
+    fact: &str,
+    embed_timeout: std::time::Duration,
+) -> Option<Vec<f32>> {
+    match tokio::time::timeout(embed_timeout, provider.embed(fact)).await {
         Ok(Ok(v)) => Some(v),
         Ok(Err(err)) => {
             tracing::warn!(error = %err, "belief_revision: embed failed");
@@ -112,6 +116,7 @@ pub async fn find_superseded_edges(
     new_edge_type: EdgeType,
     provider: &AnyProvider,
     config: &BeliefRevisionConfig,
+    embed_timeout: std::time::Duration,
 ) -> Result<Vec<i64>, MemoryError> {
     // Filter to edges of the same type with a related relation domain.
     let candidates: Vec<&Edge> = existing_edges
@@ -127,7 +132,7 @@ pub async fn find_superseded_edges(
 
     let mut superseded = Vec::new();
     for edge in candidates {
-        let Some(existing_emb) = embed_fact(provider, &edge.fact).await else {
+        let Some(existing_emb) = embed_fact(provider, &edge.fact, embed_timeout).await else {
             continue;
         };
         let sim = cosine_similarity(new_fact_embedding, &existing_emb);
@@ -288,6 +293,7 @@ mod tests {
             crate::graph::types::EdgeType::Semantic,
             &provider,
             &config,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -316,6 +322,7 @@ mod tests {
             crate::graph::types::EdgeType::Semantic,
             &provider,
             &config,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -347,6 +354,7 @@ mod tests {
             crate::graph::types::EdgeType::Semantic,
             &provider,
             &config,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -384,6 +392,7 @@ mod tests {
             crate::graph::types::EdgeType::Semantic,
             &provider,
             &config,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -417,6 +426,7 @@ mod tests {
             crate::graph::types::EdgeType::Semantic,
             &provider,
             &config,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();

--- a/crates/zeph-memory/src/graph/resolver/mod.rs
+++ b/crates/zeph-memory/src/graph/resolver/mod.rs
@@ -79,6 +79,8 @@ pub struct EntityResolver<'a> {
     ///
     /// Arc-wrapped so future clones or spawned tasks can share the same gate.
     collection_ensured: Arc<tokio::sync::OnceCell<()>>,
+    /// Per-call timeout for every `embed()` invocation. Default: 5 s.
+    embed_timeout: std::time::Duration,
 }
 
 impl<'a> EntityResolver<'a> {
@@ -99,7 +101,17 @@ impl<'a> EntityResolver<'a> {
             name_locks: Arc::new(DashMap::new()),
             fallback_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             collection_ensured: Arc::new(tokio::sync::OnceCell::new()),
+            embed_timeout: std::time::Duration::from_secs(5),
         }
+    }
+
+    /// Set the per-call timeout for every `embed()` invocation.
+    ///
+    /// Default: 5 s.
+    #[must_use]
+    pub fn with_embed_timeout(mut self, timeout_secs: u64) -> Self {
+        self.embed_timeout = std::time::Duration::from_secs(timeout_secs);
+        self
     }
 
     #[must_use]
@@ -977,12 +989,7 @@ impl<'a> EntityResolver<'a> {
             (belief_revision, self.provider)
         {
             // Kumiho belief revision: embed new fact once, find semantically contradicted edges.
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                provider.embed(&normalized_fact),
-            )
-            .await
-            {
+            match tokio::time::timeout(self.embed_timeout, provider.embed(&normalized_fact)).await {
                 Ok(Ok(new_emb)) => {
                     match crate::graph::belief_revision::find_superseded_edges(
                         &existing_edges,
@@ -991,6 +998,7 @@ impl<'a> EntityResolver<'a> {
                         edge_type,
                         provider,
                         cfg,
+                        self.embed_timeout,
                     )
                     .await
                     {

--- a/crates/zeph-memory/src/graph/retrieval.rs
+++ b/crates/zeph-memory/src/graph/retrieval.rs
@@ -48,6 +48,7 @@ pub async fn graph_recall(
     edge_types: &[EdgeType],
     hebbian_enabled: bool,
     hebbian_lr: f32,
+    embed_timeout: std::time::Duration,
 ) -> Result<Vec<GraphFact>, MemoryError> {
     // graph_recall has no SpreadingActivationParams — use spec defaults.
     const DEFAULT_STRUCTURAL_WEIGHT: f32 = 0.4;
@@ -66,6 +67,7 @@ pub async fn graph_recall(
         limit,
         DEFAULT_STRUCTURAL_WEIGHT,
         DEFAULT_COMMUNITY_CAP,
+        embed_timeout,
     )
     .await?;
 
@@ -210,15 +212,11 @@ async fn seed_embedding_fallback(
     query: &str,
     limit: usize,
     fts_map: &mut HashMap<i64, (super::types::Entity, f32)>,
+    embed_timeout: std::time::Duration,
 ) -> bool {
     use zeph_llm::LlmProvider as _;
     const ENTITY_COLLECTION: &str = "zeph_graph_entities";
-    let embedding = match tokio::time::timeout(
-        std::time::Duration::from_secs(5),
-        provider.embed(query),
-    )
-    .await
-    {
+    let embedding = match tokio::time::timeout(embed_timeout, provider.embed(query)).await {
         Ok(Ok(v)) => v,
         Ok(Err(e)) => {
             tracing::warn!(error = %e, "seed fallback: embed() failed, returning empty seeds");
@@ -252,6 +250,7 @@ async fn seed_embedding_fallback(
     true
 }
 
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) async fn find_seed_entities(
     store: &GraphStore,
     embeddings: Option<&EmbeddingStore>,
@@ -260,6 +259,7 @@ pub(crate) async fn find_seed_entities(
     limit: usize,
     structural_weight: f32,
     community_cap: usize,
+    embed_timeout: std::time::Duration,
 ) -> Result<HashMap<i64, f32>, MemoryError> {
     use crate::graph::types::ScoredEntity;
 
@@ -291,7 +291,16 @@ pub(crate) async fn find_seed_entities(
     // Step 2: embedding fallback when FTS5 returns nothing.
     if fts_map.is_empty()
         && let Some(emb_store) = embeddings
-        && !seed_embedding_fallback(store, emb_store, provider, query, limit, &mut fts_map).await
+        && !seed_embedding_fallback(
+            store,
+            emb_store,
+            provider,
+            query,
+            limit,
+            &mut fts_map,
+            embed_timeout,
+        )
+        .await
     {
         return Ok(HashMap::new());
     }
@@ -402,6 +411,7 @@ pub async fn graph_recall_activated(
     edge_types: &[EdgeType],
     hebbian_enabled: bool,
     hebbian_lr: f32,
+    embed_timeout: std::time::Duration,
 ) -> Result<Vec<ActivatedFact>, MemoryError> {
     if limit == 0 {
         return Ok(Vec::new());
@@ -415,6 +425,7 @@ pub async fn graph_recall_activated(
         limit,
         params.seed_structural_weight,
         params.seed_community_cap,
+        embed_timeout,
     )
     .await?;
 
@@ -503,6 +514,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -525,6 +537,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -563,6 +576,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -611,6 +625,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -650,6 +665,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -704,6 +720,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -760,6 +777,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -804,6 +822,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -851,6 +870,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -872,6 +892,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -941,6 +962,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -996,6 +1018,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -1046,6 +1069,7 @@ mod tests {
             &[],
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -1098,6 +1122,7 @@ mod tests {
             &[],
             true,
             0.5,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -1145,6 +1170,7 @@ mod tests {
             &[],
             false,
             0.5,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -1183,7 +1209,15 @@ mod tests {
             emb_store_pool,
         );
 
-        let fut = seed_embedding_fallback(&store, &emb_store, &slow, "query", 5, &mut fts_map);
+        let fut = seed_embedding_fallback(
+            &store,
+            &emb_store,
+            &slow,
+            "query",
+            5,
+            &mut fts_map,
+            std::time::Duration::from_secs(5),
+        );
         let (result, ()) = tokio::join!(fut, async {
             tokio::time::advance(std::time::Duration::from_secs(6)).await;
         });

--- a/crates/zeph-memory/src/graph/retrieval_astar.rs
+++ b/crates/zeph-memory/src/graph/retrieval_astar.rs
@@ -108,6 +108,7 @@ pub async fn graph_recall_astar(
     hebbian_enabled: bool,
     hebbian_lr: f32,
     query_sensitive_cost: bool,
+    embed_timeout: std::time::Duration,
 ) -> Result<Vec<GraphFact>, MemoryError> {
     let _span = tracing::info_span!("memory.graph.astar", query_len = query.len()).entered();
 
@@ -123,6 +124,7 @@ pub async fn graph_recall_astar(
         limit,
         DEFAULT_STRUCTURAL_WEIGHT,
         DEFAULT_COMMUNITY_CAP,
+        embed_timeout,
     )
     .await?;
 
@@ -426,6 +428,7 @@ mod tests {
             false,
             0.0,
             false,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -448,6 +451,7 @@ mod tests {
             false,
             0.0,
             false,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -485,6 +489,7 @@ mod tests {
             false,
             0.0,
             false,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -526,6 +531,7 @@ mod tests {
             false,
             0.0,
             true, // query_sensitive_cost enabled but no embedding store
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -581,6 +587,7 @@ mod tests {
             false,
             0.0,
             true,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();

--- a/crates/zeph-memory/src/graph/retrieval_beam.rs
+++ b/crates/zeph-memory/src/graph/retrieval_beam.rs
@@ -42,6 +42,7 @@ pub async fn graph_recall_beam(
     temporal_decay_rate: f64,
     hebbian_enabled: bool,
     hebbian_lr: f32,
+    embed_timeout: std::time::Duration,
 ) -> Result<Vec<GraphFact>, MemoryError> {
     let _span = tracing::info_span!("memory.graph.beam", query_len = query.len()).entered();
 
@@ -57,6 +58,7 @@ pub async fn graph_recall_beam(
         limit,
         DEFAULT_STRUCTURAL_WEIGHT,
         DEFAULT_COMMUNITY_CAP,
+        embed_timeout,
     )
     .await?;
 
@@ -238,6 +240,7 @@ mod tests {
             0.0,
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -260,6 +263,7 @@ mod tests {
             0.0,
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -297,6 +301,7 @@ mod tests {
             0.0,
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();

--- a/crates/zeph-memory/src/graph/retrieval_watercircles.rs
+++ b/crates/zeph-memory/src/graph/retrieval_watercircles.rs
@@ -44,6 +44,7 @@ pub async fn graph_recall_watercircles(
     temporal_decay_rate: f64,
     hebbian_enabled: bool,
     hebbian_lr: f32,
+    embed_timeout: std::time::Duration,
 ) -> Result<Vec<GraphFact>, MemoryError> {
     let _span = tracing::info_span!("memory.graph.watercircles", query_len = query.len()).entered();
 
@@ -59,6 +60,7 @@ pub async fn graph_recall_watercircles(
         limit,
         DEFAULT_STRUCTURAL_WEIGHT,
         DEFAULT_COMMUNITY_CAP,
+        embed_timeout,
     )
     .await?;
 
@@ -220,6 +222,7 @@ mod tests {
             0.0,
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -242,6 +245,7 @@ mod tests {
             0.0,
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();
@@ -285,6 +289,7 @@ mod tests {
             0.0,
             false,
             0.0,
+            std::time::Duration::from_secs(5),
         )
         .await
         .unwrap();

--- a/crates/zeph-memory/src/quality_gate.rs
+++ b/crates/zeph-memory/src/quality_gate.rs
@@ -187,6 +187,8 @@ pub struct QualityGate {
     rejection_counts: std::sync::Mutex<std::collections::HashMap<QualityRejectionReason, u64>>,
     /// Rolling rejection-rate tracker (last 100 writes).
     rate_tracker: std::sync::Mutex<RollingRateTracker>,
+    /// Per-call timeout for every `embed()` invocation. Default: 5 s.
+    embed_timeout: std::time::Duration,
 }
 
 impl QualityGate {
@@ -199,7 +201,17 @@ impl QualityGate {
             graph_store: None,
             rejection_counts: std::sync::Mutex::new(std::collections::HashMap::new()),
             rate_tracker: std::sync::Mutex::new(RollingRateTracker::new(100)),
+            embed_timeout: std::time::Duration::from_secs(5),
         }
+    }
+
+    /// Set the per-call timeout for every `embed()` invocation.
+    ///
+    /// Default: 5 s. Must be non-zero; the minimum effective value is 1 s.
+    #[must_use]
+    pub fn with_embed_timeout(mut self, timeout_secs: u64) -> Self {
+        self.embed_timeout = std::time::Duration::from_secs(timeout_secs.max(1));
+        self
     }
 
     /// Attach an LLM provider for optional blended scoring.
@@ -248,7 +260,13 @@ impl QualityGate {
             return None;
         }
 
-        let info_val = compute_information_value(content, embed_provider, recent_embeddings).await;
+        let info_val = compute_information_value(
+            content,
+            embed_provider,
+            recent_embeddings,
+            self.embed_timeout,
+        )
+        .await;
         let ref_comp = if self.config.reference_check_lang_en {
             compute_reference_completeness(content)
         } else {
@@ -328,6 +346,7 @@ async fn compute_information_value(
     content: &str,
     provider: &AnyProvider,
     recent_embeddings: &[Vec<f32>],
+    embed_timeout: std::time::Duration,
 ) -> f32 {
     if recent_embeddings.is_empty() {
         return 1.0;
@@ -335,9 +354,7 @@ async fn compute_information_value(
     if !provider.supports_embeddings() {
         return 1.0;
     }
-    let candidate = match tokio::time::timeout(Duration::from_secs(5), provider.embed(content))
-        .await
-    {
+    let candidate = match tokio::time::timeout(embed_timeout, provider.embed(content)).await {
         Ok(Ok(v)) => v,
         Ok(Err(e)) => {
             tracing::debug!(error = %e, "quality_gate: embed failed, treating info_val = 1.0 (fail-open)");

--- a/crates/zeph-memory/src/reasoning.rs
+++ b/crates/zeph-memory/src/reasoning.rs
@@ -628,6 +628,8 @@ pub struct ProcessTurnConfig {
     pub extraction_timeout: Duration,
     /// Timeout for the distillation LLM call.
     pub distill_timeout: Duration,
+    /// Timeout for each `embed()` invocation in the pipeline. Default: 5 s.
+    pub embed_timeout: Duration,
     /// Maximum number of recent messages sliced from the turn history before passing
     /// to the self-judge evaluator. Narrowing the window prevents digest/recap messages
     /// from prior sessions from confusing the classifier. Default: `2`.
@@ -660,6 +662,7 @@ pub async fn process_turn(
         store_limit,
         extraction_timeout,
         distill_timeout,
+        embed_timeout,
         self_judge_window,
         min_assistant_chars,
     } = cfg;
@@ -706,22 +709,18 @@ pub async fn process_turn(
 
     // Embed task_hint + summary for Qdrant retrieval (S2 from architect plan).
     let embed_input = format!("{}\n{}", outcome.task_hint, summary);
-    let embedding = match tokio::time::timeout(
-        std::time::Duration::from_secs(5),
-        embed_provider.embed(&embed_input),
-    )
-    .await
-    {
-        Ok(Ok(v)) => v,
-        Ok(Err(e)) => {
-            tracing::warn!(error = %e, "reasoning: embedding failed — strategy not stored");
-            return Ok(());
-        }
-        Err(_) => {
-            tracing::warn!("reasoning: embed timed out — strategy not stored");
-            return Ok(());
-        }
-    };
+    let embedding =
+        match tokio::time::timeout(embed_timeout, embed_provider.embed(&embed_input)).await {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "reasoning: embedding failed — strategy not stored");
+                return Ok(());
+            }
+            Err(_) => {
+                tracing::warn!("reasoning: embed timed out — strategy not stored");
+                return Ok(());
+            }
+        };
 
     let id = uuid::Uuid::new_v4().to_string();
     let strategy = ReasoningStrategy {
@@ -1199,6 +1198,7 @@ mod tests {
             store_limit: 100,
             extraction_timeout: std::time::Duration::from_secs(1),
             distill_timeout: std::time::Duration::from_secs(1),
+            embed_timeout: std::time::Duration::from_secs(5),
             self_judge_window: 2,
             min_assistant_chars: 0,
         };

--- a/crates/zeph-memory/src/semantic/corrections.rs
+++ b/crates/zeph-memory/src/semantic/corrections.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::time::Duration;
-
 use zeph_llm::provider::LlmProvider as _;
 
 use crate::error::MemoryError;
@@ -29,7 +27,7 @@ impl SemanticMemory {
             return Ok(());
         }
         let embedding = match tokio::time::timeout(
-            Duration::from_secs(5),
+            self.embed_timeout,
             self.effective_embed_provider().embed(correction_text),
         )
         .await
@@ -75,7 +73,7 @@ impl SemanticMemory {
             return Ok(vec![]);
         }
         let embedding = match tokio::time::timeout(
-            Duration::from_secs(5),
+            self.embed_timeout,
             self.effective_embed_provider().embed(query),
         )
         .await

--- a/crates/zeph-memory/src/semantic/cross_session.rs
+++ b/crates/zeph-memory/src/semantic/cross_session.rs
@@ -99,7 +99,7 @@ impl SemanticMemory {
         }
 
         let vector = match tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            self.embed_timeout,
             self.effective_embed_provider().embed(summary_text),
         )
         .await
@@ -161,7 +161,7 @@ impl SemanticMemory {
         }
 
         let vector = match tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            self.embed_timeout,
             self.effective_embed_provider().embed(query),
         )
         .await

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -59,6 +59,8 @@ pub struct GraphExtractionConfig {
     pub apex_mem_enabled: bool,
     /// LLM call timeout for extraction, in seconds. Default: `30`.
     pub llm_timeout_secs: u64,
+    /// Per-call timeout for every `embed()` invocation, in seconds. Default: `5`.
+    pub embed_timeout_secs: u64,
 }
 
 impl Default for GraphExtractionConfig {
@@ -81,6 +83,7 @@ impl Default for GraphExtractionConfig {
             conversation_id: None,
             apex_mem_enabled: false,
             llm_timeout_secs: 30,
+            embed_timeout_secs: 5,
         }
     }
 }
@@ -401,8 +404,9 @@ pub async fn extract_and_store(
         EntityResolver::new(&store)
             .with_embedding_store(emb)
             .with_provider(&provider)
+            .with_embed_timeout(config.embed_timeout_secs)
     } else {
-        EntityResolver::new(&store)
+        EntityResolver::new(&store).with_embed_timeout(config.embed_timeout_secs)
     };
 
     let (entity_name_to_id, entities_upserted) = upsert_entities(&resolver, &result.entities).await;

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -385,6 +385,10 @@ pub struct SemanticMemory {
     /// `Some` when `memory.five_signal.enabled = true` at bootstrap.
     /// `None` guarantees zero overhead per NFR-005.
     pub(crate) five_signal: Option<Arc<crate::five_signal::FiveSignalRuntime>>,
+    /// Per-call timeout applied to every `embed()` invocation in this instance.
+    ///
+    /// Configurable via `[memory.semantic] embed_timeout_secs`. Default: 5 s.
+    pub(crate) embed_timeout: std::time::Duration,
 }
 
 impl SemanticMemory {
@@ -519,6 +523,7 @@ impl SemanticMemory {
             summarization_llm_timeout_secs: 60,
             query_sensitive_cost: false,
             five_signal: None,
+            embed_timeout: std::time::Duration::from_secs(5),
         })
     }
 
@@ -585,6 +590,7 @@ impl SemanticMemory {
             summarization_llm_timeout_secs: 60,
             query_sensitive_cost: false,
             five_signal: None,
+            embed_timeout: std::time::Duration::from_secs(5),
         })
     }
 
@@ -735,6 +741,19 @@ impl SemanticMemory {
     #[must_use]
     pub fn with_summarization_timeout(mut self, timeout_secs: u64) -> Self {
         self.summarization_llm_timeout_secs = timeout_secs;
+        self
+    }
+
+    /// Set the per-call timeout for every `embed()` invocation inside this instance.
+    ///
+    /// Configures the timeout applied at all embedding call sites: admission control,
+    /// quality gate, recall, summarization, graph retrieval, consolidation, and tree
+    /// consolidation. Must be non-zero; the minimum effective value is 1 s. Default: `5`.
+    #[must_use]
+    pub fn with_embed_timeout(mut self, timeout_secs: u64) -> Self {
+        let t = std::time::Duration::from_secs(timeout_secs.max(1));
+        self.embed_timeout = t;
+        self.hebbian_spread.embed_timeout = Some(t);
         self
     }
 
@@ -935,9 +954,7 @@ impl SemanticMemory {
         let texts: Vec<String> = facts.iter().map(|f| f.content.clone()).collect();
         let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(texts.len());
         for text in &texts {
-            match tokio::time::timeout(std::time::Duration::from_secs(5), provider.embed(text))
-                .await
-            {
+            match tokio::time::timeout(self.embed_timeout, provider.embed(text)).await {
                 Ok(Ok(v)) => embeddings.push(v),
                 Ok(Err(e)) => {
                     tracing::warn!(error = %e, "query-bias: failed to embed persona fact — skipping");
@@ -1131,6 +1148,7 @@ impl SemanticMemory {
             summarization_llm_timeout_secs: 60,
             query_sensitive_cost: false,
             five_signal: None,
+            embed_timeout: std::time::Duration::from_secs(5),
         }
     }
 
@@ -1216,6 +1234,7 @@ impl SemanticMemory {
             summarization_llm_timeout_secs: 60,
             query_sensitive_cost: false,
             five_signal: None,
+            embed_timeout: std::time::Duration::from_secs(5),
         })
     }
 
@@ -1223,6 +1242,12 @@ impl SemanticMemory {
     #[must_use]
     pub fn sqlite(&self) -> &SqliteStore {
         &self.sqlite
+    }
+
+    /// Return the per-call embed timeout configured for this instance.
+    #[must_use]
+    pub fn embed_timeout(&self) -> std::time::Duration {
+        self.embed_timeout
     }
 
     /// Check if the vector store backend is reachable.
@@ -1391,7 +1416,7 @@ impl SemanticMemory {
             return Ok(Vec::new());
         }
         let embedding = match tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            self.embed_timeout,
             self.effective_embed_provider().embed(query),
         )
         .await

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -761,7 +761,7 @@ impl SemanticMemory {
         {
             let embed_input = self.apply_search_prompt(query);
             let query_vector = match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
+                self.embed_timeout,
                 self.effective_embed_provider().embed(&embed_input),
             )
             .await
@@ -822,7 +822,7 @@ impl SemanticMemory {
         }
         let embed_input = self.apply_search_prompt(query);
         let query_vector = match tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            self.embed_timeout,
             self.effective_embed_provider().embed(&embed_input),
         )
         .await
@@ -1448,6 +1448,7 @@ impl SemanticMemory {
             edge_types,
             self.hebbian_reinforcement.is_enabled(),
             self.hebbian_lr,
+            self.embed_timeout,
         )
         .await?;
 
@@ -1498,6 +1499,7 @@ impl SemanticMemory {
             edge_types,
             self.hebbian_reinforcement.is_enabled(),
             self.hebbian_lr,
+            self.embed_timeout,
         )
         .await?;
 
@@ -1804,6 +1806,7 @@ impl SemanticMemory {
             self.hebbian_reinforcement.is_enabled(),
             self.hebbian_lr,
             self.query_sensitive_cost,
+            self.embed_timeout,
         )
         .await
     }
@@ -1839,6 +1842,7 @@ impl SemanticMemory {
             temporal_decay_rate,
             self.hebbian_reinforcement.is_enabled(),
             self.hebbian_lr,
+            self.embed_timeout,
         )
         .await
     }
@@ -1874,6 +1878,7 @@ impl SemanticMemory {
             temporal_decay_rate,
             self.hebbian_reinforcement.is_enabled(),
             self.hebbian_lr,
+            self.embed_timeout,
         )
         .await
     }
@@ -2150,6 +2155,7 @@ mod tests {
             summarization_llm_timeout_secs: 60,
             query_sensitive_cost: false,
             five_signal: None,
+            embed_timeout: std::time::Duration::from_secs(5),
         }
     }
 

--- a/crates/zeph-memory/src/semantic/summarization.rs
+++ b/crates/zeph-memory/src/semantic/summarization.rs
@@ -146,7 +146,7 @@ impl SemanticMemory {
             && self.effective_embed_provider().supports_embeddings()
         {
             match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
+                self.embed_timeout,
                 self.effective_embed_provider().embed(summary_text),
             )
             .await
@@ -263,7 +263,7 @@ impl SemanticMemory {
             return;
         };
         let first_vector = match tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            self.embed_timeout,
             self.effective_embed_provider().embed(first_fact),
         )
         .await
@@ -300,7 +300,7 @@ impl SemanticMemory {
 
         for fact in filtered[1..].iter().copied() {
             match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
+                self.embed_timeout,
                 self.effective_embed_provider().embed(fact),
             )
             .await
@@ -386,7 +386,7 @@ impl SemanticMemory {
         }
 
         let vector = match tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            self.embed_timeout,
             self.effective_embed_provider().embed(query),
         )
         .await
@@ -442,7 +442,7 @@ impl SemanticMemory {
             return Ok(Vec::new());
         }
         let vector = match tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            self.embed_timeout,
             self.effective_embed_provider().embed(query),
         )
         .await

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -380,6 +380,7 @@ async fn memory_with_in_memory_vector_store() -> (
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     };
 
     (memory, embedding_store)

--- a/crates/zeph-memory/src/semantic/tests/mod.rs
+++ b/crates/zeph-memory/src/semantic/tests/mod.rs
@@ -71,6 +71,7 @@ pub(super) async fn test_semantic_memory(_supports_embeddings: bool) -> Semantic
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     }
 }
 
@@ -180,6 +181,7 @@ async fn effective_embed_provider_routes_to_dedicated_embed_provider() {
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     };
 
     assert!(
@@ -593,6 +595,7 @@ async fn store_correction_embedding_sqlite_clean_db_roundtrip() {
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     };
 
     memory
@@ -716,6 +719,7 @@ async fn load_promotion_window_populates_embeddings_from_qdrant() {
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     };
 
     let window = memory.load_promotion_window(10).await.unwrap();

--- a/crates/zeph-memory/src/semantic/tests/query_bias.rs
+++ b/crates/zeph-memory/src/semantic/tests/query_bias.rs
@@ -109,6 +109,7 @@ async fn test_apply_query_bias_dimension_mismatch_returns_unchanged() {
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     };
 
     let embedding = vec![0.1_f32, 0.2, 0.3];

--- a/crates/zeph-memory/src/semantic/tests/recall.rs
+++ b/crates/zeph-memory/src/semantic/tests/recall.rs
@@ -88,6 +88,7 @@ async fn test_semantic_memory_sqlite_remember_recall_roundtrip() {
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-memory/src/semantic/tests/summarization.rs
+++ b/crates/zeph-memory/src/semantic/tests/summarization.rs
@@ -365,6 +365,7 @@ async fn summarize_fails_when_provider_chat_fails() {
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     };
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
@@ -448,6 +449,7 @@ async fn summarize_fallback_to_plain_text_when_structured_fails() {
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();
@@ -616,6 +618,7 @@ async fn make_embed_memory_with_threshold(threshold: f32) -> super::super::Seman
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     }
 }
 
@@ -727,6 +730,7 @@ async fn store_key_facts_fail_open_on_search_error() {
         summarization_llm_timeout_secs: 60,
         query_sensitive_cost: false,
         five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-memory/src/semantic/tree_consolidation.rs
+++ b/crates/zeph-memory/src/semantic/tree_consolidation.rs
@@ -32,12 +32,21 @@ Return only the summary text — no JSON, no preamble.";
 /// Configuration for the tree consolidation loop.
 #[derive(Clone)]
 pub struct TreeConsolidationConfig {
+    /// Enable or disable the tree consolidation background loop.
     pub enabled: bool,
+    /// Interval between consolidation sweeps, in seconds.
     pub sweep_interval_secs: u64,
+    /// Maximum number of leaf nodes processed per sweep.
     pub batch_size: usize,
+    /// Cosine similarity threshold for clustering nodes (0.0–1.0). Nodes with similarity
+    /// above this value are merged into a parent node.
     pub similarity_threshold: f32,
+    /// Maximum depth of the memory tree (levels above leaf nodes).
     pub max_level: u32,
+    /// Minimum cluster size required to trigger LLM consolidation.
     pub min_cluster_size: usize,
+    /// Per-call timeout for every `embed()` invocation, in seconds. Default: `5`.
+    pub embed_timeout_secs: u64,
 }
 
 /// Result of one consolidation sweep.
@@ -132,7 +141,12 @@ pub async fn run_tree_consolidation_sweep(
             continue;
         }
 
-        let embedded = embed_candidates(provider, &candidates).await;
+        let embedded = embed_candidates(
+            provider,
+            &candidates,
+            Duration::from_secs(config.embed_timeout_secs),
+        )
+        .await;
         if embedded.len() < config.min_cluster_size {
             continue;
         }
@@ -216,6 +230,7 @@ const EMBED_CONCURRENCY: usize = 8;
 async fn embed_candidates(
     provider: &AnyProvider,
     candidates: &[MemoryTreeRow],
+    embed_timeout: Duration,
 ) -> Vec<(i64, String, Vec<f32>)> {
     let mut embedded = Vec::with_capacity(candidates.len());
 
@@ -227,11 +242,8 @@ async fn embed_candidates(
                 let id = row.id;
                 let content = row.content.clone();
                 async move {
-                    let result = tokio::time::timeout(
-                        std::time::Duration::from_secs(5),
-                        provider.embed(&content),
-                    )
-                    .await;
+                    let result =
+                        tokio::time::timeout(embed_timeout, provider.embed(&content)).await;
                     let result = match result {
                         Ok(r) => r,
                         Err(_elapsed) => {
@@ -359,7 +371,7 @@ mod tests {
 
         tokio::time::pause();
 
-        let fut = embed_candidates(&slow, &candidates);
+        let fut = embed_candidates(&slow, &candidates, Duration::from_secs(5));
         let (result, ()) = tokio::join!(fut, async {
             tokio::time::advance(std::time::Duration::from_secs(6)).await;
         });

--- a/crates/zeph-memory/src/tiers.rs
+++ b/crates/zeph-memory/src/tiers.rs
@@ -49,6 +49,8 @@ pub struct TierPromotionConfig {
     pub sweep_interval_secs: u64,
     /// Maximum number of candidates to process per sweep.
     pub sweep_batch_size: usize,
+    /// Per-call timeout for every `embed()` invocation, in seconds. Default: `5`.
+    pub embed_timeout_secs: u64,
 }
 
 /// Start the background tier promotion loop.
@@ -192,7 +194,15 @@ async fn run_promotion_sweep(
 
         let source_conv_id = cluster[0].0.conversation_id;
 
-        match merge_cluster_and_promote(store, provider, &cluster, source_conv_id).await {
+        match merge_cluster_and_promote(
+            store,
+            provider,
+            &cluster,
+            source_conv_id,
+            Duration::from_secs(config.embed_timeout_secs),
+        )
+        .await
+        {
             Ok(()) => stats.promotions_completed += 1,
             Err(e) => {
                 tracing::warn!(
@@ -255,6 +265,7 @@ async fn merge_cluster_and_promote(
     provider: &AnyProvider,
     cluster: &[(PromotionCandidate, Vec<f32>)],
     conversation_id: ConversationId,
+    embed_timeout: Duration,
 ) -> Result<(), MemoryError> {
     let contents: Vec<&str> = cluster.iter().map(|(c, _)| c.content.as_str()).collect();
     let original_ids: Vec<crate::types::MessageId> = cluster.iter().map(|(c, _)| c.id).collect();
@@ -274,7 +285,7 @@ async fn merge_cluster_and_promote(
     if provider.supports_embeddings() {
         let embeddings_available = cluster.iter().any(|(_, emb)| !emb.is_empty());
         if embeddings_available {
-            match tokio::time::timeout(Duration::from_secs(5), provider.embed(&merged)).await {
+            match tokio::time::timeout(embed_timeout, provider.embed(&merged)).await {
                 Ok(Ok(merged_vec)) => {
                     let max_sim = cluster
                         .iter()
@@ -459,7 +470,9 @@ mod tests {
             (make_candidate(m2.0), vec![1.0_f32, 0.0, 0.0]),
         ];
 
-        let result = merge_cluster_and_promote(&store, &provider, &cluster, conv_id).await;
+        let result =
+            merge_cluster_and_promote(&store, &provider, &cluster, conv_id, Duration::from_secs(5))
+                .await;
         assert!(
             result.is_ok(),
             "embed failure during merge validation must be fail-open (Ok), got {result:?}"

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -486,6 +486,8 @@ impl AppBuilder {
         memory =
             memory.with_summarization_timeout(self.config.memory.summarization_llm_timeout_secs);
 
+        memory = memory.with_embed_timeout(self.config.memory.semantic.embed_timeout_secs);
+
         memory = self.attach_five_signal(memory);
 
         Ok(memory)
@@ -781,7 +783,8 @@ impl AppBuilder {
             self.config.memory.admission.threshold,
             self.config.memory.admission.fast_path_margin,
             weights,
-        );
+        )
+        .with_embed_timeout(self.config.memory.semantic.embed_timeout_secs);
         if !self.config.memory.admission.admission_provider.is_empty() {
             match create_named_provider(
                 &self.config.memory.admission.admission_provider,
@@ -874,7 +877,8 @@ impl AppBuilder {
             llm_weight: qg_cfg.llm_weight,
             reference_check_lang_en: qg_cfg.reference_check_lang_en,
         };
-        let mut gate = zeph_memory::quality_gate::QualityGate::new(runtime_cfg);
+        let mut gate = zeph_memory::quality_gate::QualityGate::new(runtime_cfg)
+            .with_embed_timeout(self.config.memory.semantic.embed_timeout_secs);
 
         if let Some(ref gs) = memory.graph_store {
             gate = gate.with_graph_store(gs.clone());

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1536,6 +1536,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             similarity_threshold: config.memory.tiers.similarity_threshold,
             sweep_interval_secs: config.memory.tiers.sweep_interval_secs,
             sweep_batch_size: config.memory.tiers.sweep_batch_size,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
         };
         let tier_provider = provider.clone();
         let cancel = supervisor.cancellation_token();
@@ -1588,6 +1589,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             sweep_batch_size: config.memory.consolidation.sweep_batch_size,
             similarity_threshold: config.memory.consolidation.similarity_threshold,
             llm_timeout_secs: config.memory.consolidation.llm_timeout_secs,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
         };
         let consolidation_provider = app
             .build_consolidation_provider()
@@ -1669,6 +1671,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             similarity_threshold: config.memory.tree.similarity_threshold,
             max_level: config.memory.tree.max_level,
             min_cluster_size: config.memory.tree.min_cluster_size,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
         };
         let cancel = supervisor.cancellation_token();
         supervisor.spawn(TaskDescriptor {


### PR DESCRIPTION
## Summary

- Added `embed_timeout_secs: u64` (default `5` s) to `SemanticConfig` in `zeph-config` and `ConsolidationConfig` in `zeph-common`
- All ~30 hardcoded `Duration::from_secs(5)` embed call sites in `zeph-memory` now read from config — threaded through `AdmissionControl`, `QualityGate`, `EntityResolver`, `TreeConsolidationConfig`, `TierPromotionConfig`, `GraphExtractionConfig`, `ConsolidationConfig`, `SemanticMemory` (incl. `hebbian_spread`), and all graph recall variants
- Fixed 2 additional zeph-core sites (`autodream.rs`, `agent_access_impl.rs`) that constructed config structs with hardcoded `5`
- Added `///` doc comments to all 6 pub fields of `TreeConsolidationConfig`

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 10212 PASS, 21 skipped
- [ ] `cargo +nightly fmt --check` — CLEAN
- [ ] `cargo clippy --workspace --lib --bins --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — CLEAN
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — CLEAN
- [ ] No hardcoded `Duration::from_secs(5)` remains in production code: `grep -rn 'Duration::from_secs(5)' crates/zeph-memory/src/ crates/zeph-core/src/ | grep -v '#\[cfg(test)\]\|Default::default\|new()'`

Closes #4601
Closes #4603