### PR TITLE
spec(worktree-subsystem): add specification for native worktree subsystem

### DIFF
--- a/specs/063-worktree-subsystem/brd.md
+++ b/specs/063-worktree-subsystem/brd.md
@@ -1,0 +1,108 @@
+---
+aliases:
+  - Worktree Subsystem BRD
+  - BRD-063
+tags:
+  - sdd
+  - brd
+  - worktree
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/063-worktree-subsystem/srs]]"
+  - "[[specs/063-worktree-subsystem/spec]]"
+  - "[[specs/parity-claude-code-3918/spec]]"
+  - "[[specs/045-subagent-lifecycle/spec]]"
+---
+
+# BRD-063: Worktree Subsystem + `worktree.base_ref`
+
+## 1. Business Context
+
+Zeph's subagents today share the parent agent's working directory. When a subagent performs file edits,
+shell commands, or code generation, those changes immediately affect the repository that the parent is
+also operating in. This creates two problems:
+
+1. **Contamination risk** — a failing or incorrect subagent modifies the parent's working tree.
+2. **Lack of isolation** — multiple subagents running concurrently may step on each other's filesystem
+   changes, producing unpredictable results.
+
+Claude Code (the primary parity target, `specs/parity-claude-code-3918/spec.md`) provides
+`worktree.baseRef` semantics that give each agent an isolated git worktree. Zeph deferred this
+capability in the parity spec (rows 40–41) because no worktree subsystem existed. Issue #4655 delivers
+that subsystem as a prerequisite for the deferred parity items.
+
+## 2. Stakeholders
+
+| Stakeholder | Interest |
+|---|---|
+| Agent operators (developers using Zeph) | Agents that write code operate in isolation without contaminating the main branch |
+| Zeph core contributors | Clean architecture: git I/O lives in a dedicated crate, not scattered across tools |
+| Security-conscious users | Subagent blast radius is bounded to its worktree branch |
+
+## 3. Business Goals
+
+**BG-1.** Provide per-subagent git worktree isolation so that file-system operations performed by a
+subagent do not affect the parent working tree or other subagents.
+
+**BG-2.** Deliver a `worktree.base_ref` config knob (`fresh | head`) controlling whether a subagent
+branches from the pristine remote default (`origin/<default_branch>`) or from the parent's current
+local `HEAD`.
+
+**BG-3.** Keep the feature entirely opt-in (`worktree.enabled = false` default) so existing deployments
+are unaffected.
+
+**BG-4.** Establish the infrastructure foundation for the deferred parity items: `worktree.bgIsolation`
+(child-process isolation, issue #4656) and full concurrent worktree execution.
+
+## 4. Scope
+
+### In Scope
+
+- New `zeph-worktree` crate: `WorktreeManager`, `WorktreeHandle`, `WorktreeError`, `GitRunner` trait.
+- Config types in `zeph-config`: `WorktreeConfig`, `WorktreeBaseRef`.
+- Integration with `zeph-subagent`: per-agent opt-in via `permissions.worktree`, serialised execution
+  under `CwdGuard` mutex, `set_working_directory` disabled for worktree agents.
+- Bootstrap integration in binary: capability probe, manager construction.
+- CLI: `zeph worktree list`, `zeph worktree clean`.
+- TUI: command palette entry.
+- `--init` wizard option; `--migrate-config` step 53.
+- Live-testing playbook and coverage-status rows.
+
+### Out of Scope (deferred)
+
+- `bgIsolation` / child-process isolation — deferred to issue #4656.
+- True concurrent worktree agent execution — deferred to cwd-threading or bgIsolation PR.
+- Merge/rebase orchestration between worktree and main branch.
+- Conflict resolution tooling.
+- Embedded `git2` / `gix` library — shell-out only.
+
+## 5. Constraints
+
+| Constraint | Rationale |
+|---|---|
+| `worktree.enabled = false` by default | Zero impact on existing users |
+| Shell out to `git` (no `git2`/`gix`) | Matches codebase convention; no new heavy deps |
+| MVP: concurrency-1 for worktree agents | In-process agents share process cwd; safe isolation requires serialisation |
+| All secrets resolved from age vault | Vault-first policy (CLAUDE.md) |
+
+## 6. Success Criteria
+
+| Criterion | Measurable Target |
+|---|---|
+| Worktree created for opted-in subagent | `git worktree list` shows the worktree after spawn |
+| `base_ref = fresh` produces a branch at `origin/<default>` | Resolved commit = `git rev-parse origin/<default>` |
+| `base_ref = head` produces a branch at parent HEAD | Resolved commit = `git rev-parse HEAD` at spawn time |
+| CwdGuard serialises concurrent worktree agent | Second worktree agent blocks until first releases guard |
+| Worktree removed on completion | `git worktree list` no longer shows it after cleanup |
+| Non-worktree agents unaffected | Existing test suite passes with `worktree.enabled = false` |
+| Startup capability probe catches missing git | Clear error at bootstrap, not at first spawn |
+
+## 7. Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `git fetch` latency blocks spawn (fresh mode) | Medium | Single-attempt with await-discipline timeout; clear error |
+| `origin/HEAD` symref unset in CI/shallow clones | Medium | `config.default_branch` escape hatch; error `BaseRefUnresolved` |
+| Worktree leak on crash | Low | `worktree clean` CLI op; startup reconciler via `git worktree list --porcelain` |
+| User confusion: uncommitted changes absent in worktree | Medium | Runtime dirty-tree warning; docs |

--- a/specs/063-worktree-subsystem/nfr.md
+++ b/specs/063-worktree-subsystem/nfr.md
@@ -1,0 +1,130 @@
+---
+aliases:
+  - Worktree Subsystem NFR
+  - NFR-063
+tags:
+  - sdd
+  - nfr
+  - worktree
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/063-worktree-subsystem/brd]]"
+  - "[[specs/063-worktree-subsystem/srs]]"
+  - "[[specs/063-worktree-subsystem/spec]]"
+---
+
+# NFR-063: Worktree Subsystem Non-Functional Requirements
+
+ISO/IEC 25010:2011 — Software Product Quality
+
+## 1. Performance Efficiency (ISO 25010 §4.1)
+
+**NFR-PERF-01 — Worktree creation latency (head mode):**  
+`WorktreeManager::create` with `base_ref = head` SHALL complete within **2 seconds** on a local SSD
+under normal conditions (no network I/O). `git worktree add` is the dominant operation.
+
+**NFR-PERF-02 — Worktree creation latency (fresh mode):**  
+`WorktreeManager::create` with `base_ref = fresh` SHOULD complete within **30 seconds** when network
+connectivity is available and the repo has a recent fetch cache. The await-discipline timeout SHALL
+abort the `git fetch` and fail fast if this bound is exceeded.
+
+**NFR-PERF-03 — Worktree removal latency:**  
+`WorktreeManager::remove` SHALL complete within **1 second** on a local SSD.
+
+**NFR-PERF-04 — Zero overhead when disabled:**  
+When `worktree.enabled = false`, the worktree subsystem SHALL contribute zero runtime overhead to the
+agent spawn path. No git invocations, no mutex contention, no cwd manipulation.
+
+## 2. Reliability (ISO 25010 §4.2)
+
+**NFR-REL-01 — Cwd restore on panic:**  
+The `CwdGuard` RAII guard SHALL restore the previous cwd even if the worktree agent task panics.
+The process cwd MUST NOT be left pointing to a removed or foreign directory after any code path.
+
+**NFR-REL-02 — Cleanup on cancellation:**  
+A cancelled worktree agent SHALL trigger cwd restoration and worktree removal (if `cleanup_on_completion
+= true`). The guard SHALL be released before the worktree is removed (see FR-CLEANUP-02/03).
+
+**NFR-REL-03 — Stale worktree detection:**  
+After a crash that leaves worktrees on disk, the next startup SHALL detect them via
+`WorktreeManager::reconcile()` (reading `git worktree list --porcelain`) and offer removal via
+`zeph worktree clean`.
+
+## 3. Security (ISO 25010 §4.3)
+
+**NFR-SEC-01 — Branch name sanitisation:**  
+Branch name components derived from subagent IDs SHALL match `^[A-Za-z0-9._-]+$`. Any component not
+matching SHALL be rejected with `WorktreeError::InvalidBranchName` before any git call.
+
+**NFR-SEC-02 — Path traversal prevention:**  
+`config.root` SHALL be canonicalised at construction. The canonical path MUST be inside the repo root
+or an explicitly-allowed sibling. Paths outside SHALL be rejected with `WorktreeError::RootOutsideRepo`.
+
+**NFR-SEC-03 — Git arg hygiene:**  
+All `git` invocations that accept user-derived values SHALL use `--` separators. Commitish arguments
+SHALL be pre-validated with `git rev-parse --verify` before being passed to `git worktree add`.
+
+**NFR-SEC-04 — `set_working_directory` disabled:**  
+Worktree-opted agents SHALL have `set_working_directory` in their effective denylist, enforced through
+the existing `FilteredToolExecutor` machinery. This prevents in-session cwd escape.
+
+**NFR-SEC-05 — Sanitised error messages:**  
+Raw git stderr SHALL be logged at `tracing::debug` level only. User-facing error messages SHALL be
+locale-independent, sanitised strings that do not leak internal paths or credentials.
+
+## 4. Maintainability (ISO 25010 §4.4)
+
+**NFR-MAIN-01 — Testability:**  
+`GitRunner` trait SHALL be the sole seam for unit testing path/branch-name logic without a real git
+repo. All `WorktreeManager` logic that depends on git output SHALL route through `GitRunner`.
+
+**NFR-MAIN-02 — Crate isolation:**  
+`zeph-worktree` SHALL NOT depend on `zeph-core`, `zeph-subagent`, or `zeph-channels`. Dependency
+direction is `zeph-subagent → zeph-worktree → (zeph-config, tokio, thiserror, tracing, serde)`.
+
+**NFR-MAIN-03 — TODO markers for deferred work:**  
+The `WorktreeManager` doc comment SHALL contain:
+```
+// TODO(critic D1): concurrent per-agent cwd isolation requires child-process bgIsolation or
+// full ToolExecutor cwd-threading; in-process MVP is concurrency-1 only.
+```
+The `base_ref` resolution logic SHALL contain:
+```
+// TODO(critic D2): head worktree does not include parent uncommitted changes by design;
+// revisit if users need stash-based propagation.
+```
+
+**NFR-MAIN-04 — Documentation:**  
+All `pub` types, traits, functions, and methods SHALL have `///` doc comments explaining what the item
+does and why a caller would use it, per the project documentation policy.
+
+## 5. Portability (ISO 25010 §4.5)
+
+**NFR-PORT-01 — Git on PATH:**  
+The subsystem requires `git` ≥ 2.5 on PATH. This is detected at startup (FR-PROBE-01) when enabled.
+No other external binaries are required.
+
+**NFR-PORT-02 — macOS, Linux:**  
+The subsystem SHALL work on macOS and Linux. Windows is not a supported target for Zeph.
+
+## 6. Usability (ISO 25010 §4.6)
+
+**NFR-USE-01 — Clear startup error:**  
+When the capability probe (FR-PROBE-01/02) fails, the error message SHALL name the missing capability,
+state the minimum version or configuration required, and suggest a corrective action (e.g. "Install git
+≥ 2.5 or set `worktree.enabled = false`").
+
+**NFR-USE-02 — Dirty-tree warning:**  
+The runtime warning for uncommitted changes (FR-WT-04) SHALL include the list of changed paths
+(truncated at 5 entries with "…and N more" if longer) to help users understand what is excluded.
+
+## 7. Compatibility (ISO 25010 §4.7)
+
+**NFR-COMPAT-01 — Existing configs:**  
+Adding the `[worktree]` section to an existing config via `--migrate-config` step 53 SHALL be
+idempotent: re-running migration on a config that already has `[worktree]` SHALL be a no-op.
+
+**NFR-COMPAT-02 — Default-off:**  
+All existing behaviour when `worktree.enabled = false` SHALL be identical to behaviour before this
+feature was introduced (no code paths touched in the hot agent loop).

--- a/specs/063-worktree-subsystem/plan.md
+++ b/specs/063-worktree-subsystem/plan.md
@@ -1,0 +1,306 @@
+---
+aliases:
+  - Worktree Subsystem Implementation Plan
+  - plan-063
+tags:
+  - sdd
+  - plan
+  - worktree
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/063-worktree-subsystem/spec]]"
+  - "[[specs/063-worktree-subsystem/tasks]]"
+---
+
+# Implementation Plan — Worktree Subsystem (#4655)
+
+## Phase Overview
+
+| Phase | Description | Crates Touched | LOC Estimate |
+|---|---|---|---|
+| P1 | Config types | `zeph-config` | ~80 |
+| P2 | `zeph-worktree` crate (core logic) | `zeph-worktree` (new) | ~500 |
+| P3 | Integration: subagent manager + CwdGuard | `zeph-subagent` | ~200 |
+| P4 | Bootstrap, CLI, TUI, init/migrate | binary, `zeph-tui`, `zeph-config` | ~150 |
+| P5 | Playbook, coverage-status, docs | `.local/testing/`, `docs/` | non-code |
+
+Total estimated code: ~930 LOC (new + changed). These are net-new lines, not file sizes.
+
+---
+
+## Phase 1: Config Types (`zeph-config`)
+
+**Goal:** Define `WorktreeConfig` and `WorktreeBaseRef` so all other phases can depend on them.
+
+### Files
+
+- `crates/zeph-config/src/worktree.rs` — new file
+- `crates/zeph-config/src/root.rs` — add `pub worktree: WorktreeConfig` field
+- `crates/zeph-config/src/migrate/steps.rs` — add step 53
+
+### Key content
+
+```rust
+// worktree.rs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WorktreeConfig {
+    pub enabled: bool,
+    pub base_ref: WorktreeBaseRef,
+    pub default_branch: String,
+    pub root: String,
+    pub branch_prefix: String,
+    pub prune_branch_on_remove: bool,
+    pub cleanup_on_completion: bool,
+}
+
+impl Default for WorktreeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            base_ref: WorktreeBaseRef::default(),
+            default_branch: "main".into(),
+            root: ".claude/worktrees".into(),
+            branch_prefix: "agent/".into(),
+            prune_branch_on_remove: false,
+            cleanup_on_completion: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum WorktreeBaseRef {
+    #[default]
+    Head,
+    Fresh,
+}
+```
+
+Migration step 53: insert `[worktree]` section with defaults if absent. Must be idempotent.
+
+### Acceptance criteria
+- `cargo test -p zeph-config` passes
+- `cargo check -p zeph-config --all-features` clean
+- `WorktreeConfig::default()` round-trips through `toml::to_string` / `toml::from_str`
+
+---
+
+## Phase 2: `zeph-worktree` Crate
+
+**Goal:** Full crate with `WorktreeManager`, `WorktreeHandle`, `WorktreeError`, `GitRunner`.
+
+### New files
+
+```
+crates/zeph-worktree/
+  Cargo.toml
+  src/
+    lib.rs            -- pub re-exports + module declarations
+    manager.rs        -- WorktreeManager impl
+    handle.rs         -- WorktreeHandle struct
+    error.rs          -- WorktreeError (thiserror)
+    git_runner.rs     -- GitRunner trait + DefaultGitRunner impl
+    sanitize.rs       -- branch_name_valid(), canonicalize_root()
+```
+
+### `Cargo.toml` dependencies
+
+```toml
+[dependencies]
+zeph-config = { path = "../zeph-config" }
+tokio = { workspace = true, features = ["process", "fs"] }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
+```
+
+### Logical sub-components
+
+**`sanitize.rs`**
+- `fn validate_branch_component(s: &str) -> Result<(), WorktreeError>` — regex `^[A-Za-z0-9._-]+$`, no leading `-`/`.`, no `..`
+- `fn canonicalize_root(root: &Path, repo_root: &Path) -> Result<PathBuf, WorktreeError>` — canonicalise, assert inside or sibling of repo root
+
+**`git_runner.rs`**
+- `GitRunner` trait: single `async fn run(&self, args: &[&str], cwd: &Path) -> Result<Output, WorktreeError>`
+- `DefaultGitRunner`: invokes `tokio::process::Command::new("git")` with a configurable timeout (default 30s for fetch, 5s for other ops); non-zero exit → `WorktreeError::GitCommand`
+- `FakeGitRunner` (cfg(test)): record args, return pre-configured outputs — used by unit tests
+
+**`manager.rs`** (core logic, ~300 LOC)
+- `WorktreeManager::new` — validate repo root + config, run no git calls here (probe is at bootstrap)
+- `create` — validate branch component, resolve base_ref, call git ops, emit dirty-tree warning, store handle
+- `remove` — `git worktree remove`, optionally `git branch -D`
+- `list` — return `&[WorktreeHandle]` (in-RAM only)
+- `reconcile` — `git worktree list --porcelain` + scan `config.root` dir; return stale handles
+
+### Test surface
+
+| Test | Mechanism |
+|---|---|
+| Branch name validation (good/bad inputs) | Unit test, `FakeGitRunner` |
+| Root canonicalization (inside/outside/symlink) | Unit test with `tempfile` |
+| `create` → git args sent correctly for `head` | `FakeGitRunner`, assert args |
+| `create` → git args sent correctly for `fresh` | `FakeGitRunner`, assert args |
+| `create` fails → `InvalidBranchName` | `FakeGitRunner` |
+| `create` fails → `BaseRefUnresolved` | `FakeGitRunner` (fake `symbolic-ref` fails, `default_branch` empty) |
+| `remove` → `git worktree remove` called | `FakeGitRunner` |
+| `remove` with `prune_branch` → `git branch -D` called | `FakeGitRunner` |
+| `reconcile` → parses `git worktree list --porcelain` output | `FakeGitRunner` with canned output |
+| Dirty-tree warning emitted | `FakeGitRunner`, capture tracing output |
+| Git `--` separator present in all add calls | Assert arg slice in `FakeGitRunner` captures |
+
+### Acceptance criteria
+- `cargo test -p zeph-worktree` passes
+- `cargo clippy -p zeph-worktree -- -D warnings` clean
+- `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc -p zeph-worktree --no-deps` clean
+- All doc-tests pass: `cargo test --doc -p zeph-worktree`
+
+---
+
+## Phase 3: Integration — `zeph-subagent` + CwdGuard
+
+**Goal:** Wire `WorktreeManager` into `SubAgentManager`; implement `CwdGuard` + `CwdRestoreGuard`.
+
+### Files changed
+
+- `crates/zeph-subagent/src/permissions.rs` — add `pub worktree: bool` to `SubAgentPermissions`/`RawPermissions`
+- `crates/zeph-subagent/src/manager.rs` — add `worktree_manager: Option<Arc<WorktreeManager>>`, `cwd_guard: Arc<tokio::sync::Mutex<()>>` fields; integrate in `spawn`
+- `crates/zeph-subagent/src/cwd_guard.rs` — new: `CwdRestoreGuard` (RAII restore + guard holder)
+
+### `CwdRestoreGuard` (RAII)
+
+```rust
+struct CwdRestoreGuard<'a> {
+    prev: PathBuf,
+    _guard: tokio::sync::MutexGuard<'a, ()>,
+}
+
+impl Drop for CwdRestoreGuard<'_> {
+    fn drop(&mut self) {
+        // Attempt restore; log error if it fails (cannot propagate from Drop)
+        if let Err(e) = std::env::set_current_dir(&self.prev) {
+            tracing::error!(path = ?self.prev, err = ?e, "Failed to restore process cwd");
+        }
+    }
+}
+```
+
+### `spawn` integration (pseudocode)
+
+```rust
+// In SubAgentManager::spawn, before building system prompt:
+if let (Some(wm), true) = (&self.worktree_manager, def.permissions.worktree) {
+    // Acquire process-global guard (blocks all other agents)
+    let guard = self.cwd_guard.lock().await;
+    let handle = wm.create(&task_id).await?;   // INV-4: failure = fatal to this spawn
+    let prev = std::env::current_dir()?;
+    std::env::set_current_dir(handle.path())?;
+    let _cwd_guard = CwdRestoreGuard { prev, _guard: guard };
+    // _cwd_guard held for agent's entire run via task-local drop on task completion
+    // ... build system prompt using handle.path() as cwd
+    // ... run agent
+    // _cwd_guard dropped here: restores cwd, releases mutex
+    // THEN: wm.remove(&handle, config.prune_branch_on_remove).await
+}
+```
+
+### `build_filtered_executor` change
+
+```rust
+let mut disallowed = def.disallowed_tools.clone();
+if def.permissions.worktree {
+    disallowed.push(ToolName::from("set_working_directory"));
+}
+FilteredToolExecutor::with_disallowed(base, def.tools.as_deref(), &disallowed)
+```
+
+### Tests
+
+- Concurrency serialisation test (M4 acceptance test):
+  Spawn a fake worktree agent that holds `CwdGuard` for a known duration; assert a second agent's tool
+  execution is queued and does not proceed until the guard is released.
+- Cancellation path: cancel the worktree agent mid-run; assert cwd is restored via `CwdRestoreGuard`
+  `Drop` and the guard is released.
+- `set_working_directory` absent from executor tool list when `permissions.worktree = true`.
+
+### Acceptance criteria
+- Both tests pass
+- `cargo test -p zeph-subagent -- worktree` passes
+- Integration: `cargo nextest run --workspace --lib --bins` passes
+
+---
+
+## Phase 4: Bootstrap, CLI, TUI, Init/Migrate
+
+**Goal:** Wire everything from Phase 1–3 into the binary entry points.
+
+### Bootstrap (binary)
+
+- In `src/agent_setup.rs` or `src/bootstrap.rs`: when `config.worktree.enabled`, run capability probe,
+  construct `WorktreeManager::new(repo_root, config.worktree.clone())`, inject into `SubAgentManager`.
+
+### CLI (`src/cli.rs`)
+
+- Add `Worktree { command: WorktreeCommand }` to top-level enum (or extend `Agents`)
+- `WorktreeCommand::List` → prints table from `reconcile()`
+- `WorktreeCommand::Clean` → calls `reconcile()`, removes stale entries, prints summary
+- Add `--worktree-base-ref` session override to root `Cli` struct
+
+### TUI (`crates/zeph-tui`)
+
+- Add `/worktree list` and `/worktree clean` to command palette
+- During `WorktreeManager::create` / `remove`: emit `SystemStatus` with spinner message
+  "Creating worktree for {agent_id}…" / "Removing worktree for {agent_id}…"
+
+### `--init` wizard
+
+- Add a "Subagent isolation" section after the existing subagent config questions:
+  - "Enable per-subagent git worktrees? [y/N]" → `worktree.enabled`
+  - If yes: "Branch from local HEAD or fetch from remote? [head/fresh]" → `worktree.base_ref`
+  - If fresh: "Default remote branch?" → `worktree.default_branch`
+
+### `--migrate-config` step 53
+
+- Check if `[worktree]` section exists; if not, append with all defaults.
+- Idempotent: skip if already present.
+
+### Acceptance criteria
+- `zeph worktree list` and `zeph worktree clean` exit 0 with expected output on a test repo
+- `--worktree-base-ref fresh` overrides `config.worktree.base_ref` for the session
+- `--migrate-config --in-place` adds `[worktree]` section to a config without one; re-running is a no-op
+- TUI shows spinner during worktree create/remove
+
+---
+
+## Phase 5: Documentation and Testing Artifacts
+
+### Files
+
+- `.local/testing/playbooks/worktree.md` — live testing scenarios (mandatory per CLAUDE.md)
+- `.local/testing/coverage-status.md` — add rows for `zeph-worktree` and `worktree` integration (status: Untested initially)
+- `docs/src/worktree.md` — user-facing docs (mdbook)
+- `CHANGELOG.md` — entry under `[Unreleased]`
+
+### Playbook scenarios
+
+See `spec.md` "Live-Testing Playbook" section for the required scenario list.
+
+### CHANGELOG entry template
+
+```markdown
+### Added
+- `zeph-worktree` crate: git worktree lifecycle management for subagents (#4655)
+- `worktree.base_ref` config (`fresh | head`): controls base commit for subagent worktrees
+- `worktree.enabled` master switch (default `false`): opt-in, zero impact on existing deployments
+- `CwdGuard` process-level serialisation for worktree agents
+- `zeph worktree list` / `zeph worktree clean` CLI commands
+- Startup capability probe for `git` ≥ 2.5 when worktrees enabled
+- Config migration step 53: adds `[worktree]` defaults to existing configs
+```

