### PR TITLE
spec(knowledge-ingest): add specification for zeph knowledge ingest (spec-067)

### DIFF
--- a/specs/067-knowledge-ingest/README.md
+++ b/specs/067-knowledge-ingest/README.md
@@ -1,0 +1,79 @@
+---
+aliases:
+  - Knowledge Ingest Spec Package
+  - spec-067 index
+tags:
+  - sdd
+  - spec
+  - memory
+  - cross-cutting
+created: 2026-06-07
+status: draft
+github_issue: 5012
+related:
+  - "[[004-memory/spec]]"
+  - "[[004-memory/004-9-memory-write-gate]]"
+  - "[[004-memory/004-6-graph-memory]]"
+  - "[[012-graph-memory/spec]]"
+  - "[[018-index/spec]]"
+  - "[[041-sanitizer/spec]]"
+  - "[[056-autoskill-trace-extraction/spec]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[constitution]]"
+---
+
+# Spec 067: Knowledge Ingest (`zeph knowledge ingest`)
+
+One-shot operator command that populates Zeph's memory subsystems with accumulated project
+knowledge — specs, changelog, handoffs, coverage reports, and agent episode transcripts —
+instead of relying solely on background extraction from live conversation.
+
+GitHub epic: #5012 — `feat(memory): knowledge ingest command (spec 067)`; milestone M29;
+branch `feat/m29/knowledge-ingest`.
+
+## Document Index
+
+| Document | Purpose |
+|---|---|
+| `brd.md` | Business Requirements Document — business problem, stakeholders, success criteria |
+| `srs.md` | Software Requirements Specification (ISO/IEC/IEEE 29148:2018) — EARS functional requirements |
+| `nfr.md` | Non-Functional Requirements (ISO/IEC 25010:2011) — measurable quality targets |
+| `spec.md` | Technical specification — design decisions, invariants, two-sink architecture, §7 gate |
+| `plan.md` | Implementation plan — phases, milestones, dependencies, risk register |
+| `tasks.md` | Task breakdown — implementable units with issue traceability (#5015–#5024) |
+
+## Scope Summary
+
+**Ships in M29:**
+
+- `zeph knowledge ingest --source <SRC>... [--dry-run] [--max-documents N] [--provider NAME] [--yes]`
+- `zeph knowledge rollback <import_batch_id>`
+- `zeph knowledge status`
+- **Phase 0 (prerequisite):** provenance columns (`origin`, `import_batch_id`, `source_uri`) on
+  `graph_edges` + `graph_entities`; backfill; recall isolation flag; `knowledge rollback`
+- **Phase 1:** static project artifacts (`specs`, `changelog`, `handoff`, `coverage`, `git-log`)
+  ingested as semantic notes via the existing `IngestionPipeline` (no graph writes)
+- **Phase 2:** subagent transcripts → knowledge graph — **gated by §7 measurement spike**
+- `[knowledge]` config section; `--init` wizard step; `--migrate-config` migration
+- TUI status spinner + command palette entries
+- Content-hash ledger for idempotent re-runs (re-read/cost guard — not a drift guard)
+
+**Explicitly excluded from M29:**
+
+- Raw source code ingestion (owned by `zeph-index`)
+- External-agent transcript import (Claude Code / Codex) — Phase 3, deferred (#5024)
+- Automatic or scheduled ingest (explicit operator command only)
+- Structural code graph (call/def edges) in `graph_edges`
+
+## Traceability Map
+
+```
+BR-1..BR-5 (brd.md)
+  └─ FR-001..FR-042 (srs.md / spec.md §3)
+       ├─ NFR-001..NFR-007 (nfr.md / spec.md §4)
+       └─ INV-1..INV-8 (spec.md §5)
+            ├─ Phase 0: F1 #5015, F2 #5016
+            ├─ Phase 1: F3 #5017, N1 #5018, N2 #5019, N3 #5020
+            ├─ Phase 2 (gated): G1 #5021, G0 #5022 (GATE), G2 #5023
+            └─ Deferred: D1 #5024
+```

--- a/specs/067-knowledge-ingest/brd.md
+++ b/specs/067-knowledge-ingest/brd.md
@@ -1,0 +1,105 @@
+---
+aliases:
+  - Knowledge Ingest BRD
+tags:
+  - brd
+  - memory
+  - cross-cutting
+created: 2026-06-07
+status: draft
+spec_id: "067"
+---
+
+# BRD: Knowledge Ingest (`zeph knowledge ingest`)
+
+## 1. Business Problem
+
+Zeph's knowledge graph and semantic memory are populated only as a side effect of live
+conversation — background, RPE-gated, fire-and-forget. There is no way to deliberately seed
+memory with the project's accumulated knowledge: its specifications, changelog, agent handoffs,
+coverage reports, and the episodic record of work that agents (including Zeph's own subagents)
+have already done.
+
+The result is that a new operator or a fresh database starts blind to all prior project context,
+despite that context being fully available on disk. The agent re-discovers known facts across
+sessions, wastes tokens, and cannot answer cross-session questions such as "why did we switch
+the durable backend to a dedicated SQLite file?" without manual context injection.
+
+Competitor tools (Goose, Codex, Aider) do not solve this problem at the memory-subsystem level
+either — Zeph's graph + semantic-note architecture provides a unique opportunity to make a fresh
+instance project-aware in a single operator command.
+
+## 2. Stakeholders
+
+| Role | Concern |
+|---|---|
+| Operator / team lead | Seed a fresh Zeph instance with full project context in one command; verify with `--dry-run` before committing |
+| Developer using Zeph daily | Recall cross-session project decisions without re-injecting context manually each session |
+| Security-conscious operator | Guarantee imported content passes sanitizer and stays confined to the current project; ability to roll back any batch |
+| CI/CD integrator | Understand that ingest is an explicit, manual command — not a background side effect that could pollute production memory |
+
+## 3. Business Requirements
+
+**BR-1 — Project-context bootstrap.** An operator must be able to run a single command to load
+accumulated project knowledge (specs, changelog, handoffs, coverage status, git log) into Zeph's
+semantic memory so that a fresh instance answers cross-session questions without manual context
+injection.
+
+**BR-2 — Idempotent re-runs.** Running the ingest command multiple times on unchanged inputs
+must not re-issue LLM calls or create duplicate memory entries, so that operators can run it
+safely at any time (e.g., after adding new specs) without unexpected cost.
+
+**BR-3 — Dry-run preview.** Before writing anything to memory, the operator must be able to
+preview what would be ingested: files discovered, projected chunk/token count, and — for the
+graph path — projected entity/edge counts and hub-degree distribution. No surprises, no
+unexpected charges.
+
+**BR-4 — Provenance and rollback.** Every imported edge and entity must be tagged with the
+source batch so that an operator can reverse a bad import with `zeph knowledge rollback <batch>`
+without affecting conversation-derived knowledge.
+
+**BR-5 — Gated episode layer.** The relational graph is reserved for the cross-agent episode
+layer (subagent transcripts) where multi-hop traversal genuinely pays off. This path must be
+gated behind a measurement spike that proves a real multi-hop recall benefit over the simpler
+semantic-notes path before it ships. If the spike fails, the graph path is abandoned and episode
+sources are rerouted to the notes pipeline.
+
+## 4. Constraints
+
+- No new inter-crate dependency edges beyond what already exists in the workspace.
+- Sources are confined to the current project root — no traversal into other projects.
+- The write-quality gate (spec 004-9) and admission control (004-3) must remain active; only
+  the RPE per-turn heuristic is bypassed (it has no meaning for batch documents).
+- Every imported document must pass the `zeph-sanitizer` validator before any entity or fact
+  string is persisted.
+- Graph writes require explicit confirmation (`--yes` or interactive) before execution.
+- External-agent transcripts (Claude Code / Codex) are out of scope until provenance, write-path
+  PII redaction, and a version-pinned strict parser are in place.
+- Migration must be SQLite + PostgreSQL parity, enforced by `migration_parity.rs`.
+- Ingest must never run during a live agent turn.
+
+## 5. Success Criteria
+
+| Criterion | Measurement |
+|---|---|
+| A fresh instance becomes project-aware in one command | Manual test: query cross-session decision after `--source specs` ingest; correct recall without manual context |
+| Re-run on unchanged inputs costs zero LLM/embed calls | Unit test: ledger hit rate = 100% on second identical ingest run |
+| `--dry-run` writes nothing and reports accurate preview | Integration test: zero Qdrant/graph/ledger writes; chunk count matches actual ingest count |
+| `rollback <batch>` removes all imported edges/entities without touching conversation knowledge | Integration test: conversation-origin row count unchanged after rollback |
+| Sanitizer validation is enforced on every graph document | Unit test: document with synthetic PII pattern is rejected at the validator; edge count = 0 |
+| Phase 2 ships only if §7 spike passes all three thresholds | Manual gate: spike results recorded in playbook before Phase 2 PR is opened |
+| Sources outside the current project root are rejected fast | Unit test: path outside root → clear error, zero writes |
+
+## 6. Out of Scope
+
+- **Raw source code ingestion.** Owned by `zeph-index` (tree-sitter → Qdrant + symbol index +
+  repo map). Duplicating it in the knowledge graph floods relational recall with hub nodes.
+- **External-agent transcript import (Claude Code / Codex).** Deferred to Phase 3 (#5024):
+  requires provenance migration (Phase 0), write-path PII redaction, and a version-pinned
+  strict allowlist parser.
+- **Automatic / scheduled ingest.** Ingest is an explicit operator command. A future hook or
+  scheduler tap is out of scope for M29; a TODO marker is left in `src/commands/knowledge.rs`.
+- **Structural code graph (call/def edges into `graph_edges`).** Covered by `zeph-index` MCP tools.
+- **Multi-project transcript import.** Sources are confined to the current project root (INV-6).
+- **Drift reconciliation via the content-hash ledger.** The ledger is a re-read/cost guard only,
+  not a semantic-equivalence guarantee across model versions (INV-5).

--- a/specs/067-knowledge-ingest/nfr.md
+++ b/specs/067-knowledge-ingest/nfr.md
@@ -1,0 +1,195 @@
+---
+aliases:
+  - Knowledge Ingest NFR
+tags:
+  - nfr
+  - memory
+  - quality
+created: 2026-06-07
+status: draft
+spec_id: "067"
+standard: "ISO/IEC 25010:2011"
+---
+
+# NFR: Knowledge Ingest (`zeph knowledge ingest`)
+
+Standard: ISO/IEC 25010:2011 (product quality characteristics). Eight characteristic areas are
+evaluated. Where a characteristic does not apply, the reason is stated.
+
+---
+
+## NFR-1 — Performance Efficiency
+
+**NFR-1.1 — Bounded concurrency.**
+Extraction concurrency must not exceed `[knowledge].concurrency` (default 3). The implementation
+must use `futures::buffer_unordered(concurrency)` — unbounded `join_all` over LLM calls is
+prohibited. This protects local Ollama single-threading and respects cloud rate limits.
+Verification: code review confirming `buffer_unordered` usage; load test with `concurrency = 1`
+showing sequential execution.
+
+**NFR-1.2 — Ledger skip overhead.**
+The `is_ingested(uri, hash)` ledger query must complete in < 5 ms per document on a SQLite
+database with up to 10 000 ledger entries. Measurement: `criterion` benchmark against a
+pre-seeded ledger.
+
+**NFR-1.3 — No agent loop latency.**
+Ingest is an operator command. It must not add any latency to a live agent turn. The ingest
+path must not share a connection pool with the agent's hot database path when ingest is active.
+Verification: integration test asserting agent response time is unaffected when `ingest` runs
+concurrently in a separate process.
+
+**NFR-1.4 — Dry-run token estimate accuracy.**
+The `--dry-run` token estimate for the notes path must be within 20% of actual embedding token
+consumption on a test corpus of 50 documents. Measurement: post-run comparison of estimated
+vs. billed tokens.
+
+---
+
+## NFR-2 — Reliability
+
+**NFR-2.1 — No batch abort on single failure.**
+A parse error, LLM timeout, or DB write failure on one `IngestDocument` must not abort the
+batch. The system must collect the error, mark the document failed in `IngestReport`, leave
+it absent from the ledger (so re-run can retry it), and continue processing the remainder.
+Verification: unit test injecting a failing LLM call on document N; documents N+1..M must
+complete and appear in the ledger.
+
+**NFR-2.2 — Rollback completeness.**
+After `zeph knowledge rollback <batch>`, no `graph_edges` or `graph_entities` row with that
+`import_batch_id` must remain. Conversation-origin rows must be unmodified. Verification:
+integration test asserting row counts before/after rollback.
+
+**NFR-2.3 — Interrupted-run resumability.**
+If an ingest run is interrupted (SIGINT, process kill), already-committed documents appear
+in the ledger with their `import_batch_id`. Re-running resumes the remainder. `rollback <batch>`
+removes the partial batch cleanly. Verification: manual test interrupting a run mid-batch;
+re-run processes only the remaining documents.
+
+**NFR-2.4 — Idempotent re-runs.**
+Running ingest twice on unchanged inputs must produce zero additional LLM calls, zero new
+ledger rows, and zero new Qdrant or graph rows (the existing entity/edge dedup provides
+defense-in-depth). Verification: unit test asserting LLM mock was called exactly N times
+across two consecutive identical runs.
+
+---
+
+## NFR-3 — Security
+
+**NFR-3.1 — Sanitizer enforcement.**
+Every `IngestDocument` must pass the `zeph-sanitizer` `PostExtractValidator` before any entity
+or fact string is persisted to the graph. A document rejected by the sanitizer must result in
+zero entity/edge writes; the rejection must be logged at DEBUG and counted in `IngestReport`.
+Verification: unit test with a synthetic PII pattern; assert entity count = 0 and dropped count = 1.
+
+**NFR-3.2 — Project-root confinement.**
+Source paths must be validated against the current project root before any file is read.
+Paths outside the root must be rejected immediately with a clear error and zero reads.
+Verification: unit test providing a path to `/tmp`; assert `MemoryError::Ingest` with the
+"outside project root" message.
+
+**NFR-3.3 — Write-gate enforcement.**
+The write-quality gate (spec 004-9) and admission control (spec 004-3) must execute for every
+candidate edge produced by graph extraction. Verification: unit test asserting the gate mock
+was invoked once per candidate edge; a gate-rejected edge must not appear in the graph.
+
+**NFR-3.4 — No privilege escalation.**
+The ingest command must not require elevated privileges (sudo, admin) for any operation.
+Verification: code review; run as non-root user in CI.
+
+---
+
+## NFR-4 — Maintainability
+
+**NFR-4.1 — Adapter isolation.**
+`IngestSourceAdapter::parse` implementations inside `zeph-memory` must be pure functions with
+no I/O and no imports from `zeph-subagent`, `zeph-core`, or `zeph-agent-*` crates. Disk-walking
+and JSONL reading happen exclusively in the binary command (`src/commands/knowledge.rs`).
+Verification: `cargo check -p zeph-memory` must compile without `zeph-subagent` in its
+dependency tree.
+
+**NFR-4.2 — No parallel loader.**
+Phase 1 must reuse the existing `TextLoader`/`TextSplitter`/`IngestionPipeline` verbatim — not
+duplicate them. Verification: code review confirming the same pipeline types are used in both
+`src/commands/ingest.rs` and `src/commands/knowledge.rs`.
+
+**NFR-4.3 — Error consolidation.**
+Ingest errors must be represented as a `MemoryError::Ingest` variant — no new top-level error
+enum and no new crate for error types. Verification: `grep -r "enum.*IngestError" crates/` must
+return zero hits outside `error.rs`.
+
+**NFR-4.4 — Doc comment coverage.**
+All public types, traits, and methods introduced by this feature must have `///` doc comments
+explaining what and why. `SemanticMemory::ingest_documents` and `IngestLedger` must include
+`# Examples` sections with `no_run` doc-tests.
+Verification: `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-memory` passes with zero warnings.
+
+---
+
+## NFR-5 — Portability
+
+**NFR-5.1 — SQLite and PostgreSQL migration parity.**
+The Phase 0 provenance migration and the ledger table creation must be provided in both
+`crates/zeph-db/migrations/sqlite/` and `crates/zeph-db/migrations/postgres/`, and must pass
+`migration_parity.rs` validation. Verification: CI parity check.
+
+**NFR-5.2 — Cross-platform compilation.**
+The `zeph knowledge` command must compile without errors or warnings on Linux x86_64, macOS
+aarch64, and Windows x86_64 (where Rust is supported). No platform-specific code outside
+`#[cfg(target_os)]` guards may be introduced. Verification: CI matrix.
+
+---
+
+## NFR-6 — Usability
+
+**NFR-6.1 — Error message quality.**
+All error messages from the ingest path must name the specific problem (not "ingest error"),
+suggest a corrective action where applicable, and never expose an internal Rust backtrace to
+the operator. Verification: manual review of error paths listed in spec §6.
+
+**NFR-6.2 — Dry-run discoverability.**
+The `--help` output for `zeph knowledge ingest` must mention `--dry-run` and explain that it
+writes nothing. Verification: `zeph knowledge ingest --help` output contains the string
+`--dry-run`.
+
+**NFR-6.3 — Progress visibility.**
+During any write operation, a `Ingesting knowledge: <uri>...` status indicator must be visible
+in both TUI and CLI modes. In CLI mode this is a progress line; in TUI mode it is a spinner
+in the system status area. Verification: manual test.
+
+---
+
+## NFR-7 — Compatibility
+
+**NFR-7.1 — Config forward compatibility.**
+The `[knowledge]` section uses `#[serde(default)]` throughout. An existing config without the
+section must load without error. Verification: unit test loading a config that omits `[knowledge]`.
+
+**NFR-7.2 — Backward-compatible migration.**
+The Phase 0 `ALTER TABLE` statements are additive (new nullable columns with defaults). Existing
+rows remain valid; existing queries that do not reference the new columns are unaffected.
+Verification: run existing graph integration tests against the migrated schema.
+
+**NFR-7.3 — Non-exhaustive enum forward compatibility.**
+`IngestSourceKind` must be marked `#[non_exhaustive]` so that adding Phase 3 sources
+(`ExternalAgent`) does not break downstream match arms compiled against an older version.
+Verification: code review.
+
+---
+
+## NFR-8 — Safety
+
+**NFR-8.1 — No graph write without provenance.**
+THE SYSTEM must panic in debug mode (assert) and return `MemoryError::Ingest` in release mode
+if `ingest_documents` is called without a valid `ImportBatchId`. An untagged graph write would
+be permanently unrollbackable. Verification: unit test asserting the error variant when
+`batch_id` is empty.
+
+**NFR-8.2 — No silent content drop.**
+If the sanitizer rejects a fact, the rejection must be logged at DEBUG level and counted in
+`IngestReport.dropped`. The operator must be informed of the drop count at completion.
+Verification: unit test asserting `IngestReport.dropped > 0` when a PII pattern is present.
+
+**NFR-8.3 — Ledger limitation documented.**
+The `knowledge_ingest_ledger` must carry a SQL comment and a corresponding `///` doc comment
+on `IngestLedger` stating explicitly that it is a re-read/cost guard only — it does not protect
+against LLM extraction drift across model versions (INV-5). Verification: code review.

--- a/specs/067-knowledge-ingest/plan.md
+++ b/specs/067-knowledge-ingest/plan.md
@@ -1,0 +1,199 @@
+---
+aliases:
+  - Knowledge Ingest Implementation Plan
+tags:
+  - plan
+  - memory
+  - cross-cutting
+created: 2026-06-07
+status: draft
+spec_id: "067"
+related:
+  - "[[067-knowledge-ingest/spec]]"
+  - "[[067-knowledge-ingest/srs]]"
+  - "[[067-knowledge-ingest/nfr]]"
+  - "[[constitution]]"
+---
+
+# Implementation Plan: Knowledge Ingest (067)
+
+## Phases
+
+### Phase 0 — Provenance and Rollback Prerequisite (Wave 1, PRs F1 + F2)
+
+**Goal:** Add the schema columns that make graph imports reversible and identifiable. No ingest
+logic ships in this phase — only migration + ledger table + recall isolation flag. This phase
+unblocks both the notes rollback path (N2) and the graph batch API (G1).
+
+**Deliverables:**
+
+- `crates/zeph-db/migrations/sqlite/<NNN>_knowledge_provenance.sql`:
+  - `ALTER TABLE graph_edges ADD COLUMN origin TEXT NOT NULL DEFAULT 'conversation'`
+  - `ALTER TABLE graph_edges ADD COLUMN import_batch_id TEXT`
+  - `ALTER TABLE graph_edges ADD COLUMN source_uri TEXT`
+  - `ALTER TABLE graph_entities ADD COLUMN origin TEXT NOT NULL DEFAULT 'conversation'`
+  - `ALTER TABLE graph_entities ADD COLUMN import_batch_id TEXT`
+  - Backfill: `UPDATE graph_edges SET origin = 'conversation' WHERE origin IS NULL` (pre-migration rows)
+- Matching `crates/zeph-db/migrations/postgres/<NNN>_knowledge_provenance.sql` with parity guard
+- `[knowledge].recall_include_imported: bool` field in `zeph-config` (FR-003, FR-060)
+- `knowledge_ingest_ledger` table (FR-080):
+
+  ```sql
+  CREATE TABLE IF NOT EXISTS knowledge_ingest_ledger (
+      source_uri      TEXT    NOT NULL,
+      content_hash    TEXT    NOT NULL,
+      import_batch_id TEXT    NOT NULL,
+      ingested_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+      entities        INTEGER NOT NULL DEFAULT 0,
+      edges           INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (source_uri, content_hash)
+  );
+  ```
+
+- `IngestLedger` repository struct in `crates/zeph-memory/src/graph/ingest/ledger.rs`
+  (FR-012, FR-025, NFR-4.3)
+- Unit tests: ledger `is_ingested` / `mark_ingested` round-trip; migration parity check
+
+**Acceptance:** `cargo nextest run -p zeph-memory -p zeph-db` passes; existing graph integration
+tests pass against the migrated schema (no regressions on existing column set).
+
+---
+
+### Phase 1 — CLI Scaffold, Config, and Static Artifacts to Semantic Notes (Wave 1+2, PRs F3 + N1 + N2 + N3)
+
+**Goal:** Ship the lowest-risk, highest-value slice: a working `zeph knowledge ingest --source specs`
+(and the other static sources) that feeds the existing `IngestionPipeline` with a dry-run preview
+and idempotent re-runs. The rollback and status commands ship alongside (they are trivial for the
+notes path since notes are not rollback-tracked beyond the Qdrant pipeline).
+
+**Deliverables:**
+
+F3 — CLI scaffold + config + wizard:
+- `Command::Knowledge { Ingest { .. }, Rollback { .. }, Status }` in `src/cli.rs`
+- Dispatch in `src/runner.rs` to `src/commands/knowledge.rs` (mirrors `ingest.rs`)
+- `[knowledge]` config section in `zeph-config/src/knowledge.rs` with `#[serde(default)]`
+- `--migrate-config` migration step adding `[knowledge]` with defaults (FR-062)
+- `--init` wizard `step_knowledge()` (FR-061)
+- `ProviderName` resolution chain: `ingest_provider → extract_provider → primary` (FR-041)
+
+N1 — Static notes sink:
+- `src/commands/knowledge.rs`: disk-walking for each source kind (specs, changelog, handoff,
+  coverage, git-log); `--dry-run` preview (FR-013); progress streaming via `IngestProgress`
+  (FR-014); confirmation gate (`--yes` / interactive) before Qdrant writes (FR-040)
+- Reuse `TextLoader`/`TextSplitter`/`IngestionPipeline` verbatim (FR-011, NFR-4.2)
+- Ledger integration: skip unchanged inputs (FR-012), mark on success
+
+N2 — Rollback + status:
+- `zeph knowledge rollback <batch>`: `DELETE FROM graph_edges WHERE import_batch_id = ?`
+  + orphan entity cleanup (FR-004)
+- `zeph knowledge status`: list batches from ledger (FR-029)
+
+N3 — TUI integration:
+- Command palette entries: `/knowledge ingest <source>`, `/knowledge status`,
+  `/knowledge rollback <batch>`
+- Spinner with `Ingesting knowledge: <uri>...` (FR-014, FR-071, NFR-6.3)
+
+**Acceptance:** `cargo run -- knowledge ingest --source specs --dry-run` reports files and
+projected chunks and writes nothing. `cargo run -- knowledge ingest --source specs --yes`
+ingests all spec files; re-run produces zero LLM/embed calls (ledger hit rate 100%).
+
+---
+
+### Phase 2 — Subagent Transcripts to Knowledge Graph (Wave 3+4+5, PRs G1 + G0 (gate) + G2)
+
+**Goal:** Extend the batch extraction path to the knowledge graph for subagent transcripts.
+This phase is gated: G1 builds the batch API and types; G0 runs the measurement spike; G2
+connects the graph write path only if G0 passes.
+
+**Deliverables:**
+
+G1 — Batch API + types + technical-document prompt:
+- `crates/zeph-memory/src/graph/ingest/mod.rs`: `IngestSourceKind` (`#[non_exhaustive]`),
+  `IngestDocument`, `Provenance`, `ImportBatchId`, `IngestProgress`, `IngestReport`
+  (NFR-7.3, spec §2.4)
+- `crates/zeph-memory/src/graph/ingest/adapter.rs`: sealed `IngestSourceAdapter` trait;
+  `SubagentJsonl` adapter (pure, no I/O) (spec §2.4, NFR-4.1)
+- `crates/zeph-memory/src/graph/extractor.rs`: second `const` technical-document extraction
+  prompt selectable by `IngestSourceKind` (FR-023, spec §2.5)
+- `SemanticMemory::ingest_documents()` on `crates/zeph-memory/src/semantic/graph.rs`
+  (spec §2.3): ledger check → `buffer_unordered(concurrency)` → `extract_and_store()` reuse
+  → `mark_ingested`; collect-errors fail strategy (FR-028, NFR-2.1)
+- `MemoryError::Ingest` variant in `crates/zeph-memory/src/error.rs` (NFR-4.3)
+- Dry-run hub-degree projection report (FR-026)
+- TODO deferred markers at `IngestSourceKind::ExternalAgent` and `ingest_documents` (spec §9)
+
+G0 — Measurement spike (gate):
+- Run `--dry-run` over 10 specs + all current-project subagent transcripts
+- Author 3 concrete multi-hop recall queries; measure recall@5 vs. notes baseline on ≥10
+  held-out cross-session questions (FR-050)
+- Verify hub-degree < 15% and S/N ≥ 50% (FR-051, FR-052)
+- Record GO / NO-GO decision and evidence in `.local/testing/playbooks/knowledge-ingest.md`
+- If any kill-criterion is met (FR-053): abandon graph sink, route `--source subagents` to
+  Phase 1 notes pipeline, close G2 as "wontfix per §7 kill-criterion"
+
+G2 — Graph go-live + sanitizer (conditional on G0 GO):
+- Wire `--source subagents` in `src/commands/knowledge.rs` to `ingest_documents()`:
+  JSONL reading + `TranscriptEntry` discovery (binary-level; no new `zeph-memory` deps)
+- `PostExtractValidator` wired to `zeph-sanitizer` on the write path (FR-022, INV-4)
+- Provenance stamping: `origin`, `source_uri`, `import_batch_id` on every edge/entity (FR-024)
+- Write-quality gate and admission control enforcement assertion (FR-021, INV-3)
+- Integration tests: rollback removes tagged rows; conversation rows untouched; sanitizer
+  rejects synthetic PII; gate mock invoked per candidate edge
+
+**Acceptance (G2):** `zeph knowledge ingest --source subagents --yes` ingests transcripts;
+every created edge has `origin = 'subagent'` and non-null `import_batch_id`; `rollback <batch>`
+removes them cleanly; sanitizer and write-gate mocks were invoked.
+
+---
+
+### Phase 3 — External Import (Deferred, PR D1)
+
+Deferred to a post-M29 backlog issue (#5024). Prerequisites: Phase 0 provenance in production,
+write-path PII redaction closed, version-pinned strict allowlist parser for Claude Code / Codex
+schemas, and current-project scope enforcement. A `TODO(critic D1)` marker is placed at
+`IngestSourceKind::ExternalAgent` (spec §9).
+
+---
+
+## Milestones
+
+| Milestone | Content | Wave | Target |
+|---|---|---|---|
+| M29-W1 | Phase 0 + F3 scaffold (F1 #5015, F2 #5016, F3 #5017 merged in parallel) | Wave 1 | Sprint N |
+| M29-W2 | Phase 1 value (N1 #5018, N2 #5019, N3 #5020) | Wave 2 | Sprint N |
+| M29-W3 | Graph batch API (G1 #5021) | Wave 3 | Sprint N+1 |
+| M29-W4 | Measurement spike GATE (G0 #5022) — GO or NO-GO | Wave 4 | Sprint N+1 |
+| M29-W5 | Graph go-live if G0 GO (G2 #5023) | Wave 5 | Sprint N+2 |
+| M29-Deferred | External import (D1 #5024) | Backlog | Post-M29 |
+
+## Dependencies
+
+- `blake3` — already in workspace (used by `zeph-index`); reuse for `content_hash`
+- `futures` — already in workspace; `buffer_unordered` for bounded concurrency
+- `zeph-sanitizer` — Layer 2; already a dependency of `zeph-agent-context`; binary can access it
+- No new inter-crate dependency edges are introduced (binary already depends on
+  `zeph-subagent` + `zeph-memory` + `zeph-sanitizer`)
+
+## Risk Register
+
+| Risk | Impact | Probability | Mitigation |
+|---|---|---|---|
+| Phase 0 migration contention on hot `graph_edges` table (5+ indexes) | High | Low | Run migration during maintenance window; additive `ALTER TABLE` does not rebuild indexes in SQLite; test on production-sized DB before PR |
+| §7 spike fails → Phase 2 abandoned mid-implementation | Medium | Medium | G1 batch API still ships and provides value for future sources; G0 is an explicit gate; NO-GO is a defined outcome, not a failure |
+| Technical-document prompt under-extracts specs/handoffs | High | Medium | Validate with `--dry-run` over 10 specs before G0; tune prompt if S/N < 50% |
+| Hub-node explosion (PR numbers, crate names dominate graph) | High | Medium | Hub-degree check in dry-run (FR-026, FR-051); kill-criterion in G0 blocks G2 if exceeded |
+| LLM non-determinism creates near-duplicate edges across runs | Medium | High | Documented as INV-5; existing `canonical_relation` + `import_batch_id` supersession is the mitigation; `rollback` + re-ingest is the operator escape hatch |
+| Postgres migration diverges from SQLite | Medium | Low | `migration_parity.rs` enforced in CI |
+
+## Constitution Compliance
+
+| Principle | Status | Notes |
+|---|---|---|
+| No new inter-crate dependency edges | Compliant | Adapters stay pure in `zeph-memory`; JSONL reading in binary |
+| Multi-model provider resolution | Compliant | `ingest_provider → extract_provider → primary` (INV-8) |
+| SQLite + Postgres parity | Compliant | `migration_parity.rs` enforced |
+| TUI spinner for background ops | Compliant | `Ingesting knowledge: <uri>...` spinner (NFR-6.3) |
+| Tests before merge | Compliant | Unit + integration tests for each phase (NFR-2.1, NFR-3.1..3.3) |
+| No `unwrap`/`expect` in production | Compliant | `MemoryError::Ingest` propagated via `?` throughout |
+| Doc comments on public API | Compliant | NFR-4.4 mandates `///` on all public items |
+| CLAUDE.md dev-rules 1–7 | Compliant | Config, CLI, TUI, `--init`, `--migrate-config`, playbook, coverage-status all explicitly required by tasks |

--- a/specs/067-knowledge-ingest/spec.md
+++ b/specs/067-knowledge-ingest/spec.md
@@ -10,6 +10,7 @@ tags:
   - cross-cutting
 created: 2026-06-07
 status: draft
+spec_id: "067"
 related:
   - "[[MOC-specs]]"
   - "[[001-system-invariants/spec]]"

--- a/specs/067-knowledge-ingest/spec.md
+++ b/specs/067-knowledge-ingest/spec.md
@@ -1,0 +1,498 @@
+---
+aliases:
+  - Knowledge Ingest
+  - Knowledge Ingest Command
+  - spec-067
+tags:
+  - sdd
+  - spec
+  - memory
+  - cross-cutting
+created: 2026-06-07
+status: draft
+related:
+  - "[[MOC-specs]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[004-memory/spec]]"
+  - "[[004-memory/004-9-memory-write-gate]]"
+  - "[[004-memory/004-6-graph-memory]]"
+  - "[[012-graph-memory/spec]]"
+  - "[[018-index/spec]]"
+  - "[[041-sanitizer/spec]]"
+  - "[[056-autoskill-trace-extraction/spec]]"
+  - "[[constitution]]"
+---
+
+# Spec-067: Knowledge Ingest (`zeph knowledge ingest`)
+
+**GitHub:** #5012 (epic) — child issues #5015–#5024; milestone M29
+**Branch:** `feat/m29/knowledge-ingest`
+**Crate:** `zeph-memory` (extends), `zeph-db` (migration), `zeph-config` (extends), `zeph` (binary, new `src/commands/knowledge.rs`), reuses `zeph-sanitizer`
+**Status:** draft — pre-implementation; Phase 2 graph path is **gated behind a measurement spike** (see §7).
+
+---
+
+## Summary
+
+A one-shot operator command that loads project knowledge into Zeph's memory subsystems on demand,
+instead of relying solely on the background extraction tied to live conversation.
+
+The feature has **two distinct sinks**, decided after architect + adversarial-critic review
+(handoffs: `.local/handoff/knowledge-ingest-architect.md`, `.local/handoff/knowledge-ingest-critique.md`):
+
+1. **Static project artifacts → semantic notes (Qdrant)** via the *existing* `IngestionPipeline`
+   used by `zeph ingest`. No graph writes. Proven path, zero relational-recall risk. This is the
+   default and lowest-risk slice.
+2. **Agent episodes → knowledge graph** (relational, multi-hop). The graph is reserved **only** for
+   the cross-agent episode layer, where multi-hop traversal genuinely pays off. MVP source is Zeph's
+   own subagent transcripts (current project, already `zeph_llm::Message`-typed). This path is gated:
+   it ships **only if** a measurement spike proves signal-to-noise and a real multi-hop query benefit.
+
+Raw source code is **explicitly out of scope** — it is already owned by `zeph-index`
+(tree-sitter → Qdrant + symbol index + repo map). Duplicating it in the conversational graph would
+flood relational recall with hub nodes.
+
+External-agent transcript import (Claude Code / OpenAI Codex) is **deferred to a later gated phase**
+(§9, Phase 3) due to undocumented/unstable schemas, cross-project privacy blast radius, and the
+verbatim-no-PII-redaction write path.
+
+---
+
+## Sources
+
+### Internal
+| File | Contents |
+|---|---|
+| `crates/zeph-memory/src/semantic/graph.rs` | `SemanticMemory::extract_and_store()` (the reuse seam); new `ingest_documents()` |
+| `crates/zeph-memory/src/graph/extractor.rs` | `GraphExtractor`, hardcoded conversational system prompt (lines 12-60) |
+| `crates/zeph-memory/src/graph/rpe.rs` | RPE per-turn surprise gate (agent-layer only) |
+| `crates/zeph-core/src/agent/persistence/extract.rs` | `enqueue_graph_extraction_task` — where RPE + guards live |
+| `crates/zeph-config/src/memory/graph.rs` | `[memory.graph]` config, `extract_provider` (line 549), `write_gate` |
+| `src/commands/ingest.rs` | Existing doc-loader precedent → `IngestionPipeline` → Qdrant notes |
+| `crates/zeph-subagent/src/transcript.rs` | `TranscriptEntry { seq, timestamp, message }` JSONL reader |
+| `crates/zeph-sanitizer/` | PII / exfiltration validators for the write path |
+| `crates/zeph-db/migrations/sqlite/021_knowledge_graph.sql` | `graph_edges` / `graph_entities` schema (no provenance column today) |
+| `crates/zeph-db/migrations/sqlite/029_graph_edge_dedup.sql` | `UNIQUE(source_entity_id, target_entity_id, relation)` active-edge dedup |
+
+### Related specs
+- `[[004-memory/004-9-memory-write-gate]]` — MemReader write-quality gate; project evidence that
+  *write pollution collapses recall faster than scoring drift*. **This spec MUST honor that gate, not bypass it.**
+- `[[004-memory/004-3-admission-control|A-MAC Admission Control]]` — admission control (INV §14).
+- `[[018-index/spec]]` — code RAG; the boundary this spec must not cross.
+- `[[056-autoskill-trace-extraction/spec]]` — precedent for background extraction from session history
+  with a per-session idempotency table (`skill_trace_sessions`) and `*_provider` config.
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+Zeph's knowledge graph and semantic memory are populated only as a side effect of live conversation
+(background, RPE-gated, fire-and-forget). There is no way to deliberately seed memory with the
+project's accumulated knowledge — its specs, changelog, handoffs, and the episodic record of work
+that agents (including Zeph's own subagents) have done. A new operator or a fresh database starts
+blind to all prior project context.
+
+### Goal
+
+A `zeph knowledge ingest` command that, on demand and idempotently:
+
+- loads high-signal static project artifacts into **semantic notes** (Qdrant) so they are recallable
+  by vector similarity; and
+- (gated) extracts the **relational episode layer** from subagent transcripts into the **knowledge graph**,
+  enabling multi-hop recall over cross-session project decisions — *only if* this is measurably better
+  than semantic notes alone.
+
+When done: an operator can run one command to make a fresh Zeph instance project-aware, with full
+provenance, idempotent re-runs, a `--dry-run` preview, and a rollback path for graph imports.
+
+### Out of Scope
+
+- **Raw source code → graph.** Owned by `zeph-index`. Never duplicated here.
+- **External-agent transcript import (Claude Code / Codex).** Deferred to Phase 3 (§9), gated on
+  provenance (Phase 0), write-path PII redaction maturity, and a version-pinned strict parser.
+- **Bypassing the write-quality gate (004-9) or admission control (004-3).** Only RPE is bypassed,
+  and only because it is a per-turn conversational heuristic with no meaning for batch documents.
+- **Automatic / scheduled ingest.** This is an explicit operator command. A future hook/scheduler
+  tap is out of scope (a TODO marker is left for it).
+- **Structural code graph (call/def edges into `graph_edges`).** Out of scope; `zeph-index` MCP tools cover it.
+
+---
+
+## 2. Architecture / Design
+
+### 2.1 Two sinks, one command
+
+```
+zeph knowledge ingest --source <SRC>... [--dry-run] [--max-documents N] [--provider NAME] [--yes]
+zeph knowledge rollback <import_batch_id>
+zeph knowledge status                      # list import batches + ledger summary
+
+SRC ∈ { specs, changelog, handoff, coverage, git-log,    ← Phase 1: → semantic notes (Qdrant)
+        subagents,                                        ← Phase 2: → knowledge graph (gated)
+        claude-code, codex }                              ← Phase 3: deferred (rejected pre-gate)
+```
+
+- **Notes sink (Phase 1):** static artifacts are read from disk, chunked with the *existing*
+  `TextLoader` / `TextSplitter`, and fed to the *existing* `IngestionPipeline` (the same path
+  `src/commands/ingest.rs` uses). No new loader. No graph writes.
+- **Graph sink (Phase 2):** subagent transcripts are normalized to `IngestDocument`s and fed to a new
+  batch extraction API on `SemanticMemory` that **reuses `extract_and_store()`** per document.
+
+### 2.2 Crate placement (no new crate, no new dependency edges)
+
+| Layer | Lives in | Responsibility |
+|---|---|---|
+| Batch extraction API + ledger + adapter trait | `zeph-memory` (`src/graph/ingest/`) | Graph owner. Pure text→document adapters (no I/O on peer crates). |
+| Disk walking, transcript discovery, external-format reading, progress render | `zeph` binary (`src/commands/knowledge.rs`) | Already depends on `zeph-subagent` + `zeph-memory`; mirrors `ingest.rs`. |
+| Config | `zeph-config` (`[knowledge]` + `[memory.graph]` extensions) | Pure data. |
+| Migration | `zeph-db` (sqlite + postgres parity) | Provenance columns + ledger table. |
+
+A standalone `zeph-knowledge` crate is **rejected** for MVP (no second consumer; would force a DRY or
+dependency-direction violation — see INV-1 watch in §8).
+
+### 2.3 The synchronous batch API (graph sink)
+
+```rust
+// crates/zeph-memory/src/semantic/graph.rs
+impl SemanticMemory {
+    /// Extract knowledge from a batch of documents into the graph.
+    ///
+    /// Bypasses the RPE per-turn gate (not meaningful for batch docs) but routes every
+    /// candidate edge through the write-quality gate (004-9) and admission control (004-3).
+    /// Each document is content-hash-checked against the ingest ledger; unchanged inputs
+    /// are skipped with no LLM call. Progress is streamed on `progress`.
+    pub async fn ingest_documents(
+        &self,
+        documents: Vec<IngestDocument>,
+        provider: AnyProvider,           // resolved ingest_provider → extract_provider → primary
+        config: GraphExtractionConfig,
+        validator: PostExtractValidator, // zeph-sanitizer hook on the write path (mandatory for ingest)
+        batch_id: ImportBatchId,
+        concurrency: usize,              // bounded; futures::buffer_unordered(concurrency)
+        progress: mpsc::Sender<IngestProgress>,
+    ) -> Result<IngestReport, MemoryError>;
+}
+```
+
+Internally: `is_ingested(uri, hash)` filter → `buffer_unordered(concurrency)` over
+`extract_and_store(doc.content, doc.context, …, Some(Provenance { origin, source_uri, batch_id }))`
+→ on success `mark_ingested`. **Reuse `extract_and_store()` verbatim** — it does not contain RPE
+(RPE lives in the agent layer at `extract.rs`). Fail strategy: **collect-errors, continue** — one bad
+transcript MUST NOT abort the batch; failures are reported in `IngestReport`.
+
+### 2.4 Key types (`crates/zeph-memory/src/graph/ingest/`)
+
+| Type | Pattern | Purpose |
+|---|---|---|
+| `IngestSourceKind` | `#[non_exhaustive]` enum | `StaticArtifact`, `SubagentTranscript`, `ExternalAgent` (Phase 3). Maps to `graph_edges.origin`. |
+| `IngestDocument` | valid-by-construction struct, private fields | `content`, `context: Vec<String>`, `provenance: Provenance`, `content_hash: blake3::Hash`. Built only via adapters. |
+| `Provenance` | newtype | `{ kind: IngestSourceKind, source_uri: String, batch_id: ImportBatchId }`. `source_uri` e.g. `"subagent:<task_id>"`, `"specs/004/spec.md@<git-sha>"`. |
+| `ImportBatchId` | newtype over UUID/ULID string | One per ingest run; the rollback key. |
+| `IngestSourceAdapter` | sealed trait, one impl per format | `fn parse(raw: &str) -> Result<Vec<IngestDocument>, MemoryError>`. Pure. MVP: `SubagentJsonl` (trivial — already `Message`). |
+| `IngestLedger` | repository over new table | `is_ingested(uri, hash)`, `mark_ingested(uri, hash, batch, counts)`. Re-read/cost guard **only** (see INV-5). |
+| `IngestProgress` / `IngestReport` | progress enum + summary, modeled after `IndexProgress` | Streamed to CLI/TUI spinner; report lists per-source counts + failures. |
+
+Errors consolidate into `MemoryError::Ingest` — **no new error enum / no new crate**.
+
+### 2.5 Technical-document extraction prompt
+
+The hardcoded extractor prompt (`extractor.rs:12-60`) is tuned for first-person conversational claims
+and explicitly *rejects* code, config keys, file paths, tool names, and structured data — i.e. exactly
+what specs/changelog/handoffs/transcripts contain. Feeding them the conversational prompt silently
+under-extracts.
+
+→ Add a **second `const` system prompt** ("technical-document" mode) selectable by `IngestSourceKind`,
+keeping entity types `project / tool / concept / file` but dropping the conversational-filler rules.
+This applies to the graph sink only (Phase 2). The notes sink (Phase 1) does not run extraction at all.
+
+### 2.6 Multi-model provider wiring (CLAUDE.md compliance)
+
+Add `[knowledge].ingest_provider: ProviderName`. Resolution chain:
+`ingest_provider` (if non-empty) → `[memory.graph].extract_provider` → primary. Resolve via the
+existing `resolve_background_provider` path (bypasses the quality gate for JSON extraction).
+Ingest is a simple/medium task → default config points it at the `fast` provider. **Never hardcode a model.**
+
+---
+
+## 3. Functional Requirements
+
+### Phase 0 — Provenance + rollback prerequisite (MUST land before any graph write)
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL add `origin TEXT NOT NULL DEFAULT 'conversation'` to `graph_edges` AND `graph_entities`; existing rows backfill to `'conversation'` | must |
+| FR-002 | THE SYSTEM SHALL add `import_batch_id TEXT NULL` and `source_uri TEXT NULL` to `graph_edges` (and `import_batch_id` to `graph_entities`) | must |
+| FR-003 | WHEN recall scores edges, THE SYSTEM SHALL be able to exclude or down-weight rows where `origin != 'conversation'`, controlled by `[knowledge].recall_include_imported` (default `true`) | must |
+| FR-004 | THE SYSTEM SHALL provide `zeph knowledge rollback <import_batch_id>` that deletes all entities/edges carrying that `import_batch_id` (and orphaned imported entities) | must |
+
+### Phase 1 — Static artifacts → semantic notes
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-010 | WHEN `--source specs\|changelog\|handoff\|coverage\|git-log`, THE SYSTEM SHALL load the corresponding artifacts of the **current project only** and ingest them as semantic notes via the existing `IngestionPipeline` | must |
+| FR-011 | THE SYSTEM SHALL reuse the existing `TextLoader`/`TextSplitter`/`IngestionPipeline` — NOT a parallel loader | must |
+| FR-012 | THE SYSTEM SHALL skip unchanged inputs via the content-hash ledger (no re-embed of unchanged files) | must |
+| FR-013 | WHEN `--dry-run`, THE SYSTEM SHALL report files discovered, chunks that would be produced, and estimated embedding token cost, and write nothing | must |
+| FR-014 | THE SYSTEM SHALL stream progress (`IngestProgress`) to a TUI/CLI status indicator (`Ingesting knowledge: <uri>…`) | must |
+
+### Phase 2 — Subagent transcripts → graph (GATED, see §7)
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-020 | WHEN `--source subagents`, THE SYSTEM SHALL read Zeph subagent transcripts of the current project from the configured `transcript_dir`, normalize each to `IngestDocument`s, and call `ingest_documents()` | must |
+| FR-021 | WHEN extracting graph knowledge during ingest, THE SYSTEM SHALL route every candidate edge through the write-quality gate (004-9) and admission control (004-3); it SHALL NOT bypass them | must |
+| FR-022 | THE SYSTEM SHALL run the `zeph-sanitizer` PII/exfiltration validator as the `PostExtractValidator` for every ingest document | must |
+| FR-023 | THE SYSTEM SHALL select the technical-document extraction prompt for non-conversational sources | must |
+| FR-024 | THE SYSTEM SHALL stamp every imported edge/entity with `origin`, `source_uri`, and `import_batch_id` | must |
+| FR-025 | THE SYSTEM SHALL skip documents whose `(source_uri, content_hash)` is already in the ledger (no LLM call) | must |
+| FR-026 | WHEN `--dry-run`, THE SYSTEM SHALL report documents, turns, estimated extraction tokens, projected entity/edge counts, AND the projected hub-degree distribution (top-N entities by degree), and write nothing | must |
+| FR-027 | THE SYSTEM SHALL bound concurrency (`[knowledge].concurrency`, default 2–4) and cap total work via `--max-documents` / `[knowledge].max_documents` | must |
+| FR-028 | THE SYSTEM SHALL collect per-document failures and continue; a single failed transcript MUST NOT abort the batch | must |
+| FR-029 | `zeph knowledge status` SHALL list import batches (`import_batch_id`, source, timestamp, entity/edge counts) and ledger summary | should |
+
+### Cross-cutting
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-040 | THE SYSTEM SHALL require explicit confirmation (`--yes` or interactive) before any write that targets the graph | must |
+| FR-041 | THE SYSTEM SHALL resolve the ingest provider via `ingest_provider → extract_provider → primary`; unknown names warn and fall back, never panic | must |
+| FR-042 | THE SYSTEM SHALL refuse sources outside the current project root (path allowlist), failing with a clear error | must |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Reliability | Ingest failure (parse, LLM, DB) MUST be logged and reported in `IngestReport`; it MUST NEVER crash the process or leave a half-written batch unrollbackable |
+| NFR-002 | Cost | A full backfill MUST be cost-bounded: ledger skip + bounded concurrency + `max_documents` + `--dry-run` token estimate before any write |
+| NFR-003 | Security | Imported content MUST pass the sanitizer validator before graph write; sources MUST be confined to the current project (FR-042) |
+| NFR-004 | Idempotency | Re-running ingest on unchanged inputs MUST NOT re-issue LLM calls (ledger) and MUST NOT create duplicate rows (existing entity/edge dedup as defense in depth) |
+| NFR-005 | Observability | Tracing spans `memory.ingest.*` for adapter parse, ledger check, extraction, write; per-source counts logged |
+| NFR-006 | Latency | Ingest is an operator command; it MUST NOT run during a live turn and MUST NOT add latency to the agent loop |
+| NFR-007 | Portability | Migration MUST be sqlite + postgres parity (enforced by `migration_parity.rs`) |
+
+---
+
+## 5. Key Invariants
+
+### Always (without asking)
+- **INV-1 — Two sinks, never crossed.** Static artifacts go to **semantic notes**; only the episode
+  layer (subagent transcripts) goes to the **graph**. Code never goes to either (it is `zeph-index`'s).
+- **INV-2 — Provenance is a prerequisite, not a feature.** No ingest may write to the graph until
+  `origin` / `import_batch_id` / `source_uri` columns exist and recall can isolate imported rows.
+  Every imported edge/entity carries a non-null `import_batch_id`.
+- **INV-3 — Gates stay on.** Ingest bypasses **only** RPE (a per-turn conversational heuristic).
+  The write-quality gate (004-9) and admission control (004-3) MUST run for every candidate edge.
+- **INV-4 — Sanitizer on the write path.** Every ingest document passes the `zeph-sanitizer`
+  validator before any entity/fact string is persisted.
+- **INV-5 — The ledger is a re-read/cost guard, NOT a drift guard.** Content-hash idempotency only
+  prevents re-reading unchanged input. It does NOT reconcile LLM extraction drift (same input → different
+  relation verbs across model versions). Drift is mitigated by `canonical_relation` and by
+  `import_batch_id` supersession on re-ingest — and this limitation is documented to operators.
+- **INV-6 — Current project only.** Sources are confined to the current project root by an explicit
+  allowlist. No traversal into other projects' artifacts or transcripts.
+- **INV-7 — Operator-explicit.** Ingest runs only when invoked; graph writes require confirmation.
+- **INV-8 — Provider resolved, never hardcoded.** `ingest_provider → extract_provider → primary`.
+
+### Ask First
+- Enabling the graph sink (Phase 2) for any source other than subagent transcripts.
+- Relaxing the technical-document prompt's entity allow-list (risk of hub-node pollution).
+- Changing `recall_include_imported` default to exclude (changes recall behavior project-wide).
+
+### Never
+- **NEVER** ingest raw source code into the graph (use `zeph-index`).
+- **NEVER** bypass the write-quality gate (004-9) or admission control (004-3) for ingest.
+- **NEVER** write imported edges/entities without `import_batch_id` (would be unrollbackable — the C1 blocker).
+- **NEVER** persist an ingest fact that has not passed the sanitizer validator.
+- **NEVER** ingest external-agent (Claude Code / Codex) transcripts in MVP — deferred to Phase 3 (§9).
+- **NEVER** traverse outside the current project root.
+- **NEVER** present the content-hash ledger as protection against extraction drift.
+- **NEVER** hardcode the ingest model.
+- **NEVER** run ingest synchronously inside a live agent turn.
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Empty / no artifacts found for a `--source` | Report 0 documents, exit 0, no rows written |
+| Malformed transcript JSONL line | Skip the line (warn), continue the file; report skipped count |
+| LLM extraction failure on one document | Log WARN, mark document failed in `IngestReport`, do NOT mark ledger, continue batch |
+| Re-run after model upgrade (drift) | Unchanged inputs skipped (ledger); operator may `rollback <batch>` then re-ingest to supersede (INV-5) |
+| Partial batch interrupted (Ctrl-C) | Already-extracted documents are in the ledger + tagged with `batch_id`; re-run resumes the rest; `rollback` removes the partial batch cleanly |
+| Source path outside project root | Fail fast with `MemoryError::Ingest` "source outside project root" (FR-042 / INV-6) |
+| `--dry-run` | Extraction-preview / chunk-preview only; **zero** writes to Qdrant, graph, or ledger |
+| Sanitizer rejects a fact | Drop that edge, log at debug, continue; report dropped count |
+| Hub-node explosion detected in dry-run | Surface in report; operator decides; Phase 2 gate (§7) may block the real run |
+
+---
+
+## 7. Phase 2 Gate — Measurement Spike & Kill-Criterion
+
+Phase 2 (graph sink) ships **only if** the spike below passes. This directly answers the critic's
+S1 (graph-vs-notes) and S2 (taxonomy/hub-node pollution).
+
+**Spike (run via `--dry-run` over 10 specs + all current-project subagent transcripts):**
+1. **Multi-hop benefit.** Author 3 concrete recall queries that (a) the team actually asks,
+   (b) require ≥2-hop traversal, (c) demonstrably fail with semantic-note recall alone. Measure
+   recall@5 of the graph path vs. the notes baseline on a held-out set of ≥10 cross-session questions.
+2. **Hub-degree health.** No single entity may account for > 15% of projected edges; the top-10
+   entities by degree must not dominate the graph (community structure must survive).
+3. **Signal-to-noise.** ≥ 50% of projected edges must be non-trivial (not bare `tool`↔`project`
+   "mentioned-in" links).
+
+**Kill-criterion (any of):**
+- The 3 multi-hop queries do not beat the notes baseline on recall@5 → **abandon the graph sink**;
+  route subagent episodes to the notes pipeline instead and ship Phase 1 only.
+- Hub-degree or S/N thresholds fail → **abandon** until the technical-document prompt / taxonomy is fixed.
+
+The spike result and decision are recorded in the live-testing playbook before the Phase 2 PR is opened.
+
+---
+
+## 8. Integration Points (CLAUDE.md Development Rules 1–7)
+
+### `zeph-config`
+- New `[knowledge]` section: `ingest_provider`, `concurrency` (default 3), `max_documents` (default 0 = unlimited),
+  `recall_include_imported` (default `true`), `transcript_scope = "current-project"`.
+- `#[serde(default)]` on all fields; `--migrate-config` step adds the section to existing configs.
+
+### CLI (`src/cli.rs`, `src/runner.rs`)
+- `Command::Knowledge { Ingest { sources, dry_run, max_documents, provider, yes }, Rollback { batch_id }, Status }`.
+- Dispatch to `src/commands/knowledge.rs` (mirrors `ingest.rs`).
+
+### TUI (`zeph-tui`)
+- Palette: `/knowledge ingest <source>`, `/knowledge status`, `/knowledge rollback <batch>`.
+- Mandatory status spinner during ingest (`Ingesting knowledge: <uri>…`) per TUI rules.
+
+### `--init` wizard
+- `step_knowledge()` offering: enable graph episode sink (default off), choose `ingest_provider`.
+  Emit `[knowledge]` only when the user opts into non-default values.
+
+### `--migrate-config`
+- Migration step adds `[knowledge]` with defaults; idempotent (`--in-place`).
+
+### Database (`zeph-db`)
+- One migration (sqlite + postgres) — see §3 Phase 0 + the ledger table below — parity-guarded.
+
+### Live-testing playbook + coverage-status (MANDATORY before PR)
+- Create `.local/testing/playbooks/knowledge-ingest.md` (scenarios in §10).
+- Add `coverage-status.md` rows (status `Untested`) for: notes sink, graph sink, rollback, ledger,
+  dry-run, sanitizer-on-write, provider resolution.
+
+**INV-1 dependency watch:** adapters' `parse` / `into_documents` stay **pure** inside `zeph-memory`
+(no `zeph-subagent` / `zeph-core` deps). The JSONL *reading* of transcripts and disk-walking happen in
+the binary command (which already depends on those crates). This keeps `zeph-memory`'s dependency
+direction clean (the project tracks INV-1 violations).
+
+### Database schema
+
+```sql
+-- Provenance (Phase 0 prerequisite)
+ALTER TABLE graph_edges    ADD COLUMN origin         TEXT NOT NULL DEFAULT 'conversation';
+ALTER TABLE graph_edges    ADD COLUMN import_batch_id TEXT;       -- NULL for conversation edges
+ALTER TABLE graph_edges    ADD COLUMN source_uri     TEXT;        -- e.g. "subagent:<task_id>"
+ALTER TABLE graph_entities ADD COLUMN origin         TEXT NOT NULL DEFAULT 'conversation';
+ALTER TABLE graph_entities ADD COLUMN import_batch_id TEXT;
+
+-- Idempotency ledger (re-read/cost guard only — INV-5)
+CREATE TABLE IF NOT EXISTS knowledge_ingest_ledger (
+    source_uri      TEXT    NOT NULL,
+    content_hash    TEXT    NOT NULL,          -- blake3 hex
+    import_batch_id TEXT    NOT NULL,
+    ingested_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+    entities        INTEGER NOT NULL DEFAULT 0,
+    edges           INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (source_uri, content_hash)
+);
+```
+Migration number: next available in `crates/zeph-db/migrations/`. blake3 reuses the workspace dep.
+
+---
+
+## 9. Phases & Deferred Items
+
+| Phase | Scope | Gate |
+|---|---|---|
+| **0** | Provenance columns + recall isolation flag + `rollback` | Hard prerequisite for any graph write |
+| **1** | Static artifacts → semantic notes (existing pipeline) + `--dry-run` + ledger + CLI/TUI/config/migration | Ships first; lowest risk; no graph |
+| **2** | Subagent transcripts → graph (gates on, sanitizer, technical-document prompt, provenance, dry-run) | **Gated by §7 measurement spike + kill-criterion** |
+| **3 (deferred)** | External Claude Code / Codex transcript import | Requires Phase 0 + write-path PII redaction + version-pinned strict allowlist parser + current-project allowlist |
+
+**Deferred markers (place verbatim at the named code sites):**
+
+- `// TODO(critic D1): external-agent transcript ingest (Claude Code / Codex) deferred — requires graph provenance (Phase 0), write-path PII redaction (S4), and a version-pinned allowlist parser keyed on type==user/assistant only; current-project scope mandatory. Do not implement until all land.`
+  → at the `IngestSourceKind::ExternalAgent` arm.
+- `// TODO(critic D2): graph-backed ingest is gated on the §7 spike; if multi-hop benefit is unproven, route episodes to the notes pipeline and drop the graph sink.`
+  → at `SemanticMemory::ingest_documents`.
+- `// TODO: automatic/scheduled ingest (hook or scheduler tap) is out of MVP scope; this is an explicit operator command.`
+  → at `src/commands/knowledge.rs`.
+
+---
+
+## 10. Success Criteria
+
+```
+GIVEN a fresh database and --source specs --dry-run
+WHEN the command runs
+THEN it reports files + projected chunks + estimated tokens
+AND writes nothing to Qdrant, the graph, or the ledger
+
+GIVEN --source specs (no dry-run, confirmed)
+WHEN ingest completes
+THEN current-project spec artifacts are present as semantic notes recallable by vector search
+AND re-running the same command re-embeds nothing (ledger skip)
+
+GIVEN Phase 0 has landed
+WHEN --source subagents ingests transcripts
+THEN every created edge/entity has origin='subagent' and a non-null import_batch_id
+AND every candidate passed the write-quality gate, admission control, and the sanitizer
+
+GIVEN a completed graph import with batch B
+WHEN `zeph knowledge rollback B` runs
+THEN all edges/entities tagged B are deleted
+AND conversation-origin knowledge is untouched
+
+GIVEN ingest provider = "fast" (valid named provider)
+WHEN ingest runs
+THEN extraction uses the "fast" provider; an unknown name warns and falls back without panic
+
+GIVEN a source path outside the current project root
+WHEN ingest is invoked
+THEN it fails fast with a clear "outside project root" error and writes nothing
+
+GIVEN the §7 spike fails the multi-hop / hub-degree / S-N thresholds
+WHEN the team reviews results
+THEN the graph sink is abandoned and subagent episodes are routed to the notes pipeline instead
+```
+
+Checklist:
+- [ ] Phase 0 migration (sqlite + postgres parity) lands and backfills `origin='conversation'`
+- [ ] `rollback` removes a batch cleanly, leaving conversation knowledge intact
+- [ ] Phase 1 notes sink reuses `IngestionPipeline` (no parallel loader)
+- [ ] `--dry-run` writes nothing for both sinks
+- [ ] Ledger skips unchanged inputs (no LLM/embed call)
+- [ ] Sanitizer runs on every graph-ingest document
+- [ ] Write-quality gate + admission control run for every candidate edge (no RPE-bypass shortcut into raw writes)
+- [ ] §7 spike executed and decision recorded in the playbook before the Phase 2 PR
+- [ ] CLI + TUI + `[knowledge]` config + `--init` + `--migrate-config` integration points complete
+- [ ] Playbook + coverage-status rows added
+
+---
+
+## 11. See Also
+
+- [[004-memory/spec]] — memory subsystem, graph extraction, recall pipeline
+- [[004-memory/004-9-memory-write-gate]] — write-quality gate that ingest MUST honor
+- [[004-memory/004-6-graph-memory]] — MAGMA edges, SYNAPSE, A-MEM weights
+- [[012-graph-memory/spec]] — entity graph, BFS recall, community detection
+- [[018-index/spec]] — code RAG boundary (code never enters the graph)
+- [[041-sanitizer/spec]] — PII / exfiltration validators for the write path
+- [[056-autoskill-trace-extraction/spec]] — precedent: background extraction from session history + idempotency table
+- [[001-system-invariants/spec]] — system contracts (INV-1 dependency direction, write-pollution)
+- [[constitution]] — project-wide non-negotiable rules
+```

--- a/specs/067-knowledge-ingest/srs.md
+++ b/specs/067-knowledge-ingest/srs.md
@@ -1,0 +1,232 @@
+---
+aliases:
+  - Knowledge Ingest SRS
+tags:
+  - srs
+  - memory
+  - requirements
+created: 2026-06-07
+status: draft
+spec_id: "067"
+standard: "ISO/IEC/IEEE 29148:2018"
+---
+
+# SRS: Knowledge Ingest (`zeph knowledge ingest`)
+
+Standard: ISO/IEC/IEEE 29148:2018. EARS notation is used for all functional requirements.
+"shall" = mandatory; "should" = recommended; "may" = optional.
+
+---
+
+## 1. Phase 0 — Provenance and Rollback Prerequisite
+
+This phase is a hard prerequisite for any graph write. It must land before Phase 2 begins.
+
+**FR-001** (→ BR-4, INV-2)
+THE SYSTEM SHALL add `origin TEXT NOT NULL DEFAULT 'conversation'` to both `graph_edges` and
+`graph_entities` tables; all existing rows SHALL be backfilled to the value `'conversation'`
+in the same migration.
+
+**FR-002** (→ BR-4, INV-2)
+THE SYSTEM SHALL add `import_batch_id TEXT NULL` and `source_uri TEXT NULL` to `graph_edges`;
+THE SYSTEM SHALL add `import_batch_id TEXT NULL` to `graph_entities`. These columns SHALL be
+NULL for conversation-origin rows and non-NULL for all imported rows.
+
+**FR-003** (→ BR-4, INV-2)
+WHEN recall scores edges, THE SYSTEM SHALL support excluding or down-weighting rows where
+`origin != 'conversation'`, controlled by the config flag `[knowledge].recall_include_imported`
+(default `true`).
+
+**FR-004** (→ BR-4)
+THE SYSTEM SHALL provide a `zeph knowledge rollback <import_batch_id>` command that deletes
+all `graph_edges` and `graph_entities` rows carrying that `import_batch_id` and any orphaned
+imported entities, without modifying rows where `origin = 'conversation'`.
+
+---
+
+## 2. Phase 1 — Static Artifacts to Semantic Notes
+
+**FR-010** (→ BR-1, INV-1)
+WHEN `--source specs`, `--source changelog`, `--source handoff`, `--source coverage`, or
+`--source git-log` is specified, THE SYSTEM SHALL load the corresponding artifacts of the
+current project only and ingest them as semantic notes via the existing `IngestionPipeline`.
+No graph writes SHALL occur in Phase 1.
+
+**FR-011** (→ INV-1, spec §2.1)
+THE SYSTEM SHALL reuse the existing `TextLoader`, `TextSplitter`, and `IngestionPipeline`
+for Phase 1; it SHALL NOT create a parallel or duplicate document loader.
+
+**FR-012** (→ BR-2, INV-5)
+THE SYSTEM SHALL skip documents whose `(source_uri, content_hash)` is already present in the
+ingest ledger; no re-embedding or LLM call SHALL be issued for unchanged inputs.
+
+**FR-013** (→ BR-3)
+WHEN `--dry-run` is specified, THE SYSTEM SHALL report: files discovered, chunks that would
+be produced, and estimated embedding token cost. THE SYSTEM SHALL write nothing to Qdrant,
+the graph, or the ledger during a dry run.
+
+**FR-014** (→ spec §8 TUI rules)
+THE SYSTEM SHALL stream `IngestProgress` events to a TUI or CLI status indicator displaying
+`Ingesting knowledge: <uri>...` during any write operation.
+
+---
+
+## 3. Phase 2 — Subagent Transcripts to Knowledge Graph (Gated)
+
+> [!warning] Gate
+> Phase 2 requirements are conditional. They are activated only if the §7 measurement spike
+> (FR-050 through FR-053) passes all kill-criterion thresholds. If the spike fails, subagent
+> episode sources are rerouted to the notes pipeline (Phase 1) and these requirements are abandoned.
+
+**FR-020** (→ BR-5, INV-1)
+WHEN `--source subagents` is specified, THE SYSTEM SHALL read Zeph subagent transcript files
+for the current project from the configured `transcript_dir`, normalize each entry to an
+`IngestDocument`, and invoke `SemanticMemory::ingest_documents()`.
+
+**FR-021** (→ INV-3)
+WHEN extracting graph knowledge during ingest, THE SYSTEM SHALL route every candidate edge
+through the write-quality gate (spec 004-9) and admission control (spec 004-3). THE SYSTEM
+SHALL NOT bypass either gate. Only the RPE per-turn heuristic is bypassed (it is a
+conversational gate with no meaning for batch documents).
+
+**FR-022** (→ INV-4, NFR-003)
+THE SYSTEM SHALL run the `zeph-sanitizer` PII and exfiltration validator as the
+`PostExtractValidator` callback for every ingest document before any entity or fact string
+is persisted.
+
+**FR-023** (→ spec §2.5)
+THE SYSTEM SHALL select the technical-document extraction system prompt (the second `const`
+in `extractor.rs`) for non-conversational sources (`IngestSourceKind != SubagentTranscript`
+conversational turns). This prompt retains entity types `project`, `tool`, `concept`, `file`
+but drops conversational-filler rejection rules.
+
+**FR-024** (→ INV-2)
+THE SYSTEM SHALL stamp every imported `graph_edges` row and `graph_entities` row with the
+values `origin`, `source_uri`, and `import_batch_id` from the `Provenance` struct of the
+originating `IngestDocument`.
+
+**FR-025** (→ BR-2, INV-5)
+THE SYSTEM SHALL skip any `IngestDocument` whose `(source_uri, content_hash)` is already
+recorded in the `knowledge_ingest_ledger` table; no LLM extraction call SHALL be issued
+for that document.
+
+**FR-026** (→ BR-3)
+WHEN `--dry-run` is specified for a graph-targeted source, THE SYSTEM SHALL report: document
+count, turn count, estimated extraction token cost, projected entity and edge counts, AND a
+projected hub-degree distribution showing the top-N entities by degree. THE SYSTEM SHALL write
+nothing to the graph, Qdrant, or the ledger.
+
+**FR-027** (→ NFR-002)
+THE SYSTEM SHALL bound extraction concurrency to `[knowledge].concurrency` (default 3) using
+`futures::buffer_unordered`; total work MAY be capped with `--max-documents` or
+`[knowledge].max_documents` (default 0 = unlimited).
+
+**FR-028** (→ NFR-001)
+THE SYSTEM SHALL collect per-document failures and continue processing the remainder of the
+batch; a single failed transcript MUST NOT abort the ingest run. All failures SHALL be
+reported in the `IngestReport` at completion.
+
+**FR-029** (→ BR-4)
+`zeph knowledge status` SHOULD list import batches (`import_batch_id`, source kind, timestamp,
+entity count, edge count) and a ledger summary.
+
+---
+
+## 4. Cross-Cutting Requirements
+
+**FR-040** (→ INV-7)
+THE SYSTEM SHALL require explicit confirmation — either the `--yes` flag or an interactive
+`y/N` prompt — before any write that targets the knowledge graph.
+
+**FR-041** (→ INV-8)
+THE SYSTEM SHALL resolve the ingest LLM provider via the chain:
+`[knowledge].ingest_provider` (if non-empty) → `[memory.graph].extract_provider` → primary.
+An unknown provider name SHALL emit a WARN and fall back to the primary; THE SYSTEM SHALL
+NOT panic or abort on an unresolvable name.
+
+**FR-042** (→ INV-6, NFR-003)
+THE SYSTEM SHALL reject any source path that does not reside under the current project root,
+failing fast with a `MemoryError::Ingest` "source outside project root" error and writing
+nothing.
+
+---
+
+## 5. Phase 2 Gate — Measurement Spike
+
+**FR-050** (→ BR-5, spec §7)
+THE SYSTEM SHALL provide a spike evaluation procedure (`--dry-run` over a representative
+corpus) that measures recall@5 of the graph path against the semantic-notes baseline on a
+held-out set of at least 10 cross-session questions.
+
+**FR-051** (→ BR-5, spec §7)
+THE SYSTEM SHALL evaluate hub-degree health: no single entity may account for more than 15%
+of projected edges in the dry-run report.
+
+**FR-052** (→ BR-5, spec §7)
+THE SYSTEM SHALL evaluate signal-to-noise: at least 50% of projected edges must be non-trivial
+(not bare `tool`↔`project` "mentioned-in" links).
+
+**FR-053** (→ BR-5, spec §7)
+WHEN any of the following kill-criteria are met, Phase 2 SHALL be abandoned and subagent
+episode sources SHALL be rerouted to the existing notes pipeline:
+- The 3 designated multi-hop queries do not beat the notes baseline on recall@5;
+- The hub-degree threshold (> 15%) is violated;
+- The signal-to-noise threshold (< 50%) is violated.
+
+---
+
+## 6. Configuration Requirements
+
+**FR-060**
+THE SYSTEM SHALL add a `[knowledge]` section to `zeph-config` with `#[serde(default)]` on
+all fields. Required fields: `ingest_provider: ProviderName` (default empty string, meaning
+fall through to `extract_provider`), `concurrency: usize` (default 3), `max_documents: usize`
+(default 0 = unlimited), `recall_include_imported: bool` (default `true`),
+`transcript_scope: String` (default `"current-project"`).
+
+**FR-061**
+WHEN `zeph --init` runs, THE SYSTEM SHALL present a `step_knowledge()` wizard step offering
+the operator the ability to enable the graph episode sink (default off) and choose
+`ingest_provider`. THE SYSTEM SHALL emit the `[knowledge]` section only when the user
+opts into non-default values.
+
+**FR-062**
+WHEN `zeph --migrate-config` runs and the `[knowledge]` section is absent from the existing
+config, THE SYSTEM SHALL inject the section with all default values. The migration SHALL be
+idempotent.
+
+---
+
+## 7. CLI Integration Requirements
+
+**FR-070**
+THE SYSTEM SHALL add a `Command::Knowledge` variant to `src/cli.rs` with three subcommands:
+`Ingest { sources, dry_run, max_documents, provider, yes }`,
+`Rollback { batch_id }`, and `Status`. Dispatch SHALL occur in `src/runner.rs` to
+`src/commands/knowledge.rs`, mirroring the structure of the existing `src/commands/ingest.rs`.
+
+**FR-071**
+THE SYSTEM SHALL add command palette entries to `zeph-tui`: `/knowledge ingest <source>`,
+`/knowledge status`, `/knowledge rollback <batch>`. A visible spinner with the message
+`Ingesting knowledge: <uri>...` SHALL be displayed during any ingest write operation.
+
+---
+
+## 8. Database Migration Requirements
+
+**FR-080** (→ FR-001, FR-002, NFR-007)
+THE SYSTEM SHALL provide a single migration file in both `crates/zeph-db/migrations/sqlite/`
+and `crates/zeph-db/migrations/postgres/` that adds the provenance columns
+(`origin`, `import_batch_id`, `source_uri`) to `graph_edges` and `graph_entities`, creates
+the `knowledge_ingest_ledger` table, and backfills `origin = 'conversation'`. The migration
+SHALL be validated by `migration_parity.rs`.
+
+---
+
+## 9. Open Questions
+
+| ID | Question | Owner | Decision needed by |
+|---|---|---|---|
+| OQ-1 | Should `recall_include_imported` default to `false` after the §7 spike to avoid importing noise into recall before the graph quality is proven? | team-lead | Before Phase 2 PR |
+| OQ-2 | Should `zeph knowledge status` include per-batch recall@5 metrics collected during the §7 spike? | architect | Before G0 #5022 |
+| OQ-3 | `max_documents = 0` means unlimited — should there be a hard safety cap (e.g., 10 000) to prevent runaway cost on large corpora? | team-lead | Before N1 #5018 |

--- a/specs/067-knowledge-ingest/tasks.md
+++ b/specs/067-knowledge-ingest/tasks.md
@@ -1,0 +1,450 @@
+---
+aliases:
+  - Knowledge Ingest Tasks
+tags:
+  - tasks
+  - memory
+  - cross-cutting
+created: 2026-06-07
+status: draft
+spec_id: "067"
+related:
+  - "[[067-knowledge-ingest/spec]]"
+  - "[[067-knowledge-ingest/plan]]"
+---
+
+# Developer Tasks: Knowledge Ingest (067)
+
+Each task maps to one GitHub issue and is implementable as a single PR review cycle.
+Tasks within each wave are ordered by dependency. A developer should be able to implement one
+task per session using `spec.md` and `plan.md` as the implementation contract.
+
+Traceability: each task references the FR/NFR/INV/issue it satisfies.
+
+---
+
+## Progress
+
+- [ ] TASK-F1: Phase 0 provenance migration + recall isolation flag (#5015)
+- [ ] TASK-F2: Ingest ledger table + `IngestLedger` repository (#5016)
+- [ ] TASK-F3: `zeph knowledge` CLI scaffold + config + `--init` / `--migrate-config` (#5017)
+- [ ] TASK-N1: Static artifacts → semantic notes (existing pipeline) (#5018)
+- [ ] TASK-N2: `knowledge rollback` + `knowledge status` (#5019)
+- [ ] TASK-N3: TUI palette + status spinner (#5020)
+- [ ] TASK-G1: Graph batch API + types + technical-document prompt + subagent adapter + dry-run projection (#5021)
+- [ ] TASK-G0: Measurement spike GATE — GO / NO-GO decision (#5022)
+- [ ] TASK-G2: Graph go-live `--source subagents` + sanitizer on write path (#5023)
+- [ ] TASK-D1: DEFERRED — external Claude Code / Codex import (#5024)
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    F1[TASK-F1 #5015 provenance migration]
+    F2[TASK-F2 #5016 ledger]
+    F3[TASK-F3 #5017 CLI scaffold]
+    N1[TASK-N1 #5018 notes sink]
+    N2[TASK-N2 #5019 rollback + status]
+    N3[TASK-N3 #5020 TUI]
+    G1[TASK-G1 #5021 graph batch API]
+    G0[TASK-G0 #5022 GATE spike]
+    G2[TASK-G2 #5023 graph go-live]
+    D1[TASK-D1 #5024 deferred]
+
+    F3 --> N1
+    F3 --> N3
+    F2 --> N1
+    F1 --> N2
+    F3 --> N2
+    F1 --> G1
+    F2 --> G1
+    G1 --> G0
+    G0 -->|GO only| G2
+    D1
+```
+
+---
+
+## Wave 1 — Foundation (parallel: F1, F2, F3)
+
+### TASK-F1 — Phase 0 Provenance Migration + Recall Isolation Flag
+
+**GitHub issue:** #5015
+**Context:** No graph write may occur without these columns. Every imported edge must carry
+`origin`, `import_batch_id`, and `source_uri` so that `rollback` can delete by batch and recall
+can optionally down-weight imports. This is the C1 critic blocker baked in as a prerequisite.
+**Spec reference:** [[067-knowledge-ingest/spec#FR-001]], [[067-knowledge-ingest/spec#FR-002]],
+[[067-knowledge-ingest/spec#FR-003]], [[067-knowledge-ingest/spec#INV-2]], NFR-005, NFR-007
+**Acceptance criteria:**
+- [ ] Migration file exists in both `sqlite/` and `postgres/` directories and passes `migration_parity.rs`
+- [ ] `graph_edges` gains `origin TEXT NOT NULL DEFAULT 'conversation'`, `import_batch_id TEXT`, `source_uri TEXT`
+- [ ] `graph_entities` gains `origin TEXT NOT NULL DEFAULT 'conversation'`, `import_batch_id TEXT`
+- [ ] All pre-migration rows have `origin = 'conversation'` after backfill
+- [ ] `[knowledge].recall_include_imported: bool` field exists in `zeph-config` with `#[serde(default = "true")]`
+- [ ] Existing graph integration tests pass against the migrated schema (zero regressions)
+- [ ] `cargo nextest run -p zeph-db -p zeph-memory` passes
+**Dependencies:** none
+**Files:**
+- `crates/zeph-db/migrations/sqlite/<NNN>_knowledge_provenance.sql` (new)
+- `crates/zeph-db/migrations/postgres/<NNN>_knowledge_provenance.sql` (new)
+- `crates/zeph-config/src/knowledge.rs` (`recall_include_imported` field)
+**Complexity:** medium
+
+---
+
+### TASK-F2 — Ingest Ledger Table + `IngestLedger` Repository
+
+**GitHub issue:** #5016
+**Context:** The content-hash ledger prevents re-reading unchanged inputs and avoids redundant
+LLM/embed calls on re-runs. It is a re-read/cost guard only — NOT a drift guard (INV-5 and the
+C3 critic blocker). The ledger lives in the same graph DB pool; write volume is low (one row per
+document, not per token), so the dedicated-DB-file pattern is not warranted.
+**Spec reference:** [[067-knowledge-ingest/spec#FR-012]], [[067-knowledge-ingest/spec#FR-025]],
+[[067-knowledge-ingest/spec#INV-5]], NFR-2.4, NFR-4.3, NFR-8.3
+**Acceptance criteria:**
+- [ ] `knowledge_ingest_ledger` table created with `PRIMARY KEY (source_uri, content_hash)` in both SQLite and Postgres migrations (part of TASK-F1 migration or a separate consecutive one)
+- [ ] `IngestLedger` struct in `crates/zeph-memory/src/graph/ingest/ledger.rs` with `is_ingested(uri, hash)` and `mark_ingested(uri, hash, batch_id, entities, edges)` async methods
+- [ ] SQL comment and `///` doc comment on `IngestLedger` explicitly state it is a re-read/cost guard, not a drift guard (NFR-8.3)
+- [ ] `is_ingested` round-trip unit test passes; `mark_ingested` is idempotent (duplicate `mark` does not error)
+- [ ] Ledger query completes in < 5 ms on a 10 000-row table (`criterion` benchmark or timing assertion)
+- [ ] `cargo nextest run -p zeph-memory` passes
+**Dependencies:** TASK-F1 (migration number must follow)
+**Files:**
+- `crates/zeph-memory/src/graph/ingest/ledger.rs` (new)
+- `crates/zeph-memory/src/graph/ingest/mod.rs` (new, re-exports `IngestLedger`)
+- `crates/zeph-memory/src/error.rs` (add `MemoryError::Ingest` variant)
+**Complexity:** medium
+
+---
+
+### TASK-F3 — `zeph knowledge` CLI Scaffold + Config + `--init` / `--migrate-config`
+
+**GitHub issue:** #5017
+**Context:** The CLI scaffold and config section must land in Wave 1 alongside F1/F2 so that
+N1 and N2 have a stable dispatch path to build against. The config section is intentionally
+minimal: non-default values only when the user opts in via `--init`.
+**Spec reference:** [[067-knowledge-ingest/spec#FR-040]], [[067-knowledge-ingest/spec#FR-041]],
+[[067-knowledge-ingest/spec#FR-060]], [[067-knowledge-ingest/spec#FR-061]],
+[[067-knowledge-ingest/spec#FR-062]], [[067-knowledge-ingest/spec#FR-070]], NFR-7.1
+**Acceptance criteria:**
+- [ ] `Command::Knowledge { Ingest { sources, dry_run, max_documents, provider, yes }, Rollback { batch_id }, Status }` added to `src/cli.rs`
+- [ ] Dispatch in `src/runner.rs` routes to `src/commands/knowledge.rs` (stub initially returning `Ok(())`)
+- [ ] `[knowledge]` config section in `zeph-config/src/knowledge.rs` with all fields `#[serde(default)]`; fields: `ingest_provider`, `concurrency` (3), `max_documents` (0), `recall_include_imported` (true), `transcript_scope` ("current-project")
+- [ ] Provider resolution chain implemented: `ingest_provider → extract_provider → primary`; unknown name emits WARN and falls back (FR-041)
+- [ ] `--migrate-config` step injects `[knowledge]` with defaults when absent; idempotent on second run (FR-062)
+- [ ] `--init` wizard presents `step_knowledge()` offering episode sink toggle and provider choice; emits `[knowledge]` section only on non-default choice (FR-061)
+- [ ] Config file without `[knowledge]` loads without error (NFR-7.1 unit test)
+- [ ] `zeph knowledge ingest --help` output contains `--dry-run` and `--yes` (NFR-6.2)
+- [ ] `cargo nextest run -p zeph-config` passes; `cargo run -- knowledge ingest --help` works
+**Dependencies:** none (can land in parallel with F1/F2)
+**Files:**
+- `src/cli.rs` (modify)
+- `src/runner.rs` (modify)
+- `src/commands/knowledge.rs` (new, stub)
+- `crates/zeph-config/src/knowledge.rs` (new)
+- `crates/zeph-config/src/lib.rs` (add `pub mod knowledge`)
+- `src/init.rs` (add `step_knowledge`)
+- `--migrate-config` module (add migration step)
+**Complexity:** large
+
+---
+
+## Wave 2 — Phase 1 Value (N1 first, then N2 + N3 in parallel)
+
+### TASK-N1 — Static Artifacts to Semantic Notes (Existing Pipeline)
+
+**GitHub issue:** #5018
+**Context:** This is the highest-value, lowest-risk slice. Static project artifacts (specs,
+changelog, handoffs, coverage, git-log) are read from disk, chunked with the existing
+`TextLoader`/`TextSplitter`, and fed to the existing `IngestionPipeline` — the same path that
+`src/commands/ingest.rs` uses. No graph writes. No new loader. Reuse everything.
+**Spec reference:** [[067-knowledge-ingest/spec#FR-010]], [[067-knowledge-ingest/spec#FR-011]],
+[[067-knowledge-ingest/spec#FR-012]], [[067-knowledge-ingest/spec#FR-013]],
+[[067-knowledge-ingest/spec#FR-014]], [[067-knowledge-ingest/spec#INV-1]], NFR-2.4, NFR-4.2, NFR-6.3
+**Acceptance criteria:**
+- [ ] `src/commands/knowledge.rs` implements disk-walking for each `--source` kind relative to the current project root
+- [ ] Source paths outside the project root are rejected fast with a clear error and zero reads (FR-042, NFR-3.2)
+- [ ] `--dry-run` reports: file count, projected chunk count, estimated embedding token cost; writes nothing to Qdrant, graph, or ledger (FR-013)
+- [ ] Unchanged inputs are skipped via ledger (FR-012); second run of same source produces zero embed calls (NFR-2.4)
+- [ ] Progress events `IngestProgress::{ Ingesting { uri }, Skipped { uri }, Done(report) }` are streamed to CLI status line (FR-014)
+- [ ] Confirmation gate (`--yes` or interactive `y/N`) is required before any Qdrant write (FR-040)
+- [ ] `TextLoader`/`TextSplitter`/`IngestionPipeline` types from `zeph-memory` are reused verbatim — no duplicate loader (NFR-4.2)
+- [ ] Integration test: `--source specs --dry-run` writes nothing; `--source specs --yes` ingests; re-run skips all (ledger hit = 100%)
+- [ ] `cargo nextest run -p zeph-memory` and `cargo nextest run --workspace --lib --bins` pass
+**Dependencies:** TASK-F2 (ledger), TASK-F3 (CLI dispatch)
+**Files:**
+- `src/commands/knowledge.rs` (implement notes sink, replace stub)
+- `crates/zeph-memory/src/graph/ingest/mod.rs` (re-export `IngestProgress`, `IngestReport`)
+**Complexity:** large
+
+---
+
+### TASK-N2 — `knowledge rollback` + `knowledge status`
+
+**GitHub issue:** #5019
+**Context:** Rollback gives the operator a safe undo for any graph import batch. It must target
+only imported rows (`import_batch_id` column from Phase 0) and must not touch
+conversation-origin knowledge. Status provides observability over the ledger.
+**Spec reference:** [[067-knowledge-ingest/spec#FR-004]], [[067-knowledge-ingest/spec#FR-029]],
+NFR-2.2
+**Acceptance criteria:**
+- [ ] `zeph knowledge rollback <batch_id>` deletes all `graph_edges` + `graph_entities` rows where `import_batch_id = ?`; orphaned imported entities are also removed
+- [ ] Conversation-origin rows (`origin = 'conversation'`) are untouched after rollback
+- [ ] Rollback reports deleted edge count and entity count to stdout
+- [ ] `zeph knowledge status` lists all import batches from the ledger: `import_batch_id`, source kind, `ingested_at`, entity count, edge count
+- [ ] Integration test: ingest a batch; rollback; assert graph row counts match pre-ingest baseline; conversation rows unchanged
+- [ ] `cargo nextest run --workspace --lib --bins` passes
+**Dependencies:** TASK-F1 (provenance columns), TASK-F3 (CLI dispatch)
+**Files:**
+- `src/commands/knowledge.rs` (add rollback + status handlers)
+- `crates/zeph-memory/src/graph/ingest/ledger.rs` (add `list_batches`, `delete_batch` methods)
+**Complexity:** medium
+
+---
+
+### TASK-N3 — TUI Palette + Status Spinner
+
+**GitHub issue:** #5020
+**Context:** Per CLAUDE.md TUI rules: any background or implicit operation must have a visible
+spinner. Ingest is a foreground operator command but can be long-running; the TUI must show
+progress at all times during a write operation.
+**Spec reference:** [[067-knowledge-ingest/spec#FR-014]], [[067-knowledge-ingest/spec#FR-071]],
+NFR-6.3
+**Acceptance criteria:**
+- [ ] TUI command palette accepts `/knowledge ingest <source>`, `/knowledge status`, `/knowledge rollback <batch>`
+- [ ] During any ingest write, the system status area shows a spinner with `Ingesting knowledge: <uri>...`
+- [ ] On completion, the spinner is replaced with a summary line: `Ingest complete: N notes added, M skipped`
+- [ ] The spinner is absent when `--dry-run` is active (dry run is fast; a simple progress line is sufficient)
+- [ ] Manual test: TUI mode with `--source specs --yes` shows spinner throughout and summary at end
+**Dependencies:** TASK-N1 (progress events), TASK-F3 (CLI dispatch)
+**Files:**
+- `crates/zeph-tui/src/` (relevant command palette + status module)
+**Complexity:** medium
+
+---
+
+## Wave 3 — Graph Batch API (G1)
+
+### TASK-G1 — Graph Batch API + Types + Technical-Document Prompt + Subagent Adapter + Dry-Run Projection
+
+**GitHub issue:** #5021
+**Context:** This task builds the graph-layer plumbing needed for Phase 2 without activating
+the `--source subagents` write path (that is G2). It delivers: the key types, the sealed adapter
+trait, the batch extraction method on `SemanticMemory`, the technical-document extraction prompt,
+and the hub-degree dry-run projection. The write path is present but unreachable from the binary
+until G2 wires it. G0 uses the dry-run projection to make the GO/NO-GO decision.
+**Spec reference:** [[067-knowledge-ingest/spec#FR-020]], [[067-knowledge-ingest/spec#FR-023]],
+[[067-knowledge-ingest/spec#FR-025]], [[067-knowledge-ingest/spec#FR-026]],
+[[067-knowledge-ingest/spec#FR-027]], [[067-knowledge-ingest/spec#FR-028]],
+[[067-knowledge-ingest/spec#INV-3]], [[067-knowledge-ingest/spec#INV-4]], NFR-1.1, NFR-4.1, NFR-4.3, NFR-7.3
+**Acceptance criteria:**
+- [ ] `IngestSourceKind` enum marked `#[non_exhaustive]` with variants `StaticArtifact`, `SubagentTranscript`, `ExternalAgent` (NFR-7.3)
+- [ ] `IngestDocument` struct (private fields, valid-by-construction): `content`, `context`, `provenance: Provenance`, `content_hash: blake3::Hash`
+- [ ] `Provenance` struct: `kind: IngestSourceKind`, `source_uri: String`, `batch_id: ImportBatchId`
+- [ ] `ImportBatchId` newtype over UUID/ULID string
+- [ ] Sealed `IngestSourceAdapter` trait with `fn parse(raw: &str) -> Result<Vec<IngestDocument>, MemoryError>` (pure, no async, no I/O)
+- [ ] `SubagentJsonl` adapter impl: parses `TranscriptEntry` JSONL lines into `IngestDocument`s; malformed lines are skipped with a WARN, not an error (spec §6)
+- [ ] Second `const` technical-document extraction prompt in `extractor.rs` selectable by `IngestSourceKind` (FR-023)
+- [ ] `SemanticMemory::ingest_documents()` with signature per spec §2.3: ledger check → `buffer_unordered(concurrency)` → `extract_and_store()` reuse → `mark_ingested`; collect-errors fail strategy
+- [ ] Dry-run path: hub-degree projection report (top-N entities by degree, total edges projected) returned in `IngestReport` (FR-026)
+- [ ] `TODO(critic D1)` and `TODO(critic D2)` deferred markers placed at `ExternalAgent` arm and `ingest_documents` respectively (spec §9)
+- [ ] All public types have `///` doc comments; `ingest_documents` has `# Examples` with `no_run` (NFR-4.4)
+- [ ] `cargo nextest run -p zeph-memory` passes; `cargo check -p zeph-memory` must not pull `zeph-subagent` (NFR-4.1)
+**Dependencies:** TASK-F1 (provenance columns), TASK-F2 (ledger)
+**Files:**
+- `crates/zeph-memory/src/graph/ingest/mod.rs` (key types)
+- `crates/zeph-memory/src/graph/ingest/adapter.rs` (sealed trait + `SubagentJsonl`)
+- `crates/zeph-memory/src/graph/ingest/ledger.rs` (extend with batch methods)
+- `crates/zeph-memory/src/graph/extractor.rs` (add technical-document prompt)
+- `crates/zeph-memory/src/semantic/graph.rs` (add `ingest_documents`)
+- `crates/zeph-memory/src/error.rs` (confirm `MemoryError::Ingest`)
+**Complexity:** extra-large
+
+---
+
+## Wave 4 — Measurement Spike GATE (G0)
+
+### TASK-G0 — Measurement Spike + Kill-Criterion Decision
+
+**GitHub issue:** #5022
+**Context:** This is a research / operator task, not a code task. The developer runs `--dry-run`
+over the representative corpus, measures the three thresholds defined in spec §7, records the
+evidence, and makes the GO/NO-GO decision. If NO-GO, G2 is closed as abandoned and
+`--source subagents` is rerouted to the Phase 1 notes pipeline.
+**Spec reference:** [[067-knowledge-ingest/spec#§7]], FR-050..FR-053
+**Acceptance criteria:**
+- [ ] `--dry-run --source subagents` runs over the current-project transcript corpus (requires G1 dry-run projection)
+- [ ] 3 concrete multi-hop recall queries authored; recall@5 measured: graph path vs. notes baseline on ≥ 10 held-out cross-session questions (FR-050)
+- [ ] Hub-degree distribution checked: no entity accounts for > 15% of projected edges (FR-051)
+- [ ] Signal-to-noise checked: ≥ 50% of projected edges are non-trivial (FR-052)
+- [ ] Decision (GO / NO-GO) and supporting evidence recorded in `.local/testing/playbooks/knowledge-ingest.md`
+- [ ] If NO-GO: G2 #5023 closed with reason "§7 kill-criterion: <which threshold failed>"; `--source subagents` added to Phase 1 notes pipeline (new sub-task of N1)
+- [ ] If GO: G2 #5023 opened for implementation
+**Dependencies:** TASK-G1 (dry-run projection), TASK-N1 (notes baseline for comparison)
+**Files:**
+- `.local/testing/playbooks/knowledge-ingest.md` (spike results section)
+**Complexity:** medium
+
+---
+
+## Wave 5 — Graph Go-Live (G2, conditional on G0 GO)
+
+### TASK-G2 — Graph Go-Live `--source subagents` + Sanitizer on Write Path
+
+**GitHub issue:** #5023
+**Context:** Activates the full graph write path for subagent transcripts. Wires
+`--source subagents` in the binary command to `SemanticMemory::ingest_documents()`. Enforces
+the sanitizer, write-quality gate, and admission control on every candidate edge (C2 and S4
+critic blockers). Provenance stamping is tested end-to-end.
+**Spec reference:** [[067-knowledge-ingest/spec#FR-020..FR-028]], [[067-knowledge-ingest/spec#INV-3]],
+[[067-knowledge-ingest/spec#INV-4]], NFR-3.1, NFR-3.3, NFR-2.2
+**Acceptance criteria:**
+- [ ] `src/commands/knowledge.rs`: `--source subagents` reads `TranscriptEntry` JSONL from `transcript_dir`; JSONL reading and disk discovery happen here (binary level), not in `zeph-memory` (INV-4.1)
+- [ ] `PostExtractValidator` is wired to `zeph-sanitizer`'s PII/exfiltration validator (FR-022, INV-4)
+- [ ] Write-quality gate (004-9) and admission control (004-3) mocks are invoked once per candidate edge in tests (FR-021, INV-3)
+- [ ] Every created `graph_edges` row has `origin = 'subagent'` and a non-null `import_batch_id` (FR-024)
+- [ ] `rollback <batch>` after a successful import removes all tagged rows; conversation rows untouched (NFR-2.2)
+- [ ] Sanitizer rejection: document with synthetic PII pattern produces `IngestReport.dropped > 0` and zero entity writes (NFR-3.1, NFR-8.2)
+- [ ] Integration test covering the full write-rollback cycle (NFR-2.2)
+- [ ] `cargo nextest run --workspace --lib --bins` passes; pre-merge checks pass
+**Dependencies:** TASK-G0 (GO decision), TASK-N2 (rollback infra)
+**Files:**
+- `src/commands/knowledge.rs` (add `--source subagents` handler)
+- `crates/zeph-memory/src/semantic/graph.rs` (`ingest_documents` wired to sanitizer)
+**Complexity:** large
+
+---
+
+## Deferred
+
+### TASK-D1 — External Claude Code / Codex Transcript Import
+
+**GitHub issue:** #5024
+**Context:** Deferred due to undocumented/unstable external schemas (critic S3), cross-project
+privacy blast radius (critic S4), and the requirement for a version-pinned strict allowlist
+parser. A `TODO(critic D1)` marker in `IngestSourceKind::ExternalAgent` documents the conditions
+that must be met before this task is actionable.
+**Spec reference:** [[067-knowledge-ingest/spec#§9]], spec §5 (NEVER items)
+**Acceptance criteria (when undeferred):**
+- [ ] Phase 0 provenance in production
+- [ ] Write-path PII redaction closed (pre-1.0 limitation resolved)
+- [ ] Version-pinned strict allowlist parser for Claude Code / Codex schemas (accept only `type == "user"/"assistant"` + `message.role`; fail loud on unknown schema)
+- [ ] Current-project scope enforcement via path allowlist
+**Dependencies:** TASK-G2 (graph write path stable), write-path PII redaction (tracked separately)
+**Files:** TBD at time of activation
+**Complexity:** extra-large
+
+---
+
+## Cross-Cutting Tasks (all phases)
+
+### TASK-X1 — Testing Playbook + Coverage-Status Rows
+
+**Files:**
+- `.local/testing/playbooks/knowledge-ingest.md` (main repo)
+- `.local/testing/coverage-status.md` (main repo)
+
+**What:** Per CLAUDE.md dev-rules points 6 and 7 (mandatory before PR):
+1. Write `knowledge-ingest.md` playbook with scenarios covering: notes sink dry-run, notes sink
+   write + re-run idempotency, rollback end-to-end, sanitizer rejection, provider resolution
+   (valid + unknown name), source-outside-root rejection, `--source subagents` dry-run
+   (G0 spike evidence), and TUI spinner visibility. Minimum 12 numbered scenarios.
+2. Add rows to `coverage-status.md` with `Status = Untested` for: notes sink, graph sink,
+   rollback, ledger, dry-run (notes + graph), sanitizer-on-write, provider resolution, TUI
+   spinner.
+
+**Acceptance:** Playbook has ≥ 12 numbered scenarios with expected outcomes; coverage-status
+has ≥ 8 new rows.
+**Dependencies:** TASK-N1, TASK-G0 (spike evidence section)
+
+---
+
+### TASK-X2 — Doc Comments + Rustdoc Verification
+
+**Files:** All new public items in `zeph-memory` and `zeph-config`
+
+**What:** Ensure all `pub` types, traits, and methods introduced by this feature have `///`
+doc comments; `SemanticMemory::ingest_documents` and `IngestLedger` include `# Examples`
+with `no_run` doc-tests (NFR-4.4).
+
+**Acceptance:**
+`RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-memory --all-features` passes with zero warnings.
+
+---
+
+### TASK-X3 — CHANGELOG.md Update
+
+**Files:** `CHANGELOG.md`
+
+**What:** Add to the `[Unreleased]` section at end of each wave merge:
+
+Wave 1/2 entry:
+```
+### Added
+- `zeph knowledge ingest --source <SRC>` command for seeding project knowledge into semantic notes (#5012)
+- `zeph knowledge rollback <batch>` and `zeph knowledge status` for import management (#5019)
+- `[knowledge]` config section with `ingest_provider`, `concurrency`, `max_documents`, `recall_include_imported`
+- Phase 0: provenance columns (`origin`, `import_batch_id`, `source_uri`) on `graph_edges` and `graph_entities` (#5015)
+- Content-hash ledger for idempotent ingest re-runs (#5016)
+- TUI command palette entries for knowledge ingest (#5020)
+```
+
+Wave 5 entry (if G0 GO):
+```
+### Added
+- `zeph knowledge ingest --source subagents` — subagent episode extraction to knowledge graph (gated, #5023)
+```
+
+---
+
+### TASK-X4 — Register Spec 067 in `specs/README.md`
+
+**Files:** `specs/README.md`
+
+**What:** Add the spec-067 entry to the Feature Docs table:
+
+```
+| `067-knowledge-ingest/spec.md` | Knowledge ingest command — static artifacts → semantic notes; subagent episodes → graph (gated §7); two-sink design, rollback, ledger | `zeph-memory`, `zeph-config`, `zeph-db`, binary |
+```
+
+---
+
+## Implementation Notes
+
+### Order of execution
+Wave 1 tasks (F1, F2, F3) are fully parallel — they touch disjoint files. Wave 2 (N1, N2, N3)
+requires Wave 1 to complete; N2 and N3 can run in parallel after N1 merges. G1 requires F1+F2.
+G0 requires G1+N1 (needs the dry-run projection and the notes baseline). G2 requires G0 GO.
+D1 is entirely deferred.
+
+### Reuse patterns
+- Notes sink: copy the `IngestionPipeline` invocation pattern from `src/commands/ingest.rs`
+  verbatim; only the source-walking and progress loop are new.
+- Graph extraction: call `extract_and_store()` unchanged inside `ingest_documents()`; it does
+  not contain RPE. Threading `Provenance` through to the edge writer is the only addition.
+- Provider resolution: copy the `resolve_background_provider` call pattern from
+  `crates/zeph-memory/src/graph/extractor.rs`.
+
+### Gotchas
+- `graph_edges` has 5+ indexes; the `ALTER TABLE` migration is additive (nullable columns do
+  not rebuild existing indexes in SQLite). Test on a production-sized DB before merging F1.
+- `extract_and_store()` is an `async fn` that performs I/O (LLM + DB). Do not call it inside a
+  synchronous context; always `await` inside the `buffer_unordered` stream.
+- The ledger's `PRIMARY KEY (source_uri, content_hash)` is intentional: the same file at a
+  different hash (i.e. changed content) gets a new row and will be re-ingested.
+- `IngestSourceAdapter::parse` must be pure (no async, no I/O) to satisfy NFR-4.1. JSONL file
+  reading happens upstream in the binary command, not inside the adapter.
+- The technical-document prompt (TASK-G1) must not drop file paths and tool names — these are
+  the entities that matter for project-decision knowledge. Verify with `--dry-run` over 10 specs
+  before G0 to confirm S/N > 50%.
+
+## See Also
+
+- [[067-knowledge-ingest/spec]] — technical specification and invariants
+- [[067-knowledge-ingest/plan]] — implementation plan, phases, risk register
+- [[004-memory/spec]] — memory subsystem
+- [[004-memory/004-9-memory-write-gate]] — write-quality gate (must not be bypassed)
+- [[041-sanitizer/spec]] — PII/exfiltration validators
+- [[001-system-invariants/spec]] — system contracts (INV-1 dependency direction)

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -52,6 +52,7 @@ status: moc
 - [[004-memory/spec|Memory Pipeline]] — SQLite + Qdrant dual backend, semantic response cache, anchored summarization, compaction probe, importance scoring, A-MAC admission control, MemScene consolidation, cost-sensitive store routing, temporal decay, multi-vector chunking, GAAMA episode nodes, BATS budget hints, Focus compression, SleepGate forgetting pass, persona/trajectory/category-aware memory, TiMem tree, microcompact, autoDream, MagicDocs, embed backfill batching
 - [[012-graph-memory/spec|Entity Graph Memory]] — entity graph, BFS recall, community detection, MAGMA typed edges, SYNAPSE spreading activation; works with [[004-memory/spec|Memory Pipeline]]
   - [[004-memory/004-6-graph-memory|Graph Memory (memory sub-spec)]] — concise reference within the memory subsystem: data model overview, MAGMA edge types, SYNAPSE config, key invariants
+- [[067-knowledge-ingest/spec|Knowledge Ingest]] — `zeph knowledge ingest` operator command; static artifacts → semantic notes (existing `IngestionPipeline`, no graph), subagent transcripts → graph (gated by measurement spike); Phase 0 provenance (`origin`/`import_batch_id`/`source_uri`) + `rollback`; honors write-gate (004-9) + admission (004-3), bypasses only RPE; sanitizer on write path; external Claude/Codex import deferred; code stays in [[018-index/spec|zeph-index]]
 
 ### Configuration & Loading
 - [[020-config-loading/spec|Config Loading]] — config resolution order, mode-agnostic defaults, environment overrides
@@ -229,6 +230,7 @@ status: moc
 | 063 | [[063-worktree-subsystem/spec\|Worktree Subsystem]] | specify | approved |
 | 064 | [[064-durable-execution/spec\|Durable Execution]] | specify | approved |
 | 065 | [[065-ephemeral-plugins-provider-overrides/spec\|Ephemeral Plugins & Provider Overrides]] | specify | implemented |
+| 067 | [[067-knowledge-ingest/spec\|Knowledge Ingest]] | specify | draft |
 
 ---
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -25,7 +25,7 @@ See `[[constitution]]` for project-wide non-negotiable rules.
 
 ## Numbering Scheme
 
-Spec IDs (001–065) follow a logical grouping:
+Spec IDs (001–067) follow a logical grouping:
 
 - **001–010**: Foundational contracts and core systems (invariants, loop, providers, memory, skills, tools, channels, mcp, orchestration, security)
 - **011–020**: User-facing features and operational integration (TUI, graph memory, protocols, self-learning, filtering, indexing, scheduler, gateway, config loading)
@@ -48,6 +48,7 @@ Spec IDs (001–065) follow a logical grouping:
 - **063**: Worktree subsystem — `zeph-worktree` crate, `worktree.base_ref: fresh|head`, CwdGuard serialisation, startup probe, CLI commands, `git_timeout_secs` (default 30, migration step 55), `--init` wizard `step_worktree()`; GitHub #4655, #4704, #4784, #4847
 - **064**: Durable execution — `zeph-durable` Layer-0 crate, journal/replay, `DurableStep`, `EffectClass`, `JournalWriter` actor, AEAD payload cipher, `DurablePromise`/timers, dedicated `durable.db`, P1-P4 integration adapters (agent-loop, orchestration, scheduler, subagent); `restate` feature flag
 - **065**: Ephemeral plugin loading and provider override persistence — `--plugin-url` HTTPS-only session-scoped plugin loading (`TempDir` lifetime, blocking scan), provider parameter override persistence (`reasoning_effort`/`temperature` via `channel_preferences` key-value row, no ALTER TABLE); GitHub #3918
+- **067**: Knowledge Ingest — `zeph knowledge ingest` operator command with two sinks: static project artifacts → semantic notes (existing `IngestionPipeline`, no graph) and subagent transcripts → knowledge graph (gated by a measurement spike); Phase 0 provenance columns (`origin`/`import_batch_id`/`source_uri`) + `rollback`; honors write-gate (004-9) + admission (004-3), only RPE bypassed; sanitizer on write path; external Claude/Codex import deferred to Phase 3; code stays in `zeph-index`; epic #5012, milestone M29 [draft]
 
 ---
 
@@ -151,3 +152,4 @@ Spec IDs (001–065) follow a logical grouping:
 | `064-durable-execution/spec.md` | Durable execution: `zeph-durable` Layer-0 crate, append-only journal, `DurableStep`/`DurableContext` (`&self` + `AtomicU32`), `EffectClass`+`OnAmbiguous`, `JournalWriter` actor (mpsc, ACK, group-commit), AEAD `PayloadCipher` (XChaCha20-Poly1305, vault-keyed), `DurablePromise`/resolver-token auth, `DurableTimer`, dedicated `durable.db` pool+migrations, `ReplayDivergence` guard, `read_execution_range` cursor, `restate` feature flag; P1 agent-loop, P2 orchestration `/plan resume`, P3 scheduler exactly-once, P4 subagent promise | `zeph-durable` (new), `zeph-agent-tools`, `zeph-orchestration`, `zeph-scheduler`, `zeph-subagent` |
 | `065-ephemeral-plugins-provider-overrides/spec.md` | Ephemeral plugin loading and provider override persistence: `--plugin-url` (HTTPS-only, blocking scan, TempDir lifetime) + provider parameter override persistence (reasoning_effort, temperature via `channel_preferences` key-value row, no ALTER TABLE); defers worktree.baseRef, bgIsolation, Ctrl+R; GitHub #3918 | `zeph-plugins`, `zeph-core`, `zeph-config`, `zeph-commands` |
 | `066-deep-link-scheme/spec.md` | zeph:// URI scheme — `zeph url-open`, `zeph url-scheme {register,unregister,status}`, OS registration (Linux/Windows full, macOS dispatch-only), INV-CWD security validation order, `[deep_link]` config, `deep-link` feature flag; ACP attach deferred to v2; GitHub #4687 | `zeph-common`, `zeph-config`, binary |
+| `067-knowledge-ingest/spec.md` | Knowledge Ingest (`zeph knowledge ingest`): two sinks — static artifacts → semantic notes via existing `IngestionPipeline` (no graph), subagent transcripts → knowledge graph (gated by §7 measurement spike/kill-criterion); Phase 0 provenance migration (`origin`/`import_batch_id`/`source_uri` on `graph_edges`/`graph_entities`) + `knowledge rollback`; reuses `extract_and_store`, honors write-gate (004-9) + admission (004-3), bypasses only RPE; sanitizer as `PostExtractValidator`; technical-document extraction prompt; `knowledge_ingest_ledger` (re-read guard only, INV-5); external Claude/Codex import deferred to Phase 3; code excluded (owned by `zeph-index`); epic #5012, milestone M29 [draft] | `zeph-memory`, `zeph-db`, `zeph-config`, `zeph` (binary), `zeph-sanitizer` |


### PR DESCRIPTION
## Summary

Adds the full Spec-Driven Development package for `zeph knowledge ingest` (spec-067) — BRD / SRS / NFR / technical spec / implementation plan / developer tasks — and registers it in the specs index. **Docs/spec only — no Rust code changed.**

The command seeds Zeph's memory with project knowledge on demand. Design decided after architect + adversarial-critic review, with a **two-sink** split:

1. **Static project artifacts → semantic notes (Qdrant)** via the *existing* `IngestionPipeline` (the `zeph ingest` path). No graph writes; ships first; lowest risk.
2. **Agent episodes → knowledge graph** (relational, multi-hop), reserved for the cross-agent episode layer. MVP source is Zeph's own subagent transcripts. **Gated by a measurement spike + kill-criterion** — ships only if it measurably beats semantic notes.

Raw source code stays in `zeph-index`. External Claude Code / Codex transcript import is deferred (unstable schemas, cross-project privacy, verbatim-no-PII-redaction write path).

## Critic blockers addressed as prerequisites / invariants

- **C1** (no provenance → irreversible imports): Phase 0 migration adds `origin`/`import_batch_id`/`source_uri` to `graph_edges`+`graph_entities` + `knowledge rollback`.
- **C2** (RPE bypass vs write-pollution spec 004-9): ingest bypasses **only** RPE; the write-quality gate (004-9) and admission control (004-3) stay ON.
- **C3** (ledger false confidence): content-hash ledger documented as a re-read/cost guard only.
- **S2** (hub-node pollution): technical-document extraction prompt + dry-run hub-degree report + the §7 spike gate.
- **S4** (privacy): sanitizer as `PostExtractValidator` + current-project allowlist.

## Phases

- **Phase 0** — provenance + rollback prerequisite (blocks all graph writes)
- **Phase 1** — static artifacts → semantic notes (ships first; no graph)
- **Phase 2** — subagent transcripts → graph (gated by §7 measurement spike)
- **Phase 3** — external Claude/Codex import (deferred)

## Changes

New `specs/067-knowledge-ingest/` package (matches the `066-deep-link-scheme` SDD layout):

- `spec.md` — technical/principle spec: FR/NFR, invariants (INV-1..8), schema, phases, §7 gate, acceptance criteria.
- `README.md` — package index + scope summary + traceability map.
- `brd.md` — business requirements (BR-1..BR-5, stakeholders, success criteria, out of scope).
- `srs.md` — software requirements (EARS, ISO/IEC/IEEE 29148:2018); §9 lists 3 open questions (OQ-1..3) with owners/deadlines.
- `nfr.md` — non-functional requirements (8 ISO/IEC 25010:2011 characteristics, each with a verification method).
- `plan.md` — implementation plan: phases, milestones, dependencies, risk register.
- `tasks.md` — developer tasks tracing to issues #5015–#5024 and to FR/NFR/INV.

Plus `specs/README.md`, `specs/MOC-specs.md` — index registration.

## Tracking

Epic #5012 (milestone M29). Decomposed into 10 child issues #5015–#5024. This PR delivers the spec only; implementation lands per-issue starting with the foundation wave (#5017 + #5015 + #5016).

## Validation

Docs/spec only — no `.rs` touched, so the Rust pre-PR gate (fmt/clippy/nextest) is not applicable. Spec frontmatter and wikilinks follow `specs/TEMPLATE.md`; all internal links resolve.
