### PR TITLE
refactor(orchestration): extract init_common and add graph_dirty checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `refactor(orchestration)`: extract `DagScheduler::init_common()` private helper from `::new` and
+  `::resume_from`, eliminating ~75 lines of duplicated struct initialization code. Only
+  graph-state-specific setup (pre-validation, tracing) differs between the two constructors. Closes #4781.
+
 ### Fixed
 
 - `fix(config)`: `migrate_worktree_config` now uses a line-anchored check (`lines().any(|l| l.trim() == "[worktree]")`) instead of a bare `contains("[worktree]")`, preventing false-positive idempotency detection when `[worktree]` appears inside a config value string. Adds regression test `step_54_does_not_skip_when_worktree_in_value`. Closes #4793.
 - `OpenAiProvider::context_window()` now returns `Some(200_000)` for o-series models
   (o1, o1-mini, o3, o3-mini, o4-mini) instead of `None`, preventing silent context overflow (#4801)
+
+- `fix(orchestration)`: add `graph_dirty: bool` field to `DagScheduler` that is set on all durable
+  graph mutations (task completion, failure, fatal spawn failure, cancel_all, timeout).
+  `GraphPersistence::save()` in the scheduler loop now fires only when `graph_dirty` is true,
+  ensuring task states (`TaskStatus` transitions, retry counts, predicate outcomes, lineage chains)
+  survive mid-execution process crashes. Previously, a SIGKILL between task completions discarded
+  all in-flight progress. Adds 8 unit tests for the flag lifecycle. Closes #4747.
 - `fix(memory,scheduler)`: `MemoryError` and `SchedulerError` now use distinct display strings for
   their `Sqlx` and `Db` variants (`"sqlx error: {0}"` and `"db error: {0}"` respectively), making
   it possible to distinguish raw SQLx query failures from zeph-db lifecycle/migration errors in log

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -512,11 +512,11 @@ impl<C: crate::channel::Channel> Agent<C> {
                 m.orchestration_graph = Some(snapshot);
             });
 
