### PR TITLE
refactor(sanitizer,mcp): add guardrail tracing spans and fix mcp client span naming

### DIFF
--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -223,7 +223,7 @@ impl rmcp::ClientHandler for ToolListChangedHandler {
 
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.tool_refresh", skip_all, fields(server_id = %self.server_id))
+        tracing::instrument(name = "mcp.client.tool_refresh", skip_all, fields(server_id = %self.server_id))
     )]
     async fn on_tool_list_changed(&self, context: NotificationContext<RoleClient>) {
         // Rate limit: skip if last refresh was too recent.
@@ -381,7 +381,7 @@ impl McpClient {
     /// Returns `McpError::Connection` if the process cannot be spawned or handshake fails.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.connect", skip_all, fields(server_id = %server_id))
+        tracing::instrument(name = "mcp.client.connect", skip_all, fields(server_id = %server_id))
     )]
     #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
     pub async fn connect(
@@ -474,7 +474,7 @@ impl McpClient {
     /// `McpError::Connection` if the HTTP connection or handshake fails.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.connect_url", skip_all, fields(server_id = %server_id))
+        tracing::instrument(name = "mcp.client.connect_url", skip_all, fields(server_id = %server_id))
     )]
     pub async fn connect_url(
         server_id: &str,
@@ -531,7 +531,7 @@ impl McpClient {
     // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.connect_url", skip_all, fields(server_id = %server_id))
+        tracing::instrument(name = "mcp.client.connect_url", skip_all, fields(server_id = %server_id))
     )]
     pub async fn connect_url_with_headers(
         server_id: &str,
@@ -616,7 +616,7 @@ impl McpClient {
     // complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.connect_url", skip_all, fields(server_id = %server_id))
+        tracing::instrument(name = "mcp.client.connect_url", skip_all, fields(server_id = %server_id))
     )]
     pub async fn connect_url_oauth(
         server_id: &str,
@@ -823,7 +823,7 @@ impl McpClient {
     /// or `McpError::ToolCall` if listing fails.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.list_tools", skip_all, fields(tool_count = tracing::field::Empty))
+        tracing::instrument(name = "mcp.client.list_tools", skip_all, fields(tool_count = tracing::field::Empty))
     )]
     pub async fn list_tools(&self) -> Result<Vec<McpTool>, McpError> {
         let tools = tokio::time::timeout(self.timeout, self.service.list_all_tools())
@@ -875,7 +875,7 @@ impl McpClient {
     /// Returns `McpError::Timeout` or `McpError::ToolCall` on failure.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.call_tool", skip_all, fields(server_id = %self.server_id, tool_name = %name))
+        tracing::instrument(name = "mcp.client.call_tool", skip_all, fields(server_id = %self.server_id, tool_name = %name))
     )]
     pub async fn call_tool(
         &self,
@@ -897,7 +897,7 @@ impl McpClient {
     /// `McpError::ToolCall` if the server returns an error response.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.call_tool", skip_all, fields(server_id = %self.server_id, tool_name = %name))
+        tracing::instrument(name = "mcp.client.call_tool", skip_all, fields(server_id = %self.server_id, tool_name = %name))
     )]
     pub async fn call_tool_with_timeout(
         &self,
@@ -1040,7 +1040,7 @@ impl McpClient {
     /// Graceful shutdown.
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.shutdown", skip_all, fields(server_id = %self.server_id))
+        tracing::instrument(name = "mcp.client.shutdown", skip_all, fields(server_id = %self.server_id))
     )]
     pub async fn shutdown(self) {
         match Arc::try_unwrap(self.service) {

--- a/crates/zeph-sanitizer/src/guardrail.rs
+++ b/crates/zeph-sanitizer/src/guardrail.rs
@@ -15,6 +15,8 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use tracing::Instrument as _;
+use tracing::info_span;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 
@@ -232,28 +234,41 @@ impl GuardrailFilter {
     /// - On timeout or LLM error, returns `GuardrailVerdict::Error` and applies
     ///   `fail_strategy` (the caller decides whether to block or allow).
     pub async fn check(&self, content: &str) -> GuardrailVerdict {
-        // Empty or whitespace-only input is trivially safe — skip the LLM call.
-        if content.trim().is_empty() {
-            return GuardrailVerdict::Safe;
-        }
-        let start = std::time::Instant::now();
-        let verdict = self.check_inner(content).await;
-        let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-
-        self.total_checks.fetch_add(1, Ordering::Relaxed);
-        self.total_latency_ms
-            .fetch_add(elapsed_ms, Ordering::Relaxed);
-        match &verdict {
-            GuardrailVerdict::Flagged { .. } => {
-                self.flagged_count.fetch_add(1, Ordering::Relaxed);
+        let span = info_span!(
+            "sanitizer.guardrail.check",
+            text_len = content.len(),
+            allowed = tracing::field::Empty
+        );
+        async move {
+            // Empty or whitespace-only input is trivially safe — skip the LLM call.
+            if content.trim().is_empty() {
+                tracing::Span::current().record("allowed", true);
+                return GuardrailVerdict::Safe;
             }
-            GuardrailVerdict::Error { .. } => {
-                self.error_count.fetch_add(1, Ordering::Relaxed);
-            }
-            GuardrailVerdict::Safe => {}
-        }
+            let start = std::time::Instant::now();
+            let verdict = self.check_inner(content).await;
+            let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
-        verdict
+            self.total_checks.fetch_add(1, Ordering::Relaxed);
+            self.total_latency_ms
+                .fetch_add(elapsed_ms, Ordering::Relaxed);
+            let is_allowed = match &verdict {
+                GuardrailVerdict::Flagged { .. } => {
+                    self.flagged_count.fetch_add(1, Ordering::Relaxed);
+                    false
+                }
+                GuardrailVerdict::Error { .. } => {
+                    self.error_count.fetch_add(1, Ordering::Relaxed);
+                    false
+                }
+                GuardrailVerdict::Safe => true,
+            };
+            tracing::Span::current().record("allowed", is_allowed);
+
+            verdict
+        }
+        .instrument(span)
+        .await
     }
 
     /// Whether to block on an `Error` verdict (respects `fail_strategy`).
@@ -293,48 +308,59 @@ impl GuardrailFilter {
 
     // Internal: performs the LLM call with truncation and timeout.
     async fn check_inner(&self, content: &str) -> GuardrailVerdict {
-        // Truncate to guard model context limit (MEDIUM-06).
-        // max_input_chars counts Unicode scalar values (chars), not bytes.
-        let truncated = if content.chars().count() > self.max_input_chars {
-            tracing::debug!(
-                original_chars = content.chars().count(),
-                max_input_chars = self.max_input_chars,
-                "guardrail input truncated"
-            );
-            // Find the byte offset after the max_input_chars-th char.
-            let byte_end = content
-                .char_indices()
-                .nth(self.max_input_chars)
-                .map_or(content.len(), |(i, _)| i);
-            &content[..byte_end]
-        } else {
-            content
-        };
-
-        let messages = vec![
-            Message::from_legacy(Role::System, GUARDRAIL_SYSTEM_PROMPT),
-            Message::from_legacy(Role::User, truncated),
-        ];
-
-        let call = self.provider.chat(&messages);
-        match tokio::time::timeout(self.timeout, call).await {
-            Ok(Ok(response)) => parse_response(response.trim(), self.action),
-            Ok(Err(e)) => {
-                tracing::warn!(error = %e, "guardrail LLM call failed");
-                GuardrailVerdict::Error {
-                    error: e.to_string(),
-                }
-            }
-            Err(_elapsed) => {
-                tracing::warn!(
-                    timeout_ms = self.timeout.as_millis(),
-                    "guardrail check timed out"
+        let span = info_span!(
+            "sanitizer.guardrail.check_inner",
+            text_len = content.len(),
+            allowed = tracing::field::Empty
+        );
+        async move {
+            // Truncate to guard model context limit (MEDIUM-06).
+            // max_input_chars counts Unicode scalar values (chars), not bytes.
+            let truncated = if content.chars().count() > self.max_input_chars {
+                tracing::debug!(
+                    original_chars = content.chars().count(),
+                    max_input_chars = self.max_input_chars,
+                    "guardrail input truncated"
                 );
-                GuardrailVerdict::Error {
-                    error: format!("guardrail check timed out after {}ms", self.timeout_ms()),
+                // Find the byte offset after the max_input_chars-th char.
+                let byte_end = content
+                    .char_indices()
+                    .nth(self.max_input_chars)
+                    .map_or(content.len(), |(i, _)| i);
+                &content[..byte_end]
+            } else {
+                content
+            };
+
+            let messages = vec![
+                Message::from_legacy(Role::System, GUARDRAIL_SYSTEM_PROMPT),
+                Message::from_legacy(Role::User, truncated),
+            ];
+
+            let call = self.provider.chat(&messages);
+            let verdict = match tokio::time::timeout(self.timeout, call).await {
+                Ok(Ok(response)) => parse_response(response.trim(), self.action),
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, "guardrail LLM call failed");
+                    GuardrailVerdict::Error {
+                        error: e.to_string(),
+                    }
                 }
-            }
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        timeout_ms = self.timeout.as_millis(),
+                        "guardrail check timed out"
+                    );
+                    GuardrailVerdict::Error {
+                        error: format!("guardrail check timed out after {}ms", self.timeout_ms()),
+                    }
+                }
+            };
+            tracing::Span::current().record("allowed", matches!(verdict, GuardrailVerdict::Safe));
+            verdict
         }
+        .instrument(span)
+        .await
     }
 }
 


### PR DESCRIPTION
## Summary

- **#4896**: Adds `info_span!` instrumentation to `GuardrailFilter::check` and `check_inner` in `zeph-sanitizer`. Span names follow the `sanitizer.guardrail.<op>` convention; `text_len` (byte count) and `allowed` (bool) are recorded as span fields via `field::Empty` + `Span::record()` after the verdict. Uses `.instrument(span).await` pattern — consistent with `nli.rs` — to keep the span active across the LLM `await` inside `tokio::time::timeout`.
- **#4865**: Renames 12 span name strings in `zeph-mcp/src/client.rs` from the legacy `mcp.<op>` pattern to `mcp.client.<op>`, completing the `<crate>.<subsystem>.<operation>` naming convention required by `continuous-improvement.md`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-sanitizer -p zeph-mcp -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10519/10519 passed (1 leaky, 21 skipped)

## Notes

- `check_inner` records its own `text_len`/`allowed` child span fields, which are redundant since `check` already wraps the entire call. The duplication is non-blocking and left for a future cleanup pass.
- MCP spans remain feature-gated (`#[cfg_attr(feature = "profiling", ...)]`) while the new guardrail spans are unconditional — this matches the existing convention in `zeph-sanitizer` (`nli.rs`, `ipi_filter.rs`) and is a pre-existing cross-crate divergence, not introduced here.

Closes #4896
Closes #4865