### PR TITLE
perf(context),refactor(llm): add fidelity tracing spans and extract response body helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `perf(context)`: add `#[tracing::instrument]` to `embed_prepass_dyn` and `render_compressed`
+  in `zeph-context/fidelity.rs` — both async hot-path functions were invisible to local Chrome
+  JSON traces and Jaeger; now emit `context.fidelity.embed_prepass_dyn` and
+  `context.fidelity.render_compressed` spans. (#4872)
+- `refactor(llm)`: add `check_response` and `read_response_body` helpers to
+  `zeph-llm/src/http.rs`; replace duplicated `status + text().await + map_error_response`
+  pattern at 8 call sites across `openai/mod.rs` and `claude/mod.rs`. (#4877)
 - `refactor(llm)`: `OpenAiProvider` now resolves context window via three-step lookup: explicit
   `context_window` field in `OpenAiConfig` → model-prefix table → `128_000` fallback for unknown
   models. Eliminates silent `None` for unrecognised model names. (#4876)
-
 - `refactor(llm)`: `OpenAiProvider::generation_params()` private helper extracted; removes 4
   duplicate `generation_overrides` tuple expansions in `send_request`, `send_stream_request`,
   `debug_request_json`, and `chat_with_tools`. (#4873)
-
 - `refactor(llm)`: `parse_gemini_error` in `zeph-llm` now delegates the base `ApiError` and
   `ContextLengthExceeded` construction to `crate::http::map_error_response`, consistent with all
   other backends (claude, openai, gonka, cocoon). Gemini-specific `RESOURCE_EXHAUSTED → RateLimited`

--- a/crates/zeph-context/src/fidelity.rs
+++ b/crates/zeph-context/src/fidelity.rs
@@ -75,6 +75,7 @@ impl EmbedCall for ProviderEmbed<'_> {
 ///
 /// `messages` is the slice to embed (callers pre-slice to `[..score_end]` when needed).
 /// Indices in the returned map are relative to the start of the passed slice.
+#[tracing::instrument(name = "context.fidelity.embed_prepass_dyn", skip_all)]
 async fn embed_prepass_dyn(
     messages: &[Message],
     embed: &dyn EmbedCall,
@@ -674,6 +675,7 @@ fn score_to_level(score: f32, config: &FidelityConfig) -> ContextFidelity {
     }
 }
 
+#[tracing::instrument(name = "context.fidelity.render_compressed", skip_all)]
 async fn render_compressed(
     msg: &mut Message,
     config: &FidelityConfig,

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -838,8 +838,7 @@ impl ClaudeProvider {
             })
             .await?;
 
-            let status = response.status();
-            let text = response.text().await.map_err(LlmError::Http)?;
+            let (status, text) = crate::http::read_response_body(response).await?;
 
             if !status.is_success() {
                 if !retried && Self::is_compact_beta_rejection(status, &text) {
@@ -1168,8 +1167,7 @@ impl LlmProvider for ClaudeProvider {
                     .send()
             })
             .await?;
-            let status = response.status();
-            let text = response.text().await.map_err(LlmError::Http)?;
+            let (status, text) = crate::http::read_response_body(response).await?;
             if !status.is_success() {
                 if !retried && Self::is_compact_beta_rejection(status, &text) {
                     self.server_compaction_rejected
@@ -1360,8 +1358,7 @@ impl LlmProvider for ClaudeProvider {
             })
             .await?;
 
-            let status = response.status();
-            let text = response.text().await.map_err(LlmError::Http)?;
+            let (status, text) = crate::http::read_response_body(response).await?;
 
             if !status.is_success() {
                 if !retried && Self::is_compact_beta_rejection(status, &text) {

--- a/crates/zeph-llm/src/http.rs
+++ b/crates/zeph-llm/src/http.rs
@@ -38,6 +38,40 @@ pub fn llm_client(request_timeout_secs: u64) -> reqwest::Client {
 /// authentication errors, server errors, and unexpected 4xx codes that are not
 /// context-length failures.
 ///
+/// Read the response body text and check the HTTP status code in one step.
+///
+/// Returns the body text on success. On non-2xx responses, logs the error at
+/// `error` level and returns the appropriate [`LlmError`] via [`map_error_response`].
+///
+/// Use this for call sites where the only error action is returning
+/// `map_error_response(status, text, provider)` — i.e. no retry logic or
+/// custom error variant selection based on the status.
+pub(crate) async fn check_response(
+    response: reqwest::Response,
+    provider: &str,
+) -> Result<String, LlmError> {
+    let status = response.status();
+    let text = response.text().await.map_err(LlmError::Http)?;
+    if !status.is_success() {
+        tracing::error!(%provider, %status, body = %text, "API error response");
+        return Err(map_error_response(status, &text, provider));
+    }
+    Ok(text)
+}
+
+/// Extract the HTTP status code and response body text together.
+///
+/// Use when the caller needs to inspect both `status` and `text` before
+/// deciding the error path — for example, retry logic, `InvalidInput`
+/// variants based on status code, or custom error messages.
+pub(crate) async fn read_response_body(
+    response: reqwest::Response,
+) -> Result<(reqwest::StatusCode, String), LlmError> {
+    let status = response.status();
+    let text = response.text().await.map_err(LlmError::Http)?;
+    Ok((status, text))
+}
+
 /// Only call this function after confirming the response is not a 2xx success.
 pub(crate) fn map_error_response(
     status: reqwest::StatusCode,

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -431,13 +431,7 @@ impl OpenAiProvider {
             .await?
         };
 
-        let status = response.status();
-        let text = response.text().await.map_err(LlmError::Http)?;
-
-        if !status.is_success() {
-            tracing::error!("OpenAI API error {status}: {text}");
-            return Err(crate::http::map_error_response(status, &text, "openai"));
-        }
+        let text = crate::http::check_response(response, "openai").await?;
 
         let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
 
@@ -596,8 +590,7 @@ impl LlmProvider for OpenAiProvider {
             .send()
             .await?;
 
-        let status = response.status();
-        let body_text = response.text().await.map_err(LlmError::Http)?;
+        let (status, body_text) = crate::http::read_response_body(response).await?;
 
         if !status.is_success() {
             tracing::error!("OpenAI embedding API error {status}: {body_text}");
@@ -649,8 +642,7 @@ impl LlmProvider for OpenAiProvider {
             .send()
             .await?;
 
-        let status = response.status();
-        let body_text = response.text().await.map_err(LlmError::Http)?;
+        let (status, body_text) = crate::http::read_response_body(response).await?;
 
         if !status.is_success() {
             tracing::error!("OpenAI batch embedding API error {status}: {body_text}");
@@ -835,12 +827,7 @@ impl LlmProvider for OpenAiProvider {
             .send()
             .await?;
 
-        let status = response.status();
-        let text = response.text().await.map_err(LlmError::Http)?;
-
-        if !status.is_success() {
-            return Err(crate::http::map_error_response(status, &text, "openai"));
-        }
+        let text = crate::http::check_response(response, "openai").await?;
 
         let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
 
@@ -927,8 +914,7 @@ impl LlmProvider for OpenAiProvider {
             .send()
             .await?;
 
-        let status = response.status();
-        let text = response.text().await.map_err(LlmError::Http)?;
+        let (status, text) = crate::http::read_response_body(response).await?;
 
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
             return Err(LlmError::RateLimited);


### PR DESCRIPTION
## Summary

- **#4872**: Add `#[tracing::instrument]` to `embed_prepass_dyn` and `render_compressed` in `zeph-context/fidelity.rs`. Both async hot-path functions were invisible to local Chrome JSON traces and Jaeger — they absorbed all their latency into the parent `AgentContextService` span. All five production async fns in `fidelity.rs` now emit `context.fidelity.*` spans.
- **#4877**: Add `check_response` and `read_response_body` helpers to `zeph-llm/src/http.rs`. Replace the duplicated three-line `status + text().await + map_error_response` pattern at eight call sites across `openai/mod.rs` (5 sites) and `claude/mod.rs` (3 sites). Streaming call sites and those with custom retry/error-variant logic are left unchanged.

## Changed files

- `crates/zeph-context/src/fidelity.rs` — 2 new `#[tracing::instrument]` attributes
- `crates/zeph-llm/src/http.rs` — 2 new pub(crate) async helpers
- `crates/zeph-llm/src/openai/mod.rs` — 5 call sites simplified
- `crates/zeph-llm/src/claude/mod.rs` — 3 call sites simplified
- `CHANGELOG.md` — [Unreleased] section updated

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` → 10510 passed
- [ ] `cargo +nightly fmt --check` → clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` → clean
- [ ] Verify `context.fidelity.embed_prepass_dyn` and `context.fidelity.render_compressed` spans appear in local Chrome JSON trace after a session with `memory.n.enabled = true`

Closes #4872
Closes #4877