### PR TITLE
fix(core): add wildcard arm to InjectionVerdict matches for non_exhaustive compat

### DIFF
--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2043,6 +2043,7 @@ impl<C: Channel> Agent<C> {
                     tracing::warn!("injection_classifier soft_signal on user input");
                 }
                 zeph_sanitizer::InjectionVerdict::Clean => {}
+                _ => {}
             }
         }
         #[cfg(feature = "classifiers")]

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -229,6 +229,7 @@ impl<C: Channel> Agent<C> {
                     self.update_metrics(|m| m.classifier_tool_suspicious += 1);
                 }
                 zeph_sanitizer::InjectionVerdict::Clean => {}
+                _ => {}
             }
         }
         None


### PR DESCRIPTION
## Summary

Fixes CI failure introduced when `InjectionVerdict` was marked `#[non_exhaustive]` in #4616.

Two `match` expressions in `zeph-core` covered all three explicit variants (`Blocked`, `Suspicious`, `Clean`) but lacked a `_ => {}` wildcard arm required by `#[non_exhaustive]` when matching from a downstream crate. The `classifiers` feature build failed with `E0004: non-exhaustive patterns` on all targets.

- `crates/zeph-core/src/agent/tool_execution/sanitize.rs:232` — match on ML tool-output verdict
- `crates/zeph-core/src/agent/mod.rs:2045` — match on ML user-input verdict

Both sites now have `_ => {}` as the final arm.

Closes CI run https://github.com/bug-ops/zeph/actions/runs/26652563987