### PR TITLE
feat(skills,commands): surface skill load failures and enrich /model+/provider help

### DIFF
--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -135,14 +135,14 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo {
         name: "/model",
         args: "[id|refresh]",
-        description: "Show or switch the active model",
+        description: "Show or switch the active model. Examples: `/model claude-sonnet-4-6` to switch, `/model refresh` to re-query the provider model list",
         category: SlashCategory::Configuration,
         feature_gate: None,
     },
     CommandInfo {
         name: "/provider",
         args: "[name|status]",
-        description: "List configured providers or switch to one by name",
+        description: "List configured providers or switch to one by name. Examples: `/provider quality` to switch, `/provider status` to show health of all configured providers",
         category: SlashCategory::Configuration,
         feature_gate: None,
     },

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -489,15 +489,16 @@ impl<C: crate::channel::Channel> Agent<C> {
         use std::collections::BTreeMap;
         use std::fmt::Write;
 
-        let all_meta: Vec<zeph_skills::loader::SkillMeta> = self
-            .services
-            .skill
-            .registry
-            .read()
-            .all_meta()
-            .into_iter()
-            .cloned()
-            .collect();
+        let (all_meta, load_errors): (
+            Vec<zeph_skills::loader::SkillMeta>,
+            Vec<(std::path::PathBuf, String)>,
+        ) = {
+            let reg = self.services.skill.registry.read();
+            (
+                reg.all_meta().into_iter().cloned().collect(),
+                reg.load_errors().to_vec(),
+            )
+        };
 
         // Clone Arc before .await to avoid holding &self across suspension points.
         let memory = self.services.memory.persistence.memory.clone();
@@ -555,6 +556,13 @@ impl<C: crate::channel::Channel> Agent<C> {
                 }
                 Ok(_) => {}
                 Err(e) => tracing::warn!("failed to load skill usage: {e:#}"),
+            }
+        }
+
+        if !load_errors.is_empty() {
+            output.push_str("\nFailed to load:\n");
+            for (path, reason) in &load_errors {
+                let _ = writeln!(output, "- {}: {reason}", path.display());
             }
         }
 

--- a/crates/zeph-skills/src/registry.rs
+++ b/crates/zeph-skills/src/registry.rs
@@ -50,7 +50,7 @@
 
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use walkdir::WalkDir;
@@ -85,7 +85,12 @@ pub struct SkillRegistry {
     /// Skills whose `skill_dir` is under one of these paths are hub-installed and
     /// must never have their `.bundled` marker respected — the marker would bypass
     /// the injection scanner (defense-in-depth for #3040).
-    hub_dirs: Vec<std::path::PathBuf>,
+    hub_dirs: Vec<PathBuf>,
+    /// Skills that failed to load during the last `load()` or `reload()` call.
+    ///
+    /// Each entry is `(path_to_SKILL_md, error_message)`. Populated during `load()`;
+    /// callers use `load_errors()` to surface failures to the user.
+    load_errors: Vec<(PathBuf, String)>,
 }
 
 impl std::fmt::Debug for SkillRegistry {
@@ -94,6 +99,7 @@ impl std::fmt::Debug for SkillRegistry {
             .field("count", &self.entries.len())
             .field("fingerprint", &self.fingerprint)
             .field("hub_dirs", &self.hub_dirs.len())
+            .field("load_errors", &self.load_errors.len())
             .finish()
     }
 }
@@ -166,6 +172,7 @@ impl SkillRegistry {
     pub fn load(paths: &[impl AsRef<Path>]) -> Self {
         let mut entries = Vec::new();
         let mut seen = HashSet::new();
+        let mut load_errors: Vec<(PathBuf, String)> = Vec::new();
 
         for base in paths {
             let base = base.as_ref();
@@ -205,7 +212,11 @@ impl SkillRegistry {
                             tracing::debug!("duplicate skill '{}', skipping", skill_path.display());
                         }
                     }
-                    Err(e) => tracing::warn!("skipping {}: {e:#}", skill_path.display()),
+                    Err(e) => {
+                        let reason = format!("{e:#}");
+                        tracing::warn!("skipping {}: {reason}", skill_path.display());
+                        load_errors.push((skill_path.to_path_buf(), reason));
+                    }
                 }
             }
         }
@@ -217,16 +228,38 @@ impl SkillRegistry {
             entries,
             fingerprint,
             hub_dirs: Vec::new(),
+            load_errors,
         }
     }
 
     /// Reload skills from the given paths, replacing the current set.
     ///
     /// Hub directories registered via [`Self::with_hub_dirs`] are preserved across reloads.
+    /// Load errors from the previous call are replaced with those from the new load.
     pub fn reload(&mut self, paths: &[impl AsRef<Path>]) {
         let hub_dirs = std::mem::take(&mut self.hub_dirs);
         *self = Self::load(paths);
         self.hub_dirs = hub_dirs;
+    }
+
+    /// Skills that failed to load during the last [`Self::load`] or [`Self::reload`] call.
+    ///
+    /// Each entry is `(path_to_SKILL_md, error_message)`. Empty when all skills loaded
+    /// successfully or when the registry was created via [`Self::empty`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use zeph_skills::registry::SkillRegistry;
+    ///
+    /// let registry = SkillRegistry::load(&["/path/to/skills"]);
+    /// for (path, reason) in registry.load_errors() {
+    ///     eprintln!("warning: skill '{}' skipped: {}", path.display(), reason);
+    /// }
+    /// ```
+    #[must_use]
+    pub fn load_errors(&self) -> &[(PathBuf, String)] {
+        &self.load_errors
     }
 
     /// Content fingerprint based on file metadata (name + mtime + size).
@@ -484,6 +517,9 @@ mod tests {
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
         assert_eq!(registry.all_meta().len(), 1);
         assert_eq!(registry.all_meta()[0].name, "good");
+        let errors = registry.load_errors();
+        assert_eq!(errors.len(), 1);
+        assert!(!errors[0].1.is_empty());
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1116,6 +1116,16 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         registry.read().all_meta().into_iter().cloned().collect();
     let skill_count = all_meta_owned.len();
 
+    // Emit load errors to the user immediately at startup.
+    for (path, reason) in registry.read().load_errors() {
+        let name = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("<unknown>");
+        let _ = agent_status_tx.send(format!("warning: skill '{name}' skipped: {reason}"));
+    }
+
     // Populate trust DB for all loaded skills.
     {
         let trust_cfg = config.skills.trust.clone();


### PR DESCRIPTION
## Summary

- **#5073**: skill load errors are now accumulated in `SkillRegistry` and exposed via `load_errors()`. At startup, each failed skill emits a visible warning through the status channel. `/skills` output appends a "Failed to load:" section when errors are present.
- **#5074**: `/model` and `/provider` descriptions now include inline usage examples.

## Changes

- `crates/zeph-skills/src/registry.rs` — add `load_errors: Vec<(PathBuf, String)>` field, accumulate in `load()`, expose via `load_errors()`, test assertion in `skips_invalid_skills`
- `crates/zeph-core/src/agent/slash_commands.rs` — `/skills` reads `load_errors()` in same lock scope, appends "Failed to load:" section when non-empty
- `src/runner.rs` — emit one `agent_status_tx.send()` per failed skill at startup
- `crates/zeph-commands/src/commands.rs` — enrich `/model` and `/provider` descriptions with inline examples

## Test plan

- [x] fmt clean, clippy clean, 649 tests passed (zeph-skills + zeph-commands)

Closes #5073
Closes #5074