### PR TITLE
feat(commands): add /undo and /redo slash commands with checkpoint stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - `PageUp`/`PageDown` now scroll the transcript in Insert mode (previously silently ignored).
   - `EnableAlternateScroll` (DECSET 1007h) is retained; native terminal scroll and click-drag text selection work without holding Shift or Option.
   - `auto_scroll` suppresses auto-scrolling to the bottom when the user has manually scrolled up (offset > 1), preserving the user's position during streaming.
+- `fix(core)`: add regression tests for `skill_fallback_mode` compact-prompt paths — covers
+  no-matcher, embed-infra-error, and healthy-matcher scenarios (#5000). Root cause: `TempDir`
+  dropped before lazy `load_skill_body()` disk read; fixed by keeping `TempDir` alive in caller.
 
 - `fix(init)`: align the default config output path in the init wizard with the runtime config search order. The wizard now defaults to `$XDG_CONFIG_HOME/zeph/config.toml` (same as `resolve_config_path`), so a config written during `zeph init` is found automatically on the next `zeph` invocation (closes #4984)
 - `fix(skills)`: when the embedding matcher is unavailable (no embedding provider configured, or embed/Qdrant infrastructure failure), skill injection now uses the description-only compact format (`format_skills_prompt_compact`) instead of injecting all skill bodies. Eliminates the ~57k-token baseline footprint for Claude-only and Ollama-without-embeddings setups; affected sessions see a `tracing::warn` pointing to embedding provider configuration (closes #4989)
@@ -35,6 +38,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - `feat(skills,commands)`: add caveman ultra-compressed output mode (#4985). Two cooperating mechanisms: (1) bundled `caveman/SKILL.md` — natural-language activates telegraphic style via skill matcher; (2) `/caveman [on|off|status]` command — explicit runtime toggle. `SessionState::caveman_active` flag drives `CAVEMAN_DIRECTIVE` injection into the volatile system-prompt block on every turn. `CavemanConfig { default_on: bool }` in `[caveman]` config section (migration step 59). Preserves code blocks, file paths, and commands verbatim.
+- `feat(commands)`: add `/undo [N|list]` and `/redo` session commands (#4990). Session-scoped
+  checkpoint system that captures file state before write commands. Requires
+  `[tools.shell] checkpoints_enabled = true`. Checkpoints are in-memory only (lost on restart)
+  and cover regular files within `transaction_scope`. Redo-of-delete is supported. The undo
+  stack is bounded by `max_checkpoints` (default 20). Out-of-sandbox paths and symlinks are
+  excluded from snapshots. Migration step 60.
 - `feat(cli)`: add `--json` flag to `zeph durable list`, `zeph durable show`, and `zeph durable inspect`. When set, structured JSON is emitted to stdout instead of a human-readable table. `ExecutionSummary`, `RedactedEntry`, and `ExecutionStatus` now implement `serde::Serialize`; `ExecutionStatus` serializes in `snake_case` to match the DB column values. `--reveal` and `--json` are mutually exclusive (Clap `conflicts_with`) to prevent silent non-JSON output (closes #4978)
 - `feat(zeph-durable)`: criterion benchmarks for `zeph-durable` — all 10 groups from spec-064 §Benchmarks (`bench_step_run_idempotent`, `bench_step_run_atleastonce`, `bench_step_run_exactly_once_n`, `bench_parallel_n`, `bench_replay_cursor_n`, `bench_journal_append_buffered`, `bench_journal_append_acked`, `bench_payload_seal`, `bench_payload_open`, `bench_prune_batch`). NFR gate tests added in `tests/nfr_gates.rs`: NFR-DE-07 runs in CI; NFR-DE-01/02 are `#[ignore]` (5 ms bound requires release builds). Closes #4950.
 - `feat(zeph-subagent)`: durable promise adapter for subagent spawn/await (spec-064 §P4, closes #4954). `zeph-subagent` gains `durable.rs` with `make_durable_promise`, `await_durable_subagent`, `resolve_durable_promise`, `DurableResolverSeat`, and `SubagentResult`. The resolver seat carries a `Zeroizing<[u8; 32]>` token from parent to child background task (INV-9 channel rule). On parent resume after crash, `await_durable_subagent` returns the journaled `SubagentResult` immediately (spec §1038 finished-child replay). `zeph-core` wires the gate via `maybe_make_durable_seat` in `handle_agent_background` and `handle_agent_spawn_foreground`.

--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -66,6 +66,21 @@ pub const COMMANDS: &[CommandInfo] = &[
         category: SlashCategory::Session,
         feature_gate: None,
     },
+    // --- Undo / Redo ---
+    CommandInfo {
+        name: "/undo",
+        args: "[N | list]",
+        description: "Undo the last N file-mutating shell commands (session-scoped)",
+        category: SlashCategory::Session,
+        feature_gate: None,
+    },
+    CommandInfo {
+        name: "/redo",
+        args: "",
+        description: "Re-apply the last undone shell command",
+        category: SlashCategory::Session,
+        feature_gate: None,
+    },
     // --- Session ---
     CommandInfo {
         name: "/exit",

--- a/crates/zeph-commands/src/handlers/checkpoint.rs
+++ b/crates/zeph-commands/src/handlers/checkpoint.rs
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `/undo` and `/redo` slash command handlers.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::context::CommandContext;
+use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
+
+/// Undo the last N file-mutating shell commands executed in this session.
+///
+/// Syntax: `/undo [N]` — omit N to undo one step, or pass `list` to show the undo stack.
+pub struct UndoCommand;
+
+impl CommandHandler<CommandContext<'_>> for UndoCommand {
+    fn name(&self) -> &'static str {
+        "/undo"
+    }
+
+    fn description(&self) -> &'static str {
+        "Undo the last N file-mutating shell commands (session-scoped)"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "[N | list]"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        use tracing::Instrument as _;
+        let span = tracing::info_span!("commands.undo.handle");
+        Box::pin(
+            async move {
+                let result = ctx.agent.handle_undo(args).await?;
+                Ok(CommandOutput::Message(result))
+            }
+            .instrument(span),
+        )
+    }
+}
+
+/// Re-apply the last undone shell command.
+///
+/// Syntax: `/redo` — re-applies the most recently undone command.
+pub struct RedoCommand;
+
+impl CommandHandler<CommandContext<'_>> for RedoCommand {
+    fn name(&self) -> &'static str {
+        "/redo"
+    }
+
+    fn description(&self) -> &'static str {
+        "Re-apply the last undone shell command"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        ""
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        use tracing::Instrument as _;
+        let span = tracing::info_span!("commands.redo.handle");
+        Box::pin(
+            async move {
+                let result = ctx.agent.handle_redo(args).await?;
+                Ok(CommandOutput::Message(result))
+            }
+            .instrument(span),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
+    use crate::sink::NullSink;
+
+    #[test]
+    fn undo_name_and_description() {
+        assert_eq!(UndoCommand.name(), "/undo");
+        assert!(!UndoCommand.description().is_empty());
+    }
+
+    #[test]
+    fn redo_name_and_description() {
+        assert_eq!(RedoCommand.name(), "/redo");
+        assert!(!RedoCommand.description().is_empty());
+    }
+
+    #[tokio::test]
+    async fn undo_not_supported_returns_ok_message() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+        let result = UndoCommand.handle(&mut ctx, "").await;
+        assert!(result.is_ok());
+        if let Ok(CommandOutput::Message(msg)) = result {
+            assert!(!msg.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn redo_not_supported_returns_ok_message() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+        let result = RedoCommand.handle(&mut ctx, "").await;
+        assert!(result.is_ok());
+        if let Ok(CommandOutput::Message(msg)) = result {
+            assert!(!msg.is_empty());
+        }
+    }
+}

--- a/crates/zeph-commands/src/handlers/mod.rs
+++ b/crates/zeph-commands/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod acp;
 pub mod agent_cmd;
 pub mod agents_fleet;
 pub mod caveman;
+pub mod checkpoint;
 #[cfg(feature = "cocoon")]
 pub mod cocoon;
 pub mod compaction;

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -499,6 +499,31 @@ pub trait AgentAccess: Send {
         None
     }
 
+    // ----- /undo, /redo -----
+
+    /// Execute `/undo [N]` or `/undo list`.
+    ///
+    /// `args` is everything after `/undo`. Empty string means undo 1 step.
+    /// Returns a formatted response string. The default returns a "not supported" message.
+    fn handle_undo<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let _ = args;
+        Box::pin(async move { Ok("Undo is not supported in this context.".to_owned()) })
+    }
+
+    /// Execute `/redo`.
+    ///
+    /// Returns a formatted response string. The default returns a "not supported" message.
+    fn handle_redo<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let _ = args;
+        Box::pin(async move { Ok("Redo is not supported in this context.".to_owned()) })
+    }
+
     // ----- /agents -----
 
     /// Handle `/agents [subcommand] [args]` and return a formatted response string.

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -607,13 +607,13 @@ use steps::{
     MigrateOtelFilter, MigratePlannerModelToProvider, MigrateProviderMaxConcurrent,
     MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter,
     MigrateSchedulerDaemon, MigrateSessionPersistProviderOverrides,
-    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellTransactional,
-    MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
-    MigrateToolsCompressionConfig, MigrateTraceMetadata, MigrateVigilConfig, MigrateWorktreeConfig,
-    MigrateWorktreeGitTimeout,
+    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellCheckpointsConfig,
+    MigrateShellTransactional, MigrateSttToProvider, MigrateSupervisorConfig,
+    MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateTraceMetadata,
+    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–59).
+/// Ordered registry of all sequential migration steps (steps 1–60).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -714,6 +714,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateEvalModelToProvider),
             // Step 59 — add [caveman] ultra-compressed output section (#4985)
             Box::new(MigrateCavemanConfig),
+            // Step 60 — add [tools.shell] checkpoints_enabled and max_checkpoints (#4990)
+            Box::new(MigrateShellCheckpointsConfig),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -42,10 +42,10 @@ use super::{
     migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
     migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_persist_provider_overrides, migrate_session_provider_persistence,
-    migrate_session_recap_config, migrate_shell_transactional, migrate_stt_to_provider,
-    migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
-    migrate_trace_metadata, migrate_vigil_config, migrate_worktree_config,
-    migrate_worktree_git_timeout,
+    migrate_session_recap_config, migrate_shell_checkpoints_config, migrate_shell_transactional,
+    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
+    migrate_tools_compression_config, migrate_trace_metadata, migrate_vigil_config,
+    migrate_worktree_config, migrate_worktree_git_timeout,
 };
 
 // ── Wrapper structs for all 59 sequential migration steps ───────────────────────────────────────
@@ -696,5 +696,16 @@ impl Migration for MigrateCavemanConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_caveman_config(toml_src)
+    }
+}
+
+pub(super) struct MigrateShellCheckpointsConfig;
+impl Migration for MigrateShellCheckpointsConfig {
+    fn name(&self) -> &'static str {
+        "migrate_shell_checkpoints_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_shell_checkpoints_config(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        59,
-        "MIGRATIONS registry must contain all 59 sequential steps"
+        60,
+        "MIGRATIONS registry must contain all 60 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -1645,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 59);
+    assert_eq!(MIGRATIONS.len(), 60);
 }
 
 #[test]
@@ -1684,7 +1684,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–59).
+    // Names must follow the documented step order (steps 1–60).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1745,6 +1745,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_durable_config",
         "migrate_eval_model_to_provider",
         "migrate_caveman_config",
