### PR TITLE
fix(tracing): replace span.enter() across .await with .instrument()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`, `zeph-context`, `zeph-skills`, `zeph-tools`: replace six `span.enter()` guards held
+  across `.await` boundaries with `.instrument(span).await` (and `.instrument(span)` on
+  `async move` blocks passed to `tokio::task::spawn`). The synchronous guard is `!Send` and caused
+  incorrect parent–child span relationships under the tokio multi-thread scheduler. Closes #4777.
+- `zeph-tools`: normalize all span names in `scrape.rs`, `shell/mod.rs`, `diagnostics.rs`,
+  `file.rs`, and `search_code.rs` to the `tools.<subsystem>.<operation>` convention; eliminates the
+  mix of `tool.*`, `tools.*`, and bare `scrape.*` prefixes. Closes #4714.
 - `zeph-sanitizer`: `UNICODE_BYPASS_RE` now includes U+2060 (WORD JOINER) in its character class,
   closing a bypass where inserting that invisible character between `!` and `[` evaded markdown image
   exfiltration detection. Closes #4752.

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 
 use futures::StreamExt as _;
 use futures::future::BoxFuture;
+use tracing::Instrument as _;
 use tracing::info_span;
 use zeph_common::memory::TokenCounting;
 use zeph_common::{ContextFidelity, PlannedToolHint};
@@ -708,14 +709,12 @@ async fn render_compressed(
                 input_tokens,
                 cached = false,
             );
-            let result = {
-                let _enter = span.enter();
-                tokio::time::timeout(
-                    Duration::from_secs(config.compress_timeout_secs),
-                    p.chat(&req),
-                )
-                .await
-            };
+            let result = tokio::time::timeout(
+                Duration::from_secs(config.compress_timeout_secs),
+                p.chat(&req),
+            )
+            .instrument(span)
+            .await;
 
             match result {
                 Ok(Ok(summary)) => {

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -63,9 +63,6 @@ async fn semantic_scan_plugin_add(
     use futures::stream::StreamExt as _;
     use zeph_skills::semantic_scanner::ScanVerdict;
 
-    let span = tracing::info_span!("core.agent.scan_plugin", plugin = %source);
-    let _enter = span.enter();
-
     let plugins_dir = zeph_plugins::PluginManager::default_plugins_dir();
     let mgr_dir =
         managed_dir.unwrap_or_else(|| zeph_config::defaults::default_vault_dir().join("skills"));
@@ -1150,6 +1147,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     mcp_allowed.clone(),
                     base_shell_allowed.clone(),
                 )
+                .instrument(tracing::info_span!("core.agent.scan_plugin", plugin = %source.trim()))
                 .await?
             {
                 return Ok(err);

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -86,6 +86,8 @@ use zeph_skills::prompt::format_skills_prompt;
 use zeph_skills::registry::SkillRegistry;
 use zeph_tools::executor::{ErasedToolExecutor, ToolExecutor};
 
+use tracing::Instrument as _;
+
 use crate::channel::Channel;
 use crate::config::Config;
 use crate::context::{ContextBudget, build_system_prompt};
@@ -3718,9 +3720,6 @@ impl<C: Channel> Agent<C> {
             agent_supervisor::TaskClass::Enrichment,
             "compression_spectrum.promotion_scan",
             async move {
-                let span = tracing::info_span!("memory.compression.promote.background");
-                let _enter = span.enter();
-
                 let window = match memory.load_promotion_window(promotion_window).await {
                     Ok(w) => w,
                     Err(e) => {
@@ -3752,7 +3751,8 @@ impl<C: Channel> Agent<C> {
                 }
 
                 tracing::info!(candidates = candidates.len(), "promotion scan: complete");
-            },
+            }
+            .instrument(tracing::info_span!("memory.compression.promote.background")),
         );
 
         if accepted {

--- a/crates/zeph-skills/src/evaluator.rs
+++ b/crates/zeph-skills/src/evaluator.rs
@@ -23,6 +23,7 @@
 
 use std::time::Duration;
 
+use tracing::Instrument as _;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 
@@ -201,11 +202,12 @@ impl SkillEvaluator {
             Message::from_legacy(Role::User, &prompt),
         ];
 
-        let llm_result = tokio::time::timeout(Duration::from_millis(self.timeout_ms), async {
-            let span = tracing::info_span!("skills.eval.llm_call");
-            let _enter = span.enter();
-            self.critic.chat(&messages).await
-        })
+        let llm_result = tokio::time::timeout(
+            Duration::from_millis(self.timeout_ms),
+            self.critic
+                .chat(&messages)
+                .instrument(tracing::info_span!("skills.eval.llm_call")),
+        )
         .await;
 
         let raw = match llm_result {

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -93,7 +93,7 @@ impl ToolExecutor for DiagnosticsExecutor {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "tool.diagnostics", skip_all)
+        tracing::instrument(name = "tools.diagnostics.execute", skip_all)
     )]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         if call.tool_id != "diagnostics" {

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -205,7 +205,7 @@ impl FileExecutor {
     /// Returns `ToolError` on sandbox violations or I/O failures.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "tool.file", skip_all, fields(operation = %tool_id))
+        tracing::instrument(name = "tools.file.execute", skip_all, fields(operation = %tool_id))
     )]
     pub async fn execute_file_tool(
         &self,
@@ -648,7 +648,7 @@ impl ToolExecutor for FileExecutor {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "tool.file.execute_call", skip_all, fields(tool_id = %call.tool_id))
+        tracing::instrument(name = "tools.file.execute_call", skip_all, fields(tool_id = %call.tool_id))
     )]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         self.execute_file_tool(call.tool_id.as_str(), &call.params)

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -326,7 +326,7 @@ impl ToolExecutor for WebScrapeExecutor {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "tool.web_scrape", skip_all)
+        tracing::instrument(name = "tools.scrape.fetch", skip_all)
     )]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         match call.tool_id.as_str() {

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -391,7 +391,7 @@ impl ToolExecutor for SearchCodeExecutor {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "tool.search_code", skip_all)
+        tracing::instrument(name = "tools.search_code.execute", skip_all)
     )]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         if call.tool_id != "search_code" {

--- a/crates/zeph-tools/src/shadow_probe.rs
+++ b/crates/zeph-tools/src/shadow_probe.rs
@@ -20,7 +20,7 @@
 
 use std::sync::Arc;
 
-use tracing::info_span;
+use tracing::{Instrument as _, info_span};
 
 use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};
 use crate::registry::ToolDef;
@@ -142,7 +142,6 @@ impl<T: ToolExecutor> ToolExecutor for ShadowProbeExecutor<T> {
             "security.shadow.probe_executor",
             tool_id = %call.tool_id
         );
-        let _enter = span.enter();
 
         let args = serde_json::Value::Object(call.params.clone());
         let turn = self.current_turn();
@@ -151,6 +150,7 @@ impl<T: ToolExecutor> ToolExecutor for ShadowProbeExecutor<T> {
         let outcome = self
             .probe
             .probe(call.tool_id.as_str(), &args, turn, &risk)
+            .instrument(span)
             .await;
 
         match outcome {
@@ -177,7 +177,6 @@ impl<T: ToolExecutor> ToolExecutor for ShadowProbeExecutor<T> {
             "security.shadow.probe_executor_confirmed",
             tool_id = %call.tool_id
         );
-        let _enter = span.enter();
 
         let args = serde_json::Value::Object(call.params.clone());
         let turn = self.current_turn();
@@ -186,6 +185,7 @@ impl<T: ToolExecutor> ToolExecutor for ShadowProbeExecutor<T> {
         let outcome = self
             .probe
             .probe(call.tool_id.as_str(), &args, turn, &risk)
+            .instrument(span)
             .await;
 
         match outcome {

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -621,7 +621,7 @@ impl ShellExecutor {
     /// Returns `ToolError` on blocked commands, sandbox violations, or execution failures.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "tool.shell", skip_all, fields(exit_code = tracing::field::Empty, duration_ms = tracing::field::Empty))
+        tracing::instrument(name = "tools.shell.execute", skip_all, fields(exit_code = tracing::field::Empty, duration_ms = tracing::field::Empty))
     )]
     pub async fn execute_confirmed(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
         self.execute_inner(response, true).await
@@ -801,7 +801,7 @@ impl ShellExecutor {
     ///
     /// This is the structured-tool-call path — it uses the resolved CWD and env directly
     /// instead of re-reading process state on every call.
-    #[tracing::instrument(name = "tool.shell.execute_block", skip(self, resolved), level = "info",
+    #[tracing::instrument(name = "tools.shell.execute_block", skip(self, resolved), level = "info",
         fields(cwd = %resolved.cwd.display(), env_name = resolved.name.as_deref().unwrap_or("")))]
     async fn execute_block_with_context(
         &self,
@@ -1637,7 +1637,7 @@ impl ToolExecutor for ShellExecutor {
         }]
     }
 
-    #[tracing::instrument(name = "tool.shell.execute_tool_call", skip(self, call), level = "info",
+    #[tracing::instrument(name = "tools.shell.execute_tool_call", skip(self, call), level = "info",
         fields(tool_id = %call.tool_id, env = call.context.as_ref().and_then(|c| c.name()).unwrap_or("")))]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         if call.tool_id != "bash" {


### PR DESCRIPTION
## Summary

- Fix 6 locations where a synchronous `span.enter()` guard was held across an `.await` boundary (`!Send`, causes incorrect trace parent-child relationships under tokio multi-thread) — replaced with `.instrument(span).await` or `async move { ... }.instrument(span)` for `spawn()` blocks.
- Normalize 8 span name strings in `zeph-tools` from the inconsistent `tool.*` / `scrape.*` prefixes to the canonical `tools.<subsystem>.<operation>` convention from CLAUDE.md.

## Files changed

| File | Change |
|------|--------|
| `zeph-core/src/agent/agent_access_impl.rs` | `.instrument(span).await` on semantic scan future |
| `zeph-core/src/agent/mod.rs` | `.instrument(span)` on supervisor `async move` spawn block |
| `zeph-context/src/fidelity.rs` | `.instrument(span).await` on `timeout(p.chat(...))` |
| `zeph-skills/src/evaluator.rs` | `.instrument(span)` inside `timeout` async block |
| `zeph-tools/src/shadow_probe.rs` (×2) | `.instrument(span).await` on both probe calls |
| `zeph-tools/src/{scrape,shell/mod,diagnostics,file,search_code}.rs` | Span name renames |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core -p zeph-context -p zeph-skills -p zeph-tools -- -D warnings` — clean
- [x] `cargo nextest run -p zeph-core -p zeph-context -p zeph-skills -p zeph-tools` — 3579/3579 passed
- [x] `RUSTFLAGS="-D warnings" cargo check -p zeph-core -p zeph-context -p zeph-skills -p zeph-tools` — clean

## Notes

- The `mod.rs` supervisor span becomes a sibling of `bg_task` instead of its child (span was moved from inside the `async move` block to the call site). Cosmetic trace-tree change only, no behavioral impact.
- 4 additional `span.enter()` anti-patterns were found outside this PR's scope during review: tracked in #4787 (P2: `memcot/accumulator.rs:158` has extra `record()` fragility; P3: 3 locations in `zeph-plugins`).

Closes #4777, #4714