### PR TITLE
feat(tui,experiments): reverse search backward nav and subject error tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   of the assistant text to the channel (spec-064 §15 RuntimeLayer observe-only). When `durable_ctx`
   is `None` (durable disabled or `agent_turns = false`) the loop runs exactly as before with zero
   overhead. On `DurableError` the adapter degrades gracefully to non-durable mode with a `WARN` log.
+- `feat(tui)`: `ReverseSearchState` now supports backward navigation — `select_previous()` cycles
+  toward newer matches (with wrap-around) and is bound to `Ctrl+S` in the reverse-search overlay,
+  matching bash/zsh `Ctrl+R`/`Ctrl+S` conventions. (#4691)
+- `feat(experiments)`: added `tolerate_subject_errors: bool` config field to `ExperimentConfig`
+  (default `false`, preserving existing abort-on-failure semantics). When `true`, per-case Phase 1
+  failures are excluded from scoring instead of aborting the run, matching Phase 2 graceful
+  degradation behavior. Failed cases are logged at `WARN` and counted in `error_count`; the report
+  `is_partial` flag is set to `true` so callers can distinguish partial runs from clean ones.
+  `EvalReport::is_partial` documents the partial-anchor comparison caveat. (#4856)
 
 - `feat(durable)`: scaffolded the new Layer-0 `zeph-durable` crate (spec-064) — the foundation of
   the native durable execution layer. This first slice is type-level only, with no runtime

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -494,6 +494,15 @@ pub struct ExperimentConfig {
     pub auto_apply: bool,
     #[serde(default)]
     pub schedule: ExperimentSchedule,
+    /// When `true`, a subject call failure (LLM error or timeout) excludes the case from
+    /// scoring instead of aborting the entire evaluation run.
+    ///
+    /// Default: `false` (preserves existing abort-on-error semantics). Set to `true` when
+    /// running parallel evaluations where a single subject timeout should not discard all
+    /// already-billed responses from other in-flight futures — at the cost of producing a
+    /// partial result rather than a guaranteed complete evaluation.
+    #[serde(default)]
+    pub tolerate_subject_errors: bool,
 }
 
 impl Default for ExperimentConfig {
@@ -508,6 +517,7 @@ impl Default for ExperimentConfig {
             eval_budget_tokens: default_experiment_eval_budget_tokens(),
             auto_apply: false,
             schedule: ExperimentSchedule::default(),
+            tolerate_subject_errors: false,
         }
     }
 }

--- a/crates/zeph-core/src/agent/experiment_cmd.rs
+++ b/crates/zeph-core/src/agent/experiment_cmd.rs
@@ -37,7 +37,8 @@ impl<C: Channel> Agent<C> {
             .as_ref()
             .map_or_else(|| Arc::clone(&provider_arc), |p| Arc::new(p.clone()));
         let evaluator = Evaluator::new(judge_arc, benchmark, config.eval_budget_tokens)
-            .map_err(|e| format!("Failed to create evaluator: {e}"))?;
+            .map_err(|e| format!("Failed to create evaluator: {e}"))?
+            .with_tolerate_subject_errors(config.tolerate_subject_errors);
 
         let generator = Box::new(GridStep::new(SearchSpace::default()));
         // Use the pre-built baseline snapshot that reflects actual runtime config values.
@@ -386,6 +387,36 @@ mod tests {
         assert!(
             result.contains("Memory is not enabled"),
             "expected no-memory message, got: {result:?}"
+        );
+    }
+
+    /// Verify that `tolerate_subject_errors` from `ExperimentConfig` is forwarded to
+    /// `Evaluator::with_tolerate_subject_errors` in `build_experiment_engine`.
+    ///
+    /// Uses a real temporary benchmark TOML so the code reaches the `.with_tolerate_subject_errors`
+    /// call site. Success (no error returned) confirms the builder chain is invoked correctly;
+    /// the underlying field value is passed through without transformation.
+    #[test]
+    fn build_experiment_engine_forwards_tolerate_subject_errors() {
+        use std::io::Write as _;
+        use zeph_config::ExperimentConfig;
+
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "[[cases]]\nprompt = \"hello\"").unwrap();
+
+        let config = ExperimentConfig {
+            enabled: true,
+            benchmark_file: Some(f.path().to_path_buf()),
+            tolerate_subject_errors: true,
+            ..ExperimentConfig::default()
+        };
+
+        let mut agent = make_agent();
+        // build_experiment_engine must succeed and silently forward the flag to the Evaluator.
+        let result = agent.build_experiment_engine(config);
+        assert!(
+            result.is_ok(),
+            "build_experiment_engine must succeed with a valid benchmark file"
         );
     }
 }

