### PR TITLE
fix(db): restore postgres backend compile and sqlite/postgres parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(memory)`: `SqliteStore::upsert_agent_session` bound the `turns` count as a bare `u32`,
+  which only implements `sqlx::Type<Sqlite>` (PostgreSQL has no unsigned integer types). This
+  pinned the query to the SQLite driver and broke the PostgreSQL backend with `E0271`
+  ("expected `Sqlite`, found `Postgres`") on any build that activates the `postgres` feature
+  (including `--all-features`). `turns` is now bound via `cast_signed()` (`i32`, matching the
+  `INTEGER` column) and the `list_agent_sessions` read tuple decodes it as `i32`, so PostgreSQL
+  does not reject the `INTEGER`/INT4 column as an `i64` mismatch. The PostgreSQL backend now
+  compiles end-to-end (`cargo check --no-default-features --features postgres`). (#4964)
+- `fix(db,memory)`: data-layer consumer crates that depend on `zeph-memory`/`zeph-db` without
+  selecting a database backend (`zeph-sanitizer`, `zeph-acp`, `zeph-bench`, `zeph-tui`, and
+  `zeph-skills` via its optional `qdrant` dependency) could not be built or doc-checked in
+  isolation (`cargo {check,test,doc} -p <crate>`): the transitive `zeph-db` had no backend
+  feature and tripped its `compile_error!` plus a cascade of follow-on errors. Each crate now
+  carries the standard `default = ["sqlite"]` / `sqlite` / `postgres` feature trio forwarding to
+  `zeph-memory`, matching the pattern already used by `zeph-mcp`/`zeph-index`/etc. The
+  backend-only imports in `zeph-db/src/migrate.rs` are now gated behind
+  `any(feature = "sqlite", feature = "postgres")` so a no-backend build surfaces only the clear
+  `compile_error!` instead of a spurious unused-import warning. (#4956)
+- `fix(db)`: the PostgreSQL migration set was missing the `fact_access_log` table and the
+  `messages.memory_tier`/`messages.qdrant_promoted` columns (five-signal SYNAPSE retrieval,
+  #4374) and the `implicit_conflict_candidates` table (graph conflict detection) — both present
+  only in the SQLite dialect, so PostgreSQL deployments ran a divergent schema (system-invariant
+  001 §13). Added forward-only PostgreSQL migrations `101_five_signal_retrieval.sql` and
+  `102_implicit_conflict_candidates.sql` (integer columns sized `BIGINT` to match the `i64` Rust
+  accessors). Added a SQLite parity placeholder `101_trajectory_memory_cascade.sql` (the cascade
+  is inline on SQLite but needs a dedicated drop-and-re-add migration on PostgreSQL) so the two
+  sequences keep an equal file count, plus a `migration_parity` integration test that fails the
+  build if the dialects ever diverge in file count, logical migration name, or defined table set.
+  (#4957)
 - `perf(acp)`: `list_directory` and `find_path` tools now offload their synchronous
   filesystem walks (`std::fs::read_dir`, `glob::glob`, per-entry `symlink_metadata` and
   sandbox canonicalization) to `tokio::task::spawn_blocking` instead of running inline on

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 
 [features]
 default = [
+    "sqlite",
     "unstable-session-delete",
     "unstable-session-fork",
     "unstable-session-usage",
@@ -21,6 +22,10 @@ default = [
     "unstable-elicitation",
     "unstable-llm-providers",
 ]
+# `zeph-memory`/`zeph-db` require a backend to compile; default to `sqlite` so this crate
+# builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
+sqlite = ["zeph-memory/sqlite"]
+postgres = ["zeph-memory/postgres"]
 acp-http = ["dep:axum", "dep:blake3", "dep:dashmap", "dep:async-stream", "dep:tower-http", "dep:subtle", "dep:tower"]
 # session/close and session/delete stabilized in acp 0.14.0; no upstream feature gate needed
 unstable-session-delete = []

--- a/crates/zeph-bench/Cargo.toml
+++ b/crates/zeph-bench/Cargo.toml
@@ -11,6 +11,13 @@ categories.workspace = true
 description = "Benchmark harness for evaluating Zeph agent performance on standardized datasets"
 publish = true
 
+[features]
+# `zeph-memory`/`zeph-db` require a backend to compile; default to `sqlite` so this crate
+# builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
+default = ["sqlite"]
+sqlite = ["zeph-memory/sqlite"]
+postgres = ["zeph-memory/postgres"]
+
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 schemars.workspace = true

--- a/crates/zeph-db/migrations/postgres/101_five_signal_retrieval.sql
+++ b/crates/zeph-db/migrations/postgres/101_five_signal_retrieval.sql
@@ -1,0 +1,21 @@
+-- Five-signal SYNAPSE retrieval: access frequency tracking and memory tier columns (issue #4374).
+-- PostgreSQL counterpart of sqlite/091_five_signal_retrieval.sql; closes the dialect gap
+-- where Postgres deployments lacked the fact_access_log table and the messages tier columns
+-- (parity defect: #4957). Integer columns are BIGINT because the Rust accessors read them as
+-- i64 (e.g. row.get::<i64, _>("qdrant_promoted")); an INTEGER/INT4 column would fail i64 decode.
+
+CREATE TABLE IF NOT EXISTS fact_access_log (
+    id          BIGSERIAL PRIMARY KEY,
+    fact_id     BIGINT NOT NULL,
+    fact_type   TEXT   NOT NULL,
+    session_id  TEXT   NOT NULL,
+    accessed_at BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_fact_access_fact         ON fact_access_log(fact_id,    accessed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_fact_access_session      ON fact_access_log(session_id, accessed_at DESC);
+-- Composite index: covers the GROUP BY query (session_id = ? AND fact_id IN (...)).
+CREATE INDEX IF NOT EXISTS idx_fact_access_session_fact ON fact_access_log(session_id, fact_id);
+
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS memory_tier     TEXT   DEFAULT 'episodic';
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS qdrant_promoted BIGINT DEFAULT 0;

--- a/crates/zeph-db/migrations/postgres/102_implicit_conflict_candidates.sql
+++ b/crates/zeph-db/migrations/postgres/102_implicit_conflict_candidates.sql
@@ -1,0 +1,22 @@
+-- PostgreSQL counterpart of sqlite/090_implicit_conflict_candidates.sql; closes the dialect
+-- gap where Postgres deployments lacked the implicit_conflict_candidates table used by graph
+-- conflict detection (parity defect: #4957). graph_edges(id) is BIGSERIAL on Postgres, so the
+-- foreign keys are BIGINT; epoch timestamps are BIGINT (bound as i64) and similarity is
+-- DOUBLE PRECISION (bound as f64), mirroring the Rust accessors in graph/implicit_conflict.rs.
+
+CREATE TABLE IF NOT EXISTS implicit_conflict_candidates (
+    id          BIGSERIAL PRIMARY KEY,
+    edge_a_id   BIGINT NOT NULL REFERENCES graph_edges(id),
+    edge_b_id   BIGINT NOT NULL REFERENCES graph_edges(id),
+    similarity  DOUBLE PRECISION NOT NULL,
+    method      TEXT   NOT NULL,
+    status      TEXT   NOT NULL DEFAULT 'pending',
+    resolution  TEXT,
+    created_at  BIGINT NOT NULL,
+    resolved_at BIGINT,
+    expires_at  BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_icc_edge_a ON implicit_conflict_candidates(edge_a_id);
+CREATE INDEX IF NOT EXISTS idx_icc_edge_b ON implicit_conflict_candidates(edge_b_id);
+CREATE INDEX IF NOT EXISTS idx_icc_status ON implicit_conflict_candidates(status, expires_at);

--- a/crates/zeph-db/migrations/sqlite/101_trajectory_memory_cascade.sql
+++ b/crates/zeph-db/migrations/sqlite/101_trajectory_memory_cascade.sql
@@ -1,0 +1,11 @@
+-- Parity placeholder for postgres/088_trajectory_memory_cascade.sql.
+--
+-- PostgreSQL cannot alter a foreign-key constraint in place, so it applies the
+-- trajectory_memory ON DELETE CASCADE behavior through a dedicated drop-and-re-add migration.
+-- SQLite defines the same cascade inline at table creation (069_trajectory_memory.sql), so no
+-- schema change is required here. This file keeps the two dialect migration sequences at an
+-- equal file count (system-invariant 001 §13) and documents the asymmetry (#4957).
+--
+-- The statement below is an idempotent no-op on any existing database (the index was created in
+-- 069_trajectory_memory.sql); it exists only so the migration carries a valid SQL statement.
+CREATE INDEX IF NOT EXISTS idx_trajectory_conversation ON trajectory_memory(conversation_id);

--- a/crates/zeph-db/src/migrate.rs
+++ b/crates/zeph-db/src/migrate.rs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+// Both items are only referenced by the backend-gated `run_migrations` definitions below;
+// gate the import so a no-backend build surfaces only the crate-level `compile_error!`
+// rather than a spurious unused-import warning (#4956).
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 use crate::{DbPool, error::DbError};
 
 /// Run all pending migrations for the active backend.

--- a/crates/zeph-db/tests/migration_parity.rs
+++ b/crates/zeph-db/tests/migration_parity.rs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Migration parity guard between the `SQLite` and `PostgreSQL` dialects.
+//!
+//! System-invariant 001 §13 requires the two migration directories to have matching file
+//! counts and schema-equivalent content: a `PostgreSQL` deployment must end with the same logical
+//! schema as a `SQLite` deployment. These tests are pure file-system checks (no database, no
+//! feature flag) so they run on every `cargo test`/`nextest` invocation and fail the build the
+//! moment the dialects drift apart — the divergence that motivated #4957.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+/// Tables that legitimately exist only in the `SQLite` dialect because `PostgreSQL` implements
+/// the same capability through a different mechanism (`FTS5` virtual tables vs `tsvector`/`GIN`
+/// indexes). Anything not listed here must exist in both dialects.
+const SQLITE_ONLY_TABLES: &[&str] = &["graph_entities_fts", "messages_fts"];
+
+fn migrations_dir(dialect: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .join(dialect)
+}
+
+/// Sorted list of `*.sql` file names in a dialect directory.
+fn sql_file_names(dialect: &str) -> Vec<String> {
+    let mut names: Vec<String> = fs::read_dir(migrations_dir(dialect))
+        .expect("migrations directory must exist")
+        .map(|entry| entry.expect("readable dir entry").path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("sql"))
+        })
+        .filter_map(|path| path.file_name()?.to_str().map(str::to_owned))
+        .collect();
+    names.sort();
+    names
+}
+
+/// Strip `--` line comments so commented-out DDL or prose mentioning `CREATE TABLE` does not
+/// produce false matches.
+fn strip_comments(sql: &str) -> String {
+    sql.lines()
+        .map(|line| line.split_once("--").map_or(line, |(code, _)| code))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Set of table names defined across all migrations of a dialect, excluding transient
+/// `*_new`/`*_v2` tables that `SQLite` creates only as part of the copy-and-rename rebuild
+/// pattern.
+fn defined_tables(dialect: &str) -> BTreeSet<String> {
+    let pattern = regex::RegexBuilder::new(
+        r#"create\s+(?:virtual\s+)?table\s+(?:if\s+not\s+exists\s+)?["`]?([a-z_][a-z0-9_]*)"#,
+    )
+    .case_insensitive(true)
+    .build()
+    .expect("valid regex");
+
+    let mut tables = BTreeSet::new();
+    for name in sql_file_names(dialect) {
+        let sql = fs::read_to_string(migrations_dir(dialect).join(&name)).expect("readable sql");
+        for caps in pattern.captures_iter(&strip_comments(&sql)) {
+            let table = caps[1].to_string();
+            if table.ends_with("_new") || table.ends_with("_v2") {
+                continue;
+            }
+            tables.insert(table);
+        }
+    }
+    tables
+}
+
+/// Both dialects must carry the same number of migration files (system-invariant 001 §13).
+#[test]
+fn file_counts_match() {
+    let sqlite = sql_file_names("sqlite").len();
+    let postgres = sql_file_names("postgres").len();
+    assert_eq!(
+        sqlite, postgres,
+        "migration file counts diverge: sqlite={sqlite}, postgres={postgres} — every logical \
+         migration must exist in both dialects (system-invariant 001 §13)"
+    );
+}
+
+/// Every migration must exist in both dialects under the same logical name (file name with the
+/// numeric prefix removed). Dialect-specific implementations of the same change must share the
+/// logical name so the sequences stay aligned.
+#[test]
+fn logical_names_match() {
+    let logical = |dialect: &str| -> BTreeSet<String> {
+        sql_file_names(dialect)
+            .into_iter()
+            .map(|name| {
+                name.split_once('_')
+                    .map_or(name.clone(), |(_, rest)| rest.to_string())
+            })
+            .collect()
+    };
+    let sqlite = logical("sqlite");
+    let postgres = logical("postgres");
+
+    let only_sqlite: Vec<_> = sqlite.difference(&postgres).collect();
+    let only_postgres: Vec<_> = postgres.difference(&sqlite).collect();
+    assert!(
+        only_sqlite.is_empty() && only_postgres.is_empty(),
+        "migration logical names diverge — sqlite-only: {only_sqlite:?}, postgres-only: \
+         {only_postgres:?}"
+    );
+}
+
+/// Every table must be defined in both dialects, except the documented `SQLite`-only `FTS` tables.
+/// This catches a table added to one dialect's migration but forgotten in the other (#4957).
+#[test]
+fn table_sets_equivalent() {
+    let sqlite = defined_tables("sqlite");
+    let postgres = defined_tables("postgres");
+
+    let allowed: BTreeSet<String> = SQLITE_ONLY_TABLES
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+
+    // The allowlist must not rot: every entry has to actually exist in SQLite.
+    for table in &allowed {
+        assert!(
+            sqlite.contains(table),
+            "allowlisted SQLite-only table `{table}` no longer exists — update SQLITE_ONLY_TABLES"
+        );
+    }
+
+    let missing_in_postgres: Vec<_> = sqlite
+        .difference(&postgres)
+        .filter(|t| !allowed.contains(*t))
+        .collect();
+    let missing_in_sqlite: Vec<_> = postgres.difference(&sqlite).collect();
+
+    assert!(
+        missing_in_postgres.is_empty(),
+        "tables defined in SQLite but missing in PostgreSQL: {missing_in_postgres:?} — add the \
+         equivalent PostgreSQL migration (or allowlist it if intentionally dialect-specific)"
+    );
+    assert!(
+        missing_in_sqlite.is_empty(),
+        "tables defined in PostgreSQL but missing in SQLite: {missing_in_sqlite:?}"
+    );
+}

