### PR TITLE
feat(tracing): add instrument spans to llm router async fns

### DIFF
--- a/crates/zeph-llm/src/router/builder.rs
+++ b/crates/zeph-llm/src/router/builder.rs
@@ -286,6 +286,7 @@ impl RouterProvider {
     /// Persist current bandit state to disk. No-op if bandit strategy is not active.
     ///
     /// Uses [`tokio::task::spawn_blocking`] so it is safe to call from any async context.
+    #[tracing::instrument(name = "llm.router.builder.save_bandit_state", skip_all)]
     pub async fn save_bandit_state(&self) {
         let (Some(bandit), Some(path)) = (&self.bandit, &self.bandit_state_path) else {
             return;
@@ -410,6 +411,7 @@ impl RouterProvider {
 
     /// Persist current reputation state to disk. No-op if reputation is disabled.
     /// Uses [`tokio::task::spawn_blocking`] so it is safe to call from any async context.
+    #[tracing::instrument(name = "llm.router.builder.save_reputation_state", skip_all)]
     pub async fn save_reputation_state(&self) {
         let (Some(reputation), Some(path)) = (&self.reputation, &self.reputation_state_path) else {
             return;
@@ -511,6 +513,7 @@ impl RouterProvider {
     ///
     /// Uses [`tokio::task::spawn_blocking`] so it is safe to call from any async context,
     /// including mid-request paths.
+    #[tracing::instrument(name = "llm.router.builder.save_thompson_state", skip_all)]
     pub async fn save_thompson_state(&self) {
         let (Some(thompson), Some(path)) = (&self.thompson, &self.thompson_state_path) else {
             return;
@@ -561,6 +564,7 @@ impl RouterProvider {
     /// # Errors
     ///
     /// Always succeeds (errors per-provider are swallowed).
+    #[tracing::instrument(name = "llm.router.builder.list_models_remote", skip_all)]
     pub async fn list_models_remote(
         &self,
     ) -> Result<Vec<crate::model_cache::RemoteModelInfo>, LlmError> {

--- a/crates/zeph-llm/src/router/cascade.rs
+++ b/crates/zeph-llm/src/router/cascade.rs
@@ -291,6 +291,7 @@ fn build_judge_prompt(response: &str) -> String {
 /// # Errors
 ///
 /// Any `LlmError` from the judge call or a timeout is swallowed and represented as `None`.
+#[tracing::instrument(name = "llm.router.cascade.judge_score", skip_all)]
 pub async fn judge_score(
     judge: &dyn LlmProviderDyn,
     response: &str,

--- a/crates/zeph-llm/src/router/coe.rs
+++ b/crates/zeph-llm/src/router/coe.rs
@@ -71,6 +71,7 @@ const MIN_INTER_LEN: usize = 50;
 ///
 /// Returns `None` when either text is shorter than the minimum guard or embedding fails.
 /// `0.0` = identical, `0.5` = orthogonal, `1.0` = opposite.
+#[tracing::instrument(name = "llm.router.coe.inter_divergence", skip_all)]
 pub async fn inter_divergence(
     primary: &str,
     secondary: &str,
@@ -139,6 +140,7 @@ pub fn decide(entropy: Option<f64>, divergence: Option<f32>, config: &CoeConfig)
 /// # Errors
 ///
 /// Secondary/embed failures are swallowed and cause fallback to the primary response (COE-02).
+#[tracing::instrument(name = "llm.router.coe.run_coe", skip_all)]
 pub async fn run_coe(
     coe: &CoeRouter,
     primary_name: String,

--- a/crates/zeph-llm/src/router/triage.rs
+++ b/crates/zeph-llm/src/router/triage.rs
@@ -207,6 +207,7 @@ impl TriageRouter {
 
     /// Classify the last user message and return the selected provider index into `tier_providers`.
     /// On failure (timeout, parse error), returns `default_index`.
+    #[tracing::instrument(name = "llm.router.triage.classify", skip_all)]
     async fn classify(&self, messages: &[Message]) -> usize {
         let start = std::time::Instant::now();
         self.metrics.calls.fetch_add(1, Ordering::Relaxed);
@@ -230,6 +231,7 @@ impl TriageRouter {
         }
     }
 
+    #[tracing::instrument(name = "llm.router.triage.try_classify", skip_all)]
     async fn try_classify(&self, messages: &[Message]) -> Option<ComplexityTier> {
         let prompt = build_triage_prompt(messages);
         let triage_msg = Message {


### PR DESCRIPTION
## Summary

- Added `#[tracing::instrument(name = "...", skip_all)]` to 9 hot-path async functions in `crates/zeph-llm/src/router/`
- Span naming convention: `llm.router.<module>.<fn_name>` — matches project-wide `<crate>.<subsystem>.<operation>` pattern

## Closes

Closes #5206, #5207, #5208

## Changes

| File | Functions instrumented |
|------|------------------------|
| `router/coe.rs` | `inter_divergence`, `run_coe` |
| `router/cascade.rs` | `judge_score` |
| `router/triage.rs` | `classify`, `try_classify` |
| `router/builder.rs` | `save_bandit_state`, `save_reputation_state`, `save_thompson_state`, `list_models_remote` |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11318 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace` — clean
- [x] Behavioral drift: none (attribute-only additions with skip_all)

## Notes

Pre-existing spans in `select.rs`/`chat.rs` use shorter `llm.router.<fn>` style (no module segment); normalization tracked separately as P4 follow-up.