### PR TITLE
feat(skills): concurrent scan with buffer_unordered(4) and extension manifest parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `zeph-skills`: add `SkillExtensions` manifest parsing for UI/keybinding/monitor declarations in
+  `SKILL.md` `extensions:` frontmatter block (`SkillExtensions`, `SkillUiElement`,
+  `SkillKeybinding`, `SkillMonitor`). Parse failures log a warning and fall back to `None` so
+  existing skills are unaffected. Closes #4683.
+
 ### Fixed
 
 - `zeph-sanitizer`: `UNICODE_BYPASS_RE` now includes U+2060 (WORD JOINER) in its character class,
@@ -15,7 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   via the provider registry and falls back to the main provider when the field is absent, matching
   the pattern used by `apply_quarantine_provider` and `apply_guardrail`. Previously the field had no
   effect and IPI probes always used the main/expensive provider. Closes #4753.
-
 - `zeph-commands`: `CommandHandler` gains a `requires_auth` method (default `false`). Handlers in
   the `Debugging`, `Configuration`, and `Advanced` categories (`/log`, `/debug-dump`, `/dump-format`,
   `/model`, `/provider`, `/experiment`, `/policy`, `/scheduler`) now return `true`, causing
@@ -33,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-core`: `detect_and_record_corrections` now runs `FeedbackDetector::detect` in
   `tokio::task::spawn_blocking` when the message exceeds 4096 bytes, preventing the async agent
   loop from blocking on CPU-bound regex work. Closes #4740.
+- `zeph-core`: concurrent skill scanning in `semantic_scan_plugin_add` with `buffer_unordered(4)`
+  and aggregate 300 s timeout; previously skills were scanned sequentially. Closes #4705.
 - `zeph-memory`: `resolve_edge_typed` now forwards `edge.confidence` to the store instead of
   hardcoding `0.8`. Introduces `DEFAULT_EDGE_CONFIDENCE` constant and fixes both the non-APEX and
   APEX-MEM paths. Closes #4723.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11243,6 +11243,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_norway",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -44,7 +44,15 @@ impl<C: Channel + Send + 'static> Agent<C> {
 
 /// Run Stage-2 LLM semantic scan for all skills in the plugin at `source`.
 ///
-/// Returns `Some(err_msg)` when a skill is blocked, `None` when all skills pass.
+/// Skills are scanned concurrently with up to 4 in-flight at a time
+/// (`buffer_unordered(4)`). An aggregate 5-minute timeout wraps the whole
+/// batch; each individual scan is already bounded by `SCAN_TIMEOUT` (30 s) in
+/// `SkillSemanticScanner`. Returns `Some(err_msg)` when any skill is blocked,
+/// `None` when all skills pass.
+///
+/// Each future carries its own `skill_name` so that the rejection message names
+/// the correct skill regardless of completion order (which differs from input
+/// order when futures complete out-of-order with `buffer_unordered`).
 async fn semantic_scan_plugin_add(
     scanner: &zeph_skills::semantic_scanner::SkillSemanticScanner,
     source: &str,
@@ -52,7 +60,11 @@ async fn semantic_scan_plugin_add(
     mcp_allowed: Vec<String>,
     base_shell_allowed: Vec<String>,
 ) -> Result<Option<String>, CommandError> {
+    use futures::stream::StreamExt as _;
     use zeph_skills::semantic_scanner::ScanVerdict;
+
+    let span = tracing::info_span!("core.agent.scan_plugin", plugin = %source);
+    let _enter = span.enter();
 
     let plugins_dir = zeph_plugins::PluginManager::default_plugins_dir();
     let mgr_dir =
@@ -72,34 +84,55 @@ async fn semantic_scan_plugin_add(
         "plugins.add: running Stage-2 semantic scan"
     );
 
-    for input in &scan_inputs {
-        let verdict = scanner
-            .scan(&input.skill_name, &input.declared_purpose, &input.skill_md)
-            .await
-            .map_err(|e| {
-                CommandError(format!(
-                    "plugin add failed: semantic scan error for skill {:?}: {e}",
-                    input.skill_name
-                ))
-            })?;
+    // Scan all skills concurrently with up to 4 in-flight. Each individual scan is
+    // already bounded by SCAN_TIMEOUT (30 s); the outer 5-min cap guards the batch.
+    // Each future owns its skill_name so verdicts carry the correct name regardless
+    // of buffer_unordered completion order (which is not the same as input order).
+    let scan_futs: Vec<_> = scan_inputs
+        .iter()
+        .map(|input| {
+            let name = input.skill_name.clone();
+            let purpose = input.declared_purpose.clone();
+            let md = input.skill_md.clone();
+            async move {
+                let verdict = scanner.scan(&name, &purpose, &md).await;
+                (name, verdict)
+            }
+        })
+        .collect();
+
+    let verdicts: Vec<_> = tokio::time::timeout(
+        std::time::Duration::from_mins(5),
+        futures::stream::iter(scan_futs)
+            .buffer_unordered(4)
+            .collect::<Vec<_>>(),
+    )
+    .await
+    .map_err(|_| CommandError("plugin scan timed out after 300s".to_owned()))?;
+
+    for (skill_name, verdict_result) in verdicts {
+        let verdict = verdict_result.map_err(|e| {
+            CommandError(format!(
+                "plugin add failed: semantic scan error for skill {skill_name:?}: {e}"
+            ))
+        })?;
         match verdict {
             ScanVerdict::Allow => {
                 tracing::debug!(
-                    skill = %input.skill_name,
+                    skill = %skill_name,
                     "plugins.add: skill passed semantic scan"
                 );
             }
             ScanVerdict::Warn(ref reason) => {
                 tracing::warn!(
-                    skill = %input.skill_name,
+                    skill = %skill_name,
                     reason = %reason,
                     "plugins.add: skill passed with warning"
                 );
             }
             ScanVerdict::Block(reason) => {
                 return Ok(Some(format!(
-                    "plugin add failed: skill {:?} rejected by semantic scan: {}",
-                    input.skill_name, reason
+                    "plugin add failed: skill {skill_name:?} rejected by semantic scan: {reason}"
                 )));
             }
         }
@@ -1942,6 +1975,120 @@ mod tests {
                 "must not fail with scan error when semantic_scan is disabled, got: {e}"
             );
         }
+    }
+
+    // R-4705: semantic_scan_plugin_add must scan all skills concurrently and return
+    // None when every scanner call returns Allow. Verifies buffer_unordered path
+    // processes N inputs without sequential bottleneck.
+    #[tokio::test]
+    async fn semantic_scan_plugin_add_concurrent_all_allow_returns_none() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_skills::semantic_scanner::SkillSemanticScanner;
+
+        // MockProvider returns `{"verdict":"allow","reason":"ok"}` for every call.
+        let allow_json = r#"{"verdict":"allow","reason":"ok"}"#.to_owned();
+        let provider = AnyProvider::Mock(MockProvider::with_responses(vec![
+            allow_json.clone(),
+            allow_json,
+        ]));
+        let scanner = SkillSemanticScanner::new(provider);
+
+        // Build a minimal plugin layout with two skills so scan_targets returns
+        // two SkillScanInput entries.
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_toml = r#"
+[plugin]
+name = "test-plugin"
+version = "0.1.0"
+description = "test"
+
+[[skills]]
+path = "skill-a"
+
+[[skills]]
+path = "skill-b"
+"#;
+        std::fs::write(tmp.path().join("plugin.toml"), plugin_toml).unwrap();
+        for name in ["skill-a", "skill-b"] {
+            let skill_dir = tmp.path().join(name);
+            std::fs::create_dir_all(&skill_dir).unwrap();
+            std::fs::write(
+                skill_dir.join("SKILL.md"),
+                format!("# {name}\n\n## Purpose\nTest skill.\n"),
+            )
+            .unwrap();
+        }
+
+        let result =
+            semantic_scan_plugin_add(&scanner, tmp.path().to_str().unwrap(), None, vec![], vec![])
+                .await;
+
+        // All skills allowed → no error message returned.
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert!(
+            result.unwrap().is_none(),
+            "expected None (all passed) but got Some(err)"
+        );
+    }
+
+    // R-4705 regression: buffer_unordered yields in completion order, not input order.
+    // A Block verdict on the *second* skill (index 1) must name that second skill, not the
+    // first. Before the fix, the code zipped verdicts against scan_inputs by position and
+    // discarded the tuple's skill_name, so the wrong skill was reported.
+    #[tokio::test]
+    async fn semantic_scan_plugin_add_block_names_correct_skill() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_skills::semantic_scanner::SkillSemanticScanner;
+
+        // First call returns Allow, second returns Block — only the second skill is rejected.
+        let allow_json = r#"{"verdict":"allow","reason":"ok"}"#.to_owned();
+        let block_json = r#"{"verdict":"block","reason":"malicious"}"#.to_owned();
+        let provider =
+            AnyProvider::Mock(MockProvider::with_responses(vec![allow_json, block_json]));
+        let scanner = SkillSemanticScanner::new(provider);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_toml = r#"
+[plugin]
+name = "test-plugin-block"
+version = "0.1.0"
+description = "test"
+
+[[skills]]
+path = "skill-first"
+
+[[skills]]
+path = "skill-second"
+"#;
+        std::fs::write(tmp.path().join("plugin.toml"), plugin_toml).unwrap();
+        for name in ["skill-first", "skill-second"] {
+            let skill_dir = tmp.path().join(name);
+            std::fs::create_dir_all(&skill_dir).unwrap();
+            std::fs::write(
+                skill_dir.join("SKILL.md"),
+                format!("# {name}\n\n## Purpose\nTest skill.\n"),
+            )
+            .unwrap();
+        }
+
+        let result =
+            semantic_scan_plugin_add(&scanner, tmp.path().to_str().unwrap(), None, vec![], vec![])
+                .await;
+
+        assert!(result.is_ok(), "expected Ok(_), got: {result:?}");
+        let msg = result
+            .unwrap()
+            .expect("expected Some(err) for blocked skill");
+        assert!(
+            msg.contains("skill-second"),
+            "rejection must name the blocked skill 'skill-second', got: {msg}"
+        );
+        assert!(
+            !msg.contains("skill-first"),
+            "rejection must NOT name the allowed skill 'skill-first', got: {msg}"
+        );
     }
 
     // R-4706/R-4709: unknown provider name must also fail-closed rather than silently

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { workspace = true, features = ["json", "rustls"] }
 schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+serde_norway.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "time", "fs"] }
 toml = { workspace = true, optional = true }

--- a/crates/zeph-skills/src/extensions.rs
+++ b/crates/zeph-skills/src/extensions.rs
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Optional platform-extension manifest for skills.
+//!
+//! The `extensions:` YAML block inside a `SKILL.md` frontmatter lets a skill declare
+//! UI elements, keybindings, and background monitors that a host platform may wire up.
+//! Parsing is best-effort: any error in this block logs a warning and falls back to
+//! `None` so that the skill continues to load normally.
+//!
+//! # SKILL.md Format
+//!
+//! ```text
+//! ---
+//! name: my-skill
+//! description: Does something useful.
+//! extensions:
+//!   ui:
+//!     - type: toolbar_button
+//!       label: Run My Skill
+//!       icon: play
+//!   keybindings:
+//!     - chord: ctrl+shift+r
+//!       action: run-my-skill
+//!   monitors:
+//!     - trigger: file_changed
+//!       action: reload-my-skill
+//! ---
+//! ```
+
+/// A UI element declared by a skill extension manifest.
+///
+/// The `type` tag selects which variant is deserialized. Currently supported variants
+/// are `toolbar_button` and `menu_item`.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_skills::extensions::SkillUiElement;
+///
+/// let yaml = r#"
+/// - type: toolbar_button
+///   label: Run
+///   icon: play
+/// - type: menu_item
+///   label: Open Skill
+///   action: open-skill
+/// "#;
+/// let elements: Vec<SkillUiElement> = serde_norway::from_str(yaml).unwrap();
+/// assert!(matches!(elements[0], SkillUiElement::ToolbarButton { .. }));
+/// assert!(matches!(elements[1], SkillUiElement::MenuItem { .. }));
+/// ```
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SkillUiElement {
+    /// A button rendered in the host application's toolbar.
+    ToolbarButton {
+        /// Display label for the button.
+        label: String,
+        /// Optional icon identifier (platform-defined).
+        icon: Option<String>,
+    },
+    /// An item injected into a host application menu.
+    MenuItem {
+        /// Display label for the menu item.
+        label: String,
+        /// Action identifier dispatched when the item is selected.
+        action: String,
+    },
+}
+
+/// A keyboard shortcut declared by a skill extension manifest.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_skills::extensions::SkillKeybinding;
+///
+/// let yaml = "chord: ctrl+shift+r\naction: run-my-skill\n";
+/// let kb: SkillKeybinding = serde_norway::from_str(yaml).unwrap();
+/// assert_eq!(kb.chord, "ctrl+shift+r");
+/// assert_eq!(kb.action, "run-my-skill");
+/// ```
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[non_exhaustive]
+pub struct SkillKeybinding {
+    /// Key chord string in platform-normalized notation (e.g. `"ctrl+shift+r"`).
+    pub chord: String,
+    /// Action identifier dispatched when the chord is pressed.
+    pub action: String,
+}
+
+/// A background monitor declared by a skill extension manifest.
+///
+/// Monitors let a skill react to host events without explicit user invocation.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_skills::extensions::SkillMonitor;
+///
+/// let yaml = "trigger: file_changed\naction: reload-my-skill\n";
+/// let mon: SkillMonitor = serde_norway::from_str(yaml).unwrap();
+/// assert_eq!(mon.trigger, "file_changed");
+/// assert_eq!(mon.action, "reload-my-skill");
+/// ```
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[non_exhaustive]
+pub struct SkillMonitor {
+    /// Event name that activates this monitor (platform-defined).
+    pub trigger: String,
+    /// Action identifier dispatched when the trigger fires.
+    pub action: String,
+}
+
+/// Optional platform-extension manifest parsed from a skill's `SKILL.md` `extensions:` block.
+///
+/// All fields default to empty. When the `extensions:` block is absent from a SKILL.md,
+/// [`parse_extensions`] returns `None` rather than a default value.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_skills::extensions::SkillExtensions;
+///
+/// let yaml = r#"
+/// ui:
+///   - type: toolbar_button
+///     label: "Quick Refactor"
+/// keybindings:
+///   - chord: "cmd+shift+r"
+///     action: "refactor-selected"
+/// "#;
+/// let ext: SkillExtensions = serde_norway::from_str(yaml).unwrap();
+/// assert_eq!(ext.keybindings[0].chord, "cmd+shift+r");
+/// assert_eq!(ext.ui.len(), 1);
+/// ```
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq)]
+#[non_exhaustive]
+pub struct SkillExtensions {
+    /// UI elements (toolbar buttons, menu items) the skill contributes to the host UI.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ui: Vec<SkillUiElement>,
+    /// Keybindings the skill registers with the host.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keybindings: Vec<SkillKeybinding>,
+    /// Background monitors the skill wants the host to activate.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub monitors: Vec<SkillMonitor>,
+}
+
+/// Extract an `extensions:` YAML sub-block from a raw SKILL.md frontmatter string and
+/// parse it into [`SkillExtensions`].
+///
+/// Returns `None` if the block is absent or if parsing fails (a warning is logged).
+/// This function never panics and never propagates errors — failures are always `None`.
+#[must_use]
+pub fn parse_extensions(yaml_str: &str) -> Option<SkillExtensions> {
+    let block = extract_extensions_block(yaml_str)?;
+    if block.len() > 8 * 1024 {
+        tracing::warn!("'extensions:' block exceeds 8 KiB, skipping");
+        return None;
+    }
+    match serde_norway::from_str::<SkillExtensions>(&block) {
+        Ok(ext) => Some(ext),
+        Err(e) => {
+            tracing::warn!("failed to parse 'extensions:' block in SKILL.md frontmatter: {e}");
+            None
+        }
+    }
+}
+
+/// Pull the indented content under `extensions:` from a raw YAML frontmatter string.
+///
+/// Returns a YAML string suitable for deserializing into [`SkillExtensions`], or `None`
+/// if the `extensions:` key is not present.
+fn extract_extensions_block(yaml_str: &str) -> Option<String> {
+    let mut in_block = false;
+    let mut lines = Vec::new();
+
+    for line in yaml_str.lines() {
+        if in_block {
+            if line.starts_with(' ') || line.starts_with('\t') || line.trim().is_empty() {
+                // Collect indented content; strip one level of indentation (2 spaces).
+                let stripped = line.strip_prefix("  ").unwrap_or(line);
+                lines.push(stripped);
+            } else {
+                // A non-indented line means we've exited the block.
+                break;
+            }
+        } else if line.trim_start() == "extensions:" || line.starts_with("extensions:") {
+            in_block = true;
+        }
+    }
+
+    if lines.is_empty() {
+        return None;
+    }
+
+    Some(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_extensions_block() {
+        let yaml = "\
+name: my-skill
+description: A skill.
+extensions:
+  ui:
+    - type: toolbar_button
+      label: Run
+      icon: play
+  keybindings:
+    - chord: ctrl+r
+      action: run
+  monitors:
+    - trigger: file_changed
+      action: reload
+";
+        let ext = parse_extensions(yaml).expect("should parse extensions");
+        assert_eq!(ext.ui.len(), 1);
+        assert!(matches!(
+            &ext.ui[0],
+            SkillUiElement::ToolbarButton { label, icon }
+            if label == "Run" && icon.as_deref() == Some("play")
+        ));
+        assert_eq!(ext.keybindings.len(), 1);
+        assert_eq!(ext.keybindings[0].chord, "ctrl+r");
+        assert_eq!(ext.keybindings[0].action, "run");
+        assert_eq!(ext.monitors.len(), 1);
+        assert_eq!(ext.monitors[0].trigger, "file_changed");
+        assert_eq!(ext.monitors[0].action, "reload");
+    }
+
+    #[test]
+    fn parse_extensions_absent_returns_none() {
+        let yaml = "name: my-skill\ndescription: A skill.\n";
+        assert!(parse_extensions(yaml).is_none());
+    }
+
+    #[test]
+    fn parse_extensions_empty_block_returns_default() {
+        // An `extensions:` key with no sub-keys deserializes to Default.
+        let yaml = "name: my-skill\ndescription: desc.\nextensions:\nother: field\n";
+        // Block is empty → None (no lines collected).
+        let result = parse_extensions(yaml);
+        // Empty extensions block → None (nothing to parse).
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_extensions_invalid_yaml_returns_none() {
+        // Malformed YAML in extensions block must not fail skill loading.
+        let yaml = "extensions:\n  ui:\n    - type: !!invalid\n";
+        // Should not panic; may return None.
+        let _ = parse_extensions(yaml);
+    }
+
+    #[test]
+    fn parse_extensions_only_ui() {
+        let yaml = "\
+extensions:
+  ui:
+    - type: menu_item
+      label: Open
+      action: open-skill
+";
+        let ext = parse_extensions(yaml).expect("should parse");
+        assert_eq!(ext.ui.len(), 1);
+        assert!(matches!(
+            &ext.ui[0],
+            SkillUiElement::MenuItem { label, action }
+            if label == "Open" && action == "open-skill"
+        ));
+        assert!(ext.keybindings.is_empty());
+        assert!(ext.monitors.is_empty());
+    }
+
+    #[test]
+    fn parse_extensions_toolbar_button_no_icon() {
+        let yaml = "\
+extensions:
+  ui:
+    - type: toolbar_button
+      label: Run
+";
+        let ext = parse_extensions(yaml).expect("should parse");
+        assert!(matches!(
+            &ext.ui[0],
+            SkillUiElement::ToolbarButton { label, icon }
+            if label == "Run" && icon.is_none()
+        ));
+    }
+
+    #[test]
+    fn roundtrip_yaml() {
+        let ext = SkillExtensions {
+            ui: vec![SkillUiElement::ToolbarButton {
+                label: "Run".into(),
+                icon: Some("play".into()),
+            }],
+            keybindings: vec![SkillKeybinding {
+                chord: "ctrl+r".into(),
+                action: "run".into(),
+            }],
+            monitors: vec![SkillMonitor {
+                trigger: "file_changed".into(),
+                action: "reload".into(),
+            }],
+        };
+        let yaml = serde_norway::to_string(&ext).expect("serialize");
+        let parsed: SkillExtensions = serde_norway::from_str(&yaml).expect("deserialize");
+        assert_eq!(ext, parsed);
+    }
+
+    #[test]
+    fn default_is_all_empty() {
+        let ext = SkillExtensions::default();
+        assert!(ext.ui.is_empty());
+        assert!(ext.keybindings.is_empty());
+        assert!(ext.monitors.is_empty());
+    }
+
+    #[test]
+    fn extensions_block_stops_at_next_top_level_field() {
+        // After the extensions block, other frontmatter fields must not bleed into it.
+        let yaml = "\
+extensions:
+  keybindings:
+    - chord: ctrl+k
+      action: do-something
+other-field: should-not-appear
+";
+        let ext = parse_extensions(yaml).expect("should parse");
+        assert_eq!(ext.keybindings.len(), 1);
+        assert_eq!(ext.keybindings[0].chord, "ctrl+k");
+    }
+}

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -58,6 +58,7 @@ pub mod erl;
 pub mod error;
 pub mod evaluator;
 pub mod evolution;
+pub mod extensions;
 pub mod generator;
 pub mod group;
 pub mod loader;
@@ -87,6 +88,7 @@ pub use error::SkillError;
 pub use evaluator::{
     EvaluationWeights, SkillEvaluationRequest, SkillEvaluator, SkillQualityScore, SkillVerdict,
 };
+pub use extensions::{SkillExtensions, SkillKeybinding, SkillMonitor, SkillUiElement};
 pub use generator::{GeneratedSkill, SkillGenerationRequest, SkillGenerator};
 pub use group::{GroupResult, SkillGroup, SkillRole, group_skills};
 pub use matcher::{IntentClassification, MatchResult, ScoredMatch};

--- a/crates/zeph-skills/src/loader.rs
+++ b/crates/zeph-skills/src/loader.rs
@@ -58,6 +58,7 @@ use std::path::{Path, PathBuf};
 use zeph_common::SessionId;
 
 use crate::error::SkillError;
+use crate::extensions::{SkillExtensions, parse_extensions};
 
 /// Parsed frontmatter metadata for a single skill.
 ///
@@ -114,6 +115,11 @@ pub struct SkillMeta {
     /// Set when `source = "heuristic_promotion"`. Used for traceability only — no effect on
     /// skill matching or trust governance.
     pub parent_skill: Option<String>,
+    /// Optional platform-extension manifest declared in the skill's `extensions:` frontmatter block.
+    ///
+    /// `None` when the block is absent or fails to parse (a warning is logged on parse failure).
+    /// Existing SKILL.md files without `extensions:` always load with `extensions: None`.
+    pub extensions: Option<SkillExtensions>,
 }
 
 /// A fully loaded skill: metadata plus the raw Markdown body.
@@ -162,6 +168,7 @@ impl Default for SkillMeta {
             category: None,
             triggers: vec![],
             parent_skill: None,
+            extensions: None,
         }
     }
 }
