### PR TITLE
refactor(context): make embed and compress timeouts configurable in FidelityConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- refactor(context): make embed and compress timeouts in `FidelityScorer` configurable via
+  `embed_timeout_secs` / `compress_timeout_secs` in `[memory.fidelity]` config (closes #4645, #4651).
+  Both fields default to 30 seconds to preserve existing behaviour; config migration step 51 adds
+  commented-out hints for existing configs that contain a `[memory.fidelity]` section.
+
 ## [0.21.3] - 2026-05-29
 
 ### Added

--- a/config/default.toml
+++ b/config/default.toml
@@ -363,6 +363,8 @@ autosave_assistant = true
 # regrade_threshold = 0.6
 # min_query_length = 8
 # max_scored_messages = 500
+# embed_timeout_secs = 30     # timeout for embed calls in fidelity scoring (seconds)
+# compress_timeout_secs = 30  # timeout for LLM compress calls in fidelity scoring (seconds)
 
 [memory.sessions]
 # Maximum number of sessions returned by list operations (0 = unlimited)

--- a/crates/zeph-config/src/fidelity.rs
+++ b/crates/zeph-config/src/fidelity.rs
@@ -94,10 +94,26 @@ pub struct FidelityConfig {
     /// the compress call. `None` means no cap. Independent of the existing 2× cost guard.
     #[serde(default)]
     pub max_compress_input_tokens: Option<usize>,
+    /// Timeout in seconds for embed calls in fidelity scoring (default: 30).
+    ///
+    /// Applies to both the query embed and each per-message embed in the pre-pass.
+    /// Timed-out calls are skipped with a `warn`-level log; scoring falls back to keyword overlap.
+    #[serde(default = "default_thirty")]
+    pub embed_timeout_secs: u64,
+    /// Timeout in seconds for the LLM compress call in fidelity scoring (default: 30).
+    ///
+    /// When the LLM compress call exceeds this limit it is cancelled and truncation is used
+    /// as a fallback. Set higher if your compress provider has high cold-start latency.
+    #[serde(default = "default_thirty")]
+    pub compress_timeout_secs: u64,
 }
 
 fn default_embed_concurrency() -> usize {
     32
+}
+
+fn default_thirty() -> u64 {
+    30
 }
 
 impl FidelityConfig {
@@ -175,6 +191,8 @@ impl Default for FidelityConfig {
             embed_concurrency: default_embed_concurrency(),
             max_embed_input_tokens: None,
             max_compress_input_tokens: None,
+            embed_timeout_secs: default_thirty(),
+            compress_timeout_secs: default_thirty(),
         }
     }
 }
@@ -336,5 +354,31 @@ mod tests {
         assert_eq!(cfg.embed_concurrency, 8);
         assert_eq!(cfg.max_embed_input_tokens, Some(512));
         assert_eq!(cfg.max_compress_input_tokens, Some(1024));
+    }
+
+    #[test]
+    fn default_timeout_fields_are_thirty() {
+        let cfg = FidelityConfig::default();
+        assert_eq!(cfg.embed_timeout_secs, 30);
+        assert_eq!(cfg.compress_timeout_secs, 30);
+    }
+
+    #[test]
+    fn deserialize_timeout_fields_custom() {
+        let toml_str = r"
+            enabled = true
+            embed_timeout_secs = 60
+            compress_timeout_secs = 120
+        ";
+        let cfg: FidelityConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.embed_timeout_secs, 60);
+        assert_eq!(cfg.compress_timeout_secs, 120);
+    }
+
+    #[test]
+    fn deserialize_timeout_fields_default_when_omitted() {
+        let cfg: FidelityConfig = toml::from_str("enabled = false").unwrap();
+        assert_eq!(cfg.embed_timeout_secs, 30);
+        assert_eq!(cfg.compress_timeout_secs, 30);
     }
 }

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3364,11 +3364,12 @@ mod steps;
 use steps::{
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
     MigrateAutodreamConfig, MigrateCocoonProviderNotice, MigrateCompressionPredictorConfig,
-    MigrateDatabaseUrl, MigrateEgressConfig, MigrateEmbedProviderRename, MigrateFiveSignalConfig,
-    MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig, MigrateGoalsConfig,
-    MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
-    MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
-    MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
+    MigrateDatabaseUrl, MigrateEgressConfig, MigrateEmbedProviderRename,
+    MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig, MigrateFocusAutoConsolidateMinWindow,
+    MigrateForgettingConfig, MigrateGoalsConfig, MigrateGonkagateToGonka,
+    MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete, MigrateMagicDocsConfig,
+    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpRetryAndToolTimeout,
+    MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
@@ -3588,6 +3589,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateEmbedProviderRename),
             // Step 50 — add mcp startup_retry_backoff_ms and tool_timeout_secs (#4004)
             Box::new(MigrateMcpRetryAndToolTimeout),
