### PR TITLE
refactor(llm,config): extract HTTP error mapper and move embedding helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   bounded by `parallel_evals` (default: 3). Wall-time for Phase 1 drops from O(n) to O(⌈n/k⌉);
   at k=3 the hill-climbing loop evaluates ~3× more variation candidates within the same
   `max_wall_time_secs` budget. Closes #4794.
+- `refactor(llm)`: extract shared HTTP error-response mapper `map_error_response` in
+  `zeph-llm/src/http.rs`; replace 12 duplicate inline error-mapping blocks across `claude`,
+  `openai`, `gonka`, and `cocoon` backends. Closes #4850.
+- `refactor(config)`: move `effective_embedding_model` and `stable_skill_embedding_model` to
+  `LlmConfig` in `zeph-config`; remove config-layer logic from `zeph-core::provider_factory`.
+  Add `impl Default for LlmConfig`. Closes #4840.
 
 - `refactor(channels)`: add `#[cfg_attr(feature = "profiling", tracing::instrument)]` to 17
   uninstrumented async fns in `zeph-channels` — Telegram API ext (8 fns), Discord REST client

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -444,6 +444,12 @@ fn default_embedding_model_opt() -> String {
     default_embedding_model()
 }
 
+impl Default for LlmConfig {
+    fn default() -> Self {
+        toml::from_str("").expect("empty TOML produces valid LlmConfig defaults")
+    }
+}
+
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_routing_none(s: &LlmRoutingStrategy) -> bool {
     *s == LlmRoutingStrategy::None
@@ -498,6 +504,77 @@ impl LlmConfig {
                 .iter()
                 .find(|p| p.effective_name() == name_hint && p.stt_model.is_some())
         }
+    }
+
+    /// Returns the name of the effective embedding model.
+    ///
+    /// Resolution order:
+    /// 1. `embedding_model` from the `[[llm.providers]]` entry marked `embed = true`
+    /// 2. `embedding_model` from the first entry in `[[llm.providers]]`
+    /// 3. `[llm] embedding_model` global fallback (defaults to `"nomic-embed-text"`)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_config::providers::LlmConfig;
+    ///
+    /// let cfg = LlmConfig::default();
+    /// assert!(!cfg.effective_embedding_model().is_empty());
+    /// ```
+    #[must_use]
+    pub fn effective_embedding_model(&self) -> String {
+        if let Some(m) = self
+            .providers
+            .iter()
+            .find(|e| e.embed)
+            .and_then(|e| e.embedding_model.as_ref())
+        {
+            return m.clone();
+        }
+        if let Some(m) = self
+            .providers
+            .first()
+            .and_then(|e| e.embedding_model.as_ref())
+        {
+            return m.clone();
+        }
+        self.embedding_model.clone()
+    }
+
+    /// Returns the name of the stable skill embedding model.
+    ///
+    /// Prefers the `[[llm.providers]]` entry with `embed = true`, using its
+    /// `embedding_model` field first and `model` field as a secondary fallback.
+    /// Falls back to [`Self::effective_embedding_model`] when no dedicated embed
+    /// entry exists. Using the actual provider model name prevents false-positive
+    /// collection rebuilds in `zeph_memory::embedding_registry`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_config::providers::LlmConfig;
+    ///
+    /// let cfg = LlmConfig::default();
+    /// assert!(!cfg.stable_skill_embedding_model().is_empty());
+    /// ```
+    #[must_use]
+    pub fn stable_skill_embedding_model(&self) -> String {
+        let embed_entry = self
+            .providers
+            .iter()
+            .find(|e| e.embed)
+            .or_else(|| self.providers.iter().find(|e| e.embedding_model.is_some()));
+
+        if let Some(entry) = embed_entry {
+            if let Some(em) = entry.embedding_model.as_ref().filter(|s| !s.is_empty()) {
+                return em.clone();
+            }
+            if let Some(m) = entry.model.as_ref().filter(|s| !s.is_empty()) {
+                return m.clone();
+            }
+        }
+
+        self.effective_embedding_model()
     }
 
     /// Validate that the config uses the new `[[llm.providers]]` format.

--- a/crates/zeph-core/src/agent/session_config.rs
+++ b/crates/zeph-core/src/agent/session_config.rs
@@ -152,7 +152,7 @@ impl AgentSessionConfig {
                 config.security.autonomy_level,
             ),
             model_name: config.llm.effective_model().to_owned(),
