### PR TITLE
refactor(mcp,channels): fix tracing span naming and add telegram instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `docs(config)`: fix `judge_model` doc comment in `LearningConfig` — field accepts a provider
   name from `[[llm.providers]]`, not a raw model string; mark as legacy, prefer `judge_provider` (#4791)
+- `refactor(mcp,channels)`: fix tracing span naming convention violations and add missing instrumentation (#4860, #4859):
+  - **zeph-mcp**: rename `mcp.manager_call_tool` → `mcp.manager.call_tool`, `mcp.connect_all` → `mcp.manager.connect_all`, `mcp.shutdown_all` → `mcp.manager.shutdown_all` in `manager.rs` to comply with `<crate>.<subsystem>.<operation>` convention.
+  - **zeph-channels**: add `#[tracing::instrument(name = "channels.telegram.send_chunk", ...)]` to `TelegramChannel::send_chunk`, matching the existing instrumentation in `DiscordChannel` and `SlackChannel`.
 - `refactor(tracing)`: complete tracing instrumentation sweep across `zeph-channels`,
   `zeph-skills`, and `zeph-mcp` (issues #4849, #4827, #4819):
   - **zeph-channels**: add always-on `#[tracing::instrument]` to all hot-path async fns in

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -1163,6 +1163,7 @@ impl Channel for TelegramChannel {
     /// Returns `Err` if the periodic Telegram edit fails.
     ///
     /// [`flush_chunks`]: TelegramChannel::flush_chunks
+    #[tracing::instrument(name = "channels.telegram.send_chunk", skip_all, level = "debug", fields(chunk_len = %chunk.len()))]
     async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
         self.buffer.push(chunk);
         tracing::debug!(

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -695,7 +695,7 @@ impl McpManager {
     /// Does not panic under normal conditions.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.connect_all", skip_all, fields(connected = tracing::field::Empty, failed = tracing::field::Empty))
+        tracing::instrument(name = "mcp.manager.connect_all", skip_all, fields(connected = tracing::field::Empty, failed = tracing::field::Empty))
     )]
     pub async fn connect_all(&self) -> (Vec<McpTool>, Vec<ServerConnectOutcome>) {
         let join_set = self.spawn_non_oauth_connections(&self.last_refresh);
@@ -1175,7 +1175,7 @@ impl McpManager {
     /// or `McpError::ServerNotFound` if the server is not connected.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.manager_call_tool", skip_all, fields(server_id = %server_id, tool_name = %tool_name))
+        tracing::instrument(name = "mcp.manager.call_tool", skip_all, fields(server_id = %server_id, tool_name = %tool_name))
     )]
     pub async fn call_tool(
         &self,
@@ -1486,7 +1486,7 @@ impl McpManager {
     /// Graceful shutdown of all connections (takes ownership).
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.shutdown_all", skip_all)
+        tracing::instrument(name = "mcp.manager.shutdown_all", skip_all)
     )]
     pub async fn shutdown_all(self) {
         self.shutdown_all_shared().await;


### PR DESCRIPTION
## Summary

- Fix 3 MCP manager span names in `crates/zeph-mcp/src/manager.rs` that violated the `<crate>.<subsystem>.<operation>` convention: `mcp.manager_call_tool` → `mcp.manager.call_tool`, `mcp.connect_all` → `mcp.manager.connect_all`, `mcp.shutdown_all` → `mcp.manager.shutdown_all`
- Add `#[tracing::instrument(name = "channels.telegram.send_chunk", skip_all, level = "debug", fields(chunk_len = %chunk.len()))]` to `TelegramChannel::send_chunk`, matching the existing instrumentation in `DiscordChannel` and `SlackChannel` (added in #4852)

Closes #4860, #4859

## Test plan

- [x] `cargo build -p zeph-mcp -p zeph-channels` — clean build
- [x] `cargo nextest run --workspace --lib --bins` — 10506 tests passed, 0 failures
- [x] `cargo +nightly fmt --check` — no formatting issues
- [x] `cargo clippy -p zeph-mcp -p zeph-channels -- -D warnings` — no warnings
- [x] No existing tests assert on the old span name strings
- [x] `#[tracing::instrument]` on `send_chunk` introduces no behavioral drift (pure span wrapper, `skip_all` + `chunk_len` field only)