### PR TITLE
fix(tools): checkpoint_undo(0) misleading message and has_traversal backslash bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tools)`: `CheckpointStack::undo` now returns a distinct error message ("Undo count must be > 0.") when called with `n = 0` instead of the misleading "Nothing to undo." message, which falsely implied the stack was empty (closes #5033)
+- `fix(tools)`: `has_traversal` now detects Windows-style path traversal sequences using backslash separators (`..\\`) in addition to forward slashes, preventing sandbox escape via `affected_paths` on Windows or cross-platform paths (closes #5032)
+
 - `fix(llm)`: apply restored `reasoning_effort` to the active OpenAI / Compatible provider on startup. `restore_provider_overrides` (Phase 1, #4668) stored the value but never called `set_reasoning_effort` — LLM requests silently used the config-file default instead of the user-set runtime override. `AnyProvider::set_reasoning_effort` now covers both `OpenAi` and `Compatible` arms; invalid effort values are rejected with a warning (closes #5007)
 
 - `fix(tui)`: TUI transcript cannot be scrolled in Insert mode (#4988).

--- a/crates/zeph-tools/src/shell/checkpoint.rs
+++ b/crates/zeph-tools/src/shell/checkpoint.rs
@@ -68,6 +68,17 @@ impl CheckpointStack {
     ///
     /// Returns a summary of what was reverted.
     pub(crate) fn undo(&mut self, n: usize, max_snapshot_bytes: u64) -> UndoRedoResult {
+        // Distinct guard: n == 0 is a caller error, not an empty-stack condition.
+        // Without this, count = 0.min(available) → 0 falls into the same early-return
+        // branch and emits the misleading "Nothing to undo." message even when entries exist.
+        if n == 0 {
+            return UndoRedoResult {
+                reverted_commands: 0,
+                restored: 0,
+                deleted: 0,
+                message: "Undo count must be > 0.".to_owned(),
+            };
+        }
         let available = self.undo.len();
         let count = n.min(available);
         if count == 0 {
@@ -235,6 +246,25 @@ mod tests {
             paths: paths.to_vec(),
             captured_at_secs: 0,
         }
+    }
+
+    // ---- undo(0) on non-empty stack ----
+
+    #[test]
+    fn undo_zero_count_on_non_empty_stack() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("f.txt");
+        std::fs::write(&p, "v0").unwrap();
+
+        let mut stack = CheckpointStack::new(10);
+        stack.record(make_checkpoint(std::slice::from_ref(&p)));
+        assert_eq!(stack.undo.len(), 1);
+
+        let r = stack.undo(0, 0);
+        assert_eq!(r.message, "Undo count must be > 0.");
+        assert_eq!(r.reverted_commands, 0);
+        // Stack must be unchanged.
+        assert_eq!(stack.undo.len(), 1);
     }
 
     // ---- empty-stack behaviour ----

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -2656,7 +2656,7 @@ fn classify_shell_exit(
 }
 
 fn has_traversal(path: &str) -> bool {
-    path.split('/').any(|seg| seg == "..")
+    path.split(['/', '\\']).any(|seg| seg == "..")
 }
 
 fn extract_bash_blocks(text: &str) -> Vec<&str> {

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -3339,4 +3339,12 @@ mod resolve_context {
             "rm -fr .git/worktrees must be blocked"
         );
     }
+
+    #[test]
+    fn has_traversal_detects_backslash_sequences() {
+        assert!(has_traversal("..\\..\\etc\\passwd"));
+        assert!(has_traversal("../.."));
+        assert!(!has_traversal("normal/path/file.txt"));
+        assert!(!has_traversal("relative\\path\\file.txt"));
+    }
 }


### PR DESCRIPTION
## Summary

- **#5033** — `CheckpointStack::undo` returned `"Nothing to undo."` when called with `n = 0` even if the stack was non-empty. Added an explicit guard at the top of `undo` that returns `"Undo count must be > 0."`, keeping it distinct from the empty-stack path.
- **#5032** — `has_traversal` split paths on `/` only; Windows-style `..\\` sequences were not detected. Extended the split to `['/', '\\']` for defense-in-depth on cross-platform or LLM-generated paths.

Both fixes include regression tests. `cargo nextest run -p zeph-tools --lib`: 1238/1238 PASS.

## Test plan

- [ ] `shell::checkpoint::tests::undo_zero_count_on_non_empty_stack` — verifies distinct message and stack-unchanged invariant
- [ ] `shell::tests::resolve_context::has_traversal_detects_backslash_sequences` — covers pure backslash, POSIX regression, and safe paths
- [ ] `cargo clippy -p zeph-tools -- -D warnings` passes clean
- [ ] Full CI passes

Closes #5033
Closes #5032