### PR TITLE
fix(async): eliminate span.entered() across .await and blocking fs::read in async callers

### DIFF
--- a/crates/zeph-bench/src/runner.rs
+++ b/crates/zeph-bench/src/runner.rs
@@ -31,6 +31,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
+use tracing::Instrument as _;
 use zeph_common::timestamp;
 use zeph_core::agent::Agent;
 use zeph_core::instructions::InstructionBlock;
@@ -241,6 +242,7 @@ impl BenchRunner {
     /// # Errors
     ///
     /// Returns [`BenchError`] if the dataset cannot be loaded or a scenario run fails.
+    #[tracing::instrument(skip_all, fields(dataset = loader.name()), name = "bench.run_dataset")]
     pub async fn run_dataset<L, E>(
         &self,
         loader: &L,
@@ -254,13 +256,6 @@ impl BenchRunner {
     {
         let scenarios = loader.load(path)?;
         let filtered = filter_scenarios(&scenarios, &opts, loader.name())?;
-
-        let _span = tracing::info_span!(
-            "bench.run_dataset",
-            dataset = loader.name(),
-            scenarios = filtered.len(),
-        )
-        .entered();
 
         let model_id = self.provider.model_identifier().to_owned();
 
@@ -276,10 +271,10 @@ impl BenchRunner {
         };
 
         for scenario in filtered {
-            let _s = tracing::info_span!("bench.scenario", id = %scenario.id).entered();
-
             let t0 = Instant::now();
-            let response_text = Box::pin(self.run_one(scenario, opts.memory_mode)).await?;
+            let response_text = Box::pin(self.run_one(scenario, opts.memory_mode))
+                .instrument(tracing::info_span!("bench.scenario", id = %scenario.id))
+                .await?;
             let elapsed_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);
 
             let eval = evaluator.evaluate(scenario, &response_text);
@@ -310,6 +305,7 @@ impl BenchRunner {
     ///
     /// Returns [`BenchError`] if the dataset cannot be loaded, the env factory fails, or
     /// `TauBenchEvaluator::from_scenario` fails (malformed metadata).
+    #[tracing::instrument(skip_all, fields(dataset = loader.name()), name = "bench.run_dataset_with_env_factory")]
     pub async fn run_dataset_with_env_factory<L, F, X>(
         &self,
         loader: &L,
@@ -325,13 +321,6 @@ impl BenchRunner {
         let scenarios = loader.load(path)?;
         let filtered = filter_scenarios(&scenarios, &opts, loader.name())?;
 
-        let _span = tracing::info_span!(
-            "bench.run_dataset_with_env_factory",
-            dataset = loader.name(),
-            scenarios = filtered.len(),
-        )
-        .entered();
-
         let model_id = self.provider.model_identifier().to_owned();
 
         let mut run = BenchRun {
@@ -346,8 +335,6 @@ impl BenchRunner {
         };
 
         for scenario in filtered {
-            let _s = tracing::info_span!("bench.scenario", id = %scenario.id).entered();
-
             let (executor, trace) = env_factory(scenario)?;
             let evaluator = TauBenchEvaluator::from_scenario(scenario, trace)?;
 
@@ -358,6 +345,7 @@ impl BenchRunner {
                 opts.memory_mode,
                 ResponseMode::ToolUse,
             ))
+            .instrument(tracing::info_span!("bench.scenario", id = %scenario.id))
             .await?;
             let elapsed_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);
 
@@ -412,6 +400,7 @@ impl BenchRunner {
     /// Called by both [`BenchRunner::run_dataset`] (with `NoopExecutor` + `TerseAnswer`) and
     /// [`BenchRunner::run_dataset_with_env_factory`] (with the domain env + `ToolUse`).
     #[allow(clippy::too_many_lines)] // sequential setup steps; splitting adds indirection without clarity
+    #[tracing::instrument(skip_all, fields(scenario_id = %scenario.id, mode = ?mode), name = "bench.run_one")]
     async fn run_one_with_executor<X: ToolExecutor + Send + Sync + 'static>(
         &self,
         scenario: &Scenario,
@@ -419,12 +408,6 @@ impl BenchRunner {
         memory_mode: MemoryMode,
         mode: ResponseMode,
     ) -> Result<String, BenchError> {
-        let _span = tracing::info_span!(
-            "bench.run_one",
-            scenario_id = %scenario.id,
-            mode = ?mode,
-        )
-        .entered();
         let channel = BenchmarkChannel::from_turns(scenario.turns.clone());
         if channel.total() == 0 {
             return Err(BenchError::InvalidFormat(format!(

--- a/crates/zeph-core/src/agent/model_commands.rs
+++ b/crates/zeph-core/src/agent/model_commands.rs
@@ -54,10 +54,10 @@ impl<C: crate::channel::Channel> Agent<C> {
     /// List available models, returning a formatted string.
     pub(crate) async fn model_list_as_string(&mut self) -> String {
         let cache = zeph_llm::model_cache::ModelCache::for_slug(self.provider.name());
-        let cached = if cache.is_stale() {
+        let cached = if cache.is_stale_async().await {
             None
         } else {
-            cache.load().unwrap_or(None)
+            cache.load_async().await.unwrap_or(None)
         };
         let models = if let Some(m) = cached {
             m
@@ -80,15 +80,15 @@ impl<C: crate::channel::Channel> Agent<C> {
     /// Switch to a different model, returning a result message.
     pub(crate) async fn model_switch_as_string(&mut self, model_id: &str) -> String {
         let cache = zeph_llm::model_cache::ModelCache::for_slug(self.provider.name());
-        let known_models: Option<Vec<zeph_llm::model_cache::RemoteModelInfo>> = if cache.is_stale()
-        {
-            match self.provider.list_models_remote().await {
-                Ok(m) if !m.is_empty() => Some(m),
-                _ => None,
-            }
-        } else {
-            cache.load().unwrap_or(None)
-        };
+        let known_models: Option<Vec<zeph_llm::model_cache::RemoteModelInfo>> =
+            if cache.is_stale_async().await {
+                match self.provider.list_models_remote().await {
+                    Ok(m) if !m.is_empty() => Some(m),
+                    _ => None,
+                }
+            } else {
+                cache.load_async().await.unwrap_or(None)
+            };
         let list_unavailable = known_models.is_none();
         if let Some(models) = known_models {
             if !models.iter().any(|m| m.id == model_id) {

--- a/crates/zeph-llm/src/model_cache.rs
+++ b/crates/zeph-llm/src/model_cache.rs
@@ -92,6 +92,51 @@ impl ModelCache {
         now.saturating_sub(envelope.fetched_at) > TTL_SECS
     }
 
+    /// Load cached models from a tokio async context without blocking the executor.
+    ///
+    /// Offloads the blocking file read to `spawn_blocking`. Prefer this over
+    /// [`Self::load`] when calling from `async fn`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only on JSON parse failure (corrupt file).
+    pub async fn load_async(&self) -> Result<Option<Vec<RemoteModelInfo>>, LlmError> {
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || {
+            let Ok(data) = std::fs::read(&path) else {
+                return Ok(None);
+            };
+            let envelope: CacheEnvelope = serde_json::from_slice(&data).map_err(LlmError::Json)?;
+            Ok(Some(envelope.models))
+        })
+        .await
+        .map_err(|e| LlmError::Io(std::io::Error::other(e)))?
+    }
+
+    /// Returns `true` if the cache file is missing or older than 24 hours.
+    ///
+    /// Offloads the blocking file read to `spawn_blocking`. Prefer this over
+    /// [`Self::is_stale`] when calling from `async fn`.
+    #[must_use]
+    pub async fn is_stale_async(&self) -> bool {
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || {
+            let Ok(data) = std::fs::read(&path) else {
+                return true;
+            };
+            let Ok(envelope) = serde_json::from_slice::<CacheEnvelope>(&data) else {
+                return true;
+            };
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO)
+                .as_secs();
+            now.saturating_sub(envelope.fetched_at) > TTL_SECS
+        })
+        .await
+        .unwrap_or(true)
+    }
+
     /// Atomically write models to disk. Writes `.tmp` then renames.
     ///
     /// The blocking I/O is offloaded to a `spawn_blocking` thread so this
@@ -220,5 +265,46 @@ mod tests {
         let path = std::path::PathBuf::from("/tmp/models.json");
         let tmp = path.with_added_extension("tmp");
         assert_eq!(tmp.file_name().unwrap(), "models.json.tmp");
+    }
+
+    #[tokio::test]
+    async fn load_async_missing_file_returns_none() {
+        let c = tmp_cache();
+        let result = c.load_async().await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_async_matches_sync_load() {
+        let c = tmp_cache();
+        let models = vec![RemoteModelInfo {
+            id: "x1".into(),
+            display_name: "X One".into(),
+            context_window: Some(2048),
+            created_at: None,
+        }];
+        c.save(&models).await.unwrap();
+        let sync_result = c.load().unwrap();
+        let async_result = c.load_async().await.unwrap();
+        assert_eq!(sync_result, async_result);
+    }
+
+    #[tokio::test]
+    async fn is_stale_async_missing_file_returns_true() {
+        let c = tmp_cache();
+        assert!(c.is_stale_async().await);
+    }
+
+    #[tokio::test]
+    async fn is_stale_async_matches_sync_is_stale() {
+        let c = tmp_cache();
+        let models = vec![RemoteModelInfo {
+            id: "y1".into(),
+            display_name: "Y One".into(),
+            context_window: None,
+            created_at: None,
+        }];
+        c.save(&models).await.unwrap();
+        assert_eq!(c.is_stale(), c.is_stale_async().await);
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -647,7 +647,7 @@ async fn build_acp_deps(
         acp_permission_file: config.acp.permission_file.clone(),
         acp_available_models: std::sync::Arc::new(RwLock::new(
             if config.acp.available_models.is_empty() {
-                discover_models_from_config(config)
+                discover_models_from_config(config).await
             } else {
                 config.acp.available_models.clone()
             },
@@ -1039,14 +1039,14 @@ async fn spawn_acp_agent(
 ///
 /// Each key uses `"{provider_name}:{model_id}"` format matching the provider factory.
 #[cfg(feature = "acp")]
-fn discover_models_from_config(config: &zeph_core::config::Config) -> Vec<String> {
+async fn discover_models_from_config(config: &zeph_core::config::Config) -> Vec<String> {
     use zeph_llm::model_cache::ModelCache;
 
     /// Expand a provider slug using its on-disk cache, or fall back to `fallback`.
-    fn expand_from_cache(slug: &str, fallback: &str) -> Vec<String> {
+    async fn expand_from_cache(slug: &str, fallback: &str) -> Vec<String> {
         let cache = ModelCache::for_slug(slug);
-        if !cache.is_stale()
-            && let Ok(Some(entries)) = cache.load()
+        if !cache.is_stale_async().await
+            && let Ok(Some(entries)) = cache.load_async().await
             && !entries.is_empty()
         {
             return entries
@@ -1062,7 +1062,7 @@ fn discover_models_from_config(config: &zeph_core::config::Config) -> Vec<String
     for entry in &config.llm.providers {
         let slug = entry.provider_type.as_str();
         let fallback = entry.model.as_deref().unwrap_or("unknown");
-        models.extend(expand_from_cache(slug, fallback));
+        models.extend(expand_from_cache(slug, fallback).await);
     }
 
     models.dedup();
@@ -1124,11 +1124,11 @@ async fn warm_model_caches(
 
     for slug in slugs {
         let cache = ModelCache::for_slug(&slug);
-        if cache.is_stale() {
+        if cache.is_stale_async().await {
             tracing::info!(provider = %slug, "model cache still stale after warm-up");
             continue;
         }
-        if let Ok(Some(entries)) = cache.load()
+        if let Ok(Some(entries)) = cache.load_async().await
             && !entries.is_empty()
         {
             let new_keys: Vec<String> = entries
@@ -1494,7 +1494,7 @@ pub(crate) async fn run_acp_http_server(
         provider_factory: Some(build_acp_provider_factory(app.config())),
         available_models: std::sync::Arc::new(parking_lot::RwLock::new(
             if app.config().acp.available_models.is_empty() {
-                discover_models_from_config(app.config())
+                discover_models_from_config(app.config()).await
             } else {
                 app.config().acp.available_models.clone()
             },


### PR DESCRIPTION
## Summary

- **#5214**: Replace sync `span.entered()` guards held across `.await` in `zeph-bench/src/runner.rs` with `#[tracing::instrument]` on dataset functions and `.instrument()` on per-scenario futures; dataset spans now correctly wrap async fn bodies and scenario spans remain nested inside them
- **#5258**: Add `ModelCache::load_async()` and `is_stale_async()` backed by `tokio::task::spawn_blocking`; migrate all async callers (`model_commands.rs`, `acp::warm_model_caches`, `acp::discover_models_from_config` + its `expand_from_cache` helper); add 4 `#[tokio::test]` regression tests

## Changed files

| File | Change |
|---|---|
| `crates/zeph-bench/src/runner.rs` | Replace `.entered()` guards with `#[tracing::instrument]` / `.instrument()` |
| `crates/zeph-llm/src/model_cache.rs` | Add `load_async`, `is_stale_async`, 4 async tests |
| `crates/zeph-core/src/agent/model_commands.rs` | Await new async cache methods |
| `src/acp.rs` | Make `discover_models_from_config` + `expand_from_cache` async; await at both call sites |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing"` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "bench"` — clean
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11320 passed
- [x] `cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (no broken intra-doc links)
- [x] 4 new `#[tokio::test]` tests for `load_async` / `is_stale_async` cover missing-file and sync-parity paths

Closes #5214
Closes #5258