### PR TITLE
feat(tracing): instrument hot-path async fns in subagent and agent-context

### DIFF
--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -299,6 +299,7 @@ impl ContextService {
     ///
     /// Both `inject_semantic_recall` and `inject_semantic_recall_bare` share identical
     /// retrieval logic; this method holds the single implementation.
+    #[tracing::instrument(name = "agent_context.service.run_tiered_recall", skip_all, err)]
     async fn run_tiered_recall(
         &self,
         params: &SemanticRecallParams<'_>,
@@ -932,6 +933,7 @@ impl ContextService {
     ///
     /// Truncation, control-char stripping, delimiter escaping, and spotlighting are active
     /// for all hints (defense-in-depth invariant).
+    #[tracing::instrument(name = "agent_context.service.sanitize_memory_message", skip_all)]
     async fn sanitize_memory_message(
         &self,
         mut msg: zeph_llm::provider::Message,
@@ -1184,6 +1186,7 @@ impl ContextService {
     ///
     /// Does not trigger an LLM call. Does not set `compacted_this_turn` so Hard tier
     /// may still fire in the same turn if context remains above the hard threshold.
+    #[tracing::instrument(name = "agent_context.service.do_soft_compaction", skip_all)]
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
@@ -1242,6 +1245,7 @@ impl ContextService {
     }
 
     /// Execute the Hard compaction tier: soft pass first, then LLM summarization if needed.
+    #[tracing::instrument(name = "agent_context.service.do_hard_compaction", skip_all, err)]
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
@@ -1567,6 +1571,7 @@ pub(crate) fn recompute_prompt_tokens(window: &mut MessageWindowView<'_>) {
 ///
 /// A warn-level log is emitted on failure; the next turn will recompute from scratch,
 /// which is safe (the floor invariant simply won't apply until persistence succeeds).
+#[tracing::instrument(name = "agent_context.service.persist_fidelity_tags", skip_all)]
 async fn persist_fidelity_tags(
     messages: &[zeph_llm::provider::Message],
     memory: Option<&zeph_memory::semantic::SemanticMemory>,

--- a/crates/zeph-agent-context/src/summarization/compaction.rs
+++ b/crates/zeph-agent-context/src/summarization/compaction.rs
@@ -41,6 +41,7 @@ use crate::state::{CompactionOutcome, ContextSummarizationView, ProbeOutcome};
 /// # Errors
 ///
 /// Returns [`ContextError`] if LLM summarization fails.
+#[tracing::instrument(name = "agent_context.compaction.compact_context", skip_all, err)]
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn compact_context(
     summ: &mut ContextSummarizationView<'_>,
@@ -357,6 +358,7 @@ fn finalize_compacted_messages(
 /// Takes `deps` and `guidelines` by value (already extracted from `summ` by the caller)
 /// so no reference to `ContextSummarizationView` (which contains `!Sync` fields) is held
 /// across the `.await` boundary.
+#[tracing::instrument(name = "agent_context.compaction.summarize_messages", skip_all, err)]
 async fn summarize_messages(
     deps: zeph_context::summarization::SummarizationDeps,
     messages: &[Message],

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -79,6 +79,7 @@ pub(super) fn make_message(role: Role, content: String) -> Message {
     }
 }
 
+#[tracing::instrument(name = "subagent.agent_loop.append_transcript", skip_all)]
 pub(super) async fn append_transcript(
     writer: Option<&TranscriptWriter>,
     seq: &mut u32,
@@ -135,6 +136,7 @@ fn build_effective_system_prompt(
     effective
 }
 
+#[tracing::instrument(name = "subagent.agent_loop.call_provider", skip_all, err)]
 async fn call_provider_with_status(
     provider: &AnyProvider,
     messages: &[Message],
@@ -183,6 +185,7 @@ fn emit_working_status(
     });
 }
 
+#[tracing::instrument(name = "subagent.agent_loop.handle_secret_request", skip_all)]
 #[allow(clippy::too_many_arguments)]
 async fn handle_secret_request(
     transcript_writer: Option<&TranscriptWriter>,
@@ -308,6 +311,7 @@ async fn handle_no_tool_response(
 /// Initialise per-loop state: send the initial Working status, build the
 /// message list from history + task prompt, write the task message to the
 /// transcript, and collect tool definitions.
+#[tracing::instrument(name = "subagent.agent_loop.init_loop_state", skip_all)]
 async fn init_loop_state(
     status_tx: &watch::Sender<SubAgentStatus>,
     started_at: Instant,
@@ -467,6 +471,7 @@ async fn run_turn(
 }
 
 // Returns `true` if no tool was called (loop should break).
+#[tracing::instrument(name = "subagent.agent_loop.handle_tool_step", skip_all)]
 #[allow(clippy::too_many_lines)]
 async fn handle_tool_step(
     executor: &FilteredToolExecutor,


### PR DESCRIPTION
## Summary

- Adds `#[tracing::instrument]` to 5 hot-path async functions in `zeph-subagent/agent_loop.rs`: `append_transcript`, `call_provider_with_status` (LLM request, most critical), `handle_secret_request`, `init_loop_state`, `handle_tool_step`
- Adds `#[tracing::instrument]` to 5 private async functions in `zeph-agent-context/service.rs`: `run_tiered_recall`, `sanitize_memory_message`, `do_soft_compaction`, `do_hard_compaction`, `persist_fidelity_tags`
- Adds `#[tracing::instrument]` to 2 functions in `zeph-agent-context/summarization/compaction.rs`: `compact_context`, `summarize_messages`

All instrumentation follows the `<crate>.<subsystem>.<operation>` naming convention. Functions returning `Result` use `, err` to auto-record failures.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11361 passed
- [ ] Rustdoc gate — clean

Closes #5151, #5217, #5218