### PR TITLE
refactor(errors): align sqlx error display string to "sqlx error: {0}"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   their `Sqlx` and `Db` variants (`"sqlx error: {0}"` and `"db error: {0}"` respectively), making
   it possible to distinguish raw SQLx query failures from zeph-db lifecycle/migration errors in log
   output. Adds 4 regression tests. Closes #4782.
+- `fix(db,index,orchestration,core)`: align `DbError::Sqlx`, `IndexError::Sqlite`,
+  `PlanCacheError::Database`, and `PatternError::Db` display strings to `"sqlx error: {0}"`,
+  consistent with `zeph-memory` and `zeph-scheduler`. Closes #4798.
 
 ### Added
 

--- a/crates/zeph-core/src/agent/speculative/paste.rs
+++ b/crates/zeph-core/src/agent/speculative/paste.rs
@@ -46,7 +46,7 @@ pub enum ToolOutcome {
 /// Error type for `PatternStore` operations.
 #[derive(Debug, Error)]
 pub enum PatternError {
-    #[error("database error: {0}")]
+    #[error("sqlx error: {0}")]
     Db(#[from] zeph_db::sqlx::Error),
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),

--- a/crates/zeph-db/src/error.rs
+++ b/crates/zeph-db/src/error.rs
@@ -24,6 +24,6 @@ pub enum DbError {
     Io(#[from] std::io::Error),
 
     /// Generic sqlx error not covered by the above variants.
-    #[error("database error: {0}")]
+    #[error("sqlx error: {0}")]
     Sqlx(#[from] sqlx::Error),
 }

--- a/crates/zeph-index/src/error.rs
+++ b/crates/zeph-index/src/error.rs
@@ -35,7 +35,7 @@ pub enum IndexError {
     /// `SQLite` database error from `sqlx`.
     ///
     /// Raised by metadata reads/writes in [`crate::store::CodeStore`].
-    #[error("database error: {0}")]
+    #[error("sqlx error: {0}")]
     Sqlite(#[from] zeph_db::SqlxError),
 
     /// Qdrant vector store error.

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -217,7 +217,7 @@ fn unix_now() -> i64 {
 #[derive(Debug, thiserror::Error)]
 pub enum PlanCacheError {
     /// A `SQLite` query failed.
-    #[error("database error: {0}")]
+    #[error("sqlx error: {0}")]
     Database(#[from] zeph_db::SqlxError),
     /// JSON serialization or deserialization of a plan template failed.
     #[error("serialization error: {0}")]


### PR DESCRIPTION
## Summary

Aligns four remaining crates that still rendered `sqlx::Error` wrappers as `"database error: {0}"` to match the canonical prefix `"sqlx error: {0}"` established in `zeph-memory` and `zeph-scheduler` by #4782.

- `zeph-db` — `DbError::Sqlx`
- `zeph-index` — `IndexError::Sqlite`
- `zeph-orchestration` — `PlanCacheError::Database`
- `zeph-core` — `PatternError::Db`

No behavioral changes: none of the four error types are serialized to JSON/HTTP responses; no code path matches on the wrapper prefix string.

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace -- -D warnings` — pass, zero warnings
- [x] `cargo nextest run -p zeph-db -p zeph-index -p zeph-orchestration -p zeph-core` — 2025 passed, 0 failed
- [x] No `"database error"` string literals remain in any `.rs` file under `crates/`

Closes #4798