### PR TITLE
test(init): add missing build_config tests for policy_provider and utility_window

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -3099,4 +3099,28 @@ mod tests {
         };
         assert_eq!(provider_effective_name(&state), "ollama");
     }
+
+    #[test]
+    fn build_config_policy_provider_set() {
+        let state = WizardState {
+            policy_enforcer_enabled: true,
+            policy_provider: "my-llm".into(),
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert!(config.tools.policy.enabled);
+        assert_eq!(config.tools.policy.policy_provider.as_str(), "my-llm");
+    }
+
+    #[test]
+    fn build_config_utility_window_set() {
+        let state = WizardState {
+            utility_window: 5,
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert_eq!(config.tools.utility.utility_window, 5);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `build_config_policy_provider_set` test: verifies that `config.tools.policy.policy_provider` is wired correctly when `policy_enforcer_enabled = true`
- Add `build_config_utility_window_set` test: verifies that `config.tools.utility.utility_window` is wired correctly

The wizard prompts and `build_config()` wiring were already added in PR #5115. This PR adds the two unit tests that were filed as missing in #5114.

## Test plan

- [ ] `cargo nextest run -p zeph -E 'test(build_config)'` — 70 tests pass
- [ ] `cargo nextest run --workspace --lib --bins` — full workspace green (10890 tests)
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy -p zeph -- -D warnings` — clean

Closes #5114