### PR TITLE
spec(parity-claude-code-3918): add specification for Claude Code v2.1.141-v2.1.143 parity gaps

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -45,6 +45,7 @@ Spec IDs (001–044) follow a logical grouping:
 - **053**: SpeculationEngine — speculative tool execution (SSE decoding path, PASTE skill activation, ToolStartEvent{speculative:true})
 - **055**: Cocoon distributed compute integration — CocoonProvider, CocoonClient, `zeph cocoon doctor`, TUI palette entries, vault key ZEPH_COCOON_ACCESS_HASH
 - **062**: Context-Adaptive Memory (CAM) — three-level fidelity (Full/Compressed/Placeholder), heuristic FidelityScorer, proactive AgeMem regrade, PlannedToolHint for PAACE; GitHub #4016, #4017, #4018
+- **parity-claude-code-3918**: Claude Code v2.1.141–v2.1.143 parity — `--plugin-url` ephemeral loading, provider override persistence; GitHub #3918
 
 ---
 
@@ -144,3 +145,4 @@ Spec IDs (001–044) follow a logical grouping:
 | `060-autoskill-trigger-sets/spec.md` | AutoSkill A5: embed `triggers` SKILL.md frontmatter entries as additional retrieval vectors; max-cosine aggregation across triggers; `trigger_weight` blends trigger and description scores; `max_triggers_per_skill` cap; in-memory only (v1); GitHub #4451 | `zeph-skills` |
 | `061-autoskill-heuristic-promotion/spec.md` | AutoSkill A6: periodic background job promotes ERL heuristics to quarantined SKILL.md drafts when heuristic count ≥ `heuristic_promotion_threshold`; LLM evaluates body-enrichment vs. new-skill vs. none; idempotency via `skill_heuristic_promotions` table; `heuristic_promotion_provider` config field; GitHub #4452 | `zeph-skills` |
 | `062-context-adaptive-memory/spec.md` | Context-Adaptive Memory (CAM): three-level fidelity (Full/Compressed/Placeholder), heuristic FidelityScorer, proactive AgeMem regrade trigger, PlannedToolHint struct for PAACE DAG lookahead; MVP: heuristic scoring only; GitHub #4016, #4017, #4018 | `zeph-common`, `zeph-context`, `zeph-agent-context` |
+| `parity-claude-code-3918/spec.md` | Claude Code v2.1.141–v2.1.143 parity gaps: `--plugin-url` ephemeral plugin loading (HTTPS-only, blocking scan, TempDir lifetime) + provider parameter override persistence (reasoning_effort, temperature via `channel_preferences` key-value row, no ALTER TABLE); defers worktree.baseRef, bgIsolation, Ctrl+R; GitHub #3918 | `zeph-plugins`, `zeph-core`, `zeph-config`, `zeph-commands` |

--- a/specs/parity-claude-code-3918/brd.md
+++ b/specs/parity-claude-code-3918/brd.md
@@ -1,0 +1,87 @@
+---
+aliases:
+  - Parity BRD 3918
+  - Claude Code Parity Business Requirements
+tags:
+  - sdd
+  - brd
+  - parity
+  - plugins
+  - provider-persistence
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/parity-claude-code-3918/spec]]"
+  - "[[specs/parity-claude-code-3918/srs]]"
+  - "[[specs/parity-claude-code-3918/nfr]]"
+  - "[[specs/058-plugins/spec]]"
+  - "[[specs/003-llm-providers/spec]]"
+---
+
+# BRD: Claude Code v2.1.141–v2.1.143 Parity (GitHub #3918)
+
+## 1. Business Context
+
+Zeph is an AI agent targeting parity with the Claude Code CLI UX where features are directly applicable to Zeph's architecture. GitHub issue #3918 tracks parity assessment for Claude Code v2.1.141–v2.1.143 release notes. This document defines the business case for the two actionable gaps identified in that assessment.
+
+## 2. Problem Statement
+
+Claude Code v2.1.141–v2.1.143 introduced:
+
+1. **`--plugin-url` flag** — load a plugin from a URL for the duration of one session, with no permanent installation. Zeph has permanent plugin installation but no session-scoped ephemeral loading.
+2. **Background session provider persistence** — model selection and reasoning effort are preserved when the agent wakes from an idle background state. Zeph persists the provider *name* but discards per-session parameter overrides (reasoning effort, temperature) on process restart.
+
+Without these capabilities, Zeph users who prototype with third-party plugins must permanently install them (polluting their plugin store), and users who tune provider parameters lose those settings across restarts.
+
+## 3. Business Goals
+
+| ID | Goal | Priority |
+|----|------|----------|
+| BG-01 | Users can load a plugin from a URL for one session without permanent installation side-effects | P2 |
+| BG-02 | Users' provider parameter overrides (reasoning effort, temperature) survive agent restarts | P2 |
+| BG-03 | Ephemeral plugin loading is at least as secure as permanent installation (HTTPS-only, blocking scan) | P1 |
+
+## 4. Stakeholders
+
+| Role | Interest |
+|------|----------|
+| CLI user | Prototype plugins without polluting plugin store; retain provider settings across restarts |
+| Plugin developer | Test plugin during development with a single flag, no install ceremony |
+| Security administrator | Ephemeral URL plugins are not weaker than permanent plugins from an injection/MITM perspective |
+
+## 5. Out of Scope
+
+The following gaps from issue #3918 are **deferred** to follow-up work:
+
+| Gap | Reason |
+|-----|--------|
+| `worktree.baseRef` config | Requires native worktree management subsystem (does not exist in Zeph) |
+| `worktree.bgIsolation: none` | Logically depends on `worktree.baseRef` implementation |
+| Ctrl+R cross-project history search | Zeph TUI has no prompt-history infrastructure; prerequisite work is out of scope here |
+
+These deferrals are **explicit** (not silent omissions). They must be tracked as follow-up issues.
+
+## 6. Success Criteria
+
+| ID | Criterion | Measurable |
+|----|-----------|-----------|
+| SC-01 | `zeph --plugin-url <https-url>` loads and activates a plugin; skills/MCP servers from it are usable for that session only | Pass end-to-end test with ephemeral plugin fixture |
+| SC-02 | After process restart, provider parameters (effort, temperature) previously set via `/provider` are restored | Verified by integration test: set overrides → restart → confirm restored |
+| SC-03 | Plain HTTP `--plugin-url` is rejected with a clear error message | Unit test on `validate_url_scheme` |
+| SC-04 | A plugin with injected SKILL.md entries (scan failure) blocks loading when loaded via `--plugin-url` | Unit test on ephemeral load path with scan failure fixture |
+| SC-05 | The overrides JSON blob is capped at 1 KB and rejects unknown fields | Unit test on deserialization with oversized/unknown-field blob |
+
+## 7. Constraints
+
+- No new SQLite schema migration needed (use existing `channel_preferences` key-value table with a new `pref_key`)
+- Implementation stays within `zeph-plugins`, `zeph-core`, `zeph-config`, `zeph-commands`, and the root binary crate
+- MSRV remains Rust 1.95
+- No new mandatory dependencies
+
+## 8. Dependencies
+
+| Dependency | Type | Notes |
+|------------|------|-------|
+| Existing `PluginManager::add_remote()` | Internal | Provides download + SHA-256 verification; ephemeral variant reuses this path |
+| `channel_preferences` SQLite table | Internal | Key-value store; new `pref_key = "provider_overrides"` row requires no schema change |
+| `validate_url_scheme()` in `zeph-plugins` | Internal | Must be tightened to HTTPS-only for the ephemeral path |

