### PR TITLE
refactor(channels): fix DiscordChannel dead supervisor field and remove SlackChannel::with_supervisor no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `refactor(channels)`: `DiscordChannel` was always storing `supervisor: None` in the struct
+  literal even when a real supervisor was passed; now stores `supervisor.cloned()` so `Debug`
+  output correctly reflects whether the channel is supervised (#5251).
+- `refactor(channels)`: `SlackChannel::with_supervisor` silently discarded its argument — a no-op
+  method that could mislead callers. Removed it and updated doc references to point to
+  `new_with_supervisor` (#5252).
+
 - `fix(worktree)`: `WorktreeManager::create` called `canonicalize_root` (sync `std::fs`) directly
   on the async thread; now wrapped in `tokio::task::spawn_blocking` (#5200).
 - `fix(subagent)`: `check_gitignore_for_local` used `std::fs::read_to_string` inside `async fn

--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -78,7 +78,7 @@ impl DiscordChannel {
             allowed_channel_ids,
             buffer: StreamingBuffer::new(EDIT_THROTTLE),
             message_id: None,
-            supervisor: None,
+            supervisor: supervisor.cloned(),
         }
     }
 

--- a/crates/zeph-channels/src/slack/mod.rs
+++ b/crates/zeph-channels/src/slack/mod.rs
@@ -52,14 +52,14 @@ impl std::fmt::Debug for SlackChannel {
 impl SlackChannel {
     /// Create a new Slack channel and spawn the events webhook server.
     ///
-    /// Use [`with_supervisor`] to attach a [`TaskSupervisor`] so the events server task
+    /// Use [`new_with_supervisor`] to attach a [`TaskSupervisor`] so the events server task
     /// is tracked, observable in the TUI, and restarted on panic.
     ///
     /// # Errors
     ///
     /// Returns an error if the auth.test API call fails.
     ///
-    /// [`with_supervisor`]: SlackChannel::with_supervisor
+    /// [`new_with_supervisor`]: SlackChannel::new_with_supervisor
     pub async fn new(
         bot_token: String,
         signing_secret: String,
@@ -83,15 +83,14 @@ impl SlackChannel {
     /// Create a new Slack channel with a supervisor attached.
     ///
     /// Prefer this constructor in production to ensure the events server task is tracked
-    /// and restarted on panic. Equivalent to calling [`new`] followed by [`with_supervisor`],
-    /// but threads the supervisor into [`events::spawn_event_server`] at construction time.
+    /// and restarted on panic. The supervisor is threaded into [`events::spawn_event_server`]
+    /// at construction time.
     ///
     /// # Errors
     ///
     /// Returns an error if the auth.test API call fails.
     ///
     /// [`new`]: SlackChannel::new
-    /// [`with_supervisor`]: SlackChannel::with_supervisor
     pub async fn new_with_supervisor(
         bot_token: String,
         signing_secret: String,
@@ -131,22 +130,6 @@ impl SlackChannel {
             buffer: StreamingBuffer::new(EDIT_THROTTLE),
             message_ts: None,
         })
-    }
-
-    /// Attach a [`TaskSupervisor`] to an already-constructed channel.
-    ///
-    /// Note: the events server task is spawned at construction time via [`new`] or
-    /// [`new_with_supervisor`]. Calling this method after construction only stores the
-    /// supervisor for potential future use; prefer [`new_with_supervisor`] in production.
-    ///
-    /// [`new`]: SlackChannel::new
-    /// [`new_with_supervisor`]: SlackChannel::new_with_supervisor
-    #[must_use]
-    pub fn with_supervisor(self, _supervisor: TaskSupervisor) -> Self {
-        // Supervisor was already consumed at spawn_event_server call time if
-        // new_with_supervisor was used. This method is a no-op for consistency
-        // with the Telegram/Discord builder pattern — use new_with_supervisor instead.
-        self
     }
 
     fn is_authorized(&self, msg: &IncomingMessage) -> bool {


### PR DESCRIPTION
## Summary

- `DiscordChannel` was always storing `supervisor: None` in the struct literal even when a real supervisor was passed to the constructor. `Debug` output always showed the channel as unsupervised. Fixed by storing `supervisor.cloned()` at construction time.
- `SlackChannel::with_supervisor` silently discarded its argument — a no-op method that could mislead callers using the Telegram-style builder pattern. Removed the method entirely and updated doc references to point to `new_with_supervisor`.

Both issues were introduced in #5250.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11275 passed
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing private-intra-doc-links warning in zeph-channels unrelated to this PR)

Closes #5251
Closes #5252