### PR TITLE
fix(llm): add config-driven override for CompletionTokens resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(llm)`: `OpenAiProvider` now applies a 2-layer resolution strategy to the
+  `max_tokens` / `max_completion_tokens` field selection: (1) explicit config override,
+  (2) built-in model-name prefix table.
+  Added `CompletionTokensParam` enum and `completion_tokens_param` field on `OpenAiConfig`;
+  added builder `OpenAiProvider::with_completion_tokens_param`. When set, the override bypasses
+  the built-in prefix table so fine-tuned or newly-released models that don't follow the
+  `o<digit>` / `gpt-5` naming convention no longer produce 400 API errors. (#4890)
+
 ### Changed
 
 - `perf(context)`: add `#[tracing::instrument]` to `embed_prepass_dyn` and `render_compressed`

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -226,6 +226,7 @@ fn build_openai_provider(
             embedding_model: entry.embedding_model.clone(),
             reasoning_effort: entry.reasoning_effort.clone(),
             context_window: None,
+            completion_tokens_param: None,
         })
         .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
         .with_output_schema_forwarding(
@@ -311,6 +312,7 @@ fn build_compatible_provider(
         model,
         max_tokens,
         embedding_model: entry.embedding_model.clone(),
+        completion_tokens_param: None,
     })
     .with_output_schema_forwarding(
         config.mcp.forward_output_schema,

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -718,6 +718,7 @@ mod tests {
                 embedding_model: None,
                 reasoning_effort: None,
                 context_window: None,
+                completion_tokens_param: None,
             },
         ));
         assert_eq!(provider.name(), "openai");
@@ -734,6 +735,7 @@ mod tests {
                 embedding_model: None,
                 reasoning_effort: None,
                 context_window: None,
+                completion_tokens_param: None,
             },
         ));
         assert!(provider.supports_streaming());
@@ -750,6 +752,7 @@ mod tests {
                 embedding_model: Some("text-embedding-3-small".into()),
                 reasoning_effort: None,
                 context_window: None,
+                completion_tokens_param: None,
             },
         ));
         assert!(with_embed.supports_embeddings());
@@ -763,6 +766,7 @@ mod tests {
                 embedding_model: None,
                 reasoning_effort: None,
                 context_window: None,
+                completion_tokens_param: None,
             },
         ));
         assert!(!without_embed.supports_embeddings());
@@ -779,6 +783,7 @@ mod tests {
                 embedding_model: None,
                 reasoning_effort: None,
                 context_window: None,
+                completion_tokens_param: None,
             },
         ));
         let debug = format!("{provider:?}");
@@ -816,6 +821,7 @@ mod tests {
                 embedding_model: None,
                 reasoning_effort: None,
                 context_window: None,
+                completion_tokens_param: None,
             },
         ));
         assert!(provider.supports_structured_output());
@@ -848,6 +854,7 @@ mod tests {
                 embedding_model: None,
                 reasoning_effort: None,
                 context_window: None,
+                completion_tokens_param: None,
             },
         ));
         assert!(provider.supports_vision());

