### PR TITLE
fix(config): validate embed/compress timeouts and correct stale section refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   directory that is cleaned up on process exit. The plugin is never written to the permanent
   plugins store and its config overlays are never applied.
 
+### Fixed
+
+- `zeph-config`: `FidelityConfig::validate()` now rejects `embed_timeout_secs = 0` and
+  `compress_timeout_secs = 0` with a descriptive error referencing `[memory.fidelity]`; a zero
+  value caused immediate `tokio::time::timeout` expiry, silently degrading scoring to keyword
+  overlap on every turn (closes #4666).
+- `zeph-config`, `zeph-context`, `zeph-agent-context`: corrected stale `[context.fidelity]`
+  references to `[memory.fidelity]` in module doc comment, warn log, and field doc comment
+  (closes #4667).
+
 ### Changed
 
 - refactor(context): make embed and compress timeouts in `FidelityScorer` configurable via

--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -232,7 +232,7 @@ pub struct ContextAssemblyView<'a> {
     pub tiered_retrieval_validator: Option<Arc<zeph_llm::any::AnyProvider>>,
 
     // ── CAM: Context-Adaptive Memory (#4547) ─────────────────────────────────
-    /// Fidelity scoring configuration resolved from `[context.fidelity]`.
+    /// Fidelity scoring configuration resolved from `[memory.fidelity]`.
     ///
     /// `None` when fidelity scoring is not configured (treated as `enabled = false`).
     /// `Some(&cfg)` with `cfg.enabled = false` is also a no-op (early-return inside scorer).

--- a/crates/zeph-config/src/fidelity.rs
+++ b/crates/zeph-config/src/fidelity.rs
@@ -3,7 +3,7 @@
 
 //! Configuration for Context-Adaptive Memory (CAM) fidelity scoring.
 //!
-//! [`FidelityConfig`] is serialised from the `[context.fidelity]` section in `config.toml`.
+//! [`FidelityConfig`] is serialised from the `[memory.fidelity]` section in `config.toml`.
 //! When `enabled = false` (the default) the fidelity scorer is a complete no-op.
 
 use crate::providers::ProviderName;
@@ -150,22 +150,34 @@ impl FidelityConfig {
     /// ```
     pub fn validate(&self) -> Result<(), String> {
         if self.compressed_threshold < 0.0 {
-            return Err("context.fidelity: compressed_threshold must be >= 0.0".into());
+            return Err("memory.fidelity: compressed_threshold must be >= 0.0".into());
         }
         if self.full_threshold > 1.0 {
-            return Err("context.fidelity: full_threshold must be <= 1.0".into());
+            return Err("memory.fidelity: full_threshold must be <= 1.0".into());
         }
         if self.full_threshold < self.compressed_threshold {
             return Err(format!(
-                "context.fidelity: full_threshold ({}) must be >= compressed_threshold ({})",
+                "memory.fidelity: full_threshold ({}) must be >= compressed_threshold ({})",
                 self.full_threshold, self.compressed_threshold
             ));
         }
         if self.lookahead_depth > 5 {
             return Err(format!(
-                "context.fidelity: lookahead_depth ({}) must be <= 5",
+                "memory.fidelity: lookahead_depth ({}) must be <= 5",
                 self.lookahead_depth
             ));
+        }
+        if self.embed_timeout_secs == 0 {
+            return Err(
+                "memory.fidelity: embed_timeout_secs must be > 0 (zero causes immediate timeout)"
+                    .into(),
+            );
+        }
+        if self.compress_timeout_secs == 0 {
+            return Err(
+                "memory.fidelity: compress_timeout_secs must be > 0 (zero causes immediate timeout)"
+                    .into(),
+            );
         }
         Ok(())
     }
@@ -386,5 +398,41 @@ mod tests {
         let cfg: FidelityConfig = toml::from_str("enabled = false").unwrap();
         assert_eq!(cfg.embed_timeout_secs, 30);
         assert_eq!(cfg.compress_timeout_secs, 30);
+    }
+
+    #[test]
+    fn validate_embed_timeout_zero_is_err() {
+        let cfg = FidelityConfig {
+            embed_timeout_secs: 0,
+            ..FidelityConfig::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.contains("embed_timeout_secs"),
+            "error should mention embed_timeout_secs: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_compress_timeout_zero_is_err() {
+        let cfg = FidelityConfig {
+            compress_timeout_secs: 0,
+            ..FidelityConfig::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.contains("compress_timeout_secs"),
+            "error should mention compress_timeout_secs: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_timeout_one_is_ok() {
+        let cfg = FidelityConfig {
+            embed_timeout_secs: 1,
+            compress_timeout_secs: 1,
+            ..FidelityConfig::default()
+        };
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -82,7 +82,7 @@ async fn embed_prepass_dyn(
 ) -> std::collections::HashMap<usize, Vec<f32>> {
     let concurrency = if config.embed_concurrency == 0 {
         tracing::warn!(
-            "embed_concurrency is 0, clamping to 1; set a positive value in [context.fidelity]"
+            "embed_concurrency is 0, clamping to 1; set a positive value in [memory.fidelity]"
         );
         1
     } else {


### PR DESCRIPTION
## Summary

- `FidelityConfig::validate()` now rejects `embed_timeout_secs = 0` and `compress_timeout_secs = 0` with a descriptive error referencing `[memory.fidelity]`; a zero value caused immediate `tokio::time::timeout` expiry on every embed/compress call, silently degrading fidelity scoring to keyword overlap without any startup warning.
- Corrected three stale `[context.fidelity]` references to `[memory.fidelity]` in module doc comment, warn log message, and field doc comment. Tracing span names (`context.fidelity.*`) are intentionally unchanged — they follow the `<crate>.<subsystem>.<op>` naming convention, not TOML section names.

## Changes

- `crates/zeph-config/src/fidelity.rs` — added two validation checks in `validate()`; also corrected existing error messages that still used `context.fidelity:`; fixed module doc comment
- `crates/zeph-context/src/fidelity.rs` — fixed warn log message
- `crates/zeph-agent-context/src/state.rs` — fixed field doc comment
- `CHANGELOG.md` — added `### Fixed` entries in `[Unreleased]`

## Tests

Three new unit tests in `crates/zeph-config/src/fidelity.rs`:
- `validate_embed_timeout_zero_is_err` — zero returns `Err` with correct field reference
- `validate_compress_timeout_zero_is_err` — zero returns `Err` with correct field reference
- `validate_timeout_one_is_ok` — both = 1 returns `Ok`

Closes #4666, #4667