### PR TITLE
refactor(agent-tools,db): replace send_stop_hint with StopHint enum; fix sql! import guards

### DIFF
--- a/crates/zeph-agent-tools/src/channel.rs
+++ b/crates/zeph-agent-tools/src/channel.rs
@@ -17,13 +17,10 @@
 //! impl<C: zeph_core::channel::Channel> AgentChannel for AgentChannelView<'_, C>
 //! ```
 //! which is orphan-safe because `AgentChannelView` is a local type in `zeph-core`.
-//!
-//! # TODO(critic): `send_stop_hint` takes a primitive `&str` reason instead of an enum.
-//! Any new variant added to `zeph_core::channel::StopHint` MUST be mirrored at dispatcher
-//! emit-sites AND at `AgentChannelView::send_stop_hint` match arms.
-//! See `critic-3515-3516.md` F3.
 
 use std::future::Future;
+
+use zeph_common::StopHint;
 
 use crate::sealed::Sealed;
 
@@ -115,14 +112,10 @@ pub trait AgentChannel: Sealed + Send {
         prompt: &str,
     ) -> impl Future<Output = Result<bool, ChannelSinkError>> + Send;
 
-    /// Notify the channel that the assistant turn stopped for `reason`.
-    ///
-    /// `reason` is a primitive string code such as `"max_tokens"`, `"cancelled"`,
-    /// `"max_turn_requests"`, or `"timeout"`. The `AgentChannelView` impl maps these to the
-    /// concrete `zeph_core::channel::StopHint` enum and forwards.
+    /// Notify the channel that the assistant turn stopped for `hint`.
     fn send_stop_hint(
         &mut self,
-        reason: &str,
+        hint: StopHint,
     ) -> impl Future<Output = Result<(), ChannelSinkError>> + Send;
 
     /// Emit a tool-start event.

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -49,7 +49,7 @@ pub use task_supervisor::{
 };
 pub use text::format_tokens;
 pub use trust_level::SkillTrustLevel;
-pub use types::{ProviderName, SessionId, SkillName, ToolDefinition, ToolName};
+pub use types::{ProviderName, SessionId, SkillName, StopHint, ToolDefinition, ToolName};
 
 #[cfg(feature = "treesitter")]
 pub mod treesitter;

--- a/crates/zeph-common/src/types.rs
+++ b/crates/zeph-common/src/types.rs
@@ -725,6 +725,28 @@ pub struct ToolDefinition {
     pub output_schema: Option<serde_json::Value>,
 }
 
+/// Reason why the agent turn ended early.
+///
+/// Emitted by the agent loop when a non-default terminal condition is detected.
+/// Consumers (e.g. the ACP layer) map this to the protocol-level `StopReason`.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::StopHint;
+///
+/// let hint = StopHint::MaxTokens;
+/// assert!(matches!(hint, StopHint::MaxTokens));
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopHint {
+    /// The LLM response was cut off by the token limit.
+    MaxTokens,
+    /// The turn loop exhausted `max_turns` without a final text response.
+    MaxTurnRequests,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/zeph-core/src/agent/channel_impl.rs
+++ b/crates/zeph-core/src/agent/channel_impl.rs
@@ -20,7 +20,9 @@ use std::time::Instant;
 use zeph_agent_tools::channel::{AgentChannel, ChannelSinkError, ToolEventOutput, ToolEventStart};
 use zeph_agent_tools::sealed::Sealed;
 
-use crate::channel::{Channel, StopHint, ToolOutputEvent, ToolStartEvent};
+use zeph_common::StopHint;
+
+use crate::channel::{Channel, ToolOutputEvent, ToolStartEvent};
 
 /// Borrowed adapter that wraps `&mut C` so any [`Channel`] implementation can be used
 /// where [`zeph_agent_tools::AgentChannel`] is required.
@@ -81,20 +83,7 @@ impl<C: Channel + Send> AgentChannel for AgentChannelView<'_, C> {
             .map_err(|e| ChannelSinkError::new(e.to_string()))
     }
 
