### PR TITLE
feat(tui): cocoon balance opt-in and Ctrl+R prompt history reverse-search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `zeph-config`: new `[cocoon]` section with `show_balance: bool` (default `true`). When set to
+  `false`, the TON balance in the TUI status bar is rendered as `*** TON` instead of the real
+  value. Implements the redaction option from spec §15.2. Default `true` preserves current
+  behaviour. Config migration step 53 appends a commented `[cocoon]` advisory notice to existing
+  configs; the field is optional so existing configs load without modification.
+- `--init` wizard: prompts "Show Cocoon TON balance in the TUI status bar?" in the Cocoon provider
+  step (default `true`).
+- TUI: Ctrl+R reverse-search over current-session prompt history. Opens a floating overlay above
+  the input area; typing filters by substring match (newest-first); Ctrl+R again cycles to the
+  next older match; Enter copies the selection into the input (no auto-submit); Esc cancels.
+  History is current-session only (populated on each submit, empty at startup).
 - `zeph-config`: `ProviderOverrides` struct — per-session LLM generation override parameters
   persisted across restarts (Phase 1: `reasoning_effort` only). Serialized as JSON and stored
   in the `channel_preferences` table under `pref_key = "provider_overrides"`. Uses

--- a/crates/zeph-config/src/cocoon.rs
+++ b/crates/zeph-config/src/cocoon.rs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+use crate::defaults::default_true;
+
+/// Cocoon-level display and behaviour settings.
+///
+/// These options govern how Cocoon-specific information is presented in the TUI.
+/// They are independent of the Cocoon LLM provider entry in `[[llm.providers]]`.
+///
+/// # Examples
+///
+/// ```toml
+/// [cocoon]
+/// show_balance = false  # redact TON balance in the TUI status bar
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CocoonConfig {
+    /// Show the Cocoon TON balance in the TUI status bar.
+    ///
+    /// When `false`, the balance is rendered as `*** TON` instead of the real
+    /// value, implementing the redaction option described in spec §15.2.
+    /// Default is `true` (balance visible), matching the current behaviour.
+    #[serde(default = "default_true")]
+    pub show_balance: bool,
+}
+
+impl Default for CocoonConfig {
+    fn default() -> Self {
+        Self { show_balance: true }
+    }
+}

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -74,6 +74,7 @@ pub mod autonomous;
 pub mod channels;
 pub mod classifiers;
 pub mod cli;
+pub mod cocoon;
 pub mod defaults;
 pub mod dump_format;
 mod env;
@@ -115,6 +116,7 @@ pub use channels::{
     TrustCalibrationConfig, is_skill_allowed,
 };
 pub use cli::{CliConfig, LoopConfig};
+pub use cocoon::CocoonConfig;
 pub use defaults::{
     DEFAULT_DEBUG_DIR, DEFAULT_LOG_FILE, DEFAULT_SKILLS_DIR, DEFAULT_SQLITE_PATH,
     default_debug_dir, default_integrity_registry_path, default_log_file_path, default_skills_dir,

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3404,13 +3404,13 @@ pub trait Migration: Send + Sync {
 mod steps;
 use steps::{
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
-    MigrateAutodreamConfig, MigrateCocoonProviderNotice, MigrateCompressionPredictorConfig,
-    MigrateDatabaseUrl, MigrateEgressConfig, MigrateEmbedProviderRename,
-    MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig, MigrateFocusAutoConsolidateMinWindow,
-    MigrateForgettingConfig, MigrateGoalsConfig, MigrateGonkagateToGonka,
-    MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete, MigrateMagicDocsConfig,
-    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpRetryAndToolTimeout,
-    MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
+    MigrateAutodreamConfig, MigrateCocoonProviderNotice, MigrateCocoonShowBalance,
+    MigrateCompressionPredictorConfig, MigrateDatabaseUrl, MigrateEgressConfig,
+    MigrateEmbedProviderRename, MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig,
+    MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig, MigrateGoalsConfig,
+    MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
+    MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
+    MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
@@ -3634,6 +3634,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateFidelityTimeoutDefaults),
             // Step 52 — add persist_provider_overrides to [session] (#4654)
             Box::new(MigrateSessionPersistProviderOverrides),
+            // Step 53 — add [cocoon] show_balance advisory notice (#4649)
+            Box::new(MigrateCocoonShowBalance),
         ]
     });
 
@@ -3824,6 +3826,37 @@ pub fn migrate_fidelity_timeout_defaults(toml_src: &str) -> Result<MigrationResu
     }
 }
 