+            // Step 51 — add embed_timeout_secs and compress_timeout_secs to [memory.fidelity] (#4645, #4651)
+            Box::new(MigrateFidelityTimeoutDefaults),
         ]
     });
 
@@ -3716,6 +3719,68 @@ pub fn migrate_embed_provider_rename(toml_src: &str) -> Result<MigrationResult, 
     })
 }
 
+/// Add commented-out `embed_timeout_secs` and `compress_timeout_secs` to `[memory.fidelity]`
+/// when it is present in the config but does not yet have these keys (#4645, #4651).
+///
+/// Both keys default to 30 seconds when absent; this step surfaces them for discovery.
+/// Only runs when `[memory.fidelity]` is present — configs without fidelity are unchanged.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the
+/// migration function convention for use in chained pipelines.
+pub fn migrate_fidelity_timeout_defaults(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    let has_embed = toml_src.contains("embed_timeout_secs");
+    let has_compress = toml_src.contains("compress_timeout_secs");
+
+    if (has_embed && has_compress) || !toml_src.contains("[memory.fidelity]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let mut output = toml_src.to_owned();
+    let mut changed = false;
+
+    if !has_embed {
+        let comment = "# embed_timeout_secs = 30  \
+            # timeout in seconds for embed calls in fidelity scoring\n";
+        output = output.replacen(
+            "[memory.fidelity]\n",
+            &format!("[memory.fidelity]\n{comment}"),
+            1,
+        );
+        changed = true;
+    }
+
+    if !has_compress {
+        let comment = "# compress_timeout_secs = 30  \
+            # timeout in seconds for the LLM compress call in fidelity scoring\n";
+        output = output.replacen(
+            "[memory.fidelity]\n",
+            &format!("[memory.fidelity]\n{comment}"),
+            1,
+        );
+        changed = true;
+    }
+
+    if changed {
+        Ok(MigrationResult {
+            output,
+            changed_count: 1,
+            sections_changed: vec!["memory.fidelity".to_owned()],
+        })
+    } else {
+        Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        })
+    }
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {
@@ -3731,8 +3796,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            50,
-            "MIGRATIONS registry must contain all 50 sequential steps"
+            51,
+            "MIGRATIONS registry must contain all 51 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -5319,7 +5384,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_has_fifty_entries() {
-        assert_eq!(MIGRATIONS.len(), 50);
+        assert_eq!(MIGRATIONS.len(), 51);
     }
 
     #[test]
@@ -5358,7 +5423,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–49).
+        // Names must follow the documented step order (steps 1–51).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -5410,6 +5475,7 @@ prompt_cache_ttl = "1h"
             "migrate_five_signal_config",
             "migrate_embed_provider_rename",
             "migrate_mcp_retry_and_tool_timeout",
+            "migrate_fidelity_timeout_defaults",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
@@ -5792,6 +5858,51 @@ trace_extraction_embed_provider = \"live\"\n";
             result
                 .output
                 .contains("trace_extraction_embedding_provider = \"live\"")
