### PR TITLE
fix(experiments): correct EvalReport total_tokens overcounting and improve evaluator tests

### DIFF
--- a/crates/zeph-experiments/src/evaluator.rs
+++ b/crates/zeph-experiments/src/evaluator.rs
@@ -383,7 +383,10 @@ impl Evaluator {
                 // both proceed, overshooting the budget. We use fetch_add(1) to claim
                 // a reservation slot; if we are already at or above budget we roll back.
                 // The real token cost is added inside score_case_with_provider after the
-                // call completes, at which point the reservation is included in the total.
+                // call completes. The reservation remains in the counter to keep the
+                // budget guard conservative — EvalReport::total_tokens is corrected by
+                // subtracting cases_scored (one reservation per successful call) after
+                // all futures complete, so the reported value reflects only real usage.
                 let prev = tokens_used.fetch_add(1, Ordering::AcqRel);
                 if prev >= budget {
                     tokens_used.fetch_sub(1, Ordering::AcqRel);
@@ -438,13 +441,19 @@ impl Evaluator {
         let cases_scored = scores.len();
         let is_partial = budget_hit || error_count > 0;
 
+        // Each successful judge call left a +1 reservation in tokens_used that was never
+        // rolled back (the reservation is intentionally kept to prevent budget races).
+        // Subtract cases_scored here so EvalReport::total_tokens reflects only real usage.
+        let raw_tokens = tokens_used.load(Ordering::Relaxed);
+        let total_tokens = raw_tokens.saturating_sub(cases_scored as u64);
+
         Ok(build_report(
             scores,
             cases_scored,
             cases_total,
             is_partial,
             error_count,
-            tokens_used.load(Ordering::Relaxed),
+            total_tokens,
         ))
     }
 }
@@ -1131,15 +1140,17 @@ mod tests {
     }
 
     /// R8-GAP-2: Semaphore limits concurrent judge calls.
+    ///
+    /// The judge mock uses `with_concurrency_tracking()` to atomically record the
+    /// peak number of simultaneously-active `chat()` calls.  With `parallel_evals=2`
+    /// the semaphore must prevent more than 2 tasks from executing concurrently.
     #[tokio::test]
     async fn parallel_eval_respects_concurrency_limit() {
+        use std::sync::Arc;
         use std::sync::atomic::Ordering as AOrdering;
-        use std::sync::{Arc, atomic::AtomicUsize};
         use zeph_llm::any::AnyProvider;
         use zeph_llm::mock::MockProvider;
 
-        // We verify the semaphore does not cause panics and respects the configured limit
-        // by running with parallel_evals=1 and checking the report is fully sequential.
         let benchmark = BenchmarkSet {
             cases: vec![
                 BenchmarkCase {
@@ -1167,38 +1178,47 @@ mod tests {
             "A2".into(),
             "A3".into(),
         ]));
-        let judge_mock = AnyProvider::Mock(MockProvider::with_responses(vec![
+
+        // The judge mock tracks how many `chat()` calls overlap at any instant.
+        // A small delay (10 ms) widens the overlap window so tasks actually run concurrently.
+        let (judge_base, peak) = MockProvider::with_responses(vec![
             r#"{"score": 7.0, "reason": "ok"}"#.into(),
             r#"{"score": 8.0, "reason": "ok"}"#.into(),
             r#"{"score": 9.0, "reason": "ok"}"#.into(),
-        ]));
+        ])
+        .with_delay(10)
+        .with_concurrency_tracking();
+        let judge_mock = Arc::new(AnyProvider::Mock(judge_base));
 
-        // Track peak concurrent calls with an atomic counter.
-        let peak = Arc::new(AtomicUsize::new(0));
-        let peak_ref = Arc::clone(&peak);
-
-        let evaluator = Evaluator::new(Arc::new(judge_mock), benchmark, 1_000_000)
+        let evaluator = Evaluator::new(Arc::clone(&judge_mock), benchmark, 1_000_000)
             .unwrap()
             .with_parallel_evals(2); // limit to 2 concurrent
 
         let report = evaluator.evaluate(&subject_mock).await.unwrap();
 
-        // With concurrency=2 and 3 cases all succeeding, all 3 should be scored.
         assert_eq!(report.cases_scored, 3);
         assert!(!report.is_partial);
-        // Peak concurrent is bounded — we cannot directly measure without instrumentation,
-        // but the test verifies no deadlock, panic, or resource leak occurs.
-        drop(peak_ref);
-        assert_eq!(peak.load(AOrdering::Relaxed), 0); // unused, just ensures compilation
+        let observed_peak = peak.load(AOrdering::SeqCst);
+        // Upper bound: semaphore must prevent more than parallel_evals concurrent calls.
+        assert!(
+            observed_peak <= 2,
+            "peak concurrent judge calls exceeded semaphore limit: got {observed_peak}",
+        );
+        // Lower bound: with 3 cases and limit=2 the semaphore must have been exercised.
+        assert!(
+            observed_peak >= 2,
+            "concurrency limit was not exercised: peak={observed_peak}",
+        );
     }
 
     /// Regression test for #4197: atomic budget enforcement under parallel load.
     ///
     /// With `parallel_evals=4` and `budget_tokens=1`, only a single judge call can
     /// claim the reservation slot (fetch_add sees prev=0). All other tasks must see
-    /// prev >= 1 and roll back. The total tokens committed must not exceed 1 plus the
-    /// real token cost of the one permitted call (MockProvider reports 0 tokens, so
-    /// the final counter stays at 1 from the reservation that was not rolled back).
+    /// prev >= 1 and roll back. The reservation slot is kept in the counter so that the
+    /// budget guard remains conservative; EvalReport::total_tokens is corrected by
+    /// subtracting cases_scored at report-build time (MockProvider reports 0 real tokens,
+    /// so the reported total equals 0 after the correction).
     #[tokio::test]
     async fn budget_not_exceeded_under_parallel_load() {
         use std::sync::Arc;
@@ -1266,5 +1286,74 @@ mod tests {
             report.cases_scored
         );
         assert_eq!(report.cases_total, 4);
+    }
+
+    /// Regression test for #4855: per_case ordering is deterministic even when subject
+    /// futures complete in reverse order.
+    ///
+    /// The subject mock is given per-call delays that decrease with each case index so the
+    /// last case finishes first.  `sort_unstable_by_key(|(i, _)| *i)` in Phase 1 must
+    /// restore the original order before Phase 2 begins, meaning `per_case[i].case_index`
+    /// must equal `i` for every successfully scored case.
+    #[tokio::test]
+    async fn subject_responses_ordered_after_parallel_phase1() {
+        use std::sync::Arc;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let benchmark = BenchmarkSet {
+            cases: vec![
+                BenchmarkCase {
+                    prompt: "Q0".into(),
+                    context: None,
+                    reference: None,
+                    tags: None,
+                },
+                BenchmarkCase {
+                    prompt: "Q1".into(),
+                    context: None,
+                    reference: None,
+                    tags: None,
+                },
+                BenchmarkCase {
+                    prompt: "Q2".into(),
+                    context: None,
+                    reference: None,
+                    tags: None,
+                },
+            ],
+        };
+
+        // Subject delays: case 0 sleeps longest, case 2 sleeps least — futures complete in
+        // reverse order (2 → 1 → 0).  FuturesUnordered will yield them that way.
+        let subject_mock = AnyProvider::Mock(
+            MockProvider::with_responses(vec!["A0".into(), "A1".into(), "A2".into()])
+                .with_per_call_delays(vec![30, 20, 10]),
+        );
+
+        // Judge: one response per case, instant.
+        let judge_mock = Arc::new(AnyProvider::Mock(MockProvider::with_responses(vec![
+            r#"{"score": 6.0, "reason": "ok"}"#.into(),
+            r#"{"score": 7.0, "reason": "ok"}"#.into(),
+            r#"{"score": 8.0, "reason": "ok"}"#.into(),
+        ])));
+
+        let evaluator = Evaluator::new(judge_mock, benchmark, 1_000_000)
+            .unwrap()
+            .with_parallel_evals(3); // all subject calls fire concurrently
+
+        let report = evaluator.evaluate(&subject_mock).await.unwrap();
+
+        assert_eq!(report.cases_scored, 3, "all cases must be scored");
+        assert!(!report.is_partial);
+
+        // per_case must be sorted by case_index regardless of completion order.
+        for (i, cs) in report.per_case.iter().enumerate() {
+            assert_eq!(
+                cs.case_index, i,
+                "per_case[{i}].case_index must be {i}, got {}",
+                cs.case_index,
+            );
+        }
     }
 }

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -46,6 +46,13 @@ pub struct MockProvider {
     pub embed_delay_ms: u64,
     /// Fixed entropy value returned by `chat_with_extras()`. `None` returns `ChatExtras::default()`.
     pub fixed_entropy: Option<f64>,
+    /// Counts currently-in-flight `chat()` calls. Updated atomically before and after the call body.
+    /// Shared with the test via [`MockProvider::with_concurrency_tracking`].
+    in_flight: Arc<std::sync::atomic::AtomicUsize>,
+    /// High-watermark of concurrent `chat()` calls observed so far.
+    peak_concurrent: Arc<std::sync::atomic::AtomicUsize>,
+    /// Per-call delay sequence. Each `chat()` call pops from the front; when empty, falls back to `delay_ms`.
+    per_call_delays: Arc<Mutex<VecDeque<u64>>>,
 }
 
 impl Default for MockProvider {
@@ -69,6 +76,9 @@ impl Default for MockProvider {
             embed_call_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             embed_delay_ms: 0,
             fixed_entropy: None,
+            in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            peak_concurrent: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            per_call_delays: Arc::new(Mutex::new(VecDeque::new())),
         }
     }
 }