--- a/specs/063-worktree-subsystem/spec.md
+++ b/specs/063-worktree-subsystem/spec.md
@@ -1,0 +1,344 @@
+---
+aliases:
+  - Worktree Subsystem Spec
+  - spec-063
+tags:
+  - sdd
+  - spec
+  - worktree
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/063-worktree-subsystem/brd]]"
+  - "[[specs/063-worktree-subsystem/srs]]"
+  - "[[specs/063-worktree-subsystem/nfr]]"
+  - "[[specs/063-worktree-subsystem/plan]]"
+  - "[[specs/parity-claude-code-3918/spec]]"
+  - "[[specs/045-subagent-lifecycle/spec]]"
+  - "[[constitution]]"
+---
+
+# Spec-063: Worktree Subsystem + `worktree.base_ref`
+
+**GitHub:** #4655  
+**Branch:** `feat/4655-worktree-baseref-config`  
+**Crate:** `zeph-worktree` (new), `zeph-config` (extends), `zeph-subagent` (extends)  
+**Parent parity spec:** `[[specs/parity-claude-code-3918/spec]]` rows 40–41 (deferred)
+
+---
+
+## Summary
+
+This spec covers the `zeph-worktree` crate and the `worktree.base_ref: fresh | head` config knob.
+Subagents that opt in via `permissions.worktree = true` receive an isolated git worktree for their run.
+The MVP uses **concurrency-1 serialisation** (CwdGuard mutex) because in-process agents share the
+process cwd; true concurrent isolation is deferred to the `bgIsolation` child-process work (#4656).
+
+---
+
+## Key Invariants
+
+These invariants are hard constraints. Violating them silently re-introduces the race conditions that
+the CwdGuard design is built to prevent.
+
+**INV-1 — CwdGuard is run-scoped, not spawn-scoped.**  
+When `worktree.enabled = true` and an agent has `permissions.worktree = true`, a single process-global
+`tokio::sync::Mutex` (`CwdGuard`) MUST be acquired before `set_current_dir(worktree_path)` and MUST
+remain held for the agent's ENTIRE multi-turn run, including all interleaved async tool turns, until
+`set_current_dir(prev_cwd)` has completed and cleanup is done. A "spawn-admission" lock that is
+released once the task is launched is NOT sufficient: the agent executes many tool turns after spawn,
+and any other agent (worktree or plain) executing a tool during a gap would read/cross the mutated
+process cwd.
+
+All other agents — both worktree-opted and plain non-worktree agents — are quiesced (block on the mutex)
+while a worktree agent holds the guard. They share the same process cwd that the worktree agent is
+mutating.
+
+**INV-2 — cwd save/restore with restore-before-remove ordering.**  
+Before entering the worktree: `prev = std::env::current_dir()`, then `set_current_dir(worktree_path)`.
+On exit — success, error, OR cancellation — `set_current_dir(prev)` MUST run in a guaranteed-run path
+(RAII `Drop` or equivalent). The restore MUST occur BEFORE `git worktree remove`. Reversing the
+order would `set_current_dir` into an already-deleted path.
+
+Teardown sequence (normative):
+1. `set_current_dir(prev_cwd)`
+2. Release `CwdGuard`
+3. `git worktree remove {path}` (if `cleanup_on_completion`)
+
+**INV-3 — `set_working_directory` is disallowed for worktree agents.**  
+For every agent with `permissions.worktree = true`, the tool `set_working_directory` MUST appear in
+`disallowed_tools` when the filtered executor is built at `build_filtered_executor`. This is enforced
+through the existing `FilteredToolExecutor::with_disallowed` machinery, not a new mechanism.
+Rationale: `set_working_directory` calls process-global `std::env::set_current_dir` (`cwd.rs:54`);
+allowing it defeats INV-2 and lets the agent escape its worktree mid-run.
+
+**INV-4 — No silent shared-cwd fallback.**  
+If worktree creation fails, the agent spawn MUST fail with a `SubAgentError` wrapping the
+`WorktreeError`. It MUST NOT silently proceed with the parent's cwd. Opting into `worktree: true`
+means the worktree is required. Best-effort fallback is forbidden because it would silently run the
+agent in the wrong repository tree.
+
+---
+
+## NEVER
+
+- **NEVER** hold `CwdGuard` for less than the full run scope (spawn to teardown, including all tool turns).
+- **NEVER** remove the worktree directory before restoring the previous cwd.
+- **NEVER** pass an unvalidated branch component or un-canonicalised `root` path to any `git` invocation.
+- **NEVER** pass a subagent-id derived value as the first argument position in a `git` call without using `--` separator; git interprets leading `-` as flags.
+- **NEVER** expose raw git stderr to the user; log it at `debug`, return a sanitised message.
+- **NEVER** allow `base_ref = fresh` to silently fall back to HEAD when a fetch fails; fail with a clear error.
+- **NEVER** add the `set_working_directory` tool to the allowed list for a worktree-opted agent, even if the caller explicitly requests it.
+- **NEVER** skip the capability probe when `worktree.enabled = true`; a missing `git` must be caught at bootstrap, not at first spawn.
+
+---
+
+## Config Schema
+
+```toml
+[worktree]
+enabled = false                    # opt-in; false = current behaviour, no worktrees created
+base_ref = "head"                  # "fresh" | "head" — base commit for the worktree branch
+default_branch = "main"            # used when base_ref = "fresh"; empty = auto-detect origin/HEAD
+root = ".claude/worktrees"         # relative to repo root; canonicalised at bootstrap
+branch_prefix = "agent/"           # branch = "{prefix}{subagent_id}"
+prune_branch_on_remove = false     # delete the branch after removing the worktree
+cleanup_on_completion = true       # remove worktree when agent completes or is cancelled
+```
+
+Per-agent opt-in in subagent definition frontmatter:
+```yaml
+permissions:
+  worktree: true
+```
+
+---
+
+## Architecture
+
+### New Crate: `crates/zeph-worktree`
+
+Dependency direction: `zeph-subagent → zeph-worktree → (zeph-config, tokio, thiserror, tracing, serde)`
+
+`zeph-worktree` MUST NOT depend on `zeph-core`, `zeph-subagent`, or `zeph-channels`.
+
+```
+WorktreeManager          // owns base repo path + config; create/remove/list/reconcile
+WorktreeHandle           // path, branch_name, base_ref_resolved, subagent_id, created_at (UTC)
+WorktreeError            // thiserror enum — see variants below
+GitRunner (trait)        // abstraction for git invocations (testability seam)
+DefaultGitRunner         // impl: tokio::process::Command, timeout applied inside run()
+```
+
+### `WorktreeManager` API
+
+```rust
+impl WorktreeManager {
+    pub fn new(repo_root: PathBuf, config: WorktreeConfig) -> Result<Self, WorktreeError>;
+    pub async fn create(&self, subagent_id: &str) -> Result<WorktreeHandle, WorktreeError>;
+    pub async fn remove(&self, handle: &WorktreeHandle, prune_branch: bool) -> Result<(), WorktreeError>;
+    pub fn list(&self) -> &[WorktreeHandle];           // live-session in-RAM only
+    pub async fn reconcile(&self) -> Result<Vec<WorktreeHandle>, WorktreeError>; // reads git registry
+}
+```
+
+### `WorktreeError` Variants
+
+```rust
+pub enum WorktreeError {
+    NotAGitRepo,
+    GitCommand { op: String, stderr: String },   // stderr = debug-only; user sees sanitised message
+    PathExists(PathBuf),
+    BaseRefUnresolved { attempted: String },
+    InvalidBranchName(String),
+    RootOutsideRepo(PathBuf),
+    Io(#[from] std::io::Error),
+}
+```
+
+### `GitRunner` Trait
+
+```rust
+#[async_trait]
+pub trait GitRunner: Send + Sync {
+    async fn run(&self, args: &[&str], cwd: &Path) -> Result<std::process::Output, WorktreeError>;
+}
+```
+
+`cwd` is an explicit parameter — this is the one place in the call stack where cwd threading is correct
+by construction. The `DefaultGitRunner` implementation applies the await-discipline external-call timeout
+*inside* `run`; no call site is responsible for applying it.
+
+---
+
+## `base_ref` → Git Operations
+
+### `base_ref = head`
+
+```
+git worktree add -b {branch} -- {path} HEAD
+```
+
+Emits a `tracing::warn!` when `git status --porcelain` is non-empty (see FR-WT-04).
+
+### `base_ref = fresh`
+
+```
+git fetch origin {default_branch}         # single attempt; fail fast on timeout
+git rev-parse --verify origin/{default}   # validate commitish
+git worktree add -b {branch} -- {path} origin/{default_branch}
+```
+
+`default_branch` resolution order:
+1. `config.default_branch` (if non-empty)
+2. `git symbolic-ref refs/remotes/origin/HEAD` → strip `refs/remotes/origin/`
+3. Fail with `WorktreeError::BaseRefUnresolved`
+
+### Default-Branch Auto-Detection
+
+`git symbolic-ref refs/remotes/origin/HEAD` is commonly unset in CI or shallow clones. When this
+command fails and `config.default_branch` is not set, the spawn fails immediately with a clear message:
+> "Cannot resolve default branch: `origin/HEAD` is not set and `worktree.default_branch` is not
+> configured. Set `default_branch` in the `[worktree]` config section."
+
+---
+
+## CwdGuard: Process-Level Serialisation
+
+The `CwdGuard` is a `tokio::sync::Mutex<()>` held at process scope (one instance per
+`WorktreeManager`). The guard lifecycle is:
+
+```
+acquire CwdGuard
+  └─ prev = std::env::current_dir()
+  └─ set_current_dir(worktree_path)
+  └─ run agent (all tool turns, all LLM turns)
+  └─ [on success / error / cancel]
+     └─ RAII Drop: set_current_dir(prev)
+     └─ release CwdGuard
+  └─ git worktree remove {path}   ← AFTER guard released
+```
+
+The RAII guard (`CwdRestoreGuard`) captures `prev` at construction and calls `set_current_dir(prev)`
+in its `Drop` impl. This ensures restore happens on panic and cancellation, not just normal completion.
+
+### Acceptance Test (M4 — concurrency serialisation)
+
+A test MUST verify: when a worktree agent is active (holds `CwdGuard`), a second agent's tool turn is
+blocked until the first agent's run completes and the guard is released. Specifically:
+
+> Spawn a worktree agent. While it is running (before it releases the guard), attempt to execute a
+> tool call from a plain subagent. Assert that the plain agent's tool call does not begin until the
+> worktree agent has completed its run and the guard is released.
+
+This test ensures INV-1 holds for both worktree-opted and plain agents.
+
+---
+
+## Startup Capability Probe
+
+Runs at bootstrap when `worktree.enabled = true` (before any spawn):
+
+1. `git --version` → parse major.minor; fail if < 2.5 with: "git ≥ 2.5 is required for worktree support (found: {version}). Upgrade git or set `worktree.enabled = false`."
+2. `git rev-parse --is-inside-work-tree` from `repo_root` → fail if returns non-zero: "Zeph's working directory is not inside a git repository. Worktree support requires a git repo. Set `worktree.enabled = false` to disable."
+
+Neither probe runs when `worktree.enabled = false`.
+
+---
+
+## Branch and Path Sanitisation
+
+**Branch component validation:**  
+The `{subagent_id}` component of the branch name MUST match `^[A-Za-z0-9._-]+$`.  
+It MUST NOT begin with `-` or `.`.  
+It MUST NOT contain `..` or `/`.  
+Violation: `WorktreeError::InvalidBranchName(id)`.
+
+**Root path canonicalisation:**  
+`config.root` is canonicalised via `std::fs::canonicalize` or equivalent at `WorktreeManager::new`.  
+The canonical path MUST be a subdirectory of `repo_root` or a sibling of `repo_root`.  
+Paths that resolve outside: `WorktreeError::RootOutsideRepo(canonical)`.
+
+**git arg hygiene:**  
+All git invocations that accept branch names or paths use `--` separator:  
+```
+git worktree add -b {branch} -- {path} {commitish}
+```
+Commitish is pre-validated with `git rev-parse --verify {commitish}` before use.
+
+---
+
+## Integration Points
+
+### `zeph-config`
+
+New file `crates/zeph-config/src/worktree.rs`:
+- `WorktreeConfig` struct with `#[serde(default)]` on all fields
+- `WorktreeBaseRef` enum: `#[non_exhaustive]`, `#[default] Head`, serde `rename_all = "snake_case"`
+- Add `pub worktree: WorktreeConfig` to root config struct (alongside `agents: SubAgentConfig`)
+
+### `zeph-subagent`
+
+- `SubAgentPermissions` gains `pub worktree: bool` (default `false`)
+- `SubAgentManager` gains `Option<Arc<WorktreeManager>>` (set at bootstrap when enabled)
+- `spawn` path: if `worktree_manager.is_some()` AND `def.permissions.worktree` → acquire `CwdGuard`, create worktree, set cwd, build system prompt using worktree path, run agent, restore on teardown
+- `build_filtered_executor`: when `def.permissions.worktree`, append `"set_working_directory"` to `disallowed_tools`
+
+### Binary Bootstrap
+
+- Construct `WorktreeManager` during agent setup from `config.worktree` + detected repo root
+- Run capability probe when `worktree.enabled = true`
+- Inject `WorktreeManager` into `SubAgentManager`
+
+### CLI
+
+- Add `WorktreeCommand { List, Clean }` under `zeph worktree` (or extend `zeph agents`)
+- `--worktree-base-ref <fresh|head>` session override flag
+
+### TUI
+
+- Command palette: `/worktree list`, `/worktree clean`
+- Status spinner during worktree create/remove: "Creating worktree for {agent_id}…"
+
+---
+
+## Error Classification
+
+| Scenario | `WorktreeError` variant | User-facing message |
+|---|---|---|
+| Not in a git repo | `NotAGitRepo` | "Not inside a git repository" |
+| `git fetch` fails | `GitCommand { op: "fetch", .. }` | "Failed to fetch origin/{branch}: {sanitised reason}" |
+| `origin/HEAD` unset, no `default_branch` | `BaseRefUnresolved` | "Cannot resolve default branch; set `worktree.default_branch`" |
+| Branch name invalid | `InvalidBranchName` | "Subagent ID contains invalid characters for a branch name: {id}" |
+| Root outside repo | `RootOutsideRepo` | "Worktree root resolves outside the repository: {path}" |
+| Worktree path exists | `PathExists` | "Worktree path already exists: {path}" |
+| `git` not on PATH or too old | Detected in probe | "git ≥ 2.5 is required; found: {version}" |
+
+---
+
+## Implementation Notes (Deferred Items)
+
+**TODO(critic D1): concurrent per-agent cwd isolation requires child-process bgIsolation or full
+ToolExecutor cwd-threading; in-process MVP is concurrency-1 only.**
+
+Place this TODO on `WorktreeManager` struct doc comment. It marks the entry point for the deferred
+`bgIsolation` work (#4656) and the `ToolExecutor` cwd-threading track.
+
+**TODO(critic D2): head worktree does not include parent uncommitted changes by design; revisit if
+users need stash-based propagation.**
+
+Place this TODO near the `base_ref = Head` resolution in `WorktreeManager::create`.
+
+---
+
+## Live-Testing Playbook
+
+See `.local/testing/playbooks/worktree.md` for concrete scenarios:
+- `enabled = false` (default): no worktrees created
+- `base_ref = head` + clean working tree
+- `base_ref = head` + dirty working tree (expect dirty-tree warning)
+- `base_ref = fresh` + valid origin
+- `base_ref = fresh` + no network (expect clear error)
+- Cancellation mid-run (expect cwd restored, worktree removed)
+- Crash simulation (worktree clean reconciles stale entries)
+- Concurrent plain agent during active worktree agent (expect serialisation)

--- a/specs/063-worktree-subsystem/srs.md
+++ b/specs/063-worktree-subsystem/srs.md
@@ -1,0 +1,181 @@
+---
+aliases:
+  - Worktree Subsystem SRS
+  - SRS-063
+tags:
+  - sdd
+  - srs
+  - worktree
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/063-worktree-subsystem/brd]]"
+  - "[[specs/063-worktree-subsystem/nfr]]"
+  - "[[specs/063-worktree-subsystem/spec]]"
+---
+
+# SRS-063: Worktree Subsystem + `worktree.base_ref`
+
+ISO/IEC/IEEE 29148:2018 — Software Requirements Specification
+
+## 1. Scope
+
+This SRS specifies the functional requirements for the `zeph-worktree` crate and its integration points
+into `zeph-config`, `zeph-subagent`, and the Zeph binary. It traces to BRD-063.
+
+## 2. Definitions
+
+| Term | Definition |
+|---|---|
+| **worktree** | A git linked working tree created by `git worktree add`. |
+| **CwdGuard** | A process-global `tokio::sync::Mutex` that serialises all worktree-attached agent runs. |
+| **base_ref** | Config field controlling the commit from which a worktree branch is created. |
+| **worktree agent** | A subagent whose definition has `permissions.worktree = true`. |
+| **capability probe** | Startup check validating git presence and in-repo status. |
+
+## 3. Functional Requirements
+
+### 3.1 Configuration (`zeph-config`)
+
+**FR-CFG-01** [BG-2]: The config schema SHALL expose a `[worktree]` TOML section with the fields:
+```toml
+[worktree]
+enabled = false
+base_ref = "head"            # "fresh" | "head"
+default_branch = "main"
+root = ".claude/worktrees"
+branch_prefix = "agent/"
+prune_branch_on_remove = false
+cleanup_on_completion = true
+```
+
+**FR-CFG-02** [BG-3]: `worktree.enabled` SHALL default to `false`. When `false`, all worktree
+behaviour is bypassed and subagents continue to share the parent cwd as today.
+
+**FR-CFG-03** [BG-2]: `worktree.base_ref` SHALL accept the values `"head"` and `"fresh"` (case-
+insensitive, serde `rename_all = snake_case`). The default SHALL be `"head"`.
+
+**FR-CFG-04**: `WorktreeBaseRef` SHALL be `#[non_exhaustive]` to allow future values without a
+breaking change.
+
+**FR-CFG-05**: Per-agent opt-in SHALL be expressed as `permissions.worktree: true` in subagent
+definition frontmatter (a new `bool` field on `SubAgentPermissions`, default `false`).
+
+### 3.2 Crate `zeph-worktree`
+
+**FR-WT-01**: The crate SHALL expose `WorktreeManager::new(repo_root: PathBuf, config: WorktreeConfig) -> Result<Self, WorktreeError>` that validates the repo root and config.
+
+**FR-WT-02** [BG-1]: `WorktreeManager::create(subagent_id: &str) -> Result<WorktreeHandle, WorktreeError>` SHALL create a git worktree for the given subagent at `<root>/<subagent_id>/`.
+
+**FR-WT-03**: `create` SHALL resolve the base commit according to `config.base_ref`:
+- `Head` → base commit = `HEAD` (`git worktree add -b {branch} -- {path} HEAD`)
+- `Fresh` → `git fetch origin {default_branch}`, then base = `origin/{default_branch}` (`git worktree add -b {branch} -- {path} origin/{default_branch}`)
+
+**FR-WT-04**: `create` SHALL emit a `tracing::warn!` when `base_ref = Head` and `git status --porcelain` is non-empty: "parent working tree has uncommitted changes; the worktree branches from the last commit and will NOT include them."
+
+**FR-WT-05**: `WorktreeManager::remove(handle: &WorktreeHandle, prune_branch: bool) -> Result<(), WorktreeError>` SHALL run `git worktree remove {path}` and, when `prune_branch = true`, run `git branch -D {branch_name}`.
+
+**FR-WT-06**: `WorktreeManager::list(&self) -> &[WorktreeHandle]` SHALL return handles for worktrees created in the current process session. This is live-session in-RAM only; it does NOT enumerate worktrees from prior sessions.
+
+**FR-WT-07**: `WorktreeManager::reconcile() -> Result<Vec<WorktreeHandle>, WorktreeError>` SHALL enumerate worktrees from `git worktree list --porcelain` combined with a filesystem scan of `config.root`, and return stale entries (present on disk but not in the current session). This is the source of truth for the CLI `worktree clean` command and startup reconciliation.
+
+**FR-WT-08**: `WorktreeError` SHALL be a `thiserror`-derived enum with variants:
+- `NotAGitRepo`
+- `GitCommand { op: String, stderr: String }` — stderr logged at `debug`, sanitised message returned to user
+- `PathExists(PathBuf)`
+- `BaseRefUnresolved { attempted: String }`
+- `InvalidBranchName(String)`
+- `RootOutsideRepo(PathBuf)`
+- `Io(std::io::Error)`
+
+**FR-WT-09**: `GitRunner` trait SHALL have a single method:
+```rust
+async fn run(&self, args: &[&str], cwd: &Path) -> Result<std::process::Output, WorktreeError>;
+```
+The default implementation SHALL invoke `tokio::process::Command` with the `await-discipline` external-call timeout applied *inside* `run`. No call site shall be responsible for applying the timeout.
+
+**FR-WT-10**: Branch names SHALL follow the pattern `{branch_prefix}{subagent_id}`. The `{subagent_id}` component SHALL be validated to match `^[A-Za-z0-9._-]+$`, MUST NOT begin with `-` or `.`, MUST NOT contain `..`. Violation returns `WorktreeError::InvalidBranchName`.
+
+**FR-WT-11**: `config.root` SHALL be canonicalised at `WorktreeManager::new`. The canonical path MUST resolve to a path inside the repo root or a sibling of the repo root. Paths that canonicalise outside this boundary SHALL return `WorktreeError::RootOutsideRepo`.
+
+**FR-WT-12**: All `git` invocations that accept branch names or paths SHALL use `--` separators (`git worktree add -b {branch} -- {path} {commitish}`) to prevent git from misinterpreting arguments as flags.
+
+**FR-WT-13**: The `{commitish}` argument passed to `git worktree add` SHALL be validated with `git rev-parse --verify {commitish}` before use.
+
+### 3.3 Startup Capability Probe
+
+**FR-PROBE-01** [R6]: When `worktree.enabled = true`, the Zeph bootstrap SHALL run `git --version` and verify it reports ≥ 2.5. Failure SHALL abort startup with a clear, actionable error message.
+
+**FR-PROBE-02**: When `worktree.enabled = true`, the bootstrap SHALL run `git rev-parse --is-inside-work-tree` from the repo root. Failure (not a git repo) SHALL abort startup with a clear message.
+
+**FR-PROBE-03**: The capability probe SHALL NOT run when `worktree.enabled = false`.
+
+### 3.4 CwdGuard — Process-Level Serialisation
+
+**FR-CWD-01** [INV-1]: A single process-global `tokio::sync::Mutex` named `CwdGuard` SHALL be held from the moment `set_current_dir(worktree_path)` is called until `set_current_dir(prev_cwd)` has completed and the guard is dropped, spanning the agent's full multi-turn run.
+
+**FR-CWD-02**: Acquiring `CwdGuard` SHALL block all other agents (both worktree-opted and plain agents) from executing tool calls until the worktree agent's run and cwd restoration are complete.
+
+**FR-CWD-03** [INV-2]: Before entering the worktree, the previous cwd SHALL be captured: `prev = std::env::current_dir()`. After the agent completes (success, error, or cancellation), `set_current_dir(prev)` SHALL run in a guaranteed-run path (RAII `Drop` implementation or equivalent). This restore SHALL occur BEFORE `git worktree remove`.
+
+**FR-CWD-04** [INV-3]: For every worktree-opted agent, `set_working_directory` (`TOOL_NAME = "set_working_directory"`) SHALL be added to the effective denylist via `FilteredToolExecutor::with_disallowed`. This is enforced at `build_filtered_executor` time in `zeph-subagent`.
+
+**FR-CWD-05** [INV-4]: If worktree creation fails, the agent spawn SHALL fail with a `SubAgentError` wrapping the `WorktreeError`. The agent SHALL NOT proceed with the parent's shared cwd as fallback.
+
+**FR-CWD-06**: Non-worktree subagents (those with `permissions.worktree = false`) SHALL NOT be restricted by the `CwdGuard` in isolation; they only become serialised while a worktree agent holds the guard.
+
+### 3.5 Teardown and Cleanup
+
+**FR-CLEANUP-01**: On agent completion or cancellation, if `cleanup_on_completion = true`, `WorktreeManager::remove` SHALL be called as a tracked background task (not fire-and-forget). The `CwdGuard` SHALL be released after `set_current_dir(prev_cwd)` completes and before `git worktree remove` is called, per the normative teardown sequence in FR-CLEANUP-02.
+
+**FR-CLEANUP-02** [A1]: The teardown sequence SHALL be: (1) `set_current_dir(prev_cwd)`, (2) release `CwdGuard`, (3) `git worktree remove`.
+
+**FR-CLEANUP-03** [A2]: The cancellation path SHALL follow the same sequence as normal completion — cwd is restored and the guard is released before any worktree removal.
+
+**FR-CLEANUP-04**: The CLI command `zeph worktree clean` SHALL call `WorktreeManager::reconcile()`, enumerate stale entries, and remove each via `git worktree remove --force` followed by `git worktree prune`.
+
+### 3.6 `base_ref = fresh` Network Behaviour
+
+**FR-FRESH-01**: For `fresh` mode, the fetch SHALL be a single-attempt `git fetch origin {default_branch}` with the await-discipline timeout. There is no retry in the MVP.
+
+**FR-FRESH-02**: If the fetch fails (non-zero exit or timeout), the spawn SHALL fail with `WorktreeError::GitCommand`. The error message SHALL state that the fetch failed and suggest checking network connectivity and `default_branch` config.
+
+**FR-FRESH-03**: `config.default_branch` SHALL override the auto-detected default branch. When `default_branch` is empty and `git symbolic-ref refs/remotes/origin/HEAD` fails, the spawn SHALL fail with `WorktreeError::BaseRefUnresolved`.
+
+### 3.7 CLI Integration
+
+**FR-CLI-01**: The Zeph CLI SHALL expose `zeph worktree list` — prints active worktrees (session + stale).
+
+**FR-CLI-02**: The Zeph CLI SHALL expose `zeph worktree clean` — removes stale/leaked worktrees.
+
+**FR-CLI-03**: A session-scoped override `--worktree-base-ref <fresh|head>` SHALL override `config.worktree.base_ref` for the session, analogous to `--permission-mode`.
+
+### 3.8 TUI and `--init` / `--migrate-config`
+
+**FR-TUI-01**: The TUI command palette SHALL include a `worktree` section with entries:
+- `/worktree list` — shows active worktrees
+- `/worktree clean` — triggers reconciliation and removal of stale entries
+
+**FR-INIT-01**: The `--init` wizard SHALL prompt for `worktree.enabled`, `worktree.base_ref`, and `worktree.default_branch` under a new "Subagent isolation" section.
+
+**FR-MIGRATE-01**: Config migration step 53 SHALL add the `[worktree]` section with all defaults to existing configs that lack it.
+
+### 3.9 Tracing and Observability
+
+**FR-TRACE-01**: Every `async fn` in `WorktreeManager` that awaits an external resource (git command, filesystem operation) SHALL be wrapped in a `tracing::info_span!` using the naming convention `worktree.<operation>` (e.g. `worktree.create`, `worktree.remove`, `worktree.fetch`).
+
+**FR-TRACE-02**: Span naming SHALL follow the project convention `<crate_short>.<subsystem>.<operation>`.
+
+## 4. Traceability Matrix
+
+| FR | BRD Goal | Architect Plan Section |
+|---|---|---|
+| FR-CFG-01..05 | BG-2, BG-3 | §3, §6 |
+| FR-WT-01..13 | BG-1, BG-2, BG-4 | §2, §3, §5 |
+| FR-PROBE-01..03 | BG-3, R6 | S3 |
+| FR-CWD-01..06 | BG-1 | INV-1..INV-4, C1 Option 1 |
+| FR-CLEANUP-01..04 | BG-1 | A1, A2, §7 |
+| FR-FRESH-01..03 | BG-2 | §5, R4 |
+| FR-CLI-01..03 | BG-2 | §4 |
+| FR-TUI-01, FR-INIT-01, FR-MIGRATE-01 | BG-3 | §4 |
+| FR-TRACE-01..02 | — | §9 (continuous-improvement.md) |

