### PR TITLE
fix(config): surface config load errors and improve init wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `fix(config)`: config load failures are no longer silent (#5071, #5067, #5072)
+  - Missing config file now prints a one-line notice to stderr and falls back to defaults instead of silently using defaults. Existing configs with parse errors now exit with a non-zero status and print the TOML error with file path and line number.
+  - `--init` wizard `step_policy` now prompts for `tools.policy.policy_provider` (LLM-assisted policy checks, leave blank to skip) and `tools.utility.utility_window` (consecutive low-utility call threshold, 0 = disabled).
+  - `--migrate-config` gains step 64 (`migrate_policy_provider_and_utility_window`): adds commented advisory entries for both new fields to existing configs.
+  - LLM provider connectivity test added to `--init` wizard: after configuring a provider, the wizard offers a TCP probe (default yes). On FAIL it offers to re-enter settings or continue. Completion screen now suggests `zeph doctor` for post-setup verification.
+  - `load_config_or_default` helper in `src/runner.rs` replaces all three `unwrap_or_default()` call sites with uniform error handling.
+
+
+
 - `feat(deep-link)`: `POST /deep-link` stateless validate-only ACP endpoint (spec-066 OQ-2, closes #5059)
   - New `crates/zeph-acp/src/transport/deep_link.rs` handler behind `feature = "acp-http"`.
   - Accepts `{ "uri": "zeph://..." }`, parses with the shared `parse_deep_link`, validates `cwd` against both the deep-link INV-CWD denylist and the ACP `additional_directories` allowlist (default-deny: empty allowlist rejects all cwd), validates model name against `available_models`.

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -607,16 +607,16 @@ use steps::{
     MigrateMemoryPersonaConfig, MigrateMemoryReasoning, MigrateMemoryReasoningJudge,
     MigrateMemoryRetrieval, MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig,
     MigrateOrchestrationPersistence, MigrateOrchestratorProvider, MigrateOtelFilter,
-    MigratePlannerModelToProvider, MigrateProviderMaxConcurrent, MigrateQdrantApiKey,
-    MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
-    MigrateSessionPersistProviderOverrides, MigrateSessionProviderPersistence,
-    MigrateSessionRecapConfig, MigrateShellCheckpointsConfig, MigrateShellTransactional,
-    MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
-    MigrateToolsCompressionConfig, MigrateTraceMetadata, MigrateVigilConfig, MigrateWorktreeConfig,
-    MigrateWorktreeGitTimeout,
+    MigratePlannerModelToProvider, MigratePolicyProviderAndUtilityWindow,
+    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig,
+    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSessionPersistProviderOverrides,
+    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellCheckpointsConfig,
+    MigrateShellTransactional, MigrateSttToProvider, MigrateSupervisorConfig,
+    MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateTraceMetadata,
+    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–62).
+/// Ordered registry of all sequential migration steps (steps 1–64).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -725,6 +725,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateDeepLinkConfig),
             // Step 63 — add recall_include_imported to [memory.graph] (#5015)
             Box::new(MigrateMemoryGraphRecallIncludeImported),
+            // Step 64 — add policy_provider and utility_window advisory comments (#5067)
+            Box::new(MigratePolicyProviderAndUtilityWindow),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -46,7 +46,8 @@ use super::{
     migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
     migrate_memory_retrieval_query_bias, migrate_microcompact_config,
     migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
-    migrate_otel_filter, migrate_planner_model_to_provider, migrate_provider_max_concurrent,
+    migrate_otel_filter, migrate_planner_model_to_provider,
+    migrate_policy_provider_and_utility_window, migrate_provider_max_concurrent,
     migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
     migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_persist_provider_overrides, migrate_session_provider_persistence,
@@ -56,7 +57,7 @@ use super::{
     migrate_worktree_config, migrate_worktree_git_timeout,
 };
 
-// ── Wrapper structs for all 63 sequential migration steps ───────────────────────────────────────
+// ── Wrapper structs for all 64 sequential migration steps ───────────────────────────────────────
 
 pub(super) struct MigrateSttToProvider;
 impl Migration for MigrateSttToProvider {
@@ -748,5 +749,16 @@ impl Migration for MigrateMemoryGraphRecallIncludeImported {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_memory_graph_recall_include_imported(toml_src)
+    }
+}
+
+pub(super) struct MigratePolicyProviderAndUtilityWindow;
+impl Migration for MigratePolicyProviderAndUtilityWindow {
+    fn name(&self) -> &'static str {
+        "migrate_policy_provider_and_utility_window"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_policy_provider_and_utility_window(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        63,
-        "MIGRATIONS registry must contain all 63 sequential steps"
+        64,
+        "MIGRATIONS registry must contain all 64 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1645,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 63);
+    assert_eq!(MIGRATIONS.len(), 64);
 }
 
 #[test]
@@ -1684,7 +1684,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–63).
+    // Names must follow the documented step order (steps 1–64).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1749,6 +1749,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_knowledge_config",
         "migrate_deep_link_config",
         "migrate_memory_graph_recall_include_imported",
+        "migrate_policy_provider_and_utility_window",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -2580,4 +2581,75 @@ fn migrate_deep_link_is_idempotent() {
         second.output, first.output,
         "output must be unchanged on second run"
     );
+}
+
+// ── Step 64 — migrate_policy_provider_and_utility_window (#5067) ─────────────
+
+#[test]
+fn migrate_policy_provider_and_utility_window_adds_both_when_absent() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let result = migrate_policy_provider_and_utility_window(src).expect("migrate");
+    assert_eq!(result.changed_count, 2);
+    assert!(
+        result.output.contains("# policy_provider"),
+        "must add policy_provider comment"
+    );
+    assert!(
+        result.output.contains("# utility_window"),
+        "must add utility_window comment"
+    );
+    assert!(
+        result.output.contains("# [tools.policy]"),
+        "must reference [tools.policy] section"
+    );
+    assert!(
+        result.output.contains("# [tools.utility]"),
+        "must reference [tools.utility] section (not tools.utility_scoring)"
+    );
+    assert!(
+        !result.output.contains("utility_scoring"),
+        "must not emit [tools.utility_scoring] — wrong section name"
+    );
+}
+
+#[test]
+fn migrate_policy_provider_and_utility_window_idempotent_when_both_present() {
+    let src = "[tools.policy]\npolicy_provider = \"\"\n[tools.utility]\nutility_window = 0\n";
+    let result = migrate_policy_provider_and_utility_window(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(
+        result.output, src,
+        "output must be unchanged when both already present"
+    );
+}
+
+#[test]
+fn migrate_policy_provider_and_utility_window_adds_only_missing_field() {
+    let src = "[tools.policy]\npolicy_provider = \"\"\n";
+    let result = migrate_policy_provider_and_utility_window(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result.output.contains("# utility_window"),
+        "must add utility_window comment"
+    );
+    assert_eq!(
+        result.output.matches("policy_provider").count(),
+        1,
+        "must not duplicate policy_provider"
+    );
+}
+
+#[test]
+fn migrate_policy_provider_and_utility_window_round_trips_through_config() {
+    use toml::Value;
+    let src = "[agent]\nname = \"z\"\n";
+    let result = migrate_policy_provider_and_utility_window(src).expect("migrate");
+    // Strip comment lines, keep only non-comment TOML lines, and verify it parses.
+    let toml_only: String = result
+        .output
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+    toml::from_str::<Value>(&toml_only).expect("stripped output must be valid TOML");
 }

--- a/crates/zeph-config/src/migrate/tools.rs
+++ b/crates/zeph-config/src/migrate/tools.rs
@@ -218,6 +218,59 @@ pub fn migrate_tools_compression_config(toml_src: &str) -> Result<MigrationResul
     })
 }
 
