### PR TITLE
feat(llm): configurable SSE buffer caps and profiling tracing coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `feat(llm): make SSE buffer caps configurable via LlmConfig.stream_limits (#4750)` — adds
+  `StreamLimits` struct to `zeph-config` with `max_tool_json_bytes` (4 MiB), `max_thinking_bytes`
+  (1 MiB), and `max_compaction_bytes` (32 KiB) defaults. All three were previously hardcoded
+  constants in `sse.rs`. `ClaudeProvider` gains a `with_stream_limits()` builder method and is
+  wired from `provider_factory.rs`. Migration step 56 adds a commented `[llm.stream_limits]` hint
+  to existing configs. Backward-compatible: configs without the section parse with defaults.
+
+- `feat(tracing): add profiling instrument to LlmProvider trait methods (#4808, #4790)` — adds
+  `#[cfg_attr(feature = "profiling", tracing::instrument(...))]` to `chat_with_tools` on
+  `ClaudeProvider`, `OpenAiProvider`, `GeminiProvider`, and `CompatibleProvider`; to `embed_batch`
+  on `CompatibleProvider`; and to all five `LlmProvider` trait methods plus `bandit_chat` and
+  `cascade_chat` on `RouterProvider`. Span names follow `llm.<provider>.<method>` convention.
+
 - `feat(worktree): make DefaultGitRunner timeout configurable via WorktreeConfig (#4704)` — adds
   `git_timeout_secs: u64` (default `30`) to `WorktreeConfig`; both production construction sites
   now use `DefaultGitRunner::with_timeout(Duration::from_secs(...))`. Configs without the field

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -160,8 +160,8 @@ pub use providers::{
     BanditConfig, CacheTtl, CandleConfig, CandleInlineConfig, CascadeClassifierMode, CascadeConfig,
     CocoonPricing, CoeConfig, ComplexityRoutingConfig, FAST_TIER_MODEL_HINTS, GeminiThinkingLevel,
     GenerationParams, GonkaNode, LlmConfig, LlmRoutingStrategy, MAX_TOKENS_CAP, ProviderEntry,
-    ProviderKind, ProviderName, ProviderOverrides, RouterConfig, RouterStrategyConfig, SttConfig,
-    ThinkingConfig, ThinkingEffort, TierMapping, validate_pool,
+    ProviderKind, ProviderName, ProviderOverrides, RouterConfig, RouterStrategyConfig,
+    StreamLimits, SttConfig, ThinkingConfig, ThinkingEffort, TierMapping, validate_pool,
 };
 pub use providers::{default_stt_language, default_stt_provider};
 pub use quality::{QualityConfig, TriggerPolicy};

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3434,14 +3434,15 @@ use steps::{
     MigrateEmbedProviderRename, MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig,
     MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig, MigrateGoalsConfig,
     MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
-    MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
-    MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
-    MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
-    MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
-    MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
-    MigrateOrchestratorProvider, MigrateOtelFilter, MigratePlannerModelToProvider,
-    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig,
-    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSessionPersistProviderOverrides,
+    MigrateLlmStreamLimits, MigrateMagicDocsConfig, MigrateMcpElicitationConfig,
+    MigrateMcpMaxConnectAttempts, MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels,
+    MigrateMemoryGraph, MigrateMemoryHebbian, MigrateMemoryHebbianConsolidation,
+    MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig, MigrateMemoryReasoning,
+    MigrateMemoryReasoningJudge, MigrateMemoryRetrieval, MigrateMemoryRetrievalQueryBias,
+    MigrateMicrocompactConfig, MigrateOrchestrationPersistence, MigrateOrchestratorProvider,
+    MigrateOtelFilter, MigratePlannerModelToProvider, MigrateProviderMaxConcurrent,
+    MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter,
+    MigrateSchedulerDaemon, MigrateSessionPersistProviderOverrides,
     MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellTransactional,
     MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
     MigrateToolsCompressionConfig, MigrateTraceMetadata, MigrateVigilConfig, MigrateWorktreeConfig,
@@ -3666,6 +3667,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateWorktreeConfig),
             // Step 55 — add git_timeout_secs to [worktree] (#4704)
             Box::new(MigrateWorktreeGitTimeout),
+            // Step 56 — add [llm.stream_limits] commented advisory notice (#4750)
+            Box::new(MigrateLlmStreamLimits),
         ]
     });
 
@@ -3978,6 +3981,39 @@ pub fn migrate_worktree_git_timeout(toml_src: &str) -> Result<MigrationResult, M
     })
 }
 
