### PR TITLE
docs/refactor: fix acp intra-doc links and extract DRY helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Add `#[must_use]` to public validate/scan functions across workspace (zeph-config, zeph-skills, zeph-orchestration, zeph-experiments, zeph-common, zeph-core, zeph-mcp, zeph-plugins, zeph-tools) to prevent silent discard of validation errors (closes #4943, #4961, #4963)
+- `docs(acp)`: fix broken intra-doc links in `transport/` and `client/error` — feature-gated items referenced as plain backtick text; private `SubagentCommand::Close` link removed from public doc (closes #4941)
+- `refactor(tools)`: extract `build_audit_entry` private helper in `ShellExecutor`; `log_audit` and `log_audit_with_context` now delegate to it (closes #4960)
+- `refactor(memory)`: extract `lock_entries` and `lock_next_id` private helpers in `InMemoryFacade` to eliminate repeated lock-poisoning boilerplate (closes #4962)
 
 ### Added
 

--- a/crates/zeph-acp/src/client/error.rs
+++ b/crates/zeph-acp/src/client/error.rs
@@ -65,7 +65,7 @@ pub enum AcpClientError {
     Timeout,
 
     /// The session was closed by a call to [`super::SubagentHandle::close`] or via
-    /// a [`super::SubagentCommand::Close`] command.
+    /// a `SubagentCommand::Close` command.
     #[error("session is closed")]
     Closed,
 

--- a/crates/zeph-acp/src/lib.rs
+++ b/crates/zeph-acp/src/lib.rs
@@ -26,8 +26,8 @@
 //! | Transport | Entry point | Feature flag |
 //! |-----------|-------------|--------------|
 //! | stdio (default) | [`serve_stdio`] | always |
-//! | HTTP + SSE | [`acp_router`] | `acp-http` |
-//! | WebSocket | [`acp_router`] | `acp-http` |
+//! | HTTP + SSE | `acp_router` | `acp-http` |
+//! | WebSocket | `acp_router` | `acp-http` |
 //!
 //! # Feature flags
 //!

--- a/crates/zeph-acp/src/transport/mod.rs
+++ b/crates/zeph-acp/src/transport/mod.rs
@@ -12,8 +12,8 @@
 //! | Transport | Function/Type |
 //! |-----------|---------------|
 //! | stdio | [`serve_stdio`], [`serve_connection`] |
-//! | HTTP + SSE | [`acp_router`] (feature `acp-http`) |
-//! | WebSocket | part of [`acp_router`] (feature `acp-http`) |
+//! | HTTP + SSE | `acp_router` (feature `acp-http`) |
+//! | WebSocket | part of `acp_router` (feature `acp-http`) |
 //!
 //! [`ZephAcpAgentState`]: crate::agent::ZephAcpAgentState
 

--- a/crates/zeph-acp/src/transport/router.rs
+++ b/crates/zeph-acp/src/transport/router.rs
@@ -4,8 +4,7 @@
 //! Axum router construction for the ACP HTTP transport.
 //!
 //! The router is the single axum `Router` that wires up all ACP endpoints.
-//! Callers attach it to their axum `Server` and call
-//! [`AcpHttpState::mark_ready`](crate::transport::http::AcpHttpState::mark_ready) after
+//! Callers attach it to their axum `Server` and call `AcpHttpState::mark_ready` after
 //! initialization.
 
 #[cfg(feature = "acp-http")]

--- a/crates/zeph-acp/src/transport/ws.rs
+++ b/crates/zeph-acp/src/transport/ws.rs
@@ -9,8 +9,7 @@
 //!
 //! A 30-second ping keepalive detects stale connections; the handler closes after
 //! 90 seconds without a pong. Each connection is registered in
-//! [`AcpHttpState::connections`](crate::transport::http::AcpHttpState) for lifecycle
-//! tracking and counted against `max_sessions`.
+//! `AcpHttpState::connections` for lifecycle tracking and counted against `max_sessions`.
 
 #[cfg(feature = "acp-http")]
 use std::sync::Arc;

--- a/crates/zeph-memory/src/facade.rs
+++ b/crates/zeph-memory/src/facade.rs
@@ -231,29 +231,34 @@ impl InMemoryFacade {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    fn lock_entries(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, BTreeMap<i64, MemoryEntry>>, MemoryError> {
+        self.entries
+            .lock()
+            .map_err(|e| MemoryError::LockPoisoned(format!("InMemoryFacade lock poisoned: {e}")))
+    }
+
+    fn lock_next_id(&self) -> Result<std::sync::MutexGuard<'_, i64>, MemoryError> {
+        self.next_id
+            .lock()
+            .map_err(|e| MemoryError::LockPoisoned(format!("InMemoryFacade lock poisoned: {e}")))
+    }
 }
 
 impl MemoryFacade for InMemoryFacade {
     async fn remember(&self, entry: MemoryEntry) -> Result<MessageId, MemoryError> {
-        let mut id_guard = self
-            .next_id
-            .lock()
-            .map_err(|e| MemoryError::LockPoisoned(format!("InMemoryFacade lock poisoned: {e}")))?;
+        let mut id_guard = self.lock_next_id()?;
         *id_guard += 1;
         let id = *id_guard;
-        let mut entries = self
-            .entries
-            .lock()
-            .map_err(|e| MemoryError::LockPoisoned(format!("InMemoryFacade lock poisoned: {e}")))?;
+        let mut entries = self.lock_entries()?;
         entries.insert(id, entry);
         Ok(MessageId(id))
     }
 
     async fn recall(&self, query: &str, limit: usize) -> Result<Vec<MemoryMatch>, MemoryError> {
-        let entries = self
-            .entries
-            .lock()
-            .map_err(|e| MemoryError::LockPoisoned(format!("InMemoryFacade lock poisoned: {e}")))?;
+        let entries = self.lock_entries()?;
         let query_lower = query.to_lowercase();
         let mut matches: Vec<MemoryMatch> = entries
             .values()
@@ -271,10 +276,7 @@ impl MemoryFacade for InMemoryFacade {
     }
 
     async fn summarize(&self, conv_id: ConversationId) -> Result<String, MemoryError> {
-        let entries = self
-            .entries
-            .lock()
-            .map_err(|e| MemoryError::LockPoisoned(format!("InMemoryFacade lock poisoned: {e}")))?;
+        let entries = self.lock_entries()?;
         let texts: Vec<&str> = entries
             .values()
             .filter(|e| e.conversation_id == conv_id)
@@ -284,10 +286,7 @@ impl MemoryFacade for InMemoryFacade {
     }
 
     async fn compact(&self, ctx: &CompactionContext) -> Result<CompactionResult, MemoryError> {
-        let mut entries = self
-            .entries
-            .lock()
-            .map_err(|e| MemoryError::LockPoisoned(format!("InMemoryFacade lock poisoned: {e}")))?;
+        let mut entries = self.lock_entries()?;
         let ids_to_remove: Vec<i64> = entries
             .iter()
             .filter(|(_, e)| e.conversation_id == ctx.conversation_id)

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -1500,6 +1500,52 @@ impl ShellExecutor {
         None
     }
 
+    fn build_audit_entry(
+        command: &str,
+        result: AuditResult,
+        duration_ms: u64,
+        error: Option<&ToolError>,
+        exit_code: Option<i32>,
+        truncated: bool,
+        resolved: Option<&ResolvedContext>,
+    ) -> AuditEntry {
+        let (error_category, error_domain, error_phase) = error.map_or((None, None, None), |e| {
+            let cat = e.category();
+            (
+                Some(cat.label().to_owned()),
+                Some(cat.domain().label().to_owned()),
+                Some(cat.phase().label().to_owned()),
+            )
+        });
+        AuditEntry {
+            timestamp: chrono_now(),
+            tool: "shell".into(),
+            command: command.into(),
+            result,
+            duration_ms,
+            error_category,
+            error_domain,
+            error_phase,
+            claim_source: Some(ClaimSource::Shell),
+            mcp_server_id: None,
+            injection_flagged: false,
+            embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
+            adversarial_policy_decision: None,
+            exit_code,
+            truncated,
+            caller_id: None,
+            skill_name: None,
+            policy_match: None,
+            correlation_id: None,
+            vigil_risk: None,
+            execution_env: resolved.and_then(|r| r.name.clone()),
+            resolved_cwd: resolved.map(|r| r.cwd.display().to_string()),
+            scope_at_definition: None,
+            scope_at_dispatch: None,
+        }
+    }
+
     async fn log_audit(
         &self,
         command: &str,
@@ -1510,42 +1556,15 @@ impl ShellExecutor {
         truncated: bool,
     ) {
         if let Some(ref logger) = self.audit_logger {
-            let (error_category, error_domain, error_phase) =
-                error.map_or((None, None, None), |e| {
-                    let cat = e.category();
-                    (
-                        Some(cat.label().to_owned()),
-                        Some(cat.domain().label().to_owned()),
-                        Some(cat.phase().label().to_owned()),
-                    )
-                });
-            let entry = AuditEntry {
-                timestamp: chrono_now(),
-                tool: "shell".into(),
-                command: command.into(),
+            let entry = Self::build_audit_entry(
+                command,
                 result,
                 duration_ms,
-                error_category,
-                error_domain,
-                error_phase,
-                claim_source: Some(ClaimSource::Shell),
-                mcp_server_id: None,
-                injection_flagged: false,
-                embedding_anomalous: false,
-                cross_boundary_mcp_to_acp: false,
-                adversarial_policy_decision: None,
+                error,
                 exit_code,
                 truncated,
-                caller_id: None,
-                skill_name: None,
-                policy_match: None,
-                correlation_id: None,
-                vigil_risk: None,
-                execution_env: None,
-                resolved_cwd: None,
-                scope_at_definition: None,
-                scope_at_dispatch: None,
-            };
+                None,
+            );
             logger.log(&entry).await;
         }
     }
@@ -1562,42 +1581,15 @@ impl ShellExecutor {
         resolved: &ResolvedContext,
     ) {
         if let Some(ref logger) = self.audit_logger {
-            let (error_category, error_domain, error_phase) =
-                error.map_or((None, None, None), |e| {
-                    let cat = e.category();
-                    (
-                        Some(cat.label().to_owned()),
-                        Some(cat.domain().label().to_owned()),
-                        Some(cat.phase().label().to_owned()),
-                    )
-                });
-            let entry = AuditEntry {
-                timestamp: chrono_now(),
-                tool: "shell".into(),
-                command: command.into(),
+            let entry = Self::build_audit_entry(
+                command,
                 result,
                 duration_ms,
-                error_category,
-                error_domain,
-                error_phase,
-                claim_source: Some(ClaimSource::Shell),
-                mcp_server_id: None,
-                injection_flagged: false,
-                embedding_anomalous: false,
-                cross_boundary_mcp_to_acp: false,
-                adversarial_policy_decision: None,
+                error,
                 exit_code,
                 truncated,
-                caller_id: None,
-                skill_name: None,
-                policy_match: None,
-                correlation_id: None,
-                vigil_risk: None,
-                execution_env: resolved.name.clone(),
-                resolved_cwd: Some(resolved.cwd.display().to_string()),
-                scope_at_definition: None,
-                scope_at_dispatch: None,
-            };
+                Some(resolved),
+            );
             logger.log(&entry).await;
         }
     }


### PR DESCRIPTION
## Summary

- Fix 7 broken `rustdoc` intra-doc links in `zeph-acp` that blocked the mandatory `cargo doc --deny broken_intra_doc_links` gate
- Extract `build_audit_entry` private helper in `ShellExecutor` to eliminate ~48-line duplicated struct literal
- Extract `lock_entries` / `lock_next_id` private helpers in `InMemoryFacade` to eliminate 5 repeated lock-guard patterns

## Changes

| Crate | Change | Issue |
|-------|--------|-------|
| `zeph-acp` | Replace unresolvable feature-gated doc links with backtick text | Closes #4941 |
| `zeph-tools` | Extract `build_audit_entry(Option<&ResolvedContext>)` in `ShellExecutor` | Closes #4960 |
| `zeph-memory` | Extract `lock_entries()` / `lock_next_id()` in `InMemoryFacade` | Closes #4962 |

## Test plan

- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-acp` — zero errors
- [x] `cargo clippy -p zeph-acp -p zeph-tools -p zeph-memory --all-features -- -D warnings` — clean
- [x] `cargo nextest run -p zeph-acp -p zeph-tools -p zeph-memory --lib` — 2759 passed, 8 skipped
- [x] `RUSTFLAGS="-D warnings" cargo check --all-targets` — clean
- [x] No behavioral drift confirmed by adversarial review (field-by-field equivalence for #4960, lock error string byte-identical for #4962)