### PR TITLE
fix(tracing): replace EnteredSpan-across-.await with .instrument() in zeph-context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `fire_shell_hook` in `zeph-subagent/hooks.rs`, making hook dispatch latency visible in local
   Chrome JSON traces. Closes #4805.
 
+- `refactor(context)`: add `#[tracing::instrument]` to four previously uninstrumented `pub async fn`
+  in `zeph-context`: `embed_prepass` and `FidelityScorer::score_and_apply` in `fidelity.rs`, and
+  `CompactionAuditSink::open` / `::flush` in `typed_page.rs`. The remaining four functions listed in
+  #4829 (`ContextAssembler::gather`, `summarize_structured`, `single_pass_summary`,
+  `summarize_with_llm`) were already instrumented by prior PRs. Closes #4829.
+
 - `refactor(orchestration)`: extract `DagScheduler::init_common()` private helper from `::new` and
   `::resume_from`, eliminating ~75 lines of duplicated struct initialization code. Only
   graph-state-specific setup (pre-validation, tracing) differs between the two constructors. Closes #4781.
 
 ### Fixed
+
+- `zeph-context`: replace three synchronous `EnteredSpan` guards held across `.await` boundaries in
+  `fidelity.rs` with `.instrument(span).await` (inline futures) and `#[tracing::instrument]` (function
+  attribute). Affected call sites: `embed_query` (line 273), inline `embed_prepass_dyn` (line 304),
+  `apply_scores` (line 477). Holding a synchronous span guard across an await point silently prevents
+  work-stealing on the tokio multi-thread scheduler. Closes #4828.
 
 - `zeph-agent-context`: replace four synchronous `EnteredSpan` guards held across `.await`
   boundaries with `#[tracing::instrument]` (standalone async fns) and `.instrument(span).await`

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -155,6 +155,7 @@ async fn embed_prepass_dyn(
 ///     let _embeddings = embed_prepass(&messages, &embed, &cfg, 0).await;
 /// }
 /// ```
+#[tracing::instrument(name = "context.fidelity.embed_prepass", skip_all)]
 pub async fn embed_prepass<F>(
     messages: &[Message],
     embed: &F,
@@ -248,6 +249,7 @@ impl FidelityScorer {
     ///
     /// The two providers may be the same instance or different ones (e.g. a fast embedding
     /// model for `embed_provider` and a generative model for `compress_provider`).
+    #[tracing::instrument(name = "context.fidelity.score_and_apply", skip_all)]
     #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     pub async fn score_and_apply(
         &self,
@@ -270,11 +272,11 @@ impl FidelityScorer {
             (config.semantic_scoring_provider.is_some(), embed_provider)
             && p.supports_embeddings()
         {
-            let _span = info_span!("context.fidelity.embed_query").entered();
             match tokio::time::timeout(
                 Duration::from_secs(config.embed_timeout_secs),
                 p.embed(query),
             )
+            .instrument(info_span!("context.fidelity.embed_query"))
             .await
             {
                 Ok(Ok(v)) => Some(v),
@@ -301,13 +303,13 @@ impl FidelityScorer {
             } else {
                 n
             };
-            let _span = info_span!("context.fidelity.embed_prepass").entered();
             let embeddings = embed_prepass_dyn(
                 &messages[..score_end],
                 &ProviderEmbed(p),
                 config,
                 inserted_count,
             )
+            .instrument(info_span!("context.fidelity.embed_prepass"))
             .await;
             for (i, emb) in embeddings {
                 messages[i].metadata.embedding = Some(emb);
@@ -467,6 +469,7 @@ fn compute_scores(
     scores
 }
 
+#[tracing::instrument(name = "context.fidelity.apply", skip_all)]
 async fn apply_scores(
     messages: &mut [Message],
     scores: &[Option<FidelityScore>],
@@ -474,7 +477,6 @@ async fn apply_scores(
     tc: &dyn TokenCounting,
     provider: Option<&dyn LlmProviderDyn>,
 ) {
-    let _apply_span = info_span!("context.fidelity.apply").entered();
     let (mut full_count, mut compressed_count, mut placeholder_count, mut tokens_saved) =
         (0u32, 0u32, 0u32, 0u32);
 

--- a/crates/zeph-context/src/typed_page.rs
+++ b/crates/zeph-context/src/typed_page.rs
@@ -925,6 +925,7 @@ impl CompactionAuditSink {
     /// # Errors
     ///
     /// Returns an error when `path` cannot be opened for appending.
+    #[tracing::instrument(name = "context.typed_page.open", skip_all)]
     pub async fn open(path: &std::path::Path, capacity: usize) -> Result<Self, std::io::Error> {
         use tokio::io::AsyncWriteExt as _;
 
@@ -1000,6 +1001,7 @@ impl CompactionAuditSink {
     /// Sends a `Flush` sentinel through the same channel as records, so ordering is
     /// preserved — the writer task responds only after all preceding records are written.
     /// If the writer task does not respond within 100 ms, the flush times out silently.
+    #[tracing::instrument(name = "context.typed_page.flush", skip_all)]
     pub async fn flush(&self) {
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
         if self.tx.send(AuditCommand::Flush(tx)).await.is_ok() {


### PR DESCRIPTION
## Summary

- Fixes three `span.entered()` guards held across `.await` points in `fidelity.rs` — an async correctness bug that silently prevents work-stealing on the tokio multi-thread scheduler
- Adds `#[tracing::instrument]` to four previously uninstrumented `pub async fn` in `zeph-context`

## Changes

**`crates/zeph-context/src/fidelity.rs`**
- `embed_query` (line ~273): inline span replaced with `.instrument(info_span!(...)).await`
- `embed_prepass_dyn` call (line ~304): inline span replaced with `.instrument(info_span!(...)).await`
- `apply_scores` (line ~477): body-level `.entered()` replaced with `#[tracing::instrument(name = "context.fidelity.apply", skip_all)]` on the function
- `embed_prepass` free fn + `FidelityScorer::score_and_apply`: added `#[tracing::instrument]`

**`crates/zeph-context/src/typed_page.rs`**
- `CompactionAuditSink::open` + `::flush`: added `#[tracing::instrument]`

## Test plan

- [ ] `cargo check -p zeph-context` — clean
- [ ] `cargo clippy -p zeph-context --all-targets -- -D warnings` — clean
- [ ] `cargo nextest run -p zeph-context` — 232/232 pass
- [ ] `cargo nextest run --workspace --lib --bins` — 10496/10496 pass
- [ ] `cargo +nightly fmt --check` — clean

Closes #4828
Closes #4829