### PR TITLE
fix(sanitizer): add U+2060 to UNICODE_BYPASS_RE and wire CausalIpiConfig.provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-sanitizer`: `UNICODE_BYPASS_RE` now includes U+2060 (WORD JOINER) in its character class,
+  closing a bypass where inserting that invisible character between `!` and `[` evaded markdown image
+  exfiltration detection. Closes #4752.
+- `zeph-core`: `apply_causal_analyzer` in `agent_setup.rs` now resolves `CausalIpiConfig.provider`
+  via the provider registry and falls back to the main provider when the field is absent, matching
+  the pattern used by `apply_quarantine_provider` and `apply_guardrail`. Previously the field had no
+  effect and IPI probes always used the main/expensive provider. Closes #4753.
+
 - `zeph-commands`: `CommandHandler` gains a `requires_auth` method (default `false`). Handlers in
   the `Debugging`, `Configuration`, and `Advanced` categories (`/log`, `/debug-dump`, `/dump-format`,
   `/model`, `/provider`, `/experiment`, `/policy`, `/scheduler`) now return `true`, causing

--- a/crates/zeph-sanitizer/src/exfiltration.rs
+++ b/crates/zeph-sanitizer/src/exfiltration.rs
@@ -72,11 +72,11 @@ static HTML_IMG_RE: LazyLock<Regex> = LazyLock::new(|| {
 
 /// Detects zero-width Unicode characters between `!` and `[` used to bypass markdown regex.
 ///
-/// Adversaries insert U+200B (ZWSP), U+200C (ZWNJ), U+200D (ZWJ), or U+FEFF (BOM) between
-/// the `!` and `[` characters to prevent standard regex matchers from recognising the
+/// Adversaries insert U+200B (ZWSP), U+200C (ZWNJ), U+200D (ZWJ), U+2060 (WJ), or U+FEFF (BOM)
+/// between the `!` and `[` characters to prevent standard regex matchers from recognising the
 /// markdown image syntax. This pattern catches those sequences for stripping.
 static UNICODE_BYPASS_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new("![\u{200B}\u{200C}\u{200D}\u{FEFF}]+\\[").expect("valid UNICODE_BYPASS_RE")
+    Regex::new("![\u{200B}\u{200C}\u{200D}\u{2060}\u{FEFF}]+\\[").expect("valid UNICODE_BYPASS_RE")
 });
 
 // ---------------------------------------------------------------------------
@@ -683,6 +683,25 @@ mod tests {
         assert!(
             !cleaned.contains('\u{200B}'),
             "zero-width char must be stripped: {cleaned}"
+        );
+        assert!(
+            !cleaned.starts_with('!'),
+            "image trigger `!` must be removed: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn unicode_word_joiner_bypass_blocked() {
+        let guard = ExfiltrationGuard::new(ExfiltrationGuardConfig {
+            block_markdown_images: true,
+            ..ExfiltrationGuardConfig::default()
+        });
+        // U+2060 (WORD JOINER) inserted between ! and [ to evade markdown regex.
+        let input = "!\u{2060}[alt](https://evil.com/track)";
+        let (cleaned, _events) = guard.scan_output(input);
+        assert!(
+            !cleaned.contains('\u{2060}'),
+            "U+2060 word joiner must be stripped: {cleaned}"
         );
         assert!(
             !cleaned.starts_with('!'),

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -128,6 +128,7 @@ struct SharedAgentDeps {
     #[cfg(feature = "classifiers")]
     classifiers_config: zeph_core::config::ClassifiersConfig,
     causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig,
+    causal_provider: Option<zeph_llm::any::AnyProvider>,
     vigil_config: zeph_config::VigilConfig,
     probe_provider: Option<zeph_llm::any::AnyProvider>,
     planner_provider: Option<zeph_llm::any::AnyProvider>,
@@ -529,6 +530,26 @@ async fn build_acp_deps(
         #[cfg(feature = "classifiers")]
         classifiers_config: config.classifiers.clone(),
         causal_ipi_config: config.security.causal_ipi.clone(),
+        causal_provider: config
+            .security
+            .causal_ipi
+            .provider
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .and_then(|name| match crate::bootstrap::create_named_provider(name, config) {
+                Ok(p) => {
+                    tracing::info!(provider = %name, "causal IPI dedicated provider configured (acp)");
+                    Some(p)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %name,
+                        error = %e,
+                        "causal IPI provider resolution failed, falling back to primary (acp)"
+                    );
+                    None
+                }
+            }),
         vigil_config: config.security.vigil.clone(),
         probe_provider: app.build_probe_provider(),
         planner_provider: app.build_planner_provider(),
@@ -642,6 +663,7 @@ async fn spawn_acp_agent(
     #[cfg(feature = "classifiers")]
     let classifiers_config = d.classifiers_config.clone();
     let causal_ipi_config = d.causal_ipi_config.clone();
+    let causal_provider = d.causal_provider.clone();
     let vigil_config = d.vigil_config.clone();
     let probe_provider = d.probe_provider.clone();
     let planner_provider = d.planner_provider.clone();
@@ -891,8 +913,12 @@ async fn spawn_acp_agent(
         agent = agent_setup::apply_three_class_classifier_with_cfg(agent, &classifiers_config);
         agent = agent_setup::apply_pii_classifier_with_cfg(agent, &classifiers_config);
     }
-    agent =
-        agent_setup::apply_causal_analyzer_with_cfg(agent, provider.clone(), &causal_ipi_config);
+    agent = agent_setup::apply_causal_analyzer_with_cfg(
+        agent,
+        provider.clone(),
+        causal_provider,
+        &causal_ipi_config,
+    );
     agent = agent_setup::apply_vigil(agent, &vigil_config);
 
     if debug_config.enabled {

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -968,20 +968,48 @@ pub(crate) fn apply_causal_analyzer<C: Channel>(
     provider: zeph_llm::any::AnyProvider,
     config: &Config,
 ) -> zeph_core::agent::Agent<C> {
-    apply_causal_analyzer_with_cfg(agent, provider, &config.security.causal_ipi)
+    let resolved = config
+        .security
+        .causal_ipi
+        .provider
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .and_then(
+            |name| match crate::bootstrap::create_named_provider(name, config) {
+                Ok(p) => {
+                    tracing::info!(provider = %name, "causal IPI dedicated provider configured");
+                    Some(p)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %name,
+                        error = %e,
+                        "causal IPI provider resolution failed, falling back to primary"
+                    );
+                    None
+                }
+            },
+        );
+    apply_causal_analyzer_with_cfg(agent, provider, resolved, &config.security.causal_ipi)
 }
 
 /// Wire the `TurnCausalAnalyzer` into the agent's security config (takes `CausalIpiConfig` directly).
+///
+/// `resolved_provider` is an already-resolved named provider from `[[llm.providers]]` for probe
+/// calls. When `None`, `provider` (the session's primary) is used as fallback.
 pub(crate) fn apply_causal_analyzer_with_cfg<C: Channel>(
     agent: zeph_core::agent::Agent<C>,
     provider: zeph_llm::any::AnyProvider,
+    resolved_provider: Option<zeph_llm::any::AnyProvider>,
     causal_config: &zeph_sanitizer::causal_ipi::CausalIpiConfig,
 ) -> zeph_core::agent::Agent<C> {
     let agent = agent.with_shadow_memory_config(&causal_config.shadow_memory);
     if !causal_config.enabled {
         return agent;
     }
-    let analyzer = zeph_sanitizer::causal_ipi::TurnCausalAnalyzer::new(provider, causal_config);
+    let probe_provider = resolved_provider.unwrap_or(provider);
+    let analyzer =
+        zeph_sanitizer::causal_ipi::TurnCausalAnalyzer::new(probe_provider, causal_config);
     tracing::info!(
         threshold = causal_config.threshold,
         probe_timeout_ms = causal_config.probe_timeout_ms,


### PR DESCRIPTION
## Summary

- Adds U+2060 (WORD JOINER) to `UNICODE_BYPASS_RE` in `zeph-sanitizer`, closing a bypass where inserting that invisible character between `!` and `[` evaded markdown image exfiltration detection. Includes a regression test `unicode_word_joiner_bypass_blocked`.
- Wires `CausalIpiConfig.provider` in `apply_causal_analyzer` (`agent_setup.rs`) so IPI probes are routed to the configured provider instead of always using the main provider. Follows the `apply_quarantine_provider`/`apply_guardrail` pattern. `SharedAgentDeps` in `acp.rs` gains a `causal_provider` field initialised at startup.

## Test plan

- [ ] `cargo nextest run -p zeph-sanitizer --lib` — 320 passed, new `unicode_word_joiner_bypass_blocked` test verified
- [ ] `cargo nextest run --workspace --features desktop,ide,server,chat,pdf,scheduler --lib --bins` — 10690 passed, 0 regressions
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — 0 warnings
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean

Closes #4752
Closes #4753