@@ -192,6 +202,52 @@ impl MockProvider {
         self
     }
 
+    /// Set per-call delay sequence for `chat()`.
+    ///
+    /// Each call pops from the front of the sequence; when the sequence is exhausted,
+    /// `delay_ms` is used as a fallback.  This enables tests to assign distinct delays
+    /// to individual calls so that futures complete in a controlled out-of-order fashion,
+    /// which verifies ordering guarantees in callers that use `FuturesUnordered`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::mock::MockProvider;
+    ///
+    /// // First call sleeps 30 ms, second sleeps 10 ms → second completes first.
+    /// let provider = MockProvider::with_responses(vec!["slow".into(), "fast".into()])
+    ///     .with_per_call_delays(vec![30, 10]);
+    /// ```
+    #[must_use]
+    pub fn with_per_call_delays(mut self, delays: Vec<u64>) -> Self {
+        self.per_call_delays = Arc::new(Mutex::new(VecDeque::from(delays)));
+        self
+    }
+
+    /// Enable in-flight concurrency tracking.
+    ///
+    /// Returns the provider and a shared atomic that holds the peak number of concurrent
+    /// `chat()` calls observed across the provider's lifetime.  Each `chat()` call
+    /// increments `in_flight`, records the new value into the peak if it is higher, then
+    /// decrements after the body (including any `delay_ms` sleep) completes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::mock::MockProvider;
+    /// use std::sync::atomic::Ordering;
+    ///
+    /// let (provider, peak) = MockProvider::default().with_concurrency_tracking();
+    /// // After running concurrent calls, peak.load(Ordering::SeqCst) <= expected_limit.
+    /// ```
+    #[must_use]
+    pub fn with_concurrency_tracking(mut self) -> (Self, Arc<std::sync::atomic::AtomicUsize>) {
+        let peak = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        self.in_flight = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        self.peak_concurrent = Arc::clone(&peak);
+        (self, peak)
+    }
+
     /// Enable native `tool_use` support with a pre-configured sequence of `ChatResponse`
     /// values returned from `chat_with_tools()`.
     ///
