### PR TITLE
fix(build): enable testing feature in zeph-llm dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,7 +341,7 @@ serial_test.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true
 zeph-core.workspace = true
-zeph-llm.workspace = true
+zeph-llm = { workspace = true, features = ["testing"] }
 zeph-memory.workspace = true
 zeph-skills.workspace = true
 # Features are declared by the crates that use them, see workspace dependencies


### PR DESCRIPTION
## Summary

- Adds `features = ["testing"]` to the `zeph-llm` entry in `[dev-dependencies]` of the root `Cargo.toml`

## Problem

`cargo test --package zeph --no-run` failed with 10 compile errors because `AnyProvider::Mock` and `zeph_llm::mock` are gated behind `#[cfg(any(test, feature = "testing"))]` in `zeph-llm`, but the binary's dev-dependency only listed `zeph-llm.workspace = true` without enabling the `testing` feature.

`cargo nextest run --workspace --lib --bins` was unaffected (nextest skips inline test module compilation for binary crates under `--lib --bins`).

## Fix

One-line change in root `Cargo.toml`:

```toml
# before
zeph-llm.workspace = true

# after
zeph-llm = { workspace = true, features = ["testing"] }
```

## Test plan

- [x] `cargo test --package zeph --no-run` — compiles cleanly (was: 10 errors)
- [x] `cargo nextest run --workspace --lib --bins` — 10218 PASS, no regressions
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean

Closes #4611