+        );
+    }
+
+    // ── migrate_fidelity_timeout_defaults tests (#4645, #4651) ───────────────
+
+    #[test]
+    fn migrate_fidelity_timeout_defaults_adds_both_comments_when_absent() {
+        let src = "[memory.fidelity]\nenabled = true\n";
+        let result = migrate_fidelity_timeout_defaults(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(result.output.contains("embed_timeout_secs"));
+        assert!(result.output.contains("compress_timeout_secs"));
+        assert!(
+            result
+                .sections_changed
+                .contains(&"memory.fidelity".to_owned())
+        );
+    }
+
+    #[test]
+    fn migrate_fidelity_timeout_defaults_idempotent_when_both_present() {
+        let src = "[memory.fidelity]\nembed_timeout_secs = 30\ncompress_timeout_secs = 30\n";
+        let result = migrate_fidelity_timeout_defaults(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+    }
+
+    #[test]
+    fn migrate_fidelity_timeout_defaults_skips_when_no_fidelity_section() {
+        let src = "[agent]\nname = \"test\"\n";
+        let result = migrate_fidelity_timeout_defaults(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_fidelity_timeout_defaults_adds_only_missing_key() {
+        let src = "[memory.fidelity]\nenabled = true\nembed_timeout_secs = 60\n";
+        let result = migrate_fidelity_timeout_defaults(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(result.output.contains("compress_timeout_secs"));
+        // embed_timeout_secs already present as a real key, must not be duplicated
+        assert_eq!(
+            result.output.matches("embed_timeout_secs").count(),
+            1,
+            "embed_timeout_secs must appear exactly once"
         );
     }
 }

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -9,7 +9,8 @@
 //! admission control, and `GonkaGate` advisory notice; step 46 is an advisory notice for Cocoon;
 //! steps 47–48 add trace metadata and five-signal SYNAPSE config; step 49 renames
 //! `embed_provider` → `embedding_provider` (#4480); step 50 adds MCP
-//! `startup_retry_backoff_ms` and `tool_timeout_secs` (#4004).
+//! `startup_retry_backoff_ms` and `tool_timeout_secs` (#4004); step 51 adds
+//! `embed_timeout_secs` and `compress_timeout_secs` to `[memory.fidelity]` (#4645, #4651).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -19,26 +20,27 @@ use super::{
     MigrateError, Migration, MigrationResult, migrate_acp_subagents_config,
     migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_autodream_config,
     migrate_cocoon_provider_notice, migrate_compression_predictor_config, migrate_database_url,
-    migrate_egress_config, migrate_embed_provider_rename, migrate_five_signal_config,
-    migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
-    migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
-    migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
-    migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels, migrate_memory_graph_config,
-    migrate_memory_hebbian_config, migrate_memory_hebbian_consolidation_config,
-    migrate_memory_hebbian_spread_config, migrate_memory_persona_config,
-    migrate_memory_reasoning_config, migrate_memory_reasoning_judge_config,
-    migrate_memory_retrieval_config, migrate_memory_retrieval_query_bias,
-    migrate_microcompact_config, migrate_orchestration_orchestrator_provider,
-    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
-    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_quality_config,
-    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
+    migrate_egress_config, migrate_embed_provider_rename, migrate_fidelity_timeout_defaults,
+    migrate_five_signal_config, migrate_focus_auto_consolidate_min_window,
+    migrate_forgetting_config, migrate_goals_config, migrate_hooks_permission_denied_config,
+    migrate_hooks_turn_complete_config, migrate_magic_docs_config, migrate_mcp_elicitation_config,
+    migrate_mcp_max_connect_attempts, migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels,
+    migrate_memory_graph_config, migrate_memory_hebbian_config,
+    migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
+    migrate_memory_persona_config, migrate_memory_reasoning_config,
+    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
+    migrate_memory_retrieval_query_bias, migrate_microcompact_config,
+    migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
+    migrate_otel_filter, migrate_planner_model_to_provider, migrate_provider_max_concurrent,
+    migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
+    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
     migrate_telemetry_config, migrate_tools_compression_config, migrate_trace_metadata,
     migrate_vigil_config,
 };
 
-// ── Wrapper structs for all 50 sequential migration steps ───────────────────────────────────────
+// ── Wrapper structs for all 51 sequential migration steps ───────────────────────────────────────
 
 pub(super) struct MigrateSttToProvider;
 impl Migration for MigrateSttToProvider {
@@ -587,5 +589,16 @@ impl Migration for MigrateMcpRetryAndToolTimeout {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_mcp_retry_and_tool_timeout(toml_src)
+    }
+}
+
+pub(super) struct MigrateFidelityTimeoutDefaults;
+impl Migration for MigrateFidelityTimeoutDefaults {
+    fn name(&self) -> &'static str {
+        "migrate_fidelity_timeout_defaults"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_fidelity_timeout_defaults(toml_src)
     }
 }

--- a/crates/zeph-context/benches/fidelity_scorer.rs
+++ b/crates/zeph-context/benches/fidelity_scorer.rs
@@ -61,6 +61,8 @@ fn bench_score_500(c: &mut Criterion) {
         embed_concurrency: 32,
         max_embed_input_tokens: None,
         max_compress_input_tokens: None,
+        embed_timeout_secs: 30,
+        compress_timeout_secs: 30,
     };
     let tc = CharDivTc(4);
     let base_messages = make_synthetic_messages(500);

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -38,8 +38,8 @@ pub use zeph_config::FidelityConfig;
 /// Indexes not included in the result either had no content, already had an embedding
 /// cached in `msg.metadata.embedding`, or produced an error (errors are logged at `debug`
 /// level and silently skipped — scoring falls back to keyword overlap for those messages).
-/// Each embed call is bounded by a 30-second timeout; timed-out messages are skipped with
-/// a `warn`-level log.
+/// Each embed call is bounded by [`FidelityConfig::embed_timeout_secs`]; timed-out messages
+/// are skipped with a `warn`-level log.
 ///
 /// Only exempt messages (focus-pinned, inserted memory, system) are skipped; for non-exempt messages the content
 /// is optionally truncated to `config.max_embed_input_tokens * 4` bytes (at a char boundary)
@@ -101,9 +101,10 @@ where
         Some((i, content))
     });
 
