### PR TITLE
feat(core): durable agent tool-loop steps with crash-resume (#4951)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `feat(core)`: P1 durable adapter for the agent tool-loop (spec-064 §P1, closes #4951).
+  `SessionState` gains `durable_ctx: Option<Arc<DurableContext>>` and `durable_turn_replayed: bool`.
+  The new `call_llm_durable` helper in `tier_loop.rs` wraps each LLM turn as an
+  `ExactlyOnceGuarded / CostBearingOrBoundaryIdempotent / OnAmbiguous::Skip` durable step; a
+  `core.durable.turn` tracing span is emitted with the `execution_id` field for distributed traces.
+  When the step is replayed from the journal, `durable_turn_replayed = true` suppresses re-delivery
+  of the assistant text to the channel (spec-064 §15 RuntimeLayer observe-only). When `durable_ctx`
+  is `None` (durable disabled or `agent_turns = false`) the loop runs exactly as before with zero
+  overhead. On `DurableError` the adapter degrades gracefully to non-durable mode with a `WARN` log.
+
 - `feat(durable)`: scaffolded the new Layer-0 `zeph-durable` crate (spec-064) — the foundation of
   the native durable execution layer. This first slice is type-level only, with no runtime
   behavior: journal-boundary newtypes (`ExecutionId`/`PromiseId`/`TimerId` as UUIDv7, `StepId`,

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -780,6 +780,18 @@ pub(crate) struct SessionState {
     /// When `true`, the agent prompt includes a brief guest-context annotation, and the response
     /// is delivered via `answerGuestQuery` instead of `sendMessage`.
     pub(crate) is_guest_context: bool,
+    /// Active durable execution context for the P1 agent-loop adapter (spec-064 §P1).
+    ///
+    /// `Some` when `[durable] enabled = true` and `agent_turns = true`. The context is opened
+    /// once per session (or resumed from a prior crash) and shared across all turns via `Arc`.
+    /// `None` when durable execution is disabled — in which case the loop runs unmodified.
+    pub(crate) durable_ctx: Option<std::sync::Arc<zeph_durable::DurableContext>>,
+    /// Set to `true` for the duration of a turn whose LLM step was replayed from the journal.
+    ///
+    /// Used by `process_single_native_turn` to suppress re-printing already-emitted assistant
+    /// output (spec-064 §INV-001 §15 `RuntimeLayer` double-print suppression). Cleared at the
+    /// start of each turn.
+    pub(crate) durable_turn_replayed: bool,
 }
 
 /// Extracted hook lists from `[hooks]` config, stored in `SessionState`.
@@ -1144,6 +1156,8 @@ impl SessionState {
             policy_config: None,
             hooks_config: HooksConfigSnapshot::default(),
             is_guest_context: false,
+            durable_ctx: None,
+            durable_turn_replayed: false,
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -70,6 +70,8 @@ fn make_session_state() -> SessionState {
         hooks_config: HooksConfigSnapshot::default(),
         last_assistant_at: None,
         is_guest_context: false,
+        durable_ctx: None,
+        durable_turn_replayed: false,
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -3,6 +3,7 @@
 
 use futures::FutureExt as _;
 use tracing::Instrument;
+use zeph_durable::{EffectIntentSubClass, OnAmbiguous, StepDescriptor};
 use zeph_llm::provider::{Message, MessagePart, Role};
 use zeph_tools::ExecutionContext;
 use zeph_tools::executor::ToolCall;
@@ -2476,6 +2477,60 @@ impl<C: Channel> Agent<C> {
         Ok(false)
     }
 
+    /// Drive an LLM chat call through the durable step journal when a [`DurableContext`] is
+    /// attached to the session.
+    ///
+    /// The step commits an `ExactlyOnceGuarded` / `CostBearingOrBoundaryIdempotent` intent
+    /// before the real call runs, so a crash between the API response and journal acknowledgement
+    /// is handled safely (`OnAmbiguous::Skip` — the cost is already incurred). The closure payload
+    /// is `None` — the actual call always executes in every branch because `&mut self` cannot be
+    /// captured inside the durable closure. The [`DurableStep::was_replayed`] flag is used to
+    /// suppress double-printing in the caller.
+    ///
+    /// When `durable_ctx` is `None` the call is forwarded directly without any journaling.
+    async fn call_llm_durable(
+        &mut self,
+        tool_defs: &[ToolDefinition],
+        iteration: usize,
+    ) -> Result<Option<zeph_llm::provider::ChatResponse>, crate::agent::error::AgentError> {
+        let Some(ctx) = self.services.session.durable_ctx.clone() else {
+            return self.call_chat_with_tools_retry(tool_defs, 2).await;
+        };
+
+        let turn_span = tracing::info_span!(
+            "core.durable.turn",
+            iteration,
+            execution_id = %ctx.execution_id().as_uuid(),
+        );
+        let cached_tokens = self.runtime.providers.cached_prompt_tokens;
+        let fp_input = format!("llm_call:iter={iteration}:tokens={cached_tokens}").into_bytes();
+        let desc = StepDescriptor::exactly_once_guarded(
+            "llm_call",
+            EffectIntentSubClass::CostBearingOrBoundaryIdempotent,
+            Some(OnAmbiguous::Skip),
+            fp_input,
+        )
+        .expect("CostBearingOrBoundaryIdempotent never requires explicit policy");
+
+        let step = ctx
+            .step_recorded::<Option<i64>, _, _>(desc, |_handle| async move { Ok(None::<i64>) })
+            .instrument(turn_span)
+            .await;
+
+        match step {
+            Ok(record) if record.was_replayed() => {
+                // Already delivered to the user in a prior run; suppress re-printing.
+                self.services.session.durable_turn_replayed = true;
+                self.call_chat_with_tools_retry(tool_defs, 2).await
+            }
+            Ok(_) => self.call_chat_with_tools_retry(tool_defs, 2).await,
+            Err(e) => {
+                tracing::warn!(error = %e, "durable LLM step error; degrading to non-durable");
+                self.call_chat_with_tools_retry(tool_defs, 2).await
+            }
+        }
+    }
+
     /// Execute one turn of the native tool loop. Returns `Ok(Some(()))` when the LLM produced
     /// a terminal text response (caller should return `Ok(())`), `Ok(None)` to continue the
     /// loop, or `Err` on a hard error.
@@ -2492,6 +2547,9 @@ impl<C: Channel> Agent<C> {
         iteration: usize,
         query_embedding: Option<Vec<f32>>,
     ) -> Result<Option<()>, crate::agent::error::AgentError> {
+        // Clear the per-turn replay flag; it is set below when the LLM step is replayed.
+        self.services.session.durable_turn_replayed = false;
+
         // Track iteration for BudgetHint injection (#2267).
         self.services.tool_state.current_tool_iteration = iteration;
         self.channel.send_typing().await?;
@@ -2520,7 +2578,9 @@ impl<C: Channel> Agent<C> {
         } else {
             let _ = self.channel.send_status("thinking...").await;
         }
-        let chat_result = self.call_chat_with_tools_retry(tool_defs, 2).await?;
+
+        let chat_result = self.call_llm_durable(tool_defs, iteration).await?;
+
         let _ = self.channel.send_status("").await;
 
         let Some(chat_result) = chat_result else {
@@ -2541,12 +2601,18 @@ impl<C: Channel> Agent<C> {
                 return Ok(Some(()));
             }
             let cleaned = self.scan_output_and_warn(text);
-            if !cleaned.is_empty() {
-                let display = self.maybe_redact(&cleaned);
-                self.channel.send(&display).await?;
+            // Double-print suppression: when the LLM step was replayed from the journal, the
+            // assistant text was already delivered in a previous run; skip re-sending it to the
+            // channel. Persistence and in-memory push still run so the context is consistent
+            // (spec-064 §001 §15 RuntimeLayer observe-only; replay control is NOT in RuntimeLayer).
+            if !self.services.session.durable_turn_replayed {
+                if !cleaned.is_empty() {
+                    let display = self.maybe_redact(&cleaned);
+                    self.channel.send(&display).await?;
+                }
+                self.store_response_in_cache(&cleaned, query_embedding)
+                    .await;
             }
-            self.store_response_in_cache(&cleaned, query_embedding)
-                .await;
             self.persist_message(Role::Assistant, &cleaned, &[], false)
                 .await;
             self.msg


### PR DESCRIPTION
## Summary

- Adds `SessionState.durable_ctx` and `durable_turn_replayed` fields for per-session durable execution context.
- Adds `call_llm_durable` helper in `tier_loop.rs` that wraps each LLM call as an `ExactlyOnceGuarded / CostBearingOrBoundaryIdempotent / OnAmbiguous::Skip` durable step.
- Emits a `core.durable.turn` tracing span with `execution_id` for distributed trace correlation.
- Suppresses double-printing assistant text when `was_replayed() == true` (spec-064 §15 RuntimeLayer observe-only).
- Degrades gracefully to non-durable mode on `DurableError` (WARN log, no panic).
- Zero overhead when `durable_ctx` is `None` (disabled or `agent_turns = false`).

Closes #4951

## Deferred

- **Tool dispatch wrapping per EffectClass**: `ToolOutput` does not implement `Serialize + DeserializeOwned` — required by `DurableContext::step()`. Needs a separate cross-crate change (add serde to `ToolOutput` or introduce a serializable wrapper). Deferred to a follow-up PR.
- **Auto-injection of `durable_ctx` from `DurableConfig`**: callers must set `durable_ctx` manually. Wiring from config → `DurableContext` construction → session attachment is not yet in the binary startup path.
- **LLM skip on replay**: `call_chat_with_tools_retry` still fires on replay (ChatResponse cannot yet be rehydrated from persisted messages). Only channel output is suppressed. Full skip-on-replay is P2.

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 10657 PASS (=baseline, no regressions)
- [x] `cargo clippy -p zeph-core -p zeph-durable -p zeph-config -- -D warnings` — 0 warnings
- [x] `cargo +nightly fmt --check` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean
- [ ] Live crash-resume session (blocked: `durable_ctx` not yet auto-injected from config; manual wiring required)