### PR TITLE
feat(context,orchestration): wire PAACE lookahead from DAG into ContextAssemblyInput

### DIFF
--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -633,7 +633,7 @@ impl ContextService {
             scrub: view.scrub,
             active_levels,
             router,
-            planned_next_tools: &[],
+            planned_next_tools: view.planned_next_tools,
         };
 
         let mut prepared = zeph_context::assembler::ContextAssembler::gather(&input).await?;

--- a/crates/zeph-config/src/fidelity.rs
+++ b/crates/zeph-config/src/fidelity.rs
@@ -8,6 +8,10 @@
 
 use serde::{Deserialize, Serialize};
 
+fn fidelity_lookahead_depth_default() -> u8 {
+    FidelityConfig::default_lookahead_depth()
+}
+
 /// Configuration for the heuristic fidelity scorer (CAM §8.1).
 ///
 /// All weight fields must be positive. Weights are normalised at runtime by
@@ -65,9 +69,25 @@ pub struct FidelityConfig {
     /// When `None`, keyword overlap is used instead.
     #[serde(default)]
     pub semantic_scoring_provider: Option<String>,
+    /// Maximum BFS depth for PAACE lookahead hints derived from the orchestration DAG.
+    ///
+    /// Controls how many steps ahead in the active task graph are converted to
+    /// `PlannedToolHint` values and passed to `FidelityScorer`.
+    /// `0` disables lookahead (returns an empty hint slice). Valid range: `0..=5`.
+    #[serde(default = "fidelity_lookahead_depth_default")]
+    pub lookahead_depth: u8,
 }
 
 impl FidelityConfig {
+    /// Default value for [`lookahead_depth`](FidelityConfig::lookahead_depth): 3 BFS steps.
+    ///
+    /// Used as the `serde` default function and for callers that need the fallback value without
+    /// constructing a full [`FidelityConfig`].
+    #[must_use]
+    pub fn default_lookahead_depth() -> u8 {
+        3
+    }
+
     /// Validate threshold ordering: `full_threshold >= compressed_threshold >= 0.0`.
     ///
     /// Call this at config load time to catch inverted thresholds before they silently
@@ -102,6 +122,12 @@ impl FidelityConfig {
                 self.full_threshold, self.compressed_threshold
             ));
         }
+        if self.lookahead_depth > 5 {
+            return Err(format!(
+                "context.fidelity: lookahead_depth ({}) must be <= 5",
+                self.lookahead_depth
+            ));
+        }
         Ok(())
     }
 }
@@ -123,6 +149,7 @@ impl Default for FidelityConfig {
             exempt_tail_messages: 0,
             compress_provider: None,
             semantic_scoring_provider: None,
+            lookahead_depth: Self::default_lookahead_depth(),
         }
     }
 }
