### PR TITLE
fix(agent-pipeline): add #[non_exhaustive] to error enums (#4717, #4718, #4719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   discarding operator-configured Benna-Fusi rates and falling back to hardcoded defaults
   (fast=0.5, slow=0.05). Both rates are now threaded through `GraphExtractionConfig` and applied
   at all extraction callsites, including the backfill path in `agent_access_impl.rs`. Closes #4711.
+- `zeph-agent-tools`: add `#[non_exhaustive]` to `ToolDispatchError` to allow adding variants
+  without breaking downstream crates. Updated exhaustive match sites in `zeph-core`. Closes #4717.
+- `zeph-agent-context`: add `#[non_exhaustive]` to `ContextError`, `CompactionOutcome`, and
+  `SubgoalState`. Updated exhaustive match sites in `zeph-core`. Closes #4718.
+- `zeph-agent-persistence`: add `#[non_exhaustive]` to `PersistenceError` to allow adding
+  variants without breaking downstream crates. Closes #4719.
 
 ### Performance
 

--- a/crates/zeph-agent-context/src/compaction.rs
+++ b/crates/zeph-agent-context/src/compaction.rs
@@ -290,6 +290,7 @@ pub struct SubgoalId(pub u32);
 
 /// Lifecycle state of a subgoal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SubgoalState {
     /// Currently being worked on. Messages tagged with this subgoal are protected.
     Active,

--- a/crates/zeph-agent-context/src/error.rs
+++ b/crates/zeph-agent-context/src/error.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 /// The caller in `zeph-core` maps these variants to `AgentError` via a `From` impl.
 /// Each variant corresponds to one subsystem that the context service touches.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ContextError {
     /// Memory backend returned an error during recall or summary loading.
     ///

--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -467,6 +467,7 @@ pub type QdrantPersistFuture = Pin<Box<dyn Future<Output = bool> + Send + 'stati
 /// Gives `maybe_compact()` enough information to handle probe rejection without triggering
 /// the `Exhausted` state — which would only be correct if summarization itself is stuck.
 #[must_use]
+#[non_exhaustive]
 pub enum CompactionOutcome {
     /// Messages were drained and replaced with a summary. `SQLite` persistence succeeded.
     ///

--- a/crates/zeph-agent-persistence/src/error.rs
+++ b/crates/zeph-agent-persistence/src/error.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 /// The caller in `zeph-core` maps these variants to `AgentError` via `From<PersistenceError>`.
 /// Callers can distinguish degradable errors (Qdrant offline) from fatal errors (`SQLite` corrupt).
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum PersistenceError {
     /// Qdrant vector store is unavailable. Embedding is skipped; `SQLite` write may still succeed.
     /// Callers should degrade gracefully and continue the conversation without semantic search.

--- a/crates/zeph-agent-tools/src/error.rs
+++ b/crates/zeph-agent-tools/src/error.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 ///
 /// The caller in `zeph-core` maps these to `AgentError` via `From<ToolDispatchError>`.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ToolDispatchError {
     /// LLM provider returned an error during tool-loop inference.
     #[error("LLM provider error: {0}")]

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -83,6 +83,7 @@ impl<C: Channel> Agent<C> {
                  Original context preserved."
                     .to_owned())
             }
+            _ => Ok("Context compacted successfully.".to_owned()),
         }
     }
 

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -320,6 +320,7 @@ impl DebugDumper {
                 let state_str = match sg.state {
                     zeph_agent_context::SubgoalState::Active => "Active   ",
                     zeph_agent_context::SubgoalState::Completed => "Completed",
+                    _ => "Unknown  ",
                 };
                 let _ = std::fmt::write(
                     &mut output,


### PR DESCRIPTION
## Summary

Add `#[non_exhaustive]` to five public error enums across the agent pipeline crates, enforcing the workspace convention from #4658/#4660. Without this attribute, adding a new variant to any of these enums is a silent breaking change for downstream crates.

**Affected enums:**
- `ToolDispatchError` — `crates/zeph-agent-tools/src/error.rs`
- `ContextError`, `CompactionOutcome`, `SubgoalState` — `crates/zeph-agent-context/src/`
- `PersistenceError` — `crates/zeph-agent-persistence/src/error.rs`

**Downstream match sites updated:**
- `zeph-core/src/agent/context/summarization/compaction.rs` — `compact_context_command()` wildcard for `CompactionOutcome`
- `zeph-core/src/debug_dump/mod.rs` — `SubgoalState` display arm

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10414 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean

Closes #4717
Closes #4718
Closes #4719