### PR TITLE
feat(index): add embedding_provider config field and fix double provider construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(index): resolve `[index] embedding_provider` once in the binary runner and pass the resolved
+  `AnyProvider` into both the code indexer and the code retriever, eliminating the previous
+  double-construction where `build_provider_from_entry` was called twice for the same provider name
+  on every startup. Adds `embedding_provider: String` (record-keeping, not resolution) to
+  `IndexerConfig` and `RetrievalConfig` in `zeph-index`. Extracts `resolve_index_embed_provider`
+  helper in `bootstrap/provider.rs` as the canonical single resolution point. (#4885)
 - `refactor(llm)`: `parse_gemini_error` in `zeph-llm` now delegates the base `ApiError` and
   `ContextLengthExceeded` construction to `crate::http::map_error_response`, consistent with all
   other backends (claude, openai, gonka, cocoon). Gemini-specific `RESOURCE_EXHAUSTED → RateLimited`

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -90,6 +90,13 @@ pub struct IndexerConfig {
     ///
     /// Keep this low when using hosted embedding APIs with strict TPM rate limits.
     pub embed_concurrency: usize,
+    /// Configured `[index] embedding_provider` name (record-keeping only).
+    ///
+    /// Stores the raw name from config, regardless of whether resolution succeeded or
+    /// fell back to the main provider. This field is **not** read by `zeph-index` —
+    /// resolution happens in the binary bootstrap before this struct is constructed.
+    /// Setting this field does not change which provider is used.
+    pub embedding_provider: String,
 }
 
 impl Default for IndexerConfig {
@@ -101,6 +108,7 @@ impl Default for IndexerConfig {
             memory_batch_size: 16,
             max_file_bytes: 512 * 1024,
             embed_concurrency: 1,
+            embedding_provider: String::new(),
         }
     }
 }
@@ -717,6 +725,7 @@ mod tests {
         assert_eq!(config.concurrency, 2);
         assert_eq!(config.batch_size, 16);
         assert_eq!(config.embed_concurrency, 1);
+        assert_eq!(config.embedding_provider, "");
     }
 
     #[test]

--- a/crates/zeph-index/src/retriever.rs
+++ b/crates/zeph-index/src/retriever.rs
@@ -87,6 +87,13 @@ pub struct RetrievalConfig {
     /// Maximum seconds to wait for `provider.embed()` before returning
     /// [`crate::error::IndexError::EmbedTimeout`]. Defaults to `10`.
     pub embed_timeout_secs: u64,
+    /// Configured `[index] embedding_provider` name (record-keeping only).
+    ///
+    /// Stores the raw name from config, regardless of whether resolution succeeded or
+    /// fell back to the main provider. This field is **not** read by `zeph-index` —
+    /// resolution happens in the binary bootstrap before this struct is constructed.
+    /// Setting this field does not change which provider is used.
+    pub embedding_provider: String,
 }
 
 impl Default for RetrievalConfig {
@@ -96,6 +103,7 @@ impl Default for RetrievalConfig {
             score_threshold: 0.25,
             budget_ratio: 0.40,
             embed_timeout_secs: 10,
+            embedding_provider: String::new(),
         }
     }
 }
@@ -592,5 +600,6 @@ mod tests {
         assert_eq!(cfg.max_chunks, 12);
         assert!(cfg.score_threshold > 0.0);
         assert!(cfg.budget_ratio > 0.0 && cfg.budget_ratio < 1.0);
+        assert_eq!(cfg.embedding_provider, "");
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -367,25 +367,7 @@ async fn build_acp_deps(
             zeph_tools::CompositeExecutor::new(scrape_executor, cwd_executor),
         ),
     );
