### PR TITLE
feat(scheduler): add tracing instrumentation to scheduler and store hot paths

### DIFF
--- a/crates/zeph-scheduler/src/lib.rs
+++ b/crates/zeph-scheduler/src/lib.rs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+// Tracing instrumentation on deeply-nested async state machines (scheduler tick + catch-up path)
+// requires a higher recursion limit for the compiler's layout queries.
+#![recursion_limit = "256"]
+
 //! Cron-based periodic task scheduler with `SQLite` persistence.
 //!
 //! `zeph-scheduler` drives time-based work inside the Zeph agent. It supports two

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -455,6 +455,7 @@ impl Scheduler {
     /// Execute a named periodic task and advance its `next_run`.
     ///
     /// Returns `Ok(true)` if the task was found and executed, `Ok(false)` if not found.
+    #[tracing::instrument(name = "scheduler.run_periodic_task", skip_all, fields(task = %name), err)]
     async fn run_periodic_task_by_name(
         &self,
         name: &str,
@@ -591,6 +592,7 @@ impl Scheduler {
         }
     }
 
+    #[tracing::instrument(name = "scheduler.drain_channel", skip_all, level = "debug")]
     async fn drain_channel(&mut self) {
         while let Ok(msg) = self.task_rx.try_recv() {
             match msg {
@@ -613,6 +615,7 @@ impl Scheduler {
         }
     }
 
+    #[tracing::instrument(name = "scheduler.register_descriptor", skip_all, fields(task = %desc.name))]
     async fn register_descriptor(&mut self, desc: TaskDescriptor) {
         // Check capacity only when adding a new task (upsert of existing name does not count).
         let is_new = !self.tasks.iter().any(|t| t.name == desc.name);
@@ -912,6 +915,7 @@ impl Scheduler {
     }
 
     /// Inject a custom oneshot task prompt, wrapping in durable exactly-once journaling when available.
+    #[tracing::instrument(name = "scheduler.inject_custom_task", skip_all, fields(task = %task.name), err)]
     async fn inject_custom_task(
         &self,
         task: &ScheduledTask,

--- a/crates/zeph-scheduler/src/store.rs
+++ b/crates/zeph-scheduler/src/store.rs
@@ -114,6 +114,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns [`SchedulerError::Db`] if the connection cannot be established.
+    #[tracing::instrument(name = "sched.store.open", skip_all, fields(path = %path), err)]
     pub async fn open(path: &str) -> Result<Self, SchedulerError> {
         let pool = zeph_db::DbConfig {
             url: path.to_string(),
@@ -134,6 +135,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if any migration fails.
+    #[tracing::instrument(name = "sched.store.init", skip_all, err)]
     pub async fn init(&self) -> Result<(), SchedulerError> {
         zeph_db::run_migrations(&self.pool).await?;
         Ok(())
@@ -144,6 +146,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL statement fails.
+    #[tracing::instrument(name = "sched.store.upsert_job", skip_all, fields(task = %name), err)]
     pub async fn upsert_job(
         &self,
         name: &str,
@@ -159,6 +162,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL statement fails.
+    #[tracing::instrument(name = "sched.store.upsert_job_with_mode", skip_all, fields(task = %name), err)]
     pub async fn upsert_job_with_mode(
         &self,
         name: &str,
@@ -180,6 +184,7 @@ impl JobStore {
     ///
     /// Returns an error if the SQL statement fails.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(name = "sched.store.upsert_job_with_provenance", skip_all, fields(task = %name), err)]
     pub async fn upsert_job_with_provenance(
         &self,
         name: &str,
@@ -219,6 +224,7 @@ impl JobStore {
     ///
     /// Returns [`SchedulerError::DuplicateJob`] on unique constraint violation,
     /// or [`SchedulerError::Database`] on other SQL errors.
+    #[tracing::instrument(name = "sched.store.insert_job", skip_all, fields(task = %name), err)]
     pub async fn insert_job(
         &self,
         name: &str,
@@ -257,6 +263,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL statement fails.
+    #[tracing::instrument(name = "sched.store.record_run", skip_all, fields(task = %name), err)]
     pub async fn record_run(
         &self,
         name: &str,
@@ -279,6 +286,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL statement fails.
+    #[tracing::instrument(name = "sched.store.mark_done", skip_all, fields(task = %name), err)]
     pub async fn mark_done(&self, name: &str) -> Result<(), SchedulerError> {
         zeph_db::query(sql!(
             "UPDATE scheduled_jobs SET status = 'done', last_run = CURRENT_TIMESTAMP WHERE name = ?"
@@ -297,6 +305,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL statement fails.
+    #[tracing::instrument(name = "sched.store.mark_error", skip_all, fields(task = %name), err)]
     pub async fn mark_error(&self, name: &str) -> Result<(), SchedulerError> {
         zeph_db::query(sql!(
             "UPDATE scheduled_jobs SET status = 'error' WHERE name = ?"
@@ -312,6 +321,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL statement fails.
+    #[tracing::instrument(name = "sched.store.delete_job", skip_all, fields(task = %name), err)]
     pub async fn delete_job(&self, name: &str) -> Result<bool, SchedulerError> {
         let result = zeph_db::query(sql!("DELETE FROM scheduled_jobs WHERE name = ?"))
             .bind(name)
@@ -325,6 +335,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL query fails.
+    #[tracing::instrument(name = "sched.store.job_exists", skip_all, fields(task = %name), err)]
     pub async fn job_exists(&self, name: &str) -> Result<bool, SchedulerError> {
         let row: Option<(i64,)> =
             zeph_db::query_as(sql!("SELECT 1 FROM scheduled_jobs WHERE name = ?"))
@@ -339,6 +350,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL statement fails.
+    #[tracing::instrument(name = "sched.store.set_next_run", skip_all, fields(task = %name), err)]
     pub async fn set_next_run(&self, name: &str, next_run: &str) -> Result<(), SchedulerError> {
         zeph_db::query(sql!(
             "UPDATE scheduled_jobs SET next_run = ? WHERE name = ?"
@@ -355,6 +367,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL query fails.
+    #[tracing::instrument(name = "sched.store.get_next_run", skip_all, fields(task = %name), err)]
     pub async fn get_next_run(&self, name: &str) -> Result<Option<String>, SchedulerError> {
         let row: Option<(Option<String>,)> =
             zeph_db::query_as(sql!("SELECT next_run FROM scheduled_jobs WHERE name = ?"))
@@ -373,6 +386,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL query fails.
+    #[tracing::instrument(name = "sched.store.list_jobs", skip_all, err)]
     pub async fn list_jobs(&self) -> Result<Vec<ScheduledTaskRecord>, SchedulerError> {
         let rows: Vec<(String, String, String, Option<String>)> = zeph_db::query_as(
             sql!("SELECT name, kind, task_mode, COALESCE(next_run, run_at) FROM scheduled_jobs WHERE status != 'done' ORDER BY name"),
@@ -400,6 +414,7 @@ impl JobStore {
     /// # Errors
     ///
     /// Returns an error if the SQL query fails.
+    #[tracing::instrument(name = "sched.store.list_jobs_full", skip_all, err)]
     pub async fn list_jobs_full(&self) -> Result<Vec<ScheduledTaskInfo>, SchedulerError> {
         #[allow(clippy::type_complexity)]
         let rows: Vec<(String, String, String, String, Option<String>, String, String, String)> =


### PR DESCRIPTION
## Summary

- Add `#[tracing::instrument]` to 4 hot-path async fns in `scheduler.rs` (`drain_channel`, `register_descriptor`, `run_periodic_task_by_name`, `inject_custom_task`) — closes #5157
- Add `#[tracing::instrument]` to all 15 public async fns on `JobStore` in `store.rs` — closes #5195
- Raise `recursion_limit` to 256 in `lib.rs`: required for the compiler's layout queries on deeply-nested async state machines on the scheduler tick path

## Span names

`scheduler.rs` spans follow the existing crate convention (`scheduler.daemon.*`, `scheduler.task.*`):
- `scheduler.drain_channel` — `level = "debug"` (called every tick)
- `scheduler.register_descriptor`
- `scheduler.run_periodic_task`
- `scheduler.inject_custom_task`

`store.rs` spans use the `sched.store.*` prefix per #5195:
- `sched.store.open`, `sched.store.init`, `sched.store.upsert_job`, `sched.store.upsert_job_with_mode`, `sched.store.upsert_job_with_provenance`, `sched.store.insert_job`, `sched.store.record_run`, `sched.store.mark_done`, `sched.store.mark_error`, `sched.store.delete_job`, `sched.store.job_exists`, `sched.store.set_next_run`, `sched.store.get_next_run`, `sched.store.list_jobs`, `sched.store.list_jobs_full`

All `Result`-returning fns carry `err`; all use `skip_all` with relevant `fields(task = %name)` where applicable.

## Test plan

- [ ] `cargo +nightly fmt --check` — PASS
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — PASS
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11361/11361 PASS
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — PASS