--- a/specs/parity-claude-code-3918/nfr.md
+++ b/specs/parity-claude-code-3918/nfr.md
@@ -1,0 +1,81 @@
+---
+aliases:
+  - Parity NFR 3918
+  - Claude Code Parity Non-Functional Requirements
+tags:
+  - sdd
+  - nfr
+  - parity
+  - plugins
+  - provider-persistence
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/parity-claude-code-3918/brd]]"
+  - "[[specs/parity-claude-code-3918/srs]]"
+  - "[[specs/parity-claude-code-3918/spec]]"
+---
+
+# NFR: Claude Code v2.1.141–v2.1.143 Parity (GitHub #3918)
+
+ISO/IEC 25010:2011 quality model.
+
+---
+
+## Performance Efficiency
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-PE-01 | Ephemeral plugin download + extraction must not block the agent event loop | Runs in `tokio::task::spawn_blocking` or equivalent off-thread |
+| NFR-PE-02 | Provider overrides restore adds no observable latency to session startup | < 1 ms (single SQLite row read) |
+| NFR-PE-03 | Overrides blob size is capped to prevent unbounded deserialization time | Hard cap: 1 KB; validated before `serde_json::from_str` |
+
+---
+
+## Reliability
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-RE-01 | Ephemeral plugin TempDir is cleaned up even on panic unwind | Guaranteed by `TempDir` Drop impl (RAII) |
+| NFR-RE-02 | A corrupted or oversized overrides blob must not prevent session startup | Discard blob + log warning; proceed without overrides |
+| NFR-RE-03 | If `--plugin-url` download fails (network error, bad digest), the session starts without the plugin and reports the error; agent does not crash | Verified by unit test with a mock that returns network error |
+
+---
+
+## Security
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-SE-01 | `--plugin-url` accepts only HTTPS scheme | `validate_url_scheme` must return `InsecureUrl` for `http://` or any non-HTTPS scheme |
+| NFR-SE-02 | Path traversal in ephemeral plugin archives is blocked | Reuse existing extraction guard in `add_remote` |
+| NFR-SE-03 | `scan_skill_entries` failures are blocking for ephemeral plugins | `strict_scan = true` causes load abort, not advisory warning |
+| NFR-SE-04 | Ephemeral plugins never write to permanent plugin store | `add_remote_ephemeral` uses a `TempDir`, not `plugins_dir` |
+| NFR-SE-05 | Overrides blob rejects unknown fields | `#[serde(deny_unknown_fields)]` on `ProviderOverrides` struct |
+
+---
+
+## Maintainability
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-MA-01 | `add_remote_ephemeral` shares core logic with `add_remote` — no duplication | Extract shared download/verify/extract into a helper; both variants call it |
+| NFR-MA-02 | `ProviderOverrides` is a concrete typed struct, not `HashMap<String, Value>` | Enables compile-time completeness checks and `deny_unknown_fields` |
+| NFR-MA-03 | All public APIs introduced by this spec have doc comments with `# Examples` | Pre-merge doc check: `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc -p zeph-plugins -p zeph-core` |
+
+---
+
+## Portability
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-PO-01 | Ephemeral plugin extraction uses `std::env::temp_dir()` or `tempfile::TempDir` | Works on Linux, macOS, Windows |
+
+---
+
+## Usability
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-US-01 | Error message for `--plugin-url http://...` clearly states HTTPS is required | Contains the word "HTTPS" and the rejected URL |
+| NFR-US-02 | Error message for scan failure names the offending SKILL.md entry | Contains the skill name and pattern that triggered blocking |
+| NFR-US-03 | `plugin list` output shows `[ephemeral]` tag for session-loaded plugins | Verified by snapshot test |

