### PR TITLE
fix(tracing): replace EnteredSpan-across-.await with .instrument() in zeph-memory

### DIFF
--- a/crates/zeph-memory/src/graph/experience.rs
+++ b/crates/zeph-memory/src/graph/experience.rs
@@ -102,13 +102,12 @@ impl ExperienceStore {
     /// # Errors
     ///
     /// Returns [`MemoryError`] if any database insert fails.
+    #[tracing::instrument(skip_all, name = "memory.experience.link_entities", fields(exp = experience_id.0))]
     pub async fn link_to_entities(
         &self,
         experience_id: ExperienceId,
         entity_ids: &[EntityId],
     ) -> Result<(), MemoryError> {
-        let _span =
-            tracing::info_span!("memory.experience.link_entities", exp = experience_id.0).entered();
         for &entity_id in entity_ids {
             zeph_db::query(sql!(
                 "INSERT INTO experience_entity_links

--- a/crates/zeph-memory/src/graph/implicit_conflict.rs
+++ b/crates/zeph-memory/src/graph/implicit_conflict.rs
@@ -126,6 +126,7 @@ impl ImplicitConflictDetector {
     /// # Errors
     ///
     /// Returns a [`MemoryError`] on database write failure.
+    #[tracing::instrument(skip_all, name = "memory.graph.implicit_conflict.stage", fields(count = candidates.len()))]
     pub async fn stage_candidates(
         &self,
         candidates: &[ConflictCandidate],
@@ -135,12 +136,6 @@ impl ImplicitConflictDetector {
         if candidates.is_empty() {
             return Ok(());
         }
-
-        let _span = tracing::info_span!(
-            "memory.graph.implicit_conflict.stage",
-            count = candidates.len(),
-        )
-        .entered();
 
         #[allow(clippy::cast_possible_wrap)]
         let now = SystemTime::now()
@@ -215,6 +210,7 @@ impl ImplicitConflictDetector {
 /// # Errors
 ///
 /// Returns a [`MemoryError`] on database query failure.
+#[tracing::instrument(skip_all, name = "memory.graph.implicit_conflict.annotate", fields(facts = facts.len()))]
 pub async fn annotate_conflicts(
     facts: &mut [ActivatedFact],
     tx: &mut DbTransaction<'_>,
@@ -222,12 +218,6 @@ pub async fn annotate_conflicts(
     if facts.is_empty() {
         return Ok(());
     }
-
-    let _span = tracing::info_span!(
-        "memory.graph.implicit_conflict.annotate",
-        facts = facts.len(),
-    )
-    .entered();
 
     let edge_ids: Vec<i64> = facts.iter().map(|f| f.edge.id).collect();
 

--- a/crates/zeph-memory/src/graph/retrieval_astar.rs
+++ b/crates/zeph-memory/src/graph/retrieval_astar.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use petgraph::algo::astar;
 use petgraph::graph::{NodeIndex, UnGraph};
+use tracing::Instrument as _;
 
 use crate::embedding_store::EmbeddingStore;
 use crate::error::MemoryError;
@@ -95,7 +96,9 @@ pub(crate) fn cap_node_map<V>(
 /// # Errors
 ///
 /// Returns an error if any database query fails.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+// complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
+#[tracing::instrument(skip_all, name = "memory.graph.astar", fields(query_len = query.len()))]
 pub async fn graph_recall_astar(
     store: &GraphStore,
     embeddings: Option<&EmbeddingStore>,
@@ -110,8 +113,6 @@ pub async fn graph_recall_astar(
     query_sensitive_cost: bool,
     embed_timeout: std::time::Duration,
 ) -> Result<Vec<GraphFact>, MemoryError> {
-    let _span = tracing::info_span!("memory.graph.astar", query_len = query.len()).entered();
-
     if limit == 0 {
         return Ok(Vec::new());
     }
@@ -165,11 +166,12 @@ pub async fn graph_recall_astar(
         match embeddings {
             Some(emb_store) => {
                 const PRISM_EMBED_TIMEOUT: Duration = Duration::from_secs(10);
-                let _embed_span = tracing::info_span!("memory.graph.astar.prism_embed").entered();
+                let prism_span = tracing::info_span!("memory.graph.astar.prism_embed");
                 match tokio::time::timeout(
                     PRISM_EMBED_TIMEOUT,
                     zeph_llm::LlmProvider::embed(provider, query),
                 )
+                .instrument(prism_span)
                 .await
                 {
                     Err(_elapsed) => {

--- a/crates/zeph-memory/src/graph/retrieval_beam.rs
+++ b/crates/zeph-memory/src/graph/retrieval_beam.rs
@@ -29,7 +29,9 @@ const DEFAULT_COMMUNITY_CAP: usize = 3;
 /// # Errors
 ///
 /// Returns an error if any database query fails.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+// complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
+#[tracing::instrument(skip_all, name = "memory.graph.beam", fields(query_len = query.len()))]
 pub async fn graph_recall_beam(
     store: &GraphStore,
     embeddings: Option<&EmbeddingStore>,
@@ -44,8 +46,6 @@ pub async fn graph_recall_beam(
     hebbian_lr: f32,
     embed_timeout: std::time::Duration,
 ) -> Result<Vec<GraphFact>, MemoryError> {
-    let _span = tracing::info_span!("memory.graph.beam", query_len = query.len()).entered();
-
     if limit == 0 {
         return Ok(Vec::new());
     }

--- a/crates/zeph-memory/src/graph/retrieval_watercircles.rs
+++ b/crates/zeph-memory/src/graph/retrieval_watercircles.rs
@@ -31,7 +31,9 @@ const DEFAULT_COMMUNITY_CAP: usize = 3;
 /// # Errors
 ///
 /// Returns an error if any database query fails.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+// complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
+#[tracing::instrument(skip_all, name = "memory.graph.watercircles", fields(query_len = query.len()))]
 pub async fn graph_recall_watercircles(
     store: &GraphStore,
     embeddings: Option<&EmbeddingStore>,
@@ -46,8 +48,6 @@ pub async fn graph_recall_watercircles(
     hebbian_lr: f32,
     embed_timeout: std::time::Duration,
 ) -> Result<Vec<GraphFact>, MemoryError> {
-    let _span = tracing::info_span!("memory.graph.watercircles", query_len = query.len()).entered();
-
     if limit == 0 {
         return Ok(Vec::new());
     }

--- a/crates/zeph-memory/src/graph/strategy_classifier.rs
+++ b/crates/zeph-memory/src/graph/strategy_classifier.rs
@@ -38,9 +38,8 @@ Query: "#;
 /// assert!(["astar", "watercircles", "beam_search", "synapse"].contains(&strategy.as_str()));
 /// # }
 /// ```
+#[tracing::instrument(skip_all, name = "memory.graph.classify_strategy")]
 pub async fn classify_retrieval_strategy(provider: &AnyProvider, query: &str) -> String {
-    let _span = tracing::info_span!("memory.graph.classify_strategy").entered();
-
     let prompt = format!("{CLASSIFY_PROMPT}{query}");
     let messages = [Message {
         role: Role::User,


### PR DESCRIPTION
## Summary

- Fixes 8 locations in `crates/zeph-memory/src/graph/` where a synchronous `Entered<'_>` guard was held across `.await` points, preventing Tokio work-stealing on multi-thread executors
- Replaces `span.entered()` pattern with `#[tracing::instrument(skip_all, name="...", fields(...))]` on 6 async fns and inline `.instrument()` for 1 nested sub-span
- One remaining `.entered()` in `implicit_conflict.rs` (`detect_candidates`) is on a sync fn — left intentionally unchanged

## Changed files

| File | Span | Fix |
|------|------|-----|
| `graph/retrieval_watercircles.rs` | `memory.graph.watercircles` | `#[tracing::instrument]` on `async fn` |
| `graph/retrieval_astar.rs` | `memory.graph.astar` | `#[tracing::instrument]` on `async fn` |
| `graph/retrieval_astar.rs` | `memory.graph.astar.prism_embed` | `.instrument(span).await` inline |
| `graph/retrieval_beam.rs` | `memory.graph.beam` | `#[tracing::instrument]` on `async fn` |
| `graph/experience.rs` | `memory.experience.link_entities` | `#[tracing::instrument]` on `async fn` |
| `graph/implicit_conflict.rs` | `memory.graph.implicit_conflict.stage` | `#[tracing::instrument]` on `async fn` |
| `graph/implicit_conflict.rs` | `memory.graph.implicit_conflict.annotate` | `#[tracing::instrument]` on `async fn` |
| `graph/strategy_classifier.rs` | `memory.graph.classify_strategy` | `#[tracing::instrument]` on `async fn` |

## Test plan

- [x] `cargo +nightly fmt --check -p zeph-memory` — clean
- [x] `cargo clippy -p zeph-memory -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check -p zeph-memory --lib` — clean
- [x] `cargo nextest run -p zeph-memory --lib` — 1451 passed, 0 failed
- [x] Impl-critic adversarial review: APPROVED
- [x] Code review: APPROVED

Closes #4830
Closes #4838