### PR TITLE
feat(plugins): support multiple --plugin-url values and add PluginName newtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   optional SHA-256 digest, scanned for injection patterns (blocking), and loaded into a temporary
   directory that is cleaned up on process exit. The plugin is never written to the permanent
   plugins store and its config overlays are never applied.
+- `--plugin-url` now accepts multiple values (pass the flag once per URL; closes #4675). Each
+  value can be a plain `https://…` URL or an inline `https://…@sha256hex` pair for integrity
+  pinning. The separate `--plugin-sha256` flag has been removed; use the `url@sha256` syntax
+  instead.
+- `zeph-plugins`: `PluginName` newtype (closes #4674). `AddResult::name`,
+  `InstalledPlugin::name`, and `AutoUpdateResult::name` now carry a `PluginName` instead of a
+  plain `String`. Construct via `PluginName::try_from("name")` — the conversion delegates to
+  `validate_plugin_name` and returns `PluginError::InvalidName` on failure. `PluginName`
+  implements `Display`, `AsRef<str>`, `Ord`, `serde::Serialize` (transparent), and
+  `serde::Deserialize` (validating — rejects names that fail `validate_plugin_name`).
 
 ### Fixed
 

--- a/crates/zeph-plugins/src/lib.rs
+++ b/crates/zeph-plugins/src/lib.rs
@@ -23,6 +23,7 @@ pub(crate) mod integrity;
 pub mod manager;
 pub mod manifest;
 pub mod overlay;
+pub mod types;
 
 pub use error::PluginError;
 pub use manager::{
@@ -32,3 +33,4 @@ pub use manager::{
 };
 pub use manifest::PluginManifest;
 pub use overlay::{ResolvedOverlay, apply_plugin_config_overlays};
+pub use types::PluginName;

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -13,6 +13,7 @@ use zeph_skills::scanner::scan_skill_body;
 
 use crate::PluginError;
 use crate::manifest::{PluginManifest, PluginMcpServer};
+use crate::types::PluginName;
 
 /// Maximum number of entries allowed in `plugin.dependencies`.
 ///
@@ -32,7 +33,7 @@ const CONFIG_SAFELIST: &[&str] = &[
 #[derive(Debug)]
 pub struct AddResult {
     /// Installed plugin name.
-    pub name: String,
+    pub name: PluginName,
     /// Absolute path to the installed plugin root.
     ///
     /// Callers should pass each entry in `installed_skill_dirs` to
@@ -80,7 +81,7 @@ pub struct DisableResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstalledPlugin {
     /// Plugin name.
-    pub name: String,
+    pub name: PluginName,
     /// Plugin version.
     pub version: String,
     /// Plugin description.
@@ -121,7 +122,7 @@ pub struct PluginSource {
 #[derive(Debug)]
 pub struct AutoUpdateResult {
     /// Plugin name.
-    pub name: String,
+    pub name: PluginName,
     /// Specific outcome for this plugin.
     pub status: AutoUpdateStatus,
 }
@@ -357,7 +358,8 @@ impl PluginManager {
         );
 
         Ok(AddResult {
-            name: manifest.plugin.name,
+            // validate_plugin_name already verified the name above; TryFrom is infallible here.
+            name: PluginName::try_from(manifest.plugin.name)?,
             plugin_root: dest,
             installed_skills: skill_names,
             mcp_server_ids,
@@ -503,7 +505,7 @@ impl PluginManager {
         };
         let source_path = self
             .plugins_dir
-            .join(&result.name)
+            .join(result.name.as_str())
             .join(".plugin-source.toml");
         match toml::to_string(&source) {
             Ok(toml_str) => {
@@ -628,8 +630,11 @@ impl PluginManager {
             };
             let skill_names = collect_skill_names(&path, &manifest);
             let auto_update = manifest.plugin.auto_update;
+            let Ok(name) = PluginName::try_from(manifest.plugin.name) else {
+                continue;
+            };
             plugins.push(InstalledPlugin {
-                name: manifest.plugin.name,
+                name,
                 version: manifest.plugin.version,
                 description: manifest.plugin.description,
                 path,
@@ -795,7 +800,7 @@ impl PluginManager {
         let staging = self.plugins_dir.join(format!(".staging-{}", plugin.name));
         let backup = self.plugins_dir.join(format!(".backup-{}", plugin.name));
         let dest = plugin.path.clone();
-        let plugin_name = plugin.name.clone();
+        let plugin_name = plugin.name.as_str().to_owned();
 
         // Offload all blocking filesystem operations to a dedicated thread.
         let mcp_allowed = self.mcp_allowed_commands.clone();
@@ -1251,11 +1256,11 @@ impl PluginManager {
         let mut other_plugin_skills: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
         for plugin in &installed {
-            if plugin.name == this_plugin {
+            if plugin.name.as_str() == this_plugin {
                 continue;
             }
             for name in &plugin.skill_names {
-                other_plugin_skills.insert(name.clone(), plugin.name.clone());
+                other_plugin_skills.insert(name.clone(), plugin.name.as_str().to_owned());
             }
         }
 

--- a/crates/zeph-plugins/src/types.rs
+++ b/crates/zeph-plugins/src/types.rs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Validated newtypes for plugin domain values.
+
+use std::fmt;
+
+use crate::PluginError;
+use crate::manager::validate_plugin_name;
+
+/// A validated plugin name.
+///
+/// A `PluginName` is guaranteed to satisfy the plugin naming rules:
+/// `[a-z][a-z0-9-]*`, at most 64 characters, no path separators or dots.
+///
+/// Construct via [`TryFrom<String>`] or [`TryFrom<&str>`]; both delegate to the
+/// same `validate_plugin_name` predicate used throughout the plugin manager.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_plugins::PluginName;
+///
+/// let name: PluginName = "my-plugin".try_into().unwrap();
+/// assert_eq!(name.as_str(), "my-plugin");
+/// assert_eq!(name.to_string(), "my-plugin");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+#[serde(transparent)]
+pub struct PluginName(String);
+
+impl<'de> serde::Deserialize<'de> for PluginName {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        PluginName::try_from(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl PluginName {
+    /// Returns the plugin name as a `&str`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_plugins::PluginName;
+    ///
+    /// let name: PluginName = "cool-plugin".try_into().unwrap();
+    /// assert_eq!(name.as_str(), "cool-plugin");
+    /// ```
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for PluginName {
+    type Error = PluginError;
+
+    /// Validate and wrap a plugin name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PluginError::InvalidName`] when the string does not satisfy the
+    /// naming rules: `[a-z][a-z0-9-]*`, at most 64 characters, no path separators
+    /// or dots.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_plugins::PluginName;
+    ///
+    /// let ok: PluginName = PluginName::try_from("valid-name".to_owned()).unwrap();
+    /// assert_eq!(ok.as_str(), "valid-name");
+    ///
+    /// // Uppercase letters are rejected.
+    /// let err = PluginName::try_from("Invalid_Name".to_owned());
+    /// assert!(err.is_err());
+    ///
+    /// // Empty string is rejected.
+    /// let err = PluginName::try_from(String::new());
+    /// assert!(err.is_err());
+    ///
+    /// // Names longer than 64 characters are rejected.
+    /// let err = PluginName::try_from("a".repeat(65));
+    /// assert!(err.is_err());
+    /// ```
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        validate_plugin_name(&value)?;
+        Ok(Self(value))
+    }
+}
+
+impl TryFrom<&str> for PluginName {
+    type Error = PluginError;
+
+    /// Validate and wrap a plugin name from a string slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PluginError::InvalidName`] when the string does not satisfy the
+    /// naming rules: `[a-z][a-z0-9-]*`, at most 64 characters, no path separators
+    /// or dots.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_plugins::PluginName;
+    ///
+    /// let ok: PluginName = PluginName::try_from("another-plugin").unwrap();
+    /// assert_eq!(ok.as_str(), "another-plugin");
+    ///
+    /// let err = PluginName::try_from("BAD");
+    /// assert!(err.is_err());
+    /// ```
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        validate_plugin_name(value)?;
+        Ok(Self(value.to_owned()))
+    }
+}
+
+impl fmt::Display for PluginName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for PluginName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq<str> for PluginName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for PluginName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<String> for PluginName {
+    fn eq(&self, other: &String) -> bool {
+        &self.0 == other
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -254,18 +254,16 @@ pub(crate) struct Cli {
 
     /// URL of an ephemeral plugin archive to load for this session only (HTTPS required).
     ///
+    /// May be repeated to load multiple plugins. Each value is either a plain URL or a
+    /// `url@sha256` pair for integrity pinning, e.g.:
+    ///
+    ///   `--plugin-url https://example.com/p.tar.gz@abc123...`
+    ///
     /// The archive is downloaded, scanned for injection patterns, and loaded into a temporary
     /// directory that is cleaned up on process exit. The plugin is never written to the
-    /// permanent plugins store. Pair with `--plugin-sha256` for integrity verification.
-    #[arg(long)]
-    pub(crate) plugin_url: Option<String>,
-
-    /// Expected SHA-256 hex digest of the plugin archive at `--plugin-url`.
-    ///
-    /// When provided, the downloaded archive is verified before extraction. The session aborts
-    /// if the digest does not match. Requires `--plugin-url`.
-    #[arg(long, requires = "plugin_url")]
-    pub(crate) plugin_sha256: Option<String>,
+    /// permanent plugins store.
+    #[arg(long, action = clap::ArgAction::Append)]
+    pub(crate) plugin_url: Vec<String>,
 
     #[command(subcommand)]
     pub(crate) command: Option<Command>,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1779,33 +1779,35 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         });
     }
 
-    // Load ephemeral plugin from --plugin-url before building the skill registry.
-    let ephemeral_plugin_dir: Option<tempfile::TempDir> = if let Some(ref url) = cli.plugin_url {
-        let sha256 = cli.plugin_sha256.as_deref();
+    // Load ephemeral plugins from --plugin-url (may be repeated) before building the skill registry.
+    let mut ephemeral_plugin_dirs: Vec<tempfile::TempDir> = Vec::new();
+    if !cli.plugin_url.is_empty() {
         let mgr = zeph_plugins::PluginManager::new(
             crate::bootstrap::plugins_dir(),
             crate::bootstrap::managed_skills_dir(),
             config.mcp.allowed_commands.clone(),
             config.tools.shell.allowed_commands.clone(),
         );
-        match mgr.add_remote_ephemeral(url, sha256).await {
-            Ok(tmp) => {
-                tracing::info!(url, "ephemeral plugin loaded for this session");
-                Some(tmp)
-            }
-            Err(e) => {
-                return Err(anyhow::anyhow!(
-                    "failed to load ephemeral plugin from {url}: {e}"
-                ));
+        for raw in &cli.plugin_url {
+            // Accept both plain URLs and `url@sha256` pairs.
+            let (url, sha256) = parse_plugin_url_arg(raw);
+            match mgr.add_remote_ephemeral(url, sha256).await {
+                Ok(tmp) => {
+                    tracing::info!(url, "ephemeral plugin loaded for this session");
+                    ephemeral_plugin_dirs.push(tmp);
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "failed to load ephemeral plugin from {url}: {e}"
+                    ));
+                }
             }
         }
-    } else {
-        None
-    };
+    }
 
     let mut skill_paths = app.skill_paths_for_registry();
     // Include ephemeral plugin skill dirs in the registry.
-    if let Some(ref tmp) = ephemeral_plugin_dir {
+    for tmp in &ephemeral_plugin_dirs {
         let manifest_path = tmp.path().join("plugin.toml");
         if let Ok(manifest_str) = std::fs::read_to_string(&manifest_path)
             && let Ok(manifest) = toml::from_str::<zeph_plugins::PluginManifest>(&manifest_str)
@@ -2332,10 +2334,10 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     .await;
 
     // Hold ephemeral plugin TempDir handles in the agent for the session lifetime.
-    let agent = if let Some(tmp) = ephemeral_plugin_dir {
-        agent.with_ephemeral_plugins(vec![tmp])
-    } else {
+    let agent = if ephemeral_plugin_dirs.is_empty() {
         agent
+    } else {
+        agent.with_ephemeral_plugins(ephemeral_plugin_dirs)
     };
 
     // Wire JsonEventLayer when --json is active so tool_call / tool_result events
@@ -3671,10 +3673,64 @@ fn parse_thinking_arg(s: &str) -> anyhow::Result<ThinkingConfig> {
     )
 }
 
+/// Split a `--plugin-url` argument into `(url, sha256)`.
+///
+/// Accepts either a plain URL (`https://host/plugin.tar.gz`) or an inline
+/// `url@sha256` pair (`https://host/p.tar.gz@abc123def...`).  The split point
+/// is the *last* `@` in the string, which avoids confusing `user@host` in
+/// hypothetical non-HTTPS URLs while still working for typical HTTPS archives.
+fn parse_plugin_url_arg(raw: &str) -> (&str, Option<&str>) {
+    match raw.rfind('@') {
+        Some(pos) => (&raw[..pos], Some(&raw[pos + 1..])),
+        None => (raw, None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::Parser;
+
+    // --- parse_plugin_url_arg ---
+
+    #[test]
+    fn parse_plugin_url_plain_url() {
+        let (url, sha256) = parse_plugin_url_arg("https://example.com/plugin.tar.gz");
+        assert_eq!(url, "https://example.com/plugin.tar.gz");
+        assert_eq!(sha256, None);
+    }
+
+    #[test]
+    fn parse_plugin_url_with_sha256() {
+        let (url, sha256) = parse_plugin_url_arg("https://example.com/plugin.tar.gz@abc123def456");
+        assert_eq!(url, "https://example.com/plugin.tar.gz");
+        assert_eq!(sha256, Some("abc123def456"));
+    }
+
+    #[test]
+    fn parse_plugin_url_multiple_at_signs_splits_on_last() {
+        // URL-like strings with multiple '@' — split on the LAST one (rfind semantics).
+        let (url, sha256) =
+            parse_plugin_url_arg("https://user@host.example.com/plugin.tar.gz@deadbeef");
+        assert_eq!(url, "https://user@host.example.com/plugin.tar.gz");
+        assert_eq!(sha256, Some("deadbeef"));
+    }
+
+    #[test]
+    fn parse_plugin_url_at_only_yields_empty_sha256_part() {
+        // A bare '@' at the end produces an empty digest string, not None.
+        let (url, sha256) = parse_plugin_url_arg("https://example.com/plugin.tar.gz@");
+        assert_eq!(url, "https://example.com/plugin.tar.gz");
+        assert_eq!(sha256, Some(""));
+    }
+
+    #[test]
+    fn parse_plugin_url_empty_string() {
+        // Empty input should return empty url and no sha256.
+        let (url, sha256) = parse_plugin_url_arg("");
+        assert_eq!(url, "");
+        assert_eq!(sha256, None);
+    }
 
     // --- resolve_logging_config ---
 


### PR DESCRIPTION
## Summary

- **#4675**: `--plugin-url` now accepts multiple values via `ArgAction::Append`; `--plugin-sha256` removed in favour of inline `url@sha256` syntax per URL. Runner iterates over all URLs and passes the full `Vec<TempDir>` to `with_ephemeral_plugins()`.
- **#4674**: `PluginName` newtype introduced in `zeph-plugins` — `TryFrom<String>` / `TryFrom<&str>` validate via `validate_plugin_name()` at construction; `Deserialize` delegates to `TryFrom` (never bypasses validation); `Serialize` is transparent. `AddResult`, `InstalledPlugin`, and `AutoUpdateResult` carry `PluginName` instead of raw `String`.

## Breaking changes

- `--plugin-sha256` CLI flag removed; use `url@sha256` inline syntax instead
- `.name` on `AddResult`, `InstalledPlugin`, `AutoUpdateResult` is now `PluginName`; use `.name.as_str()` or `.name.to_string()` where `&str` / `String` is required

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 10572 passed, 22 skipped
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean
- [ ] Two new unit tests for `parse_plugin_url_arg` (multiple `@`, bare `@`, empty string)
- [ ] `PluginName` doc-tests cover happy path, empty string, >64 char rejection
- [ ] Manual `Deserialize` for `PluginName` rejects invalid names; transparent `Serialize` roundtrips correctly

Closes #4675
Closes #4674