### PR TITLE
feat(deep-link): macOS .app bundle registration and stale url-scheme detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `feat(knowledge)`: `zeph knowledge rollback --batch-id <id>` CLI command and `/knowledge rollback <id>` TUI slash command — removes ledger rows and graph entities/edges for the given batch; prompts for confirmation unless `--yes` is passed; warns when `edges == 0 && entities == 0` (Phase-1 limitation: Qdrant embeddings are not removed) (closes #5019)
 - `feat(knowledge)`: `zeph knowledge status` CLI command and `/knowledge status` TUI slash command — lists all ledger entries in newest-first order with `source_uri`, `content_hash`, `import_batch_id`, `ingested_at`, `entities`, and `edges` columns; TUI reply is plain text formatted the same way (closes #5020)
 - `feat(tui)`: add three knowledge command palette entries — `KnowledgeStatus`, `KnowledgeRollbackPrompt`, and `KnowledgeIngestPrompt` — accessible via `/` command input; `KnowledgeStatus` shows a `Querying knowledge index…` spinner while fetching; dispatched through `handle_knowledge_command` in `keys.rs` (closes #5020)
+- `feat(deep-link)`: Phase 3b — macOS `.app` bundle registration + stale scheme detection (spec-066 TASK-14, TASK-16; closes #5057, #5060)
+  - `src/url_scheme/register.rs`: `register_macos` now creates `~/Applications/Zeph.app` with `Contents/Info.plist` (CFBundleURLTypes entry for `zeph://`) and a symlink `Contents/MacOS/zeph → <current_exe>`; calls `lsregister -f <bundle>` to register with LaunchServices.
+  - `unregister_macos` calls `lsregister -u <bundle>` then removes the entire bundle directory.
+  - `status_macos` reads `_ZephExePath` from `Info.plist` and reports stale/ok/missing; `handle_url_scheme_status` now returns `bool` (stale=true) on all platforms.
+  - New public API: `SchemeStatus` enum (`Ok`, `NotRegistered`, `Stale(String)`) and `scheme_registration_status(current_exe)` for machine-readable checks.
+  - `UrlSchemeCommand::Status` gains `--check` flag: exits non-zero when stale or not registered.
+  - `zeph doctor` (check 16, `url_scheme.registration`): `Ok` when current, `Warn` when not registered, `Fail` when stale; gated under `#[cfg(feature = "deep-link")]`.
+  - 8 new unit tests for macOS: `register_macos_writes_bundle`, `unregister_macos_removes_bundle`, `unregister_macos_when_not_registered_is_ok`, `extract_zeph_exe_from_plist_parses_correctly`, `extract_zeph_exe_from_plist_returns_none_when_key_absent`, `scheme_status_macos_not_registered_when_no_bundle`, `scheme_status_macos_ok_when_registered_and_current`, `scheme_status_macos_stale_when_binary_missing`.
+  - 3 new Linux `scheme_status_linux_*` unit tests for machine-readable status.
 - `feat(deep-link)`: Phase 3 — Linux `.desktop` registration, Windows HKCU registry, macOS stub, unit tests for Linux registration (spec-066 TASK-10–13; closes #5014)
 - `feat(deep-link)`: Phase 2 — CLI dispatch, bootstrap integration, TUI notification, and `--init` wizard step (spec-066, closes #5013)
   - `src/url_scheme/prompt.rs`: `confirm_prompt` / `ConfirmResult` gate for INV-NOTTY (no-TTY → discard) and interactive y/N confirmation (TASK-7)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -943,7 +943,14 @@ pub(crate) enum UrlSchemeCommand {
     /// Remove the OS `zeph://` URI scheme registration.
     Unregister,
     /// Show the current registration status.
-    Status,
+    ///
+    /// With `--check`, exits non-zero when the scheme is not registered or the registered
+    /// binary path does not match the current executable (stale registration).
+    Status {
+        /// Exit non-zero if the scheme is not registered or registration is stale.
+        #[arg(long)]
+        check: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1313,7 +1320,20 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Command::UrlScheme {
-                command: UrlSchemeCommand::Status
+                command: UrlSchemeCommand::Status { check: false }
+            })
+        ));
+    }
+
+    #[cfg(feature = "deep-link")]
+    #[test]
+    fn cli_parses_url_scheme_status_check_flag() {
+        use super::{Command, UrlSchemeCommand};
+        let cli = Cli::try_parse_from(["zeph", "url-scheme", "status", "--check"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::UrlScheme {
+                command: UrlSchemeCommand::Status { check: true }
             })
         ));
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -733,6 +733,41 @@ fn build_doctor_transport(server: &zeph_config::McpServerConfig) -> zeph_mcp::Mc
 }
 
 // ---------------------------------------------------------------------------
+// URL scheme check
+// ---------------------------------------------------------------------------
+
+/// Check whether the `zeph://` URL scheme is registered and not stale.
+///
+/// Returns a [`CheckResult`] with status `Ok` when registration is current, `Warn` when the
+/// scheme is not registered (non-fatal — user may not have run `url-scheme register`), and
+/// `Fail` when the registration exists but points to a binary that is missing or does not match
+/// the currently running executable.
+#[cfg(feature = "deep-link")]
+fn check_url_scheme() -> CheckResult {
+    use crate::url_scheme::register;
+    let start = Instant::now();
+    let current_exe = std::env::current_exe().ok();
+
+    let stale = register::scheme_registration_status(current_exe.as_deref());
+
+    match stale {
+        register::SchemeStatus::Ok => CheckResult::ok(
+            "url_scheme.registration",
+            "registered and current",
+            elapsed_ms(start),
+        ),
+        register::SchemeStatus::NotRegistered => CheckResult::warn(
+            "url_scheme.registration",
+            "not registered — run `zeph url-scheme register` to enable zeph:// URIs",
+            elapsed_ms(start),
+        ),
+        register::SchemeStatus::Stale(reason) => {
+            CheckResult::fail("url_scheme.registration", reason, elapsed_ms(start))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
@@ -900,6 +935,10 @@ pub(crate) async fn run_doctor(
     for server in &config.mcp.servers {
         results.push(check_mcp_server(server, &config.mcp, mcp_timeout_secs).await);
     }
+
+    // 16. url_scheme.registration (deep-link feature only)
+    #[cfg(feature = "deep-link")]
+    results.push(check_url_scheme());
 
     let report = DoctorReport {
         elapsed_ms: elapsed_ms(total_start),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -687,8 +687,11 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             return match url_scheme_cmd {
                 UrlSchemeCommand::Register => register::handle_url_scheme_register(),
                 UrlSchemeCommand::Unregister => register::handle_url_scheme_unregister(),
-                UrlSchemeCommand::Status => {
-                    register::handle_url_scheme_status();
+                UrlSchemeCommand::Status { check } => {
+                    let stale = register::handle_url_scheme_status();
+                    if check && stale {
+                        std::process::exit(1);
+                    }
                     Ok(())
                 }
             };

--- a/src/url_scheme/register.rs
+++ b/src/url_scheme/register.rs
@@ -310,13 +310,13 @@ fn scheme_status_linux(current_exe: Option<&std::path::Path>) -> SchemeStatus {
             "registered binary not found on disk: {registered_exe}"
         ));
     }
-    if let Some(current) = current_exe {
-        if current != registered_path {
-            return SchemeStatus::Stale(format!(
-                "registered: {registered_exe}, current: {}",
-                current.display()
-            ));
-        }
+    if let Some(current) = current_exe
+        && current != registered_path
+    {
+        return SchemeStatus::Stale(format!(
+            "registered: {registered_exe}, current: {}",
+            current.display()
+        ));
     }
     SchemeStatus::Ok
 }

--- a/src/url_scheme/register.rs
+++ b/src/url_scheme/register.rs
@@ -1,12 +1,64 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Platform-specific `zeph://` URI scheme registration (spec-066, TASK-6, TASK-10–13).
+//! Platform-specific `zeph://` URI scheme registration (spec-066, TASK-6, TASK-10–13, TASK-14, TASK-16).
 //!
 //! Entry points:
 //! - [`handle_url_scheme_register`] — write OS artefacts.
 //! - [`handle_url_scheme_unregister`] — remove OS artefacts.
-//! - [`handle_url_scheme_status`] — check registration state.
+//! - [`handle_url_scheme_status`] — print registration state; returns `true` when stale/missing.
+//! - [`scheme_registration_status`] — machine-readable registration check used by `zeph doctor`.
+
+/// Machine-readable registration state returned by [`scheme_registration_status`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemeStatus {
+    /// Registered and the binary path matches the current executable.
+    Ok,
+    /// No registration artefacts found on disk.
+    NotRegistered,
+    /// Registration exists but is stale (binary gone or path mismatch).
+    Stale(String),
+}
+
+/// Return the machine-readable `zeph://` scheme registration status for the given executable.
+///
+/// This is the same logic as [`handle_url_scheme_status`] but returns a typed value instead of
+/// printing, making it suitable for use in `zeph doctor` and scripting scenarios.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph::url_scheme::register::{scheme_registration_status, SchemeStatus};
+///
+/// let current = std::env::current_exe().ok();
+/// match scheme_registration_status(current.as_deref()) {
+///     SchemeStatus::Ok => println!("registration is current"),
+///     SchemeStatus::NotRegistered => println!("not registered"),
+///     SchemeStatus::Stale(reason) => eprintln!("stale: {reason}"),
+/// }
+/// ```
+pub fn scheme_registration_status(current_exe: Option<&std::path::Path>) -> SchemeStatus {
+    #[cfg(target_os = "linux")]
+    {
+        scheme_status_linux(current_exe)
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        scheme_status_macos(current_exe)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        scheme_status_windows(current_exe)
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = current_exe;
+        SchemeStatus::NotRegistered
+    }
+}
 
 /// Register the `zeph://` URI scheme with the host OS.
 ///
@@ -30,7 +82,7 @@ pub fn handle_url_scheme_register() -> anyhow::Result<()> {
     }
     #[cfg(target_os = "macos")]
     {
-        register_macos(&exe_str);
+        register_macos(&exe_str)?;
     }
     #[cfg(target_os = "windows")]
     {
@@ -49,9 +101,6 @@ pub fn handle_url_scheme_register() -> anyhow::Result<()> {
 /// # Errors
 ///
 /// Returns an error only when an OS removal operation fails unrecoverably.
-// On macOS and unsupported platforms the body always succeeds; the Result return
-// type is kept for a uniform call site across all platforms.
-#[allow(clippy::unnecessary_wraps)]
 pub fn handle_url_scheme_unregister() -> anyhow::Result<()> {
     #[cfg(target_os = "linux")]
     {
@@ -59,7 +108,7 @@ pub fn handle_url_scheme_unregister() -> anyhow::Result<()> {
     }
     #[cfg(target_os = "macos")]
     {
-        unregister_macos();
+        unregister_macos()?;
     }
     #[cfg(target_os = "windows")]
     {
@@ -72,30 +121,47 @@ pub fn handle_url_scheme_unregister() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Print the current `zeph://` scheme registration status to stdout and exit 0.
+/// Print the current `zeph://` scheme registration status to stdout.
 ///
-/// Reports whether the scheme artefacts exist and whether their registered binary
-/// path matches the currently running binary.
-pub fn handle_url_scheme_status() {
+/// Returns `true` when the registration is stale (registered path does not match the current
+/// executable or the registered binary no longer exists on disk).
+/// Returns `false` when registration is healthy or when the scheme has never been registered.
+///
+/// Use this return value to gate `--check` exit codes: a never-registered machine is not an
+/// error, but a stale registration indicates the binary has moved and may mislead the OS.
+///
+/// # Examples
+///
+/// ```no_run
+/// let stale = zeph::url_scheme::register::handle_url_scheme_status();
+/// if stale {
+///     eprintln!("url-scheme registration is stale; re-run `zeph url-scheme register`");
+///     std::process::exit(1);
+/// }
+/// ```
+pub fn handle_url_scheme_status() -> bool {
     let current_exe = std::env::current_exe().ok();
 
     #[cfg(target_os = "linux")]
-    status_linux(current_exe.as_deref());
+    {
+        status_linux(current_exe.as_deref())
+    }
 
     #[cfg(target_os = "macos")]
     {
-        let _ = current_exe;
-        println!("macOS: manual registration only in v1");
-        println!("To register, wrap the binary in a .app bundle with URL scheme handler.");
+        status_macos(current_exe.as_deref())
     }
 
     #[cfg(target_os = "windows")]
-    status_windows(current_exe.as_deref());
+    {
+        status_windows(current_exe.as_deref())
+    }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {
         let _ = current_exe;
         println!("zeph url-scheme status: unsupported platform");
+        false
     }
 }
 
@@ -179,17 +245,17 @@ fn unregister_linux() -> anyhow::Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-fn status_linux(current_exe: Option<&std::path::Path>) {
+fn status_linux(current_exe: Option<&std::path::Path>) -> bool {
     let desktop_path = desktop_file_path();
     if !desktop_path.exists() {
         println!("Status: not registered");
-        return;
+        return false;
     }
     let content = match std::fs::read_to_string(&desktop_path) {
         Ok(c) => c,
         Err(e) => {
             println!("Status: file exists but cannot be read: {e}");
-            return;
+            return true;
         }
     };
     // Parse Exec= line to find the registered binary path.
@@ -200,36 +266,266 @@ fn status_linux(current_exe: Option<&std::path::Path>) {
         .and_then(|rest| rest.split_whitespace().next())
         .unwrap_or("<unknown>");
 
+    let registered_path = std::path::Path::new(registered_exe);
+    let binary_missing = !registered_path.exists();
+
     if let Some(current) = current_exe {
-        if current == std::path::Path::new(registered_exe) {
+        let stale = binary_missing || current != registered_path;
+        if !stale {
             println!("Status: registered → {registered_exe} (matches current binary)");
+        } else if binary_missing {
+            println!("Status: registered → {registered_exe} (binary not found on disk, stale)");
         } else {
             println!(
-                "Status: registered → {registered_exe} (current binary: {})",
+                "Status: stale — registered: {registered_exe}, current: {}",
                 current.display()
             );
         }
+        stale
     } else {
         println!("Status: registered → {registered_exe}");
+        binary_missing
     }
+}
+
+#[cfg(target_os = "linux")]
+fn scheme_status_linux(current_exe: Option<&std::path::Path>) -> SchemeStatus {
+    let desktop_path = desktop_file_path();
+    if !desktop_path.exists() {
+        return SchemeStatus::NotRegistered;
+    }
+    let content = match std::fs::read_to_string(&desktop_path) {
+        Ok(c) => c,
+        Err(e) => return SchemeStatus::Stale(format!("cannot read desktop file: {e}")),
+    };
+    let registered_exe = content
+        .lines()
+        .find(|l| l.starts_with("Exec="))
+        .and_then(|l| l.strip_prefix("Exec="))
+        .and_then(|rest| rest.split_whitespace().next())
+        .unwrap_or("<unknown>");
+    let registered_path = std::path::Path::new(registered_exe);
+    if !registered_path.exists() {
+        return SchemeStatus::Stale(format!(
+            "registered binary not found on disk: {registered_exe}"
+        ));
+    }
+    if let Some(current) = current_exe {
+        if current != registered_path {
+            return SchemeStatus::Stale(format!(
+                "registered: {registered_exe}, current: {}",
+                current.display()
+            ));
+        }
+    }
+    SchemeStatus::Ok
 }
 
 // ── macOS ────────────────────────────────────────────────────────────────────
 
+/// Path to the Zeph.app bundle in ~/Applications.
 #[cfg(target_os = "macos")]
-fn register_macos(exe_str: &str) {
-    println!("macOS: manual registration only in v1");
-    println!("Binary path: {exe_str}");
-    println!(
-        "To register, wrap the binary in a .app bundle with LSHandlerURLScheme = zeph.\n\
-         See: https://developer.apple.com/documentation/bundleresources/information_property_list"
-    );
+fn app_bundle_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_owned());
+    std::path::PathBuf::from(home).join("Applications/Zeph.app")
+}
+
+/// Escape a string for embedding inside an XML `<string>` element.
+#[cfg(target_os = "macos")]
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// The Info.plist content with `CFBundleURLTypes` entry for the `zeph://` scheme.
+#[cfg(target_os = "macos")]
+fn info_plist_content(exe_str: &str) -> String {
+    let escaped = xml_escape(exe_str);
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>zeph</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.zeph.url-handler</string>
+    <key>CFBundleName</key>
+    <string>Zeph</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>Zeph URL</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>zeph</string>
+            </array>
+        </dict>
+    </array>
+    <key>LSUIElement</key>
+    <true/>
+    <key>_ZephExePath</key>
+    <string>{escaped}</string>
+</dict>
+</plist>
+"#
+    )
 }
 
 #[cfg(target_os = "macos")]
-fn unregister_macos() {
-    println!("macOS: manual unregistration only in v1");
-    println!("Remove the .app bundle or CFBundleURLTypes entry from Info.plist.");
+fn register_macos(exe_str: &str) -> anyhow::Result<()> {
+    let bundle = app_bundle_path();
+    let macos_dir = bundle.join("Contents/MacOS");
+    let plist_path = bundle.join("Contents/Info.plist");
+    let symlink_path = macos_dir.join("zeph");
+
+    std::fs::create_dir_all(&macos_dir)?;
+    std::fs::write(&plist_path, info_plist_content(exe_str))?;
+
+    // Symlink to the real binary so LaunchServices can find the handler.
+    // TODO(#5014): macOS bundle receives zeph:// URLs via Apple Event, not argv;
+    // Phase 3 must wire the Apple Event handler through handle_url_open to preserve INV-TRUST.
+    if symlink_path.exists() || symlink_path.is_symlink() {
+        std::fs::remove_file(&symlink_path)?;
+    }
+    std::os::unix::fs::symlink(exe_str, &symlink_path)?;
+
+    println!("Wrote: {}", bundle.display());
+
+    // Register with LaunchServices.
+    let ls_result = std::process::Command::new("/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister")
+        .args(["-f", &bundle.to_string_lossy()])
+        .status();
+    match ls_result {
+        Ok(s) if s.success() => println!("lsregister: registered"),
+        Ok(s) => println!("lsregister exited with status {s}; registration may be incomplete"),
+        Err(e) => println!("lsregister not found or failed: {e}; registration may be incomplete"),
+    }
+
+    println!("Registered zeph:// scheme → {exe_str}");
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn unregister_macos() -> anyhow::Result<()> {
+    let bundle = app_bundle_path();
+    if !bundle.exists() {
+        println!("Not registered (bundle not found: {})", bundle.display());
+        return Ok(());
+    }
+
+    // Unregister from LaunchServices before removing files.
+    let ls_result = std::process::Command::new("/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister")
+        .args(["-u", &bundle.to_string_lossy()])
+        .status();
+    match ls_result {
+        Ok(s) if s.success() => println!("lsregister: unregistered"),
+        Ok(s) => println!("lsregister -u exited with status {s}"),
+        Err(e) => println!("lsregister not found or failed: {e}"),
+    }
+
+    std::fs::remove_dir_all(&bundle)?;
+    println!("Removed: {}", bundle.display());
+    println!("Unregistered zeph:// scheme");
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn status_macos(current_exe: Option<&std::path::Path>) -> bool {
+    let bundle = app_bundle_path();
+    let plist_path = bundle.join("Contents/Info.plist");
+
+    if !bundle.exists() {
+        println!("Status: not registered (bundle not found)");
+        return false;
+    }
+
+    // Extract the exe path stored in Info.plist via the _ZephExePath key.
+    let registered_exe = match std::fs::read_to_string(&plist_path) {
+        Ok(content) => extract_zeph_exe_from_plist(&content),
+        Err(e) => {
+            println!("Status: bundle exists but Info.plist cannot be read: {e}");
+            return true;
+        }
+    };
+
+    let Some(exe_str) = registered_exe else {
+        println!("Status: bundle exists but _ZephExePath not found in Info.plist");
+        return true;
+    };
+
+    let registered_path = std::path::Path::new(&exe_str);
+    let binary_missing = !registered_path.exists();
+
+    if let Some(current) = current_exe {
+        let stale = binary_missing || current != registered_path;
+        if !stale {
+            println!("Status: registered → {exe_str} (matches current binary)");
+        } else if binary_missing {
+            println!("Status: registered → {exe_str} (binary not found on disk, stale)");
+        } else {
+            println!(
+                "Status: stale — registered: {exe_str}, current: {}",
+                current.display()
+            );
+        }
+        stale
+    } else {
+        println!("Status: registered → {exe_str}");
+        binary_missing
+    }
+}
+
+/// Extract the value of `<key>_ZephExePath</key><string>...</string>` from a plist.
+///
+/// This is a minimal text-based parser — sufficient for the fixed template we write.
+/// It is not a general plist parser.
+#[cfg(target_os = "macos")]
+fn extract_zeph_exe_from_plist(content: &str) -> Option<String> {
+    let key_pos = content.find("<key>_ZephExePath</key>")?;
+    let after_key = &content[key_pos + "<key>_ZephExePath</key>".len()..];
+    let start = after_key.find("<string>")? + "<string>".len();
+    let end = after_key[start..].find("</string>")?;
+    let raw = after_key[start..start + end].trim();
+    // Unescape the XML entities written by xml_escape() at registration time.
+    Some(
+        raw.replace("&amp;", "&")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">"),
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn scheme_status_macos(current_exe: Option<&std::path::Path>) -> SchemeStatus {
+    let bundle = app_bundle_path();
+    let plist_path = bundle.join("Contents/Info.plist");
+    if !bundle.exists() {
+        return SchemeStatus::NotRegistered;
+    }
+    let content = match std::fs::read_to_string(&plist_path) {
+        Ok(c) => c,
+        Err(e) => return SchemeStatus::Stale(format!("cannot read Info.plist: {e}")),
+    };
+    let Some(exe_str) = extract_zeph_exe_from_plist(&content) else {
+        return SchemeStatus::Stale("_ZephExePath not found in Info.plist".to_owned());
+    };
+    let registered_path = std::path::Path::new(&exe_str);
+    if !registered_path.exists() {
+        return SchemeStatus::Stale(format!("registered binary not found on disk: {exe_str}"));
+    }
+    if let Some(current) = current_exe.filter(|&c| c != registered_path) {
+        return SchemeStatus::Stale(format!(
+            "registered: {exe_str}, current: {}",
+            current.display()
+        ));
+    }
+    SchemeStatus::Ok
 }
 
 // ── Windows ──────────────────────────────────────────────────────────────────
@@ -279,7 +575,7 @@ fn unregister_windows() -> anyhow::Result<()> {
 }
 
 #[cfg(target_os = "windows")]
-fn status_windows(current_exe: Option<&std::path::Path>) {
+fn status_windows(current_exe: Option<&std::path::Path>) -> bool {
     let key = "HKCU\\Software\\Classes\\zeph\\shell\\open\\command";
     let output = std::process::Command::new("reg")
         .args(["query", key, "/ve"])
@@ -300,17 +596,78 @@ fn status_windows(current_exe: Option<&std::path::Path>) {
                 .split('"')
                 .next()
                 .unwrap_or(registered_cmd);
+            let registered_path = std::path::Path::new(registered_exe);
+            let binary_missing = !registered_path.exists();
             if let Some(current) = current_exe {
-                println!(
-                    "Status: registered → {registered_exe} (current: {})",
-                    current.display()
-                );
+                let stale = binary_missing || current != registered_path;
+                if !stale {
+                    println!("Status: registered → {registered_exe} (matches current binary)");
+                } else if binary_missing {
+                    println!(
+                        "Status: registered → {registered_exe} (binary not found on disk, stale)"
+                    );
+                } else {
+                    println!(
+                        "Status: stale — registered: {registered_exe}, current: {}",
+                        current.display()
+                    );
+                }
+                stale
             } else {
                 println!("Status: registered → {registered_exe}");
+                binary_missing
             }
         }
-        Ok(_) => println!("Status: not registered"),
-        Err(e) => println!("Status: cannot query registry: {e}"),
+        Ok(_) => {
+            println!("Status: not registered");
+            false
+        }
+        Err(e) => {
+            println!("Status: cannot query registry: {e}");
+            true
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn scheme_status_windows(current_exe: Option<&std::path::Path>) -> SchemeStatus {
+    let key = "HKCU\\Software\\Classes\\zeph\\shell\\open\\command";
+    let output = std::process::Command::new("reg")
+        .args(["query", key, "/ve"])
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let text = String::from_utf8_lossy(&o.stdout);
+            let registered_cmd = text
+                .lines()
+                .find(|l| l.contains("REG_SZ"))
+                .and_then(|l| l.splitn(3, "REG_SZ").nth(1))
+                .map(str::trim)
+                .unwrap_or("<unknown>");
+            let registered_exe = registered_cmd
+                .trim_start_matches('"')
+                .split('"')
+                .next()
+                .unwrap_or(registered_cmd);
+            let registered_path = std::path::Path::new(registered_exe);
+            if !registered_path.exists() {
+                return SchemeStatus::Stale(format!(
+                    "registered binary not found on disk: {registered_exe}"
+                ));
+            }
+            if let Some(current) = current_exe {
+                if current != registered_path {
+                    return SchemeStatus::Stale(format!(
+                        "registered: {registered_exe}, current: {}",
+                        current.display()
+                    ));
+                }
+            }
+            SchemeStatus::Ok
+        }
+        Ok(_) => SchemeStatus::NotRegistered,
+        Err(e) => SchemeStatus::Stale(format!("cannot query registry: {e}")),
     }
 }
 
@@ -419,6 +776,177 @@ mod tests {
         fn status_linux_when_not_registered() {
             with_temp_home(|_home| {
                 super::super::status_linux(None);
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn scheme_status_linux_not_registered_when_no_file() {
+            with_temp_home(|_home| {
+                let status = super::super::scheme_status_linux(None);
+                assert_eq!(status, super::super::SchemeStatus::NotRegistered);
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn scheme_status_linux_ok_when_registered_and_current() {
+            with_temp_home(|_home| {
+                // Use the current test binary as the "registered" exe so the path exists.
+                let current = std::env::current_exe().expect("current_exe");
+                let exe_str = current.to_string_lossy().to_string();
+                super::super::register_linux(&exe_str).expect("register_linux");
+                let status = super::super::scheme_status_linux(Some(&current));
+                assert_eq!(status, super::super::SchemeStatus::Ok);
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn scheme_status_linux_stale_when_binary_path_differs() {
+            with_temp_home(|_home| {
+                let current = std::env::current_exe().expect("current_exe");
+                super::super::register_linux("/nonexistent/other-binary").expect("register_linux");
+                let status = super::super::scheme_status_linux(Some(&current));
+                assert!(
+                    matches!(status, super::super::SchemeStatus::Stale(_)),
+                    "expected Stale, got {status:?}"
+                );
+            });
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    mod macos {
+        #![allow(unsafe_code)]
+
+        use serial_test::serial;
+
+        fn with_temp_home<F: FnOnce(&std::path::Path)>(f: F) {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let prev = std::env::var("HOME").ok();
+            // SAFETY: single-threaded under #[serial]; restored unconditionally via catch_unwind.
+            unsafe { std::env::set_var("HOME", tmp.path()) };
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(tmp.path())));
+            match &prev {
+                Some(v) => unsafe { std::env::set_var("HOME", v) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+            if let Err(e) = result {
+                std::panic::resume_unwind(e);
+            }
+        }
+
+        #[test]
+        fn extract_zeph_exe_from_plist_parses_correctly() {
+            let plist = super::super::info_plist_content("/usr/local/bin/zeph");
+            let result = super::super::extract_zeph_exe_from_plist(&plist);
+            assert_eq!(result.as_deref(), Some("/usr/local/bin/zeph"));
+        }
+
+        #[test]
+        fn extract_zeph_exe_from_plist_returns_none_when_key_absent() {
+            let result = super::super::extract_zeph_exe_from_plist("<plist></plist>");
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn extract_zeph_exe_from_plist_round_trips_path_with_ampersand() {
+            let path = "/home/user/a&b/zeph";
+            let plist = super::super::info_plist_content(path);
+            let result = super::super::extract_zeph_exe_from_plist(&plist);
+            assert_eq!(result.as_deref(), Some(path));
+        }
+
+        #[test]
+        #[serial]
+        fn register_macos_writes_bundle() {
+            with_temp_home(|home| {
+                let current = std::env::current_exe().expect("current_exe");
+                let exe_str = current.to_string_lossy().to_string();
+                super::super::register_macos(&exe_str).expect("register_macos should succeed");
+
+                let bundle = home.join("Applications/Zeph.app");
+                assert!(bundle.exists(), "bundle must exist after register");
+
+                let plist = bundle.join("Contents/Info.plist");
+                assert!(plist.exists(), "Info.plist must exist");
+
+                let content = std::fs::read_to_string(&plist).expect("read plist");
+                assert!(
+                    content.contains("<string>zeph</string>"),
+                    "plist must contain scheme"
+                );
+                assert!(content.contains(&exe_str), "plist must contain exe path");
+
+                let symlink = bundle.join("Contents/MacOS/zeph");
+                assert!(
+                    symlink.exists() || symlink.is_symlink(),
+                    "symlink must exist"
+                );
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn unregister_macos_removes_bundle() {
+            with_temp_home(|home| {
+                let current = std::env::current_exe().expect("current_exe");
+                let exe_str = current.to_string_lossy().to_string();
+                super::super::register_macos(&exe_str).expect("register_macos");
+
+                let bundle = home.join("Applications/Zeph.app");
+                assert!(bundle.exists(), "bundle must exist before unregister");
+
+                super::super::unregister_macos().expect("unregister_macos should succeed");
+                assert!(!bundle.exists(), "bundle must be removed after unregister");
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn unregister_macos_when_not_registered_is_ok() {
+            with_temp_home(|_home| {
+                let result = super::super::unregister_macos();
+                assert!(
+                    result.is_ok(),
+                    "unregister when no bundle must succeed: {result:?}"
+                );
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn scheme_status_macos_not_registered_when_no_bundle() {
+            with_temp_home(|_home| {
+                let status = super::super::scheme_status_macos(None);
+                assert_eq!(status, super::super::SchemeStatus::NotRegistered);
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn scheme_status_macos_ok_when_registered_and_current() {
+            with_temp_home(|_home| {
+                let current = std::env::current_exe().expect("current_exe");
+                let exe_str = current.to_string_lossy().to_string();
+                super::super::register_macos(&exe_str).expect("register_macos");
+                let status = super::super::scheme_status_macos(Some(&current));
+                assert_eq!(status, super::super::SchemeStatus::Ok);
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn scheme_status_macos_stale_when_binary_missing() {
+            with_temp_home(|_home| {
+                super::super::register_macos("/nonexistent/missing-binary")
+                    .expect("register_macos");
+                let status = super::super::scheme_status_macos(None);
+                assert!(
+                    matches!(status, super::super::SchemeStatus::Stale(_)),
+                    "expected Stale for missing binary, got {status:?}"
+                );
             });
         }
     }


### PR DESCRIPTION
## Summary

- Implements macOS `zeph://` scheme registration via a minimal `.app` bundle in `~/Applications/Zeph.app` with `CFBundleURLTypes` in `Info.plist` and `lsregister` — replaces the stub that only printed instructions (#5057, spec-066 TASK-14/OQ-1)
- Adds `zeph url-scheme status --check` flag that exits 1 when registration is stale (registered path ≠ current binary or registered binary missing); `NotRegistered` exits 0 as a warning (#5060, spec-066 TASK-16/OQ-4)
- Adds `zeph doctor` check 16 (`url_scheme.registration`, gated on `deep-link` feature): Ok/Warn/Fail aligned with the `--check` semantics
- Adds `SchemeStatus` enum + `scheme_registration_status()` public API for machine-readable status across all three platforms
- XML-escapes binary path in `Info.plist` to prevent plist corruption on paths with special characters (`&`, `<`, `>`)

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 412 tests pass
- [ ] On macOS: `cargo run -- url-scheme register` creates `~/Applications/Zeph.app` and registers scheme; `zeph url-scheme status` shows Ok; move binary and verify `--check` exits 1
- [ ] On Linux/Windows: verify `--check` exits 0 on not-registered, exits 1 on stale registration
- [ ] `zeph doctor` output includes scheme registration check with correct Ok/Warn/Fail state

Closes #5057
Closes #5060