+/// Add a commented-out `[llm.stream_limits]` section when `[llm]` is present but the
+/// section is absent (#4750).
+///
+/// All three fields carry compile-time defaults that reproduce pre-existing behavior, so
+/// existing deployments that skip the section are unaffected.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the
+/// migration function convention for use in chained pipelines.
+pub fn migrate_llm_stream_limits(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("[llm.stream_limits]") || !toml_src.contains("[llm]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# SSE streaming buffer caps (#4750). Defaults match pre-existing behavior.\n\
+        # [llm.stream_limits]\n\
+        # max_tool_json_bytes  = 4194304   # 4 MiB\n\
+        # max_thinking_bytes   = 1048576   # 1 MiB\n\
+        # max_compaction_bytes = 32768     # 32 KiB\n";
+
+    let output = format!("{toml_src}{comment}");
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["llm.stream_limits".to_owned()],
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {
@@ -3993,8 +4029,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            55,
-            "MIGRATIONS registry must contain all 55 sequential steps"
+            56,
+            "MIGRATIONS registry must contain all 56 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -5581,7 +5617,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_has_fifty_entries() {
-        assert_eq!(MIGRATIONS.len(), 55);
+        assert_eq!(MIGRATIONS.len(), 56);
     }
 
     #[test]
@@ -5620,7 +5656,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–55).
+        // Names must follow the documented step order (steps 1–56).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -5677,6 +5713,7 @@ prompt_cache_ttl = "1h"
             "migrate_cocoon_show_balance",
             "migrate_worktree_config",
             "migrate_worktree_git_timeout",
+            "migrate_llm_stream_limits",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3992,7 +3992,7 @@ pub fn migrate_worktree_git_timeout(toml_src: &str) -> Result<MigrationResult, M
 /// This function is infallible in practice; the `Result` return type matches the
 /// migration function convention for use in chained pipelines.
 pub fn migrate_llm_stream_limits(toml_src: &str) -> Result<MigrationResult, MigrateError> {
-    if toml_src.contains("[llm.stream_limits]") || !toml_src.contains("[llm]") {
+    if section_header_present(toml_src, "llm.stream_limits") || !toml_src.contains("[llm]") {
         return Ok(MigrationResult {
             output: toml_src.to_owned(),
             changed_count: 0,

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -14,7 +14,8 @@
 //! step 52 adds `[session] persist_provider_overrides` (#4654);
 //! step 53 adds `[cocoon] show_balance` advisory notice (#4649);
 //! step 54 adds `[worktree]` section with defaults (#4679);
-//! step 55 adds `git_timeout_secs` to `[worktree]` (#4704).
+//! step 55 adds `git_timeout_secs` to `[worktree]` (#4704);
+//! step 56 adds `[llm.stream_limits]` advisory notice (#4750).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -28,16 +29,17 @@ use super::{
     migrate_embed_provider_rename, migrate_fidelity_timeout_defaults, migrate_five_signal_config,
     migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
-    migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
-    migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels, migrate_memory_graph_config,
-    migrate_memory_hebbian_config, migrate_memory_hebbian_consolidation_config,
-    migrate_memory_hebbian_spread_config, migrate_memory_persona_config,
-    migrate_memory_reasoning_config, migrate_memory_reasoning_judge_config,
-    migrate_memory_retrieval_config, migrate_memory_retrieval_query_bias,
-    migrate_microcompact_config, migrate_orchestration_orchestrator_provider,
-    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
-    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_quality_config,
-    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
+    migrate_llm_stream_limits, migrate_magic_docs_config, migrate_mcp_elicitation_config,
+    migrate_mcp_max_connect_attempts, migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels,
+    migrate_memory_graph_config, migrate_memory_hebbian_config,
+    migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
+    migrate_memory_persona_config, migrate_memory_reasoning_config,
+    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
+    migrate_memory_retrieval_query_bias, migrate_microcompact_config,
+    migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
+    migrate_otel_filter, migrate_planner_model_to_provider, migrate_provider_max_concurrent,
+    migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
+    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_persist_provider_overrides, migrate_session_provider_persistence,
     migrate_session_recap_config, migrate_shell_transactional, migrate_stt_to_provider,
     migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
@@ -45,7 +47,7 @@ use super::{
     migrate_worktree_git_timeout,
 };
 
-// ── Wrapper structs for all 55 sequential migration steps ───────────────────────────────────────
+// ── Wrapper structs for all 56 sequential migration steps ───────────────────────────────────────
 
 pub(super) struct MigrateSttToProvider;
 impl Migration for MigrateSttToProvider {
@@ -649,5 +651,16 @@ impl Migration for MigrateWorktreeGitTimeout {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_worktree_git_timeout(toml_src)
+    }
+}
+
+pub(super) struct MigrateLlmStreamLimits;
+impl Migration for MigrateLlmStreamLimits {
+    fn name(&self) -> &'static str {
+        "migrate_llm_stream_limits"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_llm_stream_limits(toml_src)
     }
 }

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -276,6 +276,64 @@ impl std::fmt::Display for ProviderKind {
     }
 }
 
+fn default_max_tool_json_bytes() -> usize {
+    4 * 1024 * 1024
+}
+
+fn default_max_thinking_bytes() -> usize {
+    1024 * 1024
+}
+
+fn default_max_compaction_bytes() -> usize {
+    32 * 1024
+}
+
+fn stream_limits_is_default(v: &StreamLimits) -> bool {
+    v.max_tool_json_bytes == default_max_tool_json_bytes()
+        && v.max_thinking_bytes == default_max_thinking_bytes()
+        && v.max_compaction_bytes == default_max_compaction_bytes()
+}
+
+/// Per-buffer byte caps for Claude SSE streaming.
+///
+/// Controls the maximum number of bytes accumulated in each streaming buffer before
+/// excess data is discarded with a warning. All caps default to values that match the
+/// pre-existing hardcoded constants, so omitting `[llm.stream_limits]` in the config
+/// preserves identical behavior.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [llm.stream_limits]
+/// max_tool_json_bytes  = 8388608   # 8 MiB  — raise for unusually large tool results
+/// max_thinking_bytes   = 2097152   # 2 MiB  — raise for deep extended-thinking runs
+/// max_compaction_bytes = 65536     # 64 KiB — raise for verbose compaction summaries
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct StreamLimits {
+    /// Maximum bytes for an accumulated tool-use JSON buffer. Default: 4 MiB.
+    #[serde(default = "default_max_tool_json_bytes")]
+    pub max_tool_json_bytes: usize,
+
+    /// Maximum bytes for an accumulated thinking block. Default: 1 MiB.
+    #[serde(default = "default_max_thinking_bytes")]
+    pub max_thinking_bytes: usize,
+
+    /// Maximum bytes for an accumulated server-side compaction summary. Default: 32 KiB.
+    #[serde(default = "default_max_compaction_bytes")]
+    pub max_compaction_bytes: usize,
+}
+
+impl Default for StreamLimits {
+    fn default() -> Self {
+        Self {
+            max_tool_json_bytes: default_max_tool_json_bytes(),
+            max_thinking_bytes: default_max_thinking_bytes(),
+            max_compaction_bytes: default_max_compaction_bytes(),
+        }
+    }
+}
+
 /// LLM configuration, nested under `[llm]` in TOML.
 ///
 /// Declares the provider pool and controls routing, embedding, caching, and STT.
@@ -372,6 +430,14 @@ pub struct LlmConfig {
     /// Collaborative Entropy (`CoE`) configuration. `None` = `CoE` disabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coe: Option<CoeConfig>,
+
+    /// SSE streaming buffer size limits.
+    ///
+    /// Controls the maximum bytes accumulated in per-block SSE buffers before excess
+    /// data is silently discarded. All fields have sane defaults; omitting the section
+    /// keeps pre-existing behavior.
+    #[serde(default, skip_serializing_if = "stream_limits_is_default")]
+    pub stream_limits: StreamLimits,
 }
 
 fn default_embedding_model_opt() -> String {

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -200,6 +200,7 @@ impl Default for Config {
                 summary_provider: None,
                 complexity_routing: None,
                 coe: None,
+                stream_limits: crate::StreamLimits::default(),
             },
             skills: SkillsConfig {
                 paths: default_skill_paths(),

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -184,6 +184,7 @@ fn build_claude_provider(
         .map_err(|e| BootstrapError::Provider(format!("invalid thinking config: {e}")))?
         .with_server_compaction(entry.server_compaction)
         .with_prompt_cache_ttl(entry.prompt_cache_ttl)
+        .with_stream_limits(config.llm.stream_limits.clone())
         .with_output_schema_forwarding(
             config.mcp.forward_output_schema,
             config.mcp.output_schema_hint_bytes,

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -126,6 +126,8 @@ pub struct ClaudeProvider {
     enable_extended_context: bool,
     /// Prompt cache TTL variant. `None` means default (~5 min ephemeral).
     prompt_cache_ttl: Option<CacheTtl>,
+    /// SSE buffer size caps (tool JSON, thinking, compaction). Sourced from config.
+    stream_limits: zeph_config::StreamLimits,
 }
 
 impl fmt::Debug for ClaudeProvider {
@@ -155,6 +157,7 @@ impl fmt::Debug for ClaudeProvider {
             )
             .field("enable_extended_context", &self.enable_extended_context)
             .field("prompt_cache_ttl", &self.prompt_cache_ttl)
+            .field("stream_limits", &self.stream_limits)
             .field("forward_output_schema", &self.forward_output_schema)
             .field("output_schema_hint_bytes", &self.output_schema_hint_bytes)
             .field(
@@ -186,6 +189,7 @@ impl Clone for ClaudeProvider {
             forward_output_schema: self.forward_output_schema,
             output_schema_hint_bytes: self.output_schema_hint_bytes,
             max_tool_description_bytes: self.max_tool_description_bytes,
+            stream_limits: self.stream_limits.clone(),
         }
     }
 }
@@ -225,6 +229,7 @@ impl ClaudeProvider {
             last_compaction: Mutex::new(None),
             enable_extended_context: false,
             prompt_cache_ttl: None,
+            stream_limits: zeph_config::StreamLimits::default(),
         }
     }
 
@@ -369,6 +374,15 @@ impl ClaudeProvider {
             );
         }
         self.prompt_cache_ttl = ttl;
+        self
+    }
+
+    /// Override SSE streaming buffer caps (tool JSON, thinking, compaction).
+    ///
+    /// Call this when the config provides non-default `[llm.stream_limits]` values.
+    #[must_use]
+    pub fn with_stream_limits(mut self, limits: zeph_config::StreamLimits) -> Self {
+        self.stream_limits = limits;
         self
     }
 
@@ -980,7 +994,7 @@ impl ClaudeProvider {
                 });
             }
 
-            return Ok(claude_sse_to_tool_stream(response));
+            return Ok(claude_sse_to_tool_stream(response, &self.stream_limits));
         }
     }
 
@@ -1074,7 +1088,7 @@ impl LlmProvider for ClaudeProvider {
     )]
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, LlmError> {
         let response = self.send_stream_request(messages).await?;
-        Ok(claude_sse_to_stream(response))
+        Ok(claude_sse_to_stream(response, &self.stream_limits))
     }
 
     fn supports_streaming(&self) -> bool {
@@ -1318,6 +1332,14 @@ impl LlmProvider for ClaudeProvider {
             .unwrap_or_else(|e| serde_json::json!({ "serialization_error": e.to_string() }))
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.chat_with_tools",
+            skip_all,
+            fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
+        )
+    )]
     async fn chat_with_tools(
         &self,
         messages: &[Message],

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -210,6 +210,14 @@ impl LlmProvider for CompatibleProvider {
         self.inner.embed(text).await
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.embed_batch",
+            skip_all,
+            fields(provider = self.name(), model = self.model_identifier())
+        )
+    )]
     async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
         self.inner.embed_batch(texts).await
     }
