### PR TITLE
refactor(acp): add #[tracing::instrument] to permission check and HTTP transport handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `::resume_from`, eliminating ~75 lines of duplicated struct initialization code. Only
   graph-state-specific setup (pre-validation, tracing) differs between the two constructors. Closes #4781.
 
+- `refactor(acp)`: add `#[tracing::instrument]` to `AcpPermissionGate::check_permission`
+  (`acp.permission.check`) and 5 HTTP transport handlers in `transport/http.rs`
+  (`acp.http.post`, `acp.http.get`, `acp.http.health`, `acp.http.list_sessions`,
+  `acp.http.session_messages`), making ACP permission round-trip and HTTP session latency
+  visible in traces. Closes #4837, #4806, #4842.
+
 ### Fixed
 
 - `fix(orchestration)`: `check_graph_completion` deadlock→Failed branch now sets `graph_dirty` flag,

--- a/crates/zeph-acp/src/permission.rs
+++ b/crates/zeph-acp/src/permission.rs
@@ -281,6 +281,7 @@ impl AcpPermissionGate {
     ///
     /// Returns `AcpError::ChannelClosed` when the `LocalSet` handler has exited,
     /// or `AcpError::ClientError` when the IDE returns a protocol error.
+    #[tracing::instrument(skip_all, name = "acp.permission.check", fields(session_id = %session_id))]
     pub async fn check_permission(
         &self,
         session_id: acp::schema::SessionId,

--- a/crates/zeph-acp/src/transport/http.rs
+++ b/crates/zeph-acp/src/transport/http.rs
@@ -290,6 +290,7 @@ impl AcpHttpState {
 ///
 /// Returns `503 Service Unavailable` until the ACP server marks itself ready.
 #[cfg(feature = "acp-http")]
+#[tracing::instrument(skip_all, name = "acp.http.health")]
 pub async fn health_handler(State(state): State<AcpHttpState>) -> impl IntoResponse {
     let ready = state.ready.load(Ordering::Acquire);
     let status = if ready {
@@ -388,6 +389,7 @@ pub(crate) fn create_connection(
 /// Returns `500 Internal Server Error` if writing to the agent channel fails.
 /// Returns `503 Service Unavailable` if `max_sessions` is reached.
 #[cfg(feature = "acp-http")]
+#[tracing::instrument(skip_all, name = "acp.http.post")]
 pub async fn post_handler(
     State(state): State<AcpHttpState>,
     headers: HeaderMap,
@@ -454,6 +456,7 @@ pub async fn post_handler(
 /// Returns `400 Bad Request` if `Acp-Session-Id` header is missing or not a valid UUID.
 /// Returns `404 Not Found` if the session ID is not found.
 #[cfg(feature = "acp-http")]
+#[tracing::instrument(skip_all, name = "acp.http.get")]
 pub async fn get_handler(
     State(state): State<AcpHttpState>,
     headers: HeaderMap,
@@ -497,6 +500,7 @@ pub async fn get_handler(
 /// Returns `503 Service Unavailable` if no `SQLite` store is configured.
 /// Returns `500 Internal Server Error` if the database query fails.
 #[cfg(feature = "acp-http")]
+#[tracing::instrument(skip_all, name = "acp.http.list_sessions")]
 pub async fn list_sessions_handler(
     State(state): State<AcpHttpState>,
 ) -> Result<impl IntoResponse, StatusCode> {
@@ -526,6 +530,7 @@ pub async fn list_sessions_handler(
 /// Returns `404 Not Found` if the session does not exist.
 /// Returns `500 Internal Server Error` if the database query fails.
 #[cfg(feature = "acp-http")]
+#[tracing::instrument(skip_all, name = "acp.http.session_messages", fields(session_id = %session_id))]
 pub async fn session_messages_handler(
     State(state): State<AcpHttpState>,
     Path(session_id): Path<String>,


### PR DESCRIPTION
## Summary

- `AcpPermissionGate::check_permission` (`permission.rs`) now emits span `acp.permission.check` with `session_id` field, making IDE round-trip latency visible in local Chrome JSON traces.
- Five HTTP transport handlers in `transport/http.rs` now emit `acp.http.health`, `acp.http.post`, `acp.http.get`, `acp.http.list_sessions`, `acp.http.session_messages` spans, completing HTTP-path trace coverage (the stdio/JSON-RPC path in `agent/mod.rs` already had 14 handler spans).
- Issue #4842 (3 fns in `summarization.rs`) was confirmed as a false positive by CI-975: all three target functions were already instrumented by prior PRs — this PR resolves the issue as "already done".

## Changes

| File | Change |
|------|--------|
| `crates/zeph-acp/src/permission.rs` | `+1` line: `#[tracing::instrument]` on `check_permission` |
| `crates/zeph-acp/src/transport/http.rs` | `+5` lines: `#[tracing::instrument]` on 5 HTTP handlers |
| `CHANGELOG.md` | Entry in `[Unreleased] ### Changed` |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-acp -p zeph-context -- -D warnings` — 0 warnings
- [x] `RUSTFLAGS="-D warnings" cargo check -p zeph-acp -p zeph-context --all-targets --locked` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9510 passed, 0 failed, 21 skipped (integration)

Closes #4837, #4806, #4842.