### PR TITLE
fix(init): align default config output path with runtime search order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(init)`: align the default config output path in the init wizard with the runtime config search order. The wizard now defaults to `$XDG_CONFIG_HOME/zeph/config.toml` (same as `resolve_config_path`), so a config written during `zeph init` is found automatically on the next `zeph` invocation (closes #4984)
 - `fix(durable)`: emit `durable.journal.writer.degraded_appends_total` metrics counter in `append_acked_degrading` when `JournalUnavailable` is returned — the degradation path was previously observable only via `WARN` log (closes #4973)
 
 ### Added

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -1664,7 +1664,14 @@ fn step_review_and_write(state: &WizardState, output: Option<PathBuf>) -> anyhow
     println!("{toml_str}");
     println!("------------------------\n");
 
-    let default_path = PathBuf::from("config.toml");
+    let default_path = dirs::config_dir()
+        .unwrap_or_else(|| {
+            std::env::var("HOME")
+                .map_or_else(|_| PathBuf::from("~"), PathBuf::from)
+                .join(".config")
+        })
+        .join("zeph")
+        .join("config.toml");
     let path = output.unwrap_or_else(|| {
         Input::new()
             .with_prompt("Write config to")


### PR DESCRIPTION
## Summary

- Init wizard defaulted to `./config.toml` (CWD-relative); runtime never searches that path — it uses `config/default.toml` then `$XDG_CONFIG_HOME/zeph/config.toml`.
- User accepting defaults would have their config silently ignored on next `zeph` invocation.
- Fix: default to the same XDG path the resolver uses (`dirs::config_dir().join("zeph/config.toml")`), with fallback to `~/.config/` when `config_dir()` is `None`.

## Changes

- `src/init/mod.rs:1646–1654` — replace `PathBuf::from("config.toml")` with the XDG path matching `src/bootstrap/config.rs:40-47`
- `CHANGELOG.md` — `[Unreleased] → Fixed`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10665 passed, 0 failed
- [ ] Live: run `zeph init`, accept default path, run `zeph` — config should be found automatically (blocked: embed provider not configured in testing env)

## Follow-up

- P3 regression test: pin init wizard XDG default == `resolve_config_path` XDG fallback (tester + critic noted no cross-check unit test; tracked separately)

Closes #4984