### PR TITLE
feat(acp): stateless POST /deep-link endpoint for zeph:// URI dispatch (spec-066 TASK-15, #5059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `feat(deep-link)`: `POST /deep-link` stateless validate-only ACP endpoint (spec-066 OQ-2, closes #5059)
+  - New `crates/zeph-acp/src/transport/deep_link.rs` handler behind `feature = "acp-http"`.
+  - Accepts `{ "uri": "zeph://..." }`, parses with the shared `parse_deep_link`, validates `cwd` against both the deep-link INV-CWD denylist and the ACP `additional_directories` allowlist (default-deny: empty allowlist rejects all cwd), validates model name against `available_models`.
+  - Returns `{ working_dir, prompt, prompt_trust_level: "external_untrusted", model }`. No session created, no store write.
+  - Total URI cap of 65 536 bytes before parsing (M2); NUL/C0 check on decoded cwd (M3).
+  - Status codes: 400 (malformed/oversized URI, NUL in cwd), 403 (cwd rejected), 422 (unknown model), 401 (bearer auth layer).
+  - `validate_deep_link_cwd` and `CwdValidationError` extracted from `src/url_scheme/validate.rs` (binary-only) to `crates/zeph-common/src/deep_link.rs` (shared); binary re-exports via `pub use`.
+  - 9 unit tests covering all failure/happy-path branches.
+  - `acp-http` feature now implies `zeph-common/deep-link`.
+  - Advisory contract documented in handler rustdoc and spec-066 §13.
+  - Follow-up issue filed: ACP `session/prompt` does not tag inbound prompts as `ExternalUntrusted` (INV-TRUST gap, #5063).
 - `feat(knowledge-ingest)`: Phase 0 provenance migration + recall isolation flag (spec-067 §3, closes #5015)
   - DB migrations: `102_graph_provenance.sql` (SQLite) and `103_graph_provenance.sql` (Postgres) add `origin TEXT NOT NULL DEFAULT 'conversation'`, `import_batch_id TEXT`, `source_uri TEXT` to `graph_edges` and `origin`, `import_batch_id` to `graph_entities`.
   - New types `GraphOrigin` (enum: `Conversation`, `Ingest`) and `GraphProvenance { origin, import_batch_id, source_uri }` in `zeph-memory::graph::types`.

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -26,7 +26,7 @@ default = [
 # builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
 sqlite = ["zeph-memory/sqlite"]
 postgres = ["zeph-memory/postgres"]
-acp-http = ["dep:axum", "dep:blake3", "dep:dashmap", "dep:async-stream", "dep:tower-http", "dep:subtle", "dep:tower"]
+acp-http = ["dep:axum", "dep:blake3", "dep:dashmap", "dep:async-stream", "dep:tower-http", "dep:subtle", "dep:tower", "zeph-common/deep-link"]
 # session/close and session/delete stabilized in acp 0.14.0; no upstream feature gate needed
 unstable-session-delete = []
 unstable-session-fork = ["agent-client-protocol/unstable_session_fork"]

--- a/crates/zeph-acp/src/transport/deep_link.rs
+++ b/crates/zeph-acp/src/transport/deep_link.rs
@@ -1,0 +1,446 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `POST /deep-link` handler for the ACP HTTP transport.
+//!
+//! This endpoint parses and validates a `zeph://` URI supplied by an IDE, then returns
+//! the extracted, validated fields as JSON. It is **stateless** and performs **no store
+//! writes** — no session is created, no `create_acp_session` is called.
+//!
+//! # Advisory contract (MANDATORY)
+//!
+//! This endpoint is **advisory**. It validates and normalizes a `zeph://` URI and returns
+//! the cleaned data for the caller to act on. The authoritative cwd-enforcement point for
+//! the ACP runtime is the per-connection `session/new` / `session/load` boundary
+//! (`args.cwd`), which is unchanged by this feature. A client that ignores the returned
+//! `working_dir` and passes a different `args.cwd` to `session/new` is subject only to that
+//! path's existing `file://` / `additional_directories` checks.
+
+#![cfg(feature = "acp-http")]
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use zeph_common::deep_link::{parse_deep_link, validate_deep_link_cwd};
+
+use crate::transport::http::AcpHttpState;
+
+/// Maximum total URI length accepted before parsing.
+///
+/// `parse_deep_link` bounds only the decoded prompt (8192 bytes), not the raw URI.
+/// A URI with a giant `cwd` or `profile` component could reach `canonicalize` without
+/// this guard (M2 from the architecture review).
+const MAX_URI_BYTES: usize = 65_536;
+
+// ── Request / response types ──────────────────────────────────────────────────
+
+/// Request body for `POST /deep-link`.
+#[derive(Debug, Deserialize)]
+pub struct DeepLinkRequest {
+    /// The `zeph://` URI to parse and validate.
+    pub uri: String,
+}
+
+/// Response body for a successful `POST /deep-link`.
+///
+/// All fields are optional: only the URI components present and validated are populated.
+#[derive(Debug, Serialize)]
+pub struct DeepLinkResponse {
+    /// Canonicalized working directory extracted from the URI, or `null` if not present.
+    pub working_dir: Option<PathBuf>,
+    /// Decoded prompt text from the URI, or `null` if not present.
+    pub prompt: Option<String>,
+    /// Trust level of the inbound prompt. Always `"external_untrusted"` for URI-sourced
+    /// prompts — this label is advisory for the IDE; enforcement is the caller's responsibility.
+    pub prompt_trust_level: &'static str,
+    /// Validated model/provider name from the URI, or `null` if not present.
+    pub model: Option<String>,
+}
+
+// ── Error body ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ErrorBody {
+    error: &'static str,
+    detail: String,
+}
+
+fn bad_request(detail: impl Into<String>) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorBody {
+            error: "bad_request",
+            detail: detail.into(),
+        }),
+    )
+        .into_response()
+}
+
+fn forbidden() -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorBody {
+            error: "forbidden",
+            // Generic body: avoids leaking whether the path exists or is merely outside the allowlist.
+            detail: "working directory rejected".to_owned(),
+        }),
+    )
+        .into_response()
+}
+
+fn unprocessable(detail: impl Into<String>) -> Response {
+    (
+        StatusCode::UNPROCESSABLE_ENTITY,
+        Json(ErrorBody {
+            error: "unprocessable_entity",
+            detail: detail.into(),
+        }),
+    )
+        .into_response()
+}
+
+fn internal_error(detail: impl Into<String>) -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorBody {
+            error: "internal_server_error",
+            detail: detail.into(),
+        }),
+    )
+        .into_response()
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+/// `POST /deep-link` — parse and validate a `zeph://` URI (stateless, advisory).
+///
+/// Accepts a JSON body with a `uri` field containing a `zeph://` URI, parses it,
+/// validates the `cwd` against both the deep-link denylist and the ACP
+/// `additional_directories` allowlist, validates the model name against the known
+/// provider list, and returns the cleaned fields.
+///
+/// **This endpoint is advisory.** It does not create a session or write any state.
+/// The authoritative cwd-enforcement point is `session/new` (`args.cwd`). See the
+/// module-level doc for the full advisory contract.
+///
+/// # Status codes
+///
+/// | Code | Condition |
+/// |------|-----------|
+/// | 200  | URI parsed and validated successfully |
+/// | 400  | Malformed URI, unknown host action, URI exceeds 65 536 bytes, NUL/C0 in cwd, prompt too long |
+/// | 403  | `cwd` rejected by denylist or `additional_directories` allowlist |
+/// | 422  | URI is valid but the model/provider name is unknown |
+/// | 401  | Missing or invalid bearer token (enforced by `BearerAuthLayer`) |
+///
+/// # Errors
+///
+/// Returns non-200 status with a JSON `{"error": "...", "detail": "..."}` body on failure.
+pub async fn deep_link_handler(
+    State(state): State<AcpHttpState>,
+    Json(req): Json<DeepLinkRequest>,
+) -> Response {
+    // M2: cap total URI length before any parsing to prevent a giant cwd from reaching canonicalize.
+    if req.uri.len() > MAX_URI_BYTES {
+        return bad_request(format!(
+            "URI exceeds maximum length of {MAX_URI_BYTES} bytes"
+        ));
+    }
+
+    // Parse the URI.
+    let link = match parse_deep_link(&req.uri) {
+        Ok(l) => l,
+        Err(e) => return bad_request(e.to_string()),
+    };
+
+    let zeph_common::deep_link::DeepLink::NewSession(params) = link;
+
+    // M3: check decoded cwd for NUL bytes and C0 control characters before PathBuf construction.
+    // `parse_deep_link` already built a PathBuf, but we re-check the raw string value here
+    // because PathBuf on some platforms silently strips or transforms NUL-containing paths.
+    if let Some(ref cwd) = params.cwd {
+        let cwd_str = cwd.to_string_lossy();
+        if cwd_str
+            .bytes()
+            .any(|b| b == 0 || (b < 0x20 && !matches!(b, 0x09 | 0x0a | 0x0d)))
+        {
+            return bad_request("cwd contains disallowed control characters");
+        }
+    }
+
+    // Validate model name against available providers if specified.
+    if let Some(ref model) = params.model {
+        let models = state.server_config.available_models.read();
+        if !models.is_empty() && !models.iter().any(|m| m == model) {
+            return unprocessable(format!("unknown model '{model}'"));
+        }
+    }
+
+    // Validate and canonicalize cwd if present, applying two gates in order:
+    // 1. deep-link INV-CWD denylist via `validate_deep_link_cwd`
+    // 2. ACP `additional_directories` allowlist (default-deny: empty list rejects all cwd)
+    let working_dir = if let Some(ref cwd) = params.cwd {
+        let allowlist = &state.server_config.additional_directories;
+
+        // Gate 2 (allowlist) checked first: empty allowlist means no directory is permitted.
+        if allowlist.is_empty() {
+            tracing::debug!(cwd = %cwd.display(), "deep-link cwd rejected: additional_directories allowlist is empty");
+            return forbidden();
+        }
+
+        let allowed_roots: Vec<PathBuf> = allowlist
+            .iter()
+            .map(|d| d.as_path().to_path_buf())
+            .collect();
+
+        // Run both gates. Map all failure variants to 403 with a generic body to
+        // avoid leaking filesystem-existence information via distinct status codes.
+        let join_result = tokio::task::spawn_blocking({
+            let cwd = cwd.clone();
+            move || validate_deep_link_cwd(&cwd, &allowed_roots)
+        })
+        .await;
+
+        let validation_result = match join_result {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "spawn_blocking panicked in validate_deep_link_cwd");
+                return internal_error("internal validation error");
+            }
+        };
+
+        match validation_result {
+            Ok(canonical) => Some(canonical),
+            Err(e) => {
+                tracing::debug!(error = %e, cwd = %cwd.display(), "deep-link cwd validation rejected");
+                return forbidden();
+            }
+        }
+    } else {
+        None
+    };
+
+    Json(DeepLinkResponse {
+        working_dir,
+        prompt: params.prompt,
+        prompt_trust_level: "external_untrusted",
+        model: params.model,
+    })
+    .into_response()
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::post;
+    use tower::ServiceExt as _;
+    use zeph_core::channel::LoopbackChannel;
+
+    use super::*;
+    use crate::agent::{AcpContext, SendAgentSpawner, SessionContext};
+    use crate::transport::{AcpServerConfig, SharedAvailableModels};
+
+    fn shared_models_empty() -> SharedAvailableModels {
+        Arc::new(parking_lot::RwLock::new(vec![]))
+    }
+
+    fn shared_models_with(names: &[&str]) -> SharedAvailableModels {
+        Arc::new(parking_lot::RwLock::new(
+            names.iter().map(std::string::ToString::to_string).collect(),
+        ))
+    }
+
+    fn noop_spawner() -> SendAgentSpawner {
+        Arc::new(
+            |_ch: LoopbackChannel, _ctx: Option<AcpContext>, _sess: SessionContext| {
+                Box::pin(async {})
+                    as Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>
+            },
+        )
+    }
+
+    fn build_router(state: AcpHttpState) -> Router {
+        Router::new()
+            .route("/deep-link", post(deep_link_handler))
+            .with_state(state)
+    }
+
+    fn make_state(models: SharedAvailableModels) -> AcpHttpState {
+        make_state_with_config(
+            models,
+            AcpServerConfig {
+                agent_name: "test".into(),
+                agent_version: "0.0.1".into(),
+                ..AcpServerConfig::default()
+            },
+        )
+    }
+
+    fn make_state_with_config(
+        models: SharedAvailableModels,
+        mut config: AcpServerConfig,
+    ) -> AcpHttpState {
+        config.available_models = models;
+        AcpHttpState::new(noop_spawner(), config).with_ready(true)
+    }
+
+    async fn post_deep_link(app: Router, body: serde_json::Value) -> axum::response::Response {
+        app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/deep-link")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn malformed_uri_returns_400() {
+        let app = build_router(make_state(shared_models_empty()));
+        let resp = post_deep_link(app, serde_json::json!({ "uri": "not-a-uri" })).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn wrong_scheme_returns_400() {
+        let app = build_router(make_state(shared_models_empty()));
+        let resp = post_deep_link(app, serde_json::json!({ "uri": "http://example.com" })).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn unknown_host_returns_400() {
+        let app = build_router(make_state(shared_models_empty()));
+        let resp = post_deep_link(app, serde_json::json!({ "uri": "zeph://unknown-action" })).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn oversized_uri_returns_400() {
+        let app = build_router(make_state(shared_models_empty()));
+        let giant_uri = format!("zeph://new-session?cwd=/{}", "a".repeat(MAX_URI_BYTES));
+        let resp = post_deep_link(app, serde_json::json!({ "uri": giant_uri })).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn unknown_model_returns_422() {
+        let app = build_router(make_state(shared_models_with(&["fast", "quality"])));
+        let resp = post_deep_link(
+            app,
+            serde_json::json!({ "uri": "zeph://new-session?model=nonexistent" }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn cwd_outside_empty_allowlist_returns_403() {
+        // additional_directories is empty → any non-None cwd must be rejected (default-deny).
+        let app = build_router(make_state(shared_models_empty()));
+        let tmp = std::env::temp_dir();
+        let uri = format!("zeph://new-session?cwd={}", tmp.display());
+        let resp = post_deep_link(app, serde_json::json!({ "uri": uri })).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn no_cwd_in_uri_returns_200() {
+        let app = build_router(make_state(shared_models_empty()));
+        let resp = post_deep_link(
+            app,
+            serde_json::json!({ "uri": "zeph://new-session?prompt=hi" }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["prompt"], "hi");
+        assert_eq!(body["prompt_trust_level"], "external_untrusted");
+        assert!(body["working_dir"].is_null());
+    }
+
+    #[tokio::test]
+    async fn bare_new_session_returns_200_with_nulls() {
+        let app = build_router(make_state(shared_models_empty()));
+        let resp = post_deep_link(app, serde_json::json!({ "uri": "zeph://new-session" })).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(body["working_dir"].is_null());
+        assert!(body["prompt"].is_null());
+        assert_eq!(body["prompt_trust_level"], "external_untrusted");
+        assert!(body["model"].is_null());
+    }
+
+    #[tokio::test]
+    async fn known_model_with_empty_list_returns_200() {
+        // When available_models list is empty, model validation is skipped.
+        let app = build_router(make_state(shared_models_empty()));
+        let resp = post_deep_link(
+            app,
+            serde_json::json!({ "uri": "zeph://new-session?model=anything" }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["model"], "anything");
+    }
+
+    #[tokio::test]
+    async fn cwd_outside_nonempty_allowlist_returns_403() {
+        use zeph_core::config::AdditionalDir;
+
+        // Create two distinct real temp dirs so AdditionalDir::parse (which canonicalizes) succeeds.
+        let allowed_dir = tempfile::TempDir::new().unwrap();
+        let cwd_dir = tempfile::TempDir::new().unwrap();
+
+        // The allowed root is `allowed_dir`; cwd points to `cwd_dir` which is outside it.
+        let config = AcpServerConfig {
+            agent_name: "test".into(),
+            agent_version: "0.0.1".into(),
+            additional_directories: vec![AdditionalDir::parse(allowed_dir.path()).unwrap()],
+            ..AcpServerConfig::default()
+        };
+        let app = build_router(make_state_with_config(shared_models_empty(), config));
+        let uri = format!("zeph://new-session?cwd={}", cwd_dir.path().display());
+        let resp = post_deep_link(app, serde_json::json!({ "uri": uri })).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn nul_byte_in_cwd_returns_400() {
+        use zeph_core::config::AdditionalDir;
+
+        // Provide a non-empty allowlist so the empty-allowlist gate does not fire first.
+        let allowed_dir = tempfile::TempDir::new().unwrap();
+        let config = AcpServerConfig {
+            agent_name: "test".into(),
+            agent_version: "0.0.1".into(),
+            additional_directories: vec![AdditionalDir::parse(allowed_dir.path()).unwrap()],
+            ..AcpServerConfig::default()
+        };
+        let app = build_router(make_state_with_config(shared_models_empty(), config));
+        // `%2F%00evil` decodes to `/\x00evil` — NUL byte in cwd triggers the M3 guard.
+        let resp = post_deep_link(
+            app,
+            serde_json::json!({ "uri": "zeph://new-session?cwd=%2F%00evil" }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/zeph-acp/src/transport/mod.rs
+++ b/crates/zeph-acp/src/transport/mod.rs
@@ -22,6 +22,8 @@ pub mod auth;
 #[cfg(feature = "acp-http")]
 pub mod crud;
 #[cfg(feature = "acp-http")]
+pub mod deep_link;
+#[cfg(feature = "acp-http")]
 pub mod discovery;
 pub mod http;
 pub mod router;

--- a/crates/zeph-acp/src/transport/router.rs
+++ b/crates/zeph-acp/src/transport/router.rs
@@ -23,6 +23,8 @@ use crate::transport::crud::{
     create_session_handler, delete_session_handler, get_session_handler, update_session_handler,
 };
 #[cfg(feature = "acp-http")]
+use crate::transport::deep_link::deep_link_handler;
+#[cfg(feature = "acp-http")]
 use crate::transport::discovery::{agent_json_handler, discovery_handler};
 #[cfg(feature = "acp-http")]
 use crate::transport::http::{
@@ -55,6 +57,7 @@ const MAX_BODY_BYTES: usize = 1_048_576;
 /// | `PATCH` | `/sessions/{id}` | Update mutable session metadata |
 /// | `DELETE` | `/sessions/{id}` | Delete a session and its history |
 /// | `GET` | `/sessions/{id}/messages` | Get all events for a session |
+/// | `POST` | `/deep-link` | Parse and validate a `zeph://` URI (stateless, advisory) |
 /// | `GET` | `/health` | Public readiness probe |
 /// | `GET` | `/.well-known/acp.json` | Discovery manifest (always public, no auth) |
 /// | `GET` | `/agent.json` | Agent identity manifest for ACP Registry (always public) |
@@ -99,6 +102,7 @@ pub fn acp_router(state: AcpHttpState) -> Router {
                 .delete(delete_session_handler),
         )
         .route("/sessions/{id}/messages", get(session_messages_handler))
+        .route("/deep-link", post(deep_link_handler))
         .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
         .layer(CorsLayer::new());
 

--- a/crates/zeph-common/src/deep_link.rs
+++ b/crates/zeph-common/src/deep_link.rs
@@ -1,12 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! `zeph://` URI parser (spec-066).
+//! `zeph://` URI parser and CWD validator (spec-066).
 //!
-//! This module provides [`parse_deep_link`], a sync, panic-free, I/O-free parser for
-//! `zeph://` URIs. It lives in `zeph-common` (Layer-0a) so it can be used by both the
-//! CLI entry point and any future channel that needs to handle deep-link URIs without
-//! pulling in higher-level crates.
+//! This module provides [`parse_deep_link`] and [`validate_deep_link_cwd`], both sync and
+//! panic-free. It lives in `zeph-common` (Layer-0a) so it can be shared by the CLI entry
+//! point and the ACP HTTP transport without pulling in higher-level crates.
 //!
 //! # Supported URIs
 //!
@@ -25,10 +24,10 @@
 //!   DEL `0x7f` are rejected with [`DeepLinkError::PromptContainsControlChars`] to prevent
 //!   terminal injection attacks.
 //! - `cwd` must be an absolute path; relative paths are rejected with
-//!   [`DeepLinkError::CwdNotAbsolute`]. Further validation (canonicalization, denylist,
-//!   allowlist) is performed by `validate_deep_link_cwd` in `src/url_scheme/validate.rs`.
+//!   [`DeepLinkError::CwdNotAbsolute`]. Full validation (canonicalization, denylist,
+//!   allowlist, `is_dir`) is performed by [`validate_deep_link_cwd`].
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const PROMPT_MAX_BYTES: usize = 8192;
 
@@ -207,6 +206,145 @@ fn parse_new_session_params(url: &url::Url) -> Result<NewSessionParams, DeepLink
     }
 
     Ok(params)
+}
+
+// ── CWD validation (shared between CLI and ACP) ───────────────────────────────
+
+/// Errors returned by [`validate_deep_link_cwd`].
+#[derive(Debug, thiserror::Error)]
+pub enum CwdValidationError {
+    /// The supplied path is not absolute.
+    #[error("path must be absolute")]
+    NotAbsolute,
+    /// `std::fs::canonicalize` failed (I/O error or path does not exist).
+    #[error("canonicalization failed: {0}")]
+    CanonicalizeFailed(std::io::Error),
+    /// The canonical path matches a hardcoded denylist entry.
+    #[error("path is in a denied location: {0}")]
+    Denied(String),
+    /// `allowed_roots` is non-empty and the canonical path does not start with any root.
+    #[error("path is outside allowed roots")]
+    OutsideAllowedRoots,
+    /// The canonical path exists but is not a directory.
+    #[error("path is not a directory")]
+    NotADirectory,
+}
+
+impl From<std::io::Error> for CwdValidationError {
+    fn from(e: std::io::Error) -> Self {
+        Self::CanonicalizeFailed(e)
+    }
+}
+
+/// Validates a cwd path received from a deep-link URI for safe use as a working directory.
+///
+/// Follows INV-CWD from spec §3: absolute → canonicalize → case-fold →
+/// denylist → allowlist → `is_dir`. Steps must not be reordered.
+///
+/// # Errors
+///
+/// Returns [`CwdValidationError`] on the first validation failure.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::PathBuf;
+/// use zeph_common::deep_link::validate_deep_link_cwd;
+///
+/// let result = validate_deep_link_cwd(&PathBuf::from("/home/user/project"), &[]);
+/// assert!(result.is_ok());
+/// ```
+pub fn validate_deep_link_cwd(
+    raw: &Path,
+    allowed_roots: &[PathBuf],
+) -> Result<PathBuf, CwdValidationError> {
+    if !raw.is_absolute() {
+        return Err(CwdValidationError::NotAbsolute);
+    }
+
+    // SAFETY: TOCTOU window between canonicalize and use is accepted per spec §3.
+    let canonical = std::fs::canonicalize(raw)?;
+
+    let canonical_str = canonical.to_string_lossy().into_owned();
+    #[cfg(not(target_os = "linux"))]
+    let folded = canonical_str.to_lowercase();
+    #[cfg(target_os = "linux")]
+    let folded = canonical_str.clone();
+
+    let denied = build_cwd_denylist();
+    for entry in &denied {
+        // A denylist entry "/proc" must block "/proc" and "/proc/anything" but not "/processing".
+        let is_exact = folded == *entry;
+        let is_prefix = folded.starts_with(&format!("{entry}/"));
+        if is_exact || is_prefix {
+            return Err(CwdValidationError::Denied(canonical_str));
+        }
+    }
+
+    if !allowed_roots.is_empty() {
+        let allowed = allowed_roots.iter().any(|root| canonical.starts_with(root));
+        if !allowed {
+            return Err(CwdValidationError::OutsideAllowedRoots);
+        }
+    }
+
+    let meta = canonical.metadata()?;
+    if !meta.is_dir() {
+        return Err(CwdValidationError::NotADirectory);
+    }
+
+    Ok(canonical)
+}
+
+/// Builds the case-folded hardcoded denylist of root prefixes for CWD validation.
+///
+/// On non-Linux platforms entries are lowercased; on Linux they are returned as-is
+/// since filesystem paths are case-sensitive.
+///
+/// When `HOME` is unset or empty, home-directory entries are omitted from the denylist.
+pub fn build_cwd_denylist() -> Vec<String> {
+    #[cfg(target_os = "linux")]
+    let static_entries: &[&str] = &["/proc", "/sys", "/dev", "/etc", "/root", "/boot", "/run"];
+    #[cfg(target_os = "macos")]
+    let static_entries: &[&str] = &["/proc", "/sys", "/dev", "/System", "/Library/Keychains"];
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    let static_entries: &[&str] = &["/proc", "/sys", "/dev"];
+
+    let home = std::env::var("HOME").unwrap_or_default();
+
+    let home_entries: Vec<String> = if home.is_empty() {
+        Vec::new()
+    } else {
+        vec![
+            format!("{home}/.ssh"),
+            format!("{home}/.gnupg"),
+            format!("{home}/.aws"),
+        ]
+    };
+
+    let mut result: Vec<String> = static_entries
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
+    result.extend(home_entries);
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::env;
+        if let Ok(sysroot) = env::var("SystemRoot") {
+            result.push(sysroot);
+        }
+        if let Ok(windir) = env::var("WINDIR") {
+            result.push(windir);
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        result = result.into_iter().map(|s| s.to_lowercase()).collect();
+    }
+
+    result
 }
 
 #[cfg(test)]

--- a/specs/066-deep-link-scheme/spec.md
+++ b/specs/066-deep-link-scheme/spec.md
@@ -269,9 +269,31 @@ Full registration support tracked in follow-up issue (OQ-1).
   process. Documented as v2 follow-up.
 - **`?profile=` accepting a raw filesystem path** — rejected: config injection vector.
 
-## 13. ACP Attach Follow-up Scope (v2 design sketch)
+## 13. ACP Attach — OQ-2 Implementation (shipped in #5059)
 
-For the v2 spec: ACP HTTP attach requires:
+OQ-2 ships a **stateless validate-only** `POST /deep-link` endpoint in `zeph-acp`
+(feature `acp-http`). It parses a `zeph://` URI, validates the `cwd` against
+both the deep-link INV-CWD denylist and the ACP `additional_directories` allowlist,
+validates the model name, and returns the cleaned fields as JSON.
+
+**Advisory contract (MANDATORY for callers):** This endpoint does not create a session
+or write any state. It is advisory — the authoritative cwd-enforcement point for the
+ACP runtime is the per-connection `session/new` / `session/load` boundary (`args.cwd`),
+which is unchanged by this feature. A client that ignores the returned `working_dir` and
+passes a different `args.cwd` to `session/new` is subject only to that path's existing
+`file://` / `additional_directories` checks.
+
+**INV-TRUST gap (tracked, not closed here):** The ACP `session/prompt` path does not
+currently tag inbound prompts as `ExternalUntrusted` (pre-existing gap, see #5063).
+The deep-link feature's own INV-TRUST obligation is limited to: (a) never elevating
+the prompt to system/instruction (trivially met — the endpoint never injects), and
+(b) labeling it `"external_untrusted"` in the response. Both are met.
+
+**Status codes:** 400 (malformed URI / oversized / NUL in cwd), 403 (cwd rejected),
+422 (unknown model), 401 (bearer auth, enforced by `BearerAuthLayer`).
+
+Full stateful attach (persisted cwd + re-validation on load + trust-tagging) remains
+a future epic. For the v2 spec, ACP HTTP attach requires:
 1. A discovery mechanism (local pidfile / Unix socket) advertising the running ACP server's
    HTTP port and a one-time bearer token.
 2. `url-open` reads the pidfile, validates it points to a live process (kill -0), reads the
@@ -281,4 +303,4 @@ For the v2 spec: ACP HTTP attach requires:
    allowlist applies.
 4. Token rotation: the one-time token must be regenerated after each attach to prevent replay.
 
-This is a separate spec and a separate PR.
+Full stateful attach is a separate spec and a separate PR.

--- a/src/url_scheme/validate.rs
+++ b/src/url_scheme/validate.rs
@@ -1,160 +1,21 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
-#![allow(dead_code)]
-use std::path::{Path, PathBuf};
-use thiserror::Error;
 
-/// Errors returned by [`validate_deep_link_cwd`].
-#[derive(Debug, Error)]
-pub enum CwdValidationError {
-    /// The supplied path is not absolute.
-    #[error("path must be absolute")]
-    NotAbsolute,
-    /// `std::fs::canonicalize` failed (I/O error or path does not exist).
-    #[error("canonicalization failed: {0}")]
-    CanonicalizeFailed(std::io::Error),
-    /// The canonical path matches a hardcoded denylist entry.
-    #[error("path is in a denied location: {0}")]
-    Denied(String),
-    /// `allowed_roots` is non-empty and the canonical path does not start with any root.
-    #[error("path is outside allowed roots")]
-    OutsideAllowedRoots,
-    /// The canonical path exists but is not a directory.
-    #[error("path is not a directory")]
-    NotADirectory,
-}
+//! CWD path validation for `zeph://` deep links.
+//!
+//! The implementation lives in `zeph-common` so it can be shared with the ACP HTTP
+//! transport. This module re-exports the shared types for use by the CLI entry point.
 
-impl From<std::io::Error> for CwdValidationError {
-    fn from(e: std::io::Error) -> Self {
-        Self::CanonicalizeFailed(e)
-    }
-}
+pub use zeph_common::deep_link::validate_deep_link_cwd;
 
-/// Validates a cwd path received from a deep-link URI for safe use as a working directory.
-///
-/// Follows INV-CWD from spec §3: absolute → canonicalize → case-fold →
-/// denylist → allowlist → `is_dir`. Steps must not be reordered.
-///
-/// # Errors
-///
-/// Returns [`CwdValidationError`] on the first validation failure.
-///
-/// # Examples
-///
-/// ```no_run
-/// use std::path::PathBuf;
-/// # use zeph::url_scheme::validate::validate_deep_link_cwd;
-/// let result = validate_deep_link_cwd(&PathBuf::from("/home/user/project"), &[]);
-/// assert!(result.is_ok());
-/// ```
-pub fn validate_deep_link_cwd(
-    raw: &Path,
-    allowed_roots: &[PathBuf],
-) -> Result<PathBuf, CwdValidationError> {
-    // Step 1: assert path is absolute.
-    if !raw.is_absolute() {
-        return Err(CwdValidationError::NotAbsolute);
-    }
-
-    // Step 2: canonicalize to resolve symlinks, .., and ..
-    // SAFETY: TOCTOU window between canonicalize and use is accepted per spec §3.
-    let canonical = std::fs::canonicalize(raw)?;
-
-    // Step 3: case-fold for comparison (lowercase on macOS/Windows; no-op on Linux).
-    let canonical_str = canonical.to_string_lossy().into_owned();
-    #[cfg(not(target_os = "linux"))]
-    let folded = canonical_str.to_lowercase();
-    #[cfg(target_os = "linux")]
-    let folded = canonical_str.clone();
-
-    // Step 4: compare against hardcoded denylist (case-folded root prefixes).
-    let denied = build_denylist();
-    for entry in &denied {
-        // A denylist entry "/proc" must block "/proc" and "/proc/anything" but not "/processing".
-        // Use starts_with + boundary check: either exact match or followed by '/'.
-        let is_exact = folded == *entry;
-        let is_prefix = folded.starts_with(&format!("{entry}/"));
-        if is_exact || is_prefix {
-            return Err(CwdValidationError::Denied(canonical_str));
-        }
-    }
-
-    // Step 5: if allowed_roots non-empty, assert starts_with at least one root.
-    if !allowed_roots.is_empty() {
-        let allowed = allowed_roots.iter().any(|root| canonical.starts_with(root));
-        if !allowed {
-            return Err(CwdValidationError::OutsideAllowedRoots);
-        }
-    }
-
-    // Step 6: assert metadata().is_dir().
-    let meta = canonical.metadata()?;
-    if !meta.is_dir() {
-        return Err(CwdValidationError::NotADirectory);
-    }
-
-    Ok(canonical)
-}
-
-/// Builds the case-folded hardcoded denylist of root prefixes.
-///
-/// On non-Linux platforms the entries are lowercased; on Linux they are returned as-is
-/// since filesystem paths are case-sensitive.
-///
-/// # Note
-///
-/// When `HOME` is unset or empty, home-directory entries are omitted from the denylist.
-/// This is safe: an unset `HOME` typically indicates a sandboxed or service environment
-/// where the user's home directory is not accessible.
-pub(crate) fn build_denylist() -> Vec<String> {
-    #[cfg(target_os = "linux")]
-    let static_entries: &[&str] = &["/proc", "/sys", "/dev", "/etc", "/root", "/boot", "/run"];
-    #[cfg(target_os = "macos")]
-    let static_entries: &[&str] = &["/proc", "/sys", "/dev", "/System", "/Library/Keychains"];
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    let static_entries: &[&str] = &["/proc", "/sys", "/dev"];
-
-    let home = std::env::var("HOME").unwrap_or_default();
-
-    let home_entries: Vec<String> = if home.is_empty() {
-        Vec::new()
-    } else {
-        vec![
-            format!("{home}/.ssh"),
-            format!("{home}/.gnupg"),
-            format!("{home}/.aws"),
-        ]
-    };
-
-    let mut result: Vec<String> = static_entries
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect();
-    result.extend(home_entries);
-
-    #[cfg(target_os = "windows")]
-    {
-        use std::env;
-        if let Ok(sysroot) = env::var("SystemRoot") {
-            result.push(sysroot);
-        }
-        if let Ok(windir) = env::var("WINDIR") {
-            result.push(windir);
-        }
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        result = result.into_iter().map(|s| s.to_lowercase()).collect();
-    }
-
-    result
-}
+#[cfg(test)]
+use zeph_common::deep_link::{CwdValidationError, build_cwd_denylist};
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn absolute_path_to_temp_dir_is_ok() {
@@ -211,8 +72,6 @@ mod tests {
     #[test]
     fn path_within_allowed_roots_is_ok() {
         let dir = std::env::temp_dir();
-        // Canonicalize the allowed root so it matches what validate_deep_link_cwd produces.
-        // On macOS /var/folders resolves to /private/var/folders after canonicalize.
         let canonical_root = std::fs::canonicalize(&dir).expect("canonicalize temp dir");
         let allowed = vec![canonical_root];
         let result = validate_deep_link_cwd(&dir, &allowed);
@@ -254,7 +113,7 @@ mod tests {
                     "~/.ssh should be denied: {result:?}"
                 );
             } else {
-                let denylist = build_denylist();
+                let denylist = build_cwd_denylist();
                 let ssh_entry = format!("{home}/.ssh").to_lowercase();
                 assert!(
                     denylist.iter().any(|d| d == &ssh_entry),
@@ -266,8 +125,7 @@ mod tests {
 
     #[test]
     fn denylist_false_positive_processing() {
-        // /processing must NOT be blocked by the /proc entry.
-        let denylist = build_denylist();
+        let denylist = build_cwd_denylist();
         let candidate = "/processing";
         for entry in &denylist {
             let is_exact = candidate == entry.as_str();


### PR DESCRIPTION
## Summary

- Extracts `validate_deep_link_cwd` from the binary (`src/url_scheme/validate.rs`) into `zeph-common/src/deep_link.rs`, giving CLI and ACP a single shared CWD validator
- Adds `POST /deep-link` to `zeph-acp` (behind `acp-http` feature, `BearerAuthLayer` required)
- Endpoint is **stateless validate-only** (Option B from arch review): parses `zeph://` URI, runs double CWD allowlist check, returns `{working_dir, prompt, prompt_trust_level: "external_untrusted", model}` — no session record created
- Updates spec-066 §13 with the advisory-contract note
- 12 handler unit tests (including FIX-2 `cwd_outside_nonempty_allowlist_returns_403` and FIX-3 `nul_byte_in_cwd_returns_400`)

## Design decisions

**Stateless advisory contract**: the original design (Option A, stateful with persisted `working_dir`) was blocked by CRITICAL-1 — `AcpSessionInfo` has no `working_dir` field and `do_load_session` takes client-supplied cwd unchecked. Option B removes the dead enforcement rather than patching it. The IDE submits the returned `working_dir` in its own `session/new`; the authoritative CWD-enforcement point stays at `session/new` (unchanged).

**No process-global side effects**: no `set_var("ZEPH_URL_OPEN_DEPTH")` (racy in a multi-connection server), no `set_current_dir`.

## Security

- URI length capped at 65 536 B **before** `parse_deep_link` (M2, DoS guard)
- NUL/C0 control characters checked in decoded cwd after PathBuf construction but before `canonicalize` (M3, defense-in-depth)
- 403 uses identical body for both "path does not exist" and "path outside allowlist" to avoid filesystem-existence info-leak
- Bearer auth applied via `BearerAuthLayer` at the router group level
- Security audit: PASS (no exploitable findings; `cargo deny` advisories are pre-existing transitive-only)

## Known limitations / follow-ups

- **#5065**: ACP `session/prompt` does not tag inbound prompts as `ExternalUntrusted` and does not run `ContentSanitizer` (pre-existing INV-TRUST gap; out of scope here)
- NIT: `validate.rs:51` uses a fixed tempfile name — could race under parallel CI; low priority

## Nits documented (no code change required)
- 422 row in handler rustdoc should note "Skipped if `available_models` is empty" — cosmetic
- Comment at L150–152 (M3 justification) is slightly imprecise but correct

## Test plan

- [x] 12 handler unit tests pass (including all M2/M3/403/422 paths)
- [x] 10804 workspace tests pass
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` clean
- [x] `cargo test --doc --workspace` clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-acp -p zeph-common` clean
- [ ] Live HTTP e2e (ACP server + IDE attach via returned working_dir) — tracked in coverage-status as Untested; follow-up playbook scenarios 21–27 added to `.local/testing/playbooks/deep-link.md`

Closes #5059