### PR TITLE
fix(acp,feedback,core): non_exhaustive enums, judge_provider config, spawn_blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   success paths) now call `redact_url_for_log` instead of passing the raw `current_url`. This
   completes the redaction coverage started in #4713; the connection-error and SSRF-blocked paths were
   already correct. Closes #4738.
-
+- `zeph-acp`: `AcpError`, `AcpClientError`, `LspDiagnosticSeverity`, and `LspSymbolKind` are now
+  marked `#[non_exhaustive]`. Closes #4749.
+- `zeph-config`: `LearningConfig` gains a `judge_provider` field that accepts a named provider from
+  `[[llm.providers]]`, taking precedence over `judge_model` for the judge detector. Closes #4739.
+- `zeph-core`: `detect_and_record_corrections` now runs `FeedbackDetector::detect` in
+  `tokio::task::spawn_blocking` when the message exceeds 4096 bytes, preventing the async agent
+  loop from blocking on CPU-bound regex work. Closes #4740.
 - `zeph-memory`: `resolve_edge_typed` now forwards `edge.confidence` to the store instead of
   hardcoding `0.8`. Introduces `DEFAULT_EDGE_CONFIDENCE` constant and fixes both the non-APEX and
   APEX-MEM paths. Closes #4723.

--- a/config/default.toml
+++ b/config/default.toml
@@ -212,6 +212,9 @@ max_versions = 10
 cooldown_minutes = 60
 # Correction detector strategy: "regex" (default), "judge" (LLM-based), or "model" (ML classifier)
 # detector_mode = "regex"
+# Named provider from [[llm.providers]] for the judge detector. Takes precedence over judge_model.
+# Empty = fall back to judge_model, then to primary provider.
+# judge_provider = ""
 # LLM model for judge detector (e.g. "claude-sonnet-4-6"). Empty = use primary provider.
 # judge_model = ""
 # HuggingFace repo ID for ML correction detector (requires detector_mode = "model" and classifiers feature).

