### PR TITLE
fix(commands): add requires_auth guard to Advanced/Debugging handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `CommandRegistry::dispatch` to reject them with an error when `trusted = false`. The dispatch call
   sites in `zeph-core` pass `channel.supports_exit()` as the trust signal, so remote channels
   (Telegram, Discord, Slack) can no longer invoke privileged commands. Closes #4741.
+- `zeph-commands`: extend auth guard to the remaining Advanced and Debugging handlers that were
+  missing `requires_auth` coverage: `/trajectory`, `/scope`, `/loop`, `/lsp`, `/cache-stats`,
+  `/notify-test`, `/status`, `/guardrail`, `/focus`, `/sidequest`. Also registers `/trajectory`
+  and `/scope` in the `COMMANDS` static list so they appear in `/help` output. Closes #4755.
 - `zeph-tools`: three `EgressEvent` construction sites in `fetch_html` (non-2xx, body-too-large, and
   success paths) now call `redact_url_for_log` instead of passing the raw `current_url`. This
   completes the redaction coverage started in #4713; the connection-error and SSRF-blocked paths were

--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -250,6 +250,20 @@ pub const COMMANDS: &[CommandInfo] = &[
     },
     // --- Advanced (feature-gated) ---
     CommandInfo {
+        name: "/trajectory",
+        args: "[status|reset]",
+        description: "Show trajectory risk sentinel status or reset it",
+        category: SlashCategory::Advanced,
+        feature_gate: None,
+    },
+    CommandInfo {
+        name: "/scope",
+        args: "[list [task_type]]",
+        description: "List configured capability scopes (spec 050)",
+        category: SlashCategory::Advanced,
+        feature_gate: None,
+    },
+    CommandInfo {
         name: "/scheduler",
         args: "[list]",
         description: "List scheduled tasks",

--- a/crates/zeph-commands/src/handlers/loop_cmd.rs
+++ b/crates/zeph-commands/src/handlers/loop_cmd.rs
@@ -37,6 +37,10 @@ impl CommandHandler<CommandContext<'_>> for LoopCommand {
         SlashCategory::Advanced
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,

--- a/crates/zeph-commands/src/handlers/lsp.rs
+++ b/crates/zeph-commands/src/handlers/lsp.rs
@@ -29,6 +29,10 @@ impl CommandHandler<CommandContext<'_>> for LspCommand {
         Some("lsp-context")
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,

--- a/crates/zeph-commands/src/handlers/misc.rs
+++ b/crates/zeph-commands/src/handlers/misc.rs
@@ -25,6 +25,10 @@ impl CommandHandler<CommandContext<'_>> for CacheStatsCommand {
         SlashCategory::Debugging
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -56,6 +60,10 @@ impl CommandHandler<CommandContext<'_>> for NotifyTestCommand {
 
     fn category(&self) -> SlashCategory {
         SlashCategory::Debugging
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
     }
 
     fn handle<'a>(

--- a/crates/zeph-commands/src/handlers/status.rs
+++ b/crates/zeph-commands/src/handlers/status.rs
@@ -25,6 +25,10 @@ impl CommandHandler<CommandContext<'_>> for StatusCommand {
         SlashCategory::Debugging
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -60,6 +64,10 @@ impl CommandHandler<CommandContext<'_>> for GuardrailCommand {
 
     fn feature_gate(&self) -> Option<&'static str> {
         Some("guardrail")
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
     }
 
     fn handle<'a>(
@@ -99,6 +107,10 @@ impl CommandHandler<CommandContext<'_>> for FocusCommand {
         Some("context-compression")
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -134,6 +146,10 @@ impl CommandHandler<CommandContext<'_>> for SideQuestCommand {
 
     fn feature_gate(&self) -> Option<&'static str> {
         Some("context-compression")
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
     }
 
     fn handle<'a>(

--- a/crates/zeph-commands/src/handlers/trajectory.rs
+++ b/crates/zeph-commands/src/handlers/trajectory.rs
@@ -31,6 +31,10 @@ impl CommandHandler<CommandContext<'_>> for TrajectoryCommand {
         SlashCategory::Advanced
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -68,6 +72,10 @@ impl CommandHandler<CommandContext<'_>> for ScopeCommand {
 
     fn category(&self) -> SlashCategory {
         SlashCategory::Advanced
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
     }
 
     fn handle<'a>(


### PR DESCRIPTION
## Summary

- Added `requires_auth() -> bool { true }` override to 10 command handlers that were accessible from remote channels (Telegram, Discord, Slack) without authorization after PR #4751
- Added `/trajectory` and `/scope` entries to the `COMMANDS` registry (they were registered in the agent but absent from the command list)

## Handlers now guarded

| Handler | Command | Category | Risk |
|---------|---------|---------|------|
| `LoopCommand` | `/loop` | Advanced | injects recurring prompts (highest risk) |
| `NotifyTestCommand` | `/notify-test` | Debugging | triggers outbound notifications |
| `TrajectoryCommand` | `/trajectory` | Advanced | exposes sentinel state |
| `ScopeCommand` | `/scope` | Advanced | exposes capability scopes |
| `StatusCommand` | `/status` | Debugging | exposes model/token/uptime |
| `GuardrailCommand` | `/guardrail` | Debugging | exposes guardrail config |
| `FocusCommand` | `/focus` | Advanced | read-only status |
| `SideQuestCommand` | `/sidequest` | Advanced | read-only status |
| `LspCommand` | `/lsp` | Debugging | exposes LSP config |
| `CacheStatsCommand` | `/cache-stats` | Debugging | exposes cache internals |

`HelpCommand` remains intentionally public.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10435/10435 passed

Closes #4755