### PR TITLE
fix(spawn): migrate skills/mcp/llm raw spawns to supervised tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(skills)`: migrate `SkillWatcher` background task from raw `tokio::spawn` to
+  `TaskSupervisor::spawn_oneshot` so the watcher is named, observable in `list_tasks()`,
+  and abortable via `shutdown_all()` (closes #5170).
+- `fix(mcp)`: migrate `McpManager::spawn_refresh_task` from raw `tokio::spawn` to
+  `TaskSupervisor::spawn` with `RestartPolicy::RunOnce`; bound `EmbeddingAnomalyGuard`
+  concurrent fire-and-forget spawns with an `Arc<Semaphore>` (capacity 32) so the guard
+  no longer leaks untracked tasks (closes #5202).
+- `fix(llm)`: eliminate raw `tokio::spawn` in `CandleProvider::chat_stream` by replacing
+  the fake-streaming mpsc pattern with `tokio_stream::iter` over pre-built chunks —
+  structured concurrency, no dropped `JoinHandle` (closes #5219).
+
 ### Added
 
 - `feat(tui)`: breeze spinner (▹▹▹→▸▹▹→▸▸▹→▸▸▸→▹▸▸→▹▹▸) replaces braille throbber across all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11208,6 +11208,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",

--- a/crates/zeph-llm/src/candle_provider/mod.rs
+++ b/crates/zeph-llm/src/candle_provider/mod.rs
@@ -257,27 +257,22 @@ impl LlmProvider for CandleProvider {
         self.dispatch(messages.to_vec()).await
     }
 
-    // NOTE: MVP fake streaming — generates all tokens then chunks
+    // NOTE: MVP fake streaming — generates all tokens then chunks into 32-byte slices.
+    // No spawn needed: text is fully available before streaming begins, so we yield
+    // pre-built chunks via tokio_stream::iter (structured concurrency, no JoinHandle).
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, LlmError> {
         let text = self.dispatch(messages.to_vec()).await?;
-        let (tx, rx) = tokio::sync::mpsc::channel(64);
-
-        tokio::spawn(async move {
-            let mut start = 0;
-            while start < text.len() {
-                let mut end = (start + 32).min(text.len());
-                while !text.is_char_boundary(end) {
-                    end -= 1;
-                }
-                let chunk = StreamChunk::Content(text[start..end].to_string());
-                if tx.send(Ok(chunk)).await.is_err() {
-                    break;
-                }
-                start = end;
+        let mut chunks: Vec<Result<StreamChunk, LlmError>> = Vec::new();
+        let mut start = 0;
+        while start < text.len() {
+            let mut end = (start + 32).min(text.len());
+            while !text.is_char_boundary(end) {
+                end -= 1;
             }
-        });
-
-        Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
+            chunks.push(Ok(StreamChunk::Content(text[start..end].to_string())));
+            start = end;
+        }
+        Ok(Box::pin(tokio_stream::iter(chunks)))
     }
 
     fn supports_streaming(&self) -> bool {

--- a/crates/zeph-mcp/src/embedding_guard.rs
+++ b/crates/zeph-mcp/src/embedding_guard.rs
@@ -61,6 +61,12 @@ struct CentroidState {
 /// Default timeout for embedding computation inside the background anomaly-check task.
 const DEFAULT_EMBED_TIMEOUT_MS: u64 = 5000;
 
+/// Maximum number of concurrent in-flight embedding tasks spawned by [`EmbeddingAnomalyGuard::check_async`].
+///
+/// When this limit is reached, new calls are silently dropped (fail-open). The guard
+/// is a background observation layer and must never stall the tool output path.
+const MAX_CONCURRENT_EMBED_TASKS: usize = 32;
+
 /// Detects anomalous MCP tool output via embedding distance from a per-server centroid.
 ///
 /// `check_async()` is fire-and-forget: it returns immediately and sends results via
@@ -78,6 +84,8 @@ pub struct EmbeddingAnomalyGuard {
     /// Maximum milliseconds to wait for the embedding computation. `0` means no timeout.
     embed_timeout_ms: u64,
     result_tx: mpsc::UnboundedSender<EmbeddingGuardEvent>,
+    /// Bounds concurrent in-flight embedding tasks; tasks are dropped (fail-open) when full.
+    task_semaphore: Arc<tokio::sync::Semaphore>,
 }
 
 impl std::fmt::Debug for EmbeddingAnomalyGuard {
@@ -116,6 +124,7 @@ impl EmbeddingAnomalyGuard {
             ema_floor,
             embed_timeout_ms: DEFAULT_EMBED_TIMEOUT_MS,
             result_tx: tx,
+            task_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_EMBED_TASKS)),
         };
         (guard, rx)
     }
@@ -162,6 +171,14 @@ impl EmbeddingAnomalyGuard {
             return;
         };
 
+        let Some(permit) = self.task_semaphore.clone().try_acquire_owned().ok() else {
+            tracing::debug!(
+                server_id,
+                "embedding guard: concurrent task limit reached, skipping check"
+            );
+            return;
+        };
+
         let embed_fn = Arc::clone(&self.embed_fn);
         let threshold = self.threshold;
         let embed_timeout_ms = self.embed_timeout_ms;
@@ -171,6 +188,7 @@ impl EmbeddingAnomalyGuard {
         let output = tool_output.to_owned();
 
         tokio::spawn(async move {
+            let _permit = permit; // released when task completes
             let embed_result = if embed_timeout_ms > 0 {
                 let timeout = Duration::from_millis(embed_timeout_ms);
                 if let Ok(r) = tokio::time::timeout(timeout, (embed_fn)(&output)).await {

--- a/crates/zeph-mcp/src/manager/connect.rs
+++ b/crates/zeph-mcp/src/manager/connect.rs
@@ -86,10 +86,14 @@ impl McpManager {
     /// when all senders are dropped (i.e., after `shutdown_all_shared()` drops `refresh_tx`
     /// and all connected clients are shut down).
     ///
+    /// When `supervisor` is `Some`, the task is registered under `"mcp.refresh_task"` and
+    /// participates in graceful shutdown via `shutdown_all()`. When `None` (test contexts),
+    /// a raw `tokio::spawn` is used.
+    ///
     /// # Panics
     ///
     /// Panics if the refresh receiver has already been taken (i.e., this method is called twice).
-    pub fn spawn_refresh_task(&self) {
+    pub fn spawn_refresh_task(&self, supervisor: Option<&zeph_common::TaskSupervisor>) {
         let rx = self
             .refresh_rx
             .lock()
@@ -106,7 +110,7 @@ impl McpManager {
         let lock_tool_list = self.lock_tool_list;
         let tool_list_locked = Arc::clone(&self.tool_list_locked);
 
-        tokio::spawn(async move {
+        let task = async move {
             let mut rx = rx;
             while let Some(event) = rx.recv().await {
                 // MF-2: reject refresh for locked servers before any processing.
@@ -161,7 +165,27 @@ impl McpManager {
                 let _ = tools_watch_tx.send(all_tools);
             }
             tracing::debug!("MCP refresh task terminated: channel closed");
-        });
+        };
+
+        if let Some(sup) = supervisor {
+            let cell = std::sync::Arc::new(parking_lot::Mutex::new(Some(task)));
+            // spawn() requires Fn; wrap the FnOnce payload in Arc<Mutex<Option>> so the
+            // factory can be called once for RunOnce without capturing by move.
+            sup.spawn(zeph_common::TaskDescriptor {
+                name: "mcp.refresh_task",
+                restart: zeph_common::RestartPolicy::RunOnce,
+                factory: move || {
+                    let fut = cell.lock().take();
+                    async move {
+                        if let Some(f) = fut {
+                            f.await;
+                        }
+                    }
+                },
+            });
+        } else {
+            tokio::spawn(task); // EXEMPT(test): no supervisor available in unit-test context
+        }
     }
 
     /// Connect to all non-OAuth configured servers concurrently.

--- a/crates/zeph-mcp/src/manager/tests.rs
+++ b/crates/zeph-mcp/src/manager/tests.rs
@@ -450,7 +450,7 @@ fn make_tool(server_id: &str, name: &str) -> McpTool {
 async fn refresh_task_updates_watch_channel() {
     let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]));
     let mut rx = mgr.subscribe_tool_changes();
-    mgr.spawn_refresh_task();
+    mgr.spawn_refresh_task(None);
 
     // Send a refresh event directly through the internal channel.
     let tx = mgr.clone_refresh_tx().unwrap();
@@ -471,7 +471,7 @@ async fn refresh_task_updates_watch_channel() {
 async fn refresh_task_multiple_servers_combined() {
     let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]));
     let mut rx = mgr.subscribe_tool_changes();
-    mgr.spawn_refresh_task();
+    mgr.spawn_refresh_task(None);
 
     let tx = mgr.clone_refresh_tx().unwrap();
     tx.try_send(crate::client::ToolRefreshEvent {
@@ -496,7 +496,7 @@ async fn refresh_task_multiple_servers_combined() {
 async fn refresh_task_replaces_tools_for_same_server() {
     let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]));
     let mut rx = mgr.subscribe_tool_changes();
-    mgr.spawn_refresh_task();
+    mgr.spawn_refresh_task(None);
 
     let tx = mgr.clone_refresh_tx().unwrap();
     tx.try_send(crate::client::ToolRefreshEvent {
@@ -526,7 +526,7 @@ async fn refresh_task_replaces_tools_for_same_server() {
 #[tokio::test]
 async fn shutdown_all_terminates_refresh_task() {
     let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]));
-    mgr.spawn_refresh_task();
+    mgr.spawn_refresh_task(None);
     // The refresh task should terminate naturally after shutdown drops all senders.
     mgr.shutdown_all_shared().await;
     // If we try to send after shutdown, the tx should be gone.
@@ -536,7 +536,7 @@ async fn shutdown_all_terminates_refresh_task() {
 #[tokio::test]
 async fn remove_server_cleans_up_server_tools() {
     let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]));
-    mgr.spawn_refresh_task();
+    mgr.spawn_refresh_task(None);
 
     // Inject a tool via refresh event.
     let tx = mgr.clone_refresh_tx().unwrap();

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -65,6 +65,7 @@ criterion.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+tokio-util.workspace = true
 tracing-test.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }
 

--- a/crates/zeph-skills/src/watcher.rs
+++ b/crates/zeph-skills/src/watcher.rs
@@ -8,19 +8,25 @@
 //! Only `SKILL.md` file changes trigger an event; other filesystem activity is
 //! silently ignored.
 //!
-//! The watcher task runs for as long as the [`SkillWatcher`] handle is alive.
-//! Dropping the handle aborts the background task and stops all watches.
+//! The watcher task is registered with the provided [`TaskSupervisor`] under the
+//! name `"skills.watcher"` so it is visible to `list_tasks()` and participates
+//! in graceful shutdown via `shutdown_all()`.
 //!
 //! # Examples
 //!
 //! ```rust,no_run
