### PR TITLE
fix(index): eliminate async violations in zeph-index

### DIFF
--- a/crates/zeph-index/src/mcp_server.rs
+++ b/crates/zeph-index/src/mcp_server.rs
@@ -115,7 +115,10 @@ impl IndexMcpServer {
     /// Call this when watcher events indicate file changes.
     #[tracing::instrument(name = "index.mcp_server.refresh", skip_all)]
     pub async fn refresh(&self) {
-        let index = build_index(&self.project_root);
+        let root = self.project_root.clone();
+        let index = tokio::task::spawn_blocking(move || build_index(&root))
+            .await
+            .unwrap_or_default();
         *self.index.write().await = index;
     }
 }
@@ -307,15 +310,15 @@ fn run_symbol_definition(
     }
 }
 
-fn run_find_text_references(
+fn run_find_text_references_paths(
     root: &Path,
-    index: &SymbolIndex,
+    rel_paths: &[PathBuf],
     params: &FindTextReferencesParams,
 ) -> serde_json::Value {
     let name = &params.name;
     let mut hits: Vec<serde_json::Value> = Vec::new();
 
-    'outer: for rel_path in index.modules.keys() {
+    'outer: for rel_path in rel_paths {
         let abs = root.join(rel_path);
         let Ok(source) = std::fs::read_to_string(&abs) else {
             continue;
@@ -409,25 +412,35 @@ impl ToolExecutor for IndexMcpServer {
     }
 
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
-        let index = self.index.read().await;
-        let result = match call.tool_id.as_str() {
-            "symbol_definition" => {
-                let params: SymbolDefinitionParams = deserialize_params(&call.params)?;
-                run_symbol_definition(&index, &params)
+        let result = if call.tool_id == "find_text_references" {
+            // `run_find_text_references` calls `std::fs::read_to_string` in a loop.
+            // Clone the data needed out of the RwLock guard, drop the guard, then
+            // offload the blocking I/O to the dedicated blocking thread pool.
+            let params: FindTextReferencesParams = deserialize_params(&call.params)?;
+            let root = self.project_root.clone();
+            let rel_paths: Vec<PathBuf> = self.index.read().await.modules.keys().cloned().collect();
+            tokio::task::spawn_blocking(move || {
+                run_find_text_references_paths(&root, &rel_paths, &params)
+            })
+            .await
+            .unwrap_or_else(|_| serde_json::Value::Array(vec![]))
+        } else {
+            let index = self.index.read().await;
+            match call.tool_id.as_str() {
+                "symbol_definition" => {
+                    let params: SymbolDefinitionParams = deserialize_params(&call.params)?;
+                    run_symbol_definition(&index, &params)
+                }
+                "call_graph" => {
+                    let params: CallGraphParams = deserialize_params(&call.params)?;
+                    run_call_graph(&index, params)
+                }
+                "module_summary" => {
+                    let params: ModuleSummaryParams = deserialize_params(&call.params)?;
+                    run_module_summary(&index, &params)
+                }
+                _ => return Ok(None),
             }
-            "find_text_references" => {
-                let params: FindTextReferencesParams = deserialize_params(&call.params)?;
-                run_find_text_references(&self.project_root, &index, &params)
-            }
-            "call_graph" => {
-                let params: CallGraphParams = deserialize_params(&call.params)?;
-                run_call_graph(&index, params)
-            }
-            "module_summary" => {
-                let params: ModuleSummaryParams = deserialize_params(&call.params)?;
-                run_module_summary(&index, &params)
-            }
-            _ => return Ok(None),
         };
 
         let summary = serde_json::to_string_pretty(&result).unwrap_or_default();
@@ -529,11 +542,12 @@ impl Foo {
     fn find_text_references_finds_occurrences() {
         let (dir, server) = setup_with_rust_file();
         let index = server.index.blocking_read();
+        let rel_paths: Vec<PathBuf> = index.modules.keys().cloned().collect();
         let params = FindTextReferencesParams {
             name: "hello".to_string(),
             max_results: 10,
         };
-        let result = run_find_text_references(dir.path(), &index, &params);
+        let result = run_find_text_references_paths(dir.path(), &rel_paths, &params);
         let arr = result.as_array().unwrap();
         assert!(
             !arr.is_empty(),
@@ -545,11 +559,12 @@ impl Foo {
     fn find_text_references_empty_for_unknown() {
         let (dir, server) = setup_with_rust_file();
         let index = server.index.blocking_read();
+        let rel_paths: Vec<PathBuf> = index.modules.keys().cloned().collect();
         let params = FindTextReferencesParams {
             name: "zzz_not_present_zzz".to_string(),
             max_results: 10,
         };
-        let result = run_find_text_references(dir.path(), &index, &params);
+        let result = run_find_text_references_paths(dir.path(), &rel_paths, &params);
         assert!(result.as_array().unwrap().is_empty());
     }
 
@@ -656,11 +671,12 @@ impl Foo {
         std::fs::write(dir.path().join("many.rs"), &content).unwrap();
         let server = IndexMcpServer::new(dir.path());
         let index = server.index.blocking_read();
+        let rel_paths: Vec<PathBuf> = index.modules.keys().cloned().collect();
         let params = FindTextReferencesParams {
             name: "target".to_string(),
             max_results: 5,
         };
-        let result = run_find_text_references(dir.path(), &index, &params);
+        let result = run_find_text_references_paths(dir.path(), &rel_paths, &params);
         let arr = result.as_array().unwrap();
         assert!(
             arr.len() <= 5,

--- a/crates/zeph-index/src/watcher.rs
+++ b/crates/zeph-index/src/watcher.rs
@@ -34,6 +34,7 @@ use std::time::Duration;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
 use tokio::sync::mpsc;
+use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};
 
 use crate::error::Result;
 use crate::indexer::CodeIndexer;
@@ -60,11 +61,23 @@ fn is_gitignored(gitignore: &Gitignore, root: &Path, path: &Path) -> bool {
         .is_ignore()
 }
 
+/// Opaque handle keeping the background watcher task alive.
+#[allow(dead_code)]
+enum WatcherHandle {
+    Supervised(zeph_common::task_supervisor::TaskHandle),
+    Unsupervised(tokio::task::JoinHandle<()>),
+}
+
 /// A running file-system watcher that triggers incremental re-indexing on file saves.
 ///
-/// Created by [`IndexWatcher::start`]. Dropping the `IndexWatcher` aborts the
-/// background Tokio task and the underlying `notify` watcher, stopping all
-/// file-system monitoring.
+/// Created by [`IndexWatcher::start`].
+///
+/// When started with a supervisor (`supervisor: Some`), the background task is owned by
+/// the supervisor's `JoinSet` and lives until `supervisor.shutdown_all()` — dropping this
+/// handle does not abort it.
+///
+/// When started without a supervisor (`supervisor: None`, test-only path), dropping this
+/// handle aborts the background task and the underlying `notify` watcher.
 ///
 /// # Examples
 ///
@@ -76,12 +89,12 @@ fn is_gitignored(gitignore: &Gitignore, root: &Path, path: &Path) -> bool {
 /// # let indexer: Arc<zeph_index::indexer::CodeIndexer> = panic!("placeholder");
 ///
 /// // Start watching — the returned handle keeps the watcher alive.
-/// let _watcher = IndexWatcher::start(Path::new("."), indexer, None)?;
+/// let _watcher = IndexWatcher::start(Path::new("."), indexer, None, None)?;
 /// # Ok(())
 /// # }
 /// ```
 pub struct IndexWatcher {
-    _handle: tokio::task::JoinHandle<()>,
+    _handle: WatcherHandle,
 }
 
 impl IndexWatcher {
@@ -91,6 +104,11 @@ impl IndexWatcher {
     /// reindex begins, and an empty string is sent when it completes (clearing the TUI
     /// status bar). Pass `None` in non-TUI modes where no status indicator is needed.
     ///
+    /// When `supervisor` is `Some`, the background debounce-reindex loop is registered
+    /// as a named `RunOnce` task under `"index.watcher"` so it appears in supervisor
+    /// snapshots and is subject to graceful shutdown. When `None`, the task is spawned
+    /// directly via `tokio::spawn` for backward-compatibility.
+    ///
     /// # Errors
     ///
     /// Returns an error if the filesystem watcher cannot be initialized.
@@ -98,6 +116,7 @@ impl IndexWatcher {
         root: &Path,
         indexer: Arc<CodeIndexer>,
         status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+        supervisor: Option<TaskSupervisor>,
     ) -> Result<Self> {
         const DEBOUNCE: Duration = Duration::from_millis(500);
         // Under sustained FS writes the deadline resets on every event. MAX_DEBOUNCE
@@ -139,7 +158,7 @@ impl IndexWatcher {
         let root = root.to_path_buf();
         let gitignore = build_gitignore(&root);
 
-        let handle = tokio::spawn(async move {
+        let fut = async move {
             let _debouncer = debouncer;
             let mut pending: HashSet<PathBuf> = HashSet::new();
             let mut deadline = tokio::time::Instant::now() + DEBOUNCE;
@@ -181,7 +200,29 @@ impl IndexWatcher {
                     }
                 }
             }
-        });
+        };
+
+        let handle = if let Some(sup) = supervisor {
+            // Wrap the one-shot future so the `Fn` factory can hand it off exactly once.
+            // `parking_lot::Mutex` is available transitively via `zeph_common`.
+            let fut_cell = std::sync::Arc::new(std::sync::Mutex::new(Some(fut)));
+            let task_handle = sup.spawn(TaskDescriptor {
+                name: "index.watcher",
+                restart: RestartPolicy::RunOnce,
+                factory: move || {
+                    let f = fut_cell.lock().ok().and_then(|mut g| g.take());
+                    async move {
+                        if let Some(f) = f {
+                            f.await;
+                        }
+                    }
+                },
+            });
+            WatcherHandle::Supervised(task_handle)
+        } else {
+            // Fallback: no supervisor provided (e.g. test environments).
+            WatcherHandle::Unsupervised(tokio::spawn(fut))
+        };
 
         Ok(Self { _handle: handle })
     }
@@ -219,7 +260,7 @@ mod tests {
     #[tokio::test]
     async fn start_with_valid_directory() {
         let dir = tempfile::tempdir().unwrap();
-        let watcher = IndexWatcher::start(dir.path(), create_test_indexer().await, None);
+        let watcher = IndexWatcher::start(dir.path(), create_test_indexer().await, None, None);
         assert!(watcher.is_ok());
     }
 
@@ -228,6 +269,7 @@ mod tests {
         let result = IndexWatcher::start(
             Path::new("/nonexistent/path/xyz"),
             create_test_indexer().await,
+            None,
             None,
         );
         assert!(result.is_err());

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1124,10 +1124,16 @@ pub(crate) async fn apply_code_indexer(
                 workspace_root.clone(),
                 progress_tx,
                 cli_mode,
-                supervisor,
+                supervisor.clone(),
             );
             tracing::info!("code indexer started");
-            let watcher = start_index_watcher(config.watch, &workspace_root, indexer, status_tx);
+            let watcher = start_index_watcher(
+                config.watch,
+                &workspace_root,
+                indexer,
+                status_tx,
+                supervisor,
+            );
             (watcher, Some(progress_rx))
         }
         Err(e) => {
@@ -1224,11 +1230,12 @@ fn start_index_watcher(
     root: &std::path::Path,
     indexer: std::sync::Arc<CodeIndexer>,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    supervisor: Option<zeph_common::TaskSupervisor>,
 ) -> Option<IndexWatcher> {
     if !watch {
         return None;
     }
-    match IndexWatcher::start(root, indexer, status_tx) {
+    match IndexWatcher::start(root, indexer, status_tx, supervisor) {
         Ok(w) => {
             tracing::info!("index watcher started");
             Some(w)


### PR DESCRIPTION
## Summary

- **mcp_server.rs** (#5162): `refresh()` and `execute_tool_call()` now offload `build_index` / `run_find_text_references_paths` to `tokio::task::spawn_blocking`. The `RwLock` read guard is released before the blocking work is awaited — prevents tokio worker thread stalls on large repos.
- **watcher.rs** (#5163): `IndexWatcher::start` accepts `Option<TaskSupervisor>`; when `Some`, the debounce-reindex loop is registered as `"index.watcher"` via `TaskDescriptor` (`RunOnce` policy) per spec-039. Raw `tokio::spawn` fallback retained for `None` (test environments only — sole production call in `agent_setup.rs` always passes `Some`).
- **watcher.rs** (doc fix): corrected stale `IndexWatcher` struct doc — drop semantics now correctly distinguish supervised vs unsupervised paths.
- **indexer.rs / retriever.rs** (#5213): tracing spans were already present; no changes required.

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — pass
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11266/11266 pass
- [x] rustdoc gate — pass

Closes #5162, Closes #5163, Closes #5213