### PR TITLE
fix(knowledge): make rollback atomic across all three tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(knowledge)`: make `knowledge rollback` atomic — wraps graph-edge, graph-entity, and ledger DELETEs in a single `BEGIN IMMEDIATE` SQLite transaction; propagates ledger errors instead of silently discarding them (closes #5054)
 - fix(deep-link): add `#[non_exhaustive]` to `DeepLinkError` to prevent future variant additions from breaking downstream match expressions (closes #5045)
 - fix(deep-link): gate `DeepLinkConfig` and `deep_link` modules behind `#[cfg(feature = "deep-link")]` to match stated intent in module doc (closes #5046)
 - `fix(llm)`: `CompatibleProvider` now delegates `context_window()`, `supports_vision()`, and `last_reasoning_tokens()` to its inner `OpenAiProvider` instead of returning trait defaults (`None`, `false`, `None`). Callers that depend on context-budget decisions, vision capability detection, or reasoning-token accounting now receive correct values for compatible endpoints (closes #5048)

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use tracing::Instrument as _;
 use zeph_commands::CommandError;
 use zeph_commands::traits::agent::AgentAccess;
+use zeph_db;
 use zeph_memory::semantic::SemanticMemory;
 use zeph_memory::{GraphExtractionConfig, GraphStore, MessageId, extract_and_store};
 
@@ -755,11 +756,20 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     );
                 };
 
-                let (edges, entities) = graph_store
-                    .delete_batch(batch_id)
+                let mut tx = zeph_db::begin_write(&pool)
                     .await
                     .map_err(|e| CommandError(e.to_string()))?;
-                let _ = ledger.delete_batch(batch_id).await;
+
+                let (edges, entities) = graph_store
+                    .delete_batch_in_tx(batch_id, &mut tx)
+                    .await
+                    .map_err(|e| CommandError(e.to_string()))?;
+                ledger
+                    .delete_batch_in_tx(batch_id, &mut tx)
+                    .await
+                    .map_err(|e| CommandError(e.to_string()))?;
+
+                tx.commit().await.map_err(|e| CommandError(e.to_string()))?;
 
                 let mut msg = format!(
                     "Rolled back batch '{batch_id}': removed {edges} edge(s) and \

--- a/crates/zeph-memory/src/graph/ingest/ledger.rs
+++ b/crates/zeph-memory/src/graph/ingest/ledger.rs
@@ -209,6 +209,29 @@ impl IngestLedger {
         Ok(result.rows_affected())
     }
 
+    /// Deletes all ledger rows for `batch_id` within a caller-provided transaction.
+    ///
+    /// Executes the same DELETE as [`Self::delete_batch`] but uses `tx` so the caller can
+    /// combine it with other writes in a single atomic unit.
+    /// Returns the number of rows removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Sqlx`] on database failure.
+    pub async fn delete_batch_in_tx(
+        &self,
+        batch_id: &str,
+        tx: &mut zeph_db::DbTransaction<'_>,
+    ) -> Result<u64, MemoryError> {
+        let result = query(sql!(
+            "DELETE FROM knowledge_ingest_ledger WHERE import_batch_id = ?"
+        ))
+        .bind(batch_id)
+        .execute(&mut **tx)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     /// Returns all ledger rows ordered by `ingested_at` descending, newest first.
     ///
     /// This is the data source for `zeph knowledge status`.

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -1577,6 +1577,45 @@ impl GraphStore {
         Ok((edges_deleted, entities_deleted))
     }
 
+    /// Delete all graph edges and orphaned entities for `batch_id` within a caller-provided
+    /// transaction.
+    ///
+    /// Executes the same two-step DELETE as [`Self::delete_batch`] but uses `tx` so the
+    /// caller can combine it with other writes in a single atomic unit.
+    /// Returns `(edges_deleted, entities_deleted)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Sqlx`] on database failure.
+    pub async fn delete_batch_in_tx(
+        &self,
+        batch_id: &str,
+        tx: &mut zeph_db::DbTransaction<'_>,
+    ) -> Result<(u64, u64), MemoryError> {
+        let edges_deleted =
+            zeph_db::query(sql!("DELETE FROM graph_edges WHERE import_batch_id = ?"))
+                .bind(batch_id)
+                .execute(&mut **tx)
+                .await?
+                .rows_affected();
+
+        let entities_deleted = zeph_db::query(sql!(
+            "DELETE FROM graph_entities
+             WHERE import_batch_id = ?
+               AND id NOT IN (
+                   SELECT DISTINCT source_entity_id FROM graph_edges
+                   UNION
+                   SELECT DISTINCT target_entity_id FROM graph_edges
+               )"
+        ))
+        .bind(batch_id)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected();
+
+        Ok((edges_deleted, entities_deleted))
+    }
+
     /// Delete the oldest excess entities when count exceeds `max_entities`.
     ///
     /// Entities are ranked by ascending edge count, then ascending `last_seen_at` (LRU).

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -696,16 +696,24 @@ async fn handle_rollback(
         }
     }
 
-    let graph_store = GraphStore::new(pool);
+    let graph_store = GraphStore::new(pool.clone());
+    let mut tx = zeph_db::begin_write(&pool)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to begin transaction: {e}"))?;
+
     let (edges, entities) = graph_store
-        .delete_batch(batch_id)
+        .delete_batch_in_tx(batch_id, &mut tx)
         .await
         .map_err(|e| anyhow::anyhow!("graph delete failed: {e}"))?;
 
-    let _ = ledger
-        .delete_batch(batch_id)
+    ledger
+        .delete_batch_in_tx(batch_id, &mut tx)
         .await
         .map_err(|e| anyhow::anyhow!("ledger delete failed: {e}"))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| anyhow::anyhow!("transaction commit failed: {e}"))?;
 
     if edges == 0 && entities == 0 {
         println!(


### PR DESCRIPTION
## Summary

- Wraps graph_edges, graph_entity, and knowledge_ingest_ledger DELETEs in a single `BEGIN IMMEDIATE` transaction in both the CLI path (`handle_rollback`) and the agent path (`knowledge_rollback`).
- Adds `delete_batch_in_tx` helper methods on `GraphStore` and `IngestLedger` so SQL is defined once and shared across both call sites.
- Propagates ledger `delete_batch` error in `agent_access_impl::knowledge_rollback` instead of silently discarding it.

## Root cause

Three separate autocommit SQL operations. A mid-operation failure left graph rows deleted but the ledger row intact (or vice versa), making the knowledge store inconsistent.

## Test plan

- [x] `cargo +nightly fmt --check` — PASS
- [x] `cargo clippy --workspace -- -D warnings` — PASS
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 10792 passed, 0 failed

Closes #5054