-            if scheduler.take_graph_dirty() {
-                if let Some(ref persistence) = self.services.orchestration.graph_persistence {
-                    let graph_clone = scheduler.graph().clone();
-                    save_graph_snapshot(persistence, graph_clone).await;
-                }
+            if scheduler.take_graph_dirty()
+                && let Some(ref persistence) = self.services.orchestration.graph_persistence
+            {
+                let graph_clone = scheduler.graph().clone();
+                save_graph_snapshot(persistence, graph_clone).await;
             }
 
             tokio::select! {

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -512,9 +512,11 @@ impl<C: crate::channel::Channel> Agent<C> {
                 m.orchestration_graph = Some(snapshot);
             });
 
-            if let Some(ref persistence) = self.services.orchestration.graph_persistence {
-                let graph_clone = scheduler.graph().clone();
-                save_graph_snapshot(persistence, graph_clone).await;
+            if scheduler.take_graph_dirty() {
+                if let Some(ref persistence) = self.services.orchestration.graph_persistence {
+                    let graph_clone = scheduler.graph().clone();
+                    save_graph_snapshot(persistence, graph_clone).await;
+                }
             }
 
             tokio::select! {

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -288,6 +288,10 @@ pub struct DagScheduler {
     /// Agents with `model = None` or `Inherit` are absent from this map; their tasks
     /// bypass the gate (treated as ungated).
     pub(super) agent_provider_map: HashMap<String, String>,
+    /// Set to `true` when any graph mutation occurs during a tick (task status transitions,
+    /// spawn-failure cascades, cancellations). Consumed by [`DagScheduler::take_graph_dirty`]
+    /// to drive persistence checkpoints without the scheduler holding a persistence reference.
+    pub(super) graph_dirty: bool,
 }
 
 impl std::fmt::Debug for DagScheduler {
@@ -342,38 +346,6 @@ impl DagScheduler {
             }
         }
 
-        let agent_provider_map: HashMap<String, String> = available_agents
-            .iter()
-            .filter_map(|def| {
-                if let Some(zeph_subagent::ModelSpec::Named(provider)) = &def.model {
-                    Some((def.name.clone(), provider.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        let (event_tx, event_rx) = mpsc::channel(64);
-
-        let task_timeout = if config.task_timeout_secs > 0 {
-            Duration::from_secs(config.task_timeout_secs)
-        } else {
-            Duration::from_mins(10)
-        };
-
-        let topology = TopologyClassifier::analyze(&graph, config);
-        let max_parallel = topology.max_parallel;
-        let config_max_parallel = config.max_parallel as usize;
-
-        if config.topology_selection {
-            tracing::debug!(
-                topology = ?topology.topology,
-                strategy = ?topology.strategy,
-                max_parallel,
-                "topology-aware concurrency limit applied"
-            );
-        }
-
         // Validate cascade_routing dependency on topology_selection.
         if config.cascade_routing && !config.topology_selection {
             tracing::warn!(
@@ -382,56 +354,14 @@ impl DagScheduler {
             );
         }
 
-        let cascade_detector = if config.cascade_routing && config.topology_selection {
-            Some(CascadeDetector::new(CascadeConfig {
-                failure_threshold: config.cascade_failure_threshold,
-            }))
-        } else {
-            None
-        };
-
-        Ok(Self {
+        Ok(Self::init_common(
             graph,
-            max_parallel,
-            config_max_parallel,
-            running: HashMap::new(),
-            event_rx,
-            event_tx,
-            task_timeout,
+            HashMap::new(),
+            config,
             router,
             available_agents,
-            dependency_context_budget: config.dependency_context_budget,
-            buffered_events: VecDeque::new(),
-            sanitizer: ContentSanitizer::new(&ContentIsolationConfig::default()),
-            deferral_backoff: Duration::from_millis(config.deferral_backoff_ms),
-            consecutive_spawn_failures: 0,
-            topology,
-            topology_dirty: false,
-            current_level: 0,
-            verify_completeness: config.verify_completeness,
-            verify_provider: config.verify_provider.as_str().trim().to_owned(),
-            task_replan_counts: HashMap::new(),
-            global_replan_count: 0,
-            max_replans: config.max_replans,
-            completeness_threshold_value: config.completeness_threshold,
-            cascade_detector,
-            tree_optimized_dispatch: config.tree_optimized_dispatch,
-            cascade_routing: config.cascade_routing && config.topology_selection,
-            lineage_chains: HashMap::new(),
-            cascade_chain_threshold: config.cascade_chain_threshold,
-            cascade_failure_rate_abort_threshold: config.cascade_failure_rate_abort_threshold,
-            lineage_ttl_secs: config.lineage_ttl_secs,
-            verify_predicate_enabled: config.verify_predicate_enabled,
-            predicate_provider: config.predicate_provider.as_str().trim().to_owned(),
-            orchestrator_provider: config.orchestrator_provider.as_str().trim().to_owned(),
-            max_predicate_replans: config.max_predicate_replans,
-            predicate_replans_used: 0,
-            predicate_reasons: HashMap::new(),
             admission_gate,
-            default_task_budget_cents: config.default_task_budget_cents,
-            pending_permits: HashMap::new(),
-            agent_provider_map,
-        })
+        ))
     }
 
     /// Create a scheduler from a graph that is in `Paused` or `Failed` status.
@@ -490,6 +420,69 @@ impl DagScheduler {
             })
             .collect();
 
+        // `pending_permits` is not persisted; resume always starts with an empty map.
+        // Resumed tasks that were `Running` start without an admission permit (see
+        // `RunningTask::admission_permit: None` above). This is intentional: their
+        // slots were released when the process exited and must be re-acquired on next
+        // dispatch if the task is re-spawned.
+        Ok(Self::init_common(
+            graph,
+            running,
+            config,
+            router,
+            available_agents,
+            admission_gate,
+        ))
+    }
+
+    /// Validate that `verify_provider` references a known provider name.
+    ///
+    /// Call this after construction when `verify_completeness = true` to catch
+    /// misconfiguration early rather than failing open at runtime.
+    ///
+    /// - Empty `verify_provider` is always valid (falls back to the primary provider).
+    /// - If `provider_names` is empty, validation is skipped (provider set is unknown).
+    /// - Provider names are compared case-sensitively (matching the existing resolution convention).
+    ///
+    /// # Errors
+    ///
+    /// Returns `OrchestrationError::InvalidConfig` when `verify_completeness = true`,
+    /// `verify_provider` is non-empty, and the name is not present in `provider_names`.
+    pub fn validate_verify_config(
+        &self,
+        provider_names: &[&str],
+    ) -> Result<(), OrchestrationError> {
+        if !self.verify_completeness {
+            return Ok(());
+        }
+        let name = self.verify_provider.as_str();
+        if name.is_empty() || provider_names.is_empty() {
+            return Ok(());
+        }
+        if !provider_names.contains(&name) {
+            return Err(OrchestrationError::InvalidConfig(format!(
+                "verify_provider \"{}\" not found in [[llm.providers]]; available: [{}]",
+                name,
+                provider_names.join(", ")
+            )));
+        }
+        Ok(())
+    }
+
+    /// Build a fully-initialized `DagScheduler` from the supplied pre-configured state.
+    ///
+    /// Called by both [`DagScheduler::new`] and [`DagScheduler::resume_from`] after they
+    /// perform their graph-state-specific setup (status transitions, root-task marking,
+    /// running-map reconstruction). Centralizes all field construction that is identical
+    /// between the two constructors.
+    fn init_common(
+        graph: TaskGraph,
+        running: HashMap<TaskId, RunningTask>,
+        config: &OrchestrationConfig,
+        router: Box<dyn AgentRouter>,
+        available_agents: Vec<zeph_subagent::SubAgentDef>,
+        admission_gate: Option<super::admission::AdmissionGate>,
+    ) -> Self {
         let agent_provider_map: HashMap<String, String> = available_agents
             .iter()
             .filter_map(|def| {
@@ -513,6 +506,15 @@ impl DagScheduler {
         let max_parallel = topology.max_parallel;
         let config_max_parallel = config.max_parallel as usize;
 
+        if config.topology_selection {
+            tracing::debug!(
+                topology = ?topology.topology,
+                strategy = ?topology.strategy,
+                max_parallel,
+                "topology-aware concurrency limit applied"
+            );
+        }
+
         let cascade_detector = if config.cascade_routing && config.topology_selection {
             Some(CascadeDetector::new(CascadeConfig {
                 failure_threshold: config.cascade_failure_threshold,
@@ -521,7 +523,7 @@ impl DagScheduler {
             None
         };
 
-        Ok(Self {
+        Self {
             graph,
             max_parallel,
             config_max_parallel,
@@ -560,48 +562,10 @@ impl DagScheduler {
             predicate_reasons: HashMap::new(),
             admission_gate,
             default_task_budget_cents: config.default_task_budget_cents,
-            // `pending_permits` is not persisted; resume always starts with an empty map.
-            // Resumed tasks that were `Running` start without an admission permit (see
-            // `RunningTask::admission_permit: None` above). This is intentional: their
-            // slots were released when the process exited and must be re-acquired on next
-            // dispatch if the task is re-spawned.
             pending_permits: HashMap::new(),
             agent_provider_map,
-        })
-    }
-
-    /// Validate that `verify_provider` references a known provider name.
-    ///
-    /// Call this after construction when `verify_completeness = true` to catch
-    /// misconfiguration early rather than failing open at runtime.
-    ///
-    /// - Empty `verify_provider` is always valid (falls back to the primary provider).
-    /// - If `provider_names` is empty, validation is skipped (provider set is unknown).
-    /// - Provider names are compared case-sensitively (matching the existing resolution convention).
-    ///
-    /// # Errors
-    ///
-    /// Returns `OrchestrationError::InvalidConfig` when `verify_completeness = true`,
-    /// `verify_provider` is non-empty, and the name is not present in `provider_names`.
-    pub fn validate_verify_config(
-        &self,
-        provider_names: &[&str],
-    ) -> Result<(), OrchestrationError> {
-        if !self.verify_completeness {
-            return Ok(());
+            graph_dirty: false,
         }
-        let name = self.verify_provider.as_str();
-        if name.is_empty() || provider_names.is_empty() {
-            return Ok(());
-        }
-        if !provider_names.contains(&name) {
-            return Err(OrchestrationError::InvalidConfig(format!(
-                "verify_provider \"{}\" not found in [[llm.providers]]; available: [{}]",
-                name,
-                provider_names.join(", ")
-            )));
-        }
-        Ok(())
     }
 
     /// Get a clone of the event sender for injection into sub-agent loops.
@@ -684,6 +648,23 @@ impl DagScheduler {
     #[must_use]
     pub fn has_running_tasks(&self) -> bool {
         !self.running.is_empty()
+    }
+
+    /// Check whether the graph was mutated since the last call and reset the flag.
+    ///
+    /// The scheduler sets `graph_dirty` on every operation that changes task or graph state:
+    /// task completions, failures, timeouts, fatal spawn-failure cascades, and cancellations.
+    /// The caller (scheduler loop in `zeph-core`) consumes the flag after each tick to decide
+    /// whether to issue a persistence checkpoint — without the scheduler holding a persistence
+    /// reference.
+    ///
+    /// Returns `true` if the graph was mutated since the previous call, and resets the flag
+    /// to `false`.
+    #[must_use]
+    pub fn take_graph_dirty(&mut self) -> bool {
+        let dirty = self.graph_dirty;
+        self.graph_dirty = false;
+        dirty
     }
 }
 

--- a/crates/zeph-orchestration/src/scheduler/tick.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick.rs
@@ -366,6 +366,7 @@ impl DagScheduler {
             error = %error_excerpt,
             "spawn failed, marking task failed"
         );
+        self.graph_dirty = true;
         self.graph.tasks[task_id.index()].status = TaskStatus::Failed;
         let cancel_ids = dag::propagate_failure(&mut self.graph, task_id, &self.topology.rev_adj);
         let mut actions = Vec::new();
@@ -410,6 +411,7 @@ impl DagScheduler {
     /// checks the cancellation token. Callers should inspect the task graph state and clean
     /// up partially-written artifacts manually.
     pub fn cancel_all(&mut self) -> Vec<SchedulerAction> {
+        self.graph_dirty = true;
         self.graph.status = GraphStatus::Canceled;
         self.graph.finished_at = Some(crate::graph::chrono_now());
 
@@ -528,6 +530,7 @@ impl DagScheduler {
         output: String,
         artifacts: Vec<std::path::PathBuf>,
     ) -> Vec<SchedulerAction> {
+        self.graph_dirty = true;
         self.graph.tasks[task_id.index()].status = TaskStatus::Completed;
         self.graph.tasks[task_id.index()].result = Some(TaskResult {
             output: output.clone(),
@@ -585,6 +588,7 @@ impl DagScheduler {
 
     /// Apply the Failed outcome branch: build lineage, evaluate cascade abort, propagate failure.
     fn handle_failed_outcome(&mut self, task_id: TaskId, error: &str) -> Vec<SchedulerAction> {
+        self.graph_dirty = true;
         // SEC-ORCH-04: truncate error to avoid logging sensitive internal details.
         let error_excerpt: String = error.chars().take(512).collect();
         tracing::warn!(
@@ -735,6 +739,7 @@ impl DagScheduler {
                 timeout_secs = self.task_timeout.as_secs(),
                 "task timed out"
             );
+            self.graph_dirty = true;
             self.running.remove(&task_id);
             self.graph.tasks[task_id.index()].status = TaskStatus::Failed;
 
@@ -2001,6 +2006,207 @@ mod tests {
         assert!(
             !scheduler.pending_permits.contains_key(&task_id),
             "pending permit must be removed after fatal spawn failure"
+        );
+    }
+
+    // --- graph_dirty / take_graph_dirty checkpoint flag tests ---
+
+    #[test]
+    fn graph_dirty_clear_at_construction() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let scheduler = make_scheduler(graph);
+        assert!(
+            !scheduler.graph_dirty,
+            "graph_dirty must be false immediately after construction"
+        );
+    }
+
+    #[test]
+    fn take_graph_dirty_returns_false_when_no_mutations() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let mut scheduler = make_scheduler(graph);
+        // No tick or mutation — flag must stay false.
+        assert!(
+            !scheduler.take_graph_dirty(),
+            "take_graph_dirty must return false when no mutations occurred"
+        );
+        // Calling again must still return false (idempotent on clean state).
+        assert!(
+            !scheduler.take_graph_dirty(),
+            "take_graph_dirty must remain false after a second call"
+        );
+    }
+
+    #[test]
+    fn take_graph_dirty_true_after_task_completes() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let mut scheduler = make_scheduler(graph);
+
+        scheduler.graph.tasks[0].status = TaskStatus::Running;
+        scheduler.running.insert(
+            TaskId(0),
+            RunningTask {
+                agent_handle_id: "h0".to_string(),
+                agent_def_name: "worker".to_string(),
+                started_at: std::time::Instant::now(),
+                admission_permit: None,
+            },
+        );
+
+        let event = TaskEvent {
+            task_id: TaskId(0),
+            agent_handle_id: "h0".to_string(),
+            outcome: TaskOutcome::Completed {
+                output: "done".to_string(),
+                artifacts: vec![],
+            },
+        };
+        scheduler.buffered_events.push_back(event);
+        scheduler.tick();
+
+        assert!(
+            scheduler.take_graph_dirty(),
+            "take_graph_dirty must return true after a task completes"
+        );
+        // Reset invariant: second call must return false.
+        assert!(
+            !scheduler.take_graph_dirty(),
+            "take_graph_dirty must return false on the second call (reset invariant)"
+        );
+    }
+
+    #[test]
+    fn take_graph_dirty_true_after_task_fails() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let mut scheduler = make_scheduler(graph);
+
+        scheduler.graph.tasks[0].status = TaskStatus::Running;
+        scheduler.running.insert(
+            TaskId(0),
+            RunningTask {
+                agent_handle_id: "h0".to_string(),
+                agent_def_name: "worker".to_string(),
+                started_at: std::time::Instant::now(),
+                admission_permit: None,
+            },
+        );
+
+        let event = TaskEvent {
+            task_id: TaskId(0),
+            agent_handle_id: "h0".to_string(),
+            outcome: TaskOutcome::Failed {
+                error: "boom".to_string(),
+            },
+        };
+        scheduler.buffered_events.push_back(event);
+        scheduler.tick();
+
+        assert!(
+            scheduler.take_graph_dirty(),
+            "take_graph_dirty must return true after a task fails"
+        );
+        assert!(
+            !scheduler.take_graph_dirty(),
+            "take_graph_dirty must return false on the second call (reset invariant)"
+        );
+    }
+
+    #[test]
+    fn take_graph_dirty_true_after_fatal_spawn_failure() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let mut scheduler = make_scheduler(graph);
+        scheduler.graph.tasks[0].status = TaskStatus::Running;
+
+        let fatal = zeph_subagent::SubAgentError::Spawn("provider gone".to_string());
+        scheduler.record_spawn_failure(TaskId(0), &fatal);
+
+        assert!(
+            scheduler.take_graph_dirty(),
+            "take_graph_dirty must return true after a fatal spawn failure marks task Failed"
+        );
+        assert!(
+            !scheduler.take_graph_dirty(),
+            "take_graph_dirty must reset to false on second call"
+        );
+    }
+
+    #[test]
+    fn take_graph_dirty_false_after_transient_concurrency_failure() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let mut scheduler = make_scheduler(graph);
+        scheduler.graph.tasks[0].status = TaskStatus::Running;
+
+        // Transient: task reverts to Ready — no terminal state change.
+        let transient = zeph_subagent::SubAgentError::ConcurrencyLimit { active: 1, max: 1 };
+        scheduler.record_spawn_failure(TaskId(0), &transient);
+
+        assert!(
+            !scheduler.take_graph_dirty(),
+            "transient concurrency deferral must not set graph_dirty (no terminal mutation)"
+        );
+    }
+
+    #[test]
+    fn take_graph_dirty_true_after_cancel_all() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let mut scheduler = make_scheduler(graph);
+
+        scheduler.graph.tasks[0].status = TaskStatus::Running;
+        scheduler.running.insert(
+            TaskId(0),
+            RunningTask {
+                agent_handle_id: "h0".to_string(),
+                agent_def_name: "worker".to_string(),
+                started_at: std::time::Instant::now(),
+                admission_permit: None,
+            },
+        );
+
+        scheduler.cancel_all();
+
+        assert!(
+            scheduler.take_graph_dirty(),
+            "take_graph_dirty must return true after cancel_all"
+        );
+        assert!(
+            !scheduler.take_graph_dirty(),
+            "take_graph_dirty must reset to false on second call"
+        );
+    }
+
+    #[test]
+    fn take_graph_dirty_true_after_timeout() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let config = zeph_config::OrchestrationConfig {
+            task_timeout_secs: 1,
+            ..make_config()
+        };
+        let defs = vec![make_def("worker")];
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+
+        scheduler.graph.tasks[0].status = TaskStatus::Running;
+        scheduler.running.insert(
+            TaskId(0),
+            RunningTask {
+                agent_handle_id: "h0".to_string(),
+                agent_def_name: "worker".to_string(),
+                started_at: std::time::Instant::now()
+                    .checked_sub(Duration::from_secs(2))
+                    .unwrap(),
+                admission_permit: None,
+            },
+        );
+
+        scheduler.tick();
+
+        assert!(
+            scheduler.take_graph_dirty(),
+            "take_graph_dirty must return true after a task times out"
+        );
+        assert!(
+            !scheduler.take_graph_dirty(),
+            "take_graph_dirty must reset to false on second call"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Extracts `DagScheduler::init_common()` private helper from `::new` and `::resume_from`, eliminating ~75 lines of duplicated struct initialization code (#4781).
- Adds `graph_dirty: bool` field set on all durable graph mutations; `GraphPersistence::save()` in the scheduler loop fires only when the flag is set, ensuring task states survive mid-execution crashes (#4747).
- Adds 8 unit tests covering the full `graph_dirty` flag lifecycle (set-on-terminal, reset-on-take, false-on-dispatch-only).

## Changes

- `crates/zeph-orchestration/src/scheduler/mod.rs` — `init_common()` helper, `graph_dirty` field, `take_graph_dirty()` method
- `crates/zeph-orchestration/src/scheduler/tick.rs` — sets `graph_dirty` on 5 mutation paths + 8 new unit tests
- `crates/zeph-core/src/agent/scheduler_loop.rs` — conditional `GraphPersistence::save()` based on `graph_dirty`

## Test plan

- [ ] `cargo nextest run -p zeph-orchestration -p zeph-core --lib --bins` — 1906 passed
- [ ] `cargo nextest run --workspace --lib --bins` — 10464 passed
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy -p zeph-orchestration -p zeph-core -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean

## Follow-up

`inject_tasks` and `record_predicate_outcome` in `persistence.rs` also mutate task states durably but do not set `graph_dirty` (pre-existing gap, not introduced by this PR). Filed as a follow-up P3 issue.

Closes #4747
Closes #4781