--- a/specs/parity-claude-code-3918/plan.md
+++ b/specs/parity-claude-code-3918/plan.md
@@ -1,0 +1,214 @@
+---
+aliases:
+  - Parity Plan 3918
+  - Claude Code Parity Implementation Plan
+tags:
+  - sdd
+  - plan
+  - parity
+  - plugins
+  - provider-persistence
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/parity-claude-code-3918/spec]]"
+  - "[[specs/parity-claude-code-3918/tasks]]"
+---
+
+# Implementation Plan: Claude Code v2.1.141–v2.1.143 Parity (GitHub #3918)
+
+## Recommended Implementation Order
+
+**Phase 1: Provider override persistence (Feature B)** — implement first.
+
+Rationale (from architect and critic both agree):
+- Self-contained: extends existing `provider_cmd.rs` and `channel_preferences` table
+- No new network I/O or security surface
+- No dependency on other in-flight work
+- Estimated effort: ~150 LOC across 3 files
+
+**Phase 2: `--plugin-url` ephemeral loading (Feature A)** — implement second.
+
+Rationale:
+- Builds on existing `add_remote` infrastructure
+- Security surface (HTTPS gate, blocking scan) benefits from Phase 1 being merged and stable
+- Estimated effort: ~200 LOC across 5 files (including new `PluginError::InsecureUrl`)
+
+**Phase 3: Deferred gap issues** — file GitHub issues for deferred gaps after Phase 1+2 merge.
+
+---
+
+## Phase 1: Provider Override Persistence
+
+### P1-1: Add `ProviderOverrides` struct
+
+**File:** `crates/zeph-config/src/providers.rs`
+
+Add:
+```rust
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderOverrides {
+    pub reasoning_effort: Option<String>,
+    pub temperature: Option<f32>,
+}
+
+impl ProviderOverrides {
+    pub fn is_empty(&self) -> bool {
+        self.reasoning_effort.is_none() && self.temperature.is_none()
+    }
+}
+```
+
+### P1-2: Add config gate
+
+**File:** `crates/zeph-config/src/session.rs` (or equivalent session config file)
+
+Add `persist_provider_overrides: bool` field (default `true`) to `SessionConfig`.
+
+### P1-3: Extend provider persistence
+
+**File:** `crates/zeph-core/src/agent/provider_cmd.rs`
+
+- `persist_channel_provider()`: after persisting provider name, if `persist_provider_overrides && !overrides.is_empty()`, serialize overrides to JSON (assert `len() <= 1024`), upsert `pref_key = "provider_overrides"`
+- `restore_channel_provider()`: after restoring provider name, load `pref_key = "provider_overrides"`, validate size, deserialize with `deny_unknown_fields`, apply to provider (skip inapplicable params with `tracing::warn!`)
+
+### P1-4: Wire `--init` wizard
+
+**File:** `src/main.rs` or wizard module
+
+Add prompt for `persist_provider_overrides` to the interactive configuration wizard (`--init`).
+
+### P1-5: Update `--migrate-config`
+
+No migration needed. Confirm in code that no schema change is made.
+
+### P1-6: Tests
+
+- `crates/zeph-core/src/agent/provider_cmd.rs` (inline `#[cfg(test)]`)
+  - `test_persist_restore_overrides`
+  - `test_oversized_blob_discarded`
+  - `test_unknown_field_rejected`
+  - `test_inapplicable_param_skipped`
+
+### P1-7: Playbook + coverage-status
+
+- Create `.local/testing/playbooks/provider-persistence.md`
+- Add row to `.local/testing/coverage-status.md` (Untested)
+
+---
+
+## Phase 2: `--plugin-url` Ephemeral Plugin Loading
+
+### P2-1: Add `PluginError::InsecureUrl`
+
+**File:** `crates/zeph-plugins/src/error.rs`
+
+Add variant:
+```rust
+#[error("plugin URL must use HTTPS scheme, got: {0}")]
+InsecureUrl(String),
+```
+
+### P2-2: Update `validate_url_scheme`
+
+**File:** `crates/zeph-plugins/src/manager.rs`
+
+Add `ephemeral: bool` parameter. When `ephemeral = true`, reject `http://` with `PluginError::InsecureUrl`. Existing callers pass `ephemeral = false` (no behavior change).
+
+Alternatively: create a separate `validate_url_scheme_ephemeral()` to avoid touching existing callers' signatures.
+
+### P2-3: Extract shared download/extract helper
+
+**File:** `crates/zeph-plugins/src/manager.rs`
+
+Refactor: extract `download_and_extract(url, sha256, dest: &Path, strict_scan: bool) -> Result<AddResult>` as a private helper used by both `add_remote` and `add_remote_ephemeral`.
+
+### P2-4: Add `add_remote_ephemeral`
+
+**File:** `crates/zeph-plugins/src/manager.rs`
+
+```rust
+pub async fn add_remote_ephemeral(
+    &self,
+    url: &str,
+    sha256: Option<&str>,
+) -> Result<(AddResult, TempDir)>
+```
+
+Implementation:
+1. Call `validate_url_scheme_ephemeral(url)` → error on non-HTTPS
+2. Create `TempDir`
+3. Call `download_and_extract(url, sha256, tempdir.path(), strict_scan=true)`
+4. Return `(result, tempdir)` — caller holds ownership
+
+### P2-5: Update CLI
+
+**File:** `src/cli.rs`
+
+Add to top-level `Args`:
+```rust
+#[arg(long)]
+plugin_url: Option<String>,
+
+#[arg(long)]
+plugin_sha256: Option<String>,
+```
+
+### P2-6: Update `AgentBuilder` and `AgentRuntime`
+
+**Files:**
+- `crates/zeph-core/src/agent/builder.rs`: add `with_ephemeral_plugins(plugins: Vec<TempDir>) -> Self`
+- `crates/zeph-core/src/agent/state/mod.rs`: add `ephemeral_plugins: Vec<TempDir>` to `AgentRuntime`
+
+### P2-7: Bootstrap wiring
+
+**File:** `src/main.rs`
+
+After config load, if `args.plugin_url.is_some()`:
+1. Call `plugin_manager.add_remote_ephemeral(url, sha256).await`
+2. Register returned skills in `SkillRegistry`
+3. Register returned MCP servers in MCP lifecycle
+4. Pass `TempDir` to `AgentBuilder::with_ephemeral_plugins`
+
+### P2-8: `plugin list` display
+
+**File:** `crates/zeph-commands/src/plugin_list.rs` (or wherever `plugin list` is handled)
+
+For each ephemeral plugin in `AgentRuntime::ephemeral_plugins`, display with `[ephemeral]` tag.
+
+### P2-9: Tests
+
+- `crates/zeph-plugins/src/manager.rs` (inline `#[cfg(test)]`)
+  - `test_validate_url_scheme_ephemeral_rejects_http`
+  - `test_add_remote_ephemeral_blocks_on_scan_failure`
+  - `test_add_remote_ephemeral_succeeds_with_good_archive`
+  - `test_tempdir_drops_on_agent_exit`
+
+### P2-10: Playbook + coverage-status
+
+- Create `.local/testing/playbooks/ephemeral-plugins.md`
+- Add row to `.local/testing/coverage-status.md` (Untested)
+
+---
+
+## Phase 3: Deferred Gap Issues
+
+File three GitHub issues (see `tasks.md`):
+- `worktree.baseRef` config (P3)
+- `worktree.bgIsolation: none` (P3)
+- Ctrl+R cross-project history search (P3)
+
+---
+
+## Pre-Merge Checklist
+
+- [ ] `cargo +nightly fmt --check`
+- [ ] `cargo clippy --workspace --all-features -- -D warnings`
+- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --all-features --lib --bins`
+- [ ] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-plugins -p zeph-core -p zeph-config`
+- [ ] `cargo test --doc -p zeph-plugins -p zeph-core -p zeph-config`
+- [ ] RUSTFLAGS="-D warnings" cargo check --workspace --all-targets
+- [ ] Update `CHANGELOG.md` (`[Unreleased]` section)
+- [ ] Feature B does NOT touch LLM serialization paths — no live API test required
+- [ ] Feature A download path is network-bound — integration test uses mock HTTP server

