### PR TITLE
feat(skills): recursive nested skill discovery and egress attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `zeph-skills`: recursive `SKILL.md` discovery now uses depth-first pre-order traversal
+  (siblings sorted lexicographically, `max_depth = 16`) via `walkdir`, replacing the previous
+  flat single-level `read_dir` scan. Skills at any nesting depth are discovered and registered;
+  symlinked directories are not followed; per-file path validation is unchanged. The first
+  encountered skill wins on duplicate names (DFS pre-order within each base directory, base
+  directories ordered by caller priority). Closes #4682.
+- `zeph-tools`: `ToolCall` now carries `skill_name: Option<Vec<String>>` (turn-level attribution
+  of which skills were active in the system prompt when the tool call was issued). The field is
+  propagated to `AuditEntry` and `EgressEvent` (both with `#[serde(skip_serializing_if =
+  "Option::is_none")]` to preserve existing JSONL consumers). Attribution is set in the main agent
+  loop (`tier_loop.rs`) and threads through all decorator executors (`ScopedToolExecutor`,
+  `PolicyGateExecutor`, `AdversarialPolicyGateExecutor`) and the scrape executor's egress path.
+  `ToolCall` now derives `Default` to reduce churn at struct literal sites. Closes #4684.
+
 ### Research
 
 - Competitive parity scan: assessed Goose v1.34.0–v1.35.0 features against Zeph. Three features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11250,6 +11250,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "uuid",
