### PR TITLE
fix(llm,orchestration,mcp): eliminate blocking I/O on async threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(llm)`: `ModelCache::save()` no longer blocks the tokio async thread on fsync+rename; wrapped
+  in `spawn_blocking` across all four LLM backends (claude, openai, ollama, gemini) (closes #5129)
+- `fix(orchestration)`: `TopologyAdvisor::save()` no longer blocks the tokio thread during agent
+  shutdown; `parking_lot::Mutex` is released before the `spawn_blocking` boundary (closes #5130)
+- `fix(mcp)`: `validate_roots()` now uses `tokio::fs::canonicalize` instead of blocking
+  `std::fs::canonicalize`; `handler_cfg_for`, `spawn_non_oauth_connections`, and
+  `spawn_oauth_connections` made `async` accordingly (closes #5132)
+
 - `fix(durable)`: `ReplayCursor::lookup` no longer holds a `tokio::sync::Mutex` guard across async
   SQLite I/O — `ensure_loaded_through` now snapshots decision fields, drops the lock, performs I/O,
   and re-acquires the lock only for the merge; concurrent callers are handled by an idempotency guard

--- a/crates/zeph-core/src/agent/shutdown.rs
+++ b/crates/zeph-core/src/agent/shutdown.rs
@@ -293,7 +293,7 @@ impl<C: Channel> Agent<C> {
 
         // Persist AdaptOrch Beta-arm table alongside Thompson state.
         if let Some(ref advisor) = self.services.orchestration.topology_advisor
-            && let Err(e) = advisor.save()
+            && let Err(e) = advisor.save().await
         {
             tracing::warn!(error = %e, "adaptorch: failed to persist state");
         }

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -528,7 +528,7 @@ impl ClaudeProvider {
         }
 
         let cache = crate::model_cache::ModelCache::for_slug("claude");
-        cache.save(&models)?;
+        cache.save(&models).await?;
         Ok(models)
     }
 

--- a/crates/zeph-llm/src/gemini/mod.rs
+++ b/crates/zeph-llm/src/gemini/mod.rs
@@ -420,7 +420,7 @@ impl GeminiProvider {
             .collect();
 
         let cache = crate::model_cache::ModelCache::for_slug("gemini");
-        cache.save(&models)?;
+        cache.save(&models).await?;
         Ok(models)
     }
 }

--- a/crates/zeph-llm/src/model_cache.rs
+++ b/crates/zeph-llm/src/model_cache.rs
@@ -94,24 +94,33 @@ impl ModelCache {
 
     /// Atomically write models to disk. Writes `.tmp` then renames.
     ///
+    /// The blocking I/O is offloaded to a `spawn_blocking` thread so this
+    /// function is safe to call from an async context.
+    ///
     /// # Errors
     ///
     /// Returns an error if the directory cannot be created or the file cannot be written.
-    pub fn save(&self, models: &[RemoteModelInfo]) -> Result<(), LlmError> {
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent).map_err(LlmError::Io)?;
-        }
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or(Duration::ZERO)
-            .as_secs();
-        let envelope = CacheEnvelope {
-            fetched_at: now,
-            models: models.to_vec(),
-        };
-        let json = serde_json::to_vec_pretty(&envelope).map_err(LlmError::Json)?;
-        zeph_common::fs_secure::atomic_write_private(&self.path, &json).map_err(LlmError::Io)?;
-        Ok(())
+    pub async fn save(&self, models: &[RemoteModelInfo]) -> Result<(), LlmError> {
+        let path = self.path.clone();
+        let models = models.to_vec();
+        tokio::task::spawn_blocking(move || {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).map_err(LlmError::Io)?;
+            }
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO)
+                .as_secs();
+            let envelope = CacheEnvelope {
+                fetched_at: now,
+                models,
+            };
+            let json = serde_json::to_vec_pretty(&envelope).map_err(LlmError::Json)?;
+            zeph_common::fs_secure::atomic_write_private(&path, &json).map_err(LlmError::Io)?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| LlmError::Io(std::io::Error::other(e)))?
     }
 
     /// Remove the cache file (for `/model refresh`).
@@ -143,8 +152,8 @@ mod tests {
         assert!(c.is_stale());
     }
 
-    #[test]
-    fn fresh_cache_is_not_stale() {
+    #[tokio::test]
+    async fn fresh_cache_is_not_stale() {
         let c = tmp_cache();
         let models = vec![RemoteModelInfo {
             id: "m1".into(),
@@ -152,12 +161,12 @@ mod tests {
             context_window: Some(4096),
             created_at: None,
         }];
-        c.save(&models).unwrap();
+        c.save(&models).await.unwrap();
         assert!(!c.is_stale());
     }
 
-    #[test]
-    fn json_round_trip() {
+    #[tokio::test]
+    async fn json_round_trip() {
         let c = tmp_cache();
         let models = vec![
             RemoteModelInfo {
@@ -173,7 +182,7 @@ mod tests {
                 created_at: None,
             },
         ];
-        c.save(&models).unwrap();
+        c.save(&models).await.unwrap();
         let loaded = c.load().unwrap().unwrap();
         assert_eq!(loaded, models);
     }
@@ -196,11 +205,11 @@ mod tests {
         assert!(c.is_stale());
     }
 
-    #[test]
-    fn invalidate_removes_file() {
+    #[tokio::test]
+    async fn invalidate_removes_file() {
         let c = tmp_cache();
         let models = vec![];
-        c.save(&models).unwrap();
+        c.save(&models).await.unwrap();
         assert!(c.path.exists());
         c.invalidate();
         assert!(!c.path.exists());

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -230,7 +230,7 @@ impl OllamaProvider {
             .collect();
 
         let cache = crate::model_cache::ModelCache::for_slug("ollama");
-        cache.save(&models)?;
+        cache.save(&models).await?;
         Ok(models)
     }
 

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -489,7 +489,7 @@ impl OpenAiProvider {
 
         let slug = self.cache_slug();
         let cache = crate::model_cache::ModelCache::for_slug(&slug);
-        cache.save(&models)?;
+        cache.save(&models).await?;
         Ok(models)
     }
 

--- a/crates/zeph-mcp/src/manager/connect.rs
+++ b/crates/zeph-mcp/src/manager/connect.rs
@@ -67,8 +67,11 @@ impl McpManager {
         std::time::Duration::from_secs(secs)
     }
 
-    pub(super) fn handler_cfg_for(&self, entry: &ServerEntry) -> crate::client::HandlerConfig {
-        let roots = Arc::new(validate_roots(&entry.roots, &entry.id));
+    pub(super) async fn handler_cfg_for(
+        &self,
+        entry: &ServerEntry,
+    ) -> crate::client::HandlerConfig {
+        let roots = Arc::new(validate_roots(&entry.roots, &entry.id).await);
         crate::client::HandlerConfig {
             roots,
             max_description_bytes: self.max_description_bytes,
@@ -182,7 +185,7 @@ impl McpManager {
         tracing::instrument(name = "mcp.manager.connect_all", skip_all, fields(connected = tracing::field::Empty, failed = tracing::field::Empty))
     )]
     pub async fn connect_all(&self) -> (Vec<McpTool>, Vec<ServerConnectOutcome>) {
-        let join_set = self.spawn_non_oauth_connections(&self.last_refresh);
+        let join_set = self.spawn_non_oauth_connections(&self.last_refresh).await;
         let raw = drain_connect_results(join_set).await;
         let limits = IngestLimits {
             description_bytes: self.max_description_bytes,
@@ -194,7 +197,7 @@ impl McpManager {
         (all_tools, outcomes)
     }
 
-    fn spawn_non_oauth_connections(
+    async fn spawn_non_oauth_connections(
         &self,
         last_refresh: &Arc<DashMap<String, Instant>>,
     ) -> JoinSet<(String, Result<McpClient, McpError>)> {
@@ -218,7 +221,7 @@ impl McpManager {
             let Some(tx) = self.clone_refresh_tx() else {
                 continue;
             };
-            let handler_cfg = self.handler_cfg_for(&config);
+            let handler_cfg = self.handler_cfg_for(&config).await;
             // MF-2: register the lock BEFORE spawning the connection task so there is no
             // window between connect handshake completion and lock insertion.
             // The lock entry is removed inside handle_connect_result if connection fails.
@@ -334,7 +337,7 @@ impl McpManager {
             description_bytes: self.max_description_bytes,
             instructions_bytes: self.max_instructions_bytes,
         };
-        let join_set = self.spawn_oauth_connections(&self.last_refresh);
+        let join_set = self.spawn_oauth_connections(&self.last_refresh).await;
         let raw = drain_oauth_results(join_set).await;
         let outputs = self.process_oauth_results(raw, limits).await;
         let all_tools: Vec<McpTool> = outputs
@@ -345,7 +348,7 @@ impl McpManager {
         self.log_tool_collisions(&all_tools).await;
     }
 
-    fn spawn_oauth_connections(
+    async fn spawn_oauth_connections(
         &self,
         last_refresh: &Arc<DashMap<String, Instant>>,
     ) -> JoinSet<(String, Result<McpClient, String>)> {
@@ -392,7 +395,7 @@ impl McpManager {
             let server_id = config.id.clone();
             let trusted = matches!(config.trust_level, McpTrustLevel::Trusted);
             let timeout = config.timeout;
-            let handler_cfg = self.handler_cfg_for(&config);
+            let handler_cfg = self.handler_cfg_for(&config).await;
             let status_tx = self.status_tx.clone();
             let last_refresh = Arc::clone(last_refresh);
 
@@ -780,37 +783,37 @@ async fn drain_oauth_results(
 /// - Warns if a URI does not use `file://` scheme.
 /// - Warns if the path does not exist on the filesystem.
 /// - Filters out roots with non-`file://` URIs (MCP spec requires filesystem roots).
