### PR TITLE
fix(acp,gateway): fix stdio stack overflow and sanitize webhook body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `fix(acp)`: spawn agent connection thread with explicit 8 MiB stack (`thread::Builder::new().stack_size(ACP_AGENT_STACK_SIZE)`) in HTTP and WebSocket transports; bare `thread::spawn` overflowed the default 512 KiB macOS stack on `session/prompt`. `spawn_agent_connection` now returns `io::Result` — spawn failure responds 503 on HTTP and cleanly releases the WS slot. Follow-up: stdio transport tracked in #4901. (#4897)
+- `fix(acp)`: `serve_stdio` now spawns a dedicated OS thread with an explicit 8 MiB stack and a `current_thread` Tokio runtime; the previous implementation ran the agent future on a tokio worker thread (2 MiB default), which was insufficient for deeply nested agent sessions. The thread name is `acp-stdio`; spawn failures and runtime-build errors propagate as `AcpError::Transport`. (#4901)
+- `fix(gateway)`: webhook `body` field is now sanitized with `strip_control_chars_preserve_whitespace` before being forwarded to the agent, consistent with `sender` and `channel`; previously raw control characters (null bytes, ANSI escapes) in `body` bypassed sanitization. (#4904)
 - `fix(llm)`: `OpenAiProvider` now applies a 2-layer resolution strategy to the
   `max_tokens` / `max_completion_tokens` field selection: (1) explicit config override,
   (2) built-in model-name prefix table.

--- a/crates/zeph-acp/src/transport/stdio.rs
+++ b/crates/zeph-acp/src/transport/stdio.rs
@@ -113,11 +113,24 @@ pub(crate) async fn build_agent_state(
     state
 }
 
+/// Stack size for the dedicated stdio agent thread.
+///
+/// Agent futures are deeply nested (~512 KiB measured on overflow). The tokio
+/// multi-thread runtime uses a 2 MiB worker-thread stack by default, which was
+/// insufficient for complex sessions. 8 MiB provides comfortable headroom.
+const ACP_AGENT_STACK_SIZE: usize = 8 * 1024 * 1024;
+
 /// Run the ACP server over stdin/stdout until the connection closes.
+///
+/// Agent futures are `!Send` and deeply nested, so the dispatcher runs on a
+/// dedicated OS thread with an 8 MiB stack and a `current_thread` Tokio runtime
+/// rather than on the caller's multi-thread runtime worker (which uses the
+/// default 2 MiB stack and would overflow for complex sessions).
 ///
 /// # Errors
 ///
-/// Returns `AcpError::Transport` if the underlying JSON-RPC I/O fails.
+/// Returns `AcpError::Transport` if the underlying JSON-RPC I/O fails or if the
+/// agent thread cannot be spawned.
 pub async fn serve_stdio(
     spawner: AgentSpawner,
     server_config: AcpServerConfig,
@@ -137,15 +150,39 @@ pub async fn serve_stdio(
 
     let state = build_agent_state(spawner, server_config).await;
 
-    // Agent session tasks use spawn_local (agent futures are !Send), so the
-    // dispatcher loop must run within a LocalSet.
-    tokio::task::LocalSet::new()
-        .run_until(run_agent(
-            state,
-            acp::ByteStreams::new(stdout, tokio::io::stdin().compat()),
-        ))
-        .await
-        .map_err(|e| AcpError::Transport(e.to_string()))
+    // Run the agent on a dedicated thread with a larger stack.
+    // Agent session tasks use spawn_local (futures are !Send), so the thread
+    // uses a current_thread runtime wrapped in a LocalSet.
+    let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), AcpError>>();
+    std::thread::Builder::new()
+        .name("acp-stdio".into())
+        .stack_size(ACP_AGENT_STACK_SIZE)
+        .spawn(move || {
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    let _ = tx.send(Err(AcpError::Transport(format!(
+                        "failed to build tokio runtime: {e}"
+                    ))));
+                    return;
+                }
+            };
+            let local = tokio::task::LocalSet::new();
+            let result = rt
+                .block_on(local.run_until(run_agent(
+                    state,
+                    acp::ByteStreams::new(stdout, tokio::io::stdin().compat()),
+                )))
+                .map_err(|e| AcpError::Transport(e.to_string()));
+            let _ = tx.send(result);
+        })
+        .map_err(|e| AcpError::Transport(format!("failed to spawn stdio agent thread: {e}")))?;
+
+    rx.await
+        .map_err(|_| AcpError::Transport("stdio agent thread panicked".into()))?
 }
 
 /// Run the ACP server over arbitrary async byte streams.

