### PR TITLE
refactor(experiments,init): rename eval_model → eval_provider, add XDG parity test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(config)`: rename `ExperimentConfig.eval_model: Option<String>` → `eval_provider: ProviderName` to comply with the multi-model design principle. `eval_provider` references a `[[llm.providers]]` name; an empty value falls back to the primary provider. Migration step 58 (`migrate_eval_model_to_provider`) comments out the old key and emits a warning. Config wizard updated to write `eval_provider`. **BREAKING CHANGE**: `experiments.eval_model` is removed; update `[experiments]` sections to use `eval_provider = "<provider-name>"` (closes #4987, #4993)
 - Add `#[must_use]` to public validate/scan functions across workspace (zeph-config, zeph-skills, zeph-orchestration, zeph-experiments, zeph-common, zeph-core, zeph-mcp, zeph-plugins, zeph-tools) to prevent silent discard of validation errors (closes #4943, #4961, #4963)
 - `docs(acp)`: fix broken intra-doc links in `transport/` and `client/error` — feature-gated items referenced as plain backtick text; private `SubagentCommand::Close` link removed from public doc (closes #4941)
 - `refactor(tools)`: extract `build_audit_entry` private helper in `ShellExecutor`; `log_audit` and `log_audit_with_context` now delegate to it (closes #4960)

--- a/config/default.toml
+++ b/config/default.toml
@@ -1065,6 +1065,9 @@ ner_model = "iiiorg/piiranha-v1-detect-personal-information"
 [experiments]
 # Enable the autonomous self-experimentation engine
 enabled = false
+# Provider name (from [[llm.providers]]) used as LLM-as-judge for experiment evaluation.
+# Empty = primary provider. Use a provider different from the one under test to avoid self-judge bias.
+eval_provider = ""
 # Maximum number of experiments to run in a single session
 max_experiments = 20
 # Maximum wall-clock time per experiment session in seconds

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -479,8 +479,11 @@ impl Default for OrchestrationConfig {
 pub struct ExperimentConfig {
     /// Enable autonomous self-experimentation. Default: `false`.
     pub enabled: bool,
-    /// Model identifier used for evaluating experiment outcomes.
-    pub eval_model: Option<String>,
+    /// Provider name (from `[[llm.providers]]`) used as the LLM-as-judge for experiment
+    /// evaluation. An empty value falls back to the primary provider. Prefer a capable,
+    /// low-self-judge-bias model (e.g. a different provider than the one being evaluated).
+    #[serde(default)]
+    pub eval_provider: ProviderName,
     /// Path to a benchmark JSONL file for evaluating experiments.
     pub benchmark_file: Option<std::path::PathBuf>,
     #[serde(default = "default_experiment_max_experiments")]
@@ -509,7 +512,7 @@ impl Default for ExperimentConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            eval_model: None,
+            eval_provider: ProviderName::default(),
             benchmark_file: None,
             max_experiments: default_experiment_max_experiments(),
             max_wall_time_secs: default_experiment_max_wall_time_secs(),

--- a/crates/zeph-config/src/migrate/llm.rs
+++ b/crates/zeph-config/src/migrate/llm.rs
@@ -1173,3 +1173,67 @@ pub fn migrate_llm_stream_limits(toml_src: &str) -> Result<MigrationResult, Migr
         sections_changed: vec!["llm.stream_limits".to_owned()],
     })
 }
+
+/// Rename `[experiments] eval_model` → `eval_provider` (#4987).
+///
+/// `eval_model` held a raw model name (e.g. `"claude-opus-4"`), while `eval_provider` must
+/// reference a `[[llm.providers]]` `name` field. A migrated value would cause a silent `warn!`
+/// from `build_eval_provider()` when resolution fails, so the old value is commented out.
+///
+/// If `eval_model` is absent in `[experiments]`, the input is returned unchanged.
+///
+/// # Errors
+///
+/// Returns `MigrateError::Parse` if the input TOML is invalid.
+pub fn migrate_eval_model_to_provider(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    let mut doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+
+    let old_value = doc
+        .get("experiments")
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|t| t.get("eval_model"))
+        .and_then(toml_edit::Item::as_value)
+        .and_then(toml_edit::Value::as_str)
+        .map(ToOwned::to_owned);
+
+    let Some(old_model) = old_value else {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    };
+
+    let commented_out = format!(
+        "# eval_provider = \"{old_model}\"  \
+         # MIGRATED: was eval_model; update to a [[llm.providers]] name"
+    );
+
+    let exp_table = doc
+        .get_mut("experiments")
+        .and_then(toml_edit::Item::as_table_mut)
+        .ok_or(MigrateError::InvalidStructure(
+            "[experiments] is not a table",
+        ))?;
+    exp_table.remove("eval_model");
+    let decor = exp_table.decor_mut();
+    let existing_suffix = decor.suffix().and_then(|s| s.as_str()).unwrap_or("");
+    let new_suffix = if existing_suffix.trim().is_empty() {
+        format!("\n{commented_out}\n")
+    } else {
+        format!("{existing_suffix}\n{commented_out}\n")
+    };
+    decor.set_suffix(new_suffix);
+
+    eprintln!(
+        "Migration warning: [experiments].eval_model has been renamed to eval_provider \
+         and its value commented out. `eval_provider` must reference a [[llm.providers]] \
+         `name` field, not a raw model name. Update or remove the commented line."
+    );
+
+    Ok(MigrationResult {
+        output: doc.to_string(),
+        changed_count: 1,
+        sections_changed: vec!["experiments.eval_provider".to_owned()],
+    })
+}

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -590,12 +590,12 @@ use steps::{
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
     MigrateAutodreamConfig, MigrateCocoonProviderNotice, MigrateCocoonShowBalance,
     MigrateCompressionPredictorConfig, MigrateDatabaseUrl, MigrateDurableConfig,
-    MigrateEgressConfig, MigrateEmbedProviderRename, MigrateFidelityTimeoutDefaults,
-    MigrateFiveSignalConfig, MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig,
-    MigrateGoalsConfig, MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig,
-    MigrateHooksTurnComplete, MigrateLlmStreamLimits, MigrateMagicDocsConfig,
-    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpRetryAndToolTimeout,
-    MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
+    MigrateEgressConfig, MigrateEmbedProviderRename, MigrateEvalModelToProvider,
+    MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig, MigrateFocusAutoConsolidateMinWindow,
+    MigrateForgettingConfig, MigrateGoalsConfig, MigrateGonkagateToGonka,
+    MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete, MigrateLlmStreamLimits,
+    MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
+    MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
@@ -608,7 +608,7 @@ use steps::{
     MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–47).
+/// Ordered registry of all sequential migration steps (steps 1–58).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -705,6 +705,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateLlmStreamLimits),
             // Step 57 — add [durable] execution-layer section, default-off (spec-064, #4949)
             Box::new(MigrateDurableConfig),
+            // Step 58 — rename [experiments] eval_model → eval_provider (#4987)
+            Box::new(MigrateEvalModelToProvider),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -26,20 +26,21 @@ use super::{
     migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_autodream_config,
     migrate_cocoon_provider_notice, migrate_cocoon_show_balance,
     migrate_compression_predictor_config, migrate_database_url, migrate_durable_config,
-    migrate_egress_config, migrate_embed_provider_rename, migrate_fidelity_timeout_defaults,
-    migrate_five_signal_config, migrate_focus_auto_consolidate_min_window,
-    migrate_forgetting_config, migrate_goals_config, migrate_hooks_permission_denied_config,
-    migrate_hooks_turn_complete_config, migrate_llm_stream_limits, migrate_magic_docs_config,
-    migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
-    migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels, migrate_memory_graph_config,
-    migrate_memory_hebbian_config, migrate_memory_hebbian_consolidation_config,
-    migrate_memory_hebbian_spread_config, migrate_memory_persona_config,
-    migrate_memory_reasoning_config, migrate_memory_reasoning_judge_config,
-    migrate_memory_retrieval_config, migrate_memory_retrieval_query_bias,
-    migrate_microcompact_config, migrate_orchestration_orchestrator_provider,
-    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
-    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_quality_config,
-    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
+    migrate_egress_config, migrate_embed_provider_rename, migrate_eval_model_to_provider,
+    migrate_fidelity_timeout_defaults, migrate_five_signal_config,
+    migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
+    migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
+    migrate_llm_stream_limits, migrate_magic_docs_config, migrate_mcp_elicitation_config,
+    migrate_mcp_max_connect_attempts, migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels,
+    migrate_memory_graph_config, migrate_memory_hebbian_config,
+    migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
+    migrate_memory_persona_config, migrate_memory_reasoning_config,
+    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
+    migrate_memory_retrieval_query_bias, migrate_microcompact_config,
+    migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
+    migrate_otel_filter, migrate_planner_model_to_provider, migrate_provider_max_concurrent,
+    migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
+    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_persist_provider_overrides, migrate_session_provider_persistence,
     migrate_session_recap_config, migrate_shell_transactional, migrate_stt_to_provider,
     migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
@@ -47,7 +48,7 @@ use super::{
     migrate_worktree_git_timeout,
 };
 
-// ── Wrapper structs for all 56 sequential migration steps ───────────────────────────────────────
+// ── Wrapper structs for all 58 sequential migration steps ───────────────────────────────────────
 
 pub(super) struct MigrateSttToProvider;
 impl Migration for MigrateSttToProvider {
@@ -673,5 +674,16 @@ impl Migration for MigrateDurableConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_durable_config(toml_src)
+    }
+}
+
+pub(super) struct MigrateEvalModelToProvider;
+impl Migration for MigrateEvalModelToProvider {
+    fn name(&self) -> &'static str {
+        "migrate_eval_model_to_provider"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_eval_model_to_provider(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        57,
-        "MIGRATIONS registry must contain all 57 sequential steps"
+        58,
+        "MIGRATIONS registry must contain all 58 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -685,6 +685,52 @@ enabled = true
 max_tasks = 20
 ";
     let result = migrate_planner_model_to_provider(input).expect("migration must succeed");
+    assert_eq!(
+        result.changed_count, 0,
+        "changed_count must be 0 when field is absent"
+    );
+    assert_eq!(
+        result.output, input,
+        "output must equal input when nothing to migrate"
+    );
+}
+
+#[test]
+fn migrate_eval_model_to_provider_with_field() {
+    let input = r#"
+[experiments]
+enabled = true
+eval_model = "claude-opus-4"
+max_experiments = 20
+"#;
+    let result = migrate_eval_model_to_provider(input).expect("migration must succeed");
+    assert_eq!(result.changed_count, 1, "changed_count must be 1");
+    assert!(
+        !result.output.contains("eval_model = "),
+        "eval_model key must be removed from output"
+    );
+    assert!(
+        result.output.contains("# eval_provider"),
+        "commented-out eval_provider entry must be present"
+    );
+    assert!(
+        result.output.contains("claude-opus-4"),
+        "old value must appear in the comment"
+    );
+    assert!(
+        result.output.contains("MIGRATED"),
+        "comment must include MIGRATED marker"
+    );
+}
+
+#[test]
+fn migrate_eval_model_to_provider_no_op() {
+    let input = r"
+[experiments]
+enabled = true
+max_experiments = 20
+";
+    let result = migrate_eval_model_to_provider(input).expect("migration must succeed");
     assert_eq!(
         result.changed_count, 0,
         "changed_count must be 0 when field is absent"
@@ -1599,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 57);
+    assert_eq!(MIGRATIONS.len(), 58);
 }
 
 #[test]
@@ -1697,6 +1743,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_worktree_git_timeout",
         "migrate_llm_stream_limits",
         "migrate_durable_config",
+        "migrate_eval_model_to_provider",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -543,7 +543,7 @@ impl<C: Channel> Agent<C> {
     /// Set a dedicated judge provider for experiment evaluation.
     ///
     /// When set, the evaluator uses this provider instead of the agent's primary provider,
-    /// eliminating self-judge bias. Corresponds to `experiments.eval_model` in config.
+    /// eliminating self-judge bias. Corresponds to `experiments.eval_provider` in config.
     #[must_use]
     pub fn with_eval_provider(mut self, provider: AnyProvider) -> Self {
         self.services.experiments.eval_provider = Some(provider);

--- a/crates/zeph-core/src/agent/experiment_cmd.rs
+++ b/crates/zeph-core/src/agent/experiment_cmd.rs
@@ -28,7 +28,7 @@ impl<C: Channel> Agent<C> {
             .map_err(|e| format!("Failed to load benchmark: {e}"))?;
 
         let provider_arc = Arc::new(self.provider.clone());
-        // Use a dedicated eval provider when `eval_model` is configured, so the judge is
+        // Use a dedicated eval provider when `eval_provider` is configured, so the judge is
         // independent from the agent under test. Fall back to the primary provider otherwise.
         let judge_arc = self
             .services

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -167,4 +167,16 @@ mod tests {
             result.display()
         );
     }
+
+    #[test]
+    fn xdg_fallback_matches_wizard_default() {
+        // The runtime loader and the init wizard must propose the same path so that
+        // a config written by `zeph --init` is found automatically at startup.
+        let runtime_path = resolve_config_path_impl(None, no_env, false);
+        let wizard_path = crate::init::wizard_default_config_path();
+        assert_eq!(
+            runtime_path, wizard_path,
+            "init wizard default path and runtime XDG fallback diverged"
+        );
+    }
 }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1798,15 +1798,18 @@ impl AppBuilder {
     }
 
     pub fn build_eval_provider(&self) -> Option<AnyProvider> {
-        let model_spec = self.config.experiments.eval_model.as_deref()?;
-        match create_summary_provider(model_spec, &self.config) {
+        let name = &self.config.experiments.eval_provider;
+        if name.is_empty() {
+            return None;
+        }
+        match create_named_provider(name, &self.config) {
             Ok(p) => {
-                tracing::info!(eval_model = %model_spec, "experiment eval provider configured");
+                tracing::info!(eval_provider = %name, "experiment eval provider configured");
                 Some(p)
             }
             Err(e) => {
                 tracing::warn!(
-                    eval_model = %model_spec,
+                    eval_provider = %name,
                     error = %e,
                     "failed to create eval provider — primary provider will be used as judge"
                 );

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -138,7 +138,7 @@ pub(crate) struct WizardState {
     pub(crate) hard_compaction_threshold: f32,
     // Experiments
     pub(crate) experiments_enabled: bool,
-    pub(crate) experiments_eval_model: Option<String>,
+    pub(crate) experiments_eval_provider: String,
     pub(crate) experiments_schedule_enabled: bool,
     pub(crate) experiments_schedule_cron: String,
     // Security
@@ -361,7 +361,7 @@ impl Default for WizardState {
             soft_compaction_threshold: 0.60,
             hard_compaction_threshold: 0.90,
             experiments_enabled: false,
-            experiments_eval_model: None,
+            experiments_eval_provider: String::new(),
             experiments_schedule_enabled: false,
             experiments_schedule_cron: String::new(),
             pii_filter_enabled: false,
@@ -1122,10 +1122,8 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
 
     if state.experiments_enabled {
         config.experiments.enabled = true;
-        config
-            .experiments
-            .eval_model
-            .clone_from(&state.experiments_eval_model);
+        config.experiments.eval_provider =
+            ProviderName::new(state.experiments_eval_provider.as_str());
         if state.experiments_schedule_enabled {
             config.experiments.schedule.enabled = true;
             if !state.experiments_schedule_cron.is_empty() {
@@ -1462,7 +1460,7 @@ fn step_experiments(state: &mut WizardState) -> anyhow::Result<()> {
             ))
             .default(default_provider.clone())
             .interact_text()?;
-        state.experiments_eval_model = if input.is_empty() { None } else { Some(input) };
+        state.experiments_eval_provider = input;
 
         state.experiments_schedule_enabled = Confirm::new()
             .with_prompt("Schedule automatic experiment runs?")
@@ -1654,6 +1652,22 @@ fn step_quality(state: &mut WizardState) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Compute the XDG default config path used by the init wizard.
+///
+/// Mirrors the fallback logic in `resolve_config_path_impl` so that the path the wizard
+/// proposes matches the path the runtime loads when no CLI override or `ZEPH_CONFIG` env var
+/// is set and `config/default.toml` does not exist.
+pub(crate) fn wizard_default_config_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| {
+            std::env::var("HOME")
+                .map_or_else(|_| PathBuf::from("~"), PathBuf::from)
+                .join(".config")
+        })
+        .join("zeph")
+        .join("config.toml")
+}
+
 fn step_review_and_write(state: &WizardState, output: Option<PathBuf>) -> anyhow::Result<()> {
     println!("== Step 10/10: Review & Write ==\n");
 
@@ -1664,14 +1678,7 @@ fn step_review_and_write(state: &WizardState, output: Option<PathBuf>) -> anyhow
     println!("{toml_str}");
     println!("------------------------\n");
 
-    let default_path = dirs::config_dir()
-        .unwrap_or_else(|| {
-            std::env::var("HOME")
-                .map_or_else(|_| PathBuf::from("~"), PathBuf::from)
-                .join(".config")
-        })
-        .join("zeph")
-        .join("config.toml");
+    let default_path = wizard_default_config_path();
     let path = output.unwrap_or_else(|| {
         Input::new()
             .with_prompt("Write config to")
@@ -2067,7 +2074,7 @@ mod tests {
     fn build_config_experiments_enabled() {
         let state = WizardState {
             experiments_enabled: true,
-            experiments_eval_model: Some("claude".into()),
+            experiments_eval_provider: "claude".into(),
             experiments_schedule_enabled: true,
             experiments_schedule_cron: "0 4 * * *".into(),
             vault_backend: "env".into(),
@@ -2075,7 +2082,7 @@ mod tests {
         };
         let config = build_config(&state);
         assert!(config.experiments.enabled);
-        assert_eq!(config.experiments.eval_model.as_deref(), Some("claude"));
+        assert_eq!(config.experiments.eval_provider.as_str(), "claude");
         assert!(config.experiments.schedule.enabled);
         assert_eq!(config.experiments.schedule.cron, "0 4 * * *");
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3617,7 +3617,7 @@ async fn run_experiment_session(
         .map_err(|e| anyhow::anyhow!("failed to load benchmark: {e}"))?;
 
     let provider_arc = Arc::new(provider);
-    // Use a dedicated eval provider when `eval_model` is configured to avoid self-judge bias.
+    // Use a dedicated eval provider when `eval_provider` is configured to avoid self-judge bias.
     let judge_arc = app
         .build_eval_provider()
         .map_or_else(|| Arc::clone(&provider_arc), Arc::new);


### PR DESCRIPTION
## Summary

- Replace `ExperimentConfig.eval_model: Option<String>` with `eval_provider: ProviderName` — aligns with the project's multi-model design principle where all LLM-calling subsystems reference `[[llm.providers]]` by name
- Add migration step 58 (`migrate_eval_model_to_provider`) for in-place config upgrade; init wizard and `--migrate-config` updated
- Extract `wizard_default_config_path()` helper and add `xdg_fallback_matches_wizard_default` test pinning path parity between init wizard and runtime `resolve_config_path`

## Breaking change

`experiments.eval_model` is removed. Update `[experiments]` config sections:

```toml
# Before
eval_model = "gpt-4o-mini"

# After (eval_provider must reference a [[llm.providers]] name)
eval_provider = "fast"
```

Run `zeph --migrate-config` to upgrade automatically.

## Test plan

- [ ] 10690/10690 tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] `cargo +nightly fmt --check` clean
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `xdg_fallback_matches_wizard_default` test exists and passes
- [ ] `migrate_eval_model_to_provider_with_field` and `_no_op` tests cover migration body
- [ ] No stale `eval_model` references in workspace

Closes #4987, #4993