### PR TITLE
fix(a2a): add TTL eviction to TaskManager and replace now_rfc3339 with chrono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `fix(acp)`: spawn agent connection thread with explicit 8 MiB stack (`thread::Builder::new().stack_size(ACP_AGENT_STACK_SIZE)`) in HTTP and WebSocket transports; bare `thread::spawn` overflowed the default 512 KiB macOS stack on `session/prompt`. `spawn_agent_connection` now returns `io::Result` — spawn failure responds 503 on HTTP and cleanly releases the WS slot. Follow-up: stdio transport tracked in #4901. (#4897)
 - `fix(acp)`: `serve_stdio` now spawns a dedicated OS thread with an explicit 8 MiB stack and a `current_thread` Tokio runtime; the previous implementation ran the agent future on a tokio worker thread (2 MiB default), which was insufficient for deeply nested agent sessions. The thread name is `acp-stdio`; spawn failures and runtime-build errors propagate as `AcpError::Transport`. (#4901)
 - `fix(gateway)`: webhook `body` field is now sanitized with `strip_control_chars_preserve_whitespace` before being forwarded to the agent, consistent with `sender` and `channel`; previously raw control characters (null bytes, ANSI escapes) in `body` bypassed sanitization. (#4904)
+- `fix(a2a)`: `TaskManager` now evicts terminal tasks (Completed, Failed, Canceled,
+  Rejected) after a configurable TTL (default 1 hour) via a background loop in
+  `A2aServer::serve`. The in-memory `HashMap` previously grew without bound.
+  New `A2aServer::with_task_ttl(Option<Duration>)` builder method; new
+  `A2aServerConfig::task_ttl_secs` config field (default 3600). (#4903)
+- `fix(a2a)`: Replace 45-line hand-rolled `now_rfc3339()` (custom leap-year arithmetic)
+  with `chrono::Utc::now().to_rfc3339()`. (#4905)
 - `fix(llm)`: `OpenAiProvider` now applies a 2-layer resolution strategy to the
   `max_tokens` / `max_completion_tokens` field selection: (1) explicit config override,
   (2) built-in model-name prefix table.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10498,6 +10498,7 @@ version = "0.21.4"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
+ "chrono",
  "eventsource-stream",
  "futures",
  "futures-core",

--- a/crates/zeph-a2a/Cargo.toml
+++ b/crates/zeph-a2a/Cargo.toml
@@ -19,6 +19,7 @@ server = ["dep:axum", "dep:tower", "dep:tower-http", "zeph-common/http-middlewar
 [dependencies]
 axum = { workspace = true, optional = true }
 base64.workspace = true
+chrono = { workspace = true, features = ["clock"] }
 eventsource-stream.workspace = true
 futures.workspace = true
 futures-core.workspace = true

--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -102,6 +102,8 @@ pub struct A2aServer {
     auth_cfg: AuthConfig,
     rate_limit: u32,
     max_body_size: usize,
+    /// TTL for terminal tasks; `None` disables background eviction.
+    task_ttl: Option<Duration>,
 }
 
 impl A2aServer {
@@ -140,6 +142,7 @@ impl A2aServer {
             auth_cfg: AuthConfig::new(None, false),
             rate_limit: 0,
             max_body_size: 1_048_576,
+            task_ttl: Some(Duration::from_hours(1)),
         }
     }
 
@@ -204,6 +207,20 @@ impl A2aServer {
         self
     }
 
+    /// Set the TTL for terminal tasks in the in-memory store (default: 3600 seconds).
+    ///
+    /// Tasks in a terminal state ([`crate::TaskState::Completed`], [`crate::TaskState::Failed`],
+    /// [`crate::TaskState::Canceled`], [`crate::TaskState::Rejected`]) that have been in the
+    /// store longer than this duration are evicted by a background loop running every 60 seconds.
+    ///
+    /// Pass `None` to disable background eviction entirely. In that case the task store grows
+    /// without bound and the operator is responsible for eviction (e.g., via process restart).
+    #[must_use]
+    pub fn with_task_ttl(mut self, ttl: Option<Duration>) -> Self {
+        self.task_ttl = ttl;
+        self
+    }
+
     /// Bind to the configured address and start serving A2A requests.
     ///
     /// Runs until a `true` value is received on the `shutdown_rx` channel provided to
@@ -219,6 +236,17 @@ impl A2aServer {
                 "A2A server running without bearer auth — ensure this is a trusted-network-only deployment"
             );
         }
+
+        let eviction_handle = self.task_ttl.map(|ttl| {
+            let tm = self.state.task_manager.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_mins(1));
+                loop {
+                    interval.tick().await;
+                    tm.evict_expired(ttl).await;
+                }
+            })
+        });
 
         let router = build_router_with_full_config(
             self.state,
@@ -247,6 +275,10 @@ impl A2aServer {
         })
         .await
         .map_err(|e| A2aError::Server(format!("server error: {e}")))?;
+
+        if let Some(handle) = eviction_handle {
+            handle.abort();
+        }
 
         Ok(())
     }

