### PR TITLE
fix(tui): add expand/collapse affordance to grouped tool summary line

### DIFF
--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -571,6 +571,11 @@ fn render_grouped_tool_cell(
     let mut lines = wrap_spans(summary_spans, wrap_width);
 
     if tool_density == ToolDensity::Compact {
+        let dim = Style::default().add_modifier(Modifier::DIM);
+        if let Some(last) = lines.last_mut() {
+            last.spans
+                .push(Span::styled("  (press 'e' to expand)", dim));
+        }
         return lines;
     }
 
@@ -2057,6 +2062,10 @@ mod tests {
             .join("");
         assert!(text.contains("Explored"), "compact: summary present");
         assert!(!text.contains("f0.rs"), "compact: no sub-list items");
+        assert!(
+            text.contains("press 'e' to expand"),
+            "compact: expand affordance shown"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Grouped tool summary lines in Compact density (e.g. `● Edited 3 files`) now show a dim `(press 'e' to expand)` hint appended inline, matching the existing affordance style used by paste blocks and tool output collapse ellipses
- Updated `render_grouped_cell_compact_no_sublist` test to assert the affordance is present
- No behavior change in Inline or Block density modes

## Test plan

- [ ] `cargo nextest run -p zeph-tui --lib` — all 615 tests pass
- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11264 tests pass
- [ ] `cargo clippy --profile ci -p zeph-tui -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean

Closes #5123