-            embed_model: crate::provider_factory::stable_skill_embedding_model(config),
+            embed_model: config.llm.stable_skill_embedding_model(),
             semantic_cache_enabled: config.llm.semantic_cache_enabled,
             semantic_cache_threshold: config.llm.semantic_cache_threshold,
             semantic_cache_max_candidates: config.llm.semantic_cache_max_candidates,
@@ -232,10 +232,7 @@ mod tests {
         assert_eq!(sc.tool_summarization, config.tools.summarize_output);
         assert_eq!(sc.tool_call_cutoff, config.memory.tool_call_cutoff);
         assert_eq!(sc.model_name, config.llm.effective_model());
-        assert_eq!(
-            sc.embed_model,
-            crate::provider_factory::stable_skill_embedding_model(&config)
-        );
+        assert_eq!(sc.embed_model, config.llm.stable_skill_embedding_model());
         assert_eq!(sc.semantic_cache_enabled, config.llm.semantic_cache_enabled);
         assert!(
             (sc.semantic_cache_threshold - config.llm.semantic_cache_threshold).abs()

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -602,70 +602,6 @@ pub fn select_device(
     }
 }
 
-/// Determine the effective embedding model name for the memory subsystem.
-///
-/// Resolution order:
-/// 1. `embedding_model` from the `[[llm.providers]]` entry marked `embed = true`
-/// 2. `embedding_model` from the first entry in `[[llm.providers]]`
-/// 3. `[llm] embedding_model` global fallback
-#[must_use]
-pub fn effective_embedding_model(config: &Config) -> String {
-    // Prefer a dedicated embed provider.
-    if let Some(m) = config
-        .llm
-        .providers
-        .iter()
-        .find(|e| e.embed)
-        .and_then(|e| e.embedding_model.as_ref())
-    {
-        return m.clone();
-    }
-    // Fall back to the first provider's embedding model.
-    if let Some(m) = config
-        .llm
-        .providers
-        .first()
-        .and_then(|e| e.embedding_model.as_ref())
-    {
-        return m.clone();
-    }
-    config.llm.embedding_model.clone()
-}
-
-/// Resolve the stable embedding model name for skill-matcher collection versioning.
-///
-/// This uses the same entry resolution as the embedding provider itself: the entry
-/// with `embed = true`, preferring its `embedding_model` field and falling back to
-/// its `model` field. Using the actual provider's model name prevents the
-/// `model_has_changed` check in [`zeph_memory::embedding_registry`] from triggering
-/// false positives that would rebuild the `zeph_skills` collection on every startup.
-///
-/// Falls back to [`effective_embedding_model`] when no dedicated embed entry exists.
-#[must_use]
-pub fn stable_skill_embedding_model(config: &Config) -> String {
-    // Find the dedicated embed entry (same lookup as `create_embedding_provider`).
-    let embed_entry = config.llm.providers.iter().find(|e| e.embed).or_else(|| {
-        config
-            .llm
-            .providers
-            .iter()
-            .find(|e| e.embedding_model.is_some())
-    });
-
-    if let Some(entry) = embed_entry {
-        // Prefer the explicit `embedding_model` field; fall back to the `model` field.
-        if let Some(em) = entry.embedding_model.as_ref().filter(|s| !s.is_empty()) {
-            return em.clone();
-        }
-        if let Some(m) = entry.model.as_ref().filter(|s| !s.is_empty()) {
-            return m.clone();
-        }
-    }
-
-    // No dedicated embed entry — fall back to the general embedding model resolution.
-    effective_embedding_model(config)
-}
-
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "candle")]
@@ -715,7 +651,6 @@ mod tests {
 
     #[cfg(any(feature = "gonka", feature = "cocoon"))]
     use super::build_provider_from_entry;
-    use super::{effective_embedding_model, stable_skill_embedding_model};
     use crate::config::{Config, ProviderKind};
     use zeph_config::providers::ProviderEntry;
 
@@ -824,7 +759,7 @@ mod tests {
             Some("chat-model"),
             Some("embed-v2"),
         )];
