### PR TITLE
docs(cocoon): security/trust model, deferred features, TEE threat model

### DIFF
--- a/specs/055-cocoon/spec.md
+++ b/specs/055-cocoon/spec.md
@@ -428,6 +428,9 @@ Result: 5/5 checks passed
 > - NEVER implement TON crypto operations in Zeph — delegate entirely to sidecar
 > - NEVER store Cocoon payment state in Zeph's SQLite — sidecar owns all payment and balance state
 > - NEVER use `openssl-sys` — rustls everywhere per constitution
+> - NEVER assume Qdrant data is TEE-protected when using Cocoon — Qdrant runs outside the TEE; only inference computation on the worker is protected
+> - NEVER implement compound attestation verification without upstream Cocoon sidecar support for forwarding attestation evidence — Zeph cannot verify the chain end-to-end unilaterally
+> - NEVER enable `cocoon_managed = true` by default — must be explicit opt-in because managing the sidecar lifecycle places Zeph inside the trusted compute base and weakens TEE attestation guarantees
 
 ---
 
@@ -464,3 +467,265 @@ Result: 5/5 checks passed
 - [[022-config-simplification/spec]] — `[[llm.providers]]` canonical format and `ProviderEntry`
 - [[038-vault/spec]] — Age vault backend, zeroize-on-drop guarantee
 - [[052-gonka-native/spec]] — Analogous native transport pattern (GonkaProvider)
