### PR TITLE
fix(core,agent-context): track JoinHandle, remove lint allow, add #[non_exhaustive]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph`: `apply_response_cache` now returns `Option<tokio::task::JoinHandle<()>>`; the caller
+  in `runner.rs` stores the handle and calls `abort()` during shutdown, ensuring the background
+  cache cleanup loop cannot outlive the agent lifecycle (closes #4612).
+- `zeph-agent-context`: removed `#![allow(clippy::unused_async)]` blanket allow from crate root;
+  `ContextService::reset_conversation` is now a plain `fn` (no `.await` calls); scaffold-phase
+  allow is no longer needed (closes #4567).
+- `zeph-core`: added `#[non_exhaustive]` to seven extensible `pub enum` types in the `quality`
+  and `shadow_sentinel` modules (`SkipReason`, `StageOutcome`, `VerdictStatus`, `TriggerPolicy`,
+  `QualityConfigError`, `ToolRiskCategory`, `ProbeVerdict`); consistent with the project-wide
+  convention from bba75144 (closes #4569).
+
 - `zeph-context`: removed dead `fidelity_config: Option<&'a FidelityConfig>` field from
   `ContextAssemblyInput`; the field was always `None` and never read after the CAM Phase 1
   refactor (closes #4595).

--- a/crates/zeph-agent-context/src/lib.rs
+++ b/crates/zeph-agent-context/src/lib.rs
@@ -1,7 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
-// Allow async stubs during scaffold phase — async signatures are load-bearing for callers.
-#![allow(clippy::unused_async)]
 
 //! Agent context-assembly service for Zeph.
 //!

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -996,7 +996,7 @@ impl ContextService {
     /// # Errors
     ///
     /// Returns [`ContextError::Memory`] if creating a new conversation in `SQLite` fails.
-    pub async fn reset_conversation(
+    pub fn reset_conversation(
         &self,
         window: &mut MessageWindowView<'_>,
         _view: &mut ContextAssemblyView<'_>,

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -54,6 +54,7 @@ use crate::agent::error::AgentError;
 /// Only `Shell`, `FileWrite`, and `ExfilCapable` tools trigger a safety probe.
 /// `Low` tools bypass the probe entirely, adding zero latency.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ToolRiskCategory {
     /// Shell execution — arbitrary commands, highest risk.
     Shell,
@@ -69,6 +70,7 @@ pub enum ToolRiskCategory {
 
 /// Result of a `SafetyProbe` evaluation.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ProbeVerdict {
     /// Tool execution is safe to proceed.
     Allow,

--- a/crates/zeph-core/src/quality/config.rs
+++ b/crates/zeph-core/src/quality/config.rs
@@ -10,6 +10,7 @@ use zeph_config::providers::ProviderName;
 /// When to run the self-check pipeline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum TriggerPolicy {
     /// Run only when the turn has retrieved context (semantic recall, summaries, cross-session).
     #[default]
@@ -133,6 +134,7 @@ impl Default for QualityConfig {
 
 /// Errors returned by [`QualityConfig::validate`].
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum QualityConfigError {
     #[error("per_call_timeout_ms ({per_call}) × 2 must be ≤ latency_budget_ms ({budget})")]
     TimeoutExceedsBudget { per_call: u64, budget: u64 },

--- a/crates/zeph-core/src/quality/types.rs
+++ b/crates/zeph-core/src/quality/types.rs
@@ -19,6 +19,7 @@ pub struct Assertion {
 /// Verdict status for a single assertion returned by the Checker.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum VerdictStatus {
     /// Evidence directly confirms the claim.
     Supported,
@@ -48,6 +49,7 @@ pub struct AssertionVerdict {
 
 /// Reason the pipeline was skipped for this turn.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum SkipReason {
     /// No assistant message found in turn (tool-only turn or error bail-out).
     NoAssistantText,
@@ -65,6 +67,7 @@ pub enum SkipReason {
 
 /// Outcome of a single pipeline stage (Proposer or Checker call).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum StageOutcome {
     /// Stage completed successfully.
     Ok,

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -669,16 +669,16 @@ pub(crate) fn apply_response_cache<C: Channel>(
     semantic_cache_enabled: bool,
     embed_model: String,
     cancel: tokio_util::sync::CancellationToken,
-) -> Agent<C> {
+) -> (Agent<C>, Option<tokio::task::JoinHandle<()>>) {
     if !enabled {
         if semantic_cache_enabled {
             tracing::warn!("semantic_cache_enabled has no effect without response_cache_enabled");
         }
-        return agent;
+        return (agent, None);
     }
     let cache = std::sync::Arc::new(zeph_memory::ResponseCache::new(pool, ttl_secs));
     let cache_clone = std::sync::Arc::clone(&cache);
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_hours(1));
         interval.tick().await; // skip immediate first tick
         loop {
@@ -697,7 +697,7 @@ pub(crate) fn apply_response_cache<C: Channel>(
             }
         }
     });
-    agent.with_response_cache(cache)
+    (agent.with_response_cache(cache), Some(handle))
 }
 
 pub(crate) fn apply_cost_tracker<C: Channel>(
@@ -1711,8 +1711,12 @@ mod tests {
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
         let agent = make_agent();
         let cancel = tokio_util::sync::CancellationToken::new();
-        let result =
+        let (result, handle) =
             apply_response_cache(agent, false, pool, 300, false, "embed-model".into(), cancel);
+        assert!(
+            handle.is_none(),
+            "disabled cache must not spawn a background task"
+        );
         drop(result);
     }
 
@@ -1723,17 +1727,15 @@ mod tests {
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
         let agent = make_agent();
         let cancel = tokio_util::sync::CancellationToken::new();
-        let result =
+        let (result, handle) =
             apply_response_cache(agent, true, pool, 300, false, "embed-model".into(), cancel);
+        assert!(handle.is_some(), "enabled cache must return a JoinHandle");
         drop(result);
+        drop(handle);
     }
 
     #[tokio::test]
     async fn apply_response_cache_cleanup_spawns_without_panic() {
-        // NOTE: apply_response_cache is sync and drops the inner JoinHandle internally.
-        // This test verifies the function does not panic and returns promptly when
-        // the token is cancelled during setup, but cannot verify the inner cleanup
-        // loop exits — that requires exposing the inner JoinHandle (tracked separately).
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let db_url = format!("sqlite:{}", tmp.path().display());
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
@@ -1741,17 +1743,16 @@ mod tests {
         let cancel = tokio_util::sync::CancellationToken::new();
         let child = cancel.child_token();
 
-        let handle = tokio::spawn(async move {
-            apply_response_cache(agent, true, pool, 300, false, "embed-model".into(), child)
-        });
+        let (_, cleanup_handle) =
+            apply_response_cache(agent, true, pool, 300, false, "embed-model".into(), child);
+        let cleanup_handle = cleanup_handle.expect("enabled cache must return a JoinHandle");
 
-        tokio::task::yield_now().await;
         cancel.cancel();
 
-        tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+        tokio::time::timeout(std::time::Duration::from_secs(1), cleanup_handle)
             .await
-            .expect("apply_response_cache did not complete within 1 s")
-            .expect("apply_response_cache panicked");
+            .expect("cleanup loop did not exit within 1 s after cancellation")
+            .expect("cleanup loop panicked");
     }
 
     #[tokio::test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -116,7 +116,7 @@ impl zeph_tools::ProbeGate for ShadowSentinelProbeGateAdapter {
             {
                 ProbeVerdict::Allow => ProbeOutcome::Allow,
                 ProbeVerdict::Deny { reason } => ProbeOutcome::Deny { reason },
-                ProbeVerdict::Skip => ProbeOutcome::Skip,
+                _ => ProbeOutcome::Skip,
             }
         })
     }
@@ -2456,7 +2456,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         .with_instruction_blocks(instruction_blocks)
         .with_instruction_reload(instruction_reload_rx, instruction_reload_state);
 
-    let agent = agent_setup::apply_response_cache(
+    let (agent, cache_cleanup_handle) = agent_setup::apply_response_cache(
         agent,
         config.llm.response_cache_enabled,
         cache_pool,
@@ -3377,6 +3377,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // are killed while the tokio runtime is still active (#2693).
     shutdown_mcp_manager.shutdown_all_shared().await;
     agent.shutdown().await;
+    if let Some(h) = cache_cleanup_handle {
+        h.abort();
+    }
     supervisor
         .shutdown_all(std::time::Duration::from_secs(10))
         .await;


### PR DESCRIPTION
## Summary

Three code quality fixes grouped in one PR:

- **#4612** — `apply_response_cache` in `src/agent_setup.rs` now returns `Option<tokio::task::JoinHandle<()>>`; the runner stores the handle and calls `abort()` during shutdown, preventing the background cleanup loop from outliving the agent lifecycle.
- **#4567** — Removed `#![allow(clippy::unused_async)]` blanket allow from `zeph-agent-context` crate root (scaffold-phase allow, no longer needed); `ContextService::reset_conversation` is now a plain `fn`.
- **#4569** — Added `#[non_exhaustive]` to seven extensible `pub enum` types in `zeph-core` quality and shadow_sentinel modules: `SkipReason`, `StageOutcome`, `VerdictStatus`, `TriggerPolicy`, `QualityConfigError`, `ToolRiskCategory`, `ProbeVerdict`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10232 passed, 21 skipped
- [x] `cargo test --doc -p zeph-agent-context` — 2 passed
- [x] `cargo test --doc -p zeph-core` — 32 passed
- [x] Rebased onto origin/main after #4614 and #4615 landed mid-session

Closes #4612, #4567, #4569