### PR TITLE
fix(tools): redact URLs in scrape audit log and fix IPI tracing span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-tools`: scrape executor now redacts sensitive query parameters (tokens, API keys) from URLs
+  before writing them to audit JSONL via `redact_url_for_log`. Previously, raw URLs were passed
+  directly to `log_audit` and `run_with_audit` in both the legacy fenced-block `execute()` path and
+  the structured `execute_tool_call` path. Closes #4713.
+- `zeph-tools`: `apply_ipi_filter` tracing span now correctly covers the `filter_async().await` call
+  using `#[tracing::instrument]`. Previously a manual `span.enter()` was called after the await
+  point, making the IPI filtering invisible in traces. Closes #4712.
+
 ### Added
 
 - `zeph-skills`: recursive `SKILL.md` discovery now uses depth-first pre-order traversal

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -281,7 +281,7 @@ impl ToolExecutor for WebScrapeExecutor {
                 Ok(output) => {
                     self.log_audit(
                         "web_scrape",
-                        &instruction.url,
+                        &redact_url_for_log(&instruction.url),
                         AuditResult::Success,
                         duration_ms,
                         None,
@@ -296,7 +296,7 @@ impl ToolExecutor for WebScrapeExecutor {
                     let audit_result = tool_error_to_audit_result(&e);
                     self.log_audit(
                         "web_scrape",
-                        &instruction.url,
+                        &redact_url_for_log(&instruction.url),
                         audit_result,
                         duration_ms,
                         Some(&e),
@@ -347,7 +347,7 @@ impl ToolExecutor for WebScrapeExecutor {
                 self.run_with_audit(
                     "web_scrape",
                     "web-scrape",
-                    &instruction.url,
+                    &redact_url_for_log(&instruction.url),
                     call.caller_id.clone(),
                     call.skill_name.clone(),
                     correlation_id,
@@ -373,7 +373,7 @@ impl ToolExecutor for WebScrapeExecutor {
                 self.run_with_audit(
                     "fetch",
                     "fetch",
-                    &p.url,
+                    &redact_url_for_log(&p.url),
                     call.caller_id.clone(),
                     call.skill_name.clone(),
                     correlation_id,
@@ -1007,14 +1007,13 @@ impl WebScrapeExecutor {
     /// # Errors
     ///
     /// Returns a [`ToolError`] if the blocking scan task panics.
+    #[tracing::instrument(name = "tools.scrape.apply_ipi_filter", skip(self, body), fields(body_len = body.len()))]
     async fn apply_ipi_filter(&self, body: &str, url: &str) -> Result<String, ToolError> {
-        let span = tracing::info_span!("tools.scrape.apply_ipi_filter", url, body_len = body.len());
         let verdict = self
             .ipi_filter
             .filter_async(body.to_owned())
             .await
             .map_err(|e| ToolError::Execution(std::io::Error::other(e.to_string())))?;
-        let _enter = span.enter();
         if !verdict.patterns_found.is_empty() {
             tracing::warn!(
                 url = url,


### PR DESCRIPTION
## Summary

- Applies `redact_url_for_log()` at all four audit call sites in `scrape.rs` so sensitive query parameters (tokens, API keys) are stripped before writing to audit JSONL. Closes #4713.
- Replaces manual `tracing::info_span!` + `span.enter()` after `.await` in `apply_ipi_filter` with `#[tracing::instrument]`, so the span correctly covers `filter_async().await`. Closes #4712.

## Changes

- `crates/zeph-tools/src/scrape.rs`: four `&instruction.url` / `&p.url` replaced with `&redact_url_for_log(...)`, manual span replaced with attribute macro
- `CHANGELOG.md`: two entries under `[Unreleased] ### Fixed`

## Test plan

- [x] `cargo check -p zeph-tools` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-tools -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check -p zeph-tools --all-targets` — clean
- [x] `cargo nextest run -p zeph-tools --lib --bins` — 1228 passed, 0 skipped