--- a/specs/parity-claude-code-3918/spec.md
+++ b/specs/parity-claude-code-3918/spec.md
@@ -1,0 +1,204 @@
+---
+aliases:
+  - Parity Spec 3918
+  - Claude Code Parity Implementation Spec
+tags:
+  - sdd
+  - spec
+  - parity
+  - plugins
+  - provider-persistence
+created: 2026-05-29
+status: approved
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[specs/parity-claude-code-3918/brd]]"
+  - "[[specs/parity-claude-code-3918/srs]]"
+  - "[[specs/parity-claude-code-3918/nfr]]"
+  - "[[specs/parity-claude-code-3918/plan]]"
+  - "[[specs/058-plugins/spec]]"
+  - "[[specs/003-llm-providers/spec]]"
+  - "[[specs/010-security/spec]]"
+---
+
+# Spec: Claude Code v2.1.141–v2.1.143 Parity (GitHub #3918)
+
+> This spec is the authoritative implementation contract for the two actionable parity gaps
+> identified in GitHub issue #3918. It is derived from the architect plan
+> (`.local/handoff/2026-05-29T18-24-25-architect.md`) and the critic review
+> (`.local/handoff/2026-05-29T18-30-12-critic.md`). All critic findings are incorporated.
+
+---
+
+## 1. Gap Assessment Summary
+
+| Gap | Verdict | Priority | Rationale |
+|-----|---------|----------|-----------|
+| `--plugin-url` session-scoped loading | **Implement** | P2 | Download infra exists; missing ephemeral variant + HTTPS gate |
+| Session provider override persistence | **Implement** | P2 | Persistence infra exists; missing overrides blob per channel |
+| `worktree.baseRef` config | Defer | P3 | Requires native worktree subsystem (does not exist) |
+| `worktree.bgIsolation: none` | Defer | P3 | Depends on worktree.baseRef |
+| Ctrl+R cross-project history | Defer | P3 | Zeph TUI has no prompt-history infrastructure |
+
+Deferred gaps **must** have follow-up GitHub issues filed. See `tasks.md`.
+
+---
+
+## 2. Feature A: `--plugin-url` Ephemeral Plugin Loading
+
+### 2.1 Sources (Architect Plan §Gap 3 + Critic Findings 1, 4)
+
+**Architect plan:** CLI flag `--plugin-url`, reuse `add_remote`, store `TempDir` in agent runtime.
+
+**Critic amendments incorporated:**
+- Finding 1 (P1): `validate_url_scheme` currently accepts `http`. For the ephemeral path, must enforce HTTPS-only. A new `PluginError::InsecureUrl` variant is the correct return.
+- Finding 4 (P2): `scan_skill_entries` is advisory-only. For ephemeral plugins from arbitrary URLs, failures must be blocking. The `add_remote_ephemeral` function takes a `strict_scan: bool` parameter defaulting to `true`.
+
+### 2.2 Crate Impact
+
+| Crate | File | Change |
+|-------|------|--------|
+| `src/cli.rs` | — | Add `--plugin-url: Option<String>` and `--plugin-sha256: Option<String>` top-level args |
+| `crates/zeph-plugins/src/manager.rs` | `add_remote_ephemeral()` | New function: download + verify + extract to `TempDir`; calls shared helper with `strict_scan = true` |
+| `crates/zeph-plugins/src/manager.rs` | `validate_url_scheme()` | Add `ephemeral: bool` parameter; when `true`, reject `http` (return `PluginError::InsecureUrl`) |
+| `crates/zeph-plugins/src/error.rs` | `PluginError` | Add `InsecureUrl(String)` variant |
+| `crates/zeph-core/src/agent/builder.rs` | `AgentBuilder` | Add `with_ephemeral_plugins(Vec<TempDir>)` to hold ownership |
+| `crates/zeph-core/src/agent/state/mod.rs` | `AgentRuntime` | Add `ephemeral_plugins: Vec<TempDir>` field |
+| `src/main.rs` | bootstrap | If `--plugin-url` is set: call `add_remote_ephemeral`, register skills + MCP, pass `TempDir` to builder |
+
+### 2.3 Shared Helper Pattern
+
+```
+download_and_extract(url, sha256, dest_dir)  ← shared by add_remote and add_remote_ephemeral
+add_remote(url, sha256) → installs to plugins_dir, strict_scan=false
+add_remote_ephemeral(url, sha256) → TempDir, strict_scan=true, validate_url_scheme(ephemeral=true)
+```
+
+This avoids duplication (NFR-MA-01).
+
+### 2.4 Security Invariants
+
+- HTTPS-only for ephemeral path (SRS FR-A-02, NFR-SE-01)
+- Path traversal protection reused from existing extraction guard (NFR-SE-02)
+- `scan_skill_entries` failures block load (SRS FR-A-03, NFR-SE-03)
+- No write to `plugins_dir` (NFR-SE-04)
+- No config overlay applied (SRS FR-A-06)
+
+### 2.5 Key Invariants
+
+- **NEVER** accept a plain `http://` URL for `--plugin-url`
+- **NEVER** install to permanent plugin store
+- **NEVER** apply config overlays from ephemeral plugins
+- **ALWAYS** run blocking scan before registering skills
+
+---
+
+## 3. Feature B: Provider Parameter Override Persistence
+
+### 3.1 Sources (Architect Plan §Gap 4 + Critic Findings 3, 5)
+
+**Architect plan:** Extend `channel_preferences` with `overrides_json` column via `ALTER TABLE`.
+
+**Critic amendments incorporated:**
+- Finding 3 (P2): No `ALTER TABLE` needed. The `channel_preferences` table is already key-value (`pref_key` / `pref_value`). Store overrides as a new row with `pref_key = "provider_overrides"`. Zero migration required.
+- Finding 5 (P3): `ProviderOverrides` must be a typed struct with `#[serde(deny_unknown_fields)]` and a 1 KB blob size cap.
+
+### 3.2 `ProviderOverrides` Struct
+
+```rust
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderOverrides {
+    pub reasoning_effort: Option<String>,
+    pub temperature: Option<f32>,
+}
+```
+
+Constraints:
+- Serialized form must not exceed 1024 bytes (validated before persist and after load)
+- `Option` fields: omitted when `None` (compact JSON)
+- Unknown fields on deserialize: return `serde_json::Error`, discard blob + warn (SRS FR-B-03)
+
+### 3.3 Crate Impact
+
+| Crate | File | Change |
+|-------|------|--------|
+| `crates/zeph-config/src/providers.rs` | — | Add `ProviderOverrides` struct |
+| `crates/zeph-core/src/agent/provider_cmd.rs` | `persist_channel_provider()` | Also upsert `pref_key = "provider_overrides"` with serialized overrides JSON |
+| `crates/zeph-core/src/agent/provider_cmd.rs` | `restore_channel_provider()` | Also load `pref_key = "provider_overrides"`, deserialize, apply to active provider |
+| `crates/zeph-config/src/session.rs` | `SessionConfig` | Add `persist_provider_overrides: bool` (default: `true`) |
+
+### 3.4 Persistence Flow
+
+```
+On /provider switch:
+  persist_channel_provider(channel_id, provider_name)
+  if persist_provider_overrides:
+    overrides_json = serde_json::to_string(&current_overrides)?
+    assert overrides_json.len() <= 1024
+    upsert channel_preferences(channel_id, "provider_overrides", overrides_json)
+
+On session start:
+  restore_channel_provider(channel_id) → provider_name
+  if persist_provider_overrides:
+    load channel_preferences(channel_id, "provider_overrides") → blob
+    if blob.len() > 1024: warn, skip
+    ProviderOverrides::deserialize(blob) → overrides (discard on error, warn)
+    apply overrides to restored provider (skip inapplicable params with warn)
+```
+
+### 3.5 Key Invariants
+
+- **NEVER** require a DB schema migration for this feature (use existing key-value row)
+- **ALWAYS** validate blob size before persist (prevent unbounded growth)
+- **ALWAYS** use `#[serde(deny_unknown_fields)]` on `ProviderOverrides`
+- **NEVER** crash on corrupted overrides blob — log and proceed without overrides
+
+---
+
+## 4. Integration Points
+
+Per project rules, all new functionality must wire up:
+
+| Integration Point | Feature A | Feature B |
+|-------------------|-----------|-----------|
+| CLI arg | `--plugin-url`, `--plugin-sha256` | `--reset-overrides` (optional, low priority) |
+| Config section | — | `[session] persist_provider_overrides = true` |
+| TUI command palette | `plugin list` shows `[ephemeral]` tag | `/effort` slash command (Phase 2, separate issue) |
+| `--init` wizard | N/A (URL is session flag, not persistent config) | Prompt for `persist_provider_overrides` |
+| `--migrate-config` | N/A | N/A (no config schema change, only new key) |
+| Test playbook | `.local/testing/playbooks/ephemeral-plugins.md` | `.local/testing/playbooks/provider-persistence.md` |
+| Coverage status | Add row `ephemeral-plugins` (Untested) | Add row `provider-overrides` (Untested) |
+
+---
+
+## 5. Testing Requirements
+
+### Feature A
+
+- Unit: `validate_url_scheme` with `ephemeral=true` rejects `http://`
+- Unit: `add_remote_ephemeral` with fixture archive containing injected SKILL.md → returns error
+- Unit: `add_remote_ephemeral` with good archive → `TempDir` returned, skills registered
+- Unit: `TempDir` drop cleans up (implicit via `tempfile` crate behavior)
+- Integration: full session with `--plugin-url` fixture (HTTPS mock) → skills active
+
+### Feature B
+
+- Unit: `persist_channel_provider` serializes `ProviderOverrides` to correct `pref_key`
+- Unit: `restore_channel_provider` restores overrides and applies to provider
+- Unit: oversized blob (> 1024 bytes) is discarded without panic
+- Unit: blob with unknown field `{"foo": 1}` is rejected by `deny_unknown_fields`
+- Unit: inapplicable param (effort on Ollama) logs warn and skips
+- Integration: set overrides → `persist` → `restore` → overrides applied
+
+---
+
+## 6. Relationship to Existing Specs
+
+| This spec | Existing spec | Relationship |
+|-----------|---------------|-------------|
+| Feature A | `[[specs/058-plugins/spec]]` | Extends plugin system with ephemeral variant |
+| Feature A | `[[specs/010-security/spec]]` | Must comply with SSRF + path traversal guards |
+| Feature B | `[[specs/003-llm-providers/spec]]` | Extends provider persistence; `ProviderOverrides` is a new type in the provider config layer |
+| Feature B | `[[specs/021-config-loading/spec]]` | New `persist_provider_overrides` key follows existing config resolution rules |

