### PR TITLE
fix(subagent,memory): eliminate async violations in SubAgentManager and RetrievalFailureLogger

### DIFF
--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -155,16 +155,19 @@ impl<C: crate::channel::Channel> Agent<C> {
             }
         };
 
-        match mgr.spawn_for_task(
-            &agent_def_name,
-            &prompt,
-            provider,
-            tool_executor,
-            skills,
-            &cfg,
-            spawn_ctx,
-            on_done,
-        ) {
+        match mgr
+            .spawn_for_task(
+                &agent_def_name,
+                &prompt,
+                provider,
+                tool_executor,
+                skills,
+                &cfg,
+                spawn_ctx,
+                on_done,
+            )
+            .await
+        {
             Ok(handle_id) => {
                 *spawn_counter += 1;
                 let _ = self

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -414,15 +414,18 @@ impl<C: Channel> Agent<C> {
             spawn_ctx.durable_resolver = Some(seat);
         }
         let mgr = self.services.orchestration.subagent_manager.as_mut()?;
-        match mgr.spawn(
-            name,
-            prompt,
-            provider,
-            tool_executor,
-            skills,
-            &cfg,
-            spawn_ctx,
-        ) {
+        match mgr
+            .spawn(
+                name,
+                prompt,
+                provider,
+                tool_executor,
+                skills,
+                &cfg,
+                spawn_ctx,
+            )
+            .await
+        {
             Ok(id) => Some(format!(
                 "Sub-agent '{name}' started in background (id: {short})",
                 short = &id[..8.min(id.len())]
@@ -448,15 +451,18 @@ impl<C: Channel> Agent<C> {
             spawn_ctx.durable_resolver = Some(seat);
         }
         let mgr = self.services.orchestration.subagent_manager.as_mut()?;
-        let task_id = match mgr.spawn(
-            name,
-            prompt,
-            provider,
-            tool_executor,
-            skills,
-            &cfg,
-            spawn_ctx,
-        ) {
+        let task_id = match mgr
+            .spawn(
+                name,
+                prompt,
+                provider,
+                tool_executor,
+                skills,
+                &cfg,
+                spawn_ctx,
+            )
+            .await
+        {
             Ok(id) => id,
             Err(e) => return Some(format!("Failed to spawn sub-agent: {e}")),
         };

--- a/crates/zeph-memory/src/retrieval_failure_logger.rs
+++ b/crates/zeph-memory/src/retrieval_failure_logger.rs
@@ -7,10 +7,12 @@
 //! [`RetrievalFailureLogger::log`] on the hot path without blocking. A
 //! background task coalesces records into batches and flushes them to `SQLite`.
 
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 use tracing::Instrument as _;
+use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};
 
 use crate::store::SqliteStore;
 use crate::store::retrieval_failures::RetrievalFailureRecord;
@@ -26,18 +28,16 @@ const CLEANUP_FLUSH_INTERVAL: u32 = 500;
 /// from the recall hot path. Records are sent via a bounded channel; if the channel is
 /// full the record is silently dropped (zero hot-path latency, per INV-1).
 ///
-/// Fields are `Option` so that [`shutdown`](Self::shutdown) can take them without a
-/// move-out-of-`Drop` conflict, and so the `Drop` impl can abort any task not yet drained.
-/// `tx` is declared before `handle` to ensure the channel is closed before the handle is
-/// dropped, which allows the background task to exit cleanly when `Drop` fires.
+/// The background writer task is registered with [`TaskSupervisor`] for lifecycle
+/// visibility and graceful shutdown. Call [`shutdown`](Self::shutdown) for a clean drain.
 pub struct RetrievalFailureLogger {
-    // tx MUST be declared before handle — drop order closes the channel before the handle.
     tx: Option<mpsc::Sender<RetrievalFailureRecord>>,
-    handle: Option<tokio::task::JoinHandle<()>>,
+    /// Notified by `writer_task` after the final flush completes.
+    done: Arc<Notify>,
 }
 
 impl RetrievalFailureLogger {
-    /// Spawn the background writer task and return a logger handle.
+    /// Spawn the background writer task under `supervisor` and return a logger handle.
     ///
     /// `batch_size` records are flushed at once, or after `flush_interval` elapses,
     /// whichever comes first. Old records are purged every `CLEANUP_FLUSH_INTERVAL`
@@ -49,19 +49,32 @@ impl RetrievalFailureLogger {
         batch_size: usize,
         flush_interval: Duration,
         retention_days: u32,
+        supervisor: &TaskSupervisor,
     ) -> Self {
         let (tx, rx) = mpsc::channel(channel_capacity);
-        let handle = tokio::spawn(writer_task(
+        let done = Arc::new(Notify::new());
+        let fut = writer_task(
             sqlite,
             rx,
             batch_size,
             flush_interval,
             retention_days,
-        ));
-        Self {
-            tx: Some(tx),
-            handle: Some(handle),
-        }
+            Arc::clone(&done),
+        );
+        let cell = Arc::new(Mutex::new(Some(fut)));
+        supervisor.spawn(TaskDescriptor {
+            name: "memory.retrieval-failure-logger",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                let f = cell.lock().ok().and_then(|mut g| g.take());
+                async move {
+                    if let Some(f) = f {
+                        f.await;
+                    }
+                }
+            },
+        });
+        Self { tx: Some(tx), done }
     }
 
     /// Queue a retrieval failure record for async persistence.
@@ -90,27 +103,14 @@ impl RetrievalFailureLogger {
         }
     }
 
-    /// Shut down the background writer, draining any queued records.
+    /// Drain queued records and wait for the writer to flush before returning.
     ///
-    /// Closes the sender and waits for the background task to complete. Drop is
-    /// best-effort only; call this method for a clean drain on process exit.
+    /// Drops the sender so `writer_task` exits its receive loop, flushes the
+    /// remaining batch, and fires the `done` notify. `TaskSupervisor::shutdown_all`
+    /// should be called after this to clean up the registry entry.
     pub async fn shutdown(mut self) {
         drop(self.tx.take());
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.await;
-        }
-    }
-}
-
-impl Drop for RetrievalFailureLogger {
-    /// Abort the background writer task on drop.
-    ///
-    /// For a clean drain (flushing queued records) call [`RetrievalFailureLogger::shutdown`]
-    /// explicitly before dropping. This impl ensures the task is not silently detached.
-    fn drop(&mut self) {
-        if let Some(handle) = &self.handle {
-            handle.abort();
-        }
+        self.done.notified().await;
     }
 }
 
@@ -120,6 +120,7 @@ async fn writer_task(
     batch_size: usize,
     flush_interval: Duration,
     retention_days: u32,
+    done: Arc<Notify>,
 ) {
     let mut batch: Vec<RetrievalFailureRecord> = Vec::with_capacity(batch_size);
     let mut flush_counter: u32 = 0;
@@ -141,6 +142,7 @@ async fn writer_task(
                     } else {
                         // Sender dropped — drain remaining and exit.
                         flush_batch(&sqlite, &mut batch, &mut flush_counter, retention_days).await;
+                        done.notify_one();
                         return;
                     }
                 }
@@ -185,9 +187,16 @@ async fn flush_batch(
 mod tests {
     use std::time::Duration;
 
+    use tokio_util::sync::CancellationToken;
+    use zeph_common::task_supervisor::TaskSupervisor;
+
     use super::*;
     use crate::store::SqliteStore;
     use crate::store::retrieval_failures::{RetrievalFailureRecord, RetrievalFailureType};
+
+    fn make_supervisor() -> TaskSupervisor {
+        TaskSupervisor::new(CancellationToken::new())
+    }
 
     fn no_hit_record() -> RetrievalFailureRecord {
         RetrievalFailureRecord {
@@ -226,10 +235,18 @@ mod tests {
     #[tokio::test]
     async fn no_hit_failure_is_persisted() {
         let sqlite = SqliteStore::new(":memory:").await.unwrap();
-        let logger =
-            RetrievalFailureLogger::new(sqlite.clone(), 256, 16, Duration::from_millis(10), 90);
+        let sup = make_supervisor();
+        let logger = RetrievalFailureLogger::new(
+            sqlite.clone(),
+            256,
+            16,
+            Duration::from_millis(10),
+            90,
+            &sup,
+        );
         logger.log(no_hit_record());
         logger.shutdown().await;
+        sup.shutdown_all(Duration::from_secs(5)).await;
 
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT failure_type FROM memory_retrieval_failures WHERE failure_type = 'no_hit'",
@@ -243,10 +260,18 @@ mod tests {
     #[tokio::test]
     async fn low_confidence_failure_is_persisted() {
         let sqlite = SqliteStore::new(":memory:").await.unwrap();
-        let logger =
-            RetrievalFailureLogger::new(sqlite.clone(), 256, 16, Duration::from_millis(10), 90);
+        let sup = make_supervisor();
+        let logger = RetrievalFailureLogger::new(
+            sqlite.clone(),
+            256,
+            16,
+            Duration::from_millis(10),
+            90,
+            &sup,
+        );
         logger.log(low_confidence_record(0.3, 0.7));
         logger.shutdown().await;
+        sup.shutdown_all(Duration::from_secs(5)).await;
 
         let rows: Vec<(String, f32, f32)> = sqlx::query_as(
             "SELECT failure_type, top_score, confidence_threshold \
@@ -267,8 +292,10 @@ mod tests {
     #[tokio::test]
     async fn log_does_not_block_when_channel_is_full() {
         let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        let sup = make_supervisor();
         // capacity = 1 so the second send will be dropped
-        let logger = RetrievalFailureLogger::new(sqlite.clone(), 1, 16, Duration::from_mins(1), 90);
+        let logger =
+            RetrievalFailureLogger::new(sqlite.clone(), 1, 16, Duration::from_mins(1), 90, &sup);
         // First log fills the channel (capacity 1).
         logger.log(no_hit_record());
         // Second log must not block — try_send drops the record silently.
@@ -280,19 +307,28 @@ mod tests {
             "log() must be non-blocking even when channel is full, elapsed={elapsed:?}"
         );
         logger.shutdown().await;
+        sup.shutdown_all(Duration::from_secs(5)).await;
     }
 
     #[tokio::test]
     async fn query_text_truncated_to_512_chars() {
         let sqlite = SqliteStore::new(":memory:").await.unwrap();
-        let logger =
-            RetrievalFailureLogger::new(sqlite.clone(), 256, 16, Duration::from_millis(10), 90);
+        let sup = make_supervisor();
+        let logger = RetrievalFailureLogger::new(
+            sqlite.clone(),
+            256,
+            16,
+            Duration::from_millis(10),
+            90,
+            &sup,
+        );
         let long_query = "x".repeat(1000);
         let mut record = no_hit_record();
         record.query_text = long_query;
         record.query_len = 1000;
         logger.log(record);
         logger.shutdown().await;
+        sup.shutdown_all(Duration::from_secs(5)).await;
 
         let rows: Vec<(String,)> =
             sqlx::query_as("SELECT query_text FROM memory_retrieval_failures")
@@ -329,13 +365,21 @@ mod tests {
     #[tokio::test]
     async fn multiple_records_batch_flushed() {
         let sqlite = SqliteStore::new(":memory:").await.unwrap();
-        let logger =
-            RetrievalFailureLogger::new(sqlite.clone(), 256, 16, Duration::from_millis(10), 90);
+        let sup = make_supervisor();
+        let logger = RetrievalFailureLogger::new(
+            sqlite.clone(),
+            256,
+            16,
+            Duration::from_millis(10),
+            90,
+            &sup,
+        );
         for _ in 0..5 {
             logger.log(no_hit_record());
         }
         logger.log(low_confidence_record(0.2, 0.8));
         logger.shutdown().await;
+        sup.shutdown_all(Duration::from_secs(5)).await;
 
         let rows: Vec<(i64,)> = sqlx::query_as("SELECT COUNT(*) FROM memory_retrieval_failures")
             .fetch_all(sqlite.pool())

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -277,7 +277,7 @@ pub(crate) fn apply_constraint_propagation(def: &mut SubAgentDef, ctx: &SpawnCon
 /// Known limitation: agents may use Read/Write/Edit beyond the memory directory.
 /// See issue #1152 for future `FilteredToolExecutor` path-restriction enhancement.
 #[cfg_attr(test, allow(dead_code))]
-pub(crate) fn build_system_prompt_with_memory(
+pub(crate) async fn build_system_prompt_with_memory(
     def: &mut SubAgentDef,
     scope: Option<MemoryScope>,
     ctx: &SpawnContext,
@@ -314,7 +314,7 @@ pub(crate) fn build_system_prompt_with_memory(
         return format!("{}{}", orchestrator_header, def.system_prompt);
     }
 
-    let memory_dir = match ensure_memory_dir(scope, &def.name) {
+    let memory_dir = match ensure_memory_dir(scope, &def.name).await {
         Ok(dir) => dir,
         Err(e) => {
             tracing::warn!(
@@ -362,7 +362,7 @@ pub(crate) fn build_system_prompt_with_memory(
         path = memory_dir.display()
     );
 
-    let memory_block = load_memory_content(&memory_dir).map(|content| {
+    let memory_block = load_memory_content(&memory_dir).await.map(|content| {
         let escaped = escape_memory_content(&content);
         format!("\n\n<agent-memory>\n{escaped}\n</agent-memory>")
     });
@@ -517,7 +517,7 @@ impl SubAgentManager {
     #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     // complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
     #[tracing::instrument(name = "subagent.manager.spawn", skip_all, fields(def_name = def_name))]
-    pub fn spawn(
+    pub async fn spawn(
         &mut self,
         def_name: &str,
         task_prompt: &str,
@@ -586,7 +586,7 @@ impl SubAgentManager {
         // IMPORTANT (REV-HIGH-03): build_system_prompt_with_memory may mutate def.tools
         // (auto-enables Read/Write/Edit for AllowList memory). FilteredToolExecutor MUST
         // be constructed AFTER this call to pick up the updated tool list.
-        let system_prompt = build_system_prompt_with_memory(&mut def, effective_memory, &ctx);
+        let system_prompt = build_system_prompt_with_memory(&mut def, effective_memory, &ctx).await;
 
         let memory_dir = effective_memory
             .and_then(|scope| super::super::memory::resolve_memory_dir(scope, &def.name).ok());
@@ -1150,7 +1150,7 @@ impl SubAgentManager {
     /// Panics if the internal agent entry is missing after a successful `spawn` call.
     /// This is a programming error and should never occur in normal operation.
     #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
-    pub fn spawn_for_task<F>(
+    pub async fn spawn_for_task<F>(
         &mut self,
         def_name: &str,
         task_prompt: &str,
@@ -1164,15 +1164,17 @@ impl SubAgentManager {
     where
         F: FnOnce(String, Result<String, SubAgentError>) + Send + 'static,
     {
-        let handle_id = self.spawn(
-            def_name,
-            task_prompt,
-            provider,
-            tool_executor,
-            skills,
-            config,
-            ctx,
-        )?;
+        let handle_id = self
+            .spawn(
+                def_name,
+                task_prompt,
+                provider,
+                tool_executor,
+                skills,
+                config,
+                ctx,
+            )
+            .await?;
 
         let handle = self
             .agents

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -97,7 +97,11 @@ fn noop_executor() -> Arc<dyn ErasedToolExecutor> {
     Arc::new(NoopExecutor)
 }
 
-fn do_spawn(mgr: &mut SubAgentManager, name: &str, prompt: &str) -> Result<String, SubAgentError> {
+async fn do_spawn(
+    mgr: &mut SubAgentManager,
+    name: &str,
+    prompt: &str,
+) -> Result<String, SubAgentError> {
     mgr.spawn(
         name,
         prompt,
@@ -107,6 +111,7 @@ fn do_spawn(mgr: &mut SubAgentManager, name: &str, prompt: &str) -> Result<Strin
         &SubAgentConfig::default(),
         SpawnContext::default(),
     )
+    .await
 }
 
 #[test]
@@ -123,23 +128,21 @@ fn load_definitions_populates_vec() {
     assert_eq!(mgr.definitions()[0].name, "helper");
 }
 
-#[test]
-fn spawn_not_found_error() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn spawn_not_found_error() {
     let mut mgr = make_manager();
-    let err = do_spawn(&mut mgr, "nonexistent", "prompt").unwrap_err();
+    let err = do_spawn(&mut mgr, "nonexistent", "prompt")
+        .await
+        .unwrap_err();
     assert!(matches!(err, SubAgentError::NotFound(_)));
 }
 
-#[test]
-fn spawn_and_cancel() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn spawn_and_cancel() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
-    let task_id = do_spawn(&mut mgr, "bot", "do stuff").unwrap();
+    let task_id = do_spawn(&mut mgr, "bot", "do stuff").await.unwrap();
     assert!(!task_id.is_empty());
 
     mgr.cancel(&task_id).unwrap();
@@ -158,7 +161,7 @@ async fn collect_removes_agent() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
-    let task_id = do_spawn(&mut mgr, "bot", "do stuff").unwrap();
+    let task_id = do_spawn(&mut mgr, "bot", "do stuff").await.unwrap();
     mgr.cancel(&task_id).unwrap();
 
     // Wait briefly for the task to observe cancellation
@@ -177,14 +180,12 @@ async fn collect_unknown_task_id_returns_not_found() {
     assert!(matches!(err, SubAgentError::NotFound(_)));
 }
 
-#[test]
-fn approve_secret_grants_access() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn approve_secret_grants_access() {
     let mut mgr = make_manager();
     mgr.definitions.push(def_with_secrets());
 
-    let task_id = do_spawn(&mut mgr, "bot", "work").unwrap();
+    let task_id = do_spawn(&mut mgr, "bot", "work").await.unwrap();
     mgr.approve_secret(&task_id, "api-key", std::time::Duration::from_mins(1))
         .unwrap();
 
@@ -196,14 +197,12 @@ fn approve_secret_grants_access() {
     );
 }
 
-#[test]
-fn approve_secret_denied_for_unlisted_key() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn approve_secret_denied_for_unlisted_key() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def()); // no secrets in allowed list
 
-    let task_id = do_spawn(&mut mgr, "bot", "work").unwrap();
+    let task_id = do_spawn(&mut mgr, "bot", "work").await.unwrap();
     let err = mgr
         .approve_secret(&task_id, "not-allowed", std::time::Duration::from_mins(1))
         .unwrap_err();
@@ -219,90 +218,80 @@ fn approve_secret_unknown_task_id_returns_not_found() {
     assert!(matches!(err, SubAgentError::NotFound(_)));
 }
 
-#[test]
-fn statuses_returns_active_agents() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn statuses_returns_active_agents() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
-    let task_id = do_spawn(&mut mgr, "bot", "work").unwrap();
+    let task_id = do_spawn(&mut mgr, "bot", "work").await.unwrap();
     let statuses = mgr.statuses();
     assert_eq!(statuses.len(), 1);
     assert_eq!(statuses[0].0, task_id);
 }
 
-#[test]
-fn concurrency_limit_enforced() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn concurrency_limit_enforced() {
     let mut mgr = SubAgentManager::new(1);
     mgr.definitions.push(sample_def());
 
-    let _first = do_spawn(&mut mgr, "bot", "first").unwrap();
-    let err = do_spawn(&mut mgr, "bot", "second").unwrap_err();
+    let _first = do_spawn(&mut mgr, "bot", "first").await.unwrap();
+    let err = do_spawn(&mut mgr, "bot", "second").await.unwrap_err();
     assert!(matches!(err, SubAgentError::ConcurrencyLimit { .. }));
 }
 
 // --- #1619 regression tests: reserved_slots ---
 
-#[test]
-fn test_reserve_slots_blocks_spawn() {
+#[tokio::test]
+async fn test_reserve_slots_blocks_spawn() {
     // max_concurrent=2, reserved=1, active=1 → active+reserved >= max → ConcurrencyLimit.
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
     let mut mgr = SubAgentManager::new(2);
     mgr.definitions.push(sample_def());
 
     // Occupy one slot.
-    let _first = do_spawn(&mut mgr, "bot", "first").unwrap();
+    let _first = do_spawn(&mut mgr, "bot", "first").await.unwrap();
     // Reserve the remaining slot.
     mgr.reserve_slots(1);
     // Now active(1) + reserved(1) >= max_concurrent(2) → should reject.
-    let err = do_spawn(&mut mgr, "bot", "second").unwrap_err();
+    let err = do_spawn(&mut mgr, "bot", "second").await.unwrap_err();
     assert!(
         matches!(err, SubAgentError::ConcurrencyLimit { .. }),
         "expected ConcurrencyLimit, got: {err}"
     );
 }
 
-#[test]
-fn test_release_reservation_allows_spawn() {
+#[tokio::test]
+async fn test_release_reservation_allows_spawn() {
     // After release_reservation(), the reserved slot is freed and spawn succeeds.
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
     let mut mgr = SubAgentManager::new(2);
     mgr.definitions.push(sample_def());
 
     // Reserve one slot (no active agents yet).
     mgr.reserve_slots(1);
     // active(0) + reserved(1) < max_concurrent(2), so one more spawn is allowed.
-    let _first = do_spawn(&mut mgr, "bot", "first").unwrap();
+    let _first = do_spawn(&mut mgr, "bot", "first").await.unwrap();
     // Now active(1) + reserved(1) >= max_concurrent(2) → blocked.
-    let err = do_spawn(&mut mgr, "bot", "second").unwrap_err();
+    let err = do_spawn(&mut mgr, "bot", "second").await.unwrap_err();
     assert!(matches!(err, SubAgentError::ConcurrencyLimit { .. }));
 
     // Release the reservation — active(1) + reserved(0) < max_concurrent(2).
     mgr.release_reservation(1);
-    let result = do_spawn(&mut mgr, "bot", "third");
+    let result = do_spawn(&mut mgr, "bot", "third").await;
     assert!(
         result.is_ok(),
         "spawn must succeed after release_reservation, got: {result:?}"
     );
 }
 
-#[test]
-fn test_reservation_with_zero_active_blocks_spawn() {
+#[tokio::test]
+async fn test_reservation_with_zero_active_blocks_spawn() {
     // Reserved slots alone (no active agents) should block spawn when reserved >= max.
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
     let mut mgr = SubAgentManager::new(2);
     mgr.definitions.push(sample_def());
 
     // Reserve all slots — no active agents.
     mgr.reserve_slots(2);
     // active(0) + reserved(2) >= max_concurrent(2) → blocked.
-    let err = do_spawn(&mut mgr, "bot", "first").unwrap_err();
+    let err = do_spawn(&mut mgr, "bot", "first").await.unwrap_err();
     assert!(
         matches!(err, SubAgentError::ConcurrencyLimit { .. }),
         "reservation alone must block spawn when reserved >= max_concurrent"
@@ -317,7 +306,7 @@ async fn background_agent_does_not_block_caller() {
     // Spawn should return immediately without waiting for LLM
     let result = tokio::time::timeout(
         std::time::Duration::from_millis(100),
-        std::future::ready(do_spawn(&mut mgr, "bot", "work")),
+        do_spawn(&mut mgr, "bot", "work"),
     )
     .await;
     assert!(result.is_ok(), "spawn() must not block");
@@ -351,6 +340,7 @@ async fn max_turns_terminates_agent_loop() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     // Wait for completion
@@ -368,7 +358,7 @@ async fn cancellation_token_stops_agent_loop() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
-    let task_id = do_spawn(&mut mgr, "bot", "long task").unwrap();
+    let task_id = do_spawn(&mut mgr, "bot", "long task").await.unwrap();
 
     // Cancel immediately
     mgr.cancel(&task_id).unwrap();
@@ -385,8 +375,8 @@ async fn shutdown_all_cancels_all_active_agents() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
-    do_spawn(&mut mgr, "bot", "task 1").unwrap();
-    do_spawn(&mut mgr, "bot", "task 2").unwrap();
+    do_spawn(&mut mgr, "bot", "task 1").await.unwrap();
+    do_spawn(&mut mgr, "bot", "task 2").await.unwrap();
 
     assert_eq!(mgr.agents.len(), 2);
     mgr.shutdown_all();
@@ -397,13 +387,11 @@ async fn shutdown_all_cancels_all_active_agents() {
     }
 }
 
-#[test]
-fn debug_impl_does_not_expose_sensitive_fields() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn debug_impl_does_not_expose_sensitive_fields() {
     let mut mgr = make_manager();
     mgr.definitions.push(def_with_secrets());
-    let task_id = do_spawn(&mut mgr, "bot", "work").unwrap();
+    let task_id = do_spawn(&mut mgr, "bot", "work").await.unwrap();
     let handle = &mgr.agents[&task_id];
     let debug_str = format!("{handle:?}");
     // SubAgentHandle Debug must not expose grant contents or secrets
@@ -412,8 +400,6 @@ fn debug_impl_does_not_expose_sensitive_fields() {
 
 #[tokio::test]
 async fn llm_failure_transitions_to_failed_state() {
-    let rt_handle = tokio::runtime::Handle::current();
-    let _guard = rt_handle.enter();
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
@@ -428,6 +414,7 @@ async fn llm_failure_transitions_to_failed_state() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     // Poll until the background task transitions to Failed (or 5s timeout).
@@ -535,8 +522,6 @@ async fn tool_call_loop_two_turns() {
         }
     }
 
-    let rt_handle = tokio::runtime::Handle::current();
-    let _guard = rt_handle.enter();
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
@@ -569,6 +554,7 @@ async fn tool_call_loop_two_turns() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     // Wait for background loop to finish.
@@ -584,7 +570,7 @@ async fn collect_on_running_task_completes_eventually() {
     mgr.definitions.push(sample_def());
 
     // Spawn with a slow response so the task is still running.
-    let task_id = do_spawn(&mut mgr, "bot", "slow work").unwrap();
+    let task_id = do_spawn(&mut mgr, "bot", "slow work").await.unwrap();
 
     // collect() awaits the JoinHandle, so it will finish when the task completes.
     let result =
@@ -595,17 +581,15 @@ async fn collect_on_running_task_completes_eventually() {
     assert!(inner.is_ok(), "collect returned error: {inner:?}");
 }
 
-#[test]
-fn concurrency_slot_freed_after_cancel() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn concurrency_slot_freed_after_cancel() {
     let mut mgr = SubAgentManager::new(1); // limit to 1
     mgr.definitions.push(sample_def());
 
-    let id1 = do_spawn(&mut mgr, "bot", "task 1").unwrap();
+    let id1 = do_spawn(&mut mgr, "bot", "task 1").await.unwrap();
 
     // Concurrency limit reached — second spawn should fail.
-    let err = do_spawn(&mut mgr, "bot", "task 2").unwrap_err();
+    let err = do_spawn(&mut mgr, "bot", "task 2").await.unwrap_err();
     assert!(
         matches!(err, SubAgentError::ConcurrencyLimit { .. }),
         "expected concurrency limit error, got: {err}"
@@ -615,7 +599,7 @@ fn concurrency_slot_freed_after_cancel() {
     mgr.cancel(&id1).unwrap();
 
     // Now a new spawn should succeed.
-    let result = do_spawn(&mut mgr, "bot", "task 3");
+    let result = do_spawn(&mut mgr, "bot", "task 3").await;
     assert!(
         result.is_ok(),
         "expected spawn to succeed after cancel, got: {result:?}"
@@ -645,6 +629,7 @@ async fn skill_bodies_prepended_to_system_prompt() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     // Poll until the provider is called (or 5 s timeout — guards against CI load).
@@ -696,6 +681,7 @@ async fn no_skills_does_not_add_fence_to_system_prompt() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     // Poll until the provider is called (or 5 s timeout — guards against CI load).
@@ -727,7 +713,7 @@ async fn statuses_does_not_include_collected_task() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
-    let task_id = do_spawn(&mut mgr, "bot", "task").unwrap();
+    let task_id = do_spawn(&mut mgr, "bot", "task").await.unwrap();
     assert_eq!(mgr.statuses().len(), 1);
 
     // Wait for task completion then collect.
@@ -776,6 +762,7 @@ async fn background_agent_auto_denies_secret_request() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     // Should complete without blocking — background auto-denies the secret.
@@ -788,11 +775,8 @@ async fn background_agent_auto_denies_secret_request() {
     drop(recorded);
 }
 
-#[test]
-fn spawn_with_plan_mode_definition_succeeds() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
-
+#[tokio::test]
+async fn spawn_with_plan_mode_definition_succeeds() {
     let def = SubAgentDef::parse(indoc! {"
         ---
         name: planner
@@ -808,16 +792,13 @@ fn spawn_with_plan_mode_definition_succeeds() {
     let mut mgr = make_manager();
     mgr.definitions.push(def);
 
-    let task_id = do_spawn(&mut mgr, "planner", "make a plan").unwrap();
+    let task_id = do_spawn(&mut mgr, "planner", "make a plan").await.unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
 }
 
-#[test]
-fn spawn_with_disallowed_tools_definition_succeeds() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
-
+#[tokio::test]
+async fn spawn_with_disallowed_tools_definition_succeeds() {
     let def = SubAgentDef::parse(indoc! {"
         ---
         name: safe-bot
@@ -839,18 +820,15 @@ fn spawn_with_disallowed_tools_definition_succeeds() {
     let mut mgr = make_manager();
     mgr.definitions.push(def);
 
-    let task_id = do_spawn(&mut mgr, "safe-bot", "task").unwrap();
+    let task_id = do_spawn(&mut mgr, "safe-bot", "task").await.unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
 }
 
 // ── #1180: default_permission_mode / default_disallowed_tools applied at spawn ──
 
-#[test]
-fn spawn_applies_default_permission_mode_from_config() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
-
+#[tokio::test]
+async fn spawn_applies_default_permission_mode_from_config() {
     // Agent has Default permission mode — config sets Plan as default.
     let def =
         SubAgentDef::parse("---\nname: bot\ndescription: A bot\n---\n\nDo things.\n").unwrap();
@@ -874,16 +852,14 @@ fn spawn_applies_default_permission_mode_from_config() {
             &cfg,
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
 }
 
-#[test]
-fn spawn_does_not_override_explicit_permission_mode() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
-
+#[tokio::test]
+async fn spawn_does_not_override_explicit_permission_mode() {
     // Agent explicitly sets DontAsk — config default must not override it.
     let def = SubAgentDef::parse(indoc! {"
         ---
@@ -916,16 +892,14 @@ fn spawn_does_not_override_explicit_permission_mode() {
             &cfg,
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
 }
 
-#[test]
-fn spawn_merges_global_disallowed_tools() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
-
+#[tokio::test]
+async fn spawn_merges_global_disallowed_tools() {
     let def =
         SubAgentDef::parse("---\nname: bot\ndescription: A bot\n---\n\nDo things.\n").unwrap();
 
@@ -947,6 +921,7 @@ fn spawn_merges_global_disallowed_tools() {
             &cfg,
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
@@ -954,11 +929,8 @@ fn spawn_merges_global_disallowed_tools() {
 
 // ── #1182: bypass_permissions blocked without config gate ─────────────
 
-#[test]
-fn spawn_bypass_permissions_without_config_gate_is_error() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
-
+#[tokio::test]
+async fn spawn_bypass_permissions_without_config_gate_is_error() {
     let def = SubAgentDef::parse(indoc! {"
         ---
         name: bypass-bot
@@ -986,15 +958,13 @@ fn spawn_bypass_permissions_without_config_gate_is_error() {
             &cfg,
             SpawnContext::default(),
         )
+        .await
         .unwrap_err();
     assert!(matches!(err, SubAgentError::Invalid(_)));
 }
 
-#[test]
-fn spawn_bypass_permissions_with_config_gate_succeeds() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
-
+#[tokio::test]
+async fn spawn_bypass_permissions_with_config_gate_succeeds() {
     let def = SubAgentDef::parse(indoc! {"
         ---
         name: bypass-bot
@@ -1025,6 +995,7 @@ fn spawn_bypass_permissions_with_config_gate_succeeds() {
             &cfg,
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
@@ -1200,10 +1171,8 @@ fn resume_def_not_found_returns_not_found_error() {
     assert!(matches!(err, SubAgentError::NotFound(_)));
 }
 
-#[test]
-fn resume_concurrency_limit_reached_returns_error() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
+#[tokio::test]
+async fn resume_concurrency_limit_reached_returns_error() {
     let tmp = tempfile::tempdir().unwrap();
     let agent_id = "babe0000-0000-0000-0000-000000000000";
     write_completed_meta(tmp.path(), agent_id, "bot");
@@ -1212,14 +1181,11 @@ fn resume_concurrency_limit_reached_returns_error() {
     mgr.definitions.push(sample_def());
 
     // Occupy the single slot.
-    {
-        let _guard = rt.enter();
-        let _running_id = do_spawn(&mut mgr, "bot", "occupying slot").unwrap();
-    }
+    let _running_id = do_spawn(&mut mgr, "bot", "occupying slot").await.unwrap();
 
     let cfg = make_cfg_with_dir(tmp.path());
-    let err = rt
-        .block_on(mgr.resume(
+    let err = mgr
+        .resume(
             "babe0000",
             "continue",
             mock_provider(vec!["done"]),
@@ -1227,7 +1193,8 @@ fn resume_concurrency_limit_reached_returns_error() {
             None,
             &cfg,
             None,
-        ))
+        )
+        .await
         .unwrap_err();
     assert!(
         matches!(err, SubAgentError::ConcurrencyLimit { .. }),
@@ -1512,6 +1479,7 @@ async fn spawn_with_memory_scope_project_creates_directory() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
@@ -1565,6 +1533,7 @@ async fn spawn_with_config_default_memory_scope_applies_when_def_has_none() {
             &cfg,
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
@@ -1619,6 +1588,7 @@ async fn spawn_with_memory_blocked_by_disallowed_tools_skips_memory() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
@@ -1667,6 +1637,7 @@ async fn spawn_without_memory_scope_no_directory_created() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
@@ -1681,9 +1652,9 @@ async fn spawn_without_memory_scope_no_directory_created() {
     std::env::set_current_dir(orig_dir).unwrap();
 }
 
-#[test]
+#[tokio::test]
 #[serial]
-fn build_prompt_injects_memory_block_after_behavioral_prompt() {
+async fn build_prompt_injects_memory_block_after_behavioral_prompt() {
     let tmp = tempfile::tempdir().unwrap();
     let orig_dir = std::env::current_dir().unwrap();
     std::env::set_current_dir(tmp.path()).unwrap();
@@ -1712,7 +1683,8 @@ fn build_prompt_injects_memory_block_after_behavioral_prompt() {
         &mut def,
         Some(MemoryScope::Project),
         &SpawnContext::default(),
-    );
+    )
+    .await;
 
     // Memory block must appear AFTER behavioral prompt text.
     let behavioral_pos = prompt.find("Behavioral instructions").unwrap();
@@ -1729,9 +1701,9 @@ fn build_prompt_injects_memory_block_after_behavioral_prompt() {
     std::env::set_current_dir(orig_dir).unwrap();
 }
 
-#[test]
+#[tokio::test]
 #[serial]
-fn build_prompt_auto_enables_read_write_edit_for_allowlist() {
+async fn build_prompt_auto_enables_read_write_edit_for_allowlist() {
     let tmp = tempfile::tempdir().unwrap();
     let orig_dir = std::env::current_dir().unwrap();
     std::env::set_current_dir(tmp.path()).unwrap();
@@ -1759,7 +1731,8 @@ fn build_prompt_auto_enables_read_write_edit_for_allowlist() {
         &mut def,
         Some(MemoryScope::Project),
         &SpawnContext::default(),
-    );
+    )
+    .await;
 
     // read/write/edit must be auto-added to the AllowList.
     assert!(
@@ -1812,6 +1785,7 @@ async fn spawn_with_explicit_def_memory_overrides_config_default() {
             &cfg,
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
@@ -1873,6 +1847,7 @@ async fn spawn_memory_blocked_by_deny_list_policy() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
     assert!(!task_id.is_empty());
     mgr.cancel(&task_id).unwrap();
@@ -2116,8 +2091,8 @@ async fn run_agent_loop_executes_native_tool_call() {
 
 // --- Fix #2582 tests ---
 
-#[test]
-fn build_system_prompt_injects_working_directory() {
+#[tokio::test]
+async fn build_system_prompt_injects_working_directory() {
     use tempfile::TempDir;
 
     let tmp = TempDir::new().unwrap();
@@ -2133,7 +2108,7 @@ fn build_system_prompt_injects_working_directory() {
     "})
     .unwrap();
 
-    let prompt = build_system_prompt_with_memory(&mut def, None, &SpawnContext::default());
+    let prompt = build_system_prompt_with_memory(&mut def, None, &SpawnContext::default()).await;
     std::env::set_current_dir(orig).unwrap();
 
     assert!(
@@ -2248,8 +2223,6 @@ fn context_injection_last_assistant_fallback_when_no_assistant() {
 
 #[tokio::test]
 async fn spawn_model_inherit_resolves_to_parent_provider() {
-    let rt = tokio::runtime::Handle::current();
-    let _guard = rt.enter();
     let mut mgr = make_manager();
     let mut def = sample_def();
     def.model = Some(ModelSpec::Inherit);
@@ -2260,15 +2233,17 @@ async fn spawn_model_inherit_resolves_to_parent_provider() {
         ..SpawnContext::default()
     };
     // spawn should succeed without error (model resolution doesn't fail on missing provider)
-    let result = mgr.spawn(
-        "bot",
-        "task",
-        mock_provider(vec!["done"]),
-        noop_executor(),
-        None,
-        &SubAgentConfig::default(),
-        ctx,
-    );
+    let result = mgr
+        .spawn(
+            "bot",
+            "task",
+            mock_provider(vec!["done"]),
+            noop_executor(),
+            None,
+            &SubAgentConfig::default(),
+            ctx,
+        )
+        .await;
     assert!(
         result.is_ok(),
         "spawn with Inherit model should succeed: {result:?}"
@@ -2277,29 +2252,27 @@ async fn spawn_model_inherit_resolves_to_parent_provider() {
 
 #[tokio::test]
 async fn spawn_model_named_uses_value() {
-    let rt = tokio::runtime::Handle::current();
-    let _guard = rt.enter();
     let mut mgr = make_manager();
     let mut def = sample_def();
     def.model = Some(ModelSpec::Named("fast".to_owned()));
     mgr.definitions.push(def);
 
-    let result = mgr.spawn(
-        "bot",
-        "task",
-        mock_provider(vec!["done"]),
-        noop_executor(),
-        None,
-        &SubAgentConfig::default(),
-        SpawnContext::default(),
-    );
+    let result = mgr
+        .spawn(
+            "bot",
+            "task",
+            mock_provider(vec!["done"]),
+            noop_executor(),
+            None,
+            &SubAgentConfig::default(),
+            SpawnContext::default(),
+        )
+        .await;
     assert!(result.is_ok());
 }
 
-#[test]
-fn spawn_exceeds_max_depth_returns_error() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn spawn_exceeds_max_depth_returns_error() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
@@ -2321,6 +2294,7 @@ fn spawn_exceeds_max_depth_returns_error() {
             &cfg,
             ctx,
         )
+        .await
         .unwrap_err();
     assert!(
         matches!(err, SubAgentError::MaxDepthExceeded { depth: 2, max: 2 }),
@@ -2328,10 +2302,8 @@ fn spawn_exceeds_max_depth_returns_error() {
     );
 }
 
-#[test]
-fn spawn_at_max_depth_minus_one_succeeds() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn spawn_at_max_depth_minus_one_succeeds() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
@@ -2343,25 +2315,25 @@ fn spawn_at_max_depth_minus_one_succeeds() {
         spawn_depth: 2, // one below max → should succeed
         ..SpawnContext::default()
     };
-    let result = mgr.spawn(
-        "bot",
-        "task",
-        mock_provider(vec!["done"]),
-        noop_executor(),
-        None,
-        &cfg,
-        ctx,
-    );
+    let result = mgr
+        .spawn(
+            "bot",
+            "task",
+            mock_provider(vec!["done"]),
+            noop_executor(),
+            None,
+            &cfg,
+            ctx,
+        )
+        .await;
     assert!(
         result.is_ok(),
         "spawn at depth 2 with max 3 should succeed: {result:?}"
     );
 }
 
-#[test]
-fn spawn_foreground_uses_child_token() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn spawn_foreground_uses_child_token() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
@@ -2381,6 +2353,7 @@ fn spawn_foreground_uses_child_token() {
             &SubAgentConfig::default(),
             ctx,
         )
+        .await
         .unwrap();
 
     // Cancel parent — child should also be cancelled
@@ -2700,6 +2673,7 @@ async fn spawn_with_user_memory_scope_sets_memory_aware_executor() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     assert!(!task_id.is_empty());
@@ -2718,8 +2692,8 @@ async fn spawn_with_user_memory_scope_sets_memory_aware_executor() {
     }
 }
 
-#[test]
-fn build_prompt_includes_orchestrator_identity_when_name_is_set() {
+#[tokio::test]
+async fn build_prompt_includes_orchestrator_identity_when_name_is_set() {
     let mut def = SubAgentDef::parse(indoc! {"
         ---
         name: worker-agent
@@ -2734,7 +2708,7 @@ fn build_prompt_includes_orchestrator_identity_when_name_is_set() {
         orchestrator_role: Some("task-router".to_owned()),
         ..SpawnContext::default()
     };
-    let prompt = build_system_prompt_with_memory(&mut def, None, &ctx_name_and_role);
+    let prompt = build_system_prompt_with_memory(&mut def, None, &ctx_name_and_role).await;
     assert!(
         prompt.contains("You were spawned by orchestrator: planner (role: task-router)."),
         "prompt must contain full orchestrator identity line, got: {prompt}"
@@ -2749,7 +2723,7 @@ fn build_prompt_includes_orchestrator_identity_when_name_is_set() {
         orchestrator_role: None,
         ..SpawnContext::default()
     };
-    let prompt_no_role = build_system_prompt_with_memory(&mut def, None, &ctx_name_only);
+    let prompt_no_role = build_system_prompt_with_memory(&mut def, None, &ctx_name_only).await;
     assert!(
         prompt_no_role.contains("You were spawned by orchestrator: planner."),
         "prompt must contain name-only orchestrator line, got: {prompt_no_role}"
@@ -2763,7 +2737,8 @@ fn build_prompt_includes_orchestrator_identity_when_name_is_set() {
         "name-only branch must use updated wording, got: {prompt_no_role}"
     );
 
-    let prompt_no_orch = build_system_prompt_with_memory(&mut def, None, &SpawnContext::default());
+    let prompt_no_orch =
+        build_system_prompt_with_memory(&mut def, None, &SpawnContext::default()).await;
     assert!(
         !prompt_no_orch.contains("You were spawned by orchestrator"),
         "orchestrator header must be absent when orchestrator_name is None"
@@ -2775,7 +2750,7 @@ fn build_prompt_includes_orchestrator_identity_when_name_is_set() {
         orchestrator_role: Some("planner".to_owned()),
         ..SpawnContext::default()
     };
-    let prompt_role_only = build_system_prompt_with_memory(&mut def, None, &ctx_role_only);
+    let prompt_role_only = build_system_prompt_with_memory(&mut def, None, &ctx_role_only).await;
     assert!(
         !prompt_role_only.contains("You were spawned by orchestrator"),
         "orchestrator header must be absent when orchestrator_name is None (role-only case), \
@@ -2788,7 +2763,7 @@ fn build_prompt_includes_orchestrator_identity_when_name_is_set() {
         orchestrator_role: Some("planner".to_owned()),
         ..SpawnContext::default()
     };
-    let prompt_empty = build_system_prompt_with_memory(&mut def, None, &ctx_empty_name);
+    let prompt_empty = build_system_prompt_with_memory(&mut def, None, &ctx_empty_name).await;
     assert!(
         !prompt_empty.contains("You were spawned by orchestrator"),
         "orchestrator header must be absent when orchestrator_name is empty string, \
@@ -2839,10 +2814,8 @@ fn mcp_server_config(id: &str) -> zeph_config::McpServerConfig {
     serde_json::from_str(&format!(r#"{{"id":"{id}"}}"#)).unwrap()
 }
 
-#[test]
-fn spawn_context_session_mcp_servers_merged() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn spawn_context_session_mcp_servers_merged() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
@@ -2861,16 +2834,15 @@ fn spawn_context_session_mcp_servers_merged() {
             &SubAgentConfig::default(),
             ctx,
         )
+        .await
         .unwrap();
     let names = &mgr.agents[&task_id].mcp_tool_names;
     assert!(names.contains(&"existing-server".to_owned()));
     assert!(names.contains(&"new-server".to_owned()));
 }
 
-#[test]
-fn spawn_context_session_mcp_servers_dedup() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let _guard = rt.enter();
+#[tokio::test]
+async fn spawn_context_session_mcp_servers_dedup() {
     let mut mgr = make_manager();
     mgr.definitions.push(sample_def());
 
@@ -2889,6 +2861,7 @@ fn spawn_context_session_mcp_servers_dedup() {
             &SubAgentConfig::default(),
             ctx,
         )
+        .await
         .unwrap();
     let names = &mgr.agents[&task_id].mcp_tool_names;
     assert_eq!(
@@ -3066,6 +3039,7 @@ async fn fleet_register_active_called_on_spawn() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     // Wait until the background task calls register_active.
@@ -3099,6 +3073,7 @@ async fn fleet_mark_terminal_completed_on_collect() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
@@ -3139,6 +3114,7 @@ async fn fleet_mark_terminal_cancelled_on_cancel() {
             &SubAgentConfig::default(),
             SpawnContext::default(),
         )
+        .await
         .unwrap();
 
     mgr.cancel(&task_id).unwrap();

--- a/crates/zeph-subagent/src/memory.rs
+++ b/crates/zeph-subagent/src/memory.rs
@@ -14,7 +14,6 @@
 //! - Files larger than 256 KiB or containing null bytes are rejected.
 //! - `<agent-memory>` tags in file content are escaped to prevent prompt injection.
 
-use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
@@ -115,13 +114,18 @@ pub fn resolve_memory_dir(scope: MemoryScope, agent_name: &str) -> Result<PathBu
 ///
 /// Returns [`SubAgentError::Invalid`] if the agent name is invalid.
 /// Returns [`SubAgentError::Memory`] if the directory cannot be created.
-pub fn ensure_memory_dir(scope: MemoryScope, agent_name: &str) -> Result<PathBuf, SubAgentError> {
+pub async fn ensure_memory_dir(
+    scope: MemoryScope,
+    agent_name: &str,
+) -> Result<PathBuf, SubAgentError> {
     let dir = resolve_memory_dir(scope, agent_name)?;
     // create_dir_all is idempotent — no need for a prior exists() check (REV-MED-02).
-    std::fs::create_dir_all(&dir).map_err(|e| SubAgentError::Memory {
-        name: agent_name.to_owned(),
-        reason: format!("cannot create memory directory '{}': {e}", dir.display()),
-    })?;
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| SubAgentError::Memory {
+            name: agent_name.to_owned(),
+            reason: format!("cannot create memory directory '{}': {e}", dir.display()),
+        })?;
     tracing::debug!(
         agent = agent_name,
         scope = ?scope,
@@ -146,16 +150,16 @@ pub fn ensure_memory_dir(scope: MemoryScope, agent_name: &str) -> Result<PathBuf
 /// - Opens the canonical path after the boundary check (no TOCTOU window).
 /// - Rejects files larger than 256 KiB.
 /// - Rejects files containing null bytes.
-pub fn load_memory_content(dir: &Path) -> Option<String> {
+pub async fn load_memory_content(dir: &Path) -> Option<String> {
     let memory_path = dir.join("MEMORY.md");
 
     // Canonicalize to resolve any symlinks before opening.
-    let canonical = std::fs::canonicalize(&memory_path).ok()?;
+    let canonical = tokio::fs::canonicalize(&memory_path).await.ok()?;
 
     // Boundary check: MEMORY.md must be within the memory directory.
     // REV-LOW-01: canonicalize dir separately (can't derive from canonical — symlink
     // target's parent differs from the original dir when symlink escapes boundary).
-    let canonical_dir = std::fs::canonicalize(dir).ok()?;
+    let canonical_dir = tokio::fs::canonicalize(dir).await.ok()?;
     if !canonical.starts_with(&canonical_dir) {
         tracing::warn!(
             path = %canonical.display(),
@@ -165,10 +169,8 @@ pub fn load_memory_content(dir: &Path) -> Option<String> {
         return None;
     }
 
-    // Open the canonical path — no TOCTOU window for symlink swap after this point.
-    // Read content via the same handle to avoid re-opening (REV-CRIT-01).
-    let mut file = std::fs::File::open(&canonical).ok()?;
-    let meta = file.metadata().ok()?;
+    // Stat the canonical path before reading to check size and file type.
+    let meta = tokio::fs::metadata(&canonical).await.ok()?;
 
     if !meta.is_file() {
         return None;
@@ -183,8 +185,7 @@ pub fn load_memory_content(dir: &Path) -> Option<String> {
         return None;
     }
 
-    let mut content = String::with_capacity(usize::try_from(meta.len()).unwrap_or(0));
-    file.read_to_string(&mut content).ok()?;
+    let content = tokio::fs::read_to_string(&canonical).await.ok()?;
 
     // Security: reject files with null bytes (potential binary or injection attack).
     if content.contains('\0') {
@@ -354,27 +355,33 @@ mod tests {
 
     // ── ensure_memory_dir ────────────────────────────────────────────────────
 
-    #[test]
-    fn ensure_creates_directory_for_project_scope() {
+    #[tokio::test]
+    async fn ensure_creates_directory_for_project_scope() {
         let tmp = tempfile::tempdir().unwrap();
         let orig_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
 
-        let result = ensure_memory_dir(MemoryScope::Project, "test-agent").unwrap();
+        let result = ensure_memory_dir(MemoryScope::Project, "test-agent")
+            .await
+            .unwrap();
         assert!(result.exists());
         assert!(result.ends_with(".zeph/agent-memory/test-agent"));
 
         std::env::set_current_dir(orig_dir).unwrap();
     }
 
-    #[test]
-    fn ensure_idempotent_when_directory_exists() {
+    #[tokio::test]
+    async fn ensure_idempotent_when_directory_exists() {
         let tmp = tempfile::tempdir().unwrap();
         let orig_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
 
-        let dir1 = ensure_memory_dir(MemoryScope::Project, "idempotent-agent").unwrap();
-        let dir2 = ensure_memory_dir(MemoryScope::Project, "idempotent-agent").unwrap();
+        let dir1 = ensure_memory_dir(MemoryScope::Project, "idempotent-agent")
+            .await
+            .unwrap();
+        let dir2 = ensure_memory_dir(MemoryScope::Project, "idempotent-agent")
+            .await
+            .unwrap();
         assert_eq!(dir1, dir2);
 
         std::env::set_current_dir(orig_dir).unwrap();
@@ -382,22 +389,22 @@ mod tests {
 
     // ── load_memory_content ───────────────────────────────────────────────────
 
-    #[test]
-    fn load_returns_none_when_no_file() {
+    #[tokio::test]
+    async fn load_returns_none_when_no_file() {
         let tmp = tempfile::tempdir().unwrap();
-        assert!(load_memory_content(tmp.path()).is_none());
+        assert!(load_memory_content(tmp.path()).await.is_none());
     }
 
-    #[test]
-    fn load_returns_content_when_file_exists() {
+    #[tokio::test]
+    async fn load_returns_content_when_file_exists() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("MEMORY.md"), "# Notes\nkey: value\n").unwrap();
-        let content = load_memory_content(tmp.path()).unwrap();
+        let content = load_memory_content(tmp.path()).await.unwrap();
         assert!(content.contains("key: value"));
     }
 
-    #[test]
-    fn load_truncates_at_200_lines() {
+    #[tokio::test]
+    async fn load_truncates_at_200_lines() {
         let tmp = tempfile::tempdir().unwrap();
         let mut lines = String::new();
         for i in 0..300 {
@@ -405,30 +412,30 @@ mod tests {
             writeln!(&mut lines, "line {i}").unwrap();
         }
         std::fs::write(tmp.path().join("MEMORY.md"), &lines).unwrap();
-        let content = load_memory_content(tmp.path()).unwrap();
+        let content = load_memory_content(tmp.path()).await.unwrap();
         let line_count = content.lines().count();
         // Truncated content has 200 data lines + 1 truncation marker line.
         assert!(line_count <= 202, "expected <= 202 lines, got {line_count}");
         assert!(content.contains("truncated at 200 lines"));
     }
 
-    #[test]
-    fn load_rejects_null_bytes() {
+    #[tokio::test]
+    async fn load_rejects_null_bytes() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("MEMORY.md"), "valid\0content").unwrap();
-        assert!(load_memory_content(tmp.path()).is_none());
+        assert!(load_memory_content(tmp.path()).await.is_none());
     }
 
-    #[test]
-    fn load_returns_none_for_empty_file() {
+    #[tokio::test]
+    async fn load_returns_none_for_empty_file() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("MEMORY.md"), "").unwrap();
-        assert!(load_memory_content(tmp.path()).is_none());
+        assert!(load_memory_content(tmp.path()).await.is_none());
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(unix)]
-    fn load_rejects_symlink_escape() {
+    async fn load_rejects_symlink_escape() {
         let tmp = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         let target = outside.path().join("secret.md");
@@ -438,23 +445,23 @@ mod tests {
         std::os::unix::fs::symlink(&target, &link).unwrap();
 
         // The symlink points outside the tmp directory — should be rejected.
-        assert!(load_memory_content(tmp.path()).is_none());
+        assert!(load_memory_content(tmp.path()).await.is_none());
     }
 
-    #[test]
-    fn load_returns_none_for_whitespace_only_file() {
+    #[tokio::test]
+    async fn load_returns_none_for_whitespace_only_file() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("MEMORY.md"), "   \n\n   \n").unwrap();
-        assert!(load_memory_content(tmp.path()).is_none());
+        assert!(load_memory_content(tmp.path()).await.is_none());
     }
 
-    #[test]
-    fn load_rejects_file_over_size_cap() {
+    #[tokio::test]
+    async fn load_rejects_file_over_size_cap() {
         let tmp = tempfile::tempdir().unwrap();
         // 257 KiB of content — exceeds the 256 KiB limit.
         let content = "x".repeat(257 * 1024);
         std::fs::write(tmp.path().join("MEMORY.md"), content).unwrap();
-        assert!(load_memory_content(tmp.path()).is_none());
+        assert!(load_memory_content(tmp.path()).await.is_none());
     }
 
     // ── escape_memory_content ─────────────────────────────────────────────────

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -259,7 +259,9 @@ async fn build_acp_deps(
     let embedding_provider = crate::bootstrap::create_embedding_provider(app.config(), &provider);
     let budget_tokens = app.auto_budget_tokens(&provider);
     let registry = std::sync::Arc::new(RwLock::new(app.build_registry()));
-    let memory = std::sync::Arc::new(app.build_memory(&provider).await?);
+    let acp_mem_cancel = tokio_util::sync::CancellationToken::new();
+    let acp_mem_supervisor = zeph_common::TaskSupervisor::new(acp_mem_cancel);
+    let memory = std::sync::Arc::new(app.build_memory(&provider, &acp_mem_supervisor).await?);
 
     {
         let sqlite = memory.sqlite().clone();

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -363,6 +363,7 @@ impl AppBuilder {
     pub async fn build_memory(
         &self,
         provider: &AnyProvider,
+        supervisor: &zeph_common::TaskSupervisor,
     ) -> Result<SemanticMemory, BootstrapError> {
         let embed_model = self.embedding_model();
         // Resolve the database path: prefer database_url (PostgreSQL) over sqlite_path.
@@ -496,7 +497,7 @@ impl AppBuilder {
         memory =
             memory.with_key_facts_dedup_threshold(self.config.memory.key_facts_dedup_threshold);
 
-        if let Some(logger) = self.build_retrieval_failure_logger(memory.sqlite()) {
+        if let Some(logger) = self.build_retrieval_failure_logger(memory.sqlite(), supervisor) {
             memory = memory.with_retrieval_failure_logger(logger);
         }
 
@@ -513,6 +514,7 @@ impl AppBuilder {
     fn build_retrieval_failure_logger(
         &self,
         sqlite: &zeph_memory::store::DbStore,
+        supervisor: &zeph_common::TaskSupervisor,
     ) -> Option<zeph_memory::RetrievalFailureLogger> {
         if !self.config.memory.retrieval_failures.enabled {
             return None;
@@ -524,6 +526,7 @@ impl AppBuilder {
             rf_cfg.batch_size,
             std::time::Duration::from_millis(rf_cfg.flush_interval_ms),
             rf_cfg.retention_days,
+            supervisor,
         );
         tracing::info!("retrieval failure logging enabled");
         Some(logger)

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -408,6 +408,40 @@ fn run_dry_run(source_items: &[SourceItem], total_files: usize, discovery_errors
     println!("Dry run complete. Run without --dry-run to ingest.");
 }
 
+async fn build_ingest_resources(
+    config_path: Option<&Path>,
+) -> anyhow::Result<(IngestionPipeline, IngestLedger, String, String)> {
+    let app = AppBuilder::new(config_path, None, None, None).await?;
+    let config = app.config();
+    let qdrant = QdrantOps::new(
+        &config.memory.qdrant_url,
+        config.memory.qdrant_api_key.as_ref().map(Secret::expose),
+    )
+    .map_err(|e| anyhow::anyhow!("failed to connect to Qdrant: {e}"))?;
+    let collection = config.memory.documents.collection.clone();
+    let (provider, _status_tx, _status_rx) = app.build_provider().await?;
+    let provider = Arc::new(provider);
+    let embed_fn = {
+        let p = Arc::clone(&provider);
+        move |text: &str| -> zeph_llm::provider::EmbedFuture {
+            let p = Arc::clone(&p);
+            let owned = text.to_owned();
+            Box::pin(async move { p.embed(&owned).await })
+        }
+    };
+    let pipeline = IngestionPipeline::new(
+        TextSplitter::new(SplitterConfig::default()),
+        qdrant,
+        &collection,
+        Box::new(embed_fn),
+    );
+    let kn_sup = zeph_common::TaskSupervisor::new(tokio_util::sync::CancellationToken::new());
+    let mem = app.build_memory(&provider, &kn_sup).await?;
+    let ledger = IngestLedger::new(mem.sqlite().pool().clone());
+    let batch_id = uuid::Uuid::new_v4().to_string();
+    Ok((pipeline, ledger, batch_id, collection))
+}
+
 /// Execute the normal ingest path: build Qdrant + provider + ledger, then ingest each file.
 #[tracing::instrument(skip_all)]
 async fn run_ingest(
@@ -417,35 +451,8 @@ async fn run_ingest(
     per_source_counts: Vec<(&'static str, usize)>,
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
-    let app = AppBuilder::new(config_path, None, None, None).await?;
-    let config = app.config();
-
-    let qdrant = QdrantOps::new(
-        &config.memory.qdrant_url,
-        config.memory.qdrant_api_key.as_ref().map(Secret::expose),
-    )
-    .map_err(|e| anyhow::anyhow!("failed to connect to Qdrant: {e}"))?;
-
-    let collection = config.memory.documents.collection.clone();
-
-    let (provider, _status_tx, _status_rx) = app.build_provider().await?;
-    let provider = Arc::new(provider);
-
-    let embed_fn = {
-        let p = Arc::clone(&provider);
-        move |text: &str| -> zeph_llm::provider::EmbedFuture {
-            let p = Arc::clone(&p);
-            let owned = text.to_owned();
-            Box::pin(async move { p.embed(&owned).await })
-        }
-    };
-
-    let splitter = TextSplitter::new(SplitterConfig::default());
-    let pipeline = IngestionPipeline::new(splitter, qdrant, &collection, Box::new(embed_fn));
-
-    let mem = app.build_memory(&provider).await?;
-    let ledger = IngestLedger::new(mem.sqlite().pool().clone());
-    let batch_id = uuid::Uuid::new_v4().to_string();
+    let (pipeline, ledger, batch_id, collection) =
+        Box::pin(build_ingest_resources(config_path)).await?;
 
     // FR-014: create a dedicated progress channel and spawn a CLI printer consumer.
     let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel::<IngestProgress>();
@@ -803,7 +810,8 @@ async fn run_graph_ingest(
         Arc::new(p)
     };
 
-    let memory = app.build_memory(&provider).await?;
+    let kn_sup2 = zeph_common::TaskSupervisor::new(tokio_util::sync::CancellationToken::new());
+    let memory = app.build_memory(&provider, &kn_sup2).await?;
 
     // Build SharedPostExtractValidator wrapping MemoryWriteValidator (INV-4).
     // Always Some — required on both dry-run and live paths (spec-067 §G-5 S3).
@@ -1241,7 +1249,8 @@ async fn handle_external_agent_ingest(
     let app = AppBuilder::new(config_path, None, None, None).await?;
     let app_config = app.config();
     let (provider, _status_tx, _status_rx) = app.build_provider().await?;
-    let mem = app.build_memory(&provider).await?;
+    let kn_sup3 = zeph_common::TaskSupervisor::new(tokio_util::sync::CancellationToken::new());
+    let mem = app.build_memory(&provider, &kn_sup3).await?;
 
     // Build SharedPostExtractValidator wrapping MemoryWriteValidator (INV-4, spec-067 §G-5 S3).
     let validator_inner = zeph_sanitizer::memory_validation::MemoryWriteValidator::new(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -299,7 +299,9 @@ pub(crate) async fn run_daemon(
     let budget_tokens = app.auto_budget_tokens(&provider);
 
     let registry = std::sync::Arc::new(RwLock::new(app.build_registry()));
-    let memory = std::sync::Arc::new(app.build_memory(&provider).await?);
+    let mem_cancel = tokio_util::sync::CancellationToken::new();
+    let mem_supervisor = zeph_common::TaskSupervisor::new(mem_cancel.clone());
+    let memory = std::sync::Arc::new(app.build_memory(&provider, &mem_supervisor).await?);
     let all_meta_owned: Vec<zeph_skills::loader::SkillMeta> =
         registry.read().all_meta().into_iter().cloned().collect();
     let all_meta_refs: Vec<&zeph_skills::loader::SkillMeta> = all_meta_owned.iter().collect();
@@ -327,6 +329,15 @@ pub(crate) async fn run_daemon(
     }
 
     let (shutdown_tx, shutdown_rx) = AppBuilder::build_shutdown();
+
+    // Wire shutdown to mem_supervisor (created before build_memory for retrieval-failure-logger).
+    {
+        let mut rx = shutdown_rx.clone();
+        tokio::spawn(async move {
+            let _ = rx.changed().await;
+            mem_cancel.cancel();
+        });
+    }
 
     let daemon_cancel = tokio_util::sync::CancellationToken::new();
     let task_supervisor = zeph_common::TaskSupervisor::new(daemon_cancel.clone());

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1054,14 +1054,20 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         std::process::exit(130);
     });
 
+    // Create TaskSupervisor early so background tasks spawned during build_memory
+    // (e.g. retrieval-failure-logger) are registered before the shutdown bridge is wired.
+    // The shutdown bridge (shutdown_rx → mem_cancel) is attached below after build_shutdown().
+    let mem_cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = std::sync::Arc::new(TaskSupervisor::new(mem_cancel.clone()));
+
     #[cfg(feature = "tui")]
     tui_status!("Loading memory...");
     let memory = if exec_mode.bare {
         // Bare mode: use an ephemeral in-process SQLite with no Qdrant, no graph store,
-        // and no embed backfill. Avoids all startup file and network I/O.
+        // and no embed backfill. Avoids all startup file and memory I/O.
         std::sync::Arc::new(app.build_bare_memory(&provider).await?)
     } else {
-        std::sync::Arc::new(app.build_memory(&provider).await?)
+        std::sync::Arc::new(app.build_memory(&provider, &supervisor).await?)
     };
     // backfill_rx: progress tracking for embed backfill.
     // None = idle/done, Some(progress) = in progress.
@@ -1503,10 +1509,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         zeph_core::ShellOverlaySnapshot { blocked, allowed }
     };
 
-    // Create a TaskSupervisor for all memory background loops.
-    // A single bridge from shutdown_rx → cancel token replaces per-loop cancel bridges.
-    let mem_cancel = tokio_util::sync::CancellationToken::new();
-    let supervisor = std::sync::Arc::new(TaskSupervisor::new(mem_cancel.clone()));
+    // Wire shutdown_rx → mem_cancel bridge so the supervisor (created before build_memory)
+    // shuts down cleanly when the shutdown signal fires.
     {
         let mut rx = shutdown_rx.clone();
         let cancel = mem_cancel.clone();
@@ -3723,7 +3727,13 @@ async fn run_experiment_session(
     let exp_config = config.experiments.clone();
 
     // Build memory for persisting results (best effort — if unavailable, results are logged only).
-    let memory = app.build_memory(&provider_arc).await.ok().map(Arc::new);
+    let exp_cancel = tokio_util::sync::CancellationToken::new();
+    let exp_supervisor = TaskSupervisor::new(exp_cancel.clone());
+    let memory = app
+        .build_memory(&provider_arc, &exp_supervisor)
+        .await
+        .ok()
+        .map(Arc::new);
 
     let mut engine = ExperimentEngine::new(
         evaluator,


### PR DESCRIPTION
## Summary

- **#5152**: `SubAgentManager::spawn` called `std::fs::create_dir_all`, `std::fs::canonicalize`, `std::fs::File::open`, and `read_to_string` on async threads. Converted `ensure_memory_dir` and `load_memory_content` to `async fn` using `tokio::fs`, propagated `async` up through `build_system_prompt_with_memory`, `spawn`, and `spawn_for_task`.
- **#5172**: `RetrievalFailureLogger` spawned its writer task via raw `tokio::spawn`, invisible to `TaskSupervisor`. Replaced with `supervisor.spawn(TaskDescriptor { ... })` using the `Arc<Mutex<Option<Future>>>` factory pattern. Made `shutdown()` async to guarantee a clean flush before the supervisor can abort the task.
- Updated `build_memory` to require `&TaskSupervisor` at all call sites; added supervisor creation in `runner.rs`, `daemon.rs`, `acp.rs`, and `knowledge.rs`.
- Extracted `build_ingest_resources` helper to keep `run_ingest` within the `too_many_lines` clippy limit.
- Converted all `zeph-subagent` manager tests from `#[test]` + `rt.enter()` to `#[tokio::test] async fn`.

## Test plan

- [ ] `cargo +nightly fmt --check` — passes
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — passes
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11263/11263 passed
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — passes

Closes #5152
Closes #5172