### PR TITLE
refactor(llm): extract generation_params() helper and fix context_window fallback in OpenAiProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(llm)`: `OpenAiProvider` now resolves context window via three-step lookup: explicit
+  `context_window` field in `OpenAiConfig` → model-prefix table → `128_000` fallback for unknown
+  models. Eliminates silent `None` for unrecognised model names. (#4876)
+
+- `refactor(llm)`: `OpenAiProvider::generation_params()` private helper extracted; removes 4
+  duplicate `generation_overrides` tuple expansions in `send_request`, `send_stream_request`,
+  `debug_request_json`, and `chat_with_tools`. (#4873)
+
 - `refactor(llm)`: `parse_gemini_error` in `zeph-llm` now delegates the base `ApiError` and
   `ContextLengthExceeded` construction to `crate::http::map_error_response`, consistent with all
   other backends (claude, openai, gonka, cocoon). Gemini-specific `RESOURCE_EXHAUSTED → RateLimited`

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -225,6 +225,7 @@ fn build_openai_provider(
             max_tokens,
             embedding_model: entry.embedding_model.clone(),
             reasoning_effort: entry.reasoning_effort.clone(),
+            context_window: None,
         })
         .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
         .with_output_schema_forwarding(

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -717,6 +717,7 @@ mod tests {
                 max_tokens: 1024,
                 embedding_model: None,
                 reasoning_effort: None,
+                context_window: None,
             },
         ));
         assert_eq!(provider.name(), "openai");
@@ -732,6 +733,7 @@ mod tests {
                 max_tokens: 1024,
                 embedding_model: None,
                 reasoning_effort: None,
+                context_window: None,
             },
         ));
         assert!(provider.supports_streaming());
@@ -747,6 +749,7 @@ mod tests {
                 max_tokens: 1024,
                 embedding_model: Some("text-embedding-3-small".into()),
                 reasoning_effort: None,
+                context_window: None,
             },
         ));
         assert!(with_embed.supports_embeddings());
@@ -759,6 +762,7 @@ mod tests {
                 max_tokens: 1024,
                 embedding_model: None,
                 reasoning_effort: None,
+                context_window: None,
             },
         ));
         assert!(!without_embed.supports_embeddings());
@@ -774,6 +778,7 @@ mod tests {
                 max_tokens: 1024,
                 embedding_model: None,
                 reasoning_effort: None,
+                context_window: None,
             },
         ));
         let debug = format!("{provider:?}");
@@ -810,6 +815,7 @@ mod tests {
                 max_tokens: 1024,
                 embedding_model: None,
                 reasoning_effort: None,
+                context_window: None,
             },
         ));
         assert!(provider.supports_structured_output());
@@ -841,6 +847,7 @@ mod tests {
                 max_tokens: 1024,
                 embedding_model: None,
                 reasoning_effort: None,
+                context_window: None,
             },
         ));
         assert!(provider.supports_vision());

--- a/crates/zeph-llm/src/cocoon/provider.rs
+++ b/crates/zeph-llm/src/cocoon/provider.rs
@@ -172,6 +172,7 @@ impl CocoonProvider {
             max_tokens,
             embedding_model: embedding_model.clone(),
             reasoning_effort: None,
+            context_window: None,
         });
         Self {
             inner,

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -87,6 +87,7 @@ impl CompatibleProvider {
             max_tokens: cfg.max_tokens,
             embedding_model: cfg.embedding_model,
             reasoning_effort: None,
+            context_window: None,
         });
         Self {
             inner,

--- a/crates/zeph-llm/src/gonka/provider.rs
+++ b/crates/zeph-llm/src/gonka/provider.rs
@@ -190,6 +190,7 @@ impl GonkaProvider {
             max_tokens: cfg.max_tokens,
             embedding_model: cfg.embedding_model.clone(),
             reasoning_effort: None,
+            context_window: None,
         });
         // HTTP client timeout is generous to avoid double-timeout with tokio::time::timeout.
         let client = crate::http::llm_client(cfg.timeout.as_secs().saturating_add(30));

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -52,6 +52,7 @@ use serde::{Deserialize, Serialize};
 ///     max_tokens: 4096,
 ///     embedding_model: Some("text-embedding-3-small".into()),
 ///     reasoning_effort: None,
+///     context_window: None,
 /// };
 /// let provider = OpenAiProvider::new(cfg);
 /// ```
