### PR TITLE
feat(durable): add tracing instrumentation to hot-path async fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `feat(durable)`: add `#[tracing::instrument]` to hot-path async fns in `zeph-durable`:
+  `JournalWriter::run`, `flush_buffer`, `JournalWriterHandle::append_acked`, `flush`
+  (closes #5204); `DurableContext::step`, `step_recorded`, `promise`, `sleep_until`,
+  `drain_background`, `take_resolved_promise`, `check_divergence`, `on_divergence`,
+  `resolve_ambiguous`, `run_op`, `journal_result`, `append_acked_degrading`
+  (closes #5205); `DurableTimerService::run`, `fire_due`; `DurableRetentionService::run`.
+  All `run` loops wrapped in per-iteration spans (`durable.{writer,timer,retention}.run.iter`);
+  no `span.entered()` across `.await`.
 - `feat(tui)`: breeze spinner (▹▹▹→▸▹▹→▸▸▹→▸▸▸→▹▸▸→▹▹▸) replaces braille throbber across all
   five spinner sites; ASCII fallback (..→>..→>>.→>>>→.>>→..>) keyed off `detect_unicode_capable()`.
   Shared `widgets/spinner.rs` module ensures one motion language everywhere (closes #5095).

--- a/crates/zeph-durable/src/handle.rs
+++ b/crates/zeph-durable/src/handle.rs
@@ -178,6 +178,11 @@ impl DurableContext {
     /// assert_eq!(lines, 42);
     /// # Ok(()) }
     /// ```
+    #[tracing::instrument(
+        name = "durable.context.step",
+        skip_all,
+        fields(execution_id = %self.execution_id.as_uuid(), step_name = desc.name())
+    )]
     pub async fn step<T, F, Fut>(&self, desc: StepDescriptor, op: F) -> Result<T, DurableError>
     where
         T: Serialize + DeserializeOwned + Send,
@@ -195,6 +200,11 @@ impl DurableContext {
     /// # Errors
     ///
     /// Identical to [`step`](DurableContext::step).
+    #[tracing::instrument(
+        name = "durable.context.step_recorded",
+        skip_all,
+        fields(execution_id = %self.execution_id.as_uuid(), step_name = desc.name())
+    )]
     pub async fn step_recorded<T, F, Fut>(
         &self,
         desc: StepDescriptor,
@@ -231,6 +241,11 @@ impl DurableContext {
     ///
     /// - [`DurableError::StepCapExceeded`] if the promise would exceed the per-execution step cap.
     /// - A storage error if the promise row cannot be read or inserted.
+    #[tracing::instrument(
+        name = "durable.context.promise",
+        skip_all,
+        fields(execution_id = %self.execution_id.as_uuid())
+    )]
     pub async fn promise<T>(&self) -> Result<DurablePromise<T>, DurableError> {
         let step_id = self.checked_step_id()?;
         let promise_id = PromiseId::derive(self.execution_id, step_id);
@@ -305,6 +320,7 @@ impl DurableContext {
     }
 
     /// Read a promise's state and, if resolved, open and decode its value.
+    #[tracing::instrument(name = "durable.context.take_resolved_promise", skip_all, fields(promise_id = %id.as_uuid()))]
     async fn take_resolved_promise<T: DeserializeOwned>(
         &self,
         id: PromiseId,
@@ -338,6 +354,11 @@ impl DurableContext {
     ///
     /// - [`DurableError::StepCapExceeded`] if the timer would exceed the per-execution step cap.
     /// - A storage error if the timer cannot be armed or its state read.
+    #[tracing::instrument(
+        name = "durable.context.sleep_until",
+        skip_all,
+        fields(execution_id = %self.execution_id.as_uuid())
+    )]
     pub async fn sleep_until(&self, due: SystemTime) -> Result<(), DurableError> {
         let step_id = self.checked_step_id()?;
         let timer_id = TimerId::derive(self.execution_id, step_id);
@@ -400,6 +421,7 @@ impl DurableContext {
     ///
     /// The soft step-cap fold runs on a spawned task so it never blocks step dispatch; call this at
     /// a turn boundary to ensure the journal is compacted before the next phase observes it.
+    #[tracing::instrument(name = "durable.context.drain_background", skip_all, fields(execution_id = %self.execution_id.as_uuid()))]
     pub async fn drain_background(&self) {
         let mut set = {
             let mut guard = self
@@ -549,6 +571,7 @@ impl DurableContext {
     }
 
     /// Compare a journaled step's fingerprint against the current descriptor's; abort on mismatch.
+    #[tracing::instrument(name = "durable.context.check_divergence", skip_all, fields(step_id = step_id.value()))]
     async fn check_divergence(
         &self,
         step_id: StepId,
@@ -565,6 +588,7 @@ impl DurableContext {
     }
 
     /// Mark the execution aborted and disable replay so it restarts fresh (FR-DE-03).
+    #[tracing::instrument(name = "durable.context.on_divergence", skip_all, fields(step_id = step_id.value(), execution_id = %self.execution_id.as_uuid()))]
     async fn on_divergence(&self, step_id: StepId) {
         self.diverged.store(true, Ordering::Release);
         tracing::warn!(
@@ -582,6 +606,7 @@ impl DurableContext {
     }
 
     /// Apply the [`OnAmbiguous`] policy for a guarded step resumed in the ambiguous window.
+    #[tracing::instrument(name = "durable.context.resolve_ambiguous", skip_all, fields(step_id = step_id.value(), execution_id = %self.execution_id.as_uuid()))]
     async fn resolve_ambiguous<T, F, Fut>(
         &self,
         step_id: StepId,
@@ -615,6 +640,7 @@ impl DurableContext {
     }
 
     /// Invoke the operation closure, mapping its failure to [`DurableError::StepFailed`].
+    #[tracing::instrument(name = "durable.context.run_op", skip_all, fields(step_id = step_id.value(), step_name = name))]
     async fn run_op<T, F, Fut>(
         &self,
         op: F,
@@ -633,6 +659,7 @@ impl DurableContext {
     }
 
     /// Journal a step's already-serialized result with the durability class its effect requires.
+    #[tracing::instrument(name = "durable.context.journal_result", skip_all, fields(step_id = step_id.value(), effect_class = effect.as_str(), step_name = name))]
     async fn journal_result(
         &self,
         payload: bytes::Bytes,
@@ -690,6 +717,7 @@ impl DurableContext {
     }
 
     /// ACK an append, degrading to non-durable mode on a writer timeout (INV-12) rather than failing.
+    #[tracing::instrument(name = "durable.context.append_acked_degrading", skip_all, fields(step_name = name))]
     async fn append_acked_degrading(
         &self,
         entry: JournalEntry,

--- a/crates/zeph-durable/src/retention.rs
+++ b/crates/zeph-durable/src/retention.rs
@@ -218,6 +218,7 @@ impl DurableRetentionService {
     ///
     /// Each tick prunes terminal executions older than their TTL; a prune failure is logged and the
     /// loop continues (a transient database error must not kill retention).
+    #[tracing::instrument(name = "durable.retention.run", skip_all)]
     pub async fn run(self) {
         let mut tick = tokio::time::interval(self.interval);
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -226,14 +227,18 @@ impl DurableRetentionService {
         tick.tick().await;
         loop {
             tick.tick().await;
-            match self.backend.prune(&self.policy).await {
-                Ok(deleted) => {
-                    tracing::debug!(deleted, "durable retention prune sweep completed");
-                }
-                Err(error) => {
-                    tracing::warn!(%error, "durable retention prune sweep failed; will retry");
+            async {
+                match self.backend.prune(&self.policy).await {
+                    Ok(deleted) => {
+                        tracing::debug!(deleted, "durable retention prune sweep completed");
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "durable retention prune sweep failed; will retry");
+                    }
                 }
             }
+            .instrument(tracing::info_span!("durable.retention.run.iter"))
+            .await;
         }
     }
 }

--- a/crates/zeph-durable/src/timer.rs
+++ b/crates/zeph-durable/src/timer.rs
@@ -19,6 +19,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use tracing::Instrument as _;
+
 use crate::backend::DurableBackendEnum;
 use crate::backend::local::now_unix_millis;
 
@@ -69,16 +71,20 @@ impl DurableTimerService {
     /// Each tick fires every timer whose `due_at` has elapsed (including, on the first tick after a
     /// restart, timers that came due during downtime — FR-DE-06). A backend error is logged and the
     /// loop continues so a transient failure does not strand future timers.
+    #[tracing::instrument(name = "durable.timer.run", skip_all)]
     pub async fn run(self) {
         let mut tick = tokio::time::interval(self.poll_interval);
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             tick.tick().await;
-            self.fire_due().await;
+            self.fire_due()
+                .instrument(tracing::info_span!("durable.timer.run.iter"))
+                .await;
         }
     }
 
     /// Fire every currently-due timer once. Exposed for a deterministic test poll.
+    #[tracing::instrument(name = "durable.timer.fire_due", skip_all)]
     pub(crate) async fn fire_due(&self) {
         let now = now_unix_millis();
         let due = match self.backend.due_timers(now).await {

--- a/crates/zeph-durable/src/writer.rs
+++ b/crates/zeph-durable/src/writer.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
+use tracing::Instrument as _;
 
 use crate::backend::local::LocalBackend;
 use crate::config::DurableConfig;
@@ -116,6 +117,7 @@ impl JournalWriter {
     /// before every acked commit (INV-4), and emits a `durable.journal.writer.queue_depth` gauge per
     /// commit cycle. When the channel closes it drains any remaining buffered entries and returns,
     /// so the supervisor can restart it cleanly.
+    #[tracing::instrument(name = "durable.writer.run", skip_all)]
     pub async fn run(mut self) {
         let resume = match self.backend.max_seq().await {
             Ok(seq) => seq,
@@ -134,33 +136,45 @@ impl JournalWriter {
         flush.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
         loop {
-            tokio::select! {
-                maybe_msg = self.rx.recv() => match maybe_msg {
-                    Some(JournalMsg::AppendBuffered(entry)) => {
-                        buffer.push(entry);
-                        if buffer.len() >= self.max_batch {
-                            self.flush_buffer(&mut buffer).await;
+            let keep_running = async {
+                tokio::select! {
+                    maybe_msg = self.rx.recv() => match maybe_msg {
+                        Some(JournalMsg::AppendBuffered(entry)) => {
+                            buffer.push(entry);
+                            if buffer.len() >= self.max_batch {
+                                self.flush_buffer(&mut buffer).await;
+                            }
+                            true
                         }
-                    }
-                    Some(JournalMsg::AppendAcked(entry, reply)) => {
-                        // INV-4: every causally-preceding buffered entry is durable before the
-                        // exactly-once entry commits.
+                        Some(JournalMsg::AppendAcked(entry, reply)) => {
+                            // INV-4: every causally-preceding buffered entry is durable before the
+                            // exactly-once entry commits.
+                            self.flush_buffer(&mut buffer).await;
+                            let result = self.backend.append(entry).await;
+                            let _ = reply.send(result);
+                            true
+                        }
+                        Some(JournalMsg::Flush(reply)) => {
+                            self.flush_buffer(&mut buffer).await;
+                            let _ = reply.send(());
+                            true
+                        }
+                        None => {
+                            self.flush_buffer(&mut buffer).await;
+                            false
+                        }
+                    },
+                    _ = flush.tick() => {
                         self.flush_buffer(&mut buffer).await;
-                        let result = self.backend.append(entry).await;
-                        let _ = reply.send(result);
+                        true
                     }
-                    Some(JournalMsg::Flush(reply)) => {
-                        self.flush_buffer(&mut buffer).await;
-                        let _ = reply.send(());
-                    }
-                    None => {
-                        self.flush_buffer(&mut buffer).await;
-                        break;
-                    }
-                },
-                _ = flush.tick() => {
-                    self.flush_buffer(&mut buffer).await;
                 }
+            }
+            .instrument(tracing::info_span!("durable.writer.run.iter"))
+            .await;
+
+            if !keep_running {
+                break;
             }
         }
         tracing::info!("journal writer stopped");
@@ -170,6 +184,7 @@ impl JournalWriter {
     ///
     /// A failed group-commit drops the buffered entries with a `WARN` (they re-run safely on
     /// resume) rather than wedging the actor.
+    #[tracing::instrument(name = "durable.writer.flush_buffer", skip_all, fields(batch_size = buffer.len()))]
     async fn flush_buffer(&self, buffer: &mut Vec<JournalEntry>) {
         if buffer.is_empty() {
             return;
@@ -226,6 +241,7 @@ impl JournalWriterHandle {
     /// Returns [`DurableError::JournalUnavailable`] if the writer does not acknowledge within the
     /// timeout or is unreachable, and propagates a backend [`DurableError`] if the commit itself
     /// fails. The caller never blocks indefinitely (INV-12).
+    #[tracing::instrument(name = "durable.writer.append_acked", skip_all)]
     pub async fn append_acked(&self, entry: JournalEntry) -> Result<JournalSeq, DurableError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let send_and_wait = async {
@@ -249,6 +265,7 @@ impl JournalWriterHandle {
     ///
     /// Returns [`DurableError::JournalUnavailable`] if the writer does not confirm within the
     /// timeout or is unreachable.
+    #[tracing::instrument(name = "durable.writer.flush", skip_all)]
     pub async fn flush(&self) -> Result<(), DurableError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let send_and_wait = async {

--- a/crates/zeph-scheduler/src/durable.rs
+++ b/crates/zeph-scheduler/src/durable.rs
@@ -109,6 +109,7 @@ impl SchedulerDurableAdapter {
 /// # Examples
 ///
 /// ```no_run
+/// # #![recursion_limit = "256"]
 /// # use std::sync::Arc;
 /// # use std::future::Future;
 /// # use zeph_scheduler::durable::{SchedulerDurableAdapter, fire_with_durable};


### PR DESCRIPTION
## Summary

- Add `#[tracing::instrument]` to all hot-path async fns in `zeph-durable` that were invisible to trace analysis (Perfetto/Jaeger)
- `writer.rs`: `JournalWriter::run`, `flush_buffer`, `JournalWriterHandle::append_acked`, `flush`
- `timer.rs`: `DurableTimerService::run`, `fire_due`
- `retention.rs`: `DurableRetentionService::run`
- `handle.rs`: `DurableContext::step`, `step_recorded`, `promise`, `sleep_until`, `drain_background` + 7 private helpers

## Details

All `run()` loops wrap their body in a per-iteration span via `.instrument(info_span!("....iter"))` rather than a single spanning span for the loop lifetime. No `span.entered()` across any `.await` point. Naming follows the `durable.<subsystem>.<fn>` convention consistent with existing spans in the crate.

## Test plan

- [x] `cargo nextest run -p zeph-durable` — 100/100 pass, 2 skipped
- [x] `cargo clippy --profile ci -p zeph-durable --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] Rustdoc gate (`RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`) — clean
- [x] No `span.entered()` across `.await` (verified by impl-critic and tester)
- [x] All required fns from #5204 and #5205 covered

Closes #5204
Closes #5205