--- a/crates/zeph-llm/src/cocoon/provider.rs
+++ b/crates/zeph-llm/src/cocoon/provider.rs
@@ -173,6 +173,7 @@ impl CocoonProvider {
             embedding_model: embedding_model.clone(),
             reasoning_effort: None,
             context_window: None,
+            completion_tokens_param: None,
         });
         Self {
             inner,

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -23,7 +23,7 @@
 use std::fmt;
 
 use crate::error::LlmError;
-use crate::openai::{OpenAiConfig, OpenAiProvider};
+use crate::openai::{CompletionTokensParam, OpenAiConfig, OpenAiProvider};
 use crate::provider::{
     ChatExtras, ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, StatusTx,
     ToolDefinition,
@@ -46,6 +46,7 @@ use crate::provider::{
 ///     model: "meta-llama/Llama-3.3-70B-Instruct-Turbo".into(),
 ///     max_tokens: 4096,
 ///     embedding_model: None,
+///     completion_tokens_param: None,
 /// };
 /// let provider = CompatibleProvider::new(cfg);
 /// ```
@@ -63,6 +64,12 @@ pub struct CompatibleConfig {
     pub max_tokens: u32,
     /// Embedding model identifier. Set to `None` when the endpoint does not support embeddings.
     pub embedding_model: Option<String>,
+    /// Override which token-limit parameter is used in API requests.
+    ///
+    /// When `None`, the provider infers the correct field from the model name via the built-in
+    /// prefix table. Set explicitly for models the table does not recognise (e.g. fine-tuned
+    /// reasoning models whose names do not start with `o` + digit).
+    pub completion_tokens_param: Option<CompletionTokensParam>,
 }
 
 /// [`LlmProvider`] adapter for OpenAI-compatible REST endpoints.
@@ -88,6 +95,7 @@ impl CompatibleProvider {
             embedding_model: cfg.embedding_model,
             reasoning_effort: None,
             context_window: None,
+            completion_tokens_param: cfg.completion_tokens_param,
         });
         Self {
             inner,
@@ -137,6 +145,34 @@ impl CompatibleProvider {
     #[must_use]
     pub fn with_generation_overrides(mut self, overrides: GenerationOverrides) -> Self {
         self.inner = self.inner.with_generation_overrides(overrides);
+        self
+    }
+
+    /// Override which token-limit parameter is sent in API requests.
+    ///
+    /// Delegates to the inner [`OpenAiProvider`]. Use this when the model name is not covered
+    /// by the built-in prefix table and the inferred field would produce a 400 error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::compatible::{CompatibleConfig, CompatibleProvider};
+    /// use zeph_llm::openai::CompletionTokensParam;
+    ///
+    /// let provider = CompatibleProvider::new(CompatibleConfig {
+    ///     provider_name: "my-provider".into(),
+    ///     api_key: "key".into(),
+    ///     base_url: "https://api.example.com/v1".into(),
+    ///     model: "my-ft-reasoner-v1".into(),
+    ///     max_tokens: 4096,
+    ///     embedding_model: None,
+    ///     completion_tokens_param: None,
+    /// })
+    /// .with_completion_tokens_param(CompletionTokensParam::MaxCompletionTokens);
+    /// ```
+    #[must_use]
+    pub fn with_completion_tokens_param(mut self, param: CompletionTokensParam) -> Self {
+        self.inner = self.inner.with_completion_tokens_param(param);
         self
     }
 
@@ -297,6 +333,7 @@ mod tests {
             model: "llama-3.3-70b".into(),
             max_tokens: 4096,
             embedding_model: None,
+            completion_tokens_param: None,
         })
     }
 
@@ -330,6 +367,7 @@ mod tests {
             model: "m".into(),
             max_tokens: 100,
             embedding_model: Some("embed-model".into()),
+            completion_tokens_param: None,
         });
         assert!(p.supports_embeddings());
     }
@@ -357,6 +395,7 @@ mod tests {
             model: "m".into(),
             max_tokens: 100,
             embedding_model: None,
+            completion_tokens_param: None,
         });
         let msgs = vec![Message::from_legacy(crate::provider::Role::User, "hello")];
         assert!(p.chat(&msgs).await.is_err());

--- a/crates/zeph-llm/src/gonka/provider.rs
+++ b/crates/zeph-llm/src/gonka/provider.rs
@@ -191,6 +191,7 @@ impl GonkaProvider {
             embedding_model: cfg.embedding_model.clone(),
             reasoning_effort: None,
             context_window: None,
+            completion_tokens_param: None,
         });
         // HTTP client timeout is generous to avoid double-timeout with tokio::time::timeout.
         let client = crate::http::llm_client(cfg.timeout.as_secs().saturating_add(30));

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -113,7 +113,7 @@ pub use classifier::metrics::{ClassifierMetrics, ClassifierMetricsSnapshot, Task
 pub use compatible::CompatibleConfig;
 pub use error::LlmError;
 pub use extractor::Extractor;
-pub use openai::OpenAiConfig;
+pub use openai::{CompletionTokensParam, OpenAiConfig};
 pub use provider::{ChatExtras, ChatStream, LlmProvider, StreamChunk, ThinkingBlock};
 pub use provider_dyn::LlmProviderDyn;
 pub use router::aware::RouterAware;

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -35,6 +35,40 @@ use crate::tool_desc::build_tool_description;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
 
+/// Which token-limit field to use in the API request body.
+///
+/// `OpenAI` introduced `max_completion_tokens` for reasoning (`o*`) models while keeping
+/// `max_tokens` for legacy ones.  The [`OpenAiProvider`] infers the correct field from the
+/// model name via a prefix table, but that table cannot cover every fine-tuned or
+/// newly-released variant.  Set this override when the inference would be wrong for your model.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::openai::{CompletionTokensParam, OpenAiConfig, OpenAiProvider};
+///
+/// // Force max_completion_tokens for a fine-tuned reasoning model
+/// // whose name does not start with "o" + digit.
+/// let cfg = OpenAiConfig {
+///     api_key: "sk-...".into(),
+///     base_url: "https://api.openai.com/v1".into(),
+///     model: "my-ft-reasoner-v1".into(),
+///     max_tokens: 8192,
+///     embedding_model: None,
+///     reasoning_effort: None,
+///     context_window: None,
+///     completion_tokens_param: Some(CompletionTokensParam::MaxCompletionTokens),
+/// };
+/// let provider = OpenAiProvider::new(cfg);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionTokensParam {
+    /// Use the legacy `max_tokens` field (standard chat models).
+    MaxTokens,
+    /// Use `max_completion_tokens` (required by `o*` reasoning models and `gpt-5`).
+    MaxCompletionTokens,
+}
+
 /// Configuration for [`OpenAiProvider`].
 ///
 /// Pass to [`OpenAiProvider::new`] instead of individual positional arguments to avoid
