### PR TITLE
feat(config): migration step 66 — tui.theme active defaults (#5091)

### DIFF
--- a/crates/zeph-config/src/migrate/features.rs
+++ b/crates/zeph-config/src/migrate/features.rs
@@ -7,6 +7,8 @@
 //! the [`Migration`](super::Migration) trait, and the [`MIGRATIONS`](super::MIGRATIONS)
 //! registry remain in the parent module.
 
+use regex::Regex;
+
 use super::{MigrateError, MigrationResult};
 
 /// Strip any existing `[memory.compression.predictor]` section from the config (#3251).
@@ -405,6 +407,110 @@ pub fn migrate_knowledge_config(toml_src: &str) -> Result<MigrationResult, Migra
         output,
         changed_count: 1,
         sections_changed: vec!["knowledge".to_owned()],
+    })
+}
+
+static TUI_THEME_HEADER_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"(?m)^[ \t]*\[tui\.theme\][ \t]*(?:#[^\r\n]*)?\r?\n").expect("static pattern")
+});
+
+/// Insert active `name` and `color_mode` defaults into `[tui.theme]` when the section
+/// exists but those keys are absent (#5091).
+///
+/// Step 65 added a commented-out advisory block so users could discover the new section.
+/// This step upgrades configs that already have an active `[tui.theme]` section (either
+/// hand-edited or promoted from the advisory block) by injecting the two mandatory keys
+/// with their safe defaults so that the runtime never falls back to compiled-in values
+/// silently.
+///
+/// The step is idempotent: if either key is already present the function is a no-op.
+/// If the `[tui.theme]` section is absent entirely the step is also a no-op (step 65
+/// handles that case).
+///
+/// # Errors
+///
+/// Returns `MigrateError::TomlParse` if the input is not valid TOML.
+pub fn migrate_tui_theme_defaults(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Check whether a key with the exact name exists inside [tui.theme].
+    // Uses exact-key matching: trim the line, strip a leading `#` for commented keys,
+    // split on `=`, and compare the key token — prevents prefix false-positives
+    // (e.g. `name_hint` must NOT satisfy `has_name`).
+    let key_in_tui_theme = |key: &str| {
+        let mut in_tui_theme = false;
+        toml_src.lines().any(|l| {
+            let t = l.trim();
+            // Section header line — update scope flag and keep scanning.
+            if !t.starts_with('#') && t.starts_with('[') {
+                in_tui_theme = t == "[tui.theme]";
+                return false;
+            }
+            if !in_tui_theme {
+                return false;
+            }
+            // Strip optional leading `#` for commented-out keys.
+            let body = t.trim_start_matches('#').trim();
+            // Extract the key token (everything before `=`), trim whitespace.
+            let lhs = body.split('=').next().unwrap_or("").trim();
+            lhs == key
+        })
+    };
+
+    let has_name = key_in_tui_theme("name");
+    let has_color_mode = key_in_tui_theme("color_mode");
+
+    // If [tui.theme] is absent, step 65 handles it — this step is a no-op.
+    let has_section = toml_src.contains("[tui.theme]");
+    if !has_section || (has_name && has_color_mode) {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Normalise: ensure the source ends with a newline so the regex can always
+    // match the header line (hand-edited files may omit the trailing newline).
+    let owned;
+    let src = if toml_src.ends_with('\n') {
+        toml_src
+    } else {
+        owned = format!("{toml_src}\n");
+        &owned
+    };
+
+    if !TUI_THEME_HEADER_RE.is_match(src) {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let mut insert = String::new();
+    if !has_name {
+        insert
+            .push_str("name       = \"zephyr\"  # built-in preset; see /theme for alternatives\n");
+    }
+    if !has_color_mode {
+        insert.push_str("color_mode = \"auto\"    # auto | truecolor | ansi256 | ansi16 | never\n");
+    }
+
+    let output = TUI_THEME_HEADER_RE
+        .replacen(src, 1, |caps: &regex::Captures| {
+            format!("{}{insert}", &caps[0])
+        })
+        .into_owned();
+
+    let changed = output != toml_src;
+    let changed_count = usize::from(changed);
+    Ok(MigrationResult {
+        output,
+        changed_count,
+        sections_changed: if changed {
+            vec!["tui.theme".to_owned()]
+        } else {
+            Vec::new()
+        },
     })
 }
 

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -23,7 +23,7 @@ pub use features::{
     migrate_autodream_config, migrate_caveman_config, migrate_compression_predictor_config,
     migrate_deep_link_config, migrate_five_signal_config, migrate_goals_config,
     migrate_knowledge_config, migrate_magic_docs_config, migrate_microcompact_config,
-    migrate_orchestration_persistence, migrate_tui_theme_config,
+    migrate_orchestration_persistence, migrate_tui_theme_config, migrate_tui_theme_defaults,
 };
 pub use infra::*;
 /// Advisory `GonkaGate` migration is crate-internal (registered via the [`MIGRATIONS`] registry).
@@ -613,10 +613,11 @@ use steps::{
     MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellCheckpointsConfig,
     MigrateShellTransactional, MigrateSttToProvider, MigrateSupervisorConfig,
     MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateTraceMetadata,
-    MigrateTuiThemeConfig, MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
+    MigrateTuiThemeConfig, MigrateTuiThemeDefaults, MigrateVigilConfig, MigrateWorktreeConfig,
+    MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–65).
+/// Ordered registry of all sequential migration steps (steps 1–66).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -729,6 +730,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigratePolicyProviderAndUtilityWindow),
             // Step 65 — add [tui.theme] advisory block (Theme System 2.0, #5087)
             Box::new(MigrateTuiThemeConfig),
+            // Step 66 — insert active name/color_mode defaults into [tui.theme] (#5091)
+            Box::new(MigrateTuiThemeDefaults),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -22,7 +22,10 @@
 //! step 60 adds `[tools.shell]` checkpoints (#4990);
 //! step 61 adds `[knowledge]` section advisory notice (spec-067, #5017);
 //! step 62 adds `[deep_link]` advisory notice (spec-066, #5011);
-//! step 63 adds `recall_include_imported` to `[memory.graph]` (#5015).
+//! step 63 adds `recall_include_imported` to `[memory.graph]` (#5015);
+//! step 64 adds `policy_provider` and `utility_window` advisory comments (#5067);
+//! step 65 adds `[tui.theme]` advisory block (Theme System 2.0, #5087);
+//! step 66 inserts active `name`/`color_mode` defaults into `[tui.theme]` (#5091).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -54,7 +57,8 @@ use super::{
     migrate_session_recap_config, migrate_shell_checkpoints_config, migrate_shell_transactional,
     migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
     migrate_tools_compression_config, migrate_trace_metadata, migrate_tui_theme_config,
-    migrate_vigil_config, migrate_worktree_config, migrate_worktree_git_timeout,
+    migrate_tui_theme_defaults, migrate_vigil_config, migrate_worktree_config,
+    migrate_worktree_git_timeout,
 };
 
 // ── Wrapper structs for all 64 sequential migration steps ───────────────────────────────────────
@@ -771,5 +775,16 @@ impl Migration for MigrateTuiThemeConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_tui_theme_config(toml_src)
+    }
+}
+
+pub(super) struct MigrateTuiThemeDefaults;
+impl Migration for MigrateTuiThemeDefaults {
+    fn name(&self) -> &'static str {
+        "migrate_tui_theme_defaults"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_tui_theme_defaults(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        65,
-        "MIGRATIONS registry must contain all 65 sequential steps"
+        66,
+        "MIGRATIONS registry must contain all 66 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1645,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 65);
+    assert_eq!(MIGRATIONS.len(), 66);
 }
 
 #[test]
@@ -1751,6 +1751,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_memory_graph_recall_include_imported",
         "migrate_policy_provider_and_utility_window",
         "migrate_tui_theme_config",
+        "migrate_tui_theme_defaults",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -2815,5 +2816,80 @@ fn step_65_idempotent_on_own_output() {
     assert_eq!(
         second.output, first.output,
         "output unchanged on second run"
+    );
+}
+
+// ── Step 66 — migrate_tui_theme_defaults (#5091) ──────────────────────────
+
+#[test]
+fn step_66_inserts_defaults_when_section_present_but_keys_absent() {
+    let src = "[tui]\ntool_density = \"compact\"\n\n[tui.theme]\n";
+    let result = migrate_tui_theme_defaults(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result.sections_changed.contains(&"tui.theme".to_owned()),
+        "sections_changed must include tui.theme"
+    );
+    assert!(
+        result.output.contains("name"),
+        "output must contain name key"
+    );
+    assert!(
+        result.output.contains("color_mode"),
+        "output must contain color_mode key"
+    );
+    assert!(
+        result.output.contains("zephyr"),
+        "name default must be zephyr"
+    );
+    assert!(
+        result.output.contains("auto"),
+        "color_mode default must be auto"
+    );
+}
+
+#[test]
+fn step_66_noop_when_section_absent() {
+    let src = "[tui]\ntool_density = \"compact\"\n";
+    let result = migrate_tui_theme_defaults(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_66_noop_when_both_keys_present() {
+    let src = "[tui]\ntool_density = \"compact\"\n\n[tui.theme]\nname = \"gruvbox-dark\"\ncolor_mode = \"truecolor\"\n";
+    let result = migrate_tui_theme_defaults(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_66_idempotent_on_own_output() {
+    let src = "[tui]\ntool_density = \"compact\"\n\n[tui.theme]\n";
+    let first = migrate_tui_theme_defaults(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_tui_theme_defaults(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
+    );
+}
+
+#[test]
+fn step_66_inserts_only_missing_key_when_one_present() {
+    let src = "[tui.theme]\nname = \"classic\"\n";
+    let result = migrate_tui_theme_defaults(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result.output.contains("color_mode"),
+        "color_mode must be inserted"
+    );
+    // name must not be duplicated
+    assert_eq!(
+        result.output.matches("name").count(),
+        1,
+        "name must appear exactly once"
     );
 }


### PR DESCRIPTION
## Summary

Closes #5091. Completes epic #5083 (TUI Theme System 2.0 — all child issues now closed).

Adds migration step 66 (`migrate_tui_theme_defaults`) that inserts `name = "zephyr"` and `color_mode = "auto"` into an existing `[tui.theme]` section when those keys are absent. Step 65 added a commented advisory block so users could discover the new section; step 66 activates the live defaults so the runtime never falls back silently to compiled-in values.

## Integration points checklist (CLAUDE.md Development Rules)

- [x] **Config section** — `[tui.theme]` with `name` and `color_mode` fields (added in Theme 2.0 epic)
- [x] **CLI argument** — `--theme <preset>` flag (added in #5090)
- [x] **TUI command palette** — `app:theme` (list) and `app:theme-list` entries registered; `app:theme-set` intentionally absent (no input mechanism in palette — use `/theme <name>` directly)
- [x] **`--init` wizard** — `step_tui_theme` (src/init/mod.rs:1793) uses `dialoguer::Select` over theme presets
- [x] **`--migrate-config`** — step 65 (advisory comment) + **step 66** (active defaults, this PR)
- [x] **Live testing playbook** — `.local/testing/playbooks/tui-theme.md` extended with #5091 integration-point scenarios including step 66 and negative hot-reload test
- [x] **Coverage-status rows** — rows 237–238 added (Untested) with playbook links

## Changes

**`crates/zeph-config/src/migrate/`**

- `features.rs` — `migrate_tui_theme_defaults` function with `key_in_tui_theme` closure (exact LHS-token matching, not `starts_with`); trailing-newline normalization for EOF configs
- `steps.rs` — `MigrateTuiThemeDefaults` struct
- `mod.rs` — step 66 registered; `MIGRATIONS` count = 66
- `tests.rs` — 5 new tests: happy path, no-op when section absent, no-op when both keys present, idempotency, partial injection

**No source changes to `zeph-tui`** — wizard step, `/theme` command, and command palette entries were already fully implemented.

## Test plan

- `cargo nextest run -p zeph-config -p zeph-tui --lib --bins` — 1270 passed, 0 failed
- `cargo +nightly fmt --check` — clean
- `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- rustdoc gate — clean

## Notes

- One pre-existing flaky failure in `zeph-llm model_cache::tests::load_async_missing_file_returns_none` (passes in isolation, unrelated to this PR)
- Config-driven theme hot-reload is intentionally absent — documented as a known limitation in the playbook; live switching is `/theme <name>` or the `t` key