### PR TITLE
fix(async): eliminate blocking std::fs calls on async threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(worktree)`: `WorktreeManager::create` called `canonicalize_root` (sync `std::fs`) directly
+  on the async thread; now wrapped in `tokio::task::spawn_blocking` (#5200).
+- `fix(subagent)`: `check_gitignore_for_local` used `std::fs::read_to_string` inside `async fn
+  ensure_memory_dir`; converted to an async fn using `tokio::fs::try_exists` and
+  `tokio::fs::read_to_string` (#5191).
+- `fix(tui)`: `run_tui_remote` called `resolve_palette` (which may invoke `std::fs` for user
+  themes) directly on the async thread; now runs via `tokio::task::spawn_blocking` (#5173).
+
 ### Added
 
 - `feat(tui)`: theme config, `/theme` slash command, `ToggleTheme` real implementation, hot-reload,

--- a/crates/zeph-subagent/src/memory.rs
+++ b/crates/zeph-subagent/src/memory.rs
@@ -135,7 +135,7 @@ pub async fn ensure_memory_dir(
 
     // Warn for Local scope if .gitignore likely does not cover the directory.
     if scope == MemoryScope::Local {
-        check_gitignore_for_local(&dir);
+        check_gitignore_for_local(&dir).await;
     }
 
     Ok(dir)
@@ -245,25 +245,34 @@ pub fn escape_memory_content(content: &str) -> String {
 /// Check if `.zeph/agent-memory-local/` appears in `.gitignore` and warn if not.
 ///
 /// This is best-effort — only checks the project-root `.gitignore`.
-fn check_gitignore_for_local(memory_dir: &Path) {
-    // Walk up to find .gitignore (at most 5 levels up from memory dir).
+async fn check_gitignore_for_local(memory_dir: &Path) {
+    // Collect candidate .gitignore paths (up to 5 levels up) before any I/O so
+    // we avoid holding path references across await points.
+    let mut candidates: Vec<std::path::PathBuf> = Vec::with_capacity(5);
     let mut current = memory_dir;
     for _ in 0..5 {
         let Some(parent) = current.parent() else {
             break;
         };
         current = parent;
-        let gitignore = current.join(".gitignore");
-        if gitignore.exists() {
-            if std::fs::read_to_string(&gitignore).is_ok_and(|c| c.contains("agent-memory-local")) {
-                return;
-            }
-            tracing::warn!(
-                "local agent memory directory is not in .gitignore — \
-                 sensitive data may be committed. Add '.zeph/agent-memory-local/' to .gitignore"
-            );
+        candidates.push(current.join(".gitignore"));
+    }
+
+    for gitignore in candidates {
+        if !tokio::fs::try_exists(&gitignore).await.unwrap_or(false) {
+            continue;
+        }
+        if tokio::fs::read_to_string(&gitignore)
+            .await
+            .is_ok_and(|c| c.contains("agent-memory-local"))
+        {
             return;
         }
+        tracing::warn!(
+            "local agent memory directory is not in .gitignore — \
+             sensitive data may be committed. Add '.zeph/agent-memory-local/' to .gitignore"
+        );
+        return;
     }
 }
 

--- a/crates/zeph-worktree/src/manager.rs
+++ b/crates/zeph-worktree/src/manager.rs
@@ -130,7 +130,11 @@ impl<R: GitRunner> WorktreeManager<R> {
         validate_branch_component(subagent_id)?;
 
         let branch_name = format!("{}{}", self.config.branch_prefix, subagent_id);
-        let worktree_root = canonicalize_root(Path::new(&self.config.root), &self.repo_root)?;
+        let root = PathBuf::from(&self.config.root);
+        let repo = self.repo_root.clone();
+        let worktree_root = tokio::task::spawn_blocking(move || canonicalize_root(&root, &repo))
+            .await
+            .map_err(|e| WorktreeError::Io(std::io::Error::other(e)))??;
         let path = worktree_root.join(subagent_id);
 
         if path.exists() {

--- a/src/tui_remote.rs
+++ b/src/tui_remote.rs
@@ -131,14 +131,26 @@ pub(crate) async fn run_tui_remote(
         use zeph_tui::theme::{EffectiveColorMode, Theme, resolve_color_mode, resolve_palette};
         let theme_cfg = &config.tui.theme;
         let mode = resolve_color_mode(theme_cfg.color_mode);
-        match resolve_palette(&theme_cfg.name) {
-            Ok(p) => (
+        // resolve_palette may do std::fs I/O for user-defined themes — run off the async thread.
+        let theme_name = theme_cfg.name.clone();
+        let palette_result =
+            tokio::task::spawn_blocking(move || resolve_palette(&theme_name)).await;
+        match palette_result {
+            Ok(Ok(p)) => (
                 Theme::from_palette_with_mode(&p, mode),
                 theme_cfg.name.clone(),
                 mode,
             ),
-            Err(e) => {
+            Ok(Err(e)) => {
                 tracing::warn!("TUI theme '{}' could not be loaded: {e}", theme_cfg.name);
+                (
+                    Theme::default(),
+                    "zephyr".to_owned(),
+                    EffectiveColorMode::Truecolor,
+                )
+            }
+            Err(e) => {
+                tracing::warn!("TUI theme '{}' resolution panicked: {e}", theme_cfg.name);
                 (
                     Theme::default(),
                     "zephyr".to_owned(),


### PR DESCRIPTION
## Summary

- **#5200** — `WorktreeManager::create`: `canonicalize_root` (sync `std::fs::create_dir_all` + `std::fs::canonicalize`) was called directly on the async thread; now wrapped in `tokio::task::spawn_blocking`.
- **#5191** — `check_gitignore_for_local` in `zeph-subagent/src/memory.rs`: sync `std::fs::read_to_string` inside `async fn ensure_memory_dir`; converted to an `async fn` using `tokio::fs::try_exists` + `tokio::fs::read_to_string`.
- **#5173** — `run_tui_remote` in `src/tui_remote.rs`: `resolve_palette` may call `std::fs::symlink_metadata` + `std::fs::File::open` for user-defined themes; now runs via `tokio::task::spawn_blocking`.

All three violations block the async executor on I/O that belongs off-thread, contrary to the non-blocking contract in spec-039 and CLAUDE.md.

Closes #5200
Closes #5191
Closes #5173

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — 0 errors (full workspace, no sccache)
- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — all pass
- [ ] Rustdoc gate: `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — in progress