+- [[055-cocoon/threat-model]] — TEE threat model: six-layer stack mapping and nine security goals (arXiv:2605.03213)
+
+---
+
+## 15. Security and Trust Model
+
+> [!info]
+> This section documents the TEE trust boundary for the Zeph/Cocoon integration,
+> known security limitations, and operator guidance. It is based on threat model
+> analysis from arXiv:2605.03213. See [[055-cocoon/threat-model]] for the full
+> mapping of the six-layer agent stack and nine security goals.
+
+### 15.1 TEE Trust Boundary
+
+The Cocoon integration provides TEE-backed confidential inference for the
+**computation only**. The trust boundary is narrow and must be understood by
+operators choosing Cocoon for privacy-sensitive workloads.
+
+```
+Zeph process (no TEE)
+    │  plaintext prompt assembled here
+    ▼
+Context assembly + Qdrant memory (no TEE)
+    │  plaintext prompt crosses trust boundary
+    ▼
+CocoonClient → localhost HTTP → Cocoon C++ sidecar (no TEE)
+    │  RA-TLS — channel is encrypted
+    ▼
+Cocoon Proxy (TEE — Intel TDX)
+    │  RA-TLS — channel is encrypted; worker is attested
+    ▼
+Cocoon Worker (TEE + GPU — Intel TDX + NVIDIA H100 CC)
+    └── inference computation protected inside TEE
+```
+
+**What is TEE-protected:** inference computation on the worker node. Prompt
+and response content are processed inside the TEE worker; the worker's memory
+is inaccessible to the host OS or cloud provider.
+
+**What is NOT TEE-protected:** everything upstream of the sidecar, including
+Zeph process memory, SQLite conversation history, Qdrant embeddings and
+retrieved context, and the localhost plaintext segment between Zeph and the
+sidecar.
+
+### 15.2 Known Limitations
+
+> [!danger] Known Limitations — read before choosing Cocoon for confidential workloads
+>
+> **1. Compound attestation gap**
+> Zeph trusts the sidecar implicitly via localhost without verifying the
+> attestation chain end-to-end. The sidecar verifies proxy attestation via
+> RA-TLS and the proxy verifies worker attestation. However, Zeph has no way
+> to verify that the sidecar's RA-TLS connection leads to a genuine TEE worker
+> rather than a proxy that terminated the RA-TLS session. True compound
+> attestation would require the sidecar to forward attestation evidence to
+> Zeph — this is a protocol-level capability gap in the current Cocoon design,
+> not something Zeph can resolve unilaterally.
+>
+> **2. Qdrant memory outside the TEE**
+> Conversation history, extracted knowledge graphs, and semantic embeddings are
+> stored in SQLite and Qdrant, both running entirely outside any TEE. When Zeph
+> assembles context for a Cocoon inference request, the retrieved content crosses
+> the TEE boundary in plaintext. The TEE only protects the computation on the
+> worker; it does not protect data at rest in Qdrant or in transit through the
+> context assembly pipeline. Full protection would require a TEE-backed vector
+> database — not feasible with the current architecture.
+>
+> **3. Localhost-only validation and containerised deployments**
+> `cocoon_client_url` is validated to accept only localhost addresses
+> (`localhost`, `127.0.0.1`, `::1`). This is correct for bare-metal: the sidecar
+> MUST be co-located to preserve confidentiality (non-localhost HTTP exposes
+> plaintext prompts on the network). In Kubernetes pods, containers share a
+> network namespace, so `localhost` works. In Docker Compose with separate
+> container services (e.g., `cocoon-sidecar:10000`), the sidecar address is a
+> container hostname rather than `localhost`. Docker Compose users who run the
+> sidecar as a separate service MUST use host networking (`network_mode: host`)
+> or a shared network namespace to satisfy the localhost constraint. Relaxing
+> the localhost restriction to allow arbitrary remote hosts would negate TEE
+> confidentiality benefits and is not planned.
+>
+> **4. `ton_balance` side-channel**
+> `CocoonHealth.ton_balance` is returned by `/stats` and displayed in the TUI
+> sidebar. In shared-access or shared-screen scenarios, an observer with TUI
+> visibility can infer the user's spending volume and usage pattern from
+> balance changes over time. This is not a TEE break but is a privacy
+> consideration. Operators in multi-user environments should consider making
+> balance display opt-in or redacting the value in the TUI status area.
+>
+> **5. GPU-TEE overhead**
+> Intel TDX provides CPU-level TEE protection; NVIDIA H100 Confidential
+> Computing provides GPU-level TEE protection. Running inference inside a
+> GPU-TEE incurs 10–30% latency overhead compared to non-confidential GPU
+> inference (per arXiv:2605.03213). This is a Cocoon infrastructure
+> characteristic, not a Zeph implementation issue, but operators making
+> provider selection decisions should account for it.
+
+### 15.3 TEE Attestation Chain
+
+The attestation chain Zeph relies on is:
+
+1. **Sidecar ↔ Proxy**: RA-TLS — the sidecar verifies the proxy's TDX
+   attestation quote before establishing a connection. If attestation fails, the
+   sidecar refuses to connect (transparent to Zeph).
+2. **Proxy ↔ Worker**: RA-TLS — the proxy verifies the worker's TDX+GPU
+   attestation quote. Zeph has no visibility into this sub-chain.
+3. **Zeph ↔ Sidecar**: plain localhost HTTP. No attestation. Zeph trusts the
+   sidecar by virtue of it running on the same host.
+
+**Gap**: Zeph cannot verify the full chain end-to-end. The `proxy_connected`
+and `worker_count` fields from `/stats` are informational signals, not
+cryptographic attestation evidence. A future `cocoon attestation` command
+could fetch chain evidence if the sidecar exposes it, but this requires
+upstream Cocoon protocol support.
+
+### 15.4 Updated Key Invariants (Security)
+
+Add the following to Section 11 "Key Invariants":
+
+**Never (additional):**
+
+> [!danger]
+> - NEVER assume Qdrant data is TEE-protected when using Cocoon — Qdrant runs
+>   outside the TEE; only inference computation is protected
+> - NEVER implement compound attestation verification without upstream Cocoon
+>   sidecar support for forwarding attestation evidence
+> - NEVER enable `cocoon_managed = true` by default — explicit opt-in required
+>   because managing the sidecar lifecycle makes Zeph part of the trusted
+>   compute base and weakens TEE attestation guarantees
+
+---
+
+## 16. Deferred Features — Research Findings
+
+This section records research outcomes for features explicitly deferred from
+the initial Cocoon implementation. Each entry documents the design decision,
+the config interface reserved for future use, and acceptance criteria for
+eventual implementation.
+
+### 16.1 Sidecar Lifecycle Management (Issue #3676)
+
+**Status:** DEFERRED to post-v1.0.0 (P3)
+
+**Research question answered:** Should Zeph spawn and supervise the Cocoon
+C++ sidecar process?
+
+**Recommendation:** No. Spawning the sidecar from Zeph makes Zeph part of the
+trusted compute base. The sidecar performs RA-TLS attestation proving to the
+proxy that it is running in a TEE-safe environment. If Zeph controls the
+sidecar's lifecycle, an adversary who compromises Zeph could substitute a
+modified sidecar binary. This weakens the TEE guarantees that Cocoon provides.
+The current model — user starts the sidecar independently, Zeph connects to it
+— maintains a clean trust separation.
+
+**Additional deferral reasons:**
+- Managing a C++ binary from Rust requires platform-specific process
+  semantics, binary location discovery, argument handling, and version pinning
+  that add complexity without clear UX benefit (`cocoon doctor` already gives
+  actionable guidance when the sidecar is down).
+- Distribution questions: the Cocoon sidecar has its own release cycle;
+  bundling it with Zeph raises packaging, platform, and update concerns.
+
+**Config interface reserved (not implemented):**
+
+```toml
+# cocoon_managed = false           # default; set true to let Zeph own sidecar lifecycle
+# cocoon_binary_path = ""          # path to cocoon-client binary; required if cocoon_managed = true
+# cocoon_args = []                 # extra args passed to sidecar at spawn
+```
+
+**Future implementation acceptance criteria (post-v1.0.0):**
+- GIVEN `cocoon_managed = true` and `cocoon_binary_path` set
+- WHEN Zeph starts and `/stats` is unreachable
+- THEN Zeph spawns the binary, waits for health, and registers a SIGTERM hook
+  for clean shutdown; exponential backoff with max 3 retries before giving up
+- Platform: Unix-only initially; Windows deferred
+- MUST document in operator guide that `cocoon_managed = true` weakens TEE
+  attestation guarantees
+
+### 16.2 End-to-End Payload Encryption (Issue #3677)
+
+**Status:** DEFERRED (P3)
+
+**Research question answered:** Is E2E payload encryption beyond RA-TLS
+feasible and warranted?
+
+**Recommendation:** The feature is technically feasible and the Cocoon protocol
+supports it per Cocoon documentation (Ed25519 keypair, public key in request,
+worker encrypts response, client decrypts). Deferral is due to implementation
+complexity — key management, streaming encryption, vault integration — not
+because the feature is blocked on upstream. The open question is whether
+encryption should happen at the sidecar level or at the client (Zeph) level.
+
+**Threat model context:** RA-TLS already encrypts the sidecar ↔ proxy ↔
+worker channel. E2E encryption provides additional defense-in-depth against a
+compromised proxy node that terminates RA-TLS but does not have access to
+worker TEE memory. This is a narrow but real threat in a decentralised
+multi-operator proxy network.
+
+**Protocol sketch (from Cocoon docs):**
+1. Zeph generates an Ed25519 keypair at startup
+2. Private key stored in age vault as `ZEPH_COCOON_E2E_PRIVATE_KEY`
+3. Public key sent in request header `X-Cocoon-E2E-Pubkey`
+4. Worker encrypts response payload with the public key
+5. Zeph decrypts with the private key
+
+**Key design question:** The issue's primary open question — whether
+encryption is performed by the Cocoon sidecar on behalf of the client, or
+by Zeph directly before sending to the sidecar — must be resolved with the
+Cocoon upstream before implementation. Option A (Zeph encrypts, sidecar passes
+opaque ciphertext) is the stronger model; Option B (sidecar encrypts after
+receiving plaintext from Zeph) provides no security improvement over RA-TLS
+alone since localhost plaintext exposure remains.
+
+**Config interface reserved (not implemented):**
+
+```toml
+# cocoon_e2e_encryption = false    # default; enable Ed25519 E2E encryption if supported by sidecar
+```
+
+**Vault key reserved:**
+
+| Key | Usage |
+|-----|-------|
+| `ZEPH_COCOON_E2E_PRIVATE_KEY` | Ed25519 private key for E2E encryption; generated at setup |
+
+**Deferred challenges:**
+- Key rotation mid-conversation requires protocol support
+- SSE streaming: per-chunk encryption requires a streaming cipher mode (AEAD
+  per chunk), significantly more complex than request/response encryption
+- Older sidecar versions without E2E support require graceful fallback
+
+**Future implementation acceptance criteria (post-v1.0.0):**
+- GIVEN `cocoon_e2e_encryption = true` and `ZEPH_COCOON_E2E_PRIVATE_KEY` in vault
+- WHEN Zeph sends a chat or embed request
+- THEN the Ed25519 public key is included in the request header and the
+  response is decrypted before deserialisation
+- MUST verify with Cocoon upstream which encryption point (sidecar vs. client)
+  is supported before starting implementation
+
+---
+
+## 17. Updated Open Questions
+
+> [!question]
+> The following questions extend the original open questions in Section 13:
+>
+> - **`/stats` schema stability**: `CocoonHealth` parses `proxy_connected`,
+>   `worker_count`, `ton_balance` with `#[serde(default)]`. If Cocoon changes
+>   the schema, parsing silently succeeds with defaults. Is there a versioning
+>   mechanism or a way to detect schema drift?
+> - **Attestation evidence endpoint**: Does the Cocoon sidecar expose
+>   attestation chain information (proxy certificate details, TDX quote)? This
+>   would enable partial compound attestation verification from Zeph.
+> - **E2E encryption point**: Does the current Cocoon sidecar support E2E
+>   encryption at the client level (Zeph encrypts before sending) or only at
+>   the sidecar level? This determines which Option (A vs. B) is viable for #3677.
+> - **Streaming E2E**: If E2E encryption is added, what cipher mode does Cocoon
+>   use for SSE streaming chunks? Per-chunk AEAD, or a session cipher with
+>   stream continuity?
+> - **Cost model for TEE**: `cocoon_pricing` allows manual per-1K-token pricing.
+>   Does the sidecar expose real-time cost estimates that Zeph could use for
+>   dynamic cost tracking?