--- a/crates/zeph-experiments/src/evaluator.rs
+++ b/crates/zeph-experiments/src/evaluator.rs
@@ -108,7 +108,12 @@ pub struct EvalReport {
     pub cases_scored: usize,
     /// Total number of cases in the benchmark set (including failed ones).
     pub cases_total: usize,
-    /// `true` if any case was excluded due to budget exhaustion or judge errors.
+    /// `true` if any case was excluded due to budget exhaustion, judge errors, or subject errors.
+    ///
+    /// When `is_partial = true` and `cases_scored < cases_total`, `mean_score` reflects only the
+    /// surviving subset of cases. Callers must not compare a partial-sample `mean_score` against a
+    /// full-sample baseline as if they are equivalent — the delta may be an artifact of which cases
+    /// failed rather than a real quality improvement.
     pub is_partial: bool,
     /// Number of cases that failed (LLM error, parse error, or budget exceeded).
     pub error_count: usize,
@@ -171,6 +176,8 @@ pub struct Evaluator {
     subject_timeout_secs: u64,
     /// Maximum seconds to wait for the judge model to respond per case.
     judge_timeout_secs: u64,
+    /// When `true`, subject call failures are excluded from scores instead of aborting the run.
+    tolerate_subject_errors: bool,
 }
 
 impl Evaluator {
@@ -192,6 +199,7 @@ impl Evaluator {
             parallel_evals: DEFAULT_PARALLEL_EVALS,
             subject_timeout_secs: DEFAULT_SUBJECT_TIMEOUT_SECS,
             judge_timeout_secs: DEFAULT_JUDGE_TIMEOUT_SECS,
+            tolerate_subject_errors: false,
         })
     }
 
@@ -288,6 +296,42 @@ impl Evaluator {
         self
     }
 
+    /// Control whether subject call failures abort the run or are excluded from scoring.
+    ///
+    /// When `true`, a failed subject case (LLM error or timeout) is logged at `WARN` level
+    /// and excluded from Phase 2 scoring — matching Phase 2's graceful-degradation semantics.
+    /// The report will have `is_partial = true` and the failed cases counted in
+    /// [`EvalReport::error_count`].
+    ///
+    /// When `false` (the default), any subject failure immediately aborts the evaluation and
+    /// returns an error, preserving the existing semantics.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use std::sync::Arc;
+    /// # use zeph_experiments::{BenchmarkSet, BenchmarkCase, Evaluator, EvalError};
+    /// # use zeph_llm::any::AnyProvider;
+    /// # use zeph_llm::mock::MockProvider;
+    /// # fn example() -> Result<Evaluator, EvalError> {
+    /// let judge = Arc::new(AnyProvider::Mock(MockProvider::with_responses(vec![])));
+    /// let benchmark = BenchmarkSet {
+    ///     cases: vec![BenchmarkCase {
+    ///         prompt: "hi".into(), context: None, reference: None, tags: None,
+    ///     }],
+    /// };
+    /// let evaluator = Evaluator::new(judge, benchmark, 10_000)?.with_tolerate_subject_errors(true);
+    /// # Ok(evaluator)
+    /// # }
+    /// ```
+    ///
+    /// [`EvalReport::error_count`]: EvalReport::error_count
+    #[must_use]
+    pub fn with_tolerate_subject_errors(mut self, tolerate: bool) -> Self {
+        self.tolerate_subject_errors = tolerate;
+        self
+    }
+
     /// Run the full benchmark against `subject`, returning aggregate scores.
     ///
     /// Both subject and judge calls are parallelized up to `parallel_evals` concurrent
@@ -343,10 +387,22 @@ impl Evaluator {
             });
         }
 
-        // Collect subject responses; any error is fatal (propagate immediately).
+        // Collect subject responses. When `tolerate_subject_errors` is false (default) any
+        // error aborts the run immediately. When true, failed cases are excluded from Phase 2.
         let mut indexed_responses: Vec<(usize, String)> = Vec::with_capacity(cases_total);