@@ -659,6 +666,8 @@ pub fn load_skill_meta_from_str(content: &str) -> Result<(SkillMeta, String), Sk
         tracing::warn!("'requires-secrets' is deprecated, use 'x-requires-secrets'");
     }
 
+    let extensions = parse_extensions(yaml_str);
+
     let meta = SkillMeta {
         name,
         description,
@@ -676,6 +685,7 @@ pub fn load_skill_meta_from_str(content: &str) -> Result<(SkillMeta, String), Sk
         category: raw.category,
         triggers: raw.triggers,
         parent_skill: raw.parent_skill,
+        extensions,
     };
 
     Ok((meta, body.to_string()))
@@ -740,6 +750,8 @@ pub fn load_skill_meta(path: &Path) -> Result<SkillMeta, SkillError> {
         );
     }
 
+    let extensions = parse_extensions(yaml_str);
+
     Ok(SkillMeta {
         name,
         description,
@@ -757,6 +769,7 @@ pub fn load_skill_meta(path: &Path) -> Result<SkillMeta, SkillError> {
         category: raw.category,
         triggers: raw.triggers,
         parent_skill: raw.parent_skill,
+        extensions,
     })
 }
 
@@ -1705,5 +1718,63 @@ mod tests {
         );
         let meta = load_skill_meta(&path).unwrap();
         assert!(meta.parent_skill.is_none());
