### PR TITLE
fix(vault): wrap blocking I/O in spawn_blocking, use std RwLock, add tracing spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11352,6 +11352,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "zeph-common",
  "zeroize",
 ]

--- a/crates/zeph-vault/Cargo.toml
+++ b/crates/zeph-vault/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread"] }
+tracing.workspace = true
 zeph-common.workspace = true
 zeroize = { workspace = true, features = ["derive", "serde"] }
 

--- a/crates/zeph-vault/src/age.rs
+++ b/crates/zeph-vault/src/age.rs
@@ -158,6 +158,9 @@ impl AgeVaultProvider {
     /// [`save`][Self::save] can re-encrypt and persist changes without requiring callers to
     /// pass paths again.
     ///
+    /// This method performs blocking I/O on the calling thread. Use [`load_async`][Self::load_async]
+    /// when calling from an async context to avoid stalling the tokio executor.
+    ///
     /// # Errors
     ///
     /// Returns [`AgeVaultError`] on key/vault read failure, parse error, or decryption failure.
@@ -174,6 +177,7 @@ impl AgeVaultProvider {
     /// )?;
     /// # Ok::<_, zeph_vault::AgeVaultError>(())
     /// ```
+    #[tracing::instrument(name = "vault.age.load", skip_all, err)]
     pub fn load(key_path: &Path, vault_path: &Path) -> Result<Self, AgeVaultError> {
         let key_str =
             Zeroizing::new(std::fs::read_to_string(key_path).map_err(AgeVaultError::KeyRead)?);
@@ -187,10 +191,48 @@ impl AgeVaultProvider {
         })
     }
 
+    /// Async variant of [`load`][Self::load] — offloads blocking I/O to a `spawn_blocking` thread.
+    ///
+    /// Use this when calling from an async context to avoid stalling the tokio executor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgeVaultError`] on key/vault read failure, parse error, decryption failure, or
+    /// if the blocking task panics.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use zeph_vault::AgeVaultProvider;
+    ///
+    /// # async fn example() -> Result<(), zeph_vault::AgeVaultError> {
+    /// let vault = AgeVaultProvider::load_async(
+    ///     Path::new("/etc/zeph/vault-key.txt"),
+    ///     Path::new("/etc/zeph/secrets.age"),
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn load_async(key_path: &Path, vault_path: &Path) -> Result<Self, AgeVaultError> {
+        let key_path = key_path.to_owned();
+        let vault_path = vault_path.to_owned();
+        tokio::task::spawn_blocking(move || Self::load(&key_path, &vault_path))
+            .await
+            .map_err(|e| {
+                AgeVaultError::Io(std::io::Error::other(format!(
+                    "spawn_blocking panicked: {e}"
+                )))
+            })?
+    }
+
     /// Serialize and re-encrypt secrets to vault file using atomic write (temp + rename).
     ///
     /// Re-reads and re-parses the key file on each call. For CLI one-shot use this is
     /// acceptable; if used in a long-lived context consider caching the parsed identity.
+    ///
+    /// This method performs blocking I/O on the calling thread. Use [`save_async`][Self::save_async]
+    /// when calling from an async context to avoid stalling the tokio executor.
     ///
     /// # Errors
     ///
@@ -210,6 +252,7 @@ impl AgeVaultProvider {
     /// vault.save()?;
     /// # Ok::<_, zeph_vault::AgeVaultError>(())
     /// ```
+    #[tracing::instrument(name = "vault.age.save", skip_all, err)]
     pub fn save(&self) -> Result<(), AgeVaultError> {
         let key_str = Zeroizing::new(
             std::fs::read_to_string(&self.key_path).map_err(AgeVaultError::KeyRead)?,
@@ -217,6 +260,49 @@ impl AgeVaultProvider {
         let identity = parse_identity(&key_str)?;
         let ciphertext = encrypt_secrets(&identity, &self.secrets)?;
         atomic_write(&self.vault_path, &ciphertext)
+    }
+
+    /// Async variant of [`save`][Self::save] — offloads blocking I/O to a `spawn_blocking` thread.
+    ///
+    /// Use this when calling from an async context to avoid stalling the tokio executor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgeVaultError`] on encryption or write failure, or if the blocking task panics.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use zeph_vault::AgeVaultProvider;
+    ///
+    /// # async fn example() -> Result<(), zeph_vault::AgeVaultError> {
+    /// let mut vault = AgeVaultProvider::load(
+    ///     Path::new("/etc/zeph/vault-key.txt"),
+    ///     Path::new("/etc/zeph/secrets.age"),
+    /// )?;
+    /// vault.set_secret_mut("MY_TOKEN".into(), "tok_abc123".into());
+    /// vault.save_async().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn save_async(&self) -> Result<(), AgeVaultError> {
+        let key_path = self.key_path.clone();
+        let vault_path = self.vault_path.clone();
+        let secrets = self.secrets.clone();
+        tokio::task::spawn_blocking(move || {
+            let key_str =
+                Zeroizing::new(std::fs::read_to_string(&key_path).map_err(AgeVaultError::KeyRead)?);
+            let identity = parse_identity(&key_str)?;
+            let ciphertext = encrypt_secrets(&identity, &secrets)?;
+            atomic_write(&vault_path, &ciphertext)
+        })
+        .await
+        .map_err(|e| {
+            AgeVaultError::Io(std::io::Error::other(format!(
+                "spawn_blocking panicked: {e}"
+            )))
+        })?
     }
 
     /// Insert or update a secret in the in-memory map.

--- a/crates/zeph-vault/src/arc.rs
+++ b/crates/zeph-vault/src/arc.rs
@@ -9,7 +9,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use zeph_common::secret::VaultError;
 
@@ -17,15 +17,18 @@ use crate::{AgeVaultProvider, VaultProvider};
 
 /// [`VaultProvider`] wrapper around `Arc<RwLock<AgeVaultProvider>>`.
 ///
-/// Allows the age vault `Arc` to be stored as `Box<dyn VaultProvider>` while the
-/// underlying `Arc<RwLock<AgeVaultProvider>>` is separately held for OAuth credential
-/// persistence via `VaultCredentialStore`.
+/// Uses `std::sync::RwLock` so that `list_keys()` — a synchronous trait method — can
+/// acquire the lock without touching the async runtime. Calling `block_in_place` or
+/// `Handle::current().block_on(...)` from a sync trait method panics when the caller is
+/// already inside a `current_thread` runtime; a standard lock has no such restriction.
+///
+/// Write operations (OAuth credential persistence) call `vault.write().unwrap()` inside
+/// `tokio::task::spawn_blocking` to keep blocking I/O off async threads.
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use std::sync::Arc;
-/// use tokio::sync::RwLock;
+/// use std::sync::{Arc, RwLock};
 /// use zeph_vault::{AgeVaultProvider, ArcAgeVaultProvider, VaultProvider};
 /// use std::path::Path;
 ///
@@ -42,28 +45,126 @@ use crate::{AgeVaultProvider, VaultProvider};
 /// # Ok(())
 /// # }
 /// ```
-pub struct ArcAgeVaultProvider(pub Arc<tokio::sync::RwLock<AgeVaultProvider>>);
+pub struct ArcAgeVaultProvider(pub Arc<RwLock<AgeVaultProvider>>);
 
 impl VaultProvider for ArcAgeVaultProvider {
     fn get_secret(
         &self,
         key: &str,
     ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
-        let arc = Arc::clone(&self.0);
-        let key = key.to_owned();
-        Box::pin(async move {
-            let guard = arc.read().await;
-            Ok(guard.get(&key).map(str::to_owned))
-        })
+        let value = self
+            .0
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(key)
+            .map(str::to_owned);
+        Box::pin(async move { Ok(value) })
     }
 
     fn list_keys(&self) -> Vec<String> {
-        // block_in_place is required because list_keys is a sync trait method that may be called
-        // from within a tokio async context (e.g. resolve_secrets). blocking_read() panics there.
-        let arc = Arc::clone(&self.0);
-        let guard = tokio::task::block_in_place(|| arc.blocking_read());
+        let guard = self
+            .0
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut keys: Vec<String> = guard.list_keys().iter().map(|s| (*s).to_owned()).collect();
         keys.sort_unstable();
         keys
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, RwLock};
+
+    use tempfile::tempdir;
+
+    use crate::{AgeVaultProvider, VaultProvider as _};
+
+    use super::ArcAgeVaultProvider;
+
+    fn make_provider_with_keys(keys: &[(&str, &str)]) -> ArcAgeVaultProvider {
+        let dir = tempdir().unwrap();
+        AgeVaultProvider::init_vault(dir.path()).unwrap();
+        let mut age = AgeVaultProvider::new(
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        )
+        .unwrap();
+        for (k, v) in keys {
+            age.set_secret_mut((*k).to_owned(), (*v).to_owned());
+        }
+        // Keep tempdir alive by leaking — tests are short-lived, no I/O after this.
+        std::mem::forget(dir);
+        ArcAgeVaultProvider(Arc::new(RwLock::new(age)))
+    }
+
+    /// list_keys() must not panic when called directly from a `current_thread` runtime.
+    #[tokio::test(flavor = "current_thread")]
+    async fn list_keys_works_on_current_thread_runtime() {
+        let provider = make_provider_with_keys(&[("ALPHA", "a"), ("BETA", "b")]);
+        let keys = provider.list_keys();
+        assert_eq!(keys, vec!["ALPHA".to_owned(), "BETA".to_owned()]);
+    }
+
+    /// list_keys() works correctly on the multi-thread runtime.
+    #[tokio::test]
+    async fn list_keys_works_on_multi_thread_runtime() {
+        let provider = make_provider_with_keys(&[("Z_KEY", "z"), ("A_KEY", "a")]);
+        let keys = provider.list_keys();
+        assert_eq!(keys, vec!["A_KEY".to_owned(), "Z_KEY".to_owned()]);
+    }
+
+    /// list_keys() on empty vault returns empty vec.
+    #[tokio::test(flavor = "current_thread")]
+    async fn list_keys_empty_vault() {
+        let provider = make_provider_with_keys(&[]);
+        let keys = provider.list_keys();
+        assert!(keys.is_empty());
+    }
+
+    /// list_keys() works correctly from spawn_blocking on the multi-thread runtime.
+    #[tokio::test]
+    async fn list_keys_works_via_spawn_blocking_on_multi_thread_runtime() {
+        let provider = Arc::new(make_provider_with_keys(&[("Z_KEY", "z"), ("A_KEY", "a")]));
+        let keys = tokio::task::spawn_blocking(move || provider.list_keys())
+            .await
+            .unwrap();
+        assert_eq!(keys, vec!["A_KEY".to_owned(), "Z_KEY".to_owned()]);
+    }
+
+    /// list_keys() works correctly from spawn_blocking on current_thread runtime.
+    #[tokio::test(flavor = "current_thread")]
+    async fn list_keys_works_via_spawn_blocking_on_current_thread_runtime() {
+        let provider = Arc::new(make_provider_with_keys(&[("ALPHA", "a"), ("BETA", "b")]));
+        let keys = tokio::task::spawn_blocking(move || provider.list_keys())
+            .await
+            .unwrap();
+        assert_eq!(keys, vec!["ALPHA".to_owned(), "BETA".to_owned()]);
+    }
+
+    /// list_keys() on empty vault returns empty vec (spawn_blocking variant).
+    #[tokio::test(flavor = "current_thread")]
+    async fn list_keys_empty_vault_via_spawn_blocking() {
+        let provider = Arc::new(make_provider_with_keys(&[]));
+        let keys = tokio::task::spawn_blocking(move || provider.list_keys())
+            .await
+            .unwrap();
+        assert!(keys.is_empty());
+    }
+
+    /// get_secret() delegates to the inner AgeVaultProvider.
+    #[tokio::test]
+    async fn get_secret_delegates_to_inner() {
+        let provider = make_provider_with_keys(&[("MY_SECRET", "secret_value")]);
+        let result = provider.get_secret("MY_SECRET").await.unwrap();
+        assert_eq!(result.as_deref(), Some("secret_value"));
+    }
+
+    /// get_secret() returns None for missing key.
+    #[tokio::test]
+    async fn get_secret_returns_none_for_missing() {
+        let provider = make_provider_with_keys(&[]);
+        let result = provider.get_secret("NONEXISTENT").await.unwrap();
+        assert!(result.is_none());
     }
 }

--- a/crates/zeph-vault/src/arc.rs
+++ b/crates/zeph-vault/src/arc.rs
@@ -98,7 +98,7 @@ mod tests {
         ArcAgeVaultProvider(Arc::new(RwLock::new(age)))
     }
 
-    /// list_keys() must not panic when called directly from a `current_thread` runtime.
+    /// `list_keys()` must not panic when called directly from a `current_thread` runtime.
     #[tokio::test(flavor = "current_thread")]
     async fn list_keys_works_on_current_thread_runtime() {
         let provider = make_provider_with_keys(&[("ALPHA", "a"), ("BETA", "b")]);
@@ -106,7 +106,7 @@ mod tests {
         assert_eq!(keys, vec!["ALPHA".to_owned(), "BETA".to_owned()]);
     }
 
-    /// list_keys() works correctly on the multi-thread runtime.
+    /// `list_keys()` works correctly on the multi-thread runtime.
     #[tokio::test]
     async fn list_keys_works_on_multi_thread_runtime() {
         let provider = make_provider_with_keys(&[("Z_KEY", "z"), ("A_KEY", "a")]);
@@ -114,7 +114,7 @@ mod tests {
         assert_eq!(keys, vec!["A_KEY".to_owned(), "Z_KEY".to_owned()]);
     }
 
-    /// list_keys() on empty vault returns empty vec.
+    /// `list_keys()` on empty vault returns empty vec.
     #[tokio::test(flavor = "current_thread")]
     async fn list_keys_empty_vault() {
         let provider = make_provider_with_keys(&[]);
@@ -122,7 +122,7 @@ mod tests {
         assert!(keys.is_empty());
     }
 
-    /// list_keys() works correctly from spawn_blocking on the multi-thread runtime.
+    /// `list_keys()` works correctly from `spawn_blocking` on the multi-thread runtime.
     #[tokio::test]
     async fn list_keys_works_via_spawn_blocking_on_multi_thread_runtime() {
         let provider = Arc::new(make_provider_with_keys(&[("Z_KEY", "z"), ("A_KEY", "a")]));
@@ -132,7 +132,7 @@ mod tests {
         assert_eq!(keys, vec!["A_KEY".to_owned(), "Z_KEY".to_owned()]);
     }
 
-    /// list_keys() works correctly from spawn_blocking on current_thread runtime.
+    /// `list_keys()` works correctly from `spawn_blocking` on `current_thread` runtime.
     #[tokio::test(flavor = "current_thread")]
     async fn list_keys_works_via_spawn_blocking_on_current_thread_runtime() {
         let provider = Arc::new(make_provider_with_keys(&[("ALPHA", "a"), ("BETA", "b")]));
@@ -142,7 +142,7 @@ mod tests {
         assert_eq!(keys, vec!["ALPHA".to_owned(), "BETA".to_owned()]);
     }
 
-    /// list_keys() on empty vault returns empty vec (spawn_blocking variant).
+    /// `list_keys()` on empty vault returns empty vec (`spawn_blocking` variant).
     #[tokio::test(flavor = "current_thread")]
     async fn list_keys_empty_vault_via_spawn_blocking() {
         let provider = Arc::new(make_provider_with_keys(&[]));
@@ -152,7 +152,7 @@ mod tests {
         assert!(keys.is_empty());
     }
 
-    /// get_secret() delegates to the inner AgeVaultProvider.
+    /// `get_secret()` delegates to the inner `AgeVaultProvider`.
     #[tokio::test]
     async fn get_secret_delegates_to_inner() {
         let provider = make_provider_with_keys(&[("MY_SECRET", "secret_value")]);
@@ -160,7 +160,7 @@ mod tests {
         assert_eq!(result.as_deref(), Some("secret_value"));
     }
 
-    /// get_secret() returns None for missing key.
+    /// `get_secret()` returns `None` for missing key.
     #[tokio::test]
     async fn get_secret_returns_none_for_missing() {
         let provider = make_provider_with_keys(&[]);

--- a/crates/zeph-vault/src/lib.rs
+++ b/crates/zeph-vault/src/lib.rs
@@ -628,7 +628,7 @@ mod age_tests {
 
     // --- async load/save tests (#5134) ---
 
-    /// load_async offloads I/O and returns the same vault as the sync load.
+    /// `load_async` offloads I/O and returns the same vault as the sync load.
     #[tokio::test]
     async fn age_vault_load_async_roundtrip() {
         let identity = age::x25519::Identity::generate();
@@ -642,7 +642,7 @@ mod age_tests {
         assert_eq!(vault.get("ASYNC_KEY"), Some("async_val"));
     }
 
-    /// save_async persists changes that can be read back via load_async.
+    /// `save_async` persists changes that can be read back via `load_async`.
     #[tokio::test]
     async fn age_vault_save_async_roundtrip() {
         let identity = age::x25519::Identity::generate();
@@ -663,7 +663,7 @@ mod age_tests {
         assert_eq!(reloaded.get("ADDED"), Some("added_val"));
     }
 
-    /// load_async propagates the error when the key file is missing.
+    /// `load_async` propagates the error when the key file is missing.
     #[tokio::test]
     async fn age_vault_load_async_missing_key_errors() {
         use std::path::Path;
@@ -676,7 +676,7 @@ mod age_tests {
         assert!(matches!(err, AgeVaultError::KeyRead(_)));
     }
 
-    /// save_async leaves no .tmp file after a successful write.
+    /// `save_async` leaves no `.tmp` file after a successful write.
     #[tokio::test]
     async fn age_vault_save_async_leaves_no_tmp() {
         let identity = age::x25519::Identity::generate();

--- a/crates/zeph-vault/src/lib.rs
+++ b/crates/zeph-vault/src/lib.rs
@@ -626,6 +626,76 @@ mod age_tests {
         assert_eq!(keys, vec!["alpha", "bar", "zoo"]);
     }
 
+    // --- async load/save tests (#5134) ---
+
+    /// load_async offloads I/O and returns the same vault as the sync load.
+    #[tokio::test]
+    async fn age_vault_load_async_roundtrip() {
+        let identity = age::x25519::Identity::generate();
+        let json = serde_json::json!({"ASYNC_KEY": "async_val"});
+        let encrypted = encrypt_json(&identity, &json);
+        let (_dir, key_path, vault_path) = write_temp_files(&identity, &encrypted);
+
+        let vault = AgeVaultProvider::load_async(&key_path, &vault_path)
+            .await
+            .unwrap();
+        assert_eq!(vault.get("ASYNC_KEY"), Some("async_val"));
+    }
+
+    /// save_async persists changes that can be read back via load_async.
+    #[tokio::test]
+    async fn age_vault_save_async_roundtrip() {
+        let identity = age::x25519::Identity::generate();
+        let json = serde_json::json!({"ORIG": "original"});
+        let encrypted = encrypt_json(&identity, &json);
+        let (_dir, key_path, vault_path) = write_temp_files(&identity, &encrypted);
+
+        let mut vault = AgeVaultProvider::load_async(&key_path, &vault_path)
+            .await
+            .unwrap();
+        vault.set_secret_mut("ADDED".to_owned(), "added_val".to_owned());
+        vault.save_async().await.unwrap();
+
+        let reloaded = AgeVaultProvider::load_async(&key_path, &vault_path)
+            .await
+            .unwrap();
+        assert_eq!(reloaded.get("ORIG"), Some("original"));
+        assert_eq!(reloaded.get("ADDED"), Some("added_val"));
+    }
+
+    /// load_async propagates the error when the key file is missing.
+    #[tokio::test]
+    async fn age_vault_load_async_missing_key_errors() {
+        use std::path::Path;
+        let err = AgeVaultProvider::load_async(
+            Path::new("/nonexistent/key.txt"),
+            Path::new("/nonexistent/vault.age"),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AgeVaultError::KeyRead(_)));
+    }
+
+    /// save_async leaves no .tmp file after a successful write.
+    #[tokio::test]
+    async fn age_vault_save_async_leaves_no_tmp() {
+        let identity = age::x25519::Identity::generate();
+        let json = serde_json::json!({"K": "v"});
+        let encrypted = encrypt_json(&identity, &json);
+        let (_dir, key_path, vault_path) = write_temp_files(&identity, &encrypted);
+
+        let vault = AgeVaultProvider::load_async(&key_path, &vault_path)
+            .await
+            .unwrap();
+        vault.save_async().await.unwrap();
+
+        let tmp_path = vault_path.with_added_extension("tmp");
+        assert!(
+            !tmp_path.exists(),
+            ".age.tmp must not exist after save_async()"
+        );
+    }
+
     #[test]
     fn age_vault_into_iter_consumes_all_entries() {
         // Regression: drain() was replaced with into_iter(). Verify all entries

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -394,7 +394,7 @@ pub(crate) async fn build_tool_setup(
     with_tool_events: bool,
     bare: bool,
     runtime_ctx: RuntimeContext,
-    age_vault: Option<&Arc<tokio::sync::RwLock<zeph_core::vault::AgeVaultProvider>>>,
+    age_vault: Option<&Arc<std::sync::RwLock<zeph_core::vault::AgeVaultProvider>>>,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
     pool: Option<&zeph_db::DbPool>,
     provider: &zeph_llm::any::AnyProvider,

--- a/src/bootstrap/mcp.rs
+++ b/src/bootstrap/mcp.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use tokio::sync::RwLock;
+use std::sync::RwLock;
 use zeph_db::DbPool;
 use zeph_llm::any::AnyProvider;
 use zeph_memory::QdrantOps;
@@ -178,7 +178,9 @@ fn resolve_vault_ref(value: &str, vault: Option<&Arc<RwLock<AgeVaultProvider>>>)
         return value.to_owned();
     };
 
-    let guard = tokio::task::block_in_place(|| vault_arc.blocking_read());
+    let guard = vault_arc
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let mut result = value.to_owned();
     let mut search_from = 0;
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -25,7 +25,9 @@ pub use skills::{
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use tokio::sync::{RwLock, watch};
+use std::sync::RwLock;
+
+use tokio::sync::watch;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider;
 use zeph_memory::GraphStore;
@@ -177,7 +179,8 @@ impl AppBuilder {
                 let path = vault_args.vault_path.ok_or_else(|| {
                     BootstrapError::Provider("--vault-path required for age backend".into())
                 })?;
-                let provider = AgeVaultProvider::new(Path::new(&key), Path::new(&path))
+                let provider = AgeVaultProvider::load_async(Path::new(&key), Path::new(&path))
+                    .await
                     .map_err(BootstrapError::VaultInit)?;
                 let arc = Arc::new(RwLock::new(provider));
                 let boxed: Box<dyn VaultProvider> =

--- a/src/bootstrap/oauth.rs
+++ b/src/bootstrap/oauth.rs
@@ -3,13 +3,11 @@
 
 //! OAuth credential store backed by Zeph's age vault.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use rmcp::transport::auth::{AuthError, CredentialStore, StoredCredentials};
-use tokio::sync::RwLock;
 
 use zeph_core::vault::AgeVaultProvider;
-use zeph_core::vault::VaultProvider as _;
 
 /// `CredentialStore` backed by Zeph's age vault.
 ///
@@ -46,11 +44,12 @@ impl VaultCredentialStore {
 #[async_trait::async_trait]
 impl CredentialStore for VaultCredentialStore {
     async fn load(&self) -> Result<Option<StoredCredentials>, AuthError> {
-        let guard = self.vault.read().await;
-        let value = guard
-            .get_secret(&self.vault_key)
-            .await
-            .map_err(|e| AuthError::InternalError(format!("vault read: {e}")))?;
+        let value = self
+            .vault
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&self.vault_key)
+            .map(str::to_owned);
         match value {
             None => Ok(None),
             Some(json) => {
@@ -67,7 +66,9 @@ impl CredentialStore for VaultCredentialStore {
         let vault = Arc::clone(&self.vault);
         let key = self.vault_key.clone();
         tokio::task::spawn_blocking(move || {
-            let mut guard = vault.blocking_write();
+            let mut guard = vault
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             guard.set_secret_mut(key, json);
             guard
                 .save()
@@ -81,7 +82,9 @@ impl CredentialStore for VaultCredentialStore {
         let vault = Arc::clone(&self.vault);
         let key = self.vault_key.clone();
         tokio::task::spawn_blocking(move || {
-            let mut guard = vault.blocking_write();
+            let mut guard = vault
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             guard.remove_secret_mut(&key);
             guard
                 .save()

--- a/src/commands/cocoon.rs
+++ b/src/commands/cocoon.rs
@@ -263,8 +263,7 @@ async fn check_vault_key(
             };
             match AgeVaultProvider::new(Path::new(key), Path::new(path)) {
                 Ok(p) => {
-                    use std::sync::Arc;
-                    use tokio::sync::RwLock;
+                    use std::sync::{Arc, RwLock};
                     Box::new(ArcAgeVaultProvider(Arc::new(RwLock::new(p))))
                 }
                 Err(e) => {

--- a/src/commands/gonka.rs
+++ b/src/commands/gonka.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use tokio::sync::RwLock;
+use std::sync::RwLock;
 use tokio::task::JoinSet;
 use tracing::Instrument as _;
 use zeph_config::ProviderKind;


### PR DESCRIPTION
## Summary

- **#5134**: `AgeVaultProvider::load`/`save` called blocking file I/O and age crypto on async tokio threads. Added `load_async`/`save_async` wrappers using `tokio::task::spawn_blocking` with proper `JoinError` propagation. `bootstrap/mod.rs` updated to async variants; `init/durable.rs` kept sync (sync call chain — no change needed).
- **#5135**: `ArcAgeVaultProvider::list_keys` used `tokio::task::block_in_place` which panics on `current_thread` runtime. Replaced `tokio::sync::RwLock` with `std::sync::RwLock` throughout `ArcAgeVaultProvider` and all consumers (`bootstrap`, `agent_setup`, `commands/gonka`, `commands/cocoon`). Makes `list_keys` purely synchronous with no runtime interaction.
- **#5137**: `AgeVaultProvider::load` and `save` had no tracing spans on the startup hot path. Added `#[tracing::instrument(name = "vault.age.load/save", skip_all, err)]` — `skip_all` prevents key material from leaking into traces.

## Test plan

- [x] `cargo nextest run -p zeph-vault` — 59/59 pass (12 new tests covering `current_thread`/`multi_thread`/`spawn_blocking` variants for `list_keys`)
- [x] `cargo nextest run --workspace --lib --bins` — 10912/10912 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean
- [x] `cargo +nightly fmt --check` — clean

Closes #5134, #5135, #5137