### PR TITLE
feat(durable): durable promises, timers, and retention/compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   structured audit record (FR-DE-10), and a writer timeout degrades the step to non-durable mode
   rather than blocking (INV-12). The `ReplayCursor` reads the journal in bounded step-range segments
   (NFR-DE-02). The promise, timer, and retention layers land in follow-up issues. (#4947)
+- `feat(durable)`: completed the `DurableContext` API surface with durable promises, durable timers,
+  and the retention/compaction machinery. `ctx.promise::<T>()` mints an externally-resolved handle
+  carrying a 32-byte CSPRNG resolver token (zeroized on drop); only its domain-separated BLAKE3 hash,
+  bound to `(promise_id, execution_id)`, is persisted, and `DurableHandle::resolve()` authenticates a
+  presented token in constant time before sealing and committing the value (FR-DE-05, INV-9). The
+  resolver token is the sole capability — a `PromiseId` is derivable from the journal and is not a
+  bearer secret — so the LLM, which never sees the token, cannot resolve its own promises.
+  `ctx.await_promise()` parks on a `tokio::sync::Notify` keyed by promise id with a `durable_promises`
+  poll fallback (`promise_poll_interval_secs`), degrading to pure polling above `max_parked_promises`.
+  `ctx.sleep_until()` arms a `durable_timers` row at a deterministic, position-derived `TimerId`;
+  the background `DurableTimerService` fires due timers and wakes parked waiters, and a timer whose
+  instant elapsed during downtime fires immediately on the first poll after restart (FR-DE-06).
+  Promises and timers correlate across a crash-resume by deriving their ids from
+  `(execution_id, step_id)`, so a resumed program re-attaches to the pending row rather than minting
+  an orphan. The `DurableRetentionService` prunes terminal executions past their TTL in batches,
+  yielding between them so the sweep never touches the dispatch hot path (spec NEVER); crossing the
+  soft step cap (90% of `max_steps_per_execution`) folds the committed-idempotent prefix into a
+  single AEAD-sealed `Checkpoint` entry on a background task and deletes the folded rows, while the
+  hard cap (100%) aborts with `DurableError::StepCapExceeded`. A resume replays folded steps from the
+  checkpoint snapshot — preserving each step's idempotency key for the divergence guard — without
+  re-running their operations. (#4948)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10865,6 +10865,7 @@ dependencies = [
  "bytes",
  "futures",
  "metrics",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -10874,6 +10875,7 @@ dependencies = [
  "tracing",
  "uuid",
  "zeph-db",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/zeph-durable/Cargo.toml
+++ b/crates/zeph-durable/Cargo.toml
@@ -23,13 +23,15 @@ postgres = ["zeph-db/postgres"]
 blake3.workspace = true
 bytes.workspace = true
 metrics.workspace = true
+rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["macros", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 tracing.workspace = true
-uuid = { workspace = true, features = ["serde", "v7"] }
+uuid = { workspace = true, features = ["serde", "v7", "v8"] }
 zeph-db.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
 futures.workspace = true

--- a/crates/zeph-durable/src/backend.rs
+++ b/crates/zeph-durable/src/backend.rs
@@ -26,10 +26,14 @@
 
 use std::sync::Arc;
 
+use bytes::Bytes;
+
 use crate::config::RetentionPolicy;
 use crate::error::DurableError;
-use crate::ids::{ExecutionId, IdempotencyKey, JournalSeq};
+use crate::ids::{ExecutionId, IdempotencyKey, JournalSeq, PromiseId, TimerId};
 use crate::journal::{ExecutionStatus, Journal, JournalEntry};
+use crate::promise::PromiseRecord;
+use crate::waiters::NotifyRegistry;
 
 pub mod local;
 
@@ -190,6 +194,149 @@ impl ExecutionBackend for DurableBackendEnum {
     ) -> Result<Option<JournalEntry>, DurableError> {
         match self {
             Self::Local(backend) => backend.lookup_committed_result(id, idem_key).await,
+        }
+    }
+}
+
+/// Promise, timer, and retention dispatch.
+///
+/// These methods back the [`DurablePromise`](crate::DurablePromise) /
+/// [`DurableTimerService`](crate::DurableTimerService) / [`DurableRetentionService`] surfaces. They
+/// are inherent on the enum rather than on the sealed [`ExecutionBackend`] trait because they are
+/// implemented through the local backend's dedicated `durable_promises` / `durable_timers` tables; a
+/// future cross-process backend (Restate) would satisfy the same surface through its own SDK
+/// primitives, so the closed `match` here gains a new arm at that point — a compile-time prompt
+/// rather than a silent gap.
+impl DurableBackendEnum {
+    /// Insert a freshly-created promise row. See [`LocalBackend::insert_promise`].
+    pub(crate) async fn insert_promise(
+        &self,
+        id: PromiseId,
+        execution_id: ExecutionId,
+        resolver_token_hash: [u8; 32],
+        created_at_ms: i64,
+    ) -> Result<(), DurableError> {
+        match self {
+            Self::Local(backend) => {
+                backend
+                    .insert_promise(id, execution_id, resolver_token_hash, created_at_ms)
+                    .await
+            }
+        }
+    }
+
+    /// Read a promise's persisted state. See [`LocalBackend::promise_state`].
+    pub(crate) async fn promise_state(
+        &self,
+        id: PromiseId,
+    ) -> Result<Option<PromiseRecord>, DurableError> {
+        match self {
+            Self::Local(backend) => backend.promise_state(id).await,
+        }
+    }
+
+    /// Commit a resolved value to a pending promise. See [`LocalBackend::resolve_promise`].
+    pub(crate) async fn resolve_promise(
+        &self,
+        id: PromiseId,
+        execution_id: ExecutionId,
+        value_plaintext: &[u8],
+        resolved_at_ms: i64,
+    ) -> Result<bool, DurableError> {
+        match self {
+            Self::Local(backend) => {
+                backend
+                    .resolve_promise(id, execution_id, value_plaintext, resolved_at_ms)
+                    .await
+            }
+        }
+    }
+
+    /// Open a promise's sealed resolved payload. See [`LocalBackend::open_promise_payload`].
+    pub(crate) fn open_promise_payload(
+        &self,
+        id: PromiseId,
+        execution_id: ExecutionId,
+        sealed: &[u8],
+    ) -> Result<Bytes, DurableError> {
+        match self {
+            Self::Local(backend) => backend.open_promise_payload(id, execution_id, sealed),
+        }
+    }
+
+    /// The in-process promise wakeup registry. See [`LocalBackend::promise_waiters`].
+    pub(crate) fn promise_waiters(&self) -> &NotifyRegistry {
+        match self {
+            Self::Local(backend) => backend.promise_waiters(),
+        }
+    }
+
+    /// Arm a durable timer. See [`LocalBackend::arm_timer`].
+    pub(crate) async fn arm_timer(
+        &self,
+        id: TimerId,
+        execution_id: ExecutionId,
+        due_at_ms: i64,
+        created_at_ms: i64,
+    ) -> Result<(), DurableError> {
+        match self {
+            Self::Local(backend) => {
+                backend
+                    .arm_timer(id, execution_id, due_at_ms, created_at_ms)
+                    .await
+            }
+        }
+    }
+
+    /// Read a timer's `(due_at_ms, fired)` state. See [`LocalBackend::timer_state`].
+    pub(crate) async fn timer_state(
+        &self,
+        id: TimerId,
+    ) -> Result<Option<(i64, bool)>, DurableError> {
+        match self {
+            Self::Local(backend) => backend.timer_state(id).await,
+        }
+    }
+
+    /// List unfired timers due at or before `now_ms`. See [`LocalBackend::due_timers`].
+    pub(crate) async fn due_timers(&self, now_ms: i64) -> Result<Vec<TimerId>, DurableError> {
+        match self {
+            Self::Local(backend) => backend.due_timers(now_ms).await,
+        }
+    }
+
+    /// Mark a timer fired and wake its waiter. See [`LocalBackend::mark_timer_fired`].
+    pub(crate) async fn mark_timer_fired(&self, id: TimerId) -> Result<bool, DurableError> {
+        match self {
+            Self::Local(backend) => backend.mark_timer_fired(id).await,
+        }
+    }
+
+    /// The in-process timer wakeup registry. See [`LocalBackend::timer_waiters`].
+    pub(crate) fn timer_waiters(&self) -> &NotifyRegistry {
+        match self {
+            Self::Local(backend) => backend.timer_waiters(),
+        }
+    }
+
+    /// Fold an execution's idempotent prefix into a checkpoint. See [`LocalBackend::checkpoint_fold`].
+    pub(crate) async fn checkpoint_fold(
+        &self,
+        execution_id: ExecutionId,
+        up_to_step: u32,
+    ) -> Result<u64, DurableError> {
+        match self {
+            Self::Local(backend) => backend.checkpoint_fold(execution_id, up_to_step).await,
+        }
+    }
+
+    /// Reconstruct folded step results from every checkpoint. See [`LocalBackend::read_checkpoints`].
+    pub(crate) async fn read_checkpoints(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<Vec<JournalEntry>, DurableError> {
+        match self {
+            Self::Local(backend) => backend.read_checkpoints(execution_id).await,
         }
     }
 }

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -43,8 +43,13 @@ use crate::backend::{BackendCapabilities, ExecutionBackend};
 use crate::cipher::{EntryKindTag, PayloadAad, PayloadCipher, ensure_payload_within_limit};
 use crate::config::RetentionPolicy;
 use crate::error::DurableError;
-use crate::ids::{ExecutionId, ExecutionKind, IdempotencyKey, JournalSeq, StepId};
+use crate::ids::{
+    ExecutionId, ExecutionKind, IdempotencyKey, JournalSeq, PromiseId, StepId, TimerId,
+};
 use crate::journal::{EntryKind, ExecutionStatus, Journal, JournalEntry};
+use crate::promise::PromiseRecord;
+use crate::retention::{CheckpointSnapshot, FoldedStep, decode_checkpoint, encode_checkpoint};
+use crate::waiters::NotifyRegistry;
 use tracing::Instrument as _;
 
 /// Slack added to `max_payload_bytes` for the read-side size guard.
@@ -78,6 +83,10 @@ pub struct LocalBackend {
     cipher: Option<Arc<dyn PayloadCipher>>,
     hmac_key: Option<[u8; 32]>,
     max_payload_bytes: u64,
+    /// In-process wakeup map for parked promise awaits, shared with the resolver path.
+    promise_waiters: NotifyRegistry,
+    /// In-process wakeup map for parked timers, shared with the timer service.
+    timer_waiters: NotifyRegistry,
 }
 
 impl fmt::Debug for LocalBackend {
@@ -104,6 +113,8 @@ impl LocalBackend {
             cipher: None,
             hmac_key: None,
             max_payload_bytes,
+            promise_waiters: NotifyRegistry::default(),
+            timer_waiters: NotifyRegistry::default(),
         }
     }
 
@@ -328,6 +339,502 @@ impl LocalBackend {
         Ok(max.map(JournalSeq::new))
     }
 
+    /// The in-process wakeup registry for parked promise awaits, shared with the resolver path.
+    pub(crate) fn promise_waiters(&self) -> &NotifyRegistry {
+        &self.promise_waiters
+    }
+
+    /// The in-process wakeup registry for parked timers, shared with the timer service.
+    pub(crate) fn timer_waiters(&self) -> &NotifyRegistry {
+        &self.timer_waiters
+    }
+
+    /// Insert a freshly-created promise row (INV-9: only the resolver-token hash is stored).
+    ///
+    /// Called by `promise()` for a brand-new promise; a resumed execution detects the existing row
+    /// via [`promise_state`](Self::promise_state) and never re-inserts. Span: `durable.promise.create`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if the insert fails.
+    pub(crate) async fn insert_promise(
+        &self,
+        id: PromiseId,
+        execution_id: ExecutionId,
+        resolver_token_hash: [u8; 32],
+        created_at_ms: i64,
+    ) -> Result<(), DurableError> {
+        let span = tracing::info_span!("durable.promise.create", promise_id = %id.as_uuid());
+        async move {
+            zeph_db::query(sql!(
+                "INSERT INTO durable_promises
+                    (promise_id, execution_id, resolver_token_hash, resolved, payload, created_at, resolved_at)
+                 VALUES (?, ?, ?, 0, NULL, ?, NULL)"
+            ))
+            .bind(id.as_uuid().to_string())
+            .bind(execution_id.as_uuid().to_string())
+            .bind(resolver_token_hash.to_vec())
+            .bind(created_at_ms)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("insert_promise", e))?;
+            Ok(())
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Read a promise's persisted state, or `None` if it does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if the query fails, or [`DurableError::Decode`] if a stored
+    /// field cannot be reconstructed.
+    pub(crate) async fn promise_state(
+        &self,
+        id: PromiseId,
+    ) -> Result<Option<PromiseRecord>, DurableError> {
+        let row: Option<PromiseRowRead> = zeph_db::query_as(sql!(
+            "SELECT execution_id, resolver_token_hash, resolved, payload
+             FROM durable_promises WHERE promise_id = ?"
+        ))
+        .bind(id.as_uuid().to_string())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DurableError::storage("promise_state", e))?;
+        let Some((exec, hash, resolved, payload)) = row else {
+            return Ok(None);
+        };
+        Ok(Some(PromiseRecord {
+            execution_id: parse_execution_id(&exec)?,
+            resolver_token_hash: slice_to_array32(&hash, "promise resolver_token_hash")?,
+            resolved: resolved != 0,
+            payload,
+        }))
+    }
+
+    /// Commit a resolved value to a pending promise, returning whether it transitioned.
+    ///
+    /// The conditional `WHERE resolved = 0` makes a double-resolve a no-op (returns `false`); the
+    /// caller has already authenticated the resolver token. On a real transition any in-process
+    /// waiter is woken. Span: `durable.promise.resolve`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::PayloadTooLarge`] if the value exceeds the limit, a cipher failure if
+    /// sealing fails, or [`DurableError::Storage`] on a database error.
+    pub(crate) async fn resolve_promise(
+        &self,
+        id: PromiseId,
+        execution_id: ExecutionId,
+        value_plaintext: &[u8],
+        resolved_at_ms: i64,
+    ) -> Result<bool, DurableError> {
+        let span = tracing::info_span!("durable.promise.resolve", promise_id = %id.as_uuid());
+        async move {
+            ensure_payload_within_limit(value_plaintext.len(), self.max_payload_bytes)?;
+            let aad = promise_payload_aad(execution_id, id);
+            let sealed = self.seal_payload(value_plaintext, &aad)?;
+            let affected = zeph_db::query(sql!(
+                "UPDATE durable_promises SET resolved = 1, payload = ?, resolved_at = ?
+                 WHERE promise_id = ? AND resolved = 0"
+            ))
+            .bind(sealed)
+            .bind(resolved_at_ms)
+            .bind(id.as_uuid().to_string())
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("resolve_promise", e))?
+            .rows_affected();
+            if affected > 0 {
+                self.promise_waiters.wake(id.as_uuid());
+            }
+            Ok(affected > 0)
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Open a promise's sealed resolved payload back to plaintext.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::ReplayIntegrity`] if the sealed blob does not authenticate, or
+    /// [`DurableError::PayloadTooLarge`] if it exceeds the read-side limit.
+    pub(crate) fn open_promise_payload(
+        &self,
+        id: PromiseId,
+        execution_id: ExecutionId,
+        sealed: &[u8],
+    ) -> Result<Bytes, DurableError> {
+        ensure_payload_within_limit(
+            sealed.len(),
+            self.max_payload_bytes.saturating_add(SEAL_OVERHEAD_SLACK),
+        )?;
+        let aad = promise_payload_aad(execution_id, id);
+        self.open_payload(sealed, &aad)
+    }
+
+    /// Arm a durable timer to fire at `due_at_ms` (a `durable_timers` row).
+    ///
+    /// Span: `durable.timer.arm`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if the insert fails.
+    pub(crate) async fn arm_timer(
+        &self,
+        id: TimerId,
+        execution_id: ExecutionId,
+        due_at_ms: i64,
+        created_at_ms: i64,
+    ) -> Result<(), DurableError> {
+        let span = tracing::info_span!("durable.timer.arm", timer_id = %id.as_uuid(), due_at_ms);
+        async move {
+            zeph_db::query(sql!(
+                "INSERT INTO durable_timers (timer_id, execution_id, due_at, fired, created_at)
+                 VALUES (?, ?, ?, 0, ?)"
+            ))
+            .bind(id.as_uuid().to_string())
+            .bind(execution_id.as_uuid().to_string())
+            .bind(due_at_ms)
+            .bind(created_at_ms)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("arm_timer", e))?;
+            Ok(())
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Read a timer's `(due_at_ms, fired)` state, or `None` if it does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if the query fails.
+    pub(crate) async fn timer_state(
+        &self,
+        id: TimerId,
+    ) -> Result<Option<(i64, bool)>, DurableError> {
+        let row: Option<(i64, i64)> = zeph_db::query_as(sql!(
+            "SELECT due_at, fired FROM durable_timers WHERE timer_id = ?"
+        ))
+        .bind(id.as_uuid().to_string())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DurableError::storage("timer_state", e))?;
+        Ok(row.map(|(due_at, fired)| (due_at, fired != 0)))
+    }
+
+    /// List every unfired timer whose instant is at or before `now_ms`.
+    ///
+    /// The `idx_durable_timers_due(fired, due_at)` index makes this a range scan over due, unfired
+    /// timers rather than a full-table scan.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if the query fails, or [`DurableError::Decode`] on a
+    /// malformed id.
+    pub(crate) async fn due_timers(&self, now_ms: i64) -> Result<Vec<TimerId>, DurableError> {
+        let rows: Vec<(String,)> = zeph_db::query_as(sql!(
+            "SELECT timer_id FROM durable_timers WHERE fired = 0 AND due_at <= ? ORDER BY due_at"
+        ))
+        .bind(now_ms)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DurableError::storage("due_timers", e))?;
+        rows.into_iter().map(|(id,)| parse_timer_id(&id)).collect()
+    }
+
+    /// Mark a timer fired, returning whether it transitioned, and wake its parked waiter.
+    ///
+    /// Span: `durable.timer.fire`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if the update fails.
+    pub(crate) async fn mark_timer_fired(&self, id: TimerId) -> Result<bool, DurableError> {
+        let span = tracing::info_span!("durable.timer.fire", timer_id = %id.as_uuid());
+        async move {
+            let affected = zeph_db::query(sql!(
+                "UPDATE durable_timers SET fired = 1 WHERE timer_id = ? AND fired = 0"
+            ))
+            .bind(id.as_uuid().to_string())
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("mark_timer_fired", e))?
+            .rows_affected();
+            if affected > 0 {
+                self.timer_waiters.wake(id.as_uuid());
+            }
+            Ok(affected > 0)
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Open each foldable step result's sealed payload into a [`FoldedStep`], in step order.
+    ///
+    /// The per-step AAD is reconstructed from the row so the opened plaintext authenticates exactly
+    /// as it did at rest; the idempotency key is preserved so the replayed-from-snapshot step still
+    /// satisfies the divergence guard.
+    fn open_foldable_steps(
+        &self,
+        execution_id: ExecutionId,
+        rows: Vec<FoldableRowRead>,
+    ) -> Result<Vec<FoldedStep>, DurableError> {
+        let mut folded = Vec::with_capacity(rows.len());
+        for (step_raw, idem, version, payload) in rows {
+            let step = u32::try_from(step_raw).map_err(|_| DurableError::Decode {
+                context: "checkpoint step_id out of u32 range",
+            })?;
+            let idem_bytes = idem.ok_or(DurableError::Decode {
+                context: "checkpoint step result missing idem_key",
+            })?;
+            let idem_key =
+                IdempotencyKey::from_bytes(slice_to_array32(&idem_bytes, "checkpoint idem_key")?);
+            let sealed = payload.ok_or(DurableError::Decode {
+                context: "checkpoint step result missing payload",
+            })?;
+            let aad = PayloadAad::new(
+                execution_id,
+                StepId::new(step),
+                EntryKindTag::StepResult,
+                Some(idem_key),
+            );
+            let plaintext = self.open_payload(&sealed, &aad)?;
+            let payload_version =
+                u8::try_from(version.unwrap_or(1)).map_err(|_| DurableError::Decode {
+                    context: "checkpoint payload_version out of u8 range",
+                })?;
+            folded.push(FoldedStep {
+                step_id: step,
+                idem_key: *idem_key.as_bytes(),
+                payload_version,
+                payload: plaintext,
+            });
+        }
+        Ok(folded)
+    }
+
+    /// Fold an execution's committed-idempotent prefix below `up_to_step` into one checkpoint entry.
+    ///
+    /// Reads the foldable idempotent step results, packs as many as fit the payload budget into a
+    /// sealed snapshot, writes a single [`EntryKind::Checkpoint`] entry, and deletes the folded rows
+    /// — all in one transaction. A resume replays the folded steps from the snapshot (the snapshot
+    /// preserves each step's idempotency key for the divergence guard) instead of re-running them.
+    /// Returns the number of steps folded. Runs only on a background task (spec NEVER: not the hot
+    /// path). Span: `durable.journal.checkpoint`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] on a database error, or a cipher failure if (re)sealing
+    /// fails.
+    pub(crate) async fn checkpoint_fold(
+        &self,
+        execution_id: ExecutionId,
+        up_to_step: u32,
+    ) -> Result<u64, DurableError> {
+        let span = tracing::info_span!(
+            "durable.journal.checkpoint",
+            execution_id = %execution_id.as_uuid(),
+            folded_count = tracing::field::Empty,
+        );
+        async move {
+            let exec = execution_id.as_uuid().to_string();
+            let rows: Vec<FoldableRowRead> = zeph_db::query_as(sql!(
+                "SELECT step_id, idem_key, payload_version, payload FROM durable_journal
+                 WHERE execution_id = ? AND entry_kind = 'step_result'
+                   AND effect_class = 'idempotent' AND step_id < ?
+                 ORDER BY step_id"
+            ))
+            .bind(&exec)
+            .bind(i64::from(up_to_step))
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("checkpoint", e))?;
+            if rows.is_empty() {
+                return Ok(0);
+            }
+
+            // Open each sealed result, then keep the budget-bounded prefix that fits a checkpoint.
+            let mut folded = self.open_foldable_steps(execution_id, rows)?;
+            let lens: Vec<usize> = folded.iter().map(|s| s.payload.len()).collect();
+            let take = crate::retention::fold_prefix_len(
+                &lens,
+                crate::retention::checkpoint_budget(self.max_payload_bytes),
+            );
+            if take == 0 {
+                // Not even one result fits the budget; leave the prefix un-folded rather than write
+                // an over-limit checkpoint.
+                return Ok(0);
+            }
+            folded.truncate(take);
+            let fold_end = folded.last().map_or(up_to_step, |s| s.step_id.saturating_add(1));
+
+            let snapshot = encode_checkpoint(&folded);
+            let snap_aad =
+                PayloadAad::new(execution_id, StepId::new(fold_end), EntryKindTag::Checkpoint, None);
+            let sealed_snapshot = self.seal_payload(&snapshot, &snap_aad)?;
+
+            let mut tx = zeph_db::begin_write(&self.pool)
+                .await
+                .map_err(|e| DurableError::storage("checkpoint", e))?;
+            zeph_db::query(sql!(
+                "INSERT INTO durable_journal
+                    (execution_id, step_id, entry_kind, idem_key, effect_class, payload, payload_version, hmac, created_at)
+                 VALUES (?, ?, 'checkpoint', NULL, NULL, ?, ?, NULL, ?)"
+            ))
+            .bind(&exec)
+            .bind(i64::from(fold_end))
+            .bind(sealed_snapshot)
+            .bind(i32::from(crate::step::PAYLOAD_VERSION))
+            .bind(now_unix_millis())
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| DurableError::storage("checkpoint", e))?;
+            zeph_db::query(sql!(
+                "DELETE FROM durable_journal
+                 WHERE execution_id = ? AND entry_kind = 'step_result'
+                   AND effect_class = 'idempotent' AND step_id < ?"
+            ))
+            .bind(&exec)
+            .bind(i64::from(fold_end))
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| DurableError::storage("checkpoint", e))?;
+            tx.commit()
+                .await
+                .map_err(|e| DurableError::storage("checkpoint", e))?;
+
+            let count = folded.len() as u64;
+            tracing::Span::current().record("folded_count", count);
+            Ok(count)
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Read every checkpoint snapshot for an execution and reconstruct its folded step results.
+    ///
+    /// The replay cursor calls this once on resume to preload folded results before walking the
+    /// surviving journal rows: each returned [`JournalEntry`] is a `StepResult` whose individual row
+    /// was deleted by the fold but whose replay value (and idempotency key, for the divergence guard)
+    /// lives in the snapshot. Each snapshot is AEAD-opened with its checkpoint-bound AAD. Returns an
+    /// empty vector when the execution has never been folded.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] on a database error, or a decode/cipher failure if a
+    /// snapshot is corrupt.
+    pub(crate) async fn read_checkpoints(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<Vec<JournalEntry>, DurableError> {
+        let rows: Vec<(i64, Option<Vec<u8>>)> = zeph_db::query_as(sql!(
+            "SELECT step_id, payload FROM durable_journal
+             WHERE execution_id = ? AND entry_kind = 'checkpoint' ORDER BY step_id"
+        ))
+        .bind(execution_id.as_uuid().to_string())
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DurableError::storage("read_checkpoints", e))?;
+        if rows.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut folded: CheckpointSnapshot = Vec::new();
+        for (up_to, payload) in rows {
+            let up_to = u32::try_from(up_to).map_err(|_| DurableError::Decode {
+                context: "checkpoint up_to_step out of u32 range",
+            })?;
+            let sealed = payload.ok_or(DurableError::Decode {
+                context: "checkpoint entry missing snapshot payload",
+            })?;
+            ensure_payload_within_limit(
+                sealed.len(),
+                self.max_payload_bytes.saturating_add(SEAL_OVERHEAD_SLACK),
+            )?;
+            let aad = PayloadAad::new(
+                execution_id,
+                StepId::new(up_to),
+                EntryKindTag::Checkpoint,
+                None,
+            );
+            let plaintext = self.open_payload(&sealed, &aad)?;
+            folded.extend(decode_checkpoint(&plaintext)?);
+        }
+        // Reconstruct each folded step as a replayable `StepResult` entry under the real execution
+        // kind, so the cursor serves it exactly like a surviving row.
+        let kind = self.lookup_kind(execution_id).await?;
+        let entries = folded
+            .into_iter()
+            .map(|step| JournalEntry {
+                seq: None,
+                execution_id,
+                kind,
+                step_id: StepId::new(step.step_id),
+                entry: EntryKind::StepResult {
+                    idempotency_key: IdempotencyKey::from_bytes(step.idem_key),
+                    payload: step.payload,
+                    effect: crate::EffectClass::Idempotent,
+                    payload_version: step.payload_version,
+                },
+                created_at_ms: 0,
+            })
+            .collect();
+        Ok(entries)
+    }
+
+    /// Delete one bounded batch of prunable terminal executions and their child rows.
+    ///
+    /// Selects up to `batch` executions past their TTL, then deletes their journal, promise, timer,
+    /// and execution rows in a single transaction (children first, to respect the foreign keys).
+    /// Returns the number of executions removed; the retention loop stops once a batch returns fewer
+    /// than `batch`.
+    async fn delete_prune_batch(
+        &self,
+        cutoffs: crate::retention::PruneCutoffs,
+        batch: u64,
+    ) -> Result<u64, DurableError> {
+        let ids: Vec<(String,)> = zeph_db::query_as(sql!(
+            "SELECT execution_id FROM durable_executions
+             WHERE finalized_at IS NOT NULL
+               AND ( (status = 'completed' AND finalized_at <= ?)
+                  OR (status IN ('failed', 'aborted') AND finalized_at <= ?) )
+             ORDER BY finalized_at LIMIT ?"
+        ))
+        .bind(cutoffs.completed_before_ms)
+        .bind(cutoffs.failed_before_ms)
+        .bind(i64::try_from(batch).unwrap_or(i64::MAX))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DurableError::storage("prune", e))?;
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let journal = sql!("DELETE FROM durable_journal WHERE execution_id = ?");
+        let promises = sql!("DELETE FROM durable_promises WHERE execution_id = ?");
+        let timers = sql!("DELETE FROM durable_timers WHERE execution_id = ?");
+        let executions = sql!("DELETE FROM durable_executions WHERE execution_id = ?");
+        let mut tx = zeph_db::begin_write(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("prune", e))?;
+        for (id,) in &ids {
+            for stmt in [journal, promises, timers, executions] {
+                zeph_db::query(stmt)
+                    .bind(id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| DurableError::storage("prune", e))?;
+            }
+        }
+        tx.commit()
+            .await
+            .map_err(|e| DurableError::storage("prune", e))?;
+        Ok(ids.len() as u64)
+    }
+
     /// Seal a plaintext payload, or pass it through verbatim when no cipher is configured.
     fn seal_payload(&self, plaintext: &[u8], aad: &PayloadAad) -> Result<Vec<u8>, DurableError> {
         match &self.cipher {
@@ -527,6 +1034,7 @@ impl LocalBackend {
                     hmac,
                 }
             }
+            "checkpoint" => self.checkpoint_entry(id, step_id, payload)?,
             other => {
                 return Err(DurableError::UnsupportedEntryKind {
                     kind: static_entry_tag(other),
@@ -540,6 +1048,31 @@ impl LocalBackend {
             step_id,
             entry,
             created_at_ms: created_at,
+        })
+    }
+
+    /// Reconstruct a [`EntryKind::Checkpoint`] from a stored row, opening its sealed snapshot.
+    ///
+    /// `step_id` carries the checkpoint's `up_to_step` (the fold boundary); the snapshot is bound to
+    /// it in the AAD so a checkpoint blob cannot be relocated to a different fold boundary.
+    fn checkpoint_entry(
+        &self,
+        id: ExecutionId,
+        step_id: StepId,
+        payload: Option<Vec<u8>>,
+    ) -> Result<EntryKind, DurableError> {
+        let sealed = payload.ok_or(DurableError::Decode {
+            context: "checkpoint entry missing snapshot payload",
+        })?;
+        ensure_payload_within_limit(
+            sealed.len(),
+            self.max_payload_bytes.saturating_add(SEAL_OVERHEAD_SLACK),
+        )?;
+        let aad = PayloadAad::new(id, step_id, EntryKindTag::Checkpoint, None);
+        let snapshot = self.open_payload(&sealed, &aad)?;
+        Ok(EntryKind::Checkpoint {
+            up_to_step: step_id.value(),
+            snapshot,
         })
     }
 
@@ -681,11 +1214,12 @@ impl Journal for LocalBackend {
         .await
     }
 
-    async fn prune(&self, _policy: &RetentionPolicy) -> Result<u64, DurableError> {
-        // The retention sweep lands with the compaction layer; this stub keeps the trait total and
-        // the span present for the trace-analysis loop.
-        let _span = tracing::info_span!("durable.journal.prune", deleted_count = 0u64).entered();
-        Ok(0)
+    async fn prune(&self, policy: &RetentionPolicy) -> Result<u64, DurableError> {
+        let now = now_unix_millis();
+        crate::retention::prune_in_batches(policy, now, |cutoffs, batch| {
+            self.delete_prune_batch(cutoffs, batch)
+        })
+        .await
     }
 }
 
@@ -742,6 +1276,14 @@ type JournalRowRead = (
     i64,
 );
 
+/// A `durable_promises` row read back from storage, in `SELECT` column order:
+/// `(execution_id, resolver_token_hash, resolved, payload)`.
+type PromiseRowRead = (String, Vec<u8>, i64, Option<Vec<u8>>);
+
+/// A foldable `durable_journal` step-result row, in `SELECT` column order:
+/// `(step_id, idem_key, payload_version, payload)`.
+type FoldableRowRead = (i64, Option<Vec<u8>>, Option<i32>, Option<Vec<u8>>);
+
 /// Current Unix time in milliseconds, clamped into `i64` and never panicking.
 pub(crate) fn now_unix_millis() -> i64 {
     SystemTime::now()
@@ -752,6 +1294,42 @@ pub(crate) fn now_unix_millis() -> i64 {
 /// Decode a stored blob into a fixed 32-byte array, failing closed on the wrong length.
 fn slice_to_array32(bytes: &[u8], field: &'static str) -> Result<[u8; 32], DurableError> {
     <[u8; 32]>::try_from(bytes).map_err(|_| DurableError::Decode { context: field })
+}
+
+/// Parse a stored `execution_id` TEXT column back into an [`ExecutionId`], failing closed.
+fn parse_execution_id(text: &str) -> Result<ExecutionId, DurableError> {
+    uuid::Uuid::parse_str(text)
+        .map(ExecutionId::from_uuid)
+        .map_err(|_| DurableError::Decode {
+            context: "execution_id is not a valid UUID",
+        })
+}
+
+/// Parse a stored `timer_id` TEXT column back into a [`TimerId`], failing closed.
+fn parse_timer_id(text: &str) -> Result<TimerId, DurableError> {
+    uuid::Uuid::parse_str(text)
+        .map(TimerId::from_uuid)
+        .map_err(|_| DurableError::Decode {
+            context: "timer_id is not a valid UUID",
+        })
+}
+
+/// The AAD binding a promise's resolved payload to `(execution_id, promise_id)`.
+///
+/// A promise has no [`StepId`], so the promise id is folded into the AAD's idempotency-key slot:
+/// a payload sealed for one promise cannot be opened as another's (fail-closed on relocation).
+fn promise_payload_aad(execution_id: ExecutionId, promise_id: PromiseId) -> PayloadAad {
+    let binding = IdempotencyKey::derive(
+        execution_id,
+        StepId::new(0),
+        promise_id.as_uuid().as_bytes(),
+    );
+    PayloadAad::new(
+        execution_id,
+        StepId::new(0),
+        EntryKindTag::PromiseResolved,
+        Some(binding),
+    )
 }
 
 /// Map a database `entry_kind` string to a `'static` tag for [`DurableError::UnsupportedEntryKind`].
@@ -1133,5 +1711,188 @@ mod tests {
             "the SQLite local backend is in-process"
         );
         assert_eq!(caps.max_payload, 4096);
+    }
+
+    #[tokio::test]
+    async fn promise_insert_state_and_resolve_round_trip() {
+        let backend = mem_backend(1_048_576)
+            .await
+            .with_cipher(Arc::new(XorCipher));
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let promise = PromiseId::derive(exec, StepId::new(0));
+        backend
+            .insert_promise(promise, exec, [9u8; 32], 100)
+            .await
+            .unwrap();
+
+        let pending = backend.promise_state(promise).await.unwrap().unwrap();
+        assert!(!pending.resolved);
+        assert_eq!(pending.execution_id, exec);
+        assert_eq!(pending.resolver_token_hash, [9u8; 32]);
+
+        // Resolve seals the value at rest; a second resolve is a no-op.
+        assert!(
+            backend
+                .resolve_promise(promise, exec, b"answer", 200)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !backend
+                .resolve_promise(promise, exec, b"again", 300)
+                .await
+                .unwrap()
+        );
+
+        let resolved = backend.promise_state(promise).await.unwrap().unwrap();
+        assert!(resolved.resolved);
+        let sealed = resolved.payload.expect("resolved payload present");
+        assert_ne!(sealed.as_slice(), b"answer", "payload is sealed at rest");
+        let opened = backend
+            .open_promise_payload(promise, exec, &sealed)
+            .unwrap();
+        assert_eq!(opened.as_ref(), b"answer");
+    }
+
+    #[tokio::test]
+    async fn timer_arm_due_and_fire() {
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let past = TimerId::derive(exec, StepId::new(0));
+        let future = TimerId::derive(exec, StepId::new(1));
+        backend.arm_timer(past, exec, 1_000, 0).await.unwrap();
+        backend
+            .arm_timer(future, exec, 9_000_000_000_000, 0)
+            .await
+            .unwrap();
+
+        // Only the past-due timer is returned at now = 5000.
+        let due = backend.due_timers(5_000).await.unwrap();
+        assert_eq!(due, vec![past]);
+
+        assert!(backend.mark_timer_fired(past).await.unwrap());
+        assert!(
+            !backend.mark_timer_fired(past).await.unwrap(),
+            "second fire is a no-op"
+        );
+        assert_eq!(
+            backend.timer_state(past).await.unwrap(),
+            Some((1_000, true))
+        );
+        // The fired timer no longer appears as due.
+        assert!(backend.due_timers(5_000).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn prune_deletes_terminal_executions_past_ttl() {
+        let backend = mem_backend(1_048_576).await;
+        // An old completed execution (finalized long ago) and a fresh running one.
+        let old = ExecutionId::new();
+        backend
+            .open_execution(old, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        backend.append(step_result(old, 0, b"x")).await.unwrap();
+        // Backdate its finalized_at far into the past.
+        zeph_db::query(sql!(
+            "UPDATE durable_executions SET status = 'completed', finalized_at = 1000 WHERE execution_id = ?"
+        ))
+        .bind(old.as_uuid().to_string())
+        .execute(backend.pool())
+        .await
+        .unwrap();
+
+        let live = ExecutionId::new();
+        backend
+            .open_execution(live, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        backend.append(step_result(live, 0, b"y")).await.unwrap();
+
+        let policy = RetentionPolicy {
+            ttl_completed_secs: 1,
+            prune_batch_size: 10,
+            ..RetentionPolicy::default()
+        };
+        let deleted = backend.prune(&policy).await.unwrap();
+        assert_eq!(deleted, 1, "only the aged terminal execution is pruned");
+
+        // The old execution and its journal are gone; the live one survives.
+        assert!(backend.read_execution(old).await.unwrap().is_empty());
+        assert!(
+            backend
+                .promise_state(PromiseId::derive(old, StepId::new(0)))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(backend.read_execution(live).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_fold_compacts_idempotent_prefix_and_replays() {
+        let backend = mem_backend(1_048_576)
+            .await
+            .with_cipher(Arc::new(XorCipher));
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        for step in 0..5 {
+            backend
+                .append(step_result(exec, step, format!("v{step}").as_bytes()))
+                .await
+                .unwrap();
+        }
+
+        // Fold steps 0..3 into a checkpoint.
+        let folded = backend.checkpoint_fold(exec, 3).await.unwrap();
+        assert_eq!(folded, 3);
+
+        // The individual rows for the folded steps are gone; steps 3 and 4 remain, plus a checkpoint.
+        let remaining = backend.read_execution(exec).await.unwrap();
+        let step_results: Vec<u32> = remaining
+            .iter()
+            .filter(|e| matches!(e.entry, EntryKind::StepResult { .. }))
+            .map(|e| e.step_id.value())
+            .collect();
+        assert_eq!(step_results, vec![3, 4], "folded step rows are deleted");
+        assert!(
+            remaining
+                .iter()
+                .any(|e| matches!(e.entry, EntryKind::Checkpoint { .. })),
+            "a checkpoint entry replaces the folded prefix"
+        );
+
+        // The reconstructed folded results carry the original values and idempotency keys.
+        let preloaded = backend.read_checkpoints(exec).await.unwrap();
+        assert_eq!(preloaded.len(), 3);
+        for (i, entry) in preloaded.iter().enumerate() {
+            let step = u32::try_from(i).unwrap();
+            assert_eq!(entry.step_id, StepId::new(step));
+            match &entry.entry {
+                EntryKind::StepResult {
+                    payload,
+                    idempotency_key,
+                    ..
+                } => {
+                    assert_eq!(payload.as_ref(), format!("v{step}").as_bytes());
+                    assert_eq!(
+                        *idempotency_key,
+                        IdempotencyKey::derive(exec, StepId::new(step), b"tool:read")
+                    );
+                }
+                other => panic!("unexpected folded entry: {other:?}"),
+            }
+        }
     }
 }

--- a/crates/zeph-durable/src/error.rs
+++ b/crates/zeph-durable/src/error.rs
@@ -138,6 +138,18 @@ pub enum DurableError {
         /// The name of the step whose result failed to serialize.
         step: &'static str,
     },
+
+    /// A promise resolution referenced a promise that has no `durable_promises` row — either never
+    /// created, or pruned. Fails closed rather than silently succeeding. Per INV-5 the raw
+    /// `PromiseId` is semi-sensitive and is therefore not embedded in the message.
+    #[error("promise resolution failed: no such promise")]
+    UnknownPromise,
+
+    /// A promise resolution presented a resolver token that did not match the stored hash (INV-9).
+    /// The comparison is constant-time, and neither the presented token nor the raw `PromiseId`
+    /// appears in the message (INV-5). The pending promise is left untouched.
+    #[error("promise resolution rejected: resolver token did not authenticate")]
+    PromiseRejected,
 }
 
 impl DurableError {

--- a/crates/zeph-durable/src/handle.rs
+++ b/crates/zeph-durable/src/handle.rs
@@ -38,22 +38,27 @@
 //! journaled value is returned rather than re-firing the effect.
 
 use std::fmt::Write as _;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::time::SystemTime;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
 
+use rand::Rng as _;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use tokio::task::JoinSet;
 use tracing::Instrument as _;
+use zeroize::Zeroizing;
 
 use crate::backend::local::now_unix_millis;
 use crate::backend::{DurableBackendEnum, ExecutionBackend as _};
 use crate::config::DurableConfig;
 use crate::effect::{EffectClass, OnAmbiguous};
 use crate::error::DurableError;
-use crate::ids::{ExecutionId, ExecutionKind, IdempotencyKey, StepId};
+use crate::ids::{ExecutionId, ExecutionKind, IdempotencyKey, PromiseId, StepId, TimerId};
 use crate::journal::{EntryKind, ExecutionStatus, Journal as _, JournalEntry};
+use crate::promise::{DurablePromise, RESOLVER_TOKEN_LEN, resolver_token_hash};
 use crate::replay::{DEFAULT_SEGMENT_STEPS, ReplayCursor, StepReplay};
+use crate::retention::step_cap_thresholds;
 use crate::step::{
     DurableStep, PAYLOAD_VERSION, StepDescriptor, StepError, StepHandle, deserialize_result,
     serialize_result,
@@ -78,6 +83,16 @@ pub struct DurableContext {
     writer: JournalWriterHandle,
     max_steps_per_execution: u32,
     max_payload_bytes: u64,
+    /// Soft step-cap threshold (90% of the cap): the first step at or past it folds a checkpoint.
+    soft_step_cap: u32,
+    /// Database fallback poll interval for parked promises and timers.
+    poll_interval: Duration,
+    /// Above this many concurrently-parked promises, awaits fall back to pure polling.
+    max_parked_promises: u32,
+    /// Fires the soft-cap checkpoint fold exactly once per execution.
+    checkpoint_requested: AtomicBool,
+    /// Tracks the spawned background checkpoint-fold task(s) so they are abortable and drainable.
+    fold_tasks: Mutex<JoinSet<()>>,
 }
 
 impl DurableContext {
@@ -98,6 +113,7 @@ impl DurableContext {
         config: &DurableConfig,
     ) -> Self {
         let cursor = ReplayCursor::new(backend.clone(), execution_id, DEFAULT_SEGMENT_STEPS);
+        let (soft_step_cap, _hard) = step_cap_thresholds(config.max_steps_per_execution);
         Self {
             execution_id,
             kind,
@@ -109,6 +125,11 @@ impl DurableContext {
             writer,
             max_steps_per_execution: config.max_steps_per_execution,
             max_payload_bytes: config.max_payload_bytes,
+            soft_step_cap,
+            poll_interval: Duration::from_secs(config.promise_poll_interval_secs.max(1)),
+            max_parked_promises: config.max_parked_promises,
+            checkpoint_requested: AtomicBool::new(false),
+            fold_tasks: Mutex::new(JoinSet::new()),
         }
     }
 
@@ -198,35 +219,248 @@ impl DurableContext {
         ParallelScope { ctx: self }
     }
 
-    /// Durable timer entry point — **not yet wired**; durable timers land with the promise/timer
-    /// layer (C5).
+    /// Create a durable promise resolved out of band by an operator or A2A reply (FR-DE-05).
+    ///
+    /// The promise occupies a deterministic program position, so a resumed execution re-derives the
+    /// same [`PromiseId`] and re-attaches to the pending row rather than minting an orphan. A *fresh*
+    /// promise carries its 32-byte resolver token — hand it to the resolving channel via
+    /// [`DurablePromise::resolver_token`]; a *resumed* promise carries none (the original token was
+    /// delivered before the crash). Await the result with [`await_promise`](Self::await_promise).
     ///
     /// # Errors
     ///
-    /// Currently always returns [`DurableError::UnsupportedEntryKind`]: the backend does not yet
-    /// persist `timer_armed` entries. The signature is stable so consumers can target it ahead of
-    /// the timer layer.
-    #[allow(
-        clippy::unused_async,
-        reason = "stub: the C5 timer layer adds the awaiting body; the async signature is the stable surface"
-    )]
+    /// - [`DurableError::StepCapExceeded`] if the promise would exceed the per-execution step cap.
+    /// - A storage error if the promise row cannot be read or inserted.
+    pub async fn promise<T>(&self) -> Result<DurablePromise<T>, DurableError> {
+        let step_id = self.checked_step_id()?;
+        let promise_id = PromiseId::derive(self.execution_id, step_id);
+
+        // Replay/resume: a row at this position means the promise was already created in a prior run.
+        if self.backend.promise_state(promise_id).await?.is_some() {
+            return Ok(DurablePromise::resumed(promise_id));
+        }
+
+        let mut token = Zeroizing::new([0u8; RESOLVER_TOKEN_LEN]);
+        rand::rng().fill_bytes(&mut *token);
+        let hash = resolver_token_hash(promise_id, self.execution_id, &token);
+        self.backend
+            .insert_promise(
+                promise_id,
+                self.execution_id,
+                *hash.as_bytes(),
+                now_unix_millis(),
+            )
+            .await?;
+        Ok(DurablePromise::fresh(promise_id, token))
+    }
+
+    /// Await a durable promise's resolved value, parking until it is resolved.
+    ///
+    /// Returns immediately if the promise is already resolved (the common replay case). Otherwise it
+    /// parks on an in-process notify keyed by the promise id and falls back to a database poll every
+    /// `promise_poll_interval_secs`; above `max_parked_promises` concurrent waiters it polls without
+    /// parking. A resolution committed by [`DurableHandle::resolve`](crate::DurableHandle::resolve)
+    /// wakes the waiter at once.
+    ///
+    /// # Errors
+    ///
+    /// - [`DurableError::UnknownPromise`] if the promise row is missing (e.g. pruned).
+    /// - A decode/integrity error if the resolved payload cannot be opened into `T`.
+    pub async fn await_promise<T: DeserializeOwned>(
+        &self,
+        promise: DurablePromise<T>,
+    ) -> Result<T, DurableError> {
+        let id = promise.id();
+        let key = id.as_uuid();
+        let cap = usize::try_from(self.max_parked_promises).unwrap_or(usize::MAX);
+        let span = tracing::info_span!("durable.promise.await", promise_id = %key);
+        async move {
+            loop {
+                if let Some(value) = self.take_resolved_promise::<T>(id).await? {
+                    return Ok(value);
+                }
+                match self.backend.promise_waiters().register(key, Some(cap)) {
+                    Some(notify) => {
+                        let notified = notify.notified();
+                        tokio::pin!(notified);
+                        // Register interest, then re-check: this closes the window where a resolution
+                        // lands between the read above and the wait below.
+                        notified.as_mut().enable();
+                        if let Some(value) = self.take_resolved_promise::<T>(id).await? {
+                            self.backend.promise_waiters().cancel(key);
+                            return Ok(value);
+                        }
+                        tokio::select! {
+                            () = notified => {}
+                            () = tokio::time::sleep(self.poll_interval) => {}
+                        }
+                    }
+                    // Over the parked cap: pure poll, no registration.
+                    None => tokio::time::sleep(self.poll_interval).await,
+                }
+            }
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Read a promise's state and, if resolved, open and decode its value.
+    async fn take_resolved_promise<T: DeserializeOwned>(
+        &self,
+        id: PromiseId,
+    ) -> Result<Option<T>, DurableError> {
+        let record = self
+            .backend
+            .promise_state(id)
+            .await?
+            .ok_or(DurableError::UnknownPromise)?;
+        if !record.resolved {
+            return Ok(None);
+        }
+        let sealed = record.payload.ok_or(DurableError::Decode {
+            context: "resolved promise is missing its payload",
+        })?;
+        let plaintext = self
+            .backend
+            .open_promise_payload(id, record.execution_id, &sealed)?;
+        deserialize_result(&plaintext).map(Some)
+    }
+
+    /// Durably sleep until `due`, surviving a process restart (FR-DE-06).
+    ///
+    /// Arms a `durable_timers` row at a deterministic position (so a resume re-attaches to it),
+    /// then parks until the instant arrives — firing the timer itself when due, or returning at once
+    /// if a restart finds it already fired or past due. The
+    /// [`DurableTimerService`](crate::DurableTimerService), when running, fires due timers and wakes
+    /// the waiter; without it, this loop still makes progress on its own.
+    ///
+    /// # Errors
+    ///
+    /// - [`DurableError::StepCapExceeded`] if the timer would exceed the per-execution step cap.
+    /// - A storage error if the timer cannot be armed or its state read.
     pub async fn sleep_until(&self, due: SystemTime) -> Result<(), DurableError> {
-        let due_ms = due
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX));
-        tracing::debug!(
-            execution_id = %self.execution_id.as_uuid(),
-            due_ms,
-            "durable timers are not yet wired; sleep_until lands with the promise/timer layer"
-        );
-        Err(DurableError::UnsupportedEntryKind {
-            kind: "timer_armed",
-        })
+        let step_id = self.checked_step_id()?;
+        let timer_id = TimerId::derive(self.execution_id, step_id);
+        let due_ms = system_time_to_millis(due);
+
+        match self.backend.timer_state(timer_id).await? {
+            // Fired during downtime (or earlier in this run) → return immediately (FR-DE-06).
+            Some((_, true)) => return Ok(()),
+            // Already armed in a prior run: re-attach without re-arming.
+            Some((_, false)) => {}
+            // First execution at this position: arm it.
+            None => {
+                self.backend
+                    .arm_timer(timer_id, self.execution_id, due_ms, now_unix_millis())
+                    .await?;
+            }
+        }
+
+        let key = timer_id.as_uuid();
+        loop {
+            let now = now_unix_millis();
+            if now >= due_ms {
+                // Due: fire it (idempotent — the service may race us; `WHERE fired = 0` dedups).
+                self.backend.mark_timer_fired(timer_id).await?;
+                return Ok(());
+            }
+            let notify = self.backend.timer_waiters().register(key, None);
+            let remaining = u64::try_from(due_ms.saturating_sub(now)).unwrap_or(u64::MAX);
+            let wait = self.poll_interval.min(Duration::from_millis(remaining));
+            match notify {
+                Some(notify) => {
+                    let notified = notify.notified();
+                    tokio::pin!(notified);
+                    notified.as_mut().enable();
+                    if matches!(self.backend.timer_state(timer_id).await?, Some((_, true))) {
+                        self.backend.timer_waiters().cancel(key);
+                        return Ok(());
+                    }
+                    tokio::select! {
+                        () = notified => {}
+                        () = tokio::time::sleep(wait) => {}
+                    }
+                }
+                None => tokio::time::sleep(wait).await,
+            }
+        }
+    }
+
+    /// Build an out-of-band [`DurableHandle`](crate::DurableHandle) over this context's backend.
+    ///
+    /// The handle is the operator/A2A resolution surface; it MUST NOT be exposed to an LLM tool
+    /// (INV-9). It shares the same backend, so a resolution it commits wakes an
+    /// [`await_promise`](Self::await_promise) parked on the same process at once.
+    #[must_use]
+    pub fn resolver_handle(&self) -> crate::promise::DurableHandle {
+        crate::promise::DurableHandle::new(self.backend.clone())
+    }
+
+    /// Await any in-flight background checkpoint folds — a turn-boundary / test barrier.
+    ///
+    /// The soft step-cap fold runs on a spawned task so it never blocks step dispatch; call this at
+    /// a turn boundary to ensure the journal is compacted before the next phase observes it.
+    pub async fn drain_background(&self) {
+        let mut set = {
+            let mut guard = self
+                .fold_tasks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *guard)
+        };
+        while set.join_next().await.is_some() {}
     }
 
     /// Assign the next deterministic step id (INV-2).
     fn assign_step_id(&self) -> StepId {
         StepId::new(self.next_step.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Assign the next step id, rejecting it if it exceeds the per-execution step cap.
+    fn checked_step_id(&self) -> Result<StepId, DurableError> {
+        let step_id = self.assign_step_id();
+        if self.max_steps_per_execution != 0 && step_id.value() >= self.max_steps_per_execution {
+            return Err(DurableError::StepCapExceeded {
+                cap: self.max_steps_per_execution,
+            });
+        }
+        Ok(step_id)
+    }
+
+    /// Fold a checkpoint on a background task the first time a step crosses the soft cap.
+    ///
+    /// Compaction NEVER runs on the dispatch hot path (spec NEVER), so the fold is spawned and
+    /// tracked in `fold_tasks` (drainable via [`drain_background`](Self::drain_background), aborted
+    /// on drop). It fires exactly once per execution; the hard cap aborts any execution that keeps
+    /// growing past it.
+    fn maybe_checkpoint(&self, step_id: StepId) {
+        if step_id.value() < self.soft_step_cap {
+            return;
+        }
+        if self.checkpoint_requested.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let backend = self.backend.clone();
+        let execution_id = self.execution_id;
+        let up_to = self.soft_step_cap;
+        let mut guard = self
+            .fold_tasks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.spawn(async move {
+            match backend.checkpoint_fold(execution_id, up_to).await {
+                Ok(folded) => {
+                    tracing::info!(
+                        execution_id = %execution_id.as_uuid(),
+                        folded,
+                        "durable checkpoint fold compacted the idempotent prefix"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "durable checkpoint fold failed");
+                }
+            }
+        });
     }
 
     /// Whether replay is currently consulted (a resume that has not diverged).
@@ -246,11 +480,13 @@ impl DurableContext {
         F: FnOnce(StepHandle) -> Fut + Send,
         Fut: Future<Output = Result<T, StepError>> + Send,
     {
-        if step_id.value() >= self.max_steps_per_execution {
+        if self.max_steps_per_execution != 0 && step_id.value() >= self.max_steps_per_execution {
             return Err(DurableError::StepCapExceeded {
                 cap: self.max_steps_per_execution,
             });
         }
+        // Soft cap (90%): fold a checkpoint on a background task, once per execution.
+        self.maybe_checkpoint(step_id);
         let effect = desc.effect();
         let idem_key =
             IdempotencyKey::derive(self.execution_id, step_id, &desc.fingerprint_input());
@@ -547,6 +783,14 @@ fn replay_value<T: DeserializeOwned>(
     }
 }
 
+/// Convert a [`SystemTime`] to Unix epoch milliseconds, clamped into `i64` and never panicking.
+///
+/// A pre-epoch instant clamps to `0`; an overflowing one clamps to [`i64::MAX`].
+fn system_time_to_millis(time: SystemTime) -> i64 {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+}
+
 /// Hex-encode the first 8 bytes of an idempotency key for an audit record.
 ///
 /// The key is a BLAKE3 hash, not secret material; the spec redaction rule shows only its first 8
@@ -565,6 +809,7 @@ mod tests {
     use crate::backend::local::LocalBackend;
     use crate::config::DurableConfig;
     use crate::effect::EffectIntentSubClass;
+    use crate::timer::DurableTimerService;
     use crate::writer::JournalWriter;
     use std::pin::Pin;
     use std::sync::atomic::AtomicU32;
@@ -965,6 +1210,241 @@ mod tests {
             "a failed step journals no result"
         );
         h.shutdown().await;
+    }
+
+    /// Build a fresh context over a shared in-memory backend with a custom config (e.g. a small cap).
+    fn context_with(
+        local: &Arc<LocalBackend>,
+        handle: &JournalWriterHandle,
+        exec: ExecutionId,
+        is_resume: bool,
+        config: &DurableConfig,
+    ) -> DurableContext {
+        let dispatch = Arc::new(DurableBackendEnum::Local(local.clone()));
+        DurableContext::new(
+            exec,
+            ExecutionKind::AgentTurn,
+            is_resume,
+            dispatch,
+            handle.clone(),
+            config,
+        )
+    }
+
+    #[tokio::test]
+    async fn promise_resolves_with_token_and_await_returns_value() {
+        // FR-DE-05: a promise resolves only via its token; resolution wakes the parked await.
+        let exec = ExecutionId::new();
+        let h = Harness::open(exec, false).await;
+        let promise = h.ctx.promise::<u32>().await.unwrap();
+        assert!(!promise.is_resumed());
+        let token = *promise
+            .resolver_token()
+            .expect("fresh promise carries a token");
+        let id = promise.id();
+        let resolver = h.ctx.resolver_handle();
+
+        let (awaited, ack) = tokio::join!(h.ctx.await_promise::<u32>(promise), async {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            resolver.resolve(id, &token, 1234u32).await
+        });
+        ack.unwrap();
+        assert_eq!(
+            awaited.unwrap(),
+            1234,
+            "the awaiter receives the resolved value"
+        );
+        h.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn wrong_resolver_token_is_rejected_but_correct_one_resolves() {
+        // INV-9: resolution requires the matching token; a wrong token is rejected (constant-time).
+        let exec = ExecutionId::new();
+        let h = Harness::open(exec, false).await;
+        let promise = h.ctx.promise::<String>().await.unwrap();
+        let id = promise.id();
+        let token = *promise.resolver_token().unwrap();
+        let resolver = h.ctx.resolver_handle();
+
+        // The LLM, lacking the token, cannot resolve: a guessed token is rejected and leaves the
+        // promise pending.
+        let mut wrong = token;
+        wrong[0] ^= 0xFF;
+        assert!(matches!(
+            resolver.resolve(id, &wrong, "forged".to_string()).await,
+            Err(DurableError::PromiseRejected)
+        ));
+        assert!(
+            !h.backend.promise_state(id).await.unwrap().unwrap().resolved,
+            "a rejected resolution must not resolve the promise"
+        );
+
+        // The genuine token resolves it.
+        resolver
+            .resolve(id, &token, "ok".to_string())
+            .await
+            .unwrap();
+        assert!(h.backend.promise_state(id).await.unwrap().unwrap().resolved);
+
+        // Resolving an unknown promise fails closed.
+        assert!(matches!(
+            resolver
+                .resolve(PromiseId::new(), &token, "x".to_string())
+                .await,
+            Err(DurableError::UnknownPromise)
+        ));
+        h.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn resumed_promise_awaits_the_resolved_value() {
+        // A promise created and resolved before a crash is re-attached on resume and awaited.
+        let exec = ExecutionId::new();
+        let h = Harness::open(exec, false).await;
+        let promise = h.ctx.promise::<u32>().await.unwrap();
+        let id = promise.id();
+        let token = *promise.resolver_token().unwrap();
+        h.ctx
+            .resolver_handle()
+            .resolve(id, &token, 77u32)
+            .await
+            .unwrap();
+
+        // Resume: promise() at the same position returns a token-less, resumed handle.
+        let resumed = h.resume();
+        let promise2 = resumed.promise::<u32>().await.unwrap();
+        assert!(promise2.is_resumed());
+        assert_eq!(
+            promise2.id(),
+            id,
+            "the resumed promise re-derives the same id"
+        );
+        assert_eq!(resumed.await_promise::<u32>(promise2).await.unwrap(), 77);
+        h.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn sleep_until_returns_when_the_instant_passes() {
+        let exec = ExecutionId::new();
+        let h = Harness::open(exec, false).await;
+        // A near-future instant: the context fires its own timer when due (no service needed).
+        let due = SystemTime::now() + Duration::from_millis(40);
+        tokio::time::timeout(Duration::from_secs(2), h.ctx.sleep_until(due))
+            .await
+            .expect("sleep_until completes before the test timeout")
+            .expect("sleep_until succeeds");
+        h.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn sleep_until_past_due_returns_immediately_on_resume() {
+        // FR-DE-06: a timer whose instant elapsed during downtime fires at once on resume.
+        let exec = ExecutionId::new();
+        let h = Harness::open(exec, false).await;
+        // Arm a long-past timer at the position sleep_until will re-derive on resume (step 0).
+        let timer = TimerId::derive(exec, StepId::new(0));
+        h.backend.arm_timer(timer, exec, 1_000, 0).await.unwrap();
+
+        // The timer service fires the past-due timer on its first poll.
+        let service = DurableTimerService::new(
+            Arc::new(DurableBackendEnum::Local(h.backend.clone())),
+            Duration::from_millis(5),
+        );
+        service.fire_due().await;
+        assert_eq!(
+            h.backend.timer_state(timer).await.unwrap(),
+            Some((1_000, true))
+        );
+
+        // A resumed sleep_until at the same position returns immediately (already fired).
+        let resumed = h.resume();
+        tokio::time::timeout(
+            Duration::from_millis(200),
+            resumed.sleep_until(SystemTime::now() + Duration::from_hours(1)),
+        )
+        .await
+        .expect("resumed sleep_until returns immediately")
+        .unwrap();
+        h.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn soft_cap_triggers_checkpoint_fold_and_replay_skips_folded_steps() {
+        // Soft cap (90% of 10 = 9): the step at id 9 folds the idempotent prefix [0..9).
+        let exec = ExecutionId::new();
+        let local = Arc::new(LocalBackend::open(":memory:", 1_048_576).await.unwrap());
+        local.init().await.unwrap();
+        local
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let (writer, handle) = JournalWriter::new(local.clone(), &fast_config());
+        let task = tokio::spawn(writer.run());
+        let config = DurableConfig {
+            max_steps_per_execution: 10,
+            ..fast_config()
+        };
+        let ctx = context_with(&local, &handle, exec, false, &config);
+
+        let desc = |i: u32| StepDescriptor::idempotent("s", format!("op:{i}").into_bytes());
+        // Steps 0..=8 run and are committed before the soft-cap step triggers the fold.
+        for i in 0..9 {
+            let v: u32 = ctx
+                .step(desc(i), move |_| async move { Ok(i) })
+                .await
+                .unwrap();
+            assert_eq!(v, i);
+        }
+        handle.flush().await.unwrap();
+        // Step id 9 crosses the soft cap and spawns the background fold of [0..9).
+        ctx.step::<u32, _, _>(desc(9), |_| async { Ok(9) })
+            .await
+            .unwrap();
+        ctx.drain_background().await;
+        handle.flush().await.unwrap();
+
+        // The folded prefix is compacted into a single checkpoint; steps 9 survives as a row.
+        let entries = local.read_execution(exec).await.unwrap();
+        let checkpoints = entries
+            .iter()
+            .filter(|e| matches!(e.entry, EntryKind::Checkpoint { .. }))
+            .count();
+        assert_eq!(checkpoints, 1, "the soft cap folded one checkpoint");
+        let surviving: Vec<u32> = entries
+            .iter()
+            .filter(|e| matches!(e.entry, EntryKind::StepResult { .. }))
+            .map(|e| e.step_id.value())
+            .collect();
+        assert_eq!(surviving, vec![9], "only the post-fold step row survives");
+
+        // Resume: the folded steps replay from the checkpoint without re-running their ops.
+        let resumed = context_with(&local, &handle, exec, true, &config);
+        let reran = Arc::new(AtomicU32::new(0));
+        for i in 0..9 {
+            let counter = reran.clone();
+            let v: u32 = resumed
+                .step(desc(i), move |_| {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        Ok(999)
+                    }
+                })
+                .await
+                .unwrap();
+            assert_eq!(v, i, "folded step {i} replays its journaled value");
+        }
+        assert_eq!(
+            reran.load(Ordering::SeqCst),
+            0,
+            "no folded operation closure re-ran on replay"
+        );
+
+        drop(ctx);
+        drop(resumed);
+        drop(handle);
+        task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/zeph-durable/src/ids.rs
+++ b/crates/zeph-durable/src/ids.rs
@@ -19,6 +19,29 @@ use uuid::Uuid;
 /// produced for any other purpose, even under identical key material.
 const IDEMPOTENCY_CONTEXT: &str = "zeph-durable v1 idempotency-key 2026";
 
+/// Domain-separation context for the deterministic [`PromiseId::derive`] correlation id.
+const PROMISE_DERIVE_CONTEXT: &str = "zeph-durable v1 promise-id 2026";
+
+/// Domain-separation context for the deterministic [`TimerId::derive`] correlation id.
+const TIMER_DERIVE_CONTEXT: &str = "zeph-durable v1 timer-id 2026";
+
+/// Derive a deterministic [`Uuid`] from a domain context and an execution/step position.
+///
+/// Promises and timers are correlated across a crash-resume by *position*, not by a runtime-minted
+/// random id: on replay the program re-runs and re-derives the same id for the same `(execution_id,
+/// step_id)`, so the existing `durable_promises` / `durable_timers` row is found rather than a new,
+/// orphaned one created. The BLAKE3 `derive_key` output seeds a `UUIDv8` (custom layout) so the id is
+/// a well-formed, collision-resistant UUID with a deterministic value.
+fn derive_position_uuid(context: &str, execution_id: ExecutionId, step_id: StepId) -> Uuid {
+    let mut input = [0u8; 20];
+    input[..16].copy_from_slice(execution_id.as_bytes());
+    input[16..].copy_from_slice(&step_id.value().to_le_bytes());
+    let hash = blake3::derive_key(context, &input);
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&hash[..16]);
+    Uuid::new_v8(bytes)
+}
+
 /// Identifier of a single durable execution.
 ///
 /// Runtime-minted as a `UUIDv7` (time-ordered) at execution start. It is **never** consumer-supplied
@@ -54,6 +77,15 @@ impl ExecutionId {
     #[must_use]
     pub fn as_bytes(&self) -> &[u8; 16] {
         self.0.as_bytes()
+    }
+
+    /// Reconstruct an execution identity from a [`Uuid`] read back from storage.
+    ///
+    /// Used by a journal backend to rebuild the id of a persisted promise or timer row. A new
+    /// execution always uses [`ExecutionId::new`]; this constructor is for resume-time reconstruction
+    /// only.
+    pub(crate) fn from_uuid(uuid: Uuid) -> Self {
+        Self(uuid)
     }
 }
 
@@ -227,6 +259,33 @@ impl PromiseId {
         Self(Uuid::now_v7())
     }
 
+    /// Derive the deterministic promise id for a `(execution_id, step_id)` position.
+    ///
+    /// Used by `promise()` so a resumed execution re-derives the same id at the same program point
+    /// and re-attaches to the pending `durable_promises` row instead of minting an orphan. The id is
+    /// guessable from the execution journal, but that is harmless: a `PromiseId` is *not* a bearer
+    /// capability (INV-9) — resolution requires the separate high-entropy resolver token.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_durable::{ExecutionId, PromiseId, StepId};
+    ///
+    /// let exec = ExecutionId::new();
+    /// let a = PromiseId::derive(exec, StepId::new(3));
+    /// let b = PromiseId::derive(exec, StepId::new(3));
+    /// assert_eq!(a, b, "the same position derives the same promise id");
+    /// assert_ne!(a, PromiseId::derive(exec, StepId::new(4)));
+    /// ```
+    #[must_use]
+    pub fn derive(execution_id: ExecutionId, step_id: StepId) -> Self {
+        Self(derive_position_uuid(
+            PROMISE_DERIVE_CONTEXT,
+            execution_id,
+            step_id,
+        ))
+    }
+
     /// Return the underlying UUID.
     #[must_use]
     pub fn as_uuid(self) -> Uuid {
@@ -258,6 +317,37 @@ impl TimerId {
     #[must_use]
     pub fn new() -> Self {
         Self(Uuid::now_v7())
+    }
+
+    /// Derive the deterministic timer id for a `(execution_id, step_id)` position.
+    ///
+    /// As with [`PromiseId::derive`], a resumed `sleep_until` at the same program point re-derives
+    /// the same id and re-attaches to the journaled `durable_timers` row, so a timer that fired
+    /// during downtime is recognized on replay rather than re-armed afresh (FR-DE-06).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_durable::{ExecutionId, StepId, TimerId};
+    ///
+    /// let exec = ExecutionId::new();
+    /// assert_eq!(
+    ///     TimerId::derive(exec, StepId::new(1)),
+    ///     TimerId::derive(exec, StepId::new(1)),
+    /// );
+    /// ```
+    #[must_use]
+    pub fn derive(execution_id: ExecutionId, step_id: StepId) -> Self {
+        Self(derive_position_uuid(
+            TIMER_DERIVE_CONTEXT,
+            execution_id,
+            step_id,
+        ))
+    }
+
+    /// Reconstruct a timer identity from a [`Uuid`] read back from storage.
+    pub(crate) fn from_uuid(uuid: Uuid) -> Self {
+        Self(uuid)
     }
 
     /// Return the underlying UUID.
@@ -375,6 +465,37 @@ mod tests {
         let json = serde_json::to_string(&seq).unwrap();
         let back: JournalSeq = serde_json::from_str(&json).unwrap();
         assert_eq!(seq, back);
+    }
+
+    #[test]
+    fn derived_promise_and_timer_ids_are_position_stable_and_disjoint() {
+        let exec = ExecutionId::new();
+        let other = ExecutionId::new();
+        // Deterministic for a fixed position…
+        assert_eq!(
+            PromiseId::derive(exec, StepId::new(2)),
+            PromiseId::derive(exec, StepId::new(2))
+        );
+        assert_eq!(
+            TimerId::derive(exec, StepId::new(2)),
+            TimerId::derive(exec, StepId::new(2))
+        );
+        // …yet distinct across step, execution, and the promise/timer domain separation.
+        assert_ne!(
+            PromiseId::derive(exec, StepId::new(2)),
+            PromiseId::derive(exec, StepId::new(3))
+        );
+        assert_ne!(
+            PromiseId::derive(exec, StepId::new(2)),
+            PromiseId::derive(other, StepId::new(2))
+        );
+        let promise = PromiseId::derive(exec, StepId::new(2)).as_uuid();
+        let timer = TimerId::derive(exec, StepId::new(2)).as_uuid();
+        assert_ne!(
+            promise, timer,
+            "promise and timer ids never collide at the same position"
+        );
+        assert_eq!(promise.get_version_num(), 8, "derived ids are UUIDv8");
     }
 
     #[test]

--- a/crates/zeph-durable/src/lib.rs
+++ b/crates/zeph-durable/src/lib.rs
@@ -72,6 +72,7 @@
 
 mod replay;
 mod sealed;
+mod waiters;
 
 pub mod backend;
 pub mod cipher;
@@ -81,7 +82,10 @@ pub mod error;
 pub mod handle;
 pub mod ids;
 pub mod journal;
+pub mod promise;
+pub mod retention;
 pub mod step;
+pub mod timer;
 pub mod writer;
 
 #[doc(hidden)]
@@ -97,5 +101,8 @@ pub use error::DurableError;
 pub use handle::{DurableContext, ParallelScope};
 pub use ids::{ExecutionId, ExecutionKind, IdempotencyKey, JournalSeq, PromiseId, StepId, TimerId};
 pub use journal::{EntryKind, ExecutionStatus, Journal, JournalEntry};
+pub use promise::{DurableHandle, DurablePromise};
+pub use retention::DurableRetentionService;
 pub use step::{DurableStep, StepDescriptor, StepError, StepHandle, StepOutcome};
+pub use timer::DurableTimerService;
 pub use writer::{JournalWriter, JournalWriterHandle};

--- a/crates/zeph-durable/src/promise.rs
+++ b/crates/zeph-durable/src/promise.rs
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Durable promises: externally-completed handles that survive a crash-resume.
+//!
+//! A [`DurablePromise`] represents a value that an *out-of-band* party will supply later — a
+//! human-in-the-loop approval, an async A2A reply, or a subagent result. The awaiting execution can
+//! crash and resume while the promise is still pending; on resume it re-derives the same
+//! [`PromiseId`] for its program position (see [`PromiseId::derive`]) and re-attaches to the pending
+//! `durable_promises` row rather than minting a fresh one.
+//!
+//! # The resolver token is the capability (INV-9)
+//!
+//! A `PromiseId` is **not** a bearer capability — it is derivable from the execution journal and may
+//! appear in traces. The authority to resolve a promise is a separate 32-byte high-entropy *resolver
+//! token*, generated once when the promise is created and held only inside the [`DurablePromise`]
+//! value (zeroized on drop). Only its BLAKE3 hash — domain-separated and bound to
+//! `(promise_id, execution_id)` — is persisted. [`DurableHandle::resolve`] re-derives that hash from
+//! a presented token and compares it in **constant time**; a wrong token is rejected without ever
+//! revealing whether it was close.
+//!
+//! The consumer is responsible for the INV-9 channel rule: a [`DurableHandle`] is an operator/A2A
+//! surface and MUST NOT be reachable from an LLM tool. The LLM never sees the resolver token (it is
+//! handed out of band when the promise is created), so it cannot resolve its own pending promises.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use serde::Serialize;
+use zeroize::Zeroizing;
+
+use crate::backend::DurableBackendEnum;
+use crate::backend::local::now_unix_millis;
+use crate::error::DurableError;
+use crate::ids::{ExecutionId, PromiseId};
+
+/// Length of a resolver token in bytes.
+pub(crate) const RESOLVER_TOKEN_LEN: usize = 32;
+
+/// Domain-separation context for the resolver-token hash (BLAKE3 `derive_key` mode).
+const RESOLVER_CONTEXT: &str = "zeph-durable v1 promise resolver-token 2026";
+
+/// The persisted state of a promise, read back by the resolve and await paths.
+///
+/// The `payload` is the AEAD-sealed resolved value when `resolved` is `true`; the backend opens it
+/// with the promise-bound AAD. The stored `resolver_token_hash` is compared against a presented
+/// token during resolution.
+#[derive(Debug, Clone)]
+pub(crate) struct PromiseRecord {
+    /// The execution that created the promise — half of the resolver-token binding.
+    pub(crate) execution_id: ExecutionId,
+    /// BLAKE3 hash of the bound resolver token (the token itself is never stored).
+    pub(crate) resolver_token_hash: [u8; 32],
+    /// Whether the promise has been resolved.
+    pub(crate) resolved: bool,
+    /// The AEAD-sealed resolved value, present once `resolved` is `true`.
+    pub(crate) payload: Option<Vec<u8>>,
+}
+
+/// Compute the domain-separated, position-bound hash of a resolver token.
+///
+/// Binding `(promise_id, execution_id)` into the hash means a token is meaningless against any other
+/// promise even if leaked, and the fixed `derive_key` context keeps these hashes disjoint from every
+/// other BLAKE3 use in the workspace. The returned [`blake3::Hash`] compares in constant time.
+pub(crate) fn resolver_token_hash(
+    promise_id: PromiseId,
+    execution_id: ExecutionId,
+    token: &[u8; RESOLVER_TOKEN_LEN],
+) -> blake3::Hash {
+    let mut input = [0u8; 16 + 16 + RESOLVER_TOKEN_LEN];
+    input[..16].copy_from_slice(promise_id.as_uuid().as_bytes());
+    input[16..32].copy_from_slice(execution_id.as_bytes());
+    input[32..].copy_from_slice(token);
+    blake3::Hash::from(blake3::derive_key(RESOLVER_CONTEXT, &input))
+}
+
+/// A typed handle to a value that an out-of-band party will resolve later.
+///
+/// Created by [`DurableContext::promise`](crate::DurableContext::promise) and consumed by
+/// [`DurableContext::await_promise`](crate::DurableContext::await_promise). The type parameter `T`
+/// ties the awaited result type to the creation site; `T` is a phantom (`fn() -> T`, so the handle
+/// is unconditionally `Send + Sync` and owns no `T`).
+///
+/// On a *fresh* creation the handle carries the resolver token; hand it to the resolving channel via
+/// [`resolver_token`](DurablePromise::resolver_token). On *resume* the original token was already
+/// delivered out of band before the crash and is unrecoverable, so a resumed handle carries no token
+/// ([`is_resumed`](DurablePromise::is_resumed) is `true`) — it can still be awaited.
+#[derive(Debug)]
+pub struct DurablePromise<T> {
+    id: PromiseId,
+    resolver_token: Option<Zeroizing<[u8; RESOLVER_TOKEN_LEN]>>,
+    _t: PhantomData<fn() -> T>,
+}
+
+impl<T> DurablePromise<T> {
+    /// Construct a freshly-created promise holding its resolver token.
+    pub(crate) fn fresh(
+        id: PromiseId,
+        resolver_token: Zeroizing<[u8; RESOLVER_TOKEN_LEN]>,
+    ) -> Self {
+        Self {
+            id,
+            resolver_token: Some(resolver_token),
+            _t: PhantomData,
+        }
+    }
+
+    /// Construct a resumed promise whose token lives out of band (delivered before the crash).
+    pub(crate) fn resumed(id: PromiseId) -> Self {
+        Self {
+            id,
+            resolver_token: None,
+            _t: PhantomData,
+        }
+    }
+
+    /// The promise's identifier.
+    #[must_use]
+    pub fn id(&self) -> PromiseId {
+        self.id
+    }
+
+    /// Borrow the resolver token to hand to the out-of-band resolving channel.
+    ///
+    /// Returns `None` for a resumed promise (the token was delivered before the crash and cannot be
+    /// recovered). The token is secret: deliver it only over the operator/A2A channel, never to the
+    /// LLM (INV-9).
+    #[must_use]
+    pub fn resolver_token(&self) -> Option<&[u8; RESOLVER_TOKEN_LEN]> {
+        self.resolver_token.as_deref()
+    }
+
+    /// Whether this handle was reconstructed on resume (and therefore holds no token).
+    #[must_use]
+    pub fn is_resumed(&self) -> bool {
+        self.resolver_token.is_none()
+    }
+}
+
+/// The out-of-band entry point that resolves pending promises.
+///
+/// Cheap to clone (it holds only an `Arc` to the shared backend) and `Send + Sync`, so it can be
+/// handed to an operator command handler or an A2A reply path. It deliberately exposes *only*
+/// [`resolve`](DurableHandle::resolve): a holder can complete a promise given the matching token but
+/// can neither create nor inspect executions.
+#[derive(Clone, Debug)]
+pub struct DurableHandle {
+    backend: Arc<DurableBackendEnum>,
+}
+
+impl DurableHandle {
+    /// Build a resolver handle over the shared backend.
+    #[must_use]
+    pub fn new(backend: Arc<DurableBackendEnum>) -> Self {
+        Self { backend }
+    }
+
+    /// Resolve a promise by presenting its resolver token and the completion value (FR-DE-05).
+    ///
+    /// The token is hashed (domain-separated, bound to `(promise_id, execution_id)`) and compared in
+    /// constant time against the stored hash. On a match the value is sealed and committed and any
+    /// in-process waiter is woken; resolving an already-resolved promise with the correct token is a
+    /// no-op success. A wrong token is rejected with [`DurableError::PromiseRejected`] and leaves the
+    /// promise untouched.
+    ///
+    /// # Errors
+    ///
+    /// - [`DurableError::UnknownPromise`] if no promise with `id` exists.
+    /// - [`DurableError::PromiseRejected`] if `resolver_token` does not authenticate.
+    /// - [`DurableError::Serialize`] if `value` cannot be serialized, or a storage error from the
+    ///   backend.
+    pub async fn resolve<T: Serialize>(
+        &self,
+        id: PromiseId,
+        resolver_token: &[u8; RESOLVER_TOKEN_LEN],
+        value: T,
+    ) -> Result<(), DurableError> {
+        let span = tracing::info_span!("durable.promise.resolve", promise_id = %id.as_uuid());
+        let _enter = span.enter();
+
+        let record = self
+            .backend
+            .promise_state(id)
+            .await?
+            .ok_or(DurableError::UnknownPromise)?;
+
+        // Constant-time authentication (INV-9): blake3::Hash equality is constant-time, so a wrong
+        // token reveals no timing signal. Authenticate *before* the already-resolved short-circuit so
+        // an attacker cannot use a resolved promise as an oracle.
+        let presented = resolver_token_hash(id, record.execution_id, resolver_token);
+        if presented != blake3::Hash::from(record.resolver_token_hash) {
+            return Err(DurableError::PromiseRejected);
+        }
+        if record.resolved {
+            return Ok(());
+        }
+
+        let payload = serde_json::to_vec(&value).map_err(|_| DurableError::Serialize {
+            step: "promise.resolve",
+        })?;
+        self.backend
+            .resolve_promise(id, record.execution_id, &payload, now_unix_millis())
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::StepId;
+
+    #[test]
+    fn resolver_hash_binds_promise_and_execution() {
+        let exec = ExecutionId::new();
+        let promise = PromiseId::derive(exec, StepId::new(0));
+        let token = [7u8; RESOLVER_TOKEN_LEN];
+
+        let base = resolver_token_hash(promise, exec, &token);
+        assert_eq!(
+            base,
+            resolver_token_hash(promise, exec, &token),
+            "deterministic for fixed inputs"
+        );
+        // A different promise, execution, or token all change the hash.
+        let other_promise = PromiseId::derive(exec, StepId::new(1));
+        assert_ne!(base, resolver_token_hash(other_promise, exec, &token));
+        assert_ne!(
+            base,
+            resolver_token_hash(promise, ExecutionId::new(), &token)
+        );
+        assert_ne!(
+            base,
+            resolver_token_hash(promise, exec, &[8u8; RESOLVER_TOKEN_LEN])
+        );
+    }
+
+    #[test]
+    fn fresh_promise_carries_token_resumed_does_not() {
+        let fresh: DurablePromise<u32> =
+            DurablePromise::fresh(PromiseId::new(), Zeroizing::new([1u8; RESOLVER_TOKEN_LEN]));
+        assert!(fresh.resolver_token().is_some());
+        assert!(!fresh.is_resumed());
+
+        let resumed: DurablePromise<u32> = DurablePromise::resumed(PromiseId::new());
+        assert!(resumed.resolver_token().is_none());
+        assert!(resumed.is_resumed());
+    }
+}

--- a/crates/zeph-durable/src/replay.rs
+++ b/crates/zeph-durable/src/replay.rs
@@ -67,6 +67,8 @@ struct CursorState {
     next_step_to_load: u32,
     /// Whether the journal has been read to its end (a short final segment was seen).
     exhausted: bool,
+    /// Whether the folded-step checkpoint preload has run (once, before the first segment read).
+    checkpoints_preloaded: bool,
 }
 
 /// A forward-walking, segment-buffered view of a resumed execution's journal.
@@ -108,6 +110,7 @@ impl ReplayCursor {
                 loaded: BTreeMap::new(),
                 next_step_to_load: 0,
                 exhausted: false,
+                checkpoints_preloaded: false,
             }),
         }
     }
@@ -151,8 +154,33 @@ impl ReplayCursor {
         state: &mut CursorState,
         step: u32,
     ) -> Result<(), DurableError> {
+        if !state.checkpoints_preloaded {
+            self.preload_checkpoints(state).await?;
+        }
         while !state.exhausted && state.next_step_to_load <= step {
             self.load_segment(state).await?;
+        }
+        Ok(())
+    }
+
+    /// Inject folded step results from any compaction checkpoint, once, before the forward walk.
+    ///
+    /// A checkpoint fold deletes the individual `StepResult` rows of an execution's idempotent
+    /// prefix, so those steps would otherwise read as `Fresh` on resume and re-run. Preloading the
+    /// snapshot's reconstructed results into the resident window makes the cursor serve them exactly
+    /// like a surviving row — including the idempotency key the divergence guard compares (INV-3).
+    async fn preload_checkpoints(&self, state: &mut CursorState) -> Result<(), DurableError> {
+        state.checkpoints_preloaded = true;
+        let entries = self
+            .backend
+            .read_checkpoints(self.execution_id)
+            .instrument(tracing::info_span!(
+                "durable.replay.cursor.preload",
+                execution_id = %self.execution_id.as_uuid(),
+            ))
+            .await?;
+        for entry in entries {
+            insert_entry(state, entry);
         }
         Ok(())
     }

--- a/crates/zeph-durable/src/retention.rs
+++ b/crates/zeph-durable/src/retention.rs
@@ -1,0 +1,424 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Journal retention, the background prune sweep, and the checkpoint-fold codec.
+//!
+//! Two mechanisms bound journal growth, and neither runs on the step-dispatch hot path (spec NEVER):
+//!
+//! - **Background prune** — [`DurableRetentionService`] is a tokio task that wakes every
+//!   `prune_interval_secs` and calls [`Journal::prune`](crate::Journal::prune), which deletes
+//!   *terminal* executions older than their TTL in `prune_batch_size` batches, yielding between
+//!   batches so a large sweep never holds the write lock.
+//! - **In-execution checkpoint fold** — a long *in-flight* execution that crosses the soft step cap
+//!   (90% of `max_steps_per_execution`) folds its committed-idempotent prefix into a single
+//!   [`Checkpoint`](crate::EntryKind::Checkpoint) entry. The fold packs each folded step's replay
+//!   value into the checkpoint snapshot and deletes the individual rows, so a resume still replays
+//!   those steps from the snapshot rather than re-running them. The hard cap (100%) aborts the
+//!   execution with [`DurableError::StepCapExceeded`].
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use tracing::Instrument as _;
+
+use crate::backend::DurableBackendEnum;
+use crate::config::RetentionPolicy;
+use crate::error::DurableError;
+use crate::journal::Journal as _;
+
+/// Wire-format version for the checkpoint snapshot encoding.
+const CHECKPOINT_FORMAT_V1: u8 = 1;
+
+/// One step's replay value, folded into a checkpoint snapshot.
+///
+/// The fold preserves exactly what a resume needs to replay the step without re-running its
+/// operation: the [`IdempotencyKey`](crate::IdempotencyKey) bytes (so the replay-divergence guard
+/// still matches, INV-3), the payload wire-format version, and the *plaintext* result bytes (the
+/// snapshot as a whole is AEAD-sealed by the backend, so individual step payloads need no further
+/// sealing inside it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FoldedStep {
+    /// Position of the folded step within its execution.
+    pub(crate) step_id: u32,
+    /// The step's 32-byte idempotency key, for the divergence guard on replay.
+    pub(crate) idem_key: [u8; 32],
+    /// Wire-format version of the result payload.
+    pub(crate) payload_version: u8,
+    /// Plaintext result bytes.
+    pub(crate) payload: Bytes,
+}
+
+/// A decoded checkpoint snapshot: the folded prefix of an execution, in step order.
+pub(crate) type CheckpointSnapshot = Vec<FoldedStep>;
+
+/// Per-step fixed framing overhead in the encoded snapshot (step + version + `idem_key` + len).
+const FOLDED_STEP_OVERHEAD: usize = 4 + 1 + 32 + 4;
+
+/// Encoded size one [`FoldedStep`] contributes (framing + payload).
+pub(crate) fn folded_step_encoded_len(payload_len: usize) -> usize {
+    FOLDED_STEP_OVERHEAD.saturating_add(payload_len)
+}
+
+/// Serialize a checkpoint snapshot into a compact, self-describing byte buffer.
+///
+/// Layout: `version(1) || count(u32 le) || [ step(u32 le) version(1) idem_key(32) len(u32 le)
+/// payload(len) ]*`. Fixed-width framing keeps the encoding injective and the per-step size
+/// predictable, so the backend can cut the fold at the payload ceiling without trial encoding.
+pub(crate) fn encode_checkpoint(steps: &[FoldedStep]) -> Vec<u8> {
+    let total: usize = steps
+        .iter()
+        .map(|s| folded_step_encoded_len(s.payload.len()))
+        .sum();
+    let mut out = Vec::with_capacity(5 + total);
+    out.push(CHECKPOINT_FORMAT_V1);
+    out.extend_from_slice(&u32::try_from(steps.len()).unwrap_or(u32::MAX).to_le_bytes());
+    for step in steps {
+        out.extend_from_slice(&step.step_id.to_le_bytes());
+        out.push(step.payload_version);
+        out.extend_from_slice(&step.idem_key);
+        out.extend_from_slice(
+            &u32::try_from(step.payload.len())
+                .unwrap_or(u32::MAX)
+                .to_le_bytes(),
+        );
+        out.extend_from_slice(&step.payload);
+    }
+    out
+}
+
+/// Decode a checkpoint snapshot, failing closed on truncation or an unknown format version.
+///
+/// # Errors
+///
+/// Returns [`DurableError::Decode`] if the buffer is truncated, declares more steps than it
+/// contains, or carries an unrecognized format version.
+pub(crate) fn decode_checkpoint(bytes: &[u8]) -> Result<CheckpointSnapshot, DurableError> {
+    let mut cursor = Reader::new(bytes);
+    let version = cursor.u8()?;
+    if version != CHECKPOINT_FORMAT_V1 {
+        return Err(DurableError::Decode {
+            context: "checkpoint snapshot has an unknown format version",
+        });
+    }
+    let count = cursor.u32()? as usize;
+    let mut steps = Vec::with_capacity(count.min(1024));
+    for _ in 0..count {
+        let step_id = cursor.u32()?;
+        let payload_version = cursor.u8()?;
+        let idem_key = cursor.array32()?;
+        let len = cursor.u32()? as usize;
+        let payload = Bytes::copy_from_slice(cursor.take(len)?);
+        steps.push(FoldedStep {
+            step_id,
+            idem_key,
+            payload_version,
+            payload,
+        });
+    }
+    Ok(steps)
+}
+
+/// A bounds-checked forward reader over the snapshot buffer; every read fails closed on underrun.
+struct Reader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn take(&mut self, len: usize) -> Result<&'a [u8], DurableError> {
+        let end = self.pos.checked_add(len).ok_or(DurableError::Decode {
+            context: "checkpoint snapshot length overflow",
+        })?;
+        let slice = self.bytes.get(self.pos..end).ok_or(DurableError::Decode {
+            context: "checkpoint snapshot is truncated",
+        })?;
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn u8(&mut self) -> Result<u8, DurableError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u32(&mut self) -> Result<u32, DurableError> {
+        let bytes = self.take(4)?;
+        Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn array32(&mut self) -> Result<[u8; 32], DurableError> {
+        let mut out = [0u8; 32];
+        out.copy_from_slice(self.take(32)?);
+        Ok(out)
+    }
+}
+
+/// Compute the soft and hard step-cap thresholds for a `max_steps_per_execution` budget.
+///
+/// The soft threshold (90%) triggers a checkpoint fold; the hard threshold (the cap itself) aborts.
+/// A `max` of zero disables both (returns `(u32::MAX, u32::MAX)`), so an unconfigured cap never folds
+/// or aborts.
+#[must_use]
+pub(crate) fn step_cap_thresholds(max: u32) -> (u32, u32) {
+    if max == 0 {
+        return (u32::MAX, u32::MAX);
+    }
+    // `max * 9 / 10 <= max`, so the result always fits back into u32; the widening guards the
+    // intermediate product against overflow.
+    let soft = u32::try_from(u64::from(max) * 9 / 10).unwrap_or(max);
+    (soft, max)
+}
+
+/// Background task that prunes terminal executions on a fixed interval.
+///
+/// Spawn [`DurableRetentionService::run`] on a supervised task (alongside the
+/// [`JournalWriter`](crate::JournalWriter)). It owns no write path of its own — it calls
+/// [`Journal::prune`](crate::Journal::prune) on the shared backend, which performs the batched delete
+/// off the hot path.
+#[derive(Debug)]
+pub struct DurableRetentionService {
+    backend: Arc<DurableBackendEnum>,
+    policy: RetentionPolicy,
+    interval: Duration,
+}
+
+impl DurableRetentionService {
+    /// Build the service from the shared backend and the configured retention policy.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::sync::Arc;
+    /// use zeph_durable::{DurableBackendEnum, DurableRetentionService, LocalBackend, RetentionPolicy};
+    ///
+    /// let backend = Arc::new(DurableBackendEnum::Local(Arc::new(
+    ///     LocalBackend::open("durable.db", 1_048_576).await?,
+    /// )));
+    /// let service = DurableRetentionService::new(backend, RetentionPolicy::default());
+    /// let task = tokio::spawn(service.run());
+    /// # let _ = task;
+    /// # Ok(()) }
+    /// ```
+    #[must_use]
+    pub fn new(backend: Arc<DurableBackendEnum>, policy: RetentionPolicy) -> Self {
+        let interval = Duration::from_secs(policy.prune_interval_secs.max(1));
+        Self {
+            backend,
+            policy,
+            interval,
+        }
+    }
+
+    /// Run the prune loop until the task is aborted.
+    ///
+    /// Each tick prunes terminal executions older than their TTL; a prune failure is logged and the
+    /// loop continues (a transient database error must not kill retention).
+    pub async fn run(self) {
+        let mut tick = tokio::time::interval(self.interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // The first immediate tick fires at startup; skip pruning on it so a just-launched daemon
+        // does not sweep before the first real interval elapses.
+        tick.tick().await;
+        loop {
+            tick.tick().await;
+            match self.backend.prune(&self.policy).await {
+                Ok(deleted) => {
+                    tracing::debug!(deleted, "durable retention prune sweep completed");
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "durable retention prune sweep failed; will retry");
+                }
+            }
+        }
+    }
+}
+
+/// Run one batched prune pass over the journal, deleting terminal executions past their TTL.
+///
+/// This is the shared body behind [`Journal::prune`](crate::Journal::prune) for the local backend.
+/// It is a free function (rather than a method) so the backend can keep its prune implementation thin
+/// while the batching/yielding policy lives next to the rest of retention. `delete_batch` performs
+/// one bounded `DELETE` transaction and returns the rows it removed; the loop yields between batches
+/// so a large sweep never monopolizes the runtime.
+pub(crate) async fn prune_in_batches<F, Fut>(
+    policy: &RetentionPolicy,
+    now_ms: i64,
+    delete_batch: F,
+) -> Result<u64, DurableError>
+where
+    F: Fn(PruneCutoffs, u64) -> Fut,
+    Fut: Future<Output = Result<u64, DurableError>>,
+{
+    let cutoffs = PruneCutoffs::from_policy(policy, now_ms);
+    let batch = policy.prune_batch_size.max(1);
+    let mut total = 0u64;
+    let span = tracing::info_span!(
+        "durable.journal.prune",
+        deleted_count = tracing::field::Empty
+    );
+    async {
+        loop {
+            let deleted = delete_batch(cutoffs, batch).await?;
+            total = total.saturating_add(deleted);
+            if deleted < batch {
+                break;
+            }
+            // Release the write lock and let other tasks run before the next batch.
+            tokio::task::yield_now().await;
+        }
+        tracing::Span::current().record("deleted_count", total);
+        Ok(total)
+    }
+    .instrument(span)
+    .await
+}
+
+/// The absolute `finalized_at` cutoffs (Unix ms) below which a terminal execution is prunable.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PruneCutoffs {
+    /// Completed executions finalized at or before this instant are prunable.
+    pub(crate) completed_before_ms: i64,
+    /// Failed/aborted executions finalized at or before this instant are prunable.
+    pub(crate) failed_before_ms: i64,
+}
+
+impl PruneCutoffs {
+    fn from_policy(policy: &RetentionPolicy, now_ms: i64) -> Self {
+        let completed =
+            i64::try_from(policy.ttl_completed_secs.saturating_mul(1000)).unwrap_or(i64::MAX);
+        let failed = i64::try_from(policy.ttl_failed_secs.saturating_mul(1000)).unwrap_or(i64::MAX);
+        Self {
+            completed_before_ms: now_ms.saturating_sub(completed),
+            failed_before_ms: now_ms.saturating_sub(failed),
+        }
+    }
+}
+
+/// The largest payload the backend will pack into a single checkpoint snapshot.
+///
+/// The fold cuts its prefix at this ceiling so a checkpoint entry obeys the same `max_payload_bytes`
+/// read/write guard as any other payload (INV-11). Steps that do not fit stay un-folded until a later
+/// checkpoint.
+#[must_use]
+pub(crate) fn checkpoint_budget(max_payload_bytes: u64) -> usize {
+    usize::try_from(max_payload_bytes).unwrap_or(usize::MAX)
+}
+
+/// Decide how many leading folded steps fit within the checkpoint payload budget.
+///
+/// Returns the count of steps from the front of `payload_lens` whose cumulative encoded size stays
+/// within `budget` (including the 5-byte snapshot header). A single step larger than the whole budget
+/// yields `0`, leaving it un-folded rather than producing an over-limit checkpoint.
+#[must_use]
+pub(crate) fn fold_prefix_len(payload_lens: &[usize], budget: usize) -> usize {
+    let mut used = 5usize; // version + count header
+    let mut taken = 0usize;
+    for &len in payload_lens {
+        let next = used.saturating_add(folded_step_encoded_len(len));
+        if next > budget {
+            break;
+        }
+        used = next;
+        taken += 1;
+    }
+    taken
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn folded(step: u32, payload: &[u8]) -> FoldedStep {
+        FoldedStep {
+            step_id: step,
+            idem_key: [u8::try_from(step % 256).unwrap_or(0); 32],
+            payload_version: 1,
+            payload: Bytes::copy_from_slice(payload),
+        }
+    }
+
+    #[test]
+    fn checkpoint_round_trips() {
+        let steps = vec![
+            folded(0, b"alpha"),
+            folded(1, b""),
+            folded(2, b"gamma-payload"),
+        ];
+        let encoded = encode_checkpoint(&steps);
+        let decoded = decode_checkpoint(&encoded).unwrap();
+        assert_eq!(decoded, steps);
+    }
+
+    #[test]
+    fn decode_rejects_truncation() {
+        let steps = vec![folded(0, b"data")];
+        let mut encoded = encode_checkpoint(&steps);
+        encoded.truncate(encoded.len() - 2);
+        assert!(matches!(
+            decode_checkpoint(&encoded),
+            Err(DurableError::Decode { .. })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_unknown_version() {
+        let mut encoded = encode_checkpoint(&[folded(0, b"x")]);
+        encoded[0] = 99;
+        assert!(matches!(
+            decode_checkpoint(&encoded),
+            Err(DurableError::Decode { .. })
+        ));
+    }
+
+    #[test]
+    fn step_cap_thresholds_are_ninety_percent_and_full() {
+        assert_eq!(step_cap_thresholds(10_000), (9_000, 10_000));
+        assert_eq!(step_cap_thresholds(10), (9, 10));
+        assert_eq!(step_cap_thresholds(0), (u32::MAX, u32::MAX));
+    }
+
+    #[test]
+    fn fold_prefix_respects_budget() {
+        // Each step encodes to 41 + payload; with a 4-byte payload that is 45 bytes + the 5-byte
+        // header. A budget of 5 + 45 + 45 = 95 admits exactly two steps.
+        let lens = vec![4, 4, 4, 4];
+        assert_eq!(fold_prefix_len(&lens, 95), 2);
+        // A step larger than the entire budget is left un-folded.
+        assert_eq!(fold_prefix_len(&[10_000], 50), 0);
+    }
+
+    #[test]
+    fn prune_cutoffs_subtract_ttl_from_now() {
+        let policy = RetentionPolicy {
+            ttl_completed_secs: 10,
+            ttl_failed_secs: 20,
+            ..RetentionPolicy::default()
+        };
+        let cutoffs = PruneCutoffs::from_policy(&policy, 100_000);
+        assert_eq!(cutoffs.completed_before_ms, 90_000);
+        assert_eq!(cutoffs.failed_before_ms, 80_000);
+        assert_eq!(checkpoint_budget(1_048_576), 1_048_576);
+    }
+
+    #[tokio::test]
+    async fn prune_in_batches_loops_until_drained_and_yields() {
+        use std::cell::Cell;
+        // Three full batches (500) then a short one (120) → four calls, totalling 1620.
+        let remaining = Cell::new(1_620u64);
+        let policy = RetentionPolicy::default();
+        let total = prune_in_batches(&policy, 0, |_cutoffs, batch| {
+            let deleted = remaining.get().min(batch);
+            remaining.set(remaining.get() - deleted);
+            async move { Ok(deleted) }
+        })
+        .await
+        .unwrap();
+        assert_eq!(total, 1_620);
+        assert_eq!(remaining.get(), 0);
+    }
+}

--- a/crates/zeph-durable/src/timer.rs
+++ b/crates/zeph-durable/src/timer.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Durable timers: wakes that survive a process restart.
+//!
+//! [`DurableContext::sleep_until`](crate::DurableContext::sleep_until) journals a `durable_timers`
+//! row at a deterministic [`TimerId`](crate::TimerId) for its program position and parks until the
+//! instant arrives. The [`DurableTimerService`] is a background task that polls the backend for due
+//! timers, marks them fired, and wakes their parked waiters.
+//!
+//! # Restart semantics (FR-DE-06)
+//!
+//! A timer is persisted with its `due_at`, so a process that was down when the instant elapsed
+//! recovers correctly: on the first poll after restart the service sees the timer's `due_at` is in
+//! the past and fires it immediately. The awaiting execution, replaying to the same `sleep_until`
+//! call, re-derives the timer id, finds it already fired, and returns at once instead of sleeping
+//! again.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::backend::DurableBackendEnum;
+use crate::backend::local::now_unix_millis;
+
+/// Background task that fires durable timers whose instant has arrived.
+///
+/// Spawn [`DurableTimerService::run`] on a supervised task. It owns no timer state of its own — the
+/// `durable_timers` table is the source of truth — so it is safe to stop and restart: a restarted
+/// service re-reads due timers and fires any that elapsed while it was down.
+#[derive(Debug)]
+pub struct DurableTimerService {
+    backend: Arc<DurableBackendEnum>,
+    poll_interval: Duration,
+}
+
+impl DurableTimerService {
+    /// Build the service from the shared backend and a poll cadence.
+    ///
+    /// `poll_interval` is the worst-case latency between a timer's instant and its firing; the
+    /// `promise_poll_interval_secs` config value (default 2 s) is the natural source.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::sync::Arc;
+    /// use std::time::Duration;
+    /// use zeph_durable::{DurableBackendEnum, DurableTimerService, LocalBackend};
+    ///
+    /// let backend = Arc::new(DurableBackendEnum::Local(Arc::new(
+    ///     LocalBackend::open("durable.db", 1_048_576).await?,
+    /// )));
+    /// let service = DurableTimerService::new(backend, Duration::from_secs(2));
+    /// let task = tokio::spawn(service.run());
+    /// # let _ = task;
+    /// # Ok(()) }
+    /// ```
+    #[must_use]
+    pub fn new(backend: Arc<DurableBackendEnum>, poll_interval: Duration) -> Self {
+        Self {
+            backend,
+            // Tokio's interval panics on a zero period; clamp to at least 1 ms.
+            poll_interval: poll_interval.max(Duration::from_millis(1)),
+        }
+    }
+
+    /// Run the timer poll loop until the task is aborted.
+    ///
+    /// Each tick fires every timer whose `due_at` has elapsed (including, on the first tick after a
+    /// restart, timers that came due during downtime — FR-DE-06). A backend error is logged and the
+    /// loop continues so a transient failure does not strand future timers.
+    pub async fn run(self) {
+        let mut tick = tokio::time::interval(self.poll_interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tick.tick().await;
+            self.fire_due().await;
+        }
+    }
+
+    /// Fire every currently-due timer once. Exposed for a deterministic test poll.
+    pub(crate) async fn fire_due(&self) {
+        let now = now_unix_millis();
+        let due = match self.backend.due_timers(now).await {
+            Ok(due) => due,
+            Err(error) => {
+                tracing::warn!(%error, "durable timer poll failed; will retry next tick");
+                return;
+            }
+        };
+        for timer in due {
+            match self.backend.mark_timer_fired(timer).await {
+                Ok(true) => tracing::debug!(timer_id = %timer.as_uuid(), "durable timer fired"),
+                // Already fired by a concurrent poll — nothing to do.
+                Ok(false) => {}
+                Err(error) => {
+                    tracing::warn!(%error, timer_id = %timer.as_uuid(), "failed to mark timer fired");
+                }
+            }
+        }
+    }
+}

--- a/crates/zeph-durable/src/waiters.rs
+++ b/crates/zeph-durable/src/waiters.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! In-process wakeup registry for parked promises and timers.
+//!
+//! A [`NotifyRegistry`] is the rendezvous between a task awaiting an external completion (a
+//! [`DurablePromise`](crate::DurablePromise) or a `sleep_until`) and the task that satisfies it (a
+//! [`DurableHandle::resolve`](crate::DurableHandle::resolve) call, or the
+//! [`DurableTimerService`](crate::DurableTimerService)). Both reach the *same* registry through the
+//! shared [`LocalBackend`](crate::LocalBackend), so an in-process resolution wakes the waiter
+//! immediately rather than waiting out the database poll interval.
+//!
+//! The registry is a pure in-memory optimization layered on top of the durable database state: the
+//! database row is always the source of truth (resolution is committed before the wake fires), and a
+//! waiter that registered before a cross-process resolution — or that could not register because the
+//! parked cap was reached — still observes the result through its periodic poll. Losing a wakeup
+//! therefore costs at most one extra poll interval; it never costs correctness.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::Notify;
+use uuid::Uuid;
+
+/// A keyed map of one-shot [`Notify`] handles shared between waiters and resolvers.
+///
+/// Keyed by the raw [`Uuid`] of a [`PromiseId`](crate::PromiseId) or
+/// [`TimerId`](crate::TimerId). The inner `Mutex` only ever guards map insertion and removal — never
+/// an `.await` — so it cannot deadlock the async runtime: a waiter clones its `Arc<Notify>` out and
+/// awaits it with the lock released.
+#[derive(Debug, Default)]
+pub(crate) struct NotifyRegistry {
+    inner: Mutex<HashMap<Uuid, Arc<Notify>>>,
+}
+
+impl NotifyRegistry {
+    /// Register interest in `key`, returning the shared [`Notify`] to await on.
+    ///
+    /// `cap` bounds the number of distinct parked keys (the `max_parked_promises` budget). When the
+    /// registry already holds `cap` distinct keys and `key` is not among them, registration is
+    /// declined (`None`) and the caller falls back to pure database polling. An already-registered
+    /// `key` always returns its existing handle regardless of the cap, so a re-poll never trips it.
+    pub(crate) fn register(&self, key: Uuid, cap: Option<usize>) -> Option<Arc<Notify>> {
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(existing) = guard.get(&key) {
+            return Some(existing.clone());
+        }
+        if let Some(cap) = cap
+            && guard.len() >= cap
+        {
+            return None;
+        }
+        let notify = Arc::new(Notify::new());
+        guard.insert(key, notify.clone());
+        Some(notify)
+    }
+
+    /// Wake every task parked on `key` and drop the registration.
+    ///
+    /// Called once the backing row has been committed to a satisfied state. Uses
+    /// [`Notify::notify_waiters`] so only tasks already parked at the call are woken; a waiter that
+    /// registers afterward re-reads the committed state and returns without parking.
+    pub(crate) fn wake(&self, key: Uuid) {
+        let notify = {
+            let mut guard = self
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            guard.remove(&key)
+        };
+        if let Some(notify) = notify {
+            notify.notify_waiters();
+        }
+    }
+
+    /// Drop a registration without waking, for a waiter that has observed the result and is leaving.
+    pub(crate) fn cancel(&self, key: Uuid) {
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.remove(&key);
+    }
+
+    /// Current number of distinct parked keys (for the parked-cap gauge and tests).
+    #[cfg(test)]
+    pub(crate) fn parked(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn register_is_idempotent_per_key() {
+        let reg = NotifyRegistry::default();
+        let key = Uuid::now_v7();
+        let a = reg.register(key, None).unwrap();
+        let b = reg.register(key, None).unwrap();
+        assert!(Arc::ptr_eq(&a, &b), "the same key shares one Notify");
+        assert_eq!(reg.parked(), 1);
+    }
+
+    #[test]
+    fn cap_declines_new_keys_but_admits_existing() {
+        let reg = NotifyRegistry::default();
+        let first = Uuid::now_v7();
+        assert!(reg.register(first, Some(1)).is_some());
+        // A second distinct key is declined at the cap → caller polls.
+        assert!(reg.register(Uuid::now_v7(), Some(1)).is_none());
+        // The already-parked key is still served (a re-poll must not be locked out).
+        assert!(reg.register(first, Some(1)).is_some());
+    }
+
+    #[tokio::test]
+    async fn wake_releases_a_parked_waiter() {
+        let reg = Arc::new(NotifyRegistry::default());
+        let key = Uuid::now_v7();
+        let notify = reg.register(key, None).unwrap();
+        let parked = {
+            let notify = notify.clone();
+            tokio::spawn(async move { notify.notified().await })
+        };
+        // Give the spawned task a moment to park before we wake it.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        reg.wake(key);
+        tokio::time::timeout(Duration::from_secs(1), parked)
+            .await
+            .expect("waiter is woken")
+            .expect("task joins");
+        assert_eq!(reg.parked(), 0, "wake drops the registration");
+    }
+}


### PR DESCRIPTION
## Summary

Completes the `DurableContext` API surface — **C5 of epic #4707** (spec-064, `zeph-durable`). Builds on C1–C4 (#4944/#4945/#4946/#4947, all merged) and adds durable promises, durable timers, and the retention/compaction machinery. Pure additive change to `zeph-durable`; `zeph-core` (the only reverse dependency) is unaffected.

Closes #4948.

## What landed

**Durable promises (`promise.rs`, FR-DE-05, INV-9)**
- `ctx.promise::<T>()` mints a `PromiseId` derived from `(execution_id, step_id)` plus a 32-byte CSPRNG resolver token (`Zeroizing`, zeroized on drop). Only the domain-separated BLAKE3 hash — bound to `(promise_id, execution_id)` — is stored in `durable_promises.resolver_token_hash`.
- `DurableHandle::resolve(id, token, value)` authenticates the token in **constant time** (`blake3::Hash` equality) before sealing the value with a `(execution_id, promise_id)`-bound AAD and committing it. Wrong token → `PromiseRejected`; unknown promise → `UnknownPromise`; double-resolve is a no-op.
- The resolver token is the only capability — a `PromiseId` is derivable from the journal and appears in spans, but the LLM never sees the token, so it cannot resolve its own promises (INV-9). `DurableHandle` must be kept off any LLM-reachable tool surface.
- `ctx.await_promise()` parks on a `tokio::sync::Notify` keyed by promise id with a `promise_poll_interval_secs` DB-poll fallback; above `max_parked_promises` parked waiters it polls without registering.

**Durable timers (`timer.rs`, FR-DE-06)**
- `ctx.sleep_until(due)` arms a `durable_timers` row at a deterministic `TimerId::derive(exec, step)` and parks until due; it fires its own timer even with no service running.
- `DurableTimerService` polls `due_timers(now)` (covered by `idx_durable_timers_due`), fires them idempotently, and wakes parked waiters. A timer whose instant elapsed during downtime fires on the first poll after restart; a resumed `sleep_until` returns immediately because it re-derives the same `TimerId`.

**Retention & compaction (`retention.rs`, spec NEVER: never on the hot path)**
- `DurableRetentionService` prunes terminal executions past `ttl_completed_secs`/`ttl_failed_secs` in `prune_batch_size` batches (children-then-parent FK order), yielding between batches.
- Crossing the soft step cap (90% of `max_steps_per_execution`) spawns a **background** checkpoint fold (tracked in a `JoinSet`, drainable via `ctx.drain_background()`): the committed-idempotent prefix is packed into one AEAD-sealed `Checkpoint` (budget-capped at `max_payload_bytes`) and the folded rows are deleted. The hard cap (100%) aborts with `StepCapExceeded`.
- On resume the cursor preloads checkpoints, reconstructing each folded step as a `StepResult` (idempotency key preserved) so folded idempotent steps replay their journaled value **without** re-running the op and without tripping the divergence guard (INV-3).

## Design notes

- **Deterministic promise/timer ids.** Promises/timers correlate across a crash-resume by deriving their ids from `(execution_id, step_id)` (UUIDv8) rather than a random UUIDv7, so a resumed program re-attaches to the pending row instead of minting an orphan. This is security-neutral: INV-9 makes the resolver token — not the id — the capability.
- **Backend surface.** Promise/timer/checkpoint/prune methods are inherent on `DurableBackendEnum` (forwarding to `LocalBackend`'s dedicated `durable_promises`/`durable_timers` tables), not on the sealed `ExecutionBackend` trait — they are local-table-specific; a future Restate backend would satisfy them via its own SDK, and the closed `match` makes that a compile-time prompt.
- New deps (Layer-0 infra, INV-1): `rand` (resolver-token CSPRNG), `zeroize` (`Zeroizing` token), `uuid` `v8` feature.

## Tests & gates

- `cargo nextest run -p zeph-durable` → **102 pass** (+10): promise auth (right/wrong/unknown token, constant-time), notify-wake, resumed-promise await, timer arm/due/fire + restart re-arm, prune, checkpoint fold + replay-through-checkpoint, soft/hard cap.
- `cargo clippy --all-targets -- -D warnings` clean on **sqlite and postgres**.
- `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps` clean; `cargo test --doc` 34 pass.
- `RUSTFLAGS="-D warnings" cargo check --all-targets` clean on both backends.
- `cargo +nightly fmt --check` clean; `zeph-core` (consumer) 1532 tests pass.

## Spans added

`durable.promise.create/await/resolve`, `durable.timer.arm/fire`, `durable.journal.prune` (real body), `durable.journal.checkpoint`, `durable.replay.cursor.preload`.

## Out of scope (other epic children)

CLI/TUI/config/init/migrate wiring (C6 #4949); the agent-loop adapter (A1 #4951, LLM live-API gate); subagent promise wiring (A4 #4954); the long-running `service::run` interval loops are exercised via the deterministic `fire_due`/single-`prune` paths, not a live tick; Postgres-server parity (testcontainers).