-//! use tokio::sync::mpsc;
-//! use zeph_skills::watcher::{SkillEvent, SkillWatcher};
 //! use std::path::PathBuf;
+//! use std::sync::Arc;
+//!
+//! use tokio::sync::mpsc;
+//! use tokio_util::sync::CancellationToken;
+//! use zeph_common::TaskSupervisor;
+//! use zeph_skills::watcher::{SkillEvent, SkillWatcher};
 //!
 //! # async fn run() -> Result<(), zeph_skills::SkillError> {
+//! let supervisor = TaskSupervisor::new(CancellationToken::new());
 //! let (tx, mut rx) = mpsc::channel(16);
-//! let _watcher = SkillWatcher::start(&[PathBuf::from("/path/to/skills")], tx)?;
+//! let _watcher = SkillWatcher::start(&[PathBuf::from("/path/to/skills")], tx, &supervisor)?;
 //!
 //! while let Some(event) = rx.recv().await {
 //!     match event {
@@ -33,10 +39,12 @@
 //! ```
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
 use tokio::sync::mpsc;
+use zeph_common::TaskSupervisor;
 
 use crate::error::SkillError;
 
@@ -53,20 +61,28 @@ pub enum SkillEvent {
 
 /// Handle to the background filesystem watcher task.
 ///
-/// Dropping this value aborts the watcher task and releases all filesystem watches.
+/// When the `SkillWatcher` is dropped the underlying task is cancelled through the
+/// supervisor's `CancellationToken`. All filesystem watches are released when the
+/// `_debouncer` inside the task is dropped on exit.
 pub struct SkillWatcher {
-    _handle: tokio::task::JoinHandle<()>,
+    _handle: zeph_common::task_supervisor::BlockingHandle<()>,
 }
 
 impl SkillWatcher {
     /// Start watching directories for SKILL.md changes.
     ///
     /// Sends `SkillEvent::Changed` on any filesystem change (debounced 500ms).
+    /// The watcher task is registered under `"skills.watcher"` in `supervisor`
+    /// and is visible to `list_tasks()` and abortable via `shutdown_all()`.
     ///
     /// # Errors
     ///
     /// Returns an error if the filesystem watcher cannot be initialized.
-    pub fn start(paths: &[PathBuf], tx: mpsc::Sender<SkillEvent>) -> Result<Self, SkillError> {
+    pub fn start(
+        paths: &[PathBuf],
+        tx: mpsc::Sender<SkillEvent>,
+        supervisor: &TaskSupervisor,
+    ) -> Result<Self, SkillError> {
         let (notify_tx, mut notify_rx) = mpsc::channel(16);
 
         let mut debouncer = new_debouncer(
@@ -97,7 +113,7 @@ impl SkillWatcher {
                 .watch(path, notify::RecursiveMode::Recursive)?;
         }
 
-        let handle = tokio::spawn(async move {
+        let handle = supervisor.spawn_oneshot(Arc::from("skills.watcher"), move || async move {
             let _debouncer = debouncer;
             while notify_rx.recv().await.is_some() {
                 if tx.send(SkillEvent::Changed).await.is_err() {
@@ -112,13 +128,23 @@ impl SkillWatcher {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use tokio_util::sync::CancellationToken;
+    use zeph_common::TaskSupervisor;
+
     use super::*;
+
+    fn test_supervisor() -> Arc<TaskSupervisor> {
+        Arc::new(TaskSupervisor::new(CancellationToken::new()))
+    }
 
     #[tokio::test]
     async fn start_with_valid_directory() {
         let dir = tempfile::tempdir().unwrap();
         let (tx, _rx) = mpsc::channel(16);
-        let watcher = SkillWatcher::start(&[dir.path().to_path_buf()], tx);
+        let sup = test_supervisor();
+        let watcher = SkillWatcher::start(&[dir.path().to_path_buf()], tx, &sup);
         assert!(watcher.is_ok());
     }
 
@@ -127,22 +153,28 @@ mod tests {
         let dir1 = tempfile::tempdir().unwrap();
         let dir2 = tempfile::tempdir().unwrap();
         let (tx, _rx) = mpsc::channel(16);
-        let watcher =
-            SkillWatcher::start(&[dir1.path().to_path_buf(), dir2.path().to_path_buf()], tx);
+        let sup = test_supervisor();
+        let watcher = SkillWatcher::start(
+            &[dir1.path().to_path_buf(), dir2.path().to_path_buf()],
+            tx,
+            &sup,
+        );
         assert!(watcher.is_ok());
     }
 
     #[tokio::test]
     async fn start_with_nonexistent_directory_fails() {
         let (tx, _rx) = mpsc::channel(16);
-        let result = SkillWatcher::start(&[PathBuf::from("/nonexistent/path/xyz")], tx);
+        let sup = test_supervisor();
+        let result = SkillWatcher::start(&[PathBuf::from("/nonexistent/path/xyz")], tx, &sup);
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn start_with_empty_paths() {
         let (tx, _rx) = mpsc::channel(16);
-        let watcher = SkillWatcher::start(&[], tx);
+        let sup = test_supervisor();
+        let watcher = SkillWatcher::start(&[], tx, &sup);
         assert!(watcher.is_ok());
     }
 
@@ -150,7 +182,8 @@ mod tests {
     async fn detects_skill_file_change() {
         let dir = tempfile::tempdir().unwrap();
         let (tx, mut rx) = mpsc::channel(16);
-        let _watcher = SkillWatcher::start(&[dir.path().to_path_buf()], tx).unwrap();
+        let sup = test_supervisor();
+        let _watcher = SkillWatcher::start(&[dir.path().to_path_buf()], tx, &sup).unwrap();
 
         let skill_path = dir.path().join("SKILL.md");
         std::fs::write(&skill_path, "initial").unwrap();
@@ -169,7 +202,8 @@ mod tests {
     async fn ignores_non_skill_file_change() {
         let dir = tempfile::tempdir().unwrap();
         let (tx, mut rx) = mpsc::channel(16);
-        let _watcher = SkillWatcher::start(&[dir.path().to_path_buf()], tx).unwrap();
+        let sup = test_supervisor();
+        let _watcher = SkillWatcher::start(&[dir.path().to_path_buf()], tx, &sup).unwrap();
 
         let other_path = dir.path().join("README.md");
         std::fs::write(&other_path, "content").unwrap();

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -547,7 +547,7 @@ pub(crate) async fn build_tool_setup(
     let mcp_elicitation_rx = mcp_manager.take_elicitation_rx();
     if !bare {
         // Spawn the background task that processes tools/list_changed events.
-        mcp_manager.spawn_refresh_task();
+        mcp_manager.spawn_refresh_task(supervisor);
     }
 
     let mcp_shared_tools = Arc::new(RwLock::new(mcp_tools.clone()));

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1132,16 +1132,17 @@ impl AppBuilder {
 
         let skill_paths = self.skill_paths_for_watcher();
         let (skill_tx, skill_reload_rx) = instrumented_channel(4, "skill_reload_rx");
-        let skill_watcher = match SkillWatcher::start(&skill_paths, skill_tx.into_inner()) {
-            Ok(w) => {
-                tracing::info!("skill watcher started");
-                Some(w)
-            }
-            Err(e) => {
-                tracing::warn!("skill watcher unavailable: {e:#}");
-                None
-            }
-        };
+        let skill_watcher =
+            match SkillWatcher::start(&skill_paths, skill_tx.into_inner(), supervisor) {
+                Ok(w) => {
+                    tracing::info!("skill watcher started");
+                    Some(w)
+                }
+                Err(e) => {
+                    tracing::warn!("skill watcher unavailable: {e:#}");
+                    None
+                }
+            };
 
         let (config_tx, config_reload_rx) = instrumented_channel(4, "config_reload_rx");
         let config_watcher =


### PR DESCRIPTION
## Summary

- **zeph-skills** (#5170): `SkillWatcher::start` now accepts `&TaskSupervisor` and registers the watcher task under `"skills.watcher"` via `spawn_oneshot`; eliminates raw `tokio::spawn` and makes the task visible to `list_tasks()` and abortable via `shutdown_all()`.
- **zeph-mcp** (#5202): `McpManager::spawn_refresh_task` accepts `Option<&TaskSupervisor>` and uses `spawn` with `RestartPolicy::RunOnce` when a supervisor is present. `EmbeddingAnomalyGuard::check_async` is bounded to 32 concurrent spawns via `Arc<Semaphore>`.
- **zeph-llm** (#5219): `CandleProvider::chat_stream` replaces the `mpsc` + dropped-`JoinHandle` pattern with `tokio_stream::iter` over pre-built chunks; structured concurrency, no unsupervised task.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11316 passed
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean

Closes #5170, #5202, #5219.