### PR TITLE
fix(plugins): replace blocking std::fs reads with tokio::fs in add_remote_ephemeral

### DIFF
--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -1314,8 +1314,9 @@ impl PluginManager {
         // Read manifest to get skill entries for blocking scan.
         let manifest_path = tmp.path().join("plugin.toml");
         if manifest_path.exists() {
-            let manifest_str =
-                std::fs::read_to_string(&manifest_path).map_err(|e| PluginError::Io {
+            let manifest_str = tokio::fs::read_to_string(&manifest_path)
+                .await
+                .map_err(|e| PluginError::Io {
                     path: manifest_path.clone(),
                     source: e,
                 })?;
@@ -1323,7 +1324,7 @@ impl PluginManager {
                 // Blocking scan: treat any injection match as a hard error.
                 for entry in &manifest.skills {
                     let skill_md_path = tmp.path().join(&entry.path).join("SKILL.md");
-                    if let Ok(content) = std::fs::read_to_string(&skill_md_path) {
+                    if let Ok(content) = tokio::fs::read_to_string(&skill_md_path).await {
                         let result = zeph_skills::scanner::scan_skill_body(&content);
                         if result.has_matches() {
                             return Err(PluginError::SemanticViolation {


### PR DESCRIPTION
## Summary

- Replace two `std::fs::read_to_string` calls in `PluginManager::add_remote_ephemeral` with `tokio::fs::read_to_string(...).await`
- Fixes blocking of the tokio runtime thread during ephemeral plugin security scanning
- Consistent with `read_plugin_source` helper and `add_remote`/`update_one_plugin` in the same file

## Test plan

- [x] `cargo nextest run -p zeph-plugins --lib --bins` — 117/117 passed
- [x] `cargo +nightly fmt --check -p zeph-plugins` — clean
- [x] `cargo clippy -p zeph-plugins -- -D warnings` — zero warnings

## Notes

Tester identified two analogous blocking `std::fs::read_to_string` calls in `add_remote` (lines 587, 631) — out of scope for this PR, tracked separately.

Closes #4839