@@ -242,6 +250,14 @@ impl LlmProvider for CompatibleProvider {
         self.inner.chat_typed(messages).await
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.chat_with_tools",
+            skip_all,
+            fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
+        )
+    )]
     async fn chat_with_tools(
         &self,
         messages: &[Message],

--- a/crates/zeph-llm/src/gemini/mod.rs
+++ b/crates/zeph-llm/src/gemini/mod.rs
@@ -1224,6 +1224,14 @@ impl LlmProvider for GeminiProvider {
         true
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.chat_with_tools",
+            skip_all,
+            fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
+        )
+    )]
     async fn chat_with_tools(
         &self,
         messages: &[Message],

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -846,6 +846,14 @@ impl LlmProvider for OpenAiProvider {
         true
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.chat_with_tools",
+            skip_all,
+            fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
+        )
+    )]
     async fn chat_with_tools(
         &self,
         messages: &[Message],

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -1538,6 +1538,14 @@ impl LlmProvider for RouterProvider {
             .and_then(LlmProvider::context_window)
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.router.chat",
+            skip_all,
+            fields(model = self.model_identifier())
+        )
+    )]
     #[allow(clippy::too_many_lines)] // CoE + quality-gate inline logic; extracting would obscure the control flow
     fn chat(
         &self,
@@ -1704,6 +1712,10 @@ impl LlmProvider for RouterProvider {
         })
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.chat_stream", skip_all, fields(model = self.model_identifier()))
+    )]
     fn chat_stream(
         &self,
         messages: &[Message],
@@ -1775,6 +1787,10 @@ impl LlmProvider for RouterProvider {
             .any(LlmProvider::supports_streaming)
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.embed", skip_all, fields(model = self.model_identifier()))
+    )]
     fn embed(
         &self,
         text: &str,
@@ -1879,6 +1895,10 @@ impl LlmProvider for RouterProvider {
         })
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.embed_batch", skip_all, fields(model = self.model_identifier()))
+    )]
     fn embed_batch(
         &self,
         texts: &[&str],
@@ -2006,6 +2026,14 @@ impl LlmProvider for RouterProvider {
             .collect()
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.router.chat_with_tools",
+            skip_all,
+            fields(model = self.model_identifier(), tool_count = tools.len())
+        )
+    )]
     #[allow(refining_impl_trait_reachable)]
     fn chat_with_tools(
         &self,
@@ -2117,6 +2145,10 @@ impl LlmProvider for RouterProvider {
 
 impl RouterProvider {
     /// Bandit `chat()` implementation: select provider, call, record reward.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.bandit_chat", skip_all)
+    )]
     async fn bandit_chat(
         &self,
         messages: &[Message],
@@ -2229,6 +2261,10 @@ impl RouterProvider {
     /// Cascade chat: try providers in order, escalate on degenerate output.
     ///
     /// Returns the best-seen response if all providers fail or budget is exhausted.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.cascade_chat", skip_all)
+    )]
     #[allow(clippy::too_many_lines)] // cascade loop: per-provider error/ok/budget/escalation branches are tightly coupled — extracting would obscure the control flow
     async fn cascade_chat(
         &self,

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -1538,14 +1538,6 @@ impl LlmProvider for RouterProvider {
             .and_then(LlmProvider::context_window)
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.router.chat",
-            skip_all,
-            fields(model = self.model_identifier())
-        )
-    )]
     #[allow(clippy::too_many_lines)] // CoE + quality-gate inline logic; extracting would obscure the control flow
     fn chat(
         &self,
@@ -1554,10 +1546,12 @@ impl LlmProvider for RouterProvider {
         let status_tx = self.status_tx.clone();
         let messages = messages.to_vec();
         let router = self.clone();
+        #[cfg(feature = "profiling")]
+        let model = self.model_identifier().to_owned();
         // NOTE: `chat` and `chat_stream` share error-path logic via `record_fallback_error`.
         // Their success paths diverge (quality gate + CoE vs. plain stream-open), so a
         // shared loop helper would reduce clarity without removing significant duplication.
-        Box::pin(async move {
+        let fut = Box::pin(async move {
             // Increment turn counter once per top-level chat() call. All concurrent sub-calls
             // (tool schema fetches, embed probes) that re-enter chat() will see the same
             // turn_id via the shared Arc<AtomicU64>, enabling ASI debounce.
@@ -1709,13 +1703,15 @@ impl LlmProvider for RouterProvider {
             }
 
             Err(LlmError::NoProviders)
-        })
+        });
+        #[cfg(feature = "profiling")]
+        let fut = {
+            use tracing::Instrument as _;
+            fut.instrument(tracing::info_span!("llm.router.chat", model = model))
+        };
+        fut
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.chat_stream", skip_all, fields(model = self.model_identifier()))
-    )]
     fn chat_stream(
         &self,
         messages: &[Message],
@@ -1723,7 +1719,9 @@ impl LlmProvider for RouterProvider {
         let status_tx = self.status_tx.clone();
         let messages = messages.to_vec();
         let router = self.clone();
-        Box::pin(async move {
+        #[cfg(feature = "profiling")]
+        let model = self.model_identifier().to_owned();
+        let fut = Box::pin(async move {
             // NOTE: see DRY design decision above `chat()` — error path shared via
             // `record_fallback_error`; success paths diverge intentionally.
             if router.strategy == RouterStrategy::Cascade {
@@ -1777,7 +1775,13 @@ impl LlmProvider for RouterProvider {
                 }
             }
             Err(LlmError::NoProviders)
-        })
+        });
+        #[cfg(feature = "profiling")]
+        let fut = {
+            use tracing::Instrument as _;
+            fut.instrument(tracing::info_span!("llm.router.chat_stream", model = model))
+        };
+        fut
     }
 
     fn supports_streaming(&self) -> bool {
@@ -1787,10 +1791,7 @@ impl LlmProvider for RouterProvider {
             .any(LlmProvider::supports_streaming)
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.embed", skip_all, fields(model = self.model_identifier()))
-    )]
+    #[allow(clippy::too_many_lines)] // retry + timeout + fallback + availability tracking: splitting would break the shared `last_err` accumulator
     fn embed(
         &self,
         text: &str,
@@ -1800,7 +1801,9 @@ impl LlmProvider for RouterProvider {
         let text = text.to_owned();
         let router = self.clone();
         let embed_timeout_ms = self.embed_timeout_ms;
-        Box::pin(async move {
+        #[cfg(feature = "profiling")]
+        let model = self.model_identifier().to_owned();
+        let fut = Box::pin(async move {
             for p in &providers {
                 if !p.supports_embeddings() {
                     continue;
@@ -1892,13 +1895,15 @@ impl LlmProvider for RouterProvider {
                 }
             }
             Err(LlmError::NoProviders)
-        })
+        });
+        #[cfg(feature = "profiling")]
+        let fut = {
+            use tracing::Instrument as _;
+            fut.instrument(tracing::info_span!("llm.router.embed", model = model))
+        };
+        fut
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.embed_batch", skip_all, fields(model = self.model_identifier()))
-    )]
     fn embed_batch(
         &self,
         texts: &[&str],
@@ -1908,7 +1913,9 @@ impl LlmProvider for RouterProvider {
         let owned = owned_strs(texts);
         let router = self.clone();
         let semaphore = self.state.embed_semaphore.clone();
-        Box::pin(async move {
+        #[cfg(feature = "profiling")]
+        let model = self.model_identifier().to_owned();
+        let fut = Box::pin(async move {
             // Acquire embed semaphore permit before any HTTP work to cap concurrency.
             let _permit = if let Some(ref sem) = semaphore {
                 Some(sem.acquire().await.map_err(|_| LlmError::NoProviders)?)
@@ -1991,7 +1998,13 @@ impl LlmProvider for RouterProvider {
                 }
             }
             Err(LlmError::NoProviders)
-        })
+        });
+        #[cfg(feature = "profiling")]
+        let fut = {
+            use tracing::Instrument as _;
+            fut.instrument(tracing::info_span!("llm.router.embed_batch", model = model))
+        };
+        fut
     }
 
     fn supports_embeddings(&self) -> bool {
@@ -2026,14 +2039,6 @@ impl LlmProvider for RouterProvider {
             .collect()
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.router.chat_with_tools",
-            skip_all,
-            fields(model = self.model_identifier(), tool_count = tools.len())
-        )
-    )]
     #[allow(refining_impl_trait_reachable)]
     fn chat_with_tools(
         &self,
@@ -2041,10 +2046,14 @@ impl LlmProvider for RouterProvider {
         tools: &[ToolDefinition],
     ) -> impl std::future::Future<Output = Result<ChatResponse, LlmError>> + Send {
         let messages = messages.to_vec();
+        #[cfg(feature = "profiling")]
+        let tool_count = tools.len();
         let tools = tools.to_vec();
         let status_tx = self.status_tx.clone();
         let router = self.clone();
-        Box::pin(async move {
+        #[cfg(feature = "profiling")]
+        let model = self.model_identifier().to_owned();
+        let fut = Box::pin(async move {
             // Bandit routing for tool calls: select a single provider, no quality escalation.
             if router.strategy == RouterStrategy::Bandit {
                 let query = messages
@@ -2114,7 +2123,17 @@ impl LlmProvider for RouterProvider {
                 }
             }
             Err(LlmError::NoProviders)
-        })
+        });
+        #[cfg(feature = "profiling")]
+        let fut = {
+            use tracing::Instrument as _;
+            fut.instrument(tracing::info_span!(
+                "llm.router.chat_with_tools",
+                model = model,
+                tool_count = tool_count
+            ))
+        };
+        fut
     }
 
     fn debug_request_json(

--- a/crates/zeph-llm/src/sse.rs
+++ b/crates/zeph-llm/src/sse.rs
@@ -4,6 +4,7 @@
 use eventsource_stream::Eventsource;
 use serde::Deserialize;
 use tokio_stream::StreamExt;
+use zeph_config::StreamLimits;
 
 use crate::error::LlmError;
 use crate::provider::{ChatStream, StreamChunk, ThinkingBlock, ToolUseRequest};
@@ -65,7 +66,11 @@ struct ClaudeSseState {
 }
 
 /// Convert a Claude streaming response into a `ChatStream`.
-pub(crate) fn claude_sse_to_stream(response: reqwest::Response) -> ChatStream {
+pub(crate) fn claude_sse_to_stream(
+    response: reqwest::Response,
+    limits: &StreamLimits,
+) -> ChatStream {
+    let limits = limits.clone();
     let event_stream = response.bytes_stream().eventsource();
     let s = async_stream::stream! {
         let mut state = ClaudeSseState::default();
@@ -73,7 +78,7 @@ pub(crate) fn claude_sse_to_stream(response: reqwest::Response) -> ChatStream {
         while let Some(event) = pinned.next().await {
             match event {
                 Ok(ev) => {
-                    for chunk in parse_claude_sse_events(&mut state, &ev.data, &ev.event) {
+                    for chunk in parse_claude_sse_events(&mut state, &ev.data, &ev.event, &limits) {
                         yield chunk;
                     }
                 }
@@ -89,7 +94,11 @@ pub(crate) fn claude_sse_to_stream(response: reqwest::Response) -> ChatStream {
 /// Emits `ToolSseEvent` variants so `SpeculativeStreamDrainer` can intercept
 /// `InputJsonDelta` events for early speculative dispatch, while passing other
 /// events through to reconstruct a `ChatResponse` at the end.
-pub(crate) fn claude_sse_to_tool_stream(response: reqwest::Response) -> ToolSseStream {
+pub(crate) fn claude_sse_to_tool_stream(
+    response: reqwest::Response,
+    limits: &StreamLimits,
+) -> ToolSseStream {
+    let limits = limits.clone();
     let event_stream = response.bytes_stream().eventsource();
     let s = async_stream::stream! {
         let mut state = ClaudeSseState::default();
@@ -97,7 +106,7 @@ pub(crate) fn claude_sse_to_tool_stream(response: reqwest::Response) -> ToolSseS
         while let Some(event) = pinned.next().await {
             match event {
                 Ok(ev) => {
-                    for tool_ev in parse_claude_tool_sse_events(&mut state, &ev.data, &ev.event) {
+                    for tool_ev in parse_claude_tool_sse_events(&mut state, &ev.data, &ev.event, &limits) {
                         yield tool_ev;
                     }
                 }
@@ -140,6 +149,7 @@ fn parse_claude_sse_events(
     state: &mut ClaudeSseState,
     data: &str,
     event_type: &str,
+    limits: &StreamLimits,
 ) -> Vec<Result<StreamChunk, LlmError>> {
     match event_type {
         "content_block_start" => {
@@ -168,11 +178,12 @@ fn parse_claude_sse_events(
                     match delta.delta_type.as_str() {
                         "text_delta" if !delta.text.is_empty() => {
                             if let Some(ref mut buf) = state.compaction_buf {
-                                const MAX_COMPACTION_BUF: usize = 32 * 1024;
-                                let remaining = MAX_COMPACTION_BUF.saturating_sub(buf.len());
+                                let remaining =
+                                    limits.max_compaction_bytes.saturating_sub(buf.len());
                                 if remaining == 0 {
                                     tracing::warn!(
-                                        "compaction buffer exceeded 32 KiB cap; discarding excess"
+                                        cap = limits.max_compaction_bytes,
+                                        "compaction buffer exceeded cap; discarding excess"
                                     );
                                 } else {
                                     let to_append = &delta.text[..delta.text.len().min(remaining)];
@@ -227,6 +238,7 @@ fn parse_claude_tool_sse_events(
     state: &mut ClaudeSseState,
     data: &str,
     event_type: &str,
+    limits: &StreamLimits,
 ) -> Vec<ToolSseEvent> {
     match event_type {
         "content_block_start" => {
@@ -289,13 +301,17 @@ fn parse_claude_tool_sse_events(
             state.in_thinking_block = false;
             events
         }
-        "content_block_delta" => parse_tool_delta_event(state, data),
+        "content_block_delta" => parse_tool_delta_event(state, data, limits),
         "error" => parse_sse_error_event(data),
         _ => vec![],
     }
 }
 
-fn parse_tool_delta_event(state: &mut ClaudeSseState, data: &str) -> Vec<ToolSseEvent> {
+fn parse_tool_delta_event(
+    state: &mut ClaudeSseState,
+    data: &str,
+    limits: &StreamLimits,
+) -> Vec<ToolSseEvent> {
     let Ok(event) = serde_json::from_str::<ClaudeStreamEvent>(data) else {
         return vec![ToolSseEvent::Error(LlmError::SseParse(format!(
             "failed to parse SSE data: {data}"
@@ -307,13 +323,15 @@ fn parse_tool_delta_event(state: &mut ClaudeSseState, data: &str) -> Vec<ToolSse
     match delta.delta_type.as_str() {
         "text_delta" if !delta.text.is_empty() => {
             if let Some(ref mut buf) = state.compaction_buf {
-                const MAX_COMPACTION_BUF: usize = 32 * 1024;
-                let remaining = MAX_COMPACTION_BUF.saturating_sub(buf.len());
+                let remaining = limits.max_compaction_bytes.saturating_sub(buf.len());
                 if remaining > 0 {
                     let to_append = &delta.text[..delta.text.len().min(remaining)];
                     buf.push_str(to_append);
                 } else {
-                    tracing::warn!("compaction buffer exceeded 32 KiB cap; discarding excess");
+                    tracing::warn!(
+                        cap = limits.max_compaction_bytes,
+                        "compaction buffer exceeded cap; discarding excess"
+                    );
                 }
                 return vec![];
             }
@@ -321,9 +339,11 @@ fn parse_tool_delta_event(state: &mut ClaudeSseState, data: &str) -> Vec<ToolSse
         }
         "input_json_delta" if !delta.partial_json.is_empty() => {
             if let Some((_, _, _, ref mut json)) = state.tool_block {
-                const MAX_TOOL_JSON_BUF: usize = 4 * 1024 * 1024;
-                if json.len() >= MAX_TOOL_JSON_BUF {
-                    tracing::warn!("tool JSON buffer exceeded 4 MiB cap; discarding excess");
+                if json.len() >= limits.max_tool_json_bytes {
+                    tracing::warn!(
+                        cap = limits.max_tool_json_bytes,
+                        "tool JSON buffer exceeded cap; discarding excess"
+                    );
                 } else {
                     json.push_str(&delta.partial_json);
                 }
@@ -336,9 +356,11 @@ fn parse_tool_delta_event(state: &mut ClaudeSseState, data: &str) -> Vec<ToolSse
         }
         "thinking_delta" if !delta.thinking.is_empty() => {
             if let Some((ref mut t, _)) = state.thinking_block {
-                const MAX_THINKING_BUF: usize = 1024 * 1024;
-                if t.len() >= MAX_THINKING_BUF {
-                    tracing::warn!("thinking buffer exceeded 1 MiB cap; discarding excess");
+                if t.len() >= limits.max_thinking_bytes {
+                    tracing::warn!(
+                        cap = limits.max_thinking_bytes,
+                        "thinking buffer exceeded cap; discarding excess"
+                    );
                 } else {
                     t.push_str(&delta.thinking);
                 }
@@ -587,12 +609,18 @@ struct GeminiStreamPart {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zeph_config::StreamLimits;
 
     #[test]
     fn claude_parse_text_delta() {
         let mut state = ClaudeSseState::default();
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
-        let mut results = parse_claude_sse_events(&mut state, data, "content_block_delta");
+        let mut results = parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_delta",
+            &StreamLimits::default(),
+        );
         assert_eq!(results.len(), 1);
         let chunk = results.remove(0).unwrap();
         assert!(matches!(chunk, StreamChunk::Content(s) if s == "Hello"));
@@ -603,7 +631,12 @@ mod tests {
         let mut state = ClaudeSseState::default();
         let data =
             r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}"#;
-        let results = parse_claude_sse_events(&mut state, data, "content_block_delta");
+        let results = parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_delta",
+            &StreamLimits::default(),
+        );
         assert!(results.is_empty());
     }
 
@@ -611,7 +644,8 @@ mod tests {
     fn claude_parse_error_event() {
         let mut state = ClaudeSseState::default();
         let data = r#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#;
-        let mut results = parse_claude_sse_events(&mut state, data, "error");
+        let mut results =
+            parse_claude_sse_events(&mut state, data, "error", &StreamLimits::default());
         assert_eq!(results.len(), 1);
         let err = results.remove(0).unwrap_err();
         assert!(err.to_string().contains("overloaded_error"));
@@ -620,7 +654,7 @@ mod tests {
     #[test]
     fn claude_parse_unknown_event_skipped() {
         let mut state = ClaudeSseState::default();
-        let results = parse_claude_sse_events(&mut state, "{}", "ping");
+        let results = parse_claude_sse_events(&mut state, "{}", "ping", &StreamLimits::default());
         assert!(results.is_empty());
     }
 
@@ -656,7 +690,12 @@ mod tests {
     fn claude_thinking_delta_emitted_as_thinking_chunk() {
         let mut state = ClaudeSseState::default();
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"I need to think about this"}}"#;
-        let mut results = parse_claude_sse_events(&mut state, data, "content_block_delta");
+        let mut results = parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_delta",
+            &StreamLimits::default(),
+        );
         assert_eq!(results.len(), 1);
         let chunk = results.remove(0).unwrap();
         assert!(matches!(chunk, StreamChunk::Thinking(s) if s == "I need to think about this"));
@@ -666,7 +705,12 @@ mod tests {
     fn claude_thinking_delta_empty_not_emitted() {
         let mut state = ClaudeSseState::default();
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}"#;
-        let results = parse_claude_sse_events(&mut state, data, "content_block_delta");
+        let results = parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_delta",
+            &StreamLimits::default(),
+        );
         assert!(results.is_empty());
     }
 
@@ -683,7 +727,12 @@ mod tests {
     fn claude_signature_delta_not_emitted_to_stream() {
         let mut state = ClaudeSseState::default();
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"abc123"}}"#;
-        let results = parse_claude_sse_events(&mut state, data, "content_block_delta");
+        let results = parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_delta",
+            &StreamLimits::default(),
+        );
         assert!(results.is_empty());
     }
 
@@ -692,7 +741,12 @@ mod tests {
         let mut state = ClaudeSseState::default();
         assert!(state.compaction_buf.is_none());
         let data = r#"{"type":"content_block_start","index":0,"content_block":{"type":"compaction","text":""}}"#;
-        let results = parse_claude_sse_events(&mut state, data, "content_block_start");
+        let results = parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_start",
+            &StreamLimits::default(),
+        );
         assert!(results.is_empty());
         assert!(state.compaction_buf.is_some());
     }
@@ -702,7 +756,12 @@ mod tests {
         let mut state = ClaudeSseState::default();
         let data =
             r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
-        let results = parse_claude_sse_events(&mut state, data, "content_block_start");
+        let results = parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_start",
+            &StreamLimits::default(),
+        );
         assert!(results.is_empty());
         assert!(state.compaction_buf.is_none());
     }
@@ -714,7 +773,12 @@ mod tests {
             ..Default::default()
         };
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Summary text"}}"#;
-        let results = parse_claude_sse_events(&mut state, data, "content_block_delta");
+        let results = parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_delta",
+            &StreamLimits::default(),
+        );
         assert!(results.is_empty());
         assert_eq!(state.compaction_buf.as_deref(), Some("Summary text"));
     }
@@ -726,7 +790,12 @@ mod tests {
             ..Default::default()
         };
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" more"}}"#;
-        let results = parse_claude_sse_events(&mut state, data, "content_block_delta");
+        let results = parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_delta",
+            &StreamLimits::default(),
+        );
         // Must not emit a Content chunk while accumulating compaction.
         assert!(results.is_empty());
         assert_eq!(state.compaction_buf.as_deref(), Some("so far more"));
@@ -738,7 +807,12 @@ mod tests {
             compaction_buf: Some("Final summary".to_owned()),
             ..Default::default()
         };
-        let mut results = parse_claude_sse_events(&mut state, "{}", "content_block_stop");
+        let mut results = parse_claude_sse_events(
+            &mut state,
+            "{}",
+            "content_block_stop",
+            &StreamLimits::default(),
+        );
         assert_eq!(results.len(), 1);
         let chunk = results.remove(0).unwrap();
         assert!(
@@ -751,7 +825,12 @@ mod tests {
     #[test]
     fn claude_stop_without_compaction_buf_returns_none() {
         let mut state = ClaudeSseState::default();
-        let results = parse_claude_sse_events(&mut state, "{}", "content_block_stop");
+        let results = parse_claude_sse_events(
+            &mut state,
+            "{}",
+            "content_block_stop",
+            &StreamLimits::default(),
+        );
         assert!(results.is_empty());
     }
 
@@ -764,7 +843,12 @@ mod tests {
         // Two-byte push that would exceed cap.
         let data =
             r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ab"}}"#;
-        parse_claude_sse_events(&mut state, data, "content_block_delta");
+        parse_claude_sse_events(
+            &mut state,
+            data,
+            "content_block_delta",
+            &StreamLimits::default(),
+        );
         let buf = state.compaction_buf.as_ref().unwrap();
         assert!(buf.len() <= 32 * 1024, "buffer must not exceed 32 KiB");
     }
@@ -774,12 +858,33 @@ mod tests {
         let mut state = ClaudeSseState::default();
         // 1. block_start with compaction type
         let start = r#"{"type":"content_block_start","index":0,"content_block":{"type":"compaction","text":""}}"#;
-        assert!(parse_claude_sse_events(&mut state, start, "content_block_start").is_empty());
+        assert!(
+            parse_claude_sse_events(
+                &mut state,
+                start,
+                "content_block_start",
+                &StreamLimits::default()
+            )
+            .is_empty()
+        );
         // 2. delta
         let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Summarized context"}}"#;
-        assert!(parse_claude_sse_events(&mut state, delta, "content_block_delta").is_empty());
+        assert!(
+            parse_claude_sse_events(
+                &mut state,
+                delta,
+                "content_block_delta",
+                &StreamLimits::default()
+            )
+            .is_empty()
+        );
         // 3. stop
-        let mut results = parse_claude_sse_events(&mut state, "{}", "content_block_stop");
+        let mut results = parse_claude_sse_events(
+            &mut state,
+            "{}",
+            "content_block_stop",
+            &StreamLimits::default(),
+        );
         assert_eq!(results.len(), 1);
         let chunk = results.remove(0).unwrap();
         assert!(matches!(chunk, StreamChunk::Compaction(s) if s == "Summarized context"));
@@ -793,7 +898,12 @@ mod tests {
             ..Default::default()
         };
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"cmd\":\"ls"}}"#;
-        let events = parse_claude_tool_sse_events(&mut state, data, "content_block_delta");
+        let events = parse_claude_tool_sse_events(
+            &mut state,
+            data,
+            "content_block_delta",
+            &StreamLimits::default(),
+        );
         assert_eq!(events.len(), 1);
         assert!(
             matches!(&events[0], ToolSseEvent::InputJsonDelta { index: 0, delta } if delta == r#"{"cmd":"ls"#)
@@ -812,7 +922,12 @@ mod tests {
             current_block_index: 1,
             ..Default::default()
         };
-        let events = parse_claude_tool_sse_events(&mut state, "{}", "content_block_stop");
+        let events = parse_claude_tool_sse_events(
+            &mut state,
+            "{}",
+            "content_block_stop",
+            &StreamLimits::default(),
+        );
         assert!(state.tool_block.is_none());
         assert!(
             events.iter().any(|e| matches!(e, ToolSseEvent::ToolCallComplete { index: 1, name, .. } if name == "read_file"))
@@ -826,7 +941,12 @@ mod tests {
             in_thinking_block: true,
             ..Default::default()
         };
-        let events = parse_claude_tool_sse_events(&mut state, "{}", "content_block_stop");
+        let events = parse_claude_tool_sse_events(
+            &mut state,
+            "{}",
+            "content_block_stop",
+            &StreamLimits::default(),
+        );
         assert!(state.thinking_block.is_none());
         assert!(
             events.iter().any(|e| matches!(e, ToolSseEvent::ThinkingBlockDone(ThinkingBlock::Thinking { thinking, .. }) if thinking == "think"))
@@ -1022,7 +1142,7 @@ mod tests {
             ..Default::default()
         };
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OVERFLOW"}}"#;
-        parse_tool_delta_event(&mut state, data);
+        parse_tool_delta_event(&mut state, data, &StreamLimits::default());
         let buf_len = state.tool_block.as_ref().unwrap().3.len();
         assert_eq!(
             buf_len,
@@ -1039,7 +1159,7 @@ mod tests {
             ..Default::default()
         };
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"k\":1}"}}"#;
-        parse_tool_delta_event(&mut state, data);
+        parse_tool_delta_event(&mut state, data, &StreamLimits::default());
         let buf = &state.tool_block.as_ref().unwrap().3;
         assert_eq!(buf, r#"{"k":1}"#);
     }
@@ -1052,7 +1172,7 @@ mod tests {
             ..Default::default()
         };
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"OVERFLOW"}}"#;
-        parse_tool_delta_event(&mut state, data);
+        parse_tool_delta_event(&mut state, data, &StreamLimits::default());
         let thinking_len = state.thinking_block.as_ref().unwrap().0.len();
         assert_eq!(
             thinking_len,
@@ -1069,7 +1189,7 @@ mod tests {
             ..Default::default()
         };
         let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"step one"}}"#;
-        parse_tool_delta_event(&mut state, data);
+        parse_tool_delta_event(&mut state, data, &StreamLimits::default());
         assert_eq!(state.thinking_block.as_ref().unwrap().0, "step one");
     }
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -703,6 +703,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
         summary_provider: None,
         complexity_routing: None,
         coe: None,
+        stream_limits: zeph_config::StreamLimits::default(),
     };
 
     // When postgres backend was chosen, sqlite_path is left at its serde default (unused).


### PR DESCRIPTION
## Summary

- **#4750** — Add `StreamLimits` config struct (`[llm.stream_limits]`) with `max_tool_json_bytes` (4 MiB), `max_thinking_bytes` (1 MiB), `max_compaction_bytes` (32 KiB). Wire through `LlmConfig`, `ClaudeProvider.with_stream_limits()` builder, `provider_factory`, and `src/init`. Migration step 56 injects a commented `[llm.stream_limits]` hint. Defaults preserve existing behavior exactly.
- **#4808** — Add `#[cfg_attr(feature = "profiling", tracing::instrument(name = "llm.chat_with_tools", ...))]` to `chat_with_tools` on Claude, OpenAI, Gemini, and Compatible providers; also adds missing `embed_batch` instrument to Compatible.
- **#4790** — Add profiling-gated spans to all 7 `RouterProvider` hot-path methods. The 5 `fn -> impl Future` methods (chat, chat_stream, embed, embed_batch, chat_with_tools) use manual `.instrument(span)` on the returned `Box::pin` future to correctly capture async execution. The 2 `async fn` helpers (bandit_chat, cascade_chat) use the standard `#[cfg_attr]` attribute.

## LLM serialization gate

Not applicable — no `#[derive(Serialize, Deserialize)]` structs, `MessagePart`, `Message`, `ToolDefinition`, or context assembly paths were modified. Changes are limited to compile-time tracing annotations (`profiling` feature only) and SSE buffer size config (no request/response format changes).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo clippy -p zeph-llm -p zeph-config -p zeph-core --features profiling -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — **10496 PASS**, 21 skipped
- [x] `cargo test --doc -p zeph-config -p zeph-llm` — 15 PASS
- [x] Behavioral drift check: `StreamLimits::default()` values == old hardcoded constants (4 MiB / 1 MiB / 32 KiB)
- [x] Rebased onto origin/main (HEAD includes #4811, #4809, #4812, #4816)

## Follow-up

- `OllamaProvider::chat_with_tools` is the only backend still missing the profiling instrument (out of #4808 scope). File as P4.
- Missing unit tests for `StreamLimits::default()` values and custom-cap SSE path. File as P4.

Closes #4750, #4808, #4790.