### PR TITLE
fix: add #[non_exhaustive] to public enums in context, db, vault, bench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `SubgoalState`. Updated exhaustive match sites in `zeph-core`. Closes #4718.
 - `zeph-agent-persistence`: add `#[non_exhaustive]` to `PersistenceError` to allow adding
   variants without breaking downstream crates. Closes #4719.
+- `zeph-context`: add `#[non_exhaustive]` to `CompactionTier`, `CompactionOutcome`,
+  `AssemblerError`, and `PageType`. Updated exhaustive match sites in `zeph-agent-context`.
+  Closes #4733, #4734.
+- `zeph-db`: add `#[non_exhaustive]` to `DbError`. Closes #4736.
+- `zeph-vault`: add `#[non_exhaustive]` to `AgeVaultError`. Closes #4736.
+- `zeph-bench`: add `#[non_exhaustive]` to `BenchError` and `Role`. Closes #4736.
 
 ### Performance
 

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -1183,12 +1183,12 @@ impl ContextService {
             .context_manager
             .compaction_tier(*summ.cached_prompt_tokens)
         {
-            CompactionTier::None => Ok(()),
             CompactionTier::Soft => {
                 self.do_soft_compaction(summ, status).await;
                 Ok(())
             }
             CompactionTier::Hard => self.do_hard_compaction(summ, status, in_cooldown).await,
+            _ => Ok(()),
         }
     }
 

--- a/crates/zeph-agent-context/src/summarization/compaction.rs
+++ b/crates/zeph-agent-context/src/summarization/compaction.rs
@@ -439,7 +439,7 @@ fn classify_to_compact_batch(
                     excerpt_labels.push(source_label.clone());
                 }
             }
-            PageType::SystemContext | PageType::ConversationTurn => {}
+            _ => {}
         }
 
         pages.push(TypedPage::new(
@@ -482,7 +482,7 @@ fn derive_origin(msg: &Message, index: usize, page_type: PageType) -> PageOrigin
                 .unwrap_or_else(|| format!("msg_{index}"));
             PageOrigin::System { key }
         }
-        PageType::ConversationTurn => PageOrigin::Turn {
+        _ => PageOrigin::Turn {
             message_id: index.to_string(),
         },
     }

--- a/crates/zeph-bench/src/error.rs
+++ b/crates/zeph-bench/src/error.rs
@@ -16,6 +16,7 @@
 ///
 /// assert!(example().is_err());
 /// ```
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum BenchError {
     /// A named dataset was requested but is not registered in [`crate::DatasetRegistry`].

--- a/crates/zeph-bench/src/scenario.rs
+++ b/crates/zeph-bench/src/scenario.rs
@@ -15,6 +15,7 @@ use crate::error::BenchError;
 /// assert!(matches!(Role::User, Role::User));
 /// assert!(matches!(Role::Assistant, Role::Assistant));
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Role {
     /// A message from the human user.

--- a/crates/zeph-context/src/error.rs
+++ b/crates/zeph-context/src/error.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 /// All async fetch operations in [`crate::assembler::ContextAssembler`] propagate
 /// errors through this type. Callers in `zeph-core` convert to `AgentError` at the
 /// boundary using `From<AssemblerError> for AgentError`.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum AssemblerError {
     /// A memory subsystem operation failed.

--- a/crates/zeph-context/src/manager.rs
+++ b/crates/zeph-context/src/manager.rs
@@ -125,6 +125,7 @@ impl CompactionState {
 }
 
 /// Indicates which compaction tier applies for the current context size.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompactionTier {
     /// Context is within budget — no compaction needed.

--- a/crates/zeph-context/src/slot.rs
+++ b/crates/zeph-context/src/slot.rs
@@ -49,6 +49,7 @@ pub enum ContextSlot {
 ///
 /// Gives `maybe_compact()` enough information to handle probe rejection without triggering
 /// the `Exhausted` state — which would only be correct if summarization itself is stuck.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompactionOutcome {
     /// Messages were drained and replaced with a summary.

--- a/crates/zeph-context/src/typed_page.rs
+++ b/crates/zeph-context/src/typed_page.rs
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Every [`TypedPage`] carries exactly one `PageType`. Unclassifiable segments
 /// default to [`PageType::ConversationTurn`] (see [`classify`]).
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PageType {

--- a/crates/zeph-db/src/error.rs
+++ b/crates/zeph-db/src/error.rs
@@ -4,6 +4,7 @@
 use thiserror::Error;
 
 /// Unified database error type for `zeph-db`.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum DbError {
     /// Connection failed. The URL stored here is always credential-redacted.

--- a/crates/zeph-vault/src/age.rs
+++ b/crates/zeph-vault/src/age.rs
@@ -36,6 +36,7 @@ use zeph_common::secret::VaultError;
 /// let err = AgeVaultError::KeyParse("no identity line found".into());
 /// assert!(err.to_string().contains("failed to parse age identity"));
 /// ```
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum AgeVaultError {
     /// The key file could not be read from disk.


### PR DESCRIPTION
## Summary

- Add `#[non_exhaustive]` to eight public enums missing the attribute across four crates, continuing the workspace-wide convention from #4658
- Fix three exhaustive match sites in `zeph-agent-context` that required wildcard arms after the change

## Affected enums

| Enum | Crate | File |
|------|-------|------|
| `CompactionTier` | zeph-context | `crates/zeph-context/src/manager.rs` |
| `CompactionOutcome` | zeph-context | `crates/zeph-context/src/slot.rs` |
| `AssemblerError` | zeph-context | `crates/zeph-context/src/error.rs` |
| `PageType` | zeph-context | `crates/zeph-context/src/typed_page.rs` |
| `DbError` | zeph-db | `crates/zeph-db/src/error.rs` |
| `AgeVaultError` | zeph-vault | `crates/zeph-vault/src/age.rs` |
| `BenchError` | zeph-bench | `crates/zeph-bench/src/error.rs` |
| `Role` | zeph-bench | `crates/zeph-bench/src/scenario.rs` |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace --lib --bins` — 10420 passed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean

Closes #4734, #4733, #4736