@@ -71,6 +72,12 @@ pub struct OpenAiConfig {
     /// Reasoning effort level for `o*` models (`"low"`, `"medium"`, or `"high"`).
     /// Leave `None` for standard chat models.
     pub reasoning_effort: Option<String>,
+    /// Explicit context-window size override in tokens.
+    ///
+    /// When set, this value is returned by [`LlmProvider::context_window`] instead of the
+    /// built-in prefix-match table. Use this to supply the correct value for models that are
+    /// not yet in the table (e.g. newly released or fine-tuned variants).
+    pub context_window: Option<u32>,
 }
 
 use crate::provider::{
@@ -91,6 +98,7 @@ const MAX_RETRIES: u32 = 3;
 /// Construct with [`OpenAiProvider::new`] and chain optional builder methods:
 /// - [`with_generation_overrides`](Self::with_generation_overrides)
 /// - [`with_status_tx`](Self::with_status_tx)
+/// - [`with_context_window`](Self::with_context_window)
 pub struct OpenAiProvider {
     client: reqwest::Client,
     api_key: String,
@@ -109,6 +117,9 @@ pub struct OpenAiProvider {
     output_schema_hint_bytes: usize,
     /// Maximum bytes of the combined description (base + hint). `usize::MAX` means no cap.
     max_tool_description_bytes: usize,
+    /// Explicit context-window override set via [`OpenAiConfig::context_window`] or
+    /// [`OpenAiProvider::with_context_window`]. Takes precedence over the prefix-match table.
+    context_window_override: Option<usize>,
 }
 
 impl fmt::Debug for OpenAiProvider {
@@ -130,6 +141,7 @@ impl fmt::Debug for OpenAiProvider {
                 "max_tool_description_bytes",
                 &self.max_tool_description_bytes,
             )
+            .field("context_window_override", &self.context_window_override)
             .finish()
     }
 }
@@ -150,6 +162,7 @@ impl Clone for OpenAiProvider {
             forward_output_schema: self.forward_output_schema,
             output_schema_hint_bytes: self.output_schema_hint_bytes,
             max_tool_description_bytes: self.max_tool_description_bytes,
+            context_window_override: self.context_window_override,
         }
     }
 }
@@ -176,6 +189,7 @@ impl OpenAiProvider {
             forward_output_schema: false,
             output_schema_hint_bytes: 1024,
             max_tool_description_bytes: usize::MAX,
+            context_window_override: cfg.context_window.map(|v| v as usize),
         }
     }
 