@@ -53,6 +87,7 @@ use serde::{Deserialize, Serialize};
 ///     embedding_model: Some("text-embedding-3-small".into()),
 ///     reasoning_effort: None,
 ///     context_window: None,
+///     completion_tokens_param: None,
 /// };
 /// let provider = OpenAiProvider::new(cfg);
 /// ```
@@ -78,6 +113,12 @@ pub struct OpenAiConfig {
     /// built-in prefix-match table. Use this to supply the correct value for models that are
     /// not yet in the table (e.g. newly released or fine-tuned variants).
     pub context_window: Option<u32>,
+    /// Override which token-limit parameter is used in API requests.
+    ///
+    /// When `None`, the provider infers the correct field from the model name via the built-in
+    /// prefix table. Set explicitly for models the table does not recognise (e.g. fine-tuned
+    /// reasoning models whose names do not start with `o` + digit).
+    pub completion_tokens_param: Option<CompletionTokensParam>,
 }
 
 use crate::provider::{
@@ -120,6 +161,9 @@ pub struct OpenAiProvider {
     /// Explicit context-window override set via [`OpenAiConfig::context_window`] or
     /// [`OpenAiProvider::with_context_window`]. Takes precedence over the prefix-match table.
     context_window_override: Option<usize>,
+    /// Override which token-limit field to use. `None` means infer from the model name prefix
+    /// table via [`CompletionTokens::for_model`].
+    completion_tokens_override: Option<CompletionTokensParam>,
 }
 
 impl fmt::Debug for OpenAiProvider {
@@ -142,6 +186,10 @@ impl fmt::Debug for OpenAiProvider {
                 &self.max_tool_description_bytes,
             )
             .field("context_window_override", &self.context_window_override)
+            .field(
+                "completion_tokens_override",
+                &self.completion_tokens_override,
+            )
             .finish()
     }
 }
@@ -163,6 +211,7 @@ impl Clone for OpenAiProvider {
             output_schema_hint_bytes: self.output_schema_hint_bytes,
             max_tool_description_bytes: self.max_tool_description_bytes,
             context_window_override: self.context_window_override,
+            completion_tokens_override: self.completion_tokens_override,
         }
     }
 }
@@ -190,6 +239,7 @@ impl OpenAiProvider {
             output_schema_hint_bytes: 1024,
             max_tool_description_bytes: usize::MAX,
             context_window_override: cfg.context_window.map(|v| v as usize),
+            completion_tokens_override: cfg.completion_tokens_param,
         }
     }
 
