### PR TITLE
feat(init): add worktree isolation step to --init wizard (#4656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `--init` wizard now includes a worktree isolation step: prompts for `worktree.enabled`, `bg_isolation` (`none`/`worktree`), and `base_ref` (`head`/`fresh`) (#4656)
+
 ### Changed
 
 - `refactor(channels)`: add `#[cfg_attr(feature = "profiling", tracing::instrument)]` to 17

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -2685,10 +2685,12 @@ mod tests {
 
     #[test]
     fn build_config_worktree_enabled_bg_isolation_none() {
-        let mut state = WizardState::default();
-        state.worktree_enabled = true;
-        state.worktree_bg_isolation = BgIsolation::None;
-        state.worktree_base_ref = WorktreeBaseRef::Fresh;
+        let state = WizardState {
+            worktree_enabled: true,
+            worktree_bg_isolation: BgIsolation::None,
+            worktree_base_ref: WorktreeBaseRef::Fresh,
+            ..WizardState::default()
+        };
         let config = build_config(&state);
         assert!(config.worktree.enabled);
         assert_eq!(config.worktree.bg_isolation, BgIsolation::None);

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -4,7 +4,9 @@
 use std::path::PathBuf;
 
 use dialoguer::{Confirm, Input, Password, Select};
-use zeph_config::{GeminiThinkingLevel, ThinkingConfig, VaultBackend};
+use zeph_config::{
+    BgIsolation, GeminiThinkingLevel, ThinkingConfig, VaultBackend, WorktreeBaseRef,
+};
 use zeph_core::config::{
     AcpConfig, ChannelSkillsConfig, Config, DiscordConfig, LlmConfig, LlmRoutingStrategy,
     McpServerConfig, McpTrustLevel, MemoryConfig, OrchestrationConfig, ProviderEntry, ProviderKind,
@@ -19,12 +21,14 @@ pub(super) mod llm;
 pub(super) mod mcp;
 pub(super) mod memory;
 pub(super) mod security;
+pub(super) mod worktree;
 
 use agents::{step_agents, step_learning, step_orchestration, step_router};
 use llm::step_llm;
 use mcp::{step_mcp_discovery, step_mcp_remote, step_mcpls, write_mcpls_config};
 use memory::{step_context_compression, step_memory};
 use security::{step_policy, step_sandbox, step_security, step_trajectory};
+use worktree::step_worktree;
 
 #[cfg_attr(test, derive(Clone))]
 #[allow(clippy::struct_excessive_bools)]
@@ -255,6 +259,10 @@ pub(crate) struct WizardState {
     // CAM fidelity (#4547)
     /// Enable heuristic fidelity scoring (Full/Compressed/Placeholder).
     pub(crate) fidelity_enabled: bool,
+    // Worktree isolation for sub-agents (#4656)
+    pub(crate) worktree_enabled: bool,
+    pub(crate) worktree_bg_isolation: BgIsolation,
+    pub(crate) worktree_base_ref: WorktreeBaseRef,
 }
 
 impl Default for WizardState {
@@ -431,6 +439,9 @@ impl Default for WizardState {
             cocoon_wants_access_hash: false,
             cocoon_show_balance: true,
             fidelity_enabled: false,
+            worktree_enabled: false,
+            worktree_bg_isolation: BgIsolation::Worktree,
+            worktree_base_ref: WorktreeBaseRef::Head,
         }
     }
 }
@@ -486,6 +497,7 @@ pub fn run(output: Option<PathBuf>) -> anyhow::Result<()> {
     step_mcp_discovery(&mut state)?;
     step_lsp_context(&mut state)?;
     step_agents(&mut state)?;
+    step_worktree(&mut state)?;
     step_router(&mut state)?;
     step_learning(&mut state)?;
     step_security(&mut state)?;
@@ -889,6 +901,13 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
         .user_agents_dir
         .clone_from(&state.agents_user_dir);
     config.agents.default_memory_scope = state.agents_default_memory_scope;
+
+    // Worktree isolation for sub-agents (#4656)
+    if state.worktree_enabled {
+        config.worktree.enabled = true;
+        config.worktree.bg_isolation = state.worktree_bg_isolation;
+        config.worktree.base_ref = state.worktree_base_ref.clone();
+    }
 
     match state.detector_mode.as_deref() {
         Some("judge") => {
@@ -2655,5 +2674,24 @@ mod tests {
         let config = build_config(&state);
         let p = &config.llm.providers[0];
         assert!(p.cocoon_access_hash.is_none());
+    }
+
+    #[test]
+    fn build_config_worktree_disabled_by_default() {
+        let state = WizardState::default();
+        let config = build_config(&state);
+        assert!(!config.worktree.enabled);
+    }
+
+    #[test]
+    fn build_config_worktree_enabled_bg_isolation_none() {
+        let mut state = WizardState::default();
+        state.worktree_enabled = true;
+        state.worktree_bg_isolation = BgIsolation::None;
+        state.worktree_base_ref = WorktreeBaseRef::Fresh;
+        let config = build_config(&state);
+        assert!(config.worktree.enabled);
+        assert_eq!(config.worktree.bg_isolation, BgIsolation::None);
+        assert!(matches!(config.worktree.base_ref, WorktreeBaseRef::Fresh));
     }
 }

--- a/src/init/worktree.rs
+++ b/src/init/worktree.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use dialoguer::{Confirm, Select};
+use zeph_config::{BgIsolation, WorktreeBaseRef};
+
+use super::WizardState;
+
+/// Interactive wizard step that configures `[worktree]` in the generated config.
+///
+/// When the user opts in, prompts for `base_ref` and `bg_isolation`. When the
+/// user opts out, the fields remain at their defaults (`enabled = false`) and
+/// the step returns immediately.
+///
+/// # Errors
+///
+/// Returns an error when a `dialoguer` prompt fails (e.g., non-interactive TTY).
+pub(super) fn step_worktree(state: &mut WizardState) -> anyhow::Result<()> {
+    println!("== Worktree Isolation ==\n");
+    println!(
+        "Enables per-subagent git worktree isolation. Each subagent that opts in \
+         receives a dedicated branch, preventing concurrent agents from conflicting \
+         with the working copy.\n"
+    );
+
+    state.worktree_enabled = Confirm::new()
+        .with_prompt("Enable git worktree isolation for sub-agents?")
+        .default(false)
+        .interact()?;
+
+    if !state.worktree_enabled {
+        println!();
+        return Ok(());
+    }
+
+    let base_ref_items = &[
+        "head (branch from local HEAD — no network required)",
+        "fresh (fetch origin/<default_branch> first — starts from latest remote state)",
+    ];
+    let base_ref_idx = Select::new()
+        .with_prompt("Base ref for new worktree branches")
+        .items(base_ref_items)
+        .default(0)
+        .interact()?;
+    state.worktree_base_ref = match base_ref_idx {
+        1 => {
+            println!(
+                "  Note: adjust worktree.default_branch in config.toml if your default branch is not 'main'."
+            );
+            WorktreeBaseRef::Fresh
+        }
+        _ => WorktreeBaseRef::Head,
+    };
+
+    let bg_isolation_items = &[
+        "worktree (background agents get dedicated git worktrees — recommended)",
+        "none (background agents edit the working copy directly)",
+    ];
+    let bg_isolation_idx = Select::new()
+        .with_prompt("Background agent isolation mode")
+        .items(bg_isolation_items)
+        .default(0)
+        .interact()?;
+    state.worktree_bg_isolation = match bg_isolation_idx {
+        1 => BgIsolation::None,
+        _ => BgIsolation::Worktree,
+    };
+
+    println!();
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add `step_worktree()` to the interactive `--init` configuration wizard
- Prompts for `worktree.enabled`, `bg_isolation` (`none`/`worktree`), and `base_ref` (`head`/`fresh`)
- When user selects `base_ref = fresh`, a note reminds to adjust `worktree.default_branch` if the default branch is not `main`
- `build_config()` emits the `[worktree]` section only when the user opts in (`enabled = true`)

Closes #4656

## Changes

- **`src/init/worktree.rs`** (new) — `step_worktree()` following the established wizard step pattern
- **`src/init/mod.rs`** — new module, `WizardState` fields with defaults, step call in `run()`, config mapping in `build_config()`, 2 unit tests
- **`CHANGELOG.md`** — `[Unreleased]` entry

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph -- -D warnings` — zero warnings
- [x] `cargo nextest run -p zeph --lib` — 336/336 pass (including `build_config_worktree_disabled_by_default` and `build_config_worktree_enabled_bg_isolation_none`)
- [x] `RUSTFLAGS="-D warnings" cargo check -p zeph --all-targets --locked` — clean
- [ ] Live `--init` wizard run (requires interactive TTY — see playbook `playbooks/worktree.md` Scenario 11)