@@ -214,6 +228,53 @@ impl OpenAiProvider {
     pub fn with_status_tx(mut self, tx: StatusTx) -> Self {
         self.status_tx = Some(tx);
         self
+    }
+
+    /// Override the context-window size reported by [`LlmProvider::context_window`].
+    ///
+    /// Use this when the model identifier is not yet in the built-in prefix table.
+    /// The value takes precedence over the table and the default fallback.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::openai::{OpenAiConfig, OpenAiProvider};
+    /// use zeph_llm::provider::LlmProvider;
+    ///
+    /// let provider = OpenAiProvider::new(OpenAiConfig {
+    ///     api_key: "k".into(),
+    ///     base_url: "https://api.openai.com/v1".into(),
+    ///     model: "custom-model-v1".into(),
+    ///     max_tokens: 4096,
+    ///     embedding_model: None,
+    ///     reasoning_effort: None,
+    ///     context_window: None,
+    /// })
+    /// .with_context_window(200_000);
+    /// assert_eq!(provider.context_window(), Some(200_000));
+    /// ```
+    #[must_use]
+    pub fn with_context_window(mut self, tokens: usize) -> Self {
+        self.context_window_override = Some(tokens);
+        self
+    }
+
+    /// Extract generation override parameters as a flat tuple.
+    ///
+    /// Returns `(temperature, top_p, frequency_penalty, presence_penalty)`.
+    /// All values are `None` when no override is set.
+    fn generation_params(&self) -> (Option<f64>, Option<f64>, Option<f64>, Option<f64>) {
+        self.generation_overrides
+            .as_ref()
+            .map(|ov| {
+                (
+                    ov.temperature,
+                    ov.top_p,
+                    ov.frequency_penalty,
+                    ov.presence_penalty,
+                )
+            })
+            .unwrap_or_default()
     }
 
     /// Derive a filesystem-safe cache slug from the provider's base URL hostname.
@@ -328,17 +389,7 @@ impl OpenAiProvider {
             .as_deref()
             .map(|effort| Reasoning { effort });
 
-        let (temperature, top_p, frequency_penalty, presence_penalty) =
-            if let Some(ref ov) = self.generation_overrides {
-                (
-                    ov.temperature,
-                    ov.top_p,
-                    ov.frequency_penalty,
-                    ov.presence_penalty,
-                )
-            } else {
-                (None, None, None, None)
-            };
+        let (temperature, top_p, frequency_penalty, presence_penalty) = self.generation_params();
 
         let response = if has_image_parts(messages) {
             let vision_messages = convert_messages_vision(messages);
@@ -412,17 +463,7 @@ impl OpenAiProvider {
             .as_deref()
             .map(|effort| Reasoning { effort });
 
-        let (temperature, top_p, frequency_penalty, presence_penalty) =
-            if let Some(ref ov) = self.generation_overrides {
-                (
-                    ov.temperature,
-                    ov.top_p,
-                    ov.frequency_penalty,
-                    ov.presence_penalty,
-                )
-            } else {
-                (None, None, None, None)
-            };
+        let (temperature, top_p, frequency_penalty, presence_penalty) = self.generation_params();
 
         let body = ChatRequest {
             model: &self.model,
@@ -464,7 +505,17 @@ impl OpenAiProvider {
 }
 
 impl LlmProvider for OpenAiProvider {
+    /// Returns the context-window size for the configured model.
+    ///
+    /// Resolution order:
+    /// 1. Explicit override set via [`OpenAiConfig::context_window`] or [`Self::with_context_window`].
+    /// 2. Built-in prefix table for well-known `OpenAI` model families.
+    /// 3. Default fallback of `128_000` tokens for unrecognised models, so callers always receive
+    ///    a usable value rather than `None`.
     fn context_window(&self) -> Option<usize> {
+        if let Some(override_size) = self.context_window_override {
+            return Some(override_size);
+        }
         if self.model.starts_with("gpt-4o") || self.model.starts_with("gpt-4") {
             Some(128_000)
         } else if self.model.starts_with("gpt-3.5") {
@@ -474,7 +525,8 @@ impl LlmProvider for OpenAiProvider {
         } else if starts_with_o_digit(&self.model) {
             Some(200_000)
         } else {
-            None
+            // Unknown model: fall back to 128k so callers always get a usable budget.
+            Some(128_000)
         }
     }
 
@@ -670,18 +722,7 @@ impl LlmProvider for OpenAiProvider {
             .reasoning_effort
             .as_deref()
             .map(|effort| Reasoning { effort });
-        let (temperature, top_p, frequency_penalty, presence_penalty) = self
-            .generation_overrides
-            .as_ref()
-            .map(|ov| {
-                (
-                    ov.temperature,
-                    ov.top_p,
-                    ov.frequency_penalty,
-                    ov.presence_penalty,
-                )
-            })
-            .unwrap_or_default();
+        let (temperature, top_p, frequency_penalty, presence_penalty) = self.generation_params();
 
         if !tools.is_empty() {
             let api_messages = convert_messages_structured(messages);
@@ -867,18 +908,7 @@ impl LlmProvider for OpenAiProvider {
             })
             .collect();
 
-        let (temperature, top_p, frequency_penalty, presence_penalty) = self
-            .generation_overrides
-            .as_ref()
-            .map(|ov| {
-                (
-                    ov.temperature,
-                    ov.top_p,
-                    ov.frequency_penalty,
-                    ov.presence_penalty,
-                )
-            })
-            .unwrap_or_default();
+        let (temperature, top_p, frequency_penalty, presence_penalty) = self.generation_params();
         let body = ToolChatRequest {
             model: &self.model,
             messages: &api_messages,

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -30,6 +30,7 @@ fn test_provider() -> OpenAiProvider {
         max_tokens: 4096,
         embedding_model: Some("text-embedding-3-small".into()),
         reasoning_effort: None,
+        context_window: None,
     })
 }
 
@@ -42,6 +43,7 @@ fn context_window_gpt4o() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.context_window(), Some(128_000));
 }
@@ -52,7 +54,7 @@ fn context_window_gpt5() {
 }
 
 #[test]
-fn context_window_unknown() {
+fn context_window_unknown_falls_back_to_128k() {
     let p = OpenAiProvider::new(OpenAiConfig {
         api_key: "k".into(),
         base_url: "https://api.openai.com/v1".into(),
@@ -60,8 +62,38 @@ fn context_window_unknown() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
-    assert!(p.context_window().is_none());
+    assert_eq!(p.context_window(), Some(128_000));
+}
+
+#[test]
+fn context_window_override_takes_precedence() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: Some(256_000),
+    });
+    assert_eq!(p.context_window(), Some(256_000));
+}
+
+#[test]
+fn context_window_override_via_builder() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "custom-model".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+    })
+    .with_context_window(200_000);
+    assert_eq!(p.context_window(), Some(200_000));
 }
 
 fn test_provider_no_embed() -> OpenAiProvider {
@@ -72,6 +104,7 @@ fn test_provider_no_embed() -> OpenAiProvider {
         max_tokens: 4096,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     })
 }
 
@@ -95,6 +128,7 @@ fn new_with_reasoning_effort() {
         max_tokens: 4096,
         embedding_model: None,
         reasoning_effort: Some("high".into()),
+        context_window: None,
     });
     assert_eq!(p.reasoning_effort.as_deref(), Some("high"));
 }
