### PR TITLE
feat(tracing): instrument hot-path async fns in zeph-core agent module (#5181, #5182, #5183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `feat(tracing)`: instrument 17 hot-path async fns in `zeph-core` agent module
+  (`tool_execution/mod.rs`, `autodream.rs`, `hooks_dispatch.rs`,
+  `context/summarization/{scheduling,compaction,deferred}.rs`) with
+  `#[tracing::instrument]` spans using `core.{agent|tool|context}.<fn>` naming,
+  making compaction, PII scrubbing, cache, and file-change paths visible in traces
+  (closes #5181, #5182, #5183).
+
 - `refactor(agent-context)`: collapse 10 structurally identical inject-sanitize blocks in
   `apply_prepared_context` into a single `slots` slice + loop, eliminating DRY violation
   (closes #5117).

--- a/crates/zeph-core/src/agent/autodream.rs
+++ b/crates/zeph-core/src/agent/autodream.rs
@@ -65,6 +65,7 @@ impl<C: Channel> super::Agent<C> {
     /// Fires after the main agent loop exits. Uses the configured
     /// `consolidation_provider` (falls back to the primary provider).
     /// Respects `max_iterations` as a safety bound via timeout.
+    #[tracing::instrument(name = "core.agent.maybe_autodream", skip_all, level = "debug")]
     pub(super) async fn maybe_autodream(&mut self) {
         let cfg = self.services.memory.subsystems.autodream_config.clone();
         if !cfg.enabled {
@@ -158,6 +159,7 @@ impl<C: Channel> super::Agent<C> {
         self.flush_taco_hit_counts().await;
     }
 
+    #[tracing::instrument(name = "core.agent.flush_taco_hit_counts", skip_all, level = "debug")]
     async fn flush_taco_hit_counts(&self) {
         if let Some(ref compressor) = self.services.taco_compressor
             && let Err(e) = compressor.flush_hit_counts().await

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -23,6 +23,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// [`ContextSummarizationView`]: zeph_agent_context::state::ContextSummarizationView
     /// [`AgentError`]: crate::agent::error::AgentError
+    #[tracing::instrument(name = "core.context.compact_context", skip_all, level = "debug")]
     pub(in crate::agent) async fn compact_context(
         &mut self,
     ) -> Result<CompactionOutcome, crate::agent::error::AgentError> {
@@ -91,6 +92,11 @@ impl<C: Channel> Agent<C> {
     ///
     /// Extracts all fields from `&self` synchronously before the first `.await` so
     /// `&self` is not held across the await boundary (required for `Send` futures).
+    #[tracing::instrument(
+        name = "core.context.load_compression_guidelines_for_compact",
+        skip_all,
+        level = "debug"
+    )]
     pub(super) async fn load_compression_guidelines_for_compact(&mut self) -> Option<String> {
         let enabled = self
             .services

--- a/crates/zeph-core/src/agent/context/summarization/deferred.rs
+++ b/crates/zeph-core/src/agent/context/summarization/deferred.rs
@@ -5,6 +5,11 @@ use crate::agent::Agent;
 use crate::channel::Channel;
 
 impl<C: Channel> Agent<C> {
+    #[tracing::instrument(
+        name = "core.context.maybe_summarize_tool_pair",
+        skip_all,
+        level = "debug"
+    )]
     pub(in crate::agent) async fn maybe_summarize_tool_pair(&mut self) {
         let svc = zeph_agent_context::ContextService::new();
         let providers = self.providers();
@@ -22,6 +27,11 @@ impl<C: Channel> Agent<C> {
         svc.apply_deferred_summaries(&mut summ)
     }
 
+    #[tracing::instrument(
+        name = "core.context.flush_deferred_summaries",
+        skip_all,
+        level = "debug"
+    )]
     pub(in crate::agent) async fn flush_deferred_summaries(&mut self) {
         let svc = zeph_agent_context::ContextService::new();
         let mut summ = self.summarization_view();

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -18,6 +18,7 @@ impl<C: Channel> Agent<C> {
     /// - Status messages collected during the service call are forwarded to `channel.send_status`.
     /// - `context_compactions` and `compaction_hard_count` metrics are updated — the service
     ///   cannot access these because `MetricsCallback` is not part of [`ContextSummarizationView`].
+    #[tracing::instrument(name = "core.context.maybe_compact", skip_all, level = "debug")]
     pub(in crate::agent) async fn maybe_compact(
         &mut self,
     ) -> Result<(), crate::agent::error::AgentError> {
@@ -84,6 +85,11 @@ impl<C: Channel> Agent<C> {
     /// because Focus state is not part of [`ContextSummarizationView`]. Focus
     /// auto-consolidation lives only on `Agent<C>` and is not delegated to
     /// `ContextService`.
+    #[tracing::instrument(
+        name = "core.context.maybe_proactive_compress",
+        skip_all,
+        level = "debug"
+    )]
     pub(in crate::agent) async fn maybe_proactive_compress(
         &mut self,
     ) -> Result<(), crate::agent::error::AgentError> {
@@ -98,6 +104,11 @@ impl<C: Channel> Agent<C> {
     }
 
     /// Emit a UX status signal when tokens were actually freed by compaction.
+    #[tracing::instrument(
+        name = "core.context.emit_compaction_status_signal",
+        skip_all,
+        level = "debug"
+    )]
     pub(in crate::agent) async fn emit_compaction_status_signal(&mut self, tokens_before: u64) {
         let tokens_after = self.runtime.providers.cached_prompt_tokens;
         if tokens_after < tokens_before {

--- a/crates/zeph-core/src/agent/hooks_dispatch.rs
+++ b/crates/zeph-core/src/agent/hooks_dispatch.rs
@@ -26,6 +26,7 @@ impl<C: Channel> Agent<C> {
     /// Called after each tool batch completes. The check is a single syscall and has
     /// negligible cost. Only fires when cwd actually changed (defense-in-depth: normally
     /// only `set_working_directory` changes cwd; shell child processes cannot affect it).
+    #[tracing::instrument(name = "core.agent.check_cwd_changed", skip_all, level = "debug")]
     pub(crate) async fn check_cwd_changed(&mut self) {
         let current = match std::env::current_dir() {
             Ok(p) => p,
@@ -74,6 +75,7 @@ impl<C: Channel> Agent<C> {
         let _ = self.channel.send_status("").await;
     }
     /// Handle a `FileChangedEvent` from the file watcher.
+    #[tracing::instrument(name = "core.agent.handle_file_changed", skip_all, level = "debug")]
     pub(crate) async fn handle_file_changed(
         &mut self,
         event: crate::file_watcher::FileChangedEvent,

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -189,6 +189,7 @@ impl<C: Channel> Agent<C> {
             .map_or("", |m| m.content.as_str())
     }
 
+    #[tracing::instrument(name = "core.tool.summarize_tool_output", skip_all, level = "debug")]
     pub(super) async fn summarize_tool_output(&self, output: &str, threshold: usize) -> String {
         let truncated = zeph_tools::truncate_tool_output_at(output, threshold);
         let query = self.last_user_query();
@@ -232,6 +233,11 @@ impl<C: Channel> Agent<C> {
         }
     }
 
+    #[tracing::instrument(
+        name = "core.tool.maybe_summarize_tool_output",
+        skip_all,
+        level = "debug"
+    )]
     pub(super) async fn maybe_summarize_tool_output(&self, output: &str) -> String {
         let threshold = self.tool_orchestrator.overflow_config.threshold;
         if output.len() <= threshold {
@@ -314,6 +320,7 @@ impl<C: Channel> Agent<C> {
     /// Run regex PII filter and (optionally) NER classifier, merge spans, and redact in one pass.
     ///
     /// Thin wrapper: delegates to [`SecurityState::scrub_pii`] and applies metrics side-effects.
+    #[tracing::instrument(name = "core.tool.scrub_pii_union", skip_all, level = "debug")]
     async fn scrub_pii_union(&mut self, text: &str, tool_name: &str) -> String {
         let result = self.services.security.scrub_pii(text, tool_name).await;
         if result.ner_timeouts > 0 {
@@ -336,6 +343,11 @@ impl<C: Channel> Agent<C> {
     }
 
     /// Delegate guardrail check to [`SecurityState::check_guardrail`].
+    #[tracing::instrument(
+        name = "core.tool.apply_guardrail_to_tool_output",
+        skip_all,
+        level = "debug"
+    )]
     async fn apply_guardrail_to_tool_output(&self, body: String, tool_name: &str) -> String {
         self.services
             .security
@@ -428,6 +440,7 @@ impl<C: Channel> Agent<C> {
             .map(|m| m.content.as_str())
     }
 
+    #[tracing::instrument(name = "core.tool.check_response_cache", skip_all, level = "debug")]
     async fn check_response_cache(&mut self) -> Result<CacheCheckResult, super::error::AgentError> {
         let Some(ref cache) = self.services.session.response_cache else {
             return Ok(CacheCheckResult::Miss {
@@ -514,6 +527,7 @@ impl<C: Channel> Agent<C> {
         })
     }
 
+    #[tracing::instrument(name = "core.tool.store_response_in_cache", skip_all, level = "debug")]
     async fn store_response_in_cache(&self, response: &str, query_embedding: Option<Vec<f32>>) {
         let Some(ref cache) = self.services.session.response_cache else {
             return;


### PR DESCRIPTION
## Summary

- Add `#[tracing::instrument]` to 17 hot-path async functions across 6 files in `crates/zeph-core/src/agent/` that were invisible to trace analysis
- Span naming follows `core.{agent|tool|context}.<fn_name>` convention with `skip_all` and `level = "debug"`, consistent with existing patterns in `tier_loop.rs` and `assembly.rs`
- No behavioral changes — attribute-only diff

## Files changed

| File | Functions |
|---|---|
| `tool_execution/mod.rs` | `summarize_tool_output`, `maybe_summarize_tool_output`, `scrub_pii_union`, `apply_guardrail_to_tool_output`, `check_response_cache`, `store_response_in_cache` |
| `autodream.rs` | `maybe_autodream`, `flush_taco_hit_counts` |
| `hooks_dispatch.rs` | `check_cwd_changed`, `handle_file_changed` |
| `context/summarization/scheduling.rs` | `maybe_compact`, `maybe_proactive_compress`, `emit_compaction_status_signal` |
| `context/summarization/compaction.rs` | `compact_context`, `load_compression_guidelines_for_compact` |
| `context/summarization/deferred.rs` | `maybe_summarize_tool_pair`, `flush_deferred_summaries` |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run ... --workspace --lib --bins` — 11 361 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc ...` — clean

Closes #5181, #5182, #5183