### PR TITLE
refactor(subagent): add tracing span to resume and remove utc_now_pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   handling is preserved. (#4868)
 - refactor(memory): remove `ScoredCandidate` single-field wrapper in `tiered_retrieval.rs` ([#4867](https://github.com/bug-ops/zeph/issues/4867))
 - fix(memory): replace `.entered()` span guard with removal in `tiered_retrieval.rs` async fn ([#4866](https://github.com/bug-ops/zeph/issues/4866))
+- `zeph-subagent`: removed public `transcript::utc_now_pub()` — use `transcript::utc_now()` (now `pub(crate)`) from within the crate instead. Closes #4886.
+- `zeph-subagent`: `SubAgentManager::resume` now emits `subagent.manager.resume` tracing span. Closes #4883.
+
+### Fixed
 - `docs(config)`: `CandleConfig` in `zeph-config` now has a `///` doc comment describing its
   purpose (`[llm.candle]` TOML section) and its relationship to `CandleInlineConfig`. (#4869)
 

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -1350,7 +1350,7 @@ impl SubAgentManager {
             grants: PermissionGrants::default(),
             pending_secret_rx,
             secret_tx,
-            started_at_str: crate::transcript::utc_now_pub(),
+            started_at_str: crate::transcript::utc_now(),
             transcript_dir: handle_transcript_dir,
             mcp_tool_names: handle_mcp_tool_names,
         };
@@ -1363,7 +1363,7 @@ impl SubAgentManager {
             let info = FleetSessionInfo {
                 id: task_id.clone(),
                 agent_name: def_name.to_owned(),
-                started_at: crate::transcript::utc_now_pub(),
+                started_at: crate::transcript::utc_now(),
             };
             self.spawn_hook_task(async move {
                 if let Err(e) = registry.register_active(&info).await {
@@ -1439,7 +1439,7 @@ impl SubAgentManager {
                     agent_name: agent_name.to_owned(),
                     def_name: agent_name.to_owned(),
                     status: SubAgentState::Submitted,
-                    started_at: crate::transcript::utc_now_pub(),
+                    started_at: crate::transcript::utc_now(),
                     finished_at: None,
                     resumed_from: resumed_from.map(str::to_owned),
                     turns_used: 0,
@@ -1728,7 +1728,7 @@ impl SubAgentManager {
                 def_name: handle.def.name.clone(),
                 status: final_state,
                 started_at: handle.started_at_str.clone(),
-                finished_at: Some(crate::transcript::utc_now_pub()),
+                finished_at: Some(crate::transcript::utc_now()),
                 resumed_from: None,
                 turns_used,
                 mcp_tool_names: handle.mcp_tool_names.clone(),
@@ -1762,6 +1762,7 @@ impl SubAgentManager {
     /// [`SubAgentError::Transcript`] on I/O or parse failure,
     /// [`SubAgentError::ConcurrencyLimit`] if the concurrency limit is exceeded.
     #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+    #[tracing::instrument(name = "subagent.manager.resume", skip_all, fields(id_prefix = id_prefix))]
     pub fn resume(
         &mut self,
         id_prefix: &str,
@@ -1946,7 +1947,7 @@ impl SubAgentManager {
             grants: PermissionGrants::default(),
             pending_secret_rx,
             secret_tx,
-            started_at_str: crate::transcript::utc_now_pub(),
+            started_at_str: crate::transcript::utc_now(),
             transcript_dir: resume_handle_transcript_dir,
             mcp_tool_names: resumed_mcp_tool_names,
         };

--- a/crates/zeph-subagent/src/transcript.rs
+++ b/crates/zeph-subagent/src/transcript.rs
@@ -329,27 +329,7 @@ pub fn sweep_old_transcripts(dir: &Path, max_files: usize) -> io::Result<usize> 
     Ok(deleted)
 }
 
-/// Returns the current UTC time as an ISO 8601 string (`"YYYY-MM-DDTHH:MM:SSZ"`).
-///
-/// This is the public companion of the internal `utc_now()` helper, exposed for
-/// use by [`SubAgentManager`][crate::SubAgentManager] when writing transcript sidecars.
-///
-/// # Examples
-///
-/// ```rust
-/// use zeph_subagent::transcript::utc_now_pub;
-///
-/// let ts = utc_now_pub();
-/// assert_eq!(ts.len(), 20, "expected 20-char ISO 8601 timestamp");
-/// assert!(ts.ends_with('Z'));
-/// assert!(ts.contains('T'));
-/// ```
-#[must_use]
-pub fn utc_now_pub() -> String {
-    utc_now()
-}
-
-fn utc_now() -> String {
+pub(crate) fn utc_now() -> String {
     // Use SystemTime for a zero-dependency ISO 8601 timestamp.
     // Format: 2026-03-05T00:18:16Z
     let secs = std::time::SystemTime::now()


### PR DESCRIPTION
## Summary

- Add `#[tracing::instrument(name = "subagent.manager.resume", skip_all, fields(id_prefix))]` to `SubAgentManager::resume` in `crates/zeph-subagent/src/manager.rs`, making the resume lifecycle path visible in traces alongside existing `spawn`/`collect`/`shutdown_all` spans. Closes #4883.
- Remove the `utc_now_pub()` wrapper from `crates/zeph-subagent/src/transcript.rs`; change `utc_now()` to `pub(crate)` and update all 5 call sites in `manager.rs`. Closes #4886.

## Test plan

- [ ] `cargo +nightly fmt --check` — passes
- [ ] `cargo clippy --workspace -- -D warnings` — passes
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10513 passed
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — passes
- [ ] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 10 doctests pass
- [ ] No `utc_now_pub` references remain in `crates/` (verified by grep)