+/// Add a commented-out `[cocoon]` section with `show_balance` advisory notice (#4649).
+///
+/// Implements spec §15.2 opt-in redaction: when `show_balance = false`, the TUI
+/// status bar renders the TON balance as `*** TON` instead of the real value.
+/// The default remains `true` (visible), so existing configs are unaffected.
+///
+/// Idempotent: skipped if `show_balance` is already present (as an active key or comment).
+///
+/// # Errors
+///
+/// Infallible in practice; `Result` matches the migration convention.
+pub fn migrate_cocoon_show_balance(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("show_balance") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let section = "\n[cocoon]\n\
+        # show_balance = true  \
+        # set to false to redact TON balance in TUI status bar (spec §15.2) (#4649)\n";
+    let output = format!("{toml_src}{section}");
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["cocoon".to_owned()],
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {
@@ -3839,8 +3872,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            52,
-            "MIGRATIONS registry must contain all 52 sequential steps"
+            53,
+            "MIGRATIONS registry must contain all 53 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -5427,7 +5460,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_has_fifty_entries() {
-        assert_eq!(MIGRATIONS.len(), 52);
+        assert_eq!(MIGRATIONS.len(), 53);
     }
 
     #[test]
@@ -5466,7 +5499,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–51).
+        // Names must follow the documented step order (steps 1–53).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -5520,6 +5553,7 @@ prompt_cache_ttl = "1h"
             "migrate_mcp_retry_and_tool_timeout",
             "migrate_fidelity_timeout_defaults",
             "migrate_session_persist_provider_overrides",
+            "migrate_cocoon_show_balance",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
@@ -5948,5 +5982,41 @@ trace_extraction_embed_provider = \"live\"\n";
             1,
             "embed_timeout_secs must appear exactly once"
         );