@@ -382,6 +416,7 @@ async fn chat_unreachable_endpoint_errors() {
         max_tokens: 100,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -401,6 +436,7 @@ async fn stream_unreachable_endpoint_errors() {
         max_tokens: 100,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -420,6 +456,7 @@ async fn embed_unreachable_endpoint_errors() {
         max_tokens: 100,
         embedding_model: Some("embed-model".into()),
         reasoning_effort: None,
+        context_window: None,
     });
     assert!(p.embed("test").await.is_err());
 }
@@ -446,6 +483,7 @@ fn base_url_strips_trailing_slash() {
         max_tokens: 100,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.base_url, "https://api.openai.com/v1");
 }
@@ -492,6 +530,7 @@ async fn integration_openai_chat() {
         max_tokens: 256,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
 
     let messages = vec![Message {
@@ -516,6 +555,7 @@ async fn integration_openai_chat_stream() {
         max_tokens: 256,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
 
     let messages = vec![Message {
@@ -547,6 +587,7 @@ fn context_window_o1() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -560,6 +601,7 @@ fn context_window_o1_mini() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -573,6 +615,7 @@ fn context_window_o3() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -586,6 +629,7 @@ fn context_window_o3_mini() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -599,6 +643,7 @@ fn context_window_o4_mini() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -612,6 +657,7 @@ fn context_window_gpt35() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.context_window(), Some(16_385));
 }
@@ -625,6 +671,7 @@ fn context_window_gpt4_turbo() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.context_window(), Some(128_000));
 }
@@ -640,6 +687,7 @@ async fn integration_openai_embed() {
         max_tokens: 256,
         embedding_model: Some("text-embedding-3-small".into()),
         reasoning_effort: None,
+        context_window: None,
     });
 
     let embedding = provider.embed("Hello world").await.unwrap();
@@ -1053,6 +1101,7 @@ fn cache_slug_openai() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.cache_slug(), "api_openai_com");
 }
