### PR TITLE
feat(deep-link): Phase 1 — parser, config, cwd validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - `feat(knowledge)`: add `zeph knowledge` CLI with `ingest`, `rollback` (stub), and `status` subcommands. `KnowledgeSource` ValueEnum covers `specs`, `changelog`, `handoff`, `coverage`, `git-log` sources. INV-6 path allowlist enforced via canonical `starts_with(project_root)` check on both sides (closes #5017)
-- `feat(knowledge)`: add `[knowledge]` config section (`ingest_provider`, `concurrency`, `max_documents`, `recall_include_imported`, `transcript_scope`). Migration step 60 (`migrate_knowledge_config`) adds the section idempotently to existing configs. `--init` wizard emits `[knowledge]` only when non-default values are chosen (closes #5017)
+- `feat(knowledge)`: add `[knowledge]` config section (`ingest_provider`, `concurrency`, `max_documents`, `recall_include_imported`, `transcript_scope`). Migration step 61 (`migrate_knowledge_config`) adds the section idempotently to existing configs. `--init` wizard emits `[knowledge]` only when non-default values are chosen (closes #5017)
 - `feat(knowledge)`: add `IngestLedger` repository in `zeph-memory` — idempotency re-read guard for both ingest sinks. Dual migrations: `sqlite/102_knowledge_ingest_ledger.sql` and `postgres/103_knowledge_ingest_ledger.sql`. `ingested_at` stored as ISO-8601 TEXT in both dialects. INV-5: re-read/cost guard only, not a drift guard; rustdoc states the limitation explicitly (closes #5016)
 - `feat(knowledge)`: wire notes sink into `zeph knowledge ingest` — static project artifacts (`specs/`, `CHANGELOG.md`, `.local/handoff/`, coverage-status, `git log`) ingested into Qdrant via existing `IngestionPipeline`. Ledger skip prevents re-embedding unchanged files. `--dry-run` reports file count, projected chunks, and estimated embed tokens without writing anything. `source_uri` threaded into Qdrant payload. Tracing spans on all I/O paths (closes #5018)
+- `feat(deep-link)`: Phase 1 foundation for the `zeph://` deep link scheme (spec-066, closes #5011)
+  - `deep-link` Cargo feature (included in `desktop` bundle, not in `default`)
+  - `crates/zeph-common`: `parse_deep_link(uri)` — sync, panic-free URI parser; percent-decodes query params; enforces 8192-byte prompt cap and control-char rejection; drops `auto`/`-y` params with WARN (INV-NOAUTO); backed by proptest fuzz
+  - `crates/zeph-config`: `DeepLinkConfig` + `AcpPreference` types; `confirm_before_prompt` defaults to `true` (secure default); migration step 62 injects `[deep_link]` advisory block into existing configs
+  - `src/url_scheme`: `validate_deep_link_cwd` following INV-CWD (absolute → canonicalize → case-fold → denylist → allowlist → is_dir); expanded denylist (Linux: `/etc` `/root` `/boot` `/run`; macOS: `/System` `/Library/Keychains`; Windows: `SystemRoot`/`WINDIR`)
+- `docs(spec-066)`: correct INV-TRUST reference — `TrustLevel::Untrusted` (non-existent) replaced with `ContentTrustLevel::ExternalUntrusted` from `zeph-sanitizer`; Phase 1 deferral note added; `DeferredHost` error variant removed in favour of `UnknownHost` for all unknown actions (closes #5030)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10455,6 +10455,7 @@ dependencies = [
  "sqlx",
  "sysinfo",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
@@ -10713,6 +10714,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "parking_lot",
+ "proptest",
  "regex",
  "schemars 1.2.1",
  "serde",
@@ -10729,6 +10731,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "url",
  "uuid",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ readme = "README.md"
 default = ["scheduler", "sqlite"]
 
 # === Use-case bundles ===
-desktop = ["tui"]
+desktop = ["tui", "deep-link"]
 ide     = ["acp", "acp-http"]
 server  = ["gateway", "a2a", "otel", "prometheus"]
 chat    = ["discord", "slack"]
@@ -218,6 +218,7 @@ sandbox    = ["zeph-tools/sandbox"]
 bench      = ["dep:zeph-bench"]
 
 # === Individual feature flags ===
+deep-link = []
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server", "zeph-a2a?/ibct"]
 acp = ["dep:zeph-acp", "zeph-acp/unstable-session-delete", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-logout", "zeph-acp/unstable-auth-methods", "zeph-acp/unstable-message-id", "zeph-acp/unstable-session-add-dirs"]
 acp-http = ["acp", "dep:axum", "zeph-acp/acp-http"]
@@ -304,6 +305,7 @@ serde_json.workspace = true
 similar.workspace = true
 sysinfo = { workspace = true, optional = true }
 tempfile.workspace = true
+thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util.workspace = true
 toml.workspace = true

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -44,11 +44,13 @@ tree-sitter-javascript = { workspace = true, optional = true }
 tree-sitter-python = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
+url.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 zeroize = { workspace = true, features = ["alloc", "derive", "serde"] }
 
 [dev-dependencies]
 metrics-util = { workspace = true, features = ["debugging"] }
+proptest.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/zeph-common/src/deep_link.rs
+++ b/crates/zeph-common/src/deep_link.rs
@@ -1,0 +1,346 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `zeph://` URI parser (spec-066).
+//!
+//! This module provides [`parse_deep_link`], a sync, panic-free, I/O-free parser for
+//! `zeph://` URIs. It lives in `zeph-common` (Layer-0a) so it can be used by both the
+//! CLI entry point and any future channel that needs to handle deep-link URIs without
+//! pulling in higher-level crates.
+//!
+//! # Supported URIs
+//!
+//! - `zeph://new-session` — open a new agent session with optional parameters:
+//!   - `?prompt=<text>` — percent-encoded prompt text (max 8192 bytes after decoding)
+//!   - `?cwd=<path>` — absolute working directory (validated by caller via INV-CWD)
+//!   - `?profile=<name>` — named config profile (validated against known profiles by caller)
+//!   - `?model=<name>` — provider name from `[[llm.providers]]` (validated by caller)
+//!
+//! # Security
+//!
+//! - `auto` and `-y` query parameters are silently dropped with a `WARN` log (INV-NOAUTO).
+//! - Prompt length is checked after percent-decoding; URIs with prompt > 8192 bytes are
+//!   rejected with [`DeepLinkError::PromptTooLong`].
+//! - Prompts containing C0 control characters (except TAB `0x09`, LF `0x0a`, CR `0x0d`) or
+//!   DEL `0x7f` are rejected with [`DeepLinkError::PromptContainsControlChars`] to prevent
+//!   terminal injection attacks.
+//! - `cwd` must be an absolute path; relative paths are rejected with
+//!   [`DeepLinkError::CwdNotAbsolute`]. Further validation (canonicalization, denylist,
+//!   allowlist) is performed by `validate_deep_link_cwd` in `src/url_scheme/validate.rs`.
+
+use std::path::PathBuf;
+
+const PROMPT_MAX_BYTES: usize = 8192;
+
+/// Parsed representation of a `zeph://` URI.
+///
+/// Currently only the `new-session` action is defined. Additional variants may be added
+/// in future spec revisions.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::deep_link::{DeepLink, parse_deep_link};
+///
+/// let link = parse_deep_link("zeph://new-session?prompt=Hello").unwrap();
+/// assert!(matches!(link, DeepLink::NewSession(_)));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeepLink {
+    /// Open a new agent session with the given parameters.
+    NewSession(NewSessionParams),
+}
+
+/// Parameters extracted from a `zeph://new-session` URI.
+///
+/// All fields are optional; callers validate non-`None` values against their respective
+/// registries (profile names, provider names) before use.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::deep_link::{DeepLink, parse_deep_link};
+/// use std::path::PathBuf;
+///
+/// let link = parse_deep_link("zeph://new-session?cwd=%2Fhome%2Fuser&prompt=Hi").unwrap();
+/// let DeepLink::NewSession(params) = link;
+/// assert_eq!(params.cwd, Some(PathBuf::from("/home/user")));
+/// assert_eq!(params.prompt.as_deref(), Some("Hi"));
+/// ```
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NewSessionParams {
+    /// Absolute working directory (percent-decoded). Callers must invoke
+    /// `validate_deep_link_cwd` before using this value.
+    pub cwd: Option<PathBuf>,
+    /// Percent-decoded prompt text. Length is capped at 8192 bytes.
+    /// Not yet sanitized — callers must pass through the content sanitizer.
+    pub prompt: Option<String>,
+    /// Named config profile alias. Validated against known profiles by the caller.
+    pub profile: Option<String>,
+    /// Provider name from `[[llm.providers]]`. Validated by the caller.
+    pub model: Option<String>,
+}
+
+/// Errors returned by [`parse_deep_link`].
+#[derive(Debug, thiserror::Error)]
+pub enum DeepLinkError {
+    /// The URI is structurally invalid (not a valid URL, wrong scheme, etc.).
+    #[error("malformed URI: {0}")]
+    Malformed(String),
+
+    /// The host portion names an unknown action.
+    ///
+    /// This typically means the user has a URI intended for a newer version of Zeph.
+    /// Unknown hosts are rejected; new host actions added in future versions will still
+    /// return this error until Zeph is upgraded.
+    #[error("unknown scheme action '{0}'; try upgrading zeph")]
+    UnknownHost(String),
+
+    /// The decoded `prompt` parameter exceeds the 8192-byte limit.
+    #[error("prompt too long: {0} bytes (limit: 8192)")]
+    PromptTooLong(usize),
+
+    /// The `cwd` parameter is a relative path; only absolute paths are accepted.
+    #[error("cwd must be an absolute path")]
+    CwdNotAbsolute,
+
+    /// The decoded `prompt` contains disallowed control characters.
+    #[error("prompt contains disallowed control characters")]
+    PromptContainsControlChars,
+}
+
+/// Parses a `zeph://` URI string into a typed [`DeepLink`].
+///
+/// This function is sync, panic-free, and performs no I/O or network calls.
+/// Percent-encoding in query parameters is decoded automatically by the `url` crate.
+///
+/// # Security
+///
+/// - `auto` and `-y` query parameters are silently dropped with a `WARN` log (INV-NOAUTO).
+/// - Prompt length is enforced after decoding; URIs with > 8192-byte prompts are rejected.
+/// - `cwd` is checked for absolute path; further validation is the caller's responsibility.
+///
+/// # Errors
+///
+/// - [`DeepLinkError::Malformed`] — URI cannot be parsed or has a scheme other than `zeph`.
+/// - [`DeepLinkError::UnknownHost`] — the host part does not name a known action.
+/// - [`DeepLinkError::PromptTooLong`] — decoded prompt exceeds 8192 bytes.
+/// - [`DeepLinkError::CwdNotAbsolute`] — `cwd` query param is a relative path.
+/// - [`DeepLinkError::PromptContainsControlChars`] — prompt contains bytes < 0x20 (except TAB/LF/CR) or 0x7f.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::deep_link::{DeepLink, parse_deep_link};
+///
+/// let link = parse_deep_link("zeph://new-session?prompt=Hello").unwrap();
+/// assert!(matches!(link, DeepLink::NewSession(_)));
+///
+/// let err = parse_deep_link("http://example.com");
+/// assert!(err.is_err());
+/// ```
+pub fn parse_deep_link(uri: &str) -> Result<DeepLink, DeepLinkError> {
+    let parsed = url::Url::parse(uri).map_err(|e| DeepLinkError::Malformed(e.to_string()))?;
+
+    if parsed.scheme() != "zeph" {
+        return Err(DeepLinkError::Malformed(format!(
+            "expected scheme 'zeph', got '{}'",
+            parsed.scheme()
+        )));
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| DeepLinkError::Malformed("missing action host".to_owned()))?;
+
+    match host {
+        "new-session" => {
+            let params = parse_new_session_params(&parsed)?;
+            Ok(DeepLink::NewSession(params))
+        }
+        other => Err(DeepLinkError::UnknownHost(other.to_owned())),
+    }
+}
+
+fn contains_control_chars(s: &str) -> bool {
+    s.bytes()
+        .any(|b| matches!(b, 0x00..=0x08 | 0x0b | 0x0c | 0x0e..=0x1f | 0x7f))
+}
+
+fn parse_new_session_params(url: &url::Url) -> Result<NewSessionParams, DeepLinkError> {
+    let mut params = NewSessionParams::default();
+
+    for (key, value) in url.query_pairs() {
+        match key.as_ref() {
+            "prompt" => {
+                let text = value.into_owned();
+                if text.len() > PROMPT_MAX_BYTES {
+                    return Err(DeepLinkError::PromptTooLong(text.len()));
+                }
+                if contains_control_chars(&text) {
+                    return Err(DeepLinkError::PromptContainsControlChars);
+                }
+                params.prompt = Some(text);
+            }
+            "cwd" => {
+                let path = PathBuf::from(value.as_ref());
+                if path.is_relative() {
+                    return Err(DeepLinkError::CwdNotAbsolute);
+                }
+                params.cwd = Some(path);
+            }
+            "profile" => {
+                params.profile = Some(value.into_owned());
+            }
+            "model" => {
+                params.model = Some(value.into_owned());
+            }
+            "auto" | "-y" => {
+                // INV-NOAUTO: auto-escalation params are silently dropped.
+                tracing::warn!(param = %key, "deep-link: auto-escalation param dropped (INV-NOAUTO)");
+            }
+            _ => {
+                // Unknown params are silently ignored for forward compatibility.
+            }
+        }
+    }
+
+    Ok(params)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_new_session_with_prompt_and_cwd() {
+        let link = parse_deep_link("zeph://new-session?prompt=Hello&cwd=/home/user").unwrap();
+        let DeepLink::NewSession(p) = link;
+        assert_eq!(p.prompt.as_deref(), Some("Hello"));
+        assert_eq!(p.cwd, Some(PathBuf::from("/home/user")));
+    }
+
+    #[test]
+    fn invalid_scheme_returns_malformed() {
+        let err = parse_deep_link("http://example.com").unwrap_err();
+        assert!(matches!(err, DeepLinkError::Malformed(_)));
+    }
+
+    #[test]
+    fn unknown_host_returns_error() {
+        let err = parse_deep_link("zeph://unknown-action").unwrap_err();
+        assert!(matches!(err, DeepLinkError::UnknownHost(_)));
+    }
+
+    #[test]
+    fn oversized_prompt_returns_error() {
+        let big = "x".repeat(PROMPT_MAX_BYTES + 1);
+        let uri = format!("zeph://new-session?prompt={big}");
+        let err = parse_deep_link(&uri).unwrap_err();
+        assert!(matches!(err, DeepLinkError::PromptTooLong(n) if n == PROMPT_MAX_BYTES + 1));
+    }
+
+    #[test]
+    fn percent_decoded_prompt() {
+        let link = parse_deep_link("zeph://new-session?prompt=Hello%20World").unwrap();
+        let DeepLink::NewSession(p) = link;
+        assert_eq!(p.prompt.as_deref(), Some("Hello World"));
+    }
+
+    #[test]
+    fn auto_param_dropped_prompt_still_parsed() {
+        let link = parse_deep_link("zeph://new-session?auto=true&prompt=ok").unwrap();
+        let DeepLink::NewSession(p) = link;
+        assert_eq!(p.prompt.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn relative_cwd_returns_error() {
+        let err = parse_deep_link("zeph://new-session?cwd=relative/path").unwrap_err();
+        assert!(matches!(err, DeepLinkError::CwdNotAbsolute));
+    }
+
+    #[test]
+    fn absolute_cwd_stored() {
+        let link = parse_deep_link("zeph://new-session?cwd=/home/user").unwrap();
+        let DeepLink::NewSession(p) = link;
+        assert_eq!(p.cwd, Some(PathBuf::from("/home/user")));
+    }
+
+    #[test]
+    fn profile_and_model_stored() {
+        let link = parse_deep_link("zeph://new-session?profile=dev&model=fast").unwrap();
+        let DeepLink::NewSession(p) = link;
+        assert_eq!(p.profile.as_deref(), Some("dev"));
+        assert_eq!(p.model.as_deref(), Some("fast"));
+    }
+
+    #[test]
+    fn dash_y_param_dropped() {
+        let link = parse_deep_link("zeph://new-session?-y&prompt=ok").unwrap();
+        let DeepLink::NewSession(p) = link;
+        assert_eq!(p.prompt.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn unknown_params_silently_ignored() {
+        let link = parse_deep_link("zeph://new-session?foo=bar&prompt=hi").unwrap();
+        let DeepLink::NewSession(p) = link;
+        assert_eq!(p.prompt.as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn nul_byte_in_prompt_returns_control_chars_error() {
+        let uri = "zeph://new-session?prompt=hello%00world";
+        let err = parse_deep_link(uri).unwrap_err();
+        assert!(
+            matches!(err, DeepLinkError::PromptContainsControlChars),
+            "expected PromptContainsControlChars, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn tab_and_lf_in_prompt_are_accepted() {
+        let uri = "zeph://new-session?prompt=line1%09tab%0Aline2";
+        let result = parse_deep_link(uri).unwrap();
+        let DeepLink::NewSession(p) = result;
+        assert_eq!(p.prompt.as_deref(), Some("line1\ttab\nline2"));
+    }
+
+    #[test]
+    fn esc_sequence_in_prompt_returns_control_chars_error() {
+        // ESC byte is 0x1b — must be rejected
+        let uri = "zeph://new-session?prompt=hello%1bworld";
+        // 0x1b falls in 0x0e..=0x1f range: rejected
+        let err = parse_deep_link(uri).unwrap_err();
+        assert!(
+            matches!(err, DeepLinkError::PromptContainsControlChars),
+            "expected PromptContainsControlChars for ESC, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn prompt_exactly_8192_bytes_ok() {
+        let prompt = "a".repeat(8192);
+        let uri = format!("zeph://new-session?prompt={prompt}");
+        let result = parse_deep_link(&uri);
+        assert!(result.is_ok(), "exactly 8192 bytes should be accepted");
+    }
+
+    #[test]
+    fn bare_new_session_no_params() {
+        let result = parse_deep_link("zeph://new-session").unwrap();
+        let DeepLink::NewSession(p) = result;
+        assert!(p.cwd.is_none());
+        assert!(p.prompt.is_none());
+        assert!(p.profile.is_none());
+        assert!(p.model.is_none());
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn fuzz_parse_deep_link_no_panic(s in ".*") {
+            let _ = parse_deep_link(&s);
+        }
+    }
+}

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod audit;
 pub mod config;
+pub mod deep_link;
 pub mod error_taxonomy;
 pub mod fidelity;
 pub mod fs_secure;

--- a/crates/zeph-config/src/deep_link.rs
+++ b/crates/zeph-config/src/deep_link.rs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Configuration types for the `zeph://` deep-link scheme (spec-066).
+//!
+//! This module provides [`DeepLinkConfig`] for the `[deep_link]` config section and the
+//! [`AcpPreference`] enum for controlling ACP attach behaviour. All types use explicit
+//! `Default` impls where needed to preserve secure defaults that differ from Rust's
+//! type-level defaults (e.g., `bool::default()` is `false`, but `confirm_before_prompt`
+//! must default to `true`).
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the `[deep_link]` section.
+///
+/// Controls security gates, path allowlists, and ACP attach preferences for sessions
+/// initiated via `zeph://` URIs. Gated by the `deep-link` Cargo feature.
+///
+/// All fields have `#[serde(default)]` so existing configs without `[deep_link]` parse
+/// cleanly with secure defaults.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_config::deep_link::DeepLinkConfig;
+///
+/// let cfg = DeepLinkConfig::default();
+/// assert!(cfg.confirm_before_prompt, "default must require confirmation");
+/// assert!(cfg.allowed_cwd_roots.is_empty());
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct DeepLinkConfig {
+    /// When `true`, the agent presents the injected prompt to the user and requires
+    /// explicit confirmation before enqueuing it. Defaults to `true` (secure default).
+    ///
+    /// Set to `false` only in environments where prompt injection risk is fully
+    /// mitigated (e.g., internal tooling with a known-good URL source).
+    pub confirm_before_prompt: bool,
+
+    /// Restrict the working directory to these root prefixes. An empty list means any
+    /// non-denylisted absolute path is accepted.
+    ///
+    /// Validation is performed by `validate_deep_link_cwd` in `src/url_scheme/validate.rs`
+    /// after canonicalization and denylist checks (INV-CWD order).
+    pub allowed_cwd_roots: Vec<PathBuf>,
+
+    /// ACP server attach preference for deep-link sessions.
+    ///
+    /// `Never` (default) always spawns a fresh session. `Auto` and `Always` are reserved
+    /// for v2 and are currently treated identically to `Never`.
+    pub prefer_acp: AcpPreference,
+}
+
+impl Default for DeepLinkConfig {
+    /// Returns a `DeepLinkConfig` with secure defaults.
+    ///
+    /// `confirm_before_prompt` is `true` — this is intentional. `bool::default()` is
+    /// `false`, so `#[derive(Default)]` would silently produce an insecure default.
+    fn default() -> Self {
+        Self {
+            confirm_before_prompt: true,
+            allowed_cwd_roots: Vec::new(),
+            prefer_acp: AcpPreference::Never,
+        }
+    }
+}
+
+/// ACP server attach preference for deep-link-initiated sessions.
+///
+/// `Never` is the only supported mode in v1. `Auto` and `Always` are parsed and accepted
+/// by the config but treated identically to `Never` until the v2 ACP discovery mechanism
+/// is implemented (see spec-066 §13 for the v2 design sketch).
+///
+/// # Examples
+///
+/// ```
+/// use zeph_config::deep_link::AcpPreference;
+///
+/// let pref = AcpPreference::default();
+/// assert!(matches!(pref, AcpPreference::Never));
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AcpPreference {
+    /// Always spawn a fresh session; never attempt ACP attach. This is the only
+    /// mode that has effect in v1.
+    #[default]
+    Never,
+    /// Attempt ACP attach when a running session is detected; fall back to spawn.
+    /// Reserved for v2 — currently treated as `Never`.
+    Auto,
+    /// Always attempt ACP attach; fail if no running session is found.
+    /// Reserved for v2 — currently treated as `Never`.
+    Always,
+}

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -76,6 +76,7 @@ pub mod classifiers;
 pub mod cli;
 pub mod cocoon;
 mod de_helpers;
+pub mod deep_link;
 pub mod defaults;
 pub mod dump_format;
 pub mod durable;
@@ -199,5 +200,6 @@ pub use worktree::{BgIsolation, WorktreeBaseRef, WorktreeConfig};
 
 // Top-level config struct, error type, and resolved secrets — moved from zeph-core.
 pub use classifiers::{ClassifiersConfig, InjectionEnforcementMode};
+pub use deep_link::{AcpPreference, DeepLinkConfig};
 pub use error::ConfigError;
 pub use root::{Config, ResolvedSecrets};

--- a/crates/zeph-config/src/migrate/features.rs
+++ b/crates/zeph-config/src/migrate/features.rs
@@ -286,6 +286,39 @@ pub fn migrate_caveman_config(toml_src: &str) -> Result<MigrationResult, Migrate
     })
 }
 
+/// Add a commented-out `[deep_link]` section if absent (spec-066, #5011).
+///
+/// All `DeepLinkConfig` fields have `#[serde(default)]` so existing configs parse without
+/// changes; this migration only surfaces the section so users can discover and configure it.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the migration
+/// function convention.
+pub fn migrate_deep_link_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("[deep_link]") || toml_src.contains("# [deep_link]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [deep_link] — zeph:// URI scheme configuration (spec-066, #5011).\n\
+         # Requires the `deep-link` Cargo feature to be active.\n\
+         # [deep_link]\n\
+         # confirm_before_prompt = true   # require y/N before injecting prompt (secure default)\n\
+         # allowed_cwd_roots = []          # restrict cwd to these prefixes; empty = any non-denylisted path\n\
+         # prefer_acp = \"never\"           # v1 only: \"never\"; \"auto\"/\"always\" reserved for v2\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["deep_link".to_owned()],
+    })
+}
+
 /// Add a commented-out `[memory.five_signal]` section if absent (#4374).
 ///
 /// All five-signal fields have `#[serde(default)]` so existing configs parse without changes.

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -21,8 +21,9 @@ mod tools;
 
 pub use features::{
     migrate_autodream_config, migrate_caveman_config, migrate_compression_predictor_config,
-    migrate_five_signal_config, migrate_goals_config, migrate_knowledge_config,
-    migrate_magic_docs_config, migrate_microcompact_config, migrate_orchestration_persistence,
+    migrate_deep_link_config, migrate_five_signal_config, migrate_goals_config,
+    migrate_knowledge_config, migrate_magic_docs_config, migrate_microcompact_config,
+    migrate_orchestration_persistence,
 };
 pub use infra::*;
 /// Advisory `GonkaGate` migration is crate-internal (registered via the [`MIGRATIONS`] registry).
@@ -90,6 +91,7 @@ static CANONICAL_ORDER: &[&str] = &[
     "lsp",
     "telemetry",
     "session",
+    "deep_link",
 ];
 
 /// Error type for migration failures.
@@ -594,7 +596,7 @@ use steps::{
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
     MigrateAutodreamConfig, MigrateCavemanConfig, MigrateCocoonProviderNotice,
     MigrateCocoonShowBalance, MigrateCompressionPredictorConfig, MigrateDatabaseUrl,
-    MigrateDurableConfig, MigrateEgressConfig, MigrateEmbedProviderRename,
+    MigrateDeepLinkConfig, MigrateDurableConfig, MigrateEgressConfig, MigrateEmbedProviderRename,
     MigrateEvalModelToProvider, MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig,
     MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig, MigrateGoalsConfig,
     MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
@@ -718,6 +720,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateShellCheckpointsConfig),
             // Step 61 — add [knowledge] section advisory notice (spec-067, #5017)
             Box::new(MigrateKnowledgeConfig),
+            // Step 62 — add [deep_link] section advisory notice (spec-066, #5011)
+            Box::new(MigrateDeepLinkConfig),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -16,7 +16,12 @@
 //! step 54 adds `[worktree]` section with defaults (#4679);
 //! step 55 adds `git_timeout_secs` to `[worktree]` (#4704);
 //! step 56 adds `[llm.stream_limits]` advisory notice (#4750);
-//! step 60 adds `[knowledge]` section advisory notice (spec-067, #5017).
+//! step 57 adds `[durable]` execution-layer section (spec-064, #4949);
+//! step 58 renames `eval_model` → `eval_provider` (#4987);
+//! step 59 adds `[caveman]` ultra-compressed output section (#4985);
+//! step 60 adds `[tools.shell]` checkpoints (#4990);
+//! step 61 adds `[knowledge]` section advisory notice (spec-067, #5017);
+//! step 62 adds `[deep_link]` advisory notice (spec-066, #5011).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -26,9 +31,9 @@ use super::{
     MigrateError, Migration, MigrationResult, migrate_acp_subagents_config,
     migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_autodream_config,
     migrate_caveman_config, migrate_cocoon_provider_notice, migrate_cocoon_show_balance,
-    migrate_compression_predictor_config, migrate_database_url, migrate_durable_config,
-    migrate_egress_config, migrate_embed_provider_rename, migrate_eval_model_to_provider,
-    migrate_fidelity_timeout_defaults, migrate_five_signal_config,
+    migrate_compression_predictor_config, migrate_database_url, migrate_deep_link_config,
+    migrate_durable_config, migrate_egress_config, migrate_embed_provider_rename,
+    migrate_eval_model_to_provider, migrate_fidelity_timeout_defaults, migrate_five_signal_config,
     migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
     migrate_knowledge_config, migrate_llm_stream_limits, migrate_magic_docs_config,
@@ -49,7 +54,7 @@ use super::{
     migrate_worktree_config, migrate_worktree_git_timeout,
 };
 
-// ── Wrapper structs for all 59 sequential migration steps ───────────────────────────────────────
+// ── Wrapper structs for all 61 sequential migration steps ───────────────────────────────────────
 
 pub(super) struct MigrateSttToProvider;
 impl Migration for MigrateSttToProvider {
@@ -719,5 +724,16 @@ impl Migration for MigrateKnowledgeConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_knowledge_config(toml_src)
+    }
+}
+
+pub(super) struct MigrateDeepLinkConfig;
+impl Migration for MigrateDeepLinkConfig {
+    fn name(&self) -> &'static str {
+        "migrate_deep_link_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_deep_link_config(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        61,
-        "MIGRATIONS registry must contain all 61 sequential steps"
+        62,
+        "MIGRATIONS registry must contain all 62 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1684,7 +1684,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–60).
+    // Names must follow the documented step order (steps 1–61).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1747,6 +1747,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_caveman_config",
         "migrate_shell_checkpoints_config",
         "migrate_knowledge_config",
+        "migrate_deep_link_config",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -2546,5 +2547,36 @@ fn step_61_idempotent_on_own_output() {
     assert_eq!(
         second.changed_count, 0,
         "step_61 must be idempotent on its own output"
+    );
+}
+
+// ── Step 62 — migrate_deep_link_config (#5011) ────────────────────────────────
+
+#[test]
+fn migrate_deep_link_adds_advisory_comment_when_absent() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let result = migrate_deep_link_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result.sections_changed.contains(&"deep_link".to_owned()),
+        "sections_changed should include 'deep_link'"
+    );
+    assert!(
+        result.output.contains("# [deep_link]"),
+        "output should contain commented [deep_link] advisory block"
+    );
+}
+
+#[test]
+fn migrate_deep_link_is_idempotent() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let first = migrate_deep_link_config(src).expect("first migration");
+    assert_eq!(first.changed_count, 1);
+
+    let second = migrate_deep_link_config(&first.output).expect("second migration");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output must be unchanged on second run"
     );
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -1645,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 61);
+    assert_eq!(MIGRATIONS.len(), 62);
 }
 
 #[test]

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -150,6 +150,9 @@ pub struct Config {
     /// document limit, and recall inclusion of imported rows (spec-067).
     #[serde(default)]
     pub knowledge: crate::knowledge::KnowledgeConfig,
+    /// Deep-link scheme configuration (`[deep_link]`). Gated by the `deep-link` feature.
+    #[serde(default)]
+    pub deep_link: crate::deep_link::DeepLinkConfig,
 }
 
 /// Secrets resolved from the vault at runtime.
@@ -355,6 +358,7 @@ impl Default for Config {
             durable: crate::durable::DurableConfig::default(),
             caveman: crate::features::CavemanConfig::default(),
             knowledge: crate::knowledge::KnowledgeConfig::default(),
+            deep_link: crate::deep_link::DeepLinkConfig::default(),
         }
     }
 }

--- a/specs/066-deep-link-scheme/spec.md
+++ b/specs/066-deep-link-scheme/spec.md
@@ -73,12 +73,12 @@ pub enum DeepLinkError {
     Malformed(String),
     #[error("unknown scheme action '{0}'; try upgrading zeph")]
     UnknownHost(String),
-    #[error("unsupported action '{0}' (reserved for a future version)")]
-    DeferredHost(String),
     #[error("prompt too long: {0} bytes (limit: 8192)")]
     PromptTooLong(usize),
     #[error("cwd must be an absolute path")]
     CwdNotAbsolute,
+    #[error("prompt contains disallowed control characters")]
+    PromptContainsControlChars,
 }
 ```
 
@@ -132,7 +132,7 @@ NewSessionParams { cwd, prompt, profile, model }
     ├── profile → equivalent of --config <profile_path> (look up in [profiles] map)
     ├── model   → set active_provider by name before agent start
     ├── cwd     → set process working directory (after validate_deep_link_cwd)
-    └── prompt  → enqueue as first QueuedMessage with trust_level = Untrusted
+    └── prompt  → enqueue as first QueuedMessage with ContentTrustLevel::ExternalUntrusted
                   (after confirmation gate)
 ```
 
@@ -141,9 +141,15 @@ a thin pre-processor, not a separate agent loop.
 
 ## 6. Prompt Trust Invariant (INV-TRUST)
 
-ANY prompt injected via a deep link MUST carry `trust_level = Untrusted`.
+ANY prompt injected via a deep link MUST carry `ContentTrustLevel::ExternalUntrusted`.
 It MUST NOT enter the message queue as a system or instruction message.
-The `TrustLevel` enum in `zeph-common/src/trust_level.rs` is the authoritative reference.
+`ContentTrustLevel` is defined in `zeph-sanitizer` (`zeph-sanitizer/src/types.rs`) and is
+the authoritative trust-level type for content entering the agent pipeline.
+
+> **Phase 1 note:** `QueuedMessage` in `crates/zeph-core/src/agent/message_queue.rs`
+> currently has no `trust_level` field — INV-TRUST enforcement is deferred to Phase 2
+> (CLI dispatch arm in `runner.rs`), where the sanitizer will be invoked before the prompt
+> is enqueued. Phase 1 only establishes the type reference.
 
 ## 7. Configuration Schema
 
@@ -247,7 +253,7 @@ Full registration support tracked in follow-up issue (OQ-1).
 |---|---|---|
 | INV-CWD | cwd validation order: decode → absolute → canonicalize → case-fold → denylist → allowlist → is_dir | `validate.rs` |
 | INV-LOOP | url-open checks ZEPH_URL_OPEN_DEPTH before dispatching; sets it before launching child | `runner.rs` |
-| INV-TRUST | prompt from deep link is always Untrusted | `runner.rs` enqueue path |
+| INV-TRUST | prompt from deep link always carries `ContentTrustLevel::ExternalUntrusted` (from `zeph-sanitizer/src/types.rs`) | `runner.rs` enqueue path (Phase 2) |
 | INV-NOAUTO | auto-escalation params (`auto`, `-y`) are silently dropped + WARN logged | `parse_deep_link` |
 | INV-SYNC | `parse_deep_link` is sync, panic-free, no I/O, no zeph-* deps | `deep_link.rs` |
 | INV-NOTTY | if no TTY + confirm_before_prompt=true, prompt discarded, blank session starts | `runner.rs` |

--- a/specs/066-deep-link-scheme/tasks.md
+++ b/specs/066-deep-link-scheme/tasks.md
@@ -49,8 +49,8 @@ Traceability: each task references the FR/NFR/INV it satisfies.
 2. Implement `DeepLink`, `NewSessionParams`, `DeepLinkError` (exact signatures from spec §2).
 3. Implement `parse_deep_link(uri: &str) -> Result<DeepLink, DeepLinkError>`:
    - Reject non-`zeph://` schemes.
-   - Dispatch on host: `new-session` → parse query params; deferred hosts → `DeferredHost`;
-     others → `UnknownHost`.
+   - Dispatch on host: `new-session` → parse query params; others → `UnknownHost`
+     (unknown hosts include future deferred-action hosts — no separate variant).
    - Percent-decode ALL query param values before validation.
    - `prompt`: measure byte length post-decode; return `PromptTooLong` if > 8192.
    - `cwd`: store as raw `PathBuf` (no I/O here — validation is in TASK-3).
@@ -60,7 +60,7 @@ Traceability: each task references the FR/NFR/INV it satisfies.
 
 **Acceptance** (FR-1, FR-2, FR-3, FR-4, FR-7, FR-10, INV-SYNC, NFR-2.1, NFR-4.1):
 - `parse_deep_link("zeph://new-session")` returns `Ok(DeepLink::NewSession(..))`.
-- `parse_deep_link("zeph://resume")` returns `Err(DeepLinkError::DeferredHost("resume"))`.
+- `parse_deep_link("zeph://resume")` returns `Err(DeepLinkError::UnknownHost("resume"))`.
 - `parse_deep_link("zeph://foo")` returns `Err(DeepLinkError::UnknownHost("foo"))`.
 - `parse_deep_link("zeph://new-session?prompt=" + "a".repeat(8193))` returns
   `Err(DeepLinkError::PromptTooLong(8193))`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,8 @@ mod startup_checks;
 mod tracing_init;
 mod tui_bridge;
 mod tui_remote;
+#[cfg(feature = "deep-link")]
+mod url_scheme;
 
 use clap::Parser;
 use cli::Cli;

--- a/src/url_scheme/mod.rs
+++ b/src/url_scheme/mod.rs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! URL scheme handling for `zeph://` deep links.
+//!
+//! This module contains platform-specific registration and validation logic for
+//! the `zeph://` URI scheme. It is gated behind the `deep-link` feature flag.
+//!
+//! # Modules
+//!
+//! - [`validate`] — CWD path validation following INV-CWD from spec §3.
+
+pub mod validate;

--- a/src/url_scheme/validate.rs
+++ b/src/url_scheme/validate.rs
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+#![allow(dead_code)]
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Errors returned by [`validate_deep_link_cwd`].
+#[derive(Debug, Error)]
+pub enum CwdValidationError {
+    /// The supplied path is not absolute.
+    #[error("path must be absolute")]
+    NotAbsolute,
+    /// `std::fs::canonicalize` failed (I/O error or path does not exist).
+    #[error("canonicalization failed: {0}")]
+    CanonicalizeFailed(std::io::Error),
+    /// The canonical path matches a hardcoded denylist entry.
+    #[error("path is in a denied location: {0}")]
+    Denied(String),
+    /// `allowed_roots` is non-empty and the canonical path does not start with any root.
+    #[error("path is outside allowed roots")]
+    OutsideAllowedRoots,
+    /// The canonical path exists but is not a directory.
+    #[error("path is not a directory")]
+    NotADirectory,
+}
+
+impl From<std::io::Error> for CwdValidationError {
+    fn from(e: std::io::Error) -> Self {
+        Self::CanonicalizeFailed(e)
+    }
+}
+
+/// Validates a cwd path received from a deep-link URI for safe use as a working directory.
+///
+/// Follows INV-CWD from spec §3: absolute → canonicalize → case-fold →
+/// denylist → allowlist → `is_dir`. Steps must not be reordered.
+///
+/// # Errors
+///
+/// Returns [`CwdValidationError`] on the first validation failure.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::PathBuf;
+/// # use zeph::url_scheme::validate::validate_deep_link_cwd;
+/// let result = validate_deep_link_cwd(&PathBuf::from("/home/user/project"), &[]);
+/// assert!(result.is_ok());
+/// ```
+pub fn validate_deep_link_cwd(
+    raw: &Path,
+    allowed_roots: &[PathBuf],
+) -> Result<PathBuf, CwdValidationError> {
+    // Step 1: assert path is absolute.
+    if !raw.is_absolute() {
+        return Err(CwdValidationError::NotAbsolute);
+    }
+
+    // Step 2: canonicalize to resolve symlinks, .., and ..
+    // SAFETY: TOCTOU window between canonicalize and use is accepted per spec §3.
+    let canonical = std::fs::canonicalize(raw)?;
+
+    // Step 3: case-fold for comparison (lowercase on macOS/Windows; no-op on Linux).
+    let canonical_str = canonical.to_string_lossy().into_owned();
+    #[cfg(not(target_os = "linux"))]
+    let folded = canonical_str.to_lowercase();
+    #[cfg(target_os = "linux")]
+    let folded = canonical_str.clone();
+
+    // Step 4: compare against hardcoded denylist (case-folded root prefixes).
+    let denied = build_denylist();
+    for entry in &denied {
+        // A denylist entry "/proc" must block "/proc" and "/proc/anything" but not "/processing".
+        // Use starts_with + boundary check: either exact match or followed by '/'.
+        let is_exact = folded == *entry;
+        let is_prefix = folded.starts_with(&format!("{entry}/"));
+        if is_exact || is_prefix {
+            return Err(CwdValidationError::Denied(canonical_str));
+        }
+    }
+
+    // Step 5: if allowed_roots non-empty, assert starts_with at least one root.
+    if !allowed_roots.is_empty() {
+        let allowed = allowed_roots.iter().any(|root| canonical.starts_with(root));
+        if !allowed {
+            return Err(CwdValidationError::OutsideAllowedRoots);
+        }
+    }
+
+    // Step 6: assert metadata().is_dir().
+    let meta = canonical.metadata()?;
+    if !meta.is_dir() {
+        return Err(CwdValidationError::NotADirectory);
+    }
+
+    Ok(canonical)
+}
+
+/// Builds the case-folded hardcoded denylist of root prefixes.
+///
+/// On non-Linux platforms the entries are lowercased; on Linux they are returned as-is
+/// since filesystem paths are case-sensitive.
+///
+/// # Note
+///
+/// When `HOME` is unset or empty, home-directory entries are omitted from the denylist.
+/// This is safe: an unset `HOME` typically indicates a sandboxed or service environment
+/// where the user's home directory is not accessible.
+pub(crate) fn build_denylist() -> Vec<String> {
+    #[cfg(target_os = "linux")]
+    let static_entries: &[&str] = &["/proc", "/sys", "/dev", "/etc", "/root", "/boot", "/run"];
+    #[cfg(target_os = "macos")]
+    let static_entries: &[&str] = &["/proc", "/sys", "/dev", "/System", "/Library/Keychains"];
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    let static_entries: &[&str] = &["/proc", "/sys", "/dev"];
+
+    let home = std::env::var("HOME").unwrap_or_default();
+
+    let home_entries: Vec<String> = if home.is_empty() {
+        Vec::new()
+    } else {
+        vec![
+            format!("{home}/.ssh"),
+            format!("{home}/.gnupg"),
+            format!("{home}/.aws"),
+        ]
+    };
+
+    let mut result: Vec<String> = static_entries
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
+    result.extend(home_entries);
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::env;
+        if let Ok(sysroot) = env::var("SystemRoot") {
+            result.push(sysroot);
+        }
+        if let Ok(windir) = env::var("WINDIR") {
+            result.push(windir);
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        result = result.into_iter().map(|s| s.to_lowercase()).collect();
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn absolute_path_to_temp_dir_is_ok() {
+        let dir = std::env::temp_dir();
+        let result = validate_deep_link_cwd(&dir, &[]);
+        assert!(result.is_ok(), "temp dir should be valid: {result:?}");
+    }
+
+    #[test]
+    fn relative_path_returns_not_absolute() {
+        let result = validate_deep_link_cwd(Path::new("relative/path"), &[]);
+        assert!(
+            matches!(result, Err(CwdValidationError::NotAbsolute)),
+            "expected NotAbsolute, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn nonexistent_path_returns_canonicalize_failed() {
+        let result = validate_deep_link_cwd(
+            Path::new("/this/path/definitely/does/not/exist/zeph_test"),
+            &[],
+        );
+        assert!(
+            matches!(result, Err(CwdValidationError::CanonicalizeFailed(_))),
+            "expected CanonicalizeFailed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn file_path_returns_not_a_directory() {
+        let tmp = std::env::temp_dir();
+        let file_path = tmp.join("zeph_cwd_test_file.txt");
+        fs::write(&file_path, b"test").expect("write test file");
+        let result = validate_deep_link_cwd(&file_path, &[]);
+        let _ = fs::remove_file(&file_path);
+        assert!(
+            matches!(result, Err(CwdValidationError::NotADirectory)),
+            "expected NotADirectory, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn path_outside_allowed_roots_returns_error() {
+        let dir = std::env::temp_dir();
+        let allowed = vec![PathBuf::from("/nonexistent/root/zeph_allowed")];
+        let result = validate_deep_link_cwd(&dir, &allowed);
+        assert!(
+            matches!(result, Err(CwdValidationError::OutsideAllowedRoots)),
+            "expected OutsideAllowedRoots, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn path_within_allowed_roots_is_ok() {
+        let dir = std::env::temp_dir();
+        // Canonicalize the allowed root so it matches what validate_deep_link_cwd produces.
+        // On macOS /var/folders resolves to /private/var/folders after canonicalize.
+        let canonical_root = std::fs::canonicalize(&dir).expect("canonicalize temp dir");
+        let allowed = vec![canonical_root];
+        let result = validate_deep_link_cwd(&dir, &allowed);
+        assert!(
+            result.is_ok(),
+            "path within allowed roots should pass: {result:?}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_path_is_denied() {
+        let result = validate_deep_link_cwd(Path::new("/proc"), &[]);
+        assert!(
+            matches!(result, Err(CwdValidationError::Denied(_))),
+            "expected Denied for /proc, got {result:?}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sys_path_is_denied() {
+        let result = validate_deep_link_cwd(Path::new("/sys"), &[]);
+        assert!(
+            matches!(result, Err(CwdValidationError::Denied(_))),
+            "expected Denied for /sys, got {result:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn home_dirs_denied_macos() {
+        if let Ok(home) = std::env::var("HOME") {
+            let ssh_path = std::path::PathBuf::from(&home).join(".ssh");
+            if ssh_path.exists() {
+                let result = validate_deep_link_cwd(&ssh_path, &[]);
+                assert!(
+                    matches!(result, Err(CwdValidationError::Denied(_))),
+                    "~/.ssh should be denied: {result:?}"
+                );
+            } else {
+                let denylist = build_denylist();
+                let ssh_entry = format!("{home}/.ssh").to_lowercase();
+                assert!(
+                    denylist.iter().any(|d| d == &ssh_entry),
+                    "~/.ssh should be in denylist; got {denylist:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn denylist_false_positive_processing() {
+        // /processing must NOT be blocked by the /proc entry.
+        let denylist = build_denylist();
+        let candidate = "/processing";
+        for entry in &denylist {
+            let is_exact = candidate == entry.as_str();
+            let is_prefix = candidate.starts_with(&format!("{entry}/"));
+            assert!(
+                !is_exact && !is_prefix,
+                "/processing should not be denied by denylist entry {entry:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **#5011** — deep-link Phase 1 foundation: `parse_deep_link` URI parser (zeph-common), `DeepLinkConfig` + migration step 61 (zeph-config), `validate_deep_link_cwd` (src/url_scheme) with INV-CWD-compliant denylist
- **#5030** — spec-066 §6 fix: replace non-existent `TrustLevel::Untrusted` with `ContentTrustLevel::ExternalUntrusted` from `zeph-sanitizer`; remove dead `DeferredHost` error variant; add Phase 1 deferral note for `QueuedMessage` trust enforcement

## What changed

| Area | Change |
|---|---|
| `Cargo.toml` | New `deep-link` feature; added to `desktop` bundle |
| `zeph-common` | `parse_deep_link` — sync/panic-free URI parser; C0 control-char rejection; proptest fuzz |
| `zeph-config` | `DeepLinkConfig` (`confirm_before_prompt = true` secure default); migration step 61 |
| `src/url_scheme` | `validate_deep_link_cwd` following INV-CWD; expanded denylist (Linux/macOS/Windows) |
| `specs/066-deep-link-scheme` | INV-TRUST ref corrected; `DeferredHost` removed; `PromptContainsControlChars` added |
| `CHANGELOG.md` | Updated `[Unreleased]` section |

## Test plan

- [x] `cargo nextest run -p zeph-common -p zeph-config --features deep-link` — 1191/1191 pass
- [x] `cargo nextest run --features deep-link -p zeph` — 498/498 pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-common` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-config` — clean
- [x] Security audit: H-1 (control chars), M-1 (denylist expansion) addressed

## Deferred to Phase 2

- CLI subcommands (`zeph url-open`, `zeph url-scheme register/unregister`)
- Bootstrap integration (`runner.rs` dispatch arm, INV-TRUST enforcement at enqueue time)
- TUI status message (`Opened via zeph://new-session`)
- OS registration (Linux `.desktop`, Windows registry, macOS LaunchAgent)

Closes #5011
Closes #5030