### PR TITLE
fix(db): wrap blocking I/O in spawn_blocking in connect_sqlite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `#[tracing::instrument]` — the old `Span::enter()` guard is not `Send` and silently loses trace
   context on task suspension in multi-threaded tokio; the attribute macro generates an async-safe
   span that correctly propagates across suspension points (closes #5138)
+- `fix(db)`: `connect_sqlite` no longer performs blocking filesystem I/O on the async tokio thread — `std::fs::create_dir_all` replaced with `tokio::fs::create_dir_all`; `open_private_truncate` and the WAL/SHM chmod loop wrapped in `tokio::task::spawn_blocking` (closes #5136, #5158)
 - `fix(tui)`: uniform `ToolDensity` matrix across all `ToolKind` variants — `Compact`/`Inline`/`Normal` modes now apply consistently to `Edit`, `Web`, `Mcp`, and `Run`/`Explore` tools; previously only `Run` and `Explore` honored grouping (closes #5102)
 - `fix(tui)`: markdown table column widths now use `unicode_width::UnicodeWidthStr::width()` instead of `chars().count()` — CJK characters and emoji no longer misalign table borders and cell padding (closes #5100)
 - `fix(memory)`: `CausalDistanceComputer::compute` no longer holds a `tokio::sync::Mutex` guard across `.await` — the external lock is replaced with an internal `std::sync::Mutex` on the cache field; `compute` now takes `&self` and BFS I/O runs lock-free, eliminating serialization of concurrent recall operations and the potential for re-entrant deadlock (closes #5107)

--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -57,18 +57,24 @@ impl DbConfig {
         let url = if path == ":memory:" {
             "sqlite::memory:".to_string()
         } else {
-            let db_path = std::path::Path::new(path);
+            let db_path = std::path::PathBuf::from(path);
+
             if let Some(parent) = db_path.parent()
                 && !parent.as_os_str().is_empty()
             {
-                std::fs::create_dir_all(parent)?;
+                tokio::fs::create_dir_all(parent).await?;
             }
             // Pre-create with 0o600 so sqlx inherits the mode rather than using the
             // process umask. sqlx reopens the existing file via SQLITE_OPEN_CREATE.
             // WAL/SHM sidecars are created by sqlx after the pool opens and will still
             // inherit the process umask (sqlx limitation — best-effort chmod below).
-            if !db_path.exists() {
-                drop(zeph_common::fs_secure::open_private_truncate(db_path)?);
+            if tokio::fs::metadata(&db_path).await.is_err() {
+                let p = db_path.clone();
+                tokio::task::spawn_blocking(move || {
+                    zeph_common::fs_secure::open_private_truncate(&p)
+                })
+                .await
+                .map_err(|e| std::io::Error::other(format!("spawn_blocking panicked: {e}")))??;
             }
             format!("sqlite:{path}?mode=rwc")
         };
@@ -107,15 +113,20 @@ impl DbConfig {
         // there is no way to close it without upstream sqlx support.
         #[cfg(unix)]
         if path != ":memory:" {
-            use std::os::unix::fs::PermissionsExt as _;
-            for suffix in &["", "-wal", "-shm", "-journal"] {
-                let p = format!("{path}{suffix}");
-                if let Ok(metadata) = std::fs::metadata(&p) {
-                    let mut perms = metadata.permissions();
-                    perms.set_mode(0o600);
-                    let _ = std::fs::set_permissions(&p, perms);
+            let path_owned = path.to_owned();
+            tokio::task::spawn_blocking(move || {
+                use std::os::unix::fs::PermissionsExt as _;
+                for suffix in &["", "-wal", "-shm", "-journal"] {
+                    let p = format!("{path_owned}{suffix}");
+                    if let Ok(metadata) = std::fs::metadata(&p) {
+                        let mut perms = metadata.permissions();
+                        perms.set_mode(0o600);
+                        let _ = std::fs::set_permissions(&p, perms);
+                    }
                 }
-            }
+            })
+            .await
+            .map_err(|e| std::io::Error::other(format!("spawn_blocking panicked: {e}")))?;
         }
 
         // Run a passive WAL checkpoint after migrations to avoid unbounded WAL growth.


### PR DESCRIPTION
## Summary

- Replace `std::fs::create_dir_all` with `tokio::fs::create_dir_all` in `connect_sqlite`
- Wrap `open_private_truncate` call in `tokio::task::spawn_blocking`
- Wrap WAL/SHM `#[cfg(unix)]` chmod loop in `tokio::task::spawn_blocking`

Consistent with the established pattern from PRs #5125, #5153, #5155.

Closes #5136, #5158

## Test plan

- [x] 22/22 existing tests pass (`cargo nextest run -p zeph-db --features sqlite`)
- [x] `cargo clippy -p zeph-db --all-targets --features sqlite -- -D warnings` — 0 warnings
- [x] `cargo +nightly fmt --check` — clean