+    }
+
+    #[test]
+    fn extensions_block_parsed_from_skill_md() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = "\
+---
+name: my-skill
+description: A skill with extensions.
+extensions:
+  ui:
+    - type: toolbar_button
+      label: Run
+      icon: play
+  keybindings:
+    - chord: ctrl+r
+      action: run
+  monitors:
+    - trigger: file_changed
+      action: reload
+---
+body
+";
+        let path = write_skill(dir.path(), "my-skill", content);
+        let meta = load_skill_meta(&path).unwrap();
+        let ext = meta.extensions.expect("extensions should be parsed");
+        assert_eq!(ext.ui.len(), 1);
+        assert_eq!(ext.keybindings.len(), 1);
+        assert_eq!(ext.monitors.len(), 1);
+    }
+
+    #[test]
+    fn extensions_absent_when_not_in_skill_md() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "no-ext",
+            "---\nname: no-ext\ndescription: No extensions here.\n---\nbody",
+        );
+        let meta = load_skill_meta(&path).unwrap();
+        assert!(
+            meta.extensions.is_none(),
+            "extensions must be None when not declared"
+        );
+    }
+
+    #[test]
+    fn extensions_absent_does_not_prevent_skill_loading() {
+        // Backwards compat: existing SKILL.md files without extensions load without error.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "compat",
+            "---\nname: compat\ndescription: Existing skill.\ncategory: dev\n---\nbody",
+        );
+        let meta = load_skill_meta(&path).unwrap();
+        assert!(meta.extensions.is_none());
+        assert_eq!(meta.category.as_deref(), Some("dev"));
     }
 }

