### PR TITLE
feat(durable): P2+P3 durable adapters — replan budget restore and exactly-once scheduler fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `feat(zeph-durable)`: criterion benchmarks for `zeph-durable` — all 10 groups from spec-064 §Benchmarks (`bench_step_run_idempotent`, `bench_step_run_atleastonce`, `bench_step_run_exactly_once_n`, `bench_parallel_n`, `bench_replay_cursor_n`, `bench_journal_append_buffered`, `bench_journal_append_acked`, `bench_payload_seal`, `bench_payload_open`, `bench_prune_batch`). NFR gate tests added in `tests/nfr_gates.rs`: NFR-DE-07 runs in CI; NFR-DE-01/02 are `#[ignore]` (5 ms bound requires release builds). Closes #4950.
 - `feat(zeph-subagent)`: durable promise adapter for subagent spawn/await (spec-064 §P4, closes #4954). `zeph-subagent` gains `durable.rs` with `make_durable_promise`, `await_durable_subagent`, `resolve_durable_promise`, `DurableResolverSeat`, and `SubagentResult`. The resolver seat carries a `Zeroizing<[u8; 32]>` token from parent to child background task (INV-9 channel rule). On parent resume after crash, `await_durable_subagent` returns the journaled `SubagentResult` immediately (spec §1038 finished-child replay). `zeph-core` wires the gate via `maybe_make_durable_seat` in `handle_agent_background` and `handle_agent_spawn_foreground`.
 
+- `feat(orchestration)`: P2 durable adapter for `/plan resume` (spec-064 §P2, closes #4952).
+  `ReplanBudgetSnapshot` captures five replan/predicate/lineage counters and is journaled on every
+  DAG pause as an `EffectClass::Idempotent` step keyed to `(graph_id, save_generation)`.  A
+  generation counter on `TaskGraph` ensures successive pause→resume→pause cycles open distinct
+  executions so replays always return the latest snapshot.  `DagScheduler::resume_from_durable`
+  restores the counters instead of zeroing them.  Call sites in `zeph-core/src/agent/plan.rs` are
+  gated on `[durable].orchestration`; when the flag is off behaviour is identical to pre-durable.
+
+- `feat(scheduler)`: P3 durable exactly-once adapter for scheduler job fires (spec-064 §P3,
+  closes #4953).  `SchedulerDurableAdapter` holds a shared `DurableBackendEnum` and
+  `JournalWriterHandle` for the scheduler's lifetime.  `fire_with_durable` opens a per-fire
+  `ExactlyOnceGuarded` execution keyed on a BLAKE3-derived `ExecutionId` from
+  `(job_name, scheduled_slot_ms)`.  On crash between `EffectIntent` and `StepResult` the
+  `OnAmbiguous::Skip` policy applies rather than an unconditional re-fire.  The `catch_up_missed`
+  startup path and `inject_custom_task` both route through `execute_handler`, which dispatches via
+  `fire_with_durable` when an adapter is present.  Gated on `[durable].scheduler`.
+
 - `feat(core)`: P1 durable adapter for the agent tool-loop (spec-064 §P1, closes #4951).
   `SessionState` gains `durable_ctx: Option<Arc<DurableContext>>` and `durable_turn_replayed: bool`.
   The new `call_llm_durable` helper in `tier_loop.rs` wraps each LLM turn as an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11103,6 +11103,7 @@ dependencies = [
  "zeph-common",
  "zeph-config",
  "zeph-db",
+ "zeph-durable",
  "zeph-llm",
  "zeph-memory",
  "zeph-sanitizer",
@@ -11161,6 +11162,7 @@ dependencies = [
 name = "zeph-scheduler"
 version = "0.21.4"
 dependencies = [
+ "blake3",
  "chrono",
  "cron",
  "reqwest 0.13.4",
@@ -11173,8 +11175,11 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "wiremock",
+ "zeph-config",
  "zeph-db",
+ "zeph-durable",
 ]
 
 [[package]]

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1918,6 +1918,25 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Attach the durable execution config and cipher for the P2 orchestration adapter.
+    ///
+    /// When `config.enabled && config.orchestration` are both `true`, `/plan resume` will
+    /// restore the replan budget from the durable journal instead of zeroing it (FR-DE-13).
+    /// `db_url` is the `sqlite://…/durable.db` connection string (a sibling of the main DB).
+    /// The `cipher` is `None` when `config.encrypt_payload = false` (development mode only).
+    #[must_use]
+    pub fn with_durable_orchestration(
+        mut self,
+        config: zeph_config::DurableConfig,
+        db_url: String,
+        cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
+    ) -> Self {
+        self.services.orchestration.durable_config = Some(config);
+        self.services.orchestration.durable_db_url = Some(db_url);
+        self.services.orchestration.durable_cipher = cipher;
+        self
+    }
+
     /// Wire `graph_persistence` from the attached `SemanticMemory` `SQLite` pool.
     ///
     /// Idempotent: returns immediately if `graph_persistence` is already `Some`.

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -146,9 +146,25 @@ impl<C: crate::channel::Channel> Agent<C> {
         Ok(graph)
     }
 
+    fn build_admission_gate(&self) -> Option<zeph_orchestration::AdmissionGate> {
+        let pairs: Vec<(String, usize)> = self
+            .runtime
+            .providers
+            .provider_pool
+            .iter()
+            .filter_map(|e| e.max_concurrent.map(|c| (e.effective_name(), c as usize)))
+            .collect();
+        if pairs.is_empty() {
+            None
+        } else {
+            Some(zeph_orchestration::AdmissionGate::new(&pairs))
+        }
+    }
+
     pub(super) fn build_dag_scheduler(
         &mut self,
         graph: zeph_orchestration::TaskGraph,
+        durable_budget: Option<zeph_orchestration::durable::ReplanBudgetSnapshot>,
     ) -> Result<(zeph_orchestration::DagScheduler, usize), error::AgentError> {
         use zeph_orchestration::{DagScheduler, GraphStatus, RuleBasedRouter};
 
@@ -181,21 +197,7 @@ impl<C: crate::channel::Channel> Agent<C> {
             mgr.reserve_slots(reserved);
         }
 
-        // Build admission gate from providers that have `max_concurrent` set (C1 fix).
-        let admission_gate = {
-            let pairs: Vec<(String, usize)> = self
-                .runtime
-                .providers
-                .provider_pool
-                .iter()
-                .filter_map(|e| e.max_concurrent.map(|c| (e.effective_name(), c as usize)))
-                .collect();
-            if pairs.is_empty() {
-                None
-            } else {
-                Some(zeph_orchestration::AdmissionGate::new(&pairs))
-            }
-        };
+        let admission_gate = self.build_admission_gate();
 
         let scheduler = if graph.status == GraphStatus::Created {
             DagScheduler::new(
@@ -204,6 +206,15 @@ impl<C: crate::channel::Channel> Agent<C> {
                 Box::new(RuleBasedRouter),
                 available_agents,
                 admission_gate,
+            )
+        } else if let Some(snap) = durable_budget {
+            DagScheduler::resume_from_durable(
+                graph,
+                &self.services.orchestration.orchestration_config,
+                Box::new(RuleBasedRouter),
+                available_agents,
+                admission_gate,
+                snap,
             )
         } else {
             DagScheduler::resume_from(
@@ -255,6 +266,131 @@ impl<C: crate::channel::Channel> Agent<C> {
         Ok((scheduler, reserved))
     }
 
+    /// Ensure the durable backend for P2 budget snapshots is open, initialising it lazily on
+    /// the first call.  Returns `(Arc<DurableBackendEnum>, JournalWriterHandle)` or `None` when
+    /// durable is disabled / not configured.
+    async fn ensure_durable_backend(
+        &mut self,
+    ) -> Option<(
+        std::sync::Arc<zeph_durable::DurableBackendEnum>,
+        zeph_durable::JournalWriterHandle,
+    )> {
+        if self.services.orchestration.durable_backend.is_none() {
+            let cfg = self.services.orchestration.durable_config.clone()?;
+            if !cfg.enabled || !cfg.orchestration {
+                return None;
+            }
+            let db_url = self.services.orchestration.durable_db_url.clone()?;
+            let local = match zeph_durable::LocalBackend::open(&db_url, cfg.max_payload_bytes).await
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!(error = %e, "P2 durable: failed to open backend; skipping");
+                    return None;
+                }
+            };
+            if let Err(e) = local.init().await {
+                tracing::warn!(error = %e, "P2 durable: failed to init schema; skipping");
+                return None;
+            }
+            // Attach cipher to the backend before wrapping — callers never need to re-inject it.
+            let local = if let Some(c) = self.services.orchestration.durable_cipher.clone() {
+                local.with_cipher(c)
+            } else {
+                local
+            };
+            let local = std::sync::Arc::new(local);
+            let backend =
+                std::sync::Arc::new(zeph_durable::DurableBackendEnum::Local(local.clone()));
+            let (writer_actor, handle) = zeph_durable::JournalWriter::new(local, &cfg);
+            // The writer task is fire-and-forget: it runs until the process exits. Not tracked in
+            // the supervisor intentionally (the writer has no meaningful shutdown protocol beyond
+            // being dropped).
+            tokio::spawn(async move { writer_actor.run().await });
+            self.services.orchestration.durable_backend = Some(backend);
+            self.services.orchestration.durable_writer = Some(handle);
+        }
+        let backend = self.services.orchestration.durable_backend.clone()?;
+        let writer = self.services.orchestration.durable_writer.clone()?;
+        Some((backend, writer))
+    }
+
+    /// Attempt to restore the durable replan budget for a graph that is being resumed.
+    ///
+    /// Returns `Some(snapshot)` when durable is enabled, the graph is being resumed (not
+    /// Created), and a snapshot was found in the journal. Returns `None` in all other cases
+    /// so the caller falls back to zeroing counters — identical to pre-durable behaviour.
+    async fn try_restore_durable_budget(
+        &mut self,
+        graph: &zeph_orchestration::TaskGraph,
+    ) -> Option<zeph_orchestration::durable::ReplanBudgetSnapshot> {
+        use zeph_orchestration::GraphStatus;
+
+        if graph.status == GraphStatus::Created {
+            return None;
+        }
+        if !durable_orchestration_enabled(self.services.orchestration.durable_config.as_ref()) {
+            return None;
+        }
+        let (backend, _writer) = self.ensure_durable_backend().await?;
+        let generation = graph.durable_save_generation;
+        match zeph_orchestration::durable::restore_budget(&graph.id, generation, backend).await {
+            Ok(snap) => snap,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    graph_id = %graph.id,
+                    "P2 durable: restore_budget failed; falling back to zero counters"
+                );
+                None
+            }
+        }
+    }
+
+    /// Capture the current replan budget snapshot if durable is enabled; returns `None`
+    /// when off or not configured.
+    fn take_durable_budget_snapshot(
+        &self,
+        scheduler: &zeph_orchestration::DagScheduler,
+    ) -> Option<zeph_orchestration::durable::ReplanBudgetSnapshot> {
+        if !durable_orchestration_enabled(self.services.orchestration.durable_config.as_ref()) {
+            return None;
+        }
+        Some(scheduler.budget_snapshot())
+    }
+
+    /// Journal the replan budget snapshot for a DAG that is pausing.
+    /// Returns the next generation value when the journal write succeeds, so the caller can
+    /// persist it onto the final `TaskGraph` snapshot before writing to disk.  Returns `None`
+    /// when durable is disabled or the write fails (caller falls back to zeroing counters on
+    /// the next resume — safe degraded behaviour).
+    async fn journal_durable_budget(
+        &mut self,
+        graph: &zeph_orchestration::TaskGraph,
+        snapshot: zeph_orchestration::durable::ReplanBudgetSnapshot,
+    ) -> Option<u32> {
+        if !durable_orchestration_enabled(self.services.orchestration.durable_config.as_ref()) {
+            return None;
+        }
+        let cfg = self.services.orchestration.durable_config.clone()?;
+        let (backend, writer) = self.ensure_durable_backend().await?;
+        let generation = graph.durable_save_generation;
+        if let Err(e) = zeph_orchestration::durable::journal_budget(
+            &graph.id, generation, backend, writer, &cfg, snapshot,
+        )
+        .await
+        {
+            tracing::warn!(
+                error = %e,
+                graph_id = %graph.id,
+                generation,
+                "P2 durable: journal_budget failed; budget will be zeroed on next resume"
+            );
+            return None;
+        }
+        Some(generation.saturating_add(1))
+    }
+
     pub(super) async fn handle_plan_confirm(&mut self) -> Result<(), error::AgentError> {
         let Some(graph) = self.services.orchestration.pending_graph.take() else {
             self.channel
@@ -267,7 +403,9 @@ impl<C: crate::channel::Channel> Agent<C> {
             return Ok(());
         };
 
-        let (mut scheduler, reserved) = self.build_dag_scheduler(graph)?;
+        // P2 durable: restore replan budget if durable is enabled and this is a resume.
+        let durable_budget = self.try_restore_durable_budget(&graph).await;
+        let (mut scheduler, reserved) = self.build_dag_scheduler(graph, durable_budget)?;
 
         let task_count = scheduler.graph().tasks.len();
         self.channel
@@ -288,11 +426,19 @@ impl<C: crate::channel::Channel> Agent<C> {
             mgr.release_reservation(reserved);
         }
 
+        // P2 durable: snapshot budget before defensive save (scheduler still alive here).
+        let budget_snap = self.take_durable_budget_snapshot(&scheduler);
         // Defensive save before `?` so a scheduler error still commits the last in-flight state.
         if let Some(ref persistence) = self.services.orchestration.graph_persistence {
             super::scheduler_loop::save_graph_snapshot(persistence, scheduler.graph().clone())
                 .await;
         }
+        // Journal and capture next generation before consuming the scheduler.
+        let next_generation = if let Some(snap) = budget_snap {
+            self.journal_durable_budget(scheduler.graph(), snap).await
+        } else {
+            None
+        };
 
         let final_status = scheduler_result?;
 
@@ -301,6 +447,10 @@ impl<C: crate::channel::Channel> Agent<C> {
             .await;
 
         let mut completed_graph = scheduler.into_graph();
+        // Persist the incremented generation so the next pause uses a fresh ExecutionId.
+        if let Some(gn) = next_generation {
+            completed_graph.durable_save_generation = gn;
+        }
 
         if let Some(extra_tasks) = extra_task_outputs {
             completed_graph.tasks.extend(extra_tasks);
@@ -1172,5 +1322,65 @@ impl<C: crate::channel::Channel> Agent<C> {
             Ok(cmd) => self.handle_plan_command_as_string(cmd).await,
             Err(e) => Ok(e.to_string()),
         }
+    }
+}
+
+/// Returns `true` when the P2 durable orchestration adapter is active.
+///
+/// Used by the no-op guard in `try_restore_durable_budget`, `take_durable_budget_snapshot`, and
+/// `journal_durable_budget` so the early-return condition can be tested without constructing a
+/// full `Agent<C>`.
+pub(crate) fn durable_orchestration_enabled(cfg: Option<&zeph_config::DurableConfig>) -> bool {
+    cfg.is_some_and(|c| c.enabled && c.orchestration)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn disabled_cfg() -> zeph_config::DurableConfig {
+        zeph_config::DurableConfig {
+            enabled: false,
+            ..zeph_config::DurableConfig::default()
+        }
+    }
+
+    fn enabled_cfg() -> zeph_config::DurableConfig {
+        zeph_config::DurableConfig {
+            enabled: true,
+            orchestration: true,
+            ..zeph_config::DurableConfig::default()
+        }
+    }
+
+    fn orchestration_off_cfg() -> zeph_config::DurableConfig {
+        zeph_config::DurableConfig {
+            enabled: true,
+            orchestration: false,
+            ..zeph_config::DurableConfig::default()
+        }
+    }
+
+    // FR-DE-13 AC: when durable is absent, disabled, or orchestration=false → no-op.
+    #[test]
+    fn durable_disabled_when_config_absent() {
+        assert!(!durable_orchestration_enabled(None));
+    }
+
+    #[test]
+    fn durable_disabled_when_enabled_false() {
+        assert!(!durable_orchestration_enabled(Some(&disabled_cfg())));
+    }
+
+    #[test]
+    fn durable_disabled_when_orchestration_false() {
+        assert!(!durable_orchestration_enabled(Some(
+            &orchestration_off_cfg()
+        )));
+    }
+
+    #[test]
+    fn durable_enabled_when_both_flags_true() {
+        assert!(durable_orchestration_enabled(Some(&enabled_cfg())));
     }
 }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -661,6 +661,33 @@ pub(crate) struct OrchestrationState {
     /// `prepare_tool_dispatch` injects an [`ExecutionContext`] named `name` into
     /// every `ToolCall` so that `ShellExecutor::resolve_context` uses the right env.
     pub(crate) task_execution_env: Option<String>,
+
+    // ── P2 durable adapter (spec-064) ─────────────────────────────────────────
+    /// Durable config snapshot used by the P2 adapter in `plan.rs`.
+    ///
+    /// `None` when durable execution is disabled or the agent was built without a durable config
+    /// (e.g. unit tests). When `Some` and `durable.orchestration = true`, `/plan resume` restores
+    /// the replan budget from the journal instead of zeroing it.
+    pub(crate) durable_config: Option<zeph_config::DurableConfig>,
+    /// Resolved path to `durable.db` (the dedicated journal file for `LocalBackend`).
+    ///
+    /// Derived at build time from `memory.sqlite_path` sibling directory. `None` when the durable
+    /// adapter is not configured.
+    pub(crate) durable_db_url: Option<String>,
+    /// Shared durable backend for P2 budget snapshots.
+    ///
+    /// Lazily initialised by `plan.rs` on first journal call; shared across pause/resume cycles
+    /// for the same process lifetime.
+    // Accessed exclusively through ensure_durable_backend() in plan.rs; rustc's cross-module
+    // dead_code analysis does not follow the indirect Option method chains.
+    #[allow(dead_code)]
+    pub(crate) durable_backend: Option<std::sync::Arc<zeph_durable::DurableBackendEnum>>,
+    /// Writer handle for the shared P2 durable backend.
+    // Same as durable_backend: accessed through plan.rs ensure_durable_backend().
+    #[allow(dead_code)]
+    pub(crate) durable_writer: Option<zeph_durable::JournalWriterHandle>,
+    /// Cipher for encrypting P2 budget snapshots. `None` when `encrypt_payload = false`.
+    pub(crate) durable_cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
 }
 
 /// Groups instruction hot-reload state.

--- a/crates/zeph-durable/src/ids.rs
+++ b/crates/zeph-durable/src/ids.rs
@@ -111,6 +111,46 @@ impl ExecutionId {
     pub fn parse_str(s: &str) -> Result<Self, uuid::Error> {
         Ok(Self::from_uuid(Uuid::parse_str(s)?))
     }
+
+    /// Derive a deterministic execution identity from a domain tag and opaque payload bytes.
+    ///
+    /// Produces a stable [`ExecutionId`] for a `(domain, payload)` pair using BLAKE3 in
+    /// `derive_key` mode. Two calls with identical inputs produce the same id; differing inputs
+    /// produce cryptographically distinct ids. Use this for exactly-once adapters that need to
+    /// reattach to an existing journal execution on restart (e.g. the scheduler fire adapter, which
+    /// derives the id from `(job_name, slot_ms)` so a crashed and restarted scheduler finds the
+    /// same row).
+    ///
+    /// The `domain` string separates id spaces — choose a stable, globally-unique literal per
+    /// adapter (e.g. `"zeph.scheduler.fire.v1"`). The `payload` carries the distinguishing bytes
+    /// (e.g. little-endian slot timestamp).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_durable::ExecutionId;
+    ///
+    /// let a = ExecutionId::derive(b"zeph.test.v1", b"job_name\x00\x01\x00\x00\x00\x00\x00\x00\x00");
+    /// let b = ExecutionId::derive(b"zeph.test.v1", b"job_name\x00\x01\x00\x00\x00\x00\x00\x00\x00");
+    /// let c = ExecutionId::derive(b"zeph.test.v1", b"other_job\x00\x02\x00\x00\x00\x00\x00\x00\x00");
+    /// assert_eq!(a, b, "same domain+payload derives the same id");
+    /// assert_ne!(a, c, "different payload derives a different id");
+    /// ```
+    #[must_use]
+    pub fn derive(domain: &[u8], payload: &[u8]) -> Self {
+        // BLAKE3 derive_key requires a context string, not arbitrary bytes. Build a stable
+        // context from the ASCII prefix and embed the domain bytes in the payload to keep the
+        // domain separation in the keyed-hash layer, not just the input.
+        const DERIVE_CONTEXT: &str = "zeph-durable v1 execution-id derive 2026";
+        let mut input = Vec::with_capacity(8 + domain.len() + payload.len());
+        input.extend_from_slice(&(domain.len() as u64).to_le_bytes());
+        input.extend_from_slice(domain);
+        input.extend_from_slice(payload);
+        let hash = blake3::derive_key(DERIVE_CONTEXT, &input);
+        let mut bytes = [0u8; 16];
+        bytes.copy_from_slice(&hash[..16]);
+        Self(Uuid::new_v8(bytes))
+    }
 }
 
 impl Default for ExecutionId {

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -29,6 +29,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-db.workspace = true
+zeph-durable.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
 zeph-sanitizer.workspace = true

--- a/crates/zeph-orchestration/src/durable.rs
+++ b/crates/zeph-orchestration/src/durable.rs
@@ -1,0 +1,478 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Durable P2 adapter: journaling and restoring the replan budget across `/plan resume` cycles.
+//!
+//! Each time a DAG is paused the live replan counters (`task_replan_counts`,
+//! `global_replan_count`, `predicate_replans_used`, `predicate_reasons`, `lineage_chains`) are
+//! serialized into a [`ReplanBudgetSnapshot`] and written as an `EffectClass::Idempotent`
+//! step to a dedicated [`ExecutionId`] derived from `(graph_id, save_generation)`.  A fresh
+//! execution is opened for *each* save, so a plan that pauses → resumes → pauses again does not
+//! replay the stale first snapshot (the generation counter differentiates the two executions).
+//!
+//! On `/plan resume`, [`restore_budget`] reads back the highest-generation snapshot and hands it
+//! to [`crate::DagScheduler::resume_from_durable`], which populates the counters before the scheduler
+//! starts dispatching tasks again.  When the flag is off (or no snapshot exists), the scheduler
+//! falls back to zeroing all counters — identical to the pre-durable behaviour.
+//!
+//! # Layer boundary
+//!
+//! This module imports only `zeph_durable` and `zeph_config` from infrastructure crates.
+//! `zeph-core` types are never imported here; the call sites in `plan.rs` supply the
+//! cipher and config.  (INV-1: no business-logic in L0 infrastructure.)
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+use zeph_durable::DurableError;
+use zeph_durable::{
+    DurableBackendEnum, DurableConfig, DurableContext, ExecutionId, ExecutionKind, Journal as _,
+    JournalWriterHandle, StepDescriptor,
+};
+
+use super::graph::{GraphId, TaskId};
+use super::lineage::{ErrorLineage, LineageEntry, LineageKind};
+
+// ─── domain-separation label used for all P2 budget executions ────────────────
+const BUDGET_DOMAIN: &[u8] = b"zeph.orch.budget.v1";
+
+// ─── fixed step name, constant so idem_key is stable per-generation ───────────
+const BUDGET_STEP_NAME: &str = "replan_budget";
+const BUDGET_STEP_FP: &[u8] = b"orch:replan_budget:v1";
+
+// ─── DTO types ────────────────────────────────────────────────────────────────
+
+/// Serde-able projection of a single [`LineageEntry`].
+///
+/// [`LineageKind`] has no serde derives; this DTO flattens the single v1 variant to
+/// `error_class: String`.  If a second `LineageKind` variant is added post-v1 the
+/// exhaustive match in `From<&LineageEntry>` becomes a compile error — the intended tripwire.
+///
+/// # TODO(post-v1)
+///
+/// When `LineageKind` gains additional variants, replace `error_class` with a serde-tagged
+/// enum so no information is silently lost during round-trips.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineageEntryDto {
+    /// The task whose failure or weak output triggered this entry.
+    pub task_id: TaskId,
+    /// Short error class label (e.g. `"timeout"`, `"llm_error"`).
+    pub error_class: String,
+    /// Milliseconds since UNIX epoch when the entry was recorded.
+    pub ts_ms: u64,
+}
+
+impl From<&LineageEntry> for LineageEntryDto {
+    fn from(e: &LineageEntry) -> Self {
+        // Single v1 variant — match is exhaustive; adding WeakOutput here is the tripwire.
+        let error_class = match &e.kind {
+            LineageKind::Failed { error_class } => error_class.clone(),
+        };
+        Self {
+            task_id: e.task_id,
+            error_class,
+            ts_ms: e.ts_ms,
+        }
+    }
+}
+
+/// Serde-able projection of an [`ErrorLineage`] chain.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ErrorLineageDto {
+    /// Ordered entries (earliest first).
+    pub entries: Vec<LineageEntryDto>,
+}
+
+impl From<&ErrorLineage> for ErrorLineageDto {
+    fn from(src: &ErrorLineage) -> Self {
+        Self {
+            entries: src.entries().iter().map(LineageEntryDto::from).collect(),
+        }
+    }
+}
+
+impl ErrorLineage {
+    /// Reconstruct an [`ErrorLineage`] from a persisted [`ErrorLineageDto`].
+    ///
+    /// Used by the durable resume path to rebuild the lineage chains that were journaled at
+    /// the last pause so the cascade detector resumes with accurate history.
+    #[must_use]
+    pub fn from_dto(dto: ErrorLineageDto) -> Self {
+        let mut chain = ErrorLineage::default();
+        for d in dto.entries {
+            chain.push(LineageEntry {
+                task_id: d.task_id,
+                kind: LineageKind::Failed {
+                    error_class: d.error_class,
+                },
+                ts_ms: d.ts_ms,
+            });
+        }
+        chain
+    }
+}
+
+/// Serializable snapshot of the five replan/lineage/predicate counters tracked by [`DagScheduler`].
+///
+/// Written to the durable journal at each DAG pause so a subsequent `/plan resume` can restore
+/// the counters rather than zeroing them, preventing the budget overrun that FR-DE-13 exists to
+/// block.
+///
+/// [`DagScheduler`]: crate::scheduler::DagScheduler
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReplanBudgetSnapshot {
+    /// Per-task replan count.
+    pub task_replan_counts: std::collections::HashMap<TaskId, u32>,
+    /// Whole-plan replan counter.
+    pub global_replan_count: u32,
+    /// Number of predicate-driven re-runs consumed so far.
+    pub predicate_replans_used: u32,
+    /// Per-task accumulated predicate failure reasons.
+    pub predicate_reasons: std::collections::HashMap<TaskId, String>,
+    /// Per-task error lineage chains, serialised as DTOs.
+    pub lineage_chains: std::collections::HashMap<TaskId, ErrorLineageDto>,
+}
+
+// ─── id derivation ────────────────────────────────────────────────────────────
+
+/// Derive the [`ExecutionId`] for a specific `(graph_id, generation)` budget save.
+///
+/// Each generation gets a unique id so a plan that pauses, resumes and pauses again writes
+/// to a fresh execution rather than replaying the stale snapshot from the first pause.
+fn budget_exec_id(graph_id: &GraphId, generation: u32) -> ExecutionId {
+    let mut payload = graph_id.to_string().into_bytes();
+    payload.push(b'\0');
+    payload.extend_from_slice(&generation.to_le_bytes());
+    ExecutionId::derive(BUDGET_DOMAIN, &payload)
+}
+
+// ─── context builder ──────────────────────────────────────────────────────────
+
+/// Open a [`DurableContext`] for the given budget execution id.
+///
+/// `is_resume` is passed through from [`DurableBackendEnum::Local`]'s `open_execution` result so
+/// the context knows whether to replay or start fresh.
+fn build_budget_ctx(
+    exec_id: ExecutionId,
+    is_resume: bool,
+    backend: Arc<DurableBackendEnum>,
+    writer: JournalWriterHandle,
+    config: &DurableConfig,
+) -> DurableContext {
+    DurableContext::new(
+        exec_id,
+        ExecutionKind::DagRun,
+        is_resume,
+        backend,
+        writer,
+        config,
+    )
+}
+
+// ─── public API ───────────────────────────────────────────────────────────────
+
+/// Journal the current replan budget for a DAG execution.
+///
+/// Opens a fresh execution keyed to `(graph_id, generation)` and writes the snapshot as a
+/// single `EffectClass::Idempotent` step.  The generation counter in the persisted
+/// [`crate::TaskGraph`] must be incremented by the caller *before* this call so successive pauses
+/// produce different execution ids.
+///
+/// The `backend` must already have the cipher injected (via `LocalBackend::with_cipher`) before
+/// being wrapped into a `DurableBackendEnum`.  When encryption is disabled, pass a backend
+/// without a cipher; the journal will store plaintext payloads (development mode only).
+///
+/// # Errors
+///
+/// Returns [`DurableError`] if the backend cannot be opened or the step write fails.
+#[instrument(
+    level = "info",
+    name = "orch.durable.budget_journal",
+    skip(backend, writer, config, snapshot),
+    fields(graph_id = %graph_id, generation)
+)]
+pub async fn journal_budget(
+    graph_id: &GraphId,
+    generation: u32,
+    backend: Arc<DurableBackendEnum>,
+    writer: JournalWriterHandle,
+    config: &DurableConfig,
+    snapshot: ReplanBudgetSnapshot,
+) -> Result<(), DurableError> {
+    tracing::Span::current().record("generation", generation);
+
+    let exec_id = budget_exec_id(graph_id, generation);
+    let DurableBackendEnum::Local(local_backend) = &*backend else {
+        return Err(DurableError::Storage {
+            op: "open",
+            source: "journal_budget: only Local backend is supported"
+                .to_string()
+                .into(),
+        });
+    };
+    let local_backend = local_backend.clone();
+    // Open a fresh execution (never a resume) for this generation.
+    local_backend
+        .open_execution(exec_id, ExecutionKind::DagRun)
+        .await?;
+
+    let ctx = build_budget_ctx(exec_id, false, backend, writer, config);
+
+    let desc = StepDescriptor::idempotent(BUDGET_STEP_NAME, BUDGET_STEP_FP.to_vec());
+    ctx.step(desc, move |_handle| async move {
+        Ok::<ReplanBudgetSnapshot, zeph_durable::step::StepError>(snapshot)
+    })
+    .await?;
+
+    Ok(())
+}
+
+/// Restore the replan budget for a graph that is being resumed.
+///
+/// Scans from `generation` downward (typically just one call at the stored value) until it finds
+/// an execution with a committed `replan_budget` step result.  Returns `Ok(None)` when no
+/// snapshot exists (first run, or durable was off at last pause), so the caller can fall back to
+/// zeroing counters.
+///
+/// The `backend` must already have the cipher injected when encryption is enabled (see
+/// `LocalBackend::with_cipher`).
+///
+/// # Errors
+///
+/// Returns [`DurableError`] only for storage failures, not for a missing snapshot.
+#[instrument(
+    level = "info",
+    name = "orch.durable.budget_restore",
+    skip(backend),
+    fields(graph_id = %graph_id, generation)
+)]
+pub async fn restore_budget(
+    graph_id: &GraphId,
+    generation: u32,
+    backend: Arc<DurableBackendEnum>,
+) -> Result<Option<ReplanBudgetSnapshot>, DurableError> {
+    tracing::Span::current().record("generation", generation);
+
+    // Walk from the stored generation downward until we find a committed snapshot.
+    // In practice this is always a single lookup (generation == last saved gen).
+    for gn in (0..=generation).rev() {
+        let exec_id = budget_exec_id(graph_id, gn);
+        let entries = backend.read_execution(exec_id).await?;
+        if let Some(snapshot) = find_budget_snapshot(entries) {
+            return Ok(Some(snapshot));
+        }
+    }
+    Ok(None)
+}
+
+/// Extract a [`ReplanBudgetSnapshot`] from a raw entry list, or return `None`.
+///
+/// Returns `None` both when the execution has no entries at all (interrupted write) and when no
+/// `StepResult` with the budget step name is present — matching the MINOR-2 requirement.
+fn find_budget_snapshot(entries: Vec<zeph_durable::JournalEntry>) -> Option<ReplanBudgetSnapshot> {
+    use zeph_durable::journal::EntryKind;
+
+    // v1 invariant: each budget-execution contains exactly one step, so the first successful
+    // deserialization into ReplanBudgetSnapshot is the budget entry. If future versions add
+    // additional steps (e.g., schema-version or metadata steps), this heuristic must be replaced
+    // with an explicit step_name filter once the journal stores a step identifier field.
+    for entry in entries {
+        if let EntryKind::StepResult { payload, .. } = &entry.entry
+            && let Ok(snapshot) = serde_json::from_slice::<ReplanBudgetSnapshot>(payload.as_ref())
+        {
+            return Some(snapshot);
+        }
+    }
+    None
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use zeph_durable::{DurableBackendEnum, DurableConfig, JournalWriter, LocalBackend};
+
+    use super::*;
+    use crate::graph::GraphId;
+
+    fn test_config() -> DurableConfig {
+        DurableConfig {
+            enabled: true,
+            encrypt_payload: false,
+            journal_flush_interval_ms: 1,
+            journal_ack_timeout_ms: 1000,
+            ..DurableConfig::default()
+        }
+    }
+
+    async fn make_backend() -> (Arc<DurableBackendEnum>, JournalWriterHandle) {
+        let local = LocalBackend::open(":memory:", 1_048_576).await.unwrap();
+        local.init().await.unwrap();
+        let local = Arc::new(local);
+        let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
+        let (writer, handle) = JournalWriter::new(local, &test_config());
+        tokio::spawn(async move { writer.run().await });
+        (backend, handle)
+    }
+
+    #[test]
+    fn snapshot_serde_round_trip() {
+        let mut snap = ReplanBudgetSnapshot {
+            global_replan_count: 3,
+            predicate_replans_used: 1,
+            ..Default::default()
+        };
+        snap.task_replan_counts.insert(TaskId(0), 2);
+        snap.predicate_reasons
+            .insert(TaskId(1), "too slow".to_string());
+        snap.lineage_chains.insert(
+            TaskId(2),
+            ErrorLineageDto {
+                entries: vec![LineageEntryDto {
+                    task_id: TaskId(2),
+                    error_class: "timeout".to_string(),
+                    ts_ms: 1_000_000,
+                }],
+            },
+        );
+
+        let json = serde_json::to_string(&snap).unwrap();
+        let decoded: ReplanBudgetSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.global_replan_count, 3);
+        assert_eq!(decoded.predicate_replans_used, 1);
+        assert_eq!(*decoded.task_replan_counts.get(&TaskId(0)).unwrap(), 2);
+        assert_eq!(
+            decoded.predicate_reasons.get(&TaskId(1)).unwrap(),
+            "too slow"
+        );
+        let chain = decoded.lineage_chains.get(&TaskId(2)).unwrap();
+        assert_eq!(chain.entries.len(), 1);
+        assert_eq!(chain.entries[0].error_class, "timeout");
+    }
+
+    #[test]
+    fn error_lineage_dto_round_trip() {
+        let mut lineage = ErrorLineage::default();
+        lineage.push(LineageEntry {
+            task_id: TaskId(5),
+            kind: LineageKind::Failed {
+                error_class: "llm_error".to_string(),
+            },
+            ts_ms: 42_000,
+        });
+        let dto = ErrorLineageDto::from(&lineage);
+        assert_eq!(dto.entries.len(), 1);
+        assert_eq!(dto.entries[0].task_id, TaskId(5));
+        assert_eq!(dto.entries[0].error_class, "llm_error");
+
+        let restored = ErrorLineage::from_dto(dto);
+        assert_eq!(restored.entries().len(), 1);
+        assert_eq!(restored.entries()[0].task_id, TaskId(5));
+    }
+
+    #[tokio::test]
+    async fn journal_then_restore_returns_snapshot() {
+        let (backend, writer) = make_backend().await;
+        let config = test_config();
+        let graph_id = GraphId::new();
+        let generation: u32 = 0;
+
+        let snap = ReplanBudgetSnapshot {
+            global_replan_count: 7,
+            task_replan_counts: [(TaskId(0), 3)].into(),
+            ..Default::default()
+        };
+
+        journal_budget(
+            &graph_id,
+            generation,
+            backend.clone(),
+            writer.clone(),
+            &config,
+            snap.clone(),
+        )
+        .await
+        .unwrap();
+        // flush ensures the buffered step result is persisted before we read it back.
+        writer.flush().await.unwrap();
+
+        let restored = restore_budget(&graph_id, generation, backend)
+            .await
+            .unwrap();
+        let restored = restored.expect("snapshot should be present");
+        assert_eq!(restored.global_replan_count, 7);
+        assert_eq!(*restored.task_replan_counts.get(&TaskId(0)).unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn restore_returns_none_when_no_snapshot() {
+        let (backend, _writer) = make_backend().await;
+        let graph_id = GraphId::new();
+
+        let result = restore_budget(&graph_id, 0, backend).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn generation_counter_produces_distinct_exec_ids() {
+        let graph_id = GraphId::new();
+        let id0 = budget_exec_id(&graph_id, 0);
+        let id1 = budget_exec_id(&graph_id, 1);
+        assert_ne!(
+            id0, id1,
+            "different generations must have different execution ids"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_picks_latest_generation() {
+        let (backend, writer) = make_backend().await;
+        let config = test_config();
+        let graph_id = GraphId::new();
+
+        // First pause: global_replan_count = 1
+        let snap0 = ReplanBudgetSnapshot {
+            global_replan_count: 1,
+            ..Default::default()
+        };
+        journal_budget(
+            &graph_id,
+            0,
+            backend.clone(),
+            writer.clone(),
+            &config,
+            snap0,
+        )
+        .await
+        .unwrap();
+
+        // Second pause (after resume): global_replan_count = 2
+        let snap1 = ReplanBudgetSnapshot {
+            global_replan_count: 2,
+            ..Default::default()
+        };
+        journal_budget(
+            &graph_id,
+            1,
+            backend.clone(),
+            writer.clone(),
+            &config,
+            snap1,
+        )
+        .await
+        .unwrap();
+        // flush ensures all buffered writes are persisted before reading back.
+        writer.flush().await.unwrap();
+
+        // restore_budget with generation=1 should return snap1
+        let restored = restore_budget(&graph_id, 1, backend)
+            .await
+            .unwrap()
+            .expect("snapshot must be present");
+        assert_eq!(
+            restored.global_replan_count, 2,
+            "restore should pick the latest generation"
+        );
+    }
+}

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -449,6 +449,16 @@ pub struct TaskGraph {
     pub created_at: String,
     /// ISO-8601 UTC timestamp set when the graph reaches a terminal status.
     pub finished_at: Option<String>,
+    /// Monotonically incrementing counter used by the durable P2 adapter to key each
+    /// budget snapshot to a unique [`ExecutionId`].  Zero on creation; incremented on each
+    /// `journal_budget` call so a resumed-then-re-paused plan writes to a fresh execution
+    /// rather than overwriting the previous one (see `zeph-orchestration/src/durable.rs`).
+    ///
+    /// Persisted inside the graph blob so it survives across process restarts.
+    ///
+    /// [`ExecutionId`]: zeph_durable::ExecutionId
+    #[serde(default)]
+    pub durable_save_generation: u32,
 }
 
 impl TaskGraph {
@@ -464,6 +474,7 @@ impl TaskGraph {
             default_max_retries: 3,
             created_at: chrono_now(),
             finished_at: None,
+            durable_save_generation: 0,
         }
     }
 }

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -72,6 +72,7 @@ pub mod aggregator;
 pub mod cascade;
 pub mod command;
 pub mod dag;
+pub mod durable;
 pub mod error;
 pub mod graph;
 pub mod lineage;

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -667,6 +667,57 @@ impl DagScheduler {
         self.graph_dirty = false;
         dirty
     }
+
+    /// Capture the live replan/lineage/predicate budget for durable journaling.
+    ///
+    /// Called by the P2 adapter (`zeph-orchestration/src/durable.rs`) immediately before
+    /// `into_graph()` so the snapshot is taken while the scheduler is still alive.
+    #[must_use]
+    pub fn budget_snapshot(&self) -> crate::durable::ReplanBudgetSnapshot {
+        use crate::durable::{ErrorLineageDto, ReplanBudgetSnapshot};
+        ReplanBudgetSnapshot {
+            task_replan_counts: self.task_replan_counts.clone(),
+            global_replan_count: self.global_replan_count,
+            predicate_replans_used: self.predicate_replans_used,
+            predicate_reasons: self.predicate_reasons.clone(),
+            lineage_chains: self
+                .lineage_chains
+                .iter()
+                .map(|(k, v)| (*k, ErrorLineageDto::from(v)))
+                .collect(),
+        }
+    }
+
+    /// Resume from a graph with durable budget counters already restored.
+    ///
+    /// Identical to [`DagScheduler::resume_from`] but overlays the persisted counters from
+    /// `restored` instead of zeroing them.  This preserves the existing `resume_from` call
+    /// sites (~15) without modification; only the `/plan resume` durable path uses this ctor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OrchestrationError::InvalidGraph`] for the same terminal-state conditions as
+    /// [`DagScheduler::resume_from`].
+    pub fn resume_from_durable(
+        graph: super::graph::TaskGraph,
+        config: &zeph_config::OrchestrationConfig,
+        router: Box<dyn AgentRouter>,
+        available_agents: Vec<zeph_subagent::SubAgentDef>,
+        admission_gate: Option<super::admission::AdmissionGate>,
+        restored: crate::durable::ReplanBudgetSnapshot,
+    ) -> Result<Self, OrchestrationError> {
+        let mut sched = Self::resume_from(graph, config, router, available_agents, admission_gate)?;
+        sched.task_replan_counts = restored.task_replan_counts;
+        sched.global_replan_count = restored.global_replan_count;
+        sched.predicate_replans_used = restored.predicate_replans_used;
+        sched.predicate_reasons = restored.predicate_reasons;
+        sched.lineage_chains = restored
+            .lineage_chains
+            .into_iter()
+            .map(|(k, v)| (k, super::lineage::ErrorLineage::from_dto(v)))
+            .collect();
+        Ok(sched)
+    }
 }
 
 impl Drop for DagScheduler {

--- a/crates/zeph-scheduler/Cargo.toml
+++ b/crates/zeph-scheduler/Cargo.toml
@@ -23,6 +23,7 @@ postgres = ["zeph-db/postgres"]
 default = ["sqlite"]
 
 [dependencies]
+blake3.workspace = true
 chrono = { workspace = true, features = ["std", "clock"] }
 cron.workspace = true
 reqwest = { workspace = true, features = ["json", "rustls"] }
@@ -33,7 +34,10 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "sync", "time"] }
 tracing.workspace = true
+uuid.workspace = true
+zeph-config.workspace = true
 zeph-db.workspace = true
+zeph-durable.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [dev-dependencies]

--- a/crates/zeph-scheduler/src/durable.rs
+++ b/crates/zeph-scheduler/src/durable.rs
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Durable exactly-once adapter for scheduler job fires (FR-DE-14).
+//!
+//! This module wraps each scheduler job fire in a durable execution so that a `(job_name,
+//! scheduled_slot)` pair fires exactly once across crash-restart cycles. The guarantee is:
+//!
+//! - **Committed case**: if a prior run committed the `StepResult`, `INV-13` returns the journaled
+//!   `()` and the closure is never re-invoked.
+//! - **Ambiguous window**: if the process crashed after `EffectIntent` but before `StepResult`, the
+//!   `OnAmbiguous::Skip` policy documents the skip in the audit log; the injection is not retried.
+//! - **No journal / flag off**: the caller invokes the handler directly, with no durable overhead.
+//!
+//! The durable flag (`[durable].scheduler`) must be `true` **and** the scheduler must have been
+//! built with [`SchedulerDurableAdapter`] via [`crate::Scheduler::with_durable`] for the wrapping to
+//! take effect.
+//!
+//! # Spec reference
+//!
+//! `specs/064-durable-execution/spec.md` §Integration Adapters → P3, FR-DE-14.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use tracing::Instrument as _;
+use zeph_config::DurableConfig;
+use zeph_durable::{
+    DurableBackendEnum, DurableContext, EffectIntentSubClass, ExecutionId, ExecutionKind,
+    JournalWriterHandle, LocalBackend, StepDescriptor, StepError,
+};
+
+use crate::error::SchedulerError;
+
+/// Derive a deterministic [`ExecutionId`] for a scheduler job fire.
+///
+/// The id is stable: two calls with the same `job_name` and `slot_ms` produce the same
+/// [`ExecutionId`], which lets a restarted scheduler reattach to the existing journal row and
+/// skip the fire when it was already committed.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_scheduler::durable::derive_execution_id;
+///
+/// let a = derive_execution_id("nightly-report", 1_700_000_000_000);
+/// let b = derive_execution_id("nightly-report", 1_700_000_000_000);
+/// let c = derive_execution_id("nightly-report", 1_700_000_001_000);
+/// assert_eq!(a, b, "same job+slot derives the same id");
+/// assert_ne!(a, c, "different slot derives a different id");
+/// ```
+#[must_use]
+pub fn derive_execution_id(job_name: &str, slot_ms: i64) -> ExecutionId {
+    // Length-delimited framing: 4-byte job_name length + job_name bytes + null separator +
+    // 8-byte little-endian slot_ms. The null byte prevents `"ab" || "cd"` from colliding
+    // with `"abc" || "d"`.
+    let name_bytes = job_name.as_bytes();
+    let mut payload = Vec::with_capacity(8 + name_bytes.len() + 1 + 8);
+    payload.extend_from_slice(&(name_bytes.len() as u64).to_le_bytes());
+    payload.extend_from_slice(name_bytes);
+    payload.push(0u8);
+    payload.extend_from_slice(&slot_ms.to_le_bytes());
+    ExecutionId::derive(b"zeph.scheduler.fire.v1", &payload)
+}
+
+/// Durable adapter state held by [`Scheduler`](crate::Scheduler) for its lifetime.
+///
+/// Build one with the backend and writer from the binary's durable initialisation path, then pass
+/// it to [`crate::Scheduler::with_durable`]. A fresh [`DurableContext`] is opened per fire; the backend
+/// and writer are shared across all fires within the scheduler's lifetime.
+#[derive(Clone)]
+pub struct SchedulerDurableAdapter {
+    backend: Arc<DurableBackendEnum>,
+    writer: JournalWriterHandle,
+    config: Arc<DurableConfig>,
+}
+
+impl SchedulerDurableAdapter {
+    /// Create an adapter from the shared durable backend, journal writer, and config.
+    #[must_use]
+    pub fn new(
+        backend: Arc<DurableBackendEnum>,
+        writer: JournalWriterHandle,
+        config: Arc<DurableConfig>,
+    ) -> Self {
+        Self {
+            backend,
+            writer,
+            config,
+        }
+    }
+}
+
+/// Wrap a single scheduler job fire in a durable exactly-once execution.
+///
+/// Opens a per-fire [`DurableContext`] keyed on `(job_name, slot_ms)`. If the same `(job, slot)`
+/// was committed in a prior run the step is replayed without invoking `fire`. If the process
+/// crashed after `EffectIntent` was committed but before `StepResult`, `OnAmbiguous::Skip`
+/// documents the skip in the audit log without re-firing.
+///
+/// When `fire` succeeds its `()` result is journaled. On error no `StepResult` is committed, so a
+/// future restart retries the fire.
+///
+/// # Errors
+///
+/// Returns [`SchedulerError::TaskFailed`] when the underlying durable step fails (journal error,
+/// ambiguous-effect policy fired, or `fire` itself returned an error).
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::sync::Arc;
+/// # use std::future::Future;
+/// # use zeph_scheduler::durable::{SchedulerDurableAdapter, fire_with_durable};
+/// # async fn example(adapter: &SchedulerDurableAdapter) -> Result<(), zeph_scheduler::SchedulerError> {
+/// fire_with_durable(adapter, "nightly-report", 1_700_000_000_000, || async {
+///     // Original fire body goes here.
+///     Ok(())
+/// })
+/// .await
+/// # }
+/// ```
+pub async fn fire_with_durable<F, Fut>(
+    adapter: &SchedulerDurableAdapter,
+    job_name: &str,
+    slot_ms: i64,
+    fire: F,
+) -> Result<(), SchedulerError>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = Result<(), SchedulerError>> + Send + 'static,
+{
+    let span = tracing::info_span!("sched.durable.fire", job = job_name, slot_ms = slot_ms,);
+
+    async move {
+        let exec_id = derive_execution_id(job_name, slot_ms);
+
+        let local_backend: Arc<LocalBackend> = match &*adapter.backend {
+            DurableBackendEnum::Local(lb) => lb.clone(),
+            _ => {
+                return Err(SchedulerError::TaskFailed(
+                    "durable scheduler adapter requires a LocalBackend".into(),
+                ));
+            }
+        };
+
+        let is_resume = local_backend
+            .open_execution(exec_id, ExecutionKind::ScheduledJob)
+            .await
+            .map_err(|e| SchedulerError::TaskFailed(format!("durable open failed: {e}")))?;
+
+        let ctx = DurableContext::new(
+            exec_id,
+            ExecutionKind::ScheduledJob,
+            is_resume,
+            adapter.backend.clone(),
+            adapter.writer.clone(),
+            &adapter.config,
+        );
+
+        // CostBearingOrBoundaryIdempotent: the journal deduplicates the fire by idempotency key,
+        // so an ambiguous-window restart safely skips rather than re-injecting. Default policy is
+        // OnAmbiguous::Skip and no explicit policy override is needed.
+        let desc = StepDescriptor::exactly_once_guarded(
+            "scheduler_fire",
+            EffectIntentSubClass::CostBearingOrBoundaryIdempotent,
+            None,
+            fingerprint(job_name, slot_ms),
+        )
+        .map_err(|e| SchedulerError::TaskFailed(format!("durable descriptor error: {e}")))?;
+
+        ctx.step(desc, |_handle| async move {
+            fire().await.map_err(|e| StepError::new(e.to_string()))
+        })
+        .await
+        .map_err(|e| SchedulerError::TaskFailed(format!("durable step failed: {e}")))
+    }
+    .instrument(span)
+    .await
+}
+
+/// Build a stable, non-secret fingerprint for `(job_name, slot_ms)`.
+///
+/// Length-delimits the job name so `"ab" || "c"` ≠ `"a" || "bc"`.
+fn fingerprint(job_name: &str, slot_ms: i64) -> Vec<u8> {
+    let name_bytes = job_name.as_bytes();
+    let mut buf = Vec::with_capacity(8 + name_bytes.len() + 8);
+    buf.extend_from_slice(&(name_bytes.len() as u64).to_le_bytes());
+    buf.extend_from_slice(name_bytes);
+    buf.extend_from_slice(&slot_ms.to_le_bytes());
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use zeph_durable::config::DurableConfig;
+    use zeph_durable::{DurableBackendEnum, JournalWriter, LocalBackend};
+
+    use super::*;
+
+    #[test]
+    fn derive_execution_id_is_stable() {
+        let a = derive_execution_id("weekly-digest", 1_700_000_000_000);
+        let b = derive_execution_id("weekly-digest", 1_700_000_000_000);
+        assert_eq!(a, b, "same inputs must produce the same ExecutionId");
+    }
+
+    #[test]
+    fn derive_execution_id_differs_by_slot() {
+        let a = derive_execution_id("weekly-digest", 1_700_000_000_000);
+        let c = derive_execution_id("weekly-digest", 1_700_000_001_000);
+        assert_ne!(
+            a, c,
+            "different slot_ms must produce a different ExecutionId"
+        );
+    }
+
+    #[test]
+    fn derive_execution_id_differs_by_name() {
+        let a = derive_execution_id("job-a", 1_000);
+        let b = derive_execution_id("job-b", 1_000);
+        assert_ne!(a, b, "different job names must produce different ids");
+    }
+
+    #[test]
+    fn derive_execution_id_no_prefix_collision() {
+        // Ensure "ab"+"cd" ≠ "abc"+"d" at the same slot.
+        let a = derive_execution_id("ab", 1_000);
+        let b = derive_execution_id("abc", 1_000);
+        assert_ne!(
+            a, b,
+            "length-delimited framing must prevent prefix collisions"
+        );
+    }
+
+    fn fast_config() -> DurableConfig {
+        DurableConfig {
+            journal_flush_interval_ms: 5,
+            journal_ack_timeout_ms: 2000,
+            ..DurableConfig::default()
+        }
+    }
+
+    async fn make_adapter() -> (SchedulerDurableAdapter, tokio::task::JoinHandle<()>) {
+        let local = Arc::new(LocalBackend::open(":memory:", 1_048_576).await.unwrap());
+        local.init().await.unwrap();
+        let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
+        let cfg = Arc::new(fast_config());
+        let (writer, handle) = JournalWriter::new(local, &cfg);
+        let task = tokio::spawn(writer.run());
+        (SchedulerDurableAdapter::new(backend, handle, cfg), task)
+    }
+
+    /// First fire executes the closure and journals the result.
+    /// Second call (same job+slot, same execution) replays without invoking the closure.
+    #[tokio::test]
+    async fn fire_with_durable_replays_without_reinvocation() {
+        let (adapter, _task) = make_adapter().await;
+        let count = Arc::new(AtomicU32::new(0));
+
+        // First fire — closure must run.
+        let c = count.clone();
+        fire_with_durable(&adapter, "test-job", 1_000, move || async move {
+            c.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(count.load(Ordering::Relaxed), 1, "first fire must execute");
+
+        // Second fire — same (job, slot) — closure must NOT run again.
+        let c = count.clone();
+        fire_with_durable(&adapter, "test-job", 1_000, move || async move {
+            c.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            1,
+            "replay must not re-invoke the closure"
+        );
+    }
+
+    /// A different slot derives a different execution — the closure runs again.
+    #[tokio::test]
+    async fn fire_with_durable_different_slot_runs_again() {
+        let (adapter, _task) = make_adapter().await;
+        let count = Arc::new(AtomicU32::new(0));
+
+        let c = count.clone();
+        fire_with_durable(&adapter, "test-job", 1_000, move || async move {
+            c.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        let c = count.clone();
+        fire_with_durable(&adapter, "test-job", 2_000, move || async move {
+            c.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            2,
+            "different slot_ms must produce a separate execution and run"
+        );
+    }
+
+    /// When durable is not configured (no `with_durable`), the scheduler calls the handler directly.
+    #[test]
+    fn no_adapter_means_no_durable_overhead() {
+        // The Scheduler struct's `durable` field defaults to None; this is a structural check only.
+        // The property is validated indirectly by the scheduler_init_and_tick test in scheduler.rs.
+        assert!(derive_execution_id("job", 0) != derive_execution_id("other", 0));
+    }
+}

--- a/crates/zeph-scheduler/src/lib.rs
+++ b/crates/zeph-scheduler/src/lib.rs
@@ -77,6 +77,7 @@
 //! `zeph-db` migrations. Use [`JobStore::open`] to connect or [`JobStore::new`] when
 //! you already hold a [`zeph_db::DbPool`].
 
+pub mod durable;
 mod error;
 mod handlers;
 mod sanitize;
@@ -90,6 +91,7 @@ pub mod daemon;
 #[cfg(all(unix, feature = "daemon"))]
 pub mod pidfile;
 
+pub use durable::SchedulerDurableAdapter;
 pub use error::SchedulerError;
 pub use handlers::CustomTaskHandler;
 pub use sanitize::{sanitize_task_prompt, sanitize_task_prompt_checked};

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use chrono::Utc;
 use tokio::sync::{Mutex, mpsc, watch};
 
+use crate::durable::{SchedulerDurableAdapter, fire_with_durable};
 use crate::error::SchedulerError;
 use crate::sanitize::sanitize_task_prompt_checked;
 use crate::store::JobStore;
@@ -86,11 +87,13 @@ pub enum SchedulerMessage {
 pub struct Scheduler {
     tasks: Vec<ScheduledTask>,
     store: JobStore,
-    handlers: HashMap<String, Box<dyn TaskHandler>>,
+    handlers: HashMap<String, Arc<dyn TaskHandler>>,
     shutdown_rx: watch::Receiver<bool>,
     task_rx: mpsc::Receiver<SchedulerMessage>,
     /// Optional sender for injecting custom task prompts into the agent loop.
     custom_task_tx: Option<mpsc::Sender<String>>,
+    /// Optional durable exactly-once adapter for scheduler fires (FR-DE-14).
+    durable: Option<SchedulerDurableAdapter>,
     max_tasks: usize,
     /// Per-task execution mutex: task names of tasks currently being executed.
     ///
@@ -161,6 +164,7 @@ impl Scheduler {
             shutdown_rx,
             task_rx: rx,
             custom_task_tx: None,
+            durable: None,
             max_tasks,
             in_flight: Arc::new(Mutex::new(HashSet::new())),
             handler_timeout: Duration::from_mins(5),
@@ -178,6 +182,17 @@ impl Scheduler {
     #[must_use]
     pub fn with_custom_task_sender(mut self, tx: mpsc::Sender<String>) -> Self {
         self.custom_task_tx = Some(tx);
+        self
+    }
+
+    /// Attach a durable exactly-once adapter so each scheduler fire is journaled (FR-DE-14).
+    ///
+    /// When set, every handler execution and custom-task injection is wrapped in a durable step
+    /// keyed on `(job_name, scheduled_slot_ms)`. A committed result from a prior run short-circuits
+    /// the fire without re-invoking the handler. Without this, fires are not journaled.
+    #[must_use]
+    pub fn with_durable(mut self, adapter: SchedulerDurableAdapter) -> Self {
+        self.durable = Some(adapter);
         self
     }
 
@@ -224,7 +239,8 @@ impl Scheduler {
     /// calls the matching handler. Tasks whose kind has no registered handler are
     /// skipped with a debug-level log.
     pub fn register_handler(&mut self, kind: &TaskKind, handler: Box<dyn TaskHandler>) {
-        self.handlers.insert(kind.as_str().to_owned(), handler);
+        self.handlers
+            .insert(kind.as_str().to_owned(), Arc::from(handler));
     }
 
     /// Initialize the store, sync task definitions, compute initial `next_run` for each task,
@@ -456,31 +472,17 @@ impl Scheduler {
         };
 
         tracing::info!(task = %name, "catch_up_missed: executing overdue task");
-        let task_span = tracing::info_span!(
-            "scheduler.task.execute",
-            task.name = %name,
-            task.kind = task.kind.as_str()
-        );
-        let execute_fut = handler.execute(&task.config);
-        if self.handler_timeout.is_zero() {
-            use tracing::Instrument as _;
-            execute_fut.instrument(task_span).await?;
-        } else {
-            use tracing::Instrument as _;
-            tokio::time::timeout(self.handler_timeout, execute_fut.instrument(task_span))
-                .await
-                .map_err(|_| {
-                    tracing::warn!(
-                        task.name = %name,
-                        timeout_secs = self.handler_timeout.as_secs(),
-                        "task handler timed out"
-                    );
-                    SchedulerError::TaskFailed(format!(
-                        "handler timed out after {}s: {name}",
-                        self.handler_timeout.as_secs()
-                    ))
-                })??;
-        }
+
+        // Derive the slot_ms from the stored next_run timestamp so the durable execution-id
+        // matches the one that would have been used during the original (crashed) fire.
+        let slot_ms = match self.store.get_next_run(name).await {
+            Ok(Some(ref s)) => s
+                .parse::<chrono::DateTime<Utc>>()
+                .map_or_else(|_| now.timestamp_millis(), |dt| dt.timestamp_millis()),
+            _ => now.timestamp_millis(),
+        };
+
+        self.execute_handler(handler.clone(), task, slot_ms).await?;
 
         let next = schedule
             .after(now)
@@ -690,12 +692,16 @@ impl Scheduler {
         let mut completed_oneshots: Vec<String> = Vec::new();
 
         for task in &self.tasks {
-            let should_run = match &task.mode {
+            // Returns Some(slot_ms) when the task is due — slot_ms is the scheduled fire instant
+            // used as the durable execution identity. None means skip this tick.
+            let slot_ms: Option<i64> = match &task.mode {
                 TaskMode::Periodic { .. } => {
                     match self.store.get_next_run(&task.name).await {
-                        Ok(Some(ref s)) => {
-                            s.parse::<chrono::DateTime<Utc>>().is_ok_and(|dt| dt <= now)
-                        }
+                        Ok(Some(ref s)) => s
+                            .parse::<chrono::DateTime<Utc>>()
+                            .ok()
+                            .filter(|dt| *dt <= now)
+                            .map(|dt| dt.timestamp_millis()),
                         // PERF-SC-04 fix: missing next_run must not mean "fire now".
                         // Compute and persist next occurrence, then skip this tick.
                         Ok(None) => {
@@ -707,18 +713,24 @@ impl Scheduler {
                                     .set_next_run(&task.name, &next.to_rfc3339())
                                     .await;
                             }
-                            false
+                            None
                         }
                         Err(e) => {
                             tracing::warn!(task = %task.name, "failed to check next_run: {e}");
-                            false
+                            None
                         }
                     }
                 }
-                TaskMode::OneShot { run_at } => *run_at <= now,
+                TaskMode::OneShot { run_at } => {
+                    if *run_at <= now {
+                        Some(run_at.timestamp_millis())
+                    } else {
+                        None
+                    }
+                }
             };
 
-            if should_run {
+            if let Some(slot_ms) = slot_ms {
                 // Mechanism 1 (write-fence): skip tasks written in this same tick.
                 // Static tasks are exempt — their config is set at startup and trusted.
                 if self.reentry_defense_enabled
@@ -760,34 +772,9 @@ impl Scheduler {
 
                 if let Some(handler) = self.handlers.get(task.kind.as_str()) {
                     tracing::info!(task = %task.name, kind = task.kind.as_str(), "executing task");
-                    let task_span = tracing::info_span!(
-                        "scheduler.task.execute",
-                        task.name = %task.name,
-                        task.kind = task.kind.as_str()
-                    );
-                    let execute_result = {
-                        use tracing::Instrument as _;
-                        let execute_fut = handler.execute(&task.config).instrument(task_span);
-                        if self.handler_timeout.is_zero() {
-                            execute_fut.await
-                        } else {
-                            tokio::time::timeout(self.handler_timeout, execute_fut)
-                                .await
-                                .map_err(|_| {
-                                    tracing::warn!(
-                                        task.name = %task.name,
-                                        timeout_secs = self.handler_timeout.as_secs(),
-                                        "task handler timed out"
-                                    );
-                                    SchedulerError::TaskFailed(format!(
-                                        "handler timed out after {}s: {}",
-                                        self.handler_timeout.as_secs(),
-                                        task.name
-                                    ))
-                                })
-                                .and_then(|r| r)
-                        }
-                    };
+
+                    let execute_result = self.execute_handler(handler.clone(), task, slot_ms).await;
+
                     match execute_result {
                         Ok(()) => match &task.mode {
                             TaskMode::Periodic { schedule } => {
@@ -832,30 +819,10 @@ impl Scheduler {
                                 "RTW-A Mech4: custom prompt suppressed (external-read tick)"
                             );
                         } else {
-                            let raw = task.config.get("task").and_then(|v| v.as_str()).unwrap_or(
-                                "Execute the following scheduled task now: check status",
-                            );
-                            // Mechanism 3: injection pattern detection for External/UserAdded tasks.
-                            if self.reentry_defense_enabled
-                                && self.injection_pattern_check
-                                && task.provenance != TaskProvenance::Static
-                            {
-                                match sanitize_task_prompt_checked(raw, &task.name) {
-                                    Ok(prompt) => {
-                                        let _ = tx.try_send(prompt);
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            task = %task.name,
-                                            "RTW-A Mech3: {e}"
-                                        );
-                                    }
-                                }
-                            } else {
-                                // Static provenance or detection disabled — use basic sanitize.
-                                use crate::sanitize::sanitize_task_prompt;
-                                let prompt = sanitize_task_prompt(raw);
-                                let _ = tx.try_send(prompt);
+                            let inject_result =
+                                self.inject_custom_task(task, tx.clone(), slot_ms).await;
+                            if let Err(e) = inject_result {
+                                tracing::warn!(task = %task.name, "custom task injection failed: {e}");
                             }
                         }
                         if let Err(e) = self.store.mark_done(&task.name).await {
@@ -886,6 +853,109 @@ impl Scheduler {
         // RTW-A end-of-tick cleanup: clear per-tick state so it does not bleed into the next tick.
         self.written_this_tick.clear();
         self.tick_read_external = false;
+    }
+
+    /// Execute a registered handler, wrapping in durable exactly-once journaling when available.
+    async fn execute_handler(
+        &self,
+        handler: Arc<dyn TaskHandler>,
+        task: &ScheduledTask,
+        slot_ms: i64,
+    ) -> Result<(), SchedulerError> {
+        let task_name = task.name.clone();
+        let task_kind_str = task.kind.as_str().to_owned();
+        let handler_timeout = self.handler_timeout;
+        let config = task.config.clone();
+
+        let run = move || {
+            let handler = handler.clone();
+            let task_name = task_name.clone();
+            let task_kind_str = task_kind_str.clone();
+            let config = config.clone();
+            async move {
+                use tracing::Instrument as _;
+                let span = tracing::info_span!(
+                    "scheduler.task.execute",
+                    task.name = %task_name,
+                    task.kind = %task_kind_str,
+                );
+                let fut = handler.execute(&config).instrument(span);
+                if handler_timeout.is_zero() {
+                    fut.await
+                } else {
+                    tokio::time::timeout(handler_timeout, fut)
+                        .await
+                        .map_err(|_| {
+                            tracing::warn!(
+                                task.name = %task_name,
+                                timeout_secs = handler_timeout.as_secs(),
+                                "task handler timed out"
+                            );
+                            SchedulerError::TaskFailed(format!(
+                                "handler timed out after {}s: {}",
+                                handler_timeout.as_secs(),
+                                task_name
+                            ))
+                        })
+                        .and_then(|r| r)
+                }
+            }
+        };
+
+        if let Some(ref adapter) = self.durable {
+            let adapter = adapter.clone();
+            let task_name = task.name.clone();
+            fire_with_durable(&adapter, &task_name, slot_ms, run).await
+        } else {
+            run().await
+        }
+    }
+
+    /// Inject a custom oneshot task prompt, wrapping in durable exactly-once journaling when available.
+    async fn inject_custom_task(
+        &self,
+        task: &ScheduledTask,
+        tx: mpsc::Sender<String>,
+        slot_ms: i64,
+    ) -> Result<(), SchedulerError> {
+        // Build the sanitized prompt before entering the durable closure.
+        let raw = task
+            .config
+            .get("task")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Execute the following scheduled task now: check status");
+
+        let prompt_result = if self.reentry_defense_enabled
+            && self.injection_pattern_check
+            && task.provenance != TaskProvenance::Static
+        {
+            sanitize_task_prompt_checked(raw, &task.name)
+                .map_err(|e| SchedulerError::TaskFailed(e.to_string()))
+        } else {
+            Ok(crate::sanitize::sanitize_task_prompt(raw))
+        };
+
+        let prompt = match prompt_result {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(task = %task.name, "RTW-A Mech3: {e}");
+                return Err(e);
+            }
+        };
+
+        if let Some(ref adapter) = self.durable {
+            let task_name = task.name.clone();
+            let adapter = adapter.clone();
+
+            fire_with_durable(&adapter, &task_name, slot_ms, move || async move {
+                tx.try_send(prompt)
+                    .map_err(|e| SchedulerError::TaskFailed(format!("channel send failed: {e}")))
+            })
+            .await
+        } else {
+            tx.try_send(prompt)
+                .map_err(|e| SchedulerError::TaskFailed(format!("channel send failed: {e}")))
+        }
     }
 }
 

--- a/src/commands/scheduler_daemon.rs
+++ b/src/commands/scheduler_daemon.rs
@@ -127,6 +127,29 @@ async fn run_foreground(
         config.scheduler.security.attenuate_after_external_read,
     );
 
+    if config.durable.enabled && config.durable.scheduler {
+        let durable_url = crate::commands::durable::resolve_durable_db_url(config);
+        let local =
+            zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
+                .await
+                .context("failed to open scheduler durable backend")?;
+        local
+            .init()
+            .await
+            .context("failed to init scheduler durable schema")?;
+        let local = std::sync::Arc::new(local);
+        let backend = std::sync::Arc::new(zeph_durable::DurableBackendEnum::Local(local.clone()));
+        let durable_cfg = std::sync::Arc::new(config.durable.clone());
+        let (writer_actor, writer_handle) = zeph_durable::JournalWriter::new(local, &durable_cfg);
+        tokio::spawn(writer_actor.run());
+        let adapter = zeph_scheduler::durable::SchedulerDurableAdapter::new(
+            backend,
+            writer_handle,
+            durable_cfg,
+        );
+        scheduler = scheduler.with_durable(adapter);
+    }
+
     // Register built-in handlers available without a live agent session.
     // `UpdateCheckHandler` is self-contained (HTTP only); other handlers that
     // require the agent loop (CustomTaskHandler, ExperimentTaskHandler) are not

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2809,7 +2809,13 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             tracing::info!("worktree subsystem initialised");
         }
 
-        agent.with_orchestration(config.orchestration.clone(), agents_config, mgr)
+        let agent = agent.with_orchestration(config.orchestration.clone(), agents_config, mgr);
+        if config.durable.enabled && config.durable.orchestration {
+            let durable_url = crate::commands::durable::resolve_durable_db_url(config);
+            agent.with_durable_orchestration(config.durable.clone(), durable_url, None)
+        } else {
+            agent
+        }
     };
     let agent = {
         let baseline = zeph_experiments::ConfigSnapshot::from_config(config);


### PR DESCRIPTION
## Summary

- **P2 (#4952)**: `/plan resume` now restores five replan/predicate/lineage counters from the journal instead of zeroing them. A BLAKE3-derived `ExecutionId` keyed on `(graph_id, generation)` ensures that successive pause→resume→pause cycles produce distinct executions. `DagScheduler::resume_from_durable` accepts the restored `ReplanBudgetSnapshot`. Gated on `[durable].orchestration`.

- **P3 (#4953)**: Each scheduler job fire is now wrapped in an `ExactlyOnceGuarded` durable execution keyed on `derive_execution_id(job_name, slot_ms)`. On crash between `EffectIntent` and `StepResult`, `OnAmbiguous::Skip` applies rather than an unconditional re-fire. The `catch_up_missed` startup path also routes through the durable adapter. Gated on `[durable].scheduler`.

Both adapters are thin shims over the existing `zeph-durable` Layer-0 infrastructure (spec-064 §P2, §P3).

## Changed files

| File | Change |
|------|--------|
| `crates/zeph-durable/src/ids.rs` | Add `ExecutionId::derive(domain, payload)` — BLAKE3-based deterministic id |
| `crates/zeph-orchestration/src/durable.rs` | **New** — `ReplanBudgetSnapshot`, `ErrorLineageDto`, `journal_budget`, `restore_budget` |
| `crates/zeph-orchestration/src/scheduler/mod.rs` | `budget_snapshot()` + `resume_from_durable(snapshot)` |
| `crates/zeph-orchestration/src/graph.rs` | `durable_save_generation: u32` field on `TaskGraph` |
| `crates/zeph-core/src/agent/plan.rs` | `ensure_durable_backend`, `try_restore_durable_budget`, `journal_durable_budget` + 4 unit tests |
| `crates/zeph-core/src/agent/builder.rs` | `with_durable_orchestration` builder |
| `crates/zeph-core/src/agent/state/mod.rs` | 5 new durable fields on `OrchestrationState` |
| `crates/zeph-scheduler/src/durable.rs` | **New** — `SchedulerDurableAdapter`, `fire_with_durable`, `derive_execution_id` + 3 unit tests |
| `crates/zeph-scheduler/src/scheduler.rs` | `with_durable`, `execute_handler` durable dispatch, `slot_ms` threading |
| `src/runner.rs` | P2 binary wiring — `with_durable_orchestration` when both flags enabled |
| `src/commands/scheduler_daemon.rs` | P3 binary wiring — `SchedulerDurableAdapter` init + `with_durable` |
| `CHANGELOG.md` | `[Unreleased]` updated |

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean (0 warnings)
- [ ] `cargo nextest run --workspace --lib --bins` — 10704 PASS (1 leaky, 21 skipped)
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [ ] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-orchestration -p zeph-scheduler -p zeph-durable` — clean
- [ ] Live e2e: requires `durable.enabled=true` + `durable.orchestration=true` / `durable.scheduler=true` in testing.toml — see `.local/testing/playbooks/durable.md` §Scenario 2 and §Scenario 3

## Spec compliance

- FR-DE-13 (`/plan resume` restores budget counters): implemented in `restore_budget` + `resume_from_durable`
- FR-DE-14 (scheduler exactly-once): implemented in `fire_with_durable` + `ExactlyOnceGuarded`
- INV-1 (no business logic in L0): `durable.rs` imports only `zeph_durable` + `zeph_config`
- INV-13 (short-circuit on committed result): enforced by `ExactlyOnceGuarded` step class
- spec-018 (fire via message_queue, never direct agent call): `SchedulerDurableAdapter` wraps the existing fire closure, does not call the agent directly

Closes #4952, Closes #4953