--- a/crates/zeph-memory/src/store/agent_sessions.rs
+++ b/crates/zeph-memory/src/store/agent_sessions.rs
@@ -219,7 +219,11 @@ impl SqliteStore {
         .bind(&s.model)
         .bind(&s.created_at)
         .bind(&s.last_active_at)
-        .bind(s.turns)
+        // `turns` maps to an `INTEGER` column in both dialects; bind it as `i32` so the query
+        // stays backend-agnostic. A bare `u32` only implements `Type<Sqlite>` (Postgres has no
+        // unsigned integer types), which pins the query to the SQLite driver and breaks the
+        // Postgres backend (#4964).
+        .bind(s.turns.cast_signed())
         .bind(s.prompt_tokens.cast_signed())
         .bind(s.completion_tokens.cast_signed())
         .bind(s.reasoning_tokens.cast_signed())
@@ -309,7 +313,9 @@ impl SqliteStore {
             String,
             String,
             String,
-            i64,
+            // `turns` is an `INTEGER` column (INT4 on Postgres); decode it as `i32` so the
+            // Postgres driver does not reject it as an `i64`/BIGINT mismatch (#4964).
+            i32,
             i64,
             i64,
             i64,

--- a/crates/zeph-sanitizer/Cargo.toml
+++ b/crates/zeph-sanitizer/Cargo.toml
@@ -35,7 +35,12 @@ toml.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }
 
 [features]
-default = []
+# `zeph-memory` (and transitively `zeph-db`) needs exactly one backend selected to
+# compile. Default to `sqlite` so `cargo {check,test,doc} -p zeph-sanitizer` works in
+# isolation; the workspace build unifies on the backend chosen by the binary (#4956).
+default = ["sqlite"]
+sqlite = ["zeph-memory/sqlite"]
+postgres = ["zeph-memory/postgres"]
 classifiers = ["zeph-llm/classifiers"]
 
 [lints]

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -14,9 +14,13 @@ readme = "README.md"
 
 [features]
 profiling = []
-default = []
+default = ["sqlite"]
 miner = ["anyhow", "clap", "dirs", "toml", "tracing-subscriber"]
 qdrant = ["dep:zeph-memory", "dep:qdrant-client"]
+# `zeph-memory` is optional (pulled in by `qdrant`); when present it requires a backend.
+# These no-op unless `qdrant` activates `zeph-memory`, then select its backend (#4956).
+sqlite = ["zeph-memory?/sqlite"]
+postgres = ["zeph-memory?/postgres"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -53,9 +53,13 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util.workspace = true
 
 [features]
-default = ["clipboard"]
+default = ["clipboard", "sqlite"]
 clipboard = ["dep:arboard"]
 cocoon = []
+# `zeph-memory`/`zeph-db` require a backend to compile; default to `sqlite` so this crate
+# builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
+sqlite = ["zeph-memory/sqlite"]
+postgres = ["zeph-memory/postgres"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Restores the PostgreSQL backend and the SQLite/PostgreSQL schema parity for the data layer. Three closely related data-layer correctness defects, fixed together:

- **#4964 — PostgreSQL backend did not compile.** `SqliteStore::upsert_agent_session` bound the `turns` count as a bare `u32`, which only implements `sqlx::Type<Sqlite>` (PostgreSQL has no unsigned integer types). This pinned the query to the SQLite driver and broke the PostgreSQL backend with `E0271` ("expected `Sqlite`, found `Postgres`") on any build that activates the `postgres` feature. `turns` is now bound via `cast_signed()` (`i32`, matching the `INTEGER` column) and the read tuple decodes it as `i32` so PostgreSQL does not reject the `INTEGER`/INT4 column as an `i64` mismatch. A full-workspace `cargo check --no-default-features --features postgres` now compiles cleanly — this was the *only* PostgreSQL-breaking bind site in the workspace.

- **#4956 — consumer crates could not be built/doc-checked in isolation.** Crates depending on `zeph-memory`/`zeph-db` without selecting a backend (`zeph-sanitizer`, `zeph-acp`, `zeph-bench`, `zeph-tui`, and `zeph-skills` via its optional `qdrant` dependency) tripped the `zeph-db` `compile_error!` plus a follow-on cascade, because the `default-features = false` workspace deps stripped the default backend. Each crate now carries the standard `default = ["sqlite"]` / `sqlite` / `postgres` feature trio forwarding to `zeph-memory`, matching the established `zeph-mcp`/`zeph-index` pattern. The backend-only imports in `zeph-db/src/migrate.rs` are gated behind `any(feature = "sqlite", feature = "postgres")` so a genuine no-backend build surfaces only the clear `compile_error!`.

- **#4957 — SQLite/PostgreSQL migration sequences diverged (P2, system-invariant 001 §13).** PostgreSQL was missing the `fact_access_log` table and `messages.memory_tier`/`messages.qdrant_promoted` columns (five-signal SYNAPSE retrieval, #4374) and the `implicit_conflict_candidates` table (graph conflict detection) — present only in SQLite, so PostgreSQL deployments ran a divergent schema. Added forward-only PostgreSQL migrations `101_five_signal_retrieval.sql` and `102_implicit_conflict_candidates.sql` (integer columns sized `BIGINT` to match the `i64` Rust accessors), plus a SQLite parity placeholder `101_trajectory_memory_cascade.sql` (the cascade is inline on SQLite but needs a dedicated drop-and-re-add migration on PostgreSQL) to keep file counts equal (101 = 101). A new `migration_parity` integration test fails the build if the dialects ever diverge in file count, logical migration name, or defined table set.

## Verification

- `cargo +nightly fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace --lib --bins` — **10555 passed, 0 failed, 21 skipped**
- `cargo test -p zeph-db --test migration_parity` — 3 passed (file-count / logical-name / table-set parity)
- `cargo nextest run -p zeph-memory -E 'test(agent_session)'` — 8 passed
- `cargo check --no-default-features --features postgres` — clean (PostgreSQL backend compiles end-to-end)
- `cargo check -p {zeph-sanitizer,zeph-acp,zeph-bench,zeph-tui} --lib` and `-p zeph-skills --lib --features qdrant` — all clean (previously failed)
- `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-db -p zeph-memory` — clean (one pre-existing private-intra-doc warning, not introduced here)
- `cargo test --doc -p zeph-db -p zeph-memory` — 39 passed

## Notes / follow-ups

- A live PostgreSQL round-trip (e.g. binding `String` to the `agent_sessions` `TIMESTAMPTZ` columns) is a separate, runtime-only concern not exercised by any current CI job; tracked as a follow-up.
- The de-facto backend model is "SQLite always present, PostgreSQL wins by priority when both features are on"; this contradicts the literal wording of system-invariant 001 §13 ("enabling both is a `compile_error!`"). The code only errors on *no* backend. The invariant text should be reconciled with the implemented behavior in a follow-up.

Closes #4964
Closes #4956
Closes #4957
