### PR TITLE
refactor(tracing): add #[tracing::instrument] to channels, skills, and mcp hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(tracing)`: complete tracing instrumentation sweep across `zeph-channels`,
+  `zeph-skills`, and `zeph-mcp` (issues #4849, #4827, #4819):
+  - **zeph-channels**: add always-on `#[tracing::instrument]` to all hot-path async fns in
+    `telegram.rs` and `cli.rs`; unify span namespace from `channel.*` to `channels.*` across all
+    6 channel source files (discord, slack, telegram_api_ext, telegram_moderation — 46 spans total).
+  - **zeph-skills**: add `#[cfg_attr(feature = "profiling", tracing::instrument)]` to 13 pub async
+    fns across `proactive.rs`, `trace_extractor.rs`, `semantic_scanner.rs`, `miner.rs`,
+    `qdrant_matcher.rs`, `evaluator.rs`, `generator.rs`; remove redundant inner `.instrument()`
+    calls; rename stale `core.proactive.classify` span to `skills.proactive.classify`.
+  - **zeph-mcp**: add `#[cfg_attr(feature = "profiling", tracing::instrument)]` to 21 pub async
+    fns across 8 files (`manager.rs`, `client.rs`, `trust_score.rs`, `pruning.rs`,
+    `semantic_index.rs`, `registry.rs`, `prober.rs`, `oauth.rs`).
+  Span naming convention: `<crate>.<module>.<operation>` throughout.
+  Closes #4849, #4827, #4819.
+
 - `refactor(channels)`: add `#[cfg_attr(feature = "profiling", tracing::instrument)]` to 17
   uninstrumented async fns in `zeph-channels` — Telegram API ext (8 fns), Discord REST client
   (4 fns), and Slack API client (4 fns) plus `bot_is_admin` in telegram moderation. Span names

--- a/crates/zeph-channels/src/cli.rs
+++ b/crates/zeph-channels/src/cli.rs
@@ -383,10 +383,7 @@ impl Channel for CliChannel {
     /// This method is cancel-safe: dropping the future does not discard any
     /// buffered input. The background stdin reader task buffers messages in an
     /// mpsc channel; they remain available on the next `recv()` call.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "channel.cli.recv", skip_all, fields(msg_len = tracing::field::Empty))
-    )]
+    #[tracing::instrument(name = "channels.cli.recv", skip_all, fields(msg_len = tracing::field::Empty))]
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
         Ok(self.ensure_reader().recv().await)
     }
@@ -403,10 +400,7 @@ impl Channel for CliChannel {
     ///
     /// [`send_chunk`]: CliChannel::send_chunk
     /// [`flush_chunks`]: CliChannel::flush_chunks
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "channel.cli.send", skip_all, fields(msg_len = %text.len()))
-    )]
+    #[tracing::instrument(name = "channels.cli.send", skip_all, fields(msg_len = %text.len()))]
     async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
         println!("Zeph: {text}");
         Ok(())
@@ -423,6 +417,7 @@ impl Channel for CliChannel {
     /// Returns `Err` if the stdout flush fails.
     ///
     /// [`flush_chunks`]: CliChannel::flush_chunks
+    #[tracing::instrument(name = "channels.cli.send_chunk", skip_all, fields(chunk_len = chunk.len()))]
     async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
         use std::io::{Write, stdout};
         print!("{chunk}");
@@ -439,6 +434,7 @@ impl Channel for CliChannel {
     /// # Errors
     ///
     /// Always returns `Ok(())`.
+    #[tracing::instrument(name = "channels.cli.flush_chunks", skip_all)]
     async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
         println!();
         self.accumulated.clear();
@@ -455,6 +451,7 @@ impl Channel for CliChannel {
     ///
     /// Returns `Err` if spawning the blocking task fails or if the underlying
     /// readline call returns an I/O error.
+    #[tracing::instrument(name = "channels.cli.confirm", skip_all)]
     async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
         if !std::io::stdin().is_terminal() {
             tracing::debug!("non-interactive stdin, auto-declining confirmation");
@@ -493,6 +490,7 @@ impl Channel for CliChannel {
     /// [`ElicitationFieldType`]: zeph_core::channel::ElicitationFieldType
     /// [`ElicitationResponse::Declined`]: zeph_core::channel::ElicitationResponse::Declined
     /// [`ElicitationResponse::Cancelled`]: zeph_core::channel::ElicitationResponse::Cancelled
+    #[tracing::instrument(name = "channels.cli.elicit", skip_all, fields(server = %request.server_name))]
     async fn elicit(
         &mut self,
         request: ElicitationRequest,

--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -93,7 +93,7 @@ impl DiscordChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.send_or_edit", skip_all, level = "debug", fields(buf_len = %self.buffer.len()))
+        tracing::instrument(name = "channels.discord.send_or_edit", skip_all, level = "debug", fields(buf_len = %self.buffer.len()))
     )]
     async fn send_or_edit(&mut self) -> Result<(), ChannelError> {
         let channel_id = self
@@ -174,7 +174,7 @@ impl Channel for DiscordChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.recv", skip_all, fields(msg_len = tracing::field::Empty))
+        tracing::instrument(name = "channels.discord.recv", skip_all, fields(msg_len = tracing::field::Empty))
     )]
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
         loop {
@@ -205,7 +205,7 @@ impl Channel for DiscordChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.send", skip_all, fields(msg_len = %text.len()))
+        tracing::instrument(name = "channels.discord.send", skip_all, fields(msg_len = %text.len()))
     )]
     async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
         let channel_id = self
@@ -232,7 +232,7 @@ impl Channel for DiscordChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.send_chunk", skip_all, level = "debug", fields(chunk_len = %chunk.len()))
+        tracing::instrument(name = "channels.discord.send_chunk", skip_all, level = "debug", fields(chunk_len = %chunk.len()))
     )]
     async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
         self.buffer.push(chunk);
