### PR TITLE
refactor(agent-feedback,scheduler): expose judge rate limit via config and add CronExpr newtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `feat(acp)`: `unstable-elicitation` feature now also enables `agent-client-protocol/unstable_elicitation` core passthrough for `elicitation/create` handler wiring
 - `refactor(acp)`: provider ext-method types renamed to singular: `SetProvidersRequest/Response` → `SetProviderRequest/Response`, `DisableProvidersRequest/Response` → `DisableProviderRequest/Response`
 - `refactor(acp)`: logout, session/close, session/delete, session/resume, and additional-directories handlers are now unconditional (feature flags retained as no-op tombstones for workspace forwarding compatibility)
+- `refactor(zeph-agent-feedback)`: `JUDGE_RATE_LIMIT` and `JUDGE_RATE_WINDOW` constants removed;
+  rate-limit parameters are now configurable via `LearningConfig` fields `judge_rate_limit`
+  (default: `5`) and `judge_rate_window_secs` (default: `60`); existing TOML configs without
+  these fields continue to use the same defaults. `JudgeDetector::new()` now accepts
+  `rate_limit: usize` and `rate_window: Duration` arguments. (#4892)
+- `refactor(zeph-scheduler)`: introduced `CronExpr` validated newtype wrapping a `String`; raw
+  `String` fields for cron expressions replaced with `Option<CronExpr>`; hydration from SQLite
+  validates stored expressions and emits a `tracing::warn!` for invalid rows instead of
+  propagating hard errors. (#4884)
 
 ### Removed
 

--- a/crates/zeph-agent-feedback/src/lib.rs
+++ b/crates/zeph-agent-feedback/src/lib.rs
@@ -27,7 +27,8 @@
 //! - **CJK false-positive risk**: without word boundaries, CJK substring patterns could match
 //!   inside longer compounds. Mitigated by using 2+ character patterns only for unanchored CJK.
 //! - **Unsupported languages** (e.g., Korean, Arabic): regex returns `None`; every message
-//!   triggers a judge call, which is rate-limited to 5/min.
+//!   triggers a judge call, rate-limited to `judge_rate_limit` calls per `judge_rate_window_secs`
+//!   seconds (configurable via [`zeph_config::LearningConfig`]).
 
 use std::collections::VecDeque;
 use std::sync::LazyLock;
@@ -507,10 +508,6 @@ impl FeedbackDetector {
 const JUDGE_USER_MSG_MAX_CHARS: usize = 1000;
 /// Maximum assistant response length included in the judge prompt.
 const JUDGE_ASSISTANT_MAX_CHARS: usize = 500;
-/// Rate limiter: max judge calls per window.
-const JUDGE_RATE_LIMIT: usize = 5;
-/// Rate limiter: sliding window duration.
-const JUDGE_RATE_WINDOW: Duration = Duration::from_mins(1);
 
 const JUDGE_SYSTEM_PROMPT: &str = "\
 You are a user satisfaction classifier for an AI assistant.
@@ -605,16 +602,28 @@ pub struct JudgeDetector {
     adaptive_low: f32,
     /// Upper bound: at or above this, regex "is correction" is trusted without judge.
     adaptive_high: f32,
+    /// Maximum calls allowed within `rate_window`.
+    rate_limit: usize,
+    /// Sliding window duration for rate limiting.
+    rate_window: Duration,
     /// Sliding-window timestamps for rate limiting (owned, not shared across spawns).
     call_times: VecDeque<Instant>,
 }
 
 impl JudgeDetector {
-    /// Creates a new `JudgeDetector` with adaptive thresholds.
+    /// Creates a new `JudgeDetector` with adaptive thresholds and rate-limit parameters.
+    ///
+    /// - `rate_limit`: maximum calls allowed per `rate_window`.
+    /// - `rate_window`: sliding window duration for rate limiting.
     ///
     /// Logs a warning if `adaptive_low >= adaptive_high` (empty borderline zone).
     #[must_use]
-    pub fn new(adaptive_low: f32, adaptive_high: f32) -> Self {
+    pub fn new(
+        adaptive_low: f32,
+        adaptive_high: f32,
+        rate_limit: usize,
+        rate_window: Duration,
+    ) -> Self {
         if adaptive_low >= adaptive_high {
             tracing::warn!(
                 adaptive_low,
@@ -626,6 +635,8 @@ impl JudgeDetector {
         Self {
             adaptive_low,
             adaptive_high,
+            rate_limit,
+            rate_window,
             call_times: VecDeque::new(),
         }
     }
@@ -651,8 +662,8 @@ impl JudgeDetector {
         let now = Instant::now();
         // Evict timestamps outside the sliding window.
         self.call_times
-            .retain(|t| now.duration_since(*t) <= JUDGE_RATE_WINDOW);
-        if self.call_times.len() >= JUDGE_RATE_LIMIT {
+            .retain(|t| now.duration_since(*t) <= self.rate_window);
+        if self.call_times.len() >= self.rate_limit {
             return false;
         }
         self.call_times.push_back(now);
@@ -1077,13 +1088,13 @@ mod tests {
 
     #[test]
     fn should_invoke_no_regex_signal_returns_true() {
-        let jd = JudgeDetector::new(0.5, 0.8);
+        let jd = JudgeDetector::new(0.5, 0.8, 5, Duration::from_mins(1));
         assert!(jd.should_invoke(None));
     }
 
     #[test]
     fn should_invoke_high_confidence_returns_false() {
-        let jd = JudgeDetector::new(0.5, 0.8);
+        let jd = JudgeDetector::new(0.5, 0.8, 5, Duration::from_mins(1));
         let signal = CorrectionSignal {
             confidence: 0.85,
             kind: CorrectionKind::ExplicitRejection,
@@ -1094,7 +1105,7 @@ mod tests {
 
     #[test]
     fn should_invoke_borderline_returns_true() {
-        let jd = JudgeDetector::new(0.5, 0.8);
+        let jd = JudgeDetector::new(0.5, 0.8, 5, Duration::from_mins(1));
         let signal = CorrectionSignal {
             confidence: 0.75,
             kind: CorrectionKind::Repetition,
@@ -1105,7 +1116,7 @@ mod tests {
 
     #[test]
     fn should_invoke_below_adaptive_low_returns_false() {
-        let jd = JudgeDetector::new(0.5, 0.8);
+        let jd = JudgeDetector::new(0.5, 0.8, 5, Duration::from_mins(1));
         let signal = CorrectionSignal {
             confidence: 0.3,
             kind: CorrectionKind::AlternativeRequest,
@@ -1118,16 +1129,18 @@ mod tests {
 
     #[test]
     fn rate_limiter_allows_up_to_limit() {
-        let mut jd = JudgeDetector::new(0.5, 0.8);
-        for _ in 0..JUDGE_RATE_LIMIT {
+        let rate_limit = 5;
+        let mut jd = JudgeDetector::new(0.5, 0.8, rate_limit, Duration::from_mins(1));
+        for _ in 0..rate_limit {
             assert!(jd.check_rate_limit(), "should allow within limit");
         }
     }
 
     #[test]
     fn rate_limiter_blocks_after_limit() {
-        let mut jd = JudgeDetector::new(0.5, 0.8);
-        for _ in 0..JUDGE_RATE_LIMIT {
+        let rate_limit = 5;
+        let mut jd = JudgeDetector::new(0.5, 0.8, rate_limit, Duration::from_mins(1));
+        for _ in 0..rate_limit {
             jd.check_rate_limit();
         }
         assert!(!jd.check_rate_limit(), "should block after limit exceeded");
@@ -1136,12 +1149,14 @@ mod tests {
     #[tokio::test]
     async fn rate_limiter_evicts_expired_entries() {
         tokio::time::pause();
-        let mut jd = JudgeDetector::new(0.5, 0.8);
-        for _ in 0..JUDGE_RATE_LIMIT {
+        let rate_limit = 5;
+        let rate_window = Duration::from_mins(1);
+        let mut jd = JudgeDetector::new(0.5, 0.8, rate_limit, rate_window);
+        for _ in 0..rate_limit {
             assert!(jd.check_rate_limit());
         }
         // Advance time past the rate-limit window so all entries expire.
-        tokio::time::advance(JUDGE_RATE_WINDOW + Duration::from_secs(1)).await;
+        tokio::time::advance(rate_window + Duration::from_secs(1)).await;
         assert!(
             jd.check_rate_limit(),
             "expired entries should be evicted, new call must be allowed"
@@ -1162,7 +1177,7 @@ mod tests {
 
     #[test]
     fn should_invoke_at_adaptive_low_boundary_inclusive() {
-        let jd = JudgeDetector::new(0.5, 0.8);
+        let jd = JudgeDetector::new(0.5, 0.8, 5, Duration::from_mins(1));
         let signal = CorrectionSignal {
             confidence: 0.5,
             kind: CorrectionKind::AlternativeRequest,
@@ -1176,7 +1191,7 @@ mod tests {
 
     #[test]
     fn should_invoke_at_adaptive_high_boundary_exclusive() {
-        let jd = JudgeDetector::new(0.5, 0.8);
+        let jd = JudgeDetector::new(0.5, 0.8, 5, Duration::from_mins(1));
         let signal = CorrectionSignal {
             confidence: 0.8,
             kind: CorrectionKind::ExplicitRejection,
@@ -1192,7 +1207,7 @@ mod tests {
 
     #[test]
     fn judge_detector_inverted_thresholds_logs_warn() {
-        let jd = JudgeDetector::new(0.9, 0.5);
+        let jd = JudgeDetector::new(0.9, 0.5, 5, Duration::from_mins(1));
         assert!(jd.should_invoke(None));
         let signal = CorrectionSignal {
             confidence: 0.7,

--- a/crates/zeph-agent-feedback/src/lib.rs
+++ b/crates/zeph-agent-feedback/src/lib.rs
@@ -28,7 +28,7 @@
 //!   inside longer compounds. Mitigated by using 2+ character patterns only for unanchored CJK.
 //! - **Unsupported languages** (e.g., Korean, Arabic): regex returns `None`; every message
 //!   triggers a judge call, rate-limited to `judge_rate_limit` calls per `judge_rate_window_secs`
-//!   seconds (configurable via [`zeph_config::LearningConfig`]).
+//!   seconds (configurable via `LearningConfig`).
 
 use std::collections::VecDeque;
 use std::sync::LazyLock;

--- a/crates/zeph-config/src/learning.rs
+++ b/crates/zeph-config/src/learning.rs
@@ -152,6 +152,14 @@ fn default_heuristic_promotion_interval_hours() -> u64 {
     24
 }
 
+fn default_judge_rate_limit() -> usize {
+    5
+}
+
+fn default_judge_rate_window_secs() -> u64 {
+    60
+}
+
 /// Strategy for detecting implicit user corrections.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -417,6 +425,19 @@ pub struct LearningConfig {
     /// Interval in hours between promotion evaluation runs. Default: `24`.
     #[serde(default = "default_heuristic_promotion_interval_hours")]
     pub heuristic_promotion_interval_hours: u64,
+
+    /// Maximum number of judge LLM calls allowed within the rate window. Default: `5`.
+    ///
+    /// Applies to `detector_mode = "judge"` and `detector_mode = "model"`. When the limit
+    /// is reached, borderline messages are classified by regex alone until the window expires.
+    #[serde(default = "default_judge_rate_limit")]
+    pub judge_rate_limit: usize,
+
+    /// Sliding window duration for judge rate limiting, in seconds. Default: `60`.
+    ///
+    /// Calls older than this are evicted from the rate limiter before each new call is checked.
+    #[serde(default = "default_judge_rate_window_secs")]
+    pub judge_rate_window_secs: u64,
 }
 
 impl Default for LearningConfig {
@@ -481,6 +502,8 @@ impl Default for LearningConfig {
             heuristic_promotion_provider: ProviderName::default(),
             heuristic_promotion_threshold: default_heuristic_promotion_threshold(),
             heuristic_promotion_interval_hours: default_heuristic_promotion_interval_hours(),
+            judge_rate_limit: default_judge_rate_limit(),
+            judge_rate_window_secs: default_judge_rate_window_secs(),
         }
     }
 }
@@ -793,5 +816,30 @@ detector_mode = "judge"
             "missing judge_provider must default to empty string"
         );
         assert_eq!(cfg.judge_model, "gpt-4o");
+    }
+
+    #[test]
+    fn judge_rate_limit_defaults() {
+        let cfg = LearningConfig::default();
+        assert_eq!(cfg.judge_rate_limit, 5);
+        assert_eq!(cfg.judge_rate_window_secs, 60);
+    }
+
+    #[test]
+    fn judge_rate_limit_empty_section_uses_defaults() {
+        let cfg: LearningConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.judge_rate_limit, 5);
+        assert_eq!(cfg.judge_rate_window_secs, 60);
+    }
+
+    #[test]
+    fn judge_rate_limit_serde_roundtrip() {
+        let toml = r"
+judge_rate_limit = 10
+judge_rate_window_secs = 120
+";
+        let cfg: LearningConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.judge_rate_limit, 10);
+        assert_eq!(cfg.judge_rate_window_secs, 120);
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1986,6 +1986,8 @@ impl<C: Channel> Agent<C> {
                 self.services.feedback.judge = Some(zeph_agent_feedback::JudgeDetector::new(
                     config.judge_adaptive_low,
                     config.judge_adaptive_high,
+                    config.judge_rate_limit,
+                    std::time::Duration::from_secs(config.judge_rate_window_secs),
                 ));
             }
         }

--- a/crates/zeph-core/src/agent/corrections.rs
+++ b/crates/zeph-core/src/agent/corrections.rs
@@ -261,12 +261,31 @@ impl<C: crate::channel::Channel> Agent<C> {
                 .config
                 .as_ref()
                 .map_or(0.8, |c| c.judge_adaptive_high);
+            let rate_limit = self
+                .services
+                .learning_engine
+                .config
+                .as_ref()
+                .map_or(5, |c| c.judge_rate_limit);
+            let rate_window = self
+                .services
+                .learning_engine
+                .config
+                .as_ref()
+                .map_or(std::time::Duration::from_mins(1), |c| {
+                    std::time::Duration::from_secs(c.judge_rate_window_secs)
+                });
             let should_invoke = self
                 .services
                 .feedback
                 .judge
                 .get_or_insert_with(|| {
-                    feedback_detector::JudgeDetector::new(adaptive_low, adaptive_high)
+                    feedback_detector::JudgeDetector::new(
+                        adaptive_low,
+                        adaptive_high,
+                        rate_limit,
+                        rate_window,
+                    )
                 })
                 .should_invoke(regex_signal);
             should_invoke

--- a/crates/zeph-scheduler/src/lib.rs
+++ b/crates/zeph-scheduler/src/lib.rs
@@ -96,7 +96,7 @@ pub use sanitize::{sanitize_task_prompt, sanitize_task_prompt_checked};
 pub use scheduler::{Scheduler, SchedulerMessage};
 pub use store::{JobStore, ScheduledTaskInfo, ScheduledTaskRecord};
 pub use task::{
-    ScheduledTask, TaskDescriptor, TaskHandler, TaskKind, TaskMode, TaskProvenance,
+    CronExpr, ScheduledTask, TaskDescriptor, TaskHandler, TaskKind, TaskMode, TaskProvenance,
     normalize_cron_expr,
 };
 

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -302,10 +302,25 @@ impl Scheduler {
             if job.task_mode != "periodic" || static_names.contains(&job.name) {
                 continue;
             }
+            // `list_jobs_full` already attempted CronExpr validation; None means the stored
+            // expression was empty or invalid. Mark the row as error and skip hydration.
+            let Some(ref cron_expr) = job.cron_expr else {
+                tracing::error!(
+                    task = %job.name,
+                    "skipping persisted periodic job with missing or invalid cron expression"
+                );
+                if let Err(db_err) = self.store.mark_error(&job.name).await {
+                    tracing::warn!(
+                        task = %job.name,
+                        "failed to mark job as error in store: {db_err}"
+                    );
+                }
+                continue;
+            };
             let hydrated_provenance = TaskProvenance::from_provenance_str(&job.provenance);
             match ScheduledTask::periodic_with_provenance(
                 job.name.clone(),
-                &job.cron_expr,
+                cron_expr.as_ref(),
                 crate::task::TaskKind::from_str_kind(&job.kind),
                 serde_json::Value::Null,
                 hydrated_provenance,
@@ -340,7 +355,7 @@ impl Scheduler {
                 Err(e) => {
                     tracing::error!(
                         task = %job.name,
-                        cron_expr = %job.cron_expr,
+                        cron_expr = %cron_expr,
                         "skipping persisted job with invalid cron expression: {e}"
                     );
                     if let Err(db_err) = self.store.mark_error(&job.name).await {

--- a/crates/zeph-scheduler/src/store.rs
+++ b/crates/zeph-scheduler/src/store.rs
@@ -6,6 +6,7 @@ use zeph_db::DbPool;
 use zeph_db::sql;
 
 use crate::error::SchedulerError;
+use crate::task::CronExpr;
 
 /// A scheduled task row returned by [`JobStore::list_jobs`].
 ///
@@ -56,8 +57,9 @@ pub struct ScheduledTaskInfo {
     pub kind: String,
     /// Execution mode: `"periodic"` or `"oneshot"`.
     pub task_mode: String,
-    /// Cron expression for periodic tasks, empty string for one-shot tasks.
-    pub cron_expr: String,
+    /// Validated cron expression for periodic tasks; `None` for one-shot tasks or rows
+    /// whose stored expression is invalid (those are marked `status = "error"` in the DB).
+    pub cron_expr: Option<CronExpr>,
     /// Next scheduled run time as an ISO 8601 / RFC 3339 string, or empty if unknown.
     pub next_run: String,
     /// Stored task prompt for custom tasks; empty for config-driven built-in tasks.
@@ -390,6 +392,11 @@ impl JobStore {
 
     /// List all active (non-done) jobs with full details for display.
     ///
+    /// The `cron_expr` field of each returned [`ScheduledTaskInfo`] is `Some` for periodic tasks
+    /// with a valid expression and `None` for one-shot tasks or rows whose stored expression
+    /// failed validation. Invalid rows are not filtered out — callers can check `status` to
+    /// distinguish error rows.
+    ///
     /// # Errors
     ///
     /// Returns an error if the SQL query fails.
@@ -405,7 +412,23 @@ impl JobStore {
         Ok(rows
             .into_iter()
             .map(
-                |(name, kind, task_mode, cron_expr, next_run, task_data, status, provenance)| {
+                |(name, kind, task_mode, raw_cron, next_run, task_data, status, provenance)| {
+                    // Empty string = oneshot task (no cron). Non-empty = validate eagerly.
+                    let cron_expr = if raw_cron.is_empty() {
+                        None
+                    } else {
+                        match CronExpr::try_from(raw_cron.as_str()) {
+                            Ok(expr) => Some(expr),
+                            Err(e) => {
+                                tracing::warn!(
+                                    task = %name,
+                                    cron_expr = %raw_cron,
+                                    "invalid cron expression in DB row: {e}"
+                                );
+                                None
+                            }
+                        }
+                    };
                     ScheduledTaskInfo {
                         name,
                         kind,
@@ -633,12 +656,15 @@ mod tests {
         let periodic = jobs.iter().find(|j| j.name == "periodic_job").unwrap();
         assert_eq!(periodic.kind, "memory_cleanup");
         assert_eq!(periodic.task_mode, "periodic");
-        assert_eq!(periodic.cron_expr, "0 0 3 * * *");
+        assert_eq!(
+            periodic.cron_expr.as_ref().map(CronExpr::as_str),
+            Some("0 0 3 * * *")
+        );
 
         let oneshot = jobs.iter().find(|j| j.name == "oneshot_job").unwrap();
         assert_eq!(oneshot.kind, "custom");
         assert_eq!(oneshot.task_mode, "oneshot");
-        assert!(oneshot.cron_expr.is_empty());
+        assert!(oneshot.cron_expr.is_none());
         assert_eq!(oneshot.next_run, "2030-01-01T10:00:00Z");
     }
 

--- a/crates/zeph-scheduler/src/task.rs
+++ b/crates/zeph-scheduler/src/task.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::borrow::Cow;
+use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use cron::Schedule as CronSchedule;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::error::SchedulerError;
 
@@ -35,6 +37,93 @@ pub fn normalize_cron_expr(expr: &str) -> Cow<'_, str> {
         Cow::Owned(format!("0 {expr}"))
     } else {
         Cow::Borrowed(expr)
+    }
+}
+
+/// A validated cron expression that can only be constructed from a well-formed cron string.
+///
+/// `CronExpr` guarantees that the wrapped string is accepted by both [`normalize_cron_expr`]
+/// and `cron::Schedule::from_str`. Constructing one via [`TryFrom`] validates the expression
+/// eagerly, so any code that holds a `CronExpr` can assume the schedule is syntactically valid.
+///
+/// The raw `String` stored in the database column is not changed — `CronExpr` is a type-level
+/// wrapper that enforces validity at the boundary where cron strings enter the system.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_scheduler::CronExpr;
+///
+/// // Valid 6-field expression.
+/// let expr: CronExpr = "0 0 3 * * *".try_into().expect("valid cron");
+/// assert_eq!(expr.as_ref(), "0 0 3 * * *");
+///
+/// // Valid 5-field expression (auto-normalised to 6-field).
+/// let expr: CronExpr = "0 3 * * *".try_into().expect("valid 5-field cron");
+/// assert_eq!(expr.as_ref(), "0 0 3 * * *");
+///
+/// // Invalid expression returns an error.
+/// assert!(CronExpr::try_from("not a cron").is_err());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CronExpr(String);
+
+impl CronExpr {
+    /// Return the validated cron expression string.
+    ///
+    /// The returned string is always in the normalised 6-field form accepted by the `cron` crate.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for CronExpr {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CronExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for CronExpr {
+    type Error = SchedulerError;
+
+    /// Validate and normalise a cron expression string.
+    ///
+    /// Accepts both 5-field and 6-field expressions. Returns [`SchedulerError::InvalidCron`]
+    /// if the expression is not accepted by the `cron` parser after normalisation.
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let normalized = normalize_cron_expr(&s);
+        CronSchedule::from_str(&normalized)
+            .map_err(|e| SchedulerError::InvalidCron(format!("{s}: {e}")))?;
+        // Store the normalised form so the string round-trips consistently.
+        Ok(Self(normalized.into_owned()))
+    }
+}
+
+impl TryFrom<&str> for CronExpr {
+    type Error = SchedulerError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::try_from(s.to_owned())
+    }
+}
+
+impl Serialize for CronExpr {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for CronExpr {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::try_from(s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -609,6 +698,53 @@ mod tests {
         assert!(TaskProvenance::External.is_external());
         assert!(!TaskProvenance::Static.is_external());
         assert!(!TaskProvenance::UserAdded.is_external());
+    }
+
+    #[test]
+    fn cron_expr_valid_six_field() {
+        let expr = CronExpr::try_from("0 0 3 * * *").expect("valid 6-field");
+        assert_eq!(expr.as_ref(), "0 0 3 * * *");
+    }
+
+    #[test]
+    fn cron_expr_valid_five_field_normalised() {
+        let expr = CronExpr::try_from("0 3 * * *").expect("valid 5-field");
+        // 5-field is normalised by prepending "0 "
+        assert_eq!(expr.as_ref(), "0 0 3 * * *");
+    }
+
+    #[test]
+    fn cron_expr_invalid_returns_error() {
+        assert!(CronExpr::try_from("not a cron").is_err());
+        assert!(CronExpr::try_from("").is_err());
+    }
+
+    #[test]
+    fn cron_expr_display_and_as_str_consistent() {
+        let expr = CronExpr::try_from("* * * * * *").expect("wildcard cron");
+        assert_eq!(expr.as_str(), expr.to_string());
+    }
+
+    #[test]
+    fn cron_expr_clone_and_eq() {
+        let a = CronExpr::try_from("0 0 * * * *").expect("valid");
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn cron_expr_serialize_deserialize_roundtrip() {
+        let expr = CronExpr::try_from("0 0 3 * * *").expect("valid");
+        let json = serde_json::to_string(&expr).expect("serialize");
+        assert_eq!(json, r#""0 0 3 * * *""#);
+        let decoded: CronExpr = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(expr, decoded);
+    }
+
+    #[test]
+    fn cron_expr_deserialize_invalid_returns_error() {
+        let result: Result<CronExpr, _> = serde_json::from_str(r#""not-a-cron""#);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/commands/schedule.rs
+++ b/src/commands/schedule.rs
@@ -5,6 +5,11 @@
 use crate::cli::ScheduleCommand;
 
 #[cfg(feature = "scheduler")]
+fn cron_display(expr: Option<&zeph_scheduler::CronExpr>) -> &str {
+    expr.map_or("-", zeph_scheduler::CronExpr::as_str)
+}
+
+#[cfg(feature = "scheduler")]
 pub(crate) async fn handle_schedule_command(
     cmd: ScheduleCommand,
     config_path: Option<&std::path::Path>,
@@ -45,7 +50,11 @@ pub(crate) async fn handle_schedule_command(
             for job in &jobs {
                 println!(
                     "{:<32} {:<16} {:<10} {:<22} {}",
-                    job.name, job.kind, job.task_mode, job.next_run, job.cron_expr
+                    job.name,
+                    job.kind,
+                    job.task_mode,
+                    job.next_run,
+                    cron_display(job.cron_expr.as_ref())
                 );
             }
         }
@@ -96,20 +105,18 @@ pub(crate) async fn handle_schedule_command(
         }
 
         ScheduleCommand::Show { name } => {
-            let jobs = store
+            let job = store
                 .list_jobs_full()
                 .await
-                .map_err(|e| anyhow::anyhow!("failed to list jobs: {e}"))?;
-
-            let job = jobs
-                .iter()
+                .map_err(|e| anyhow::anyhow!("failed to list jobs: {e}"))?
+                .into_iter()
                 .find(|j| j.name == name)
                 .ok_or_else(|| anyhow::anyhow!("no scheduled job named '{name}'"))?;
 
             println!("Name:     {}", job.name);
             println!("Kind:     {}", job.kind);
             println!("Mode:     {}", job.task_mode);
-            println!("Cron:     {}", job.cron_expr);
+            println!("Cron:     {}", cron_display(job.cron_expr.as_ref()));
             println!("Next run: {}", job.next_run);
             if !job.task_data.is_empty() {
                 println!("Prompt:   {}", job.task_data);

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -365,11 +365,7 @@ impl SchedulerExecutor {
         let lines: Vec<String> = jobs
             .iter()
             .map(|t| {
-                let cron = if t.cron_expr.is_empty() {
-                    "-"
-                } else {
-                    &t.cron_expr
-                };
+                let cron = t.cron_expr.as_ref().map_or("-", |e| e.as_ref());
                 let next = if t.next_run.is_empty() {
                     "-"
                 } else {


### PR DESCRIPTION
## Summary

- **#4892** — `LearningConfig` now exposes `judge_rate_limit` (default 5) and `judge_rate_window_secs` (default 60); `JudgeDetector::new()` reads these values instead of compile-time constants. Backward-compatible via `serde` defaults — existing TOML configs without these fields continue to work.
- **#4884** — `CronExpr(String)` validated newtype replaces raw `String` in `ScheduledTaskInfo.cron_expr` (now `Option<CronExpr>`). `TryFrom<String>` validates via `normalize_cron_expr` + `cron::Schedule::from_str`. Store hydration fails-soft on invalid DB rows: logs a warning and calls `mark_error`, so a corrupted DB row cannot silently crash the scheduler tick.

## Changed files

| File | Change |
|------|--------|
| `crates/zeph-config/src/learning.rs` | +`judge_rate_limit`, `judge_rate_window_secs` with serde defaults; 3 new tests |
| `crates/zeph-agent-feedback/src/lib.rs` | Remove constants; `JudgeDetector::new()` takes `rate_limit`/`rate_window` from config |
| `crates/zeph-core/src/agent/builder.rs`, `corrections.rs` | Pass config values to `JudgeDetector` |
| `crates/zeph-scheduler/src/task.rs` | `CronExpr` newtype + full trait impl set; `ScheduledTaskInfo.cron_expr: Option<CronExpr>` |
| `crates/zeph-scheduler/src/store.rs`, `scheduler.rs` | Hydration validates `CronExpr`; invalid rows warn + mark_error |
| `src/commands/schedule.rs`, `src/scheduler_executor.rs` | Updated to use `Option<CronExpr>` |
| `CHANGELOG.md` | `[Unreleased]` entries for both changes |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10529/10529 passed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] Backward-compat: empty `[learning]` TOML deserializes to defaults (5/60s)
- [x] `CronExpr` roundtrip: valid expression constructs, invalid returns `Err`, serde validates on deserialize

Closes #4892
Closes #4884