+        "migrate_shell_checkpoints_config",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);

--- a/crates/zeph-config/src/migrate/tools.rs
+++ b/crates/zeph-config/src/migrate/tools.rs
@@ -217,3 +217,30 @@ pub fn migrate_tools_compression_config(toml_src: &str) -> Result<MigrationResul
         sections_changed: vec!["tools.compression".to_owned()],
     })
 }
+
+/// Add `checkpoints_enabled` and `max_checkpoints` to `[tools.shell]` as commented-out defaults.
+///
+/// # Errors
+///
+/// Returns [`MigrateError::Parse`] when `toml_src` is not valid TOML.
+pub fn migrate_shell_checkpoints_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("checkpoints_enabled") || toml_src.contains("max_checkpoints") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Session-scoped /undo and /redo checkpoint history (#4990).\n\
+         # Checkpoints are in-memory only and lost on agent restart.\n\
+         # [tools.shell]\n\
+         # checkpoints_enabled = false\n\
+         # max_checkpoints = 20\n";
+
+    Ok(MigrationResult {
+        output: format!("{toml_src}{comment}"),
+        changed_count: 1,
+        sections_changed: vec!["tools.shell".to_owned()],
+    })
+}

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -920,6 +920,10 @@ fn default_background_timeout_secs() -> u64 {
     1800
 }
 
+fn default_max_checkpoints() -> usize {
+    20
+}
+
 /// Shell-specific configuration: timeout, command blocklist, and allowlist overrides.
 #[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::struct_excessive_bools)]
@@ -975,6 +979,19 @@ pub struct ShellConfig {
     /// the command is blocked. Set to `None` to use the built-in default of `0.7`.
     #[serde(default)]
     pub risk_chain_threshold: Option<f32>,
+    /// Enable session-scoped checkpoint history for `/undo` and `/redo`. Default: `false`.
+    ///
+    /// When `true`, file snapshots are captured before each write command and stored
+    /// in an in-memory stack for the duration of the session. Checkpoints are lost
+    /// when the agent process exits.
+    #[serde(default)]
+    pub checkpoints_enabled: bool,
+    /// Maximum number of checkpoints retained in the undo stack. Default: `20`.
+    ///
+    /// When the stack reaches this limit, the oldest entry is evicted to make room.
+    /// Set to `0` for no limit (not recommended for long-running sessions).
+    #[serde(default = "default_max_checkpoints")]
+    pub max_checkpoints: usize,
 }
 
 impl Default for ShellConfig {
@@ -996,6 +1013,8 @@ impl Default for ShellConfig {
             max_background_runs: default_max_background_runs(),
             background_timeout_secs: default_background_timeout_secs(),
             risk_chain_threshold: None,
+            checkpoints_enabled: false,
+            max_checkpoints: default_max_checkpoints(),
         }
     }
 }

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1414,6 +1414,82 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
         })
     }
 
