### PR TITLE
refactor(llm): delegate gemini ApiError to map_error_response; docs(config): CandleConfig doc comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `refactor(llm)`: `parse_gemini_error` in `zeph-llm` now delegates the base `ApiError` and
+  `ContextLengthExceeded` construction to `crate::http::map_error_response`, consistent with all
+  other backends (claude, openai, gonka, cocoon). Gemini-specific `RESOURCE_EXHAUSTED → RateLimited`
+  handling is preserved. (#4868)
+
+### Fixed
+
+- `docs(config)`: `CandleConfig` in `zeph-config` now has a `///` doc comment describing its
+  purpose (`[llm.candle]` TOML section) and its relationship to `CandleInlineConfig`. (#4869)
+
 
 ## [0.21.4] - 2026-06-05
 

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -1087,6 +1087,12 @@ impl Default for BanditConfig {
     }
 }
 
+/// Configuration for the Candle local-inference backend.
+///
+/// Corresponds to the `[llm.candle]` section in `config.toml`. Used when the
+/// agent runs inference locally via `HuggingFace` Candle rather than a remote API.
+/// For inline provider definitions inside `[[llm.providers]]`, use
+/// [`CandleInlineConfig`] instead.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CandleConfig {
     #[serde(default = "default_candle_source")]

--- a/crates/zeph-llm/src/gemini/mod.rs
+++ b/crates/zeph-llm/src/gemini/mod.rs
@@ -445,10 +445,7 @@ fn parse_gemini_error(body: &str, status: reqwest::StatusCode) -> LlmError {
     } else {
         tracing::error!("Gemini API request failed (status {status}): {body}");
     }
-    LlmError::ApiError {
-        provider: "gemini".into(),
-        status: status.as_u16(),
-    }
+    crate::http::map_error_response(status, body, "gemini")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#4868** — `parse_gemini_error` in `zeph-llm` now delegates base `ApiError` and `ContextLengthExceeded` construction to `crate::http::map_error_response`, consistent with all other backends (claude, openai, gonka, cocoon). The Gemini-specific `RESOURCE_EXHAUSTED → RateLimited` path is preserved.
- **#4869** — `CandleConfig` in `zeph-config` now has a `///` doc comment describing its purpose and relationship to `CandleInlineConfig`.

## Changes

- `crates/zeph-llm/src/gemini/mod.rs`: remove 4-line manual `LlmError::ApiError` construction, delegate to `map_error_response(status, body, "gemini")`
- `crates/zeph-config/src/providers.rs`: add `///` doc comment to `pub struct CandleConfig`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-llm -p zeph-config -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 10510 passed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-config` — clean
- [x] Behavioral analysis: RESOURCE_EXHAUSTED→RateLimited preserved; ContextLengthExceeded preserved; argument order `(status, body, "gemini")` verified correct

Closes #4868
Closes #4869