### PR TITLE
fix(orchestration): set graph_dirty on all terminal transitions; instrument PlanCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `refactor(orchestration)`: add `#[tracing::instrument]` to `PlanCache::find_similar` and
   `PlanCache::cache_plan` in `plan_cache.rs`, making plan-cache lookup and store latency visible
   as child spans inside `orchestration.plan_cache.plan`. Closes #4807.
+- `refactor(orchestration)`: add `#[tracing::instrument]` to `PlanCache::new` and `PlanCache::evict`,
+  recording `current_embedding_model` on init and making eviction latency visible in traces (#4835)
 - `refactor(llm)`: add `#[cfg_attr(feature = "profiling", tracing::instrument)]` to
   `OllamaProvider::chat_with_tools`, completing profiling coverage across all `LlmProvider`
   backends (Claude, OpenAI, Gemini, Compatible, Ollama). Closes #4824.
@@ -41,6 +43,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   graph-state-specific setup (pre-validation, tracing) differs between the two constructors. Closes #4781.
 
 ### Fixed
+
+- `fix(orchestration)`: `check_graph_completion` deadlock→Failed branch now sets `graph_dirty` flag,
+  preventing silent loss of terminal status on crash (#4832)
 
 - `zeph-context`: replace three synchronous `EnteredSpan` guards held across `.await` boundaries in
   `fidelity.rs` with `.instrument(span).await` (inline futures) and `#[tracing::instrument]` (function

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -243,6 +243,11 @@ impl PlanCache {
     /// # Errors
     ///
     /// Returns `PlanCacheError` if the stale embedding invalidation query fails.
+    #[tracing::instrument(
+        name = "orchestration.plan_cache.new",
+        skip_all,
+        fields(current_embedding_model = current_embedding_model)
+    )]
     pub async fn new(
         pool: DbPool,
         config: PlanCacheConfig,
@@ -416,6 +421,7 @@ impl PlanCache {
     /// # Errors
     ///
     /// Returns `PlanCacheError::Database` on query failure.
+    #[tracing::instrument(name = "orchestration.plan_cache.evict", skip_all)]
     pub async fn evict(&self) -> Result<u32, PlanCacheError> {
         let now = unix_now();
         let ttl_secs = i64::from(self.config.ttl_days) * 86_400;

--- a/crates/zeph-orchestration/src/scheduler/planner.rs
+++ b/crates/zeph-orchestration/src/scheduler/planner.rs
@@ -116,6 +116,7 @@ impl DagScheduler {
         if all_terminal {
             self.graph.status = GraphStatus::Completed;
             self.graph.finished_at = Some(crate::graph::chrono_now());
+            self.graph_dirty = true;
             return vec![SchedulerAction::Done {
                 status: GraphStatus::Completed,
             }];
@@ -138,6 +139,7 @@ impl DagScheduler {
             );
             self.graph.status = GraphStatus::Failed;
             self.graph.finished_at = Some(crate::graph::chrono_now());
+            self.graph_dirty = true;
             debug_assert!(
                 self.running.is_empty(),
                 "deadlock branch reached with non-empty running map"


### PR DESCRIPTION
## Summary

- **#4832** — `check_graph_completion` was missing `graph_dirty = true` in the deadlock→Failed branch. `scheduler_loop.rs` gates all persistence on `take_graph_dirty` with no unconditional final save, so a crash after the status flip but before the next save would silently lose the terminal `Failed` status. Fix: set `graph_dirty = true` in both the `Completed` and `deadlock→Failed` branches of `check_graph_completion`, making every terminal transition consistently mark the graph for persistence.

- **#4835** — `PlanCache::new` and `PlanCache::evict` lacked `#[tracing::instrument]`. Added with span names following the `orchestration.plan_cache.*` convention; `new` records `current_embedding_model`, `evict` records no fields (eviction metrics already logged internally).

- **#4836** — `AdaptOrch::recommend` was already instrumented via `.instrument(tracing::info_span!(...))` in commit d9a1dee2 (PR #4109). Verified equivalent to `#[tracing::instrument]`; no code change needed.

## Test plan

- [ ] `cargo +nightly fmt --check` — passes
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10499/10499 passed
- [ ] Only 3 files changed, no public API modifications, no doc breakage

Closes #4832, #4835, #4836