-pub(super) fn validate_roots(
+pub(super) async fn validate_roots(
     roots: &[rmcp::model::Root],
     server_id: &str,
 ) -> Vec<rmcp::model::Root> {
-    roots
-        .iter()
-        .filter_map(|r| {
-            if !r.uri.starts_with("file://") {
-                tracing::warn!(
-                    server_id,
-                    uri = r.uri,
-                    "MCP root URI does not use file:// scheme — skipping"
-                );
-                return None;
+    let server_id = server_id.to_owned();
+    let mut result = Vec::with_capacity(roots.len());
+    for r in roots {
+        if !r.uri.starts_with("file://") {
+            tracing::warn!(
+                server_id,
+                uri = r.uri,
+                "MCP root URI does not use file:// scheme — skipping"
+            );
+            continue;
+        }
+        let raw_path = r.uri.trim_start_matches("file://");
+        if let Ok(canonical) = tokio::fs::canonicalize(raw_path).await {
+            let canonical_uri = format!("file://{}", canonical.display());
+            let mut root = rmcp::model::Root::new(canonical_uri);
+            if let Some(ref name) = r.name {
+                root = root.with_name(name.clone());
             }
-            let raw_path = r.uri.trim_start_matches("file://");
-            if let Ok(canonical) = std::fs::canonicalize(raw_path) {
-                let canonical_uri = format!("file://{}", canonical.display());
-                let mut root = rmcp::model::Root::new(canonical_uri);
-                if let Some(ref name) = r.name {
-                    root = root.with_name(name.clone());
-                }
-                Some(root)
-            } else {
-                tracing::warn!(
-                    server_id,
-                    uri = r.uri,
-                    "MCP root path does not exist on filesystem"
-                );
-                Some(r.clone())
-            }
-        })
-        .collect()
+            result.push(root);
+        } else {
+            tracing::warn!(
+                server_id,
+                uri = r.uri,
+                "MCP root path does not exist on filesystem"
+            );
+            result.push(r.clone());
+        }
+    }
+    result
 }

--- a/crates/zeph-mcp/src/manager/server.rs
+++ b/crates/zeph-mcp/src/manager/server.rs
@@ -161,7 +161,7 @@ impl McpManager {
         if self.lock_tool_list {
             self.tool_list_locked.insert(entry.id.clone(), ());
         }
-        let handler_cfg = self.handler_cfg_for(entry);
+        let handler_cfg = self.handler_cfg_for(entry).await;
         let client = match connect_entry(
             entry,
             &self.allowed_commands,

--- a/crates/zeph-mcp/src/manager/tests.rs
+++ b/crates/zeph-mcp/src/manager/tests.rs
@@ -854,20 +854,20 @@ fn ingest_tools_data_flow_blocks_high_sensitivity_on_untrusted() {
 
 // --- validate_roots ---
 
-#[test]
-fn validate_roots_empty_returns_empty() {
-    let result = validate_roots(&[], "srv");
+#[tokio::test]
+async fn validate_roots_empty_returns_empty() {
+    let result = validate_roots(&[], "srv").await;
     assert!(result.is_empty());
 }
 
-#[test]
-fn validate_roots_file_uri_is_kept() {
+#[tokio::test]
+async fn validate_roots_file_uri_is_kept() {
     use rmcp::model::Root;
     // Use temp_dir which exists on all platforms (Unix, macOS, Windows).
     let tmp = std::env::temp_dir();
     let uri = format!("file://{}", tmp.display());
     let root = Root::new(uri);
-    let result = validate_roots(&[root], "srv");
+    let result = validate_roots(&[root], "srv").await;
     assert_eq!(result.len(), 1);
     // URI is canonicalized — on macOS /tmp resolves to /private/tmp.
     assert!(result[0].uri.starts_with("file://"));
@@ -875,24 +875,24 @@ fn validate_roots_file_uri_is_kept() {
     assert!(std::path::Path::new(canonical_path).exists());
 }
 
-#[test]
-fn validate_roots_non_file_uri_is_filtered_out() {
+#[tokio::test]
+async fn validate_roots_non_file_uri_is_filtered_out() {
     use rmcp::model::Root;
     let root = Root::new("https://example.com/workspace");
-    let result = validate_roots(&[root], "srv");
+    let result = validate_roots(&[root], "srv").await;
     assert!(result.is_empty(), "non-file:// URI must be filtered");
 }
 
-#[test]
-fn validate_roots_http_uri_is_filtered_out() {
+#[tokio::test]
+async fn validate_roots_http_uri_is_filtered_out() {
     use rmcp::model::Root;
     let root = Root::new("http://localhost:8080/project");
-    let result = validate_roots(&[root], "srv");
+    let result = validate_roots(&[root], "srv").await;
     assert!(result.is_empty(), "http:// URI must be filtered");
 }
 
-#[test]
-fn validate_roots_mixed_uris_keeps_only_file() {
+#[tokio::test]
+async fn validate_roots_mixed_uris_keeps_only_file() {
     use rmcp::model::Root;
     let tmp = std::env::temp_dir();
     let roots = vec![
@@ -900,18 +900,18 @@ fn validate_roots_mixed_uris_keeps_only_file() {
         Root::new("https://evil.example.com"),
         Root::new("file:///nonexistent-path-xyz"),
     ];
-    let result = validate_roots(&roots, "srv");
+    let result = validate_roots(&roots, "srv").await;
     // Only file:// URIs are kept (path existence only emits a warn, not a filter)
     assert_eq!(result.len(), 2);
     assert!(result.iter().all(|r| r.uri.starts_with("file://")));
 }
 
-#[test]
-fn validate_roots_missing_path_is_kept_with_warning() {
+#[tokio::test]
+async fn validate_roots_missing_path_is_kept_with_warning() {
     use rmcp::model::Root;
     // Non-existent path: warn but still pass through (server decides)
     let root = Root::new("file:///nonexistent-zeph-test-path-xyz-abc");
-    let result = validate_roots(&[root], "srv");
+    let result = validate_roots(&[root], "srv").await;
     assert_eq!(
         result.len(),
         1,
@@ -919,20 +919,20 @@ fn validate_roots_missing_path_is_kept_with_warning() {
     );
 }
 
-#[test]
-fn validate_roots_path_traversal_in_uri_is_filtered_as_non_file() {
+#[tokio::test]
+async fn validate_roots_path_traversal_in_uri_is_filtered_as_non_file() {
     use rmcp::model::Root;
     // A URI with path traversal but not file:// scheme is filtered
     let root = Root::new("ftp:///../../etc/passwd");
-    let result = validate_roots(&[root], "srv");
+    let result = validate_roots(&[root], "srv").await;
     assert!(
         result.is_empty(),
         "non-file:// URI must be filtered regardless of path content"
     );
 }
 
-#[test]
-fn validate_roots_file_uri_traversal_is_canonicalized() {
+#[tokio::test]
+async fn validate_roots_file_uri_traversal_is_canonicalized() {
     use rmcp::model::Root;
     // Build a traversal path using temp_dir, which exists on all platforms.
     let tmp = std::env::temp_dir();
@@ -942,7 +942,7 @@ fn validate_roots_file_uri_traversal_is_canonicalized() {
     let traversal = parent.join(dir_name).join("..").join(dir_name);
     let uri = format!("file://{}", traversal.display());
     let root = Root::new(uri);
-    let result = validate_roots(&[root], "srv");
+    let result = validate_roots(&[root], "srv").await;
     assert_eq!(result.len(), 1);
     // After canonicalize, the traversal component must be gone.
     assert!(
@@ -1044,12 +1044,12 @@ fn elicitation_channel_is_bounded_by_capacity() {
     );
 }
 
-#[test]
-fn validate_roots_preserves_name() {
+#[tokio::test]
+async fn validate_roots_preserves_name() {
     use rmcp::model::Root;
     let tmp = std::env::temp_dir();
     let root = Root::new(format!("file://{}", tmp.display())).with_name("workspace");
-    let result = validate_roots(&[root], "srv");
+    let result = validate_roots(&[root], "srv").await;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].name.as_deref(), Some("workspace"));
 }

--- a/crates/zeph-orchestration/src/adaptorch.rs
+++ b/crates/zeph-orchestration/src/adaptorch.rs
@@ -301,12 +301,13 @@ impl TopologyAdvisor {
     /// Persist the Beta-arm table to `state_path` atomically.
     ///
     /// Called from the agent shutdown hook (once per process), mirroring
-    /// `AnyProvider::save_router_state`. Failures are logged and swallowed.
+    /// `AnyProvider::save_router_state`. The blocking I/O is offloaded via
+    /// `spawn_blocking`; the lock is released before the async boundary.
     ///
     /// # Errors
     ///
     /// Returns `io::Error` when the write fails.
-    pub fn save(&self) -> io::Result<()> {
+    pub async fn save(&self) -> io::Result<()> {
         let arms_map: HashMap<String, BetaDist> = self
             .arms
             .lock()
@@ -320,13 +321,16 @@ impl TopologyAdvisor {
         };
 
         let json = serde_json::to_string_pretty(&state).map_err(io::Error::other)?;
+        let path = self.state_path.clone();
 
-        if let Some(parent) = self.state_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        atomic_write(&self.state_path, json.as_bytes())?;
-        Ok(())
+        tokio::task::spawn_blocking(move || {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            atomic_write(&path, json.as_bytes())
+        })
+        .await
+        .map_err(io::Error::other)?
     }
 
     // ─── private helpers ─────────────────────────────────────────────────────
@@ -613,8 +617,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn persistence_round_trip() {
+    #[tokio::test]
+    async fn persistence_round_trip() {
         use zeph_llm::any::AnyProvider;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("state.json");
@@ -626,7 +630,7 @@ mod tests {
                 Duration::from_secs(4),
             );
             advisor.record_outcome(TaskClass::SequentialPipeline, TopologyHint::Sequential, 1.0);
-            advisor.save().unwrap();
+            advisor.save().await.unwrap();
         }
         {
             let mock = zeph_llm::mock::MockProvider::default();


### PR DESCRIPTION
## Summary

- `ModelCache::save()` wrapped in `spawn_blocking` across all four LLM backends (Claude, OpenAI, Ollama, Gemini) — fixes blocking `fsync`+`rename` on the tokio async thread during model list refresh (#5129)
- `TopologyAdvisor::save()` wrapped in `spawn_blocking`; call site in `Agent::shutdown()` updated to `.await` — fixes blocking FS I/O during agent shutdown (#5130)
- `validate_roots()` in `zeph-mcp` made async using `tokio::fs::canonicalize`; cascaded to `handler_cfg_for`, `spawn_non_oauth_connections`, `spawn_oauth_connections`, `connect_and_list_tools`; 9 unit tests converted to `#[tokio::test]` (#5132)

## Changes

| File | Change |
|------|--------|
| `crates/zeph-llm/src/model_cache.rs` | `save()` → `async fn`, body in `spawn_blocking` |
| `crates/zeph-llm/src/{claude,openai,ollama,gemini}/mod.rs` | add `.await` to `cache.save()` call sites |
| `crates/zeph-orchestration/src/adaptorch.rs` | `save()` → `async fn`, body in `spawn_blocking` |
| `crates/zeph-core/src/agent/shutdown.rs` | add `.await` to `advisor.save()` call site |
| `crates/zeph-mcp/src/manager/connect.rs` | `validate_roots()` → `async fn` with `tokio::fs::canonicalize` |
| `crates/zeph-mcp/src/manager/server.rs` | update async cascade |
| `crates/zeph-mcp/src/manager/tests.rs` | 9 tests converted to `#[tokio::test] async fn` |
| `CHANGELOG.md` | entries under `[Unreleased]` |

## Test plan

- `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` → 11235 passed, 23 skipped
- `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` → clean
- `cargo +nightly fmt --check` → clean
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` → clean

Closes #5129, #5130, #5132