--- a/crates/zeph-skills/src/merger.rs
+++ b/crates/zeph-skills/src/merger.rs
@@ -38,6 +38,7 @@
 //!     category: None,
 //!     triggers: vec![],
 //!     parent_skill: None,
+//!     extensions: None,
 //! };
 //!
 //! let decision = decide(0.80, 0.75, 0.90, true, &meta);
@@ -216,6 +217,7 @@ mod tests {
             category: None,
             triggers: vec![],
             parent_skill: None,
+            extensions: None,
         }
     }
 

--- a/crates/zeph-skills/src/trace_extractor.rs
+++ b/crates/zeph-skills/src/trace_extractor.rs
@@ -725,6 +725,7 @@ mod tests {
             category: None,
             triggers: vec![],
             parent_skill: None,
+            extensions: None,
         };
         let emb = SkillEmbedding::from_raw(vec![1.0, 0.0]);
         let existing = vec![(meta, emb)];


### PR DESCRIPTION
## Summary

- **#4705** — Replace sequential `for`-loop in `semantic_scan_plugin_add` with `buffer_unordered(4)` concurrent stream and a 300s aggregate `tokio::time::timeout`. Each future carries its own `(skill_name, verdict)` tuple so rejection messages always name the correct skill regardless of completion order. Adds `tracing::info_span!("core.agent.scan_plugin")`.
- **#4683** — Add `crates/zeph-skills/src/extensions.rs`: `SkillExtensions` (with `SkillUiElement`, `SkillKeybinding`, `SkillMonitor`); extend `SkillMeta` with `extensions: Option<SkillExtensions>`; parse optional `extensions:` YAML block from SKILL.md with 8 KiB byte cap before `serde_norway::from_str`; parse failure returns `None` (existing SKILL.md files load unchanged).

## Changes

- `crates/zeph-core/src/agent/agent_access_impl.rs` — concurrent scan loop, tracing span
- `crates/zeph-skills/src/extensions.rs` — new: `SkillExtensions` and supporting types
- `crates/zeph-skills/src/lib.rs` — re-export new types
- `crates/zeph-skills/src/loader.rs` — populate `extensions` field on load
- `crates/zeph-skills/src/merger.rs`, `trace_extractor.rs` — add `extensions: None` to struct literals
- `crates/zeph-skills/Cargo.toml` — add `serde_norway`
- `CHANGELOG.md` — updated under `[Unreleased]`

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 10 441 passed, 0 failed
- [ ] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all doc-tests pass including 45 in zeph-skills
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [ ] Regression test `semantic_scan_plugin_add_block_names_correct_skill` verifies correct skill name in rejection message with non-zero-index Block verdict
- [ ] Extension manifest parsing tests: with/without/malformed `extensions:` block
- [ ] Live e2e (concurrent scan, extension manifest parsing): see `.local/testing/playbooks/skill-semantic-scan.md` — blocked by LLM gate (OpenAI 429)

Closes #4705, Closes #4683