+ "walkdir",
  "zeph-common",
  "zeph-config",
  "zeph-llm",

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
@@ -180,6 +180,7 @@ impl AirlineEnv {
                 caller_id: None,
                 context: None,
                 tool_call_id: String::new(),
+                skill_name: None,
             };
             self.execute_tool_call(&call).await.map_err(|e| {
                 BenchError::InvalidFormat(format!("replay action '{}': {e}", action.name))
@@ -668,6 +669,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
@@ -199,6 +199,7 @@ impl RetailEnv {
                 caller_id: None,
                 context: None,
                 tool_call_id: String::new(),
+                skill_name: None,
             };
             self.execute_tool_call(&call).await.map_err(|e| {
                 BenchError::InvalidFormat(format!("replay action '{}': {e}", action.name))
@@ -789,6 +790,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1500,6 +1500,7 @@ impl<C: Channel> Agent<C> {
                 exit_code: None,
                 truncated: false,
                 caller_id: None,
+                skill_name: None,
                 policy_match: None,
                 correlation_id: None,
                 vigil_risk: None,

--- a/crates/zeph-core/src/agent/scheduler_commands.rs
+++ b/crates/zeph-core/src/agent/scheduler_commands.rs
@@ -15,8 +15,8 @@ impl<C: Channel> Agent<C> {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
-
             tool_call_id: String::new(),
+            skill_name: None,
         };
         match self.tool_executor.execute_tool_call_erased(&call).await {
             Ok(Some(output)) => Ok(output.summary),

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -681,8 +681,8 @@ impl<C: crate::channel::Channel> Agent<C> {
                             },
                             caller_id: None,
                             context: None,
-
                             tool_call_id: String::new(),
+                            skill_name: None,
                         };
                         let output = loop {
                             tokio::select! {

--- a/crates/zeph-core/src/agent/speculative/prediction.rs
+++ b/crates/zeph-core/src/agent/speculative/prediction.rs
@@ -49,8 +49,8 @@ impl Prediction {
             params: self.args.clone(),
             caller_id: Some(call_id.into()),
             context: None,
-
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -275,6 +275,7 @@ impl<C: Channel> Agent<C> {
                 exit_code: None,
                 truncated: false,
                 caller_id: None,
+                skill_name: None,
                 policy_match: None,
                 correlation_id: None,
                 vigil_risk: None,

--- a/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
@@ -396,6 +396,7 @@ fn clear_utility_state_resets_per_turn_redundancy_tracking() {
         context: None,
 
         tool_call_id: String::new(),
+        skill_name: None,
     };
     let ctx = UtilityContext {
         tool_calls_this_turn: 0,
@@ -728,6 +729,7 @@ fn test_tool_call(tool_id: &str) -> ToolCall {
         context: None,
 
         tool_call_id: String::new(),
+        skill_name: None,
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
@@ -103,6 +103,7 @@ fn make_calls(n: usize) -> Vec<ToolCall> {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         })
         .collect()
 }

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -330,6 +330,7 @@ impl<C: Channel> Agent<C> {
                                 exit_code: None,
                                 truncated: false,
                                 caller_id: call.caller_id.clone(),
+                                skill_name: call.skill_name.clone(),
                                 policy_match: None,
                                 correlation_id: None,
                                 vigil_risk: None,
@@ -651,6 +652,11 @@ impl<C: Channel> Agent<C> {
         Ok(())
     }
 
+    fn skill_attribution(&self) -> Option<Vec<String>> {
+        (!self.services.skill.active_skill_names.is_empty())
+            .then(|| self.services.skill.active_skill_names.clone())
+    }
+
     fn prepare_tool_dispatch(
         &mut self,
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
@@ -659,7 +665,7 @@ impl<C: Channel> Agent<C> {
         // When the orchestration scheduler has set a named execution environment for the
         // current task, inject it into every ToolCall so ShellExecutor::resolve_context
         // uses the right env/cwd without the LLM having to supply it.
-        let task_ctx: Option<ExecutionContext> = self
+        let task_ctx = self
             .services
             .orchestration
             .task_execution_env
@@ -692,13 +698,12 @@ impl<C: Channel> Agent<C> {
                     caller_id: None,
                     context: task_ctx.clone(),
                     tool_call_id: tool_call_ids[idx].clone(),
+                    skill_name: self.skill_attribution(),
                 })
             })
             .collect();
-        // tool_started_ats is populated per-tier just before each tier's join_all so that
-        // audit timestamps reflect actual execution start rather than pre-build time.
-        let tool_started_ats: Vec<std::time::Instant> =
-            vec![std::time::Instant::now(); tool_calls.len()];
+        // Timestamps filled just before each tier's join_all so audit reflects actual start.
+        let tool_started_ats = vec![std::time::Instant::now(); tool_calls.len()];
 
         self.check_exfiltration_urls(tool_calls);
 

--- a/crates/zeph-core/src/agent/tool_execution/tool_result.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_result.rs
@@ -55,6 +55,7 @@ impl<C: Channel> Agent<C> {
             exit_code: None,
             truncated: false,
             caller_id: None,
+            skill_name: None,
             policy_match: None,
             correlation_id: None,
             vigil_risk,

--- a/crates/zeph-core/src/memory_tools.rs
+++ b/crates/zeph-core/src/memory_tools.rs
@@ -302,6 +302,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -323,6 +324,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -353,6 +355,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -374,6 +377,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -395,6 +399,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -418,6 +423,7 @@ mod tests {
             caller_id: None,
             context: None,
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let output = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(

--- a/crates/zeph-core/src/overflow_tools.rs
+++ b/crates/zeph-core/src/overflow_tools.rs
@@ -129,6 +129,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 
@@ -160,6 +161,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-core/src/runtime_layer.rs
+++ b/crates/zeph-core/src/runtime_layer.rs
@@ -192,6 +192,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = layer.before_tool(&ctx, &call).await;
         assert!(result.is_none());
@@ -417,6 +418,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result: Result<Option<ToolOutput>, ToolError> = Ok(None);
 
@@ -455,6 +457,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result: Result<Option<ToolOutput>, zeph_tools::ToolError> = Ok(None);
         layer.after_tool(&ctx, &call, &result).await;

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -331,6 +331,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 
@@ -345,6 +346,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 
@@ -460,6 +462,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-core/src/skill_loader.rs
+++ b/crates/zeph-core/src/skill_loader.rs
@@ -111,6 +111,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("## Instructions"));
@@ -132,6 +133,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("skill not found"));
@@ -160,6 +162,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -182,6 +185,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("truncated"));
@@ -203,6 +207,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("skill not found"));
@@ -240,6 +245,7 @@ mod tests {
                         context: None,
 
                         tool_call_id: String::new(),
+                        skill_name: None,
                     };
                     ex.execute_tool_call(&call).await
                 })
@@ -268,6 +274,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("skill not found"));
@@ -286,6 +293,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());

--- a/crates/zeph-index/src/mcp_server.rs
+++ b/crates/zeph-index/src/mcp_server.rs
@@ -679,6 +679,7 @@ impl Foo {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-mcp/src/executor.rs
+++ b/crates/zeph-mcp/src/executor.rs
@@ -192,6 +192,7 @@ impl ToolExecutor for McpToolExecutor {
                 caller_id: None,
                 context: None,
                 tool_call_id: String::new(),
+                skill_name: None,
             };
             if let Some(output) = self.execute_tool_call(&call).await? {
                 outputs.push(output.summary);
@@ -456,6 +457,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -471,6 +473,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -501,6 +504,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -529,6 +533,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err(), "expected Err when server is not connected");

--- a/crates/zeph-mcp/src/testing.rs
+++ b/crates/zeph-mcp/src/testing.rs
@@ -217,6 +217,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = mock.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -233,6 +234,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = mock.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -251,6 +253,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = mock.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -269,6 +272,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         mock.execute_tool_call(&call).await.unwrap();
 
@@ -290,6 +294,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
 
         // First call succeeds.

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -39,6 +39,7 @@ toml = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
 uuid = { workspace = true, features = ["v5"] }
+walkdir = { workspace = true }
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-llm.workspace = true

--- a/crates/zeph-skills/src/registry.rs
+++ b/crates/zeph-skills/src/registry.rs
@@ -3,14 +3,33 @@
 
 //! In-process skill registry with lazy body loading and content fingerprinting.
 //!
-//! [`SkillRegistry`] scans one or more base directories for `*/SKILL.md` files,
-//! loads their frontmatter eagerly, and reads the Markdown body on first access
-//! (via [`std::sync::OnceLock`]). This keeps startup I/O proportional to the number
+//! [`SkillRegistry`] scans one or more base directories for `SKILL.md` files at any
+//! nesting depth, loads their frontmatter eagerly, and reads the Markdown body on first
+//! access (via [`std::sync::OnceLock`]). This keeps startup I/O proportional to the number
 //! of skills, not to their total size.
+//!
+//! # Discovery order
+//!
+//! Within each base directory the registry uses a depth-first pre-order walk with
+//! siblings sorted lexicographically at each level. This means a parent directory's
+//! `SKILL.md` is always visited before any of its own descendants' `SKILL.md` files,
+//! but there is no global depth-priority across unrelated branches (e.g. `a/b/SKILL.md`
+//! is visited before `c/SKILL.md` when `a` < `c` lexicographically, regardless of depth).
+//!
+//! Symlinked *directories* are not followed (walkdir default). Symlinked `SKILL.md`
+//! *files* are resolved by [`validate_path_within`] and must canonicalize to a path
+//! inside the base directory, otherwise they are rejected with a warning.
+//!
+//! Traversal is limited to [`MAX_SKILL_DEPTH`] levels to prevent runaway recursion on
+//! adversarial directory trees. A directory at exactly that depth is still descended into;
+//! skills deeper than `MAX_SKILL_DEPTH` relative to the base are silently skipped (the
+//! limit should be set generously enough that this is never a surprise in practice).
 //!
 //! # Duplicate handling
 //!
-//! When the same skill name appears in multiple base directories the **first** path wins.
+//! When the same skill name appears in multiple base directories, or multiple times
+//! within the same base directory at different depths, the **first** encountered path
+//! wins according to the DFS pre-order described above.
 //! Pass higher-priority directories first (e.g. user-managed before bundled).
 //!
 //! # Examples
@@ -34,11 +53,20 @@ use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::sync::OnceLock;
 
+use walkdir::WalkDir;
 use zeph_common::SkillTrustLevel;
 
 use crate::error::SkillError;
 use crate::loader::{Skill, SkillMeta, load_skill_body, load_skill_meta, validate_path_within};
 use crate::scanner::{EscalationResult, ScanResult, check_capability_escalation, scan_skill_body};
+
+/// Maximum directory depth searched for `SKILL.md` files relative to a base directory.
+///
+/// A depth of 1 means only `base/*/SKILL.md` (same as the old flat scan). A depth of
+/// 16 allows deeply nested plugin bundles without bound on practical layouts. Skills at
+/// `depth > MAX_SKILL_DEPTH` are silently skipped — this limit is intentionally generous
+/// so that no real-world layout hits it.
+const MAX_SKILL_DEPTH: usize = 16;
 
 struct SkillEntry {
     meta: SkillMeta,
@@ -113,12 +141,24 @@ impl SkillRegistry {
         }
     }
 
-    /// Scan directories for `*/SKILL.md` and load metadata only (lazy body).
+    /// Scan directories recursively for `SKILL.md` files and load metadata only (lazy body).
     ///
-    /// Earlier paths have higher priority: if a skill with the same name appears
-    /// in multiple paths, only the first one is kept.
+    /// Searches at any depth up to [`MAX_SKILL_DEPTH`] using a depth-first pre-order walk
+    /// with siblings sorted lexicographically. Earlier paths have higher priority: if a skill
+    /// with the same name appears in multiple paths or multiple depths within the same path,
+    /// only the first one encountered in DFS order is kept.
     ///
     /// Invalid files are logged with `tracing::warn` and skipped.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use zeph_skills::registry::SkillRegistry;
+    ///
+    /// // Skills can live at any depth: `plugins/auth/SKILL.md`, `plugins/auth/sub/SKILL.md`
+    /// let registry = SkillRegistry::load(&["/path/to/skills"]);
+    /// println!("loaded {} skills", registry.all_meta().len());
+    /// ```
     #[cfg_attr(
         feature = "profiling",
         tracing::instrument(name = "skill.registry_load", skip_all, fields(count = tracing::field::Empty))
@@ -129,21 +169,32 @@ impl SkillRegistry {
 
         for base in paths {
             let base = base.as_ref();
-            let Ok(dir_entries) = std::fs::read_dir(base) else {
-                tracing::warn!("cannot read skill directory: {}", base.display());
-                continue;
-            };
+            // WalkDir pre-order DFS, siblings sorted lexicographically, no symlink-dir follow.
+            let walker = WalkDir::new(base)
+                .max_depth(MAX_SKILL_DEPTH)
+                .follow_links(false)
+                .sort_by_file_name();
 
-            for entry in dir_entries.flatten() {
-                let skill_path = entry.path().join("SKILL.md");
-                if !skill_path.is_file() {
+            for entry in walker {
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(e) => {
+                        tracing::warn!("skill directory walk error: {e}");
+                        continue;
+                    }
+                };
+                if !entry.file_type().is_file() {
                     continue;
                 }
-                if let Err(e) = validate_path_within(&skill_path, base) {
+                if entry.file_name() != "SKILL.md" {
+                    continue;
+                }
+                let skill_path = entry.path();
+                if let Err(e) = validate_path_within(skill_path, base) {
                     tracing::warn!("skipping skill path traversal: {e:#}");
                     continue;
                 }
-                match load_skill_meta(&skill_path) {
+                match load_skill_meta(skill_path) {
                     Ok(meta) => {
                         if seen.insert(meta.name.clone()) {
                             entries.push(SkillEntry {
@@ -699,5 +750,126 @@ mod tests {
             1,
             "after reload, hub skill must still be flagged — hub_dirs must be preserved"
         );
+    }
+
+    // --- Nested discovery tests (#4682) ---
+
+    /// Create a skill at `base/rel_path/SKILL.md`.
+    ///
+    /// The leaf component of `rel_path` must equal `name` — the loader enforces
+    /// that the skill name matches the parent directory name.
+    fn create_skill_nested(dir: &Path, rel_path: &str, description: &str, body: &str) {
+        let skill_dir = dir.join(rel_path);
+        // The skill name is the leaf directory name, per loader convention.
+        let name = skill_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("rel_path must have a non-empty leaf component");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {description}\n---\n{body}"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn discovers_skill_at_depth_two() {
+        let dir = tempfile::tempdir().unwrap();
+        // skill lives at base/vendor/auth/SKILL.md — depth 2, name == "auth"
+        create_skill_nested(dir.path(), "vendor/auth", "Auth skill", "body");
+
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        assert_eq!(registry.all_meta().len(), 1);
+        assert_eq!(registry.all_meta()[0].name, "auth");
+    }
+
+    #[test]
+    fn discovers_skills_at_mixed_depths() {
+        let dir = tempfile::tempdir().unwrap();
+        create_skill(dir.path(), "shallow", "Shallow", "body");
+        create_skill_nested(dir.path(), "vendor/deep", "Deep", "body");
+
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        let names: Vec<_> = registry
+            .all_meta()
+            .iter()
+            .map(|m| m.name.as_str())
+            .collect();
+        assert_eq!(registry.all_meta().len(), 2);
+        assert!(names.contains(&"shallow"));
+        assert!(names.contains(&"deep"));
+    }
+
+    /// DFS pre-order: a directory is visited before its own subdirectories.
+    ///
+    /// Both `shared/SKILL.md` and `shared/shared/SKILL.md` carry `name: "shared"`.
+    /// DFS pre-order visits the parent (`shared/`) before descending into `shared/shared/`,
+    /// so the shallower copy wins the first-insert-wins dedup.
+    #[test]
+    fn parent_wins_over_descendant_same_branch() {
+        let dir = tempfile::tempdir().unwrap();
+        // Top-level skill: shared/SKILL.md (name="shared", description="parent")
+        create_skill(dir.path(), "shared", "parent", "body");
+        // Nested skill: shared/shared/SKILL.md (name="shared", description="child")
+        create_skill_nested(dir.path(), "shared/shared", "child", "child body");
+
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        assert_eq!(
+            registry.all_meta().len(),
+            1,
+            "duplicate name must be deduped"
+        );
+        assert_eq!(
+            registry.all_meta()[0].description,
+            "parent",
+            "DFS pre-order: parent directory visited before its own descendants"
+        );
+    }
+
+    /// DFS pre-order with lexicographic sibling sort: `a/` branch fully traversed before `b/`.
+    ///
+    /// `a/shared/SKILL.md` and `b/shared/SKILL.md` both have `name: "shared"`.
+    /// Because siblings sort lexicographically, the `a` branch is fully traversed first,
+    /// so `a/shared` wins the duplicate-name collision even though both are at equal depth.
+    #[test]
+    fn lexicographic_sibling_order_determines_duplicate_winner() {
+        let dir = tempfile::tempdir().unwrap();
+        // a/shared/SKILL.md — visited first (a < b in sibling order)
+        create_skill_nested(dir.path(), "a/shared", "from-a", "body");
+        // b/shared/SKILL.md — visited second
+        create_skill_nested(dir.path(), "b/shared", "from-b", "body");
+
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        assert_eq!(
+            registry.all_meta().len(),
+            1,
+            "duplicate name must be deduped"
+        );
+        assert_eq!(
+            registry.all_meta()[0].description,
+            "from-a",
+            "lexicographic sibling sort: a/ branch visited before b/"
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_nested_skill_added() {
+        let dir = tempfile::tempdir().unwrap();
+        create_skill(dir.path(), "top", "Top", "body");
+
+        let mut registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        let fp_before = registry.fingerprint();
+
+        // Add a new nested skill: vendor/new-nested/SKILL.md (name="new-nested")
+        create_skill_nested(dir.path(), "vendor/new-nested", "New", "body");
+        registry.reload(&[dir.path().to_path_buf()]);
+
+        assert_ne!(
+            registry.fingerprint(),
+            fp_before,
+            "fingerprint must change when a new nested skill is added"
+        );
+        assert_eq!(registry.all_meta().len(), 2);
     }
 }

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -524,8 +524,8 @@ async fn handle_tool_step(
                     params,
                     caller_id: None,
                     context: None,
-
                     tool_call_id: String::new(),
+                    skill_name: None,
                 };
                 let tool_start = Instant::now();
                 let exec_result = executor.execute_tool_call_erased(&call).await;

--- a/crates/zeph-subagent/src/filter.rs
+++ b/crates/zeph-subagent/src/filter.rs
@@ -572,6 +572,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let res = exec.execute_tool_call_erased(&call).await.unwrap();
         assert!(res.is_some());
@@ -590,6 +591,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_err());
@@ -608,6 +610,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_err());
@@ -623,6 +626,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let res = exec.execute_tool_call_erased(&call).await.unwrap();
         assert!(res.is_some());
@@ -700,6 +704,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let res = exec.execute_tool_call_erased(&call).await.unwrap();
         assert!(res.is_some());
@@ -834,6 +839,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(
@@ -856,6 +862,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_ok(), "non-disallowed tool must be allowed");
@@ -933,6 +940,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_err(), "plan mode must block all tool execution");

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -4722,6 +4722,7 @@ mod tests {
             caller_id: None,
             context: None,
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -159,6 +159,7 @@ impl<T: ToolExecutor> AdversarialPolicyGateExecutor<T> {
             exit_code: None,
             truncated: false,
             caller_id: call.caller_id.clone(),
+            skill_name: call.skill_name.clone(),
             policy_match: None,
             correlation_id: None,
             vigil_risk: None,
@@ -334,6 +335,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -75,6 +75,13 @@ pub struct EgressEvent {
     /// Caller identity propagated from `ToolCall::caller_id`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub caller_id: Option<String>,
+    /// Skills active in the turn that triggered this egress call (turn-level attribution).
+    ///
+    /// Propagated from `ToolCall::skill_name`. `None` for system-initiated calls.
+    /// This is turn-scoped: it lists all skills injected into the system prompt for
+    /// the current turn, not necessarily the specific skill that caused this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill_name: Option<Vec<String>>,
     /// Redirect hop index (0 for the initial request). Distinguishes per-hop events
     /// sharing the same `correlation_id`.
     #[serde(default, skip_serializing_if = "is_zero_u8")]
@@ -204,6 +211,13 @@ pub struct AuditEntry {
     /// `None` when `ScopedToolExecutor` is not in the chain.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope_at_dispatch: Option<String>,
+    /// Skills active in the turn that triggered this tool call (turn-level attribution).
+    ///
+    /// Propagated from `ToolCall::skill_name`. `None` for
+    /// system-initiated or internal tool calls. This is turn-scoped: it lists all skills
+    /// injected into the system prompt for the current turn, not per-call causation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill_name: Option<Vec<String>>,
 }
 
 /// Risk level assigned by the VIGIL pre-sanitizer gate to a flagged tool output.
@@ -443,6 +457,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"success\""));
@@ -479,6 +494,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"blocked\""));
@@ -514,6 +530,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"error\""));
@@ -546,6 +563,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"timeout\""));
@@ -584,6 +602,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         logger.log(&entry).await;
     }
@@ -623,6 +642,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         logger.log(&entry).await;
 
@@ -689,6 +709,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -725,6 +746,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -770,6 +792,7 @@ mod tests {
                 resolved_cwd: None,
                 scope_at_definition: None,
                 scope_at_dispatch: None,
+                skill_name: None,
             };
             logger.log(&entry).await;
         }
@@ -805,6 +828,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -840,6 +864,7 @@ mod tests {
             resolved_cwd: None,
             scope_at_definition: None,
             scope_at_dispatch: None,
+            skill_name: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(

--- a/crates/zeph-tools/src/composite.rs
+++ b/crates/zeph-tools/src/composite.rs
@@ -294,6 +294,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = composite.execute_tool_call(&call).await.unwrap().unwrap();
         assert_eq!(result.summary, "file_handler");
@@ -309,6 +310,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = composite.execute_tool_call(&call).await.unwrap().unwrap();
         assert_eq!(result.summary, "shell_handler");
@@ -324,6 +326,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = composite.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-tools/src/compression/decorator.rs
+++ b/crates/zeph-tools/src/compression/decorator.rs
@@ -277,6 +277,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let out = executor.execute_tool_call(&call).await.unwrap().unwrap();
 
@@ -300,6 +301,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let out = executor.execute_tool_call(&call).await.unwrap().unwrap();
         // StubCompressor would return "COMPRESSED" — but threshold not met, so raw passes through.
@@ -336,6 +338,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let out = executor.execute_tool_call(&call).await.unwrap().unwrap();
         // Error compressor → raw output preserved (T4 safety invariant).

--- a/crates/zeph-tools/src/cwd.rs
+++ b/crates/zeph-tools/src/cwd.rs
@@ -106,6 +106,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 
@@ -135,6 +136,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -353,6 +353,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = exec.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -368,6 +369,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -42,10 +42,11 @@ pub struct DiffData {
 ///     caller_id: Some("user-42".to_owned()),
 ///     context: Some(ExecutionContext::new().with_name("repo")),
 ///     tool_call_id: String::new(),
+///     skill_name: None,
 /// };
 /// assert_eq!(call.tool_id, "bash");
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ToolCall {
     /// The tool identifier, matching a value from [`ToolExecutor::tool_definitions`].
     pub tool_id: ToolName,
@@ -60,6 +61,13 @@ pub struct ToolCall {
     /// Opaque tool call ID used to correlate [`ToolEvent::OutputChunk`] events with
     /// their originating tool call in the TUI. Empty when not set by the agent loop.
     pub tool_call_id: String,
+    /// Names of skills active in the turn that issued this tool call (turn-level attribution).
+    ///
+    /// This is a best-effort, turn-scoped field: it lists the skills injected into the
+    /// system prompt for the current turn, not the specific skill that caused this individual
+    /// call (the LLM does not report per-call causation). `None` for system-initiated or
+    /// internal tool calls that execute outside the skill-augmented agent loop.
+    pub skill_name: Option<Vec<String>>,
 }
 
 /// Cumulative filter statistics for a single tool execution.
@@ -316,6 +324,8 @@ pub enum ToolEvent {
         /// Opaque tool call ID matching the corresponding [`ToolEvent::Started`] event.
         /// Empty string when the executor does not have access to the call ID.
         tool_call_id: String,
+        /// Skills active in the turn that triggered this tool call (turn-level attribution).
+        skill_name: Option<Vec<String>>,
     },
     /// The tool finished. Contains the full output and optional filter/diff data.
     Completed {
@@ -1266,6 +1276,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -1413,6 +1424,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -1750,6 +1762,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -1099,6 +1099,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert_eq!(result.tool_name, "read");

--- a/crates/zeph-tools/src/moderation.rs
+++ b/crates/zeph-tools/src/moderation.rs
@@ -390,6 +390,7 @@ mod tests {
             caller_id: None,
             context: None,
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -168,6 +168,7 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
             exit_code: None,
             truncated: false,
             caller_id: call.caller_id.clone(),
+            skill_name: call.skill_name.clone(),
             policy_match: None,
             correlation_id: None,
             vigil_risk: None,
@@ -223,6 +224,7 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         exit_code: None,
                         truncated: false,
                         caller_id: call.caller_id.clone(),
+                        skill_name: call.skill_name.clone(),
                         policy_match: Some(trace.clone()),
                         correlation_id: None,
                         vigil_risk: None,
@@ -260,6 +262,7 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         exit_code: None,
                         truncated: false,
                         caller_id: call.caller_id.clone(),
+                        skill_name: call.skill_name.clone(),
                         policy_match: Some(trace.clone()),
                         correlation_id: None,
                         vigil_risk: None,
@@ -330,6 +333,7 @@ impl<T: ToolExecutor> ToolExecutor for PolicyGateExecutor<T> {
                     exit_code: None,
                     truncated: false,
                     caller_id: call.caller_id.clone(),
+                    skill_name: call.skill_name.clone(),
                     policy_match: None,
                     correlation_id: None,
                     vigil_risk: None,
@@ -442,6 +446,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 
@@ -455,6 +460,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-tools/src/scope.rs
+++ b/crates/zeph-tools/src/scope.rs
@@ -516,6 +516,7 @@ impl<E: ToolExecutor> ToolExecutor for ScopedToolExecutor<E> {
                     exit_code: None,
                     truncated: false,
                     caller_id: call.caller_id.clone(),
+                    skill_name: call.skill_name.clone(),
                     policy_match: None,
                     correlation_id: None,
                     vigil_risk: None,
@@ -575,6 +576,7 @@ impl<E: ToolExecutor> ToolExecutor for ScopedToolExecutor<E> {
                     exit_code: None,
                     truncated: false,
                     caller_id: call.caller_id.clone(),
+                    skill_name: call.skill_name.clone(),
                     policy_match: None,
                     correlation_id: None,
                     vigil_risk: None,
@@ -738,6 +740,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -150,6 +150,7 @@ impl ExtractMode {
 ///     caller_id: None,
 ///     context: None,
 ///     tool_call_id: String::new(),
+///     skill_name: None,
 /// };
 /// let _ = executor.execute_tool_call(&call).await;
 /// # }
@@ -272,7 +273,7 @@ impl ToolExecutor for WebScrapeExecutor {
             let correlation_id = EgressEvent::new_correlation_id();
             let start = Instant::now();
             let scrape_result = self
-                .scrape_instruction(&instruction, &correlation_id, None)
+                .scrape_instruction(&instruction, &correlation_id, None, None)
                 .await;
             #[allow(clippy::cast_possible_truncation)]
             let duration_ms = start.elapsed().as_millis() as u64;
@@ -283,6 +284,7 @@ impl ToolExecutor for WebScrapeExecutor {
                         &instruction.url,
                         AuditResult::Success,
                         duration_ms,
+                        None,
                         None,
                         None,
                         Some(correlation_id),
@@ -298,6 +300,7 @@ impl ToolExecutor for WebScrapeExecutor {
                         audit_result,
                         duration_ms,
                         Some(&e),
+                        None,
                         None,
                         Some(correlation_id),
                     )
@@ -332,7 +335,12 @@ impl ToolExecutor for WebScrapeExecutor {
                 let correlation_id = EgressEvent::new_correlation_id();
                 let start = Instant::now();
                 let result = self
-                    .scrape_instruction(&instruction, &correlation_id, call.caller_id.clone())
+                    .scrape_instruction(
+                        &instruction,
+                        &correlation_id,
+                        call.caller_id.clone(),
+                        call.skill_name.clone(),
+                    )
                     .await;
                 #[allow(clippy::cast_possible_truncation)]
                 let duration_ms = start.elapsed().as_millis() as u64;
@@ -341,6 +349,7 @@ impl ToolExecutor for WebScrapeExecutor {
                     "web-scrape",
                     &instruction.url,
                     call.caller_id.clone(),
+                    call.skill_name.clone(),
                     correlation_id,
                     duration_ms,
                     result,
@@ -352,7 +361,12 @@ impl ToolExecutor for WebScrapeExecutor {
                 let correlation_id = EgressEvent::new_correlation_id();
                 let start = Instant::now();
                 let result = self
-                    .handle_fetch(&p, &correlation_id, call.caller_id.clone())
+                    .handle_fetch(
+                        &p,
+                        &correlation_id,
+                        call.caller_id.clone(),
+                        call.skill_name.clone(),
+                    )
                     .await;
                 #[allow(clippy::cast_possible_truncation)]
                 let duration_ms = start.elapsed().as_millis() as u64;
@@ -361,6 +375,7 @@ impl ToolExecutor for WebScrapeExecutor {
                     "fetch",
                     &p.url,
                     call.caller_id.clone(),
+                    call.skill_name.clone(),
                     correlation_id,
                     duration_ms,
                     result,
@@ -396,6 +411,7 @@ impl WebScrapeExecutor {
         public_tool_name: &str,
         audit_command: &str,
         caller_id: Option<String>,
+        skill_name: Option<Vec<String>>,
         correlation_id: String,
         duration_ms: u64,
         result: Result<String, ToolError>,
@@ -409,6 +425,7 @@ impl WebScrapeExecutor {
                     duration_ms,
                     None,
                     caller_id,
+                    skill_name,
                     Some(correlation_id),
                 )
                 .await;
@@ -434,6 +451,7 @@ impl WebScrapeExecutor {
                     duration_ms,
                     Some(&e),
                     caller_id,
+                    skill_name,
                     Some(correlation_id),
                 )
                 .await;
@@ -451,6 +469,7 @@ impl WebScrapeExecutor {
         duration_ms: u64,
         error: Option<&ToolError>,
         caller_id: Option<String>,
+        skill_name: Option<Vec<String>>,
         correlation_id: Option<String>,
     ) {
         if let Some(ref logger) = self.audit_logger {
@@ -481,6 +500,7 @@ impl WebScrapeExecutor {
                 exit_code: None,
                 truncated: false,
                 caller_id,
+                skill_name,
                 policy_match: None,
                 correlation_id,
                 vigil_risk: None,
@@ -519,6 +539,7 @@ impl WebScrapeExecutor {
         params: &FetchParams,
         correlation_id: &str,
         caller_id: Option<String>,
+        skill_name: Option<Vec<String>>,
     ) -> Result<String, ToolError> {
         let parsed = validate_url(&params.url);
         let host_str = parsed
@@ -534,6 +555,7 @@ impl WebScrapeExecutor {
                     &host_str,
                     correlation_id,
                     caller_id.clone(),
+                    skill_name.clone(),
                     "scheme",
                 );
                 self.log_egress_event(&event).await;
@@ -554,6 +576,7 @@ impl WebScrapeExecutor {
                     parsed.host_str().unwrap_or(""),
                     correlation_id,
                     caller_id.clone(),
+                    skill_name.clone(),
                     "blocklist",
                 );
                 self.log_egress_event(&event).await;
@@ -571,6 +594,7 @@ impl WebScrapeExecutor {
                         parsed.host_str().unwrap_or(""),
                         correlation_id,
                         caller_id.clone(),
+                        skill_name.clone(),
                         "ssrf",
                     );
                     self.log_egress_event(&event).await;
@@ -587,6 +611,7 @@ impl WebScrapeExecutor {
                 "fetch",
                 correlation_id,
                 caller_id,
+                skill_name,
             )
             .await?;
         self.apply_ipi_filter(&body, &params.url).await
@@ -597,6 +622,7 @@ impl WebScrapeExecutor {
         instruction: &ScrapeInstruction,
         correlation_id: &str,
         caller_id: Option<String>,
+        skill_name: Option<Vec<String>>,
     ) -> Result<String, ToolError> {
         let parsed = validate_url(&instruction.url);
         let host_str = parsed
@@ -612,6 +638,7 @@ impl WebScrapeExecutor {
                     &host_str,
                     correlation_id,
                     caller_id.clone(),
+                    skill_name.clone(),
                     "scheme",
                 );
                 self.log_egress_event(&event).await;
@@ -632,6 +659,7 @@ impl WebScrapeExecutor {
                     parsed.host_str().unwrap_or(""),
                     correlation_id,
                     caller_id.clone(),
+                    skill_name.clone(),
                     "blocklist",
                 );
                 self.log_egress_event(&event).await;
@@ -649,6 +677,7 @@ impl WebScrapeExecutor {
                         parsed.host_str().unwrap_or(""),
                         correlation_id,
                         caller_id.clone(),
+                        skill_name.clone(),
                         "ssrf",
                     );
                     self.log_egress_event(&event).await;
@@ -665,6 +694,7 @@ impl WebScrapeExecutor {
                 "web_scrape",
                 correlation_id,
                 caller_id,
+                skill_name,
             )
             .await?;
         let selector = instruction.select.clone();
@@ -685,6 +715,7 @@ impl WebScrapeExecutor {
         host: &str,
         correlation_id: &str,
         caller_id: Option<String>,
+        skill_name: Option<Vec<String>>,
         block_reason: &'static str,
     ) -> EgressEvent {
         EgressEvent {
@@ -701,6 +732,7 @@ impl WebScrapeExecutor {
             blocked: true,
             block_reason: Some(block_reason),
             caller_id,
+            skill_name,
             hop: 0,
         }
     }
@@ -724,6 +756,7 @@ impl WebScrapeExecutor {
         tool: &str,
         correlation_id: &str,
         caller_id: Option<String>,
+        skill_name: Option<Vec<String>>,
     ) -> Result<String, ToolError> {
         const MAX_REDIRECTS: usize = 3;
 
@@ -761,6 +794,7 @@ impl WebScrapeExecutor {
                             blocked: false,
                             block_reason: None,
                             caller_id: caller_id.clone(),
+                            skill_name: skill_name.clone(),
                             #[allow(clippy::cast_possible_truncation)]
                             hop: hop as u8,
                         };
@@ -814,6 +848,7 @@ impl WebScrapeExecutor {
                             blocked: true,
                             block_reason: Some("ssrf"),
                             caller_id: caller_id.clone(),
+                            skill_name: skill_name.clone(),
                             #[allow(clippy::cast_possible_truncation)]
                             hop: (hop + 1) as u8,
                         };
@@ -842,6 +877,7 @@ impl WebScrapeExecutor {
                             blocked: true,
                             block_reason: Some("ssrf"),
                             caller_id: caller_id.clone(),
+                            skill_name: skill_name.clone(),
                             #[allow(clippy::cast_possible_truncation)]
                             hop: (hop + 1) as u8,
                         };
@@ -875,6 +911,7 @@ impl WebScrapeExecutor {
                         blocked: false,
                         block_reason: None,
                         caller_id: caller_id.clone(),
+                        skill_name: skill_name.clone(),
                         #[allow(clippy::cast_possible_truncation)]
                         hop: hop as u8,
                     };
@@ -909,6 +946,7 @@ impl WebScrapeExecutor {
                         blocked: false,
                         block_reason: None,
                         caller_id: caller_id.clone(),
+                        skill_name: skill_name.clone(),
                         #[allow(clippy::cast_possible_truncation)]
                         hop: hop as u8,
                     };
@@ -944,6 +982,7 @@ impl WebScrapeExecutor {
                     blocked: false,
                     block_reason: None,
                     caller_id: caller_id.clone(),
+                    skill_name: skill_name.clone(),
                     #[allow(clippy::cast_possible_truncation)]
                     hop: hop as u8,
                 };
@@ -1740,7 +1779,7 @@ mod tests {
         let (host, addrs) = server_host_and_addr(&server);
         let url = format!("{}/page", server.uri());
         let result = executor
-            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None)
+            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None, None)
             .await;
         assert!(result.is_ok(), "expected Ok, got: {result:?}");
         assert_eq!(result.unwrap(), "<h1>OK</h1>");
@@ -1761,7 +1800,7 @@ mod tests {
         let (host, addrs) = server_host_and_addr(&server);
         let url = format!("{}/forbidden", server.uri());
         let result = executor
-            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None)
+            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None, None)
             .await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -1783,7 +1822,7 @@ mod tests {
         let (host, addrs) = server_host_and_addr(&server);
         let url = format!("{}/missing", server.uri());
         let result = executor
-            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None)
+            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None, None)
             .await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -1806,7 +1845,7 @@ mod tests {
         let (host, addrs) = server_host_and_addr(&server);
         let url = format!("{}/redirect-no-loc", server.uri());
         let result = executor
-            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None)
+            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None, None)
             .await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -1945,7 +1984,7 @@ mod tests {
         let (host, addrs) = server_host_and_addr(&server);
         let url = format!("{}/big", server.uri());
         let result = small_limit_executor
-            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None)
+            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None, None)
             .await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -2209,6 +2248,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2232,6 +2272,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2255,6 +2296,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2271,6 +2313,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.unwrap().is_none());
@@ -2291,7 +2334,7 @@ mod tests {
         let (host, addrs) = server_host_and_addr(&server);
         let url = format!("{}/content", server.uri());
         let result = executor
-            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None)
+            .fetch_html(&url, &host, &addrs, "fetch", "test-cid", None, None)
             .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "plain text content");
@@ -2502,6 +2545,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2535,6 +2579,7 @@ mod tests {
                 "https://example.com/page",
                 AuditResult::Success,
                 42,
+                None,
                 None,
                 None,
                 None,
@@ -2579,6 +2624,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await;
 
@@ -2617,6 +2663,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2649,6 +2696,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         // Must not panic even without an audit logger
         let result = executor.execute_tool_call(&call).await;
@@ -2677,6 +2725,7 @@ mod tests {
                 &addrs,
                 "fetch",
                 "test-cid",
+                None,
                 None,
             )
             .await;

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -690,6 +690,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let err = exec.execute_tool_call(&call).await.unwrap_err();
         assert!(matches!(err, ToolError::InvalidParams { .. }));
@@ -711,6 +712,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let out = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(out.summary.contains("retry_backoff_ms"));
@@ -734,6 +736,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let out = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(out.summary.contains("grep fallback"));

--- a/crates/zeph-tools/src/shadow_probe.rs
+++ b/crates/zeph-tools/src/shadow_probe.rs
@@ -312,6 +312,7 @@ mod tests {
             caller_id: None,
             context: None,
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -1537,6 +1537,7 @@ impl ShellExecutor {
                 exit_code,
                 truncated,
                 caller_id: None,
+                skill_name: None,
                 policy_match: None,
                 correlation_id: None,
                 vigil_risk: None,
@@ -1588,6 +1589,7 @@ impl ShellExecutor {
                 exit_code,
                 truncated,
                 caller_id: None,
+                skill_name: None,
                 policy_match: None,
                 correlation_id: None,
                 vigil_risk: None,
@@ -2902,6 +2904,7 @@ async fn run_bash_stream(
                                 command: code.to_owned(),
                                 chunk: interleaved.clone(),
                                 tool_call_id: tool_call_id.to_owned(),
+                                skill_name: None,
                             });
                         }
                         combined.push_str(&interleaved);

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -1277,6 +1277,7 @@ async fn execute_tool_call_valid_command() {
         context: None,
 
         tool_call_id: String::new(),
+        skill_name: None,
     };
     let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
     assert!(result.summary.contains("hi"));
@@ -1292,6 +1293,7 @@ async fn execute_tool_call_missing_command_returns_invalid_params() {
         context: None,
 
         tool_call_id: String::new(),
+        skill_name: None,
     };
     let result = executor.execute_tool_call(&call).await;
     assert!(matches!(result, Err(ToolError::InvalidParams { .. })));
@@ -1309,6 +1311,7 @@ async fn execute_tool_call_empty_command_returns_none() {
         context: None,
 
         tool_call_id: String::new(),
+        skill_name: None,
     };
     let result = executor.execute_tool_call(&call).await.unwrap();
     assert!(result.is_none());
@@ -2714,6 +2717,7 @@ async fn execute_tool_call_with_background_true() {
         context: None,
 
         tool_call_id: String::new(),
+        skill_name: None,
     };
     let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
     assert!(
@@ -3267,6 +3271,7 @@ mod resolve_context {
             context: Some(ctx),
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let output = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(
@@ -3300,6 +3305,7 @@ mod resolve_context {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let output = executor.execute_tool_call(&call).await.unwrap().unwrap();
         let expected = std::env::current_dir().unwrap();

--- a/crates/zeph-tools/src/tool_filter.rs
+++ b/crates/zeph-tools/src/tool_filter.rs
@@ -122,6 +122,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = filter.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -137,6 +138,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = filter.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -297,6 +297,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 
@@ -310,6 +311,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 
@@ -547,6 +549,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         };
         let result = gate.execute_tool_call(&call).await;
         assert!(

--- a/crates/zeph-tools/src/utility.rs
+++ b/crates/zeph-tools/src/utility.rs
@@ -320,6 +320,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -462,8 +462,8 @@ impl ToolExecutor for SchedulerExecutor {
                     params,
                     caller_id: None,
                     context: None,
-
                     tool_call_id: String::new(),
+                    skill_name: None,
                 };
                 return self.execute_tool_call(&call).await;
             }
@@ -567,6 +567,7 @@ mod tests {
             context: None,
 
             tool_call_id: String::new(),
+            skill_name: None,
         }
     }
 

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -489,6 +489,7 @@ pub(crate) async fn forward_tool_events_to_tui(
                 command,
                 chunk,
                 tool_call_id,
+                ..
             } => zeph_tui::AgentEvent::ToolOutputChunk {
                 tool_name,
                 command,
@@ -575,6 +576,7 @@ mod tests {
                 tool_name: "shell".into(),
                 command: "ls".into(),
                 chunk: "file.txt\n".into(),
+                skill_name: None,
             })
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

- **#4682**: Replace flat `read_dir` in `SkillRegistry::load` with `WalkDir` (already a workspace dep via zeph-plugins). Skills at any subdirectory depth are now discovered. Discovery follows WalkDir pre-order DFS with lexicographic sibling ordering; first name wins on collision. Max depth 16, no symlink follow. The existing `RecursiveMode::Recursive` watcher required no changes.
- **#4684**: Extend `ToolCall`, `AuditEntry`, and `EgressEvent` with `skill_name: Option<Vec<String>>` carrying the names of skills active in the current turn. Attribution is turn-scoped. All decorator executors (`scope`, `policy_gate`, `adversarial_gate`) and all `scrape.rs` egress sites propagate the field. `ToolCall` gains `#[derive(Default)]` to keep the 177 existing struct literals compiling without churn.

## Test plan

- [ ] 10351 nextest tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] 5 new unit tests in `zeph-skills::registry::tests` verify: depth-2 discovery, mixed-depth discovery, parent-wins-over-child (same branch), lexicographic sibling order, fingerprint change on nested add
- [ ] `cargo check --workspace --all-targets` clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` clean
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` clean
- [ ] LLM serialization gate: not applicable — `ToolCall.skill_name` is audit-only (JSONL write path), not included in LLM request/response structs

Closes #4682, #4684