### PR TITLE
refactor(config): dedup unit-interval validators and complete must_use sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Refactored
 
+- `refactor(config)`: dedup 9 copy-pasted unit-interval serde validators into two shared
+  generic helpers in `de_helpers.rs` — `de_unit_open` (half-open `(0.0, 1.0]`) and
+  `de_unit_closed` (closed `[0.0, 1.0]`), each generic over `f32`/`f64` via a crate-private
+  `UnitFloat` trait. The `(0.0, 1.0]` fields (`embedding_guard.threshold`, `causal_ipi.threshold`,
+  `shadow_memory.drift_threshold`, the three classifier thresholds, `decay_lambda`,
+  `link_weight_decay_lambda`) and the `[0.0, 1.0]` fields (`similarity_threshold`, admission
+  `threshold` / `fast_path_margin`) now reference the shared helpers via `deserialize_with`.
+  Range and finiteness semantics are unchanged; the offending field is still pinpointed by the
+  TOML parse span, so the inline field-name prefix in the error message was dropped. Follow-up
+  to #4928. (#4935)
+- `refactor(config)`: add `#[must_use = "validation result must be checked"]` to the remaining
+  7 `validate(&self) -> Result<(), String>` methods — `GatewayConfig`, `TrajectorySentinelConfig`,
+  `UtilityScoringConfig`, `LearningConfig`, `FidelityConfig`, `PlanCacheConfig`, and
+  `ExperimentConfig` — so callers can no longer silently discard the validation error via a bare
+  `config.validate();` statement. Completes the sweep started in #4930/#4934. (#4936)
 - `refactor(tui)`: split `app/mod.rs` (4235 lines) into focused submodules —
   `app/{mod,state,transcript,tests}.rs` — joining the existing `draw`/`events`/`keys` split.
   `mod.rs` (now 660 lines) retains the type definitions (`App`, `Panel`, `AgentViewTarget`,

--- a/crates/zeph-config/src/classifiers.rs
+++ b/crates/zeph-config/src/classifiers.rs
@@ -53,22 +53,6 @@ fn default_three_class_threshold() -> f32 {
     0.7
 }
 
-fn validate_unit_threshold<'de, D>(deserializer: D) -> Result<f32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
-    if value.is_nan() || value.is_infinite() {
-        return Err(serde::de::Error::custom(
-            "threshold must be a finite number",
-        ));
-    }
-    if !(value > 0.0 && value <= 1.0) {
-        return Err(serde::de::Error::custom("threshold must be in (0.0, 1.0]"));
-    }
-    Ok(value)
-}
-
 /// Enforcement mode for the injection classifier.
 ///
 /// `warn` (default): scores above `injection_threshold` emit WARN and increment metrics
@@ -143,7 +127,7 @@ pub struct ClassifiersConfig {
     /// Range: `(0.0, 1.0]`. Default `0.5`. Must be ≤ `injection_threshold`.
     #[serde(
         default = "default_injection_threshold_soft",
-        deserialize_with = "validate_unit_threshold"
+        deserialize_with = "crate::de_helpers::de_unit_open"
     )]
     pub injection_threshold_soft: f32,
 
@@ -155,7 +139,7 @@ pub struct ClassifiersConfig {
     /// defense-in-depth via regex fallback and spotlighting is mandatory.
     #[serde(
         default = "default_injection_threshold",
-        deserialize_with = "validate_unit_threshold"
+        deserialize_with = "crate::de_helpers::de_unit_open"
     )]
     pub injection_threshold: f32,
 
@@ -181,7 +165,7 @@ pub struct ClassifiersConfig {
     /// Range: `(0.0, 1.0]`. Default `0.7`.
     #[serde(
         default = "default_three_class_threshold",
-        deserialize_with = "validate_unit_threshold"
+        deserialize_with = "crate::de_helpers::de_unit_open"
     )]
     pub three_class_threshold: f32,
 