+    // ----- /undo, /redo -----
+
+    fn handle_undo<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let executor = std::sync::Arc::clone(&self.tool_executor);
+        let args_owned = args.trim().to_owned();
+        Box::pin(async move {
+            if args_owned == "list" {
+                let result = executor.checkpoint_list_erased();
+                if !result.supported {
+                    return Ok(
+                        "Checkpoints are not enabled. Set `[tools.shell] checkpoints_enabled = true` in config.".to_owned()
+                    );
+                }
+                if result.entries.is_empty() {
+                    return Ok("Undo stack is empty.".to_owned());
+                }
+                let mut lines = vec![format!("Undo stack ({} entries):", result.entries.len())];
+                for e in &result.entries {
+                    lines.push(format!(
+                        "  [{}] {} ({} file(s))",
+                        e.index, e.command, e.file_count
+                    ));
+                }
+                if result.redo_depth > 0 {
+                    lines.push(format!("Redo depth: {}", result.redo_depth));
+                }
+                return Ok(lines.join("\n"));
+            }
+
+            let n: usize = if args_owned.is_empty() {
+                1
+            } else {
+                match args_owned.parse::<usize>() {
+                    Ok(v) if v > 0 => v,
+                    _ => {
+                        return Err(CommandError::new(format!(
+                            "Invalid argument: expected a positive integer or 'list', got '{args_owned}'"
+                        )));
+                    }
+                }
+            };
+
+            let result = tokio::task::spawn_blocking(move || executor.checkpoint_undo_erased(n))
+                .await
+                .map_err(|e| CommandError::new(format!("undo task panicked: {e}")))?;
+            if !result.supported {
+                return Ok(
+                    "Checkpoints are not enabled. Set `[tools.shell] checkpoints_enabled = true` in config.".to_owned()
+                );
+            }
+            Ok(result.message)
+        })
+    }
+
+    fn handle_redo<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let _ = args;
+        let executor = std::sync::Arc::clone(&self.tool_executor);
+        Box::pin(async move {
+            let result = tokio::task::spawn_blocking(move || executor.checkpoint_redo_erased())
+                .await
+                .map_err(|e| CommandError::new(format!("redo task panicked: {e}")))?;
+            if !result.supported {
+                return Ok(
+                    "Checkpoints are not enabled. Set `[tools.shell] checkpoints_enabled = true` in config.".to_owned()
+                );
+            }
+            Ok(result.message)
+        })
+    }
+
     // ----- /agents -----
 
     fn handle_agents<'a>(

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -589,6 +589,7 @@ impl<C: Channel> Agent<C> {
                     agent_cmd::AgentCommand,
                     agents_fleet::AgentsFleetCommand,
                     caveman::CavemanCommand,
+                    checkpoint::{RedoCommand, UndoCommand},
                     compaction::{CompactCommand, NewConversationCommand, RecapCommand},
                     experiment::ExperimentCommand,
                     goal::GoalCommand,
@@ -646,6 +647,8 @@ impl<C: Channel> Agent<C> {
                 agent_reg.register(TrajectoryCommand);
                 agent_reg.register(ScopeCommand);
                 agent_reg.register(GoalCommand);
+                agent_reg.register(UndoCommand);
+                agent_reg.register(RedoCommand);
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut agent_null_sink,

--- a/crates/zeph-core/src/agent/tests/agent_tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/mod.rs
@@ -14,4 +14,5 @@ mod lifecycle_tests;
 mod metrics_summary_tests;
 mod model_help_status_exit_tests;
 mod orchestration_persistence_tests;
+mod skill_fallback_tests;
 mod subagent_command_tests;

--- a/crates/zeph-core/src/agent/tests/agent_tests/skill_fallback_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/skill_fallback_tests.rs
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression tests for `skill_fallback_mode` compact-prompt paths in `assembly.rs`.
+//!
+//! Three scenarios trigger `format_skills_prompt_compact`:
+//! 1. No embedding matcher configured → immediate compact fallback.
+//! 2. Matcher present but embedding provider returns infrastructure error → compact fallback.
+//! 3. Healthy matcher and provider → full `<instructions>` prompt.
+//!
+//! Spec ref: assembly.rs lines 588–810, `skill_fallback_mode` flag.
+
+use std::sync::{Arc, Mutex};
+use zeph_llm::any::AnyProvider;
+use zeph_llm::mock::MockProvider;
+use zeph_llm::provider::{Message, Role};
+use zeph_skills::matcher::{SkillMatcher, SkillMatcherBackend};
+use zeph_skills::registry::SkillRegistry;
+
+use crate::agent::Agent;
+
+use super::{MockChannel, MockToolExecutor};
+
+/// Create a test registry and return the tempdir so the skill files stay on disk.
+///
+/// `create_test_registry()` from common.rs drops the TempDir, which deletes the
+/// `SKILL.md` file.  `registry.skill(name)` lazily reads from disk, so if the dir
+/// is gone the call returns `Err` and the skill is filtered from `active_skills`.
+/// Keeping the TempDir alive for the duration of the test prevents this.
+fn create_registry_with_live_dir() -> (SkillRegistry, tempfile::TempDir) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let skill_dir = temp_dir.path().join("test-skill");
+    std::fs::create_dir(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: test-skill\ndescription: A test skill\n---\n<instructions>\nTest skill body\n</instructions>",
+    )
+    .unwrap();
+    let registry = SkillRegistry::load(&[temp_dir.path().to_path_buf()]);
+    (registry, temp_dir)
+}
+
+/// Extract the system prompt content from a recorded message log.
+fn extract_system_prompt(recorded: &Arc<Mutex<Vec<Vec<Message>>>>) -> String {
+    let guard = recorded.lock().unwrap();
+    guard
+        .iter()
+        .flatten()
+        .find(|m| m.role == Role::System)
+        .map(|m| m.content.clone())
+        .unwrap_or_default()
+}
+
+// ---------- Test 1: no matcher → compact fallback ----------
+
+/// When no embedding matcher is configured, `assembly.rs` must inject skills via the
+/// compact `<available_skills mode="compact">` path rather than the full `<instructions>` form.
+#[tokio::test]
+async fn skill_fallback_compact_when_no_matcher() {
+    let (mock, recorded) = MockProvider::with_responses(vec!["ok".to_string()]).with_recording();
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec!["hello".to_string()]);
+    let (registry, _dir) = create_registry_with_live_dir();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    // No matcher set → services.skill.matcher = None (default).
+
+    agent.run().await.unwrap();
+
+    let sys = extract_system_prompt(&recorded);
+    assert!(
+        sys.contains("mode=\"compact\""),
+        "expected compact skill prompt when no matcher is configured, got system prompt: {sys}"
+    );
+    assert!(
+        !sys.contains("<instructions>"),
+        "full instructions prompt must not appear in compact fallback mode, got: {sys}"
+    );
+}
+
+// ---------- Test 2: embed infra error → compact fallback ----------
+
+/// When the embedding provider returns an infrastructure error during `match_skills`,
+/// `assembly.rs` must fall back to the compact prompt rather than silently running without skills.
+#[tokio::test]
+async fn skill_fallback_compact_on_embed_infra_error() {
+    // M1: Agent embedding provider fails (LlmError::InvalidInput on embed()).
+    //     Matcher is built separately with a succeeding closure so it initialises correctly.
+    let (chat_mock, recorded) =
+        MockProvider::with_responses(vec!["ok".to_string()]).with_recording();
+    // Failing embed provider — used both as chat+embed provider via AnyProvider::Mock.
+    // embed() returns InvalidInput due to with_embed_invalid_input().
+    let embed_failing = AnyProvider::Mock(chat_mock.with_embed_invalid_input());
+
+    let channel = MockChannel::new(vec!["hello".to_string()]);
+    let executor = MockToolExecutor::no_tools();
+    let (registry, _dir) = create_registry_with_live_dir();
+
+    let mut agent = Agent::new(embed_failing, channel, registry, None, 5, executor);
+
+    // Read meta from the agent's own registry (which wraps SkillRegistry in Arc<RwLock<>>).
+    let all_meta_owned: Vec<zeph_skills::loader::SkillMeta> = {
+        let registry_guard = agent.services.skill.registry.read();
+        registry_guard.all_meta().into_iter().cloned().collect()
+    };
+    // Matcher built with a succeeding embed closure so SkillMatcher::new completes.
+    let succeed_embed_fn = |_text: &str| -> zeph_skills::matcher::EmbedFuture {
+        Box::pin(async { Ok(vec![1.0_f32, 0.0]) })
+    };
+    let matcher = SkillMatcher::new(&all_meta_owned.iter().collect::<Vec<_>>(), succeed_embed_fn)
+        .await
+        .map(SkillMatcherBackend::InMemory);
+    // Inject the healthy in-memory matcher. assembly.rs will call agent.embedding_provider.embed()
+    // which returns InvalidInput → MatchResult::InfraError → skill_fallback_mode = true.
+    agent.services.skill.matcher = matcher;
+
+    agent.run().await.unwrap();
+
+    let sys = extract_system_prompt(&recorded);
+    assert!(
+        sys.contains("mode=\"compact\""),
+        "expected compact fallback on embed infra error, got system prompt: {sys}"
+    );
+}
+
+// ---------- Test 3: healthy matcher → full prompt ----------
+
+/// When a healthy matcher and embedding provider are wired, `assembly.rs` must inject the
+/// full skill prompt containing `<instructions>` rather than the compact fallback.
+#[tokio::test]
+async fn skill_fallback_full_when_matcher_healthy() {
+    let (mock, recorded) = MockProvider::with_responses(vec!["ok".to_string()])
+        .with_embedding(vec![1.0_f32, 0.0])
+        .with_recording();
+    let provider = AnyProvider::Mock(mock);
+
+    let channel = MockChannel::new(vec!["hello".to_string()]);
+    let executor = MockToolExecutor::no_tools();
+    let (registry, _dir) = create_registry_with_live_dir();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    let all_meta_owned: Vec<zeph_skills::loader::SkillMeta> = {
+        let registry_guard = agent.services.skill.registry.read();
+        registry_guard.all_meta().into_iter().cloned().collect()
+    };
+    let embed_fn = |_text: &str| -> zeph_skills::matcher::EmbedFuture {
+        Box::pin(async { Ok(vec![1.0_f32, 0.0]) })
+    };
+    let matcher = SkillMatcher::new(&all_meta_owned.iter().collect::<Vec<_>>(), embed_fn)
+        .await
+        .map(SkillMatcherBackend::InMemory);
+    agent.services.skill.matcher = matcher;
+
+    agent.run().await.unwrap();
+
+    let sys = extract_system_prompt(&recorded);
+    assert!(
+        sys.contains("<instructions>"),
+        "expected full skill prompt with <instructions> when matcher is healthy, got: {sys}"
+    );
+    assert!(
+        !sys.contains("mode=\"compact\""),
+        "compact fallback must not appear when matcher is healthy, got: {sys}"
+    );
+}

--- a/crates/zeph-core/src/agent/tests/agent_tests/skill_fallback_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/skill_fallback_tests.rs
@@ -23,10 +23,10 @@ use super::{MockChannel, MockToolExecutor};
 
 /// Create a test registry and return the tempdir so the skill files stay on disk.
 ///