--- a/specs/parity-claude-code-3918/srs.md
+++ b/specs/parity-claude-code-3918/srs.md
@@ -1,0 +1,174 @@
+---
+aliases:
+  - Parity SRS 3918
+  - Claude Code Parity Software Requirements
+tags:
+  - sdd
+  - srs
+  - parity
+  - plugins
+  - provider-persistence
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/parity-claude-code-3918/brd]]"
+  - "[[specs/parity-claude-code-3918/spec]]"
+  - "[[specs/parity-claude-code-3918/nfr]]"
+---
+
+# SRS: Claude Code v2.1.141–v2.1.143 Parity (GitHub #3918)
+
+ISO/IEC/IEEE 29148:2018 compliant. Requirements use EARS notation.
+
+## 1. Scope
+
+This SRS covers two implementation gaps:
+
+- **Feature A**: `--plugin-url` session-scoped ephemeral plugin loading
+- **Feature B**: Provider parameter override persistence across restarts
+
+Deferred gaps (worktree.baseRef, bgIsolation, Ctrl+R) are acknowledged in BRD §5 and excluded here.
+
+---
+
+## 2. Feature A: `--plugin-url` Ephemeral Plugin Loading
+
+### FR-A-01: CLI Flag
+
+**WHEN** the user starts Zeph with `--plugin-url <url>`,
+**THE SYSTEM SHALL** treat `<url>` as a plugin archive to download and load for the current session only.
+
+**WHEN** `--plugin-sha256 <hex>` is also provided,
+**THE SYSTEM SHALL** verify the SHA-256 digest of the downloaded archive before loading.
+
+### FR-A-02: HTTPS Enforcement
+
+**WHEN** `--plugin-url` is specified,
+**IF** the URL scheme is not `https`,
+**THE SYSTEM SHALL** reject the request with a `PluginError::InsecureUrl` error and a human-readable message before any network I/O occurs.
+
+> Rationale: existing `validate_url_scheme` accepts `http`. The ephemeral path requires HTTPS-only to prevent MITM (Critic Finding 1, P1). The general `add_remote` behavior is a separate concern.
+
+### FR-A-03: Blocking Security Scan
+
+**WHEN** an ephemeral plugin is downloaded,
+**THE SYSTEM SHALL** run `scan_skill_entries` with strict mode (`strict_scan = true`).
+
+**WHEN** `scan_skill_entries` finds an injection pattern in any SKILL.md entry,
+**THE SYSTEM SHALL** abort the load and return an error to the user.
+
+> Rationale: for permanent plugins the advisory-only scan is acceptable because the user explicitly chose to install. For ephemeral plugins from arbitrary URLs, silent advisory-only is too weak (Critic Finding 4, P2).
+
+### FR-A-04: Ephemeral Lifetime
+
+**WHEN** a plugin is loaded via `--plugin-url`,
+**THE SYSTEM SHALL** extract it into a temporary directory whose lifetime is tied to the agent process.
+
+**WHEN** the agent exits (normally or via panic unwind),
+**THE SYSTEM SHALL** delete the temporary directory automatically.
+
+No manual cleanup step may be required.
+
+### FR-A-05: Skill and MCP Registration
+
+**WHEN** an ephemeral plugin is loaded successfully,
+**THE SYSTEM SHALL** register its skills in `SkillRegistry` and its MCP servers in the MCP lifecycle, identical to a permanently installed plugin.
+
+**WHEN** the agent exits,
+**THE SYSTEM SHALL NOT** leave any permanent entry in the skill registry, integrity registry, or MCP server configuration.
+
+### FR-A-06: No Config Overlay Privileges
+
+**WHEN** an ephemeral plugin is loaded,
+**THE SYSTEM SHALL NOT** apply any config overlay from its `plugin.toml`.
+
+> Rationale: session ends before any damage persists, but principle of least privilege.
+
+### FR-A-07: `plugin list` Visibility
+
+**WHEN** the user runs `zeph plugin list` during a session with an active ephemeral plugin,
+**THE SYSTEM SHALL** include the ephemeral plugin in the listing with an `[ephemeral]` tag.
+
+### FR-A-08: CLI-Only Scope
+
+**WHEN** `--plugin-url` is specified in a non-CLI mode (Telegram, Discord, Slack, ACP),
+**THE SYSTEM SHALL** ignore the flag silently (CLI-only convenience flag; other channels have no CLI argument parsing).
+
+---
+
+## 3. Feature B: Provider Parameter Override Persistence
+
+### FR-B-01: Persist Overrides
+
+**WHEN** the user sets a provider override (reasoning effort, temperature) in a session via `/provider` or `/effort`,
+**THE SYSTEM SHALL** persist the override values alongside the provider name in `channel_preferences` using `pref_key = "provider_overrides"`.
+
+### FR-B-02: Restore Overrides on Startup
+
+**WHEN** `provider_persistence_enabled = true` and the agent starts,
+**THE SYSTEM SHALL** restore provider overrides from `channel_preferences` (pref_key `"provider_overrides"`) for the active channel.
+
+**WHEN** the stored overrides blob references a parameter not applicable to the restored provider (e.g., `reasoning_effort` on an Ollama provider),
+**THE SYSTEM SHALL** silently skip that parameter with a `tracing::warn!` log.
+
+### FR-B-03: Overrides Schema Validation
+
+**WHEN** the overrides blob is deserialized,
+**THE SYSTEM SHALL** reject blobs containing unknown fields (via `#[serde(deny_unknown_fields)]`).
+
+**WHEN** the overrides blob exceeds 1 KB,
+**THE SYSTEM SHALL** discard it and log a warning, then proceed without overrides.
+
+> Rationale: prevents unbounded growth and unvalidated keys (Critic Finding 5, P3).
+
+### FR-B-04: Zero Schema Migration
+
+**THE SYSTEM SHALL NOT** require an `ALTER TABLE` migration to add the `provider_overrides` pref_key.
+
+The existing `channel_preferences` key-value design (`pref_key` / `pref_value`) accommodates a new row without schema change.
+
+> Rationale: eliminates critic Finding 3 (schema migration gap). A new `pref_key` row is append-only.
+
+### FR-B-05: Config Gate
+
+**WHEN** `[session] persist_provider_overrides = false` (default: `true`),
+**THE SYSTEM SHALL NOT** persist or restore provider overrides.
+
+---
+
+## 4. Deferred Requirements (Acknowledged)
+
+### FR-D-01: `worktree.baseRef`
+
+Deferred (P3). Requires native worktree management subsystem. No implementation in this spec.
+
+### FR-D-02: `bgIsolation: none`
+
+Deferred (P3). Depends on FR-D-01. No implementation in this spec.
+
+### FR-D-03: Ctrl+R Cross-Project History Search
+
+Deferred (P3). Zeph TUI has no prompt-history infrastructure. No implementation in this spec.
+
+---
+
+## 5. Traceability Matrix
+
+| Requirement | BRD Goal | Critic Finding |
+|-------------|----------|----------------|
+| FR-A-01 | BG-01 | — |
+| FR-A-02 | BG-03 | Finding 1 (P1, HTTPS) |
+| FR-A-03 | BG-03 | Finding 4 (P2, blocking scan) |
+| FR-A-04 | BG-01 | — |
+| FR-A-05 | BG-01 | — |
+| FR-A-06 | BG-03 | — |
+| FR-A-07 | BG-01 | — |
+| FR-A-08 | BG-01 | — |
+| FR-B-01 | BG-02 | — |
+| FR-B-02 | BG-02 | — |
+| FR-B-03 | BG-02 | Finding 5 (P3, validation) |
+| FR-B-04 | BG-02 | Finding 3 (P2, no ALTER TABLE) |
+| FR-B-05 | BG-02 | — |
+| FR-D-01 | — | Finding 2 (P2, explicit defer) |
+| FR-D-02 | — | Finding 2 (P2, explicit defer) |
+| FR-D-03 | — | Finding 2 (P2, explicit defer) |

