### PR TITLE
feat(context,memory): persist ContextFidelity per message for cross-turn floor invariant (#4550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `zeph-db`: SQLite migration 095 adds `fidelity_tag INTEGER NOT NULL DEFAULT 0` column to
+  `messages` table; PostgreSQL migration adds equivalent `SMALLINT NOT NULL DEFAULT 0` column.
+  Enables per-message fidelity level persistence for cross-turn stability (CAM Phase 2-B, #4550).
+- `zeph-common`: `ContextFidelity::from_u8(v: u8) -> Self` — converts a database integer to a
+  fidelity level; unknown values map to `Full` (safe default).
+- `zeph-memory`: `MessageStore::update_fidelity_tags(&[(MessageId, u8)])` — batch-updates fidelity
+  tags for messages in a single transaction; no-op when slice is empty.
+- `zeph-memory`: `load_history` and `load_history_filtered` now read `fidelity_tag` from the DB and
+  populate `Message::metadata.fidelity_tag`; DB value `0` maps to `None` (never scored) to avoid
+  imposing a spurious floor on pre-CAM messages.
+- `zeph-context`: Floor invariant in `FidelityScorer::score_and_apply` — messages with a persisted
+  `Compressed` tag cannot upgrade to `Full`; messages with `Placeholder` cannot upgrade at all.
+  Bypass via new `allow_upgrade: bool` parameter (used by proactive regrade path only).
+- `zeph-context`: `more_restrictive(a, b)` — helper propagating the stricter fidelity level across
+  tool-use / tool-result atomicity pairs, preventing floor bypass via raw float score.
+- `zeph-agent-context`: `persist_fidelity_tags` — private helper that collects `(MessageId, u8)`
+  pairs from scored messages and batch-writes them to SQLite; called inline after each scoring pass
+  (normal path and prograde path) so floor constraints survive to the next turn.
+
 ### Changed
 
 - `zeph-memory`: embed timeout is now configurable via `memory.semantic.embed_timeout_secs` (default

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -679,7 +679,10 @@ impl ContextService {
                 fidelity_cfg,
                 &*view.token_counter,
                 inserted_count,
+                false, // floor invariant enforced on normal scoring path
             );
+            // Persist fidelity tags so subsequent turns see the floor invariant.
+            persist_fidelity_tags(window.messages, view.memory.as_deref()).await;
             recompute_prompt_tokens(window);
             if let Some(ref tx) = view.status_tx {
                 let _ = tx.send(String::new());
@@ -1115,7 +1118,10 @@ impl ContextService {
                 fidelity_cfg,
                 &*summ.token_counter,
                 0,
+                true, // proactive regrade: allow upgrading past the persisted floor
             );
+            // Persist upgraded fidelity tags so the new levels survive the next turn (F-3).
+            persist_fidelity_tags(summ.messages, summ.memory.as_deref()).await;
             recompute_prompt_tokens_summ(summ);
             summ.context_manager.set_regraded_this_turn(true);
             tracing::debug!(
@@ -1510,6 +1516,39 @@ pub(crate) fn recompute_prompt_tokens(window: &mut MessageWindowView<'_>) {
         .iter()
         .map(|m| window.token_counter.count_message_tokens(m) as u64)
         .sum();
+}
+
+/// Persist fidelity tags for all scored messages to `SQLite`.
+///
+/// Collects `(db_id, tag as u8)` pairs for messages that have both a `db_id` and a
+/// non-None `fidelity_tag`, then calls [`SqliteStore::update_fidelity_tags`] inline.
+/// The await is cheap — `SQLite` UPDATE is a sub-millisecond local I/O operation.
+///
+/// A warn-level log is emitted on failure; the next turn will recompute from scratch,
+/// which is safe (the floor invariant simply won't apply until persistence succeeds).
+async fn persist_fidelity_tags(
+    messages: &[zeph_llm::provider::Message],
+    memory: Option<&zeph_memory::semantic::SemanticMemory>,
+) {
+    let Some(mem) = memory else { return };
+    let updates: Vec<(zeph_memory::MessageId, u8)> = messages
+        .iter()
+        .filter_map(|m| {
+            let db_id = m.metadata.db_id?;
+            let tag = m.metadata.fidelity_tag?;
+            Some((zeph_memory::MessageId(db_id), tag as u8))
+        })
+        .collect();
+    if updates.is_empty() {
+        return;
+    }
+    if let Err(e) = mem.sqlite().update_fidelity_tags(&updates).await {
+        tracing::warn!(
+            count = updates.len(),
+            error = %e,
+            "failed to persist fidelity tags; floor invariant will not apply next turn"
+        );
+    }
 }
 
 /// Recompute `cached_prompt_tokens` for a [`ContextSummarizationView`].

--- a/crates/zeph-common/src/fidelity.rs
+++ b/crates/zeph-common/src/fidelity.rs
@@ -26,6 +26,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// let compressed: u8 = ContextFidelity::Compressed as u8;
 /// assert_eq!(compressed, 1);
+///
+/// assert_eq!(ContextFidelity::from_u8(0), ContextFidelity::Full);
+/// assert_eq!(ContextFidelity::from_u8(1), ContextFidelity::Compressed);
+/// assert_eq!(ContextFidelity::from_u8(255), ContextFidelity::Full); // unknown → Full
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
@@ -40,6 +44,35 @@ pub enum ContextFidelity {
     /// Content replaced by a compact placeholder tag; no semantic content
     /// survives.
     Placeholder = 2,
+}
+
+impl ContextFidelity {
+    /// Convert a database integer to a fidelity level.
+    ///
+    /// Unknown values map to [`Full`](ContextFidelity::Full) as the safe default,
+    /// preserving forward compatibility when new variants are added.
+    ///
+    /// **Note for variant authors:** update this match when adding new variants,
+    /// or old code will silently upgrade persisted values to `Full`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_common::fidelity::ContextFidelity;
+    ///
+    /// assert_eq!(ContextFidelity::from_u8(0), ContextFidelity::Full);
+    /// assert_eq!(ContextFidelity::from_u8(1), ContextFidelity::Compressed);
+    /// assert_eq!(ContextFidelity::from_u8(2), ContextFidelity::Placeholder);
+    /// assert_eq!(ContextFidelity::from_u8(99), ContextFidelity::Full);
+    /// ```
+    #[must_use]
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            1 => Self::Compressed,
+            2 => Self::Placeholder,
+            _ => Self::Full, // 0 = Full (default); unknown values also map to Full
+        }
+    }
 }
 
 /// Hint about an upcoming tool call derived from the orchestration DAG.
@@ -80,6 +113,35 @@ impl PlannedToolHint {
             tool_name: tool_name.into(),
             keywords,
             distance_from_current,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContextFidelity;
+
+    #[test]
+    fn from_u8_round_trip() {
+        assert_eq!(ContextFidelity::from_u8(0), ContextFidelity::Full);
+        assert_eq!(ContextFidelity::from_u8(1), ContextFidelity::Compressed);
+        assert_eq!(ContextFidelity::from_u8(2), ContextFidelity::Placeholder);
+    }
+
+    #[test]
+    fn from_u8_unknown_defaults_to_full() {
+        assert_eq!(ContextFidelity::from_u8(3), ContextFidelity::Full);
+        assert_eq!(ContextFidelity::from_u8(255), ContextFidelity::Full);
+    }
+
+    #[test]
+    fn as_u8_matches_from_u8() {
+        for level in [
+            ContextFidelity::Full,
+            ContextFidelity::Compressed,
+            ContextFidelity::Placeholder,
+        ] {
+            assert_eq!(ContextFidelity::from_u8(level as u8), level);
         }
     }
 }

--- a/crates/zeph-context/benches/fidelity_scorer.rs
+++ b/crates/zeph-context/benches/fidelity_scorer.rs
@@ -69,6 +69,7 @@ fn bench_score_500(c: &mut Criterion) {
                 black_box(&cfg),
                 black_box(&tc),
                 black_box(0),
+                black_box(false),
             );
         });
     });

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -44,7 +44,7 @@ struct FidelityScore {
 /// let cfg = FidelityConfig { enabled: false, ..FidelityConfig::default() };
 /// // With `enabled = false` the scorer is a no-op.
 /// let mut messages = vec![];
-/// scorer.score_and_apply(&mut messages, "query", &[], &cfg, &MockTc, 0);
+/// scorer.score_and_apply(&mut messages, "query", &[], &cfg, &MockTc, 0, false);
 ///
 /// struct MockTc;
 /// impl zeph_common::memory::TokenCounting for MockTc {
@@ -61,9 +61,11 @@ impl FidelityScorer {
     /// 1. Guard: return early when `enabled == false`.
     /// 2. Build exempt set (INV-07 through INV-10).
     /// 3. Score each non-exempt message with normalized weight sum (INV-05).
-    /// 4. Apply tool-pair atomicity — both get `min(score_a, score_b)` (INV-03).
-    /// 5. Render `Compressed` / `Placeholder` messages (INV-12).
-    /// 6. Merge consecutive same-role `Placeholder` messages (INV-04).
+    /// 4. Apply floor invariant: a message with a persisted fidelity tag cannot
+    ///    be upgraded to a less restrictive level unless `allow_upgrade = true`.
+    /// 5. Apply tool-pair atomicity — both get `min(score_a, score_b)` (INV-03).
+    /// 6. Render `Compressed` / `Placeholder` messages (INV-12).
+    /// 7. Merge consecutive same-role `Placeholder` messages (INV-04).
     ///
     /// # Parameters
     ///
@@ -74,6 +76,9 @@ impl FidelityScorer {
     /// - `tc` — token counter used for `Placeholder`/`Compressed` rendering.
     /// - `inserted_count` — number of memory messages freshly injected at indices
     ///   `1..1+inserted_count`; these are always exempt (INV-10).
+    /// - `allow_upgrade` — when `true` the persisted floor invariant is bypassed.
+    ///   Pass `true` only from the proactive regrade path; pass `false` everywhere else.
+    #[allow(clippy::too_many_arguments)]
     pub fn score_and_apply(
         &self,
         messages: &mut Vec<Message>,
@@ -82,12 +87,21 @@ impl FidelityScorer {
         config: &FidelityConfig,
         tc: &dyn TokenCounting,
         inserted_count: usize,
+        allow_upgrade: bool,
     ) {
         if !config.enabled || messages.is_empty() {
             return;
         }
 
-        let scores = compute_scores(messages, query, planned_tools, config, tc, inserted_count);
+        let scores = compute_scores(
+            messages,
+            query,
+            planned_tools,
+            config,
+            tc,
+            inserted_count,
+            allow_upgrade,
+        );
         apply_scores(messages, &scores, config, tc);
 
         let _merge_span = info_span!("context.fidelity.merge").entered();
@@ -96,6 +110,7 @@ impl FidelityScorer {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compute_scores(
     messages: &[Message],
     query: &str,
@@ -103,6 +118,7 @@ fn compute_scores(
     config: &FidelityConfig,
     tc: &dyn TokenCounting,
     inserted_count: usize,
+    allow_upgrade: bool,
 ) -> Vec<Option<FidelityScore>> {
     let n = messages.len();
 
@@ -191,7 +207,28 @@ fn compute_scores(
             };
 
         let score = (raw / weight_sum).clamp(0.0, 1.0);
-        let level = score_to_level(score, config);
+        let candidate_level = score_to_level(score, config);
+
+        // Floor invariant (CAM Phase 2-B): a persisted fidelity tag constrains upgrades.
+        // A message previously scored as Compressed cannot be upgraded back to Full;
+        // Placeholder cannot be upgraded to Full or Compressed.
+        // The regrade path passes allow_upgrade=true to bypass this constraint.
+        let level = if allow_upgrade {
+            candidate_level
+        } else {
+            match msg.metadata.fidelity_tag {
+                Some(ContextFidelity::Placeholder) => ContextFidelity::Placeholder,
+                Some(ContextFidelity::Compressed) => {
+                    if candidate_level == ContextFidelity::Full {
+                        ContextFidelity::Compressed
+                    } else {
+                        candidate_level
+                    }
+                }
+                _ => candidate_level,
+            }
+        };
+
         scores[i] = Some(FidelityScore {
             score,
             level,
@@ -310,6 +347,9 @@ fn plan_relevance(content: &str, planned_tools: &[PlannedToolHint]) -> f32 {
 }
 
 /// O(N) backward scan: find `ToolUse`/`ToolResult` pairs and assign `min(score_a, score_b)`.
+///
+/// The "min" is computed over both the float score and the already-floored level, so
+/// the floor invariant set in `compute_scores` is respected (INV-03 + floor invariant).
 fn apply_tool_pair_atomicity(
     messages: &[Message],
     scores: &mut [Option<FidelityScore>],
@@ -335,7 +375,19 @@ fn apply_tool_pair_atomicity(
                 let score_a = scores[i].as_ref().map_or(1.0, |s| s.score);
                 let score_b = scores[result_idx].as_ref().map_or(1.0, |s| s.score);
                 let min_score = score_a.min(score_b);
-                let min_level = score_to_level(min_score, config);
+
+                // The level is the more restrictive of the two already-floored levels.
+                // Taking min(float) alone would bypass the floor invariant for the pair
+                // because score_to_level(min_score) ignores persisted fidelity tags.
+                let level_a = scores[i]
+                    .as_ref()
+                    .map_or(ContextFidelity::Full, |s| s.level);
+                let level_b = scores[result_idx]
+                    .as_ref()
+                    .map_or(ContextFidelity::Full, |s| s.level);
+                let float_level = score_to_level(min_score, config);
+                let min_level = more_restrictive(more_restrictive(level_a, level_b), float_level);
+
                 let tokens_a = scores[i].as_ref().map_or(0, |s| s.original_tokens);
                 let tokens_b = scores[result_idx].as_ref().map_or(0, |s| s.original_tokens);
                 scores[i] = Some(FidelityScore {
@@ -350,6 +402,18 @@ fn apply_tool_pair_atomicity(
                 });
             }
         }
+    }
+}
+
+/// Return the more restrictive of two fidelity levels.
+///
+/// Restrictiveness order: Placeholder > Compressed > Full.
+fn more_restrictive(a: ContextFidelity, b: ContextFidelity) -> ContextFidelity {
+    use ContextFidelity::{Compressed, Full, Placeholder};
+    match (a, b) {
+        (Placeholder, _) | (_, Placeholder) => Placeholder,
+        (Compressed, _) | (_, Compressed) => Compressed,
+        _ => Full,
     }
 }
 
@@ -379,10 +443,7 @@ fn truncate_to_tokens(content: &mut String, max_tokens: usize, tc: &dyn TokenCou
     }
     let mut len = content.len();
     while len > 0 && tc.count_tokens(&content[..len]) > max_tokens {
-        len /= 2;
-        while len > 0 && !content.is_char_boundary(len) {
-            len -= 1;
-        }
+        len = content.floor_char_boundary(len / 2);
     }
     content.truncate(len);
 }
@@ -545,7 +606,7 @@ mod tests {
         let cfg = make_cfg();
         let tc = FixedTc(4);
         let mut messages: Vec<Message> = vec![];
-        scorer.score_and_apply(&mut messages, "query text", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(&mut messages, "query text", &[], &cfg, &tc, 0, false);
         assert!(messages.is_empty());
     }
 
@@ -560,7 +621,7 @@ mod tests {
             // Injected memory at index 1 with inserted_count=1.
             make_msg(Role::User, "memory context"),
         ];
-        scorer.score_and_apply(&mut messages, "short", &[], &cfg, &tc, 1);
+        scorer.score_and_apply(&mut messages, "short", &[], &cfg, &tc, 1, false);
         for msg in &messages {
             assert!(
                 msg.metadata.fidelity_tag.is_none()
@@ -605,6 +666,7 @@ mod tests {
             &cfg,
             &tc,
             0,
+            false,
         );
         let tag_a = messages[1].metadata.fidelity_tag;
         let tag_b = messages[2].metadata.fidelity_tag;
@@ -625,7 +687,7 @@ mod tests {
         let mut messages: Vec<Message> = std::iter::once(make_msg(Role::System, "system"))
             .chain((0..5).map(|i| make_msg(Role::Assistant, &format!("msg {i}"))))
             .collect();
-        scorer.score_and_apply(&mut messages, "some query here", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(&mut messages, "some query here", &[], &cfg, &tc, 0, false);
         // System + 1 merged placeholder.
         assert_eq!(
             messages.len(),
@@ -646,7 +708,15 @@ mod tests {
             make_msg(Role::User, "hello"),
             make_msg(Role::Assistant, "world response"),
         ];
-        scorer.score_and_apply(&mut messages, "hello world signal", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(
+            &mut messages,
+            "hello world signal",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
         for msg in &messages {
             let _ = msg.metadata.fidelity_tag;
         }
@@ -666,7 +736,7 @@ mod tests {
             make_msg(Role::User, "test"),
         ];
         // Must not panic or produce out-of-range scores.
-        scorer.score_and_apply(&mut messages, "short", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(&mut messages, "short", &[], &cfg, &tc, 0, false);
     }
 
     // 7. AC-09: memory_first bypass is the caller's responsibility.
@@ -698,6 +768,7 @@ mod tests {
             &cfg,
             &tc,
             2,
+            false,
         );
         for (msg, orig) in messages.iter().zip(&before) {
             assert_eq!(msg.content, *orig, "content must be unchanged");
@@ -722,7 +793,7 @@ mod tests {
             make_msg(Role::User, "user message that would normally be scored"),
         ];
         let original_contents: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
-        scorer.score_and_apply(&mut messages, "query text here", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(&mut messages, "query text here", &[], &cfg, &tc, 0, false);
         for (msg, orig) in messages.iter().zip(&original_contents) {
             assert_eq!(msg.content, *orig);
             assert!(msg.metadata.fidelity_tag.is_none());
@@ -750,7 +821,7 @@ mod tests {
         let tc = FixedTc(4);
         let mut messages = vec![make_msg(Role::System, ""), make_msg(Role::User, "")];
         // Must not panic with zero weights.
-        scorer.score_and_apply(&mut messages, "", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(&mut messages, "", &[], &cfg, &tc, 0, false);
     }
 
     // 11. Token count uses tc.count_tokens for Placeholder rendering.
@@ -767,7 +838,15 @@ mod tests {
             make_msg(Role::System, "system"),
             make_msg(Role::User, "user message content for placeholder rendering"),
         ];
-        scorer.score_and_apply(&mut messages, "some query text here", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(
+            &mut messages,
+            "some query text here",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Placeholder)
@@ -809,7 +888,15 @@ mod tests {
             }))
             .collect();
 
-        scorer.score_and_apply(&mut messages, "query text here long", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
 
         // Tail messages (focus_pinned) must have no fidelity_tag.
         let tail: Vec<_> = messages
@@ -850,7 +937,15 @@ mod tests {
         let mut messages: Vec<Message> = std::iter::once(make_msg(Role::System, "system prompt"))
             .chain((1..8usize).map(|i| make_msg(roles[i % 2], &format!("message {i}"))))
             .collect();
-        scorer.score_and_apply(&mut messages, "query text here long", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
         // score_end = 8 (n=8 <= max_scored_messages=10, so exempt_tail not applied).
         // All non-system messages must be scored (tagged).
         let untagged_count = messages[1..]
@@ -878,11 +973,290 @@ mod tests {
             make_msg(Role::User, "original long content that would be truncated");
         msg_with_summary.metadata.deferred_summary = Some("short summary".to_string());
         let mut messages = vec![make_msg(Role::System, "system"), msg_with_summary];
-        scorer.score_and_apply(&mut messages, "query text here long", &[], &cfg, &tc, 0);
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Compressed)
         );
         assert_eq!(messages[1].content, "short summary");
+    }
+
+    // ── CAM Phase 2-B: floor invariant tests ────────────────────────────────
+
+    fn make_msg_with_fidelity(role: Role, content: &str, tag: Option<ContextFidelity>) -> Message {
+        let mut m = make_msg(role, content);
+        m.metadata.fidelity_tag = tag;
+        m
+    }
+
+    // Floor: Compressed cannot upgrade to Full when allow_upgrade=false.
+    #[test]
+    fn floor_prevents_compressed_upgrade_to_full() {
+        let scorer = FidelityScorer;
+        let cfg = FidelityConfig {
+            // Very low thresholds so every message naturally scores Full.
+            full_threshold: 0.0,
+            compressed_threshold: -1.0,
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg_with_fidelity(
+                Role::User,
+                "query text here long keyword",
+                Some(ContextFidelity::Compressed),
+            ),
+        ];
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long keyword",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
+        assert_eq!(
+            messages[1].metadata.fidelity_tag,
+            Some(ContextFidelity::Compressed),
+            "Compressed floor must block upgrade to Full"
+        );
+    }
+
+    // Floor: Placeholder cannot upgrade to Full.
+    #[test]
+    fn floor_prevents_placeholder_upgrade_to_full() {
+        let scorer = FidelityScorer;
+        let cfg = FidelityConfig {
+            full_threshold: 0.0,
+            compressed_threshold: -1.0,
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg_with_fidelity(
+                Role::User,
+                "query text here long keyword",
+                Some(ContextFidelity::Placeholder),
+            ),
+        ];
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long keyword",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
+        assert_eq!(
+            messages[1].metadata.fidelity_tag,
+            Some(ContextFidelity::Placeholder),
+            "Placeholder floor must block upgrade to Full"
+        );
+    }
+
+    // Floor: Placeholder cannot upgrade to Compressed.
+    #[test]
+    fn floor_prevents_placeholder_upgrade_to_compressed() {
+        let scorer = FidelityScorer;
+        // Thresholds: full=2.0 (unreachable), compressed=0.0 (everything Compressed).
+        let cfg = FidelityConfig {
+            full_threshold: 2.0,
+            compressed_threshold: 0.0,
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg_with_fidelity(
+                Role::User,
+                "message content",
+                Some(ContextFidelity::Placeholder),
+            ),
+        ];
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
+        assert_eq!(
+            messages[1].metadata.fidelity_tag,
+            Some(ContextFidelity::Placeholder),
+            "Placeholder floor must block upgrade to Compressed"
+        );
+    }
+
+    // Floor: further downgrade (Compressed → Placeholder) is allowed.
+    #[test]
+    fn floor_allows_further_downgrade() {
+        let scorer = FidelityScorer;
+        let cfg = FidelityConfig {
+            full_threshold: 2.0,
+            compressed_threshold: 2.0, // everything Placeholder
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg_with_fidelity(
+                Role::User,
+                "some content",
+                Some(ContextFidelity::Compressed),
+            ),
+        ];
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
+        assert_eq!(
+            messages[1].metadata.fidelity_tag,
+            Some(ContextFidelity::Placeholder),
+            "downgrade from Compressed to Placeholder must be allowed"
+        );
+    }
+
+    // Floor: None tag → no constraint, normal scoring.
+    #[test]
+    fn floor_no_constraint_when_none() {
+        let scorer = FidelityScorer;
+        // Force every message to Full.
+        let cfg = FidelityConfig {
+            full_threshold: 0.0,
+            compressed_threshold: -1.0,
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg_with_fidelity(Role::User, "query text here long keyword", None),
+        ];
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long keyword",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
+        assert_eq!(
+            messages[1].metadata.fidelity_tag,
+            Some(ContextFidelity::Full),
+            "None tag must not constrain scoring"
+        );
+    }
+
+    // allow_upgrade=true bypasses the Placeholder floor.
+    #[test]
+    fn allow_upgrade_bypasses_floor() {
+        let scorer = FidelityScorer;
+        let cfg = FidelityConfig {
+            full_threshold: 0.0,
+            compressed_threshold: -1.0,
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg_with_fidelity(
+                Role::User,
+                "query text here long keyword",
+                Some(ContextFidelity::Placeholder),
+            ),
+        ];
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long keyword",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            true,
+        );
+        assert_eq!(
+            messages[1].metadata.fidelity_tag,
+            Some(ContextFidelity::Full),
+            "allow_upgrade=true must bypass the Placeholder floor"
+        );
+    }
+
+    // Mixed-fidelity tool pair: None + Some(Compressed) → both end up Compressed via atomicity.
+    #[test]
+    fn mixed_fidelity_tool_pair_floor_plus_atomicity() {
+        let scorer = FidelityScorer;
+        // Force everything to Full naturally, so the floor is the only downward pressure.
+        let cfg = FidelityConfig {
+            full_threshold: 0.0,
+            compressed_threshold: -1.0,
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+        let tool_id = "tool-42".to_string();
+
+        let mut tool_use_msg = make_msg_with_fidelity(Role::Assistant, "call tool", None);
+        tool_use_msg.parts = vec![MessagePart::ToolUse {
+            id: tool_id.clone(),
+            name: "shell".to_string(),
+            input: serde_json::json!({}),
+        }];
+
+        let mut tool_result_msg =
+            make_msg_with_fidelity(Role::User, "result body", Some(ContextFidelity::Compressed));
+        tool_result_msg.parts = vec![MessagePart::ToolResult {
+            tool_use_id: tool_id.clone(),
+            content: "output".to_string(),
+            is_error: false,
+        }];
+
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            tool_use_msg,
+            tool_result_msg,
+        ];
+
+        scorer.score_and_apply(
+            &mut messages,
+            "query text here long",
+            &[],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
+
+        // After floor clamping: tool_use scores Full (no floor), tool_result scores Full but
+        // is clamped to Compressed by its floor. Atomicity then takes min(Full, Compressed) =
+        // Compressed for both.
+        let tag_use = messages[1].metadata.fidelity_tag;
+        let tag_result = messages[2].metadata.fidelity_tag;
+        assert_eq!(
+            tag_use, tag_result,
+            "tool pair must share the same fidelity level"
+        );
+        assert_eq!(
+            tag_use,
+            Some(ContextFidelity::Compressed),
+            "atomicity must bring the tool-use down to the tool-result floor"
+        );
     }
 }

--- a/crates/zeph-db/migrations/postgres/095_fidelity_tag.sql
+++ b/crates/zeph-db/migrations/postgres/095_fidelity_tag.sql
@@ -1,0 +1,5 @@
+-- CAM Phase 2-B: persist fidelity level per message (#4550).
+-- 0 = Full (default), 1 = Compressed, 2 = Placeholder.
+-- DEFAULT 0 ensures existing rows and rows from disabled-CAM paths
+-- are treated as Full without application-level intervention.
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS fidelity_tag SMALLINT NOT NULL DEFAULT 0;

--- a/crates/zeph-db/migrations/sqlite/095_fidelity_tag.sql
+++ b/crates/zeph-db/migrations/sqlite/095_fidelity_tag.sql
@@ -1,0 +1,5 @@
+-- CAM Phase 2-B: persist fidelity level per message (#4550).
+-- 0 = Full (default), 1 = Compressed, 2 = Placeholder.
+-- DEFAULT 0 ensures existing rows and rows from disabled-CAM paths
+-- are treated as Full without application-level intervention.
+ALTER TABLE messages ADD COLUMN fidelity_tag INTEGER NOT NULL DEFAULT 0;

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -4,6 +4,7 @@
 use futures::TryStreamExt as _;
 #[allow(unused_imports)]
 use zeph_common;
+use zeph_common::ContextFidelity;
 use zeph_db::ActiveDialect;
 use zeph_db::fts::sanitize_fts_query;
 #[allow(unused_imports)]
@@ -255,6 +256,10 @@ impl SqliteStore {
 
     /// Load the most recent messages for a conversation, up to `limit`.
     ///
+    /// Restores persisted `fidelity_tag` into [`MessageMetadata::fidelity_tag`].
+    /// A stored value of `0` maps to `None` (never scored / Full by default) so
+    /// messages written before CAM was enabled do not acquire a spurious floor.
+    ///
     /// # Errors
     ///
     /// Returns an error if the query fails.
@@ -263,9 +268,9 @@ impl SqliteStore {
         conversation_id: ConversationId,
         limit: u32,
     ) -> Result<Vec<Message>, MemoryError> {
-        let rows: Vec<(String, String, String, String, i64)> = zeph_db::query_as(sql!(
-            "SELECT role, content, parts, visibility, id FROM (\
-                SELECT role, content, parts, visibility, id FROM messages \
+        let rows: Vec<(String, String, String, String, i64, i32)> = zeph_db::query_as(sql!(
+            "SELECT role, content, parts, visibility, id, fidelity_tag FROM (\
+                SELECT role, content, parts, visibility, id, fidelity_tag FROM messages \
                 WHERE conversation_id = ? AND deleted_at IS NULL \
                 ORDER BY id DESC \
                 LIMIT ?\
@@ -278,23 +283,31 @@ impl SqliteStore {
 
         let messages = rows
             .into_iter()
-            .map(|(role_str, content, parts_json, visibility_str, row_id)| {
-                let parts = parse_parts_json(&role_str, &parts_json);
-                Message {
-                    role: parse_role(&role_str),
-                    content,
-                    parts,
-                    metadata: MessageMetadata {
-                        visibility: MessageVisibility::from_db_str(&visibility_str),
-                        compacted_at: None,
-                        deferred_summary: None,
-                        focus_pinned: false,
-                        focus_marker_id: None,
-                        db_id: Some(row_id),
-                        fidelity_tag: None,
-                    },
-                }
-            })
+            .map(
+                |(role_str, content, parts_json, visibility_str, row_id, fidelity_raw)| {
+                    let parts = parse_parts_json(&role_str, &parts_json);
+                    Message {
+                        role: parse_role(&role_str),
+                        content,
+                        parts,
+                        metadata: MessageMetadata {
+                            visibility: MessageVisibility::from_db_str(&visibility_str),
+                            compacted_at: None,
+                            deferred_summary: None,
+                            focus_pinned: false,
+                            focus_marker_id: None,
+                            db_id: Some(row_id),
+                            fidelity_tag: if fidelity_raw == 0 {
+                                None
+                            } else {
+                                u8::try_from(fidelity_raw)
+                                    .ok()
+                                    .map(ContextFidelity::from_u8)
+                            },
+                        },
+                    }
+                },
+            )
             .collect();
         Ok(messages)
     }
@@ -302,6 +315,10 @@ impl SqliteStore {
     /// Load messages filtered by visibility flags.
     ///
     /// Pass `Some(true)` to filter by a flag, `None` to skip filtering.
+    ///
+    /// Restores persisted `fidelity_tag` into [`MessageMetadata::fidelity_tag`].
+    /// A stored value of `0` maps to `None` (never scored / Full by default) so
+    /// messages written before CAM was enabled do not acquire a spurious floor.
     ///
     /// # Errors
     ///
@@ -321,16 +338,16 @@ impl SqliteStore {
         let exclude_user_only = agent_visible == Some(true);
         let exclude_agent_only = user_visible == Some(true);
 
-        let rows: Vec<(String, String, String, String, i64)> = zeph_db::query_as(sql!(
+        let rows: Vec<(String, String, String, String, i64, i32)> = zeph_db::query_as(sql!(
             "WITH recent AS (\
-                SELECT role, content, parts, visibility, id FROM messages \
+                SELECT role, content, parts, visibility, id, fidelity_tag FROM messages \
                 WHERE conversation_id = ? \
                   AND deleted_at IS NULL \
                   AND (NOT ? OR visibility != 'user_only') \
                   AND (NOT ? OR visibility != 'agent_only') \
                 ORDER BY id DESC \
                 LIMIT ?\
-             ) SELECT role, content, parts, visibility, id FROM recent ORDER BY id ASC"
+             ) SELECT role, content, parts, visibility, id, fidelity_tag FROM recent ORDER BY id ASC"
         ))
         .bind(conversation_id)
         .bind(exclude_user_only)
@@ -341,25 +358,63 @@ impl SqliteStore {
 
         let messages = rows
             .into_iter()
-            .map(|(role_str, content, parts_json, visibility_str, row_id)| {
-                let parts = parse_parts_json(&role_str, &parts_json);
-                Message {
-                    role: parse_role(&role_str),
-                    content,
-                    parts,
-                    metadata: MessageMetadata {
-                        visibility: MessageVisibility::from_db_str(&visibility_str),
-                        compacted_at: None,
-                        deferred_summary: None,
-                        focus_pinned: false,
-                        focus_marker_id: None,
-                        db_id: Some(row_id),
-                        fidelity_tag: None,
-                    },
-                }
-            })
+            .map(
+                |(role_str, content, parts_json, visibility_str, row_id, fidelity_raw)| {
+                    let parts = parse_parts_json(&role_str, &parts_json);
+                    Message {
+                        role: parse_role(&role_str),
+                        content,
+                        parts,
+                        metadata: MessageMetadata {
+                            visibility: MessageVisibility::from_db_str(&visibility_str),
+                            compacted_at: None,
+                            deferred_summary: None,
+                            focus_pinned: false,
+                            focus_marker_id: None,
+                            db_id: Some(row_id),
+                            fidelity_tag: if fidelity_raw == 0 {
+                                None
+                            } else {
+                                u8::try_from(fidelity_raw)
+                                    .ok()
+                                    .map(ContextFidelity::from_u8)
+                            },
+                        },
+                    }
+                },
+            )
             .collect();
         Ok(messages)
+    }
+
+    /// Batch-update fidelity tags for messages by their database IDs.
+    ///
+    /// Called after [`zeph_context::fidelity::FidelityScorer::score_and_apply`] to persist
+    /// the assigned fidelity levels so subsequent turns see the persisted floor invariant.
+    ///
+    /// All updates are committed in a single transaction for atomicity. The operation is
+    /// a no-op when `updates` is empty.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction or any UPDATE fails.
+    pub async fn update_fidelity_tags(
+        &self,
+        updates: &[(MessageId, u8)],
+    ) -> Result<(), MemoryError> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+        let mut tx = self.pool.begin().await?;
+        for &(id, tag) in updates {
+            zeph_db::query(sql!("UPDATE messages SET fidelity_tag = ? WHERE id = ?"))
+                .bind(i32::from(tag))
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
     }
 
     /// Atomically mark a range of messages as user-only and insert a summary as agent-only.

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -389,8 +389,8 @@ impl SqliteStore {
 
     /// Batch-update fidelity tags for messages by their database IDs.
     ///
-    /// Called after [`zeph_context::fidelity::FidelityScorer::score_and_apply`] to persist
-    /// the assigned fidelity levels so subsequent turns see the persisted floor invariant.
+    /// Called after fidelity scoring to persist the assigned fidelity levels so subsequent
+    /// turns see the persisted floor invariant.
     ///
     /// All updates are committed in a single transaction for atomicity. The operation is
     /// a no-op when `updates` is empty.

--- a/crates/zeph-memory/src/store/messages/tests.rs
+++ b/crates/zeph-memory/src/store/messages/tests.rs
@@ -1725,3 +1725,65 @@ async fn test_filter_out_preserved_episode_ids_removes_covered_ids() {
         "summary-covered IDs must be removed from the safe-to-delete set"
     );
 }
+
+// ── CAM Phase 2-B: fidelity tag persistence ──────────────────────────────────
+
+#[tokio::test]
+async fn update_fidelity_tags_round_trip() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let mid = store.save_message(cid, "user", "hello").await.unwrap();
+
+    store
+        .update_fidelity_tags(&[(mid, zeph_common::ContextFidelity::Compressed as u8)])
+        .await
+        .unwrap();
+
+    let history = store.load_history(cid, 10).await.unwrap();
+    assert_eq!(
+        history[0].metadata.fidelity_tag,
+        Some(zeph_common::ContextFidelity::Compressed),
+        "persisted Compressed must round-trip through load_history"
+    );
+}
+
+#[tokio::test]
+async fn update_fidelity_tags_placeholder_round_trip() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let mid = store.save_message(cid, "user", "hello").await.unwrap();
+
+    store
+        .update_fidelity_tags(&[(mid, zeph_common::ContextFidelity::Placeholder as u8)])
+        .await
+        .unwrap();
+
+    let history = store
+        .load_history_filtered(cid, 10, None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        history[0].metadata.fidelity_tag,
+        Some(zeph_common::ContextFidelity::Placeholder),
+        "persisted Placeholder must round-trip through load_history_filtered"
+    );
+}
+
+#[tokio::test]
+async fn load_history_zero_fidelity_maps_to_none() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    store.save_message(cid, "user", "hello").await.unwrap();
+
+    let history = store.load_history(cid, 10).await.unwrap();
+    assert_eq!(
+        history[0].metadata.fidelity_tag, None,
+        "default DB value 0 must load as None (never-scored marker)"
+    );
+}
+
+#[tokio::test]
+async fn update_fidelity_tags_empty_is_noop() {
+    let store = test_store().await;
+    store.update_fidelity_tags(&[]).await.unwrap();
+}


### PR DESCRIPTION
## Summary

CAM Phase 2-B: fidelity levels are now persisted to SQLite after each scoring pass and reloaded on the next turn, enforcing the floor invariant across conversation turns.

- **Migration 095** (`zeph-db`): additive `ALTER TABLE messages ADD COLUMN fidelity_tag INTEGER NOT NULL DEFAULT 0` (SQLite ≥ 3.37 O(1); PostgreSQL `SMALLINT NOT NULL DEFAULT 0`)
- **`ContextFidelity::from_u8`** (`zeph-common`): converts DB integer → enum; unknown values → `Full` (safe default); `0` → `None` sentinel avoids false floor on pre-CAM rows
- **`MessageStore::update_fidelity_tags`** (`zeph-memory`): batch-writes `(MessageId, u8)` pairs in a single transaction; no-op when slice is empty; `load_history` / `load_history_filtered` now populate `fidelity_tag` from DB
- **Floor invariant** (`zeph-context`): `score_and_apply` gains `allow_upgrade: bool` — `false` enforces floor (Compressed cannot upgrade to Full; Placeholder cannot upgrade at all); `true` bypasses floor on the proactive regrade path; `more_restrictive()` propagates floor through tool-use / tool-result atomicity pairs
- **`persist_fidelity_tags`** (`zeph-agent-context`): private helper that batch-writes after normal scoring and after regrade path, so floor constraints survive to the next turn
- **`truncate_to_tokens`** (`zeph-context`): manual `is_char_boundary` backward scan replaced with `str::floor_char_boundary` (stable since Rust 1.91)

## Test plan

- [ ] 4 new round-trip tests in `zeph-memory` (`update_fidelity_tags_round_trip`, `placeholder_round_trip`, `zero_maps_to_none`, `empty_is_noop`) — all pass
- [ ] 8 new floor invariant tests + 1 mixed atomicity test in `zeph-context` — all pass
- [ ] 1766 tests across `zeph-common`, `zeph-context`, `zeph-memory` pass
- [ ] clippy clean on all touched crates
- [ ] fmt clean workspace-wide
- [ ] No blocking std::fs — all DB writes are async

Closes #4550