--- a/crates/zeph-a2a/src/server/state.rs
+++ b/crates/zeph-a2a/src/server/state.rs
@@ -305,7 +305,7 @@ pub enum CancelError {
 }
 
 pub(super) fn now_rfc3339() -> String {
-    chrono::Utc::now().to_rfc3339()
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
 #[cfg(test)]
@@ -564,9 +564,7 @@ mod tests {
         // Even when a non-terminal task is older than the TTL it must NOT be removed,
         // because it may still be actively polled or streamed by a client.
         let tm = TaskManager::new();
-        let old = Instant::now()
-            .checked_sub(Duration::from_secs(2))
-            .unwrap();
+        let old = Instant::now().checked_sub(Duration::from_secs(2)).unwrap();
 
         for state in [
             TaskState::Submitted,

--- a/crates/zeph-a2a/src/server/state.rs
+++ b/crates/zeph-a2a/src/server/state.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::sync::RwLock;
 
@@ -107,9 +107,14 @@ pub trait TaskProcessor: Send + Sync {
 ///
 /// History trimming is done lazily on reads via `history_length` — the full history is
 /// always stored, but responses return at most `N` most-recent messages when requested.
+///
+/// Expired terminal tasks are removed by [`evict_expired`](Self::evict_expired), which is
+/// typically called from a background loop spawned by [`A2aServer`](crate::server::A2aServer).
 #[derive(Clone)]
 pub struct TaskManager {
     tasks: Arc<RwLock<HashMap<String, Task>>>,
+    /// Insertion timestamp for each task, used to compute age for TTL eviction.
+    created_at: Arc<RwLock<HashMap<String, Instant>>>,
 }
 
 impl TaskManager {
@@ -118,6 +123,7 @@ impl TaskManager {
     pub fn new() -> Self {
         Self {
             tasks: Arc::new(RwLock::new(HashMap::new())),
+            created_at: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -139,6 +145,10 @@ impl TaskManager {
             history: vec![message],
             metadata: None,
         };
+        self.created_at
+            .write()
+            .await
+            .insert(id.clone(), Instant::now());
         self.tasks.write().await.insert(id, task.clone());
         task
     }
@@ -230,6 +240,51 @@ impl TaskManager {
         };
         Ok(task.clone())
     }
+
+    /// Remove terminal tasks that have exceeded `ttl`.
+    ///
+    /// Only tasks in a terminal state ([`TaskState::Completed`], [`TaskState::Failed`],
+    /// [`TaskState::Canceled`], or [`TaskState::Rejected`]) are eligible for removal.
+    /// Non-terminal tasks are never evicted regardless of age, because they may still be
+    /// actively polled or streamed by a client.
+    ///
+    /// This method is designed to be called periodically from a background task. The caller
+    /// is responsible for choosing a suitable interval (e.g., every 60 seconds).
+    pub async fn evict_expired(&self, ttl: Duration) {
+        let now = Instant::now();
+
+        let mut ages = self.created_at.write().await;
+        let mut tasks = self.tasks.write().await;
+
+        let expired: Vec<String> = ages
+            .iter()
+            .filter_map(|(id, created)| {
+                if now.duration_since(*created) < ttl {
+                    return None;
+                }
+                let is_terminal = tasks.get(id).is_some_and(|t| {
+                    matches!(
+                        t.status.state,
+                        TaskState::Completed
+                            | TaskState::Failed
+                            | TaskState::Canceled
+                            | TaskState::Rejected
+                    )
+                });
+                is_terminal.then(|| id.clone())
+            })
+            .collect();
+
+        let count = expired.len();
+        for id in expired {
+            tasks.remove(&id);
+            ages.remove(&id);
+        }
+
+        if count > 0 {
+            tracing::debug!(evicted = count, "a2a task manager: evicted expired tasks");
+        }
+    }
 }
 
 impl Default for TaskManager {
@@ -250,51 +305,7 @@ pub enum CancelError {
 }
 
 pub(super) fn now_rfc3339() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    // Simple ISO 8601 without external dep
-    let days = secs / 86400;
-    let time_secs = secs % 86400;
-    let hours = time_secs / 3600;
-    let minutes = (time_secs % 3600) / 60;
-    let seconds = time_secs % 60;
-
-    // Days since epoch to Y-M-D (simplified leap year calc)
-    let (year, month, day) = days_to_ymd(days);
-    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
-}
-
-fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
-    let mut year = 1970;
-    loop {
-        let days_in_year = if is_leap(year) { 366 } else { 365 };
-        if days < days_in_year {
-            break;
-        }
-        days -= days_in_year;
-        year += 1;
-    }
-    let month_days: [u64; 12] = if is_leap(year) {
-        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    } else {
-        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    };
-    let mut month = 0;
-    for (i, &md) in month_days.iter().enumerate() {
-        if days < md {
-            month = i as u64 + 1;
-            break;
-        }
-        days -= md;
-    }
-    (year, month, days + 1)
-}
-
-fn is_leap(y: u64) -> bool {
-    y.is_multiple_of(4) && (!y.is_multiple_of(100) || y.is_multiple_of(400))
+    chrono::Utc::now().to_rfc3339()
 }
 
 #[cfg(test)]
@@ -451,10 +462,135 @@ mod tests {
     }
 
     #[test]
-    fn now_rfc3339_format() {
+    fn now_rfc3339_is_valid_rfc3339() {
         let ts = now_rfc3339();
-        assert!(ts.ends_with('Z'));
-        assert!(ts.contains('T'));
-        assert_eq!(ts.len(), 20);
+        assert!(ts.contains('T'), "must contain date/time separator");
+        // chrono produces RFC3339 with timezone offset or 'Z'; parse back to verify
+        chrono::DateTime::parse_from_rfc3339(&ts)
+            .expect("now_rfc3339 must produce a valid RFC3339 string");
+    }
+
+    #[tokio::test]
+    async fn evict_expired_removes_terminal_tasks_past_ttl() {
+        let tm = TaskManager::new();
+
+        // Create three tasks
+        let t_completed = tm.create_task(test_message("done")).await;
+        let t_failed = tm.create_task(test_message("fail")).await;
+        let t_working = tm.create_task(test_message("active")).await;
+
+        // Transition to terminal / non-terminal states
+        tm.update_status(&t_completed.id, TaskState::Completed, None)
+            .await;
+        tm.update_status(&t_failed.id, TaskState::Failed, None)
+            .await;
+        tm.update_status(&t_working.id, TaskState::Working, None)
+            .await;
+
+        // Back-date the completed and failed tasks by inserting a past Instant.
+        // We use a zero-duration TTL and a slightly-past instant to avoid
+        // relying on sub-millisecond timing precision in CI environments.
+        {
+            let mut ages = tm.created_at.write().await;
+            // Subtract 2s to ensure elapsed > TTL of 1s used below
+            let old = Instant::now().checked_sub(Duration::from_secs(2)).unwrap();
+            ages.insert(t_completed.id.clone(), old);
+            ages.insert(t_failed.id.clone(), old);
+            // t_working keeps its real (recent) instant
+        }
+
+        tm.evict_expired(Duration::from_secs(1)).await;
+
+        assert!(
+            tm.get_task(&t_completed.id, None).await.is_none(),
+            "completed task past TTL must be evicted"
+        );
+        assert!(
+            tm.get_task(&t_failed.id, None).await.is_none(),
+            "failed task past TTL must be evicted"
+        );
+        assert!(
+            tm.get_task(&t_working.id, None).await.is_some(),
+            "non-terminal task must not be evicted"
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_expired_keeps_terminal_tasks_within_ttl() {
+        let tm = TaskManager::new();
+
+        let task = tm.create_task(test_message("recent done")).await;
+        tm.update_status(&task.id, TaskState::Completed, None).await;
+
+        // task was just created — elapsed ≈ 0, well within 1-hour TTL
+        tm.evict_expired(Duration::from_hours(1)).await;
+
+        assert!(
+            tm.get_task(&task.id, None).await.is_some(),
+            "recently completed task within TTL must not be evicted"
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_expired_handles_all_terminal_states() {
+        let tm = TaskManager::new();
+
+        for state in [
+            TaskState::Completed,
+            TaskState::Failed,
+            TaskState::Canceled,
+            TaskState::Rejected,
+        ] {
+            let task = tm.create_task(test_message("terminal")).await;
+            tm.update_status(&task.id, state, None).await;
+
+            // Back-date the task by 2s so elapsed > TTL of 1s used below
+            {
+                let old = Instant::now().checked_sub(Duration::from_secs(2)).unwrap();
+                tm.created_at.write().await.insert(task.id.clone(), old);
+            }
+
+            tm.evict_expired(Duration::from_secs(1)).await;
+
+            assert!(
+                tm.get_task(&task.id, None).await.is_none(),
+                "terminal state {state:?} past TTL must be evicted"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn evict_expired_never_evicts_non_terminal_tasks_past_ttl() {
+        // Even when a non-terminal task is older than the TTL it must NOT be removed,
+        // because it may still be actively polled or streamed by a client.
+        let tm = TaskManager::new();
+        let old = Instant::now()
+            .checked_sub(Duration::from_secs(2))
+            .unwrap();
+
+        for state in [
+            TaskState::Submitted,
+            TaskState::Working,
+            TaskState::InputRequired,
+        ] {
+            let task = tm.create_task(test_message("active")).await;
+            tm.update_status(&task.id, state, None).await;
+            tm.created_at.write().await.insert(task.id.clone(), old);
+
+            tm.evict_expired(Duration::from_secs(1)).await;
+
+            assert!(
+                tm.get_task(&task.id, None).await.is_some(),
+                "non-terminal state {state:?} must not be evicted even past TTL"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn evict_expired_empty_store_is_noop() {
+        let tm = TaskManager::new();
+        // Must not panic on an empty store.
+        tm.evict_expired(Duration::from_secs(0)).await;
+        assert!(tm.get_task("any", None).await.is_none());
     }
 }

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -607,6 +607,9 @@ pub struct A2aServerConfig {
     /// Tasks that have reached a terminal state and whose age exceeds this value are evicted
     /// from memory by a background loop running every 60 seconds. Non-terminal tasks (submitted,
     /// working) are never evicted. Default: 3600 (1 hour).
+    ///
+    /// Set to `0` to disable eviction entirely. In that case the task store grows without bound
+    /// and the operator is responsible for managing memory (e.g., via process restart).
     #[serde(default = "default_task_ttl_secs")]
     pub task_ttl_secs: u64,
 }

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -527,6 +527,10 @@ fn default_a2a_request_timeout_ms() -> u64 {
     300_000
 }
 
+fn default_task_ttl_secs() -> u64 {
+    3600
+}
+
 /// A2A server configuration, nested under `[a2a]` in TOML.
 ///
 /// Controls the Agent-to-Agent HTTP server that exposes the agent via the A2A protocol.
@@ -598,6 +602,13 @@ pub struct A2aServerConfig {
     /// Defaults to 300 000 ms (5 minutes).
     #[serde(default = "default_a2a_request_timeout_ms")]
     pub request_timeout_ms: u64,
+    /// TTL (seconds) for completed, failed, canceled, or rejected tasks in the in-memory store.
+    ///
+    /// Tasks that have reached a terminal state and whose age exceeds this value are evicted
+    /// from memory by a background loop running every 60 seconds. Non-terminal tasks (submitted,
+    /// working) are never evicted. Default: 3600 (1 hour).
+    #[serde(default = "default_task_ttl_secs")]
+    pub task_ttl_secs: u64,
 }
 
 impl std::fmt::Debug for A2aServerConfig {
@@ -625,6 +636,7 @@ impl std::fmt::Debug for A2aServerConfig {
             .field("ibct_ttl_secs", &self.ibct_ttl_secs)
             .field("advertise_files", &self.advertise_files)
             .field("request_timeout_ms", &self.request_timeout_ms)
+            .field("task_ttl_secs", &self.task_ttl_secs)
             .finish()
     }
 }
@@ -648,6 +660,7 @@ impl Default for A2aServerConfig {
             ibct_ttl_secs: default_ibct_ttl(),
             advertise_files: false,
             request_timeout_ms: default_a2a_request_timeout_ms(),
+            task_ttl_secs: default_task_ttl_secs(),
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -67,6 +67,11 @@ fn spawn_a2a_server(
             sanitizer,
             drain_timeout: std::time::Duration::from_millis(config.a2a.drain_timeout_ms),
         });
+    let task_ttl = if config.a2a.task_ttl_secs == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(config.a2a.task_ttl_secs))
+    };
     let a2a_server = zeph_a2a::A2aServer::new(
         card,
         processor,
@@ -80,7 +85,8 @@ fn spawn_a2a_server(
     .with_max_body_size(config.a2a.max_body_size)
     .with_request_timeout(std::time::Duration::from_millis(
         config.a2a.request_timeout_ms,
-    ));
+    ))
+    .with_task_ttl(task_ttl);
 
     tracing::info!(
         "A2A server spawned on {}:{}",


### PR DESCRIPTION
## Summary

- **#4903**: `TaskManager` in `zeph-a2a` stored completed/failed/canceled tasks in an unbounded `HashMap` with no eviction — this is now fixed with a configurable TTL-based background loop.
- **#4905**: The hand-rolled `now_rfc3339()` function (~45 lines of custom leap-year arithmetic) is replaced with `chrono::Utc::now().to_rfc3339()`.

## Changes

### `crates/zeph-a2a`

- Added `created_at: Arc<RwLock<HashMap<String, Instant>>>` to `TaskManager` to track task insertion time.
- New `TaskManager::evict_expired(&self, ttl: Duration)`: removes terminal tasks (Completed/Failed/Canceled/Rejected) older than TTL from both maps. Locks are acquired in a fixed order (created_at then tasks) to prevent deadlock.
- `A2aServer::serve` spawns a tracked background loop (`JoinHandle` stored and aborted on shutdown) that calls `evict_expired` every 60 seconds.
- New builder method `A2aServer::with_task_ttl(Option<Duration>)` — pass `None` to disable eviction.
- Added `chrono = { workspace = true, features = ["clock"] }` dependency.
- Replaced `now_rfc3339()` body + removed `days_to_ymd()` and `is_leap()` helpers.

### `crates/zeph-config`

- New field `A2aServerConfig::task_ttl_secs: u64` (default 3600, serde-defaulted) in `[a2a]` config section.
- Updated `Debug` and `Default` impls for `A2aServerConfig`.

## Tests

- `evict_expired_removes_terminal_tasks_past_ttl` — completed/failed tasks past TTL are removed; working task is kept.
- `evict_expired_keeps_terminal_tasks_within_ttl` — recently completed task within TTL is not evicted.
- `evict_expired_handles_all_terminal_states` — all 4 terminal states are covered.
- `now_rfc3339_is_valid_rfc3339` — updated to validate via `chrono::DateTime::parse_from_rfc3339`.

## Test plan

- [x] `cargo check -p zeph-a2a --features server` passes
- [x] `cargo check -p zeph-config` passes
- [x] `cargo clippy -p zeph-a2a --features server --all-targets -- -D warnings` clean
- [x] `cargo nextest run -p zeph-a2a --features server --lib` — 156 passed, 0 skipped
- [x] `cargo +nightly fmt --check -p zeph-a2a` clean
- [x] `RUSTFLAGS="-D warnings" cargo check -p zeph-a2a -p zeph-config --features server --locked` passes

Closes #4903
Closes #4905