--- a/specs/parity-claude-code-3918/tasks.md
+++ b/specs/parity-claude-code-3918/tasks.md
@@ -1,0 +1,81 @@
+---
+aliases:
+  - Parity Tasks 3918
+  - Claude Code Parity Task Breakdown
+tags:
+  - sdd
+  - tasks
+  - parity
+  - plugins
+  - provider-persistence
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/parity-claude-code-3918/plan]]"
+  - "[[specs/parity-claude-code-3918/spec]]"
+---
+
+# Task Breakdown: Claude Code v2.1.141–v2.1.143 Parity (GitHub #3918)
+
+All tasks reference the implementation plan in `plan.md`.
+
+---
+
+## Phase 1: Provider Override Persistence
+
+| # | Task | Plan Step | Crate | Est. LOC |
+|---|------|-----------|-------|----------|
+| T1.1 | Add `ProviderOverrides` struct with `deny_unknown_fields` and `is_empty()` | P1-1 | `zeph-config` | ~20 |
+| T1.2 | Add `persist_provider_overrides: bool` to `SessionConfig` | P1-2 | `zeph-config` | ~5 |
+| T1.3 | Extend `persist_channel_provider` to upsert overrides blob with size assertion | P1-3 | `zeph-core` | ~30 |
+| T1.4 | Extend `restore_channel_provider` to load, validate, and apply overrides | P1-3 | `zeph-core` | ~40 |
+| T1.5 | Wire `persist_provider_overrides` prompt into `--init` wizard | P1-4 | binary | ~10 |
+| T1.6 | Write unit tests (4 cases) for persist/restore/validation | P1-6 | `zeph-core` | ~60 |
+| T1.7 | Create playbook `provider-persistence.md`, add coverage row | P1-7 | `.local/` | — |
+| T1.8 | Update `CHANGELOG.md` `[Unreleased]` | — | root | — |
+
+**Phase 1 total estimated LOC: ~165**
+
+---
+
+## Phase 2: `--plugin-url` Ephemeral Plugin Loading
+
+| # | Task | Plan Step | Crate | Est. LOC |
+|---|------|-----------|-------|----------|
+| T2.1 | Add `PluginError::InsecureUrl` variant | P2-1 | `zeph-plugins` | ~5 |
+| T2.2 | Add `validate_url_scheme_ephemeral()` (HTTPS-only) | P2-2 | `zeph-plugins` | ~15 |
+| T2.3 | Extract `download_and_extract()` shared helper | P2-3 | `zeph-plugins` | ~40 refactor |
+| T2.4 | Add `add_remote_ephemeral()` using helper with `strict_scan=true` | P2-4 | `zeph-plugins` | ~40 |
+| T2.5 | Add `--plugin-url` and `--plugin-sha256` top-level CLI args | P2-5 | binary | ~15 |
+| T2.6 | Add `with_ephemeral_plugins(Vec<TempDir>)` to `AgentBuilder` | P2-6 | `zeph-core` | ~15 |
+| T2.7 | Add `ephemeral_plugins: Vec<TempDir>` to `AgentRuntime` | P2-6 | `zeph-core` | ~10 |
+| T2.8 | Bootstrap wiring in `main.rs`: call ephemeral load, register skills + MCP, pass TempDir | P2-7 | binary | ~40 |
+| T2.9 | Update `plugin list` output to show `[ephemeral]` tag | P2-8 | `zeph-commands` | ~15 |
+| T2.10 | Write unit tests (4 cases) for URL validation + scan blocking + happy path | P2-9 | `zeph-plugins` | ~70 |
+| T2.11 | Create playbook `ephemeral-plugins.md`, add coverage row | P2-10 | `.local/` | — |
+| T2.12 | Update `CHANGELOG.md` `[Unreleased]` | — | root | — |
+
+**Phase 2 total estimated LOC: ~265 (including refactor)**
+
+---
+
+## Phase 3: Deferred Gap Issues
+
+| # | Task | GitHub Labels |
+|---|------|---------------|
+| T3.1 | File issue: `worktree.baseRef` config support (P3) | `enhancement`, `P3` |
+| T3.2 | File issue: `worktree.bgIsolation: none` support (P3, blocks on T3.1) | `enhancement`, `P3` |
+| T3.3 | File issue: Ctrl+R cross-project prompt history search in TUI (P3) | `enhancement`, `P3` |
+
+---
+
+## Acceptance Criteria (for PR merge)
+
+- [ ] All Phase 1 and Phase 2 unit tests pass (`cargo nextest run --workspace --all-features --lib --bins`)
+- [ ] No new clippy warnings (`cargo clippy --workspace --all-features -- -D warnings`)
+- [ ] Docs build without broken links (`RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-plugins -p zeph-core -p zeph-config`)
+- [ ] Doc-tests pass for all touched crates
+- [ ] `CHANGELOG.md` updated
+- [ ] Three deferred gap issues filed on GitHub (T3.1–T3.3)
+- [ ] Coverage rows added to `.local/testing/coverage-status.md`
+- [ ] Test playbooks created at `.local/testing/playbooks/`


### PR DESCRIPTION
## Summary

- Adds formal spec package at `specs/parity-claude-code-3918/` (brd, srs, nfr, spec, plan, tasks) for GitHub issue #3918
- Two parity gaps scoped for implementation (P2): `--plugin-url` ephemeral plugin loading and session provider override persistence
- Three gaps explicitly deferred (P3): `worktree.baseRef`, `bgIsolation: none`, Ctrl+R TUI history scope

## Spec chain

`architect → critic (5 findings, all incorporated) → sdd → reviewer (approved, 2 non-blocking notes)`

Key decisions from critic review:
- `--plugin-url` must enforce HTTPS-only (`validate_url_scheme` currently accepts HTTP)
- `scan_skill_entries` must be blocking (not advisory-only) for ephemeral URLs
- Provider overrides use existing `channel_preferences` key-value table — no schema migration needed
- `ProviderOverrides` JSON blob gets `#[serde(deny_unknown_fields)]` + 1 KB size cap

## Test plan

- [ ] `specs/parity-claude-code-3918/` files are present and well-formed
- [ ] `specs/README.md` updated with new entry
- [ ] Follow-up implementation issues filed (Feature A, Feature B, 3 deferred gaps)

Closes #3918