### PR TITLE
fix(acp): eliminate blocking I/O on async threads in permission and session handlers

### DIFF
--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -1226,7 +1226,8 @@ impl ZephAcpAgentState {
         args: acp::schema::NewSessionRequest,
         cx: &acp::ConnectionTo<acp::Client>,
     ) -> acp::Result<acp::schema::NewSessionResponse> {
-        self.validate_additional_directories(&args.additional_directories)?;
+        self.validate_additional_directories(&args.additional_directories)
+            .await?;
         self.evict_oldest_idle_session_if_full()?;
 
         let session_id = acp::schema::SessionId::new(uuid::Uuid::new_v4().to_string());
@@ -1488,7 +1489,8 @@ impl ZephAcpAgentState {
         args: acp::schema::LoadSessionRequest,
         cx: &acp::ConnectionTo<acp::Client>,
     ) -> acp::Result<acp::schema::LoadSessionResponse> {
-        self.validate_additional_directories(&args.additional_directories)?;
+        self.validate_additional_directories(&args.additional_directories)
+            .await?;
         if self.sessions.lock().contains_key(&args.session_id) {
             return Ok(acp::schema::LoadSessionResponse::new());
         }
@@ -1635,7 +1637,8 @@ impl ZephAcpAgentState {
         args: acp::schema::ForkSessionRequest,
         cx: &acp::ConnectionTo<acp::Client>,
     ) -> acp::Result<acp::schema::ForkSessionResponse> {
-        self.validate_additional_directories(&args.additional_directories)?;
+        self.validate_additional_directories(&args.additional_directories)
+            .await?;
         let in_memory = self.sessions.lock().contains_key(&args.session_id);
 
         if !in_memory {
@@ -1743,7 +1746,8 @@ impl ZephAcpAgentState {
         args: acp::schema::ResumeSessionRequest,
         cx: &acp::ConnectionTo<acp::Client>,
     ) -> acp::Result<acp::schema::ResumeSessionResponse> {
-        self.validate_additional_directories(&args.additional_directories)?;
+        self.validate_additional_directories(&args.additional_directories)
+            .await?;
         if self.sessions.lock().contains_key(&args.session_id) {
             return Ok(acp::schema::ResumeSessionResponse::new());
         }
@@ -1938,7 +1942,7 @@ impl ZephAcpAgentState {
     /// Each requested path is canonicalized and checked with `Path::starts_with` (component-aware)
     /// against every entry in `self.additional_directories_allow`. Returns an `invalid_params`
     /// error if any path is not covered by the allowlist.
-    fn validate_additional_directories(
+    async fn validate_additional_directories(
         &self,
         requested: &[std::path::PathBuf],
     ) -> acp::Result<Vec<std::path::PathBuf>> {
@@ -1951,7 +1955,7 @@ impl ZephAcpAgentState {
         }
         let mut out = Vec::with_capacity(requested.len());
         for p in requested {
-            let canon = std::fs::canonicalize(p).map_err(|e| {
+            let canon = tokio::fs::canonicalize(p).await.map_err(|e| {
                 acp::Error::invalid_params()
                     .data(format!("cannot canonicalize {}: {e}", p.display()))
             })?;

--- a/crates/zeph-acp/src/permission.rs
+++ b/crates/zeph-acp/src/permission.rs
@@ -420,17 +420,21 @@ async fn run_permission_handler(
                         _ => None,
                     };
                     if let Some(d) = decision {
-                        let mut guard = cache.write();
-                        // Insert session-scoped key for fast in-process lookup.
-                        guard.insert(session_cache_key, d);
-                        // For patterned tools, cache at binary granularity.
-                        if let Some(ref bin) = cmd_binary {
-                            guard.insert(format!("{tool_name}\x01{bin}"), d);
-                        } else {
-                            // Simple tool — cache at tool-name level.
-                            guard.insert(tool_name.clone(), d);
-                        }
-                        save_persisted(&permission_file, &rebuild_persisted(&guard));
+                        let persisted = {
+                            let mut guard = cache.write();
+                            // Insert session-scoped key for fast in-process lookup.
+                            guard.insert(session_cache_key, d);
+                            // For patterned tools, cache at binary granularity.
+                            if let Some(ref bin) = cmd_binary {
+                                guard.insert(format!("{tool_name}\x01{bin}"), d);
+                            } else {
+                                // Simple tool — cache at tool-name level.
+                                guard.insert(tool_name.clone(), d);
+                            }
+                            rebuild_persisted(&guard)
+                        };
+                        let file = permission_file.clone();
+                        tokio::task::spawn_blocking(move || save_persisted(&file, &persisted));
                     }
 
                     Ok(allowed)


### PR DESCRIPTION
## Summary

- **#5128** (`permission.rs:433`): `save_persisted` was called directly on the Tokio executor thread inside `run_permission_handler`, blocking it with `std::fs::create_dir_all` + `atomic_write_private`. The parking_lot write guard is now scoped to a dedicated block so it drops before the `spawn_blocking` closure, which captures owned `PathBuf` and `PersistedPermissions` values. The in-memory cache is updated under the lock before the closure is spawned, so callers see the correct permission decision immediately.
- **#5154** (`agent/mod.rs:1941`): `validate_additional_directories` was a sync `fn` calling `std::fs::canonicalize` (blocking syscall) from four async handlers. Converted to `async fn` using `tokio::fs::canonicalize`, consistent with the rest of the file. All four call sites (`do_new_session`, `do_load_session`, `do_fork_session`, `do_resume_session`) updated with `.await`.

## Test plan

- [x] `cargo check --features acp-http,sqlite -p zeph-acp` — clean, zero errors/warnings
- [x] `cargo nextest run --features acp-http,sqlite -p zeph-acp` — 149 tests passed
- [x] `cargo nextest run --workspace --lib --bins` — 10902 tests passed, no regressions
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean

Closes #5128
Closes #5154