### PR TITLE
chore(config,core,llm): post-split code-quality cleanup (#4926, #4928, #4929, #4930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(config)`: added `#[must_use = "validation result must be checked"]` to
+  `SpreadingActivationConfig::validate` (`memory/graph.rs`) and `AconConfig::validate`
+  (`memory/fidelity.rs`). Both return `Result<(), String>`; the attribute (with an explicit
+  reason, to satisfy `clippy::double_must_use`) prevents callers from silently discarding the
+  validation error via a bare `config.validate();` statement. (#4930)
 - `fix(acp)`: spawn agent connection thread with explicit 8 MiB stack (`thread::Builder::new().stack_size(ACP_AGENT_STACK_SIZE)`) in HTTP and WebSocket transports; bare `thread::spawn` overflowed the default 512 KiB macOS stack on `session/prompt`. `spawn_agent_connection` now returns `io::Result` — spawn failure responds 503 on HTTP and cleanly releases the WS slot. Follow-up: stdio transport tracked in #4901. (#4897)
 - `fix(acp)`: `serve_stdio` now spawns a dedicated OS thread with an explicit 8 MiB stack and a `current_thread` Tokio runtime; the previous implementation ran the agent future on a tokio worker thread (2 MiB default), which was insufficient for deeply nested agent sessions. The thread name is `acp-stdio`; spawn failures and runtime-build errors propagate as `AcpError::Transport`. (#4901)
 - `fix(gateway)`: webhook `body` field is now sanitized with `strip_control_chars_preserve_whitespace` before being forwarded to the agent, consistent with `sender` and `channel`; previously raw control characters (null bytes, ANSI escapes) in `body` bypassed sanitization. (#4904)
@@ -38,6 +43,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   eviction methods moved into the existing `sidequest.rs`. `mod.rs` (now ~2000 lines) retains
   the struct, constructors, and the main agent loop. The shared `impl` block is now split
   across files, so cross-module entrypoints are `pub(super)`. No public API change. (#4923)
+- `refactor(config)`: removed the duplicate `validate_unit_f32` from
+  `zeph-config/src/memory/hebbian.rs`; it was semantically identical to the `pub(crate)`
+  `validate_similarity_threshold` in `memory/mod.rs` (both reject non-finite values and values
+  outside `[0.0, 1.0]`). The write-gate `min_edge_relevance` fields now share
+  `validate_similarity_threshold` via `deserialize_with`, matching the existing usage for the
+  other Hebbian unit-interval fields. (#4928)
 - `refactor`: extract inline `#[cfg(test)]` blocks from two files into dedicated `tests`
   submodules, matching the monolith-refactor convention. `zeph-subagent/src/manager/mod.rs`
   (4118 → 527 lines) moves its three test modules to `manager/tests.rs`; the two named
@@ -83,6 +94,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and module declarations. The largest submodule is now 816 lines. Public API is unchanged:
   `McpManager`, `McpTransport`, `ServerConnectOutcome`, and `ServerEntry` are still re-exported
   from the crate root, and all inherent methods keep their original visibility. (#4919)
+
+### Performance
+
+- `perf(llm)`: added profiling-gated tracing spans
+  (`#[cfg_attr(feature = "profiling", tracing::instrument(name = "llm.router.<fn>", skip_all))]`)
+  to the four `pub(crate) async` methods in `zeph-llm/src/router/select.rs` that perform embedding
+  I/O or an LLM-judge call — `bandit_features`, `bandit_select_provider`, `evaluate_quality`,
+  `embed_cached` — so they surface in local Chrome JSON traces / Perfetto for latency analysis.
+  The split in #4920 left them uninstrumented. (#4926)
+- `perf(core)`: added a `#[tracing::instrument(name = "core.persist.rpe_should_skip", skip_all,
+  level = "debug")]` span to `rpe_should_skip` in `zeph-core/src/agent/persistence/extract.rs`,
+  which performs an embedding call with a timeout on the persistence path. The sibling
+  `enqueue_graph_extraction_task` and `load_history` were already instrumented in #4921. (#4929)
 
 ### Changed
 

--- a/crates/zeph-config/src/memory/fidelity.rs
+++ b/crates/zeph-config/src/memory/fidelity.rs
@@ -401,6 +401,7 @@ impl AconConfig {
     /// # Errors
     ///
     /// Returns a descriptive error string when any threshold invariant is violated.
+    #[must_use = "validation result must be checked"]
     pub fn validate(&self) -> Result<(), String> {
         if self.passthrough_threshold >= self.summarize_threshold {
             return Err(format!(

--- a/crates/zeph-config/src/memory/graph.rs
+++ b/crates/zeph-config/src/memory/graph.rs
@@ -271,6 +271,7 @@ impl SpreadingActivationConfig {
     /// # Errors
     ///
     /// Returns an error string if `activation_threshold >= inhibition_threshold`.
+    #[must_use = "validation result must be checked"]
     pub fn validate(&self) -> Result<(), String> {
         if self.activation_threshold >= self.inhibition_threshold {
             return Err(format!(

--- a/crates/zeph-config/src/memory/hebbian.rs
+++ b/crates/zeph-config/src/memory/hebbian.rs
@@ -20,20 +20,6 @@ fn default_conflict_recency_slow_threshold() -> f32 {
     0.2
 }
 
-fn validate_unit_f32<'de, D>(deserializer: D) -> Result<f32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
-    if !value.is_finite() {
-        return Err(serde::de::Error::custom("value must be a finite number"));
-    }
-    if !(0.0..=1.0).contains(&value) {
-        return Err(serde::de::Error::custom("value must be in [0.0, 1.0]"));
-    }
-    Ok(value)
-}
-
 /// `MemORAI` write-gate prefilter configuration (#3709).
 ///
 /// When `enabled = true`, low-signal edges (confidence below threshold + generic relation type)
@@ -50,7 +36,7 @@ pub struct WriteGateConfig {
     /// Range: `[0.0, 1.0]`.
     #[serde(
         default = "default_write_gate_min_edge_relevance",
-        deserialize_with = "validate_unit_f32"
+        deserialize_with = "validate_similarity_threshold"
     )]
     pub min_edge_relevance: f32,
 }
@@ -77,7 +63,7 @@ pub struct ConflictRecencyConfig {
     /// edges below the threshold fall back to `valid_from` comparison. Range: `[0.0, 1.0]`.
     #[serde(
         default = "default_conflict_recency_slow_threshold",
-        deserialize_with = "validate_unit_f32"
+        deserialize_with = "validate_similarity_threshold"
     )]
     pub recency_slow_threshold: f32,
 }

--- a/crates/zeph-core/src/agent/persistence/extract.rs
+++ b/crates/zeph-core/src/agent/persistence/extract.rs
@@ -473,6 +473,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// Embeds `content`, computes RPE via the router, and updates the router state.
     /// Returns `false` (do not skip) on any error — conservative fallback.
+    #[tracing::instrument(name = "core.persist.rpe_should_skip", skip_all, level = "debug")]
     async fn rpe_should_skip(&mut self, content: &str) -> bool {
         let Some(ref rpe_mutex) = self.services.memory.extraction.rpe_router else {
             return false;

--- a/crates/zeph-llm/src/router/select.rs
+++ b/crates/zeph-llm/src/router/select.rs
@@ -37,6 +37,10 @@ impl RouterProvider {
     /// - No embedding provider is configured.
     /// - The embedding call exceeds `embedding_timeout_ms`.
     /// - The embedding is shorter than `dim` or is all-zero.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.bandit_features", skip_all)
+    )]
     pub(crate) async fn bandit_features(&self, query: &str) -> Option<Vec<f32>> {
         let cfg = self.bandit_config.as_ref()?;
         let key = Self::query_hash(query);
@@ -82,6 +86,10 @@ impl RouterProvider {
     /// Falls through to Thompson or first available provider when bandit cannot decide.
     /// Budget enforcement via global `CostTracker` is handled at the caller level.
     /// Per-provider budget fractions are intentionally NOT implemented (scope creep, see #2230).
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.bandit_select_provider", skip_all)
+    )]
     pub(crate) async fn bandit_select_provider(&self, query: &str) -> Option<AnyProvider> {
         let Some(ref bandit_arc) = self.bandit else {
             return self.state.providers.first().cloned();
@@ -471,6 +479,10 @@ impl RouterProvider {
     ///
     /// For `ClassifierMode::Judge`, calls the summary provider and falls back to heuristic
     /// on any error or timeout. For `ClassifierMode::Heuristic`, evaluates synchronously.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.evaluate_quality", skip_all)
+    )]
     pub(crate) async fn evaluate_quality(
         response: &str,
         threshold: f64,
@@ -519,6 +531,10 @@ impl RouterProvider {
     /// Checks `cache` before calling the underlying provider. On a cache hit, increments
     /// `embed_cache_hits`; on a miss, embeds via `self.embed()` and populates the cache.
     /// Either way, `embed_call_count` is incremented for observability.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.embed_cached", skip_all)
+    )]
     pub(crate) async fn embed_cached(
         &self,
         text: &str,


### PR DESCRIPTION
Grouped post-refactor code-quality cleanup. All four issues were introduced by (or surfaced during) the recent monolith splits #4920 / #4921 / #4922 and are low-risk, internal-only changes.

## Changes

### `refactor(config)` — #4928 (DRY)
Removed the duplicate `validate_unit_f32` from `zeph-config/src/memory/hebbian.rs`. It was semantically identical to the `pub(crate)` `validate_similarity_threshold` in `memory/mod.rs` (both reject non-finite values and values outside `[0.0, 1.0]`). The write-gate `min_edge_relevance` and conflict-recency slow-threshold fields now share `validate_similarity_threshold` via `deserialize_with`, matching the existing usage for the other Hebbian unit-interval fields (lines 101/126). The narrower-range `validate_tier_similarity_threshold` (`[0.5, 1.0]`) in `retrieval.rs` is left as-is — its distinct range makes it a separate validator, as noted in the issue.

### `fix(config)` — #4930 (silent error discard)
Added `#[must_use = "validation result must be checked"]` to `SpreadingActivationConfig::validate` (`memory/graph.rs`) and `AconConfig::validate` (`memory/fidelity.rs`). The reason-string form is required to satisfy `clippy::double_must_use` (the returned `Result` is already `#[must_use]`).

### `perf(core)` — #4929 (observability)
Added a `core.persist.rpe_should_skip` span to `rpe_should_skip` in `zeph-core/src/agent/persistence/extract.rs`, which performs a timed embedding call on the persistence path. Note: the other two functions named in the issue (`enqueue_graph_extraction_task`, `load_history`) were **already instrumented in #4921** — the issue line numbers pointed at the `fn` definitions and missed the attributes directly above them. Only `rpe_should_skip` was genuinely uninstrumented.

### `perf(llm)` — #4926 (observability)
Added profiling-gated `tracing::instrument` spans to the four `pub(crate) async` methods in `zeph-llm/src/router/select.rs` that perform embedding I/O or an LLM-judge call — `bandit_features`, `bandit_select_provider`, `evaluate_quality`, `embed_cached` — using the `#[cfg_attr(feature = "profiling", ...)]` convention already established in `router/chat.rs`.

## Verification
- `cargo +nightly fmt --check` — clean
- `cargo clippy -p zeph-config --all-targets -- -D warnings` — clean
- `cargo clippy -p zeph-llm -p zeph-core --features profiling --all-targets -- -D warnings` — clean (exercises the `cfg_attr(profiling)` path)
- `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- `cargo nextest run -p zeph-config -p zeph-llm -p zeph-core --features profiling` — 2946 passed, 10 skipped
- `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features desktop,ide,server,chat,pdf,scheduler` — clean

No user-facing behavior, config, or public-API changes (the removed `validate_unit_f32` was a private fn; `#[must_use]` is non-breaking). CHANGELOG.md updated under `[Unreleased]`.

Closes #4926
Closes #4928
Closes #4929
Closes #4930