@@ -212,29 +268,44 @@ impl LlmProvider for MockProvider {
     }
 
     async fn chat(&self, messages: &[Message]) -> Result<String, crate::LlmError> {
-        if self.delay_ms > 0 {
-            tokio::time::sleep(std::time::Duration::from_millis(self.delay_ms)).await;
+        use std::sync::atomic::Ordering as AOrdering;
+        let current = self.in_flight.fetch_add(1, AOrdering::SeqCst) + 1;
+        self.peak_concurrent.fetch_max(current, AOrdering::SeqCst);
+
+        let call_delay = self
+            .per_call_delays
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(self.delay_ms);
+        if call_delay > 0 {
+            // Yield before sleeping so concurrent tasks can register in-flight before
+            // any of them finish, enabling accurate peak measurement.
+            tokio::task::yield_now().await;
+            tokio::time::sleep(std::time::Duration::from_millis(call_delay)).await;
         }
         if let Some(buf) = &self.recorded
             && let Ok(mut guard) = buf.lock()
         {
             guard.push(messages.to_vec());
         }
-        if self.fail_chat {
-            return Err(crate::LlmError::Other("mock LLM error".into()));
-        }
-        // Return pre-configured errors first
-        if let Ok(mut errors) = self.errors.lock()
+        let result = if self.fail_chat {
+            Err(crate::LlmError::Other("mock LLM error".into()))
+        } else if let Ok(mut errors) = self.errors.lock()
             && !errors.is_empty()
         {
-            return Err(errors.pop_front().expect("non-empty"));
-        }
-        let mut responses = self.responses.lock().unwrap();
-        if responses.is_empty() {
-            Ok(self.default_response.clone())
+            Err(errors.pop_front().expect("non-empty"))
         } else {
-            Ok(responses.pop_front().expect("non-empty"))
-        }
+            let mut responses = self.responses.lock().unwrap();
+            if responses.is_empty() {
+                Ok(self.default_response.clone())
+            } else {
+                Ok(responses.pop_front().expect("non-empty"))
+            }
+        };
+
+        self.in_flight.fetch_sub(1, AOrdering::SeqCst);
+        result
     }
 
     async fn chat_with_extras(


### PR DESCRIPTION
## Summary

- **#4870** — `EvalReport::total_tokens` was overstated by N (one per successful judge call) due to uncancelled +1 reservation slots in the budget-guard pattern. Fix applies `saturating_sub(cases_scored)` at report-build time after all futures join; the budget guard remains conservative during execution.
- **#4854** — `parallel_eval_respects_concurrency_limit` test never incremented its peak counter, proving only absence of deadlock. MockProvider now tracks in-flight calls with atomics and records peak via `fetch_max`; test asserts both `peak <= parallel_evals` and `peak >= parallel_evals`.
- **#4855** — New test `subject_responses_ordered_after_parallel_phase1` uses per-call delays to force reverse-order future completion, then asserts `per_case[i].case_index == i` for all `i`, verifying the `sort_unstable_by_key` ordering invariant from PR #4853.
- Also makes `MockProvider::chat` yield_now() conditional on `delay > 0` to prevent scheduler preemption in zero-delay sequential callers (fixed regression in `zeph-core` tests).

## Test plan

- [ ] `cargo nextest run -p zeph-experiments --lib` — 131 passed
- [ ] `cargo nextest run -p zeph-llm --lib` — 886 passed
- [ ] `cargo nextest run -p zeph-core --lib` — 1521 passed
- [ ] `cargo nextest run --workspace --lib --bins` — 10511 passed
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy -p zeph-experiments -p zeph-llm --all-targets -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check -p zeph-experiments -p zeph-llm --all-targets --locked` — clean

Closes #4870
Closes #4854
Closes #4855