### PR TITLE
docs(context): add missing modules to zeph-context lib.rs module index

### DIFF
--- a/crates/zeph-context/src/lib.rs
+++ b/crates/zeph-context/src/lib.rs
@@ -19,6 +19,9 @@
 //! - [`turn_context`] — [`turn_context::TurnId`], [`turn_context::TurnContext`] per-turn carrier
 //! - [`compression_feedback`] — context-loss detection and failure classification
 //! - [`microcompact`] — low-value tool detection helpers for time-based microcompact
+//! - [`fidelity`] — heuristic fidelity scorer for Context-Adaptive Memory (CAM)
+//! - [`tool_result_compress`] — per-result and batch-level token budget enforcement for tool outputs
+//! - [`typed_page`] — typed page classification and minimum-fidelity invariants for compaction
 //! - [`error`] — [`error::AssemblerError`]
 
 pub mod assembler;


### PR DESCRIPTION
## Summary

- `fidelity`, `tool_result_compress`, and `typed_page` were declared as `pub mod` in `lib.rs` but omitted from the `# Modules` docstring section
- Added 3 lines to bring the module index in sync with the actual public modules

## Test plan

- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-context` — passes, no broken intra-doc links
- [x] `cargo nextest run -p zeph-context` — 228/228 pass

Closes #4559