### PR TITLE
fix(tracing): add missing instrument spans to a2a, orchestration, and agent-context

### DIFF
--- a/crates/zeph-a2a/src/server/handlers.rs
+++ b/crates/zeph-a2a/src/server/handlers.rs
@@ -104,6 +104,7 @@ fn error_response(
 /// Completed tasks and their message content are not written to a persistent audit log.
 /// Only `tracing::debug` is emitted per request. For structured audit trails, a `SQLite`
 /// append-only log should be added here. Tracked as a known gap — see architecture doc.
+#[tracing::instrument(name = "a2a.jsonrpc", skip_all, fields(method = %raw.method, authenticated = %identity.authenticated))]
 pub async fn jsonrpc_handler(
     State(state): State<AppState>,
     Extension(identity): Extension<AuthIdentity>,
@@ -130,6 +131,7 @@ pub async fn jsonrpc_handler(
     Json(response)
 }
 
+#[tracing::instrument(name = "a2a.handle_send_message", skip_all)]
 async fn handle_send_message(
     state: AppState,
     id: serde_json::Value,
@@ -217,6 +219,7 @@ async fn handle_send_message(
     }
 }
 
+#[tracing::instrument(name = "a2a.handle_get_task", skip_all)]
 async fn handle_get_task(
     state: AppState,
     id: serde_json::Value,
@@ -240,6 +243,7 @@ async fn handle_get_task(
     }
 }
 
+#[tracing::instrument(name = "a2a.handle_cancel_task", skip_all)]
 async fn handle_cancel_task(
     state: AppState,
     id: serde_json::Value,
@@ -338,6 +342,7 @@ fn status_event(
     sse_rpc_event(&event)
 }
 
+#[tracing::instrument(name = "a2a.stream", skip_all, fields(authenticated = %identity.authenticated))]
 pub async fn stream_handler(
     State(state): State<AppState>,
     Extension(identity): Extension<AuthIdentity>,

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -752,6 +752,7 @@ impl ContextService {
     /// must apply via `inject_code_context`, plus the count of messages freshly inserted at
     /// indices `1..1+inserted_count` (used by the fidelity scorer as the exempt range — INV-10).
     #[allow(clippy::too_many_lines)] // sequential message injection: order matters, cannot split
+    #[tracing::instrument(name = "agent_context.service.apply_prepared_context", skip_all)]
     async fn apply_prepared_context(
         &self,
         window: &mut MessageWindowView<'_>,

--- a/crates/zeph-orchestration/src/adaptorch.rs
+++ b/crates/zeph-orchestration/src/adaptorch.rs
@@ -233,51 +233,45 @@ impl TopologyAdvisor {
     /// Classify the goal and sample the best topology hint for this turn.
     ///
     /// Classification failures fall back to `TaskClass::Unknown` + `TopologyHint::Hybrid`.
+    #[tracing::instrument(name = "orchestration.adaptorch.recommend", skip_all, fields(goal_len = goal.len()))]
     pub async fn recommend(&self, goal: &str) -> AdvisorVerdict {
-        async move {
-            self.metrics.classify_calls.fetch_add(1, Ordering::Relaxed);
+        self.metrics.classify_calls.fetch_add(1, Ordering::Relaxed);
 
-            let class = tokio::time::timeout(self.classify_timeout, self.classify(goal))
-                .await
-                .unwrap_or_else(|_| {
-                    self.metrics
-                        .classify_timeouts
-                        .fetch_add(1, Ordering::Relaxed);
-                    TaskClass::Unknown
-                });
+        let class = tokio::time::timeout(self.classify_timeout, self.classify(goal))
+            .await
+            .unwrap_or_else(|_| {
+                self.metrics
+                    .classify_timeouts
+                    .fetch_add(1, Ordering::Relaxed);
+                TaskClass::Unknown
+            });
 
-            let fallback = class == TaskClass::Unknown;
-            let (hint, exploit) = self.sample_arm(class);
+        let fallback = class == TaskClass::Unknown;
+        let (hint, exploit) = self.sample_arm(class);
 
-            match hint {
-                TopologyHint::Parallel => {
-                    self.metrics.hint_parallel.fetch_add(1, Ordering::Relaxed);
-                }
-                TopologyHint::Sequential => {
-                    self.metrics.hint_sequential.fetch_add(1, Ordering::Relaxed);
-                }
-                TopologyHint::Hierarchical => {
-                    self.metrics
-                        .hint_hierarchical
-                        .fetch_add(1, Ordering::Relaxed);
-                }
-                TopologyHint::Hybrid => {
-                    self.metrics.hint_hybrid.fetch_add(1, Ordering::Relaxed);
-                }
+        match hint {
+            TopologyHint::Parallel => {
+                self.metrics.hint_parallel.fetch_add(1, Ordering::Relaxed);
             }
-
-            AdvisorVerdict {
-                class,
-                hint,
-                exploit,
-                fallback,
+            TopologyHint::Sequential => {
+                self.metrics.hint_sequential.fetch_add(1, Ordering::Relaxed);
+            }
+            TopologyHint::Hierarchical => {
+                self.metrics
+                    .hint_hierarchical
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            TopologyHint::Hybrid => {
+                self.metrics.hint_hybrid.fetch_add(1, Ordering::Relaxed);
             }
         }
-        .instrument(tracing::info_span!(
-            "orchestration.adaptorch.recommend",
-            goal_len = goal.len(),
-        ))
-        .await
+
+        AdvisorVerdict {
+            class,
+            hint,
+            exploit,
+            fallback,
+        }
     }
 
     /// Record the binary outcome of a plan guided by `(class, hint)`.


### PR DESCRIPTION
## Summary

Adds `#[tracing::instrument]` to 7 async functions across three crates that await external resources but emitted no spans, making A2A request processing, orchestration topology advice, and agent context injection invisible in Perfetto/Jaeger trace flamecharts.

- **`zeph-a2a`** (`handlers.rs`): `jsonrpc_handler`, `stream_handler`, and 3 inner dispatch handlers — A2A request path is now fully visible with `method` and `authenticated` fields
- **`zeph-orchestration`** (`adaptorch.rs`): `TopologyAdvisor::recommend` — replaces manual `.instrument().await` wrapper with fn-level attribute to avoid double-span nesting; adds `goal_len` field
- **`zeph-agent-context`** (`service.rs`): `apply_prepared_context` — the 9 sequential `sanitize_memory_message` awaits are now anchored to a parent span instead of appearing as orphaned traces

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11264/11264 pass, 0 failures
- [x] Rustdoc gate — clean
- [x] No logic changes — purely additive `#[tracing::instrument]` attributes
- [x] No duplicate nested spans in `adaptorch.rs` (inner manual span correctly flattened)

Closes #5133, #5131, #5116