### PR TITLE
test(tui): add unit tests for /theme parsing and insta snapshots for rounded modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `test(tui)`: unit tests for `/theme` slash command parsing variants (`ListThemes`, `SetTheme`,
+  trailing-space edge case) in `parse_session_slash` (#5245). Insta snapshot tests for
+  `elicitation` and `command_palette` modals confirming `BorderType::Rounded` corners (#5243).
 - `feat(tui)`: theme config, `/theme` slash command, `ToggleTheme` real implementation, hot-reload,
   and `--theme` CLI flag (#5090). `SemanticPalette` presets (`zephyr`, `zephyr-light`,
   `high-contrast`, etc.) are selectable at runtime; `apply_theme` validates names against path

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -1590,4 +1590,28 @@ mod tests {
     fn slash_unknown_returns_none() {
         assert_eq!(App::parse_session_slash("/unknown"), None);
     }
+
+    #[test]
+    fn slash_theme_bare_lists_themes() {
+        assert_eq!(
+            App::parse_session_slash("/theme"),
+            Some(TuiCommand::ListThemes)
+        );
+    }
+
+    #[test]
+    fn slash_theme_with_name_sets_theme() {
+        assert_eq!(
+            App::parse_session_slash("/theme zephyr"),
+            Some(TuiCommand::SetTheme("zephyr".to_owned()))
+        );
+    }
+
+    #[test]
+    fn slash_theme_trailing_space_lists_themes() {
+        assert_eq!(
+            App::parse_session_slash("/theme "),
+            Some(TuiCommand::ListThemes)
+        );
+    }
 }

--- a/crates/zeph-tui/src/widgets/command_palette.rs
+++ b/crates/zeph-tui/src/widgets/command_palette.rs
@@ -261,6 +261,18 @@ mod tests {
     }
 
     #[test]
+    fn command_palette_rounded_border_snapshot() {
+        use insta::assert_snapshot;
+
+        let state = CommandPaletteState::new();
+        let output = render_to_string(80, 24, |frame, area| {
+            let theme = crate::theme::Theme::default();
+            render(&state, frame, area, &theme);
+        });
+        assert_snapshot!(output);
+    }
+
+    #[test]
     fn render_command_palette_snapshot() {
         let state = CommandPaletteState::new();
         let output = render_to_string(80, 24, |frame, area| {

--- a/crates/zeph-tui/src/widgets/elicitation.rs
+++ b/crates/zeph-tui/src/widgets/elicitation.rs
@@ -452,4 +452,27 @@ mod tests {
         state.next_field();
         assert_eq!(state.field_idx, 0);
     }
+
+    #[test]
+    fn elicitation_modal_rounded_border_snapshot() {
+        use insta::assert_snapshot;
+
+        use crate::test_utils::render_to_string;
+
+        let req = make_request(vec![
+            string_field("username", true),
+            ElicitationField {
+                name: "agree".to_owned(),
+                description: None,
+                field_type: ElicitationFieldType::Boolean,
+                required: false,
+            },
+        ]);
+        let state = ElicitationDialogState::new(req);
+        let theme = crate::theme::Theme::default();
+        let output = render_to_string(80, 24, |frame, area| {
+            super::render(&state, frame, area, &theme);
+        });
+        assert_snapshot!(output);
+    }
 }

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__command_palette__tests__command_palette_rounded_border_snapshot.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__command_palette__tests__command_palette_rounded_border_snapshot.snap
@@ -1,0 +1,26 @@
+---
+source: crates/zeph-tui/src/widgets/command_palette.rs
+expression: output
+---
+                                                                                
+                                                                                
+                ╭────────────── Command Palette ───────────────╮                
+                │:                                             │                
+                │                                              │                
+                │skill:list            List loaded skills      │                
+                │mcp:list              List MCP servers and too│                
+                │memory:stats          Show memory statistics  │                
+                │view:cost             Show cost breakdown     │                
+                │view:tools            List available tools    │                
+                │view:config           Show active configuratio│                
+                │view:autonomy         Show autonomy/trust leve│                
+                │tasks                 Toggle task registry pan│                
+                │fleet                 Fleet: show agent sessio│                
+                │durable               Durable: show durable ex│                
+                │session:new           Start new conversation  │                
+                │session:history       Browse session history [│                
+                │session:next          Switch to next session (│                
+                │session:prev          Switch to previous sessi│                
+                │session:close         Close current session (/│                
+                │session:undo          Undo last shell checkpoi│                
+                ╰──────────────────────────────────────────────╯

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__elicitation__tests__elicitation_modal_rounded_border_snapshot.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__elicitation__tests__elicitation_modal_rounded_border_snapshot.snap
@@ -1,0 +1,22 @@
+---
+source: crates/zeph-tui/src/widgets/elicitation.rs
+expression: output
+---
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+            ╭──────────── MCP Elicitation: test-server ────────────╮            
+            │Please fill in the form                               │            
+            │                                                      │            
+            │                                                      │            
+            │username*: ▌                                          │            
+            │                                                      │            
+            │agree: [ ] No                                         │            
+            │                                                      │            
+            │                                                      │            
+            │                                                      │            
+            │       [Tab] next  [Enter] submit  [Esc] cancel       │            
+            ╰──────────────────────────────────────────────────────╯


### PR DESCRIPTION
## Summary

- Add three unit tests for `parse_session_slash` `/theme` variants in `keys.rs`: bare `/theme` → `ListThemes`, `/theme zephyr` → `SetTheme("zephyr")`, trailing-space `/theme ` → `ListThemes` (not `SetTheme("")`)
- Add `cargo insta` snapshot tests for `elicitation` and `command_palette` widgets, confirming `BorderType::Rounded` corners (`╭`/`╯`) introduced in PR #5242
- Both snapshot files generated and accepted; all 11275 workspace tests pass

Closes #5245
Closes #5243

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml -p zeph-tui --lib` — all tests pass (624 in crate, 11275 workspace)
- [ ] Snapshot files contain `╭`/`╯` rounded corners confirming `BorderType::Rounded`
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci -p zeph-tui` — clean