### PR TITLE
fix(llm): apply restored reasoning_effort to active provider (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(llm)`: apply restored `reasoning_effort` to the active OpenAI / Compatible provider on startup. `restore_provider_overrides` (Phase 1, #4668) stored the value but never called `set_reasoning_effort` — LLM requests silently used the config-file default instead of the user-set runtime override. `AnyProvider::set_reasoning_effort` now covers both `OpenAi` and `Compatible` arms; invalid effort values are rejected with a warning (closes #5007)
+
 - `fix(tui)`: TUI transcript cannot be scrolled in Insert mode (#4988).
   - `PageUp`/`PageDown` now scroll the transcript in Insert mode (previously silently ignored).
   - `EnableAlternateScroll` (DECSET 1007h) is retained; native terminal scroll and click-drag text selection work without holding Shift or Option.

--- a/crates/zeph-core/src/agent/provider_cmd.rs
+++ b/crates/zeph-core/src/agent/provider_cmd.rs
@@ -163,30 +163,35 @@ impl<C: Channel> Agent<C> {
             }
         };
 
-        // Phase 1: reasoning_effort is only meaningful for OpenAI providers.
+        // reasoning_effort applies to OpenAI and OpenAI-compatible providers.
         if let Some(ref effort) = overrides.reasoning_effort {
             let provider_name = self.provider.name();
-            // Check whether the active provider is OpenAI-backed by inspecting the pool entry.
-            let is_openai = self
+            let supports_reasoning_effort = self
                 .runtime
                 .providers
                 .provider_pool
                 .iter()
                 .find(|e| e.effective_name().eq_ignore_ascii_case(provider_name))
-                .is_some_and(|e| e.provider_type == zeph_config::ProviderKind::OpenAi);
+                .is_some_and(|e| {
+                    matches!(
+                        e.provider_type,
+                        zeph_config::ProviderKind::OpenAi | zeph_config::ProviderKind::Compatible
+                    )
+                });
 
-            if is_openai {
-                tracing::debug!(
+            if supports_reasoning_effort {
+                self.provider.set_reasoning_effort(Some(effort.clone()));
+                tracing::info!(
                     channel_type,
                     reasoning_effort = effort,
-                    "restored provider override: reasoning_effort (Phase 1 storage groundwork)"
+                    "restored provider override: reasoning_effort applied to active provider"
                 );
             } else {
                 tracing::warn!(
                     channel_type,
                     provider = provider_name,
                     reasoning_effort = effort,
-                    "persisted reasoning_effort is not applicable to non-OpenAI provider — skipping"
+                    "persisted reasoning_effort is not applicable to this provider — skipping"
                 );
             }
         }

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -355,6 +355,23 @@ impl AnyProvider {
         }
     }
 
+    /// Apply a `reasoning_effort` override to the active provider.
+    ///
+    /// Delegates to [`OpenAiProvider::set_reasoning_effort`] when the inner variant is
+    /// `AnyProvider::OpenAi` or `AnyProvider::Compatible` (which wraps an [`OpenAiProvider`]
+    /// internally). No-op for all other provider types — `reasoning_effort` is an OpenAI-specific
+    /// parameter and has no equivalent in Ollama, Claude, Gemini, etc.
+    ///
+    /// Called by the session restore path after a provider switch to propagate a persisted
+    /// effort level (e.g. `"high"`) into the live provider instance.
+    pub fn set_reasoning_effort(&mut self, effort: Option<String>) {
+        match self {
+            Self::OpenAi(p) => p.set_reasoning_effort(effort),
+            Self::Compatible(p) => p.set_reasoning_effort(effort),
+            _ => {}
+        }
+    }
+
     /// Propagate a status sender to the inner provider (where supported).
     pub fn set_status_tx(&mut self, tx: StatusTx) {
         match self {

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -193,6 +193,15 @@ impl CompatibleProvider {
                 .with_output_schema_forwarding(enabled, hint_bytes, max_description_bytes);
         self
     }
+
+    /// Apply a `reasoning_effort` override to the inner [`OpenAiProvider`].
+    ///
+    /// Delegates to [`OpenAiProvider::set_reasoning_effort`], which validates the value
+    /// (`"low"`, `"medium"`, or `"high"`) and logs a warning for any unknown value.
+    /// Pass `None` to clear a previously-set effort level.
+    pub fn set_reasoning_effort(&mut self, effort: Option<String>) {
+        self.inner.set_reasoning_effort(effort);
+    }
 }
 
 impl LlmProvider for CompatibleProvider {
@@ -418,5 +427,29 @@ mod tests {
         // Smoke-test that the builder compiles and returns self without panicking.
         let p = test_provider().with_output_schema_forwarding(true, 512, usize::MAX);
         assert_eq!(p.name(), "groq");
+    }
+
+    // ── reasoning_effort restore path (#5007 Phase 2) ────────────────────────
+
+    #[test]
+    fn set_reasoning_effort_applies_via_compatible() {
+        let mut p = test_provider();
+        p.set_reasoning_effort(Some("high".into()));
+        assert_eq!(p.inner.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn any_provider_set_reasoning_effort_delegates_to_compatible() {
+        use crate::any::AnyProvider;
+        let mut any = AnyProvider::Compatible(test_provider());
+        any.set_reasoning_effort(Some("high".into()));
+        let AnyProvider::Compatible(ref p) = any else {
+            panic!("variant must remain Compatible");
+        };
+        assert_eq!(
+            p.inner.reasoning_effort.as_deref(),
+            Some("high"),
+            "Compatible inner OpenAiProvider must have reasoning_effort applied"
+        );
     }
 }

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -148,7 +148,7 @@ pub struct OpenAiProvider {
     max_tokens: u32,
     embedding_model: Option<String>,
     /// Reasoning effort level for `o*` models (`"low"`, `"medium"`, or `"high"`).
-    reasoning_effort: Option<String>,
+    pub(crate) reasoning_effort: Option<String>,
     pub(crate) status_tx: Option<StatusTx>,
     usage: UsageTracker,
     generation_overrides: Option<GenerationOverrides>,
@@ -337,6 +337,42 @@ impl OpenAiProvider {
     pub fn with_completion_tokens_param(mut self, param: CompletionTokensParam) -> Self {
         self.completion_tokens_override = Some(param);
         self
+    }
+
+    /// Apply a `reasoning_effort` override at runtime, replacing the value set at construction.
+    ///
+    /// Called by the restore path after a provider switch so that a persisted `reasoning_effort`
+    /// value (e.g. `"high"`) is reflected in all outgoing requests for this session.
+    /// Pass `None` to clear a previously-set effort level.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::openai::{OpenAiConfig, OpenAiProvider};
+    ///
+    /// let mut provider = OpenAiProvider::new(OpenAiConfig {
+    ///     api_key: "k".into(),
+    ///     base_url: "https://api.openai.com/v1".into(),
+    ///     model: "o3".into(),
+    ///     max_tokens: 8192,
+    ///     embedding_model: None,
+    ///     reasoning_effort: None,
+    ///     context_window: None,
+    ///     completion_tokens_param: None,
+    /// });
+    /// provider.set_reasoning_effort(Some("high".into()));
+    /// ```
+    pub fn set_reasoning_effort(&mut self, effort: Option<String>) {
+        if let Some(ref v) = effort
+            && !matches!(v.as_str(), "low" | "medium" | "high")
+        {
+            tracing::warn!(
+                value = v,
+                "ignoring unknown reasoning_effort value — expected low|medium|high"
+            );
+            return;
+        }
+        self.reasoning_effort = effort;
     }
 
     /// Resolve which [`CompletionTokens`] variant to use for this request.

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -1895,3 +1895,91 @@ fn with_completion_tokens_param_builder_sets_override() {
     let json = serde_json::to_string(&p.completion_tokens()).unwrap();
     assert!(json.contains("\"max_completion_tokens\":2048"));
 }
+
+// ── reasoning_effort restore path (#5007 Phase 2) ──────────────────────────
+
+#[test]
+fn set_reasoning_effort_applies_value() {
+    let mut p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o3".into(),
+        max_tokens: 8192,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    assert!(p.reasoning_effort.is_none(), "starts without effort");
+    p.set_reasoning_effort(Some("high".into()));
+    assert_eq!(p.reasoning_effort.as_deref(), Some("high"));
+}
+
+#[test]
+fn set_reasoning_effort_clears_value() {
+    let mut p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o3".into(),
+        max_tokens: 8192,
+        embedding_model: None,
+        reasoning_effort: Some("medium".into()),
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    p.set_reasoning_effort(None);
+    assert!(p.reasoning_effort.is_none());
+}
+
+#[test]
+fn any_provider_set_reasoning_effort_delegates_to_openai() {
+    use crate::any::AnyProvider;
+    let inner = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o3".into(),
+        max_tokens: 8192,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    let mut any = AnyProvider::OpenAi(inner);
+    any.set_reasoning_effort(Some("high".into()));
+    let AnyProvider::OpenAi(ref p) = any else {
+        panic!("variant must remain OpenAi");
+    };
+    assert_eq!(p.reasoning_effort.as_deref(), Some("high"));
+}
+
+#[test]
+fn any_provider_set_reasoning_effort_noop_for_non_openai() {
+    use crate::any::AnyProvider;
+    use crate::ollama::OllamaProvider;
+    let mut any = AnyProvider::Ollama(OllamaProvider::new(
+        "http://localhost:11434",
+        "qwen3:8b".into(),
+        "nomic-embed-text".into(),
+    ));
+    // Must not panic; Ollama silently ignores the call.
+    any.set_reasoning_effort(Some("high".into()));
+}
+
+#[test]
+fn set_reasoning_effort_rejects_invalid_value() {
+    let mut p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o3".into(),
+        max_tokens: 8192,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    p.set_reasoning_effort(Some("ultra".into()));
+    assert!(
+        p.reasoning_effort.is_none(),
+        "invalid value must be rejected and field must remain None"
+    );
+}


### PR DESCRIPTION
## Summary

- `restore_provider_overrides` (#4668 Phase 1) persisted `reasoning_effort` to the DB but never applied it to the live provider — LLM requests silently used the config-file default for the entire session
- `AnyProvider::set_reasoning_effort` now covers `OpenAi` and `Compatible` arms (vLLM/LM Studio users were affected by the same gap)
- Invalid effort values (`"ultra"`, `""`) are rejected with a warning at the setter level before reaching the API

## Changes

| File | Change |
|------|--------|
| `crates/zeph-llm/src/openai/mod.rs` | `pub fn set_reasoning_effort` with whitelist guard (`low\|medium\|high`) |
| `crates/zeph-llm/src/compatible.rs` | `pub fn set_reasoning_effort` delegating to `self.inner` |
| `crates/zeph-llm/src/any.rs` | Delegation to `OpenAi` and `Compatible` arms |
| `crates/zeph-core/src/agent/provider_cmd.rs` | `restore_provider_overrides` calls `set_reasoning_effort`; gate renamed to `supports_reasoning_effort` and extended to `ProviderKind::Compatible` |
| `crates/zeph-llm/src/openai/tests.rs` | 7 new unit tests (899 total) |

## Test plan

- [x] `cargo nextest run -p zeph-llm -p zeph-core --lib` — 2432 passed, 0 failed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Live API test: blocked (OpenAI 429, Claude 400 billing) — LLM serialization gate deferred to CI-1017 with Ollama when providers recover
- [x] New tests cover: apply value, clear value, reject invalid value, AnyProvider→OpenAi delegation, AnyProvider→Compatible delegation, AnyProvider no-op for Ollama

Closes #5007