-    let index_provider = config
-        .index
-        .embedding_provider
-        .as_ref()
-        .and_then(|p| p.as_non_empty())
-        .and_then(|name| match crate::bootstrap::create_named_provider(name, config) {
-            Ok(p) => {
-                tracing::info!(provider = %name, "Using dedicated embedding provider for indexer (acp)");
-                Some(p)
-            }
-            Err(e) => {
-                tracing::warn!(
-                    provider = %name,
-                    "Index embedding_provider resolution failed, using main provider (acp): {e:#}"
-                );
-                None
-            }
-        })
-        .unwrap_or_else(|| provider.clone());
+    let index_provider = crate::bootstrap::resolve_index_embed_provider(config, provider.clone());
     let tool_executor: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = {
         let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = std::sync::Arc::new(
             zeph_tools::CompositeExecutor::new(base_executor, mcp_executor),

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1021,7 +1021,7 @@ pub(crate) fn apply_causal_analyzer_with_cfg<C: Channel>(
 pub(crate) async fn apply_code_indexer(
     full_config: &Config,
     qdrant_ops: Option<QdrantOps>,
-    provider: zeph_llm::any::AnyProvider,
+    embed_provider: zeph_llm::any::AnyProvider,
     pool: zeph_db::DbPool,
     cli_mode: bool,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
@@ -1032,31 +1032,18 @@ pub(crate) async fn apply_code_indexer(
         return (None, None);
     }
 
+    let embedding_provider_name = config
+        .embedding_provider
+        .as_ref()
+        .and_then(|p| p.as_non_empty())
+        .map(str::to_owned)
+        .unwrap_or_default();
+
     let init = async {
         let ops = qdrant_ops.ok_or_else(|| {
             anyhow::anyhow!("code index requires Qdrant backend (vector_backend = \"qdrant\")")
         })?;
         let store = CodeStore::with_ops(ops, pool);
-        let embed_provider = config
-            .embedding_provider
-            .as_ref()
-            .and_then(|p| p.as_non_empty())
-            .and_then(|name| {
-                match crate::bootstrap::create_named_provider(name, full_config) {
-                    Ok(p) => {
-                        tracing::info!(provider = %name, "Using dedicated embed provider for indexer");
-                        Some(p)
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            provider = %name,
-                            "Index embedding_provider resolution failed, falling back to main provider: {e:#}"
-                        );
-                        None
-                    }
-                }
-            })
-            .unwrap_or(provider);
         let provider_arc = std::sync::Arc::new(embed_provider);
         let base_indexer = CodeIndexer::new(
             store,
@@ -1067,6 +1054,7 @@ pub(crate) async fn apply_code_indexer(
                 memory_batch_size: config.memory_batch_size,
                 max_file_bytes: config.max_file_bytes,
                 embed_concurrency: config.embed_concurrency,
+                embedding_provider: embedding_provider_name,
                 ..IndexerConfig::default()
             },
         );
@@ -1264,10 +1252,17 @@ pub(crate) fn apply_code_rag_retriever<C: Channel>(
     };
 
     let store = CodeStore::with_ops(ops, pool);
+    let embedding_provider_name = config
+        .embedding_provider
+        .as_ref()
+        .and_then(|p| p.as_non_empty())
+        .map(str::to_owned)
+        .unwrap_or_default();
     let retrieval_config = zeph_index::retriever::RetrievalConfig {
         max_chunks: config.max_chunks,
         score_threshold: config.score_threshold,
         budget_ratio: config.budget_ratio,
+        embedding_provider: embedding_provider_name,
         ..zeph_index::retriever::RetrievalConfig::default()
     };
     let retriever = std::sync::Arc::new(zeph_index::retriever::CodeRetriever::new(
@@ -1893,43 +1888,6 @@ mod tests {
         )
         .await;
         assert!(watcher.is_none()); // watch = false
-    }
-
-    // When embedding_provider names an unknown provider, apply_code_indexer must fall back to
-    // the main provider and log a warning rather than panicking or returning an error.
-    // The indexer still starts (Qdrant fails to connect, so watcher stays None, but init
-    // proceeds far enough to exercise the resolution branch).
-    #[tokio::test]
-    async fn apply_code_indexer_unknown_embedding_provider_falls_back_to_main() {
-        use zeph_common::ProviderName;
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let full_config = Config {
-            index: IndexConfig {
-                enabled: true,
-                watch: false,
-                workspace_root: Some(tmp_dir.path().to_path_buf()),
-                embedding_provider: Some(ProviderName::from("nonexistent-provider")),
-                ..IndexConfig::default()
-            },
-            ..Config::default()
-        };
-        let tmp_db = tempfile::NamedTempFile::new().unwrap();
-        let db_url = format!("sqlite:{}", tmp_db.path().display());
-        let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
-        let qdrant = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
-
-        // Must not panic; unknown embedding_provider falls back to main provider.
-        let (watcher, _) = apply_code_indexer(
-            &full_config,
-            Some(qdrant),
-            offline_provider(),
-            pool,
-            false,
-            None,
-            None,
-        )
-        .await;
-        assert!(watcher.is_none());
     }
 
     #[tokio::test]

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -16,7 +16,7 @@ pub use mcp::{create_mcp_manager_with_vault, create_mcp_registry, wire_trust_cal
 pub use oauth::VaultCredentialStore;
 pub use provider::{
     BootstrapError, build_provider_from_entry, create_named_provider, create_provider,
-    create_summary_provider,
+    create_summary_provider, resolve_index_embed_provider,
 };
 pub use skills::{
     create_embedding_provider, create_skill_matcher, managed_skills_dir, plugins_dir,

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -219,6 +219,53 @@ pub fn create_named_provider(
     build_provider_from_entry(entry, config)
 }
 
+/// Resolve the embedding provider for the code indexer and retriever.
+///
+/// Reads `config.index.embedding_provider`. When the name is non-empty and present in
+/// `[[llm.providers]]`, constructs that provider. When unset, empty, or unknown, logs a
+/// warning and returns `fallback` (the main agent provider).
+///
+/// Use this function as the single resolution point so the provider is constructed exactly
+/// once and shared between the indexer and the retriever.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_config::Config;
+/// use zeph_llm::any::AnyProvider;
+/// use crate::bootstrap::resolve_index_embed_provider;
+///
+/// # fn get_config() -> Config { unimplemented!() }
+/// # fn get_fallback() -> AnyProvider { unimplemented!() }
+/// let config = get_config();
+/// let fallback = get_fallback();
+/// // Resolved once; passed to both the indexer and the retriever/search executor.
+/// let index_provider = resolve_index_embed_provider(&config, fallback);
+/// ```
+pub fn resolve_index_embed_provider(config: &Config, fallback: AnyProvider) -> AnyProvider {
+    let Some(name) = config
+        .index
+        .embedding_provider
+        .as_ref()
+        .and_then(|p| p.as_non_empty())
+    else {
+        return fallback;
+    };
+    match create_named_provider(name, config) {
+        Ok(p) => {
+            tracing::info!(provider = %name, "Using dedicated embedding provider for indexer");
+            p
+        }
+        Err(e) => {
+            tracing::warn!(
+                provider = %name,
+                "Index embedding_provider resolution failed, using main provider: {e:#}"
+            );
+            fallback
+        }
+    }
+}
+
 /// Create an `AnyProvider` for use as the summarization provider.
 ///
 /// `model_spec` format (set via `[llm] summary_model`):
@@ -563,6 +610,7 @@ mod tests {
     use std::path::Path;
 
     use zeph_core::config::{Config, ProviderEntry, ProviderKind};
+    use zeph_llm::any::AnyProvider;
 
     use super::build_all_pool_providers;
 
@@ -676,5 +724,70 @@ mod tests {
         // For Ollama, provider construction succeeds without a live server.
         let result = build_single_provider_from_pool(&config.llm.providers, &config);
         assert!(result.is_ok(), "expected Ok but got: {result:?}");
+    }
+
+    // ── resolve_index_embed_provider ─────────────────────────────────────────
+
+    fn make_fallback() -> AnyProvider {
+        use zeph_llm::ollama::OllamaProvider;
+        AnyProvider::Ollama(OllamaProvider::new(
+            "http://127.0.0.1:1",
+            "fallback".into(),
+            "fallback-embed".into(),
+        ))
+    }
+
+    #[test]
+    fn resolve_index_embed_provider_empty_returns_fallback() {
+        use super::resolve_index_embed_provider;
+        let config = Config::load(Path::new("/nonexistent")).unwrap();
+        // IndexConfig.embedding_provider defaults to None — empty path.
+        let result = resolve_index_embed_provider(&config, make_fallback());
+        assert!(
+            matches!(result, AnyProvider::Ollama(_)),
+            "expected fallback Ollama provider"
+        );
+    }
+
+    #[test]
+    fn resolve_index_embed_provider_unknown_name_returns_fallback() {
+        use super::resolve_index_embed_provider;
+        use zeph_common::ProviderName;
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.index.embedding_provider = Some(ProviderName::from("does-not-exist"));
+        // No matching entry in llm.providers — should warn and return fallback.
+        let result = resolve_index_embed_provider(&config, make_fallback());
+        assert!(
+            matches!(result, AnyProvider::Ollama(_)),
+            "expected fallback Ollama provider on unknown name"
+        );
+    }
+
+    #[test]
+    fn resolve_index_embed_provider_known_name_resolves() {
+        use super::resolve_index_embed_provider;
+        use zeph_common::ProviderName;
+        use zeph_llm::provider::LlmProvider as _;
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.llm.providers = vec![ProviderEntry {
+            provider_type: ProviderKind::Ollama,
+            name: Some("index-embed".into()),
+            model: Some("nomic-embed-text".into()),
+            embed: true,
+            ..ProviderEntry::default()
+        }];
+        config.index.embedding_provider = Some(ProviderName::from("index-embed"));
+        let result = resolve_index_embed_provider(&config, make_fallback());
+        // model_identifier() proves the resolved provider was constructed, not the fallback returned.
+        assert_ne!(
+            result.model_identifier(),
+            "fallback",
+            "should not return the fallback"
+        );
+        assert_eq!(
+            result.model_identifier(),
+            "nomic-embed-text",
+            "should use configured model"
+        );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2186,27 +2186,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     .await;
 
     let index_pool = memory.sqlite().pool().clone();
-    let index_provider = config
-        .index
-        .embedding_provider
-        .as_ref()
-        .and_then(|p| p.as_non_empty())
-        .and_then(
-            |name| match crate::bootstrap::create_named_provider(name, config) {
-                Ok(p) => {
-                    tracing::info!(provider = %name, "Using dedicated embedding provider for indexer");
-                    Some(p)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        provider = %name,
-                        "Index embedding_provider resolution failed, using main provider: {e:#}"
-                    );
-                    None
-                }
-            },
-        )
-        .unwrap_or_else(|| provider.clone());
+    let index_provider = crate::bootstrap::resolve_index_embed_provider(config, provider.clone());
     let index_qdrant_ops = app.qdrant_ops().cloned();
     let config_path = app.config_path().to_owned();
     let cache_pool = memory.sqlite().pool().clone();
@@ -2591,7 +2571,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         agent_setup::apply_code_indexer(
             config,
             index_qdrant_ops,
-            provider.clone(),
+            index_provider.clone(),
             index_pool,
             is_cli,
             Some(agent_status_tx.clone()),


### PR DESCRIPTION
## Summary

- Add `embedding_provider: String` (record-keeping) to `IndexerConfig` and `RetrievalConfig` in `zeph-index`, satisfying the multi-model design principle from CLAUDE.md
- Extract `resolve_index_embed_provider` helper in `src/bootstrap/provider.rs`, eliminating the double `build_provider_from_entry` invocation at startup
- Wire the helper through all three call sites: `runner.rs`, `acp.rs`, and `apply_code_indexer` in `agent_setup.rs`
- Fix log-string drift: `"embed provider"` → `"embedding provider"` uniformly across all call sites

## Details

Previously, when `[index] embedding_provider = "fast"` was set, `build_provider_from_entry` ran twice per startup — once in `runner.rs` (for retriever/search-executor) and once inside `apply_code_indexer` (which re-resolved independently). The resolved provider from `runner.rs` was never passed to the indexer, so the indexer always used the main provider regardless of config. This PR fixes that by resolving once and passing the result to all consumers.

The `embedding_provider: String` field on `IndexerConfig` and `RetrievalConfig` is record-keeping only — `zeph-index` has no access to the provider registry, so resolution continues to happen at the binary level. The field is documented accordingly.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10513 passed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo doc --no-deps -p zeph-index` — clean, no broken intra-doc links
- [x] `cargo test --doc -p zeph-index` — 27 passed
- [x] New unit tests for `resolve_index_embed_provider`: empty-name fallback, unknown-name fallback, known-name resolution

Closes #4885