### PR TITLE
refactor(config): replace stringly-typed fields with typed enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(config)`: `SttConfig.provider` changed from `String` to `ProviderName` — enables
+  type-safe provider cross-references and removes the `default_stt_provider()` helper function.
+  `ProviderName::default()` (empty sentinel) serves the same auto-detect semantics. (#4899)
+- `refactor(config)`: `CandleConfig.source` and `.device` (and `CandleInlineConfig` equivalents)
+  changed from `String` to new `CandleSource` and `CandleDevice` enums respectively. Invalid
+  values that previously silently fell through to CPU/HuggingFace are now rejected at
+  deserialization. `select_device` in `zeph-core` now takes `CandleDevice` instead of `&str`. (#4900)
+
 - `perf(context)`: add `#[tracing::instrument]` to `embed_prepass_dyn` and `render_compressed`
   in `zeph-context/fidelity.rs` — both async hot-path functions were invisible to local Chrome
   JSON traces and Jaeger; now emit `context.fidelity.embed_prepass_dyn` and

--- a/config/default.toml
+++ b/config/default.toml
@@ -156,7 +156,7 @@ embedding_model = "qwen3-embedding"
 # filename = "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
 # local_path = ""                       # used when source = "local"
 # chat_template = "chatml"              # llama3, chatml, mistral, phi3, raw
-# device = "cpu"                        # auto, cpu, metal, cuda
+# device = "cpu"                        # cpu, metal, cuda, auto
 
 # Multi-provider example:
 #

--- a/crates/zeph-config/src/env.rs
+++ b/crates/zeph-config/src/env.rs
@@ -3,7 +3,8 @@
 
 use std::num::NonZeroUsize;
 
-use crate::providers::{ProviderEntry, SttConfig, default_stt_language, default_stt_provider};
+use crate::ProviderName;
+use crate::providers::{ProviderEntry, SttConfig, default_stt_language};
 use crate::root::Config;
 
 impl Config {
@@ -220,14 +221,14 @@ impl Config {
         }
         if let Ok(v) = std::env::var("ZEPH_STT_PROVIDER") {
             let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
-                provider: default_stt_provider(),
+                provider: ProviderName::default(),
                 language: default_stt_language(),
             });
-            stt.provider = v;
+            stt.provider = ProviderName::new(v);
         }
         if let Ok(v) = std::env::var("ZEPH_STT_LANGUAGE") {
             let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
-                provider: default_stt_provider(),
+                provider: ProviderName::default(),
                 language: default_stt_language(),
             });
             stt.language = v;

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -156,14 +156,15 @@ pub use memory::{
 };
 pub use metrics::MetricsConfig;
 pub use notifications::NotificationsConfig;
+pub use providers::default_stt_language;
 pub use providers::{
-    BanditConfig, CacheTtl, CandleConfig, CandleInlineConfig, CascadeClassifierMode, CascadeConfig,
-    CocoonPricing, CoeConfig, ComplexityRoutingConfig, FAST_TIER_MODEL_HINTS, GeminiThinkingLevel,
-    GenerationParams, GonkaNode, LlmConfig, LlmRoutingStrategy, MAX_TOKENS_CAP, ProviderEntry,
-    ProviderKind, ProviderName, ProviderOverrides, RouterConfig, RouterStrategyConfig,
-    StreamLimits, SttConfig, ThinkingConfig, ThinkingEffort, TierMapping, validate_pool,
+    BanditConfig, CacheTtl, CandleConfig, CandleDevice, CandleInlineConfig, CandleSource,
+    CascadeClassifierMode, CascadeConfig, CocoonPricing, CoeConfig, ComplexityRoutingConfig,
+    FAST_TIER_MODEL_HINTS, GeminiThinkingLevel, GenerationParams, GonkaNode, LlmConfig,
+    LlmRoutingStrategy, MAX_TOKENS_CAP, ProviderEntry, ProviderKind, ProviderName,
+    ProviderOverrides, RouterConfig, RouterStrategyConfig, StreamLimits, SttConfig, ThinkingConfig,
+    ThinkingEffort, TierMapping, validate_pool,
 };