+        let mut subject_error_count = 0usize;
         while let Some(result) = subject_futures.next().await {
-            indexed_responses.push(result?);
+            match result {
+                Ok(pair) => indexed_responses.push(pair),
+                Err(e) if self.tolerate_subject_errors => {
+                    tracing::warn!(
+                        error = %e,
+                        "subject call failed, excluding case from evaluation"
+                    );
+                    subject_error_count += 1;
+                }
+                Err(e) => return Err(e),
+            }
         }
         // Restore deterministic order for Phase 2 (FuturesUnordered yields in completion order).
         indexed_responses.sort_unstable_by_key(|(i, _)| *i);
@@ -439,6 +495,7 @@ impl Evaluator {
         }
 
         let cases_scored = scores.len();
+        error_count += subject_error_count;
         let is_partial = budget_hit || error_count > 0;
 
         // Each successful judge call left a +1 reservation in tokens_used that was never
@@ -1355,5 +1412,145 @@ mod tests {
                 cs.case_index,
             );
         }
+    }
+
+    /// Mixed outcome: one subject call succeeds, one fails. With tolerate=true the successful
+    /// case must be scored and the failed case must be counted in error_count.
+    #[tokio::test]
+    async fn tolerate_subject_errors_mixed_partial_result() {
+        use std::sync::Arc;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let benchmark = BenchmarkSet {
+            cases: vec![
+                BenchmarkCase {
+                    prompt: "Q1".into(),
+                    context: None,
+                    reference: None,
+                    tags: None,
+                },
+                BenchmarkCase {
+                    prompt: "Q2".into(),
+                    context: None,
+                    reference: None,
+                    tags: None,
+                },
+            ],
+        };
+        // errors queue is consumed before responses: first call returns Err, second returns "A2".
+        let subject_mock = AnyProvider::Mock(
+            MockProvider::with_responses(vec!["A2".into()]).with_errors(vec![
+                zeph_llm::LlmError::Other("subject error on case 0".into()),
+            ]),
+        );
+        let judge_mock = AnyProvider::Mock(MockProvider::with_responses(vec![
+            r#"{"score": 7.0, "reason": "ok"}"#.into(),
+        ]));
+
+        let evaluator = Evaluator::new(Arc::new(judge_mock), benchmark, 1_000_000)
+            .unwrap()
+            .with_parallel_evals(1)
+            .with_tolerate_subject_errors(true);
+
+        let report = evaluator.evaluate(&subject_mock).await.unwrap();
+
+        assert_eq!(report.cases_total, 2);
+        assert_eq!(
+            report.cases_scored, 1,
+            "only the successful case must be scored"
+        );
+        assert_eq!(
+            report.error_count, 1,
+            "the failed subject case must be counted as error"
+        );
+        assert!(
+            report.is_partial,
+            "is_partial must be true for mixed outcome"
+        );
+        assert!(
+            report.mean_score.is_finite(),
+            "mean_score must be finite for the scored case"
+        );
+    }
+
+    /// When `tolerate_subject_errors = true`, subject LLM errors exclude cases from scoring
+    /// rather than aborting the run.
+    #[tokio::test]
+    async fn tolerate_subject_errors_excludes_failed_case() {
+        use std::sync::Arc;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        // All subject calls fail; with tolerate=true the run must complete as a partial result.
+        let benchmark = BenchmarkSet {
+            cases: vec![
+                BenchmarkCase {
+                    prompt: "Q1".into(),
+                    context: None,
+                    reference: None,
+                    tags: None,
+                },
+                BenchmarkCase {
+                    prompt: "Q2".into(),
+                    context: None,
+                    reference: None,
+                    tags: None,
+                },
+            ],
+        };
+        let failing_subject = AnyProvider::Mock(MockProvider::failing());
+        let judge_mock = AnyProvider::Mock(MockProvider::with_responses(vec![]));
+
+        let evaluator = Evaluator::new(Arc::new(judge_mock), benchmark, 1_000_000)
+            .unwrap()
+            .with_parallel_evals(1)
+            .with_tolerate_subject_errors(true);
+
+        let report = evaluator.evaluate(&failing_subject).await.unwrap();
+
+        assert_eq!(report.cases_total, 2);
+        assert!(
+            report.is_partial,
+            "partial result expected when subject cases fail"
+        );
+        assert_eq!(
+            report.error_count, 2,
+            "both failed subject cases must be counted as errors"
+        );
+        assert_eq!(
+            report.cases_scored, 0,
+            "no cases can be scored when all subject calls fail"
+        );
+    }
+
+    /// When `tolerate_subject_errors = false` (default), a subject LLM error aborts the run.
+    #[tokio::test]
+    async fn tolerate_subject_errors_false_propagates_error() {
+        use std::sync::Arc;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let benchmark = BenchmarkSet {
+            cases: vec![BenchmarkCase {
+                prompt: "Q1".into(),
+                context: None,
+                reference: None,
+                tags: None,
+            }],
+        };
+        // failing() makes every chat() call return an error.
+        let failing_subject = AnyProvider::Mock(MockProvider::failing());
+        let judge_mock = AnyProvider::Mock(MockProvider::with_responses(vec![]));
+
+        let evaluator = Evaluator::new(Arc::new(judge_mock), benchmark, 1_000_000)
+            .unwrap()
+            .with_parallel_evals(1);
+
+        let result = evaluator.evaluate(&failing_subject).await;
+        assert!(
+            result.is_err(),
+            "subject error must abort the evaluation when tolerate_subject_errors = false"
+        );
     }
 }

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -633,8 +633,17 @@ async fn skill_bodies_prepended_to_system_prompt() {
         )
         .unwrap();
 
