### PR TITLE
fix(a2a): remove dead eviction_task field from AppState

### DIFF
--- a/crates/zeph-a2a/src/server/handlers.rs
+++ b/crates/zeph-a2a/src/server/handlers.rs
@@ -646,7 +646,6 @@ mod tests {
             task_manager: super::super::state::TaskManager::new(),
             processor: Arc::new(MultiChunkProcessor),
             request_timeout: std::time::Duration::from_mins(5),
-            eviction_task: None,
         }
     }
 
@@ -702,7 +701,6 @@ mod tests {
             task_manager: super::super::state::TaskManager::new(),
             processor: Arc::new(SlowProcessor),
             request_timeout: std::time::Duration::from_millis(100),
-            eviction_task: None,
         }
     }
 
@@ -781,7 +779,6 @@ mod tests {
             task_manager: TaskManager::new(),
             processor: Arc::new(NeverEndingProcessor),
             request_timeout: std::time::Duration::from_secs(30),
-            eviction_task: None,
         };
 
         let (tx, rx) = mpsc::channel::<axum::response::sse::Event>(1);

--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -131,7 +131,6 @@ impl A2aServer {
             task_manager: TaskManager::new(),
             processor,
             request_timeout: Duration::from_mins(5),
-            eviction_task: None,
         };
 
         Self {
@@ -326,7 +325,6 @@ pub(crate) mod testing {
             task_manager: TaskManager::new(),
             processor: Arc::new(EchoProcessor),
             request_timeout: std::time::Duration::from_mins(5),
-            eviction_task: None,
         }
     }
 
@@ -336,7 +334,6 @@ pub(crate) mod testing {
             task_manager: TaskManager::new(),
             processor: Arc::new(FailingProcessor),
             request_timeout: std::time::Duration::from_mins(5),
-            eviction_task: None,
         }
     }
 }

--- a/crates/zeph-a2a/src/server/state.rs
+++ b/crates/zeph-a2a/src/server/state.rs
@@ -26,11 +26,6 @@ pub struct AppState {
     /// Maximum time to wait for a [`TaskProcessor`] to complete before marking the task
     /// as [`TaskState::Failed`] and aborting the spawned future.
     pub request_timeout: Duration,
-    /// Handle for the background rate-limiter eviction task.
-    ///
-    /// Stored so the task can be aborted on server shutdown rather than running forever.
-    /// `None` when rate limiting is disabled (`rate_limit == 0`).
-    pub eviction_task: Option<Arc<tokio::task::JoinHandle<()>>>,
 }
 
 /// An event emitted by a [`TaskProcessor`] to drive the handler's response.


### PR DESCRIPTION
## Summary

- Removes the dead `eviction_task: Option<Arc<JoinHandle<()>>>` field from `AppState` in `crates/zeph-a2a/src/server/state.rs`
- Removes all 6 `eviction_task: None` initializations across `server/mod.rs` and `server/handlers.rs` (test helpers)
- The field was always `None`; inline GC eviction in the router is the correct approach per the existing comment in `router.rs:385`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-a2a --features server -- -D warnings` — 0 warnings
- [x] `cargo nextest run -p zeph-a2a` — 97/97 passed

Closes #4695