@@ -1066,6 +1115,7 @@ fn cache_slug_custom_host() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.cache_slug(), "my_llm_example_com");
 }
@@ -1079,6 +1129,7 @@ fn cache_slug_localhost_with_port() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert_eq!(p.cache_slug(), "localhost");
 }
@@ -1181,6 +1232,7 @@ async fn list_models_remote_http_error_propagates() {
         max_tokens: 1024,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     let result = p.list_models_remote().await;
     assert!(result.is_err());
@@ -1212,6 +1264,7 @@ async fn chat_happy_path_wiremock() {
         max_tokens: 256,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1257,6 +1310,7 @@ async fn chat_with_tools_handles_null_assistant_content() {
         max_tokens: 256,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1311,6 +1365,7 @@ async fn chat_429_rate_limit_propagates() {
         max_tokens: 256,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1343,6 +1398,7 @@ async fn chat_401_auth_error_propagates() {
         max_tokens: 256,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1375,6 +1431,7 @@ async fn chat_500_server_error_propagates() {
         max_tokens: 256,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1395,6 +1452,7 @@ fn with_generation_overrides_stores_overrides() {
         max_tokens: 256,
         embedding_model: None,
         reasoning_effort: None,
+        context_window: None,
     });
     assert!(provider.generation_overrides.is_none());
     let overrides = GenerationOverrides {
@@ -1559,6 +1617,7 @@ async fn embed_batch_empty_returns_empty_without_network() {
         max_tokens: 4096,
         embedding_model: Some("text-embedding-3-small".into()),
         reasoning_effort: None,
+        context_window: None,
     });
     let result = p.embed_batch(&[]).await.unwrap();
     assert!(result.is_empty());

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1212,6 +1212,7 @@ fn build_acp_provider_factory(config: &zeph_core::config::Config) -> zeph_acp::P
                             max_tokens: *max_tokens,
                             embedding_model: embed.clone(),
                             reasoning_effort: reasoning_effort.clone(),
+                            context_window: None,
                         }),
                     ));
                 }


### PR DESCRIPTION
## Summary

- **#4873**: Add private `generation_params()` to `OpenAiProvider` — eliminates 4 duplicate `generation_overrides` tuple extractions in `send_request`, `send_stream_request`, `debug_request_json`, `chat_with_tools`. Follows the `apply_generation_overrides` precedent from `ollama.rs`.
- **#4876**: Add `context_window: Option<u32>` to `OpenAiConfig` with internal `context_window_override` field and `with_context_window()` builder. Resolution order: explicit override → prefix table → `Some(128_000)` fallback. Unknown models no longer return `None`, so context-window guards (e.g. `router/triage.rs:307 maybe_escalate_for_context`) now participate in escalation checks instead of being silently skipped.

## Behavioral change (intentional)

Previously `context_window()` returned `None` for unrecognised model names — callers that used `None` as a "skip" sentinel (e.g. `maybe_escalate_for_context`) would skip the check entirely. With the 128 k fallback, unknown OpenAI models now get a conservative context-window guard. Callers needing the old skip-on-unknown behaviour can set `context_window: Some(exact_size)` in config and branch on the provider's value explicitly.

`CompletionTokens::for_model` (also named in #4876) retains its prefix-matching logic; a wrong value there produces a visible 400 error rather than a silent mismatch. Follow-up issue filed for that path.

## LLM serialization gate

This PR touches `crates/zeph-llm/src/openai/mod.rs`. Per project rules a live API session test is required before merge. Verify that at least one real LLM round-trip completes without 400/422 errors:

```bash
cargo run --features full -- --config .local/config/testing.toml
```

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10512 passed
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy -p zeph-llm -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [ ] Live API session test (required before merge — see LLM serialization gate above)