### PR TITLE
refactor(memory): remove ScoredCandidate wrapper and fix entered() span in tiered_retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `ContextLengthExceeded` construction to `crate::http::map_error_response`, consistent with all
   other backends (claude, openai, gonka, cocoon). Gemini-specific `RESOURCE_EXHAUSTED → RateLimited`
   handling is preserved. (#4868)
+- refactor(memory): remove `ScoredCandidate` single-field wrapper in `tiered_retrieval.rs` ([#4867](https://github.com/bug-ops/zeph/issues/4867))
+- fix(memory): replace `.entered()` span guard with removal in `tiered_retrieval.rs` async fn ([#4866](https://github.com/bug-ops/zeph/issues/4866))
 
 ### Fixed
 

--- a/crates/zeph-memory/src/tiered_retrieval.rs
+++ b/crates/zeph-memory/src/tiered_retrieval.rs
@@ -210,10 +210,7 @@ async fn escalation_loop(
             .instrument(tracing::debug_span!("memory.tiered.score_candidates", tier = %intent))
             .await?;
 
-        let (messages, tokens_used) = {
-            let _span = tracing::debug_span!("memory.tiered.assemble").entered();
-            assemble_within_budget(candidates, effective_budget)
-        };
+        let (messages, tokens_used) = assemble_within_budget(candidates, effective_budget);
 
         // Validate evidence quality if enabled and a validator is available.
         if config.validation_enabled
@@ -321,11 +318,6 @@ async fn retrieve_tier(
 
 // ── Five-signal retrieval scoring ─────────────────────────────────────────────
 
-/// Intermediate struct for multi-signal scoring of a single candidate.
-struct ScoredCandidate {
-    recalled: RecalledMessage,
-}
-
 /// Re-score `candidates` using up to five signals and return them sorted by final score.
 ///
 /// Overwrites `RecalledMessage::score` with the combined weighted score.
@@ -415,7 +407,7 @@ async fn score_candidates(
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0_i64, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
 
-    let mut scored: Vec<ScoredCandidate> = candidates
+    let mut scored: Vec<RecalledMessage> = candidates
         .into_iter()
         .zip(tfidf_scores)
         .map(|(recalled, tfidf)| {
@@ -456,25 +448,22 @@ async fn score_candidates(
                 + config.cognitive_signal_weight * cognitive
                 + config.tier_boost_weight * tier_signal;
 
-            ScoredCandidate {
-                recalled: RecalledMessage {
-                    // f64 → f32: deliberate truncation, score precision is adequate.
-                    #[allow(clippy::cast_possible_truncation)]
-                    score: final_score as f32,
-                    ..recalled
-                },
+            RecalledMessage {
+                // f64 → f32: deliberate truncation, score precision is adequate.
+                #[allow(clippy::cast_possible_truncation)]
+                score: final_score as f32,
+                ..recalled
             }
         })
         .collect();
 
     scored.sort_by(|a, b| {
-        b.recalled
-            .score
-            .partial_cmp(&a.recalled.score)
+        b.score
+            .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    Ok(scored.into_iter().map(|s| s.recalled).collect())
+    Ok(scored)
 }
 
 /// Compute recency score in `[0.0, 1.0]` using exponential half-life decay.


### PR DESCRIPTION
## Summary

- Remove `ScoredCandidate` private single-field wrapper struct from `score_candidates`; use `Vec<RecalledMessage>` directly, eliminating the final `.map(|s| s.recalled)` unwrap and the `.recalled` field indirection in the sort comparator.
- Remove `debug_span!("memory.tiered.assemble").entered()` guard wrapping `assemble_within_budget` inside `async fn escalation_loop`. The call is synchronous and nests under the outer `memory.tiered.retrieve` instrument span; the extra guard was a flagged anti-pattern per project convention.

## Changes

- `crates/zeph-memory/src/tiered_retrieval.rs` — two localized edits, behavior unchanged
- `CHANGELOG.md` — `[Unreleased]` section updated

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --workspace --lib --bins` — 10510 passed, 21 skipped
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [ ] `cargo doc --no-deps -p zeph-memory --all-features` — no broken intra-doc links
- [ ] `grep -rn "ScoredCandidate" crates/` — no output (struct fully removed)
- [ ] `grep -n "\.entered()" crates/zeph-memory/src/tiered_retrieval.rs` — no output

Closes #4866
Closes #4867