### PR TITLE
fix(memory,scheduler): use distinct display strings for Sqlx and Db error variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(memory,scheduler)`: `MemoryError` and `SchedulerError` now use distinct display strings for
+  their `Sqlx` and `Db` variants (`"sqlx error: {0}"` and `"db error: {0}"` respectively), making
+  it possible to distinguish raw SQLx query failures from zeph-db lifecycle/migration errors in log
+  output. Adds 4 regression tests. Closes #4782.
+
 ### Added
 
 - `feat(worktree): make DefaultGitRunner timeout configurable via WorktreeConfig (#4704)` — adds

--- a/crates/zeph-memory/src/error.rs
+++ b/crates/zeph-memory/src/error.rs
@@ -18,10 +18,10 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum MemoryError {
-    #[error("database error: {0}")]
+    #[error("sqlx error: {0}")]
     Sqlx(#[from] zeph_db::SqlxError),
 
-    #[error("database error: {0}")]
+    #[error("db error: {0}")]
     Db(#[from] zeph_db::DbError),
 
     #[error("Qdrant error: {0}")]
@@ -83,4 +83,29 @@ pub enum MemoryError {
     /// Wraps errors from clustering, skill generation, evaluator calls, or disk writes.
     #[error("promotion scan failed: {0}")]
     Promotion(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MemoryError;
+
+    #[test]
+    fn sqlx_variant_display() {
+        let inner = zeph_db::SqlxError::RowNotFound;
+        let err = MemoryError::Sqlx(inner);
+        assert!(
+            err.to_string().starts_with("sqlx error:"),
+            "unexpected display: {err}"
+        );
+    }
+
+    #[test]
+    fn db_variant_display() {
+        let inner = zeph_db::DbError::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "test"));
+        let err = MemoryError::Db(inner);
+        assert!(
+            err.to_string().starts_with("db error:"),
+            "unexpected display: {err}"
+        );
+    }
 }

--- a/crates/zeph-scheduler/src/error.rs
+++ b/crates/zeph-scheduler/src/error.rs
@@ -14,11 +14,11 @@ pub enum SchedulerError {
     InvalidCron(String),
 
     /// A low-level `SQLx` error occurred during a database operation.
-    #[error("database error: {0}")]
+    #[error("sqlx error: {0}")]
     Database(#[from] zeph_db::SqlxError),
 
     /// A high-level `zeph-db` error occurred (e.g. during migrations or connection setup).
-    #[error("database error: {0}")]
+    #[error("db error: {0}")]
     Db(#[from] zeph_db::DbError),
 
     /// The [`crate::TaskHandler`] returned an error during task execution.
@@ -76,4 +76,29 @@ pub enum SchedulerError {
         /// Name of the task that was quarantined.
         task_name: String,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SchedulerError;
+
+    #[test]
+    fn database_variant_display() {
+        let inner = zeph_db::SqlxError::RowNotFound;
+        let err = SchedulerError::Database(inner);
+        assert!(
+            err.to_string().starts_with("sqlx error:"),
+            "unexpected display: {err}"
+        );
+    }
+
+    #[test]
+    fn db_variant_display() {
+        let inner = zeph_db::DbError::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "test"));
+        let err = SchedulerError::Db(inner);
+        assert!(
+            err.to_string().starts_with("db error:"),
+            "unexpected display: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `MemoryError::Sqlx` and `SchedulerError::Database` now display as `"sqlx error: {0}"` (raw SQLx query failure — transient)
- `MemoryError::Db` and `SchedulerError::Db` now display as `"db error: {0}"` (zeph-db lifecycle/migration failure — usually fatal)
- Adds 4 regression tests (2 per crate) asserting the display prefix for each affected variant

Previously both variants in each enum shared `"database error: {0}"`, making it impossible to distinguish error types from log output alone.

## Test plan

- [x] `cargo +nightly fmt --check` — PASS
- [x] `cargo clippy --workspace -- -D warnings` — PASS (0 warnings)
- [x] `cargo nextest run --workspace --lib --bins` — 10 464 tests passed
- [x] 4 new regression tests (`sqlx_variant_display`, `db_variant_display` in each crate) — PASS

## Notes

The critic identified that `zeph-db`, `zeph-index`, `zeph-orchestration`, and `zeph-core` still use `"database error:"` for their single DB variant (no intra-enum collision — different symptom). Follow-up alignment is tracked separately.

Closes #4782