--- a/specs/063-worktree-subsystem/tasks.md
+++ b/specs/063-worktree-subsystem/tasks.md
@@ -1,0 +1,391 @@
+---
+aliases:
+  - Worktree Subsystem Tasks
+  - tasks-063
+tags:
+  - sdd
+  - tasks
+  - worktree
+created: 2026-05-29
+status: approved
+related:
+  - "[[specs/063-worktree-subsystem/plan]]"
+  - "[[specs/063-worktree-subsystem/spec]]"
+---
+
+# Task Breakdown — Worktree Subsystem (#4655)
+
+## T-01: Config types in `zeph-config`
+
+**Crate:** `zeph-config`  
+**Phase:** P1  
+**LOC estimate:** ~80
+
+**Description:**  
+Create `crates/zeph-config/src/worktree.rs` with `WorktreeConfig` and `WorktreeBaseRef`.
+Add `pub worktree: WorktreeConfig` to root config struct.
+Add `SubAgentPermissions.worktree: bool` field (default `false`) in subagent permissions.
+
+**Files:**
+- `crates/zeph-config/src/worktree.rs` (new)
+- `crates/zeph-config/src/root.rs`
+- `crates/zeph-config/src/subagent.rs` (or `permissions.rs`)
+- `crates/zeph-config/src/lib.rs` (re-export)
+
+**Acceptance criteria:**
+- `WorktreeConfig::default()` → `enabled=false`, `base_ref=Head`, `default_branch="main"`, `root=".claude/worktrees"`, `branch_prefix="agent/"`, `prune_branch_on_remove=false`, `cleanup_on_completion=true`
+- `WorktreeBaseRef` is `#[non_exhaustive]` with `#[default] Head`
+- `WorktreeConfig` and `WorktreeBaseRef` round-trip through TOML serialization
+- `cargo test -p zeph-config` passes
+- `cargo clippy -p zeph-config -- -D warnings` clean
+
+---
+
+## T-02: Config migration step 53
+
+**Crate:** `zeph-config`  
+**Phase:** P1  
+**Depends on:** T-01  
+**LOC estimate:** ~20
+
+**Description:**  
+Add migration step 53 to `crates/zeph-config/src/migrate/steps.rs` that inserts the `[worktree]`
+section with default values into configs that lack it.
+
+**Acceptance criteria:**
+- Migration is idempotent: running twice on the same config produces no change on the second run
+- `cargo nextest run -p zeph-config -- migrate` passes
+
+---
+
+## T-03: `zeph-worktree` crate scaffold
+
+**Crate:** `zeph-worktree` (new)  
+**Phase:** P2  
+**Depends on:** T-01  
+**LOC estimate:** ~100
+
+**Description:**  
+Create crate with `Cargo.toml`, module structure, and all type definitions:
+`WorktreeHandle`, `WorktreeError`, `GitRunner` trait, `DefaultGitRunner`, `FakeGitRunner` (cfg(test)).
+
+**Files:**
+- `crates/zeph-worktree/Cargo.toml`
+- `crates/zeph-worktree/src/lib.rs`
+- `crates/zeph-worktree/src/handle.rs`
+- `crates/zeph-worktree/src/error.rs`
+- `crates/zeph-worktree/src/git_runner.rs`
+- Root `Cargo.toml` workspace member
+
+**Acceptance criteria:**
+- `cargo build -p zeph-worktree` succeeds
+- All `WorktreeError` variants match spec
+- `GitRunner` trait has `async fn run(&self, args: &[&str], cwd: &Path) -> Result<Output, WorktreeError>` signature
+- `DefaultGitRunner` applies timeout inside `run` — no call site responsible for timeout
+
+---
+
+## T-04: Branch name and path sanitisation
+
+**Crate:** `zeph-worktree`  
+**Phase:** P2  
+**Depends on:** T-03  
+**LOC estimate:** ~60
+
+**Description:**  
+Implement `sanitize.rs`:
+- `validate_branch_component(s: &str) -> Result<(), WorktreeError>`
+- `canonicalize_root(root: &Path, repo_root: &Path) -> Result<PathBuf, WorktreeError>`
+
+**Acceptance criteria:**
+- Valid UUIDs (current subagent ID format) pass `validate_branch_component`
+- Inputs with `/`, `..`, leading `-`, leading `.` fail
+- Inputs containing control characters fail
+- `canonicalize_root` accepts paths inside repo root
+- `canonicalize_root` rejects paths outside repo root (symlinked escape included)
+- Unit tests cover all branches: `cargo test -p zeph-worktree sanitize`
+
+---
+
+## T-05: `WorktreeManager::create` — `head` mode
+
+**Crate:** `zeph-worktree`  
+**Phase:** P2  
+**Depends on:** T-04  
+**LOC estimate:** ~80
+
+**Description:**  
+Implement `WorktreeManager::create` for `base_ref = Head`:
+- Validate branch component
+- Emit dirty-tree warning (`git status --porcelain` non-empty)
+- Call `git worktree add -b {branch} -- {path} HEAD`
+- Store `WorktreeHandle` in session list
+- Trace span: `worktree.create`
+
+**Acceptance criteria:**
+- `FakeGitRunner` captures confirm `--` separator present in add args
+- `FakeGitRunner` captures confirm commitish is `HEAD`
+- Dirty-tree warning emitted when status returns non-empty output
+- No warning when status is empty
+- `cargo test -p zeph-worktree create_head` passes
+
+---
+
+## T-06: `WorktreeManager::create` — `fresh` mode
+
+**Crate:** `zeph-worktree`  
+**Phase:** P2  
+**Depends on:** T-04  
+**LOC estimate:** ~80
+
+**Description:**  
+Implement `WorktreeManager::create` for `base_ref = Fresh`:
+- Resolve `default_branch`: `config.default_branch` → `git symbolic-ref refs/remotes/origin/HEAD` → error
+- `git fetch origin {default_branch}` (single attempt, timeout inside `run`)
+- `git rev-parse --verify origin/{default_branch}`
+- `git worktree add -b {branch} -- {path} origin/{default_branch}`
+- Trace span: `worktree.fetch`
+
+**Acceptance criteria:**
+- `FakeGitRunner` captures confirm fetch args correct
+- `FakeGitRunner` captures confirm `rev-parse --verify` called before `worktree add`
+- `default_branch` config overrides `symbolic-ref` result
+- `symbolic-ref` failure with empty `default_branch` → `WorktreeError::BaseRefUnresolved`
+- Fetch failure (non-zero exit) → `WorktreeError::GitCommand { op: "fetch", .. }`
+- `cargo test -p zeph-worktree create_fresh` passes
+
+---
+
+## T-07: `WorktreeManager::remove` and `reconcile`
+
+**Crate:** `zeph-worktree`  
+**Phase:** P2  
+**Depends on:** T-03  
+**LOC estimate:** ~80
+
+**Description:**  
+Implement `WorktreeManager::remove` and `WorktreeManager::reconcile`.
+
+`remove`:
+- `git worktree remove {path}`
+- If `prune_branch`: `git branch -D {branch}`
+- Remove handle from session list
+
+`reconcile`:
+- `git worktree list --porcelain` → parse output
+- Scan `config.root` directory
+- Return `WorktreeHandle` entries present on disk but not in current session list
+
+**Acceptance criteria:**
+- `remove` with `prune_branch=true`: both git commands called, in correct order
+- `remove` with `prune_branch=false`: only `git worktree remove` called
+- `reconcile` correctly parses `git worktree list --porcelain` canned output in unit test
+- Session list no longer contains handle after `remove`
+- `cargo test -p zeph-worktree remove reconcile` passes
+
+---
+
+## T-08: Startup capability probe
+
+**Crate:** `zeph-worktree` (or binary)  
+**Phase:** P2  
+**Depends on:** T-03  
+**LOC estimate:** ~40
+
+**Description:**  
+Implement `WorktreeManager::probe_capabilities(runner: &dyn GitRunner) -> Result<(), WorktreeError>`:
+- `git --version` → parse, fail if < 2.5
+- `git rev-parse --is-inside-work-tree` from `repo_root` → fail if not a repo
+
+Called at bootstrap when `worktree.enabled = true`, before any spawn.
+
+**Acceptance criteria:**
+- `FakeGitRunner` returning version `2.4.0` → error with message containing "2.5"
+- `FakeGitRunner` returning non-zero for `rev-parse` → `WorktreeError::NotAGitRepo`
+- Valid git ≥ 2.5 inside a repo → `Ok(())`
+- `cargo test -p zeph-worktree probe` passes
+
+---
+
+## T-09: `CwdRestoreGuard` and `CwdGuard` in `zeph-subagent`
+
+**Crate:** `zeph-subagent`  
+**Phase:** P3  
+**Depends on:** T-03  
+**LOC estimate:** ~80
+
+**Description:**  
+Create `crates/zeph-subagent/src/cwd_guard.rs`:
+- `CwdRestoreGuard<'a>`: captures `prev: PathBuf`, holds `MutexGuard<'a, ()>`
+- `Drop` impl: calls `std::env::set_current_dir(&self.prev)`, logs error on failure (cannot propagate)
+- `SubAgentManager` gains `cwd_guard: Arc<tokio::sync::Mutex<()>>` field
+
+**Acceptance criteria (M4 — must be an explicit test):**
+
+> **Concurrency serialisation test:** Spawn a worktree agent (holding `CwdGuard`) and, while it is
+> active (before it releases the guard), attempt to execute a tool call from a second agent. Assert
+> that the second agent's tool execution does NOT begin until the worktree agent's run is complete
+> and the guard is released.
+
+- `CwdRestoreGuard::drop` restores cwd even when the agent task panics (test with `std::panic::catch_unwind` or by poisoning the task)
+- `cargo test -p zeph-subagent cwd_guard` passes
+
+---
+
+## T-10: `SubAgentManager::spawn` integration
+
+**Crate:** `zeph-subagent`  
+**Phase:** P3  
+**Depends on:** T-09, T-05, T-06  
+**LOC estimate:** ~120
+
+**Description:**  
+Wire `WorktreeManager` into `SubAgentManager::spawn`:
+- Add `worktree_manager: Option<Arc<WorktreeManager>>` field
+- In `spawn`: when worktree is applicable (manager present + `def.permissions.worktree`), acquire
+  `CwdGuard`, call `create`, build `CwdRestoreGuard`, use worktree path as cwd for system prompt
+- In `build_filtered_executor`: add `set_working_directory` to disallowed when `permissions.worktree`
+- On completion/cancel: `remove` the worktree (after cwd restore via guard drop)
+- INV-4: propagate `WorktreeError` as `SubAgentError`, do NOT fall back to shared cwd
+
+**Acceptance criteria (also covers A2 — cancellation):**
+
+> **Cancellation path test:** Create a worktree agent, cancel it mid-run. Assert that cwd is restored
+> to the pre-spawn value and the `CwdGuard` is released.
+
+- `set_working_directory` not in executor tool list when `permissions.worktree = true`
+- `set_working_directory` present in executor tool list when `permissions.worktree = false`
+- Worktree creation failure → spawn returns error, agent does NOT run
+- `cargo nextest run -p zeph-subagent -- worktree` passes
+
+---
+
+## T-11: Bootstrap wiring
+
+**Crate:** binary (`src/`)  
+**Phase:** P4  
+**Depends on:** T-08, T-10  
+**LOC estimate:** ~30
+
+**Description:**  
+In `src/agent_setup.rs` or `src/bootstrap.rs`:
+- Detect repo root (walk up to find `.git/`)
+- When `config.worktree.enabled`: run `WorktreeManager::probe_capabilities`; fail fast with actionable error if probe fails
+- Construct `WorktreeManager::new(repo_root, config.worktree.clone())`
+- Inject into `SubAgentManager`
+
+**Acceptance criteria:**
+- Binary starts successfully in a git repo with `worktree.enabled = true` and `git` ≥ 2.5 present
+- Binary prints clear error and exits non-zero when not in a git repo and `worktree.enabled = true`
+- `worktree.enabled = false` produces no git invocations at startup
+
+---
+
+## T-12: CLI commands and session override
+
+**Crate:** binary (`src/`)  
+**Phase:** P4  
+**Depends on:** T-07, T-11  
+**LOC estimate:** ~60
+
+**Description:**  
+- Add `Worktree { command: WorktreeCommand }` subcommand
+- `WorktreeCommand::List`: calls `reconcile()`, prints table
+- `WorktreeCommand::Clean`: calls `reconcile()`, removes stale entries, prints count
+- Add `--worktree-base-ref <fresh|head>` flag to root `Cli` struct; applies as session override
+
+**Acceptance criteria:**
+- `zeph worktree list` exits 0, prints header even with empty result
+- `zeph worktree clean` exits 0, reports "0 stale worktrees removed" when clean
+- `--worktree-base-ref fresh` overrides config value for the session
+
+---
+
+## T-13: TUI entries and spinners
+
+**Crate:** `zeph-tui`  
+**Phase:** P4  
+**Depends on:** T-07  
+**LOC estimate:** ~40
+
+**Description:**  
+- Add `/worktree list` and `/worktree clean` to TUI command palette
+- During `WorktreeManager::create`: emit `SystemStatus` event with message "Creating worktree for {agent_id}…"
+- During `WorktreeManager::remove`: emit "Removing worktree for {agent_id}…"
+
+**Acceptance criteria:**
+- Both commands appear in TUI autocomplete
+- Spinner appears during create/remove (manual TUI test; document in playbook)
+
+---
+
+## T-14: `--init` wizard update
+
+**Crate:** binary (`src/`)  
+**Phase:** P4  
+**Depends on:** T-01  
+**LOC estimate:** ~30
+
+**Description:**  
+Add "Subagent isolation" section to `--init` interactive wizard:
+- "Enable per-subagent git worktrees? [y/N]"
+- If yes: "Branch from local HEAD or fetch from remote? [head/fresh]"
+- If fresh: "Default remote branch? [main]"
+
+**Acceptance criteria:**
+- Wizard writes correct `[worktree]` TOML on confirmed answers
+- Answering 'N' → `enabled = false` written, no follow-up questions asked
+
+---
+
+## T-15: Live-testing playbook and coverage-status
+
+**Target:** `.local/testing/`  
+**Phase:** P5  
+**LOC estimate:** non-code
+
+**Description:**  
+Create `.local/testing/playbooks/worktree.md` with the scenarios listed in `spec.md`.
+Add rows to `.local/testing/coverage-status.md` for `zeph-worktree` and the worktree integration
+in `zeph-subagent` — initial status: `Untested`.
+
+**Scenarios to cover (from spec.md):**
+1. `enabled = false` (default): no worktrees created, no git invocations
+2. `base_ref = head` + clean working tree: worktree created at HEAD
+3. `base_ref = head` + dirty working tree: dirty-tree warning emitted
+4. `base_ref = fresh` + valid origin: worktree created at `origin/<default>`
+5. `base_ref = fresh` + no network: clear error, agent does not run
+6. Cancellation mid-run: cwd restored, worktree removed
+7. Crash simulation: `worktree clean` reconciles stale entries on next startup
+8. Concurrent plain agent during active worktree agent: plain agent tool turn serialised
+
+**Acceptance criteria:**
+- `.local/testing/playbooks/worktree.md` exists and covers all 8 scenarios with expected outcomes
+- `.local/testing/coverage-status.md` has rows for `zeph-worktree` (Untested) and `worktree-subagent-integration` (Untested)
+
+---
+
+## T-16: Pre-PR checklist
+
+**Phase:** P5
+
+**Description:**  
+Before opening the PR, run all pre-commit checks required by `branching.md`:
+
+```bash
+cargo +nightly fmt --check
+cargo clippy --all-targets --all-features --workspace -- -D warnings
+cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins
+RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked
+RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-worktree
+cargo test --doc -p zeph-worktree
+RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-config
+RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-subagent
+```
+
+Update `CHANGELOG.md` with the entry template from `plan.md`.
+
+**Acceptance criteria:**
+- All checks pass with zero warnings
+- `CHANGELOG.md` updated
+- `docs/src/worktree.md` created or updated if user-facing behaviour changed

