### PR TITLE
test(memory): add tests for deep_reasoning_query_conditioned + fix judge_model doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `test(memory)`: add unit tests for `deep_reasoning_query_conditioned` flag in `retrieve_tier` —
+  covers HELA-empty fallback path (`flag=true`) and direct `recall_routed` path (`flag=false`) (#4724)
+
 - `--init` wizard now includes a worktree isolation step: prompts for `worktree.enabled`, `bg_isolation` (`none`/`worktree`), and `base_ref` (`head`/`fresh`) (#4656)
 
 ### Changed
 
+- `docs(config)`: fix `judge_model` doc comment in `LearningConfig` — field accepts a provider
+  name from `[[llm.providers]]`, not a raw model string; mark as legacy, prefer `judge_provider` (#4791)
 - `refactor(tracing)`: complete tracing instrumentation sweep across `zeph-channels`,
   `zeph-skills`, and `zeph-mcp` (issues #4849, #4827, #4819):
   - **zeph-channels**: add always-on `#[tracing::instrument]` to all hot-path async fns in

--- a/crates/zeph-config/src/learning.rs
+++ b/crates/zeph-config/src/learning.rs
@@ -219,7 +219,7 @@ pub struct LearningConfig {
     /// Detector strategy: "regex" (default) or "judge".
     #[serde(default)]
     pub detector_mode: DetectorMode,
-    /// Model for the judge detector (e.g. "claude-sonnet-4-6"). Empty = use primary provider.
+    /// Named provider from `[[llm.providers]]` for the judge detector (legacy field, prefer `judge_provider`). Empty = use primary provider.
     #[serde(default)]
     pub judge_model: String,
     /// Named provider from `[[llm.providers]]` for the judge detector (`detector_mode = "judge"`).

--- a/crates/zeph-memory/src/tiered_retrieval.rs
+++ b/crates/zeph-memory/src/tiered_retrieval.rs
@@ -1312,4 +1312,75 @@ mod tests {
         assert_eq!(result.tokens_used, 0);
         assert!(!result.tier_escalated);
     }
+
+    /// Test 6: `deep_reasoning_query_conditioned = true` with an empty HELA graph falls back to
+    /// `recall_routed` without panicking.
+    ///
+    /// `mock_semantic_memory` has no `graph_store`, so `recall_graph_hela` returns
+    /// `Ok(Vec::new())`.  The code at `tiered_retrieval.rs:307` logs "no results" and falls
+    /// through to `recall_routed`, which must succeed and return a valid `TieredRetrievalResult`.
+    #[tokio::test]
+    async fn deep_reasoning_query_conditioned_true_falls_back_when_hela_empty() {
+        let memory = crate::testing::mock_semantic_memory()
+            .await
+            .expect("mock_semantic_memory");
+
+        let config = TieredRetrievalConfig {
+            deep_reasoning_query_conditioned: true,
+            validation_enabled: false,
+            ..TieredRetrievalConfig::default()
+        };
+
+        let result = retrieve_tier(
+            &memory,
+            "multi-hop reasoning query",
+            None,
+            IntentClass::DeepReasoning,
+            &config,
+        )
+        .await
+        .expect("retrieve_tier with empty HELA must not fail");
+
+        // HELA returned nothing → fallback to recall_routed → empty result (no stored msgs).
+        assert!(
+            result.is_empty(),
+            "expected empty result from fallback recall_routed, got {}",
+            result.len()
+        );
+    }
+
+    /// Test 7: `deep_reasoning_query_conditioned = false` with `DeepReasoning` intent completes
+    /// without panicking.
+    ///
+    /// Verifies that the pipeline completes successfully and returns a valid (empty) result when
+    /// the flag is disabled. The mock has no stored messages, so `recall_routed` returns empty.
+    #[tokio::test]
+    async fn deep_reasoning_query_conditioned_false_completes_without_panic() {
+        let memory = crate::testing::mock_semantic_memory()
+            .await
+            .expect("mock_semantic_memory");
+
+        let config = TieredRetrievalConfig {
+            deep_reasoning_query_conditioned: false,
+            validation_enabled: false,
+            ..TieredRetrievalConfig::default()
+        };
+
+        let result = retrieve_tier(
+            &memory,
+            "multi-hop reasoning query",
+            None,
+            IntentClass::DeepReasoning,
+            &config,
+        )
+        .await
+        .expect("retrieve_tier with deep_reasoning_query_conditioned=false must not fail");
+
+        // recall_routed path used; no messages stored so result is empty.
+        assert!(
+            result.is_empty(),
+            "expected empty result from recall_routed path, got {}",
+            result.len()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add two unit tests for `TieredRetrievalConfig::deep_reasoning_query_conditioned` flag in `crates/zeph-memory/src/tiered_retrieval.rs` — the HELA routing branch was a dead zone from a testing perspective
- Fix misleading `judge_model` doc comment in `crates/zeph-config/src/learning.rs` — field accepts a provider name, not a raw model string

## Changes

### `crates/zeph-memory/src/tiered_retrieval.rs`

Two new tests:
- `deep_reasoning_query_conditioned_true_falls_back_when_hela_empty` — verifies graceful fallback to `recall_routed` when flag is `true` and HELA returns no results (no graph_store in mock)
- `deep_reasoning_query_conditioned_false_completes_without_panic` — verifies pipeline completes successfully when flag is disabled

### `crates/zeph-config/src/learning.rs`

Updated `judge_model` doc comment from "Model for the judge detector (e.g. `claude-sonnet-4-6`)" to "Named provider from `[[llm.providers]]` for the judge detector (legacy field, prefer `judge_provider`)". The field is resolved via `create_named_provider()` in `bootstrap/mod.rs` — the old comment was a silent misconfiguration hazard.

## Test plan

- [x] `cargo nextest run -p zeph-memory -E 'test(deep_reasoning_query_conditioned)'` — 2 passed
- [x] `cargo nextest run -p zeph-memory` — 1453 passed, 3 pre-existing `qdrant_integration` failures (Docker absent)
- [x] `cargo clippy -p zeph-memory -p zeph-config -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo doc --no-deps -p zeph-config` — builds without broken intra-doc links

Closes #4724
Closes #4791