### PR TITLE
fix(subagent): offload blocking FS IO to spawn_blocking

### DIFF
--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -493,7 +493,7 @@ impl<C: Channel> Agent<C> {
         // look up skills by definition name rather than the UUID prefix (S1 fix).
         let def_name = {
             let mgr = self.services.orchestration.subagent_manager.as_ref()?;
-            match mgr.def_name_for_resume(id, &cfg) {
+            match mgr.def_name_for_resume(id, &cfg).await {
                 Ok(name) => name,
                 Err(e) => return Some(format!("Failed to resume sub-agent: {e}")),
             }
@@ -502,7 +502,9 @@ impl<C: Channel> Agent<C> {
         let provider = self.provider.clone();
         let tool_executor = Arc::clone(&self.tool_executor);
         let mgr = self.services.orchestration.subagent_manager.as_mut()?;
-        let (task_id, _) = match mgr.resume(id, prompt, provider, tool_executor, skills, &cfg, None)
+        let (task_id, _) = match mgr
+            .resume(id, prompt, provider, tool_executor, skills, &cfg, None)
+            .await
         {
             Ok(pair) => pair,
             Err(e) => return Some(format!("Failed to resume sub-agent: {e}")),

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -79,13 +79,13 @@ pub(super) fn make_message(role: Role, content: String) -> Message {
     }
 }
 
-pub(super) fn append_transcript(
-    writer: &mut Option<TranscriptWriter>,
+pub(super) async fn append_transcript(
+    writer: Option<&TranscriptWriter>,
     seq: &mut u32,
     msg: &Message,
 ) {
     if let Some(w) = writer {
-        if let Err(e) = w.append(*seq, msg) {
+        if let Err(e) = w.append(*seq, msg).await {
             tracing::warn!(error = %e, seq, "failed to write transcript entry");
         }
         *seq += 1;
@@ -185,7 +185,7 @@ fn emit_working_status(
 
 #[allow(clippy::too_many_arguments)]
 async fn handle_secret_request(
-    transcript_writer: &mut Option<TranscriptWriter>,
+    transcript_writer: Option<&TranscriptWriter>,
     seq: &mut u32,
     messages: &mut Vec<Message>,
     secret_request_tx: &mpsc::Sender<SecretRequest>,
@@ -226,8 +226,8 @@ async fn handle_secret_request(
         let reply = format!("[secret:{key_name}] request denied");
         let assistant_msg = make_message(Role::Assistant, response_text.to_owned());
         let user_msg = make_message(Role::User, reply);
-        append_transcript(transcript_writer, seq, &assistant_msg);
-        append_transcript(transcript_writer, seq, &user_msg);
+        append_transcript(transcript_writer, seq, &assistant_msg).await;
+        append_transcript(transcript_writer, seq, &user_msg).await;
         messages.push(assistant_msg);
         messages.push(user_msg);
         return SecretRequestOutcome::Handled;
@@ -255,8 +255,8 @@ async fn handle_secret_request(
         };
         let assistant_msg = make_message(Role::Assistant, response_text.to_owned());
         let user_msg = make_message(Role::User, reply);
-        append_transcript(transcript_writer, seq, &assistant_msg);
-        append_transcript(transcript_writer, seq, &user_msg);
+        append_transcript(transcript_writer, seq, &assistant_msg).await;
+        append_transcript(transcript_writer, seq, &user_msg).await;
         messages.push(assistant_msg);
         messages.push(user_msg);
         return SecretRequestOutcome::Handled;
@@ -277,8 +277,8 @@ enum NoToolAction {
 ///
 /// Appends new messages to the transcript, and optionally sends a one-time
 /// nudge on the first turn when no tools have been called yet.
-fn handle_no_tool_response(
-    transcript_writer: &mut Option<TranscriptWriter>,
+async fn handle_no_tool_response(
+    transcript_writer: Option<&TranscriptWriter>,
     seq: &mut u32,
     messages: &[Message],
     prev_len: usize,
@@ -287,7 +287,7 @@ fn handle_no_tool_response(
     nudge_messages: &mut Vec<Message>,
 ) -> NoToolAction {
     for msg in &messages[prev_len..] {
-        append_transcript(transcript_writer, seq, msg);
+        append_transcript(transcript_writer, seq, msg).await;
     }
     if turns == 1 && !any_tool_called {
         tracing::debug!("sub-agent text-only first turn — sending nudge to use tools");
@@ -297,7 +297,7 @@ fn handle_no_tool_response(
              Do not announce intentions — execute them."
                 .into(),
         );
-        append_transcript(transcript_writer, seq, &nudge);
+        append_transcript(transcript_writer, seq, &nudge).await;
         nudge_messages.push(nudge);
         NoToolAction::Nudge
     } else {
@@ -308,14 +308,14 @@ fn handle_no_tool_response(
 /// Initialise per-loop state: send the initial Working status, build the
 /// message list from history + task prompt, write the task message to the
 /// transcript, and collect tool definitions.
-fn init_loop_state(
+async fn init_loop_state(
     status_tx: &watch::Sender<SubAgentStatus>,
     started_at: Instant,
     effective_system_prompt: String,
     initial_messages: Vec<Message>,
     task_prompt: String,
     executor: &FilteredToolExecutor,
-    transcript_writer: &mut Option<TranscriptWriter>,
+    transcript_writer: Option<&TranscriptWriter>,
 ) -> (Vec<Message>, u32, Vec<ToolDefinition>) {
     let _ = status_tx.send(SubAgentStatus {
         state: SubAgentState::Working,
@@ -335,7 +335,7 @@ fn init_loop_state(
     if let Some(writer) = transcript_writer
         && let Some(task_msg) = messages.last()
     {
-        if let Err(e) = writer.append(seq, task_msg) {
+        if let Err(e) = writer.append(seq, task_msg).await {
             tracing::warn!(error = %e, "failed to write transcript entry");
         }
         seq += 1;
@@ -380,7 +380,7 @@ async fn run_turn(
     task_id: &str,
     agent_name: &str,
     status_tx: &watch::Sender<SubAgentStatus>,
-    transcript_writer: &mut Option<TranscriptWriter>,
+    transcript_writer: Option<&TranscriptWriter>,
     seq: &mut u32,
     turns: &mut u32,
     last_result: &mut String,
@@ -449,7 +449,9 @@ async fn run_turn(
             *turns,
             any_tool_called,
             &mut nudge_messages,
-        ) {
+        )
+        .await
+        {
             NoToolAction::Nudge => {
                 messages.extend(nudge_messages);
                 return Ok(TurnOutcome::NudgeSent);
@@ -459,7 +461,7 @@ async fn run_turn(
     }
 
     for msg in &messages[prev_len..] {
-        append_transcript(transcript_writer, seq, msg);
+        append_transcript(transcript_writer, seq, msg).await;
     }
     Ok(TurnOutcome::ToolCalled)
 }
@@ -669,7 +671,7 @@ pub(super) async fn run_agent_loop(
         task_id: loop_task_id,
         agent_name,
         initial_messages,
-        mut transcript_writer,
+        transcript_writer,
         spawn_depth: _spawn_depth,
         mcp_tool_names,
         content_isolation,
@@ -688,8 +690,9 @@ pub(super) async fn run_agent_loop(
         initial_messages,
         task_prompt,
         &executor,
-        &mut transcript_writer,
-    );
+        transcript_writer.as_ref(),
+    )
+    .await;
 
     let mut turns: u32 = 0;
     let mut last_result = String::new();
@@ -714,7 +717,7 @@ pub(super) async fn run_agent_loop(
             &loop_task_id,
             &agent_name,
             &status_tx,
-            &mut transcript_writer,
+            transcript_writer.as_ref(),
             &mut seq,
             &mut turns,
             &mut last_result,

--- a/crates/zeph-subagent/src/manager/collect.rs
+++ b/crates/zeph-subagent/src/manager/collect.rs
@@ -88,7 +88,7 @@ impl SubAgentManager {
                 turns_used,
                 mcp_tool_names: handle.mcp_tool_names.clone(),
             };
-            if let Err(e) = TranscriptWriter::write_meta(dir, task_id, &meta) {
+            if let Err(e) = TranscriptWriter::write_meta_async(dir, task_id, &meta).await {
                 tracing::warn!(error = %e, task_id, "failed to write final transcript meta");
             }
         }
@@ -110,20 +110,27 @@ impl SubAgentManager {
     /// Look up the definition name for a resumable transcript without spawning.
     ///
     /// Used by callers that need to resolve skills before calling `resume()`.
+    /// Offloads the blocking FS reads to a `spawn_blocking` thread.
     ///
     /// # Errors
     ///
     /// Returns the same errors as [`crate::transcript::TranscriptReader::find_by_prefix`] and
     /// [`crate::transcript::TranscriptReader::load_meta`].
-    pub fn def_name_for_resume(
+    pub async fn def_name_for_resume(
         &self,
         id_prefix: &str,
         config: &SubAgentConfig,
     ) -> Result<String, SubAgentError> {
         let dir = self.effective_transcript_dir(config);
-        let original_id = crate::transcript::TranscriptReader::find_by_prefix(&dir, id_prefix)?;
-        let meta = crate::transcript::TranscriptReader::load_meta(&dir, &original_id)?;
-        Ok(meta.def_name)
+        let id_prefix = id_prefix.to_owned();
+        tokio::task::spawn_blocking(move || {
+            let original_id =
+                crate::transcript::TranscriptReader::find_by_prefix(&dir, &id_prefix)?;
+            let meta = crate::transcript::TranscriptReader::load_meta(&dir, &original_id)?;
+            Ok(meta.def_name)
+        })
+        .await
+        .map_err(|e| SubAgentError::Spawn(format!("spawn_blocking panicked: {e}")))?
     }
 
     /// Return a snapshot of all active sub-agent statuses.
@@ -156,6 +163,11 @@ impl SubAgentManager {
     }
 
     /// Create a transcript writer if transcripts are enabled.
+    ///
+    /// All three blocking FS operations (sweep, file open, meta write) are offloaded via
+    /// [`tokio::task::block_in_place`] on multi-thread runtimes so the Tokio executor
+    /// thread is not stalled. Falls back to a direct call on `current_thread` runtimes
+    /// (e.g. single-threaded unit tests) where `block_in_place` would panic.
     pub(crate) fn create_transcript_writer(
         &mut self,
         config: &SubAgentConfig,
@@ -167,34 +179,54 @@ impl SubAgentManager {
             return None;
         }
         let dir = self.effective_transcript_dir(config);
-        if self.transcript_max_files > 0
-            && let Err(e) = sweep_old_transcripts(&dir, self.transcript_max_files)
-        {
-            tracing::warn!(error = %e, "transcript sweep failed");
-        }
+        let max_files = self.transcript_max_files;
         let path = dir.join(format!("{task_id}.jsonl"));
-        match TranscriptWriter::new(&path) {
-            Ok(w) => {
-                let meta = TranscriptMeta {
-                    agent_id: task_id.to_owned(),
-                    agent_name: agent_name.to_owned(),
-                    def_name: agent_name.to_owned(),
-                    status: SubAgentState::Submitted,
-                    started_at: crate::transcript::utc_now(),
-                    finished_at: None,
-                    resumed_from: resumed_from.map(str::to_owned),
-                    turns_used: 0,
-                    mcp_tool_names: Vec::new(),
-                };
-                if let Err(e) = TranscriptWriter::write_meta(&dir, task_id, &meta) {
-                    tracing::warn!(error = %e, "failed to write initial transcript meta");
+        let meta = TranscriptMeta {
+            agent_id: task_id.to_owned(),
+            agent_name: agent_name.to_owned(),
+            def_name: agent_name.to_owned(),
+            status: SubAgentState::Submitted,
+            started_at: crate::transcript::utc_now(),
+            finished_at: None,
+            resumed_from: resumed_from.map(str::to_owned),
+            turns_used: 0,
+            mcp_tool_names: Vec::new(),
+        };
+        let task_id = task_id.to_owned();
+        run_blocking(move || {
+            if max_files > 0
+                && let Err(e) = sweep_old_transcripts(&dir, max_files)
+            {
+                tracing::warn!(error = %e, "transcript sweep failed");
+            }
+            match TranscriptWriter::new(&path) {
+                Ok(w) => {
+                    if let Err(e) = TranscriptWriter::write_meta(&dir, &task_id, &meta) {
+                        tracing::warn!(error = %e, "failed to write initial transcript meta");
+                    }
+                    Some(w)
                 }
-                Some(w)
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to create transcript writer");
+                    None
+                }
             }
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to create transcript writer");
-                None
-            }
-        }
+        })
+    }
+}
+
+/// Run a blocking closure without stalling the Tokio executor.
+///
+/// On a multi-thread runtime, delegates to [`tokio::task::block_in_place`] so other
+/// tasks can continue running while the blocking work executes. On a `current_thread`
+/// runtime (unit tests, single-threaded entry points) calls the closure directly,
+/// since there is no thread pool to offload to and `block_in_place` would panic.
+fn run_blocking<T>(f: impl FnOnce() -> T) -> T {
+    if tokio::runtime::Handle::try_current()
+        .is_ok_and(|h| h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+    {
+        tokio::task::block_in_place(f)
+    } else {
+        f()
     }
 }

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -897,6 +897,9 @@ impl SubAgentManager {
     /// orchestration policy originally allowed.  Pass `None` to skip constraint propagation
     /// (equivalent to the previous behavior before this fix).
     ///
+    /// The three initial FS reads (prefix lookup, meta load, jsonl load) are offloaded to a
+    /// `spawn_blocking` thread so the Tokio executor is not stalled.
+    ///
     /// # Errors
     ///
     /// Returns [`SubAgentError::StillRunning`] if the agent is still active,
@@ -906,7 +909,7 @@ impl SubAgentManager {
     /// [`SubAgentError::ConcurrencyLimit`] if the concurrency limit is exceeded.
     #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     #[tracing::instrument(name = "subagent.manager.resume", skip_all, fields(id_prefix = id_prefix))]
-    pub fn resume(
+    pub async fn resume(
         &mut self,
         id_prefix: &str,
         task_prompt: &str,
@@ -917,12 +920,22 @@ impl SubAgentManager {
         spawn_context: Option<&SpawnContext>,
     ) -> Result<(String, String), SubAgentError> {
         let dir = self.effective_transcript_dir(config);
-        let original_id = crate::transcript::TranscriptReader::find_by_prefix(&dir, id_prefix)?;
+        let id_prefix_owned = id_prefix.to_owned();
+        let dir_clone = dir.clone();
+        let (original_id, meta, initial_messages) = tokio::task::spawn_blocking(move || {
+            let original_id =
+                crate::transcript::TranscriptReader::find_by_prefix(&dir_clone, &id_prefix_owned)?;
+            let meta = crate::transcript::TranscriptReader::load_meta(&dir_clone, &original_id)?;
+            let jsonl_path = dir_clone.join(format!("{original_id}.jsonl"));
+            let initial_messages = crate::transcript::TranscriptReader::load(&jsonl_path)?;
+            Ok::<_, SubAgentError>((original_id, meta, initial_messages))
+        })
+        .await
+        .map_err(|e| SubAgentError::Spawn(format!("spawn_blocking panicked: {e}")))??;
 
         if self.agents.contains_key(&original_id) {
             return Err(SubAgentError::StillRunning(original_id));
         }
-        let meta = crate::transcript::TranscriptReader::load_meta(&dir, &original_id)?;
 
         match meta.status {
             SubAgentState::Completed | SubAgentState::Failed | SubAgentState::Canceled => {}
@@ -932,9 +945,6 @@ impl SubAgentManager {
                 )));
             }
         }
-
-        let jsonl_path = dir.join(format!("{original_id}.jsonl"));
-        let initial_messages = crate::transcript::TranscriptReader::load(&jsonl_path)?;
 
         let mut def = self
             .definitions

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -1037,15 +1037,14 @@ fn make_cfg_with_dir(dir: &std::path::Path) -> SubAgentConfig {
 #[test]
 fn resume_not_found_returns_not_found_error() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
     let cfg = make_cfg_with_dir(tmp.path());
 
-    let err = mgr
-        .resume(
+    let err = rt
+        .block_on(mgr.resume(
             "deadbeef",
             "continue",
             mock_provider(vec!["done"]),
@@ -1053,7 +1052,7 @@ fn resume_not_found_returns_not_found_error() {
             None,
             &cfg,
             None,
-        )
+        ))
         .unwrap_err();
     assert!(matches!(err, SubAgentError::NotFound(_)));
 }
@@ -1061,7 +1060,6 @@ fn resume_not_found_returns_not_found_error() {
 #[test]
 fn resume_ambiguous_id_returns_ambiguous_error() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     write_completed_meta(tmp.path(), "aabb0001-0000-0000-0000-000000000000", "bot");
@@ -1071,8 +1069,8 @@ fn resume_ambiguous_id_returns_ambiguous_error() {
     mgr.definitions.push(sample_def());
     let cfg = make_cfg_with_dir(tmp.path());
 
-    let err = mgr
-        .resume(
+    let err = rt
+        .block_on(mgr.resume(
             "aabb",
             "continue",
             mock_provider(vec!["done"]),
@@ -1080,7 +1078,7 @@ fn resume_ambiguous_id_returns_ambiguous_error() {
             None,
             &cfg,
             None,
-        )
+        ))
         .unwrap_err();
     assert!(matches!(err, SubAgentError::AmbiguousId(_, 2)));
 }
@@ -1088,7 +1086,6 @@ fn resume_ambiguous_id_returns_ambiguous_error() {
 #[test]
 fn resume_still_running_via_active_agents_returns_error() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "cafebabe-0000-0000-0000-000000000000";
@@ -1129,8 +1126,8 @@ fn resume_still_running_via_active_agents_returns_error() {
     drop(status_tx);
 
     let cfg = make_cfg_with_dir(tmp.path());
-    let err = mgr
-        .resume(
+    let err = rt
+        .block_on(mgr.resume(
             agent_id,
             "continue",
             mock_provider(vec!["done"]),
@@ -1138,7 +1135,7 @@ fn resume_still_running_via_active_agents_returns_error() {
             None,
             &cfg,
             None,
-        )
+        ))
         .unwrap_err();
     assert!(matches!(err, SubAgentError::StillRunning(_)));
 }
@@ -1146,7 +1143,6 @@ fn resume_still_running_via_active_agents_returns_error() {
 #[test]
 fn resume_def_not_found_returns_not_found_error() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "feedface-0000-0000-0000-000000000000";
@@ -1157,8 +1153,8 @@ fn resume_def_not_found_returns_not_found_error() {
     // Do NOT push any definition — so def_name "unknown-agent" won't be found.
     let cfg = make_cfg_with_dir(tmp.path());
 
-    let err = mgr
-        .resume(
+    let err = rt
+        .block_on(mgr.resume(
             "feedface",
             "continue",
             mock_provider(vec!["done"]),
@@ -1166,7 +1162,7 @@ fn resume_def_not_found_returns_not_found_error() {
             None,
             &cfg,
             None,
-        )
+        ))
         .unwrap_err();
     assert!(matches!(err, SubAgentError::NotFound(_)));
 }
@@ -1174,7 +1170,6 @@ fn resume_def_not_found_returns_not_found_error() {
 #[test]
 fn resume_concurrency_limit_reached_returns_error() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "babe0000-0000-0000-0000-000000000000";
@@ -1184,11 +1179,14 @@ fn resume_concurrency_limit_reached_returns_error() {
     mgr.definitions.push(sample_def());
 
     // Occupy the single slot.
-    let _running_id = do_spawn(&mut mgr, "bot", "occupying slot").unwrap();
+    {
+        let _guard = rt.enter();
+        let _running_id = do_spawn(&mut mgr, "bot", "occupying slot").unwrap();
+    }
 
     let cfg = make_cfg_with_dir(tmp.path());
-    let err = mgr
-        .resume(
+    let err = rt
+        .block_on(mgr.resume(
             "babe0000",
             "continue",
             mock_provider(vec!["done"]),
@@ -1196,7 +1194,7 @@ fn resume_concurrency_limit_reached_returns_error() {
             None,
             &cfg,
             None,
-        )
+        ))
         .unwrap_err();
     assert!(
         matches!(err, SubAgentError::ConcurrencyLimit { .. }),
@@ -1207,7 +1205,6 @@ fn resume_concurrency_limit_reached_returns_error() {
 #[test]
 fn resume_happy_path_returns_new_task_id() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "deadcode-0000-0000-0000-000000000000";
@@ -1217,8 +1214,8 @@ fn resume_happy_path_returns_new_task_id() {
     mgr.definitions.push(sample_def());
     let cfg = make_cfg_with_dir(tmp.path());
 
-    let (new_id, def_name) = mgr
-        .resume(
+    let (new_id, def_name) = rt
+        .block_on(mgr.resume(
             "deadcode",
             "continue the work",
             mock_provider(vec!["done"]),
@@ -1226,7 +1223,7 @@ fn resume_happy_path_returns_new_task_id() {
             None,
             &cfg,
             None,
-        )
+        ))
         .unwrap();
 
     assert!(!new_id.is_empty(), "new task id must not be empty");
@@ -1238,13 +1235,13 @@ fn resume_happy_path_returns_new_task_id() {
     // New agent must be tracked.
     assert!(mgr.agents.contains_key(&new_id));
 
+    let _guard = rt.enter();
     mgr.cancel(&new_id).unwrap();
 }
 
 #[test]
 fn resume_populates_resumed_from_in_meta() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let original_id = "0000abcd-0000-0000-0000-000000000000";
@@ -1254,8 +1251,8 @@ fn resume_populates_resumed_from_in_meta() {
     mgr.definitions.push(sample_def());
     let cfg = make_cfg_with_dir(tmp.path());
 
-    let (new_id, _) = mgr
-        .resume(
+    let (new_id, _) = rt
+        .block_on(mgr.resume(
             "0000abcd",
             "continue",
             mock_provider(vec!["done"]),
@@ -1263,7 +1260,7 @@ fn resume_populates_resumed_from_in_meta() {
             None,
             &cfg,
             None,
-        )
+        ))
         .unwrap();
 
     // The new meta sidecar must have resumed_from = original_id.
@@ -1274,6 +1271,7 @@ fn resume_populates_resumed_from_in_meta() {
         "resumed_from must point to original agent id"
     );
 
+    let _guard = rt.enter();
     mgr.cancel(&new_id).unwrap();
 }
 
@@ -1282,7 +1280,6 @@ fn resume_with_spawn_context_applies_constraint_propagation() {
     // Verify that passing Some(SpawnContext) to resume() narrows the agent's tool allowlist
     // via apply_constraint_propagation, matching spawn() behavior.
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "c0de0000-0000-0000-0000-000000000000";
@@ -1297,8 +1294,8 @@ fn resume_with_spawn_context_applies_constraint_propagation() {
 
     // Parent context only permits shell and read — web must be removed.
     let ctx = ctx_with_allowlist(&["shell", "read"]);
-    let (new_id, _) = mgr
-        .resume(
+    let (new_id, _) = rt
+        .block_on(mgr.resume(
             "c0de0000",
             "continue",
             mock_provider(vec!["done"]),
@@ -1306,7 +1303,7 @@ fn resume_with_spawn_context_applies_constraint_propagation() {
             None,
             &cfg,
             Some(&ctx),
-        )
+        ))
         .unwrap();
 
     // The resumed handle is live; inspect the def stored in the active handle.
@@ -1324,6 +1321,7 @@ fn resume_with_spawn_context_applies_constraint_propagation() {
         other => panic!("expected AllowList after constraint propagation, got {other:?}"),
     }
 
+    let _guard = rt.enter();
     mgr.cancel(&new_id).unwrap();
 }
 
@@ -1377,7 +1375,6 @@ impl ErasedToolExecutor for TrustTrackingExecutor {
 #[test]
 fn resume_with_spawn_context_applies_trust_cap_to_executor() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "d0d00000-0000-0000-0000-000000000000";
@@ -1396,8 +1393,8 @@ fn resume_with_spawn_context_applies_trust_cap_to_executor() {
         max_trust_level: Some(SkillTrustLevel::Quarantined),
         ..SpawnContext::default()
     };
-    let (new_id, _) = mgr
-        .resume(
+    let (new_id, _) = rt
+        .block_on(mgr.resume(
             "d0d00000",
             "continue",
             mock_provider(vec!["done"]),
@@ -1405,7 +1402,7 @@ fn resume_with_spawn_context_applies_trust_cap_to_executor() {
             None,
             &cfg,
             Some(&ctx),
-        )
+        ))
         .unwrap();
 
     assert_eq!(
@@ -1414,13 +1411,13 @@ fn resume_with_spawn_context_applies_trust_cap_to_executor() {
         "executor must receive the trust cap from spawn_context"
     );
 
+    let _guard = rt.enter();
     mgr.cancel(&new_id).unwrap();
 }
 
 #[test]
 fn def_name_for_resume_returns_def_name() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "aaaabbbb-0000-0000-0000-000000000000";
@@ -1429,20 +1426,23 @@ fn def_name_for_resume_returns_def_name() {
     let mgr = make_manager();
     let cfg = make_cfg_with_dir(tmp.path());
 
-    let name = mgr.def_name_for_resume("aaaabbbb", &cfg).unwrap();
+    let name = rt
+        .block_on(mgr.def_name_for_resume("aaaabbbb", &cfg))
+        .unwrap();
     assert_eq!(name, "bot");
 }
 
 #[test]
 fn def_name_for_resume_not_found_returns_error() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let mgr = make_manager();
     let cfg = make_cfg_with_dir(tmp.path());
 
-    let err = mgr.def_name_for_resume("notexist", &cfg).unwrap_err();
+    let err = rt
+        .block_on(mgr.def_name_for_resume("notexist", &cfg))
+        .unwrap_err();
     assert!(matches!(err, SubAgentError::NotFound(_)));
 }
 
@@ -2872,7 +2872,6 @@ fn spawn_context_session_mcp_servers_dedup() {
 #[test]
 fn resume_sanitization_drops_invalid_mcp_tool_names() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "11110000-0000-0000-0000-000000000001";
@@ -2888,8 +2887,8 @@ fn resume_sanitization_drops_invalid_mcp_tool_names() {
     mgr.definitions.push(sample_def());
     let cfg = make_cfg_with_dir(tmp.path());
 
-    let (new_id, _) = mgr
-        .resume(
+    let (new_id, _) = rt
+        .block_on(mgr.resume(
             "11110000",
             "continue",
             mock_provider(vec!["done"]),
@@ -2897,7 +2896,7 @@ fn resume_sanitization_drops_invalid_mcp_tool_names() {
             None,
             &cfg,
             None,
-        )
+        ))
         .unwrap();
 
     let names = &mgr.agents[&new_id].mcp_tool_names;
@@ -2913,13 +2912,13 @@ fn resume_sanitization_drops_invalid_mcp_tool_names() {
     );
     assert_eq!(names.len(), 2, "only two valid entries must survive");
 
+    let _guard = rt.enter();
     mgr.cancel(&new_id).unwrap();
 }
 
 #[test]
 fn resume_sanitization_preserves_valid_mcp_tool_names() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
 
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "22220000-0000-0000-0000-000000000002";
@@ -2934,8 +2933,8 @@ fn resume_sanitization_preserves_valid_mcp_tool_names() {
     mgr.definitions.push(sample_def());
     let cfg = make_cfg_with_dir(tmp.path());
 
-    let (new_id, _) = mgr
-        .resume(
+    let (new_id, _) = rt
+        .block_on(mgr.resume(
             "22220000",
             "continue",
             mock_provider(vec!["done"]),
@@ -2943,7 +2942,7 @@ fn resume_sanitization_preserves_valid_mcp_tool_names() {
             None,
             &cfg,
             None,
-        )
+        ))
         .unwrap();
 
     let names = &mgr.agents[&new_id].mcp_tool_names;
@@ -2959,6 +2958,7 @@ fn resume_sanitization_preserves_valid_mcp_tool_names() {
         );
     }
 
+    let _guard = rt.enter();
     mgr.cancel(&new_id).unwrap();
 }
 

--- a/crates/zeph-subagent/src/transcript.rs
+++ b/crates/zeph-subagent/src/transcript.rs
@@ -15,6 +15,7 @@
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Write as _};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 use zeph_llm::provider::Message;
@@ -72,7 +73,9 @@ pub struct TranscriptMeta {
 /// Appends [`TranscriptEntry`] lines to a JSONL transcript file.
 ///
 /// The file handle is kept open for the writer's lifetime to avoid
-/// race conditions from repeated open/close cycles.
+/// race conditions from repeated open/close cycles. The handle is wrapped in
+/// `Arc<Mutex<File>>` so the writer can be cheaply cloned and passed to
+/// `tokio::task::spawn_blocking` for non-blocking appends.
 ///
 /// # Examples
 ///
@@ -80,11 +83,12 @@ pub struct TranscriptMeta {
 /// use std::path::Path;
 /// use zeph_subagent::transcript::TranscriptWriter;
 ///
-/// let mut writer = TranscriptWriter::new(Path::new("/tmp/session.jsonl")).unwrap();
+/// let writer = TranscriptWriter::new(Path::new("/tmp/session.jsonl")).unwrap();
 /// // writer.append(seq, &message) to persist each message.
 /// ```
+#[derive(Clone)]
 pub struct TranscriptWriter {
-    file: File,
+    file: Arc<Mutex<File>>,
 }
 
 impl TranscriptWriter {
@@ -100,15 +104,20 @@ impl TranscriptWriter {
             fs::create_dir_all(parent)?;
         }
         let file = zeph_common::fs_secure::append_private(path)?;
-        Ok(Self { file })
+        Ok(Self {
+            file: Arc::new(Mutex::new(file)),
+        })
     }
 
     /// Append a single message as a JSON line and flush immediately.
     ///
+    /// Serialization is done on the caller's thread; the blocking write and flush
+    /// are offloaded to `tokio::task::spawn_blocking` so the Tokio executor is not stalled.
+    ///
     /// # Errors
     ///
-    /// Returns `io::Error` on serialization or write failure.
-    pub fn append(&mut self, seq: u32, message: &Message) -> io::Result<()> {
+    /// Returns `io::Error` on serialization, write failure, lock poison, or thread-pool panic.
+    pub async fn append(&self, seq: u32, message: &Message) -> io::Result<()> {
         let entry = TranscriptEntry {
             seq,
             timestamp: utc_now(),
@@ -116,9 +125,17 @@ impl TranscriptWriter {
         };
         let line = serde_json::to_string(&entry)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        self.file.write_all(line.as_bytes())?;
-        self.file.write_all(b"\n")?;
-        self.file.flush()
+        let file = Arc::clone(&self.file);
+        tokio::task::spawn_blocking(move || {
+            let mut guard = file
+                .lock()
+                .map_err(|_| io::Error::other("transcript writer lock poisoned"))?;
+            guard.write_all(line.as_bytes())?;
+            guard.write_all(b"\n")?;
+            guard.flush()
+        })
+        .await
+        .map_err(|e| io::Error::other(format!("spawn_blocking panicked: {e}")))?
     }
 
     /// Write the meta sidecar file for an agent.
@@ -131,6 +148,26 @@ impl TranscriptWriter {
         let content = serde_json::to_string_pretty(meta)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         zeph_common::fs_secure::write_private(&path, content.as_bytes())
+    }
+
+    /// Async variant of [`write_meta`][Self::write_meta] that offloads the blocking FS write
+    /// to a `spawn_blocking` thread so the Tokio executor is not stalled.
+    ///
+    /// # Errors
+    ///
+    /// Returns `io::Error` on serialization, write failure, or thread-pool panic.
+    pub async fn write_meta_async(
+        dir: &Path,
+        agent_id: &str,
+        meta: &TranscriptMeta,
+    ) -> io::Result<()> {
+        let path = dir.join(format!("{agent_id}.meta.json"));
+        let content = serde_json::to_string_pretty(meta)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let bytes = content.into_bytes();
+        tokio::task::spawn_blocking(move || zeph_common::fs_secure::write_private(&path, &bytes))
+            .await
+            .map_err(|e| io::Error::other(format!("spawn_blocking panicked: {e}")))?
     }
 }
 
@@ -408,17 +445,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn writer_reader_roundtrip() {
+    #[tokio::test]
+    async fn writer_reader_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
 
         let msg1 = test_message(Role::User, "hello");
         let msg2 = test_message(Role::Assistant, "world");
 
-        let mut writer = TranscriptWriter::new(&path).unwrap();
-        writer.append(0, &msg1).unwrap();
-        writer.append(1, &msg2).unwrap();
+        let writer = TranscriptWriter::new(&path).unwrap();
+        writer.append(0, &msg1).await.unwrap();
+        writer.append(1, &msg2).await.unwrap();
         drop(writer);
 
         let messages = TranscriptReader::load(&path).unwrap();


### PR DESCRIPTION
## Summary

- `TranscriptWriter::append` converted to `async fn`; write+flush runs in `tokio::task::spawn_blocking`
- `write_meta_async` added as async variant; used in `collect` and `create_transcript_writer`
- `def_name_for_resume` and `resume` converted to `async fn`; all blocking FS reads (find_by_prefix, load_meta, load) moved into `spawn_blocking` closures
- `create_transcript_writer` (sweep, open, write_meta) wrapped in `block_in_place` via private `run_blocking` helper — preserves sync fn signature for non-async callers while correctly offloading IO on multi-thread runtimes; no-op fallback for `current_thread` runtime in tests
- JoinError propagation handled consistently at all 4 new `spawn_blocking` call sites
- `Arc<Mutex<File>>` in `TranscriptWriter`: lock held only inside `spawn_blocking`, never across `.await` points

## Test plan

- [ ] `cargo nextest run -p zeph-subagent` — 383 passed
- [ ] `cargo nextest run --workspace --lib --bins` — 10657 passed
- [ ] `cargo clippy -p zeph-subagent -p zeph-core --all-targets -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" cargo check -p zeph-subagent -p zeph-core --all-targets` — clean
- [ ] `cargo +nightly fmt --check` — clean

Closes #4955
Closes #4958