--- a/specs/README.md
+++ b/specs/README.md
@@ -45,6 +45,7 @@ Spec IDs (001–044) follow a logical grouping:
 - **053**: SpeculationEngine — speculative tool execution (SSE decoding path, PASTE skill activation, ToolStartEvent{speculative:true})
 - **055**: Cocoon distributed compute integration — CocoonProvider, CocoonClient, `zeph cocoon doctor`, TUI palette entries, vault key ZEPH_COCOON_ACCESS_HASH
 - **062**: Context-Adaptive Memory (CAM) — three-level fidelity (Full/Compressed/Placeholder), heuristic FidelityScorer, proactive AgeMem regrade, PlannedToolHint for PAACE; GitHub #4016, #4017, #4018
+- **063**: Worktree subsystem — `zeph-worktree` crate, `worktree.base_ref: fresh|head`, CwdGuard serialisation, startup probe, CLI commands; GitHub #4655
 - **parity-claude-code-3918**: Claude Code v2.1.141–v2.1.143 parity — `--plugin-url` ephemeral loading, provider override persistence; GitHub #3918
 
 ---
@@ -145,4 +146,5 @@ Spec IDs (001–044) follow a logical grouping:
 | `060-autoskill-trigger-sets/spec.md` | AutoSkill A5: embed `triggers` SKILL.md frontmatter entries as additional retrieval vectors; max-cosine aggregation across triggers; `trigger_weight` blends trigger and description scores; `max_triggers_per_skill` cap; in-memory only (v1); GitHub #4451 | `zeph-skills` |
 | `061-autoskill-heuristic-promotion/spec.md` | AutoSkill A6: periodic background job promotes ERL heuristics to quarantined SKILL.md drafts when heuristic count ≥ `heuristic_promotion_threshold`; LLM evaluates body-enrichment vs. new-skill vs. none; idempotency via `skill_heuristic_promotions` table; `heuristic_promotion_provider` config field; GitHub #4452 | `zeph-skills` |
 | `062-context-adaptive-memory/spec.md` | Context-Adaptive Memory (CAM): three-level fidelity (Full/Compressed/Placeholder), heuristic FidelityScorer, proactive AgeMem regrade trigger, PlannedToolHint struct for PAACE DAG lookahead; MVP: heuristic scoring only; GitHub #4016, #4017, #4018 | `zeph-common`, `zeph-context`, `zeph-agent-context` |