@@ -249,6 +299,7 @@ impl OpenAiProvider {
     ///     embedding_model: None,
     ///     reasoning_effort: None,
     ///     context_window: None,
+    ///     completion_tokens_param: None,
     /// })
     /// .with_context_window(200_000);
     /// assert_eq!(provider.context_window(), Some(200_000));
@@ -257,6 +308,55 @@ impl OpenAiProvider {
     pub fn with_context_window(mut self, tokens: usize) -> Self {
         self.context_window_override = Some(tokens);
         self
+    }
+
+    /// Override which token-limit parameter is sent in API requests.
+    ///
+    /// Use this when the model name is not covered by the built-in prefix table and the inferred
+    /// field would produce a 400 error.  Mirrors the config-level
+    /// [`OpenAiConfig::completion_tokens_param`] field but can also be set after construction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::openai::{CompletionTokensParam, OpenAiConfig, OpenAiProvider};
+    ///
+    /// let provider = OpenAiProvider::new(OpenAiConfig {
+    ///     api_key: "k".into(),
+    ///     base_url: "https://api.openai.com/v1".into(),
+    ///     model: "my-ft-reasoner-v1".into(),
+    ///     max_tokens: 4096,
+    ///     embedding_model: None,
+    ///     reasoning_effort: None,
+    ///     context_window: None,
+    ///     completion_tokens_param: None,
+    /// })
+    /// .with_completion_tokens_param(CompletionTokensParam::MaxCompletionTokens);
+    /// ```
+    #[must_use]
+    pub fn with_completion_tokens_param(mut self, param: CompletionTokensParam) -> Self {
+        self.completion_tokens_override = Some(param);
+        self
+    }
+
+    /// Resolve which [`CompletionTokens`] variant to use for this request.
+    ///
+    /// Resolution order:
+    /// 1. Explicit override set via [`OpenAiConfig::completion_tokens_param`] or
+    ///    [`Self::with_completion_tokens_param`].
+    /// 2. Built-in prefix table via [`CompletionTokens::for_model`].
+    fn completion_tokens(&self) -> CompletionTokens {
+        match self.completion_tokens_override {
+            Some(CompletionTokensParam::MaxCompletionTokens) => {
+                CompletionTokens::MaxCompletionTokens {
+                    max_completion_tokens: self.max_tokens,
+                }
+            }
+            Some(CompletionTokensParam::MaxTokens) => CompletionTokens::MaxTokens {
+                max_tokens: self.max_tokens,
+            },
+            None => CompletionTokens::for_model(&self.model, self.max_tokens),
+        }
     }
 
     /// Extract generation override parameters as a flat tuple.
@@ -396,7 +496,7 @@ impl OpenAiProvider {
             let body = VisionChatRequest {
                 model: &self.model,
                 messages: vision_messages,
-                completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+                completion_tokens: self.completion_tokens(),
                 stream: false,
                 reasoning,
                 temperature,
@@ -415,7 +515,7 @@ impl OpenAiProvider {
             let body = ChatRequest {
                 model: &self.model,
                 messages: &api_messages,
-                completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+                completion_tokens: self.completion_tokens(),
                 stream: false,
                 reasoning,
                 temperature,
@@ -462,7 +562,7 @@ impl OpenAiProvider {
         let body = ChatRequest {
             model: &self.model,
             messages: &api_messages,
-            completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+            completion_tokens: self.completion_tokens(),
             stream: true,
             reasoning,
             temperature,
@@ -746,7 +846,7 @@ impl LlmProvider for OpenAiProvider {
             let body = ToolChatRequest {
                 model: &self.model,
                 messages: &api_messages,
-                completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+                completion_tokens: self.completion_tokens(),
                 tools: &api_tools,
                 reasoning,
                 temperature,
@@ -763,7 +863,7 @@ impl LlmProvider for OpenAiProvider {
             let body = VisionChatRequest {
                 model: &self.model,
                 messages: vision_messages,
-                completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+                completion_tokens: self.completion_tokens(),
                 stream,
                 reasoning,
                 temperature,
@@ -779,7 +879,7 @@ impl LlmProvider for OpenAiProvider {
         let body = ChatRequest {
             model: &self.model,
             messages: &api_messages,
-            completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+            completion_tokens: self.completion_tokens(),
             stream,
             reasoning,
             temperature,
@@ -810,7 +910,7 @@ impl LlmProvider for OpenAiProvider {
         let body = TypedChatRequest {
             model: &self.model,
             messages: &api_messages,
-            completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+            completion_tokens: self.completion_tokens(),
             response_format: ResponseFormat {
                 r#type: "json_schema",
                 json_schema: JsonSchemaFormat {
@@ -899,7 +999,7 @@ impl LlmProvider for OpenAiProvider {
         let body = ToolChatRequest {
             model: &self.model,
             messages: &api_messages,
-            completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+            completion_tokens: self.completion_tokens(),
             tools: &api_tools,
             reasoning,
             temperature,
@@ -1038,7 +1138,7 @@ impl OpenAiProvider {
         let body = TypedChatRequest {
             model: &self.model,
             messages: &api_messages,
-            completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+            completion_tokens: self.completion_tokens(),
             response_format: ResponseFormat {
                 r#type: "json_schema",
                 json_schema: JsonSchemaFormat {

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -31,6 +31,7 @@ fn test_provider() -> OpenAiProvider {
         embedding_model: Some("text-embedding-3-small".into()),
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     })
 }
 
@@ -44,6 +45,7 @@ fn context_window_gpt4o() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(128_000));
 }
@@ -63,6 +65,7 @@ fn context_window_unknown_falls_back_to_128k() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(128_000));
 }
@@ -77,6 +80,7 @@ fn context_window_override_takes_precedence() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: Some(256_000),
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(256_000));
 }
@@ -91,6 +95,7 @@ fn context_window_override_via_builder() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     })
     .with_context_window(200_000);
     assert_eq!(p.context_window(), Some(200_000));
@@ -105,6 +110,7 @@ fn test_provider_no_embed() -> OpenAiProvider {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     })
 }
 
@@ -129,6 +135,7 @@ fn new_with_reasoning_effort() {
         embedding_model: None,
         reasoning_effort: Some("high".into()),
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.reasoning_effort.as_deref(), Some("high"));
 }
@@ -417,6 +424,7 @@ async fn chat_unreachable_endpoint_errors() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -437,6 +445,7 @@ async fn stream_unreachable_endpoint_errors() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -457,6 +466,7 @@ async fn embed_unreachable_endpoint_errors() {
         embedding_model: Some("embed-model".into()),
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert!(p.embed("test").await.is_err());
 }
@@ -484,6 +494,7 @@ fn base_url_strips_trailing_slash() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.base_url, "https://api.openai.com/v1");
 }
@@ -531,6 +542,7 @@ async fn integration_openai_chat() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
 
     let messages = vec![Message {
@@ -556,6 +568,7 @@ async fn integration_openai_chat_stream() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
 
     let messages = vec![Message {
@@ -588,6 +601,7 @@ fn context_window_o1() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -602,6 +616,7 @@ fn context_window_o1_mini() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -616,6 +631,7 @@ fn context_window_o3() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -630,6 +646,7 @@ fn context_window_o3_mini() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -644,6 +661,7 @@ fn context_window_o4_mini() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -658,6 +676,7 @@ fn context_window_gpt35() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(16_385));
 }
@@ -672,6 +691,7 @@ fn context_window_gpt4_turbo() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.context_window(), Some(128_000));
 }
@@ -688,6 +708,7 @@ async fn integration_openai_embed() {
         embedding_model: Some("text-embedding-3-small".into()),
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
 
     let embedding = provider.embed("Hello world").await.unwrap();
@@ -1102,6 +1123,7 @@ fn cache_slug_openai() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.cache_slug(), "api_openai_com");
 }
@@ -1116,6 +1138,7 @@ fn cache_slug_custom_host() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.cache_slug(), "my_llm_example_com");
 }
@@ -1130,6 +1153,7 @@ fn cache_slug_localhost_with_port() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert_eq!(p.cache_slug(), "localhost");
 }
@@ -1233,6 +1257,7 @@ async fn list_models_remote_http_error_propagates() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     let result = p.list_models_remote().await;
     assert!(result.is_err());
@@ -1265,6 +1290,7 @@ async fn chat_happy_path_wiremock() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1311,6 +1337,7 @@ async fn chat_with_tools_handles_null_assistant_content() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1366,6 +1393,7 @@ async fn chat_429_rate_limit_propagates() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1399,6 +1427,7 @@ async fn chat_401_auth_error_propagates() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1432,6 +1461,7 @@ async fn chat_500_server_error_propagates() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1453,6 +1483,7 @@ fn with_generation_overrides_stores_overrides() {
         embedding_model: None,
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     assert!(provider.generation_overrides.is_none());
     let overrides = GenerationOverrides {
@@ -1618,6 +1649,7 @@ async fn embed_batch_empty_returns_empty_without_network() {
         embedding_model: Some("text-embedding-3-small".into()),
         reasoning_effort: None,
         context_window: None,
+        completion_tokens_param: None,
     });
     let result = p.embed_batch(&[]).await.unwrap();
     assert!(result.is_empty());
@@ -1779,4 +1811,87 @@ fn starts_with_o_digit_rejects_non_o_series() {
             "{model} must not be detected as o-series by starts_with_o_digit"
         );
     }
+}
+
+#[test]
+fn completion_tokens_override_forces_max_completion_tokens_for_legacy_model() {
+    // A gpt-4o model would normally use max_tokens; override forces max_completion_tokens.
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: Some(CompletionTokensParam::MaxCompletionTokens),
+    });
+    let json = serde_json::to_string(&p.completion_tokens()).unwrap();
+    assert!(json.contains("\"max_completion_tokens\":1024"));
+    assert!(!json.contains("\"max_tokens\""));
+}
+
+#[test]
+fn completion_tokens_override_forces_max_tokens_for_o_series_model() {
+    // An o1 model would normally use max_completion_tokens; override forces max_tokens.
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o1-mini".into(),
+        max_tokens: 512,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: Some(CompletionTokensParam::MaxTokens),
+    });
+    let json = serde_json::to_string(&p.completion_tokens()).unwrap();
+    assert!(json.contains("\"max_tokens\":512"));
+    assert!(!json.contains("\"max_completion_tokens\""));
+}
+
+#[test]
+fn completion_tokens_override_none_falls_back_to_prefix_table() {
+    // When override is None, the prefix table still works correctly.
+    let p_legacy = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    let json = serde_json::to_string(&p_legacy.completion_tokens()).unwrap();
+    assert!(json.contains("\"max_tokens\":256"));
+
+    let p_o = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o3-mini".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    let json = serde_json::to_string(&p_o.completion_tokens()).unwrap();
+    assert!(json.contains("\"max_completion_tokens\":256"));
+}
+
+#[test]
+fn with_completion_tokens_param_builder_sets_override() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "custom-ft-model-v1".into(),
+        max_tokens: 2048,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+    })
+    .with_completion_tokens_param(CompletionTokensParam::MaxCompletionTokens);
+    let json = serde_json::to_string(&p.completion_tokens()).unwrap();
+    assert!(json.contains("\"max_completion_tokens\":2048"));
 }