@@ -244,7 +244,7 @@ impl Channel for DiscordChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.flush_chunks", skip_all, level = "debug")
+        tracing::instrument(name = "channels.discord.flush_chunks", skip_all, level = "debug")
     )]
     async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
         if self.message_id.is_some() || !self.buffer.is_empty() {
@@ -257,7 +257,7 @@ impl Channel for DiscordChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.send_typing", skip_all, level = "debug")
+        tracing::instrument(name = "channels.discord.send_typing", skip_all, level = "debug")
     )]
     async fn send_typing(&mut self) -> Result<(), ChannelError> {
         let Some(channel_id) = self.channel_id.as_deref() else {
@@ -283,7 +283,7 @@ impl Channel for DiscordChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.confirm", skip_all, fields(prompt_len = %prompt.len()))
+        tracing::instrument(name = "channels.discord.confirm", skip_all, fields(prompt_len = %prompt.len()))
     )]
     async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
         self.send(&format!(

--- a/crates/zeph-channels/src/discord/rest.rs
+++ b/crates/zeph-channels/src/discord/rest.rs
@@ -156,7 +156,7 @@ impl RestClient {
     /// Returns an error if the HTTP request fails or rate-limit retries are exhausted.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.rest.send_message", skip_all)
+        tracing::instrument(name = "channels.discord.rest.send_message", skip_all)
     )]
     pub async fn send_message(
         &self,
@@ -181,7 +181,7 @@ impl RestClient {
     /// Returns an error if the HTTP request fails or rate-limit retries are exhausted.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.rest.edit_message", skip_all)
+        tracing::instrument(name = "channels.discord.rest.edit_message", skip_all)
     )]
     pub async fn edit_message(
         &self,
@@ -209,7 +209,7 @@ impl RestClient {
     /// never returns an error (fire-and-forget caller pattern).
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.rest.register_slash_commands", skip_all)
+        tracing::instrument(name = "channels.discord.rest.register_slash_commands", skip_all)
     )]
     pub async fn register_slash_commands(&self) {
         let app_id = match self
@@ -252,7 +252,7 @@ impl RestClient {
     /// Returns an error if the HTTP request fails or rate-limit retries are exhausted.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.discord.rest.trigger_typing", skip_all)
+        tracing::instrument(name = "channels.discord.rest.trigger_typing", skip_all)
     )]
     pub async fn trigger_typing(&self, channel_id: &str) -> Result<(), reqwest::Error> {
         let url = format!("{BASE_URL}/channels/{channel_id}/typing");

--- a/crates/zeph-channels/src/slack/api.rs
+++ b/crates/zeph-channels/src/slack/api.rs
@@ -62,7 +62,7 @@ impl SlackApi {
     /// Returns an error if the HTTP request or Slack API fails.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.auth_test", skip_all)
+        tracing::instrument(name = "channels.slack.auth_test", skip_all)
     )]
     pub async fn auth_test(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let resp: Value = tokio::time::timeout(
@@ -99,7 +99,7 @@ impl SlackApi {
     /// Returns an error if the HTTP request or Slack API fails.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.post_message", skip_all)
+        tracing::instrument(name = "channels.slack.post_message", skip_all)
     )]
     pub async fn post_message(
         &self,
@@ -136,7 +136,7 @@ impl SlackApi {
     /// Returns an error if the HTTP request or Slack API fails.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.update_message", skip_all)
+        tracing::instrument(name = "channels.slack.update_message", skip_all)
     )]
     pub async fn update_message(
         &self,
@@ -172,7 +172,7 @@ impl SlackApi {
     /// Returns an error if the HTTP request fails or the response status is not success.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.download_file", skip_all)
+        tracing::instrument(name = "channels.slack.download_file", skip_all)
     )]
     pub async fn download_file(
         &self,

--- a/crates/zeph-channels/src/slack/mod.rs
+++ b/crates/zeph-channels/src/slack/mod.rs
@@ -106,7 +106,7 @@ impl SlackChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.send_or_edit", skip_all, level = "debug", fields(buf_len = %self.buffer.len()))
+        tracing::instrument(name = "channels.slack.send_or_edit", skip_all, level = "debug", fields(buf_len = %self.buffer.len()))
     )]
     async fn send_or_edit(&mut self) -> Result<(), ChannelError> {
         let channel_id = self
@@ -166,7 +166,7 @@ impl Channel for SlackChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.recv", skip_all, fields(msg_len = tracing::field::Empty))
+        tracing::instrument(name = "channels.slack.recv", skip_all, fields(msg_len = tracing::field::Empty))
     )]
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
         let Some(incoming) = self.rx.recv().await else {
@@ -203,7 +203,7 @@ impl Channel for SlackChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.send", skip_all, fields(msg_len = %text.len()))
+        tracing::instrument(name = "channels.slack.send", skip_all, fields(msg_len = %text.len()))
     )]
     async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
         let channel_id = self
@@ -220,7 +220,7 @@ impl Channel for SlackChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.send_chunk", skip_all, level = "debug", fields(chunk_len = %chunk.len()))
+        tracing::instrument(name = "channels.slack.send_chunk", skip_all, level = "debug", fields(chunk_len = %chunk.len()))
     )]
     async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
         self.buffer.push(chunk);