+    }
+
+    // ── Step 53 — cocoon.show_balance advisory notice (#4649) ────────────────────────────────────
+
+    #[test]
+    fn migrate_cocoon_show_balance_adds_section_when_absent() {
+        let src = "[agent]\nname = \"Zeph\"\n";
+        let result = migrate_cocoon_show_balance(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(
+            result.output.contains("show_balance"),
+            "output must mention show_balance"
+        );
+        assert!(
+            result.output.contains("[cocoon]"),
+            "output must contain [cocoon] section"
+        );
+    }
+
+    #[test]
+    fn migrate_cocoon_show_balance_idempotent_when_key_present() {
+        let src = "[cocoon]\n# show_balance = true\n";
+        let result = migrate_cocoon_show_balance(src).expect("migrate");
+        assert_eq!(
+            result.changed_count, 0,
+            "must not modify config that already has show_balance"
+        );
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_cocoon_show_balance_idempotent_when_active_key_present() {
+        let src = "[cocoon]\nshow_balance = false\n";
+        let result = migrate_cocoon_show_balance(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
     }
 }

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -11,7 +11,8 @@
 //! `embed_provider` → `embedding_provider` (#4480); step 50 adds MCP
 //! `startup_retry_backoff_ms` and `tool_timeout_secs` (#4004); step 51 adds
 //! `embed_timeout_secs` and `compress_timeout_secs` to `[memory.fidelity]` (#4645, #4651);
-//! step 52 adds `[session] persist_provider_overrides` (#4654).
+//! step 52 adds `[session] persist_provider_overrides` (#4654);
+//! step 53 adds `[cocoon] show_balance` advisory notice (#4649).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -20,28 +21,28 @@
 use super::{
     MigrateError, Migration, MigrationResult, migrate_acp_subagents_config,
     migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_autodream_config,
-    migrate_cocoon_provider_notice, migrate_compression_predictor_config, migrate_database_url,
-    migrate_egress_config, migrate_embed_provider_rename, migrate_fidelity_timeout_defaults,
-    migrate_five_signal_config, migrate_focus_auto_consolidate_min_window,
-    migrate_forgetting_config, migrate_goals_config, migrate_hooks_permission_denied_config,
-    migrate_hooks_turn_complete_config, migrate_magic_docs_config, migrate_mcp_elicitation_config,
-    migrate_mcp_max_connect_attempts, migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels,
-    migrate_memory_graph_config, migrate_memory_hebbian_config,
-    migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
-    migrate_memory_persona_config, migrate_memory_reasoning_config,
-    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
-    migrate_memory_retrieval_query_bias, migrate_microcompact_config,
-    migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
-    migrate_otel_filter, migrate_planner_model_to_provider, migrate_provider_max_concurrent,
-    migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
-    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
+    migrate_cocoon_provider_notice, migrate_cocoon_show_balance,
+    migrate_compression_predictor_config, migrate_database_url, migrate_egress_config,
+    migrate_embed_provider_rename, migrate_fidelity_timeout_defaults, migrate_five_signal_config,
+    migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
+    migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
+    migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
+    migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels, migrate_memory_graph_config,
+    migrate_memory_hebbian_config, migrate_memory_hebbian_consolidation_config,
+    migrate_memory_hebbian_spread_config, migrate_memory_persona_config,
+    migrate_memory_reasoning_config, migrate_memory_reasoning_judge_config,
+    migrate_memory_retrieval_config, migrate_memory_retrieval_query_bias,
+    migrate_microcompact_config, migrate_orchestration_orchestrator_provider,
+    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
+    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_quality_config,
+    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_persist_provider_overrides, migrate_session_provider_persistence,
     migrate_session_recap_config, migrate_shell_transactional, migrate_stt_to_provider,
     migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
     migrate_trace_metadata, migrate_vigil_config,
 };
 
-// ── Wrapper structs for all 51 sequential migration steps ───────────────────────────────────────
+// ── Wrapper structs for all 53 sequential migration steps ───────────────────────────────────────
 
 pub(super) struct MigrateSttToProvider;
 impl Migration for MigrateSttToProvider {
@@ -612,5 +613,16 @@ impl Migration for MigrateSessionPersistProviderOverrides {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_session_persist_provider_overrides(toml_src)
+    }
+}
+
+pub(super) struct MigrateCocoonShowBalance;
+impl Migration for MigrateCocoonShowBalance {
+    fn name(&self) -> &'static str {
+        "migrate_cocoon_show_balance"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_cocoon_show_balance(toml_src)
     }
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -12,6 +12,7 @@ use crate::agent::{AgentConfig, FocusConfig, GoalConfig, SubAgentConfig};
 use crate::channels::{A2aServerConfig, DiscordConfig, McpConfig, SlackConfig, TelegramConfig};
 use crate::classifiers::ClassifiersConfig;
 use crate::cli::CliConfig;
+use crate::cocoon::CocoonConfig;
 use crate::defaults::{default_skill_paths, default_sqlite_path_field};
 use crate::execution::ExecutionConfig;
 use crate::experiment::{ExperimentConfig, OrchestrationConfig};
@@ -126,6 +127,9 @@ pub struct Config {
     /// Long-horizon goal lifecycle configuration.
     #[serde(default)]
     pub goals: GoalConfig,
+    /// Cocoon display and behaviour settings (independent of `[[llm.providers]]` Cocoon entry).
+    #[serde(default)]
+    pub cocoon: CocoonConfig,
     /// Resolved secrets from vault. Never serialized — populated at runtime.
     #[serde(skip)]
     pub secrets: ResolvedSecrets,
@@ -327,6 +331,7 @@ impl Default for Config {
             quality: crate::quality::QualityConfig::default(),
             notifications: NotificationsConfig::default(),
             goals: GoalConfig::default(),
+            cocoon: CocoonConfig::default(),
             secrets: ResolvedSecrets::default(),
         }
     }

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -49,6 +49,15 @@ impl App {
             widgets::slash_autocomplete::render(state, frame, layout.input);
         }
 
+        if let Some(state) = &self.reverse_search {
+            widgets::reverse_search::render(
+                state,
+                &self.sessions.current().input_history,
+                frame,
+                layout.input,
+            );
+        }
+
         if let Some(state) = &self.confirm_state {
             widgets::confirm::render(&state.prompt, frame, frame.area());
         }

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -907,6 +907,13 @@ impl App {
     }
 
     fn handle_insert_key(&mut self, key: KeyEvent) {
+        // Reverse-search dispatch is checked BEFORE slash-autocomplete so that
+        // printable chars (including '/') typed into the search query are not
+        // stolen by the autocomplete trigger (C4).
+        if self.reverse_search.is_some() {
+            self.handle_reverse_search_key(key);
+            return;
+        }
         if self.slash_autocomplete.is_some() {
             self.handle_slash_autocomplete_key(key);
             return;
@@ -1089,6 +1096,15 @@ impl App {
             KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.execute_command(TuiCommand::CopyLastAssistant);
             }
+            KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                // Ignore Ctrl+R when slash autocomplete is open — mutual exclusion.
+                if self.slash_autocomplete.is_none() {
+                    let history = self.sessions.current().input_history.clone();
+                    self.reverse_search = Some(
+                        crate::widgets::reverse_search::ReverseSearchState::new(&history),
+                    );
+                }
+            }
             KeyCode::Char('@') => {
                 self.open_file_picker();
             }
@@ -1179,6 +1195,45 @@ impl App {
                     .is_none_or(|s| s.filtered.is_empty())
                 {
                     self.slash_autocomplete = None;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_reverse_search_key(&mut self, key: KeyEvent) {
+        let is_ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let is_alt = key.modifiers.contains(KeyModifiers::ALT);
+        match key.code {
+            KeyCode::Esc => {
+                self.reverse_search = None;
+            }
+            KeyCode::Enter => {
+                let selected = self.reverse_search.as_ref().and_then(|s| {
+                    let hist = &self.sessions.current().input_history;
+                    s.selected_entry(hist).map(str::to_owned)
+                });
+                self.reverse_search = None;
+                if let Some(text) = selected {
+                    self.sessions.current_mut().input = text;
+                    self.sessions.current_mut().cursor_position = self.char_count();
+                }
+            }
+            KeyCode::Char('r') if is_ctrl => {
+                if let Some(s) = self.reverse_search.as_mut() {
+                    s.select_next();
+                }
+            }
+            KeyCode::Backspace => {
+                let history = self.sessions.current().input_history.clone();
+                if let Some(s) = self.reverse_search.as_mut() {
+                    s.pop_char(&history);
+                }
+            }
+            KeyCode::Char(c) if !is_ctrl && !is_alt => {
+                let history = self.sessions.current().input_history.clone();
+                if let Some(s) = self.reverse_search.as_mut() {
+                    s.push_char(c, &history);
                 }
             }
             _ => {}

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -378,6 +378,7 @@ pub struct App {
     tool_expanded: bool,
     tool_density: ToolDensity,
     show_source_labels: bool,
+    show_balance: bool,
     throbber_state: throbber_widgets_tui::ThrobberState,
     confirm_state: Option<ConfirmState>,
     elicitation_state: Option<ElicitationState>,
@@ -386,6 +387,7 @@ pub struct App {
     file_picker_state: Option<FilePickerState>,
     file_index: Option<FileIndex>,
     slash_autocomplete: Option<SlashAutocompleteState>,
+    reverse_search: Option<crate::widgets::reverse_search::ReverseSearchState>,
     pub should_quit: bool,
     user_input_tx: mpsc::Sender<String>,
     agent_event_rx: mpsc::Receiver<AgentEvent>,
@@ -455,6 +457,7 @@ impl App {
             tool_expanded: false,
             tool_density: ToolDensity::default(),
             show_source_labels: false,
+            show_balance: true,
             throbber_state: throbber_widgets_tui::ThrobberState::default(),
             confirm_state: None,
             elicitation_state: None,
@@ -463,6 +466,7 @@ impl App {
             file_picker_state: None,
             file_index: None,
             slash_autocomplete: None,
+            reverse_search: None,
             should_quit: false,
             user_input_tx,
             agent_event_rx,
@@ -1045,6 +1049,20 @@ impl App {
             self.show_source_labels = v;
             self.sessions.current_mut().render_cache.clear();
         }
+    }
+
+    /// Return `true` when the Cocoon TON balance should be shown in the status bar.
+    ///
+    /// Controlled by `[cocoon] show_balance` in config (default `true`). When `false`,
+    /// the balance is redacted to `*** TON` per spec §15.2.
+    #[must_use]
+    pub fn show_balance(&self) -> bool {
+        self.show_balance
+    }
+
+    /// Set whether the Cocoon TON balance is shown in the status bar.
+    pub fn set_show_balance(&mut self, v: bool) {
+        self.show_balance = v;
     }
 
     /// Replace the current hyperlink span list with `links`.

--- a/crates/zeph-tui/src/widgets/mod.rs
+++ b/crates/zeph-tui/src/widgets/mod.rs
@@ -15,6 +15,7 @@ pub mod input;
 pub mod memory;
 pub mod plan_view;
 pub mod resources;
+pub mod reverse_search;
 pub mod security;
 pub mod skills;
 pub mod slash_autocomplete;

--- a/crates/zeph-tui/src/widgets/reverse_search.rs
+++ b/crates/zeph-tui/src/widgets/reverse_search.rs
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState};
+
+use crate::theme::Theme;
+
+const MAX_VISIBLE: usize = 8;
+
+/// Reverse-search state for Ctrl+R prompt history search.
+///
+/// Holds the current query and a filtered list of indices into the session's
+/// `input_history`. History is current-session only (populated on submit,
+/// empty at startup).
+pub struct ReverseSearchState {
+    /// The typed search query.
+    pub query: String,
+    /// Indices into `input_history` that contain `query` as a substring, newest-first.
+    pub matches: Vec<usize>,
+    /// Index into `matches` for the currently highlighted entry.
+    pub selected: usize,
+}
+
+impl ReverseSearchState {
+    /// Create a new state and populate `matches` from the full history (newest-first).
+    #[must_use]
+    pub fn new(history: &[String]) -> Self {
+        let matches = Self::compute_matches("", history);
+        Self {
+            query: String::new(),
+            matches,
+            selected: 0,
+        }
+    }
+
+    /// Append a character to the query and recompute matches.
+    pub fn push_char(&mut self, c: char, history: &[String]) {
+        self.query.push(c);
+        self.refilter(history);
+    }
+
+    /// Remove the last character from the query and recompute matches.
+    pub fn pop_char(&mut self, history: &[String]) {
+        self.query.pop();
+        self.refilter(history);
+    }
+
+    /// Advance `selected` to the next older match (clamps at the end).
+    pub fn select_next(&mut self) {
+        if self.selected + 1 < self.matches.len() {
+            self.selected += 1;
+        }
+    }
+
+    /// Return the history entry for the currently selected match, or `None` if history is empty.
+    #[must_use]
+    pub fn selected_entry<'h>(&self, history: &'h [String]) -> Option<&'h str> {
+        self.matches
+            .get(self.selected)
+            .and_then(|&idx| history.get(idx))
+            .map(String::as_str)
+    }
+
+    fn refilter(&mut self, history: &[String]) {
+        self.matches = Self::compute_matches(&self.query, history);
+        self.selected = self.selected.min(self.matches.len().saturating_sub(1));
+    }
+
+    fn compute_matches(query: &str, history: &[String]) -> Vec<usize> {
+        // Iterate newest-first (reverse index order).
+        (0..history.len())
+            .rev()
+            .filter(|&i| query.is_empty() || history[i].contains(query))
+            .collect()
+    }
+}
+
+/// Render the reverse-search overlay anchored above `input_area`.
+pub fn render(state: &ReverseSearchState, history: &[String], frame: &mut Frame, input_area: Rect) {
+    let theme = Theme::default();
+
+    let visible = if state.matches.is_empty() {
+        1
+    } else {
+        state.matches.len().min(MAX_VISIBLE)
+    };
+    #[allow(clippy::cast_possible_truncation)]
+    let height = (visible as u16) + 2;
+
+    let width: u16 = 60;
+    let x = if input_area.width > width {
+        input_area.x + (input_area.width - width) / 2
+    } else {
+        input_area.x
+    };
+    let actual_width = width.min(input_area.width);
+    let y = input_area.y.saturating_sub(height);
+
+    let popup = Rect {
+        x,
+        y,
+        width: actual_width,
+        height,
+    };
+
+    frame.render_widget(Clear, popup);
+
+    let title = if state.query.is_empty() {
+        " History ".to_owned()
+    } else {
+        format!(" History: {} ", state.query)
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.panel_border)
+        .title(title)
+        .title_alignment(Alignment::Center);
+
+    frame.render_widget(block, popup);
+
+    let list_area = popup.inner(ratatui::layout::Margin {
+        horizontal: 1,
+        vertical: 1,
+    });
+
+    if state.matches.is_empty() {
+        let item = ListItem::new(Line::from(Span::styled(
+            "(no history)",
+            Style::default().fg(ratatui::style::Color::DarkGray),
+        )));
+        frame.render_widget(List::new(vec![item]), list_area);
+        return;
+    }
+
+    let end = state.matches.len().min(MAX_VISIBLE);
+    let items: Vec<ListItem> = state.matches[..end]
+        .iter()
+        .enumerate()
+        .map(|(i, &idx)| {
+            let entry = history.get(idx).map_or("", String::as_str);
+            let style = if i == state.selected {
+                Style::default().bg(theme.highlight.fg.unwrap_or(ratatui::style::Color::Blue))
+            } else {
+                Style::default()
+            };
+            let max_chars = (actual_width as usize).saturating_sub(5);
+            let display = if entry.chars().count() > max_chars {
+                format!("{}…", entry.chars().take(max_chars).collect::<String>())
+            } else {
+                entry.to_owned()
+            };
+            ListItem::new(Line::from(Span::styled(display, style)))
+        })
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.selected));
+
+    frame.render_stateful_widget(List::new(items), list_area, &mut list_state);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::render_to_string;
+
+    fn make_history(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn new_with_empty_history_has_no_matches() {
+        let state = ReverseSearchState::new(&[]);
+        assert!(state.matches.is_empty());
+        assert_eq!(state.selected, 0);
+        assert!(state.query.is_empty());
+    }
+
+    #[test]
+    fn new_with_history_shows_all_newest_first() {
+        let history = make_history(&["first", "second", "third"]);
+        let state = ReverseSearchState::new(&history);
+        // matches should be indices in reverse order: [2, 1, 0]
+        assert_eq!(state.matches, vec![2, 1, 0]);
+    }
+
+    #[test]
+    fn push_char_filters_by_substring() {
+        let history = make_history(&["foo bar", "baz", "foo baz"]);
+        let mut state = ReverseSearchState::new(&history);
+        state.push_char('f', &history);
+        // "foo baz" (idx 2) and "foo bar" (idx 0) both match, newest-first
+        assert_eq!(state.matches, vec![2, 0]);
+    }
+
+    #[test]
+    fn pop_char_restores_wider_matches() {
+        let history = make_history(&["hello", "world"]);
+        let mut state = ReverseSearchState::new(&history);
+        state.push_char('h', &history);
+        assert_eq!(state.matches.len(), 1);
+        state.pop_char(&history);
+        assert_eq!(state.matches.len(), 2);
+    }
+
+    #[test]
+    fn select_next_clamps_at_end() {
+        let history = make_history(&["a", "b"]);
+        let mut state = ReverseSearchState::new(&history);
+        state.select_next();
+        state.select_next(); // should clamp, not panic
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn selected_entry_returns_correct_item() {
+        let history = make_history(&["first", "second"]);
+        let state = ReverseSearchState::new(&history);
+        // newest-first: matches = [1, 0], selected = 0 → history[1] = "second"
+        assert_eq!(state.selected_entry(&history), Some("second"));
+    }
+
+    #[test]
+    fn slash_in_query_does_not_open_slash_autocomplete() {
+        // This test verifies the data path: push_char('/') is handled by ReverseSearchState,
+        // not by the slash autocomplete trigger. The overlay receives the '/' as query input.
+        let history = make_history(&["/clear", "/help", "hello"]);
+        let mut state = ReverseSearchState::new(&history);
+        state.push_char('/', &history);
+        assert_eq!(state.query, "/");
+        // Only entries containing '/' match
+        assert_eq!(state.matches, vec![1, 0]);
+    }
+
+    #[test]
+    fn render_reverse_search_snapshot_empty() {
+        let history = vec![];
+        let state = ReverseSearchState::new(&history);
+        let output = render_to_string(80, 24, |frame, area| {
+            render(&state, &history, frame, area);
+        });
+        assert!(output.contains("History"));
+        assert!(output.contains("no history"));
+    }
+
+    #[test]
+    fn render_reverse_search_snapshot_with_items() {
+        let history = make_history(&["first prompt", "second prompt"]);
+        let state = ReverseSearchState::new(&history);
+        let output = render_to_string(80, 24, |frame, area| {
+            render(&state, &history, frame, area);
+        });
+        assert!(output.contains("History"));
+        assert!(output.contains("second prompt"));
+    }
+
+    #[test]
+    fn render_long_cyrillic_entry_does_not_panic() {
+        // Regression test for S1: byte-slice truncation panicked on multibyte UTF-8.
+        // Cyrillic chars are 2 bytes each; a 60-char string exceeds the 55-char overlay width
+        // and forces the truncation branch. Must not panic.
+        let long_cyrillic = "Привет ".repeat(10); // ~70 chars, well over overlay width
+        let history = vec![long_cyrillic];
+        let state = ReverseSearchState::new(&history);
+        // Must not panic — that is the primary assertion (previously panicked at byte boundary).
+        let output = render_to_string(60, 24, |frame, area| {
+            render(&state, &history, frame, area);
+        });
+        assert!(output.contains("History"), "overlay must render: {output}");
+    }
+}

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -270,7 +270,7 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
             )],
         );
     }
-    if let Some(cocoon_seg) = build_cocoon_spans(metrics, theme) {
+    if let Some(cocoon_seg) = build_cocoon_spans(metrics, app.show_balance(), theme) {
         list.push(Priority::Low, cocoon_seg);
     }
     if metrics.bg_enrichment_inflight > 0 || metrics.bg_telemetry_inflight > 0 {
@@ -326,7 +326,11 @@ fn context_pct(context_tokens: u64, context_max_tokens: u64) -> u64 {
     pct
 }
 
-fn build_cocoon_spans(metrics: &MetricsSnapshot, theme: &Theme) -> Option<Vec<Span<'static>>> {
+fn build_cocoon_spans(
+    metrics: &MetricsSnapshot,
+    show_balance: bool,
+    theme: &Theme,
+) -> Option<Vec<Span<'static>>> {
     match metrics.cocoon_connected {
         None => None,
         Some(true) => {
@@ -335,7 +339,11 @@ fn build_cocoon_spans(metrics: &MetricsSnapshot, theme: &Theme) -> Option<Vec<Sp
                 metrics.cocoon_model_count, metrics.cocoon_worker_count,
             );
             if let Some(balance) = metrics.cocoon_ton_balance {
-                let _ = write!(text, ", {balance:.2} TON");
+                if show_balance {
+                    let _ = write!(text, ", {balance:.2} TON");
+                } else {
+                    text.push_str(", *** TON");
+                }
             }
             Some(vec![Span::styled(text, theme.status_bar)])
         }
@@ -696,7 +704,7 @@ mod tests {
     fn cocoon_segment_none_is_empty() {
         let metrics = MetricsSnapshot::default();
         let theme = Theme::default();
-        assert!(build_cocoon_spans(&metrics, &theme).is_none());
+        assert!(build_cocoon_spans(&metrics, true, &theme).is_none());
     }
 
     #[test]
@@ -709,7 +717,7 @@ mod tests {
             cocoon_ton_balance: Some(42.5),
             ..MetricsSnapshot::default()
         };
-        let spans = build_cocoon_spans(&metrics, &theme).expect("should be Some");
+        let spans = build_cocoon_spans(&metrics, true, &theme).expect("should be Some");
         let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("healthy"), "got: {text}");
         assert!(text.contains("3 models"), "got: {text}");
@@ -724,11 +732,30 @@ mod tests {
             cocoon_connected: Some(false),
             ..MetricsSnapshot::default()
         };
-        let spans = build_cocoon_spans(&metrics, &theme).expect("should be Some");
+        let spans = build_cocoon_spans(&metrics, true, &theme).expect("should be Some");
         let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(
             text.contains("unreachable"),
             "expected 'unreachable' in segment"
+        );
+    }
+
+    #[test]
+    fn cocoon_segment_balance_redacted_when_show_balance_false() {
+        let theme = Theme::default();
+        let metrics = MetricsSnapshot {
+            cocoon_connected: Some(true),
+            cocoon_worker_count: 4,
+            cocoon_model_count: 2,
+            cocoon_ton_balance: Some(99.9),
+            ..MetricsSnapshot::default()
+        };
+        let spans = build_cocoon_spans(&metrics, false, &theme).expect("should be Some");
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("*** TON"), "balance must be redacted: {text}");
+        assert!(
+            !text.contains("99.9"),
+            "real balance must not appear: {text}"
         );
     }
 

--- a/src/init/llm.rs
+++ b/src/init/llm.rs
@@ -353,6 +353,11 @@ fn step_cocoon(state: &mut WizardState, use_age: bool) -> anyhow::Result<()> {
     }
     state.cocoon_wants_access_hash = wants_access_hash;
 
+    state.cocoon_show_balance = Confirm::new()
+        .with_prompt("Show Cocoon TON balance in the TUI status bar?")
+        .default(true)
+        .interact()?;
+
     Ok(())
 }
 

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -250,6 +250,8 @@ pub(crate) struct WizardState {
     pub(crate) cocoon_client_url: Option<String>,
     /// `true` when the user confirmed they have an access hash stored in the vault.
     pub(crate) cocoon_wants_access_hash: bool,
+    /// Show TON balance in TUI status bar (spec §15.2 opt-in redaction, #4649).
+    pub(crate) cocoon_show_balance: bool,
     // CAM fidelity (#4547)
     /// Enable heuristic fidelity scoring (Full/Compressed/Placeholder).
     pub(crate) fidelity_enabled: bool,
@@ -427,6 +429,7 @@ impl Default for WizardState {
             gonka_nodes: Vec::new(),
             cocoon_client_url: None,
             cocoon_wants_access_hash: false,
+            cocoon_show_balance: true,
             fidelity_enabled: false,
         }
     }
@@ -773,6 +776,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     config.memory.digest.enabled = state.digest_enabled;
     config.session.recap.on_resume = state.recap_on_resume;
     config.session.persist_provider_overrides = state.persist_provider_overrides;
+    config.cocoon.show_balance = state.cocoon_show_balance;
     config.mcp.elicitation_enabled = state.mcp_elicitation_enabled;
     config.mcp.elicitation_warn_sensitive_fields = state.mcp_elicitation_warn_sensitive;
     config.quality.self_check = state.quality_self_check;

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -76,6 +76,7 @@ pub(crate) fn start_tui_early(
         .with_command_tx(tui_handle.command_tx.clone())
         .with_tool_density(config.tui.tool_density);
     tui_app.set_show_source_labels(config.tui.show_source_labels);
+    tui_app.set_show_balance(config.cocoon.show_balance);
 
     let agent_tx = tui_handle.agent_tx.clone();
 
@@ -165,6 +166,7 @@ fn spawn_tui_thread(
     command_tx: tokio::sync::mpsc::Sender<zeph_tui::TuiCommand>,
     cancel_signal: std::sync::Arc<tokio::sync::Notify>,
     show_source_labels: bool,
+    show_balance: bool,
     tool_density: zeph_config::ToolDensity,
     metrics_rx: Option<tokio::sync::watch::Receiver<zeph_core::metrics::MetricsSnapshot>>,
     task_supervisor: Option<zeph_common::task_supervisor::TaskSupervisor>,
@@ -180,6 +182,7 @@ fn spawn_tui_thread(
         .with_command_tx(command_tx)
         .with_tool_density(tool_density);
     tui_app.set_show_source_labels(show_source_labels);
+    tui_app.set_show_balance(show_balance);
 
     if let Some(rx) = metrics_rx {
         tui_app = tui_app.with_metrics_rx(rx);
@@ -282,6 +285,7 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
             command_tx,
             agent.cancel_signal(),
             params.config.tui.show_source_labels,
+            params.config.cocoon.show_balance,
             params.config.tui.tool_density,
             params.metrics_rx.take(),
             params.task_supervisor.take(),


### PR DESCRIPTION
## Summary

- **#4649** — Add `cocoon.show_balance` config flag (default `true`). When set to `false`, the TUI sidebar renders `*** TON` instead of the real balance value, preventing leakage in shared-access scenarios (screen sharing, pair programming). Implements spec §15.2 / threat-model SG-8 recommendation directly.
- **#4657** — Add Ctrl+R reverse-search overlay for in-session prompt history. Single-session scope (in-memory, not persisted). Opens with Ctrl+R, filters by substring match on every keystroke, Enter copies selection to input, Esc cancels. Key dispatch checks reverse-search before slash-autocomplete (invariant C4).

## Changes

- `crates/zeph-config/src/cocoon.rs` — new `CocoonConfig { show_balance: bool }` (serde default `true`)
- `crates/zeph-config/src/root.rs` — `Config` gains `cocoon: CocoonConfig` with `#[serde(default)]`
- `crates/zeph-config/src/migrate/steps.rs` — migration step 53: adds `[cocoon]` section (no-op for existing configs)
- `crates/zeph-tui/src/widgets/reverse_search.rs` — `ReverseSearchState` widget with char-safe truncation (Cyrillic-safe)
- `crates/zeph-tui/src/app/keys.rs` — Ctrl+R dispatch, reverse-search event handling before slash-autocomplete
- `crates/zeph-tui/src/app/draw.rs` — reverse-search overlay rendering
- `crates/zeph-tui/src/widgets/status.rs` — `build_cocoon_spans` accepts `show_balance: bool`
- `src/init/mod.rs` + `src/init/llm.rs` — `--init` wizard prompts for `cocoon.show_balance`
- `src/tui_bridge.rs` — passes `show_balance` from config to `App`

## Test plan

- [ ] `cocoon.show_balance = false` in config → TUI shows `*** TON`, real balance absent from render output
- [ ] `cocoon.show_balance = true` (default) → balance shows normally
- [ ] Migration step 53 idempotent: run twice, config unchanged on second run
- [ ] `--init` wizard Cocoon section includes balance opt-in prompt
- [ ] Ctrl+R opens history overlay; typing narrows list by substring
- [ ] Enter copies selected entry to input without auto-submitting
- [ ] Esc dismisses overlay, input unchanged
- [ ] Long Cyrillic history entry renders without panic (regression test in reverse_search.rs)
- [ ] `/` typed while overlay is open goes to search query, not slash-autocomplete
- [ ] Empty history: Ctrl+R shows empty overlay, no panic

Closes #4649
Closes #4657