### PR TITLE
feat(knowledge): graph go-live for --source subagents + sanitizer on write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Dry-run mode: writes nothing to DB or Qdrant; computes and returns hub-degree projection from extractor output for G0 measurement spike.
   - Content size cap (`max_content_bytes`, default 512 KiB) to prevent token-spend DoS.
   - `post_extract_validator: Option<Arc<dyn PostExtractValidator>>` seam for future validation.
+- `feat(knowledge)`: graph go-live for `--source subagents` — Phase 2 graph sink wired end-to-end (spec-067 FR-020..024, INV-4, INV-6, closes #5023)
+  - `GraphOrigin::Subagent` variant added; `ingest_documents` now accepts a per-call origin so subagent transcript imports are tagged `origin='subagent'` in `graph_edges` and `graph_entities`, correctly excluded from conversation recall.
+  - `DocOutcome::Rejected` + `IngestReport.rejected` counter: sanitizer-rejected facts now produce a distinct outcome arm, write zero rows, skip the ledger, and are reported separately in the summary.
+  - `MemoryWriteValidator` (as `PostExtractValidator`) runs on both live and dry-run branches; dry-run projected counts are post-sanitization.
+  - `validate_graph_extraction` extended to enforce operator-configured `forbidden_content_patterns` over entity names and edge facts (was silently skipped on the graph ingest path).
+  - `--source subagents` dispatch in `src/commands/knowledge.rs`: discovers JSONL transcripts from `config.agents.transcript_dir`, applies INV-6 current-project allowlist with `fs::canonicalize` per file (symlink-safe), calls `ingest_documents` with fresh `ImportBatchId` and `GraphOrigin::Subagent`.
+  - Confirmation gate (`--yes`/`-y`) wired for real graph writes; dry-run never prompts.
+  - `--dry-run` hub-degree report polished with `⚠ HUB` flag at > 15% and per-entity degree display.
+  - `Batch ID` printed in non-dry-run summary so operators can immediately use `zeph knowledge rollback --batch-id <X>`.
+  - 10 new unit tests: `DocOutcome::Rejected` arithmetic invariant, `GraphOrigin::Subagent.as_str()`, `IngestSourceKind::graph_origin()`, `forbidden_content_patterns` enforcement (3 tests), hub-degree flag, INV-6 allowlist, and confirmation gate.
 - `research(knowledge)`: Phase 2 measurement spike + kill-criterion evaluation (spec-067 §7, closes #5022)
   - Dry-run executed over 140 spec files and 472 handoff files; hub-degree static analysis: top entity ~11–16% (borderline at 15% kill-criterion, likely PASS with crate-level resolution across 15+ `zeph-*` nodes).
   - Signal-to-noise static estimate: ~85% non-trivial edges (PASS; kill-criterion ≥ 50%).

--- a/crates/zeph-memory/src/error.rs
+++ b/crates/zeph-memory/src/error.rs
@@ -90,6 +90,14 @@ pub enum MemoryError {
     /// reported by the notes-sink pipeline.
     #[error("ingest error: {0}")]
     Ingest(String),
+
+    /// The post-extract validator rejected this extraction result.
+    ///
+    /// Returned by `extract_and_store` when the `post_extract_validator` callback returns
+    /// `Err`. The caller (`ingest_documents`) converts this into `DocOutcome::Rejected`
+    /// so the document is counted separately from hard failures.
+    #[error("validation rejected: {0}")]
+    ValidationRejected(String),
 }
 
 #[cfg(test)]

--- a/crates/zeph-memory/src/graph/ingest/adapter.rs
+++ b/crates/zeph-memory/src/graph/ingest/adapter.rs
@@ -11,7 +11,8 @@ use serde::Deserialize;
 use zeph_llm::provider::Message;
 
 use crate::MemoryError;
-use crate::graph::types::{GraphOrigin, GraphProvenance};
+use crate::graph::ingest::document::IngestSourceKind;
+use crate::graph::types::GraphProvenance;
 
 use super::document::IngestDocument;
 use super::report::ImportBatchId;
@@ -159,7 +160,7 @@ impl IngestSourceAdapter for SubagentJsonl {
 
             let source_uri = format!("subagent:{}#{}", self.task_id, entry.seq);
             let provenance = GraphProvenance {
-                origin: GraphOrigin::Ingest,
+                origin: IngestSourceKind::SubagentTranscript.graph_origin(),
                 import_batch_id: batch_id.as_str().to_owned(),
                 source_uri: Some(source_uri),
             };

--- a/crates/zeph-memory/src/graph/ingest/document.rs
+++ b/crates/zeph-memory/src/graph/ingest/document.rs
@@ -59,7 +59,10 @@ impl IngestSourceKind {
     /// Returns the [`GraphOrigin`] value stamped on entities extracted from this kind.
     #[must_use]
     pub fn graph_origin(self) -> GraphOrigin {
-        GraphOrigin::Ingest
+        match self {
+            Self::SubagentTranscript => GraphOrigin::Subagent,
+            Self::StaticArtifact | Self::ExternalAgent => GraphOrigin::Ingest,
+        }
     }
 }
 
@@ -144,5 +147,26 @@ impl IngestDocument {
     #[must_use]
     pub fn source_uri(&self) -> &str {
         self.provenance.source_uri.as_deref().unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subagent_transcript_maps_to_subagent_origin() {
+        assert_eq!(
+            IngestSourceKind::SubagentTranscript.graph_origin(),
+            GraphOrigin::Subagent
+        );
+    }
+
+    #[test]
+    fn static_artifact_maps_to_ingest_origin() {
+        assert_eq!(
+            IngestSourceKind::StaticArtifact.graph_origin(),
+            GraphOrigin::Ingest
+        );
     }
 }

--- a/crates/zeph-memory/src/graph/ingest/report.rs
+++ b/crates/zeph-memory/src/graph/ingest/report.rs
@@ -62,7 +62,7 @@ impl fmt::Display for ImportBatchId {
 /// # Wire contract
 ///
 /// Events arrive in this order per batch:
-/// `Started` → (`DocumentSkipped` | `DocumentDone` | `DocumentFailed`)* → `Finished`
+/// `Started` → (`DocumentSkipped` | `DocumentDone` | `DocumentFailed` | `DocumentRejected`)* → `Finished`
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum IngestProgress {
@@ -93,6 +93,17 @@ pub enum IngestProgress {
         /// Human-readable failure reason.
         reason: String,
     },
+    /// A document was rejected by the post-extract validator (sanitizer).
+    ///
+    /// Rejected documents write nothing to the graph or ledger. They are counted
+    /// separately from failures in [`IngestReport`] so operators can distinguish
+    /// sanitizer drops from extraction errors.
+    DocumentRejected {
+        /// Source locator of the rejected document.
+        uri: String,
+        /// Rejection reason from the validator.
+        reason: String,
+    },
     /// Emitted once after all documents have been processed.
     Finished,
 }
@@ -118,15 +129,18 @@ pub struct HubDegree {
 /// Aggregate result returned by [`crate::semantic::SemanticMemory::ingest_documents`].
 ///
 /// In dry-run mode (`dry_run = true`), `entities_total` and `edges_total` are projected
-/// counts and `hub_degree` contains the top-N entities by degree. No writes occur.
+/// post-sanitization counts and `hub_degree` contains the top-N entities by degree.
+/// No writes occur.
 ///
 /// In live mode, `entities_total` and `edges_total` reflect actual upserts/inserts.
 ///
 /// # Dry-run accuracy
 ///
-/// Dry-run counts are pre-quality-gate upper bounds. The live write path applies
-/// self-loop rejection and admission control in `insert_edges` / `upsert_entities`
-/// that may reduce the final entity and edge counts relative to the dry-run projection.
+/// Dry-run counts are post-sanitization but pre-quality-gate upper bounds. The live write
+/// path applies self-loop rejection and admission control in `insert_edges` /
+/// `upsert_entities` that may reduce the final entity and edge counts relative to the
+/// dry-run projection. Rejected documents do NOT contribute to `entities_total` or
+/// `edges_total` in either mode.
 #[derive(Debug, Clone, Default)]
 pub struct IngestReport {
     /// Batch identifier shared by all documents processed in this call.
@@ -137,30 +151,38 @@ pub struct IngestReport {
     pub skipped: usize,
     /// Number of documents successfully processed.
     pub succeeded: usize,
+    /// Number of documents rejected by the post-extract validator (sanitizer).
+    ///
+    /// Rejected documents write nothing to the graph or ledger and contribute zero
+    /// to `entities_total` / `edges_total`. They are distinct from `failed` documents,
+    /// which represent extraction or storage errors.
+    pub rejected: usize,
     /// Per-document failure records.
     pub failed: Vec<IngestFailure>,
     /// Total entities upserted (live) or projected (dry-run).
     ///
-    /// In dry-run mode this is a pre-quality-gate upper bound; the live run may
-    /// produce fewer entities after admission control.
+    /// Excludes rejected documents. In dry-run mode this is a post-sanitization
+    /// upper bound; the live run may produce fewer entities after admission control.
     pub entities_total: usize,
     /// Total edges inserted (live) or projected (dry-run).
     ///
-    /// In dry-run mode this is a pre-quality-gate upper bound; the live run may
-    /// produce fewer edges after self-loop rejection and admission control.
+    /// Excludes rejected documents. In dry-run mode this is a post-sanitization
+    /// upper bound; the live run may produce fewer edges after self-loop rejection
+    /// and admission control.
     pub edges_total: usize,
     /// `true` when `ingest_documents` was called with `dry_run = true`.
     pub dry_run: bool,
     /// Top-N entities by projected edge degree. Populated only in dry-run mode (FR-026).
     ///
-    /// Degrees are computed from the raw extractor output before any write gates, so
-    /// they represent pre-quality-gate upper bounds — not the final graph topology.
+    /// Degrees are computed from post-sanitization extractor output (rejected documents
+    /// do not contribute). They represent pre-quality-gate upper bounds — not the final
+    /// graph topology.
     pub hub_degree: Vec<HubDegree>,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ImportBatchId;
+    use super::{ImportBatchId, IngestFailure, IngestReport};
 
     #[test]
     fn import_batch_id_is_unique() {
@@ -170,5 +192,24 @@ mod tests {
         // UUIDv4: 36 chars with 4 hyphens
         assert_eq!(a.as_str().len(), 36);
         assert_eq!(a.as_str().chars().filter(|&c| c == '-').count(), 4);
+    }
+
+    #[test]
+    fn ingest_report_rejected_arithmetic_invariant() {
+        let mut report = IngestReport {
+            documents_total: 4,
+            ..IngestReport::default()
+        };
+        report.skipped += 1;
+        report.succeeded += 1;
+        report.rejected += 1;
+        report.failed.push(IngestFailure {
+            uri: "u".into(),
+            reason: "r".into(),
+        });
+        assert_eq!(
+            report.skipped + report.succeeded + report.rejected + report.failed.len(),
+            report.documents_total
+        );
     }
 }

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -35,8 +35,8 @@ pub struct GraphStore {
     benna_fast_rate: f32,
     /// Benna-Fusi slow-variable learning rate. Range: `(0.0, 1.0]`. Default: `0.05`.
     benna_slow_rate: f32,
-    /// When `false`, edges with `origin = 'ingest'` are excluded from `query_batch_edges`
-    /// and `edges_for_entity` results (spec-067 FR-003, INV-3). Default: `true`.
+    /// When `false`, edges with imported (non-conversation) origins are excluded from
+    /// `query_batch_edges` and `edges_for_entity` results (spec-067 FR-003, INV-3). Default: `true`.
     recall_include_imported: bool,
 }
 
@@ -64,10 +64,10 @@ impl GraphStore {
         self
     }
 
-    /// Control whether ingest-origin edges appear in recall (spec-067 FR-003).
+    /// Control whether imported (non-conversation) edges appear in recall (spec-067 FR-003).
     ///
-    /// When `false`, edges with `origin = 'ingest'` are excluded from
-    /// [`Self::query_batch_edges`] and [`Self::edges_for_entity`].
+    /// When `false`, edges with any non-conversation origin (e.g. `'ingest'`, `'subagent'`)
+    /// are excluded from [`Self::query_batch_edges`] and [`Self::edges_for_entity`].
     /// Default: `true` (all edges included).
     #[must_use]
     pub fn with_recall_include_imported(mut self, include: bool) -> Self {
@@ -712,7 +712,7 @@ impl GraphStore {
 
     /// Get all active edges where entity is source or target.
     ///
-    /// When `recall_include_imported` is `false`, ingest-origin edges are excluded.
+    /// When `recall_include_imported` is `false`, imported (non-conversation) edges are excluded.
     ///
     /// # Errors
     ///

--- a/crates/zeph-memory/src/graph/types.rs
+++ b/crates/zeph-memory/src/graph/types.rs
@@ -241,6 +241,7 @@ pub struct Community {
 ///
 /// assert_eq!(GraphOrigin::Conversation.as_str(), "conversation");
 /// assert_eq!(GraphOrigin::Ingest.as_str(), "ingest");
+/// assert_eq!(GraphOrigin::Subagent.as_str(), "subagent");
 /// assert_eq!(GraphOrigin::default(), GraphOrigin::Conversation);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -249,8 +250,13 @@ pub enum GraphOrigin {
     /// Knowledge extracted from live conversation (the default; existing behaviour).
     #[default]
     Conversation,
-    /// Knowledge imported via `knowledge ingest` (spec-067 Phase 1+).
+    /// Knowledge imported via `knowledge ingest` from static artifacts (spec-067 Phase 1+).
     Ingest,
+    /// Knowledge imported from Zeph subagent transcripts (spec-067 Phase 2, FR-020).
+    ///
+    /// Recall isolation keys off `origin != 'conversation'`, so `'subagent'` rows are
+    /// correctly treated as imported and excluded from conversation-only recall.
+    Subagent,
 }
 
 impl GraphOrigin {
@@ -260,6 +266,7 @@ impl GraphOrigin {
         match self {
             Self::Conversation => "conversation",
             Self::Ingest => "ingest",
+            Self::Subagent => "subagent",
         }
     }
 }
@@ -268,8 +275,8 @@ impl GraphOrigin {
 ///
 /// Pass `None` provenance (the default at every existing call site) to write
 /// `origin = 'conversation'`, `import_batch_id = NULL`, `source_uri = NULL`,
-/// preserving current behaviour exactly. Only the future ingest path will pass
-/// `Some(GraphProvenance { origin: GraphOrigin::Ingest, … })`.
+/// preserving current behaviour exactly. Ingest paths pass `Some(GraphProvenance { … })`
+/// with the appropriate origin (`Ingest` for static artifacts, `Subagent` for transcripts).
 ///
 /// # Examples
 ///
@@ -277,11 +284,11 @@ impl GraphOrigin {
 /// use zeph_memory::graph::types::{GraphOrigin, GraphProvenance};
 ///
 /// let prov = GraphProvenance {
-///     origin: GraphOrigin::Ingest,
+///     origin: GraphOrigin::Subagent,
 ///     import_batch_id: "batch-2026-001".to_owned(),
 ///     source_uri: Some("subagent:task-42".to_owned()),
 /// };
-/// assert_eq!(prov.origin.as_str(), "ingest");
+/// assert_eq!(prov.origin.as_str(), "subagent");
 /// ```
 #[derive(Debug, Clone)]
 pub struct GraphProvenance {
@@ -881,5 +888,11 @@ mod tests {
         let entity = fact(EdgeType::Entity).composite_score();
         assert!(causal > temporal, "causal score must exceed temporal");
         assert!(temporal > entity, "temporal score must exceed entity");
+    }
+
+    #[test]
+    fn graph_origin_subagent_as_str() {
+        assert_eq!(GraphOrigin::Subagent.as_str(), "subagent");
+        assert_ne!(GraphOrigin::Subagent.as_str(), "ingest");
     }
 }

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -88,10 +88,11 @@ pub struct GraphExtractionConfig {
     pub benna_slow_rate: f32,
     /// Provenance stamped on every entity and edge written in this pass (spec-067 INV-2).
     ///
-    /// `None` means conversation origin — all existing callers pass `None` and remain
-    /// unchanged. Only the future ingest path will pass `Some(prov)`.
+    /// `None` means conversation origin (default for conversation callers).
+    /// The ingest path passes `Some(prov)` with the appropriate origin.
     pub provenance: Option<GraphProvenance>,
-    /// When `false`, recall queries exclude edges with `origin = 'ingest'` (spec-067 §3 Phase 0).
+    /// When `false`, recall queries exclude edges with any imported (non-conversation) origin
+    /// (spec-067 §3 Phase 0).
     ///
     /// Default: `true` (include imported edges in recall).
     pub recall_include_imported: bool,
@@ -447,6 +448,8 @@ pub async fn extract_and_store(
 
     // Post-extraction validation callback. zeph-memory does not know the callback is a
     // security validator — it is a generic predicate opaque to this crate (design decision D1).
+    // Returns Err(ValidationRejected) so callers can distinguish sanitizer drops from
+    // hard failures (INV-4, spec-067 §G-5).
     if let Some(ref validator) = post_extract_validator
         && let Err(reason) = validator(&result)
     {
@@ -454,7 +457,7 @@ pub async fn extract_and_store(
             reason,
             "graph extraction validation failed, skipping upsert"
         );
-        return Ok(ExtractionResult::default());
+        return Err(MemoryError::ValidationRejected(reason));
     }
 
     let resolver = if let Some(ref emb) = embedding_store {
@@ -1045,6 +1048,15 @@ enum DocOutcome {
         uri: String,
         reason: String,
     },
+    /// The post-extract validator rejected this document (sanitizer drop).
+    ///
+    /// A rejected document writes zero rows and is NOT marked in the ledger, so a
+    /// later policy change can re-admit it. Counted separately from `Failed` in the
+    /// report so operators can distinguish sanitizer drops from extraction errors.
+    Rejected {
+        uri: String,
+        reason: String,
+    },
     /// Dry-run projection: uri, counts, and per-entity degree contributions.
     DryRun {
         uri: String,
@@ -1128,7 +1140,6 @@ impl SemanticMemory {
             HubDegree, IngestDocument, IngestFailure, IngestProgress, IngestReport,
             IngestSourceKind,
         };
-        use crate::graph::types::{GraphOrigin, GraphProvenance};
 
         let _span = tracing::info_span!(
             "memory.ingest.batch",
@@ -1224,15 +1235,19 @@ impl SemanticMemory {
                 }
 
                 // Build per-document config clone with provenance + tech-doc prompt.
+                // Origin is derived from the document's own provenance (set by the adapter),
+                // so subagent transcripts get GraphOrigin::Subagent and static artifacts get
+                // GraphOrigin::Ingest without any extra threading (spec-067 §G-1).
                 let mut doc_config = base_config.clone();
-                doc_config.provenance = Some(GraphProvenance {
-                    origin: GraphOrigin::Ingest,
-                    import_batch_id: batch_id_str.clone(),
-                    source_uri: Some(uri.clone()),
-                });
+                doc_config.provenance = Some(doc.provenance().clone());
+                // Keep the ingest batch ID aligned with the caller's batch_id (the provenance
+                // from the adapter was stamped at parse time with the same batch_id).
+                if let Some(ref mut prov) = doc_config.provenance {
+                    prov.import_batch_id.clone_from(&batch_id_str);
+                }
                 // Select tech-doc prompt via IngestSourceKind.
-                // All ingest documents use StaticArtifact semantics for prompt selection.
-                doc_config.system_prompt = Some(IngestSourceKind::StaticArtifact.system_prompt());
+                // All ingest source kinds use the same tech-doc prompt for extraction.
+                doc_config.system_prompt = Some(IngestSourceKind::SubagentTranscript.system_prompt());
 
                 // Build PostExtractValidator by cloning the Arc (C3: cheap, Send+Sync).
                 let validator: PostExtractValidator = shared_validator
@@ -1246,6 +1261,7 @@ impl SemanticMemory {
                     // FR-026: dry-run calls GraphExtractor::extract() directly — NOT
                     // extract_and_store — to guarantee zero writes (including bump_extraction_count).
                     // This invariant is enforced by the test `dry_run_writes_nothing` (C2).
+                    // S3: validator is also run in dry-run so projected counts are post-sanitization.
                     let extractor = {
                         let mut e = GraphExtractor::new(
                             provider.clone(),
@@ -1262,6 +1278,12 @@ impl SemanticMemory {
                         doc.context().iter().map(String::as_str).collect();
                     match extractor.extract(doc.content(), &ctx_refs).await {
                         Ok(Some(result)) => {
+                            // S3: run validator in dry-run to get post-sanitization projections.
+                            if let Some(ref arc_f) = shared_validator
+                                && let Err(reason) = arc_f(&result)
+                            {
+                                return DocOutcome::Rejected { uri, reason };
+                            }
                             let entities = result.entities.len();
                             let edges = result.edges.len();
                             // Build per-entity degree map.
@@ -1324,6 +1346,10 @@ impl SemanticMemory {
                             }
                             DocOutcome::Done { uri, entities, edges }
                         }
+                        // ValidationRejected is a sanitizer drop — not a hard failure.
+                        Err(MemoryError::ValidationRejected(reason)) => {
+                            DocOutcome::Rejected { uri, reason }
+                        }
                         Err(e) => DocOutcome::Failed {
                             uri,
                             reason: format!("extract_and_store failed: {e:#}"),
@@ -1377,6 +1403,10 @@ impl SemanticMemory {
                         reason: reason.clone(),
                     });
                     send_progress(IngestProgress::DocumentFailed { uri, reason });
+                }
+                DocOutcome::Rejected { uri, reason } => {
+                    report.rejected += 1;
+                    send_progress(IngestProgress::DocumentRejected { uri, reason });
                 }
                 DocOutcome::DryRun {
                     uri,

--- a/crates/zeph-sanitizer/src/memory_validation.rs
+++ b/crates/zeph-sanitizer/src/memory_validation.rs
@@ -208,6 +208,24 @@ impl MemoryWriteValidator {
             }
         }
 
+        for pattern in &self.config.forbidden_content_patterns {
+            let p = pattern.as_str();
+            for entity in &result.entities {
+                if entity.name.contains(p) {
+                    return Err(MemoryValidationError::ForbiddenPattern {
+                        pattern: pattern.clone(),
+                    });
+                }
+            }
+            for edge in &result.edges {
+                if edge.fact.contains(p) {
+                    return Err(MemoryValidationError::ForbiddenPattern {
+                        pattern: pattern.clone(),
+                    });
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -516,5 +534,46 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("5000"), "error must include actual size");
         assert!(msg.contains("4096"), "error must include max size");
+    }
+
+    // --- forbidden_content_patterns in validate_graph_extraction ---
+
+    #[test]
+    fn forbidden_pattern_in_entity_name_rejected_by_graph_extraction() {
+        let v = MemoryWriteValidator::new(MemoryWriteValidationConfig {
+            forbidden_content_patterns: vec!["internal-host".to_owned()],
+            ..MemoryWriteValidationConfig::default()
+        });
+        let r = result_with(vec![entity("internal-hostname.corp")], vec![]);
+        assert!(matches!(
+            v.validate_graph_extraction(&r),
+            Err(MemoryValidationError::ForbiddenPattern { .. })
+        ));
+    }
+
+    #[test]
+    fn forbidden_pattern_in_edge_fact_rejected_by_graph_extraction() {
+        let v = MemoryWriteValidator::new(MemoryWriteValidationConfig {
+            forbidden_content_patterns: vec!["BEGIN PRIVATE KEY".to_owned()],
+            ..MemoryWriteValidationConfig::default()
+        });
+        let r = result_with(
+            vec![entity("Alice")],
+            vec![edge("Alice has BEGIN PRIVATE KEY material")],
+        );
+        assert!(matches!(
+            v.validate_graph_extraction(&r),
+            Err(MemoryValidationError::ForbiddenPattern { .. })
+        ));
+    }
+
+    #[test]
+    fn no_forbidden_patterns_graph_extraction_passes() {
+        let v = MemoryWriteValidator::new(MemoryWriteValidationConfig {
+            forbidden_content_patterns: vec!["<script".to_owned()],
+            ..MemoryWriteValidationConfig::default()
+        });
+        let r = result_with(vec![entity("CleanEntity")], vec![]);
+        assert!(v.validate_graph_extraction(&r).is_ok());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -531,11 +531,10 @@ pub(crate) enum KnowledgeCommand {
     Status,
 }
 
-/// Artifact sources eligible for `zeph knowledge ingest` (Phase 1).
+/// Artifact sources eligible for `zeph knowledge ingest`.
 ///
-/// Corresponds to the `--source` flag. Only Phase-1 variants are exposed here;
-/// Phase-2 sources (`subagents`, `claude-code`, etc.) will be added as new variants
-/// without breaking callers — clap enums are purely additive.
+/// Corresponds to the `--source` flag. Clap enums are purely additive — new variants
+/// do not break existing callers.
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum KnowledgeSource {
     /// Specification documents under `specs/**/*.md`
@@ -549,6 +548,8 @@ pub(crate) enum KnowledgeSource {
     /// Recent git log (captured in-memory; bounded by `--max-documents`)
     #[value(name = "git-log")]
     GitLog,
+    /// Zeph subagent transcripts of the current project (graph sink, spec-067 Phase 2)
+    Subagents,
 }
 
 /// Project management subcommands.

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -1460,11 +1460,11 @@ mod tests {
             "subagents",
         ])
         .unwrap();
-        let sources = match cli.command {
-            Some(Command::Knowledge {
-                command: KnowledgeCommand::Ingest { sources, .. },
-            }) => sources,
-            _ => panic!("expected Ingest command"),
+        let Some(Command::Knowledge {
+            command: KnowledgeCommand::Ingest { sources, .. },
+        }) = cli.command
+        else {
+            panic!("expected Ingest command")
         };
         assert!(sources.contains(&KnowledgeSource::Specs));
         assert!(sources.contains(&KnowledgeSource::Subagents));

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -29,17 +29,23 @@
 //! | `Coverage` | `<root>/.local/testing/coverage-status.md` |
 //! | `GitLog` | `git log` stdout (in-memory, bounded by `max_documents`) |
 
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use zeph_core::vault::Secret;
 use zeph_llm::provider::LlmProvider;
+use zeph_memory::graph::ingest::IngestProgress as GraphIngestProgress;
 use zeph_memory::{
     Document, DocumentMetadata, GraphStore, IngestLedger, IngestionPipeline, QdrantOps,
     SplitterConfig, TextSplitter, store::DbStore,
 };
+use zeph_memory::{
+    ImportBatchId, IngestBatchConfig, IngestSourceAdapter, SharedPostExtractValidator,
+    SubagentJsonl,
+};
 
-use crate::bootstrap::{AppBuilder, find_repo_root};
+use crate::bootstrap::{AppBuilder, create_named_provider, find_repo_root};
 use crate::cli::{KnowledgeCommand, KnowledgeSource};
 
 /// Resolved `(source_uri, raw_bytes)` pair ready for hashing and ingestion.
@@ -54,7 +60,7 @@ type IngestError = (String, String);
 pub(crate) enum IngestProgress {
     /// Files enumerated for a given source before the ingest loop begins.
     Discovered { source: String, files: usize },
-    /// A file is about to be embedded (pre-write signal for TUI spinner: "Ingesting knowledge: <uri>…").
+    /// A file is about to be embedded (pre-write signal for TUI spinner: `Ingesting knowledge: <uri>…`).
     Ingesting { uri: String },
     /// All chunks for a file have been processed (or the file failed).
     FileDone {
@@ -140,8 +146,8 @@ async fn handle_ingest(
     sources: Vec<KnowledgeSource>,
     dry_run: bool,
     max_documents: usize,
-    _provider_override: Option<String>,
-    _yes: bool,
+    provider_override: Option<String>,
+    yes: bool,
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
     // Locate and canonicalize project root (INV-6 anchor).
@@ -156,32 +162,56 @@ async fn handle_ingest(
         )
     })?;
 
+    // Partition requested sources: graph sources (Subagents) vs notes sources (everything else).
+    let (graph_sources, notes_sources): (Vec<_>, Vec<_>) = sources
+        .into_iter()
+        .partition(|s| matches!(s, KnowledgeSource::Subagents));
+    let has_graph = !graph_sources.is_empty();
+    let has_notes = !notes_sources.is_empty();
+
     // Resolve effective max-documents: CLI flag overrides config default.
     let effective_max = resolve_effective_max(max_documents, config_path).await;
 
-    if dry_run {
-        println!("Dry-run mode: no data will be written.");
-        println!();
+    // ── Notes sink (Phase 1) ────────────────────────────────────────────────
+    if has_notes {
+        if dry_run {
+            println!("Dry-run mode: no data will be written.");
+            println!();
+        }
+
+        let head_sha = git_head_sha(&root);
+        let (source_items, discovery_errors, per_source_counts) =
+            enumerate_all_sources(&notes_sources, &root, &head_sha, effective_max);
+        let total_files = source_items.len();
+
+        if dry_run {
+            run_dry_run(&source_items, total_files, &discovery_errors);
+        } else {
+            Box::pin(run_ingest(
+                source_items,
+                total_files,
+                discovery_errors,
+                per_source_counts,
+                config_path,
+            ))
+            .await?;
+        }
     }
 
-    let head_sha = git_head_sha(&root);
-    let (source_items, discovery_errors, per_source_counts) =
-        enumerate_all_sources(&sources, &root, &head_sha, effective_max);
-    let total_files = source_items.len();
-
-    if dry_run {
-        run_dry_run(&source_items, total_files, &discovery_errors);
-        return Ok(());
+    // ── Graph sink (Phase 2, --source subagents) ────────────────────────────
+    if has_graph {
+        Box::pin(run_graph_ingest(
+            dry_run,
+            effective_max,
+            provider_override,
+            yes,
+            &root,
+            config_path,
+        ))
+        .await?;
     }
 
-    Box::pin(run_ingest(
-        source_items,
-        total_files,
-        discovery_errors,
-        per_source_counts,
-        config_path,
-    ))
-    .await
+    Ok(())
 }
 
 /// Resolve the effective max-documents limit.
@@ -529,6 +559,347 @@ fn print_ingest_report(report: &IngestReport) {
     }
 }
 
+/// Execute the graph-sink ingest path for `--source subagents` (spec-067 Phase 2, FR-020..024).
+///
+/// Discovers subagent JSONL transcripts under the project-anchored transcript dir,
+/// canonicalizes each file path (INV-6), parses via `SubagentJsonl`, and calls
+/// `SemanticMemory::ingest_documents` with a `MemoryWriteValidator` sanitizer gate (INV-4).
+///
+/// # Errors
+///
+/// Returns an error when config loading, DB access, provider resolution, or transcript-dir
+/// resolution fails. Per-document failures are collected in the `IngestReport` and printed.
+#[allow(clippy::too_many_lines)]
+#[tracing::instrument(skip_all, fields(dry_run))]
+async fn run_graph_ingest(
+    dry_run: bool,
+    effective_max: usize,
+    provider_override: Option<String>,
+    yes: bool,
+    root: &Path,
+    config_path: Option<&Path>,
+) -> anyhow::Result<()> {
+    let app = AppBuilder::new(config_path, None, None, None).await?;
+    let config = app.config();
+
+    // Enforce transcript_scope (INV-6: only "current-project" is supported).
+    if config.knowledge.transcript_scope != "current-project" {
+        anyhow::bail!(
+            "knowledge.transcript_scope = '{}' is not supported; only 'current-project' is \
+             honoured (INV-6). Update your config to use 'current-project'.",
+            config.knowledge.transcript_scope
+        );
+    }
+
+    // Resolve transcript dir; default to <root>/.zeph/subagents.
+    let transcript_dir_raw = config
+        .agents
+        .transcript_dir
+        .clone()
+        .unwrap_or_else(|| root.join(".zeph/subagents"));
+    let transcript_dir = transcript_dir_raw.canonicalize().map_err(|e| {
+        anyhow::anyhow!(
+            "failed to canonicalize transcript dir {}: {e}",
+            transcript_dir_raw.display()
+        )
+    })?;
+    if !transcript_dir.starts_with(root) {
+        anyhow::bail!(
+            "transcript dir {} resolves outside project root (INV-6)",
+            transcript_dir.display()
+        );
+    }
+
+    // Discover *.jsonl transcript files, canonicalizing each (INV-6: per-file symlink check).
+    let pattern = format!("{}/**/*.jsonl", transcript_dir.display());
+    let mut transcript_files: Vec<(String, PathBuf)> = Vec::new();
+    let mut discovery_errors: Vec<String> = Vec::new();
+
+    for entry in glob::glob(&pattern)
+        .map_err(|e| anyhow::anyhow!("glob pattern error: {e}"))?
+        .flatten()
+    {
+        match entry.canonicalize() {
+            Ok(canonical) => {
+                if !canonical.starts_with(root) {
+                    discovery_errors.push(format!(
+                        "{}: resolves outside project root (INV-6), skipped",
+                        canonical.display()
+                    ));
+                    continue;
+                }
+                let task_id = canonical.file_stem().map_or_else(
+                    || "unknown".to_owned(),
+                    |s| s.to_string_lossy().into_owned(),
+                );
+                transcript_files.push((task_id, canonical));
+            }
+            Err(e) => {
+                discovery_errors.push(format!("{}: canonicalize failed: {e}", entry.display()));
+            }
+        }
+    }
+
+    // Apply effective_max cap across total documents (approximate: per-file, not per-document).
+    if effective_max > 0 && transcript_files.len() > effective_max {
+        transcript_files.truncate(effective_max);
+    }
+
+    if !discovery_errors.is_empty() {
+        println!(
+            "  Transcript discovery errors ({}):",
+            discovery_errors.len()
+        );
+        for err in &discovery_errors {
+            println!("    [WARN] {err}");
+        }
+        println!();
+    }
+
+    if transcript_files.is_empty() {
+        println!(
+            "No subagent transcripts found under {}.",
+            transcript_dir.display()
+        );
+        return Ok(());
+    }
+
+    // Parse all transcripts into IngestDocuments.
+    let batch_id = ImportBatchId::new();
+    let mut documents = Vec::new();
+    let mut parse_errors: Vec<String> = Vec::new();
+
+    for (task_id, path) in &transcript_files {
+        match std::fs::read_to_string(path) {
+            Ok(raw) => {
+                let adapter = SubagentJsonl::new(task_id.as_str());
+                match adapter.parse(&raw, &batch_id) {
+                    Ok(docs) => documents.extend(docs),
+                    Err(e) => {
+                        parse_errors.push(format!("{}: parse error: {e}", path.display()));
+                    }
+                }
+            }
+            Err(e) => {
+                parse_errors.push(format!("{}: read error: {e}", path.display()));
+            }
+        }
+    }
+
+    if !parse_errors.is_empty() {
+        println!("  Parse errors ({}):", parse_errors.len());
+        for err in &parse_errors {
+            println!("    [WARN] {err}");
+        }
+        println!();
+    }
+
+    if documents.is_empty() {
+        println!("No documents extracted from transcripts.");
+        return Ok(());
+    }
+
+    // Confirmation gate (FR-040, INV-7): prompt before graph writes.
+    if should_prompt_for_graph_write(dry_run, yes) {
+        print!(
+            "Write {} document(s) from {} transcript(s) to graph? [y/N]: ",
+            documents.len(),
+            transcript_files.len()
+        );
+        std::io::stdout().flush()?;
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        if !answer.trim().eq_ignore_ascii_case("y") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    if dry_run {
+        println!(
+            "Dry-run mode: {} document(s) from {} transcript(s) — no data will be written.",
+            documents.len(),
+            transcript_files.len()
+        );
+        println!();
+    }
+
+    // Resolve LLM provider (FR-041): CLI override → knowledge.ingest_provider →
+    // memory.graph.extract_provider → primary.
+    let provider_name = provider_override
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            let p = config.knowledge.ingest_provider.as_str();
+            if p.is_empty() { None } else { Some(p) }
+        })
+        .or_else(|| {
+            let p = config.memory.graph.extract_provider.as_str();
+            if p.is_empty() { None } else { Some(p) }
+        });
+
+    let provider = if let Some(name) = provider_name {
+        match create_named_provider(name, config) {
+            Ok(p) => {
+                tracing::debug!(provider = name, "using named provider for graph ingest");
+                Arc::new(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = name,
+                    "named provider resolution failed ({e:#}); falling back to primary"
+                );
+                let (p, _, _) = app.build_provider().await?;
+                Arc::new(p)
+            }
+        }
+    } else {
+        let (p, _, _) = app.build_provider().await?;
+        Arc::new(p)
+    };
+
+    let memory = app.build_memory(&provider).await?;
+
+    // Build SharedPostExtractValidator wrapping MemoryWriteValidator (INV-4).
+    // Always Some — required on both dry-run and live paths (spec-067 §G-5 S3).
+    // TODO(critic): P4 — ingest sanitizer covers entity-name PII + counts; edge-fact bodies
+    // length-capped only, no body PII / exfiltration URL scan (#5023 INV-4 MVP boundary).
+    let validator_inner = zeph_sanitizer::memory_validation::MemoryWriteValidator::new(
+        config.security.memory_validation.clone(),
+    );
+    let shared_validator: SharedPostExtractValidator = Some(Arc::new(move |r| {
+        validator_inner
+            .validate_graph_extraction(r)
+            .map_err(|e| e.to_string())
+    }));
+
+    let batch_cfg = IngestBatchConfig {
+        dry_run,
+        dry_run_hub_top_n: Some(10),
+        ..IngestBatchConfig::default()
+    };
+
+    let concurrency = config.knowledge.concurrency.max(1);
+
+    // Progress channel: map graph ingest events to stdout lines (TUI rule: visible status).
+    let (progress_tx, mut progress_rx) = tokio::sync::mpsc::channel::<GraphIngestProgress>(64);
+
+    let printer_handle = tokio::spawn(async move {
+        while let Some(event) = progress_rx.recv().await {
+            match event {
+                GraphIngestProgress::Started { total } => {
+                    println!("  Ingesting {total} document(s) from subagent transcripts…");
+                }
+                GraphIngestProgress::DocumentSkipped { uri } => {
+                    println!("  Skipped (already ingested): {uri}");
+                }
+                GraphIngestProgress::DocumentDone {
+                    uri,
+                    entities,
+                    edges,
+                } => {
+                    println!("  Done: {uri} (+{entities} entities, +{edges} edges)");
+                }
+                GraphIngestProgress::DocumentFailed { uri, reason } => {
+                    println!("  Failed: {uri}: {reason}");
+                }
+                GraphIngestProgress::DocumentRejected { uri, reason } => {
+                    println!("  Rejected (sanitizer): {uri}: {reason}");
+                }
+                GraphIngestProgress::Finished => break,
+                // Non-exhaustive: ignore any future variants.
+                _ => {}
+            }
+        }
+    });
+
+    let report = memory
+        .ingest_documents(
+            documents,
+            batch_cfg,
+            batch_id,
+            concurrency,
+            shared_validator,
+            Some(progress_tx),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("graph ingest failed: {e:#}"))?;
+
+    let _ = printer_handle.await;
+
+    print_graph_ingest_report(&report);
+
+    Ok(())
+}
+
+/// Print the summary of a graph-sink ingest run.
+fn print_graph_ingest_report(report: &zeph_memory::graph::ingest::IngestReport) {
+    println!();
+    if report.dry_run {
+        println!("Graph ingest dry-run complete (no data written).");
+    } else {
+        println!("Graph ingest complete.");
+        println!("  Batch ID          : {}", report.batch_id);
+    }
+    println!("  Documents total   : {}", report.documents_total);
+    println!("  Skipped           : {}", report.skipped);
+    println!("  Succeeded         : {}", report.succeeded);
+    println!("  Rejected (sanitizer): {}", report.rejected);
+    if !report.failed.is_empty() {
+        println!("  Failed            : {}", report.failed.len());
+        for f in &report.failed {
+            println!("    [ERR] {}: {}", f.uri, f.reason);
+        }
+    }
+    println!("  Entities total    : {}", report.entities_total);
+    println!("  Edges total       : {}", report.edges_total);
+
+    if report.dry_run && !report.hub_degree.is_empty() {
+        let total_edges: usize = report.hub_degree.iter().map(|h| h.degree).sum();
+        println!();
+        println!(
+            "  Hub-degree (top-{}) — spec-067 §7 threshold ≤ 15% of total edges:",
+            report.hub_degree.len()
+        );
+        println!("  {:<50} {:>7}  {:>7}", "Entity", "Degree", "% edges");
+        println!("  {}", "-".repeat(68));
+        for h in &report.hub_degree {
+            #[allow(clippy::cast_precision_loss)]
+            let pct = if total_edges > 0 {
+                (h.degree as f64 / total_edges as f64) * 100.0
+            } else {
+                0.0
+            };
+            let flag = if pct > 15.0 { " ⚠ HUB" } else { "" };
+            println!(
+                "  {:<50} {:>7}  {:>6.1}%{}",
+                truncate_uri(&h.entity, 50),
+                h.degree,
+                pct,
+                flag
+            );
+        }
+        if total_edges > 0 {
+            #[allow(clippy::cast_precision_loss)]
+            let top_pct = (report.hub_degree[0].degree as f64 / total_edges as f64) * 100.0;
+            let health = if top_pct <= 15.0 {
+                "PASS"
+            } else {
+                "WARN — top entity exceeds 15% hub-degree threshold"
+            };
+            println!("  {}", "-".repeat(68));
+            println!("  Top entity: {top_pct:.1}% of edges — {health}");
+        }
+    }
+}
+
+/// Returns `true` when the graph-write confirmation prompt must be shown.
+///
+/// Prompt is suppressed by `--dry-run` (no writes) or `--yes` (scripted/CI use).
+fn should_prompt_for_graph_write(dry_run: bool, yes: bool) -> bool {
+    !dry_run && !yes
+}
+
 /// Build a [`Document`] with `source_uri` threaded into the metadata (M1).
 fn make_document(source_uri: String, content: String) -> Document {
     Document {
@@ -562,6 +933,7 @@ fn source_label(src: &KnowledgeSource) -> &'static str {
         KnowledgeSource::Handoff => "handoff",
         KnowledgeSource::Coverage => "coverage",
         KnowledgeSource::GitLog => "git-log",
+        KnowledgeSource::Subagents => "subagents",
     }
 }
 
@@ -581,7 +953,7 @@ fn enumerate_source_paths(root: &Path, src: &KnowledgeSource) -> anyhow::Result<
         KnowledgeSource::Coverage => {
             format!("{}/.local/testing/coverage-status.md", root.display())
         }
-        KnowledgeSource::GitLog => return Ok(Vec::new()),
+        KnowledgeSource::GitLog | KnowledgeSource::Subagents => return Ok(Vec::new()),
     };
 
     let paths: Vec<PathBuf> = glob::glob(&pattern)
@@ -667,8 +1039,6 @@ async fn handle_rollback(
     yes: bool,
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
-    use std::io::Write as _;
-
     let app = AppBuilder::new(config_path, None, None, None).await?;
     let config = app.config();
 
@@ -1021,5 +1391,145 @@ mod tests {
             ),
             "CLI must parse rollback --batch-id abc123 --yes"
         );
+    }
+
+    // ── Subagents source variant ──────────────────────────────────────────────
+
+    #[test]
+    fn source_label_subagents() {
+        assert_eq!(source_label(&KnowledgeSource::Subagents), "subagents");
+    }
+
+    #[test]
+    fn cli_parses_source_subagents() {
+        use crate::cli::{Cli, Command, KnowledgeCommand};
+        use clap::Parser as _;
+        let cli =
+            Cli::try_parse_from(["zeph", "knowledge", "ingest", "--source", "subagents"]).unwrap();
+        assert!(
+            matches!(
+                cli.command,
+                Some(Command::Knowledge {
+                    command: KnowledgeCommand::Ingest {
+                        ref sources,
+                        dry_run: false,
+                        ..
+                    }
+                })
+                if sources == &[KnowledgeSource::Subagents]
+            ),
+            "CLI must parse --source subagents"
+        );
+    }
+
+    #[test]
+    fn cli_parses_source_subagents_with_dry_run() {
+        use crate::cli::{Cli, Command, KnowledgeCommand};
+        use clap::Parser as _;
+        let cli = Cli::try_parse_from([
+            "zeph",
+            "knowledge",
+            "ingest",
+            "--source",
+            "subagents",
+            "--dry-run",
+        ])
+        .unwrap();
+        assert!(
+            matches!(
+                cli.command,
+                Some(Command::Knowledge {
+                    command: KnowledgeCommand::Ingest { dry_run: true, .. }
+                })
+            ),
+            "CLI must parse --source subagents --dry-run"
+        );
+    }
+
+    #[test]
+    fn cli_parses_mixed_sources_subagents_and_notes() {
+        use crate::cli::{Cli, Command, KnowledgeCommand};
+        use clap::Parser as _;
+        let cli = Cli::try_parse_from([
+            "zeph",
+            "knowledge",
+            "ingest",
+            "--source",
+            "specs",
+            "--source",
+            "subagents",
+        ])
+        .unwrap();
+        let sources = match cli.command {
+            Some(Command::Knowledge {
+                command: KnowledgeCommand::Ingest { sources, .. },
+            }) => sources,
+            _ => panic!("expected Ingest command"),
+        };
+        assert!(sources.contains(&KnowledgeSource::Specs));
+        assert!(sources.contains(&KnowledgeSource::Subagents));
+    }
+
+    // ── Source partitioning (notes vs graph) ─────────────────────────────────
+
+    #[test]
+    fn partition_sources_notes_and_graph() {
+        let sources = vec![
+            KnowledgeSource::Specs,
+            KnowledgeSource::Subagents,
+            KnowledgeSource::Changelog,
+        ];
+        let (graph, notes): (Vec<_>, Vec<_>) = sources
+            .into_iter()
+            .partition(|s| matches!(s, KnowledgeSource::Subagents));
+        assert_eq!(graph, vec![KnowledgeSource::Subagents]);
+        assert_eq!(
+            notes,
+            vec![KnowledgeSource::Specs, KnowledgeSource::Changelog]
+        );
+    }
+
+    #[test]
+    fn partition_sources_only_subagents() {
+        let sources = vec![KnowledgeSource::Subagents];
+        let (graph, notes): (Vec<_>, Vec<_>) = sources
+            .into_iter()
+            .partition(|s| matches!(s, KnowledgeSource::Subagents));
+        assert_eq!(graph.len(), 1);
+        assert!(notes.is_empty());
+    }
+
+    #[test]
+    fn partition_sources_no_subagents() {
+        let sources = vec![KnowledgeSource::Specs, KnowledgeSource::Changelog];
+        let (graph, notes): (Vec<_>, Vec<_>) = sources
+            .into_iter()
+            .partition(|s| matches!(s, KnowledgeSource::Subagents));
+        assert!(graph.is_empty());
+        assert_eq!(notes.len(), 2);
+    }
+
+    // ── Confirmation gate helper ──────────────────────────────────────────────
+
+    /// Dry-run never requires a confirmation prompt.
+    #[test]
+    fn should_prompt_dry_run_is_false() {
+        let dry_run = true;
+        let yes = false;
+        assert!(!should_prompt_for_graph_write(dry_run, yes));
+    }
+
+    /// `--yes` suppresses the prompt.
+    #[test]
+    fn should_prompt_yes_flag_is_false() {
+        let dry_run = false;
+        let yes = true;
+        assert!(!should_prompt_for_graph_write(dry_run, yes));
+    }
+
+    /// Neither dry-run nor --yes: prompt is required.
+    #[test]
+    fn should_prompt_interactive_is_true() {
+        assert!(should_prompt_for_graph_write(false, false));
     }
 }


### PR DESCRIPTION
## Summary

Implements spec-067 Phase 2 (G2): wires `--source subagents` into the knowledge graph via the `ingest_documents` batch API landed in G1 (#5021). Closes #5023.

- **`GraphOrigin::Subagent`** — new variant; transcript imports tagged `origin='subagent'`, correctly excluded from conversation recall without any DB migration.
- **`DocOutcome::Rejected` + `IngestReport.rejected`** — sanitizer-rejected facts now produce a distinct outcome, write zero rows, skip the ledger, and appear in the summary report.
- **Validator on dry-run** — `MemoryWriteValidator` (`PostExtractValidator`) runs on both live and dry-run branches; projected counts are post-sanitization.
- **`forbidden_content_patterns` on graph path** — extended `validate_graph_extraction` to enforce operator-configured blocklist over entity names and edge facts (was silently skipped).
- **`--source subagents` dispatch** — discovers JSONL transcripts from `config.agents.transcript_dir`, applies INV-6 current-project allowlist with `fs::canonicalize` per file (symlink-safe), calls `ingest_documents` with a fresh `ImportBatchId` and `GraphOrigin::Subagent`.
- **Confirmation gate** — `--yes`/`-y` required before real graph writes; dry-run never prompts.
- **Hub-degree report** — polished with `⚠ HUB` flag at > 15%, per-entity degree display, and `Batch ID` printed in non-dry-run summary for rollback.

## Test plan

- [ ] `cargo +nightly fmt --check` — PASS
- [ ] `cargo clippy --workspace -- -D warnings` — PASS
- [ ] `cargo nextest run --workspace --lib --bins` — **10821/10821 PASS** (+10 new tests)
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — PASS
- [ ] `cargo doc --no-deps -p zeph-memory -p zeph` — PASS (no new warnings)
- [ ] Live e2e (`--source subagents` graph write + rollback): **BLOCKED — Qdrant DOWN**. Dry-run path tested via Ollama with `--dry-run`; serialization gate met (no 400/422). Full write e2e pending Qdrant restart.

## Files changed

| Crate | File | Change |
|-------|------|--------|
| `zeph-memory` | `graph/types.rs` | `GraphOrigin::Subagent` variant |
| `zeph-memory` | `graph/ingest/document.rs` | `IngestSourceKind::graph_origin()` mapping |
| `zeph-memory` | `graph/ingest/report.rs` | `DocOutcome::Rejected` + `IngestReport.rejected` |
| `zeph-memory` | `graph/ingest/adapter.rs` | Validator short-circuit to `Rejected` |
| `zeph-memory` | `semantic/graph.rs` | Validator on dry-run branch, stale doc fix |
| `zeph-memory` | `graph/store/mod.rs` | Doc comment updates |
| `zeph-memory` | `error.rs` | `MemoryError::ValidationRejected` |
| `zeph-sanitizer` | `memory_validation.rs` | `validate_graph_extraction` enforces `forbidden_content_patterns` |
| `zeph` (bin) | `src/commands/knowledge.rs` | `--source subagents` dispatch, confirmation gate, hub-degree report |
| `zeph` (bin) | `src/cli.rs` | `IngestSourceKind::Subagents` CLI variant |
| `CHANGELOG.md` | — | `[Unreleased]` entry |