### PR TITLE
fix(sanitizer): extend UNICODE_BYPASS_RE to cover BIDI, soft hyphen, TAGS block (#4760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   instrumentation coverage for the context assembler. Previously `gather` was the only async
   function in `ContextAssembler` without a tracing span, making it invisible in traces.
   Closes #4783.
+- `zeph-sanitizer`: `UNICODE_BYPASS_RE` extended from 5 explicit codepoints to `\p{Cf}` (full
+  Unicode Format category) plus U+034F (COMBINING GRAPHEME JOINER, category Mn). Covers BIDI
+  overrides/isolates (U+202A–202E, U+2066–2069), soft hyphen (U+00AD), Mongolian vowel separator
+  (U+180E), invisible math operators (U+2061–2064), deprecated format chars (U+206A–206F), and the
+  TAGS block (U+E0000–E007F). Adds 9 regression tests. Closes #4760.
 - `zeph-sanitizer`: `UNICODE_BYPASS_RE` now includes U+2060 (WORD JOINER) in its character class,
   closing a bypass where inserting that invisible character between `!` and `[` evaded markdown image
   exfiltration detection. Closes #4752.

--- a/crates/zeph-sanitizer/src/exfiltration.rs
+++ b/crates/zeph-sanitizer/src/exfiltration.rs
@@ -70,14 +70,18 @@ static HTML_IMG_RE: LazyLock<Regex> = LazyLock::new(|| {
         .expect("valid HTML_IMG_RE")
 });
 
-/// Detects zero-width Unicode characters between `!` and `[` used to bypass markdown regex.
+/// Detects invisible Unicode characters between `!` and `[` used to bypass markdown regex.
 ///
-/// Adversaries insert U+200B (ZWSP), U+200C (ZWNJ), U+200D (ZWJ), U+2060 (WJ), or U+FEFF (BOM)
-/// between the `!` and `[` characters to prevent standard regex matchers from recognising the
-/// markdown image syntax. This pattern catches those sequences for stripping.
-static UNICODE_BYPASS_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new("![\u{200B}\u{200C}\u{200D}\u{2060}\u{FEFF}]+\\[").expect("valid UNICODE_BYPASS_RE")
-});
+/// Adversaries insert invisible formatting or combining characters between `!` and `[` to prevent
+/// standard regex matchers from recognising the markdown image syntax. This pattern covers:
+///
+/// - `\p{Cf}` (Unicode Format category): zero-width joiners/non-joiners, BIDI overrides and
+///   isolates (U+202A–202E, U+2066–2069), deprecated format chars (U+206A–206F), soft hyphen
+///   (U+00AD), Mongolian vowel separator (U+180E), and the entire TAGS block (U+E0000–E007F).
+/// - U+034F (COMBINING GRAPHEME JOINER, category Mn): invisible combining mark; not in `\p{Cf}`,
+///   added explicitly.
+static UNICODE_BYPASS_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"!(?:[\p{Cf}\x{034F}])+\[").expect("valid UNICODE_BYPASS_RE"));
 
 // ---------------------------------------------------------------------------
 // Event types