-        assert_eq!(stable_skill_embedding_model(&config), "embed-v2");
+        assert_eq!(config.llm.stable_skill_embedding_model(), "embed-v2");
     }
 
     #[test]
@@ -836,7 +771,7 @@ mod tests {
             None,
         )];
         assert_eq!(
-            stable_skill_embedding_model(&config),
+            config.llm.stable_skill_embedding_model(),
             "nomic-embed-text-v2-moe:latest"
         );
     }
@@ -848,7 +783,7 @@ mod tests {
             make_provider_entry(false, Some("chat-model"), None),
             make_provider_entry(true, Some("embed-model"), Some("text-embed-3")),
         ];
-        assert_eq!(stable_skill_embedding_model(&config), "text-embed-3");
+        assert_eq!(config.llm.stable_skill_embedding_model(), "text-embed-3");
     }
 
     #[test]
@@ -858,8 +793,8 @@ mod tests {
         // No embed=true entry, no embedding_model field set — falls back to effective_embedding_model.
         config.llm.providers = vec![make_provider_entry(false, Some("chat"), None)];
         assert_eq!(
-            stable_skill_embedding_model(&config),
-            effective_embedding_model(&config)
+            config.llm.stable_skill_embedding_model(),
+            config.llm.effective_embedding_model()
         );
     }
 

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -854,15 +854,7 @@ impl ClaudeProvider {
                     continue;
                 }
                 tracing::error!("Claude API error {status}: {text}");
-                if status == reqwest::StatusCode::BAD_REQUEST
-                    && crate::error::body_is_context_length_error(&text)
-                {
-                    return Err(LlmError::ContextLengthExceeded);
-                }
-                return Err(LlmError::ApiError {
-                    provider: "claude".into(),
-                    status: status.as_u16(),
-                });
+                return Err(crate::http::map_error_response(status, &text, "claude"));
             }
 
             if Self::has_image_parts(messages) {
@@ -983,15 +975,7 @@ impl ClaudeProvider {
                     continue;
                 }
                 tracing::error!("Claude API error {status}: {text}");
-                if status == reqwest::StatusCode::BAD_REQUEST
-                    && crate::error::body_is_context_length_error(&text)
-                {
-                    return Err(LlmError::ContextLengthExceeded);
-                }
-                return Err(LlmError::ApiError {
-                    provider: "claude".into(),
-                    status: status.as_u16(),
-                });
+                return Err(crate::http::map_error_response(status, &text, "claude"));
             }
 
             return Ok(claude_sse_to_tool_stream(response, &self.stream_limits));
@@ -1024,15 +1008,7 @@ impl ClaudeProvider {
                     continue;
                 }
                 tracing::error!("Claude API streaming request error {status}: {text}");
-                if status == reqwest::StatusCode::BAD_REQUEST
-                    && crate::error::body_is_context_length_error(&text)
-                {
-                    return Err(LlmError::ContextLengthExceeded);
-                }
-                return Err(LlmError::ApiError {
-                    provider: "claude".into(),
-                    status: status.as_u16(),
-                });
+                return Err(crate::http::map_error_response(status, &text, "claude"));
             }
 
             return Ok(response);
@@ -1207,15 +1183,7 @@ impl LlmProvider for ClaudeProvider {
                     continue;
                 }
                 tracing::error!("Claude API error {status}: {text}");
-                if status == reqwest::StatusCode::BAD_REQUEST
-                    && crate::error::body_is_context_length_error(&text)
-                {
-                    return Err(LlmError::ContextLengthExceeded);
-                }
-                return Err(LlmError::ApiError {
-                    provider: "claude".into(),
-                    status: status.as_u16(),
-                });
+                return Err(crate::http::map_error_response(status, &text, "claude"));
             }
             let resp: ToolApiResponse = serde_json::from_str(&text)?;
             if let Some(ref usage) = resp.usage {
@@ -1408,15 +1376,7 @@ impl LlmProvider for ClaudeProvider {
                     continue;
                 }
                 tracing::error!("Claude API error {status}: {text}");
-                if status == reqwest::StatusCode::BAD_REQUEST
-                    && crate::error::body_is_context_length_error(&text)
-                {
-                    return Err(LlmError::ContextLengthExceeded);
-                }
-                return Err(LlmError::ApiError {
-                    provider: "claude".into(),
-                    status: status.as_u16(),
-                });
+                return Err(crate::http::map_error_response(status, &text, "claude"));
             }
 
             let resp: ToolApiResponse = serde_json::from_str(&text)?;

