### PR TITLE
fix(deep-link): add #[non_exhaustive] to DeepLinkError and gate DeepLinkConfig behind feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - `src/url_scheme`: `validate_deep_link_cwd` following INV-CWD (absolute → canonicalize → case-fold → denylist → allowlist → is_dir); expanded denylist (Linux: `/etc` `/root` `/boot` `/run`; macOS: `/System` `/Library/Keychains`; Windows: `SystemRoot`/`WINDIR`)
 - `docs(spec-066)`: correct INV-TRUST reference — `TrustLevel::Untrusted` (non-existent) replaced with `ContentTrustLevel::ExternalUntrusted` from `zeph-sanitizer`; Phase 1 deferral note added; `DeferredHost` error variant removed in favour of `UnknownHost` for all unknown actions (closes #5030)
 
+### Fixed
+
+- fix(deep-link): add `#[non_exhaustive]` to `DeepLinkError` to prevent future variant additions from breaking downstream match expressions (closes #5045)
+- fix(deep-link): gate `DeepLinkConfig` and `deep_link` modules behind `#[cfg(feature = "deep-link")]` to match stated intent in module doc (closes #5046)
+
 ### Changed
 
 - `test(context)`: add `apply_session_config_wires_fidelity_providers` unit test in `zeph-core` — asserts that non-empty `FidelityConfig::semantic_scoring_provider` / `compress_provider` names produce `Some` in `compaction.fidelity_semantic_provider` / `fidelity_compress_provider` after `apply_session_config`, and that empty names or absent config produce `None` (closes #5035)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,7 +218,7 @@ sandbox    = ["zeph-tools/sandbox"]
 bench      = ["dep:zeph-bench"]
 
 # === Individual feature flags ===
-deep-link = []
+deep-link = ["zeph-common/deep-link", "zeph-config/deep-link"]
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server", "zeph-a2a?/ibct"]
 acp = ["dep:zeph-acp", "zeph-acp/unstable-session-delete", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-logout", "zeph-acp/unstable-auth-methods", "zeph-acp/unstable-message-id", "zeph-acp/unstable-session-add-dirs"]
 acp-http = ["acp", "dep:axum", "zeph-acp/acp-http"]

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -13,6 +13,7 @@ description = "Shared utility functions and security primitives for Zeph crates"
 readme = "README.md"
 
 [features]
+deep-link = []
 http-middleware = ["dep:axum", "dep:subtle"]
 jsonschema = ["dep:schemars"]
 treesitter = [

--- a/crates/zeph-common/src/deep_link.rs
+++ b/crates/zeph-common/src/deep_link.rs
@@ -82,6 +82,7 @@ pub struct NewSessionParams {
 }
 
 /// Errors returned by [`parse_deep_link`].
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum DeepLinkError {
     /// The URI is structurally invalid (not a valid URL, wrong scheme, etc.).

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod audit;
 pub mod config;
+#[cfg(feature = "deep-link")]
 pub mod deep_link;
 pub mod error_taxonomy;
 pub mod fidelity;

--- a/crates/zeph-config/Cargo.toml
+++ b/crates/zeph-config/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 
 [features]
 default = []
+deep-link = []
 
 [dependencies]
 dirs.workspace = true

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -76,6 +76,7 @@ pub mod classifiers;
 pub mod cli;
 pub mod cocoon;
 mod de_helpers;
+#[cfg(feature = "deep-link")]
 pub mod deep_link;
 pub mod defaults;
 pub mod dump_format;
@@ -200,6 +201,7 @@ pub use worktree::{BgIsolation, WorktreeBaseRef, WorktreeConfig};
 
 // Top-level config struct, error type, and resolved secrets — moved from zeph-core.
 pub use classifiers::{ClassifiersConfig, InjectionEnforcementMode};
+#[cfg(feature = "deep-link")]
 pub use deep_link::{AcpPreference, DeepLinkConfig};
 pub use error::ConfigError;
 pub use root::{Config, ResolvedSecrets};

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -151,6 +151,7 @@ pub struct Config {
     #[serde(default)]
     pub knowledge: crate::knowledge::KnowledgeConfig,
     /// Deep-link scheme configuration (`[deep_link]`). Gated by the `deep-link` feature.
+    #[cfg(feature = "deep-link")]
     #[serde(default)]
     pub deep_link: crate::deep_link::DeepLinkConfig,
 }
@@ -358,6 +359,7 @@ impl Default for Config {
             durable: crate::durable::DurableConfig::default(),
             caveman: crate::features::CavemanConfig::default(),
             knowledge: crate::knowledge::KnowledgeConfig::default(),
+            #[cfg(feature = "deep-link")]
             deep_link: crate::deep_link::DeepLinkConfig::default(),
         }
     }


### PR DESCRIPTION
## Summary

- Add `#[non_exhaustive]` to `DeepLinkError` to prevent downstream match exhaustiveness failures when Phase 2/3 introduce new variants (closes #5045)
- Gate `DeepLinkConfig` and `deep_link` modules behind `#[cfg(feature = "deep-link")]` to align runtime behavior with the existing module-level documentation (closes #5046)

## Changes

- `crates/zeph-common/Cargo.toml` — declare `deep-link = []` feature
- `crates/zeph-common/src/deep_link.rs` — add `#[non_exhaustive]` before `#[derive]` on `DeepLinkError`
- `crates/zeph-common/src/lib.rs` — gate `pub mod deep_link` behind `cfg(feature = "deep-link")`
- `crates/zeph-config/Cargo.toml` — declare `deep-link = []` feature
- `crates/zeph-config/src/lib.rs` — gate `pub mod deep_link` and `AcpPreference`/`DeepLinkConfig` re-exports
- `crates/zeph-config/src/root.rs` — gate `deep_link` field and its `Default` initializer
- `Cargo.toml` — propagate `deep-link = ["zeph-common/deep-link", "zeph-config/deep-link"]`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 10782 passed, 21 skipped (no regressions)
- [x] `cargo check -p zeph-common` and `cargo check -p zeph-config` without `--features deep-link` — both pass (gates complete)
- [x] `cargo check -p zeph-common --features deep-link` and `cargo check -p zeph-config --features deep-link` — both pass