-    async fn send_stop_hint(&mut self, reason: &str) -> Result<(), ChannelSinkError> {
-        // TODO(review): if new StopHint variants are added to zeph-core::channel::StopHint,
-        // mirror them here AND at any dispatcher emit-sites in zeph-agent-tools.
-        let hint = match reason {
-            "max_tokens" => StopHint::MaxTokens,
-            "max_turn_requests" => StopHint::MaxTurnRequests,
-            other => {
-                tracing::warn!(
-                    reason = other,
-                    "AgentChannelView: unknown stop reason, ignoring"
-                );
-                return Ok(());
-            }
-        };
+    async fn send_stop_hint(&mut self, hint: StopHint) -> Result<(), ChannelSinkError> {
         self.channel
             .send_stop_hint(hint)
             .await
@@ -188,17 +177,9 @@ mod tests {
     async fn agent_channel_view_send_stop_hint_max_tokens() {
         let (mut ch, mut handle) = LoopbackChannel::pair(8);
         let mut view = AgentChannelView::new(&mut ch);
-        view.send_stop_hint("max_tokens").await.unwrap();
+        view.send_stop_hint(StopHint::MaxTokens).await.unwrap();
         let event = handle.output_rx.recv().await.unwrap();
         assert!(matches!(event, LoopbackEvent::Stop(StopHint::MaxTokens)));
-    }
-
-    #[tokio::test]
-    async fn agent_channel_view_send_stop_hint_unknown_is_noop() {
-        let (mut ch, _handle) = LoopbackChannel::pair(8);
-        let mut view = AgentChannelView::new(&mut ch);
-        // Unknown reason should not send any event
-        view.send_stop_hint("unknown_reason").await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -471,19 +471,7 @@ pub trait Channel: Send {
     }
 }
 
-#[non_exhaustive]
-/// Reason why the agent turn ended — carried by [`LoopbackEvent::Stop`].
-///
-/// Emitted by the agent loop immediately before `Flush` when a non-default
-/// terminal condition is detected. Consumers (e.g. the ACP layer) map this to
-/// the protocol-level `StopReason`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StopHint {
-    /// The LLM response was cut off by the token limit.
-    MaxTokens,
-    /// The turn loop exhausted `max_turns` without a final text response.
-    MaxTurnRequests,
-}
+pub use zeph_common::StopHint;
 
 /// Event carrying data for a tool call start, emitted before execution begins.
 ///

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -66,9 +66,6 @@
 //! # }
 //! ```
 
-#[allow(unused_imports)]
-pub(crate) use zeph_db::sql;
-
 pub mod adaptorch;
 pub mod admission;
 pub mod aggregator;

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -13,7 +13,7 @@ use blake3;
 use serde::{Deserialize, Serialize};
 use zeph_config::PlanCacheConfig;
 use zeph_db::DbPool;
-#[allow(unused_imports)]
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 use zeph_db::sql;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 

--- a/crates/zeph-scheduler/src/lib.rs
+++ b/crates/zeph-scheduler/src/lib.rs
@@ -77,9 +77,6 @@
 //! `zeph-db` migrations. Use [`JobStore::open`] to connect or [`JobStore::new`] when
 //! you already hold a [`zeph_db::DbPool`].
 
-#[allow(unused_imports)]
-pub(crate) use zeph_db::sql;
-
 mod error;
 mod handlers;
 mod sanitize;

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -4,8 +4,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
-#[allow(unused_imports)]
-use zeph_db::sql;
 
 use chrono::Utc;
 use tokio::sync::{Mutex, mpsc, watch};
@@ -887,6 +885,8 @@ mod tests {
     use super::*;
     use crate::task::TaskHandler;
     use zeph_db::DbPool;
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    use zeph_db::sql;
 
     struct CountingHandler {
         count: Arc<AtomicU32>,

--- a/crates/zeph-scheduler/src/store.rs
+++ b/crates/zeph-scheduler/src/store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use zeph_db::DbPool;
-#[allow(unused_imports)]
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 use zeph_db::sql;
 
 use crate::error::SchedulerError;


### PR DESCRIPTION
## Summary

- Replace `AgentChannelView::send_stop_hint(&str)` with `send_stop_hint(StopHint)` to eliminate implicit string-based dispatch coupling and provide compile-time exhaustiveness enforcement across all call-sites. `StopHint` is moved to `zeph-common::types` (a leaf crate) to avoid a circular dependency, with re-exports in both `zeph-common` and `zeph-core::channel` for source compatibility. Closes #4792.

- Replace `#[allow(unused_imports)]` workarounds on feature-gated `sql!` use declarations in `zeph-scheduler` and `zeph-orchestration` with proper `#[cfg(any(feature = "sqlite", feature = "postgres"))]` guards. Removes the import entirely where it is unused at module level; moves it inside `#[cfg(test)]` in `scheduler.rs` where `sql!` is only used in tests. Closes #4841.

**Note:** Issue #4779 (`#[non_exhaustive]` sweep for 18 pub enums) was already resolved in PR #4759 (commit `88c8179f`) and is not part of this branch.

## Files changed (10)

- `crates/zeph-agent-tools/src/channel.rs` — `send_stop_hint` signature updated
- `crates/zeph-common/src/lib.rs` — re-export `StopHint`
- `crates/zeph-common/src/types.rs` — `StopHint` enum definition added
- `crates/zeph-core/src/agent/channel_impl.rs` — call-sites updated to enum variants
- `crates/zeph-core/src/channel.rs` — re-export `StopHint` from zeph-common
- `crates/zeph-orchestration/src/lib.rs` — `sql!` import removed (unused at module level)
- `crates/zeph-orchestration/src/plan_cache.rs` — `sql!` import guarded with `#[cfg]`
- `crates/zeph-scheduler/src/lib.rs` — `sql!` import removed (unused at module level)
- `crates/zeph-scheduler/src/scheduler.rs` — `sql!` import moved inside `#[cfg(test)]`
- `crates/zeph-scheduler/src/store.rs` — `sql!` import guarded with `#[cfg]`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,sqlite" --locked` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10500 passed, 21 skipped
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — passed