### PR TITLE
fix(skills): use compact skill catalog when embedding matcher is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `fix(init)`: align the default config output path in the init wizard with the runtime config search order. The wizard now defaults to `$XDG_CONFIG_HOME/zeph/config.toml` (same as `resolve_config_path`), so a config written during `zeph init` is found automatically on the next `zeph` invocation (closes #4984)
+- `fix(skills)`: when the embedding matcher is unavailable (no embedding provider configured, or embed/Qdrant infrastructure failure), skill injection now uses the description-only compact format (`format_skills_prompt_compact`) instead of injecting all skill bodies. Eliminates the ~57k-token baseline footprint for Claude-only and Ollama-without-embeddings setups; affected sessions see a `tracing::warn` pointing to embedding provider configuration (closes #4989)
 - `fix(durable)`: emit `durable.journal.writer.degraded_appends_total` metrics counter in `append_acked_degrading` when `JournalUnavailable` is returned — the degradation path was previously observable only via `WARN` log (closes #4973)
 
 ### Added

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -585,7 +585,9 @@ impl<C: Channel> Agent<C> {
         };
         let effective_query = rewritten_query.as_deref().unwrap_or(query);
 
-        let matched_indices: Vec<usize> = if let Some(matcher) = &self.services.skill.matcher {
+        let (matched_indices, skill_fallback_mode): (Vec<usize>, bool) = if let Some(matcher) =
+            &self.services.skill.matcher
+        {
             let provider = self.embedding_provider.clone();
             let embed_timeout_secs = self.runtime.config.timeouts.embedding_seconds;
             let _ = self.channel.send_status("matching skills...").await;
@@ -753,11 +755,14 @@ impl<C: Channel> Agent<C> {
                 }
             }
 
-            let indices: Vec<usize> = if infra_error {
+            let (indices, fallback): (Vec<usize>, bool) = if infra_error {
                 // Embed or Qdrant infrastructure failure: fall back to all skills so the agent
                 // remains functional rather than running with an empty skill set.
-                tracing::warn!("skill matcher infrastructure error, falling back to all skills");
-                (0..all_meta.len()).collect()
+                tracing::warn!(
+                    "skill matcher infrastructure error, falling back to all skills \
+                     (description-only injection to limit token use)"
+                );
+                ((0..all_meta.len()).collect(), true)
             } else {
                 // Drop skills whose score falls below the minimum injection floor.
                 let min_score = self.services.skill.min_injection_score;
@@ -788,17 +793,21 @@ impl<C: Channel> Agent<C> {
                         < self.services.skill.disambiguation_threshold
                 {
                     match self.disambiguate_skills(query, &all_meta, &scored).await {
-                        Some(reordered) => reordered,
-                        None => scored.iter().map(|s| s.index).collect(),
+                        Some(reordered) => (reordered, false),
+                        None => (scored.iter().map(|s| s.index).collect(), false),
                     }
                 } else {
-                    scored.iter().map(|s| s.index).collect()
+                    (scored.iter().map(|s| s.index).collect(), false)
                 }
             };
             let _ = self.channel.send_status("").await;
-            indices
+            (indices, fallback)
         } else {
-            (0..all_meta.len()).collect()
+            tracing::warn!(
+                "embedding matcher unavailable, injecting skill catalog (description-only); \
+                 configure an embedding provider (e.g. a local Ollama embed model) to enable semantic skill matching"
+            );
+            ((0..all_meta.len()).collect(), true)
         };
 
         let matched_indices: Vec<usize> = matched_indices
@@ -993,7 +1002,9 @@ impl<C: Channel> Agent<C> {
             other => other,
         };
 
-        let mut skills_prompt = if effective_mode == crate::config::SkillPromptMode::Compact {
+        let mut skills_prompt = if effective_mode == crate::config::SkillPromptMode::Compact
+            || skill_fallback_mode
+        {
             format_skills_prompt_compact(&active_skills)
         } else {
             let trust_levels: std::collections::HashMap<String, zeph_common::SkillTrustLevel> =


### PR DESCRIPTION
## Summary

- When the embedding matcher is `None` (no embedding provider, Claude-only setup) or fails due to infrastructure error (embed timeout, Qdrant down), both fallback paths in `assembly.rs` previously injected **all ~26 skill bodies** (~57k tokens) into every request.
- Both fallback paths now set `skill_fallback_mode = true`, which routes the prompt renderer to `format_skills_prompt_compact` (name + description only) instead of `format_skills_prompt` (full bodies).
- The working top-K matcher path is **unchanged** — still injects full bodies for the matched subset.
- Added `tracing::warn` in both fallback paths pointing to embedding provider configuration.

## Changes

- `crates/zeph-core/src/agent/context/assembly.rs` — propagate `skill_fallback_mode: bool` through the matched-indices computation; switch prompt renderer to compact when in fallback mode.
- `CHANGELOG.md` — added entry under `[Unreleased] Fixed`.

## Test plan

- [x] `cargo +nightly fmt --check` — passes
- [x] `cargo clippy --workspace -- -D warnings` — passes
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — passes
- [x] `cargo nextest run --workspace --lib --bins` — 10682 passed, 21 skipped

**LLM serialization gate note:** this PR touches `crates/zeph-core/src/agent/context/assembly.rs` (context assembly). However, the change only affects *which* prompt-formatting function is called — no serialization structs, no `Message`/`MessagePart` fields, no request/response shapes are altered. A live API session is not strictly required by the gate, but is recommended when embeddings are available.

## Follow-up

- [ ] Add regression tests for `skill_fallback_mode = true` paths (no-matcher and infra-error) in `chunk_skill_compaction_tests.rs` — filed as #4994.

Closes #4989