### PR TITLE
feat(tools): add policy_provider to PolicyConfig and utility_window hard-stop

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -720,6 +720,8 @@ enabled = false
 default_effect = "deny"
 # Optional external policy rules file (TOML). Overrides inline rules when set.
 # policy_file = "policy.toml"
+# Provider name from [[llm.providers]] for LLM-assisted policy checks. Empty = disabled.
+# policy_provider = ""
 
 # Example policy rules:
 # [[tools.policy.rules]]
@@ -731,6 +733,14 @@ default_effect = "deny"
 # effect = "allow"
 # tool = "shell"
 # paths = ["/tmp/*"]
+
+[tools.utility]
+# Enable utility-guided tool dispatch gating (scores gain/cost/redundancy per call)
+enabled = false
+# Minimum utility score to execute a tool call (0.0–1.0)
+threshold = 0.1
+# Consecutive low-utility calls before early-stopping the whole tool loop for the turn. 0 = disabled.
+# utility_window = 0
 
 [tools.retry]
 # Maximum retry attempts for transient errors per tool call (0 = disabled)

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -519,6 +519,10 @@ impl Config {
                 &self.tools.retry.parameter_reformat_provider,
             ),
             (
+                "tools.policy.policy_provider",
+                &self.tools.policy.policy_provider,
+            ),
+            (
                 "tools.adversarial_policy.policy_provider",
                 &self.tools.adversarial_policy.policy_provider,
             ),

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -1524,16 +1524,12 @@ destination = "/var/log/zeph-audit.log""#,
 
     #[test]
     fn utility_window_serde_roundtrip() {
-        let toml_str = r#"
-            [utility_scoring]
-            enabled = true
-            utility_window = 3
-        "#;
-        // Parse as a wrapper struct to exercise the nested key.
         #[derive(serde::Deserialize)]
         struct Wrapper {
             utility_scoring: UtilityScoringConfig,
         }
+
+        let toml_str = "[utility_scoring]\nenabled = true\nutility_window = 3\n";
         let w: Wrapper = toml::from_str(toml_str).unwrap();
         assert_eq!(w.utility_scoring.utility_window, 3);
 

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -254,6 +254,9 @@ pub struct PolicyConfig {
     pub rules: Vec<PolicyRuleConfig>,
     /// Optional external policy file (TOML). When set, overrides inline rules.
     pub policy_file: Option<String>,
+    /// Provider name for LLM-assisted policy checks. Empty = disabled.
+    #[serde(default)]
+    pub policy_provider: ProviderName,
 }
 
 /// A single policy rule as read from TOML.
@@ -603,6 +606,12 @@ pub struct UtilityScoringConfig {
     /// Tool names that bypass the utility gate unconditionally.
     #[serde(default = "default_utility_exempt_tools")]
     pub exempt_tools: Vec<String>,
+    /// Consecutive low-utility calls before early-stopping the loop. 0 = disabled.
+    ///
+    /// Exempt tools (`invoke_skill`, `load_skill`) do not count toward this window.
+    /// The counter resets between outer loop iterations.
+    #[serde(default)]
+    pub utility_window: usize,
 }
 
 impl Default for UtilityScoringConfig {
@@ -615,6 +624,7 @@ impl Default for UtilityScoringConfig {
             redundancy_weight: default_utility_redundancy_weight(),
             uncertainty_bonus: default_utility_uncertainty_bonus(),
             exempt_tools: default_utility_exempt_tools(),
+            utility_window: 0,
         }
     }
 }
@@ -1483,5 +1493,52 @@ destination = "/var/log/zeph-audit.log""#,
             let config: ToolsConfig = toml::from_str(toml_str).unwrap();
             assert_eq!(config.audit.destination, expected);
         }
+    }
+
+    #[test]
+    fn policy_provider_serde_roundtrip() {
+        let toml_str = r#"
+            [policy]
+            enabled = true
+            policy_provider = "my-llm"
+        "#;
+        let config: ToolsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.policy.policy_provider.as_str(), "my-llm");
+
+        let json = serde_json::to_string(&config.policy).unwrap();
+        let back: PolicyConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.policy_provider.as_str(), "my-llm");
+    }
+
+    #[test]
+    fn policy_provider_default_is_empty() {
+        let config = PolicyConfig::default();
+        assert!(config.policy_provider.is_empty());
+    }
+
+    #[test]
+    fn utility_window_default_is_zero() {
+        let config = UtilityScoringConfig::default();
+        assert_eq!(config.utility_window, 0);
+    }
+
+    #[test]
+    fn utility_window_serde_roundtrip() {
+        let toml_str = r#"
+            [utility_scoring]
+            enabled = true
+            utility_window = 3
+        "#;
+        // Parse as a wrapper struct to exercise the nested key.
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            utility_scoring: UtilityScoringConfig,
+        }
+        let w: Wrapper = toml::from_str(toml_str).unwrap();
+        assert_eq!(w.utility_scoring.utility_window, 3);
+
+        let json = serde_json::to_string(&w.utility_scoring).unwrap();
+        let back: UtilityScoringConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.utility_window, 3);
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -55,6 +55,14 @@ struct ToolDispatchContext {
     /// When `Some((score, top_signals))`, all tool calls in this batch are blocked with
     /// `ToolError::TrajectoryRiskExceeded`. Set when `mage_accumulator.is_blocked()` at dispatch time.
     mage_blocked: Option<(f64, Vec<String>)>,
+    /// System hints injected by the utility-window early-stop logic during `compute_utility_actions`.
+    early_stop_hints: Vec<String>,
+    /// Set when `compute_utility_actions` exhausted the consecutive-low window.
+    ///
+    /// When `true`, the outer `for iteration` loop must `break` after the current batch
+    /// is processed — the advisory hint alone is not sufficient because the LLM can
+    /// re-issue tool calls in the next iteration.
+    window_exhausted: bool,
 }
 
 /// Output of `Agent::classify_tool_result`: all fields derived from the raw `ToolResult`.

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -1118,3 +1118,137 @@ mod skip_ml_internal_tools {
         }
     }
 }