@@ -232,7 +232,7 @@ impl Channel for SlackChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.flush_chunks", skip_all, level = "debug")
+        tracing::instrument(name = "channels.slack.flush_chunks", skip_all, level = "debug")
     )]
     async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
         if self.message_ts.is_some() || !self.buffer.is_empty() {
@@ -259,7 +259,7 @@ impl Channel for SlackChannel {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.slack.confirm", skip_all, fields(prompt_len = %prompt.len()))
+        tracing::instrument(name = "channels.slack.confirm", skip_all, fields(prompt_len = %prompt.len()))
     )]
     async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
         self.send(&format!(

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -451,6 +451,7 @@ impl TelegramChannel {
         }
     }
 
+    #[tracing::instrument(name = "channels.telegram.send_or_edit", skip_all)]
     async fn send_or_edit(&mut self) -> Result<(), ChannelError> {
         let Some(chat_id) = self.chat_id else {
             return Err(ChannelError::NoActiveSession);
@@ -686,6 +687,7 @@ fn spawn_guest_proxy(
 ///    correctly and the same updates are never replayed.  Teloxide's
 ///    `Update::filter_message()` handler simply ignores unknown `UpdateKind`
 ///    variants, so the extra entries are silently dropped by the dispatcher.
+#[tracing::instrument(name = "channels.telegram.proxy_handler", skip_all)]
 async fn proxy_handler(State(state): State<GuestProxyState>, req: Request<Body>) -> Response {
     // Path structure from teloxide: /bot<TOKEN>/<method>
     // proxy_url passed to Bot::set_api_url is http://127.0.0.1:<port>/bot<TOKEN>
@@ -787,6 +789,7 @@ async fn proxy_handler(State(state): State<GuestProxyState>, req: Request<Body>)
 }
 
 /// Parse a raw `guest_message` JSON value and forward it to the agent.
+#[tracing::instrument(name = "channels.telegram.extract_and_forward_guest_message", skip_all)]
 async fn extract_and_forward_guest_message(
     gm_val: &serde_json::Value,
     tx: &mpsc::Sender<IncomingMessage>,
@@ -872,6 +875,7 @@ fn compute_chain_depth(msg: &Message, cap: u32) -> u32 {
 /// attachments, and forwards the assembled [`IncomingMessage`] to the agent
 /// via `tx`.  Returns `respond(())` in all branches so teloxide considers the
 /// update handled.
+#[tracing::instrument(name = "channels.telegram.handle_message", skip_all)]
 #[allow(clippy::too_many_arguments)]
 async fn handle_telegram_message(
     bot: Bot,
@@ -982,6 +986,7 @@ async fn handle_telegram_message(
     respond(())
 }
 
+#[tracing::instrument(name = "channels.telegram.download_file", skip(bot), fields(file_id))]
 async fn download_file(bot: &Bot, file_id: String, capacity: u32) -> Result<Vec<u8>, String> {
     use teloxide::net::Download;
 
@@ -1039,10 +1044,7 @@ impl Channel for TelegramChannel {
     /// # Errors
     ///
     /// Returns `Err` if sending the welcome reply for `/start` fails.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "channel.telegram.recv", skip_all, fields(msg_len = tracing::field::Empty))
-    )]
+    #[tracing::instrument(name = "channels.telegram.recv", skip_all, fields(msg_len = tracing::field::Empty))]
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
         loop {
             let Some(incoming) = self.rx.recv().await else {
@@ -1105,10 +1107,7 @@ impl Channel for TelegramChannel {
     /// Returns `Err(ChannelError::NoActiveSession)` if no active chat has been
     /// established yet (i.e. `recv` has never returned a message), or
     /// `Err(ChannelError::Telegram)` if the Telegram API call fails.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "channel.telegram.send", skip_all, fields(msg_len = %text.len()))
-    )]
+    #[tracing::instrument(name = "channels.telegram.send", skip_all, fields(msg_len = %text.len()))]
     async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
         // Guest context: accumulate full response — flush_chunks calls answerGuestQuery once.
         if self.guest_query_id.is_some() {
@@ -1196,6 +1195,7 @@ impl Channel for TelegramChannel {
     /// # Errors
     ///
     /// Returns `Err` if the final Telegram edit fails.
+    #[tracing::instrument(name = "channels.telegram.flush_chunks", skip_all)]
     async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
         tracing::debug!(
             "flushing chunks (message_id: {:?}, accumulated: {} bytes)",
@@ -1250,6 +1250,7 @@ impl Channel for TelegramChannel {
     /// # Errors
     ///
     /// Returns `Err` if the Telegram API call fails.
+    #[tracing::instrument(name = "channels.telegram.send_typing", skip_all)]
     async fn send_typing(&mut self) -> Result<(), ChannelError> {
         let Some(chat_id) = self.chat_id else {
             return Ok(());
@@ -1277,6 +1278,7 @@ impl Channel for TelegramChannel {
     /// Returns `Err` if sending the prompt message fails.
     ///
     /// [`CONFIRM_TIMEOUT`]: crate::CONFIRM_TIMEOUT
+    #[tracing::instrument(name = "channels.telegram.confirm", skip_all)]
     async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
         self.send(&format!(
             "{prompt}\nReply 'yes' to confirm (timeout: {}s).",
@@ -1340,6 +1342,7 @@ impl Channel for TelegramChannel {
     /// [`ELICITATION_TIMEOUT`]: crate::ELICITATION_TIMEOUT
     /// [`ElicitationResponse::Cancelled`]: zeph_core::channel::ElicitationResponse::Cancelled
     /// [`ElicitationResponse::Declined`]: zeph_core::channel::ElicitationResponse::Declined
+    #[tracing::instrument(name = "channels.telegram.elicit", skip_all, fields(server = %request.server_name))]
     async fn elicit(
         &mut self,
         request: ElicitationRequest,

--- a/crates/zeph-channels/src/telegram_api_ext.rs
+++ b/crates/zeph-channels/src/telegram_api_ext.rs
@@ -259,7 +259,7 @@ impl TelegramApiClient {
     /// ```
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.telegram.get_me", skip_all)
+        tracing::instrument(name = "channels.telegram.get_me", skip_all)
     )]
     pub async fn get_me(&self) -> Result<GuestUser, TelegramApiError> {
         self.post("getMe", &serde_json::json!({})).await
@@ -359,7 +359,7 @@ impl TelegramApiClient {
     /// ```
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.telegram.answer_guest_query", skip_all)
+        tracing::instrument(name = "channels.telegram.answer_guest_query", skip_all)
     )]
     pub async fn answer_guest_query(
         &self,
@@ -405,7 +405,7 @@ impl TelegramApiClient {
     /// ```
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.telegram.get_managed_bot_access_settings", skip_all)
+        tracing::instrument(name = "channels.telegram.get_managed_bot_access_settings", skip_all)
     )]
     pub async fn get_managed_bot_access_settings(
         &self,
@@ -439,7 +439,7 @@ impl TelegramApiClient {
     /// ```
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.telegram.set_managed_bot_access_settings", skip_all)
+        tracing::instrument(name = "channels.telegram.set_managed_bot_access_settings", skip_all)
     )]
     pub async fn set_managed_bot_access_settings(
         &self,
@@ -477,7 +477,7 @@ impl TelegramApiClient {
     /// ```
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.telegram.delete_message_reaction", skip_all)
+        tracing::instrument(name = "channels.telegram.delete_message_reaction", skip_all)
     )]
     pub async fn delete_message_reaction(
         &self,
@@ -533,7 +533,7 @@ impl TelegramApiClient {
     /// ```
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.telegram.get_chat_member", skip_all)
+        tracing::instrument(name = "channels.telegram.get_chat_member", skip_all)
     )]
     pub async fn get_chat_member(
         &self,
@@ -576,7 +576,7 @@ impl TelegramApiClient {
     /// ```
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.telegram.delete_all_message_reactions", skip_all)
+        tracing::instrument(name = "channels.telegram.delete_all_message_reactions", skip_all)
     )]
     pub async fn delete_all_message_reactions(
         &self,

--- a/crates/zeph-channels/src/telegram_moderation.rs
+++ b/crates/zeph-channels/src/telegram_moderation.rs
@@ -76,7 +76,7 @@ impl TelegramModerationBackend {
     /// Returns [`ModerationError`] on API or transport failure.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "channel.telegram.bot_is_admin", skip_all)
+        tracing::instrument(name = "channels.telegram.bot_is_admin", skip_all)
     )]
     pub async fn bot_is_admin(
         &self,

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -763,6 +763,10 @@ impl McpClient {
     ///
     /// Returns `McpError::OAuthError` if token exchange fails or the connection
     /// cannot be established.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.client.complete_oauth", skip(pending, code, csrf_token))
+    )]
     pub async fn complete_oauth(
         mut pending: OAuthPending,
         code: &str,
@@ -954,6 +958,10 @@ impl McpClient {
     /// List resource descriptions for injection scanning (probe path).
     ///
     /// Returns an empty vec if the server does not support resources or the call fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.client.probe_resource_descriptions", skip(self))
+    )]
     pub async fn probe_resource_descriptions(&self) -> Vec<String> {
         if !self.server_supports_resources() {
             return Vec::new();
@@ -976,6 +984,10 @@ impl McpClient {
     /// List prompt descriptions for injection scanning (probe path).
     ///
     /// Returns an empty vec if the server does not support prompts or the call fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.client.probe_prompt_descriptions", skip(self))
+    )]
     pub async fn probe_prompt_descriptions(&self) -> Vec<String> {
         if !self.server_supports_prompts() {
             return Vec::new();

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -421,6 +421,14 @@ impl McpManager {
     ///
     /// Instructions are captured from `ServerInfo.instructions` after the MCP handshake
     /// and truncated to `max_instructions_bytes`.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "mcp.manager.server_instructions",
+            skip(self),
+            fields(server_id)
+        )
+    )]
     pub async fn server_instructions(&self, server_id: &str) -> Option<String> {
         self.server_instructions
             .read()
@@ -833,6 +841,10 @@ impl McpManager {
     ///
     /// # Panics
     ///
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.manager.connect_oauth_deferred", skip_all)
+    )]
     pub async fn connect_oauth_deferred(&self) {
         let limits = IngestLimits {
             description_bytes: self.max_description_bytes,
@@ -1208,6 +1220,10 @@ impl McpManager {
     ///
     /// # Panics
     ///
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.manager.add_server", skip(self, entry), fields(server_id = %entry.id))
+    )]
     pub async fn add_server(&self, entry: &ServerEntry) -> Result<Vec<McpTool>, McpError> {
         self.check_not_already_connected(&entry.id).await?;
 
@@ -1402,6 +1418,10 @@ impl McpManager {
     ///
     /// # Panics
     ///
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.manager.remove_server", skip(self), fields(server_id))
+    )]
     pub async fn remove_server(&self, server_id: &str) -> Result<(), McpError> {
         // Serialize with commit_added_server to prevent orphaned trust/tools entries.
         let add_remove_guard = self.add_remove_lock.lock().await;
@@ -1428,6 +1448,10 @@ impl McpManager {
     }
 
     /// Return all non-empty server instructions, concatenated with double newlines.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.manager.all_server_instructions", skip_all)
+    )]
     pub async fn all_server_instructions(&self) -> String {
         let map = self.server_instructions.read().await;
         let mut parts: Vec<&str> = map.values().map(String::as_str).collect();
@@ -1436,6 +1460,10 @@ impl McpManager {
     }
 
     /// Return sorted list of connected server IDs.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.manager.list_servers", skip_all)
+    )]
     pub async fn list_servers(&self) -> Vec<String> {
         let clients = self.clients.read().await;
         let mut ids: Vec<String> = clients.keys().cloned().collect();
@@ -1471,6 +1499,10 @@ impl McpManager {
     ///
     /// # Panics
     ///
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.manager.shutdown_all_shared", skip_all)
+    )]
     pub async fn shutdown_all_shared(&self) {
         // Signal all in-flight startup retry tasks to stop sleeping and exit immediately.
         // Must be the very first action so that retry sleeps are interrupted before we

--- a/crates/zeph-mcp/src/oauth.rs
+++ b/crates/zeph-mcp/src/oauth.rs
@@ -24,6 +24,14 @@ use crate::error::McpError;
 ///
 /// Returns `McpError::OAuthCallbackTimeout` if no callback arrives within `timeout`,
 /// or `McpError::OAuthError` on parse failures.
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(
+        name = "mcp.oauth.await_oauth_callback",
+        skip(listener),
+        fields(server_id)
+    )
+)]
 pub async fn await_oauth_callback(
     listener: tokio::net::TcpListener,
     timeout: Duration,
@@ -146,6 +154,14 @@ fn hex_val(b: u8) -> Option<u8> {
 /// # Errors
 ///
 /// Returns `McpError::OAuthError` if any endpoint resolves to a private/reserved IP.
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(
+        name = "mcp.oauth.validate_oauth_metadata_urls",
+        skip(metadata),
+        fields(server_id)
+    )
+)]
 pub async fn validate_oauth_metadata_urls(
     server_id: &str,
     metadata: &rmcp::transport::auth::AuthorizationMetadata,

--- a/crates/zeph-mcp/src/prober.rs
+++ b/crates/zeph-mcp/src/prober.rs
@@ -46,6 +46,10 @@ impl DefaultMcpProber {
     /// Scoring:
     /// - No injection found: `+0.1` (small positive signal for cooperative server)
     /// - Injection found: `INJECTION_PENALTY` reduction + `block = true`
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.prober.probe", skip(self, client), fields(server_id))
+    )]
     pub async fn probe(&self, server_id: &str, client: &McpClient) -> ProbeResult {
         let mut descriptions = Vec::new();
         descriptions.extend(client.probe_resource_descriptions().await);

--- a/crates/zeph-mcp/src/pruning.rs
+++ b/crates/zeph-mcp/src/pruning.rs
@@ -186,6 +186,10 @@ pub fn tool_list_hash(tools: &[McpTool]) -> u64 {
 /// Propagates `PruningError` from [`prune_tools`] on the first (uncached) LLM
 /// failure.  Subsequent calls with the same key return `Ok(all_tools.to_vec())`
 /// from the negative cache entry.
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(name = "mcp.pruning.prune_tools_cached", skip_all)
+)]
 pub async fn prune_tools_cached<P: LlmProvider>(
     cache: &mut PruningCache,
     all_tools: &[McpTool],
@@ -277,6 +281,10 @@ impl Default for PruningParams {
 ///
 /// Returns `PruningError::LlmError` if the provider call fails.
 /// Returns `PruningError::ParseError` if the response cannot be parsed as a JSON array.
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(name = "mcp.pruning.prune_tools", skip_all)
+)]
 pub async fn prune_tools<P: LlmProvider>(
     all_tools: &[McpTool],
     task_context: &str,

--- a/crates/zeph-mcp/src/registry.rs
+++ b/crates/zeph-mcp/src/registry.rs
@@ -137,6 +137,10 @@ impl McpToolRegistry {
     /// # Errors
     ///
     /// Returns an error if Qdrant communication fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.registry.sync", skip_all)
+    )]
     pub async fn sync<F>(
         &mut self,
         tools: &[McpTool],
@@ -181,6 +185,14 @@ impl McpToolRegistry {
     ///
     /// Note: returned tools have an empty `input_schema` because Qdrant payloads only
     /// store the description fields needed for prompt construction.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "mcp.registry.search",
+            skip(self, embed_fn),
+            fields(query, limit)
+        )
+    )]
     pub async fn search<F>(&self, query: &str, limit: usize, embed_fn: F) -> Vec<McpTool>
     where
         F: Fn(&str) -> EmbedFuture,

--- a/crates/zeph-mcp/src/semantic_index.rs
+++ b/crates/zeph-mcp/src/semantic_index.rs
@@ -87,6 +87,10 @@ impl SemanticToolIndex {
     ///
     /// Returns [`SemanticIndexError::AllEmbeddingsFailed`] when every tool's embedding
     /// fails.  The caller should fall back to the `None` strategy (all tools).
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.semantic_index.build", skip_all)
+    )]
     pub async fn build<F>(tools: &[McpTool], embed_fn: &F) -> Result<Self, SemanticIndexError>
     where
         F: Fn(&str) -> zeph_llm::provider::EmbedFuture + Send + Sync,

--- a/crates/zeph-mcp/src/trust_score.rs
+++ b/crates/zeph-mcp/src/trust_score.rs
@@ -130,6 +130,10 @@ impl TrustScoreStore {
     /// # Errors
     ///
     /// Returns an error if any migration fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.trust_score.init", skip_all)
+    )]
     pub async fn init(&self) -> Result<(), zeph_db::DbError> {
         zeph_db::run_migrations(&self.pool).await?;
         Ok(())
@@ -150,6 +154,10 @@ impl TrustScoreStore {
     /// # Errors
     ///
     /// Returns an error if any SQL query fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.trust_score.load", skip(self), fields(server_id))
+    )]
     pub async fn load(
         &self,
         server_id: &str,
@@ -200,6 +208,10 @@ impl TrustScoreStore {
     /// # Errors
     ///
     /// Returns an error if the SQL execution fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.trust_score.apply_delta", skip(self), fields(server_id))
+    )]
     pub async fn apply_delta(
         &self,
         server_id: &str,
@@ -238,6 +250,14 @@ impl TrustScoreStore {
     /// # Errors
     ///
     /// Returns an error if the SQL query or execution fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "mcp.trust_score.load_and_apply_delta",
+            skip(self),
+            fields(server_id)
+        )
+    )]
     pub async fn load_and_apply_delta(
         &self,
         server_id: &str,
@@ -279,6 +299,10 @@ impl TrustScoreStore {
     /// # Errors
     ///
     /// Returns an error if the SQL query fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "mcp.trust_score.load_all", skip_all)
+    )]
     pub async fn load_all(&self) -> Result<Vec<ServerTrustScore>, zeph_db::SqlxError> {
         let rows: Vec<(String, f64, i64, i64, i64)> = zeph_db::query_as(sql!(
             "SELECT server_id, score, success_count, failure_count, updated_at_secs

--- a/crates/zeph-skills/src/evaluator.rs
+++ b/crates/zeph-skills/src/evaluator.rs
@@ -191,7 +191,10 @@ impl SkillEvaluator {
     /// # Errors
     ///
     /// Currently always returns `Ok(_)`. Error propagation is reserved for future use.
-    #[tracing::instrument(name = "skills.eval.evaluate", skip_all, fields(skill_name = %req.name))]
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.evaluator.evaluate", skip_all, fields(skill_name = %req.name))
+    )]
     pub async fn evaluate(
         &self,
         req: &SkillEvaluationRequest<'_>,

--- a/crates/zeph-skills/src/generator.rs
+++ b/crates/zeph-skills/src/generator.rs
@@ -230,6 +230,10 @@ impl SkillGenerator {
     /// Returns `SkillError::AlreadyExists` if the skill directory already exists.
     /// Returns `SkillError::Invalid` if the evaluator rejects the skill.
     /// Returns `SkillError::Io` on filesystem errors.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.generator.approve_and_save", skip(self, skill), fields(skill_name = %skill.name))
+    )]
     pub async fn approve_and_save(&self, skill: &GeneratedSkill) -> Result<PathBuf, SkillError> {
         // Validate name (paranoia — already validated during generation).
         validate_generated_name(&skill.name)?;
@@ -310,6 +314,10 @@ impl SkillGenerator {
     ///     assert!(path.to_str().unwrap().contains("_quarantine"));
     /// }
     /// ```
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.generator.write_quarantined", skip(self, skill), fields(skill_name = %skill.name))
+    )]
     pub async fn write_quarantined(&self, skill: &GeneratedSkill) -> Result<PathBuf, SkillError> {
         validate_generated_name(&skill.name)?;
         let quarantine_dir = self.output_dir.join("_quarantine").join(&skill.name);

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -148,50 +148,46 @@ impl SkillMiner {
     /// # Errors
     ///
     /// Returns `SkillError::Other` on unrecoverable pipeline failures.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.miner.run", skip(self, existing_skills), fields(query_count = self.config.queries.len(), existing_skills_count = existing_skills.len()))
+    )]
     pub async fn run(&self, existing_skills: &[SkillMeta]) -> Result<Vec<MinedSkill>, SkillError> {
-        async move {
-            // Pre-compute embeddings for all existing skill descriptions once.
-            let existing_embeddings = self.embed_existing(existing_skills).await;
+        // Pre-compute embeddings for all existing skill descriptions once.
+        let existing_embeddings = self.embed_existing(existing_skills).await;
 
-            let delay_between_requests = self.request_delay();
-            let mut results: Vec<MinedSkill> = Vec::new();
+        let delay_between_requests = self.request_delay();
+        let mut results: Vec<MinedSkill> = Vec::new();
 
-            for query in &self.config.queries {
-                tracing::info!(query = %query, "mining: searching GitHub");
-                let repos = match self.search_repos(query).await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::warn!(query = %query, error = %e, "GitHub search failed, skipping");
-                        continue;
-                    }
-                };
-                tokio::time::sleep(delay_between_requests).await;
-
-                for repo in repos {
-                    match self
-                        .process_repo(&repo, &existing_embeddings, self.config.dry_run)
-                        .await
-                    {
-                        Ok(Some(mined)) => {
-                            results.push(mined);
-                        }
-                        Ok(None) => {} // deduped or dry-run
-                        Err(e) => {
-                            tracing::warn!(repo = %repo.full_name, error = %e, "failed to process repo");
-                        }
-                    }
-                    tokio::time::sleep(delay_between_requests).await;
+        for query in &self.config.queries {
+            tracing::info!(query = %query, "mining: searching GitHub");
+            let repos = match self.search_repos(query).await {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(query = %query, error = %e, "GitHub search failed, skipping");
+                    continue;
                 }
-            }
+            };
+            tokio::time::sleep(delay_between_requests).await;
 
-            Ok(results)
+            for repo in repos {
+                match self
+                    .process_repo(&repo, &existing_embeddings, self.config.dry_run)
+                    .await
+                {
+                    Ok(Some(mined)) => {
+                        results.push(mined);
+                    }
+                    Ok(None) => {} // deduped or dry-run
+                    Err(e) => {
+                        tracing::warn!(repo = %repo.full_name, error = %e, "failed to process repo");
+                    }
+                }
+                tokio::time::sleep(delay_between_requests).await;
+            }
         }
-        .instrument(tracing::info_span!(
-            "skills.miner.run",
-            query_count = self.config.queries.len(),
-            existing_skills_count = existing_skills.len(),
-        ))
-        .await
+
+        Ok(results)
     }
 
     /// Pre-compute embeddings for existing skill descriptions.
@@ -447,95 +443,91 @@ impl SkillMiner {
     /// # Errors
     ///
     /// Returns `SkillError::Other` on network or rate-limit errors.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.miner.search_repos", skip(self), fields(query_len = query.len(), max_repos = self.config.max_repos_per_query))
+    )]
     pub async fn search_repos(&self, query: &str) -> Result<Vec<RepoCandidate>, SkillError> {
-        async move {
-            let per_page = self.config.max_repos_per_query.min(100);
-            // Build URL manually to avoid needing reqwest's query param serialization feature.
-            let encoded_query: String = query
-                .chars()
-                .flat_map(|c| {
-                    if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '~' {
-                        vec![c]
-                    } else {
-                        format!("%{:02X}", c as u32).chars().collect()
-                    }
-                })
-                .collect();
-            let url = format!(
-                "https://api.github.com/search/repositories?q={encoded_query}&sort=stars&per_page={per_page}"
-            );
+        let per_page = self.config.max_repos_per_query.min(100);
+        // Build URL manually to avoid needing reqwest's query param serialization feature.
+        let encoded_query: String = query
+            .chars()
+            .flat_map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '~' {
+                    vec![c]
+                } else {
+                    format!("%{:02X}", c as u32).chars().collect()
+                }
+            })
+            .collect();
+        let url = format!(
+            "https://api.github.com/search/repositories?q={encoded_query}&sort=stars&per_page={per_page}"
+        );
 
-            let resp = self
-                .http
-                .get(&url)
-                .header(
-                    "Authorization",
-                    format!("Bearer {}", self.github_token.expose()),
-                )
-                .header("Accept", "application/vnd.github.v3+json")
-                .send()
-                .await
-                .map_err(|e| SkillError::Other(format!("GitHub search request failed: {e}")))?;
+        let resp = self
+            .http
+            .get(&url)
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.github_token.expose()),
+            )
+            .header("Accept", "application/vnd.github.v3+json")
+            .send()
+            .await
+            .map_err(|e| SkillError::Other(format!("GitHub search request failed: {e}")))?;
 
-            if resp.status() == reqwest::StatusCode::FORBIDDEN
-                || resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
-            {
-                return Err(SkillError::Other(format!(
-                    "GitHub rate limit exceeded ({})",
-                    resp.status()
-                )));
+        if resp.status() == reqwest::StatusCode::FORBIDDEN
+            || resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+        {
+            return Err(SkillError::Other(format!(
+                "GitHub rate limit exceeded ({})",
+                resp.status()
+            )));
+        }
+
+        if !resp.status().is_success() {
+            return Err(SkillError::Other(format!(
+                "GitHub search returned {}: {}",
+                resp.status(),
+                resp.text().await.unwrap_or_default()
+            )));
+        }
+
+        let json: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| SkillError::Other(format!("GitHub search JSON parse failed: {e}")))?;
+
+        let items = json["items"].as_array().cloned().unwrap_or_default();
+        let mut candidates = Vec::with_capacity(items.len());
+
+        for item in &items {
+            let full_name = item["full_name"].as_str().unwrap_or_default().to_string();
+            let description = item["description"].as_str().unwrap_or_default().to_string();
+            let stars =
+                u32::try_from(item["stargazers_count"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
+
+            if full_name.is_empty() {
+                continue;
             }
 
-            if !resp.status().is_success() {
-                return Err(SkillError::Other(format!(
-                    "GitHub search returned {}: {}",
-                    resp.status(),
-                    resp.text().await.unwrap_or_default()
-                )));
-            }
-
-            let json: serde_json::Value = resp
-                .json()
-                .await
-                .map_err(|e| SkillError::Other(format!("GitHub search JSON parse failed: {e}")))?;
-
-            let items = json["items"].as_array().cloned().unwrap_or_default();
-            let mut candidates = Vec::with_capacity(items.len());
-
-            for item in &items {
-                let full_name = item["full_name"].as_str().unwrap_or_default().to_string();
-                let description = item["description"].as_str().unwrap_or_default().to_string();
-                let stars =
-                    u32::try_from(item["stargazers_count"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
-
-                if full_name.is_empty() {
+            let readme = match self.fetch_readme(&full_name).await {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::debug!(repo = %full_name, error = %e, "README fetch failed, skipping");
                     continue;
                 }
+            };
 
-                let readme = match self.fetch_readme(&full_name).await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::debug!(repo = %full_name, error = %e, "README fetch failed, skipping");
-                        continue;
-                    }
-                };
-
-                candidates.push(RepoCandidate {
-                    full_name,
-                    description,
-                    readme_content: readme,
-                    stars,
-                });
-            }
-
-            Ok(candidates)
+            candidates.push(RepoCandidate {
+                full_name,
+                description,
+                readme_content: readme,
+                stars,
+            });
         }
-        .instrument(tracing::info_span!(
-            "skills.miner.search_repos",
-            query_len = query.len(),
-            max_repos = self.config.max_repos_per_query,
-        ))
-        .await
+
+        Ok(candidates)
     }
 
     /// Fetch and truncate the README for a repository.
@@ -637,29 +629,25 @@ impl SkillMiner {
     /// # Errors
     ///
     /// Returns `SkillError::Other` if the embedding call fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.miner.is_novel", skip(self, candidate, existing_embeddings), fields(candidate_name = %candidate.name, existing_count = existing_embeddings.len()))
+    )]
     pub async fn is_novel(
         &self,
         candidate: &GeneratedSkill,
         existing_embeddings: &[(SkillMeta, SkillEmbedding)],
     ) -> Result<(bool, f32), SkillError> {
-        async move {
-            if existing_embeddings.is_empty() {
-                return Ok((true, 0.0));
-            }
-
-            let candidate_emb = self.embed_candidate(candidate).await?;
-
-            let max_sim =
-                find_nearest(&candidate_emb, existing_embeddings).map_or(0.0_f32, |(_, sim)| sim);
-
-            Ok((max_sim < self.config.dedup_threshold, max_sim))
+        if existing_embeddings.is_empty() {
+            return Ok((true, 0.0));
         }
-        .instrument(tracing::info_span!(
-            "skills.miner.is_novel",
-            candidate_name = %candidate.name,
-            existing_count = existing_embeddings.len(),
-        ))
-        .await
+
+        let candidate_emb = self.embed_candidate(candidate).await?;
+
+        let max_sim =
+            find_nearest(&candidate_emb, existing_embeddings).map_or(0.0_f32, |(_, sim)| sim);
+
+        Ok((max_sim < self.config.dedup_threshold, max_sim))
     }
 }
 

--- a/crates/zeph-skills/src/proactive.rs
+++ b/crates/zeph-skills/src/proactive.rs
@@ -155,7 +155,10 @@ impl ProactiveExplorer {
     ///
     /// Returns `None` when no keyword in the query matches a known domain.
     /// Returns the first matching [`DomainLabel`] otherwise.
-    #[tracing::instrument(name = "core.proactive.classify", skip_all)]
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.proactive.classify", skip_all)
+    )]
     pub fn classify(&self, query: &str) -> Option<DomainLabel> {
         let lower = query.to_lowercase();
         for token in lower.split_whitespace() {
@@ -191,7 +194,10 @@ impl ProactiveExplorer {
     /// # Errors
     ///
     /// Returns [`SkillError`] if SKILL.md generation or the filesystem write fails.
-    #[tracing::instrument(name = "core.proactive.explore", skip_all, fields(domain = %domain.0))]
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.proactive.explore", skip_all, fields(domain = %domain.0))
+    )]
     pub async fn explore(&self, domain: &DomainLabel) -> Result<(), SkillError> {
         let description = format!(
             "World-knowledge reference skill for {domain}. \

--- a/crates/zeph-skills/src/semantic_scanner.rs
+++ b/crates/zeph-skills/src/semantic_scanner.rs
@@ -151,7 +151,10 @@ impl SkillSemanticScanner {
     /// # Errors
     ///
     /// Returns [`SkillError::Other`] if the LLM call fails or times out.
-    #[tracing::instrument(skip(self, skill_md_content), fields(skill = %skill_name))]
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.scanner.scan", skip(self, skill_md_content), fields(skill = %skill_name))
+    )]
     pub async fn scan(
         &self,
         skill_name: &str,

--- a/crates/zeph-skills/src/trace_extractor.rs
+++ b/crates/zeph-skills/src/trace_extractor.rs
@@ -195,57 +195,53 @@ impl TraceExtractor {
     /// Returns `SkillError::Other` when the LLM extraction call fails. Individual candidate
     /// failures (parse error, injection, merge failure) are logged and counted but do not
     /// propagate as errors.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.trace_extractor.extract_from_trace", skip(self, messages, existing_embeddings), fields(session_id, msg_count = messages.len()))
+    )]
     pub async fn extract_from_trace(
         &self,
         messages: &[UserMessage],
         existing_embeddings: &[(SkillMeta, SkillEmbedding)],
         session_id: &str,
     ) -> Result<TraceExtractionResult, SkillError> {
-        async move {
-            let mut result = TraceExtractionResult::default();
+        let mut result = TraceExtractionResult::default();
 
-            let truncated: Vec<_> = messages.iter().take(self.max_turns as usize).collect();
-            let prompt_text = self.build_prompt_text(&truncated);
+        let truncated: Vec<_> = messages.iter().take(self.max_turns as usize).collect();
+        let prompt_text = self.build_prompt_text(&truncated);
 
-            if prompt_text.is_empty() {
-                tracing::debug!(session_id, "trace_extractor: no user messages, skipping");
-                return Ok(result);
-            }
-
-            let raw = self.call_extract_llm(&prompt_text).await?;
-
-            if raw.trim() == "NONE" || raw.trim().is_empty() {
-                tracing::debug!(session_id, "trace_extractor: LLM returned no candidates");
-                return Ok(result);
-            }
-
-            let raw_candidates: Vec<&str> = raw.split(SKILL_SEPARATOR).collect();
-            result.candidates_proposed = u32::try_from(raw_candidates.len()).unwrap_or(u32::MAX);
-
-            for raw_candidate in raw_candidates {
-                self.process_candidate(raw_candidate, existing_embeddings, session_id, &mut result)
-                    .await;
-            }
-
-            tracing::info!(
-                session_id,
-                proposed = result.candidates_proposed,
-                parse_failed = result.candidates_parse_failed,
-                saved = result.candidates_saved,
-                merged = result.candidates_merged,
-                discarded = result.candidates_discarded,
-                rejected_injection = result.candidates_rejected_injection,
-                "trace_extractor: extraction complete"
-            );
-
-            Ok(result)
+        if prompt_text.is_empty() {
+            tracing::debug!(session_id, "trace_extractor: no user messages, skipping");
+            return Ok(result);
         }
-        .instrument(tracing::info_span!(
-            "skills.trace_extraction.extract",
+
+        let raw = self.call_extract_llm(&prompt_text).await?;
+
+        if raw.trim() == "NONE" || raw.trim().is_empty() {
+            tracing::debug!(session_id, "trace_extractor: LLM returned no candidates");
+            return Ok(result);
+        }
+
+        let raw_candidates: Vec<&str> = raw.split(SKILL_SEPARATOR).collect();
+        result.candidates_proposed = u32::try_from(raw_candidates.len()).unwrap_or(u32::MAX);
+
+        for raw_candidate in raw_candidates {
+            self.process_candidate(raw_candidate, existing_embeddings, session_id, &mut result)
+                .await;
+        }
+
+        tracing::info!(
             session_id,
-            message_count = messages.len(),
-        ))
-        .await
+            proposed = result.candidates_proposed,
+            parse_failed = result.candidates_parse_failed,
+            saved = result.candidates_saved,
+            merged = result.candidates_merged,
+            discarded = result.candidates_discarded,
+            rejected_injection = result.candidates_rejected_injection,
+            "trace_extractor: extraction complete"
+        );
+
+        Ok(result)
     }
 
     /// Process a single raw candidate string through the parse → scan → embed → decide pipeline.
@@ -547,6 +543,10 @@ impl TraceExtractor {
     ///
     /// Returns `SkillError::Other` if the embed provider fails catastrophically.
     /// Skills that time out are skipped with a warning.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.trace_extractor.embed_existing", skip(self, skills), fields(skill_count = skills.len()))
+    )]
     pub async fn embed_existing(&self, skills: &[SkillMeta]) -> Vec<(SkillMeta, SkillEmbedding)> {
         let mut result = Vec::with_capacity(skills.len());
         for skill in skills {


### PR DESCRIPTION
## Summary

- **zeph-channels**: add always-on `#[tracing::instrument]` to all hot-path async fns in `telegram.rs` and `cli.rs`; unify span namespace from `channel.*` to `channels.*` across all 6 channel source files (discord, slack, telegram_api_ext, telegram_moderation) — 46 `channels.*` spans total, no `channel.*` prefixes remain
- **zeph-skills**: add profiling-gated `#[cfg_attr(feature = "profiling", tracing::instrument)]` to 13 pub async fns across proactive, trace_extractor, semantic_scanner, miner, qdrant_matcher, evaluator, generator; remove redundant inner `.instrument()` in `extract_from_trace`; rename stale `core.proactive.classify` → `skills.proactive.classify`
- **zeph-mcp**: add profiling-gated tracing to 21 pub async fns across 8 files (manager, client, trust_score, pruning, semantic_index, registry, prober, oauth)

Span naming convention: `<crate>.<module>.<operation>` throughout.

## Test plan

- [x] `cargo nextest run -p zeph-channels -p zeph-skills -p zeph-mcp --lib --bins` — 1200 passed, 0 failed
- [x] `cargo clippy -p zeph-channels -p zeph-skills -p zeph-mcp -- -D warnings` — clean
- [x] `cargo clippy ... --features profiling -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check ... --features profiling --locked` — clean
- [x] impl-critic: all significant issues fixed before review (namespace split, double span)
- [x] reviewer: approved

Closes #4849, #4827, #4819