@@ -213,5 +240,54 @@ mod tests {
             ..FidelityConfig::default()
         };
         assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn default_lookahead_depth_is_three() {
+        assert_eq!(FidelityConfig::default().lookahead_depth, 3);
+    }
+
+    #[test]
+    fn lookahead_depth_zero_is_valid() {
+        let cfg = FidelityConfig {
+            lookahead_depth: 0,
+            ..FidelityConfig::default()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn lookahead_depth_five_is_valid() {
+        let cfg = FidelityConfig {
+            lookahead_depth: 5,
+            ..FidelityConfig::default()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn lookahead_depth_above_five_is_err() {
+        let cfg = FidelityConfig {
+            lookahead_depth: 6,
+            ..FidelityConfig::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.contains("lookahead_depth"),
+            "error should mention lookahead_depth: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_lookahead_depth() {
+        let toml_str = "enabled = true\nlookahead_depth = 2";
+        let cfg: FidelityConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.lookahead_depth, 2);
+    }
+
+    #[test]
+    fn deserialize_defaults_lookahead_depth_when_omitted() {
+        let cfg: FidelityConfig = toml::from_str("enabled = false").unwrap();
+        assert_eq!(cfg.lookahead_depth, 3);
     }
 }

--- a/crates/zeph-context/benches/fidelity_scorer.rs
+++ b/crates/zeph-context/benches/fidelity_scorer.rs
@@ -57,6 +57,7 @@ fn bench_score_500(c: &mut Criterion) {
         exempt_tail_messages: 0,
         compress_provider: None,
         semantic_scoring_provider: None,
+        lookahead_depth: 3,
     };
     let tc = CharDivTc(4);
     let base_messages = make_synthetic_messages(500);

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -1934,8 +1934,8 @@ mod tests {
         }
     }
     // w_plan path: messages whose content overlaps planned tool keywords score higher.
-    #[test]
-    fn w_plan_produces_nonzero_score_for_matching_message() {
+    #[tokio::test]
+    async fn w_plan_produces_nonzero_score_for_matching_message() {
         use zeph_common::PlannedToolHint;
 
         let scorer = FidelityScorer;
@@ -1964,15 +1964,19 @@ mod tests {
             make_msg(Role::User, "what is the weather today"),
         ];
 
-        scorer.score_and_apply(
-            &mut messages,
-            "q", // short query to keep semantic inactive
-            &[hint],
-            &cfg,
-            &tc,
-            0,
-            false,
-        );
+        scorer
+            .score_and_apply(
+                &mut messages,
+                "q", // short query to keep semantic inactive
+                &[hint],
+                &cfg,
+                &tc,
+                0,
+                false,
+                None,
+                None,
+            )
+            .await;
 
         // The matching message should be scored Full (plan overlap is high).
         assert_eq!(

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -759,6 +759,7 @@ mod tests {
             exempt_tail_messages: 0,
             compress_provider: None,
             semantic_scoring_provider: None,
+            lookahead_depth: 3,
         }
     }
 
@@ -1034,6 +1035,7 @@ mod tests {
             exempt_tail_messages: 0,
             compress_provider: None,
             semantic_scoring_provider: None,
+            lookahead_depth: 3,
         };
         let tc = FixedTc(4);
         let mut messages = vec![make_msg(Role::System, ""), make_msg(Role::User, "")];
@@ -1930,5 +1932,60 @@ mod tests {
                 "all non-system messages must be scored via keyword path"
             );
         }
+    }
+    // w_plan path: messages whose content overlaps planned tool keywords score higher.
+    #[test]
+    fn w_plan_produces_nonzero_score_for_matching_message() {
+        use zeph_common::PlannedToolHint;
+
+        let scorer = FidelityScorer;
+        // Only w_plan is active: all other weights zero so plan signal is isolated.
+        // full_threshold = 0.5 so that a non-zero plan score reaches Full.
+        let cfg = FidelityConfig {
+            w_semantic: 0.0,
+            w_temporal: 0.0,
+            w_importance: 0.0,
+            w_plan: 1.0,
+            full_threshold: 0.5,
+            compressed_threshold: 0.1,
+            min_query_length: 100, // disable semantic signal
+            ..make_cfg()
+        };
+        let tc = FixedTc(4);
+
+        // Hint: tool_name="shell", keywords contain "cargo" and "build".
+        let hint = PlannedToolHint::new("shell", vec!["cargo".to_string(), "build".to_string()], 1);
+
+        // matching_msg contains words from the hint keywords.
+        // non_matching_msg has no overlap with hint keywords.
+        let mut messages = vec![
+            make_msg(Role::System, "system prompt"),
+            make_msg(Role::User, "run cargo build to compile"),
+            make_msg(Role::User, "what is the weather today"),
+        ];
+
+        scorer.score_and_apply(
+            &mut messages,
+            "q", // short query to keep semantic inactive
+            &[hint],
+            &cfg,
+            &tc,
+            0,
+            false,
+        );
+
+        // The matching message should be scored Full (plan overlap is high).
+        assert_eq!(
+            messages[1].metadata.fidelity_tag,
+            Some(ContextFidelity::Full),
+            "message matching planned tool keywords must reach Full fidelity"
+        );
+
+        // The non-matching message should not be Full (plan overlap is zero).
+        assert_ne!(
+            messages[2].metadata.fidelity_tag,
+            Some(ContextFidelity::Full),
+            "message with no keyword overlap must not reach Full fidelity via w_plan"
+        );
     }
 }

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -487,7 +487,7 @@ impl<C: Channel> Agent<C> {
                 .compaction
                 .fidelity_compress_provider
                 .clone(),
-            planned_next_tools: &[],
+            planned_next_tools: &self.services.orchestration.cached_lookahead,
             status_tx: self.services.session.status_tx.clone(),
         };
         let _ = self.channel.send_status("recalling context...").await;

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -300,6 +300,20 @@ impl<C: crate::channel::Channel> Agent<C> {
         let final_status = 'tick: loop {
             let actions = scheduler.tick();
 
+            // Update lookahead cache so prepare_context can read PAACE hints between ticks.
+            let lookahead_depth = self
+                .services
+                .memory
+                .compaction
+                .fidelity_config
+                .as_ref()
+                .map_or(
+                    zeph_config::FidelityConfig::default_lookahead_depth(),
+                    |c| c.lookahead_depth,
+                );
+            self.services.orchestration.cached_lookahead =
+                zeph_orchestration::lookahead_tools(scheduler.graph(), lookahead_depth);
+
             let mut any_spawn_success = false;
             let mut any_concurrency_failure = false;
 
@@ -584,6 +598,9 @@ impl<C: crate::channel::Channel> Agent<C> {
 
         self.process_pending_secret_requests(&mut std::collections::HashSet::new())
             .await;
+
+        // Clear lookahead cache so stale hints are never seen after plan completion.
+        self.services.orchestration.cached_lookahead = Vec::new();
 
         Ok(final_status)
     }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -583,6 +583,12 @@ pub(crate) struct MetricsState {
 /// Groups task orchestration and subagent state.
 #[derive(Default)]
 pub(crate) struct OrchestrationState {
+    /// Lookahead tool hints snapshot taken after the most recent scheduler tick.
+    ///
+    /// Populated by `run_scheduler_loop` after each `scheduler.tick()` call via
+    /// `zeph_orchestration::lookahead_tools`. Cleared when the scheduler loop exits.
+    /// Read by `prepare_context` in `assembly.rs` to pass PAACE hints to `FidelityScorer`.
+    pub(crate) cached_lookahead: Vec<zeph_common::PlannedToolHint>,
     /// On `OrchestrationState` (not `ProviderState`) because this provider is used exclusively
     /// by `LlmPlanner` during orchestration, not shared across subsystems.
     pub(crate) planner_provider: Option<AnyProvider>,

--- a/crates/zeph-orchestration/src/dag.rs
+++ b/crates/zeph-orchestration/src/dag.rs
@@ -12,6 +12,8 @@
 
 use std::collections::VecDeque;
 
+use zeph_common::fidelity::PlannedToolHint;
+
 use super::error::OrchestrationError;
 use super::graph::{FailureStrategy, GraphStatus, TaskGraph, TaskId, TaskNode, TaskStatus};
 use super::verify_predicate::PredicateOutcome;
@@ -372,6 +374,143 @@ pub fn reset_for_retry(
 
     graph.status = GraphStatus::Running;
     Ok(())
+}
+
+/// Stopwords filtered out of task keyword extraction.
+const KEYWORD_STOPWORDS: &[&str] = &["the", "a", "an", "in", "of", "for", "to", "from", "with"];
+
+/// Extract lookahead tool hints from the DAG for PAACE context scoring.
+///
+/// Performs a BFS forward from all tasks currently in `Running` or `Ready`
+/// status (the execution frontier, distance 0) and collects downstream tasks
+/// at distances 1..=`depth` as [`PlannedToolHint`] values.
+///
+/// # Arguments
+///
+/// * `graph` — the active task graph.
+/// * `depth` — maximum lookahead steps. `0` means "disabled" and returns an
+///   empty vec immediately without traversing the graph.
+///
+/// # Returns
+///
+/// A [`Vec<PlannedToolHint>`] sorted by `distance_from_current` ascending.
+/// Returns an empty vec when `depth == 0`, when no Running/Ready frontier
+/// tasks exist, or when there are no reachable downstream tasks within `depth`.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_orchestration::{TaskGraph, TaskNode, TaskStatus};
+/// use zeph_orchestration::dag::lookahead_tools;
+///
+/// let mut g = TaskGraph::new("example");
+/// g.tasks.push(TaskNode::new(0, "search", "web search"));
+/// g.tasks.push(TaskNode::new(1, "summarize", "summarize results"));
+/// g.tasks[1].depends_on = vec![zeph_orchestration::TaskId(0)];
+/// g.tasks[0].status = TaskStatus::Running;
+/// g.tasks[1].status = TaskStatus::Pending;
+///
+/// let hints = lookahead_tools(&g, 1);
+/// assert_eq!(hints.len(), 1);
+/// assert_eq!(hints[0].tool_name, "summarize");
+/// assert_eq!(hints[0].distance_from_current, 1);
+/// ```
+#[must_use]
+pub fn lookahead_tools(graph: &TaskGraph, depth: u8) -> Vec<PlannedToolHint> {
+    let _span = tracing::debug_span!("orch.dag.lookahead", depth = depth).entered();
+
+    if depth == 0 {
+        return vec![];
+    }
+
+    let tasks = &graph.tasks;
+    let n = tasks.len();
+
+    // Build forward adjacency: rev_adj[i] = tasks that depend on task i (downstream).
+    let mut forward_adj: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for task in tasks {
+        for dep in &task.depends_on {
+            forward_adj[dep.index()].push(task.id.index());
+        }
+    }
+
+    // BFS from Running/Ready frontier (distance=0, not emitted).
+    let mut visited = vec![false; n];
+    let mut queue: VecDeque<(usize, u8)> = VecDeque::new();
+
+    for task in tasks {
+        if matches!(task.status, TaskStatus::Running | TaskStatus::Ready) {
+            visited[task.id.index()] = true;
+            queue.push_back((task.id.index(), 0));
+        }
+    }
+
+    if queue.is_empty() {
+        return vec![];
+    }
+
+    let mut hints: Vec<PlannedToolHint> = Vec::new();
+
+    while let Some((idx, dist)) = queue.pop_front() {
+        for &child_idx in &forward_adj[idx] {
+            if visited[child_idx] {
+                continue;
+            }
+            visited[child_idx] = true;
+            let child_dist = dist + 1;
+            if child_dist <= depth {
+                let child = &tasks[child_idx];
+                let tool_name = child.agent_hint.as_deref().unwrap_or(&child.title);
+                hints.push(PlannedToolHint::new(
+                    tool_name,
+                    extract_keywords(tool_name, &child.description),
+                    child_dist,
+                ));
+                queue.push_back((child_idx, child_dist));
+            }
+        }
+    }
+
+    hints.sort_by_key(|h| h.distance_from_current);
+    hints
+}
+
+/// Extract up to 10 keywords from a tool name and task description prefix.
+///
+/// The full `tool_name` is always inserted first (enables exact matching by
+/// the fidelity scorer). Split tokens from `title` and `description` follow,
+/// lowercased, filtered for stopwords and minimum length, deduplicated, capped
+/// at 10 total entries.
+fn extract_keywords(tool_name: &str, description: &str) -> Vec<String> {
+    let end = description.floor_char_boundary(200);
+    let desc_prefix = &description[..end];
+    let combined = format!("{tool_name} {desc_prefix}");
+
+    let mut seen = std::collections::HashSet::new();
+    let mut keywords: Vec<String> = Vec::new();
+
+    // Always include the full tool_name first for exact matching.
+    let full = tool_name.to_lowercase();
+    seen.insert(full.clone());
+    keywords.push(full);
+
+    for token in combined.split(|c: char| !c.is_alphanumeric()) {
+        if keywords.len() == 10 {
+            break;
+        }
+        if token.len() < 3 {
+            continue;
+        }
+        let lower = token.to_lowercase();
+        if KEYWORD_STOPWORDS.contains(&lower.as_str()) {
+            continue;
+        }
+        if seen.insert(lower.clone()) {
+            keywords.push(lower);
+        }
+    }
+
+    keywords
 }
 
 #[cfg(test)]
@@ -965,5 +1104,179 @@ mod tests {
         reset_for_retry(&mut graph, &__ra).unwrap();
         assert_eq!(graph.tasks[0].status, TaskStatus::Ready);
         assert_eq!(graph.tasks[1].status, TaskStatus::Pending);
+    }
+
+    // --- lookahead_tools tests ---
+
+    fn make_node_titled(id: u32, deps: &[u32], title: &str, desc: &str) -> TaskNode {
+        let mut n = TaskNode::new(id, title, desc);
+        n.depends_on = deps.iter().map(|&d| TaskId(d)).collect();
+        n
+    }
+
+    #[test]
+    fn lookahead_depth_zero_returns_empty() {
+        let mut graph = graph_from_nodes(vec![
+            make_node_titled(0, &[], "web_search", "Search the web for results"),
+            make_node_titled(1, &[0], "summarize", "Summarize findings"),
+        ]);
+        graph.tasks[0].status = TaskStatus::Running;
+        graph.tasks[1].status = TaskStatus::Pending;
+
+        let hints = lookahead_tools(&graph, 0);
+        assert!(hints.is_empty(), "depth=0 must return empty vec");
+    }
+
+    #[test]
+    fn lookahead_depth_one_emits_only_direct_child() {
+        // A(0, Running) -> B(1, Pending, tool: web_search) -> C(2, Pending, tool: summarize)
+        let mut graph = graph_from_nodes(vec![
+            make_node_titled(0, &[], "task-a", "Root task"),
+            make_node_titled(1, &[0], "web_search", "Search the web"),
+            make_node_titled(2, &[1], "summarize", "Summarize search results"),
+        ]);
+        graph.tasks[0].status = TaskStatus::Running;
+        graph.tasks[1].status = TaskStatus::Pending;
+        graph.tasks[2].status = TaskStatus::Pending;
+
+        let hints = lookahead_tools(&graph, 1);
+        assert_eq!(hints.len(), 1, "depth=1 should emit only B");
+        assert_eq!(hints[0].tool_name, "web_search");
+        assert_eq!(hints[0].distance_from_current, 1);
+    }
+
+    #[test]
+    fn lookahead_depth_two_emits_both_children() {
+        // A(0, Running) -> B(1, Pending) -> C(2, Pending)
+        let mut graph = graph_from_nodes(vec![
+            make_node_titled(0, &[], "task-a", "Root task"),
+            make_node_titled(1, &[0], "web_search", "Search the web"),
+            make_node_titled(2, &[1], "summarize", "Summarize search results"),
+        ]);
+        graph.tasks[0].status = TaskStatus::Running;
+        graph.tasks[1].status = TaskStatus::Pending;
+        graph.tasks[2].status = TaskStatus::Pending;
+
+        let hints = lookahead_tools(&graph, 2);
+        assert_eq!(hints.len(), 2, "depth=2 should emit B and C");
+        assert_eq!(hints[0].tool_name, "web_search");
+        assert_eq!(hints[0].distance_from_current, 1);
+        assert_eq!(hints[1].tool_name, "summarize");
+        assert_eq!(hints[1].distance_from_current, 2);
+    }
+
+    #[test]
+    fn lookahead_no_frontier_returns_empty() {
+        // All tasks are Pending — no Running or Ready frontier
+        let mut graph = graph_from_nodes(vec![
+            make_node_titled(0, &[], "task-a", "Root"),
+            make_node_titled(1, &[0], "task-b", "Child"),
+        ]);
+        graph.tasks[0].status = TaskStatus::Pending;
+        graph.tasks[1].status = TaskStatus::Pending;
+
+        let hints = lookahead_tools(&graph, 2);
+        assert!(hints.is_empty(), "no frontier → empty");
+    }
+
+    #[test]
+    fn lookahead_frontier_not_emitted() {
+        // Running task itself must NOT appear in output
+        let mut graph = graph_from_nodes(vec![
+            make_node_titled(0, &[], "running-tool", "Currently executing"),
+            make_node_titled(1, &[0], "next-tool", "Next step"),
+        ]);
+        graph.tasks[0].status = TaskStatus::Running;
+        graph.tasks[1].status = TaskStatus::Pending;
+
+        let hints = lookahead_tools(&graph, 3);
+        assert!(
+            hints.iter().all(|h| h.tool_name != "running-tool"),
+            "frontier task must not be emitted"
+        );
+        assert_eq!(hints.len(), 1);
+    }
+
+    #[test]
+    fn lookahead_uses_agent_hint_as_tool_name() {
+        let mut graph = graph_from_nodes(vec![
+            make_node_titled(0, &[], "dispatch", "Root"),
+            make_node_titled(1, &[0], "raw-title", "Execute shell command"),
+        ]);
+        graph.tasks[0].status = TaskStatus::Running;
+        graph.tasks[1].status = TaskStatus::Pending;
+        graph.tasks[1].agent_hint = Some("shell_executor".to_string());
+
+        let hints = lookahead_tools(&graph, 1);
+        assert_eq!(hints.len(), 1);
+        assert_eq!(
+            hints[0].tool_name, "shell_executor",
+            "agent_hint should take precedence over title"
+        );
+    }
+
+    #[test]
+    fn lookahead_results_sorted_by_distance() {
+        // A(0, Running) -> B(1) and B(1) -> C(2): should be sorted 1, 2
+        let mut graph = graph_from_nodes(vec![
+            make_node_titled(0, &[], "root", "Root"),
+            make_node_titled(1, &[0], "step-one", "Step one"),
+            make_node_titled(2, &[1], "step-two", "Step two"),
+        ]);
+        graph.tasks[0].status = TaskStatus::Running;
+        graph.tasks[1].status = TaskStatus::Pending;
+        graph.tasks[2].status = TaskStatus::Pending;
+
+        let hints = lookahead_tools(&graph, 2);
+        for w in hints.windows(2) {
+            assert!(
+                w[0].distance_from_current <= w[1].distance_from_current,
+                "hints must be sorted by distance"
+            );
+        }
+    }
+
+    #[test]
+    fn lookahead_keywords_extracted_and_deduped() {
+        let mut graph = graph_from_nodes(vec![
+            make_node_titled(0, &[], "root", "Root task"),
+            make_node_titled(1, &[0], "search", "search search search results web"),
+        ]);
+        graph.tasks[0].status = TaskStatus::Running;
+        graph.tasks[1].status = TaskStatus::Pending;
+
+        let hints = lookahead_tools(&graph, 1);
+        assert_eq!(hints.len(), 1);
+        // "search" appears multiple times but should be deduped to one entry
+        let count = hints[0]
+            .keywords
+            .iter()
+            .filter(|k| k.as_str() == "search")
+            .count();
+        assert_eq!(count, 1, "duplicate keywords must be deduplicated");
+    }
+
+    #[test]
+    fn lookahead_stopwords_filtered() {
+        let mut graph = graph_from_nodes(vec![
+            make_node_titled(0, &[], "root", "Root"),
+            make_node_titled(
+                1,
+                &[0],
+                "task",
+                "the result of the operation from the source",
+            ),
+        ]);
+        graph.tasks[0].status = TaskStatus::Running;
+        graph.tasks[1].status = TaskStatus::Pending;
+
+        let hints = lookahead_tools(&graph, 1);
+        assert_eq!(hints.len(), 1);
+        for kw in &hints[0].keywords {
+            assert!(
+                !KEYWORD_STOPWORDS.contains(&kw.as_str()),
+                "stopword '{kw}' must not appear in keywords"
+            );
+        }
     }
 }

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -91,6 +91,7 @@ pub use admission::AdmissionGate;
 pub use aggregator::{Aggregator, LlmAggregator};
 pub use cascade::{AbortDecision, CascadeConfig, CascadeDetector, RegionHealth};
 pub use command::PlanCommand;
+pub use dag::lookahead_tools;
 pub use error::OrchestrationError;
 pub use graph::{
     ExecutionMode, FailureStrategy, GraphId, GraphPersistence, GraphStatus, PlanSlug, TaskGraph,


### PR DESCRIPTION
## Summary

CAM Phase 2-A (#4549): wires the live orchestration DAG into `ContextAssemblyInput::planned_next_tools`, activating the FidelityScorer `w_plan` relevance signal that was introduced in Phase 1 but always received `&[]`.

- **zeph-orchestration**: `lookahead_tools(graph, depth) -> Vec<PlannedToolHint>` — BFS from Running/Ready frontier (not emitted), returns downstream tool hints at distance 1..`depth`; full tool_name included as first keyword; `depth=0` = disabled fast-path; `tracing::debug_span!` instrumented
- **zeph-config**: `FidelityConfig.lookahead_depth` (default 3, range 0..=5)
- **zeph-core**: `OrchestrationState.cached_lookahead` updated after each `scheduler.tick()`, cleared on loop exit; `assembly.rs` reads cache instead of `&[]`
- **zeph-agent-context**: second hardcoded `&[]` in `service.rs` replaced with live hints
- **zeph-context**: test fixtures updated (`lookahead_depth: 3`), `w_plan` scoring test added

## Test plan

- [ ] `cargo nextest run -p zeph-orchestration -p zeph-context -p zeph-agent-context -p zeph-config -p zeph-core --lib` — 2626 pass
- [ ] Full workspace: 10248 pass
- [ ] `cargo clippy ... -- -D warnings` clean
- [ ] `cargo +nightly fmt --check` clean
- [ ] Acceptance criteria verified: `lookahead_tools(depth=0)` → `vec![]`, frontier not emitted, `w_plan` produces non-zero score for matching hints

## Follow-up

- Security S2: add 128-char cap on `PlannedToolHint.tool_name` (#TBD)
- Security S3: type-enforce depth cap via newtype or saturating clamp (#TBD)
- Perf S3: pre-build `content_words` HashSet once in `plan_relevance()` (#TBD)
- Impl S4: diamond-DAG BFS distance test (#TBD)

Closes #4549