--- a/crates/zeph-gateway/src/handlers.rs
+++ b/crates/zeph-gateway/src/handlers.rs
@@ -73,8 +73,8 @@ struct HealthResponse {
 
 /// Handler for `POST /webhook`.
 ///
-/// Validates the payload, sanitises `sender` and `channel` by stripping control
-/// characters, then forwards the message as `"[sender@channel] body"` on the
+/// Validates the payload, sanitises `sender`, `channel`, and `body` by stripping
+/// control characters, then forwards the message as `"[sender@channel] body"` on the
 /// internal webhook channel.
 ///
 /// The send is wrapped in a timeout (`AppState::webhook_send_timeout`).  If the
@@ -118,7 +118,8 @@ pub(crate) async fn webhook_handler(
     }
     let sender = zeph_common::sanitize::strip_control_chars_preserve_whitespace(&payload.sender);
     let channel = zeph_common::sanitize::strip_control_chars_preserve_whitespace(&payload.channel);
-    let msg = format!("[{}@{}] {}", sender, channel, payload.body);
+    let body = zeph_common::sanitize::strip_control_chars_preserve_whitespace(&payload.body);
+    let msg = format!("[{sender}@{channel}] {body}");
     match tokio::time::timeout(state.webhook_send_timeout, state.webhook_tx.send(msg)).await {
         Ok(Ok(())) => Json(WebhookResponse { status: "accepted" }).into_response(),
         Ok(Err(_)) => (
@@ -341,5 +342,31 @@ mod tests {
             body: "b".repeat(65536),
         };
         assert!(payload.validate().is_ok());
+    }
+
+    #[tokio::test]
+    async fn webhook_handler_sanitizes_body() {
+        use axum::extract::State;
+        use axum::response::IntoResponse as _;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(4);
+        let state = AppState {
+            webhook_tx: tx,
+            started_at: Instant::now(),
+            webhook_send_timeout: Duration::from_secs(1),
+        };
+
+        let payload = WebhookPayload {
+            channel: "ch".into(),
+            sender: "user".into(),
+            body: "hel\x01lo\x7fworld".into(),
+        };
+
+        let response = webhook_handler(State(state), Ok(axum::Json(payload)))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let msg = rx.try_recv().expect("message must be forwarded");
+        assert_eq!(msg, "[user@ch] helloworld");
     }
 }


### PR DESCRIPTION
## Summary

- **#4901 — ACP stdio stack overflow**: `serve_stdio` now runs the agent future on a dedicated OS thread named `acp-stdio` with an explicit 8 MiB stack and a `current_thread` Tokio runtime + `LocalSet`. Previously, the future ran on a tokio worker thread with the 2 MiB default stack, which was confirmed insufficient for deeply nested agent sessions. The approach mirrors `spawn_agent_connection` in the HTTP/WS transport (#4897).
- **#4904 — Gateway webhook body sanitization**: `webhook_handler` now passes `body` through `strip_control_chars_preserve_whitespace` before forwarding, consistent with `sender` and `channel`. A regression test (`webhook_handler_sanitizes_body`) is included.

## Changes

- `crates/zeph-acp/src/transport/stdio.rs`: added `ACP_AGENT_STACK_SIZE` constant, rewrote `serve_stdio` to use `std::thread::Builder::new().stack_size(ACP_AGENT_STACK_SIZE)` with a dedicated oneshot result channel.
- `crates/zeph-gateway/src/handlers.rs`: sanitize `payload.body` before format; added unit test.
- `CHANGELOG.md`: updated `[Unreleased]` with both fixes.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10520 passed (was 10519; new `webhook_handler_sanitizes_body` test added)
- [ ] Live session test with stdio ACP transport recommended before merge (LLM gate applies)

## Follow-up

A separate issue should pin the stack size for `spawn_agent_connection` (HTTP/WS path) on Windows, where `std::thread::spawn` without explicit `stack_size` defaults to 1 MiB.

Closes #4901
Closes #4904