### PR TITLE
feat(durable): --json flag for durable CLI, remove dead TUI consts, degraded metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs(acp)`: fix broken intra-doc links in `transport/` and `client/error` — feature-gated items referenced as plain backtick text; private `SubagentCommand::Close` link removed from public doc (closes #4941)
 - `refactor(tools)`: extract `build_audit_entry` private helper in `ShellExecutor`; `log_audit` and `log_audit_with_context` now delegate to it (closes #4960)
 - `refactor(memory)`: extract `lock_entries` and `lock_next_id` private helpers in `InMemoryFacade` to eliminate repeated lock-poisoning boilerplate (closes #4962)
+- `refactor(tui)`: remove three dead `pub const STATUS_*` constants (`STATUS_REPLAYING`, `STATUS_PRUNING`, `STATUS_AWAITING`) from `zeph-tui::widgets::durable` — only `STATUS_UNAVAILABLE` is referenced (closes #4977)
+
+### Fixed
+
+- `fix(durable)`: emit `durable.journal.writer.degraded_appends_total` metrics counter in `append_acked_degrading` when `JournalUnavailable` is returned — the degradation path was previously observable only via `WARN` log (closes #4973)
 
 ### Added
+
+- `feat(cli)`: add `--json` flag to `zeph durable list`, `zeph durable show`, and `zeph durable inspect`. When set, structured JSON is emitted to stdout instead of a human-readable table. `ExecutionSummary`, `RedactedEntry`, and `ExecutionStatus` now implement `serde::Serialize`; `ExecutionStatus` serializes in `snake_case` to match the DB column values. `--reveal` and `--json` are mutually exclusive (Clap `conflicts_with`) to prevent silent non-JSON output (closes #4978)
 
 - `feat(core)`: P1 durable adapter for the agent tool-loop (spec-064 §P1, closes #4951).
   `SessionState` gains `durable_ctx: Option<Arc<DurableContext>>` and `durable_turn_replayed: bool`.

--- a/crates/zeph-durable/src/backend.rs
+++ b/crates/zeph-durable/src/backend.rs
@@ -47,7 +47,7 @@ pub use local::LocalBackend;
 /// round-trip to a typed value, so the stored string is exposed verbatim for display).
 ///
 /// [`ExecutionKind::Custom`]: crate::ExecutionKind::Custom
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct ExecutionSummary {
     /// The execution identity.
     pub execution_id: ExecutionId,
@@ -71,7 +71,7 @@ pub struct ExecutionSummary {
 /// and full idempotency key — only the metadata the spec's INV-5 redaction rule permits in default
 /// output. To see decrypted payloads a caller must opt in via `--reveal`, which reads through the
 /// AEAD cipher with [`Journal::read_execution`](crate::Journal::read_execution) instead.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct RedactedEntry {
     /// Global append sequence.
     pub seq: i64,

--- a/crates/zeph-durable/src/handle.rs
+++ b/crates/zeph-durable/src/handle.rs
@@ -702,6 +702,7 @@ impl DurableContext {
                     step = name,
                     "journal writer unavailable; this step degrades to non-durable mode"
                 );
+                metrics::counter!("durable.journal.writer.degraded_appends_total").increment(1);
                 Ok(())
             }
             Err(error) => Err(error),

--- a/crates/zeph-durable/src/ids.rs
+++ b/crates/zeph-durable/src/ids.rs
@@ -470,6 +470,11 @@ mod tests {
         let json = serde_json::to_string(&id).unwrap();
         let back: ExecutionId = serde_json::from_str(&json).unwrap();
         assert_eq!(id, back);
+        // Verify the JSON shape is a bare UUID string (not {"0":"..."} or a wrapped object).
+        assert!(
+            json.starts_with('"') && json.ends_with('"'),
+            "ExecutionId must serialize as a bare UUID string, got: {json}"
+        );
     }
 
     #[test]

--- a/crates/zeph-durable/src/journal.rs
+++ b/crates/zeph-durable/src/journal.rs
@@ -37,7 +37,8 @@ use crate::ids::{
 /// assert!(ExecutionStatus::Running.is_running());
 /// assert!(!ExecutionStatus::Failed.is_running());
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ExecutionStatus {
     /// The execution is in flight.
     Running,

--- a/crates/zeph-tui/src/widgets/durable.rs
+++ b/crates/zeph-tui/src/widgets/durable.rs
@@ -17,12 +17,6 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 
 use crate::theme::Theme;
 
-/// Status message: a crashed execution is replaying its journal (spec-011).
-pub const STATUS_REPLAYING: &str = "Replaying execution…";
-/// Status message: a background retention sweep is running (spec-011).
-pub const STATUS_PRUNING: &str = "Pruning journal…";
-/// Status message: a durable promise is parked awaiting an external completion (spec-011).
-pub const STATUS_AWAITING: &str = "Awaiting external completion…";
 /// Status message: the journal is unreachable, so the agent runs without durability (spec-011).
 pub const STATUS_UNAVAILABLE: &str = "Journal unavailable — non-durable mode";
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -544,14 +544,20 @@ pub(crate) enum DurableCommand {
         /// Maximum number of executions to display
         #[arg(long, default_value = "50")]
         limit: i64,
+        /// Emit structured JSON instead of a table
+        #[arg(long)]
+        json: bool,
     },
     /// Show the journal entries of one execution (payload redacted by default)
     Show {
         /// Execution id (UUID)
         id: String,
         /// Decrypt and print payload bytes (prints a warning first; requires `ZEPH_DURABLE_KEY`)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "json")]
         reveal: bool,
+        /// Emit structured JSON instead of a table
+        #[arg(long)]
+        json: bool,
     },
     /// Inspect a single journal step entry
     Inspect {
@@ -561,8 +567,11 @@ pub(crate) enum DurableCommand {
         #[arg(long)]
         step: u32,
         /// Decrypt and print payload bytes (prints a warning first; requires `ZEPH_DURABLE_KEY`)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "json")]
         reveal: bool,
+        /// Emit structured JSON instead of a table
+        #[arg(long)]
+        json: bool,
     },
     /// Force a retention sweep over terminal executions past their TTL
     Prune {

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -10,6 +10,8 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use anyhow::Context as _;
+
 use zeph_core::config::Config;
 use zeph_core::durable::XChaCha20Poly1305Cipher;
 use zeph_core::vault::AgeVaultProvider;
@@ -88,6 +90,7 @@ async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<Lo
 /// # Errors
 ///
 /// Returns an error if the config cannot be loaded, the journal cannot be opened, or a query fails.
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn handle_durable_command(
     cmd: DurableCommand,
     config_path: Option<&Path>,
@@ -100,6 +103,7 @@ pub(crate) async fn handle_durable_command(
             status,
             kind,
             limit,
+            json,
         } => {
             let Some(backend) = open_backend(&config, false).await? else {
                 return Ok(());
@@ -108,43 +112,56 @@ pub(crate) async fn handle_durable_command(
                 .list_executions(status.as_deref(), kind.as_deref(), limit)
                 .await
                 .map_err(|e| anyhow::anyhow!("failed to list executions: {e}"))?;
-            if rows.is_empty() {
-                println!("No durable executions match.");
-                return Ok(());
-            }
-            println!(
-                "{:<36} {:<18} {:<10} {:>6}  CREATED",
-                "EXECUTION ID", "KIND", "STATUS", "STEPS"
-            );
-            println!("{}", "-".repeat(96));
-            for row in &rows {
+            if json {
                 println!(
-                    "{:<36} {:<18} {:<10} {:>6}  {}",
-                    row.execution_id.as_uuid(),
-                    row.kind,
-                    row.status.as_str(),
-                    row.step_count,
-                    fmt_ts(row.created_at_ms),
+                    "{}",
+                    serde_json::to_string_pretty(&rows)
+                        .context("failed to serialize execution list")?
                 );
+            } else {
+                if rows.is_empty() {
+                    println!("No durable executions match.");
+                    return Ok(());
+                }
+                println!(
+                    "{:<36} {:<18} {:<10} {:>6}  CREATED",
+                    "EXECUTION ID", "KIND", "STATUS", "STEPS"
+                );
+                println!("{}", "-".repeat(96));
+                for row in &rows {
+                    println!(
+                        "{:<36} {:<18} {:<10} {:>6}  {}",
+                        row.execution_id.as_uuid(),
+                        row.kind,
+                        row.status.as_str(),
+                        row.step_count,
+                        fmt_ts(row.created_at_ms),
+                    );
+                }
             }
         }
 
-        DurableCommand::Show { id, reveal } => {
+        DurableCommand::Show { id, reveal, json } => {
             let exec = ExecutionId::parse_str(&id)
                 .map_err(|e| anyhow::anyhow!("invalid execution id '{id}': {e}"))?;
             let Some(backend) = open_backend(&config, reveal).await? else {
                 return Ok(());
             };
-            show_entries(&backend, exec, reveal, None).await?;
+            show_entries(&backend, exec, reveal, None, json).await?;
         }
 
-        DurableCommand::Inspect { id, step, reveal } => {
+        DurableCommand::Inspect {
+            id,
+            step,
+            reveal,
+            json,
+        } => {
             let exec = ExecutionId::parse_str(&id)
                 .map_err(|e| anyhow::anyhow!("invalid execution id '{id}': {e}"))?;
             let Some(backend) = open_backend(&config, reveal).await? else {
                 return Ok(());
             };
-            show_entries(&backend, exec, reveal, Some(step)).await?;
+            show_entries(&backend, exec, reveal, Some(step), json).await?;
         }
 
         DurableCommand::Prune { dry_run } => {
@@ -198,7 +215,8 @@ pub(crate) async fn handle_durable_command(
 /// Show one execution's entries, optionally filtered to a single `step`, redacted unless `reveal`.
 ///
 /// `reveal` reads through the AEAD cipher (decrypted payloads) and prints a warning first; otherwise
-/// only redaction-safe metadata is shown (INV-5).
+/// only redaction-safe metadata is shown (INV-5). When `json` is set, output is serialized JSON
+/// instead of a human-readable table.
 ///
 /// # Errors
 ///
@@ -208,6 +226,7 @@ async fn show_entries(
     exec: ExecutionId,
     reveal: bool,
     step: Option<u32>,
+    json: bool,
 ) -> anyhow::Result<()> {
     if reveal {
         println!("{REVEAL_WARNING}\n");
@@ -231,7 +250,13 @@ async fn show_entries(
         if let Some(s) = step {
             entries.retain(|e| e.step_id.value() == s);
         }
-        if entries.is_empty() {
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&entries)
+                    .context("failed to serialize journal entries")?
+            );
+        } else if entries.is_empty() {
             println!("No matching journal entry.");
         } else {
             print_redacted(&entries);


### PR DESCRIPTION
## Summary

- **#4978**: Add `--json` flag to `zeph durable list`, `show`, and `inspect` for machine-readable output. Follows the same pattern as `zeph status`, `gonka doctor`, and `cocoon doctor`. `--reveal` conflicts with `--json` (AEAD ciphertext is not useful as JSON).
- **#4977**: Remove three dead `pub const STATUS_REPLAYING/PRUNING/AWAITING` from `zeph-tui` `DurableView` widget. `STATUS_UNAVAILABLE` is retained.
- **#4973**: Emit `durable.journal.writer.degraded_appends_total` counter when `append_acked_degrading` silently degrades a step to non-durable mode on `JournalUnavailable`, enabling operator alerting.

## Key decisions

- `ExecutionStatus` uses `#[serde(rename_all = "snake_case")]` so JSON output (`"running"`, `"completed"`) is consistent with the DB column, `as_str()`, and `--status` filter.
- `--reveal --json` is rejected by clap (`conflicts_with`): revealed entries contain AEAD-sealed ciphertext — emitting them as JSON would be confusing and useless.
- `#[allow(clippy::too_many_lines)]` on `handle_durable_command` follows existing project pattern in `doctor.rs`, `gonka.rs`, `skill.rs` (pure dispatch tables).
- `ExecutionId(Uuid)` newtype serializes as a bare UUID string by default (verified empirically, regression assertion added to `ids.rs`).

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 10657 passed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean
- [x] `cargo doc --workspace` — no broken intra-doc links
- [x] `cargo test --doc --workspace` — 10 doc-tests pass

Closes #4978
Closes #4977
Closes #4973