### PR TITLE
fix: add #[non_exhaustive] to ChannelError, sanitizer errors, SubAgentError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`: `ChannelError` is now marked `#[non_exhaustive]` so new variants can be added
+  without a breaking change. Closes #4726.
+- `zeph-sanitizer`: `QuarantineError`, `MemoryValidationError`, and `CausalIpiError` are now
+  marked `#[non_exhaustive]`, continuing the workspace-wide non-exhaustive cleanup (PR #4658).
+  Closes #4716.
+- `zeph-subagent`: `SubAgentError` is now marked `#[non_exhaustive]`. Closes #4732.
 - `zeph-tools`: scrape executor now redacts sensitive query parameters (tokens, API keys) from URLs
   before writing them to audit JSONL via `redact_url_for_log`. Previously, raw URLs were passed
   directly to `log_audit` and `run_with_audit` in both the legacy fenced-block `execute()` path and

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -116,6 +116,7 @@ pub enum ElicitationResponse {
 
 /// Typed error for channel operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ChannelError {
     /// Underlying I/O failure.
     #[error("I/O error: {0}")]

--- a/crates/zeph-sanitizer/src/causal_ipi.rs
+++ b/crates/zeph-sanitizer/src/causal_ipi.rs
@@ -46,6 +46,7 @@ const PROBE_QUESTION: &str = "Summarize your current task and planned next actio
 /// Probe failures are non-fatal: the caller should log a `WARN` and skip causal
 /// analysis for the current batch rather than blocking tool execution.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum CausalIpiError {
     /// The probe LLM call returned an error.
     #[error("probe LLM call failed: {0}")]

--- a/crates/zeph-sanitizer/src/memory_validation.rs
+++ b/crates/zeph-sanitizer/src/memory_validation.rs
@@ -33,6 +33,7 @@ use crate::pii::{EMAIL_RE, SSN_RE};
 /// [`validate_graph_extraction`](MemoryWriteValidator::validate_graph_extraction). Callers
 /// should log the error and skip the write rather than panicking.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MemoryValidationError {
     /// The content exceeds the configured `max_content_bytes` limit.
     #[error("content too large: {size} bytes exceeds max {max}")]

--- a/crates/zeph-sanitizer/src/quarantine.rs
+++ b/crates/zeph-sanitizer/src/quarantine.rs
@@ -49,6 +49,7 @@ Do not include any preamble, explanations, or meta-commentary — only the extra
 
 /// Errors returned by [`QuarantinedSummarizer::extract_facts`].
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum QuarantineError {
     /// The quarantine LLM call failed (network error, provider error, etc.).
     #[error("quarantine LLM call failed: {0}")]

--- a/crates/zeph-subagent/src/error.rs
+++ b/crates/zeph-subagent/src/error.rs
@@ -15,6 +15,7 @@
 /// assert!(matches!(err, SubAgentError::Parse { .. }));
 /// ```
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SubAgentError {
     /// Frontmatter parsing failed (malformed YAML/TOML or missing delimiters).
     #[error("parse error in {path}: {reason}")]


### PR DESCRIPTION
## Summary

Continues the workspace-wide `#[non_exhaustive]` cleanup started in PR #4658 (62ccdd4a). Without this attribute, adding a new error variant is a semver-breaking change for any downstream crate that matches exhaustively.

- `zeph-core`: `ChannelError` — used by all channel adapters (CLI, Telegram, Discord, Slack); expected to gain new variants as backends expand
- `zeph-sanitizer`: `QuarantineError`, `MemoryValidationError`, `CausalIpiError` — three public error enums missing the attribute
- `zeph-subagent`: `SubAgentError` — noted alongside `WorktreeError` (#4703) as part of the same cleanup

No downstream exhaustive `match` arms exist for any of these enums, so no wildcard `_` arms needed.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core -p zeph-sanitizer -p zeph-subagent -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check -p zeph-core -p zeph-sanitizer -p zeph-subagent --all-targets --locked` — clean
- [x] `cargo nextest run -p zeph-core -p zeph-sanitizer -p zeph-subagent --lib --bins` — 2222 passed, 2 skipped

Closes #4716, #4726, #4732