### PR TITLE
fix(async): eliminate blocking std::fs calls on async threads

### DIFF
--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1263,18 +1263,13 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
         let managed_dir = self.services.skill.managed_dir.clone();
         let mcp_allowed = self.services.mcp.allowed_commands.clone();
         let base_shell_allowed = self.runtime.lifecycle.startup_shell_overlay.allowed.clone();
-        // Collect ephemeral plugin names for display in the list subcommand.
-        let ephemeral_names: Vec<String> = self
+        // Collect manifest paths for ephemeral plugins. Reading the actual files is
+        // deferred into the async block below to avoid blocking the tokio worker thread.
+        let ephemeral_manifest_paths: Vec<std::path::PathBuf> = self
             .runtime
             .ephemeral_plugins
             .iter()
-            .filter_map(|tmp| {
-                let manifest_path = tmp.path().join("plugin.toml");
-                std::fs::read_to_string(manifest_path)
-                    .ok()
-                    .and_then(|s| toml::from_str::<zeph_plugins::PluginManifest>(&s).ok())
-                    .map(|m| m.plugin.name)
-            })
+            .map(|tmp| tmp.path().join("plugin.toml"))
             .collect();
 
         // Resolve scanner once, before the async block captures `self`.
@@ -1338,6 +1333,19 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
             {
                 return Ok(err);
             }
+
+            // Resolve ephemeral plugin names asynchronously before entering the blocking task.
+            let ephemeral_names: Vec<String> = {
+                use futures::future::join_all;
+                let futs = ephemeral_manifest_paths.into_iter().map(|p| async move {
+                    tokio::fs::read_to_string(&p)
+                        .await
+                        .ok()
+                        .and_then(|s| toml::from_str::<zeph_plugins::PluginManifest>(&s).ok())
+                        .map(|m| m.plugin.name)
+                });
+                join_all(futs).await.into_iter().flatten().collect()
+            };
 
             // PluginManager performs synchronous filesystem I/O (copy, remove_dir_all,
             // read_dir). Run on a blocking thread to avoid stalling the tokio worker.

--- a/crates/zeph-memory/src/document/loader/pdf.rs
+++ b/crates/zeph-memory/src/document/loader/pdf.rs
@@ -30,7 +30,7 @@ impl DocumentLoader for PdfLoader {
         let path = path.to_path_buf();
         let max_size = self.max_file_size;
         Box::pin(async move {
-            let path = std::fs::canonicalize(&path)?;
+            let path = tokio::fs::canonicalize(&path).await?;
 
             let meta = tokio::fs::metadata(&path).await?;
             if meta.len() > max_size {

--- a/crates/zeph-memory/src/document/loader/text.rs
+++ b/crates/zeph-memory/src/document/loader/text.rs
@@ -30,7 +30,7 @@ impl DocumentLoader for TextLoader {
         let path = path.to_path_buf();
         let max_size = self.max_file_size;
         Box::pin(async move {
-            let path = std::fs::canonicalize(&path)?;
+            let path = tokio::fs::canonicalize(&path).await?;
 
             let meta = tokio::fs::metadata(&path).await?;
             if meta.len() > max_size {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3872,8 +3872,9 @@ async fn run_experiment_session(
             anyhow::anyhow!("--experiment-run requires experiments.benchmark_file")
         })?;
 
-    let benchmark = BenchmarkSet::from_file(&benchmark_path)
-        .map_err(|e| anyhow::anyhow!("failed to load benchmark: {e}"))?;
+    let benchmark = tokio::task::spawn_blocking(move || BenchmarkSet::from_file(&benchmark_path))
+        .await
+        .map_err(|e| anyhow::anyhow!("spawn_blocking panicked: {e}"))??;
 
     let provider_arc = Arc::new(provider);
     // Use a dedicated eval provider when `eval_provider` is configured to avoid self-judge bias.


### PR DESCRIPTION
## Summary

Eliminates four blocking `std::fs` I/O calls that ran directly on async executor threads, violating the non-blocking contract from the project spec.

- **runner**: `run_experiment_session` called `BenchmarkSet::from_file` (which performs `std::fs::canonicalize`, `std::fs::metadata`, `std::fs::read_to_string`) synchronously on the async thread. Wrapped in `tokio::task::spawn_blocking`, matching the existing pattern in `scheduler.rs:90`.
- **core**: `handle_plugins()` collected ephemeral plugin names via `std::fs::read_to_string` in a `filter_map` before the `async move` block. Restructured: manifest paths collected synchronously (no I/O), names resolved asynchronously via `tokio::fs::read_to_string` + `futures::future::join_all` inside the async block.
- **memory/pdf**: `std::fs::canonicalize` inside `Box::pin(async move {...})` replaced with `tokio::fs::canonicalize(...).await?`.
- **memory/text**: Identical twin defect in `text.rs` (same directory, same structure) found during adversarial review and fixed alongside pdf.rs.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — 0 warnings
- [x] `cargo nextest run ... --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11279 passed, 0 failures
- [x] `cargo doc` rustdoc gate — clean

Closes #5164, #5179, #5231