### PR TITLE
fix(orchestration): set graph_dirty in inject_tasks and record_predicate_outcome; add tracing spans to memory recall and zeph-db

### DIFF
--- a/crates/zeph-db/src/migrate.rs
+++ b/crates/zeph-db/src/migrate.rs
@@ -12,6 +12,7 @@ use crate::{DbPool, error::DbError};
 ///
 /// Returns [`DbError::Migration`] if any migration fails.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[tracing::instrument(name = "db.migrate.run", skip_all, err)]
 pub async fn run_migrations(pool: &DbPool) -> Result<(), DbError> {
     sqlx::migrate!("./migrations/sqlite")
         .run(pool)
@@ -26,6 +27,7 @@ pub async fn run_migrations(pool: &DbPool) -> Result<(), DbError> {
 ///
 /// Returns [`DbError::Migration`] if any migration fails.
 #[cfg(feature = "postgres")]
+#[tracing::instrument(name = "db.migrate.run", skip_all, err)]
 pub async fn run_migrations(pool: &DbPool) -> Result<(), DbError> {
     sqlx::migrate!("./migrations/postgres")
         .run(pool)

--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -33,6 +33,7 @@ impl DbConfig {
     /// # Errors
     ///
     /// Returns [`DbError`] if connection or migration fails.
+    #[tracing::instrument(name = "db.pool.connect", skip_all, err)]
     pub async fn connect(&self) -> Result<DbPool, DbError> {
         #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
         {

--- a/crates/zeph-db/src/transaction.rs
+++ b/crates/zeph-db/src/transaction.rs
@@ -8,6 +8,7 @@ use crate::DbPool;
 /// # Errors
 ///
 /// Returns a sqlx error if the transaction cannot be started.
+#[tracing::instrument(name = "db.tx.begin", skip_all, err)]
 pub async fn begin(pool: &DbPool) -> Result<crate::DbTransaction<'_>, sqlx::Error> {
     pool.begin().await
 }
@@ -25,6 +26,7 @@ pub async fn begin(pool: &DbPool) -> Result<crate::DbTransaction<'_>, sqlx::Erro
 ///
 /// Returns a sqlx error if the transaction cannot be started.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[tracing::instrument(name = "db.tx.begin_write", skip_all, err)]
 pub async fn begin_write(pool: &DbPool) -> Result<crate::DbTransaction<'_>, sqlx::Error> {
     pool.begin_with("BEGIN IMMEDIATE").await
 }
@@ -35,6 +37,7 @@ pub async fn begin_write(pool: &DbPool) -> Result<crate::DbTransaction<'_>, sqlx
 ///
 /// Returns a sqlx error if the transaction cannot be started.
 #[cfg(feature = "postgres")]
+#[tracing::instrument(name = "db.tx.begin_write", skip_all, err)]
 pub async fn begin_write(pool: &DbPool) -> Result<crate::DbTransaction<'_>, sqlx::Error> {
     pool.begin().await
 }

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -797,6 +797,10 @@ impl SemanticMemory {
         Ok(results)
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "memory.recall.fts5", skip_all, fields(query_len = %query.len()))
+    )]
     pub(super) async fn recall_fts5_raw(
         &self,
         query: &str,
@@ -808,6 +812,10 @@ impl SemanticMemory {
             .await
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "memory.recall.vectors", skip_all, fields(query_len = %query.len()))
+    )]
     pub(super) async fn recall_vectors_raw(
         &self,
         query: &str,
@@ -850,6 +858,10 @@ impl SemanticMemory {
     /// # Errors
     ///
     /// Returns an error if the `SQLite` `messages_by_ids` query fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "memory.recall.merge_and_rank", skip_all, fields(kw_count = keyword_results.len(), vec_count = vector_results.len()))
+    )]
     #[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
     pub(super) async fn recall_merge_and_rank(
         &self,

--- a/crates/zeph-orchestration/src/scheduler/persistence.rs
+++ b/crates/zeph-orchestration/src/scheduler/persistence.rs
@@ -60,6 +60,7 @@ impl DagScheduler {
 
         // Signal that topology needs re-analysis on the next tick (critic C2).
         self.topology_dirty = true;
+        self.graph_dirty = true;
 
         // Reset cascade failure counts — the graph has fundamentally changed (C13 fix).
         if let Some(ref mut det) = self.cascade_detector {
@@ -110,6 +111,7 @@ impl DagScheduler {
         if outcome.passed {
             // Gate cleared — downstream tasks will be unblocked by ready_tasks() on next tick.
             tracing::debug!(task_id = %task_id, confidence = outcome.confidence, "predicate passed");
+            self.graph_dirty = true;
             return Ok(());
         }
 
@@ -131,6 +133,7 @@ impl DagScheduler {
             task.status = TaskStatus::Ready;
             self.predicate_replans_used += 1;
             self.predicate_reasons.insert(task_id, outcome.reason);
+            self.graph_dirty = true;
             return Ok(());
         }
 
@@ -143,6 +146,7 @@ impl DagScheduler {
             "predicate re-run budget exhausted, injecting remediation task"
         );
         self.inject_predicate_remediation(task_id, &outcome.reason, max_tasks)?;
+        self.graph_dirty = true;
         Ok(())
     }
 
@@ -917,5 +921,96 @@ mod tests {
             DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![], None)
                 .unwrap();
         assert_eq!(scheduler.graph.status, GraphStatus::Running);
+    }
+
+    // --- graph_dirty tests for inject_tasks and record_predicate_outcome ---
+
+    #[test]
+    fn inject_tasks_sets_graph_dirty() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let mut scheduler = make_scheduler(graph);
+        assert!(!scheduler.graph_dirty);
+
+        let new_task = make_node(1, &[]);
+        scheduler
+            .inject_tasks(TaskId(0), vec![new_task], 20)
+            .unwrap();
+        assert!(
+            scheduler.graph_dirty,
+            "inject_tasks must set graph_dirty after mutating the graph"
+        );
+    }
+
+    #[test]
+    fn record_predicate_outcome_pass_sets_graph_dirty() {
+        use crate::verify_predicate::{PredicateOutcome, VerifyPredicate};
+
+        let mut graph = graph_from_nodes(vec![make_node(0, &[])]);
+        graph.tasks[0].status = TaskStatus::Completed;
+        graph.tasks[0].verify_predicate = Some(VerifyPredicate::Natural("criterion".to_string()));
+        let mut scheduler = make_scheduler(graph);
+        scheduler.graph.status = GraphStatus::Running;
+
+        scheduler
+            .record_predicate_outcome(
+                TaskId(0),
+                PredicateOutcome {
+                    passed: true,
+                    confidence: 0.9,
+                    reason: "ok".to_string(),
+                },
+                20,
+            )
+            .unwrap();
+        assert!(
+            scheduler.graph_dirty,
+            "record_predicate_outcome (passed) must set graph_dirty"
+        );
+    }
+
+    #[test]
+    fn record_predicate_outcome_fail_rerun_sets_graph_dirty() {
+        use crate::verify_predicate::{PredicateOutcome, VerifyPredicate};
+
+        let mut graph = graph_from_nodes(vec![make_node(0, &[])]);
+        graph.tasks[0].status = TaskStatus::Completed;
+        graph.tasks[0].result = Some(TaskResult {
+            output: "bad".to_string(),
+            artifacts: vec![],
+            duration_ms: 1,
+            agent_id: None,
+            agent_def: None,
+        });
+        graph.tasks[0].verify_predicate = Some(VerifyPredicate::Natural("criterion".to_string()));
+        let config = zeph_config::OrchestrationConfig {
+            verify_predicate_enabled: true,
+            max_predicate_replans: 2,
+            ..make_config()
+        };
+        let mut scheduler = DagScheduler::new(
+            graph,
+            &config,
+            Box::new(FirstRouter),
+            vec![make_def("worker")],
+            None,
+        )
+        .unwrap();
+        scheduler.graph.status = GraphStatus::Running;
+
+        scheduler
+            .record_predicate_outcome(
+                TaskId(0),
+                PredicateOutcome {
+                    passed: false,
+                    confidence: 0.1,
+                    reason: "bad output".to_string(),
+                },
+                20,
+            )
+            .unwrap();
+        assert!(
+            scheduler.graph_dirty,
+            "record_predicate_outcome (failed, re-run) must set graph_dirty"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **#4810** — `inject_tasks` and `record_predicate_outcome` mutated task state durably but did not set the `graph_dirty` flag from #4809. A crash between these mutations and the next terminal event would silently lose injected tasks or predicate-resolved states. Fixed by adding `self.graph_dirty = true` after all real mutations in both methods, plus 3 regression tests.
- **#4799** — `recall_fts5_raw`, `recall_vectors_raw`, and `recall_merge_and_rank` (the innermost hot-path helpers called on every `recall()`) were invisible in Perfetto/Jaeger traces. Added `#[cfg_attr(feature = "profiling", tracing::instrument(...))]` matching the existing file pattern.
- **#4822** — All 6 public async functions in `zeph-db` (`DbConfig::connect`, both `run_migrations` variants, `begin`, both `begin_write` variants) lacked tracing coverage. Added unconditional `#[tracing::instrument(skip_all, err)]` — zeph-db has no `profiling` feature gate, consistent with the #4821 precedent.

## Changes

| File | Change |
|------|--------|
| `crates/zeph-orchestration/src/scheduler/persistence.rs` | `graph_dirty = true` in `inject_tasks` + 3 branches of `record_predicate_outcome`; 3 regression tests |
| `crates/zeph-memory/src/semantic/recall.rs` | `#[cfg_attr(profiling, tracing::instrument)]` on `recall_fts5_raw`, `recall_vectors_raw`, `recall_merge_and_rank` |
| `crates/zeph-db/src/pool.rs` | `#[tracing::instrument]` on `DbConfig::connect` |
| `crates/zeph-db/src/migrate.rs` | `#[tracing::instrument]` on both `run_migrations` variants |
| `crates/zeph-db/src/transaction.rs` | `#[tracing::instrument]` on `begin` + both `begin_write` variants |

## Test plan

- `cargo +nightly fmt --check` — clean
- `cargo clippy --workspace -- -D warnings` — 0 warnings
- `cargo nextest run --workspace --lib --bins` — **10499 passed, 21 skipped**
- `cargo check -p zeph-memory --features profiling` — tracing annotations compile
- `cargo check -p zeph-db` — db annotations compile

Closes #4810, Closes #4799, Closes #4822