### PR TITLE
fix(core): route lsp_hooks and notifications spawns through BackgroundSupervisor

### DIFF
--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1394,7 +1394,7 @@ impl<C: Channel> Agent<C> {
         if let Some(ref notifier) = self.runtime.lifecycle.notifier
             && gate_ok
         {
-            notifier.fire(&summary, &self.runtime.lifecycle.task_supervisor);
+            notifier.fire(&summary, &mut self.runtime.lifecycle.supervisor);
         }
 
         // 2) turn_complete hooks — fire-and-forget via supervisor.

--- a/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
@@ -546,8 +546,6 @@ async fn record_chat_metrics_calls_observe_llm_latency() {
 
 fn make_agent_with_lsp_note(note: &'static str) -> Agent<MockChannel> {
     use std::sync::Arc;
-    use tokio_util::sync::CancellationToken;
-    use zeph_common::TaskSupervisor;
     let mut agent = Agent::new(
         mock_provider(vec![String::new()]),
         MockChannel::new(vec![]),
@@ -558,7 +556,6 @@ fn make_agent_with_lsp_note(note: &'static str) -> Agent<MockChannel> {
     );
     let enforcer = zeph_mcp::PolicyEnforcer::new(vec![]);
     let manager = Arc::new(zeph_mcp::McpManager::new(vec![], vec![], enforcer));
-    let sup = Arc::new(TaskSupervisor::new(CancellationToken::new()));
     let mut lsp_runner = crate::lsp_hooks::LspHookRunner::new(
         manager,
         crate::lsp_hooks::LspConfig {
@@ -566,7 +563,6 @@ fn make_agent_with_lsp_note(note: &'static str) -> Agent<MockChannel> {
             token_budget: 500,
             ..crate::lsp_hooks::LspConfig::default()
         },
-        sup,
     );
     lsp_runner.push_note("hover", note, 5);
     agent.services.session.lsp_hooks = Some(lsp_runner);
@@ -622,9 +618,6 @@ async fn lsp_notes_not_duplicated_on_retry() {
     );
     let enforcer = zeph_mcp::PolicyEnforcer::new(vec![]);
     let manager = Arc::new(zeph_mcp::McpManager::new(vec![], vec![], enforcer));
-    let sup = Arc::new(zeph_common::TaskSupervisor::new(
-        tokio_util::sync::CancellationToken::new(),
-    ));
     let mut lsp_runner = crate::lsp_hooks::LspHookRunner::new(
         manager,
         crate::lsp_hooks::LspConfig {
@@ -632,7 +625,6 @@ async fn lsp_notes_not_duplicated_on_retry() {
             token_budget: 500,
             ..crate::lsp_hooks::LspConfig::default()
         },
-        sup,
     );
     lsp_runner.push_note("hover", "fn bar() -> bool", 5);
 

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -2154,8 +2154,15 @@ impl<C: Channel> Agent<C> {
             let lsp_result = tokio::time::timeout(std::time::Duration::from_secs(30), async {
                 for (name, input, output) in lsp_tool_calls {
                     if let Some(ref mut lsp) = self.services.session.lsp_hooks {
-                        lsp.after_tool(&name, &input, &output, &tc_arc, &sanitizer)
-                            .await;
+                        lsp.after_tool(
+                            &name,
+                            &input,
+                            &output,
+                            &tc_arc,
+                            &sanitizer,
+                            &mut self.runtime.lifecycle.supervisor,
+                        )
+                        .await;
                     }
                 }
             })

--- a/crates/zeph-core/src/lsp_hooks/mod.rs
+++ b/crates/zeph-core/src/lsp_hooks/mod.rs
@@ -21,11 +21,11 @@ mod hover;
 mod test_helpers;
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::mpsc;
-use zeph_common::TaskSupervisor;
 use zeph_mcp::McpManager;
+
+use crate::agent::agent_supervisor::{BackgroundSupervisor, TaskClass};
 
 pub use crate::config::LspConfig;
 
@@ -54,10 +54,6 @@ pub struct LspHookRunner {
     diagnostics_rxs: Vec<DiagnosticsRx>,
     /// Sessions statistics.
     pub(crate) stats: LspStats,
-    /// Session-level supervisor for background diagnostics fetch tasks.
-    supervisor: Arc<TaskSupervisor>,
-    /// Monotonic counter for generating unique task names per diagnostics fetch.
-    fetch_counter: Arc<AtomicU64>,
 }
 
 /// Session-level statistics for the `/lsp` TUI command.
@@ -69,21 +65,15 @@ pub struct LspStats {
 }
 
 impl LspHookRunner {
-    /// Create a new runner.
+    /// Create a new runner. Token counting uses the provided `token_counter`.
     #[must_use]
-    pub fn new(
-        manager: Arc<McpManager>,
-        config: LspConfig,
-        supervisor: Arc<TaskSupervisor>,
-    ) -> Self {
+    pub fn new(manager: Arc<McpManager>, config: LspConfig) -> Self {
         Self {
             manager,
             config,
             pending_notes: Vec::new(),
             diagnostics_rxs: Vec::new(),
             stats: LspStats::default(),
-            supervisor,
-            fetch_counter: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -122,13 +112,14 @@ impl LspHookRunner {
     /// and hover is enabled.
     ///
     /// Returns early without any MCP call if the configured server is not connected.
-    pub async fn after_tool(
+    pub(crate) async fn after_tool(
         &mut self,
         tool_name: &str,
         tool_params: &serde_json::Value,
         tool_output: &str,
         token_counter: &Arc<zeph_memory::TokenCounter>,
         sanitizer: &zeph_sanitizer::ContentSanitizer,
+        supervisor: &mut BackgroundSupervisor,
     ) {
         if !self.config.enabled {
             tracing::debug!(tool = tool_name, "LSP hook: skipped (disabled)");
@@ -148,7 +139,7 @@ impl LspHookRunner {
 
         match tool_name {
             "write" if self.config.diagnostics.enabled => {
-                self.spawn_diagnostics_fetch(tool_params, token_counter, sanitizer);
+                self.spawn_diagnostics_fetch(tool_params, token_counter, sanitizer, supervisor);
             }
             "read" if self.config.hover.enabled => {
                 if let Some(note) =
@@ -183,6 +174,7 @@ impl LspHookRunner {
         tool_params: &serde_json::Value,
         token_counter: &Arc<zeph_memory::TokenCounter>,
         sanitizer: &zeph_sanitizer::ContentSanitizer,
+        supervisor: &mut BackgroundSupervisor,
     ) {
         let Some(path) = tool_params
             .get("path")
@@ -203,9 +195,7 @@ impl LspHookRunner {
         let (tx, rx) = mpsc::channel(1);
         self.diagnostics_rxs.push(rx);
 
-        let id = self.fetch_counter.fetch_add(1, Ordering::Relaxed);
-        let name: Arc<str> = format!("core.lsp_hooks.diagnostics_fetch.{id}").into();
-        self.supervisor.spawn_oneshot(name, move || async move {
+        supervisor.spawn(TaskClass::Enrichment, "lsp_diagnostics_fetch", async move {
             // Give the LSP server time to start re-analysing after the write.
             // 200 ms is a lightweight heuristic; the diagnostic cache in mcpls
             // will serve the most-recently-published set regardless.
@@ -310,16 +300,15 @@ impl LspHookRunner {
 mod tests {
     use std::sync::Arc;
 
-    use tokio_util::sync::CancellationToken;
-    use zeph_common::TaskSupervisor;
     use zeph_mcp::McpManager;
     use zeph_memory::TokenCounter;
 
     use super::*;
+    use crate::agent::agent_supervisor::BackgroundSupervisor;
     use crate::config::{DiagnosticSeverity, LspConfig};
 
-    fn make_supervisor() -> Arc<TaskSupervisor> {
-        Arc::new(TaskSupervisor::new(CancellationToken::new()))
+    fn make_supervisor() -> BackgroundSupervisor {
+        BackgroundSupervisor::new(&zeph_config::TaskSupervisorConfig::default(), None)
     }
 
     fn make_runner(enabled: bool) -> LspHookRunner {
@@ -332,7 +321,6 @@ mod tests {
                 token_budget: 500,
                 ..LspConfig::default()
             },
-            make_supervisor(),
         )
     }
 
@@ -369,7 +357,6 @@ mod tests {
                 token_budget: 1, // extremely tight budget
                 ..LspConfig::default()
             },
-            make_supervisor(),
         );
         runner.pending_notes.push(LspNote {
             kind: "diagnostics",
@@ -426,11 +413,12 @@ mod tests {
         let tc = Arc::new(TokenCounter::default());
         let sanitizer = ContentSanitizer::new(&ContentIsolationConfig::default());
         let mut runner = make_runner(false); // lsp disabled
+        let mut supervisor = make_supervisor();
 
         // Even write tool should produce no notes when disabled.
         let params = serde_json::json!({ "path": "src/main.rs" });
         runner
-            .after_tool("write", &params, "", &tc, &sanitizer)
+            .after_tool("write", &params, "", &tc, &sanitizer, &mut supervisor)
             .await;
         // No background tasks spawned.
         assert!(runner.diagnostics_rxs.is_empty());
@@ -444,9 +432,10 @@ mod tests {
         let sanitizer = ContentSanitizer::new(&ContentIsolationConfig::default());
         // Runner enabled but no MCP server configured — is_available() returns false.
         let mut runner = make_runner(true);
+        let mut supervisor = make_supervisor();
         let params = serde_json::json!({ "path": "src/main.rs" });
         runner
-            .after_tool("write", &params, "", &tc, &sanitizer)
+            .after_tool("write", &params, "", &tc, &sanitizer, &mut supervisor)
             .await;
         // No background task spawned because server is not available.
         assert!(runner.diagnostics_rxs.is_empty());

--- a/crates/zeph-core/src/notifications.rs
+++ b/crates/zeph-core/src/notifications.rs
@@ -23,11 +23,8 @@
 //! # Examples
 //!
 //! ```no_run
-//! use std::sync::Arc;
 //! use zeph_core::notifications::{Notifier, TurnSummary, TurnExitStatus};
-//! use zeph_common::TaskSupervisor;
 //! use zeph_config::NotificationsConfig;
-//! use tokio_util::sync::CancellationToken;
 //!
 //! let cfg = NotificationsConfig {
 //!     enabled: true,
@@ -35,7 +32,6 @@
 //!     ..Default::default()
 //! };
 //! let notifier = Notifier::new(cfg);
-//! let supervisor = Arc::new(TaskSupervisor::new(CancellationToken::new()));
 //! let summary = TurnSummary {
 //!     duration_ms: 5000,
 //!     preview: "Done. Files updated.".to_owned(),
@@ -43,19 +39,18 @@
 //!     llm_requests: 1,
 //!     exit_status: TurnExitStatus::Success,
 //! };
-//! // Fire and forget — errors are logged, never propagated.
-//! notifier.fire(&summary, &supervisor);
+//! // notifier.fire(&summary, supervisor) — called from the agent loop with
+//! // its BackgroundSupervisor; fire-and-forget, errors are logged only.
+//! let _ = notifier.should_fire(&summary); // gate check
 //! ```
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use serde::Serialize;
 use tracing::warn;
-use zeph_common::TaskSupervisor;
 use zeph_config::NotificationsConfig;
 
+use crate::agent::agent_supervisor::{BackgroundSupervisor, TaskClass};
 use crate::redact::scrub_content;
 
 // ── Public types ─────────────────────────────────────────────────────────────
@@ -95,16 +90,15 @@ pub struct TurnSummary {
 /// Holds a shared [`reqwest::Client`] and the resolved config. Construct once at
 /// agent startup via [`Notifier::new`] and call [`Notifier::fire`] after each turn.
 ///
-/// All I/O is spawned onto the Tokio runtime via `tokio::spawn`; `fire` returns
-/// immediately without blocking the agent loop.
+/// All I/O is routed through the agent's [`BackgroundSupervisor`] so it is
+/// visible in TUI status and bounded by the Telemetry class concurrency limit.
+/// `fire` returns immediately without blocking the agent loop.
 ///
-/// Cloning is cheap — `reqwest::Client` and the fire counter are `Arc`-backed.
+/// Cloning is cheap — `reqwest::Client` is an `Arc`-backed handle.
 #[derive(Clone)]
 pub struct Notifier {
     cfg: NotificationsConfig,
     http: reqwest::Client,
-    /// Monotonic counter to generate unique task names for `spawn_oneshot`.
-    fire_counter: Arc<AtomicU64>,
 }
 
 impl Notifier {
@@ -131,11 +125,7 @@ impl Notifier {
         {
             cfg.webhook_url = None;
         }
-        Self {
-            cfg,
-            http,
-            fire_counter: Arc::new(AtomicU64::new(0)),
-        }
+        Self { cfg, http }
     }
 
     /// Evaluate all gate conditions and return `true` when the notification should fire.
@@ -171,17 +161,16 @@ impl Notifier {
 
     /// Fire all enabled notification channels for this turn summary.
     ///
-    /// Returns immediately — all I/O is spawned as a background task via the session
-    /// [`TaskSupervisor`]. Failures are logged at `warn` level and never propagated.
-    /// The spawned task has an internal 5-second per-channel timeout.
-    pub fn fire(&self, summary: &TurnSummary, supervisor: &Arc<TaskSupervisor>) {
+    /// Returns immediately — all I/O is routed through `supervisor` as a
+    /// [`TaskClass::Telemetry`] task, making it visible in TUI status and
+    /// bounded by the class concurrency limit. Failures are logged at `warn`
+    /// level and never propagated.
+    pub(crate) fn fire(&self, summary: &TurnSummary, supervisor: &mut BackgroundSupervisor) {
         let cfg = self.cfg.clone();
         let http = self.http.clone();
         let summary = summary.clone();
 
-        let id = self.fire_counter.fetch_add(1, Ordering::Relaxed);
-        let name: Arc<str> = format!("core.notifications.fire.{id}").into();
-        supervisor.spawn_oneshot(name, move || async move {
+        supervisor.spawn(TaskClass::Telemetry, "notify_turn_complete", async move {
             fire_all_channels(&cfg, &http, &summary).await;
         });
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2794,11 +2794,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
 
     // Wire LSP context injection hooks when the feature is enabled and configured.
     let agent = if config.lsp.enabled {
-        let runner = zeph_core::lsp_hooks::LspHookRunner::new(
-            lsp_mcp_manager,
-            config.lsp.clone(),
-            std::sync::Arc::clone(&supervisor),
-        );
+        let runner = zeph_core::lsp_hooks::LspHookRunner::new(lsp_mcp_manager, config.lsp.clone());
         agent.with_lsp_hooks(runner)
     } else {
         agent


### PR DESCRIPTION
## Summary

- `LspHookRunner::after_tool` / `spawn_diagnostics_fetch` now accept `&mut BackgroundSupervisor` and spawn the diagnostics fetch task under `TaskClass::Enrichment` — replacing a raw `tokio::spawn` with a dropped `JoinHandle`
- `Notifier::fire` now routes the turn-end notification task through `BackgroundSupervisor` under `TaskClass::Telemetry` — making it visible in TUI status and bounded by the class concurrency limit
- Both methods narrowed from `pub` to `pub(crate)` since `BackgroundSupervisor` is `pub(crate)` and all callers are within `zeph-core`

Closes #5177, #5178

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11275 passed
- [x] rustdoc gate — clean (no new errors)
- [x] `lsp_hooks::tests::after_tool_disabled_does_not_queue_notes` — passes with supervisor param
- [x] `lsp_hooks::tests::after_tool_unavailable_skips_on_write` — passes with supervisor param