-pub use providers::{default_stt_language, default_stt_provider};
 pub use quality::{QualityConfig, TriggerPolicy};
 pub use rate_limit::RateLimitConfig;
 pub use sanitizer::{

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -114,16 +114,8 @@ fn default_embedding_model() -> String {
     "qwen3-embedding".into()
 }
 
-fn default_candle_source() -> String {
-    "huggingface".into()
-}
-
 fn default_chat_template() -> String {
     "chatml".into()
-}
-
-fn default_candle_device() -> String {
-    "cpu".into()
 }
 
 fn default_temperature() -> f64 {
@@ -172,12 +164,6 @@ fn default_reputation_weight() -> f64 {
 
 fn default_reputation_min_observations() -> u64 {
     5
-}
-
-/// Returns the default STT provider name (empty string — auto-detect).
-#[must_use]
-pub fn default_stt_provider() -> String {
-    String::new()
 }
 
 /// Returns the default STT transcription language hint (`"auto"`).
@@ -603,17 +589,17 @@ impl LlmConfig {
         let found = self
             .providers
             .iter()
-            .find(|p| p.effective_name() == stt.provider);
+            .find(|p| p.effective_name() == stt.provider.as_str());
         match found {
             None => {
                 return Err(ConfigError::Validation(format!(
                     "[llm.stt].provider = {:?} does not match any [[llm.providers]] entry",
-                    stt.provider
+                    stt.provider.as_str()
                 )));
             }
             Some(entry) if entry.stt_model.is_none() => {
                 tracing::warn!(
-                    provider = stt.provider,
+                    provider = stt.provider.as_str(),
                     "[[llm.providers]] entry exists but has no `stt_model` — STT will not be activated"
                 );
             }
@@ -717,10 +703,10 @@ pub const FAST_TIER_MODEL_HINTS: &[&str] = &[
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SttConfig {
-    /// Provider name from `[[llm.providers]]`. Empty string means auto-detect first provider
+    /// Provider name from `[[llm.providers]]`. Empty means auto-detect the first provider
     /// with `stt_model` set.
-    #[serde(default = "default_stt_provider")]
-    pub provider: String,
+    #[serde(default)]
+    pub provider: ProviderName,
     /// Language hint for transcription (e.g. `"en"`, `"auto"`).
     #[serde(default = "default_stt_language")]
     pub language: String,
@@ -1087,6 +1073,43 @@ impl Default for BanditConfig {
     }
 }
 
+/// Model source for the Candle local-inference backend.
+///
+/// Controls whether the model is downloaded from Hugging Face Hub or loaded
+/// from a local filesystem path specified in `local_path`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CandleSource {
+    /// Download model weights from Hugging Face Hub using the `repo_id` from
+    /// the provider's `model` field.
+    #[default]
+    Huggingface,
+    /// Load model weights from the local filesystem path in `local_path`.
+    Local,
+}
+
+/// Compute device for the Candle local-inference backend.
+///
+/// Determines which hardware accelerator is used for inference. Feature flags
+/// `candle/metal` and `candle/cuda` must be enabled at compile time for the
+/// corresponding variants to succeed at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CandleDevice {
+    /// Run inference on the CPU.
+    #[default]
+    Cpu,
+    /// Run inference on an NVIDIA CUDA GPU (requires `cuda` feature).
+    Cuda,
+    /// Run inference on Apple Silicon via Metal (requires `metal` feature).
+    Metal,
+    /// Auto-detect the best available device: Metal → CUDA → CPU.
+    ///
+    /// Requires the corresponding `metal` or `cuda` feature to be enabled at compile time.
+    /// Falls back to CPU when no GPU features are compiled in.
+    Auto,
+}
+
 /// Configuration for the Candle local-inference backend.
 ///
 /// Corresponds to the `[llm.candle]` section in `config.toml`. Used when the
@@ -1095,16 +1118,16 @@ impl Default for BanditConfig {
 /// [`CandleInlineConfig`] instead.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CandleConfig {
-    #[serde(default = "default_candle_source")]
-    pub source: String,
+    #[serde(default)]
+    pub source: CandleSource,
     #[serde(default)]
     pub local_path: String,
     #[serde(default)]
     pub filename: Option<String>,
     #[serde(default = "default_chat_template")]
     pub chat_template: String,
-    #[serde(default = "default_candle_device")]
-    pub device: String,
+    #[serde(default)]
+    pub device: CandleDevice,
     #[serde(default)]
     pub embedding_repo: Option<String>,
     /// Resolved `HuggingFace` Hub API token for authenticated model downloads.
@@ -1374,16 +1397,16 @@ pub struct GonkaNode {
 /// Re-uses the generation params from `CandleConfig`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CandleInlineConfig {
-    #[serde(default = "default_candle_source")]
-    pub source: String,
+    #[serde(default)]
+    pub source: CandleSource,
     #[serde(default)]
     pub local_path: String,
     #[serde(default)]
     pub filename: Option<String>,
     #[serde(default = "default_chat_template")]
     pub chat_template: String,
-    #[serde(default = "default_candle_device")]
-    pub device: String,
+    #[serde(default)]
+    pub device: CandleDevice,
     #[serde(default)]
     pub embedding_repo: Option<String>,
     /// Resolved `HuggingFace` Hub API token for authenticated model downloads.
@@ -1402,11 +1425,11 @@ pub struct CandleInlineConfig {
 impl Default for CandleInlineConfig {
     fn default() -> Self {
         Self {
-            source: default_candle_source(),
+            source: CandleSource::default(),
             local_path: String::new(),
             filename: None,
             chat_template: default_chat_template(),
-            device: default_candle_device(),
+            device: CandleDevice::default(),
             embedding_repo: None,
             hf_token: None,
             generation: GenerationParams::default(),
@@ -2461,8 +2484,8 @@ language = "en"
 
     #[test]
     fn stt_config_default_provider_is_empty() {
-        // Verify that W4 fix: default_stt_provider() returns "" not "whisper".
-        assert_eq!(default_stt_provider(), "");
+        // Verify that W4 fix: default provider is empty (auto-detect), not "whisper".
+        assert!(ProviderName::default().is_empty());
     }
 
     #[test]

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -74,7 +74,7 @@ max_tokens = 4096
 # filename = "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
 # local_path = ""          # used when source = "local"
 # chat_template = "chatml"  # llama3, chatml, mistral, phi3, raw
-# device = "cpu"           # auto, cpu, metal, cuda
+# device = "cpu"           # cpu, metal, cuda, auto
 # embedding_repo = "sentence-transformers/all-MiniLM-L6-v2"
 # [llm.candle.generation]
 # temperature = 0.7

--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -9,22 +9,22 @@
 // Re-export Config types from zeph-config for internal use.
 pub use zeph_config::{
     AcpAuthMethod, AcpConfig, AcpLspConfig, AcpTransport, AdditionalDir, AdditionalDirError,
-    AgentConfig, CandleConfig, CandleInlineConfig, CascadeClassifierMode, CascadeConfig,
-    ClassifiersConfig, CompressionConfig, CompressionStrategy, Config, ConfigError, ContextFormat,
-    CostConfig, DaemonConfig, DebugConfig, DetectorMode, DiscordConfig, DocumentConfig, DumpFormat,
-    ExperimentConfig, ExperimentSchedule, FocusConfig, GatewayConfig, GenerationParams, GonkaNode,
-    GraphConfig, HookAction, HookDef, HookMatcher, IndexConfig, LearningConfig, LlmConfig,
-    LlmRoutingStrategy, LogRotation, LoggingConfig, MAX_TOKENS_CAP, McpConfig, McpOAuthConfig,
-    McpServerConfig, McpTrustLevel, MemoryConfig, MemoryScope, NoteLinkingConfig,
-    OAuthTokenStorage, OrchestrationConfig, PermissionMode, ProviderEntry, ProviderKind,
-    ProviderName, PruningStrategy, RateLimitConfig, ResolvedSecrets, RetrievalConfig, RouterConfig,
-    RouterStrategyConfig, ScheduledTaskConfig, ScheduledTaskKind, SchedulerConfig,
-    SchedulerDaemonConfig, SchedulerSecurityConfig, SecurityConfig, SemanticConfig, SessionsConfig,
-    SidequestConfig, SkillFilter, SkillPromptMode, SkillsConfig, SlackConfig, StoreRoutingConfig,
-    StoreRoutingStrategy, SttConfig, SubAgentConfig, SubAgentLifecycleHooks, SubagentHooks,
-    TaskSupervisorConfig, TelegramConfig, TimeoutConfig, ToolDiscoveryConfig,
-    ToolDiscoveryStrategyConfig, ToolFilterConfig, ToolPolicy, TraceConfig, TrustConfig, TuiConfig,
-    VaultConfig, VectorBackend,
+    AgentConfig, CandleConfig, CandleDevice, CandleInlineConfig, CandleSource,
+    CascadeClassifierMode, CascadeConfig, ClassifiersConfig, CompressionConfig,
+    CompressionStrategy, Config, ConfigError, ContextFormat, CostConfig, DaemonConfig, DebugConfig,
+    DetectorMode, DiscordConfig, DocumentConfig, DumpFormat, ExperimentConfig, ExperimentSchedule,
+    FocusConfig, GatewayConfig, GenerationParams, GonkaNode, GraphConfig, HookAction, HookDef,
+    HookMatcher, IndexConfig, LearningConfig, LlmConfig, LlmRoutingStrategy, LogRotation,
+    LoggingConfig, MAX_TOKENS_CAP, McpConfig, McpOAuthConfig, McpServerConfig, McpTrustLevel,
+    MemoryConfig, MemoryScope, NoteLinkingConfig, OAuthTokenStorage, OrchestrationConfig,
+    PermissionMode, ProviderEntry, ProviderKind, ProviderName, PruningStrategy, RateLimitConfig,
+    ResolvedSecrets, RetrievalConfig, RouterConfig, RouterStrategyConfig, ScheduledTaskConfig,
+    ScheduledTaskKind, SchedulerConfig, SchedulerDaemonConfig, SchedulerSecurityConfig,
+    SecurityConfig, SemanticConfig, SessionsConfig, SidequestConfig, SkillFilter, SkillPromptMode,
+    SkillsConfig, SlackConfig, StoreRoutingConfig, StoreRoutingStrategy, SttConfig, SubAgentConfig,
+    SubAgentLifecycleHooks, SubagentHooks, TaskSupervisorConfig, TelegramConfig, TimeoutConfig,
+    ToolDiscoveryConfig, ToolDiscoveryStrategyConfig, ToolFilterConfig, ToolPolicy, TraceConfig,
+    TrustConfig, TuiConfig, VaultConfig, VectorBackend,
 };
 
 pub use zeph_config::{
@@ -52,7 +52,7 @@ pub use zeph_config::{
     is_legacy_default_sqlite_path,
 };
 
-pub use zeph_config::providers::{default_stt_language, default_stt_provider, validate_pool};
+pub use zeph_config::providers::{default_stt_language, validate_pool};
 
 pub mod migrate {
     pub use zeph_config::migrate::*;

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -25,6 +25,8 @@ use zeph_llm::openai::OpenAiProvider;
 use zeroize::Zeroizing;
 
 use crate::agent::state::ProviderConfigSnapshot;
+#[cfg(feature = "candle")]
+use crate::config::{CandleDevice, CandleSource};
 use crate::config::{Config, ProviderEntry, ProviderKind};
 
 #[non_exhaustive]
@@ -517,11 +519,11 @@ fn build_candle_provider(
             "candle provider requires 'candle' section in [[llm.providers]]".into(),
         )
     })?;
-    let source = match candle.source.as_str() {
-        "local" => zeph_llm::candle_provider::loader::ModelSource::Local {
+    let source = match candle.source {
+        CandleSource::Local => zeph_llm::candle_provider::loader::ModelSource::Local {
             path: std::path::PathBuf::from(&candle.local_path),
         },
-        _ => zeph_llm::candle_provider::loader::ModelSource::HuggingFace {
+        CandleSource::Huggingface => zeph_llm::candle_provider::loader::ModelSource::HuggingFace {
             repo_id: entry
                 .model
                 .clone()
@@ -540,7 +542,7 @@ fn build_candle_provider(
         repeat_penalty: candle.generation.repeat_penalty,
         repeat_last_n: candle.generation.repeat_last_n,
     };
-    let device = select_device(&candle.device)?;
+    let device = select_device(candle.device)?;
     // Floor at 1s so that inference_timeout_secs = 0 does not cause every request to
     // immediately time out.
     let inference_timeout = std::time::Duration::from_secs(candle.inference_timeout_secs.max(1));
@@ -557,22 +559,18 @@ fn build_candle_provider(
     .map_err(|e| BootstrapError::Provider(e.to_string()))
 }
 
-/// Select the candle compute device based on a string preference.
-///
-/// Resolution order: `"metal"` → Metal GPU (requires `metal` feature),
-/// `"cuda"` → CUDA GPU (requires `cuda` feature), `"auto"` → best available,
-/// anything else → CPU.
+/// Select the candle compute device from a [`CandleDevice`] config value.
 ///
 /// # Errors
 ///
 /// Returns `BootstrapError::Provider` when the requested device is not available (e.g.
-/// `"metal"` requested but compiled without the `metal` feature).
+/// `CandleDevice::Metal` requested but compiled without the `metal` feature).
 #[cfg(feature = "candle")]
 pub fn select_device(
-    preference: &str,
+    preference: CandleDevice,
 ) -> Result<zeph_llm::candle_provider::Device, BootstrapError> {
     match preference {
-        "metal" => {
+        CandleDevice::Metal => {
             #[cfg(feature = "metal")]
             return zeph_llm::candle_provider::Device::new_metal(0)
                 .map_err(|e| BootstrapError::Provider(e.to_string()));
@@ -581,7 +579,7 @@ pub fn select_device(
                 "candle compiled without metal feature".into(),
             ));
         }
-        "cuda" => {
+        CandleDevice::Cuda => {
             #[cfg(feature = "cuda")]
             return zeph_llm::candle_provider::Device::new_cuda(0)
                 .map_err(|e| BootstrapError::Provider(e.to_string()));
@@ -590,7 +588,8 @@ pub fn select_device(
                 "candle compiled without cuda feature".into(),
             ));
         }
-        "auto" => {
+        CandleDevice::Cpu => Ok(zeph_llm::candle_provider::Device::Cpu),
+        CandleDevice::Auto => {
             #[cfg(feature = "metal")]
             if let Ok(device) = zeph_llm::candle_provider::Device::new_metal(0) {
                 return Ok(device);
@@ -601,7 +600,6 @@ pub fn select_device(
             }
             Ok(zeph_llm::candle_provider::Device::Cpu)
         }
-        _ => Ok(zeph_llm::candle_provider::Device::Cpu),
     }
 }
 
@@ -609,25 +607,20 @@ pub fn select_device(
 mod tests {
     #[cfg(feature = "candle")]
     use super::select_device;
+    #[cfg(feature = "candle")]
+    use crate::config::CandleDevice;
 
     #[cfg(feature = "candle")]
     #[test]
     fn select_device_cpu_default() {
-        let device = select_device("cpu").unwrap();
-        assert!(matches!(device, zeph_llm::candle_provider::Device::Cpu));
-    }
-
-    #[cfg(feature = "candle")]
-    #[test]
-    fn select_device_unknown_defaults_to_cpu() {
-        let device = select_device("unknown").unwrap();
+        let device = select_device(CandleDevice::Cpu).unwrap();
         assert!(matches!(device, zeph_llm::candle_provider::Device::Cpu));
     }
 
     #[cfg(all(feature = "candle", not(feature = "metal")))]
     #[test]
     fn select_device_metal_without_feature_errors() {
-        let result = select_device("metal");
+        let result = select_device(CandleDevice::Metal);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("metal feature"));
     }
@@ -635,21 +628,9 @@ mod tests {
     #[cfg(all(feature = "candle", not(feature = "cuda")))]
     #[test]
     fn select_device_cuda_without_feature_errors() {
-        let result = select_device("cuda");
+        let result = select_device(CandleDevice::Cuda);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("cuda feature"));
-    }
-
-    #[cfg(feature = "candle")]
-    #[test]
-    fn select_device_auto_fallback() {
-        let device = select_device("auto").unwrap();
-        assert!(matches!(
-            device,
-            zeph_llm::candle_provider::Device::Cpu
-                | zeph_llm::candle_provider::Device::Cuda(_)
-                | zeph_llm::candle_provider::Device::Metal(_)
-        ));
     }
 
     #[cfg(any(feature = "gonka", feature = "cocoon"))]

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -234,26 +234,21 @@ fn create_provider_openai_missing_api_key_errors() {
 }
 
 #[cfg(feature = "candle")]
+use zeph_config::CandleDevice;
+#[cfg(feature = "candle")]
 use zeph_core::provider_factory::select_device;
 
 #[cfg(feature = "candle")]
 #[test]
 fn select_device_cpu_default() {
-    let device = select_device("cpu").unwrap();
-    assert!(matches!(device, zeph_llm::candle_provider::Device::Cpu));
-}
-
-#[cfg(feature = "candle")]
-#[test]
-fn select_device_unknown_defaults_to_cpu() {
-    let device = select_device("unknown").unwrap();
+    let device = select_device(CandleDevice::Cpu).unwrap();
     assert!(matches!(device, zeph_llm::candle_provider::Device::Cpu));
 }
 
 #[cfg(all(feature = "candle", not(feature = "metal")))]
 #[test]
 fn select_device_metal_without_feature_errors() {
-    let result = select_device("metal");
+    let result = select_device(CandleDevice::Metal);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("metal feature"));
 }
@@ -261,7 +256,7 @@ fn select_device_metal_without_feature_errors() {
 #[cfg(all(feature = "candle", not(feature = "cuda")))]
 #[test]
 fn select_device_cuda_without_feature_errors() {
-    let result = select_device("cuda");
+    let result = select_device(CandleDevice::Cuda);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("cuda feature"));
 }
@@ -269,7 +264,7 @@ fn select_device_cuda_without_feature_errors() {
 #[cfg(feature = "candle")]
 #[test]
 fn select_device_auto_fallback() {
-    let device = select_device("auto").unwrap();
+    let device = select_device(CandleDevice::Auto).unwrap();
     assert!(matches!(
         device,
         zeph_llm::candle_provider::Device::Cpu


### PR DESCRIPTION
## Summary

- Replace `SttConfig.provider: String` with `ProviderName` newtype for consistency with all other provider-reference fields in `providers.rs`
- Introduce `CandleSource` enum (`Huggingface` | `Local`) and `CandleDevice` enum (`Cpu` | `Cuda` | `Metal` | `Auto`) replacing bare `String` fields in `CandleConfig` and `CandleInlineConfig`
- Remove `default_stt_provider()`, `default_candle_source()`, `default_candle_device()` helper functions replaced by `#[serde(default)]` on typed enums
- `select_device()` in `provider_factory.rs` now takes `CandleDevice`; exhaustive match eliminates silent wildcard fallthrough

TOML backward compatibility preserved: `#[serde(rename_all = "lowercase")]` maps existing string values; `device = "auto"` continues to work via `CandleDevice::Auto` with identical Metal→CUDA→CPU fallback logic.

Closes #4899
Closes #4900

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10519 passed, 21 skipped
- [ ] `cargo check -p zeph --features candle` — clean (stale `&str` tests in `bootstrap/tests.rs` fixed)
- [ ] Serde backward compat verified: existing TOML configs with `provider = "..."`, `source = "huggingface"`, `device = "auto"` parse correctly