### PR TITLE
perf(tracing): add #[tracing::instrument] to agent-context and agent-persistence hot paths

### DIFF
--- a/crates/zeph-agent-context/src/helpers.rs
+++ b/crates/zeph-agent-context/src/helpers.rs
@@ -95,6 +95,7 @@ pub fn effective_recall_timeout_ms(configured: u64) -> u64 {
 /// # Errors
 ///
 /// Returns [`ContextError::Memory`] when the graph recall backend returns an error.
+#[tracing::instrument(name = "agent_context.helpers.fetch_graph_facts", skip_all, err)]
 pub async fn fetch_graph_facts(
     view: &ContextAssemblyView<'_>,
     query: &str,
@@ -123,6 +124,7 @@ pub async fn fetch_graph_facts(
 ///
 /// Returns [`zeph_memory::MemoryError`] when the graph recall backend returns an error.
 #[allow(clippy::too_many_lines, clippy::items_after_statements)]
+#[tracing::instrument(name = "agent_context.helpers.fetch_graph_facts_raw", skip_all, err)]
 pub async fn fetch_graph_facts_raw(
     memory: Option<&zeph_memory::semantic::SemanticMemory>,
     graph_config: &zeph_config::GraphConfig,
@@ -727,6 +729,11 @@ pub async fn fetch_graph_facts_raw(
 ///
 /// Returns [`zeph_memory::MemoryError`] when the memory backend returns an error.
 #[allow(clippy::too_many_arguments)]
+#[tracing::instrument(
+    name = "agent_context.helpers.fetch_semantic_recall_raw",
+    skip_all,
+    err
+)]
 pub async fn fetch_semantic_recall_raw(
     memory: Option<&zeph_memory::semantic::SemanticMemory>,
     recall_limit: usize,
@@ -835,6 +842,7 @@ pub async fn fetch_semantic_recall_raw(
 /// # Errors
 ///
 /// Returns [`zeph_memory::MemoryError`] when the memory backend returns an error.
+#[tracing::instrument(name = "agent_context.helpers.fetch_summaries_raw", skip_all, err)]
 pub async fn fetch_summaries_raw(
     memory: Option<&zeph_memory::semantic::SemanticMemory>,
     conversation_id: Option<zeph_memory::ConversationId>,
@@ -885,6 +893,7 @@ pub async fn fetch_summaries_raw(
 /// # Errors
 ///
 /// Returns [`zeph_memory::MemoryError`] when the memory backend returns an error.
+#[tracing::instrument(name = "agent_context.helpers.fetch_cross_session_raw", skip_all, err)]
 pub async fn fetch_cross_session_raw(
     memory: Option<&zeph_memory::semantic::SemanticMemory>,
     conversation_id: Option<zeph_memory::ConversationId>,
@@ -946,6 +955,7 @@ pub async fn fetch_cross_session_raw(
 /// # Errors
 ///
 /// Returns [`ContextError::Memory`] when the memory recall backend returns an error.
+#[tracing::instrument(name = "agent_context.helpers.fetch_semantic_recall", skip_all, err)]
 pub async fn fetch_semantic_recall(
     view: &ContextAssemblyView<'_>,
     query: &str,
@@ -1010,6 +1020,7 @@ fn format_structured_recall_entry(item: &zeph_memory::RecalledMessage) -> String
 /// # Errors
 ///
 /// Returns [`ContextError::Memory`] when the memory backend returns an error.
+#[tracing::instrument(name = "agent_context.helpers.fetch_summaries", skip_all, err)]
 pub async fn fetch_summaries(
     view: &ContextAssemblyView<'_>,
     token_budget: usize,
@@ -1038,6 +1049,7 @@ pub async fn fetch_summaries(
 /// # Errors
 ///
 /// Returns [`ContextError::Memory`] when the memory backend returns an error.
+#[tracing::instrument(name = "agent_context.helpers.fetch_cross_session", skip_all, err)]
 pub async fn fetch_cross_session(
     view: &ContextAssemblyView<'_>,
     query: &str,

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -227,6 +227,7 @@ impl ContextService {
     /// # Errors
     ///
     /// Returns [`ContextError::Memory`] if the recall backend returns an error.
+    #[tracing::instrument(name = "agent_context.service.inject_semantic_recall", skip_all, err)]
     pub async fn inject_semantic_recall(
         &self,
         query: &str,
@@ -270,6 +271,11 @@ impl ContextService {
     /// # Errors
     ///
     /// Returns [`ContextError::Memory`] if the recall backend returns an error.
+    #[tracing::instrument(
+        name = "agent_context.service.inject_semantic_recall_bare",
+        skip_all,
+        err
+    )]
     pub async fn inject_semantic_recall_bare(
         &self,
         params: SemanticRecallParams<'_>,
@@ -372,6 +378,11 @@ impl ContextService {
     /// # Errors
     ///
     /// Returns [`ContextError::Memory`] if the memory backend returns an error.
+    #[tracing::instrument(
+        name = "agent_context.service.inject_cross_session_context",
+        skip_all,
+        err
+    )]
     pub async fn inject_cross_session_context(
         &self,
         query: &str,
@@ -407,6 +418,7 @@ impl ContextService {
     /// # Errors
     ///
     /// Returns [`ContextError::Memory`] if the memory backend returns an error.
+    #[tracing::instrument(name = "agent_context.service.inject_summaries", skip_all, err)]
     pub async fn inject_summaries(
         &self,
         token_budget: usize,
@@ -435,6 +447,7 @@ impl ContextService {
     ///
     /// Returns the reordered index list with the most likely skill first, or `None` if the
     /// LLM call fails (caller falls back to original score order).
+    #[tracing::instrument(name = "agent_context.service.disambiguate_skills", skip_all)]
     pub async fn disambiguate_skills(
         &self,
         query: &str,
@@ -506,6 +519,7 @@ impl ContextService {
     /// Returns [`ContextError::Memory`] if recall fails or [`ContextError::Assembler`]
     /// if the context assembler encounters an internal error.
     #[allow(clippy::too_many_lines)] // sequential context-assembly pipeline; splitting would reduce readability
+    #[tracing::instrument(name = "agent_context.service.prepare_context", skip_all, err)]
     pub async fn prepare_context(
         &self,
         query: &str,
@@ -1063,6 +1077,7 @@ impl ContextService {
         clippy::cast_sign_loss,
         clippy::too_many_lines
     )]
+    #[tracing::instrument(name = "agent_context.service.maybe_compact", skip_all, err)]
     pub async fn maybe_compact(
         &self,
         summ: &mut ContextSummarizationView<'_>,
@@ -1386,6 +1401,7 @@ impl ContextService {
     /// Drains the backlog of unsummarized tool-use/result pairs in a single pass,
     /// storing results as `deferred_summary` on message metadata. Applied lazily
     /// by [`Self::maybe_apply_deferred_summaries`] when context pressure rises.
+    #[tracing::instrument(name = "agent_context.service.maybe_summarize_tool_pair", skip_all)]
     pub async fn maybe_summarize_tool_pair(
         &self,
         summ: &mut ContextSummarizationView<'_>,
@@ -1412,6 +1428,7 @@ impl ContextService {
     ///
     /// Calls `apply_tool_pair_summaries` to soft-delete the original tool pairs and
     /// persist the summaries. Always clears both deferred queues regardless of outcome.
+    #[tracing::instrument(name = "agent_context.service.flush_deferred_summaries", skip_all)]
     pub async fn flush_deferred_summaries(&self, summ: &mut ContextSummarizationView<'_>) {
         if let Err(e) = crate::summarization::deferred::flush_deferred_summaries(summ).await {
             tracing::warn!(%e, "flush_deferred_summaries failed");
@@ -1441,6 +1458,7 @@ impl ContextService {
     /// # Errors
     ///
     /// Returns [`ContextError`] if summarization fails (LLM error or timeout).
+    #[tracing::instrument(name = "agent_context.service.compact_context", skip_all, err)]
     pub async fn compact_context(
         &self,
         summ: &mut ContextSummarizationView<'_>,
@@ -1463,6 +1481,7 @@ impl ContextService {
     /// Uses the `compact_context_with_budget` path (LLM summarization with an optional
     /// token cap). Skips when server compaction is active unless context exceeds 95% of
     /// the budget. Does not impose a post-compaction cooldown.
+    #[tracing::instrument(name = "agent_context.service.maybe_proactive_compress", skip_all)]
     pub async fn maybe_proactive_compress(
         &self,
         summ: &mut ContextSummarizationView<'_>,

--- a/crates/zeph-agent-persistence/src/service.rs
+++ b/crates/zeph-agent-persistence/src/service.rs
@@ -66,6 +66,7 @@ impl PersistenceService {
     /// # Errors
     ///
     /// Returns [`PersistenceError`] if `SQLite` fails during history load or soft-delete.
+    #[tracing::instrument(name = "persistence.service.load_history", skip_all, err)]
     pub async fn load_history(
         &self,
         params: LoadHistoryParams<'_>,
@@ -174,6 +175,7 @@ impl PersistenceService {
     /// Returns a [`PersistMessageOutcome`] even on write failure (the outcome's `message_id`
     /// will be `None`). Callers should log failures but continue — conversation continuity
     /// is more important than individual message persistence.
+    #[tracing::instrument(name = "persistence.service.persist_message", skip_all)]
     pub async fn persist_message(
         &self,
         request: PersistMessageRequest,

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+// tracing::instrument on large async fns in zeph-agent-context increases the
+// Future type depth beyond the default limit of 128.
+#![recursion_limit = "256"]
+
 //! Zeph core agent: multi-model inference, semantic memory, skills orchestration, and tool execution.
 //!
 //! This crate provides the [`Agent`] struct — the autonomous AI system at the heart of Zeph.


### PR DESCRIPTION
## Summary

- Add `#[tracing::instrument]` to 11 pub async functions in `zeph-agent-context/src/service.rs` (closes #4813)
- Add `#[tracing::instrument]` to 8 pub async functions in `zeph-agent-context/src/helpers.rs` (closes #4813)
- Add `#[tracing::instrument]` to 2 pub async functions in `zeph-agent-persistence/src/service.rs` (closes #4814)
- Raise `#![recursion_limit = "256"]` in `zeph-core` to accommodate deeper Future types produced by the macro

All 21 spans follow the `agent_context.service.*`, `agent_context.helpers.*`, and `persistence.service.*` naming convention. Pattern: direct `#[tracing::instrument(name = "...", skip_all)]` with `err` on Result-returning functions — matches the convention used throughout the workspace (neither crate defines a `profiling` feature, so no `cfg_attr` gate is needed).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10496/10496 passed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean