### PR TITLE
test(context): add fidelity provider wiring assertions in apply_session_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `test(context)`: add `apply_session_config_wires_fidelity_providers` unit test in `zeph-core` — asserts that non-empty `FidelityConfig::semantic_scoring_provider` / `compress_provider` names produce `Some` in `compaction.fidelity_semantic_provider` / `fidelity_compress_provider` after `apply_session_config`, and that empty names or absent config produce `None` (closes #5035)
 - `test(config)`: add 3 unit tests for `migrate_caveman_config` migration step 59 (closes #5027). Covers: fresh config (commented-out block appended), idempotency when `[caveman]` section present, idempotency when `# [caveman]` commented block present. Follows the pattern of `migrate_worktree_git_timeout` and sibling step tests.
 - `refactor(tui)`: centralise scroll-step magic numbers in `zeph-tui` — `SCROLL_STEP_PAGE = 10` constant defined once in `keys.rs` and referenced from all four `scroll_offset` mutation sites in `handle_normal_key` and `handle_insert_scroll_keys`. `SCROLL_STEP_MOUSE` omitted: mouse scroll handler was removed in #4996 (closes #4997)
 - `docs(spec-063)`: document `panic = "abort"` limitation for `CwdRestoreGuard` — the RAII Drop guarantee only holds under `panic = "unwind"`; under `panic = "abort"` (active in `[profile.release]`) Drop is skipped but the process terminates immediately so the system remains in a defined state. Updated `spec.md` and `srs.md` FR-CWD-03 accordingly (closes #4754)

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2770,6 +2770,93 @@ mod tests {
         );
     }
 
+    /// Verify that `apply_session_config` wires `fidelity_semantic_provider` and
+    /// `fidelity_compress_provider` when the corresponding `FidelityConfig` provider names are
+    /// non-empty, and leaves them `None` when the names are empty or the config is absent.
+    #[test]
+    fn apply_session_config_wires_fidelity_providers() {
+        use crate::config::Config;
+
+        // Non-empty provider names → both fields must be Some after apply_session_config.
+        let mut session_cfg = AgentSessionConfig::from_config(&Config::default(), 100_000);
+        session_cfg.fidelity_config = Some(zeph_config::FidelityConfig {
+            enabled: true,
+            semantic_scoring_provider: Some(zeph_config::ProviderName::new("embed-fast")),
+            compress_provider: Some(zeph_config::ProviderName::new("compress-quality")),
+            ..zeph_config::FidelityConfig::default()
+        });
+        let agent = make_agent().apply_session_config(session_cfg);
+        assert!(
+            agent
+                .services
+                .memory
+                .compaction
+                .fidelity_semantic_provider
+                .is_some(),
+            "fidelity_semantic_provider must be Some when semantic_scoring_provider name is non-empty"
+        );
+        assert!(
+            agent
+                .services
+                .memory
+                .compaction
+                .fidelity_compress_provider
+                .is_some(),
+            "fidelity_compress_provider must be Some when compress_provider name is non-empty"
+        );
+
+        // Empty provider names → both fields must be None.
+        let mut session_cfg_empty = AgentSessionConfig::from_config(&Config::default(), 100_000);
+        session_cfg_empty.fidelity_config = Some(zeph_config::FidelityConfig {
+            enabled: true,
+            semantic_scoring_provider: Some(zeph_config::ProviderName::new("")),
+            compress_provider: Some(zeph_config::ProviderName::new("")),
+            ..zeph_config::FidelityConfig::default()
+        });
+        let agent_empty = make_agent().apply_session_config(session_cfg_empty);
+        assert!(
+            agent_empty
+                .services
+                .memory
+                .compaction
+                .fidelity_semantic_provider
+                .is_none(),
+            "fidelity_semantic_provider must be None when semantic_scoring_provider name is empty"
+        );
+        assert!(
+            agent_empty
+                .services
+                .memory
+                .compaction
+                .fidelity_compress_provider
+                .is_none(),
+            "fidelity_compress_provider must be None when compress_provider name is empty"
+        );
+
+        // fidelity_config absent → both fields must be None.
+        let mut session_cfg_none = AgentSessionConfig::from_config(&Config::default(), 100_000);
+        session_cfg_none.fidelity_config = None;
+        let agent_none = make_agent().apply_session_config(session_cfg_none);
+        assert!(
+            agent_none
+                .services
+                .memory
+                .compaction
+                .fidelity_semantic_provider
+                .is_none(),
+            "fidelity_semantic_provider must be None when fidelity_config is absent"
+        );
+        assert!(
+            agent_none
+                .services
+                .memory
+                .compaction
+                .fidelity_compress_provider
+                .is_none(),
+            "fidelity_compress_provider must be None when fidelity_config is absent"
+        );
+    }
+
     #[test]
     fn with_skill_matching_config_sets_fields() {
         let agent = make_agent().with_skill_matching_config(0.7, true, 0.85);


### PR DESCRIPTION
## Summary

Closes #5035

Adds `apply_session_config_wires_fidelity_providers` to the `zeph-core` builder test suite. The test covers all three control-flow branches of the fidelity provider wiring path (`builder.rs:2240-2254`):

- Non-empty `FidelityConfig::semantic_scoring_provider` / `compress_provider` names → `compaction.fidelity_semantic_provider` and `compaction.fidelity_compress_provider` are both `Some` after `apply_session_config`.
- Empty names → both fields are `None`.
- Absent `FidelityConfig` → both fields are `None`.

Both fields are asserted independently so a partial regression (one field unwired while the other is not) is caught immediately.

**Coverage scope**: this test verifies Option-guard and field-wiring correctness. It does not assert end-to-end provider registry resolution (that path is a follow-up, see below).

## Test plan

- [x] `cargo nextest run -p zeph-core -E 'test(apply_session_config)'` — 3/3 pass
- [x] Full `cargo nextest run -p zeph-core` — 1547/1547 pass, 0 regressions
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core -- -D warnings` — clean
- [x] Test-only diff: no production logic changed

## Follow-up

The impl-critic identified that `resolve_background_provider` always returns a provider (never `None`), so `Some(_)` confirms the non-empty filter fired but not that the named provider was resolved from the pool. A separate P3 issue will cover end-to-end registry resolution coverage for `arise.rs`.