-/// `create_test_registry()` from common.rs drops the TempDir, which deletes the
+/// `create_test_registry()` from common.rs drops the `TempDir`, which deletes the
 /// `SKILL.md` file.  `registry.skill(name)` lazily reads from disk, so if the dir
 /// is gone the call returns `Err` and the skill is filtered from `active_skills`.
-/// Keeping the TempDir alive for the duration of the test prevents this.
+/// Keeping the `TempDir` alive for the duration of the test prevents this.
 fn create_registry_with_live_dir() -> (SkillRegistry, tempfile::TempDir) {
     let temp_dir = tempfile::tempdir().unwrap();
     let skill_dir = temp_dir.path().join("test-skill");

--- a/crates/zeph-tools/src/composite.rs
+++ b/crates/zeph-tools/src/composite.rs
@@ -107,6 +107,33 @@ impl<A: ToolExecutor, B: ToolExecutor> ToolExecutor for CompositeExecutor<A, B> 
         self.first.set_effective_trust(level);
         self.second.set_effective_trust(level);
     }
+
+    /// Delegate undo to the first inner executor that supports checkpoints.
+    fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+        let result = self.first.checkpoint_undo(n);
+        if result.supported {
+            return result;
+        }
+        self.second.checkpoint_undo(n)
+    }
+
+    /// Delegate redo to the first inner executor that supports checkpoints.
+    fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+        let result = self.first.checkpoint_redo();
+        if result.supported {
+            return result;
+        }
+        self.second.checkpoint_redo()
+    }
+
+    /// Delegate list to the first inner executor that supports checkpoints.
+    fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+        let result = self.first.checkpoint_list();
+        if result.supported {
+            return result;
+        }
+        self.second.checkpoint_list()
+    }
 }
 
 #[cfg(test)]

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -155,6 +155,60 @@ impl FilterStats {
     }
 }
 
+/// Result returned by checkpoint undo/redo operations.
+///
+/// When `supported` is `false`, the executor does not implement checkpoints; callers
+/// should surface an appropriate user-facing message without treating this as an error.
+#[derive(Debug, Clone, Default)]
+pub struct CheckpointActionResult {
+    /// Number of commands actually reverted or re-applied.
+    pub reverted_commands: usize,
+    /// Number of files restored (written from backup).
+    pub restored: usize,
+    /// Number of files deleted (were absent at capture time).
+    pub deleted: usize,
+    /// `false` when this executor does not support checkpoints.
+    pub supported: bool,
+    /// Human-readable summary of what happened.
+    pub message: String,
+}
+
+impl CheckpointActionResult {
+    /// Sentinel returned by executors that do not implement checkpoints.
+    #[must_use]
+    pub fn unsupported() -> Self {
+        Self {
+            supported: false,
+            message: String::new(),
+            ..Default::default()
+        }
+    }
+}
+
+/// A single undo-stack entry for display in `/undo list`.
+#[derive(Debug, Clone)]
+pub struct CheckpointEntryView {
+    /// Zero-based index (0 = most recent).
+    pub index: usize,
+    /// The shell command that produced this checkpoint.
+    pub command: String,
+    /// Unix timestamp (seconds since epoch) when the checkpoint was recorded.
+    pub captured_at_secs: u64,
+    /// Number of files captured.
+    pub file_count: usize,
+}
+
+/// Result returned by the checkpoint list query.
+#[derive(Debug, Clone, Default)]
+pub struct CheckpointListResult {
+    /// Undo stack entries, most-recent first.
+    pub entries: Vec<CheckpointEntryView>,
+    /// Number of redo entries available.
+    pub redo_depth: usize,
+    /// `false` when this executor does not implement checkpoints.
+    pub supported: bool,
+}
+
 /// Provenance of a tool execution result.
 ///
 /// Set by each executor at `ToolOutput` construction time. Used by the sanitizer bridge
@@ -703,6 +757,29 @@ pub trait ToolExecutor: Send + Sync {
         false
     }
 
+    /// Undo the last `n` checkpointed write commands.
+    ///
+    /// Returns [`CheckpointActionResult::unsupported`] by default. Executors that
+    /// implement checkpoints (i.e. [`ShellExecutor`](crate::ShellExecutor) with
+    /// `checkpoints_enabled = true`) override this.
+    fn checkpoint_undo(&self, _n: usize) -> CheckpointActionResult {
+        CheckpointActionResult::unsupported()
+    }
+
+    /// Redo the last undone checkpoint.
+    ///
+    /// Returns [`CheckpointActionResult::unsupported`] by default.
+    fn checkpoint_redo(&self) -> CheckpointActionResult {
+        CheckpointActionResult::unsupported()
+    }
+
+    /// List the current undo stack entries and redo depth.
+    ///
+    /// Returns an empty [`CheckpointListResult`] with `supported = false` by default.
+    fn checkpoint_list(&self) -> CheckpointListResult {
+        CheckpointListResult::default()
+    }
+
     /// Whether a tool call can be safely dispatched speculatively (before the LLM finishes).
     ///
     /// Speculative execution requires the tool to be:
