### PR TITLE
fix(tracing): replace EnteredSpan-across-.await with .instrument() in zeph-agent-context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-agent-context`: replace four synchronous `EnteredSpan` guards held across `.await`
+  boundaries with `#[tracing::instrument]` (standalone async fns) and `.instrument(span).await`
+  (inline futures). Affected functions: `fetch_graph_facts_raw` (`helpers.rs`),
+  `prepare_context` fidelity block (`service.rs`), `maybe_compact` regrade block (`service.rs`),
+  `run_focus_auto_consolidation` (`compaction.rs`). Under the tokio multi-thread scheduler,
+  holding a synchronous span guard across an await point causes spans to be attributed to the
+  wrong worker thread and `Span::current().record()` to silently write to the wrong span.
+  Closes #4815.
+
 - `fix(config)`: `migrate_worktree_config` now uses a line-anchored check (`lines().any(|l| l.trim() == "[worktree]")`) instead of a bare `contains("[worktree]")`, preventing false-positive idempotency detection when `[worktree]` appears inside a config value string. Adds regression test `step_54_does_not_skip_when_worktree_in_value`. Closes #4793.
 - `OpenAiProvider::context_window()` now returns `Some(200_000)` for o-series models
   (o1, o1-mini, o3, o3-mini, o4-mini) instead of `None`, preventing silent context overflow (#4801)

--- a/crates/zeph-agent-context/src/compaction.rs
+++ b/crates/zeph-agent-context/src/compaction.rs
@@ -526,14 +526,13 @@ pub struct SubgoalExtractionResult {
 ///
 /// Returns an error if the provider call returns an error or if the 20-second timeout
 /// elapses before the provider responds.
+#[tracing::instrument(name = "ctx.compaction.focus_auto_consolidate", skip_all)]
 pub async fn run_focus_auto_consolidation(
     messages: &[Message],
     min_window: usize,
     provider: impl LlmProvider,
     max_chars: usize,
 ) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let _span = tracing::info_span!("ctx.compaction.focus_auto_consolidate").entered();
-
     if messages.len() < min_window {
         return Ok(None);
     }

--- a/crates/zeph-agent-context/src/helpers.rs
+++ b/crates/zeph-agent-context/src/helpers.rs
@@ -124,7 +124,12 @@ pub async fn fetch_graph_facts(
 ///
 /// Returns [`zeph_memory::MemoryError`] when the graph recall backend returns an error.
 #[allow(clippy::too_many_lines, clippy::items_after_statements)]
-#[tracing::instrument(name = "agent_context.helpers.fetch_graph_facts_raw", skip_all, err)]
+#[tracing::instrument(
+    name = "agent_context.helpers.fetch_graph_facts_raw",
+    skip_all,
+    err,
+    fields(effective_strategy)
+)]
 pub async fn fetch_graph_facts_raw(
     memory: Option<&zeph_memory::semantic::SemanticMemory>,
     graph_config: &zeph_config::GraphConfig,
@@ -154,7 +159,10 @@ pub async fn fetch_graph_facts_raw(
         graph_config.retrieval_strategy
     };
 
-    let _span = tracing::info_span!("memory.graph.dispatch", ?effective_strategy).entered();
+    tracing::Span::current().record(
+        "effective_strategy",
+        tracing::field::debug(&effective_strategy),
+    );
     let strategy_str = format!("{effective_strategy:?}").to_lowercase();
     let edge_types_json = serde_json::to_string(&edge_types).ok();
 

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -701,12 +701,7 @@ impl ContextService {
             && fidelity_cfg.enabled
             && !memory_first_active
         {
-            let _span = tracing::info_span!(
-                "context.fidelity.score",
-                message_count = window.messages.len(),
-                query_len = query.len(),
-            )
-            .entered();
+            use tracing::Instrument as _;
             if let Some(ref tx) = view.status_tx {
                 let _ = tx.send("Scoring context fidelity\u{2026}".into());
             }
@@ -718,6 +713,11 @@ impl ContextService {
                 .fidelity_compress_provider
                 .as_deref()
                 .map(|p| p as &dyn zeph_llm::LlmProviderDyn);
+            let fidelity_span = tracing::info_span!(
+                "context.fidelity.score",
+                message_count = window.messages.len(),
+                query_len = query.len(),
+            );
             FidelityScorer
                 .score_and_apply(
                     window.messages,
@@ -730,6 +730,7 @@ impl ContextService {
                     embed_provider,
                     compress_provider,
                 )
+                .instrument(fidelity_span)
                 .await;
             // Persist fidelity tags so subsequent turns see the floor invariant.
             persist_fidelity_tags(window.messages, view.memory.as_deref()).await;
@@ -1158,11 +1159,7 @@ impl ContextService {
                 summ.server_compaction_active,
             )
         {
-            let _regrade_span = tracing::info_span!(
-                "context.fidelity.regrade",
-                budget_ratio = tracing::field::Empty,
-            )
-            .entered();
+            use tracing::Instrument as _;
             let regrade_embed_provider = summ
                 .fidelity_semantic_provider
                 .as_deref()
@@ -1183,6 +1180,10 @@ impl ContextService {
                     regrade_embed_provider,
                     regrade_compress_provider,
                 )
+                .instrument(tracing::info_span!(
+                    "context.fidelity.regrade",
+                    budget_ratio = tracing::field::Empty,
+                ))
                 .await;
             // Persist upgraded fidelity tags so the new levels survive the next turn (F-3).
             persist_fidelity_tags(summ.messages, summ.memory.as_deref()).await;


### PR DESCRIPTION
## Summary

- Replace four synchronous `EnteredSpan` guards held across `.await` in `zeph-agent-context` with the correct async tracing patterns (`#[tracing::instrument]` and `.instrument(span).await`)
- Affected functions: `fetch_graph_facts_raw`, `prepare_context` fidelity block, `maybe_compact` regrade block, `run_focus_auto_consolidation`
- Verified safe: four `.entered()` calls in `summarization/compaction.rs` are sync-only and left untouched

## Root cause

Holding a sync `EnteredSpan` guard across an `.await` point causes spans to be attributed to the wrong tokio worker thread; `Span::current().record()` inside those spans silently writes to the wrong span context.

## Changes

| File | Change |
|---|---|
| `helpers.rs` | `fetch_graph_facts_raw`: `#[tracing::instrument]` + keep `fields(effective_strategy)` for `Span::current().record(...)` |
| `service.rs` | `prepare_context` fidelity block: pre-compute span, wrap with `.instrument().await` |
| `service.rs` | `maybe_compact` regrade block: inline `.instrument(tracing::info_span!(...)).await` |
| `compaction.rs` | `run_focus_auto_consolidation`: `#[tracing::instrument(skip_all)]` |
| `CHANGELOG.md` | `[Unreleased] ### Fixed` entry |

## Notes

Rebased onto `bfbeab8d` (PR #4821) which added `#[tracing::instrument]` to other functions in the same crate. Conflict on `fetch_graph_facts_raw` resolved by combining PR #4821's span name convention (`agent_context.helpers.*`) with our `fields(effective_strategy)` needed for the existing `Span::current().record()` call.

Closes #4815