### PR TITLE
fix(llm): context_window for o-series models and openai_post helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `fix(config)`: `migrate_worktree_config` now uses a line-anchored check (`lines().any(|l| l.trim() == "[worktree]")`) instead of a bare `contains("[worktree]")`, preventing false-positive idempotency detection when `[worktree]` appears inside a config value string. Adds regression test `step_54_does_not_skip_when_worktree_in_value`. Closes #4793.
-- fix(llm): `OpenAiProvider::context_window()` now returns `Some(200_000)` for o-series models
+- `OpenAiProvider::context_window()` now returns `Some(200_000)` for o-series models
   (o1, o1-mini, o3, o3-mini, o4-mini) instead of `None`, preventing silent context overflow (#4801)
 - `fix(memory,scheduler)`: `MemoryError` and `SchedulerError` now use distinct display strings for
   their `Sqlx` and `Db` variants (`"sqlx error: {0}"` and `"db error: {0}"` respectively), making

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `fix(config)`: `migrate_worktree_config` now uses a line-anchored check (`lines().any(|l| l.trim() == "[worktree]")`) instead of a bare `contains("[worktree]")`, preventing false-positive idempotency detection when `[worktree]` appears inside a config value string. Adds regression test `step_54_does_not_skip_when_worktree_in_value`. Closes #4793.
-
+- fix(llm): `OpenAiProvider::context_window()` now returns `Some(200_000)` for o-series models
+  (o1, o1-mini, o3, o3-mini, o4-mini) instead of `None`, preventing silent context overflow (#4801)
 - `fix(memory,scheduler)`: `MemoryError` and `SchedulerError` now use distinct display strings for
   their `Sqlx` and `Db` variants (`"sqlx error: {0}"` and `"db error: {0}"` respectively), making
   it possible to distinguish raw SQLx query failures from zeph-db lifecycle/migration errors in log
@@ -134,6 +135,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-db`: add `#[non_exhaustive]` to `DbError`. Closes #4736.
 - `zeph-vault`: add `#[non_exhaustive]` to `AgeVaultError`. Closes #4736.
 - `zeph-bench`: add `#[non_exhaustive]` to `BenchError` and `Role`. Closes #4736.
+
+### Changed
+
+- refactor(llm): extract `openai_post()` private helper in `OpenAiProvider` to eliminate 7
+  repetitions of `Authorization`/`Content-Type` header setup (#4800)
 
 ### Performance
 

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -354,10 +354,7 @@ impl OpenAiProvider {
                 presence_penalty,
             };
             send_with_retry("OpenAI", MAX_RETRIES, self.status_tx.as_ref(), || {
-                self.client
-                    .post(format!("{}/chat/completions", self.base_url))
-                    .header("Authorization", format!("Bearer {}", self.api_key))
-                    .header("Content-Type", "application/json")
+                self.openai_post(format!("{}/chat/completions", self.base_url))
                     .json(&body)
                     .send()
             })
@@ -376,10 +373,7 @@ impl OpenAiProvider {
                 presence_penalty,
             };
             send_with_retry("OpenAI", MAX_RETRIES, self.status_tx.as_ref(), || {
-                self.client
-                    .post(format!("{}/chat/completions", self.base_url))
-                    .header("Authorization", format!("Bearer {}", self.api_key))
-                    .header("Content-Type", "application/json")
+                self.openai_post(format!("{}/chat/completions", self.base_url))
                     .json(&body)
                     .send()
             })
@@ -451,10 +445,7 @@ impl OpenAiProvider {
         };
 
         let response = send_with_retry("OpenAI", MAX_RETRIES, self.status_tx.as_ref(), || {
-            self.client
-                .post(format!("{}/chat/completions", self.base_url))
-                .header("Authorization", format!("Bearer {}", self.api_key))
-                .header("Content-Type", "application/json")
+            self.openai_post(format!("{}/chat/completions", self.base_url))
                 .json(&body)
                 .send()
         })
@@ -478,6 +469,13 @@ impl OpenAiProvider {
 
         Ok(response)
     }
+
+    fn openai_post(&self, url: String) -> reqwest::RequestBuilder {
+        self.client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .header("Content-Type", "application/json")
+    }
 }
 
 impl LlmProvider for OpenAiProvider {
@@ -488,6 +486,8 @@ impl LlmProvider for OpenAiProvider {
             Some(16_385)
         } else if self.model.starts_with("gpt-5") {
             Some(1_000_000)
+        } else if starts_with_o_digit(&self.model) {
+            Some(200_000)
         } else {
             None
         }
@@ -554,10 +554,7 @@ impl LlmProvider for OpenAiProvider {
         };
 
         let response = self
-            .client
-            .post(format!("{}/embeddings", self.base_url))
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("Content-Type", "application/json")
+            .openai_post(format!("{}/embeddings", self.base_url))
             .json(&body)
             .send()
             .await?;
@@ -610,10 +607,7 @@ impl LlmProvider for OpenAiProvider {
         let body = EmbeddingBatchRequest { model, input: refs };
 
         let response = self
-            .client
-            .post(format!("{}/embeddings", self.base_url))
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("Content-Type", "application/json")
+            .openai_post(format!("{}/embeddings", self.base_url))
             .json(&body)
             .send()
             .await?;
@@ -810,10 +804,7 @@ impl LlmProvider for OpenAiProvider {
         };
 
         let response = self
-            .client
-            .post(format!("{}/chat/completions", self.base_url))
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("Content-Type", "application/json")
+            .openai_post(format!("{}/chat/completions", self.base_url))
             .json(&body)
             .send()
             .await?;
@@ -916,10 +907,7 @@ impl LlmProvider for OpenAiProvider {
         };
 
         let response = self
-            .client
-            .post(format!("{}/chat/completions", self.base_url))
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("Content-Type", "application/json")
+            .openai_post(format!("{}/chat/completions", self.base_url))
             .json(&body)
             .send()
             .await?;

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -470,6 +470,7 @@ impl OpenAiProvider {
         Ok(response)
     }
 
+    /// Builds an authenticated POST request with `Content-Type: application/json`.
     fn openai_post(&self, url: String) -> reqwest::RequestBuilder {
         self.client
             .post(url)

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -539,6 +539,71 @@ async fn integration_openai_chat_stream() {
 }
 
 #[test]
+fn context_window_o1() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o1".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
+    assert_eq!(p.context_window(), Some(200_000));
+}
+
+#[test]
+fn context_window_o1_mini() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o1-mini".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
+    assert_eq!(p.context_window(), Some(200_000));
+}
+
+#[test]
+fn context_window_o3() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o3".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
+    assert_eq!(p.context_window(), Some(200_000));
+}
+
+#[test]
+fn context_window_o3_mini() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o3-mini".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
+    assert_eq!(p.context_window(), Some(200_000));
+}
+
+#[test]
+fn context_window_o4_mini() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o4-mini".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
+    assert_eq!(p.context_window(), Some(200_000));
+}
+
+#[test]
 fn context_window_gpt35() {
     let p = OpenAiProvider::new(OpenAiConfig {
         api_key: "k".into(),


### PR DESCRIPTION
## Summary

- `OpenAiProvider::context_window()` returned `None` for o-series models (o1, o1-mini, o3, o3-mini, o4-mini), causing silent context overflow when the budget manager used this value for trimming decisions. The fix adds an `else if starts_with_o_digit(&self.model)` branch returning `Some(200_000)`, reusing the existing private helper already used by `CompletionTokens::for_model()`. Closes #4801.
- Extracts a private `openai_post()` helper that sets the `Authorization` bearer token and `Content-Type` header in one place, replacing 7 identical call sites across `send_request` (×2), `send_stream_request`, `embed`, `embed_batch`, `chat_typed`, and `chat_with_tools`. `list_models_remote` (GET, no JSON body) is intentionally unchanged. Closes #4800.
- Adds 5 unit tests for `context_window()` with o-series model names.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — 0 warnings
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler" --locked` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins --features "desktop,ide,server,chat,pdf,scheduler"` — 10730 passed
- [ ] New tests: `context_window_o1`, `context_window_o1_mini`, `context_window_o3`, `context_window_o3_mini`, `context_window_o4_mini` — all pass