--- a/crates/zeph-skills/src/bin/miner.rs
+++ b/crates/zeph-skills/src/bin/miner.rs
@@ -224,6 +224,8 @@ fn build_provider(config: &zeph_config::Config, name: &str) -> anyhow::Result<An
                 max_tokens,
                 embedding_model,
                 reasoning_effort: None,
+                context_window: None,
+                completion_tokens_param: None,
             }))
         }
         zeph_config::ProviderKind::Ollama => {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1195,6 +1195,7 @@ fn build_acp_provider_factory(config: &zeph_core::config::Config) -> zeph_acp::P
                             embedding_model: embed.clone(),
                             reasoning_effort: reasoning_effort.clone(),
                             context_window: None,
+                            completion_tokens_param: None,
                         }),
                     ));
                 }
@@ -1214,6 +1215,7 @@ fn build_acp_provider_factory(config: &zeph_core::config::Config) -> zeph_acp::P
                                 model: model.clone(),
                                 max_tokens: *max_tokens,
                                 embedding_model: embed.clone(),
+                                completion_tokens_param: None,
                             },
                         ),
                     ));


### PR DESCRIPTION
## Summary

- Add `CompletionTokensParam` public enum (`MaxTokens` / `MaxCompletionTokens`) to `zeph-llm`
- Add `completion_tokens_param: Option<CompletionTokensParam>` to `OpenAiConfig` and `CompatibleConfig`
- Implement 2-layer resolution in a new `completion_tokens()` method: (1) explicit override, (2) built-in model prefix table — matching the `context_window()` strategy from #4889
- Expose `with_completion_tokens_param()` builder on both `OpenAiProvider` and `CompatibleProvider`

## Motivation

`CompletionTokens::for_model` used hardcoded `starts_with("gpt-5")` / `starts_with_o_digit` branching with no override path. An unrecognised model name silently falls through to `MaxTokens`, producing a 400 API error when the model requires `max_completion_tokens`. Deferred from #4876.

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 10517 passed, 21 skipped
- [ ] 4 new tests: override forces `max_completion_tokens` for legacy model, override forces `max_tokens` for o-series, `None` override falls back to prefix table, builder sets override correctly
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [ ] `cargo doc --no-deps -p zeph-llm` + `cargo test --doc -p zeph-llm` — 19 doc-tests pass
- [ ] **LLM gate**: blocked (OpenAI 429 since CI-929); mark gate as pending-live-test after quota restores