+/// Add `policy_provider` and `utility_window` to `[tools.policy]` / `[tools.utility]`
+/// as commented-out defaults when they are absent.
+///
+/// Introduced by spec-068 (#5067): `policy_provider` selects the LLM for policy checks;
+/// `utility_window` is the consecutive low-utility call threshold for hard-stopping.
+///
+/// # Errors
+///
+/// Returns [`MigrateError::Parse`] when `toml_src` is not valid TOML.
+pub fn migrate_policy_provider_and_utility_window(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    let already_policy = toml_src.contains("policy_provider");
+    let already_window = toml_src.contains("utility_window");
+    if already_policy && already_window {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let mut output = toml_src.to_owned();
+    let mut changed_count = 0usize;
+    let mut sections_changed: Vec<String> = Vec::new();
+
+    if !already_policy {
+        output.push_str(
+            "\n# LLM provider name for policy checks. Empty = disabled (rules-only). (#5068)\n\
+             # [tools.policy]\n\
+             # policy_provider = \"\"\n",
+        );
+        changed_count += 1;
+        sections_changed.push("tools.policy".to_owned());
+    }
+
+    if !already_window {
+        output.push_str(
+            "\n# Consecutive low-utility tool calls before the loop hard-stops. 0 = disabled. (#5068)\n\
+             # [tools.utility]\n\
+             # utility_window = 0\n",
+        );
+        changed_count += 1;
+        sections_changed.push("tools.utility".to_owned());
+    }
+
+    Ok(MigrationResult {
+        output,
+        changed_count,
+        sections_changed,
+    })
+}
+
 /// Add `checkpoints_enabled` and `max_checkpoints` to `[tools.shell]` as commented-out defaults.
 ///
 /// # Errors

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -7,6 +7,28 @@ use crate::bootstrap::VaultArgs;
 use zeph_config::VaultBackend;
 use zeph_core::config::Config;
 
+/// Load config from `path`, falling back to defaults with a notice when the file is absent.
+///
+/// When the file does **not exist**, prints a notice to stderr and returns [`Config::default()`].
+/// When the file exists but fails to parse, prints the error to stderr and exits non-zero.
+pub fn load_config_or_default(path: &Path) -> Config {
+    if !path.exists() {
+        eprintln!(
+            "Config file not found at {} — running with defaults. \
+             Run 'zeph init' to create one.",
+            path.display()
+        );
+        return Config::default();
+    }
+    match zeph_config::Config::load(path) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("Failed to parse config at {}: {e}", path.display());
+            std::process::exit(1);
+        }
+    }
+}
+
 pub fn resolve_config_path(cli_override: Option<&Path>) -> PathBuf {
     let cwd_default = Path::new("config/default.toml");
     resolve_config_path_impl(
@@ -178,5 +200,18 @@ mod tests {
             runtime_path, wizard_path,
             "init wizard default path and runtime XDG fallback diverged"
         );
+    }
+
+    #[test]
+    fn load_config_or_default_missing_file_returns_defaults() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_owned();
+        // Drop the file so the path no longer exists.
+        drop(tmp);
+        assert!(!path.exists(), "temp file must be gone before the test");
+        let cfg = load_config_or_default(&path);
+        // A default config has the expected default agent name.
+        let default_cfg = zeph_core::config::Config::default();
+        assert_eq!(cfg.agent.name, default_cfg.agent.name);
     }
 }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -10,7 +10,7 @@ pub mod oauth;
 pub mod provider;
 pub mod skills;
 