--- a/crates/zeph-acp/src/client/error.rs
+++ b/crates/zeph-acp/src/client/error.rs
@@ -24,6 +24,7 @@ impl std::fmt::Display for HandshakeStep {
 
 /// Errors returned by the ACP sub-agent client.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum AcpClientError {
     /// The command string was empty or could not be shell-split.
     #[error("invalid command config: {0}")]

--- a/crates/zeph-acp/src/error.rs
+++ b/crates/zeph-acp/src/error.rs
@@ -18,6 +18,7 @@
 /// assert!(err.to_string().contains("timed out"));
 /// ```
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum AcpError {
     /// The underlying JSON-RPC transport (stdio, HTTP, WebSocket) encountered an I/O error.
     #[error("transport error: {0}")]

--- a/crates/zeph-acp/src/lsp/types.rs
+++ b/crates/zeph-acp/src/lsp/types.rs
@@ -39,6 +39,7 @@ pub struct LspLocation {
 /// Diagnostic severity values as defined by the LSP specification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "u8", into = "u8")]
+#[non_exhaustive]
 pub enum LspDiagnosticSeverity {
     Error = 1,
     Warning = 2,
@@ -94,6 +95,7 @@ pub struct LspDiagnostic {
 /// LSP `SymbolKind` values (matches the LSP specification integer encoding).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "u8", into = "u8")]
+#[non_exhaustive]
 pub enum LspSymbolKind {
     File = 1,
     Module = 2,

--- a/crates/zeph-agent-feedback/src/lib.rs
+++ b/crates/zeph-agent-feedback/src/lib.rs
@@ -392,6 +392,7 @@ pub struct CorrectionSignal {
 }
 
 /// Detects implicit corrections in user messages without an LLM call.
+#[derive(Clone)]
 pub struct FeedbackDetector {
     confidence_threshold: f32,
 }
@@ -1974,5 +1975,44 @@ mod tests {
         assert!(fv.is_correction);
         assert_eq!(fv.kind, "explicit_rejection");
         assert!((fv.confidence - 0.85).abs() < 1e-5);
+    }
+
+    // Verify FeedbackDetector::detect works correctly on inputs above/below the 4096-byte threshold.
+
+    #[test]
+    fn detect_short_message_below_threshold() {
+        let d = FeedbackDetector::new(0.6);
+        let msg = "no that's wrong";
+        assert!(msg.len() < 4096);
+        let signal = d.detect(msg, &[]);
+        assert!(signal.is_some());
+        assert_eq!(signal.unwrap().kind, CorrectionKind::ExplicitRejection);
+    }
+
+    #[test]
+    fn detect_long_message_above_threshold_same_result() {
+        let d = FeedbackDetector::new(0.6);
+        // Build a message > 4096 bytes that still contains a rejection phrase.
+        let padding = "a ".repeat(2100); // 4200 bytes
+        let long_msg = format!("no that's wrong {padding}");
+        assert!(long_msg.len() > 4096);
+        let signal = d.detect(&long_msg, &[]);
+        assert!(
+            signal.is_some(),
+            "long message must still detect correction"
+        );
+        assert_eq!(signal.unwrap().kind, CorrectionKind::ExplicitRejection);
+    }
+
+    #[test]
+    fn detect_long_neutral_message_returns_none() {
+        let d = FeedbackDetector::new(0.6);
+        let neutral = "please ".repeat(800); // ~5600 bytes, no rejection phrase
+        assert!(neutral.len() > 4096);
+        let signal = d.detect(&neutral, &[]);
+        assert!(
+            signal.is_none(),
+            "long neutral message must not be classified as correction"
+        );
     }
 }

--- a/crates/zeph-config/src/learning.rs
+++ b/crates/zeph-config/src/learning.rs
@@ -222,6 +222,12 @@ pub struct LearningConfig {
     /// Model for the judge detector (e.g. "claude-sonnet-4-6"). Empty = use primary provider.
     #[serde(default)]
     pub judge_model: String,
+    /// Named provider from `[[llm.providers]]` for the judge detector (`detector_mode = "judge"`).
+    ///
+    /// When set, overrides the model-level fallback: the named provider is resolved and used
+    /// instead of the primary provider. Empty = use primary provider (same as leaving unset).
+    #[serde(default)]
+    pub judge_provider: String,
     /// Provider name from `[[llm.providers]]` for `detector_mode = "model"` (`LlmClassifier`).
     ///
     /// Empty = use the primary provider. Named but not found in registry = log warning,
@@ -428,6 +434,7 @@ impl Default for LearningConfig {
             correction_confidence_threshold: default_correction_confidence_threshold(),
             detector_mode: DetectorMode::default(),
             judge_model: String::new(),
+            judge_provider: String::new(),
             feedback_provider: ProviderName::default(),
             judge_adaptive_low: default_judge_adaptive_low(),
             judge_adaptive_high: default_judge_adaptive_high(),
@@ -751,5 +758,40 @@ heuristic_promotion_interval_hours = 48
         assert!(!cfg.heuristic_promotion_enabled);
         assert_eq!(cfg.heuristic_promotion_threshold, 5);
         assert_eq!(cfg.heuristic_promotion_interval_hours, 24);
+    }
+
+    #[test]
+    fn judge_provider_default_is_empty() {
+        let cfg = LearningConfig::default();
+        assert!(cfg.judge_provider.is_empty());
+    }
+
+    #[test]
+    fn judge_provider_serde_roundtrip() {
+        let cfg: LearningConfig = toml::from_str(r#"judge_provider = "quality""#).unwrap();
+        assert_eq!(cfg.judge_provider, "quality");
+    }
+
+    #[test]
+    fn judge_provider_and_judge_model_coexist() {
+        let toml = r#"
+judge_model = "claude-sonnet-4-6"
+judge_provider = "quality"
+detector_mode = "judge"
+"#;
+        let cfg: LearningConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.judge_model, "claude-sonnet-4-6");
+        assert_eq!(cfg.judge_provider, "quality");
+        assert_eq!(cfg.detector_mode, DetectorMode::Judge);
+    }
+
+    #[test]
+    fn judge_provider_absent_falls_back_to_empty_default() {
+        let cfg: LearningConfig = toml::from_str("judge_model = \"gpt-4o\"").unwrap();
+        assert!(
+            cfg.judge_provider.is_empty(),
+            "missing judge_provider must default to empty string"
+        );
+        assert_eq!(cfg.judge_model, "gpt-4o");
     }
 }

--- a/crates/zeph-core/src/agent/corrections.rs
+++ b/crates/zeph-core/src/agent/corrections.rs
@@ -184,11 +184,25 @@ impl<C: crate::channel::Channel> Agent<C> {
         }
 
         let previous_user_messages = self.collect_previous_user_messages();
-        let regex_signal = self
-            .services
-            .feedback
-            .detector
-            .detect(trimmed, &previous_user_messages);
+        let regex_signal = if trimmed.len() > 4096 {
+            let detector = self.services.feedback.detector.clone();
+            let msg_owned = trimmed.to_owned();
+            let prev_owned: Vec<String> = previous_user_messages
+                .iter()
+                .map(|s| (*s).to_owned())
+                .collect();
+            tokio::task::spawn_blocking(move || {
+                let prev_refs: Vec<&str> = prev_owned.iter().map(String::as_str).collect();
+                detector.detect(&msg_owned, &prev_refs)
+            })
+            .await
+            .unwrap_or(None)
+        } else {
+            self.services
+                .feedback
+                .detector
+                .detect(trimmed, &previous_user_messages)
+        };
 
         let judge_should_run = self.should_run_judge(regex_signal.as_ref());
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1290,17 +1290,33 @@ impl AppBuilder {
 
     /// Build a dedicated provider for the judge detector when `detector_mode = judge`.
     ///
-    /// Returns `None` when mode is `Regex` or `judge_model` is empty (primary provider used).
-    /// Emits a `tracing::warn` when mode is `Judge` but no model is specified.
+    /// Resolution order: `judge_provider` (named provider from `[[llm.providers]]`) →
+    /// `judge_model` (legacy model-name lookup) → primary provider (fallback, returns `None`).
+    /// Returns `None` when mode is `Regex` or both provider fields are empty.
     pub fn build_judge_provider(&self) -> Option<AnyProvider> {
         use zeph_core::config::DetectorMode;
         let learning = &self.config.skills.learning;
         if learning.detector_mode != DetectorMode::Judge {
             return None;
         }
+        if !learning.judge_provider.is_empty() {
+            return match create_named_provider(&learning.judge_provider, &self.config) {
+                Ok(jp) => {
+                    tracing::info!(provider = %learning.judge_provider, "judge provider configured");
+                    Some(jp)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %learning.judge_provider,
+                        "failed to create judge provider: {e:#}, using primary"
+                    );
+                    None
+                }
+            };
+        }
         if learning.judge_model.is_empty() {
             tracing::warn!(
-                "detector_mode=judge but judge_model is empty — primary provider will be used for judging"
+                "detector_mode=judge but judge_provider and judge_model are empty — primary provider will be used for judging"
             );
             return None;
         }


### PR DESCRIPTION
## Summary

- **#4749** — Add `#[non_exhaustive]` to `AcpError`, `AcpClientError`, `LspDiagnosticSeverity`, and `LspSymbolKind` in `zeph-acp` to enforce wildcard arms on future variants
- **#4739** — Add `judge_provider: String` to `LearningConfig` with fallback chain (named provider → `judge_model` → primary) for per-deployment LLM routing
- **#4740** — Wrap `FeedbackDetector::detect` in `spawn_blocking` for messages > 4 KiB to avoid blocking the tokio executor thread; derive `Clone` on `FeedbackDetector`

## Test plan

- [ ] `cargo build --workspace --features full` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --lib --bins` — 10434 passed, 21 skipped (Qdrant integration)
- [ ] 7 new tests added: 4 serde tests for `judge_provider` field, 3 unit tests for `FeedbackDetector::detect` (short/long/neutral paths)

Closes #4749
Closes #4739
Closes #4740