### PR TITLE
refactor(agent-context, knowledge): eliminate two DRY violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `refactor(agent-context)`: collapse 10 structurally identical inject-sanitize blocks in
+  `apply_prepared_context` into a single `slots` slice + loop, eliminating DRY violation
+  (closes #5117).
+- `refactor(knowledge)`: extract `build_shared_validator` helper to deduplicate identical
+  `SharedPostExtractValidator` construction in `run_graph_ingest` and
+  `handle_external_agent_ingest` (closes #5118).
+
 ### Fixed
 
 - `fix(skills)`: migrate `SkillWatcher` background task from raw `tokio::spawn` to

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -788,89 +788,60 @@ impl ContextService {
         let mut inserted_count: usize = 0;
 
         // Insert memory messages at position 1 (all sanitized before insertion — CRIT-02).
-        if let Some(msg) = prepared.graph_facts.filter(|_| window.messages.len() > 1) {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::ExternalContent, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-            tracing::debug!("injected knowledge graph facts into context");
-        }
-        if let Some(msg) = prepared.doc_rag.filter(|_| window.messages.len() > 1) {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::ExternalContent, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-            tracing::debug!("injected document RAG context");
-        }
-        if let Some(msg) = prepared.corrections.filter(|_| window.messages.len() > 1) {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::ConversationHistory, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-            tracing::debug!("injected past corrections into context");
-        }
-        if let Some(msg) = prepared.recall.filter(|_| window.messages.len() > 1) {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::ConversationHistory, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-        }
-        if let Some(msg) = prepared.cross_session.filter(|_| window.messages.len() > 1) {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::LlmSummary, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-        }
-        if let Some(msg) = prepared.summaries.filter(|_| window.messages.len() > 1) {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::LlmSummary, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-            tracing::debug!("injected summaries into context");
-        }
-        if let Some(msg) = prepared.persona_facts.filter(|_| window.messages.len() > 1) {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::ExternalContent, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-            tracing::debug!("injected persona facts into context");
-        }
-        if let Some(msg) = prepared
-            .trajectory_hints
-            .filter(|_| window.messages.len() > 1)
-        {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::ExternalContent, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-            tracing::debug!("injected trajectory hints into context");
-        }
-        if let Some(msg) = prepared.tree_memory.filter(|_| window.messages.len() > 1) {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::ExternalContent, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-            tracing::debug!("injected tree memory summary into context");
-        }
-        if let Some(msg) = prepared
-            .reasoning_hints
-            .filter(|_| window.messages.len() > 1)
-        {
-            let sanitized = self
-                .sanitize_memory_message(msg, MemorySourceHint::ExternalContent, view)
-                .await;
-            window.messages.insert(1, sanitized);
-            inserted_count += 1;
-            tracing::debug!("injected reasoning strategies into context");
+        // Each tuple: (optional message, hint, optional debug label).
+        let slots: &[(Option<Message>, MemorySourceHint, Option<&str>)] = &[
+            (
+                prepared.graph_facts,
+                MemorySourceHint::ExternalContent,
+                Some("injected knowledge graph facts into context"),
+            ),
+            (
+                prepared.doc_rag,
+                MemorySourceHint::ExternalContent,
+                Some("injected document RAG context"),
+            ),
+            (
+                prepared.corrections,
+                MemorySourceHint::ConversationHistory,
+                Some("injected past corrections into context"),
+            ),
+            (prepared.recall, MemorySourceHint::ConversationHistory, None),
+            (prepared.cross_session, MemorySourceHint::LlmSummary, None),
+            (
+                prepared.summaries,
+                MemorySourceHint::LlmSummary,
+                Some("injected summaries into context"),
+            ),
+            (
+                prepared.persona_facts,
+                MemorySourceHint::ExternalContent,
+                Some("injected persona facts into context"),
+            ),
+            (
+                prepared.trajectory_hints,
+                MemorySourceHint::ExternalContent,
+                Some("injected trajectory hints into context"),
+            ),
+            (
+                prepared.tree_memory,
+                MemorySourceHint::ExternalContent,
+                Some("injected tree memory summary into context"),
+            ),
+            (
+                prepared.reasoning_hints,
+                MemorySourceHint::ExternalContent,
+                Some("injected reasoning strategies into context"),
+            ),
+        ];
+        for (opt_msg, hint, label) in slots.iter().cloned() {
+            if let Some(msg) = opt_msg.filter(|_| window.messages.len() > 1) {
+                let sanitized = self.sanitize_memory_message(msg, hint, view).await;
+                window.messages.insert(1, sanitized);
+                inserted_count += 1;
+                if let Some(lbl) = label {
+                    tracing::debug!("{lbl}");
+                }
+            }
         }
 
         // Code context: sanitize inline, return body to caller via ContextDelta.

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -604,6 +604,22 @@ fn print_ingest_report(report: &IngestReport) {
     }
 }
 
+/// Build a [`SharedPostExtractValidator`] that gates graph extraction via [`zeph_sanitizer::memory_validation::MemoryWriteValidator`].
+///
+/// Wraps `cfg` in a `MemoryWriteValidator` and returns it as the shared closure expected by
+/// `SemanticMemory::ingest_documents` (INV-4, spec-067 §G-5 S3).
+#[allow(clippy::unnecessary_wraps)] // SharedPostExtractValidator is Option<Arc<...>>; callers pass it directly
+fn build_shared_validator(
+    cfg: zeph_config::sanitizer::MemoryWriteValidationConfig,
+) -> SharedPostExtractValidator {
+    let inner = zeph_sanitizer::memory_validation::MemoryWriteValidator::new(cfg);
+    Some(Arc::new(move |r| {
+        inner
+            .validate_graph_extraction(r)
+            .map_err(|e| e.to_string())
+    }))
+}
+
 /// Execute the graph-sink ingest path for `--source subagents` (spec-067 Phase 2, FR-020..024).
 ///
 /// Discovers subagent JSONL transcripts under the project-anchored transcript dir,
@@ -818,14 +834,7 @@ async fn run_graph_ingest(
     // Always Some — required on both dry-run and live paths (spec-067 §G-5 S3).
     // TODO(critic): P4 — ingest sanitizer covers entity-name PII + counts; edge-fact bodies
     // length-capped only, no body PII / exfiltration URL scan (#5023 INV-4 MVP boundary).
-    let validator_inner = zeph_sanitizer::memory_validation::MemoryWriteValidator::new(
-        config.security.memory_validation.clone(),
-    );
-    let shared_validator: SharedPostExtractValidator = Some(Arc::new(move |r| {
-        validator_inner
-            .validate_graph_extraction(r)
-            .map_err(|e| e.to_string())
-    }));
+    let shared_validator = build_shared_validator(config.security.memory_validation.clone());
 
     let batch_cfg = IngestBatchConfig {
         dry_run,
@@ -1255,14 +1264,7 @@ async fn handle_external_agent_ingest(
     let mem = app.build_memory(&provider, &kn_sup3).await?;
 
     // Build SharedPostExtractValidator wrapping MemoryWriteValidator (INV-4, spec-067 §G-5 S3).
-    let validator_inner = zeph_sanitizer::memory_validation::MemoryWriteValidator::new(
-        app_config.security.memory_validation.clone(),
-    );
-    let shared_validator: SharedPostExtractValidator = Some(Arc::new(move |r| {
-        validator_inner
-            .validate_graph_extraction(r)
-            .map_err(|e| e.to_string())
-    }));
+    let shared_validator = build_shared_validator(app_config.security.memory_validation.clone());
 
     let config = IngestBatchConfig::default();
     let report = mem


### PR DESCRIPTION
## Summary

- **#5117** (`crates/zeph-agent-context/src/service.rs`): 10 structurally identical inject-sanitize blocks in `apply_prepared_context` collapsed into a `slots` slice + loop. Each entry encodes the optional `Message`, `MemorySourceHint` variant, and optional debug label. Insertion order and all `filter(|_| window.messages.len() > 1)` guards are preserved exactly.
- **#5118** (`src/commands/knowledge.rs`): extracted `build_shared_validator` private helper to deduplicate identical `SharedPostExtractValidator` construction in `run_graph_ingest` (line ~834) and `handle_external_agent_ingest` (line ~1264).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11318 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] Adversarial critic confirmed behavior is fully preserved; verdict: minor (no blocking issues)
- [x] Code review: approved

Closes #5117, #5118.