@@ -788,6 +865,21 @@ pub trait ErasedToolExecutor: Send + Sync {
     /// Set the effective trust level for the currently active skill. No-op by default.
     fn set_effective_trust(&self, _level: crate::SkillTrustLevel) {}
 
+    /// Undo the last `n` checkpointed write commands. No-op (unsupported) by default.
+    fn checkpoint_undo_erased(&self, _n: usize) -> CheckpointActionResult {
+        CheckpointActionResult::unsupported()
+    }
+
+    /// Redo the last undone checkpoint. No-op (unsupported) by default.
+    fn checkpoint_redo_erased(&self) -> CheckpointActionResult {
+        CheckpointActionResult::unsupported()
+    }
+
+    /// List the current undo stack entries and redo depth. Returns empty by default.
+    fn checkpoint_list_erased(&self) -> CheckpointListResult {
+        CheckpointListResult::default()
+    }
+
     /// Whether the executor can safely retry this tool call on a transient error.
     fn is_tool_retryable_erased(&self, tool_id: &str) -> bool;
 
@@ -856,6 +948,18 @@ impl<T: ToolExecutor> ErasedToolExecutor for T {
         ToolExecutor::set_effective_trust(self, level);
     }
 
+    fn checkpoint_undo_erased(&self, n: usize) -> CheckpointActionResult {
+        ToolExecutor::checkpoint_undo(self, n)
+    }
+
+    fn checkpoint_redo_erased(&self) -> CheckpointActionResult {
+        ToolExecutor::checkpoint_redo(self)
+    }
+
+    fn checkpoint_list_erased(&self) -> CheckpointListResult {
+        ToolExecutor::checkpoint_list(self)
+    }
+
     fn is_tool_retryable_erased(&self, tool_id: &str) -> bool {
         ToolExecutor::is_tool_retryable(self, tool_id)
     }
@@ -922,6 +1026,18 @@ impl ToolExecutor for DynExecutor {
 
     fn set_effective_trust(&self, level: crate::SkillTrustLevel) {
         ErasedToolExecutor::set_effective_trust(self.0.as_ref(), level);
+    }
+
+    fn checkpoint_undo(&self, n: usize) -> CheckpointActionResult {
+        self.0.checkpoint_undo_erased(n)
+    }
+
+    fn checkpoint_redo(&self) -> CheckpointActionResult {
+        self.0.checkpoint_redo_erased()
+    }
+
+    fn checkpoint_list(&self) -> CheckpointListResult {
+        self.0.checkpoint_list_erased()
     }
 
     fn is_tool_retryable(&self, tool_id: &str) -> bool {

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -115,9 +115,10 @@ pub use error_taxonomy::{
 };
 pub use execution_context::ExecutionContext;
 pub use executor::{
-    ClaimSource, DiffData, DynExecutor, ErasedToolExecutor, ErrorKind, FilterStats,
-    MAX_TOOL_OUTPUT_CHARS, TOOL_EVENT_CHANNEL_CAP, ToolCall, ToolError, ToolEvent, ToolEventRx,
-    ToolEventTx, ToolExecutor, ToolOutput, truncate_tool_output, truncate_tool_output_at,
+    CheckpointActionResult, CheckpointEntryView, CheckpointListResult, ClaimSource, DiffData,
+    DynExecutor, ErasedToolExecutor, ErrorKind, FilterStats, MAX_TOOL_OUTPUT_CHARS,
+    TOOL_EVENT_CHANNEL_CAP, ToolCall, ToolError, ToolEvent, ToolEventRx, ToolEventTx, ToolExecutor,
+    ToolOutput, truncate_tool_output, truncate_tool_output_at,
 };
 pub use file::FileExecutor;
 pub use filter::{

--- a/crates/zeph-tools/src/shell/checkpoint.rs
+++ b/crates/zeph-tools/src/shell/checkpoint.rs
@@ -265,9 +265,9 @@ mod tests {
 
         let mut stack = CheckpointStack::new(2);
 
-        let cp0 = make_checkpoint(&[p.clone()]);
-        let cp1 = make_checkpoint(&[p.clone()]);
-        let cp2 = make_checkpoint(&[p.clone()]);
+        let cp0 = make_checkpoint(std::slice::from_ref(&p));
+        let cp1 = make_checkpoint(std::slice::from_ref(&p));
+        let cp2 = make_checkpoint(std::slice::from_ref(&p));
         stack.record(cp0);
         stack.record(cp1);
         // At cap; recording cp2 must evict cp0 (oldest).
@@ -282,13 +282,13 @@ mod tests {
         std::fs::write(&p, "v0").unwrap();
 
         let mut stack = CheckpointStack::new(10);
-        stack.record(make_checkpoint(&[p.clone()]));
+        stack.record(make_checkpoint(std::slice::from_ref(&p)));
         stack.undo(1, 0); // moves entry to redo
         assert_eq!(stack.redo.len(), 1);
 
         // A new record must clear redo.
         std::fs::write(&p, "v1").unwrap();
-        stack.record(make_checkpoint(&[p.clone()]));
+        stack.record(make_checkpoint(std::slice::from_ref(&p)));
         assert_eq!(stack.redo.len(), 0);
     }
 
@@ -301,7 +301,7 @@ mod tests {
         std::fs::write(&p, "v0").unwrap();
 
         let mut stack = CheckpointStack::new(10);
-        stack.record(make_checkpoint(&[p.clone()]));
+        stack.record(make_checkpoint(std::slice::from_ref(&p)));
         // Request more than available — must not panic.
         let r = stack.undo(99, 0);
         assert_eq!(r.reverted_commands, 1);
@@ -317,11 +317,11 @@ mod tests {
 
         let mut stack = CheckpointStack::new(10);
 
-        let mut cp_a = make_checkpoint(&[p.clone()]);
+        let mut cp_a = make_checkpoint(std::slice::from_ref(&p));
         cp_a.command = "cmd_a".to_owned();
         cp_a.captured_at_secs = 1;
 
-        let mut cp_b = make_checkpoint(&[p.clone()]);
+        let mut cp_b = make_checkpoint(std::slice::from_ref(&p));
         cp_b.command = "cmd_b".to_owned();
         cp_b.captured_at_secs = 2;
 
@@ -343,7 +343,7 @@ mod tests {
         std::fs::write(&p, "before").unwrap();
 
         let mut stack = CheckpointStack::new(10);
-        stack.record(make_checkpoint(&[p.clone()]));
+        stack.record(make_checkpoint(std::slice::from_ref(&p)));
 
         // Simulate the write that followed the snapshot.
         std::fs::write(&p, "after").unwrap();
@@ -369,7 +369,7 @@ mod tests {
 
         let mut stack = CheckpointStack::new(10);
         // Capture before deletion (file exists).
-        stack.record(make_checkpoint(&[p.clone()]));
+        stack.record(make_checkpoint(std::slice::from_ref(&p)));
         // Simulate deletion.
         std::fs::remove_file(&p).unwrap();
 

--- a/crates/zeph-tools/src/shell/checkpoint.rs
+++ b/crates/zeph-tools/src/shell/checkpoint.rs
@@ -1,0 +1,384 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Session-scoped checkpoint stack for `/undo` and `/redo` commands.
+//!
+//! Each successful write command captured by the transactional subsystem records a
+//! [`Checkpoint`] onto the undo stack. Checkpoints are in-memory only — they are lost
+//! when the agent process exits. The undo/redo cycle uses plain [`TransactionSnapshot`]
+//! capture-before-rollback ordering (C2 fix), so no new snapshot primitives are needed.
+
+use std::path::PathBuf;
+
+use crate::executor::CheckpointEntryView;
+
+use super::transaction::TransactionSnapshot;
+
+/// A single point-in-time capture of files before a write command.
+#[derive(Debug)]
+pub(crate) struct Checkpoint {
+    /// Before-state snapshot: rolling this back restores the pre-command file state.
+    pub(crate) before_snapshot: TransactionSnapshot,
+    /// Human-readable label (the shell command string).
+    pub(crate) command: String,
+    /// Paths captured — frozen at record time, reused during undo/redo re-capture.
+    pub(crate) paths: Vec<PathBuf>,
+    /// Unix timestamp (seconds since epoch) when this checkpoint was recorded.
+    pub(crate) captured_at_secs: u64,
+}
+
+/// In-memory undo/redo checkpoint stack.
+///
+/// The undo stack grows at the tail (most-recent last). The redo stack is cleared
+/// whenever a new checkpoint is recorded. The cap (`max_checkpoints`) is enforced at
+/// record time by evicting the oldest entry from the front.
+#[derive(Debug)]
+pub(crate) struct CheckpointStack {
+    pub(crate) undo: Vec<Checkpoint>,
+    pub(crate) redo: Vec<Checkpoint>,
+    pub(crate) max_checkpoints: usize,
+}
+
+impl CheckpointStack {
+    pub(crate) fn new(max_checkpoints: usize) -> Self {
+        Self {
+            undo: Vec::new(),
+            redo: Vec::new(),
+            max_checkpoints,
+        }
+    }
+
+    /// Push a new checkpoint, evicting the oldest if the cap is exceeded.
+    ///
+    /// Clears the redo stack — any recorded forward state is invalidated by a new mutation.
+    pub(crate) fn record(&mut self, checkpoint: Checkpoint) {
+        self.redo.clear();
+        if self.max_checkpoints > 0 && self.undo.len() >= self.max_checkpoints {
+            self.undo.remove(0);
+        }
+        self.undo.push(checkpoint);
+    }
+
+    /// Pop up to `n` checkpoints and perform undo.
+    ///
+    /// For each popped checkpoint:
+    /// 1. Capture the current (after-mutation) state BEFORE restoring — this becomes the redo entry.
+    /// 2. Roll back the before-state snapshot to restore files.
+    /// 3. Push the after-state capture onto the redo stack.
+    ///
+    /// Returns a summary of what was reverted.
+    pub(crate) fn undo(&mut self, n: usize, max_snapshot_bytes: u64) -> UndoRedoResult {
+        let available = self.undo.len();
+        let count = n.min(available);
+        if count == 0 {
+            return UndoRedoResult {
+                reverted_commands: 0,
+                restored: 0,
+                deleted: 0,
+                message: "Nothing to undo.".to_owned(),
+            };
+        }
+        let mut total_restored = 0usize;
+        let mut total_deleted = 0usize;
+        let mut reverted = Vec::new();
+
+        for _ in 0..count {
+            let Some(cp) = self.undo.pop() else {
+                break;
+            };
+            // Capture after-state BEFORE rollback so deleted files are still absent.
+            let redo_snap = match TransactionSnapshot::capture(&cp.paths, max_snapshot_bytes) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    tracing::warn!(err = %e, "checkpoint undo: redo re-capture failed, redo entry skipped");
+                    None
+                }
+            };
+            let cmd = cp.command.clone();
+            let paths = cp.paths.clone();
+            let captured_at_secs = cp.captured_at_secs;
+            match cp.before_snapshot.rollback() {
+                Ok(report) => {
+                    total_restored += report.restored_count;
+                    total_deleted += report.deleted_count;
+                    reverted.push(cmd.clone());
+                    if let Some(snap) = redo_snap {
+                        self.redo.push(Checkpoint {
+                            before_snapshot: snap,
+                            command: cmd,
+                            paths,
+                            captured_at_secs,
+                        });
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(err = %e, cmd = %cmd, "checkpoint undo: rollback failed");
+                }
+            }
+        }
+
+        let actual = reverted.len();
+        let message = if actual == 0 {
+            "Undo failed: rollback errors for all checkpoints.".to_owned()
+        } else if available > count {
+            format!(
+                "Undid {} of {} available command(s); {} more available.",
+                actual,
+                available,
+                available - count
+            )
+        } else {
+            format!("Undid {actual} command(s).")
+        };
+
+        UndoRedoResult {
+            reverted_commands: actual,
+            restored: total_restored,
+            deleted: total_deleted,
+            message,
+        }
+    }
+
+    /// Pop one redo entry and re-apply the mutation.
+    ///
+    /// Mirrors undo: capture current state first, roll back the redo snapshot, push to undo.
+    pub(crate) fn redo(&mut self, max_snapshot_bytes: u64) -> UndoRedoResult {
+        let Some(cp) = self.redo.pop() else {
+            return UndoRedoResult {
+                reverted_commands: 0,
+                restored: 0,
+                deleted: 0,
+                message: "Nothing to redo.".to_owned(),
+            };
+        };
+        // Capture current (before-state) BEFORE re-applying after-state.
+        let undo_snap = match TransactionSnapshot::capture(&cp.paths, max_snapshot_bytes) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                tracing::warn!(err = %e, "checkpoint redo: undo re-capture failed, undo entry skipped");
+                None
+            }
+        };
+        let cmd = cp.command.clone();
+        let paths = cp.paths.clone();
+        let captured_at_secs = cp.captured_at_secs;
+        match cp.before_snapshot.rollback() {
+            Ok(report) => {
+                if let Some(snap) = undo_snap {
+                    self.undo.push(Checkpoint {
+                        before_snapshot: snap,
+                        command: cmd.clone(),
+                        paths,
+                        captured_at_secs,
+                    });
+                }
+                UndoRedoResult {
+                    reverted_commands: 1,
+                    restored: report.restored_count,
+                    deleted: report.deleted_count,
+                    message: format!("Redone: {cmd}"),
+                }
+            }
+            Err(e) => {
+                tracing::error!(err = %e, cmd = %cmd, "checkpoint redo: rollback failed");
+                UndoRedoResult {
+                    reverted_commands: 0,
+                    restored: 0,
+                    deleted: 0,
+                    message: format!("Redo failed: {e}"),
+                }
+            }
+        }
+    }
+
+    /// Return view entries for the undo stack (index 0 = most recent).
+    pub(crate) fn list_undo(&self) -> Vec<CheckpointEntryView> {
+        self.undo
+            .iter()
+            .enumerate()
+            .rev()
+            .map(|(stack_idx, cp)| CheckpointEntryView {
+                index: self.undo.len() - 1 - stack_idx,
+                command: cp.command.clone(),
+                captured_at_secs: cp.captured_at_secs,
+                file_count: cp.paths.len(),
+            })
+            .collect()
+    }
+
+    /// Number of redo entries available.
+    pub(crate) fn redo_depth(&self) -> usize {
+        self.redo.len()
+    }
+}
+
+/// Result of a single undo or redo operation.
+#[derive(Debug)]
+pub(crate) struct UndoRedoResult {
+    pub(crate) reverted_commands: usize,
+    pub(crate) restored: usize,
+    pub(crate) deleted: usize,
+    pub(crate) message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn make_checkpoint(paths: &[PathBuf]) -> Checkpoint {
+        let snap = TransactionSnapshot::capture(paths, 0).unwrap();
+        Checkpoint {
+            before_snapshot: snap,
+            command: "echo test".to_owned(),
+            paths: paths.to_vec(),
+            captured_at_secs: 0,
+        }
+    }
+
+    // ---- empty-stack behaviour ----
+
+    #[test]
+    fn undo_empty_stack_returns_nothing_to_undo() {
+        let mut stack = CheckpointStack::new(10);
+        let r = stack.undo(1, 0);
+        assert_eq!(r.reverted_commands, 0);
+        assert_eq!(r.message, "Nothing to undo.");
+    }
+
+    #[test]
+    fn redo_empty_stack_returns_nothing_to_redo() {
+        let mut stack = CheckpointStack::new(10);
+        let r = stack.redo(0);
+        assert_eq!(r.reverted_commands, 0);
+        assert_eq!(r.message, "Nothing to redo.");
+    }
+
+    // ---- cap eviction + redo-clear ----
+
+    #[test]
+    fn record_at_cap_evicts_oldest() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("f.txt");
+        std::fs::write(&p, "v0").unwrap();
+
+        let mut stack = CheckpointStack::new(2);
+
+        let cp0 = make_checkpoint(&[p.clone()]);
+        let cp1 = make_checkpoint(&[p.clone()]);
+        let cp2 = make_checkpoint(&[p.clone()]);
+        stack.record(cp0);
+        stack.record(cp1);
+        // At cap; recording cp2 must evict cp0 (oldest).
+        stack.record(cp2);
+        assert_eq!(stack.undo.len(), 2);
+    }
+
+    #[test]
+    fn record_clears_redo_stack() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("f.txt");
+        std::fs::write(&p, "v0").unwrap();
+
+        let mut stack = CheckpointStack::new(10);
+        stack.record(make_checkpoint(&[p.clone()]));
+        stack.undo(1, 0); // moves entry to redo
+        assert_eq!(stack.redo.len(), 1);
+
+        // A new record must clear redo.
+        std::fs::write(&p, "v1").unwrap();
+        stack.record(make_checkpoint(&[p.clone()]));
+        assert_eq!(stack.redo.len(), 0);
+    }
+
+    // ---- undo(n > available) clamping ----
+
+    #[test]
+    fn undo_n_greater_than_available_clamped() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("f.txt");
+        std::fs::write(&p, "v0").unwrap();
+
+        let mut stack = CheckpointStack::new(10);
+        stack.record(make_checkpoint(&[p.clone()]));
+        // Request more than available — must not panic.
+        let r = stack.undo(99, 0);
+        assert_eq!(r.reverted_commands, 1);
+    }
+
+    // ---- list_undo ordering ----
+
+    #[test]
+    fn list_undo_most_recent_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("f.txt");
+        std::fs::write(&p, "v0").unwrap();
+
+        let mut stack = CheckpointStack::new(10);
+
+        let mut cp_a = make_checkpoint(&[p.clone()]);
+        cp_a.command = "cmd_a".to_owned();
+        cp_a.captured_at_secs = 1;
+
+        let mut cp_b = make_checkpoint(&[p.clone()]);
+        cp_b.command = "cmd_b".to_owned();
+        cp_b.captured_at_secs = 2;
+
+        stack.record(cp_a);
+        stack.record(cp_b);
+
+        let list = stack.list_undo();
+        // Most recent (cp_b) must be first.
+        assert_eq!(list[0].command, "cmd_b");
+        assert_eq!(list[1].command, "cmd_a");
+    }
+
+    // ---- C2: undo + redo round-trip on real files ----
+
+    #[test]
+    fn undo_redo_roundtrip_restores_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("target.txt");
+        std::fs::write(&p, "before").unwrap();
+
+        let mut stack = CheckpointStack::new(10);
+        stack.record(make_checkpoint(&[p.clone()]));
+
+        // Simulate the write that followed the snapshot.
+        std::fs::write(&p, "after").unwrap();
+
+        // Undo: should restore "before".
+        let r = stack.undo(1, 0);
+        assert_eq!(r.reverted_commands, 1);
+        assert_eq!(std::fs::read_to_string(&p).unwrap(), "before");
+
+        // Redo: should re-apply "after".
+        let r2 = stack.redo(0);
+        assert_eq!(r2.reverted_commands, 1);
+        assert_eq!(std::fs::read_to_string(&p).unwrap(), "after");
+    }
+
+    // ---- C2: redo-of-delete (undo recreates, redo re-deletes) ----
+
+    #[test]
+    fn redo_of_delete_removes_file_again() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("to_delete.txt");
+        std::fs::write(&p, "exists").unwrap();
+
+        let mut stack = CheckpointStack::new(10);
+        // Capture before deletion (file exists).
+        stack.record(make_checkpoint(&[p.clone()]));
+        // Simulate deletion.
+        std::fs::remove_file(&p).unwrap();
+
+        // Undo: file should be restored.
+        stack.undo(1, 0);
+        assert!(p.exists(), "undo must restore the deleted file");
+
+        // Redo: file should be deleted again.
+        stack.redo(0);
+        assert!(!p.exists(), "redo must re-delete the restored file");
+    }
+}

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -57,6 +57,9 @@ pub use deobfuscate::deobfuscate as deobfuscate_command;
 pub mod safe_fix;
 pub use safe_fix::SafeFixSuggestion;
 