--- a/specs/055-cocoon/threat-model.md
+++ b/specs/055-cocoon/threat-model.md
@@ -1,0 +1,193 @@
+---
+aliases:
+  - Cocoon Threat Model
+  - Cocoon Security Analysis
+  - arXiv:2605.03213 Mapping
+tags:
+  - sdd
+  - spec
+  - security
+  - tee
+  - threat-model
+created: 2026-05-29
+status: draft
+related:
+  - "[[055-cocoon/spec]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[constitution]]"
+---
+
+# Threat Model: Cocoon Confidential Compute Integration
+
+> [!info]
+> This document maps the threat model from arXiv:2605.03213 ("Confidential
+> Computing for AI Agents") to the Zeph/Cocoon integration. It identifies which
+> security goals are met, which have gaps, and what mitigations are available
+> or required.
+>
+> Issue: [#3692](https://github.com/bug-ops/zeph/issues/3692)
+> Parent spec: [[055-cocoon/spec]] — Section 15 (Security and Trust Model)
+
+---
+
+## 1. Six-Layer Agent Stack Mapping
+
+arXiv:2605.03213 defines a six-layer agent stack for confidential AI systems.
+The table below maps each layer to Zeph and Cocoon components.
+
+| Layer | Paper Definition | Zeph Component | TEE Protected? |
+|-------|-----------------|----------------|----------------|
+| **L1 — User Interface** | Input/output channel where the human interacts | CLI, TUI, Telegram/Discord channels (`zeph-channels`) | No |
+| **L2 — Agent Runtime** | Orchestration, tool dispatch, memory read/write | `zeph-core` agent loop, `zeph-orchestration`, `zeph-agent-*` crates | No |
+| **L3 — Memory & Retrieval** | Vector store, graph memory, episodic memory | Qdrant + SQLite (`zeph-memory`, `zeph-db`) | No |
+| **L4 — Tool Execution** | Shell, web, MCP tools | `zeph-tools`, `zeph-mcp` | No |
+| **L5 — Inference Gateway** | LLM provider interface, routing, prompt assembly | `zeph-llm`, `CocoonProvider`, `CocoonClient` | No (client side) |
+| **L6 — Compute Backend** | GPU/CPU inference inside TEE | Cocoon Proxy (TDX) + Worker (TDX + H100 CC) | **Yes** |
+
+**Observation:** Only Layer 6 is TEE-protected in the current architecture.
+Layers L1–L5 run in the Zeph process on the operator's host without any TEE
+enclave. This is the fundamental trust boundary constraint documented in
+Section 15.1 of the parent spec.
+
+---
+
+## 2. Nine Security Goals Assessment
+
+arXiv:2605.03213 defines nine security goals for confidential AI agents.
+
+| # | Goal | Status | Notes |
+|---|------|--------|-------|
+| SG-1 | **Confidentiality of user input** | Partial | Input is plaintext in Zeph (L1–L5); TEE protection starts at L6 entry point only |
+| SG-2 | **Confidentiality of model weights** | Met | Model weights live inside Cocoon Worker TEE; never exposed to Zeph or the proxy host OS |
+| SG-3 | **Integrity of inference computation** | Met | TDX attestation proves worker runs expected code; RA-TLS chain enforces this |
+| SG-4 | **Confidentiality of agent memory** | Not met | Qdrant and SQLite run outside TEE; embeddings and retrieved context cross trust boundary in plaintext |
+| SG-5 | **Integrity of tool execution** | Not met | `zeph-tools` and `zeph-mcp` run outside TEE; tool results are plaintext in L4 |
+| SG-6 | **Auditability of agent actions** | Partial | `zeph-agent-feedback`, tool audit log, tracing spans provide auditability; none is TEE-sealed |
+| SG-7 | **Compound attestation (end-to-end)** | Not met | Zeph cannot verify the full Zeph → sidecar → proxy → worker attestation chain; sidecar is trusted implicitly |
+| SG-8 | **Side-channel resistance** | Partial | TDX provides L6 hardware isolation; `ton_balance` in TUI is an application-level side-channel; no mitigations for timing or cache side-channels at L1–L5 |
+| SG-9 | **Secure multi-agent coordination** | Partial | Subagents (`zeph-subagent`) each independently connect to the sidecar; no shared TEE session or cross-agent attestation |
+
+---
+
+## 3. Three Open Challenges
+
+arXiv:2605.03213 identifies three open challenges for confidential AI agent
+systems. Below is their applicability to Zeph/Cocoon.
+
+### Challenge 1: Compound Attestation
+
+**Paper definition:** Verifying that the entire agent pipeline — from user
+input through every layer to the inference backend — operates within a
+continuous TEE boundary.
+
+**Zeph/Cocoon gap:** Zeph trusts the sidecar via localhost without any
+cryptographic attestation. The sidecar attests to the proxy, the proxy attests
+to the worker, but this chain is opaque to Zeph. A malicious or compromised
+sidecar binary could present valid RA-TLS certificates while routing inference
+through non-TEE infrastructure.
+
+**Current mitigation:** `cocoon doctor` checks `proxy_connected = true` and
+`worker_count > 0` from `/stats`. These are informational signals from the
+sidecar itself — not independently verifiable attestation evidence.
+
+**Gap severity:** High for operators with strong confidentiality requirements;
+acceptable for operators who trust their own host environment.
+
+**Recommended action:** File a P2 issue to investigate whether the Cocoon
+sidecar exposes attestation evidence (TDX quote, proxy certificate chain) via
+an API endpoint. If so, implement a `cocoon attestation verify` command that
+fetches and validates this evidence. This is blocked on upstream Cocoon
+protocol support.
+
+**Status of issue #3692:** Documented as a known limitation. A dedicated P2
+follow-up issue should be filed if the sidecar gains attestation evidence
+exposure in a future Cocoon release.
+
+### Challenge 2: TEE-Backed RAG Isolation
+
+**Paper definition:** Ensuring that retrieval-augmented generation (RAG)
+memory stores operate inside the TEE, preventing retrieved context from
+leaking to untrusted infrastructure.
+
+**Zeph/Cocoon gap:** Zeph's RAG pipeline — Qdrant vector search, SQLite
+episodic memory, code index (`zeph-index`) — runs entirely outside the TEE.
+This is by architectural design: Cocoon is an inference provider, not a RAG
+provider. Retrieved context is assembled in plaintext at L3 (memory layer)
+before crossing into L6 (inference backend).
+
+**Partial mitigation (future):** E2E payload encryption (#3677, Section 16.2)
+would protect context in transit from Zeph to the Cocoon worker, but would not
+protect data at rest in Qdrant or during context assembly.
+
+**Full mitigation:** Would require a TEE-backed vector store (e.g., running
+Qdrant inside a TDX enclave) — not feasible without a significant architecture
+change. This is a known architectural limitation, not a bug.
+
+### Challenge 3: GPU-TEE Overhead
+
+**Paper definition:** The performance cost of hardware-enforced GPU-TEE
+(e.g., NVIDIA H100 Confidential Computing) for inference workloads.
+
+**Zeph/Cocoon context:** NVIDIA H100 Confidential Computing adds 10–30%
+latency overhead for inference compared to non-confidential GPU execution
+(per arXiv:2605.03213 benchmarks). This overhead occurs entirely within the
+Cocoon worker and is transparent to Zeph — `CocoonProvider` does not observe
+it differently from normal sidecar latency.
+
+**Operator guidance:** Operators selecting Cocoon for confidentiality-sensitive
+workloads should expect higher per-request latency than equivalent non-TEE
+providers. This is a documented trade-off, not a Zeph issue.
+
+**Zeph mitigation (informational):** `cocoon_pricing` allows manual per-1K-token
+pricing calibrated for actual TEE costs. Future work could add a latency
+histogram specific to Cocoon in the metrics subsystem to make this overhead
+visible to operators.
+
+---
+
+## 4. Threat Table
+
+| Threat | Current Mitigation | Gap | Recommended Action |
+|--------|-------------------|-----|-------------------|
+| **Sidecar binary substitution** — attacker replaces the Cocoon C++ binary on the operator's host | Operator is responsible for binary integrity; out of scope for Zeph | No binary hash verification, no TEE attestation of the sidecar itself | Document as operator responsibility; consider adding a `zeph cocoon verify-binary` command once Cocoon publishes signed release hashes |
+| **Compromised proxy (RA-TLS termination attack)** — proxy terminates RA-TLS and inspects/modifies prompts without TEE | RA-TLS attestation verified by sidecar before connecting | Zeph cannot verify this verification occurred | Compound attestation (Challenge 1 above); partial mitigation via E2E encryption (#3677) |
+| **Localhost interception** — process on same host intercepts Zeph ↔ sidecar HTTP | Localhost-only URL validation; OS network isolation | plaintext localhost segment | Document as known limitation; E2E encryption (#3677) is the only mitigation |
+| **Memory exfiltration from Qdrant** — attacker with host access reads Qdrant data | Qdrant access control (API key if configured); network firewall | Qdrant not TEE-protected | Document as known limitation; full mitigation requires TEE-backed vector store |
+| **Side-channel via `ton_balance` TUI display** — shared-screen observer infers usage volume | None | `ton_balance` visible to anyone with TUI access | Recommend opt-in or redactable balance display (see Section 15.2 of parent spec) |
+| **Credential exfiltration via LLM prompt injection** — malicious tool output or web content triggers prompt that leaks `ZEPH_COCOON_ACCESS_HASH` | `zeph-sanitizer` exfiltration guard, PII filtering | Sanitizer is heuristic, not TEE-sealed | Rely on sanitizer; enforce `ZEPH_COCOON_ACCESS_HASH` stays in vault (never in context) |
+| **Sidecar crash loop under `cocoon_managed = true`** (deferred feature) | Feature deferred; not implemented | If implemented without circuit breaker, Zeph could hang retrying indefinitely | Acceptance criteria for #3676 implementation require exponential backoff + circuit breaker |
+| **Stale attestation** — sidecar reconnects to a different proxy after initial health check passes | `proxy_connected` checked once at `cocoon doctor` | No continuous re-attestation | Document; `cocoon doctor` is a point-in-time check, not continuous monitoring |
+
+---
+
+## 5. Filed Issues and Follow-Up Recommendations
+
+| Issue | Severity | Status | Description |
+|-------|----------|--------|-------------|
+| #3692 | P3/research | Open | arXiv:2605.03213 threat model analysis — resolved by this document |
+| #3676 | P3 | Open | Sidecar lifecycle management — DEFERRED (see Section 16.1 of parent spec) |
+| #3677 | P3 | Open | E2E payload encryption — DEFERRED (see Section 16.2 of parent spec) |
+
+**Recommended follow-up issues:**
+
+1. **Compound attestation investigation (P2)**: File if the Cocoon sidecar
+   gains an attestation evidence endpoint in a future release. The issue should
+   request: fetch TDX quote + proxy certificate chain via sidecar API; validate
+   quote signature; surface result in `cocoon doctor` output. Do not file until
+   upstream capability is confirmed.
+
+2. **`ton_balance` opt-in display (P3)**: File a UX improvement issue to make
+   the balance display in the TUI sidebar opt-in. This is a low-priority privacy
+   improvement for shared-access scenarios. The existing TUI integration points
+   (Section 9 of parent spec) make this a small UI change.
+
+---
+
+## 6. References
+
+- arXiv:2605.03213 — "Confidential Computing for AI Agents" (primary source)
+- [Intel TDX overview](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-trust-domain-extensions.html)
+- [NVIDIA H100 Confidential Computing](https://www.nvidia.com/en-us/data-center/solutions/confidential-computing/)
+- [[055-cocoon/spec]] — Parent Cocoon integration spec (implementation contract)
+- [[038-vault/spec]] — Age vault backend (ZEPH_COCOON_ACCESS_HASH storage)
+- [[001-system-invariants/spec]] — Cross-cutting invariants


### PR DESCRIPTION
## Summary

- Documents Cocoon security and trust model gaps (arXiv:2605.03213 mapping)
- Formally defers sidecar lifecycle (#3676) and E2E encryption (#3677) to post-v1.0.0 with reserved config interfaces
- Adds TEE threat model spec with six-layer stack, nine security goals, and mitigation table

## Changes

**`specs/055-cocoon/spec.md`** — three new sections appended:
- §15 Security and Trust Model: compound attestation gap, Qdrant outside TEE, GPU-TEE overhead, ton_balance side-channel, containerised deployment constraint
- §16 Deferred Features: sidecar lifecycle and E2E encryption with deferred rationale, reserved config fields, and acceptance criteria
- §17 Updated Open Questions
- §11 Key Invariants extended with 3 NEVER rules
- §14 See Also: link to new threat-model.md

**`specs/055-cocoon/threat-model.md`** — new file:
- Six-layer agent stack mapped to Zeph components
- Nine security goals: 2 Met, 3 Not Met, 4 Partial
- Eight-row threat table: threat → mitigation → gap → recommended action

## Research decisions

| Issue | Decision | Reason |
|-------|----------|--------|
| #3676 sidecar lifecycle | DEFERRED post-v1.0.0 | Spawning sidecar from Zeph enters trusted compute base, weakens TEE attestation |
| #3677 E2E encryption | DEFERRED P3 | Key management + streaming complexity; NOT upstream-blocked (protocol confirmed in Cocoon docs) |
| #3692 TEE threat model | DOCUMENTED (this PR) | P2 spec work complete; compound attestation gap documented as known limitation |

Closes #3692
Research findings for #3676, #3677 documented (implementation deferred)