### PR TITLE
fix(tracing): replace span.enter() across .await with .instrument(span)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-tools`: normalize all span names in `scrape.rs`, `shell/mod.rs`, `diagnostics.rs`,
   `file.rs`, and `search_code.rs` to the `tools.<subsystem>.<operation>` convention; eliminates the
   mix of `tool.*`, `tools.*`, and bare `scrape.*` prefixes. Closes #4714.
+- `zeph-core`, `zeph-plugins`: fix `span.enter()` held across `.await` in
+  `SemanticStateAccumulator::maybe_distill` (`accumulator.rs`) and three `PluginManager` methods
+  (`add_remote`, `add_remote_ephemeral`, `download_and_extract`). Span creation moved outside the
+  async block in `accumulator.rs`; future wrapped with `.instrument(span)`. Plugin manager methods
+  converted to `#[tracing::instrument]`. Under the tokio multi-thread scheduler, holding a
+  synchronous span guard across an await point causes spans to be attributed to the wrong worker
+  thread and `Span::current().record()` to silently write to the wrong span. Closes #4787.
+- `zeph-context`: `ContextAssembler::gather` now carries
+  `#[tracing::instrument(name = "context.assembler.gather", skip_all)]`, completing full async
+  instrumentation coverage for the context assembler. Previously `gather` was the only async
+  function in `ContextAssembler` without a tracing span, making it invisible in traces.
+  Closes #4783.
 - `zeph-sanitizer`: `UNICODE_BYPASS_RE` now includes U+2060 (WORD JOINER) in its character class,
   closing a bypass where inserting that invisible character between `!` and `[` evaded markdown image
   exfiltration detection. Closes #4752.

