### PR TITLE
fix(tools): resolve policy_provider by name in adversarial policy gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `fix(knowledge)`: external-agent ingest (`--source claude-code`, `--source codex`) now passes `MemoryWriteValidator` sanitizer gate to `ingest_documents` — INV-4 violation where `handle_external_agent_ingest` called with `None` validator, bypassing entity-name PII checks and entity/edge count limits (closes #5081)
 - `fix(memory)`: `IngestSourceKind::graph_origin()` now correctly returns `GraphOrigin::ExternalAgent` for the `ExternalAgent` variant (was `GraphOrigin::Ingest`); adapters updated to call `kind.graph_origin()` instead of hardcoding origin, removing dead code path (closes #5082)
 - `fix(knowledge)`: replaced blocking `std::fs::read_to_string` / `std::fs::canonicalize` calls with `tokio::fs` async equivalents in async ingest functions; wrapped `enumerate_all_sources`, `enumerate_claude_code_paths`, `enumerate_codex_paths`, and subagent glob discovery in `tokio::task::spawn_blocking` to avoid stalling the async runtime on large session histories (closes #5080)
+- `fix(tools)`: adversarial policy gate now resolves `policy_provider` by name instead of always using the primary provider (closes #5079)
+  - `AdversarialPolicyLlmAdapter` is constructed with the provider resolved via `create_named_provider(adv_cfg.policy_provider, config)`, falling back to the primary provider with a `warn!` log when the named provider is empty or cannot be resolved.
+  - `AdversarialPolicyInfo.provider` is now set after resolution and reflects the actually-used provider name in all three branches (named, fallback, empty → primary), not the raw config string.
+  - Pattern mirrors `shadow_sentinel.probe_provider` at `runner.rs:2135`.
+  - 3 regression tests added in `zeph-config` for `AdversarialPolicyConfig.policy_provider` serialization and default behaviour.
 
 ### Added
 

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -1546,15 +1546,15 @@ destination = "/var/log/zeph-audit.log""#,
 
     #[test]
     fn adversarial_policy_provider_serde_roundtrip() {
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            adversarial_policy: AdversarialPolicyConfig,
+        }
         let toml_str = r#"
             [adversarial_policy]
             enabled = true
             policy_provider = "fast-llm"
         "#;
-        #[derive(serde::Deserialize)]
-        struct Wrapper {
-            adversarial_policy: AdversarialPolicyConfig,
-        }
         let w: Wrapper = toml::from_str(toml_str).unwrap();
         assert_eq!(w.adversarial_policy.policy_provider.as_str(), "fast-llm");
 
@@ -1565,14 +1565,14 @@ destination = "/var/log/zeph-audit.log""#,
 
     #[test]
     fn adversarial_policy_provider_empty_when_omitted() {
-        let toml_str = r"
-            [adversarial_policy]
-            enabled = true
-        ";
         #[derive(serde::Deserialize)]
         struct Wrapper {
             adversarial_policy: AdversarialPolicyConfig,
         }
+        let toml_str = r"
+            [adversarial_policy]
+            enabled = true
+        ";
         let w: Wrapper = toml::from_str(toml_str).unwrap();
         assert!(
             w.adversarial_policy.policy_provider.is_empty(),

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -1537,4 +1537,46 @@ destination = "/var/log/zeph-audit.log""#,
         let back: UtilityScoringConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(back.utility_window, 3);
     }
+
+    #[test]
+    fn adversarial_policy_provider_default_is_empty() {
+        let config = AdversarialPolicyConfig::default();
+        assert!(config.policy_provider.is_empty());
+    }
+
+    #[test]
+    fn adversarial_policy_provider_serde_roundtrip() {
+        let toml_str = r#"
+            [adversarial_policy]
+            enabled = true
+            policy_provider = "fast-llm"
+        "#;
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            adversarial_policy: AdversarialPolicyConfig,
+        }
+        let w: Wrapper = toml::from_str(toml_str).unwrap();
+        assert_eq!(w.adversarial_policy.policy_provider.as_str(), "fast-llm");
+
+        let json = serde_json::to_string(&w.adversarial_policy).unwrap();
+        let back: AdversarialPolicyConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.policy_provider.as_str(), "fast-llm");
+    }
+
+    #[test]
+    fn adversarial_policy_provider_empty_when_omitted() {
+        let toml_str = r"
+            [adversarial_policy]
+            enabled = true
+        ";
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            adversarial_policy: AdversarialPolicyConfig,
+        }
+        let w: Wrapper = toml::from_str(toml_str).unwrap();
+        assert!(
+            w.adversarial_policy.policy_provider.is_empty(),
+            "omitted policy_provider must default to empty (→ primary provider used)"
+        );
+    }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1988,12 +1988,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                 );
             }
 
-            adv_policy_info = Some(zeph_core::AdversarialPolicyInfo {
-                provider: adv_cfg.policy_provider.to_string(),
-                policy_count: policies.len(),
-                fail_open: adv_cfg.fail_open,
-            });
-
+            let policy_count = policies.len();
             let validator = std::sync::Arc::new(zeph_tools::PolicyValidator::new(
                 policies,
                 std::time::Duration::from_millis(adv_cfg.timeout_ms),
@@ -2001,9 +1996,39 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                 adv_cfg.exempt_tools.clone(),
             ));
 
+            let (policy_provider, resolved_provider_name) = if adv_cfg.policy_provider.is_empty() {
+                let name = provider.name().to_string();
+                (provider.clone(), name)
+            } else {
+                match crate::bootstrap::create_named_provider(
+                    adv_cfg.policy_provider.as_str(),
+                    config,
+                ) {
+                    Ok(p) => {
+                        let name = p.name().to_string();
+                        (p, name)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            provider = %adv_cfg.policy_provider,
+                            error = %e,
+                            "adversarial policy provider resolution failed, using primary"
+                        );
+                        let name = provider.name().to_string();
+                        (provider.clone(), name)
+                    }
+                }
+            };
+
+            adv_policy_info = Some(zeph_core::AdversarialPolicyInfo {
+                provider: resolved_provider_name,
+                policy_count,
+                fail_open: adv_cfg.fail_open,
+            });
+
             let llm_client: std::sync::Arc<dyn zeph_tools::PolicyLlmClient> =
                 std::sync::Arc::new(AdversarialPolicyLlmAdapter {
-                    provider: provider.clone(),
+                    provider: policy_provider,
                 });
 
             let mut gate =


### PR DESCRIPTION
## Summary

- `AdversarialPolicyLlmAdapter` was always constructed with the primary provider, ignoring `adv_cfg.policy_provider`. This PR fixes the bug by applying the same `create_named_provider` pattern used by `shadow_sentinel.probe_provider` at `runner.rs:2135`.
- `AdversarialPolicyInfo.provider` is now populated after resolution and reflects the actually-used provider name in all three branches (named, fallback to primary on error, empty → primary), not the raw config string.
- 3 regression tests added in `zeph-config` for `AdversarialPolicyConfig.policy_provider`.

## Changes

- `src/runner.rs`: replace `provider.clone()` at the `AdversarialPolicyLlmAdapter` construction site with named-provider resolution + fallback; move `adv_policy_info` assignment after resolution to capture the resolved name.
- `crates/zeph-config/src/tools.rs`: 3 new unit tests — default empty, serde round-trip, omitted-field default.
- `CHANGELOG.md`: `[Unreleased] ### Fixed` entry.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run -p zeph-core -p zeph-config --lib` — 2093 passed
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean

Closes #5079