+mod checkpoint;
+use checkpoint::{Checkpoint, CheckpointStack};
+
 mod transaction;
 use transaction::{TransactionSnapshot, affected_paths, build_scope_matchers, is_write_command};
 
@@ -311,6 +314,7 @@ pub(crate) struct BashParams {
 /// # }
 /// ```
 #[derive(Debug)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct ShellExecutor {
     timeout: Duration,
     policy: Arc<ArcSwap<ShellPolicy>>,
@@ -328,6 +332,10 @@ pub struct ShellExecutor {
     snapshot_required: bool,
     max_snapshot_bytes: u64,
     transaction_scope_matchers: Vec<globset::GlobMatcher>,
+    /// Session-scoped undo/redo checkpoint stack.
+    checkpoint_stack: Arc<Mutex<CheckpointStack>>,
+    /// Whether checkpoint capture is enabled (from config).
+    checkpoints_enabled: bool,
     sandbox: Option<Arc<dyn Sandbox>>,
     sandbox_policy: Option<SandboxPolicy>,
     /// Registry of in-flight background runs. Bounded by `max_background_runs`.
@@ -414,6 +422,8 @@ impl ShellExecutor {
             snapshot_required: config.snapshot_required,
             max_snapshot_bytes: config.max_snapshot_bytes,
             transaction_scope_matchers: build_scope_matchers(&config.transaction_scope),
+            checkpoint_stack: Arc::new(Mutex::new(CheckpointStack::new(config.max_checkpoints))),
+            checkpoints_enabled: config.checkpoints_enabled,
             sandbox: None,
             sandbox_policy: None,
             background_runs: Arc::new(Mutex::new(HashMap::new())),
@@ -700,7 +710,7 @@ impl ShellExecutor {
         self.check_permissions(block, skip_confirm).await?;
         self.validate_sandbox_with_cwd(block, &resolved.cwd)?;
 
-        let (snapshot, snapshot_warning) = self.capture_snapshot_for(block)?;
+        let (snapshot, snapshot_warning, snap_paths) = self.capture_snapshot_for(block)?;
 
         if let Some(ref tx) = self.tool_event_tx {
             let sandbox_profile = self
@@ -745,9 +755,13 @@ impl ShellExecutor {
         #[allow(clippy::cast_possible_truncation)]
         let duration_ms = start.elapsed().as_millis() as u64;
 
-        if let Some(snap) = snapshot {
-            self.maybe_rollback(snap, block, exit_code, duration_ms)
-                .await;
+        if let Some(snap) = snapshot
+            && let Some(surviving) = self
+                .maybe_rollback(snap, block, exit_code, duration_ms)
+                .await
+            && self.checkpoints_enabled
+        {
+            self.record_checkpoint(surviving, block, snap_paths);
         }
 
         if let Some(err) = self
@@ -801,6 +815,7 @@ impl ShellExecutor {
     ///
     /// This is the structured-tool-call path — it uses the resolved CWD and env directly
     /// instead of re-reading process state on every call.
+    #[allow(clippy::too_many_lines)]
     #[tracing::instrument(name = "tools.shell.execute_block", skip(self, resolved), level = "info",
         fields(cwd = %resolved.cwd.display(), env_name = resolved.name.as_deref().unwrap_or("")))]
     async fn execute_block_with_context(
@@ -813,7 +828,7 @@ impl ShellExecutor {
         self.check_permissions(command, skip_confirm).await?;
         self.validate_sandbox_with_cwd(command, &resolved.cwd)?;
 
-        let (snapshot, snapshot_warning) = self.capture_snapshot_for(command)?;
+        let (snapshot, snapshot_warning, snap_paths) = self.capture_snapshot_for(command)?;
 
         if let Some(ref tx) = self.tool_event_tx {
             let sandbox_profile = self
@@ -857,9 +872,13 @@ impl ShellExecutor {
         #[allow(clippy::cast_possible_truncation)]
         let duration_ms = start.elapsed().as_millis() as u64;
 
-        if let Some(snap) = snapshot {
-            self.maybe_rollback(snap, command, exit_code, duration_ms)
-                .await;
+        if let Some(snap) = snapshot
+            && let Some(surviving) = self
+                .maybe_rollback(snap, command, exit_code, duration_ms)
+                .await
+            && self.checkpoints_enabled
+        {
+            self.record_checkpoint(surviving, command, snap_paths);
         }
 
         if let Some(err) = self
@@ -919,16 +938,63 @@ impl ShellExecutor {
         }))
     }
 
+    #[allow(clippy::type_complexity)]
     fn capture_snapshot_for(
         &self,
         block: &str,
-    ) -> Result<(Option<TransactionSnapshot>, Option<String>), ToolError> {
-        if !self.transactional || !is_write_command(block) {
-            return Ok((None, None));
+    ) -> Result<
+        (
+            Option<TransactionSnapshot>,
+            Option<String>,
+            Vec<std::path::PathBuf>,
+        ),
+        ToolError,
+    > {
+        if !(self.transactional || self.checkpoints_enabled) || !is_write_command(block) {
+            return Ok((None, None, Vec::new()));
         }
-        let paths = affected_paths(block, &self.transaction_scope_matchers);
+        let raw_paths = affected_paths(block, &self.transaction_scope_matchers);
+        if raw_paths.is_empty() {
+            return Ok((None, None, Vec::new()));
+        }
+        // Filter out paths that would escape the sandbox before capturing.
+        // `affected_paths()` strips redirect operators (`>`, `>>`, `2>`) and yields bare path
+        // strings; glued redirect tokens (e.g. `>../../etc/foo`) can produce out-of-sandbox
+        // paths that `validate_sandbox_with_cwd` never saw.  Reject any path with traversal
+        // sequences or that falls outside `allowed_paths_canonical`.
+        let paths: Vec<std::path::PathBuf> = raw_paths
+            .into_iter()
+            .filter(|p| {
+                let s = p.to_string_lossy();
+                if has_traversal(&s) {
+                    tracing::warn!(
+                        path = %p.display(),
+                        "checkpoint: skipping path with traversal sequence"
+                    );
+                    return false;
+                }
+                if !self.allowed_paths_canonical.is_empty() {
+                    let canonical = p
+                        .canonicalize()
+                        .or_else(|_| std::path::absolute(p))
+                        .unwrap_or_else(|_| p.clone());
+                    if !self
+                        .allowed_paths_canonical
+                        .iter()
+                        .any(|a| canonical.starts_with(a))
+                    {
+                        tracing::warn!(
+                            path = %p.display(),
+                            "checkpoint: skipping out-of-sandbox path"
+                        );
+                        return false;
+                    }
+                }
+                true
+            })
+            .collect();
         if paths.is_empty() {
-            return Ok((None, None));
+            return Ok((None, None, Vec::new()));
         }
         match TransactionSnapshot::capture(&paths, self.max_snapshot_bytes) {
             Ok(snap) => {
@@ -937,7 +1003,7 @@ impl ShellExecutor {
                     bytes = snap.total_bytes(),
                     "transaction snapshot captured"
                 );
-                Ok((Some(snap), None))
+                Ok((Some(snap), None, paths))
             }
             Err(e) if self.snapshot_required => Err(ToolError::SnapshotFailed {
                 reason: e.to_string(),
@@ -947,18 +1013,24 @@ impl ShellExecutor {
                 Ok((
                     None,
                     Some(format!("[warn] snapshot failed: {e}; rollback unavailable")),
+                    Vec::new(),
                 ))
             }
         }
     }
 
+    /// Perform auto-rollback if conditions are met, consuming the snapshot.
+    ///
+    /// Returns `Some(snap)` when the snapshot survived (no rollback fired) — the caller
+    /// must then either record it as a checkpoint or drop it. Returns `None` when rollback
+    /// consumed the snapshot. This design ensures exactly one consumer per snapshot (S1 fix).
     async fn maybe_rollback(
         &self,
         snap: TransactionSnapshot,
         block: &str,
         exit_code: i32,
         duration_ms: u64,
-    ) {
+    ) -> Option<TransactionSnapshot> {
         let should_rollback = self.auto_rollback
             && if self.auto_rollback_exit_codes.is_empty() {
                 exit_code >= 2
@@ -966,8 +1038,8 @@ impl ShellExecutor {
                 self.auto_rollback_exit_codes.contains(&exit_code)
             };
         if !should_rollback {
-            // Snapshot dropped here; TempDir auto-cleans.
-            return;
+            // Snapshot survives — return to caller for optional checkpoint recording.
+            return Some(snap);
         }
         match snap.rollback() {
             Ok(report) => {
@@ -1004,6 +1076,32 @@ impl ShellExecutor {
                 tracing::error!(err = %e, "transaction rollback failed");
             }
         }
+        None
+    }
+
+    /// Record a checkpoint for the given command if checkpoints are enabled.
+    ///
+    /// Called after `maybe_rollback` returns `Some` (snapshot survived). The snapshot
+    /// is consumed into the checkpoint stack; the redo stack is cleared per the standard
+    /// undo/redo invariant.
+    fn record_checkpoint(
+        &self,
+        snap: TransactionSnapshot,
+        command: &str,
+        paths: Vec<std::path::PathBuf>,
+    ) {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let captured_at_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let mut stack = self.checkpoint_stack.lock();
+        stack.record(Checkpoint {
+            before_snapshot: snap,
+            command: command.to_owned(),
+            paths,
+            captured_at_secs,
+        });
     }
 
     async fn classify_and_audit(
@@ -1674,6 +1772,50 @@ impl ToolExecutor for ShellExecutor {
 
     fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
         ShellExecutor::set_skill_env(self, env);
+    }
+
+    fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+        let result = self
+            .checkpoint_stack
+            .lock()
+            .undo(n, self.max_snapshot_bytes);
+        crate::executor::CheckpointActionResult {
+            reverted_commands: result.reverted_commands,
+            restored: result.restored,
+            deleted: result.deleted,
+            supported: true,
+            message: result.message,
+        }
+    }
+
+    fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+        let result = self.checkpoint_stack.lock().redo(self.max_snapshot_bytes);
+        crate::executor::CheckpointActionResult {
+            reverted_commands: result.reverted_commands,
+            restored: result.restored,
+            deleted: result.deleted,
+            supported: true,
+            message: result.message,
+        }
+    }
+
+    fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+        let stack = self.checkpoint_stack.lock();
+        let entries = stack
+            .list_undo()
+            .into_iter()
+            .map(|e| crate::executor::CheckpointEntryView {
+                index: e.index,
+                command: e.command,
+                captured_at_secs: e.captured_at_secs,
+                file_count: e.file_count,
+            })
+            .collect();
+        crate::executor::CheckpointListResult {
+            entries,
+            redo_depth: stack.redo_depth(),
+            supported: true,
+        }
     }
 }
 

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -21,6 +21,8 @@ fn default_config() -> ShellConfig {
         max_background_runs: 8,
         background_timeout_secs: 1800,
         risk_chain_threshold: None,
+        checkpoints_enabled: false,
+        max_checkpoints: 20,
     }
 }
 

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -430,6 +430,12 @@ impl App {
                         .to_owned(),
                 );
             }
+            TuiCommand::Undo => {
+                let _ = self.user_input_tx.try_send("/undo".to_owned());
+            }
+            TuiCommand::Redo => {
+                let _ = self.user_input_tx.try_send("/redo".to_owned());
+            }
             _ => return false,
         }
         true

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -127,6 +127,9 @@ pub enum TuiCommand {
     // Worktree subsystem (#4679)
     WorktreeList,
     WorktreeClean,
+    // Undo/redo checkpoint commands (#4990)
+    Undo,
+    Redo,
 }
 
 /// Metadata for a single entry in the command palette.
@@ -290,6 +293,20 @@ fn build_session_commands() -> Vec<CommandEntry> {
             category: "session",
             shortcut: None,
             command: TuiCommand::SessionClose,
+        },
+        CommandEntry {
+            id: "session:undo",
+            label: "Undo last shell checkpoint (/undo)",
+            category: "session",
+            shortcut: None,
+            command: TuiCommand::Undo,
+        },
+        CommandEntry {
+            id: "session:redo",
+            label: "Re-apply last undone checkpoint (/redo)",
+            category: "session",
+            shortcut: None,
+            command: TuiCommand::Redo,
         },
     ]
 }
@@ -888,7 +905,7 @@ mod tests {
 
     #[test]
     fn registry_has_correct_count() {
-        assert_eq!(command_registry().len(), 22);
+        assert_eq!(command_registry().len(), 24);
     }
 
     #[test]

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -213,6 +213,9 @@ pub(crate) struct WizardState {
     // Transactional shell (#2414)
     pub(crate) shell_transactional: bool,
     pub(crate) shell_auto_rollback: bool,
+    // Undo/redo checkpoints (#4990)
+    pub(crate) shell_checkpoints_enabled: bool,
+    pub(crate) shell_max_checkpoints: usize,
     // File read sandbox (#2525)
     pub(crate) file_deny_read: Vec<String>,
     pub(crate) file_allow_read: Vec<String>,
@@ -421,6 +424,8 @@ impl Default for WizardState {
             database_url: None,
             shell_transactional: false,
             shell_auto_rollback: false,
+            shell_checkpoints_enabled: false,
+            shell_max_checkpoints: 20,
             file_deny_read: Vec::new(),
             file_allow_read: Vec::new(),
             sandbox_enabled: false,
@@ -991,6 +996,8 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     config.security.vigil.strict_mode = state.vigil_strict_mode;
     config.tools.shell.transactional = state.shell_transactional;
     config.tools.shell.auto_rollback = state.shell_auto_rollback;
+    config.tools.shell.checkpoints_enabled = state.shell_checkpoints_enabled;
+    config.tools.shell.max_checkpoints = state.shell_max_checkpoints;
     config
         .tools
         .file

--- a/src/init/security.rs
+++ b/src/init/security.rs
@@ -260,6 +260,19 @@ pub(super) fn step_security(state: &mut WizardState) -> anyhow::Result<()> {
             .default(false)
             .interact()?;
     }
+    state.shell_checkpoints_enabled = Confirm::new()
+        .with_prompt(
+            "Enable /undo and /redo checkpoints? (captures file state before write commands for session-scoped undo/redo; requires [tools.shell] checkpoints_enabled = true)",
+        )
+        .default(false)
+        .interact()?;
+    if state.shell_checkpoints_enabled {
+        let max_str: String = dialoguer::Input::new()
+            .with_prompt("Maximum number of undo checkpoints (0 = unlimited)")
+            .default("20".to_owned())
+            .interact_text()?;
+        state.shell_max_checkpoints = max_str.trim().parse::<usize>().unwrap_or(20);
+    }
 
     let deny_raw: String = dialoguer::Input::new()
         .with_prompt(


### PR DESCRIPTION
## Summary

- Adds session-level `/undo [N|list]` and `/redo` slash commands for rolling back and restoring agent file changes (closes #4990)
- Implements a `CheckpointStack` in `zeph-tools` that reuses the existing `FileTransaction` snapshot mechanism (DRY, no new machinery)
- Fixes path traversal amplification via glued shell redirects in `capture_snapshot_for`
- Adds regression tests for `skill_fallback_mode` compact-prompt paths in `assembly.rs` (closes #5000)

## Changes

### zeph-tools
- `CheckpointStack` in `shell/checkpoint.rs` — capture-before-rollback ordering (C2 invariant), eviction cap, redo-clear on new write, `spawn_blocking` for fs-heavy ops, no `Mutex` held across `await`
- `ErasedToolExecutor` three-site extension following the `set_skill_env` precedent
- Path traversal filter in `capture_snapshot_for`: all captured paths validated through `has_traversal` + `allowed_paths_canonical` before snapshot creation
- 8 unit tests covering empty-stack, eviction, N-clamping, redo-clear, C2 round-trip, redo-of-delete

### zeph-commands
- `UndoCommand` + `RedoCommand` handlers with `/undo [N|list]` and `/redo` syntax
- Both registered in `COMMANDS`

### zeph-core
- `AgentAccess::handle_undo` / `handle_redo` trait methods with default no-op impls
- `Agent` impl with `spawn_blocking` for fs-heavy ops
- `skill_fallback_tests.rs` — 3 regression tests for compact vs full skill injection

### zeph-config
- `checkpoints_enabled` + `max_checkpoints` fields in `ShellConfig`
- Migration step 60 (`migrate_shell_checkpoints_config`)

### zeph-tui
- `TuiCommand::Undo` / `Redo` variants + `session:undo` / `session:redo` in command palette

### src/init
- Init wizard prompts for `checkpoints_enabled` and `max_checkpoints`

## Security

Closes a pre-existing path traversal amplification: glued redirect tokens (`>../../etc/foo`) were captured by `extract_redirection_targets` but not validated before being stored in checkpoints, making `/undo` an out-of-sandbox write primitive. Fixed by filtering captured paths through `has_traversal` + `allowed_paths` in `capture_snapshot_for`.

## Test plan

- [ ] `cargo +nightly fmt --check` — PASS
- [ ] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — PASS
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — PASS
- [ ] `cargo nextest run --workspace --lib --bins` — 10730 passed, 0 failed
- [ ] Live test: `cargo run --features full -- --config .local/config/testing.toml` and run `/undo list`, make a file edit, run `/undo`, verify rollback, run `/redo`, verify re-apply (see `.local/testing/playbooks/undo-redo.md`)

Closes #4990
Closes #5000