+    let timeout = Duration::from_secs(config.embed_timeout_secs);
     futures::stream::iter(tasks)
         .map(|(i, content)| async move {
-            let result = tokio::time::timeout(Duration::from_secs(30), embed(&content)).await;
+            let result = tokio::time::timeout(timeout, embed(&content)).await;
             match result {
                 Ok(Ok(vec)) => Some((i, vec)),
                 Ok(Err(e)) => {
@@ -203,7 +204,7 @@ impl FidelityScorer {
     ///
     /// The two providers may be the same instance or different ones (e.g. a fast embedding
     /// model for `embed_provider` and a generative model for `compress_provider`).
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     pub async fn score_and_apply(
         &self,
         messages: &mut Vec<Message>,
@@ -226,7 +227,12 @@ impl FidelityScorer {
             && p.supports_embeddings()
         {
             let _span = info_span!("context.fidelity.embed_query").entered();
-            match tokio::time::timeout(Duration::from_secs(30), p.embed(query)).await {
+            match tokio::time::timeout(
+                Duration::from_secs(config.embed_timeout_secs),
+                p.embed(query),
+            )
+            .await
+            {
                 Ok(Ok(v)) => Some(v),
                 Ok(Err(e)) => {
                     tracing::warn!(error = %e, "semantic scoring provider unavailable, falling back to keyword");
@@ -277,8 +283,11 @@ impl FidelityScorer {
                     },
                 ))
                 .map(|(i, content)| async move {
-                    let result =
-                        tokio::time::timeout(Duration::from_secs(30), p.embed(&content)).await;
+                    let result = tokio::time::timeout(
+                        Duration::from_secs(config.embed_timeout_secs),
+                        p.embed(&content),
+                    )
+                    .await;
                     match result {
                         Ok(Ok(v)) => Some((i, v)),
                         Ok(Err(e)) => {
@@ -697,7 +706,11 @@ async fn render_compressed(
             );
             let result = {
                 let _enter = span.enter();
-                tokio::time::timeout(Duration::from_secs(30), p.chat(&req)).await
+                tokio::time::timeout(
+                    Duration::from_secs(config.compress_timeout_secs),
+                    p.chat(&req),
+                )
+                .await
             };
 
             match result {
@@ -919,6 +932,8 @@ mod tests {
             embed_concurrency: 32,
             max_embed_input_tokens: None,
             max_compress_input_tokens: None,
+            embed_timeout_secs: 30,
+            compress_timeout_secs: 30,
         }
     }
 
@@ -1198,6 +1213,8 @@ mod tests {
             embed_concurrency: 32,
             max_embed_input_tokens: None,
             max_compress_input_tokens: None,
+            embed_timeout_secs: 30,
+            compress_timeout_secs: 30,
         };
         let tc = FixedTc(4);
         let mut messages = vec![make_msg(Role::System, ""), make_msg(Role::User, "")];
@@ -2364,9 +2381,33 @@ mod tests {
                 Ok(vec![1.0f32])
             })
         };
-        // Run the pre-pass; the 30-second timeout fires before the 60-second sleep.
+        // Run the pre-pass; the 30-second timeout fires before the 45-second sleep.
         let result = embed_prepass(&messages, &embed, &cfg, 0).await;
         assert!(result.is_empty(), "timed-out embed must be skipped");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn embed_prepass_custom_timeout_respected() {
+        let messages = vec![
+            make_msg(Role::System, "system"),
+            make_msg(Role::User, "user"),
+        ];
+        // embed_timeout_secs=5: provider takes 10 s → must be skipped.
+        let cfg = FidelityConfig {
+            embed_timeout_secs: 5,
+            ..FidelityConfig::default()
+        };
+        let embed = |_text: &str| -> EmbedFuture {
+            Box::pin(async {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                Ok(vec![1.0f32])
+            })
+        };
+        let result = embed_prepass(&messages, &embed, &cfg, 0).await;
+        assert!(
+            result.is_empty(),
+            "custom embed_timeout_secs must be honored"
+        );
     }
 
     // ── FidelityConfig new fields ─────────────────────────────────────────────
@@ -2377,6 +2418,13 @@ mod tests {
         assert_eq!(cfg.embed_concurrency, 32);
         assert!(cfg.max_embed_input_tokens.is_none());
         assert!(cfg.max_compress_input_tokens.is_none());
+    }
+
+    #[test]
+    fn fidelity_config_timeout_defaults() {
+        let cfg = FidelityConfig::default();
+        assert_eq!(cfg.embed_timeout_secs, 30);
+        assert_eq!(cfg.compress_timeout_secs, 30);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `embed_timeout_secs: u64` (default: 30) and `compress_timeout_secs: u64` (default: 30) to `FidelityConfig` in `crates/zeph-config/src/fidelity.rs`
- Replace four hardcoded `Duration::from_secs(30)` in `crates/zeph-context/src/fidelity.rs`: three embed call sites use `embed_timeout_secs`, one LLM compress call site uses `compress_timeout_secs`
- Add migration step 51 (`migrate_fidelity_timeout_defaults`) so existing `[memory.fidelity]` configs are upgraded automatically via `--migrate-config`
- Update `config/default.toml` with commented-out hints for the new fields

Operators running slow embedding providers (large local models on CPU) can now tune these values via `[memory.fidelity]` in `config.toml` instead of hitting a silent 30-second hard cutoff.

Closes #4645, Closes #4651

## Test plan

- [ ] `cargo nextest run -p zeph-config -p zeph-context --lib` — 712 tests PASS
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [ ] Default values (`embed_timeout_secs == 30`, `compress_timeout_secs == 30`) covered by unit tests
- [ ] Custom `embed_timeout_secs` flows through to embed call: `embed_prepass_custom_timeout_respected` test
- [ ] Migration step 51 tested: normal, idempotent, no-section, partial-key scenarios