--- a/crates/zeph-config/src/de_helpers.rs
+++ b/crates/zeph-config/src/de_helpers.rs
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared serde deserializers for unit-interval float configuration fields.
+//!
+//! Many configuration thresholds are constrained to the unit interval, either
+//! the half-open `(0.0, 1.0]` or the fully closed `[0.0, 1.0]`. Both shapes
+//! require the same guard: reject non-finite input (`NaN`, `±inf`) and reject
+//! values outside the interval. Centralizing that guard here keeps individual
+//! config structs free of copy-pasted validators — they reference
+//! [`de_unit_open`] or [`de_unit_closed`] via `#[serde(deserialize_with = "...")]`.
+//!
+//! The helpers are generic over the float width through the crate-private
+//! [`UnitFloat`] trait, so the same two functions serve both `f32` and `f64`
+//! fields.
+
+use serde::{Deserialize, Deserializer, de::Error as _};
+
+/// Float types that can be range-checked against the unit interval.
+///
+/// Crate-private and implemented only for [`f32`] and [`f64`]. It exposes the
+/// two interval bounds as associated constants plus a finiteness check so the
+/// deserializers can stay width-agnostic.
+pub(crate) trait UnitFloat: Copy + PartialOrd {
+    /// The lower interval bound (`0.0`).
+    const ZERO: Self;
+    /// The upper interval bound (`1.0`).
+    const ONE: Self;
+    /// Returns `true` when the value is neither `NaN` nor infinite.
+    fn is_finite(self) -> bool;
+}
+
+impl UnitFloat for f32 {
+    const ZERO: Self = 0.0;
+    const ONE: Self = 1.0;
+    fn is_finite(self) -> bool {
+        f32::is_finite(self)
+    }
+}
+
+impl UnitFloat for f64 {
+    const ZERO: Self = 0.0;
+    const ONE: Self = 1.0;
+    fn is_finite(self) -> bool {
+        f64::is_finite(self)
+    }
+}
+
+/// Deserialize a float and require it to lie in the half-open interval `(0.0, 1.0]`.
+///
+/// Rejects non-finite values and anything `<= 0.0` or `> 1.0`. Intended for
+/// decay/threshold fields where a zero value is degenerate.
+///
+/// # Errors
+///
+/// Returns a deserialization error if the value is `NaN`, infinite, or outside
+/// `(0.0, 1.0]`.
+pub(crate) fn de_unit_open<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: UnitFloat + Deserialize<'de>,
+{
+    let value = T::deserialize(deserializer)?;
+    if !value.is_finite() {
+        return Err(D::Error::custom("value must be a finite number"));
+    }
+    if !(value > T::ZERO && value <= T::ONE) {
+        return Err(D::Error::custom("value must be in (0.0, 1.0]"));
+    }
+    Ok(value)
+}
+
+/// Deserialize a float and require it to lie in the closed interval `[0.0, 1.0]`.
+///
+/// Rejects non-finite values and anything `< 0.0` or `> 1.0`. Intended for
+/// threshold/margin fields where `0.0` is a valid boundary.
+///
+/// # Errors
+///
+/// Returns a deserialization error if the value is `NaN`, infinite, or outside
+/// `[0.0, 1.0]`.
+pub(crate) fn de_unit_closed<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: UnitFloat + Deserialize<'de>,
+{
+    let value = T::deserialize(deserializer)?;
+    if !value.is_finite() {
+        return Err(D::Error::custom("value must be a finite number"));
+    }
+    if !(value >= T::ZERO && value <= T::ONE) {
+        return Err(D::Error::custom("value must be in [0.0, 1.0]"));
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(serde::Deserialize)]
+    struct OpenF32 {
+        #[serde(deserialize_with = "de_unit_open")]
+        v: f32,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct OpenF64 {
+        #[serde(deserialize_with = "de_unit_open")]
+        v: f64,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct ClosedF32 {
+        #[serde(deserialize_with = "de_unit_closed")]
+        v: f32,
+    }
+
+    #[test]
+    fn open_rejects_zero_accepts_one() {
+        assert!(toml::from_str::<OpenF32>("v = 0.0").is_err());
+        assert!(toml::from_str::<OpenF32>("v = 1.0").is_ok());
+        assert!((toml::from_str::<OpenF32>("v = 0.5").unwrap().v - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn open_rejects_out_of_range_and_non_finite() {
+        assert!(toml::from_str::<OpenF32>("v = 1.5").is_err());
+        assert!(toml::from_str::<OpenF32>("v = -0.1").is_err());
+        assert!(toml::from_str::<OpenF32>("v = nan").is_err());
+        assert!(toml::from_str::<OpenF32>("v = inf").is_err());
+    }
+
+    #[test]
+    fn closed_accepts_zero_and_one() {
+        assert!(toml::from_str::<ClosedF32>("v = 0.0").unwrap().v.abs() < 1e-6);
+        assert!((toml::from_str::<ClosedF32>("v = 1.0").unwrap().v - 1.0).abs() < 1e-6);
+        assert!(toml::from_str::<ClosedF32>("v = 1.0001").is_err());
+        assert!(toml::from_str::<ClosedF32>("v = -0.0001").is_err());
+    }
+
+    #[test]
+    fn open_works_for_f64() {
+        assert!(toml::from_str::<OpenF64>("v = 0.0").is_err());
+        assert!((toml::from_str::<OpenF64>("v = 0.25").unwrap().v - 0.25).abs() < 1e-12);
+    }
+}

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -200,6 +200,7 @@ impl PlanCacheConfig {
     /// # Errors
     ///
     /// Returns a description string if any field is outside the allowed range.
+    #[must_use = "validation result must be checked"]
     pub fn validate(&self) -> Result<(), String> {
         if !(0.5..=1.0).contains(&self.similarity_threshold) {
             return Err(format!(
@@ -595,6 +596,7 @@ impl ExperimentConfig {
     /// # Errors
     ///
     /// Returns a description string if any field is outside allowed range.
+    #[must_use = "validation result must be checked"]
     pub fn validate(&self) -> Result<(), String> {
         if !(1..=1_000).contains(&self.max_experiments) {
             return Err(format!(

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -856,6 +856,7 @@ impl GatewayConfig {
     /// - `webhook_send_timeout_secs` is `0` or exceeds `300`
     /// - `max_body_size` exceeds `10 MiB` (`10485760` bytes)
     /// - `rate_limit` is `0` (causes division-by-zero in the token-bucket rate limiter)
+    #[must_use = "validation result must be checked"]
     pub fn validate(&self) -> Result<(), String> {
         if self.webhook_send_timeout_secs == 0 || self.webhook_send_timeout_secs > 300 {
             return Err("webhook_send_timeout_secs must be between 1 and 300".to_owned());

--- a/crates/zeph-config/src/fidelity.rs
+++ b/crates/zeph-config/src/fidelity.rs
@@ -148,6 +148,7 @@ impl FidelityConfig {
     /// let invalid = FidelityConfig { full_threshold: 0.2, compressed_threshold: 0.5, ..FidelityConfig::default() };
     /// assert!(invalid.validate().is_err());
     /// ```
+    #[must_use = "validation result must be checked"]
     pub fn validate(&self) -> Result<(), String> {
         if self.compressed_threshold < 0.0 {
             return Err("memory.fidelity: compressed_threshold must be >= 0.0".into());

--- a/crates/zeph-config/src/learning.rs
+++ b/crates/zeph-config/src/learning.rs
@@ -514,6 +514,7 @@ impl LearningConfig {
     /// # Errors
     ///
     /// Returns an error string if `merge_threshold >= dedup_threshold`.
+    #[must_use = "validation result must be checked"]
     pub fn validate(&self) -> Result<(), String> {
         if self.merge_threshold >= self.dedup_threshold {
             return Err(format!(

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -75,6 +75,7 @@ pub mod channels;
 pub mod classifiers;
 pub mod cli;
 pub mod cocoon;
+mod de_helpers;
 pub mod defaults;
 pub mod dump_format;
 mod env;

--- a/crates/zeph-config/src/memory/graph.rs
+++ b/crates/zeph-config/src/memory/graph.rs
@@ -9,10 +9,7 @@
 use crate::providers::ProviderName;
 use serde::{Deserialize, Serialize};
 
-use super::{
-    BeliefRevisionConfig, ConflictRecencyConfig, RpeConfig, WriteGateConfig,
-    validate_similarity_threshold,
-};
+use super::{BeliefRevisionConfig, ConflictRecencyConfig, RpeConfig, WriteGateConfig};
 
 fn default_graph_max_entities_per_message() -> usize {
     10
@@ -155,7 +152,7 @@ pub struct SpreadingActivationConfig {
     /// Enable spreading activation (replaces BFS in graph recall when `true`). Default: `false`.
     pub enabled: bool,
     /// Per-hop activation decay factor. Range: `(0.0, 1.0]`. Default: `0.85`.
-    #[serde(deserialize_with = "validate_decay_lambda")]
+    #[serde(deserialize_with = "crate::de_helpers::de_unit_open")]
     pub decay_lambda: f32,
     /// Maximum propagation depth. Must be `>= 1`. Default: `3`.
     #[serde(deserialize_with = "validate_max_hops")]
@@ -202,24 +199,6 @@ pub struct SpreadingActivationConfig {
         deserialize_with = "validate_benna_rate"
     )]
     pub benna_slow_rate: f32,
-}
-
-fn validate_decay_lambda<'de, D>(deserializer: D) -> Result<f32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
-    if value.is_nan() || value.is_infinite() {
-        return Err(serde::de::Error::custom(
-            "decay_lambda must be a finite number",
-        ));
-    }
-    if !(value > 0.0 && value <= 1.0) {
-        return Err(serde::de::Error::custom(
-            "decay_lambda must be in (0.0, 1.0]",
-        ));
-    }
-    Ok(value)
 }
 
 fn validate_max_hops<'de, D>(deserializer: D) -> Result<u32, D::Error>
@@ -321,7 +300,7 @@ pub struct NoteLinkingConfig {
     /// Enable A-MEM note linking after graph extraction. Default: `false`.
     pub enabled: bool,
     /// Minimum cosine similarity score to create a `similar_to` edge. Default: `0.85`.
-    #[serde(deserialize_with = "validate_similarity_threshold")]
+    #[serde(deserialize_with = "crate::de_helpers::de_unit_closed")]
     pub similarity_threshold: f32,
     /// Maximum number of similar entities to link per extracted entity. Default: `10`.
     pub top_k: usize,
@@ -585,7 +564,7 @@ pub struct GraphConfig {
     /// for un-retrieved edges each decay pass. Range: `(0.0, 1.0]`. Default: `0.95`.
     #[serde(
         default = "default_link_weight_decay_lambda",
-        deserialize_with = "validate_link_weight_decay_lambda"
+        deserialize_with = "crate::de_helpers::de_unit_open"
     )]
     pub link_weight_decay_lambda: f64,
     /// Seconds between link weight decay passes. Default: `86400` (24 hours).
@@ -996,22 +975,4 @@ fn default_link_weight_decay_lambda() -> f64 {
 
 fn default_link_weight_decay_interval_secs() -> u64 {
     86400
-}
-
-fn validate_link_weight_decay_lambda<'de, D>(deserializer: D) -> Result<f64, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f64 as serde::Deserialize>::deserialize(deserializer)?;
-    if value.is_nan() || value.is_infinite() {
-        return Err(serde::de::Error::custom(
-            "link_weight_decay_lambda must be a finite number",
-        ));
-    }
-    if !(value > 0.0 && value <= 1.0) {
-        return Err(serde::de::Error::custom(
-            "link_weight_decay_lambda must be in (0.0, 1.0]",
-        ));
-    }
-    Ok(value)
 }

--- a/crates/zeph-config/src/memory/hebbian.rs
+++ b/crates/zeph-config/src/memory/hebbian.rs
@@ -10,8 +10,6 @@ use crate::providers::ProviderName;
 use serde::{Deserialize, Serialize};
 use zeph_common::memory::EdgeType;
 
-use super::validate_similarity_threshold;
-
 fn default_write_gate_min_edge_relevance() -> f32 {
     0.3
 }
@@ -36,7 +34,7 @@ pub struct WriteGateConfig {
     /// Range: `[0.0, 1.0]`.
     #[serde(
         default = "default_write_gate_min_edge_relevance",
-        deserialize_with = "validate_similarity_threshold"
+        deserialize_with = "crate::de_helpers::de_unit_closed"
     )]
     pub min_edge_relevance: f32,
 }
@@ -63,7 +61,7 @@ pub struct ConflictRecencyConfig {
     /// edges below the threshold fall back to `valid_from` comparison. Range: `[0.0, 1.0]`.
     #[serde(
         default = "default_conflict_recency_slow_threshold",
-        deserialize_with = "validate_similarity_threshold"
+        deserialize_with = "crate::de_helpers::de_unit_closed"
     )]
     pub recency_slow_threshold: f32,
 }
@@ -84,7 +82,7 @@ pub struct BeliefRevisionConfig {
     pub enabled: bool,
     /// Cosine similarity threshold for considering two facts as contradictory.
     /// Only edges with similarity >= this value are candidates for revision. Default: `0.85`.
-    #[serde(deserialize_with = "validate_similarity_threshold")]
+    #[serde(deserialize_with = "crate::de_helpers::de_unit_closed")]
     pub similarity_threshold: f32,
 }
 
@@ -109,7 +107,7 @@ pub struct RpeConfig {
     pub enabled: bool,
     /// RPE threshold. Turns with RPE < this value skip graph extraction. Range: `[0.0, 1.0]`.
     /// Default: `0.3`.
-    #[serde(deserialize_with = "validate_similarity_threshold")]
+    #[serde(deserialize_with = "crate::de_helpers::de_unit_closed")]
     pub threshold: f32,
     /// Maximum consecutive turns to skip before forcing extraction (safety valve). Default: `5`.
     pub max_skip_turns: u32,

--- a/crates/zeph-config/src/memory/mod.rs
+++ b/crates/zeph-config/src/memory/mod.rs
@@ -39,25 +39,6 @@ pub use retrieval::*;
 pub use root::*;
 pub use session::*;
 
-// Shared helpers referenced by serde attributes in more than one submodule.
-pub(crate) fn validate_similarity_threshold<'de, D>(deserializer: D) -> Result<f32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
-    if value.is_nan() || value.is_infinite() {
-        return Err(serde::de::Error::custom(
-            "similarity_threshold must be a finite number",
-        ));
-    }
-    if !(0.0..=1.0).contains(&value) {
-        return Err(serde::de::Error::custom(
-            "similarity_threshold must be in [0.0, 1.0]",
-        ));
-    }
-    Ok(value)
-}
-
 pub(crate) fn default_embed_timeout_secs() -> u64 {
     5
 }

--- a/crates/zeph-config/src/memory/retrieval.rs
+++ b/crates/zeph-config/src/memory/retrieval.rs
@@ -503,40 +503,6 @@ fn default_consolidation_llm_timeout_secs() -> u64 {
     30
 }
 
-fn validate_admission_threshold<'de, D>(deserializer: D) -> Result<f32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
-    if value.is_nan() || value.is_infinite() {
-        return Err(serde::de::Error::custom(
-            "threshold must be a finite number",
-        ));
-    }
-    if !(0.0..=1.0).contains(&value) {
-        return Err(serde::de::Error::custom("threshold must be in [0.0, 1.0]"));
-    }
-    Ok(value)
-}
-
-fn validate_admission_fast_path_margin<'de, D>(deserializer: D) -> Result<f32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
-    if value.is_nan() || value.is_infinite() {
-        return Err(serde::de::Error::custom(
-            "fast_path_margin must be a finite number",
-        ));
-    }
-    if !(0.0..=1.0).contains(&value) {
-        return Err(serde::de::Error::custom(
-            "fast_path_margin must be in [0.0, 1.0]",
-        ));
-    }
-    Ok(value)
-}
-
 fn default_admission_threshold() -> f32 {
     0.40
 }
@@ -661,11 +627,11 @@ pub struct AdmissionConfig {
     pub enabled: bool,
     /// Composite score threshold below which messages are rejected. Range: `[0.0, 1.0]`.
     /// Default: `0.40`.
-    #[serde(deserialize_with = "validate_admission_threshold")]
+    #[serde(deserialize_with = "crate::de_helpers::de_unit_closed")]
     pub threshold: f32,
     /// Margin above threshold at which the fast path admits without an LLM call. Range: `[0.0, 1.0]`.
     /// When heuristic score >= threshold + margin, LLM call is skipped. Default: `0.15`.
-    #[serde(deserialize_with = "validate_admission_fast_path_margin")]
+    #[serde(deserialize_with = "crate::de_helpers::de_unit_closed")]
     pub fast_path_margin: f32,
     /// Provider name from `[[llm.providers]]` for `future_utility` LLM evaluation.
     /// Falls back to the primary provider when empty. Default: `""`.

--- a/crates/zeph-config/src/sanitizer.rs
+++ b/crates/zeph-config/src/sanitizer.rs
@@ -24,7 +24,7 @@ pub struct EmbeddingGuardConfig {
     /// Cosine distance threshold above which outputs are flagged as anomalous.
     #[serde(
         default = "default_embedding_threshold",
-        deserialize_with = "validate_embedding_threshold"
+        deserialize_with = "crate::de_helpers::de_unit_open"
     )]
     pub threshold: f64,
     /// Minimum clean samples before centroid-based detection activates.
@@ -42,24 +42,6 @@ pub struct EmbeddingGuardConfig {
     /// changes. Default: 0.01 (1% per sample).
     #[serde(default = "default_ema_floor")]
     pub ema_floor: f32,
-}
-
-fn validate_embedding_threshold<'de, D>(deserializer: D) -> Result<f64, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f64 as serde::Deserialize>::deserialize(deserializer)?;
-    if value.is_nan() || value.is_infinite() {
-        return Err(serde::de::Error::custom(
-            "embedding_guard.threshold must be a finite number",
-        ));
-    }
-    if !(value > 0.0 && value <= 1.0) {
-        return Err(serde::de::Error::custom(
-            "embedding_guard.threshold must be in (0.0, 1.0]",
-        ));
-    }
-    Ok(value)
 }
 
 fn validate_min_samples<'de, D>(deserializer: D) -> Result<usize, D::Error>
@@ -654,24 +636,6 @@ fn default_causal_threshold() -> f32 {
     0.7
 }
 
-fn validate_causal_threshold<'de, D>(deserializer: D) -> Result<f32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
-    if value.is_nan() || value.is_infinite() {
-        return Err(serde::de::Error::custom(
-            "causal_ipi.threshold must be a finite number",
-        ));
-    }
-    if !(value > 0.0 && value <= 1.0) {
-        return Err(serde::de::Error::custom(
-            "causal_ipi.threshold must be in (0.0, 1.0]",
-        ));
-    }
-    Ok(value)
-}
-
 fn default_probe_max_tokens() -> u32 {
     100
 }
@@ -699,7 +663,7 @@ pub struct CausalIpiConfig {
     /// Content is never blocked — this is an observation layer only.
     #[serde(
         default = "default_causal_threshold",
-        deserialize_with = "validate_causal_threshold"
+        deserialize_with = "crate::de_helpers::de_unit_open"
     )]
     pub threshold: f32,
 
@@ -782,24 +746,6 @@ where
     Ok(value)
 }
 
-fn validate_shadow_drift_threshold<'de, D>(deserializer: D) -> Result<f32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
-    if value.is_nan() || value.is_infinite() {
-        return Err(serde::de::Error::custom(
-            "shadow_memory.drift_threshold must be a finite number",
-        ));
-    }
-    if !(value > 0.0 && value <= 1.0) {
-        return Err(serde::de::Error::custom(
-            "shadow_memory.drift_threshold must be in (0.0, 1.0]",
-        ));
-    }
-    Ok(value)
-}
-
 /// Per-session append-only event store for cross-turn trajectory analysis.
 ///
 /// Detects multi-turn attacks that distribute payload across several turns —
@@ -839,7 +785,7 @@ pub struct ShadowMemoryConfig {
     /// Goal drift score threshold for flagging. Range: (0.0, 1.0]. Default: 0.6.
     #[serde(
         default = "default_shadow_drift_threshold",
-        deserialize_with = "validate_shadow_drift_threshold"
+        deserialize_with = "crate::de_helpers::de_unit_open"
     )]
     pub drift_threshold: f32,
 }

--- a/crates/zeph-config/src/security.rs
+++ b/crates/zeph-config/src/security.rs
@@ -264,6 +264,7 @@ impl TrajectorySentinelConfig {
     /// # Errors
     ///
     /// Returns a description of the first validation failure found.
+    #[must_use = "validation result must be checked"]
     pub fn validate(&self) -> Result<(), String> {
         if self.decay_per_turn <= 0.0 || self.decay_per_turn > 1.0 {
             return Err(format!(

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -625,6 +625,7 @@ impl UtilityScoringConfig {
     /// # Errors
     ///
     /// Returns a description of the first invalid field found.
+    #[must_use = "validation result must be checked"]
     pub fn validate(&self) -> Result<(), String> {
         let fields = [
             ("threshold", self.threshold),


### PR DESCRIPTION
## Summary

Code-quality cleanup in `zeph-config`, continuing the DRY/`must_use` sweep from #4928/#4930/#4934. Two related P3 refactors:

### #4935 — dedup unit-interval serde validators
Replaced 9 copy-pasted private deserializers with two shared generic helpers in the new `crates/zeph-config/src/de_helpers.rs`:

- `de_unit_open` — half-open interval `(0.0, 1.0]`
- `de_unit_closed` — closed interval `[0.0, 1.0]`

Both are generic over `f32`/`f64` through a crate-private `UnitFloat` trait, so the same two functions serve every caller via `#[serde(deserialize_with = "crate::de_helpers::...")]`.

Converted callers:
- `(0.0, 1.0]`: `embedding_guard.threshold`, `causal_ipi.threshold`, `shadow_memory.drift_threshold`, the three classifier thresholds, `decay_lambda`, `link_weight_decay_lambda`
- `[0.0, 1.0]`: `similarity_threshold` (×6 across `graph.rs`/`hebbian.rs`), admission `threshold`, `fast_path_margin`

Range and finiteness semantics are unchanged. The only behavioral delta is the error text: the inline field-name prefix (e.g. `embedding_guard.threshold must be in ...`) is dropped in favor of a generic message, because the `toml` parser already pins the offending field and value via its parse span. Validators with non-unit ranges (`[0.5, 1.0]`, `[0.0, 10.0]`) or distinct multi-bound messages (`importance_weight`) are intentionally left untouched.

### #4936 — complete the `#[must_use]` sweep
Added `#[must_use = "validation result must be checked"]` to the remaining 7 `validate(&self) -> Result<(), String>` methods (`GatewayConfig`, `TrajectorySentinelConfig`, `UtilityScoringConfig`, `LearningConfig`, `FidelityConfig`, `PlanCacheConfig`, `ExperimentConfig`). PR #4934 already annotated the other 2; this covers the rest so a validation error can never be silently discarded.

## Notes
- No public API change. `de_helpers` items are `pub(crate)`; `UnitFloat` is crate-private.
- Verified no workspace caller discards any of the now-`must_use` `validate()` results.

## Verification
- `cargo +nightly fmt --check -p zeph-config`
- `cargo clippy -p zeph-config --all-targets --all-features -- -D warnings`
- `cargo nextest run -p zeph-config --all-features` — 525 passed (+4 new `de_helpers` tests)
- `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean (confirms no `unused_must_use` regression)
- `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-config` + `cargo test --doc -p zeph-config` — clean

Closes #4935
Closes #4936