### PR TITLE
fix(core): handle unknown ChatResponse variant gracefully in tier_loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   missing `requires_auth` coverage: `/trajectory`, `/scope`, `/loop`, `/lsp`, `/cache-stats`,
   `/notify-test`, `/status`, `/guardrail`, `/focus`, `/sidequest`. Also registers `/trajectory`
   and `/scope` in the `COMMANDS` static list so they appear in `/help` output. Closes #4755.
+- `zeph-core`: `process_single_native_turn` in `tier_loop.rs` now handles unknown `ChatResponse`
+  variants gracefully instead of panicking. The `else` branch of the `ChatResponse::ToolUse`
+  destructure logs a `warn!` with the discriminant and returns `Ok(Some(()))` (terminate the loop
+  cleanly). This prevents a panic if a new variant is ever added to the `#[non_exhaustive]`
+  `ChatResponse` enum in `zeph-llm`. Closes #4778.
 - `zeph-tools`: three `EgressEvent` construction sites in `fetch_html` (non-2xx, body-too-large, and
   success paths) now call `redact_url_for_log` instead of passing the raw `current_url`. This
   completes the redaction coverage started in #4713; the connection-error and SSRF-blocked paths were

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -2566,7 +2566,11 @@ impl<C: Channel> Agent<C> {
             thinking_blocks,
         } = chat_result
         else {
-            unreachable!();
+            tracing::warn!(
+                ?chat_result,
+                "unexpected ChatResponse variant in native tool loop"
+            );
+            return Ok(Some(()));
         };
         self.preserve_thinking_blocks(thinking_blocks);
         self.handle_native_tool_calls(text.as_deref(), &tool_calls)


### PR DESCRIPTION
## Summary

- Replace `unreachable!()` in the `ChatResponse::ToolUse` let-else branch in `process_single_native_turn` (`tier_loop.rs:2569`) with a `tracing::warn!(?chat_result, ...)` log and `Ok(Some(()))` early exit.
- `ChatResponse` is `#[non_exhaustive]` (added in #4759), making `unreachable!()` a latent panic on any future variant addition.
- `Ok(Some(()))` matches all other terminal early-exits in the same function (timeout, budget, Text branch).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10450 passed, 21 skipped
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean

Closes #4778.