--- a/crates/zeph-llm/src/cocoon/provider.rs
+++ b/crates/zeph-llm/src/cocoon/provider.rs
@@ -283,15 +283,7 @@ impl LlmProvider for CocoonProvider {
             if !status.is_success() {
                 let truncated: String = text.chars().take(256).collect();
                 tracing::error!("cocoon API error {status}: {truncated}");
-                if status == reqwest::StatusCode::BAD_REQUEST
-                    && crate::error::body_is_context_length_error(&text)
-                {
-                    return Err(LlmError::ContextLengthExceeded);
-                }
-                return Err(LlmError::ApiError {
-                    provider: "cocoon".into(),
-                    status: status.as_u16(),
-                });
+                return Err(crate::http::map_error_response(status, &text, "cocoon"));
             }
 
             let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
@@ -328,18 +320,9 @@ impl LlmProvider for CocoonProvider {
             let status = response.status();
             if !status.is_success() {
                 let text = response.text().await.map_err(LlmError::Http)?;
-                // MINOR-1: tag streaming errors as cocoon-specific for trace distinguishability.
                 let truncated: String = text.chars().take(256).collect();
                 tracing::error!("cocoon SSE stream error (status={status}): {truncated}");
-                if status == reqwest::StatusCode::BAD_REQUEST
-                    && crate::error::body_is_context_length_error(&text)
-                {
-                    return Err(LlmError::ContextLengthExceeded);
-                }
-                return Err(LlmError::ApiError {
-                    provider: "cocoon".into(),
-                    status: status.as_u16(),
-                });
+                return Err(crate::http::map_error_response(status, &text, "cocoon"));
             }
             Ok(openai_sse_to_stream(response))
         }

--- a/crates/zeph-llm/src/gonka/provider.rs
+++ b/crates/zeph-llm/src/gonka/provider.rs
@@ -377,15 +377,7 @@ impl LlmProvider for GonkaProvider {
 
         if !status.is_success() {
             tracing::error!("gonka API error {status}: {text}");
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
-            }
-            return Err(LlmError::ApiError {
-                provider: "gonka".into(),
-                status: status.as_u16(),
-            });
+            return Err(crate::http::map_error_response(status, &text, "gonka"));
         }
 
         let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
@@ -418,15 +410,7 @@ impl LlmProvider for GonkaProvider {
         if !status.is_success() {
             let text = response.text().await.map_err(LlmError::Http)?;
             tracing::error!("gonka streaming error {status}: {text}");
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
-            }
-            return Err(LlmError::ApiError {
-                provider: "gonka".into(),
-                status: status.as_u16(),
-            });
+            return Err(crate::http::map_error_response(status, &text, "gonka"));
         }
 
         Ok(openai_sse_to_stream(response))

--- a/crates/zeph-llm/src/http.rs
+++ b/crates/zeph-llm/src/http.rs
@@ -5,6 +5,8 @@
 
 use std::time::Duration;
 
+use crate::error::{LlmError, body_is_context_length_error};
+
 /// Create an HTTP client for LLM inference providers.
 ///
 /// Connect timeout is fixed at 30s. `request_timeout_secs` is a hard backstop
@@ -25,4 +27,84 @@ pub fn llm_client(request_timeout_secs: u64) -> reqwest::Client {
         .redirect(reqwest::redirect::Policy::limited(10))
         .build()
         .expect("LLM HTTP client construction must not fail")
+}
+
+/// Maps a non-2xx HTTP status and response body to the appropriate [`LlmError`].
+///
+/// Returns [`LlmError::ContextLengthExceeded`] when `status` is `400 Bad Request`
+/// and `body` matches known context-length-exceeded error patterns.
+///
+/// Returns [`LlmError::ApiError`] for all other non-2xx responses. This covers
+/// authentication errors, server errors, and unexpected 4xx codes that are not
+/// context-length failures.
+///
+/// Only call this function after confirming the response is not a 2xx success.
+pub(crate) fn map_error_response(
+    status: reqwest::StatusCode,
+    body: &str,
+    provider: &str,
+) -> LlmError {
+    if status == reqwest::StatusCode::BAD_REQUEST && body_is_context_length_error(body) {
+        LlmError::ContextLengthExceeded
+    } else {
+        LlmError::ApiError {
+            provider: provider.into(),
+            status: status.as_u16(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bad_request_with_context_length_body_returns_exceeded() {
+        let err = map_error_response(
+            reqwest::StatusCode::BAD_REQUEST,
+            "context length exceeded",
+            "p",
+        );
+        assert!(matches!(err, LlmError::ContextLengthExceeded));
+    }
+
+    #[test]
+    fn bad_request_without_context_body_returns_api_error() {
+        let err = map_error_response(
+            reqwest::StatusCode::BAD_REQUEST,
+            "invalid parameter",
+            "myprovider",
+        );
+        assert!(matches!(
+            err,
+            LlmError::ApiError { ref provider, status: 400 } if provider == "myprovider"
+        ));
+    }
+
+    #[test]
+    fn server_error_returns_api_error() {
+        let err = map_error_response(reqwest::StatusCode::INTERNAL_SERVER_ERROR, "", "svc");
+        assert!(matches!(
+            err,
+            LlmError::ApiError { ref provider, status: 500 } if provider == "svc"
+        ));
+    }
+
+    #[test]
+    fn unauthorized_returns_api_error() {
+        let err = map_error_response(reqwest::StatusCode::UNAUTHORIZED, "", "claude");
+        assert!(matches!(
+            err,
+            LlmError::ApiError { ref provider, status: 401 } if provider == "claude"
+        ));
+    }
+
+    #[test]
+    fn too_many_requests_returns_api_error() {
+        let err = map_error_response(reqwest::StatusCode::TOO_MANY_REQUESTS, "", "openai");
+        assert!(matches!(
+            err,
+            LlmError::ApiError { ref provider, status: 429 } if provider == "openai"
+        ));
+    }
 }

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -385,15 +385,7 @@ impl OpenAiProvider {
 
         if !status.is_success() {
             tracing::error!("OpenAI API error {status}: {text}");
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
-            }
-            return Err(LlmError::ApiError {
-                provider: "openai".into(),
-                status: status.as_u16(),
-            });
+            return Err(crate::http::map_error_response(status, &text, "openai"));
         }
 
         let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
@@ -456,15 +448,7 @@ impl OpenAiProvider {
         if !status.is_success() {
             let text = response.text().await.map_err(LlmError::Http)?;
             tracing::error!("OpenAI API streaming request error {status}: {text}");
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
-            }
-            return Err(LlmError::ApiError {
-                provider: "openai".into(),
-                status: status.as_u16(),
-            });
+            return Err(crate::http::map_error_response(status, &text, "openai"));
         }
 
         Ok(response)
@@ -814,15 +798,7 @@ impl LlmProvider for OpenAiProvider {
         let text = response.text().await.map_err(LlmError::Http)?;
 
         if !status.is_success() {
-            if status == reqwest::StatusCode::BAD_REQUEST
-                && crate::error::body_is_context_length_error(&text)
-            {
-                return Err(LlmError::ContextLengthExceeded);
-            }
-            return Err(LlmError::ApiError {
-                provider: "openai".into(),
-                status: status.as_u16(),
-            });
+            return Err(crate::http::map_error_response(status, &text, "openai"));
         }
 
         let resp: OpenAiChatResponse = serde_json::from_str(&text)?;

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -19,8 +19,7 @@ pub use provider::{
     create_summary_provider,
 };
 pub use skills::{
-    create_embedding_provider, create_skill_matcher, effective_embedding_model, managed_skills_dir,
-    plugins_dir, stable_skill_embedding_model,
+    create_embedding_provider, create_skill_matcher, managed_skills_dir, plugins_dir,
 };
 
 use std::path::{Path, PathBuf};
@@ -941,7 +940,7 @@ impl AppBuilder {
         // Use the stable model name derived from the resolved embed provider entry so that
         // `model_has_changed` in `EmbeddingRegistry` does not trigger a collection rebuild on
         // every restart when `effective_embedding_model` returns an unstable or empty string.
-        let embed_model = stable_skill_embedding_model(&self.config);
+        let embed_model = self.config.llm.stable_skill_embedding_model();
         create_skill_matcher(
             &self.config,
             provider,
@@ -1170,7 +1169,7 @@ impl AppBuilder {
     /// Delegates to [`effective_embedding_model`] and is the canonical source for the
     /// model name passed to skill matchers, memory backends, and the embed backfill task.
     pub fn embedding_model(&self) -> String {
-        effective_embedding_model(&self.config)
+        self.config.llm.effective_embedding_model()
     }
 
     pub fn build_summary_provider(&self) -> Option<AnyProvider> {

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1166,7 +1166,7 @@ impl AppBuilder {
 
     /// Return the effective embedding model name for this config.
     ///
-    /// Delegates to [`effective_embedding_model`] and is the canonical source for the
+    /// Delegates to [`zeph_config::LlmConfig::effective_embedding_model`] and is the canonical source for the
     /// model name passed to skill matchers, memory backends, and the embed backfill task.
     pub fn embedding_model(&self) -> String {
         self.config.llm.effective_embedding_model()

--- a/src/bootstrap/skills.rs
+++ b/src/bootstrap/skills.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-pub use zeph_core::provider_factory::{effective_embedding_model, stable_skill_embedding_model};
-
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -178,7 +178,7 @@ async fn health_check_claude_noop() {
 #[test]
 fn effective_embedding_model_defaults_to_llm() {
     let config = Config::load(Path::new("/nonexistent")).unwrap();
-    assert_eq!(effective_embedding_model(&config), "qwen3-embedding");
+    assert_eq!(config.llm.effective_embedding_model(), "qwen3-embedding");
 }
 
 #[test]
@@ -192,7 +192,10 @@ fn effective_embedding_model_uses_pool_embed_entry() {
         embed: true,
         ..ProviderEntry::default()
     }];
-    assert_eq!(effective_embedding_model(&config), "text-embedding-3-small");
+    assert_eq!(
+        config.llm.effective_embedding_model(),
+        "text-embedding-3-small"
+    );
 }
 
 #[test]
@@ -205,7 +208,7 @@ fn effective_embedding_model_falls_back_when_embed_missing() {
         embedding_model: None,
         ..ProviderEntry::default()
     }];
-    assert_eq!(effective_embedding_model(&config), "qwen3-embedding");
+    assert_eq!(config.llm.effective_embedding_model(), "qwen3-embedding");
 }
 
 #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2517,7 +2517,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         cache_pool,
         config.llm.response_cache_ttl_secs,
         config.llm.semantic_cache_enabled,
-        crate::bootstrap::effective_embedding_model(config),
+        config.llm.effective_embedding_model(),
         mem_cancel.child_token(),
     );
     let agent = agent_setup::apply_cost_tracker(agent, config);
@@ -3050,7 +3050,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             .and_then(|e| e.stt_model.clone());
         let compaction_model = config.llm.summary_model.clone();
         let semantic_cache_enabled = config.llm.semantic_cache_enabled;
-        let embedding_model = crate::bootstrap::effective_embedding_model(config).clone();
+        let embedding_model = config.llm.effective_embedding_model().clone();
         let self_learning_enabled = config.skills.learning.enabled;
         let token_budget = u64::try_from(budget_tokens).ok();
         let compaction_threshold = u32::try_from(budget_tokens).ok().map(|b| {


### PR DESCRIPTION
## Summary

- **#4850**: Add `map_error_response(status, body, provider) -> LlmError` to `zeph-llm::http`, replacing 12 duplicate inline error-mapping blocks across `claude`, `openai`, `gonka`, and `cocoon` backends. Eliminates `unwrap_err()` pattern — return type is `LlmError` directly.
- **#4840**: Move `effective_embedding_model` and `stable_skill_embedding_model` from `zeph-core::provider_factory` to `LlmConfig` impl in `zeph-config`, consistent with existing `stt_provider_entry`. Add `impl Default for LlmConfig` via `toml::from_str("")` leveraging `#[serde(default)]`. Update all call sites in `src/bootstrap/` and `src/runner.rs`.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --workspace --lib --bins` — 10504 passed, 0 failed
- [ ] `cargo test --doc -p zeph-llm -p zeph-config -p zeph-core` — all passed
- [ ] Rebase on main, conflict in `CHANGELOG.md` resolved (kept both new entries)

Closes #4850
Closes #4840