### PR TITLE
feat(context): CAM Phase 2-C/2-D — LLM compress + embedding semantic scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-agent-context`: `persist_fidelity_tags` — private helper that collects `(MessageId, u8)`
   pairs from scored messages and batch-writes them to SQLite; called inline after each scoring pass
   (normal path and prograde path) so floor constraints survive to the next turn.
+- `zeph-context`: CAM Phase 2-C — LLM-assisted `Compressed` rendering via `FidelityConfig.compress_provider`.
+  When set, `render_compressed()` calls the named LLM provider to generate a high-quality summary instead
+  of truncating. The summary is cached in `MessageMetadata.deferred_summary` and reused on subsequent
+  turns. A 30 s timeout and a 2× token cost guard ensure the LLM path never stalls or over-spends; both
+  fall back to truncation silently (closes #4551).
+- `zeph-context`: CAM Phase 2-D — embedding-based semantic scoring via `FidelityConfig.semantic_scoring_provider`.
+  When set, `FidelityScorer` embeds the current query once per turn and computes cosine similarity against
+  per-message embeddings cached in `MessageMetadata.embedding` (`#[serde(skip)]`, in-memory only). Each
+  embed call has a 30 s timeout with keyword-overlap fallback. Config field `w_keyword` is accepted as a
+  deprecated alias for `w_semantic` (closes #4552).
+
+### Docs
+
+- `zeph-memory` / `zeph-common`: added disambiguation notes to `ContentFidelity` (optical forgetting,
+  long-term memory store fidelity) and `ContextFidelity` (CAM, context-window fidelity) to prevent
+  confusion between the two near-identical enum names (closes #4556).
 
 ### Changed
 

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -672,15 +672,27 @@ impl ContextService {
             if let Some(ref tx) = view.status_tx {
                 let _ = tx.send("Scoring context fidelity\u{2026}".into());
             }
-            FidelityScorer.score_and_apply(
-                window.messages,
-                query,
-                view.planned_next_tools,
-                fidelity_cfg,
-                &*view.token_counter,
-                inserted_count,
-                false, // floor invariant enforced on normal scoring path
-            );
+            let embed_provider = view
+                .fidelity_semantic_provider
+                .as_deref()
+                .map(|p| p as &dyn zeph_llm::LlmProviderDyn);
+            let compress_provider = view
+                .fidelity_compress_provider
+                .as_deref()
+                .map(|p| p as &dyn zeph_llm::LlmProviderDyn);
+            FidelityScorer
+                .score_and_apply(
+                    window.messages,
+                    query,
+                    view.planned_next_tools,
+                    fidelity_cfg,
+                    &*view.token_counter,
+                    inserted_count,
+                    false, // floor invariant enforced on normal scoring path
+                    embed_provider,
+                    compress_provider,
+                )
+                .await;
             // Persist fidelity tags so subsequent turns see the floor invariant.
             persist_fidelity_tags(window.messages, view.memory.as_deref()).await;
             recompute_prompt_tokens(window);
@@ -1024,7 +1036,8 @@ impl ContextService {
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
-        clippy::cast_sign_loss
+        clippy::cast_sign_loss,
+        clippy::too_many_lines
     )]
     pub async fn maybe_compact(
         &self,
@@ -1111,15 +1124,27 @@ impl ContextService {
                 budget_ratio = tracing::field::Empty,
             )
             .entered();
-            FidelityScorer.score_and_apply(
-                summ.messages,
-                &summ.current_query,
-                &[],
-                fidelity_cfg,
-                &*summ.token_counter,
-                0,
-                true, // proactive regrade: allow upgrading past the persisted floor
-            );
+            let regrade_embed_provider = summ
+                .fidelity_semantic_provider
+                .as_deref()
+                .map(|p| p as &dyn zeph_llm::LlmProviderDyn);
+            let regrade_compress_provider = summ
+                .fidelity_compress_provider
+                .as_deref()
+                .map(|p| p as &dyn zeph_llm::LlmProviderDyn);
+            FidelityScorer
+                .score_and_apply(
+                    summ.messages,
+                    &summ.current_query,
+                    &[],
+                    fidelity_cfg,
+                    &*summ.token_counter,
+                    0,
+                    true, // proactive regrade: allow upgrading past the persisted floor
+                    regrade_embed_provider,
+                    regrade_compress_provider,
+                )
+                .await;
             // Persist upgraded fidelity tags so the new levels survive the next turn (F-3).
             persist_fidelity_tags(summ.messages, summ.memory.as_deref()).await;
             recompute_prompt_tokens_summ(summ);
@@ -1948,6 +1973,8 @@ mod tests {
                 tiered_retrieval_classifier: None,
                 tiered_retrieval_validator: None,
                 fidelity_config: None,
+                fidelity_semantic_provider: None,
+                fidelity_compress_provider: None,
                 planned_next_tools: &[],
                 status_tx: None,
             };
@@ -2101,6 +2128,8 @@ mod tests {
                 tiered_retrieval_classifier: None,
                 tiered_retrieval_validator: None,
                 fidelity_config: None,
+                fidelity_semantic_provider: None,
+                fidelity_compress_provider: None,
                 planned_next_tools: &[],
                 status_tx: None,
             };
@@ -2179,6 +2208,8 @@ mod tests {
                 tiered_retrieval_classifier: None,
                 tiered_retrieval_validator: None,
                 fidelity_config: None,
+                fidelity_semantic_provider: None,
+                fidelity_compress_provider: None,
                 planned_next_tools: &[],
                 status_tx: None,
             };
@@ -2264,6 +2295,8 @@ mod tests {
                 tiered_retrieval_classifier: None,
                 tiered_retrieval_validator: None,
                 fidelity_config: None,
+                fidelity_semantic_provider: None,
+                fidelity_compress_provider: None,
                 planned_next_tools: &[],
                 status_tx: None,
             };

--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -237,6 +237,14 @@ pub struct ContextAssemblyView<'a> {
     /// `None` when fidelity scoring is not configured (treated as `enabled = false`).
     /// `Some(&cfg)` with `cfg.enabled = false` is also a no-op (early-return inside scorer).
     pub fidelity_config: Option<&'a FidelityConfig>,
+    /// LLM provider used for query and per-message embeddings when
+    /// `fidelity_config.semantic_scoring_provider` is set. Resolved at construction time.
+    /// `None` → keyword overlap fallback is used.
+    pub fidelity_semantic_provider: Option<Arc<zeph_llm::any::AnyProvider>>,
+    /// LLM provider used for `Compressed` rendering when `fidelity_config.compress_provider`
+    /// is set. Resolved by the agent from `[[llm.providers]]` at construction time.
+    /// `None` → truncation fallback is used.
+    pub fidelity_compress_provider: Option<Arc<zeph_llm::any::AnyProvider>>,
     /// Lookahead tool hints derived from the orchestration DAG.
     ///
     /// Empty slice when no DAG lookahead is available (PAACE deferred to P2). The scorer
@@ -375,6 +383,12 @@ pub struct ContextSummarizationView<'a> {
     ///
     /// `None` → proactive regrade is skipped (scoring disabled or config absent).
     pub fidelity_config: Option<FidelityConfig>,
+    /// LLM provider used for query and per-message embeddings during proactive regrade.
+    /// `None` → keyword overlap fallback is used.
+    pub fidelity_semantic_provider: Option<Arc<zeph_llm::any::AnyProvider>>,
+    /// LLM provider used for `Compressed` rendering during proactive regrade.
+    /// `None` → truncation fallback is used.
+    pub fidelity_compress_provider: Option<Arc<zeph_llm::any::AnyProvider>>,
     /// Most recent user query — passed to the scorer as the semantic signal source.
     ///
     /// Empty string when no query is available (`AgeMem` degrades gracefully to

--- a/crates/zeph-common/src/fidelity.rs
+++ b/crates/zeph-common/src/fidelity.rs
@@ -16,6 +16,11 @@ use serde::{Deserialize, Serialize};
 /// Assigned by `FidelityScorer` based on relevance signals; stored in
 /// `MessageMetadata.fidelity_tag` for debug tracing and compaction filtering.
 ///
+/// Distinct from `zeph_memory::optical_forgetting::ContentFidelity`, which tracks
+/// long-term memory store preservation (optical forgetting): `ContextFidelity` governs
+/// rendering in the active context window; `ContentFidelity` governs what is durably
+/// stored in the `SQLite` memory store.
+///
 /// # Examples
 ///
 /// ```

--- a/crates/zeph-config/src/fidelity.rs
+++ b/crates/zeph-config/src/fidelity.rs
@@ -28,6 +28,9 @@ pub struct FidelityConfig {
     /// Master switch. When `false`, no fidelity scoring occurs.
     pub enabled: bool,
     /// Cosine/keyword semantic relevance weight.
+    ///
+    /// Previously named `w_keyword` in config — that name is still accepted for compatibility.
+    #[serde(alias = "w_keyword")]
     pub w_semantic: f32,
     /// Recency weight.
     pub w_temporal: f32,
@@ -54,6 +57,14 @@ pub struct FidelityConfig {
     /// `max_scored_messages` cap.
     #[serde(default)]
     pub exempt_tail_messages: usize,
+    /// LLM provider name (from `[[llm.providers]]`) used to summarize messages during
+    /// `Compressed` rendering. When `None`, truncation is used instead.
+    #[serde(default)]
+    pub compress_provider: Option<String>,
+    /// Embedding provider name (from `[[llm.providers]]`) used for semantic similarity scoring.
+    /// When `None`, keyword overlap is used instead.
+    #[serde(default)]
+    pub semantic_scoring_provider: Option<String>,
 }
 
 impl FidelityConfig {
@@ -110,6 +121,8 @@ impl Default for FidelityConfig {
             min_query_length: 8,
             max_scored_messages: 500,
             exempt_tail_messages: 0,
+            compress_provider: None,
+            semantic_scoring_provider: None,
         }
     }
 }
@@ -135,6 +148,26 @@ mod tests {
         assert!(cfg.enabled);
         assert!((cfg.w_semantic - 0.4).abs() < f32::EPSILON);
         assert!((cfg.regrade_threshold - 0.7).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn deserialize_w_keyword_alias() {
+        let toml_str = r"
+            enabled = true
+            w_keyword = 0.25
+        ";
+        let cfg: FidelityConfig = toml::from_str(toml_str).unwrap();
+        assert!((cfg.w_semantic - 0.25).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn deserialize_semantic_scoring_provider() {
+        let toml_str = r#"
+            enabled = true
+            semantic_scoring_provider = "embed-fast"
+        "#;
+        let cfg: FidelityConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.semantic_scoring_provider.as_deref(), Some("embed-fast"));
     }
 
     #[test]

--- a/crates/zeph-context/benches/fidelity_scorer.rs
+++ b/crates/zeph-context/benches/fidelity_scorer.rs
@@ -55,6 +55,8 @@ fn bench_score_500(c: &mut Criterion) {
         min_query_length: 5,
         max_scored_messages: 500,
         exempt_tail_messages: 0,
+        compress_provider: None,
+        semantic_scoring_provider: None,
     };
     let tc = CharDivTc(4);
     let base_messages = make_synthetic_messages(500);
@@ -62,7 +64,10 @@ fn bench_score_500(c: &mut Criterion) {
     c.bench_function("fidelity_score_and_apply_500", |b| {
         b.iter(|| {
             let mut messages = base_messages.clone();
-            scorer.score_and_apply(
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            rt.block_on(scorer.score_and_apply(
                 black_box(&mut messages),
                 black_box("query words for semantic signal"),
                 black_box(&[]),
@@ -70,7 +75,9 @@ fn bench_score_500(c: &mut Criterion) {
                 black_box(&tc),
                 black_box(0),
                 black_box(false),
-            );
+                black_box(None),
+                black_box(None),
+            ));
         });
     });
 }

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -770,7 +770,17 @@ mod tests {
         let tc = FixedTc(4);
         let mut messages: Vec<Message> = vec![];
         scorer
-            .score_and_apply(&mut messages, "query text", &[], &cfg, &tc, 0, false, None, None)
+            .score_and_apply(
+                &mut messages,
+                "query text",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
             .await;
         assert!(messages.is_empty());
     }
@@ -1657,6 +1667,7 @@ mod tests {
                 &cfg,
                 &tc,
                 0,
+                false,
                 None,
                 Some(&provider),
             )
@@ -1700,6 +1711,7 @@ mod tests {
                 &cfg,
                 &tc,
                 0,
+                false,
                 None,
                 None,
             )
@@ -1838,6 +1850,7 @@ mod tests {
                 &cfg,
                 &tc,
                 0,
+                false,
                 Some(&provider),
                 None,
             )
@@ -1897,6 +1910,7 @@ mod tests {
                 &cfg,
                 &tc,
                 0,
+                false,
                 None,
                 None,
             )

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -1635,7 +1635,7 @@ mod tests {
                 false
             }
 
-            fn name(&self) -> &str {
+            fn name(&self) -> &'static str {
                 "mock"
             }
         }
@@ -1752,19 +1752,19 @@ mod tests {
     fn cosine_similarity_zero_vector() {
         let a = vec![0.0f32, 0.0, 0.0];
         let b = vec![1.0f32, 0.0, 0.0];
-        assert_eq!(cosine_similarity(&a, &b), 0.0);
+        assert!(cosine_similarity(&a, &b).abs() < f32::EPSILON);
     }
 
     #[test]
     fn cosine_similarity_empty() {
-        assert_eq!(cosine_similarity(&[], &[]), 0.0);
+        assert!(cosine_similarity(&[], &[]).abs() < f32::EPSILON);
     }
 
     #[test]
     fn cosine_similarity_dimension_mismatch() {
         let a = vec![1.0f32, 0.0];
         let b = vec![1.0f32, 0.0, 0.0];
-        assert_eq!(cosine_similarity(&a, &b), 0.0);
+        assert!(cosine_similarity(&a, &b).abs() < f32::EPSILON);
     }
 
     // 18. semantic_scoring_higher_for_similar_messages.
@@ -1810,7 +1810,7 @@ mod tests {
             fn supports_embeddings(&self) -> bool {
                 true
             }
-            fn name(&self) -> &str {
+            fn name(&self) -> &'static str {
                 "embed-mock"
             }
         }

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -13,10 +13,13 @@
 //! `config.toml`. When `enabled = false` (the default), the scorer returns immediately
 //! without modifying the message window.
 
+use std::time::Duration;
+
 use tracing::info_span;
 use zeph_common::memory::TokenCounting;
 use zeph_common::{ContextFidelity, PlannedToolHint};
-use zeph_llm::provider::{Message, MessagePart, Role};
+use zeph_llm::LlmProviderDyn;
+use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
 
 use crate::assembler::CORRECTIONS_PREFIX;
 
@@ -37,20 +40,22 @@ struct FidelityScore {
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// use zeph_context::fidelity::{FidelityConfig, FidelityScorer};
 ///
+/// # async fn run() {
 /// let scorer = FidelityScorer;
 /// let cfg = FidelityConfig { enabled: false, ..FidelityConfig::default() };
 /// // With `enabled = false` the scorer is a no-op.
 /// let mut messages = vec![];
-/// scorer.score_and_apply(&mut messages, "query", &[], &cfg, &MockTc, 0, false);
+/// scorer.score_and_apply(&mut messages, "query", &[], &cfg, &MockTc, 0, false, None, None).await;
 ///
 /// struct MockTc;
 /// impl zeph_common::memory::TokenCounting for MockTc {
 ///     fn count_tokens(&self, text: &str) -> usize { text.len() / 4 }
 ///     fn count_tool_schema_tokens(&self, _: &serde_json::Value) -> usize { 0 }
 /// }
+/// # }
 /// ```
 pub struct FidelityScorer;
 
@@ -78,8 +83,16 @@ impl FidelityScorer {
     ///   `1..1+inserted_count`; these are always exempt (INV-10).
     /// - `allow_upgrade` — when `true` the persisted floor invariant is bypassed.
     ///   Pass `true` only from the proactive regrade path; pass `false` everywhere else.
+    /// - `embed_provider` — optional LLM provider used for query and per-message embeddings
+    ///   when `config.semantic_scoring_provider` is set. Pass `None` to fall back to keyword
+    ///   overlap.
+    /// - `compress_provider` — optional LLM provider used for `Compressed` rendering when
+    ///   `config.compress_provider` is set. Pass `None` to fall back to truncation.
+    ///
+    /// The two providers may be the same instance or different ones (e.g. a fast embedding
+    /// model for `embed_provider` and a generative model for `compress_provider`).
     #[allow(clippy::too_many_arguments)]
-    pub fn score_and_apply(
+    pub async fn score_and_apply(
         &self,
         messages: &mut Vec<Message>,
         query: &str,
@@ -88,9 +101,59 @@ impl FidelityScorer {
         tc: &dyn TokenCounting,
         inserted_count: usize,
         allow_upgrade: bool,
+        embed_provider: Option<&dyn LlmProviderDyn>,
+        compress_provider: Option<&dyn LlmProviderDyn>,
     ) {
         if !config.enabled || messages.is_empty() {
             return;
+        }
+
+        // Embed query once when semantic provider is configured.
+        let query_embedding: Option<Vec<f32>> = if let (true, Some(p)) =
+            (config.semantic_scoring_provider.is_some(), embed_provider)
+            && p.supports_embeddings()
+        {
+            let _span = info_span!("context.fidelity.embed_query").entered();
+            match tokio::time::timeout(Duration::from_secs(30), p.embed(query)).await {
+                Ok(Ok(v)) => Some(v),
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, "semantic scoring provider unavailable, falling back to keyword");
+                    None
+                }
+                Err(_) => {
+                    tracing::warn!("fidelity query embed timed out, falling back to keyword");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        // Pre-pass: compute missing per-message embeddings when query embedding is available.
+        if let (Some(q_emb), Some(p)) = (&query_embedding, embed_provider) {
+            let n = messages.len();
+            let score_end = if n > config.max_scored_messages {
+                n.saturating_sub(config.exempt_tail_messages)
+            } else {
+                n
+            };
+            for (i, msg) in messages.iter_mut().enumerate().take(score_end) {
+                if msg.metadata.embedding.is_none() && !is_exempt(msg, i, inserted_count) {
+                    let _span =
+                        info_span!("context.fidelity.embed_message", cache_hit = false).entered();
+                    match tokio::time::timeout(Duration::from_secs(30), p.embed(&msg.content)).await
+                    {
+                        Ok(Ok(v)) => msg.metadata.embedding = Some(v),
+                        Ok(Err(e)) => {
+                            tracing::warn!(error = %e, "message embed failed, skipping");
+                        }
+                        Err(_) => {
+                            tracing::warn!("fidelity message embed timed out, skipping");
+                        }
+                    }
+                }
+            }
+            let _ = q_emb; // suppress unused warning; used below in compute_scores
         }
 
         let scores = compute_scores(
@@ -101,8 +164,9 @@ impl FidelityScorer {
             tc,
             inserted_count,
             allow_upgrade,
+            query_embedding.as_deref(),
         );
-        apply_scores(messages, &scores, config, tc);
+        apply_scores(messages, &scores, config, tc, compress_provider).await;
 
         let _merge_span = info_span!("context.fidelity.merge").entered();
         let merged_count = merge_consecutive_placeholders(messages);
@@ -119,6 +183,7 @@ fn compute_scores(
     tc: &dyn TokenCounting,
     inserted_count: usize,
     allow_upgrade: bool,
+    query_embedding: Option<&[f32]>,
 ) -> Vec<Option<FidelityScore>> {
     let n = messages.len();
 
@@ -183,7 +248,10 @@ fn compute_scores(
             role_weight(msg.role)
         };
         let semantic = if semantic_active {
-            keyword_overlap(&msg.content, &query_words)
+            match (query_embedding, msg.metadata.embedding.as_deref()) {
+                (Some(q_emb), Some(m_emb)) => semantic_overlap(m_emb, q_emb),
+                _ => keyword_overlap(&msg.content, &query_words),
+            }
         } else {
             0.0
         };
@@ -240,11 +308,12 @@ fn compute_scores(
     scores
 }
 
-fn apply_scores(
+async fn apply_scores(
     messages: &mut [Message],
     scores: &[Option<FidelityScore>],
     config: &FidelityConfig,
     tc: &dyn TokenCounting,
+    provider: Option<&dyn LlmProviderDyn>,
 ) {
     let _apply_span = info_span!("context.fidelity.apply").entered();
     let (mut full_count, mut compressed_count, mut placeholder_count, mut tokens_saved) =
@@ -256,7 +325,7 @@ fn apply_scores(
             ContextFidelity::Compressed => {
                 #[allow(clippy::cast_possible_truncation)]
                 let original_tokens = fs.original_tokens;
-                render_compressed(msg, config, tc);
+                render_compressed(msg, config, tc, provider).await;
                 #[allow(clippy::cast_possible_truncation)]
                 let new_tokens = tc.count_tokens(&msg.content) as u32;
                 tokens_saved += original_tokens.saturating_sub(new_tokens);
@@ -300,6 +369,23 @@ fn role_weight(role: Role) -> f32 {
         Role::User => 0.8,
         Role::Assistant => 0.6,
     }
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
+    (dot / (norm_a * norm_b)).clamp(0.0, 1.0)
+}
+
+fn semantic_overlap(msg_embedding: &[f32], query_embedding: &[f32]) -> f32 {
+    cosine_similarity(msg_embedding, query_embedding)
 }
 
 /// Simple word-intersection semantic overlap, normalized to [0, 1].
@@ -427,12 +513,73 @@ fn score_to_level(score: f32, config: &FidelityConfig) -> ContextFidelity {
     }
 }
 
-fn render_compressed(msg: &mut Message, config: &FidelityConfig, tc: &dyn TokenCounting) {
+async fn render_compressed(
+    msg: &mut Message,
+    config: &FidelityConfig,
+    tc: &dyn TokenCounting,
+    provider: Option<&dyn LlmProviderDyn>,
+) {
+    // Priority 1: use pre-computed deferred summary when available.
     if let Some(summary) = msg.metadata.deferred_summary.take() {
         msg.content = summary;
-    } else {
-        truncate_to_tokens(&mut msg.content, config.compressed_max_tokens, tc);
+        msg.parts.clear();
+        msg.metadata.fidelity_tag = Some(ContextFidelity::Compressed);
+        return;
     }
+
+    // Priority 2: LLM-assisted compression when provider and config name are set.
+    if config.compress_provider.is_some()
+        && let Some(p) = provider
+    {
+        let input_tokens = tc.count_tokens(&msg.content);
+        // Guard: skip LLM if input is already small or within 2x of the max budget.
+        if input_tokens <= config.compressed_max_tokens * 2 || input_tokens == 0 {
+            truncate_to_tokens(&mut msg.content, config.compressed_max_tokens, tc);
+            msg.parts.clear();
+            msg.metadata.fidelity_tag = Some(ContextFidelity::Compressed);
+            return;
+        }
+
+        let prompt = format!(
+            "Summarize in {} tokens or fewer: {}",
+            config.compressed_max_tokens, msg.content
+        );
+        let req = vec![Message {
+            role: Role::User,
+            content: prompt,
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+
+        let span = info_span!(
+            "context.fidelity.compress_llm",
+            input_tokens,
+            cached = false,
+        );
+        let result = {
+            let _enter = span.enter();
+            tokio::time::timeout(Duration::from_secs(30), p.chat(&req)).await
+        };
+
+        match result {
+            Ok(Ok(summary)) => {
+                msg.metadata.deferred_summary = Some(summary.clone());
+                msg.content = summary;
+                msg.parts.clear();
+                msg.metadata.fidelity_tag = Some(ContextFidelity::Compressed);
+                return;
+            }
+            Ok(Err(e)) => {
+                tracing::debug!(error = %e, "compress_llm failed, falling back to truncation");
+            }
+            Err(_) => {
+                tracing::warn!("compress_llm timed out, falling back to truncation");
+            }
+        }
+    }
+
+    // Fallback: truncation.
+    truncate_to_tokens(&mut msg.content, config.compressed_max_tokens, tc);
     msg.parts.clear();
     msg.metadata.fidelity_tag = Some(ContextFidelity::Compressed);
 }
@@ -610,23 +757,27 @@ mod tests {
             min_query_length: 8,
             max_scored_messages: 500,
             exempt_tail_messages: 0,
+            compress_provider: None,
+            semantic_scoring_provider: None,
         }
     }
 
     // 1. Empty window → no change.
-    #[test]
-    fn empty_window_no_change() {
+    #[tokio::test]
+    async fn empty_window_no_change() {
         let scorer = FidelityScorer;
         let cfg = make_cfg();
         let tc = FixedTc(4);
         let mut messages: Vec<Message> = vec![];
-        scorer.score_and_apply(&mut messages, "query text", &[], &cfg, &tc, 0, false);
+        scorer
+            .score_and_apply(&mut messages, "query text", &[], &cfg, &tc, 0, false, None, None)
+            .await;
         assert!(messages.is_empty());
     }
 
     // 2. All-exempt window → no downgrade.
-    #[test]
-    fn all_exempt_no_downgrade() {
+    #[tokio::test]
+    async fn all_exempt_no_downgrade() {
         let scorer = FidelityScorer;
         let cfg = make_cfg();
         let tc = FixedTc(4);
@@ -635,7 +786,9 @@ mod tests {
             // Injected memory at index 1 with inserted_count=1.
             make_msg(Role::User, "memory context"),
         ];
-        scorer.score_and_apply(&mut messages, "short", &[], &cfg, &tc, 1, false);
+        scorer
+            .score_and_apply(&mut messages, "short", &[], &cfg, &tc, 1, false, None, None)
+            .await;
         for msg in &messages {
             assert!(
                 msg.metadata.fidelity_tag.is_none()
@@ -645,8 +798,8 @@ mod tests {
     }
 
     // 3. Tool pair atomicity: divergent scores → min applied.
-    #[test]
-    fn tool_pair_atomicity() {
+    #[tokio::test]
+    async fn tool_pair_atomicity() {
         let scorer = FidelityScorer;
         // Very high thresholds to force Placeholder for older messages.
         let cfg = FidelityConfig {
@@ -673,23 +826,27 @@ mod tests {
             tool_use_msg,
             tool_result_msg,
         ];
-        scorer.score_and_apply(
-            &mut messages,
-            "completely unrelated query blah",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "completely unrelated query blah",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         let tag_a = messages[1].metadata.fidelity_tag;
         let tag_b = messages[2].metadata.fidelity_tag;
         assert_eq!(tag_a, tag_b, "tool pair must share fidelity level");
     }
 
     // 4. Same-role Placeholder merge: 5 consecutive assistant → merged to 1.
-    #[test]
-    fn same_role_placeholder_merge() {
+    #[tokio::test]
+    async fn same_role_placeholder_merge() {
         let scorer = FidelityScorer;
         // Force all non-system messages to become Placeholder.
         let cfg = FidelityConfig {
@@ -701,7 +858,19 @@ mod tests {
         let mut messages: Vec<Message> = std::iter::once(make_msg(Role::System, "system"))
             .chain((0..5).map(|i| make_msg(Role::Assistant, &format!("msg {i}"))))
             .collect();
-        scorer.score_and_apply(&mut messages, "some query here", &[], &cfg, &tc, 0, false);
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "some query here",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         // System + 1 merged placeholder.
         assert_eq!(
             messages.len(),
@@ -712,8 +881,8 @@ mod tests {
     }
 
     // 5. Score normalization: active signal subset still produces [0,1].
-    #[test]
-    fn score_normalization_no_panic() {
+    #[tokio::test]
+    async fn score_normalization_no_panic() {
         let scorer = FidelityScorer;
         let cfg = make_cfg();
         let tc = FixedTc(4);
@@ -722,23 +891,27 @@ mod tests {
             make_msg(Role::User, "hello"),
             make_msg(Role::Assistant, "world response"),
         ];
-        scorer.score_and_apply(
-            &mut messages,
-            "hello world signal",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "hello world signal",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         for msg in &messages {
             let _ = msg.metadata.fidelity_tag;
         }
     }
 
     // 6. Short query fallback: query.len() < 8 → semantic signal excluded.
-    #[test]
-    fn short_query_fallback() {
+    #[tokio::test]
+    async fn short_query_fallback() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             min_query_length: 8,
@@ -750,7 +923,9 @@ mod tests {
             make_msg(Role::User, "test"),
         ];
         // Must not panic or produce out-of-range scores.
-        scorer.score_and_apply(&mut messages, "short", &[], &cfg, &tc, 0, false);
+        scorer
+            .score_and_apply(&mut messages, "short", &[], &cfg, &tc, 0, false, None, None)
+            .await;
     }
 
     // 7. AC-09: memory_first bypass is the caller's responsibility.
@@ -758,8 +933,8 @@ mod tests {
     //    memory_first simply skip the call (see service.rs guard at INV-11).
     //    This test documents the contract: the scorer itself is stateless and harmless
     //    when called with disabled config or an all-exempt window.
-    #[test]
-    fn memory_first_bypass_is_callers_responsibility() {
+    #[tokio::test]
+    async fn memory_first_bypass_is_callers_responsibility() {
         let scorer = FidelityScorer;
         // Simulate: caller would skip this call when memory_first=true.
         // The scorer itself must be a complete no-op when enabled=false.
@@ -775,15 +950,19 @@ mod tests {
         ];
         let before: Vec<_> = messages.iter().map(|m| m.content.clone()).collect();
         // Even with a real query, disabled scorer must not touch any message.
-        scorer.score_and_apply(
-            &mut messages,
-            "some user query text here",
-            &[],
-            &cfg,
-            &tc,
-            2,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "some user query text here",
+                &[],
+                &cfg,
+                &tc,
+                2,
+                false,
+                None,
+                None,
+            )
+            .await;
         for (msg, orig) in messages.iter().zip(&before) {
             assert_eq!(msg.content, *orig, "content must be unchanged");
             assert!(
@@ -794,8 +973,8 @@ mod tests {
     }
 
     // 9. enabled=false guard: no changes applied.
-    #[test]
-    fn enabled_false_guard() {
+    #[tokio::test]
+    async fn enabled_false_guard() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             enabled: false,
@@ -807,7 +986,19 @@ mod tests {
             make_msg(Role::User, "user message that would normally be scored"),
         ];
         let original_contents: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
-        scorer.score_and_apply(&mut messages, "query text here", &[], &cfg, &tc, 0, false);
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         for (msg, orig) in messages.iter().zip(&original_contents) {
             assert_eq!(msg.content, *orig);
             assert!(msg.metadata.fidelity_tag.is_none());
@@ -815,8 +1006,8 @@ mod tests {
     }
 
     // 10. Score always in [0.0, 1.0] for extreme inputs (zero weights).
-    #[test]
-    fn score_always_in_range() {
+    #[tokio::test]
+    async fn score_always_in_range() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             enabled: true,
@@ -831,16 +1022,20 @@ mod tests {
             min_query_length: 0,
             max_scored_messages: 500,
             exempt_tail_messages: 0,
+            compress_provider: None,
+            semantic_scoring_provider: None,
         };
         let tc = FixedTc(4);
         let mut messages = vec![make_msg(Role::System, ""), make_msg(Role::User, "")];
         // Must not panic with zero weights.
-        scorer.score_and_apply(&mut messages, "", &[], &cfg, &tc, 0, false);
+        scorer
+            .score_and_apply(&mut messages, "", &[], &cfg, &tc, 0, false, None, None)
+            .await;
     }
 
     // 11. Token count uses tc.count_tokens for Placeholder rendering.
-    #[test]
-    fn placeholder_uses_tc_count_tokens() {
+    #[tokio::test]
+    async fn placeholder_uses_tc_count_tokens() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             full_threshold: 2.0,
@@ -852,15 +1047,19 @@ mod tests {
             make_msg(Role::System, "system"),
             make_msg(Role::User, "user message content for placeholder rendering"),
         ];
-        scorer.score_and_apply(
-            &mut messages,
-            "some query text here",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "some query text here",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Placeholder)
@@ -874,8 +1073,8 @@ mod tests {
     //     via is_exempt() and retain no tag regardless of the merge pass.
     //     n=20, max_scored_messages=10, exempt_tail_messages=5 → score_end=15.
     //     Indices [15..19] are in the exempt tail.
-    #[test]
-    fn exempt_tail_messages_large_window() {
+    #[tokio::test]
+    async fn exempt_tail_messages_large_window() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             // Force all scored messages to Placeholder so we can see which ones got tagged.
@@ -902,15 +1101,19 @@ mod tests {
             }))
             .collect();
 
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
 
         // Tail messages (focus_pinned) must have no fidelity_tag.
         let tail: Vec<_> = messages
@@ -934,8 +1137,8 @@ mod tests {
     // 14. #4593: when n <= max_scored_messages, exempt_tail_messages has no effect.
     //     n=8, max_scored_messages=10, exempt_tail_messages=5 → score_end=8 (all scored).
     //     Use alternating roles to avoid placeholder merging.
-    #[test]
-    fn exempt_tail_messages_small_window_no_effect() {
+    #[tokio::test]
+    async fn exempt_tail_messages_small_window_no_effect() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             full_threshold: 2.0,
@@ -951,15 +1154,19 @@ mod tests {
         let mut messages: Vec<Message> = std::iter::once(make_msg(Role::System, "system prompt"))
             .chain((1..8usize).map(|i| make_msg(roles[i % 2], &format!("message {i}"))))
             .collect();
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         // score_end = 8 (n=8 <= max_scored_messages=10, so exempt_tail not applied).
         // All non-system messages must be scored (tagged).
         let untagged_count = messages[1..]
@@ -973,8 +1180,8 @@ mod tests {
     }
 
     // 12. Compressed rendering uses deferred_summary when available.
-    #[test]
-    fn compressed_uses_deferred_summary() {
+    #[tokio::test]
+    async fn compressed_uses_deferred_summary() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             full_threshold: 2.0,       // nothing reaches Full
@@ -987,15 +1194,19 @@ mod tests {
             make_msg(Role::User, "original long content that would be truncated");
         msg_with_summary.metadata.deferred_summary = Some("short summary".to_string());
         let mut messages = vec![make_msg(Role::System, "system"), msg_with_summary];
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Compressed)
@@ -1012,8 +1223,8 @@ mod tests {
     }
 
     // Floor: Compressed cannot upgrade to Full when allow_upgrade=false.
-    #[test]
-    fn floor_prevents_compressed_upgrade_to_full() {
+    #[tokio::test]
+    async fn floor_prevents_compressed_upgrade_to_full() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             // Very low thresholds so every message naturally scores Full.
@@ -1030,15 +1241,19 @@ mod tests {
                 Some(ContextFidelity::Compressed),
             ),
         ];
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long keyword",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long keyword",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Compressed),
@@ -1047,8 +1262,8 @@ mod tests {
     }
 
     // Floor: Placeholder cannot upgrade to Full.
-    #[test]
-    fn floor_prevents_placeholder_upgrade_to_full() {
+    #[tokio::test]
+    async fn floor_prevents_placeholder_upgrade_to_full() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             full_threshold: 0.0,
@@ -1064,15 +1279,19 @@ mod tests {
                 Some(ContextFidelity::Placeholder),
             ),
         ];
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long keyword",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long keyword",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Placeholder),
@@ -1081,8 +1300,8 @@ mod tests {
     }
 
     // Floor: Placeholder cannot upgrade to Compressed.
-    #[test]
-    fn floor_prevents_placeholder_upgrade_to_compressed() {
+    #[tokio::test]
+    async fn floor_prevents_placeholder_upgrade_to_compressed() {
         let scorer = FidelityScorer;
         // Thresholds: full=2.0 (unreachable), compressed=0.0 (everything Compressed).
         let cfg = FidelityConfig {
@@ -1099,15 +1318,19 @@ mod tests {
                 Some(ContextFidelity::Placeholder),
             ),
         ];
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Placeholder),
@@ -1116,8 +1339,8 @@ mod tests {
     }
 
     // Floor: further downgrade (Compressed → Placeholder) is allowed.
-    #[test]
-    fn floor_allows_further_downgrade() {
+    #[tokio::test]
+    async fn floor_allows_further_downgrade() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             full_threshold: 2.0,
@@ -1133,15 +1356,19 @@ mod tests {
                 Some(ContextFidelity::Compressed),
             ),
         ];
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Placeholder),
@@ -1150,8 +1377,8 @@ mod tests {
     }
 
     // Floor: None tag → no constraint, normal scoring.
-    #[test]
-    fn floor_no_constraint_when_none() {
+    #[tokio::test]
+    async fn floor_no_constraint_when_none() {
         let scorer = FidelityScorer;
         // Force every message to Full.
         let cfg = FidelityConfig {
@@ -1164,15 +1391,19 @@ mod tests {
             make_msg(Role::System, "system"),
             make_msg_with_fidelity(Role::User, "query text here long keyword", None),
         ];
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long keyword",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long keyword",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Full),
@@ -1181,8 +1412,8 @@ mod tests {
     }
 
     // allow_upgrade=true bypasses the Placeholder floor.
-    #[test]
-    fn allow_upgrade_bypasses_floor() {
+    #[tokio::test]
+    async fn allow_upgrade_bypasses_floor() {
         let scorer = FidelityScorer;
         let cfg = FidelityConfig {
             full_threshold: 0.0,
@@ -1198,15 +1429,19 @@ mod tests {
                 Some(ContextFidelity::Placeholder),
             ),
         ];
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long keyword",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            true,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long keyword",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                true,
+                None,
+                None,
+            )
+            .await;
         assert_eq!(
             messages[1].metadata.fidelity_tag,
             Some(ContextFidelity::Full),
@@ -1295,8 +1530,8 @@ mod tests {
     }
 
     // Mixed-fidelity tool pair: None + Some(Compressed) → both end up Compressed via atomicity.
-    #[test]
-    fn mixed_fidelity_tool_pair_floor_plus_atomicity() {
+    #[tokio::test]
+    async fn mixed_fidelity_tool_pair_floor_plus_atomicity() {
         let scorer = FidelityScorer;
         // Force everything to Full naturally, so the floor is the only downward pressure.
         let cfg = FidelityConfig {
@@ -1328,15 +1563,19 @@ mod tests {
             tool_result_msg,
         ];
 
-        scorer.score_and_apply(
-            &mut messages,
-            "query text here long",
-            &[],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
 
         // After floor clamping: tool_use scores Full (no floor), tool_result scores Full but
         // is clamped to Compressed by its floor. Atomicity then takes min(Full, Compressed) =
@@ -1352,5 +1591,330 @@ mod tests {
             Some(ContextFidelity::Compressed),
             "atomicity must bring the tool-use down to the tool-result floor"
         );
+    }
+
+    // 15. LLM path stores deferred_summary and updates content.
+    #[tokio::test]
+    async fn compress_llm_path_stores_deferred_summary() {
+        use zeph_llm::LlmError;
+        use zeph_llm::provider::ChatStream;
+
+        #[derive(Debug)]
+        struct MockProvider;
+
+        impl zeph_llm::provider::LlmProvider for MockProvider {
+            async fn chat(&self, _messages: &[Message]) -> Result<String, LlmError> {
+                Ok("summary text".to_string())
+            }
+
+            async fn chat_stream(&self, _messages: &[Message]) -> Result<ChatStream, LlmError> {
+                Err(LlmError::Unavailable)
+            }
+
+            fn supports_streaming(&self) -> bool {
+                false
+            }
+
+            async fn embed(&self, _text: &str) -> Result<Vec<f32>, LlmError> {
+                Err(LlmError::EmbedUnsupported {
+                    provider: "mock".into(),
+                })
+            }
+
+            fn supports_embeddings(&self) -> bool {
+                false
+            }
+
+            fn name(&self) -> &str {
+                "mock"
+            }
+        }
+
+        let scorer = FidelityScorer;
+        let cfg = FidelityConfig {
+            enabled: true,
+            // Force everything to Compressed.
+            full_threshold: 2.0,
+            compressed_threshold: 0.0,
+            compressed_max_tokens: 5,
+            compress_provider: Some("mock".to_string()),
+            ..make_cfg()
+        };
+        // Use tc with chars-per-token=1 so a long string has more than 5*2=10 tokens.
+        let tc = FixedTc(1);
+        let content = "a".repeat(50); // 50 chars → 50 tokens → well above 5*2=10
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg(Role::User, &content),
+        ];
+
+        let provider = MockProvider;
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "some query text here",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                None,
+                Some(&provider),
+            )
+            .await;
+
+        assert_eq!(
+            messages[1].metadata.fidelity_tag,
+            Some(ContextFidelity::Compressed),
+        );
+        assert_eq!(messages[1].content, "summary text");
+        assert_eq!(
+            messages[1].metadata.deferred_summary,
+            Some("summary text".to_string()),
+        );
+    }
+
+    // 16. LLM path skipped when provider is None → truncation used instead.
+    #[tokio::test]
+    async fn compress_llm_skipped_when_provider_none() {
+        let scorer = FidelityScorer;
+        let cfg = FidelityConfig {
+            enabled: true,
+            full_threshold: 2.0,
+            compressed_threshold: 0.0,
+            compressed_max_tokens: 5,
+            compress_provider: Some("mock".to_string()),
+            ..make_cfg()
+        };
+        let tc = FixedTc(1);
+        let content = "a".repeat(50);
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg(Role::User, &content),
+        ];
+
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "some query text here",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                None,
+                None,
+            )
+            .await;
+
+        assert_eq!(
+            messages[1].metadata.fidelity_tag,
+            Some(ContextFidelity::Compressed),
+        );
+        // Truncation path: deferred_summary must NOT be set.
+        assert!(
+            messages[1].metadata.deferred_summary.is_none(),
+            "deferred_summary must not be populated via truncation path"
+        );
+        // Content should be truncated to <= 5 chars.
+        assert!(
+            messages[1].content.len() <= 5,
+            "content must be truncated, got len={}",
+            messages[1].content.len()
+        );
+    }
+
+    // 17. cosine_similarity unit tests.
+    #[test]
+    fn cosine_similarity_identical() {
+        let v = vec![1.0f32, 0.0, 0.0];
+        assert!((cosine_similarity(&v, &v) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_similarity_orthogonal() {
+        let a = vec![1.0f32, 0.0, 0.0];
+        let b = vec![0.0f32, 1.0, 0.0];
+        assert!(cosine_similarity(&a, &b).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_similarity_zero_vector() {
+        let a = vec![0.0f32, 0.0, 0.0];
+        let b = vec![1.0f32, 0.0, 0.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn cosine_similarity_empty() {
+        assert_eq!(cosine_similarity(&[], &[]), 0.0);
+    }
+
+    #[test]
+    fn cosine_similarity_dimension_mismatch() {
+        let a = vec![1.0f32, 0.0];
+        let b = vec![1.0f32, 0.0, 0.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    // 18. semantic_scoring_higher_for_similar_messages.
+    //     Mock provider returns deterministic embeddings:
+    //       "cat"  → [1.0, 0.0, 0.0]  (similar to query)
+    //       "feline" → [0.9, 0.1, 0.0]  (similar to query)
+    //       "stock" → [0.0, 0.0, 1.0]  (orthogonal to query)
+    //       query "cat mat" → [1.0, 0.0, 0.0]
+    #[tokio::test]
+    async fn semantic_scoring_higher_for_similar_messages() {
+        use zeph_llm::LlmError;
+        use zeph_llm::provider::ChatStream;
+
+        #[derive(Debug)]
+        struct EmbedMockProvider;
+
+        impl zeph_llm::provider::LlmProvider for EmbedMockProvider {
+            async fn chat(&self, _: &[Message]) -> Result<String, LlmError> {
+                Err(LlmError::Unavailable)
+            }
+            async fn chat_stream(&self, _: &[Message]) -> Result<ChatStream, LlmError> {
+                Err(LlmError::Unavailable)
+            }
+            fn supports_streaming(&self) -> bool {
+                false
+            }
+            async fn embed(&self, text: &str) -> Result<Vec<f32>, LlmError> {
+                let v = if text.contains("cat")
+                    || text.contains("mat")
+                    || text.contains("feline")
+                    || text.contains("rug")
+                {
+                    if text.contains("feline") || text.contains("rug") {
+                        vec![0.9f32, 0.1, 0.0]
+                    } else {
+                        vec![1.0f32, 0.0, 0.0]
+                    }
+                } else {
+                    vec![0.0f32, 0.0, 1.0]
+                };
+                Ok(v)
+            }
+            fn supports_embeddings(&self) -> bool {
+                true
+            }
+            fn name(&self) -> &str {
+                "embed-mock"
+            }
+        }
+
+        let provider = EmbedMockProvider;
+        let scorer = FidelityScorer;
+        let cfg = FidelityConfig {
+            enabled: true,
+            semantic_scoring_provider: Some("embed-mock".to_string()),
+            // Only semantic + temporal active; force Full for all so we can inspect scores
+            // by checking which messages survive with Full vs not.
+            // Use extreme thresholds so all messages pass through as Full.
+            full_threshold: 0.0,
+            compressed_threshold: 0.0,
+            w_semantic: 1.0,
+            w_temporal: 0.0,
+            w_importance: 0.0,
+            w_plan: 0.0,
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+        let cat_msg = make_msg(Role::User, "The cat is on the mat");
+        let feline_msg = make_msg(Role::User, "A feline rests on the rug");
+        let stock_msg = make_msg(Role::User, "Stock prices fell today");
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            cat_msg,
+            feline_msg,
+            stock_msg,
+        ];
+
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "cat mat",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                Some(&provider),
+                None,
+            )
+            .await;
+
+        // All should be scored (Full threshold = 0.0 means everything is Full).
+        // Embeddings must have been populated.
+        assert!(
+            messages[1].metadata.embedding.is_some(),
+            "cat message must have embedding"
+        );
+        assert!(
+            messages[2].metadata.embedding.is_some(),
+            "feline message must have embedding"
+        );
+        assert!(
+            messages[3].metadata.embedding.is_some(),
+            "stock message must have embedding"
+        );
+
+        // Verify cosine directly: cat/feline should be > stock vs query [1,0,0].
+        let query_emb = [1.0f32, 0.0, 0.0];
+        let cat_emb = messages[1].metadata.embedding.as_ref().unwrap();
+        let feline_emb = messages[2].metadata.embedding.as_ref().unwrap();
+        let stock_emb = messages[3].metadata.embedding.as_ref().unwrap();
+        assert!(
+            cosine_similarity(cat_emb, &query_emb) > cosine_similarity(stock_emb, &query_emb),
+            "cat message must be more similar to query than stock message"
+        );
+        assert!(
+            cosine_similarity(feline_emb, &query_emb) > cosine_similarity(stock_emb, &query_emb),
+            "feline message must be more similar to query than stock message"
+        );
+    }
+
+    // 19. semantic_scoring_falls_back_to_keyword_when_provider_none.
+    #[tokio::test]
+    async fn semantic_scoring_falls_back_to_keyword_when_provider_none() {
+        let scorer = FidelityScorer;
+        let cfg = FidelityConfig {
+            enabled: true,
+            semantic_scoring_provider: None,
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+        let mut messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg(Role::User, "cat mat keyword test"),
+            make_msg(Role::User, "something unrelated here"),
+        ];
+
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "query text here long",
+                &[],
+                &cfg,
+                &tc,
+                0,
+                None,
+                None,
+            )
+            .await;
+
+        // No embeddings should be computed since provider is None.
+        for msg in &messages {
+            assert!(
+                msg.metadata.embedding.is_none(),
+                "no embedding must be computed when provider is None"
+            );
+        }
+        // Scoring must still work (keyword path).
+        for msg in &messages[1..] {
+            assert!(
+                msg.metadata.fidelity_tag.is_some(),
+                "all non-system messages must be scored via keyword path"
+            );
+        }
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2180,6 +2180,18 @@ impl<C: Channel> Agent<C> {
         let turn_delay =
             tokio::time::Duration::from_millis(goal_config.autonomous_turn_delay_ms.max(1));
         self.services.autonomous = crate::goal::AutonomousDriver::new(turn_delay);
+        // Resolve fidelity semantic (embed) provider by name when config specifies one.
+        self.services.memory.compaction.fidelity_semantic_provider = fidelity_config
+            .as_ref()
+            .and_then(|c| c.semantic_scoring_provider.as_deref())
+            .filter(|name| !name.is_empty())
+            .map(|name| Arc::new(self.resolve_background_provider(name)));
+        // Resolve fidelity compress provider by name when config specifies one.
+        self.services.memory.compaction.fidelity_compress_provider = fidelity_config
+            .as_ref()
+            .and_then(|c| c.compress_provider.as_deref())
+            .filter(|name| !name.is_empty())
+            .map(|name| Arc::new(self.resolve_background_provider(name)));
         self.services.memory.compaction.fidelity_config = fidelity_config;
 
         self.runtime.debug.reasoning_model_warning = anomaly_config.reasoning_model_warning;

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -128,6 +128,18 @@ impl<C: Channel> Agent<C> {
             metrics: None,
             typed_pages: None,
             fidelity_config: self.services.memory.compaction.fidelity_config.clone(),
+            fidelity_semantic_provider: self
+                .services
+                .memory
+                .compaction
+                .fidelity_semantic_provider
+                .clone(),
+            fidelity_compress_provider: self
+                .services
+                .memory
+                .compaction
+                .fidelity_compress_provider
+                .clone(),
             current_query: String::new(),
         }
     }
@@ -463,6 +475,18 @@ impl<C: Channel> Agent<C> {
                 .tiered_retrieval_validator
                 .clone(),
             fidelity_config: self.services.memory.compaction.fidelity_config.as_ref(),
+            fidelity_semantic_provider: self
+                .services
+                .memory
+                .compaction
+                .fidelity_semantic_provider
+                .clone(),
+            fidelity_compress_provider: self
+                .services
+                .memory
+                .compaction
+                .fidelity_compress_provider
+                .clone(),
             planned_next_tools: &[],
             status_tx: self.services.session.status_tx.clone(),
         };

--- a/crates/zeph-core/src/agent/state/compaction.rs
+++ b/crates/zeph-core/src/agent/state/compaction.rs
@@ -47,6 +47,16 @@ pub(crate) struct MemoryCompactionState {
     ///
     /// `None` means fidelity scoring is not configured (disabled).
     pub(crate) fidelity_config: Option<zeph_config::FidelityConfig>,
+    /// Resolved LLM provider for query and per-message embeddings (CAM §8.1, #4552).
+    ///
+    /// `None` → keyword overlap fallback; set when `fidelity_config.semantic_scoring_provider`
+    /// names a provider that exists in `[[llm.providers]]`.
+    pub(crate) fidelity_semantic_provider: Option<std::sync::Arc<zeph_llm::any::AnyProvider>>,
+    /// Resolved LLM provider for `Compressed` rendering (CAM §8.2, #4551).
+    ///
+    /// `None` → truncation is used; set when `fidelity_config.compress_provider` names a
+    /// provider that exists in `[[llm.providers]]`.
+    pub(crate) fidelity_compress_provider: Option<std::sync::Arc<zeph_llm::any::AnyProvider>>,
 }
 
 impl Default for MemoryCompactionState {
@@ -67,6 +77,8 @@ impl Default for MemoryCompactionState {
             context_strategy: crate::config::ContextStrategy::default(),
             crossover_turn_threshold: 20,
             fidelity_config: None,
+            fidelity_semantic_provider: None,
+            fidelity_compress_provider: None,
         }
     }
 }

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -474,6 +474,11 @@ pub struct MessageMetadata {
     /// Used for debug tracing and compaction input filtering (INV-02).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fidelity_tag: Option<zeph_common::ContextFidelity>,
+    /// Cached embedding vector for semantic fidelity scoring.
+    ///
+    /// In-memory only — not serialized or persisted to the database.
+    #[serde(skip)]
+    pub embedding: Option<Vec<f32>>,
 }
 
 impl Default for MessageMetadata {
@@ -486,6 +491,7 @@ impl Default for MessageMetadata {
             focus_marker_id: None,
             db_id: None,
             fidelity_tag: None,
+            embedding: None,
         }
     }
 }
@@ -502,6 +508,7 @@ impl MessageMetadata {
             focus_marker_id: None,
             db_id: None,
             fidelity_tag: None,
+            embedding: None,
         }
     }
 
@@ -516,6 +523,7 @@ impl MessageMetadata {
             focus_marker_id: None,
             db_id: None,
             fidelity_tag: None,
+            embedding: None,
         }
     }
 
@@ -530,6 +538,7 @@ impl MessageMetadata {
             focus_marker_id: None,
             db_id: None,
             fidelity_tag: None,
+            embedding: None,
         }
     }
 }

--- a/crates/zeph-memory/src/optical_forgetting.rs
+++ b/crates/zeph-memory/src/optical_forgetting.rs
@@ -45,6 +45,11 @@ use crate::store::SqliteStore;
 /// (episodic vs. declarative abstraction). `ContentFidelity` classifies memory *fidelity*:
 /// how much of the original content is preserved. A message can be both
 /// `CompressionLevel::Episodic` and `ContentFidelity::Compressed`.
+///
+/// Also distinct from [`zeph_common::fidelity::ContextFidelity`] introduced by
+/// Context-Adaptive Memory (CAM): `ContentFidelity` tracks the long-term memory store
+/// preservation level (optical forgetting in `zeph-memory`); `ContextFidelity` tracks how
+/// much of a message is shown in the active context window during LLM inference.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum ContentFidelity {

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -304,6 +304,7 @@ impl SqliteStore {
                                     .ok()
                                     .map(ContextFidelity::from_u8)
                             },
+                            embedding: None,
                         },
                     }
                 },
@@ -379,6 +380,7 @@ impl SqliteStore {
                                     .ok()
                                     .map(ContextFidelity::from_u8)
                             },
+                            embedding: None,
                         },
                     }
                 },
@@ -614,6 +616,7 @@ impl SqliteStore {
                     focus_marker_id: None,
                     db_id: None,
                     fidelity_tag: None,
+                    embedding: None,
                 },
             }
         }))


### PR DESCRIPTION
## Summary

- **CAM Phase 2-C** (#4551): LLM-assisted `Compressed` rendering via `FidelityConfig.compress_provider`. When set, `render_compressed()` calls the named provider to generate a high-quality summary instead of truncating. The result is cached in `MessageMetadata.deferred_summary` and reused on subsequent turns. A 30 s timeout and a 2× token cost guard fall back to truncation silently on failure.
- **CAM Phase 2-D** (#4552): Embedding-based semantic scoring via `FidelityConfig.semantic_scoring_provider`. `FidelityScorer` embeds the current query once per turn and computes cosine similarity against per-message embeddings cached in `MessageMetadata.embedding` (`#[serde(skip)]`, in-memory only). Keyword-overlap remains the fallback when no provider is configured. `w_keyword` accepted as a deprecated alias for `w_semantic`.
- **Docs** (#4556): Disambiguation notes added to `ContentFidelity` (zeph-memory optical forgetting) and `ContextFidelity` (zeph-common CAM) to prevent confusion between the near-identical enum names.

Closes #4551, #4552, #4556.

## Changes

- `zeph-config`: `FidelityConfig` gains `compress_provider: Option<String>` and `semantic_scoring_provider: Option<String>`; `w_semantic` accepts `w_keyword` alias
- `zeph-llm`: `MessageMetadata` gains `embedding: Option<Vec<f32>>` with `#[serde(skip)]`
- `zeph-context`: `score_and_apply()` is now `async`, split into `embed_provider` + `compress_provider` params; pre-pass embed loop; `cosine_similarity` + `semantic_overlap` functions; 30 s timeouts on all external awaits
- `zeph-agent-context`: call sites updated (`await`, separate provider handles wired from config)
- `zeph-memory`: `embedding: None` added to 3 `MessageMetadata` struct literals; `ContentFidelity` doc note added
- `zeph-common`: `ContextFidelity` doc note added
- Benchmark: `fidelity_scorer.rs` updated for new two-provider signature

## Test plan

- [ ] `cargo nextest run -p zeph-config -p zeph-context -p zeph-llm -p zeph-agent-context -p zeph-memory -p zeph-common` — 3176 tests pass
- [ ] `cargo clippy -p ... -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --all-targets` — clean
- [ ] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps` — clean
- [ ] Live session test with `compress_provider` and `semantic_scoring_provider` set (blocked pending available provider in test env)

## Follow-up issues (P3, not in this PR)

- No hard cap on embed/LLM compress input size
- LLM compress output not bounded by `compressed_max_tokens` post-processing
- Sequential embed loop (up to `max_scored_messages` sequential awaits; consider `buffer_unordered`)
- Benchmark covers fast path only; no bench for embed/compress paths