+
+// --- utility-window hard-break tests (C1/C3 fix) ---
+
+/// C3: window=2 + two consecutive low-utility calls must cause `handle_native_tool_calls`
+/// to return `true`, signalling the outer iteration loop to break.
+///
+/// Also verifies:
+/// - remaining calls in the batch are downgraded to `Stop` (produce `[skipped]`)
+/// - the system hint "Tool loop stopped early" is present in the injected ToolResult messages
+#[tokio::test]
+async fn utility_window_exhaustion_signals_hard_break() {
+    use crate::agent::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use zeph_llm::provider::{Message, MessagePart, Role, ToolUseRequest};
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+    agent
+        .msg
+        .messages
+        .push(Message::from_legacy(Role::System, "system"));
+
+    // threshold=1.0 ensures every scored call is non-ToolCall; window=2 fires after 2 calls.
+    agent
+        .tool_orchestrator
+        .set_utility_config(zeph_tools::UtilityScoringConfig {
+            enabled: true,
+            threshold: 1.0,
+            utility_window: 2,
+            ..zeph_tools::UtilityScoringConfig::default()
+        });
+
+    // Two calls: both will score below threshold → counter hits 2 → window fires.
+    let tool_calls = vec![
+        ToolUseRequest {
+            id: "call-w1".to_owned(),
+            name: "bash".to_owned().into(),
+            input: serde_json::json!({"command": "ls"}),
+        },
+        ToolUseRequest {
+            id: "call-w2".to_owned(),
+            name: "read".to_owned().into(),
+            input: serde_json::json!({"path": "/tmp/x"}),
+        },
+    ];
+
+    let window_exhausted = agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    assert!(
+        window_exhausted,
+        "handle_native_tool_calls must return true when utility_window is exhausted"
+    );
+
+    // The system hint must appear in a system-role message injected into history.
+    let has_hint = agent.msg.messages.iter().any(|m| {
+        m.role == Role::User
+            && m.parts.iter().any(|p| {
+                if let MessagePart::ToolResult { content, .. } = p {
+                    content.contains("Tool loop stopped early")
+                } else {
+                    false
+                }
+            })
+    });
+    // The hint is pushed as a pending_system_hints entry which becomes part of the
+    // tool-result batch message; verify the overall message history contains it.
+    let hint_in_content = agent
+        .msg
+        .messages
+        .iter()
+        .any(|m| m.content.contains("Tool loop stopped early"));
+    assert!(
+        has_hint || hint_in_content,
+        "system hint 'Tool loop stopped early' must be present in message history after window exhaustion"
+    );
+}
+
+/// C3: exempt tools (`invoke_skill`) must NOT count toward the utility window.
+///
+/// Configures window=1 with threshold=1.0 (every scored call fails). With only exempt
+/// calls in the batch, the window must NOT fire — `handle_native_tool_calls` returns `false`.
+#[tokio::test]
+async fn utility_window_exempt_tool_does_not_trigger_break() {
+    use crate::agent::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use zeph_llm::provider::{Message, Role, ToolUseRequest};
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+    agent
+        .msg
+        .messages
+        .push(Message::from_legacy(Role::System, "system"));
+
+    // window=1: a single scored non-ToolCall would fire.  threshold=1.0: every scored call fails.
+    agent
+        .tool_orchestrator
+        .set_utility_config(zeph_tools::UtilityScoringConfig {
+            enabled: true,
+            threshold: 1.0,
+            utility_window: 1,
+            ..zeph_tools::UtilityScoringConfig::default()
+        });
+
+    // invoke_skill is in the exempt list — must bypass note_action entirely.
+    let tool_calls = vec![ToolUseRequest {
+        id: "call-exempt".to_owned(),
+        name: "invoke_skill".to_owned().into(),
+        input: serde_json::json!({"skill": "test"}),
+    }];
+
+    let window_exhausted = agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    assert!(
+        !window_exhausted,
+        "exempt tool invoke_skill must not trigger utility-window exhaustion"
+    );
+}

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -1126,7 +1126,7 @@ mod skip_ml_internal_tools {
 ///
 /// Also verifies:
 /// - remaining calls in the batch are downgraded to `Stop` (produce `[skipped]`)
-/// - the system hint "Tool loop stopped early" is present in the injected ToolResult messages
+/// - the system hint "Tool loop stopped early" is present in the injected `ToolResult` messages
 #[tokio::test]
 async fn utility_window_exhaustion_signals_hard_break() {
     use crate::agent::agent_tests::{

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -402,7 +402,8 @@ impl<C: Channel> Agent<C> {
         &mut self,
         calls: &[ToolCall],
         pre_exec_blocked: &[bool],
-    ) -> Vec<zeph_tools::UtilityAction> {
+        pending_system_hints: &mut Vec<String>,
+    ) -> (Vec<zeph_tools::UtilityAction>, bool) {
         #[allow(clippy::cast_possible_truncation)]
         let tokens_consumed =
             usize::try_from(self.runtime.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
@@ -434,50 +435,69 @@ impl<C: Channel> Agent<C> {
                 };
                 zeph_tools::has_explicit_tool_request(&text)
             });
-        calls
-            .iter()
-            .enumerate()
-            .map(|(idx, call)| {
-                if pre_exec_blocked[idx] {
-                    return zeph_tools::UtilityAction::ToolCall;
-                }
-                if self
-                    .tool_orchestrator
-                    .utility_scorer
-                    .is_exempt(call.tool_id.as_str())
-                {
-                    return zeph_tools::UtilityAction::ToolCall;
-                }
-                let ctx = zeph_tools::UtilityContext {
-                    tool_calls_this_turn: tool_calls_this_turn + idx,
-                    tokens_consumed,
-                    token_budget,
-                    user_requested: explicit_request,
-                };
-                let score = self.tool_orchestrator.utility_scorer.score(call, &ctx);
-                let action = self
-                    .tool_orchestrator
-                    .utility_scorer
-                    .recommend_action(score.as_ref(), &ctx);
-                tracing::debug!(
+        let mut actions = Vec::with_capacity(calls.len());
+        // Once window exhaustion fires, all remaining calls in the batch are downgraded to Stop.
+        let mut window_exhausted = false;
+        for (idx, call) in calls.iter().enumerate() {
+            if window_exhausted {
+                actions.push(zeph_tools::UtilityAction::Stop);
+                continue;
+            }
+            if pre_exec_blocked[idx] {
+                actions.push(zeph_tools::UtilityAction::ToolCall);
+                continue;
+            }
+            if self
+                .tool_orchestrator
+                .utility_scorer
+                .is_exempt(call.tool_id.as_str())
+            {
+                actions.push(zeph_tools::UtilityAction::ToolCall);
+                continue;
+            }
+            let ctx = zeph_tools::UtilityContext {
+                tool_calls_this_turn: tool_calls_this_turn + idx,
+                tokens_consumed,
+                token_budget,
+                user_requested: explicit_request,
+            };
+            let score = self.tool_orchestrator.utility_scorer.score(call, &ctx);
+            let action = self
+                .tool_orchestrator
+                .utility_scorer
+                .recommend_action(score.as_ref(), &ctx);
+            tracing::debug!(
+                tool = %call.tool_id,
+                score = ?score.as_ref().map(|s| s.total),
+                threshold = self.tool_orchestrator.utility_scorer.threshold(),
+                action = ?action,
+                "utility gate: action recommended"
+            );
+            if action != zeph_tools::UtilityAction::ToolCall {
+                tracing::info!(
                     tool = %call.tool_id,
-                    score = ?score.as_ref().map(|s| s.total),
-                    threshold = self.tool_orchestrator.utility_scorer.threshold(),
                     action = ?action,
-                    "utility gate: action recommended"
+                    "utility gate: non-execute action"
                 );
-                if action != zeph_tools::UtilityAction::ToolCall {
-                    tracing::info!(
-                        tool = %call.tool_id,
-                        action = ?action,
-                        "utility gate: non-execute action"
-                    );
-                }
-                // Record call regardless so subsequent calls in this batch see it as prior.
-                self.tool_orchestrator.utility_scorer.record_call(call);
-                action
-            })
-            .collect()
+            }
+            // Record call regardless so subsequent calls in this batch see it as prior.
+            self.tool_orchestrator.utility_scorer.record_call(call);
+            // note_action increments the consecutive-low counter for scored calls only.
+            // Exempt and pre-exec-blocked calls above bypass scoring and are not tracked.
+            if self.tool_orchestrator.utility_scorer.note_action(&action) {
+                let n = self.tool_orchestrator.utility_scorer.utility_window();
+                tracing::info!(
+                    window = n,
+                    "utility gate: consecutive-low window exhausted, early-stopping loop"
+                );
+                pending_system_hints.push(format!(
+                    "Tool loop stopped early: utility below threshold for {n} consecutive calls."
+                ));
+                window_exhausted = true;
+            }
+            actions.push(action);
+        }
+        (actions, window_exhausted)
     }
 
     #[tracing::instrument(
@@ -487,11 +507,13 @@ impl<C: Channel> Agent<C> {
         fields(tool_count = tool_calls.len()),
         err
     )]
+    /// Returns `true` when the utility-window was exhausted and the outer iteration loop
+    /// should break immediately after this batch.
     pub(super) async fn handle_native_tool_calls(
         &mut self,
         text: Option<&str>,
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
-    ) -> Result<(), crate::agent::error::AgentError> {
+    ) -> Result<bool, crate::agent::error::AgentError> {
         let t_tool_exec = std::time::Instant::now();
         tracing::debug!("turn timing: tool_exec start");
         // Scan for image-exfiltration in accompanying text, send to channel, persist
@@ -513,6 +535,8 @@ impl<C: Channel> Agent<C> {
             repeat_blocked,
             cache_hits,
             mage_blocked,
+            mut early_stop_hints,
+            window_exhausted,
         } = self.prepare_tool_dispatch(tool_calls);
 
         let max_retries = self.tool_orchestrator.max_tool_retries;
@@ -564,11 +588,16 @@ impl<C: Channel> Agent<C> {
         let Some(TierLoopData {
             mut tool_results,
             pending_focus_checkpoint,
-            pending_system_hints,
+            mut pending_system_hints,
         }) = tier_data
         else {
-            return Ok(());
+            return Ok(false);
         };
+        // Prepend window-exhaustion hints so the LLM sees them before per-call skipped results.
+        if !early_stop_hints.is_empty() {
+            early_stop_hints.extend(pending_system_hints);
+            pending_system_hints = early_stop_hints;
+        }
 
         // Phases 2a / 2 / 3: confirmation, transient retry, parameter reformat.
         // Each phase may return early on cancellation (Ok(())) or propagate channel errors.
@@ -598,7 +627,7 @@ impl<C: Channel> Agent<C> {
             .tool_exec_ms
             .saturating_add(tool_exec_ms);
 
-        Ok(())
+        Ok(window_exhausted)
     }
 
     async fn push_assistant_tool_use_message(
@@ -672,8 +701,6 @@ impl<C: Channel> Agent<C> {
             .task_execution_env
             .as_deref()
             .map(|name| ExecutionContext::default().with_name(name));
-        // Assign stable IDs before execution so ToolStart, ToolOutputChunk, and ToolOutput
-        // all share the same ID, enabling correct per-tool routing in parallel execution.
         let tool_call_ids: Vec<String> = tool_calls
             .iter()
             .map(|_| uuid::Uuid::new_v4().to_string())
@@ -708,36 +735,19 @@ impl<C: Channel> Agent<C> {
 
         self.check_exfiltration_urls(tool_calls);
 
-        // Pre-execution verification (TrustBench pattern, issue #1630).
-        // Runs after exfiltration guard (flag-only) and before repeat-detection.
-        // Block: return synthetic error result for this call without executing.
-        // Warn: log + emit security event + continue execution.
+        // Pre-execution verification (TrustBench, #1630): runs before repeat-detection.
         let mut pre_exec_blocked = self.run_pre_execution_verifiers(&calls);
 
         self.apply_channel_tool_allowlist(&calls, &mut pre_exec_blocked);
 
         // Utility gate: score each call and recommend an action (#2477).
-        // user_requested is detected from the last user message only — never from LLM content or
-        // tool outputs to prevent prompt-injection bypass (C2 fix).
-        let utility_actions = self.compute_utility_actions(&calls, &pre_exec_blocked);
+        // user_requested is from the last user message only (prompt-injection guard).
+        let mut early_stop_hints: Vec<String> = Vec::new();
+        let (utility_actions, window_exhausted) =
+            self.compute_utility_actions(&calls, &pre_exec_blocked, &mut early_stop_hints);
 
-        // Per-session quota check. Counted once per logical dispatch batch (M3: retries do not
-        // consume additional quota slots). When exceeded, all calls in this batch are quota-blocked.
-        let quota_blocked = if let Some(max) = self.tool_orchestrator.check_quota() {
-            tracing::warn!(
-                max,
-                count = self.tool_orchestrator.session_tool_call_count,
-                "tool call quota exceeded for session"
-            );
-            true
-        } else {
-            // Increment before the retry loop — each call in this batch counts as one logical call.
-            self.tool_orchestrator.session_tool_call_count = self
-                .tool_orchestrator
-                .session_tool_call_count
-                .saturating_add(u32::try_from(calls.len()).unwrap_or(u32::MAX));
-            false
-        };
+        // M3: quota counted once per batch; retries do not consume additional slots.
+        let quota_blocked = self.check_and_update_quota(calls.len());
 
         // Build args hashes and check for repeats. Blocked calls get a pre-built error result.
         let args_hashes: Vec<u64> = calls.iter().map(|c| tool_args_hash(&c.params)).collect();
@@ -757,16 +767,13 @@ impl<C: Channel> Agent<C> {
                 blocked
             })
             .collect();
-        // Repeat-detection (CRIT-3): push LLM-initiated calls BEFORE execution.
-        // Cache hits are also pushed here (P1 invariant): a cached tool called N times must
-        // still trigger repeat-detection to prevent infinite loops if the LLM keeps requesting it.
+        // CRIT-3: push calls before execution; cache hits included (P1 invariant).
         for (call, &hash) in calls.iter().zip(args_hashes.iter()) {
             self.tool_orchestrator
                 .push_tool_call(call.tool_id.as_str(), hash);
         }
 
-        // Cache lookup: for each non-repeat, cacheable call, check result cache before dispatch.
-        // Hits are stored as pre-built results; cache store happens after join_all completes.
+        // Cache lookup: hits pre-built before dispatch; cache store happens after join_all.
         let cache_hits: Vec<Option<zeph_tools::ToolOutput>> = calls
             .iter()
             .zip(args_hashes.iter())
@@ -798,6 +805,8 @@ impl<C: Channel> Agent<C> {
             repeat_blocked,
             cache_hits,
             mage_blocked,
+            early_stop_hints,
+            window_exhausted,
         }
     }
 
@@ -831,6 +840,22 @@ impl<C: Channel> Agent<C> {
         );
         self.services.security.mage_accumulator.record_block();
         Some((score, top))
+    }
+
+    fn check_and_update_quota(&mut self, batch_len: usize) -> bool {
+        if let Some(max) = self.tool_orchestrator.check_quota() {
+            tracing::warn!(
+                max,
+                count = self.tool_orchestrator.session_tool_call_count,
+                "tool call quota exceeded for session"
+            );
+            return true;
+        }
+        self.tool_orchestrator.session_tool_call_count = self
+            .tool_orchestrator
+            .session_tool_call_count
+            .saturating_add(u32::try_from(batch_len).unwrap_or(u32::MAX));
+        false
     }
 
     fn check_exfiltration_urls(&mut self, tool_calls: &[zeph_llm::provider::ToolUseRequest]) {
@@ -2639,7 +2664,8 @@ impl<C: Channel> Agent<C> {
             return Ok(Some(()));
         };
         self.preserve_thinking_blocks(thinking_blocks);
-        self.handle_native_tool_calls(text.as_deref(), &tool_calls)
+        let window_exhausted = self
+            .handle_native_tool_calls(text.as_deref(), &tool_calls)
             .await?;
 
         // Summarize before pruning; apply deferred summaries after pruning.
@@ -2653,6 +2679,10 @@ impl<C: Channel> Agent<C> {
         // cooldown, or trigger Hard tier (no LLM call during tool loop).
         self.maybe_soft_compact_mid_iteration();
         self.flush_deferred_summaries().await;
+
+        if window_exhausted {
+            return Ok(Some(()));
+        }
 
         Ok(None)
     }

--- a/crates/zeph-tools/src/policy.rs
+++ b/crates/zeph-tools/src/policy.rs
@@ -428,6 +428,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/tmp/../etc/passwd");
@@ -456,6 +457,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/etc/./shadow");
@@ -484,6 +486,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -527,6 +530,7 @@ mod tests {
                 },
             ],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/tmp/secret.sh");
@@ -568,6 +572,7 @@ mod tests {
                 },
             ],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/etc/passwd");
@@ -608,6 +613,7 @@ mod tests {
                 },
             ],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/etc/passwd");
@@ -630,6 +636,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -646,6 +653,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -674,6 +682,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
 
@@ -716,6 +725,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules,
             policy_file: None,
+            policy_provider: Default::default(),
         };
         assert!(matches!(
             PolicyEnforcer::compile(&config),
@@ -739,6 +749,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/a/b/c/d/../../../../../../etc/passwd");
@@ -769,6 +780,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -846,6 +858,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(policy_path.to_string_lossy().into_owned()),
+            policy_provider: Default::default(),
         };
         let result = PolicyEnforcer::compile(&config);
         std::env::set_current_dir(&original_cwd).unwrap();
@@ -878,6 +891,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(link.to_string_lossy().into_owned()),
+            policy_provider: Default::default(),
         };
         let result = PolicyEnforcer::compile(&config);
         std::env::set_current_dir(&original_cwd).unwrap();
@@ -906,6 +920,7 @@ tool = "shell"
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -934,6 +949,7 @@ tool = "shell"
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -962,6 +978,7 @@ tool = "shell"
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -995,6 +1012,7 @@ tool = "shell"
             default_effect: DefaultEffect::Deny,
             rules,
             policy_file: None,
+            policy_provider: Default::default(),
         };
         assert!(
             PolicyEnforcer::compile(&config).is_ok(),
@@ -1024,6 +1042,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(policy_path.to_string_lossy().into_owned()),
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/etc/passwd");
@@ -1049,6 +1068,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(policy_path.to_string_lossy().into_owned()),
+            policy_provider: Default::default(),
         };
         assert!(
             matches!(
@@ -1068,6 +1088,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some("/tmp/__zeph_no_such_policy_file__.toml".to_owned()),
+            policy_provider: Default::default(),
         };
         assert!(
             matches!(
@@ -1090,6 +1111,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(policy_path.to_string_lossy().into_owned()),
+            policy_provider: Default::default(),
         };
         assert!(
             matches!(
@@ -1116,6 +1138,7 @@ tool = "shell"
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);

--- a/crates/zeph-tools/src/policy.rs
+++ b/crates/zeph-tools/src/policy.rs
@@ -391,6 +391,8 @@ fn extract_paths(params: &serde_json::Map<String, serde_json::Value>) -> Vec<Str
 mod tests {
     use std::collections::HashMap;
 
+    use zeph_config::ProviderName;
+
     use super::*;
 
     fn make_context(trust: SkillTrustLevel) -> PolicyContext {
@@ -428,7 +430,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/tmp/../etc/passwd");
@@ -457,7 +459,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/etc/./shadow");
@@ -486,7 +488,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -530,7 +532,7 @@ mod tests {
                 },
             ],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/tmp/secret.sh");
@@ -572,7 +574,7 @@ mod tests {
                 },
             ],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/etc/passwd");
@@ -613,7 +615,7 @@ mod tests {
                 },
             ],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/etc/passwd");
@@ -636,7 +638,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -653,7 +655,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -682,7 +684,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
 
@@ -725,7 +727,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules,
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         assert!(matches!(
             PolicyEnforcer::compile(&config),
@@ -749,7 +751,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/a/b/c/d/../../../../../../etc/passwd");
@@ -780,7 +782,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -858,7 +860,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(policy_path.to_string_lossy().into_owned()),
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let result = PolicyEnforcer::compile(&config);
         std::env::set_current_dir(&original_cwd).unwrap();
@@ -891,7 +893,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(link.to_string_lossy().into_owned()),
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let result = PolicyEnforcer::compile(&config);
         std::env::set_current_dir(&original_cwd).unwrap();
@@ -920,7 +922,7 @@ tool = "shell"
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -949,7 +951,7 @@ tool = "shell"
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -978,7 +980,7 @@ tool = "shell"
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);
@@ -1012,7 +1014,7 @@ tool = "shell"
             default_effect: DefaultEffect::Deny,
             rules,
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         assert!(
             PolicyEnforcer::compile(&config).is_ok(),
@@ -1042,7 +1044,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(policy_path.to_string_lossy().into_owned()),
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let params = make_params("file_path", "/etc/passwd");
@@ -1068,7 +1070,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(policy_path.to_string_lossy().into_owned()),
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         assert!(
             matches!(
@@ -1088,7 +1090,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some("/tmp/__zeph_no_such_policy_file__.toml".to_owned()),
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         assert!(
             matches!(
@@ -1111,7 +1113,7 @@ tool = "shell"
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: Some(policy_path.to_string_lossy().into_owned()),
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         assert!(
             matches!(
@@ -1138,7 +1140,7 @@ tool = "shell"
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let enforcer = PolicyEnforcer::compile(&config).unwrap();
         let ctx = make_context(SkillTrustLevel::Trusted);

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -471,6 +471,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         let result = gate.execute_tool_call(&make_call("bash")).await;
@@ -484,6 +485,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         let result = gate.execute_tool_call(&make_call("bash")).await;
@@ -505,6 +507,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         let result = gate
@@ -528,6 +531,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         let result = gate
@@ -544,6 +548,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         let err = gate
@@ -566,6 +571,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         let result = gate.execute_tool_call_confirmed(&make_call("bash")).await;
@@ -580,6 +586,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         let call = make_call("shell");
@@ -606,6 +613,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         let result = gate.execute("```bash\necho hi\n```").await;
@@ -634,6 +642,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         gate.set_effective_trust(SkillTrustLevel::Quarantined);
@@ -662,6 +671,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         gate.set_effective_trust(SkillTrustLevel::Trusted);
@@ -680,6 +690,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let slot: TrajectoryRiskSlot = Arc::new(RwLock::new(3u8)); // Critical
         let gate = make_gate(&config).with_trajectory_risk(slot);
@@ -705,6 +716,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let slot: TrajectoryRiskSlot = Arc::new(RwLock::new(2u8)); // High
         let gate = make_gate(&config).with_trajectory_risk(slot);
@@ -726,6 +738,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         // Gate starts at Trusted.
@@ -746,6 +759,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
+            policy_provider: Default::default(),
         };
         let gate = make_gate(&config);
         // Force-set context to Quarantined first.

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -397,6 +397,8 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use zeph_config::ProviderName;
+
     use super::*;
     use crate::SkillTrustLevel;
     use crate::policy::{
@@ -471,7 +473,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         let result = gate.execute_tool_call(&make_call("bash")).await;
@@ -485,7 +487,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         let result = gate.execute_tool_call(&make_call("bash")).await;
@@ -507,7 +509,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         let result = gate
@@ -531,7 +533,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         let result = gate
@@ -548,7 +550,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         let err = gate
@@ -571,7 +573,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         let result = gate.execute_tool_call_confirmed(&make_call("bash")).await;
@@ -586,7 +588,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         let call = make_call("shell");
@@ -613,7 +615,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         let result = gate.execute("```bash\necho hi\n```").await;
@@ -642,7 +644,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         gate.set_effective_trust(SkillTrustLevel::Quarantined);
@@ -671,7 +673,7 @@ mod tests {
                 capabilities: vec![],
             }],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         gate.set_effective_trust(SkillTrustLevel::Trusted);
@@ -690,7 +692,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let slot: TrajectoryRiskSlot = Arc::new(RwLock::new(3u8)); // Critical
         let gate = make_gate(&config).with_trajectory_risk(slot);
@@ -716,7 +718,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let slot: TrajectoryRiskSlot = Arc::new(RwLock::new(2u8)); // High
         let gate = make_gate(&config).with_trajectory_risk(slot);
@@ -738,7 +740,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         // Gate starts at Trusted.
@@ -759,7 +761,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![],
             policy_file: None,
-            policy_provider: Default::default(),
+            policy_provider: ProviderName::default(),
         };
         let gate = make_gate(&config);
         // Force-set context to Quarantined first.

--- a/crates/zeph-tools/src/utility.rs
+++ b/crates/zeph-tools/src/utility.rs
@@ -145,6 +145,8 @@ pub struct UtilityScorer {
     config: UtilityScoringConfig,
     /// Hashes of `(tool_name, params)` seen in the current LLM turn for redundancy detection.
     recent_calls: HashMap<u64, u32>,
+    /// Count of consecutive non-`ToolCall` recommendations since the last `ToolCall` or turn reset.
+    consecutive_low: usize,
 }
 
 impl UtilityScorer {
@@ -154,6 +156,7 @@ impl UtilityScorer {
         Self {
             config,
             recent_calls: HashMap::new(),
+            consecutive_low: 0,
         }
     }
 
@@ -282,6 +285,26 @@ impl UtilityScorer {
     /// Reset per-turn state. Call at the start of each LLM tool round.
     pub fn clear(&mut self) {
         self.recent_calls.clear();
+        self.consecutive_low = 0;
+    }
+
+    /// Record the recommended action and check whether the consecutive-low-utility window is
+    /// exhausted.
+    ///
+    /// Returns `true` when `config.utility_window > 0` and `consecutive_low >= utility_window`,
+    /// indicating that the current batch should be downgraded and the caller should signal
+    /// a hard break of the outer iteration loop. Always returns `false` when
+    /// `utility_window == 0` (disabled) so existing behaviour is fully preserved.
+    ///
+    /// Must be called only for calls that actually went through `recommend_action` — exempt and
+    /// pre-exec-blocked calls bypass scoring and must NOT call this method.
+    pub fn note_action(&mut self, action: &UtilityAction) -> bool {
+        if *action == UtilityAction::ToolCall {
+            self.consecutive_low = 0;
+        } else {
+            self.consecutive_low = self.consecutive_low.saturating_add(1);
+        }
+        self.config.utility_window > 0 && self.consecutive_low >= self.config.utility_window
     }
 
     /// Returns `true` when `tool_name` is in the exempt list (case-insensitive).
@@ -300,6 +323,12 @@ impl UtilityScorer {
     #[must_use]
     pub fn threshold(&self) -> f32 {
         self.config.threshold
+    }
+
+    /// The configured consecutive-low-utility window size. 0 means disabled.
+    #[must_use]
+    pub fn utility_window(&self) -> usize {
+        self.config.utility_window
     }
 }
 
@@ -865,5 +894,58 @@ mod tests {
     fn is_exempt_empty_list_returns_false() {
         let scorer = UtilityScorer::new(UtilityScoringConfig::default());
         assert!(!scorer.is_exempt("read"));
+    }
+
+    #[test]
+    fn note_action_window_zero_never_fires() {
+        let mut scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            utility_window: 0,
+            ..UtilityScoringConfig::default()
+        });
+        // Any number of non-ToolCall actions must not trigger early-stop when window=0.
+        for _ in 0..100 {
+            assert!(!scorer.note_action(&UtilityAction::Stop));
+        }
+    }
+
+    #[test]
+    fn note_action_window_three_fires_on_third() {
+        let mut scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            utility_window: 3,
+            ..UtilityScoringConfig::default()
+        });
+        assert!(!scorer.note_action(&UtilityAction::Stop));
+        assert!(!scorer.note_action(&UtilityAction::Respond));
+        assert!(scorer.note_action(&UtilityAction::Stop));
+    }
+
+    #[test]
+    fn note_action_tool_call_resets_counter() {
+        let mut scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            utility_window: 2,
+            ..UtilityScoringConfig::default()
+        });
+        assert!(!scorer.note_action(&UtilityAction::Stop));
+        // ToolCall resets the counter.
+        assert!(!scorer.note_action(&UtilityAction::ToolCall));
+        // One more non-ToolCall does not fire — counter was reset.
+        assert!(!scorer.note_action(&UtilityAction::Stop));
+    }
+
+    #[test]
+    fn note_action_clear_resets_counter() {
+        let mut scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            utility_window: 1,
+            ..UtilityScoringConfig::default()
+        });
+        // First Stop would fire (window=1)...
+        assert!(scorer.note_action(&UtilityAction::Stop));
+        // ...but after clear() the counter is reset so it fires again from scratch.
+        scorer.clear();
+        assert!(scorer.note_action(&UtilityAction::Stop));
     }
 }

--- a/specs/006-tools/spec.md
+++ b/specs/006-tools/spec.md
@@ -617,7 +617,10 @@ Write commands are detected via `WRITE_INDICATORS` heuristic (keywords like `rm`
 [tools.utility]
 enabled = false
 threshold = 0.0   # calls below this score are skipped
+utility_window = 0  # consecutive low-utility calls before early-stopping the turn; 0 = disabled
 ```
+
+`utility_window` — number of consecutive non-`ToolCall` recommendations (i.e., calls scored below threshold) before the entire tool loop terminates early for the current turn. Default `0` preserves the existing per-call skip behavior exactly — no loop break occurs.
 
 ### Key Invariants
 
@@ -625,6 +628,43 @@ threshold = 0.0   # calls below this score are skipped
 - Scoring errors are fail-closed — uncertain scores do not allow execution
 - NEVER skip `memory_save` or other side-effect tools on pure score alone
 - `invoke_skill` and `load_skill` are ALWAYS exempt from the utility gate — they are skill-orchestration primitives, not reducible to a utility score. Both must appear in the `exempt_tools` list of `UtilityScoringConfig` by default (enforced by a unit test in `config.rs`). This is a hard invariant: a utility gate that skips `invoke_skill` or `load_skill` can silently stall skill-driven turns.
+- The `utility_window` consecutive-low-utility counter MUST NOT increment on exempt tool calls (`invoke_skill`, `load_skill`) or on blocked/user-requested calls that early-return before scoring. Only calls that pass through `recommend_action` scoring count toward the window. A turn that still contains `invoke_skill`/`load_skill` MUST NEVER be early-stopped by this counter — incrementing on exempts would silently stall skill-driven turns (spec violation).
+- `utility_window = 0` must reproduce today's exact code path: `note_action` always returns `false` and the window counter is never consulted.
+
+---
+
+## Structural Policy Gate
+
+
+Rule-based (non-LLM) pre-execution enforcement. `PolicyEnforcer` compiles `PolicyConfig` into `CompiledRule`s; `PolicyGateExecutor` wraps an inner executor and enforces policy in `execute_tool_call` / `execute_tool_call_confirmed`. Deny-wins semantics, glob tool/path matching, trust-level thresholds, `args_match` regex, env predicates, external `policy_file` loading with symlink-escape guard, `MAX_RULES = 256`.
+
+### Config
+
+```toml
+[tools.policy]
+enabled = false
+default_effect = "allow"   # "allow" | "deny"
+policy_file = ""           # path to external policy TOML; symlink escape guarded
+policy_provider = ""       # provider name from [[llm.providers]] for future LLM-assisted
+                           # policy translation; empty = fall back to default provider.
+                           # Currently reserved — no LLM path is wired. Added to satisfy
+                           # the multi-model config contract and avoid a later breaking change.
+
+[[tools.policy.rules]]
+effect = "allow" | "deny"
+tool = "glob_pattern"
+```
+
+`policy_provider` follows the same multi-model contract as `tools.adversarial_policy.policy_provider`: it references a `[[llm.providers]]` name; empty string means disabled/default; validated against declared providers at startup (mirroring `loader.rs:522`). When a non-empty value is set, it must name a provider declared in `[[llm.providers]]` — a missing name is a startup error.
+
+### Key Invariants
+
+- Deny-wins: a single `deny` rule overrides all `allow` rules for the same call
+- `MAX_RULES = 256` — configurations exceeding this limit are rejected at compile time
+- `policy_file` loading is symlink-escape guarded — paths outside the config root are rejected
+- `[tools.policy]` rules take precedence over `[tools.authorization]` rules (first-match-wins across the merged rule set)
+- `policy_provider` MUST NOT be validated when empty — empty string means "use default", not "missing provider"; mirrors adversarial_policy handling in `loader.rs:539`
+- NEVER use `policy_provider` to gate structural rule evaluation — structural rules are non-LLM; the field is reserved for future use only
 
 ---
 


### PR DESCRIPTION
## Summary

Closes two research gaps from the tool-policy epic:

- **#4176** — `policy_provider: ProviderName` (default empty/disabled) added to `PolicyConfig`. Reserved for future LLM-assisted policy checks; validated at startup against `[[llm.providers]]`. Mirrors the existing `AdversarialPolicyConfig.policy_provider` contract.
- **#4161** — `utility_window: usize` (default 0/disabled) added to `UtilityScoringConfig`. When N consecutive tool calls score below the utility threshold, the outer tool loop **breaks deterministically** (hard-stop). Exempt tool calls (`invoke_skill`, `load_skill`) do not count toward the window per spec-006 invariant.

Both fields are `#[serde(default)]` — no config migration required, no behavioral change when disabled.

## Changes

| File | Change |
|---|---|
| `crates/zeph-config/src/tools.rs` | `PolicyConfig.policy_provider`, `UtilityScoringConfig.utility_window` |
| `crates/zeph-config/src/loader.rs` | Loader validation for `policy_provider` |
| `crates/zeph-tools/src/utility.rs` | `consecutive_low` counter, `note_action()`, `clear()` |
| `crates/zeph-tools/src/policy.rs` / `policy_gate.rs` | Struct literal updates for new field |
| `crates/zeph-core/.../tier_loop.rs` | `compute_utility_actions` returns `window_exhausted` bool; propagated to hard-break outer loop |
| `crates/zeph-core/.../mod.rs` | `ToolDispatchContext.window_exhausted` |
| `specs/006-tools/spec.md` | New fields + invariants documented |
| `config/default.toml` | Commented examples for both fields |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-config -p zeph-tools -p zeph-core -- -D warnings` — clean
- [x] `cargo nextest run -p zeph-config -p zeph-tools -p zeph-core --lib` — 3332 passed, 0 failed
- [x] `utility_window_exhaustion_signals_hard_break` — loop terminates with `window=2` + 2 consecutive Stop actions
- [x] `utility_window_exempt_tool_does_not_trigger_break` — `invoke_skill` does not increment counter
- [x] `policy_provider` serde round-trip + loader rejection tests

## Follow-up

- #5067 — `--init` wizard + `--migrate-config` entries for both new fields (deferred, both disabled by default)

Closes #4176
Closes #4161