@@ -715,6 +719,159 @@ mod tests {
         let (cleaned, events) = guard_disabled().scan_output(input);
         assert_eq!(cleaned, input);
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn unicode_bidi_override_bypass_blocked() {
+        let guard = ExfiltrationGuard::new(ExfiltrationGuardConfig {
+            block_markdown_images: true,
+            ..ExfiltrationGuardConfig::default()
+        });
+        let input = "!\u{202E}[alt](https://evil.com/track)";
+        let (cleaned, _events) = guard.scan_output(input);
+        assert!(
+            !cleaned.contains('\u{202E}'),
+            "U+202E BIDI override must be stripped: {cleaned}"
+        );
+        assert!(
+            !cleaned.starts_with('!'),
+            "image trigger `!` must be removed: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn unicode_bidi_isolate_bypass_blocked() {
+        let guard = ExfiltrationGuard::new(ExfiltrationGuardConfig {
+            block_markdown_images: true,
+            ..ExfiltrationGuardConfig::default()
+        });
+        let input = "!\u{2066}[alt](https://evil.com/track)";
+        let (cleaned, _events) = guard.scan_output(input);
+        assert!(
+            !cleaned.contains('\u{2066}'),
+            "U+2066 BIDI isolate must be stripped: {cleaned}"
+        );
+        assert!(
+            !cleaned.starts_with('!'),
+            "image trigger `!` must be removed: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn unicode_soft_hyphen_bypass_blocked() {
+        let guard = ExfiltrationGuard::new(ExfiltrationGuardConfig {
+            block_markdown_images: true,
+            ..ExfiltrationGuardConfig::default()
+        });
+        let input = "!\u{00AD}[alt](https://evil.com/track)";
+        let (cleaned, _events) = guard.scan_output(input);
+        assert!(
+            !cleaned.contains('\u{00AD}'),
+            "U+00AD soft hyphen must be stripped: {cleaned}"
+        );
+        assert!(
+            !cleaned.starts_with('!'),
+            "image trigger `!` must be removed: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn unicode_tags_block_bypass_blocked() {
+        let guard = ExfiltrationGuard::new(ExfiltrationGuardConfig {
+            block_markdown_images: true,
+            ..ExfiltrationGuardConfig::default()
+        });
+        let input = "!\u{E0041}[alt](https://evil.com/track)";
+        let (cleaned, _events) = guard.scan_output(input);
+        assert!(
+            !cleaned.contains('\u{E0041}'),
+            "U+E0041 TAGS char must be stripped: {cleaned}"
+        );
+        assert!(
+            !cleaned.starts_with('!'),
+            "image trigger `!` must be removed: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn unicode_cgj_bypass_blocked() {
+        let guard = ExfiltrationGuard::new(ExfiltrationGuardConfig {
+            block_markdown_images: true,
+            ..ExfiltrationGuardConfig::default()
+        });
+        // U+034F (CGJ) is category Mn, not Cf — must be covered by explicit addition.
+        let input = "!\u{034F}[alt](https://evil.com/track)";
+        let (cleaned, _events) = guard.scan_output(input);
+        assert!(
+            !cleaned.contains('\u{034F}'),
+            "U+034F CGJ must be stripped: {cleaned}"
+        );
+        assert!(
+            !cleaned.starts_with('!'),
+            "image trigger `!` must be removed: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn unicode_heterogeneous_run_bypass_blocked() {
+        let guard = ExfiltrationGuard::new(ExfiltrationGuardConfig {
+            block_markdown_images: true,
+            ..ExfiltrationGuardConfig::default()
+        });
+        // Mixed run: ZWSP + BIDI override + TAGS char — the `+` quantifier must consume all.
+        let input = "!\u{200B}\u{202E}\u{E0001}[alt](https://evil.com/track)";
+        let (cleaned, _events) = guard.scan_output(input);
+        assert!(
+            !cleaned.contains('\u{200B}'),
+            "U+200B must be stripped in mixed run: {cleaned}"
+        );
+        assert!(
+            !cleaned.contains('\u{202E}'),
+            "U+202E must be stripped in mixed run: {cleaned}"
+        );
+        assert!(
+            !cleaned.contains('\u{E0001}'),
+            "U+E0001 must be stripped in mixed run: {cleaned}"
+        );
+        assert!(
+            !cleaned.starts_with('!'),
+            "image trigger `!` must be removed: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn unicode_bypass_no_false_positive_on_space() {
+        let guard = ExfiltrationGuard::new(ExfiltrationGuardConfig {
+            block_markdown_images: true,
+            ..ExfiltrationGuardConfig::default()
+        });
+        // Literal space between `!` and `[` is NOT an invisible bypass char — must not be matched.
+        let input = "! [text](https://example.com/)";
+        let (cleaned, _events) = guard.scan_output(input);
+        assert_eq!(
+            cleaned, input,
+            "literal space between ! and [ must not trigger bypass detection"
+        );
+    }
+
+    #[test]
+    fn unicode_bypass_no_false_positive_on_clean_image() {
+        let guard = ExfiltrationGuard::new(ExfiltrationGuardConfig {
+            block_markdown_images: true,
+            ..ExfiltrationGuardConfig::default()
+        });
+        // Legitimate inline image is handled by Pass 1, not double-processed by Pass 4.
+        let (cleaned, events) = guard.scan_output("![alt](https://evil.com/track.gif)");
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ExfiltrationEvent::MarkdownImageBlocked { .. })),
+            "should produce MarkdownImageBlocked event, not bypass event"
+        );
+        assert!(
+            !cleaned.contains("![alt]("),
+            "clean image must be stripped by Pass 1: {cleaned}"
+        );
     }
 
     // --- validate_tool_call ---


### PR DESCRIPTION
## Summary

- Replaces the 5-codepoint explicit class in `UNICODE_BYPASS_RE` with `\p{Cf}` (Unicode Format category) plus explicit U+034F (CGJ, category Mn)
- Covers BIDI overrides/isolates (U+202A–202E, U+2066–2069), soft hyphen (U+00AD), Mongolian vowel separator (U+180E), invisible math operators, deprecated format chars (U+206A–206F), and the TAGS block (U+E0000–E007F)
- Adds 9 regression tests for each bypass vector, heterogeneous runs, and false-positive negative
- No Cargo.toml changes needed — `regex` crate already enables `unicode-perl` by default

## Security impact

BIDI override characters and the TAGS block are documented in adversarial LLM prompt injection payloads. The old 5-codepoint class left these unblocked; this fix closes the gap for all Unicode Format (`Cf`) category characters automatically, making the pattern future-proof against new `Cf` additions.

## Residual gap (follow-up)

Variation selectors (U+FE00–FE0F, category Mn) and Hangul fillers (category Lo) are not covered by `\p{Cf}` and have low practical exploitability in the `!…[` context. A separate P3 follow-up issue will track these.

## Test plan

- [x] 328/328 `zeph-sanitizer` tests pass (`cargo nextest run --workspace --features sqlite -E 'package(=zeph-sanitizer)'`)
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy -p zeph-sanitizer -p zeph-memory -p zeph-db -- -D warnings` clean
- [x] Security audit by `rust-security-maintenance` agent
- [x] Adversarial critique by `rust-critic` (verdict: minor, non-blocking)
- [x] Code review approved

Closes #4760.