### PR TITLE
fix(durable): use AtomicU32 counter in append benchmarks to avoid UNIQUE violation

### DIFF
--- a/crates/zeph-durable/benches/durable_benches.rs
+++ b/crates/zeph-durable/benches/durable_benches.rs
@@ -5,6 +5,7 @@
 
 use std::hint::black_box;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use chacha20poly1305::aead::{Aead, KeyInit};
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
@@ -422,13 +423,14 @@ fn bench_journal_append_buffered(c: &mut Criterion) {
         (exec, handle, local, writer_task)
     });
 
+    let step_counter = AtomicU32::new(0);
     group.bench_function("append_buffered", |b| {
         b.iter(|| {
             // Fire-and-forget: measure only the channel send, not the flush.
             use bytes::Bytes;
             use zeph_durable::effect::EffectClass;
             use zeph_durable::journal::{EntryKind, JournalEntry};
-            let step_id = StepId::new(0);
+            let step_id = StepId::new(step_counter.fetch_add(1, Ordering::Relaxed));
             let ikey = IdempotencyKey::derive(exec, step_id, b"bench:buffered");
             let entry = JournalEntry {
                 seq: None,
@@ -474,13 +476,14 @@ fn bench_journal_append_acked(c: &mut Criterion) {
         (exec, handle, local, writer_task)
     });
 
+    let step_counter = AtomicU32::new(0);
     group.bench_function("append_acked", |b| {
         b.iter(|| {
             rt.block_on(async {
                 use bytes::Bytes;
                 use zeph_durable::effect::EffectClass;
                 use zeph_durable::journal::{EntryKind, JournalEntry};
-                let step_id = StepId::new(0);
+                let step_id = StepId::new(step_counter.fetch_add(1, Ordering::Relaxed));
                 let ikey = IdempotencyKey::derive(exec, step_id, b"bench:acked");
                 let entry = JournalEntry {
                     seq: None,


### PR DESCRIPTION
## Summary

- `bench_journal_append_buffered` and `bench_journal_append_acked` both used `StepId::new(0)` on every criterion iteration, producing the same `IdempotencyKey` every time.
- From iteration 2 onward the `durable_journal` UNIQUE constraint on `(execution_id, step_id) WHERE entry_kind = 'step_result'` caused a panic in the acked bench and a silent no-op in the buffered bench.
- Fix: add an `AtomicU32` step counter before each `group.bench_function` call; each `b.iter(...)` call increments and uses it for a unique `StepId`.

## Test plan

- [ ] `cargo build -p zeph-durable --benches` — clean compile
- [ ] `cargo +nightly fmt --check -p zeph-durable` — no formatting issues
- [ ] `cargo clippy -p zeph-durable --benches -- -D warnings` — no warnings
- [ ] `cargo nextest run -p zeph-durable --lib --bins` — 99/99 tests pass

Closes #4995