+| `063-worktree-subsystem/spec.md` | Worktree subsystem: new `zeph-worktree` crate, `worktree.base_ref: fresh\|head`, CwdGuard process-level serialisation (INV-1..INV-4), startup capability probe, `zeph worktree list/clean` CLI; defers concurrent isolation to `bgIsolation` (#4656); GitHub #4655 | `zeph-worktree` (new), `zeph-config`, `zeph-subagent` |
 | `parity-claude-code-3918/spec.md` | Claude Code v2.1.141–v2.1.143 parity gaps: `--plugin-url` ephemeral plugin loading (HTTPS-only, blocking scan, TempDir lifetime) + provider parameter override persistence (reasoning_effort, temperature via `channel_preferences` key-value row, no ALTER TABLE); defers worktree.baseRef, bgIsolation, Ctrl+R; GitHub #3918 | `zeph-plugins`, `zeph-core`, `zeph-config`, `zeph-commands` |


### PR DESCRIPTION
## Summary

- Produces the full spec package (BRD/SRS/NFR/spec/plan/tasks) for the native worktree management subsystem required by issue #4655
- Spec lives under `specs/063-worktree-subsystem/`, registered in `specs/README.md`
- No source code changed — spec-only PR

## Design decisions encoded

**C1 — cwd isolation (MVP: Constrain, don't isolate):**
- INV-1: All worktree-attached runs serialized via a process-global `CwdGuard` mutex; non-worktree agents quiesced while held
- INV-2: Process cwd saved/restored (RAII) around agent run; restore happens BEFORE `git worktree remove`
- INV-3: `set_working_directory` in `disallowed_tools` for every worktree agent
- INV-4: Worktree creation failure aborts that agent's spawn — no silent fallback

**Config schema:**
```toml
[worktree]
enabled = false
base_ref = "head"          # "fresh" | "head"
default_branch = "main"
root = ".claude/worktrees"
branch_prefix = "agent/"
prune_branch_on_remove = false
cleanup_on_completion = true
```

**Deferred:**
- D1: True concurrent isolation via `ToolExecutor` cwd-threading
- D2: Child-process bgIsolation mode (tracked in #4656)

## Architecture

New crate `zeph-worktree` (~930 LOC, 5 phases per plan.md). Integration with `zeph-subagent`, `zeph-config`, `zeph-core`.

## Test plan

- [ ] All spec files validate (`fy validate`)
- [ ] BRD → SRS → spec → tasks traceability verified by reviewer
- [ ] INV-1..INV-4, M4, A1/A2, S2/S3, D1/D2 markers confirmed present in spec.md
- [ ] tasks.md acceptance criteria reviewed (16 tasks, concrete assertions)

Closes #4655