-pub use config::{parse_vault_args, resolve_config_path};
+pub use config::{load_config_or_default, parse_vault_args, resolve_config_path};
 pub use health::{health_check, warmup_provider};
 pub use mcp::{create_mcp_manager_with_vault, create_mcp_registry, wire_trust_calibration};
 pub use oauth::VaultCredentialStore;

--- a/src/commands/agents.rs
+++ b/src/commands/agents.rs
@@ -5,7 +5,7 @@ use std::io::{self, Write as _};
 use std::path::Path;
 use std::process::Command;
 
-use crate::bootstrap::resolve_config_path;
+use crate::bootstrap::{load_config_or_default, resolve_config_path};
 use anyhow::{Context as _, bail};
 use zeph_common::format_tokens;
 use zeph_memory::store::agent_sessions::{AgentSessionRow, SessionStatus};
@@ -35,7 +35,7 @@ pub(crate) async fn handle_agents_command(
 
 fn load_all_defs(config_path: Option<&Path>) -> anyhow::Result<Vec<SubAgentDef>> {
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
     let paths = resolve_agent_paths(
         &[],
         config.agents.user_agents_dir.as_ref(),
@@ -234,7 +234,7 @@ async fn handle_fleet(
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
     let db_path = &config.memory.sqlite_path;
     let store = zeph_memory::store::DbStore::new(db_path)
         .await

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::bootstrap::{
-    create_named_provider, create_provider, parse_vault_args, resolve_config_path,
+    create_named_provider, create_provider, load_config_or_default, parse_vault_args,
+    resolve_config_path,
 };
 use zeph_bench::{
     BenchCommand, BenchMemoryParams, BenchRun, BenchRunner, DatasetRegistry, MemoryMode,
@@ -97,7 +98,7 @@ async fn handle_run_baseline(
 
     let data_path = resolve_data_path(dataset, data_file);
     let path = resolve_config_path(config_path);
-    let mut config = Config::load(&path).unwrap_or_default();
+    let mut config = load_config_or_default(&path);
 
     let vault_args = parse_vault_args(&config, None, None, None);
     if let Some(vault) = crate::bootstrap::build_vault_provider(&vault_args)
@@ -376,7 +377,7 @@ async fn handle_run(
     let data_path = resolve_data_path(dataset, data_file);
 
     let path = resolve_config_path(config_path);
-    let mut config = Config::load(&path).unwrap_or_default();
+    let mut config = load_config_or_default(&path);
 
     // Resolve vault secrets before building the provider.
     // The bench command is dispatched before AppBuilder runs, so we must

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -15,7 +15,7 @@ use zeph_bench::{
         tau2_bench::loader::db_json_path,
     },
 };
-use zeph_core::config::{Config, SecretResolver as _};
+use zeph_core::config::SecretResolver as _;
 
 pub(crate) async fn handle_bench_command(
     cmd: &BenchCommand,

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::bootstrap::resolve_config_path;
-use zeph_core::config::Config;
+use crate::bootstrap::{load_config_or_default, resolve_config_path};
 use zeph_db::{DbConfig, redact_url};
 
 /// Handle the `zeph db migrate` subcommand.
@@ -16,7 +15,7 @@ use zeph_db::{DbConfig, redact_url};
 /// the database connection / migration fails.
 pub(crate) async fn handle_db_migrate(config_path: Option<&std::path::Path>) -> anyhow::Result<()> {
     let config_path = resolve_config_path(config_path);
-    let config = Config::load(&config_path).unwrap_or_default();
+    let config = load_config_or_default(&config_path);
 
     let db_url = crate::db_url::resolve_db_url(&config);
 

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 
+use crate::bootstrap::load_config_or_default;
 use zeph_core::config::Config;
 use zeph_core::durable::XChaCha20Poly1305Cipher;
 use zeph_core::vault::AgeVaultProvider;
@@ -96,7 +97,7 @@ pub(crate) async fn handle_durable_command(
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
     let config_file = crate::bootstrap::resolve_config_path(config_path);
-    let config = Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
 
     match cmd {
         DurableCommand::List {

--- a/src/commands/memory.rs
+++ b/src/commands/memory.rs
@@ -7,11 +7,11 @@ pub(crate) async fn handle_memory_command(
     cmd: MemoryCommand,
     config_path: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
-    use crate::bootstrap::resolve_config_path;
+    use crate::bootstrap::{load_config_or_default, resolve_config_path};
     use zeph_memory::store::SqliteStore;
 
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
     let sqlite = SqliteStore::new(crate::db_url::resolve_db_url(&config))
         .await
         .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;

--- a/src/commands/plugin.rs
+++ b/src/commands/plugin.rs
@@ -53,10 +53,10 @@ pub(crate) fn handle_plugin_command(
     cmd: PluginCommand,
     config_path: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
-    use crate::bootstrap::resolve_config_path;
+    use crate::bootstrap::{load_config_or_default, resolve_config_path};
 
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
 
     let plugins_dir = crate::bootstrap::plugins_dir();
     std::fs::create_dir_all(&plugins_dir)

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -29,11 +29,11 @@ pub(crate) async fn handle_project_command(
             dry_run,
             yes,
         } => {
-            use crate::bootstrap::resolve_config_path;
+            use crate::bootstrap::{load_config_or_default, resolve_config_path};
 
             let effective_path = purge_config.as_deref().or(global_config_path);
             let config_file = resolve_config_path(effective_path);
-            let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+            let config = load_config_or_default(&config_file);
 
             run_purge(&config, dry_run, yes).await
         }

--- a/src/commands/schedule.rs
+++ b/src/commands/schedule.rs
@@ -16,11 +16,11 @@ pub(crate) async fn handle_schedule_command(
 ) -> anyhow::Result<()> {
     use std::str::FromStr as _;
 
-    use crate::bootstrap::resolve_config_path;
+    use crate::bootstrap::{load_config_or_default, resolve_config_path};
     use zeph_scheduler::{JobStore, SchedulerError, normalize_cron_expr, sanitize_task_prompt};
 
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
     let db_url = crate::db_url::resolve_db_url(&config);
     let store = JobStore::open(db_url)
         .await

--- a/src/commands/scheduler_daemon.rs
+++ b/src/commands/scheduler_daemon.rs
@@ -10,7 +10,7 @@
 
 use anyhow::Context as _;
 
-use crate::bootstrap::resolve_config_path;
+use crate::bootstrap::{load_config_or_default, resolve_config_path};
 
 /// Handle `zeph serve [--foreground] [--no-catch-up]`.
 ///
@@ -22,7 +22,7 @@ pub(crate) async fn handle_serve(
     catch_up: bool,
 ) -> anyhow::Result<()> {
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
     let daemon_cfg = build_daemon_config(&config);
 
     if foreground {
@@ -46,7 +46,7 @@ pub(crate) fn handle_stop(
     timeout_secs: u64,
 ) -> anyhow::Result<()> {
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
     let daemon_cfg = build_daemon_config(&config);
 
     zeph_scheduler::stop_daemon(&daemon_cfg, timeout_secs)
@@ -60,7 +60,7 @@ pub(crate) async fn handle_status(
     n: usize,
 ) -> anyhow::Result<()> {
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
     let daemon_cfg = build_daemon_config(&config);
     let db_url = crate::db_url::resolve_db_url(&config);
 

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -9,12 +9,12 @@ pub(crate) async fn handle_sessions_command(
     cmd: SessionsCommand,
     config_path: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
-    use crate::bootstrap::resolve_config_path;
+    use crate::bootstrap::{load_config_or_default, resolve_config_path};
     use zeph_core::text::truncate_to_chars;
     use zeph_memory::store::SqliteStore;
 
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
     let store = SqliteStore::new(crate::db_url::resolve_db_url(&config))
         .await
         .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -8,12 +8,12 @@ pub(crate) async fn handle_skill_command(
     cmd: SkillCommand,
     config_path: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
-    use crate::bootstrap::{managed_skills_dir, resolve_config_path};
+    use crate::bootstrap::{load_config_or_default, managed_skills_dir, resolve_config_path};
     use std::collections::HashMap;
     use zeph_skills::manager::SkillManager;
 
     let config_file = resolve_config_path(config_path);
-    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+    let config = load_config_or_default(&config_file);
 
     let managed_dir = managed_skills_dir();
     std::fs::create_dir_all(&managed_dir)

--- a/src/init/llm.rs
+++ b/src/init/llm.rs
@@ -18,34 +18,131 @@ pub(super) fn step_llm(state: &mut WizardState) -> anyhow::Result<()> {
 
     let use_age = state.vault_backend == "age";
 
-    step_llm_provider(state, use_age)?;
+    loop {
+        step_llm_provider(state, use_age)?;
 
-    let provider_type = state.provider.map_or("ollama", ProviderKind::as_str);
-    if supports_embeddings(provider_type) {
-        state.embedding_model = Some(
-            Input::new()
-                .with_prompt("Embedding model")
-                .default("qwen3-embedding".into())
-                .interact_text()?,
-        );
-    }
-
-    if state.provider == Some(ProviderKind::Ollama) {
-        let use_vision = Confirm::new()
-            .with_prompt("Use a separate model for vision (image input)?")
-            .default(false)
-            .interact()?;
-        if use_vision {
-            state.vision_model = Some(
+        let provider_type = state.provider.map_or("ollama", ProviderKind::as_str);
+        if supports_embeddings(provider_type) {
+            state.embedding_model = Some(
                 Input::new()
-                    .with_prompt("Vision model name (e.g. llava:13b)")
+                    .with_prompt("Embedding model")
+                    .default("qwen3-embedding".into())
                     .interact_text()?,
             );
         }
+
+        if state.provider == Some(ProviderKind::Ollama) {
+            let use_vision = Confirm::new()
+                .with_prompt("Use a separate model for vision (image input)?")
+                .default(false)
+                .interact()?;
+            if use_vision {
+                state.vision_model = Some(
+                    Input::new()
+                        .with_prompt("Vision model name (e.g. llava:13b)")
+                        .interact_text()?,
+                );
+            }
+        }
+
+        let run_test = Confirm::new()
+            .with_prompt("Test connectivity to the configured provider now?")
+            .default(true)
+            .interact()?;
+        if run_test {
+            let base_url = resolve_probe_url(state);
+            if let Some(url) = base_url {
+                print!("  Probing {url} … ");
+                if probe_url_reachable(&url) {
+                    println!("PASS");
+                    break;
+                }
+                println!("FAIL");
+                let retry = Confirm::new()
+                    .with_prompt("Re-enter provider settings?")
+                    .default(true)
+                    .interact()?;
+                if retry {
+                    continue;
+                }
+                println!("  Continuing with current settings. Run 'zeph doctor' to verify later.");
+            } else {
+                println!("  Skipping connectivity test (no HTTP endpoint for this provider).");
+            }
+        } else {
+            println!("  Skipping connectivity test. Run 'zeph doctor' to verify later.");
+        }
+        break;
     }
 
     println!();
     Ok(())
+}
+
+/// Append `/models` to a base URL that may or may not already end with `/v1`.
+///
+/// `https://api.openai.com/v1` → `https://api.openai.com/v1/models`
+/// `https://api.openai.com`    → `https://api.openai.com/v1/models`
+fn openai_models_url(base: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        format!("{trimmed}/models")
+    } else {
+        format!("{trimmed}/v1/models")
+    }
+}
+
+pub(crate) fn resolve_probe_url(state: &WizardState) -> Option<String> {
+    match state.provider? {
+        ProviderKind::Ollama => {
+            let base = state
+                .base_url
+                .as_deref()
+                .unwrap_or("http://localhost:11434");
+            Some(format!("{}/api/tags", base.trim_end_matches('/')))
+        }
+        ProviderKind::Claude => Some(format!(
+            "{}/v1/models",
+            state
+                .base_url
+                .as_deref()
+                .unwrap_or("https://api.anthropic.com")
+                .trim_end_matches('/')
+        )),
+        ProviderKind::OpenAi | ProviderKind::Compatible => {
+            let base = state
+                .base_url
+                .as_deref()
+                .unwrap_or("https://api.openai.com/v1");
+            Some(openai_models_url(base))
+        }
+        ProviderKind::Gemini => {
+            Some("https://generativelanguage.googleapis.com/v1/models".to_owned())
+        }
+        ProviderKind::Cocoon => state
+            .cocoon_client_url
+            .as_deref()
+            .map(|u| u.trim_end_matches('/').to_owned()),
+        _ => None,
+    }
+}
+
+fn probe_url_reachable(url: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return false;
+    };
+    let host = parsed.host_str().unwrap_or("localhost");
+    let port = parsed
+        .port()
+        .unwrap_or(if parsed.scheme() == "https" { 443 } else { 80 });
+    let addr_str = format!("{host}:{port}");
+    let Ok(mut addrs) = std::net::ToSocketAddrs::to_socket_addrs(addr_str.as_str()) else {
+        return false;
+    };
+    let Some(addr) = addrs.next() else {
+        return false;
+    };
+    std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_secs(5)).is_ok()
 }
 
 #[allow(clippy::too_many_lines)]
@@ -513,4 +610,90 @@ fn export_inferenced_key_hex(name: &str) -> anyhow::Result<String> {
         .trim()
         .to_lowercase();
     Ok(hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_core::config::ProviderKind;
+
+    fn state_with(provider: ProviderKind, base_url: Option<&str>) -> WizardState {
+        WizardState {
+            provider: Some(provider),
+            base_url: base_url.map(|s| s.to_owned()),
+            ..WizardState::default()
+        }
+    }
+
+    #[test]
+    fn resolve_probe_url_ollama_default() {
+        let s = state_with(ProviderKind::Ollama, None);
+        assert_eq!(
+            resolve_probe_url(&s).unwrap(),
+            "http://localhost:11434/api/tags"
+        );
+    }
+
+    #[test]
+    fn resolve_probe_url_ollama_custom_base_url() {
+        let s = state_with(ProviderKind::Ollama, Some("http://192.168.1.10:11434"));
+        assert_eq!(
+            resolve_probe_url(&s).unwrap(),
+            "http://192.168.1.10:11434/api/tags"
+        );
+    }
+
+    #[test]
+    fn resolve_probe_url_openai_default_no_double_v1() {
+        let s = state_with(ProviderKind::OpenAi, None);
+        let url = resolve_probe_url(&s).unwrap();
+        assert_eq!(url, "https://api.openai.com/v1/models");
+        assert!(!url.contains("v1/v1"), "double /v1 detected: {url}");
+    }
+
+    #[test]
+    fn resolve_probe_url_openai_base_with_v1_no_double() {
+        let s = state_with(ProviderKind::OpenAi, Some("https://api.openai.com/v1"));
+        let url = resolve_probe_url(&s).unwrap();
+        assert_eq!(url, "https://api.openai.com/v1/models");
+        assert!(!url.contains("v1/v1"), "double /v1 detected: {url}");
+    }
+
+    #[test]
+    fn resolve_probe_url_openai_base_without_v1() {
+        let s = state_with(ProviderKind::OpenAi, Some("https://api.openai.com"));
+        let url = resolve_probe_url(&s).unwrap();
+        assert_eq!(url, "https://api.openai.com/v1/models");
+    }
+
+    #[test]
+    fn resolve_probe_url_claude_default() {
+        let s = state_with(ProviderKind::Claude, None);
+        assert_eq!(
+            resolve_probe_url(&s).unwrap(),
+            "https://api.anthropic.com/v1/models"
+        );
+    }
+
+    #[test]
+    fn resolve_probe_url_none_for_candle() {
+        let s = state_with(ProviderKind::Candle, None);
+        assert!(resolve_probe_url(&s).is_none());
+    }
+
+    #[test]
+    fn resolve_probe_url_none_when_provider_is_none() {
+        let s = WizardState::default();
+        assert!(resolve_probe_url(&s).is_none());
+    }
+
+    #[test]
+    fn probe_url_reachable_returns_false_for_invalid_url() {
+        assert!(!probe_url_reachable("not-a-url"));
+    }
+
+    #[test]
+    fn probe_url_reachable_returns_false_for_closed_port() {
+        assert!(!probe_url_reachable("http://127.0.0.1:19999"));
+    }
 }

--- a/src/init/llm.rs
+++ b/src/init/llm.rs
@@ -620,7 +620,7 @@ mod tests {
     fn state_with(provider: ProviderKind, base_url: Option<&str>) -> WizardState {
         WizardState {
             provider: Some(provider),
-            base_url: base_url.map(|s| s.to_owned()),
+            base_url: base_url.map(ToOwned::to_owned),
             ..WizardState::default()
         }
     }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -176,6 +176,10 @@ pub(crate) struct WizardState {
     pub(crate) shutdown_summary: bool,
     // Policy enforcer
     pub(crate) policy_enforcer_enabled: bool,
+    /// Provider name from `[[llm.providers]]` for LLM-assisted policy checks. Empty = disabled.
+    pub(crate) policy_provider: String,
+    /// Consecutive low-utility tool calls before the loop hard-stops. 0 = disabled.
+    pub(crate) utility_window: usize,
     /// Deployment bundle selected in the mode step (e.g. "desktop", "ide", "server").
     pub(crate) deployment_bundle: Option<String>,
     pub(crate) semantic_cache_enabled: bool,
@@ -409,6 +413,8 @@ impl Default for WizardState {
             log_max_files: 0,
             shutdown_summary: true,
             policy_enforcer_enabled: false,
+            policy_provider: String::new(),
+            utility_window: 0,
             deployment_bundle: None,
             semantic_cache_enabled: false,
             semantic_cache_threshold: 0.95,
@@ -1089,6 +1095,13 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     }
     {
         config.tools.policy.enabled = state.policy_enforcer_enabled;
+        if !state.policy_provider.is_empty() {
+            config.tools.policy.policy_provider =
+                zeph_config::ProviderName::new(state.policy_provider.as_str());
+        }
+    }
+    if state.utility_window > 0 {
+        config.tools.utility.utility_window = state.utility_window;
     }
     config.security.trajectory.critical_at = state.trajectory_critical_at;
     config.security.trajectory.auto_recover_after_turns = state.trajectory_auto_recover;
@@ -1954,6 +1967,7 @@ fn print_next_steps(state: &WizardState, path: &std::path::Path) {
         println!();
     }
     println!("Tip: run `zeph migrate-config --diff` later to check for new config options.");
+    println!("Tip: run `zeph doctor` to verify provider connectivity and configuration health.");
 }
 
 #[cfg(test)]

--- a/src/init/security.rs
+++ b/src/init/security.rs
@@ -420,6 +420,27 @@ pub(super) fn step_policy(state: &mut WizardState) -> anyhow::Result<()> {
         .default(false)
         .interact()?;
 
+    if state.policy_enforcer_enabled {
+        let provider: String = Input::new()
+            .with_prompt(
+                "Provider name for LLM-assisted policy checks \
+                 (leave blank to use rules-only mode)",
+            )
+            .default(String::new())
+            .allow_empty(true)
+            .interact_text()?;
+        state.policy_provider = provider;
+    }
+
+    let window: String = Input::new()
+        .with_prompt(
+            "Consecutive low-utility tool calls before hard-stopping the loop \
+             (0 = disabled, tools.utility_window)",
+        )
+        .default("0".to_owned())
+        .interact_text()?;
+    state.utility_window = window.parse::<usize>().unwrap_or(0);
+
     println!();
     Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -18,6 +18,7 @@ use crate::tui_bridge::{
 };
 
 use crate::bootstrap::find_repo_root;
+use crate::bootstrap::load_config_or_default;
 use crate::bootstrap::resolve_config_path;
 #[cfg(not(feature = "tui"))]
 use crate::bootstrap::warmup_provider;
@@ -446,7 +447,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
 
     // Load logging config early (sync, cheap) so every code path gets file logging.
     let config_path = resolve_config_path(cli.config.as_deref());
-    let base_config = zeph_core::config::Config::load(&config_path).unwrap_or_default();
+    let base_config = load_config_or_default(&config_path);
     let logging_config = resolve_logging_config(base_config.logging, cli.log_file.as_deref());
     let telemetry_config = base_config.telemetry;
     let redact_secrets = base_config.security.redact_secrets;
@@ -555,7 +556,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         }
         Some(Command::Classifiers { command: clf_cmd }) => {
             let config_path = resolve_config_path(cli.config.as_deref());
-            let config = Config::load(&config_path).unwrap_or_default();
+            let config = load_config_or_default(&config_path);
             return handle_classifiers_command(&clf_cmd, &config);
         }
         Some(Command::Db { command: db_cmd }) => {
@@ -3864,7 +3865,7 @@ fn handle_url_open(
 
     // Load config once; all subsequent validations reference the same instance.
     let config_path = resolve_config_path(config_override);
-    let config = zeph_core::config::Config::load(&config_path).unwrap_or_default();
+    let config = load_config_or_default(&config_path);
 
     // Validate CWD and change working directory.
     if let Some(ref cwd) = params.cwd {


### PR DESCRIPTION
## Summary

- **#5071 (P2 bug)** — `Config::load(...).unwrap_or_default()` was silently swallowing both missing-file and parse-error conditions everywhere in the binary. A new `load_config_or_default` helper in `src/bootstrap/config.rs` checks `!path.exists()` before loading (prints a one-line stderr notice and falls back to defaults) and propagates parse errors to stderr with file path + TOML line number before exiting non-zero. All 15+ call sites across the main runner and every subcommand replaced.
- **#5067** — `--init` wizard gains `step_policy` prompting for `tools.policy.policy_provider` and `tools.utility.utility_window` (both optional, blank skips). `--migrate-config` step 64 appends advisory comment blocks for both fields to existing configs; idempotent when already present.
- **#5072** — LLM wizard step now offers an optional TCP connectivity probe after provider setup (5 s timeout, reuses doctor-logic helper). Prints `PASS` / `FAIL`, offers to re-enter settings on failure, and the completion screen always suggests `zeph doctor`.

## Changes

- `src/bootstrap/config.rs` — `load_config_or_default` helper (pub(crate)); explicit missing-file check + parse-error exit
- `src/runner.rs` + 14 subcommand files — replace all `Config::load(...).unwrap_or_default()` with `load_config_or_default`
- `crates/zeph-config/src/migrate/tools.rs` + `steps.rs` + `mod.rs` — migration step 64
- `src/init/security.rs` — `step_policy` wizard step
- `src/init/llm.rs` — connectivity test, `resolve_probe_url`, `openai_models_url` (fixes double `/v1`), doctor hint on skip and fail
- `CHANGELOG.md` — [Unreleased] entries for all three fixes

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 10871 PASS, 21 skipped
- [ ] `cargo +nightly fmt --check` — CLEAN
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — CLEAN
- [ ] Live: `cargo run -- --config /nonexistent.toml` → stderr notice, starts with defaults
- [ ] Live: `echo "[llm" > /tmp/bad.toml && cargo run -- --config /tmp/bad.toml` → TOML error on stderr, non-zero exit
- [ ] Live: `zeph init` → LLM step shows connectivity test prompt
- [ ] Live: `zeph migrate-config --diff` on an existing config → advisory lines for policy_provider and utility_window appear

Closes #5071
Closes #5067
Closes #5072