### PR TITLE
fix(memory): thread CancellationToken from LifecycleState into spawn_graph_extraction

### DIFF
--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -401,6 +401,7 @@ impl<C: Channel> Agent<C> {
         let graph_store = memory.graph_store.clone();
         let metrics_tx = self.runtime.metrics.metrics_tx.clone();
         let start_time = self.runtime.lifecycle.start_time;
+        let cancel = self.runtime.lifecycle.cancel_token.child_token();
 
         self.runtime.lifecycle.supervisor.spawn(
             super::agent_supervisor::TaskClass::Enrichment,
@@ -412,6 +413,7 @@ impl<C: Channel> Agent<C> {
                     extraction_cfg,
                     validator,
                     provider_override,
+                    cancel,
                 );
 
                 // After extraction completes, refresh graph count metrics.

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -626,6 +626,7 @@ impl SemanticMemory {
         config: GraphExtractionConfig,
         post_extract_validator: PostExtractValidator,
         provider_override: Option<AnyProvider>,
+        cancel: CancellationToken,
     ) -> tokio::task::JoinHandle<()> {
         let using_override = provider_override.is_some();
         let provider = provider_override.unwrap_or_else(|| self.provider.clone());
@@ -642,7 +643,7 @@ impl SemanticMemory {
             extraction_count: self.graph_extraction_count.clone(),
             extraction_failures: self.graph_extraction_failures.clone(),
             embedding_store: self.qdrant.clone(),
-            cancel: CancellationToken::new(),
+            cancel,
         };
 
         tokio::spawn(run_graph_extraction_task(

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use tokio_util::sync::CancellationToken;
 #[allow(unused_imports)]
 use zeph_db::sql;
 use zeph_llm::any::AnyProvider;
@@ -266,6 +267,7 @@ async fn spawn_graph_extraction_zero_timeout_returns_without_panic() {
         cfg,
         None,
         None,
+        CancellationToken::new(),
     );
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 }
@@ -287,6 +289,7 @@ async fn spawn_graph_extraction_with_provider_override_does_not_panic() {
         cfg,
         None,
         Some(override_provider),
+        CancellationToken::new(),
     );
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 }


### PR DESCRIPTION
## Summary

- `spawn_graph_extraction` in `zeph-memory` now accepts a `CancellationToken` parameter instead of creating one locally via `CancellationToken::new()`
- Caller in `zeph-core/src/agent/persistence.rs` derives `cancel = self.runtime.lifecycle.cancel_token.child_token()`, connecting community detection, graph eviction, and link-weight decay to the real agent shutdown signal
- Two unit test call sites updated with `CancellationToken::new()` (correct: unit tests have no shared shutdown signal)

## Root Cause

`GraphExtractionTaskCtx.cancel` was an orphan token — no caller ever called `cancel.cancel()` on it, so all three `tokio::select!` cancellation arms in `maybe_refresh_communities` were dead code that never fired in production.

## Test Plan

- [x] `cargo nextest run -p zeph-memory --lib` — 1440 passed
- [x] `cargo nextest run -p zeph-core --lib` — 1512 passed
- [x] `cargo clippy -p zeph-memory -p zeph-core -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check -p zeph-memory -p zeph-core --all-targets` — clean
- [x] Existing regression test `maybe_refresh_communities_respects_cancelled_token` guards the cancellation path

Closes #4632