-    // Wait for the loop to call the provider at least once.
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // Poll until the provider is called (or 5 s timeout — guards against CI load).
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if !recorded.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("provider should have been called within 5 s");
 
     let calls = recorded.lock().unwrap();
     assert!(!calls.is_empty(), "provider should have been called");
@@ -675,7 +684,17 @@ async fn no_skills_does_not_add_fence_to_system_prompt() {
         )
         .unwrap();
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // Poll until the provider is called (or 5 s timeout — guards against CI load).
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if !recorded.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("provider should have been called within 5 s");
 
     let calls = recorded.lock().unwrap();
     assert!(!calls.is_empty());

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -1231,6 +1231,12 @@ impl App {
                     s.select_next();
                 }
             }
+            // Ctrl+S — move to a newer (previous) match, mirroring bash Ctrl+S.
+            KeyCode::Char('s') if is_ctrl => {
+                if let Some(s) = self.reverse_search.as_mut() {
+                    s.select_previous();
+                }
+            }
             KeyCode::Backspace => {
                 let history = self.sessions.current().input_history.clone();
                 if let Some(s) = self.reverse_search.as_mut() {

--- a/crates/zeph-tui/src/widgets/reverse_search.rs
+++ b/crates/zeph-tui/src/widgets/reverse_search.rs
@@ -49,11 +49,58 @@ impl ReverseSearchState {
         self.refilter(history);
     }
 
-    /// Advance `selected` to the next older match (clamps at the end).
+    /// Advance `selected` to the next older match (wraps at the end).
+    ///
+    /// Mirrors bash `Ctrl+R` behaviour: repeated presses cycle through older entries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_tui::widgets::reverse_search::ReverseSearchState;
+    ///
+    /// let history = vec!["first".to_owned(), "second".to_owned(), "third".to_owned()];
+    /// let mut state = ReverseSearchState::new(&history);
+    /// // starts at newest (selected = 0)
+    /// state.select_next();
+    /// assert_eq!(state.selected, 1);
+    /// state.select_next();
+    /// assert_eq!(state.selected, 2);
+    /// // wraps back to 0
+    /// state.select_next();
+    /// assert_eq!(state.selected, 0);
+    /// ```
     pub fn select_next(&mut self) {
-        if self.selected + 1 < self.matches.len() {
-            self.selected += 1;
+        if self.matches.is_empty() {
+            return;
         }
+        self.selected = (self.selected + 1) % self.matches.len();
+    }
+
+    /// Move `selected` to the previous (newer) match (wraps at the beginning).
+    ///
+    /// Mirrors bash `Ctrl+S` behaviour: moves back toward more recent matches.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_tui::widgets::reverse_search::ReverseSearchState;
+    ///
+    /// let history = vec!["first".to_owned(), "second".to_owned(), "third".to_owned()];
+    /// let mut state = ReverseSearchState::new(&history);
+    /// // wraps from 0 to last
+    /// state.select_previous();
+    /// assert_eq!(state.selected, 2);
+    /// state.select_previous();
+    /// assert_eq!(state.selected, 1);
+    /// ```
+    pub fn select_previous(&mut self) {
+        if self.matches.is_empty() {
+            return;
+        }
+        self.selected = self
+            .selected
+            .checked_sub(1)
+            .unwrap_or(self.matches.len() - 1);
     }
 
     /// Return the history entry for the currently selected match, or `None` if history is empty.
@@ -209,12 +256,50 @@ mod tests {
     }
 
     #[test]
-    fn select_next_clamps_at_end() {
+    fn select_next_wraps_at_end() {
         let history = make_history(&["a", "b"]);
         let mut state = ReverseSearchState::new(&history);
         state.select_next();
-        state.select_next(); // should clamp, not panic
         assert_eq!(state.selected, 1);
+        state.select_next(); // wraps back to 0
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn select_next_noop_on_empty() {
+        let mut state = ReverseSearchState::new(&[]);
+        state.select_next();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn select_previous_wraps_at_start() {
+        let history = make_history(&["a", "b", "c"]);
+        let mut state = ReverseSearchState::new(&history);
+        // selected = 0, wraps to last
+        state.select_previous();
+        assert_eq!(state.selected, 2);
+        state.select_previous();
+        assert_eq!(state.selected, 1);
+        state.select_previous();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn select_previous_noop_on_empty() {
+        let mut state = ReverseSearchState::new(&[]);
+        state.select_previous();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn select_next_then_previous_returns_to_start() {
+        let history = make_history(&["a", "b", "c"]);
+        let mut state = ReverseSearchState::new(&history);
+        state.select_next();
+        assert_eq!(state.selected, 1);
+        state.select_previous();
+        assert_eq!(state.selected, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#4691 (zeph-tui)**: Add `select_previous()` to `ReverseSearchState` with wrap-around semantics. Wire `Ctrl+S` in `handle_reverse_search_key` to navigate toward newer matches, matching bash/zsh `Ctrl+R`/`Ctrl+S` conventions. `select_next()` updated to also wrap around (was clamping).
- **#4856 (zeph-experiments, zeph-config)**: Add `tolerate_subject_errors: bool` to `ExperimentConfig` (default `false`). When `true`, per-case Phase 1 failures are excluded from scoring instead of aborting — matching Phase 2 graceful degradation. Failed cases logged at `WARN`, counted in `error_count`, and `is_partial = true` is set in `EvalReport`. `EvalReport::is_partial` documents the partial-anchor comparison caveat.

## Changed files

| File | Change |
|------|--------|
| `crates/zeph-tui/src/widgets/reverse_search.rs` | `select_previous()` + updated `select_next()` (wrap), 4 new tests |
| `crates/zeph-tui/src/app/keys.rs` | `Ctrl+S` binding in `handle_reverse_search_key` |
| `crates/zeph-config/src/experiment.rs` | `tolerate_subject_errors: bool` field (default false) |
| `crates/zeph-experiments/src/evaluator.rs` | Phase 1 tolerance logic + `with_tolerate_subject_errors()` builder |
| `crates/zeph-core/src/agent/experiment_cmd.rs` | Wire `config.tolerate_subject_errors` into `Evaluator` |
| `CHANGELOG.md` | `[Unreleased]` entries for both features |

## Test plan

- [x] `cargo nextest run -p zeph-tui --lib --bins`: 568 PASS (4 new reverse-search tests)
- [x] `cargo nextest run -p zeph-experiments -p zeph-config --lib --bins`: 663 PASS
- [x] `cargo nextest run -p zeph-core --lib --bins`: 1533 PASS (wiring test included)
- [x] `cargo clippy -p zeph-tui -p zeph-experiments -p zeph-config -p zeph-core -- -D warnings`: CLEAN
- [x] `cargo +nightly fmt --check`: CLEAN
- [ ] Live TUI `Ctrl+S` key — blocked (no interactive terminal in CI)
- [ ] Live `--experiment-run` with `tolerate_subject_errors = true` — blocked (LLM credits unavailable)

Closes #4691
Closes #4856