--- a/crates/zeph-context/src/assembler.rs
+++ b/crates/zeph-context/src/assembler.rs
@@ -295,6 +295,7 @@ impl ContextAssembler {
     /// # Errors
     ///
     /// Propagates errors from any async fetch operation.
+    #[tracing::instrument(name = "context.assembler.gather", skip_all)]
     pub async fn gather(
         input: &ContextAssemblyInput<'_>,
     ) -> Result<PreparedContext, AssemblerError> {

--- a/crates/zeph-core/src/agent/memcot/accumulator.rs
+++ b/crates/zeph-core/src/agent/memcot/accumulator.rs
@@ -24,6 +24,7 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::RwLock;
+use tracing::Instrument as _;
 use zeph_config::MemCotConfig;
 use zeph_llm::provider::LlmProvider as _;
 
@@ -153,58 +154,59 @@ impl SemanticStateAccumulator {
         let cfg = Arc::clone(&self.cfg);
         let content = assistant_content.to_owned();
 
-        let fut = Box::pin(async move {
-            let span = tracing::info_span!("core.memcot.distill", result = tracing::field::Empty);
-            let _guard = span.enter();
+        let span = tracing::info_span!("core.memcot.distill", result = tracing::field::Empty);
+        let fut = Box::pin(
+            async move {
+                let prompt = build_distill_prompt(&content, &state_arc).await;
+                let msgs = vec![zeph_llm::provider::Message::from_legacy(
+                    zeph_llm::provider::Role::User,
+                    prompt,
+                )];
 
-            let prompt = build_distill_prompt(&content, &state_arc).await;
-            let msgs = vec![zeph_llm::provider::Message::from_legacy(
-                zeph_llm::provider::Role::User,
-                prompt,
-            )];
+                let timeout = Duration::from_secs(cfg.distill_timeout_secs);
+                let result = tokio::time::timeout(timeout, provider.chat(&msgs)).await;
 
-            let timeout = Duration::from_secs(cfg.distill_timeout_secs);
-            let result = tokio::time::timeout(timeout, provider.chat(&msgs)).await;
+                match result {
+                    Ok(Ok(response)) => {
+                        tracing::Span::current().record("result", "ok");
+                        let raw = response.trim().to_owned();
+                        let cap = cfg.max_state_chars;
+                        let new_buf = if raw.chars().count() > cap {
+                            let cut = raw.floor_char_boundary(
+                                raw.char_indices().nth(cap).map_or(raw.len(), |(i, _)| i),
+                            );
+                            raw[..cut].to_owned()
+                        } else {
+                            raw
+                        };
 
-            match result {
-                Ok(Ok(response)) => {
-                    tracing::Span::current().record("result", "ok");
-                    let raw = response.trim().to_owned();
-                    let cap = cfg.max_state_chars;
-                    let new_buf = if raw.chars().count() > cap {
-                        let cut = raw.floor_char_boundary(
-                            raw.char_indices().nth(cap).map_or(raw.len(), |(i, _)| i),
+                        let mut state = state_arc.write().await;
+                        state.buffer = new_buf;
+                        state.turn_count = state.turn_count.saturating_add(1);
+                        state.updated_at_secs = unix_now_secs();
+                        tracing::debug!(
+                            turn = state.turn_count,
+                            buf_chars = state.buffer.chars().count(),
+                            "memcot: distill complete"
                         );
-                        raw[..cut].to_owned()
-                    } else {
-                        raw
-                    };
-
-                    let mut state = state_arc.write().await;
-                    state.buffer = new_buf;
-                    state.turn_count = state.turn_count.saturating_add(1);
-                    state.updated_at_secs = unix_now_secs();
-                    tracing::debug!(
-                        turn = state.turn_count,
-                        buf_chars = state.buffer.chars().count(),
-                        "memcot: distill complete"
-                    );
-                }
-                Ok(Err(e)) => {
-                    tracing::Span::current().record("result", "error");
-                    metrics::distill_error();
-                    tracing::warn!(error = %e, "memcot: distill failed");
-                }
-                Err(_) => {
-                    tracing::Span::current().record("result", "timeout");
-                    metrics::distill_timeout();
-                    tracing::warn!(
-                        timeout_secs = cfg.distill_timeout_secs,
-                        "memcot: distill timed out"
-                    );
+                    }
+                    Ok(Err(e)) => {
+                        tracing::Span::current().record("result", "error");
+                        metrics::distill_error();
+                        tracing::warn!(error = %e, "memcot: distill failed");
+                    }
+                    Err(_) => {
+                        tracing::Span::current().record("result", "timeout");
+                        metrics::distill_timeout();
+                        tracing::warn!(
+                            timeout_secs = cfg.distill_timeout_secs,
+                            "memcot: distill timed out"
+                        );
+                    }
                 }
             }
-        });
+            .instrument(span),
+        );
 
         supervisor_spawn("memcot_distill", fut);
     }

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -423,14 +423,12 @@ impl PluginManager {
     /// # Ok(())
     /// # }
     /// ```
+    #[tracing::instrument(name = "plugins.manager.add_remote", skip(self, expected_sha256), fields(%url))]
     pub async fn add_remote(
         &self,
         url: &str,
         expected_sha256: Option<&str>,
     ) -> Result<AddResult, PluginError> {
-        let span = tracing::info_span!("plugins.manager.add_remote", %url);
-        let _guard = span.enter();
-
         // Reject non-HTTP(S) schemes to prevent SSRF via file:// or other transports.
         validate_url_scheme(url)?;
 
@@ -1295,14 +1293,12 @@ impl PluginManager {
     /// # Ok(())
     /// # }
     /// ```
+    #[tracing::instrument(name = "plugins.manager.add_remote_ephemeral", skip(self, sha256), fields(%url))]
     pub async fn add_remote_ephemeral(
         &self,
         url: &str,
         sha256: Option<&str>,
     ) -> Result<tempfile::TempDir, PluginError> {
-        let span = tracing::info_span!("plugins.manager.add_remote_ephemeral", %url);
-        let _guard = span.enter();
-
         validate_url_scheme_ephemeral(url)?;
 
         let tmp = tempfile::tempdir().map_err(|e| PluginError::Io {
@@ -1458,15 +1454,13 @@ pub const MAX_ARCHIVE_BYTES: u64 = 52 * 1024 * 1024;
 ///   exceeded [`MAX_ARCHIVE_BYTES`], or the download timed out.
 /// - [`PluginError::IntegrityCheckFailed`] — SHA-256 mismatch when `sha256` is `Some`.
 /// - [`PluginError::InvalidSource`] — archive format is unsupported or extraction failed.
+#[tracing::instrument(name = "plugins.manager.download_and_extract", skip(sha256, dest, timeout_secs), fields(%url))]
 pub async fn download_and_extract(
     url: &str,
     sha256: Option<&str>,
     dest: &std::path::Path,
     timeout_secs: u64,
 ) -> Result<(), PluginError> {
-    let span = tracing::info_span!("plugins.manager.download_and_extract", %url);
-    let _enter = span.enter();
-
     let timeout = std::time::Duration::from_secs(timeout_secs);
 
     // Build a client that refuses to follow any redirect that downgrades from https (B1).


### PR DESCRIPTION
## Summary

- **#4787** — Fix `span.enter()` across `.await` anti-pattern in 4 locations (`accumulator.rs`, `manager.rs` ×3). Held `EnterGuard` under tokio multi-thread causes incorrect span propagation; replaced with `.instrument(span)` and `#[tracing::instrument]`.
- **#4783** — Add `#[tracing::instrument]` to `ContextAssembler::gather` (the last uninstrumented function in the context assembly hot path), completing mandatory span coverage.

## Changes

| File | Change |
|---|---|
| `crates/zeph-core/src/agent/memcot/accumulator.rs` | Move span creation outside `async move`, apply `.instrument(span)` before `Box::pin`; fix `Span::current().record()` attribution |
| `crates/zeph-plugins/src/manager.rs` | Convert `add_remote`, `add_remote_ephemeral`, `download_and_extract` to `#[tracing::instrument]` |
| `crates/zeph-context/src/assembler.rs` | Add `#[tracing::instrument(name = "context.assembler.gather", skip_all)]` |
| `CHANGELOG.md` | Update `[Unreleased]` Fixed section |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core -p zeph-plugins -p zeph-context -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 10454 passed, 0 failed
- [x] Impl-critic verified all 11 assembler.rs functions are instrumented
- [x] Tester confirmed 2 remaining `span.enter()` in `manager.rs` are in sync functions (safe)

## Follow-up

Impl-critic found 6 additional `span.enter()` across `.await` instances outside this PR's scope: `fidelity.rs:712`, `agent/mod.rs:3722`, `agent_access_impl.rs:67`, `evaluator.rs:206`, `shadow_probe.rs:145`, `shadow_probe.rs:180`. A follow-up P3 issue will be filed after merge.

Closes #4787
Closes #4783