### PR TITLE
fix(config): scope step 63 idempotency check to [memory.graph] section

### DIFF
--- a/crates/zeph-config/src/migrate/memory.rs
+++ b/crates/zeph-config/src/migrate/memory.rs
@@ -589,8 +589,41 @@ pub fn migrate_memory_graph_recall_include_imported(
         });
     }
 
-    // Idempotent: key already present (active or as comment).
-    if toml_src.contains("recall_include_imported") {
+    // Idempotent: key already present (active or as comment) within [memory.graph].
+    // We check only inside the [memory.graph] section to avoid a false positive from
+    // step 61's [knowledge] advisory block, which also contains the string
+    // "recall_include_imported" as a comment.
+    //
+    // A commented-out section header (e.g. `# [knowledge]`) is treated as ending the
+    // current section, because advisory comment blocks from other migration steps are
+    // appended at the end of the file and their keys must not be attributed to
+    // [memory.graph].
+    let in_graph_section = {
+        let mut in_section = false;
+        toml_src.lines().any(|l| {
+            let t = l.trim();
+            // Active section header: transitions in/out of [memory.graph].
+            if !t.starts_with('#') && t.starts_with('[') && !t.starts_with("[[") {
+                in_section = t == "[memory.graph]";
+                return false;
+            }
+            if t.starts_with('#') {
+                let inner = t.trim_start_matches('#').trim();
+                // Commented-out section header (e.g. `# [knowledge]`): end current section.
+                // Advisory blocks from other steps appear as `# [section]` and their keys
+                // must not be misattributed to [memory.graph].
+                if inner.starts_with('[') {
+                    in_section = false;
+                    return false;
+                }
+                // Commented-out key — counts as present only if still inside the section.
+                return in_section && inner.starts_with("recall_include_imported");
+            }
+            // Active key inside the section.
+            in_section && t.starts_with("recall_include_imported")
+        })
+    };
+    if in_graph_section {
         return Ok(MigrationResult {
             output: toml_src.to_owned(),
             changed_count: 0,

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -2653,3 +2653,128 @@ fn migrate_policy_provider_and_utility_window_round_trips_through_config() {
         .join("\n");
     toml::from_str::<Value>(&toml_only).expect("stripped output must be valid TOML");
 }
+
+// ── Step 60 — migrate_shell_checkpoints_config (#4990) ───────────────────
+
+#[test]
+fn step_60_adds_checkpoints_block_when_absent() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let result = migrate_shell_checkpoints_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result.sections_changed.contains(&"tools.shell".to_owned()),
+        "sections_changed must include 'tools.shell'"
+    );
+    assert!(
+        result.output.contains("checkpoints_enabled"),
+        "output must contain checkpoints_enabled"
+    );
+    assert!(
+        result.output.contains("max_checkpoints"),
+        "output must contain max_checkpoints"
+    );
+}
+
+#[test]
+fn step_60_noop_when_checkpoints_enabled_present() {
+    let src = "[tools.shell]\ncheckpoints_enabled = true\n";
+    let result = migrate_shell_checkpoints_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_60_noop_when_max_checkpoints_present() {
+    let src = "[tools.shell]\nmax_checkpoints = 50\n";
+    let result = migrate_shell_checkpoints_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_60_idempotent_on_own_output() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let first = migrate_shell_checkpoints_config(src).expect("migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_shell_checkpoints_config(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output must be unchanged on second run"
+    );
+}
+
+// ── Step 63 — migrate_memory_graph_recall_include_imported (#5015) ────────
+
+#[test]
+fn step_63_adds_recall_include_imported_when_absent() {
+    let src = "[memory.graph]\nenabled = true\n";
+    let result = migrate_memory_graph_recall_include_imported(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result
+            .sections_changed
+            .contains(&"memory.graph.recall_include_imported".to_owned()),
+        "sections_changed must include memory.graph.recall_include_imported"
+    );
+    assert!(
+        result.output.contains("recall_include_imported"),
+        "output must contain recall_include_imported"
+    );
+}
+
+#[test]
+fn step_63_noop_when_no_memory_graph_section() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let result = migrate_memory_graph_recall_include_imported(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_63_noop_when_key_already_in_memory_graph() {
+    let src = "[memory.graph]\nenabled = true\nrecall_include_imported = false\n";
+    let result = migrate_memory_graph_recall_include_imported(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_63_noop_when_key_commented_in_memory_graph() {
+    let src = "[memory.graph]\nenabled = true\n# recall_include_imported = true\n";
+    let result = migrate_memory_graph_recall_include_imported(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+/// Regression for #5109: step 61 adds a `recall_include_imported` comment inside [knowledge].
+/// Step 63 must NOT treat that as an idempotency hit — it must still inject into [memory.graph].
+#[test]
+fn step_63_not_fooled_by_recall_include_imported_in_knowledge_block() {
+    // Simulates a config that has been processed by step 61, which adds a [knowledge]
+    // advisory containing "recall_include_imported" as a comment line.
+    let src = "[memory.graph]\nenabled = true\n\n# [knowledge]\n# recall_include_imported = true\n";
+    let result = migrate_memory_graph_recall_include_imported(src).expect("migrate");
+    assert_eq!(
+        result.changed_count, 1,
+        "must inject into [memory.graph] even when recall_include_imported appears in [knowledge]"
+    );
+    assert!(
+        result.output.contains("recall_include_imported"),
+        "output must contain the injected key"
+    );
+}
+
+#[test]
+fn step_63_idempotent_on_own_output() {
+    let src = "[memory.graph]\nenabled = true\n";
+    let first = migrate_memory_graph_recall_include_imported(src).expect("migrate");
+    assert_eq!(first.changed_count, 1);
+    let second =
+        migrate_memory_graph_recall_include_imported(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output must be unchanged on second run"
+    );
+}


### PR DESCRIPTION
## Summary

- **#5109** — `migrate_memory_graph_recall_include_imported` (step 63) used a global `toml_src.contains("recall_include_imported")` guard. Step 61 unconditionally adds `# recall_include_imported = true` to a `[knowledge]` advisory block and always runs before step 63, causing the guard to false-positive and silently skip injection into `[memory.graph]`.

  Fix: replaced the global `contains` check with a section-scoped state machine that only recognises the key while iterating under an active `[memory.graph]` header. Commented-out headers (`# [...]`) are treated as section terminators.

- **#5110** — Steps 60 (`migrate_shell_checkpoints_config`) and 63 were the only registered migration steps with zero dedicated unit tests. Added 9 tests (4 for step 60, 5 for step 63) matching the absent/present/idempotency pattern used by steps 61-62, including a targeted regression test reproducing the post-step-61 config shape.

## Test plan

- [x] `cargo nextest run -p zeph-config` — 558/558 pass (includes 9 new tests)
- [x] `cargo clippy -p zeph-config --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt --check -p zeph-config` — clean
- [x] Regression test `step_63_not_fooled_by_recall_include_imported_in_knowledge_block` directly reproduces the #5109 scenario

Closes #5109, Closes #5110