### PR TITLE
fix(tui): use display width instead of char count for CJK and emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - `AdversarialPolicyInfo.provider` is now set after resolution and reflects the actually-used provider name in all three branches (named, fallback, empty → primary), not the raw config string.
   - Pattern mirrors `shadow_sentinel.probe_provider` at `runner.rs:2135`.
   - 3 regression tests added in `zeph-config` for `AdversarialPolicyConfig.policy_provider` serialization and default behaviour.
+- `fix(tui)`: status bar and widget columns now use display width instead of codepoint count, fixing misalignment with CJK characters and emoji (closes #5075)
+  - New `pub(crate) fn truncate_to_width(s: &str, max_width: usize) -> String` helper in `layout.rs` accumulates display width char-by-char and appends `…` within the column budget.
+  - All 6 truncation sites in `status.rs`, `subagents.rs`, `keys.rs`, `fleet.rs`, `reverse_search.rs`, and `resources.rs` route through the helper.
+  - Width measurement in `chat.rs` table columns and `wrap_spans` line-breaking corrected with `UnicodeWidthChar`.
+  - `unicode-width` added as a direct dependency of `zeph-tui` (previously only transitive via ratatui).
+  - 14 CJK/emoji regression tests added across `layout.rs`, `subagents.rs`, `status.rs`, and `chat.ms`.
 
 ### Added
 

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -7,6 +7,7 @@ pub(super) const SCROLL_STEP_PAGE: usize = 10;
 
 use crate::command::TuiCommand;
 use crate::file_picker::{FileIndex, FilePickerState};
+use crate::layout::truncate_to_width;
 use crate::widgets::command_palette::CommandPaletteState;
 use crate::widgets::slash_autocomplete::{SlashAutocompleteState, command_id_to_slash_form};
 
@@ -604,11 +605,7 @@ impl App {
                 "Provider", "Model", "Input", "Cache-R", "Cache-W", "Output", "Cost"
             );
             for (name, usage) in &self.metrics.provider_cost_breakdown {
-                let model_display = if usage.model.chars().count() > 26 {
-                    format!("{}…", usage.model.chars().take(25).collect::<String>())
-                } else {
-                    usage.model.clone()
-                };
+                let model_display = truncate_to_width(&usage.model, 26);
                 let _ = write!(
                     out,
                     "\n  {:<16} {:<28} {:>8} {:>9} {:>9} {:>8} {:>8}",

--- a/crates/zeph-tui/src/layout.rs
+++ b/crates/zeph-tui/src/layout.rs
@@ -2,6 +2,30 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Truncates `s` to fit within `max_width` display columns, appending `…` if truncated.
+///
+/// Accumulates display width character-by-character using [`UnicodeWidthChar`], reserving
+/// one column for the ellipsis. Returns an owned copy of `s` unchanged when it already fits.
+pub(crate) fn truncate_to_width(s: &str, max_width: usize) -> String {
+    if s.width() <= max_width {
+        return s.to_owned();
+    }
+    let budget = max_width.saturating_sub(1); // reserve 1 col for "…"
+    let mut out = String::new();
+    let mut cols = 0;
+    for ch in s.chars() {
+        let cw = ch.width().unwrap_or(0);
+        if cols + cw > budget {
+            break;
+        }
+        out.push(ch);
+        cols += cw;
+    }
+    out.push('…');
+    out
+}
 
 /// Returns a centered `Rect` with the given percentage width and fixed height.
 #[must_use]
@@ -144,7 +168,56 @@ impl AppLayout {
 
 #[cfg(test)]
 mod tests {
+    use unicode_width::UnicodeWidthStr;
+
     use super::*;
+
+    #[test]
+    fn truncate_to_width_ascii_fits() {
+        assert_eq!(truncate_to_width("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_to_width_ascii_truncated() {
+        let r = truncate_to_width("hello world", 7);
+        assert!(r.width() <= 7, "width={}", r.width());
+        assert!(r.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_to_width_cjk_fits() {
+        // "日本語" = 3 chars, width = 6
+        assert_eq!(truncate_to_width("日本語", 6), "日本語");
+    }
+
+    #[test]
+    fn truncate_to_width_cjk_truncated() {
+        // "日本語テスト" = 6 chars, width = 12; max=5 → must fit in 5 cols
+        let r = truncate_to_width("日本語テスト", 5);
+        assert!(r.width() <= 5, "width={} result={r:?}", r.width());
+        assert!(r.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_to_width_emoji_truncated() {
+        // "🎉🎊🎈" = 3 emoji, width = 6; max=5 → must fit in 5 cols
+        let r = truncate_to_width("🎉🎊🎈", 5);
+        assert!(r.width() <= 5, "width={} result={r:?}", r.width());
+        assert!(r.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_to_width_exact_boundary() {
+        // width == max → no truncation
+        let r = truncate_to_width("日本", 4);
+        assert_eq!(r, "日本");
+    }
+
+    #[test]
+    fn truncate_to_width_max_zero() {
+        let r = truncate_to_width("hello", 0);
+        assert!(r.width() == 1, "only ellipsis: {r:?}"); // "…" = 1 col
+    }
 
     #[test]
     fn layout_for_standard_terminal() {

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -8,6 +8,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use throbber_widgets_tui::BRAILLE_SIX;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::{App, MessageRole, RenderCache, RenderCacheKey, content_hash};
 use crate::highlight::SYNTAX_HIGHLIGHTER;
@@ -1012,7 +1013,7 @@ impl<'t> MdRenderer<'t> {
         let mut col_widths = vec![3usize; col_count];
         for row in &self.table_rows {
             for (ci, cell) in row.iter().enumerate() {
-                col_widths[ci] = col_widths[ci].max(cell.chars().count());
+                col_widths[ci] = col_widths[ci].max(cell.width());
             }
         }
 
@@ -1159,7 +1160,7 @@ fn wrap_spans(spans: Vec<Span<'static>>, max_width: usize) -> Vec<Line<'static>>
         return vec![Line::from(spans)];
     }
 
-    let total: usize = spans.iter().map(|s| s.content.chars().count()).sum();
+    let total: usize = spans.iter().map(|s| s.content.width()).sum();
     if total <= max_width {
         return vec![Line::from(spans)];
     }
@@ -1179,11 +1180,26 @@ fn wrap_spans(spans: Vec<Span<'static>>, max_width: usize) -> Vec<Line<'static>>
                 width = 0;
                 continue;
             }
-            let take = space.min(chars.len() - pos);
-            let chunk: String = chars[pos..pos + take].iter().collect();
-            current.push(Span::styled(chunk, span.style));
-            width += take;
-            pos += take;
+            // Greedily take chars whose total display width fits within `space`.
+            let mut chunk = String::new();
+            let mut chunk_width = 0;
+            while pos < chars.len() {
+                let cw = chars[pos].width().unwrap_or(0);
+                if chunk_width + cw > space {
+                    break;
+                }
+                chunk.push(chars[pos]);
+                chunk_width += cw;
+                pos += 1;
+            }
+            if !chunk.is_empty() {
+                width += chunk_width;
+                current.push(Span::styled(chunk, span.style));
+            } else if pos < chars.len() {
+                // Single char wider than remaining space — force a line break.
+                result.push(Line::from(std::mem::take(&mut current)));
+                width = 0;
+            }
 
             if width >= max_width && pos < chars.len() {
                 result.push(Line::from(std::mem::take(&mut current)));
@@ -2076,5 +2092,44 @@ mod tests {
             "5 read_file calls must render as grouped 'Explored N files'; got: {text:?}"
         );
         assert!(text.contains('5'), "group must mention count 5");
+    }
+
+    #[test]
+    fn wrap_spans_cjk_wraps_at_column_boundary() {
+        // "AB日CD": A=1, B=1, 日=2, C=1, D=1 → total width=6
+        // max_width=4: "AB日" fills exactly 4 cols → "CD" wraps to next line
+        let spans = vec![Span::raw("AB日CD")];
+        let lines = wrap_spans(spans, 4);
+        assert_eq!(lines.len(), 2, "expected 2 lines; got {lines:?}");
+        let first: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(first, "AB日", "first line should be 'AB日'; got {first:?}");
+        let second: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(second, "CD", "second line should be 'CD'; got {second:?}");
+    }
+
+    #[test]
+    fn wrap_spans_emoji_wraps_at_column_boundary() {
+        // "ab🎉cd": a=1, b=1, 🎉=2, c=1, d=1 → total width=6
+        // max_width=4: "ab🎉" fills exactly 4 cols → "cd" wraps
+        let spans = vec![Span::raw("ab🎉cd")];
+        let lines = wrap_spans(spans, 4);
+        assert_eq!(lines.len(), 2, "expected 2 lines; got {lines:?}");
+        let first: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(first, "ab🎉", "first line should be 'ab🎉'; got {first:?}");
+    }
+
+    #[test]
+    fn wrap_spans_all_cjk_wraps_correctly() {
+        // "日本語テ": each 2 cols → total 8; max_width=4 → 2 lines of 2 chars each
+        let spans = vec![Span::raw("日本語テ")];
+        let lines = wrap_spans(spans, 4);
+        assert_eq!(lines.len(), 2, "expected 2 lines; got {lines:?}");
+        let first: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(first, "日本", "first line should be '日本'; got {first:?}");
+        let second: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(
+            second, "語テ",
+            "second line should be '語テ'; got {second:?}"
+        );
     }
 }

--- a/crates/zeph-tui/src/widgets/fleet.rs
+++ b/crates/zeph-tui/src/widgets/fleet.rs
@@ -11,6 +11,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 use zeph_common::format_tokens;
 use zeph_memory::store::agent_sessions::{AgentSessionRow, SessionStatus};
 
+use crate::layout::truncate_to_width;
 use crate::theme::Theme;
 
 /// Cached fleet data loaded from the database by the background refresh task.
@@ -41,11 +42,7 @@ fn build_session_item(row: &AgentSessionRow, selected: bool) -> ListItem<'static
 
     let id_short: String = row.id.chars().take(8).collect();
 
-    let model_short = if row.model.chars().count() > 20 {
-        format!("{}…", row.model.chars().take(19).collect::<String>())
-    } else {
-        row.model.clone()
-    };
+    let model_short = truncate_to_width(&row.model, 20);
 
     let tokens = format!(
         "{}/{}",

--- a/crates/zeph-tui/src/widgets/resources.rs
+++ b/crates/zeph-tui/src/widgets/resources.rs
@@ -6,6 +6,7 @@ use ratatui::layout::Rect;
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
+use crate::layout::truncate_to_width;
 use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
 
@@ -159,12 +160,7 @@ fn append_shell_background_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsS
         let elapsed_secs = run.elapsed_secs;
         let mm = elapsed_secs / 60;
         let ss = elapsed_secs % 60;
-        let cmd = if run.command.chars().count() > 60 {
-            let end = run.command.floor_char_boundary(59);
-            format!("{}…", &run.command[..end])
-        } else {
-            run.command.clone()
-        };
+        let cmd = truncate_to_width(&run.command, 60);
         lines.push(Line::from(format!(
             "  [{}] {:02}:{:02}  {}",
             run.run_id, mm, ss, cmd

--- a/crates/zeph-tui/src/widgets/reverse_search.rs
+++ b/crates/zeph-tui/src/widgets/reverse_search.rs
@@ -7,6 +7,7 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState};
 
+use crate::layout::truncate_to_width;
 use crate::theme::Theme;
 
 const MAX_VISIBLE: usize = 8;
@@ -196,11 +197,7 @@ pub fn render(state: &ReverseSearchState, history: &[String], frame: &mut Frame,
                 Style::default()
             };
             let max_chars = (actual_width as usize).saturating_sub(5);
-            let display = if entry.chars().count() > max_chars {
-                format!("{}…", entry.chars().take(max_chars).collect::<String>())
-            } else {
-                entry.to_owned()
-            };
+            let display = truncate_to_width(entry, max_chars);
             ListItem::new(Line::from(Span::styled(display, style)))
         })
         .collect();

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -8,9 +8,11 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
+use unicode_width::UnicodeWidthStr;
 use zeph_common::format_tokens;
 
 use crate::app::{App, InputMode};
+use crate::layout::truncate_to_width;
 use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
 
@@ -45,9 +47,8 @@ impl SegmentList {
     }
 
     fn push(&mut self, priority: Priority, spans: Vec<Span<'static>>) {
-        // TODO: use unicode_width for correct CJK/emoji column count
         let width: u16 = spans.iter().fold(0u16, |acc, s| {
-            acc.saturating_add(u16::try_from(s.content.chars().count()).unwrap_or(u16::MAX))
+            acc.saturating_add(u16::try_from(s.content.width()).unwrap_or(u16::MAX))
         });
         self.segments.push(Segment {
             spans,
@@ -366,12 +367,7 @@ fn build_goal_spans(snap: &crate::metrics::GoalSnapshot, theme: &Theme) -> Vec<S
     let label = if snap.text.is_empty() {
         format!(" {icon} goal")
     } else {
-        let short: String = snap.text.chars().take(30).collect();
-        let truncated = if snap.text.chars().count() > 30 {
-            format!("{short}…")
-        } else {
-            short
-        };
+        let truncated = truncate_to_width(&snap.text, 30);
         format!(" {icon} {truncated}")
     };
     vec![
@@ -810,5 +806,51 @@ mod tests {
             super::render(&app, &metrics, frame, area);
         });
         assert_snapshot!(output);
+    }
+
+    #[test]
+    fn segment_list_cjk_width_counts_columns() {
+        let theme = Theme::default();
+        let mut list = SegmentList::new();
+        // "日本語" = 3 chars but 6 display columns
+        list.push(
+            Priority::Critical,
+            vec![Span::styled("日本語", theme.status_bar)],
+        );
+        // Low filler: 10 ASCII chars — should be dropped when max_width = 6
+        list.push(
+            Priority::Low,
+            vec![Span::styled("AAAAAAAAAA", theme.status_bar)],
+        );
+        let spans = list.layout(6);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        // CJK segment (width=6) must survive; Low (width=10) must be dropped
+        assert!(text.contains("日本語"), "CJK must survive: {text:?}");
+        assert!(
+            !text.contains("AAAAAAAAAA"),
+            "Low must be dropped: {text:?}"
+        );
+    }
+
+    #[test]
+    fn segment_list_emoji_width_counts_columns() {
+        let theme = Theme::default();
+        let mut list = SegmentList::new();
+        // "🎉🎊" = 2 emoji, each 2 cols = 4 display columns total
+        list.push(
+            Priority::Critical,
+            vec![Span::styled("🎉🎊", theme.status_bar)],
+        );
+        list.push(
+            Priority::Low,
+            vec![Span::styled("BBBBBBBBBB", theme.status_bar)],
+        );
+        let spans = list.layout(4);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("🎉🎊"), "emoji must survive: {text:?}");
+        assert!(
+            !text.contains("BBBBBBBBBB"),
+            "Low must be dropped: {text:?}"
+        );
     }
 }

--- a/crates/zeph-tui/src/widgets/subagents.rs
+++ b/crates/zeph-tui/src/widgets/subagents.rs
@@ -9,6 +9,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
 use zeph_subagent::{ModelSpec, SubAgentDef, ToolPolicy, is_valid_agent_name};
 
+use crate::layout::truncate_to_width;
 use crate::metrics::{MetricsSnapshot, SubAgentMetrics};
 use crate::theme::Theme;
 
@@ -981,12 +982,7 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 }
 
 fn truncate_str(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_owned()
-    } else {
-        let truncated: String = s.chars().take(max.saturating_sub(1)).collect();
-        format!("{truncated}…")
-    }
+    truncate_to_width(s, max)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -1398,11 +1394,10 @@ mod tests {
 
     #[test]
     fn truncate_str_unicode_safe() {
-        // String with 3 multi-byte chars.
+        use unicode_width::UnicodeWidthStr;
         let s = "αβγδε";
         let truncated = truncate_str(s, 3);
-        // Should be "αβ…" — 2 chars + ellipsis, all valid Unicode.
-        assert_eq!(truncated.chars().count(), 3);
+        assert!(truncated.width() <= 3, "width={}", truncated.width());
         assert!(truncated.ends_with('…'));
     }
 
@@ -1410,5 +1405,23 @@ mod tests {
     fn truncate_str_ascii_unchanged() {
         assert_eq!(truncate_str("hello", 10), "hello");
         assert_eq!(truncate_str("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_str_cjk_wide_chars() {
+        use unicode_width::UnicodeWidthStr;
+        // 6 CJK chars = width 12; max=5 → truncated result must fit in 5 cols
+        let r = truncate_str("日本語テスト", 5);
+        assert!(r.width() <= 5, "width={} result={r:?}", r.width());
+        assert!(r.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_str_emoji_wide_chars() {
+        use unicode_width::UnicodeWidthStr;
+        // 3 emoji = width 6; max=4 → must fit in 4 cols
+        let r = truncate_str("🎉🎊🎈", 4);
+        assert!(r.width() <= 4, "width={} result={r:?}", r.width());
+        assert!(r.ends_with('…'));
     }
 }


### PR DESCRIPTION
## Summary

- Replace `.chars().count()` with `UnicodeWidthStr::width()` across all column-layout and truncation logic in `zeph-tui`
- Add `truncate_to_width(s, max_width)` helper in `layout.rs` that accumulates display width char-by-char and appends `…` within the column budget
- Route all 6 truncation sites through the helper: `status.rs`, `subagents.rs`, `keys.rs`, `fleet.rs`, `reverse_search.rs`, `resources.rs`
- Fix `chat.rs` table column widths and `wrap_spans` line-breaking to use `UnicodeWidthChar` per grapheme
- Add `unicode-width` as a direct dependency (was previously only transitive via ratatui)
- Add 14 CJK/emoji regression tests across `layout.rs`, `subagents.rs`, `status.rs`, `chat.rs`

Closes #5075

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-tui -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 10870 passed, 21 skipped (+14 new CJK/emoji tests vs baseline)
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — exit 0