### PR TITLE
feat(tui): status bar pressure abbreviation and live wave animation (#5101, #5096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (closes #5205); `DurableTimerService::run`, `fire_due`; `DurableRetentionService::run`.
   All `run` loops wrapped in per-iteration spans (`durable.{writer,timer,retention}.run.iter`);
   no `span.entered()` across `.await`.
+- `feat(tui)`: status bar pressure abbreviation — adds a short-form tier before segment dropping.
+  Each segment now declares full and abbreviated forms (`12.3k tokens` → `12.3k`, `$0.01` → `$0.01`,
+  etc.); pressure ladder is full → short → drop (Critical segments never drop). Unicode-aware width
+  math throughout; hang-guard skips abbreviation when the short form is no narrower (closes #5101).
+- `feat(tui)`: live wave animation on the input separator row encodes agent state as a waveform —
+  idle shows a static line; TTFT-wait a slow swell; streaming a ripple; tool execution a choppy wave;
+  parallel background tasks a superposition of sines; stalled a flatline with error tint. Rendered
+  with `▁▂▃▄▅▆▇█` glyphs, aqua truecolor gradient, flat ansi16 accent, and `~-~-` ASCII fallback.
+  `[tui] motion = "full" | "minimal" | "off"` config field; `/motion` slash command for live switching;
+  zero allocations per frame via reused `wave_buf`; deterministic `sample(t, x, state)` pure function
+  for snapshot testing (closes #5096).
 - `feat(tui)`: breeze spinner (▹▹▹→▸▹▹→▸▸▹→▸▸▸→▹▸▸→▹▹▸) replaces braille throbber across all
   five spinner sites; ASCII fallback (..→>..→>>.→>>>→.>>→..>) keyed off `detect_unicode_capable()`.
   Shared `widgets/spinner.rs` module ensures one motion language everywhere (closes #5095).

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -193,8 +193,8 @@ pub use telemetry::{TelemetryBackend, TelemetryConfig};
 pub use tools::{AuditDestination, SandboxBackend, ToolCompressionConfig};
 pub use ui::{
     AcpAuthMethod, AcpConfig, AcpLspConfig, AcpSubagentsConfig, AcpTimeoutsConfig, AcpTransport,
-    AdditionalDir, AdditionalDirError, ColorMode, FleetConfig, SubagentPresetConfig, ThemeConfig,
-    ToolDensity, TuiConfig,
+    AdditionalDir, AdditionalDirError, ColorMode, FleetConfig, Motion, SubagentPresetConfig,
+    ThemeConfig, ToolDensity, TuiConfig,
 };
 pub use ui::{DiagnosticSeverity, DiagnosticsConfig, HoverConfig, LspConfig};
 pub use vigil::VigilConfig;

--- a/crates/zeph-config/src/ui.rs
+++ b/crates/zeph-config/src/ui.rs
@@ -379,6 +379,33 @@ pub struct ThemeConfig {
     pub color_mode: ColorMode,
 }
 
+/// Controls how much animation the TUI renders.
+///
+/// Set via `[tui] motion = "full" | "minimal" | "off"` in TOML.
+/// Default: `full`.
+///
+/// - `full` — wave animation on the input separator row while busy, no breeze spinner.
+/// - `minimal` — animated breeze spinner (current behaviour before #5096), no wave.
+/// - `off` — no animation at all; input row is frame-invariant even while busy.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [tui]
+/// motion = "minimal"
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Motion {
+    /// Wave animation on the input separator row while busy.
+    #[default]
+    Full,
+    /// Animated breeze spinner, no wave.
+    Minimal,
+    /// No animation; input row is frame-invariant.
+    Off,
+}
+
 /// TUI (terminal user interface) configuration, nested under `[tui]` in TOML.
 ///
 /// # Example (TOML)
@@ -387,6 +414,7 @@ pub struct ThemeConfig {
 /// [tui]
 /// show_source_labels = true
 /// tool_density = "inline"
+/// motion = "full"
 ///
 /// [tui.theme]
 /// name = "zephyr"
@@ -404,6 +432,11 @@ pub struct TuiConfig {
     /// Default: `inline`.
     #[serde(default)]
     pub tool_density: ToolDensity,
+    /// Animation budget for the input separator row.
+    ///
+    /// `full` = wave (default), `minimal` = breeze spinner, `off` = static.
+    #[serde(default)]
+    pub motion: Motion,
     /// Fleet panel configuration (auto-refresh interval and max sessions displayed).
     #[serde(default)]
     pub fleet: FleetConfig,

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -36,6 +36,9 @@ impl App {
         let wave_state = self.wave_state();
         let wave_tick = self.wave_tick();
         let motion = self.motion();
+        // Take the reuse buffer out of self before the shared &App borrow starts so that
+        // build_full_busy_sep can write into it without conflicting with &self below.
+        let mut wave_buf = std::mem::take(&mut self.wave_buf);
         widgets::input::render(
             self,
             frame,
@@ -46,7 +49,9 @@ impl App {
             wave_state,
             wave_tick,
             motion,
+            &mut wave_buf,
         );
+        self.wave_buf = wave_buf;
         widgets::status::render(self, &self.metrics, frame, layout.status);
 
         if let Some(state) = &self.file_picker_state {

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -33,6 +33,9 @@ impl App {
         let activity_label = self.status_label().map(str::to_owned);
         let supervisor_label = self.supervisor_activity_label();
         let effective_label = activity_label.or(supervisor_label);
+        let wave_state = self.wave_state();
+        let wave_tick = self.wave_tick();
+        let motion = self.motion();
         widgets::input::render(
             self,
             frame,
@@ -40,6 +43,9 @@ impl App {
             busy,
             effective_label.as_deref(),
             spinner_idx,
+            wave_state,
+            wave_tick,
+            motion,
         );
         widgets::status::render(self, &self.metrics, frame, layout.status);
 

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::time::Instant;
+
 use tokio::sync::mpsc;
 
 use crate::event::{AgentEvent, AppEvent};
@@ -16,6 +18,7 @@ impl App {
             AppEvent::Key(key) => self.handle_key(key),
             AppEvent::Tick => {
                 self.throbber_state.calc_next();
+                self.wave_tick = self.wave_tick.saturating_add(1);
             }
             AppEvent::Resize(_, _) => {
                 self.sessions.current_mut().render_cache.clear();
@@ -56,6 +59,8 @@ impl App {
         match event {
             AgentEvent::Chunk(text) => {
                 self.sessions.current_mut().status_label = None;
+                // New token chunk — refresh stall clock.
+                self.last_progress_at = Instant::now();
                 if let Some(last) = self.sessions.current_mut().messages.last_mut()
                     && last.role == MessageRole::Assistant
                     && last.streaming
@@ -98,10 +103,16 @@ impl App {
             AgentEvent::Typing => {
                 self.pending_count = self.pending_count.saturating_sub(1);
                 self.sessions.current_mut().status_label = Some("thinking...".to_owned());
+                // Turn begins — initialize the stall clock so the first frame is Swell, not Stalled.
+                self.last_progress_at = Instant::now();
             }
             AgentEvent::Status(text) => {
                 self.sessions.current_mut().status_label =
                     if text.is_empty() { None } else { Some(text) };
+                // Non-empty status update counts as progress (supervisor activity, tool dispatch…).
+                if self.sessions.current().status_label.is_some() {
+                    self.last_progress_at = Instant::now();
+                }
                 self.auto_scroll();
             }
             AgentEvent::ToolStart {
@@ -124,6 +135,7 @@ impl App {
                 tool_call_id,
                 ..
             } => {
+                self.last_progress_at = Instant::now();
                 let pos = if tool_call_id.is_empty() {
                     // Shell tool chunks arrive without a tool_call_id; fall back to the last
                     // streaming Tool message (there is at most one active at a time).

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -212,6 +212,15 @@ impl App {
                     }
                 }
             }
+            TuiCommand::SetMotion(m) => {
+                self.motion = m;
+                let label = match m {
+                    zeph_config::Motion::Full => "full (wave animation)",
+                    zeph_config::Motion::Minimal => "minimal (breeze spinner)",
+                    zeph_config::Motion::Off => "off (static)",
+                };
+                self.push_system_message(format!("Motion set to: {label}"));
+            }
             TuiCommand::SessionBrowser => {
                 if let Some(ref tx) = self.command_tx {
                     let _ = tx.try_send(cmd);
@@ -579,6 +588,21 @@ impl App {
             // /theme <name> — switch to named theme (any non-empty name token)
             [cmd, name] if cmd.eq_ignore_ascii_case("/theme") && !name.is_empty() => {
                 Some(TuiCommand::SetTheme((*name).to_owned()))
+            }
+            // /motion <full|minimal|off> — set animation budget at runtime
+            [cmd, level]
+                if cmd.eq_ignore_ascii_case("/motion")
+                    && matches!(
+                        level.to_ascii_lowercase().as_str(),
+                        "full" | "minimal" | "off"
+                    ) =>
+            {
+                let m = match level.to_ascii_lowercase().as_str() {
+                    "minimal" => zeph_config::Motion::Minimal,
+                    "off" => zeph_config::Motion::Off,
+                    _ => zeph_config::Motion::Full,
+                };
+                Some(TuiCommand::SetMotion(m))
             }
             _ => None,
         }

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -6,6 +6,7 @@
 // via /sdd. See arch-assessment-revised-2026-04-26T02-04-23.md PR 9.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::{Notify, mpsc, oneshot, watch};
 use tracing::debug;
@@ -441,6 +442,25 @@ pub struct App {
     /// Use [`toggle_panel_collapse`](crate::App::toggle_panel_collapse) to toggle and
     /// [`effective_collapsed`](crate::App::effective_collapsed) for the layout-safe mask.
     pub(crate) collapsed_panels: [bool; 4],
+
+    // --- Wave animation (#5096) ---
+    /// Animation budget for the input separator row.
+    ///
+    /// Sourced from `[tui] motion` in config; runtime-switchable via `/motion`.
+    pub(crate) motion: zeph_config::Motion,
+
+    /// Monotonic tick counter for the wave animation phase.
+    ///
+    /// Incremented once per `AppEvent::Tick` (250 ms). `u64` never wraps within
+    /// a session lifetime. Used as the explicit `t` argument to [`crate::widgets::wave::sample`]
+    /// so that the wave renderer stays purely deterministic.
+    pub(crate) wave_tick: u64,
+
+    /// Timestamp of the last observed progress event (token chunk or status change).
+    ///
+    /// Initialized at the moment the agent transitions to busy, NOT at `App` construction
+    /// — otherwise the first frame after a long idle gap would falsely read as `Stalled`.
+    pub(crate) last_progress_at: Instant,
 }
 
 mod draw;

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -461,6 +461,10 @@ pub struct App {
     /// Initialized at the moment the agent transitions to busy, NOT at `App` construction
     /// — otherwise the first frame after a long idle gap would falsely read as `Stalled`.
     pub(crate) last_progress_at: Instant,
+
+    /// Reusable buffer for wave glyph spans, allocated once and passed into
+    /// [`crate::widgets::wave::glyphs`] each busy frame to avoid per-frame `Vec` allocation.
+    pub(crate) wave_buf: Vec<ratatui::text::Span<'static>>,
 }
 
 mod draw;

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -5,6 +5,7 @@
 //! state (input, messages, scroll, panels, metrics, and display toggles).
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::{Notify, mpsc, watch};
 use zeph_common::task_supervisor::TaskSupervisor;
@@ -95,6 +96,9 @@ impl App {
             effective_color_mode: crate::theme::EffectiveColorMode::Truecolor,
             unicode_capable: crate::theme::detect_unicode_capable(),
             collapsed_panels: [false; 4],
+            motion: zeph_config::Motion::Full,
+            wave_tick: 0,
+            last_progress_at: Instant::now(),
         }
     }
 
@@ -927,6 +931,94 @@ impl App {
             eff[3] = false;
         }
         eff
+    }
+
+    /// Configure the animation budget from config.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tokio::sync::mpsc;
+    /// use zeph_config::Motion;
+    /// use zeph_tui::App;
+    ///
+    /// let (user_tx, _) = mpsc::channel(1);
+    /// let (_, agent_rx) = mpsc::channel(1);
+    /// let app = App::new(user_tx, agent_rx).with_motion(Motion::Minimal);
+    /// assert_eq!(app.motion(), Motion::Minimal);
+    /// ```
+    #[must_use]
+    pub fn with_motion(mut self, motion: zeph_config::Motion) -> Self {
+        self.motion = motion;
+        self
+    }
+
+    /// Return the current animation budget.
+    #[must_use]
+    pub fn motion(&self) -> zeph_config::Motion {
+        self.motion
+    }
+
+    /// Return the monotonic wave-tick counter.
+    ///
+    /// Passed as `t` into [`crate::widgets::wave::sample`] / [`crate::widgets::wave::glyphs`].
+    #[must_use]
+    pub fn wave_tick(&self) -> u64 {
+        self.wave_tick
+    }
+
+    /// Derive the current wave animation state from live agent state.
+    ///
+    /// Stalled is checked first so a hung turn never reads as Streaming or Swell.
+    ///
+    /// # Stall behaviour
+    ///
+    /// A slow time-to-first-token > `stall_threshold` shows `Stalled` before any token
+    /// arrives, because `last_progress_at` is set when the turn goes busy (Typing/Status)
+    /// and the threshold starts counting from that moment. Accepted for v1 simplicity.
+    #[must_use]
+    pub fn wave_state(&self) -> crate::widgets::wave::WaveState {
+        use crate::widgets::wave::WaveState;
+
+        if !self.is_agent_busy() {
+            return WaveState::Idle;
+        }
+
+        // Stalled: no progress for longer than the threshold.
+        let stall_threshold = std::time::Duration::from_secs(10);
+        if self.last_progress_at.elapsed() > stall_threshold {
+            return WaveState::Stalled;
+        }
+
+        // Tool execution.
+        if self.has_running_tool() {
+            return WaveState::Tool;
+        }
+
+        // Parallel background tasks.
+        let bg = self.metrics.bg_enrichment_inflight
+            + self.metrics.bg_telemetry_inflight
+            + self.metrics.bg_inflight;
+        if bg >= 2 {
+            #[allow(clippy::cast_possible_truncation)]
+            return WaveState::Parallel {
+                sines: (bg as u8).clamp(2, 3),
+            };
+        }
+
+        // Streaming: last message is a streaming assistant message.
+        if self
+            .sessions
+            .current()
+            .messages
+            .last()
+            .is_some_and(|m| m.streaming && m.role == crate::types::MessageRole::Assistant)
+        {
+            return WaveState::Streaming;
+        }
+
+        // Swell: busy but awaiting first token.
+        WaveState::Swell
     }
 }
 

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -23,6 +23,10 @@ use super::{
     RenderCache, SubAgentSidebarState, TranscriptCache, is_tool_use_only, parse_tool_output,
 };
 
+/// No-progress duration after which the wave transitions to `Stalled`.
+/// TODO: wire to `config.tui.stall_threshold_secs` (deferred per #5096 v1 scope)
+const STALL_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(10);
+
 impl App {
     /// Create a new `App` with the given I/O channels.
     ///
@@ -99,6 +103,7 @@ impl App {
             motion: zeph_config::Motion::Full,
             wave_tick: 0,
             last_progress_at: Instant::now(),
+            wave_buf: Vec::new(),
         }
     }
 
@@ -985,8 +990,7 @@ impl App {
         }
 
         // Stalled: no progress for longer than the threshold.
-        let stall_threshold = std::time::Duration::from_secs(10);
-        if self.last_progress_at.elapsed() > stall_threshold {
+        if self.last_progress_at.elapsed() > STALL_THRESHOLD {
             return WaveState::Stalled;
         }
 
@@ -996,9 +1000,9 @@ impl App {
         }
 
         // Parallel background tasks.
-        let bg = self.metrics.bg_enrichment_inflight
-            + self.metrics.bg_telemetry_inflight
-            + self.metrics.bg_inflight;
+        // Use bg_inflight (all-classes total) — avoids double-counting since
+        // bg_enrichment_inflight and bg_telemetry_inflight are already included in bg_inflight.
+        let bg = self.metrics.bg_inflight;
         if bg >= 2 {
             #[allow(clippy::cast_possible_truncation)]
             return WaveState::Parallel {

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -144,6 +144,9 @@ pub enum TuiCommand {
     ListThemes,
     /// Switch to the named theme preset or user file.
     SetTheme(String),
+    // Motion control (#5096)
+    /// Set the TUI animation budget at runtime (`full`, `minimal`, or `off`).
+    SetMotion(zeph_config::Motion),
 }
 
 /// Metadata for a single entry in the command palette.

--- a/crates/zeph-tui/src/widgets/help.rs
+++ b/crates/zeph-tui/src/widgets/help.rs
@@ -81,6 +81,9 @@ pub fn render(frame: &mut Frame, area: Rect, theme: &Theme) {
             "/theme <name> (cycle)",
             "palette: app:theme cycles zephyr → zephyr-light → high-contrast",
         ),
+        keybind_row("/motion full", "wave animation on input separator row"),
+        keybind_row("/motion minimal", "breeze spinner, no wave"),
+        keybind_row("/motion off", "no animation (static row)"),
     ];
 
     let header = Row::new([

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -6,29 +6,39 @@ use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph, Wrap};
 use unicode_width::UnicodeWidthStr;
+use zeph_config::Motion;
 
 use crate::app::{App, InputMode};
 use crate::theme::Theme;
 use crate::widgets::spinner::breeze_frame;
 use crate::widgets::status_verbs::humanize;
+use crate::widgets::wave::{WaveState, glyphs};
 use zeph_common::text::format_tokens;
 
 /// Prompt glyph shown at the beginning of the separator line.
 const PROMPT_GLYPH: &str = "›";
 
-/// Append spinner + human-voice label spans to the separator line.
-fn push_spinner_spans<'a>(
+/// Append human-voice label spans to the separator line (no animated glyph).
+///
+/// Used by `Motion::Minimal` (breeze spinner) and `Motion::Off` (static).
+/// Callers pass `animated_glyph = false` for `Off`.
+fn push_label_spans<'a>(
     spans: &mut Vec<Span<'a>>,
     spinner_idx: u8,
     activity_label: Option<&'a str>,
     app: &App,
     theme: &'a Theme,
+    animated: bool,
 ) {
-    let symbol = breeze_frame(u64::from(spinner_idx), app.is_ascii_only());
+    let symbol = if animated {
+        breeze_frame(u64::from(spinner_idx), app.is_ascii_only())
+    } else {
+        // Static glyph — frame-invariant under Motion::Off.
+        "·"
+    };
     if let Some(label) = activity_label {
         let phrase = humanize(label);
         if phrase.verb.is_empty() {
-            // humanize returned empty (whitespace-only label) — show bare spinner
             spans.push(Span::styled(format!("  {symbol}"), theme.highlight));
         } else {
             spans.push(Span::styled(
@@ -48,18 +58,88 @@ fn push_spinner_spans<'a>(
     spans.push(Span::styled("  esc to interrupt", theme.system_message));
 }
 
-pub fn render(
-    app: &App,
-    frame: &mut Frame,
-    area: Rect,
-    busy: bool,
-    activity_label: Option<&str>,
-    spinner_idx: u8,
-) {
-    let theme = &app.theme;
+/// Build the busy separator row for `Motion::Full`.
+///
+/// Layout (left → right):
+/// 1. `› ` prompt glyph (2 columns, always present).
+/// 2. Activity label: `verb · detail  esc to interrupt` — measured via unicode width.
+/// 3. Wave right-fills the remaining columns (`wave_w = width - prompt_w - label_w - 1`).
+///    The `+1` is a space gutter between label and wave. `wave_w = 0` → wave skipped.
+///
+/// The `~N tokens` estimate and mode hint are deliberately omitted while busy+Full to
+/// free width for the wave.
+fn build_full_busy_sep<'a>(
+    area_width: u16,
+    activity_label: Option<&'a str>,
+    app: &'a App,
+    wave_state: WaveState,
+    wave_tick: u64,
+    theme: &'a Theme,
+) -> Vec<Span<'static>> {
+    const PROMPT_W: u16 = 2; // "› " width
 
-    // Build the separator line that replaces the former top border.
-    // Format: "› mode_hint  [meta…]"
+    // Build the human-voice label text first so we can measure it.
+    let label_text: String = if let Some(label) = activity_label {
+        let phrase = humanize(label);
+        if phrase.verb.is_empty() {
+            "  esc to interrupt".to_owned()
+        } else if phrase.detail.is_empty() {
+            format!("  {} · esc to interrupt", phrase.verb)
+        } else {
+            format!("  {} · {}  esc to interrupt", phrase.verb, phrase.detail)
+        }
+    } else {
+        "  esc to interrupt".to_owned()
+    };
+
+    #[allow(clippy::cast_possible_truncation)]
+    let label_w = label_text.width() as u16;
+
+    let wave_w = area_width
+        .saturating_sub(PROMPT_W)
+        .saturating_sub(label_w)
+        .saturating_sub(1); // gutter
+
+    // Build spans — all 'static lifetime via owned Strings.
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    spans.push(Span::styled(format!("{PROMPT_GLYPH} "), theme.highlight));
+    spans.push(Span::styled(label_text, theme.system_message));
+
+    if wave_w > 0 {
+        spans.push(Span::raw(" ")); // gutter
+        let color_mode = app.effective_color_mode();
+        let ascii = app.is_ascii_only();
+        // wave_buf is borrowed mutably from App in draw.rs via app.wave_buf — but here we
+        // own the call through `&App` read access. We allocate a local buffer because the
+        // caller already has a `&App` borrow and `wave_buf` is `pub(crate)`. The cost is
+        // one Vec allocation per busy frame in Full mode; acceptable (amortized by capacity).
+        let mut local_buf: Vec<Span<'static>> = Vec::with_capacity(wave_w as usize);
+        glyphs(
+            wave_state,
+            u32::from(wave_w),
+            wave_tick,
+            color_mode,
+            ascii,
+            &mut local_buf,
+            theme,
+        );
+        spans.extend(local_buf);
+    }
+
+    spans
+}
+
+/// Build the busy separator row for `Motion::Minimal` (animated) and `Motion::Off` (static).
+///
+/// Both modes share the same layout — prompt glyph + mode hint + token estimate + queued badge
+/// + activity label. The only difference is whether the label glyph animates (`animated = true`).
+fn build_spinner_busy_sep<'a>(
+    spinner_idx: u8,
+    activity_label: Option<&'a str>,
+    app: &'a App,
+    theme: &'a Theme,
+    animated: bool,
+) -> Vec<Span<'a>> {
     let mode_hint = match app.input_mode() {
         InputMode::Normal => "press 'i' to type",
         InputMode::Insert => "esc to cancel",
@@ -70,39 +150,56 @@ pub fn render(
     } else {
         String::new()
     };
-
-    let mut sep_spans: Vec<Span<'_>> = vec![
+    let mut spans: Vec<Span<'_>> = vec![
         Span::styled(format!("{PROMPT_GLYPH} "), theme.highlight),
         Span::styled(mode_hint, theme.system_message),
         Span::styled(meta, theme.system_message),
     ];
-
     if app.queued_count() > 0 {
-        sep_spans.push(Span::styled(
+        spans.push(Span::styled(
             format!("  [+{} queued]", app.queued_count()),
             theme.highlight,
         ));
     }
     if app.editing_queued() {
-        sep_spans.push(Span::styled("  [editing queued]", theme.highlight));
+        spans.push(Span::styled("  [editing queued]", theme.highlight));
     }
-    if busy {
-        push_spinner_spans(&mut sep_spans, spinner_idx, activity_label, app, theme);
-    }
+    push_label_spans(&mut spans, spinner_idx, activity_label, app, theme, animated);
+    spans
+}
 
-    // Render separator line in the top row of the area.
-    if area.height >= 1 {
-        let sep_area = Rect { height: 1, ..area };
-        frame.render_widget(Paragraph::new(Line::from(sep_spans)), sep_area);
-    }
-
-    // The text area starts one row below the separator.
-    let text_area = Rect {
-        y: area.y.saturating_add(1),
-        height: area.height.saturating_sub(1),
-        ..area
+/// Build the idle separator row (agent not busy, all motion modes share this layout).
+fn build_idle_sep<'a>(app: &'a App, theme: &'a Theme) -> Vec<Span<'a>> {
+    let mode_hint = match app.input_mode() {
+        InputMode::Normal => "press 'i' to type",
+        InputMode::Insert => "esc to cancel",
     };
+    let estimate = app.context_token_estimate();
+    let meta = if estimate > 0 {
+        format!("  ~{} tokens", format_tokens(estimate as u64))
+    } else {
+        String::new()
+    };
+    let mut spans: Vec<Span<'_>> = vec![
+        Span::styled(format!("{PROMPT_GLYPH} "), theme.highlight),
+        Span::styled(mode_hint, theme.system_message),
+        Span::styled(meta, theme.system_message),
+    ];
+    if app.queued_count() > 0 {
+        spans.push(Span::styled(
+            format!("  [+{} queued]", app.queued_count()),
+            theme.highlight,
+        ));
+    }
+    if app.editing_queued() {
+        spans.push(Span::styled("  [editing queued]", theme.highlight));
+    }
+    spans
+}
 
+/// Render the editable text area and update the terminal cursor position.
+fn render_text_area(app: &App, frame: &mut Frame, text_area: Rect) {
+    let theme = &app.theme;
     let block = Block::default();
 
     let visible_lines = text_area.height;
@@ -165,6 +262,61 @@ pub fn render(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn render(
+    app: &App,
+    frame: &mut Frame,
+    area: Rect,
+    busy: bool,
+    activity_label: Option<&str>,
+    spinner_idx: u8,
+    wave_state: WaveState,
+    wave_tick: u64,
+    motion: Motion,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let theme = &app.theme;
+
+    let sep_spans: Vec<Span<'_>> = if busy {
+        match motion {
+            Motion::Full => build_full_busy_sep(
+                area.width,
+                activity_label,
+                app,
+                wave_state,
+                wave_tick,
+                theme,
+            ),
+            Motion::Minimal => {
+                build_spinner_busy_sep(spinner_idx, activity_label, app, theme, true)
+            }
+            Motion::Off => {
+                build_spinner_busy_sep(spinner_idx, activity_label, app, theme, false)
+            }
+        }
+    } else {
+        build_idle_sep(app, theme)
+    };
+
+    frame.render_widget(
+        Paragraph::new(Line::from(sep_spans)),
+        Rect { height: 1, ..area },
+    );
+
+    render_text_area(
+        app,
+        frame,
+        Rect {
+            y: area.y.saturating_add(1),
+            height: area.height.saturating_sub(1),
+            ..area
+        },
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
@@ -183,7 +335,17 @@ mod tests {
     fn input_insert_mode() {
         let app = make_app();
         let output = render_to_string(40, 5, |frame, area| {
-            super::render(&app, frame, area, false, None, 0);
+            super::render(
+                &app,
+                frame,
+                area,
+                false,
+                None,
+                0,
+                crate::widgets::wave::WaveState::Idle,
+                0,
+                zeph_config::Motion::Full,
+            );
         });
         assert_snapshot!(output);
     }
@@ -198,7 +360,17 @@ mod tests {
             ),
         ));
         let output = render_to_string(40, 5, |frame, area| {
-            super::render(&app, frame, area, false, None, 0);
+            super::render(
+                &app,
+                frame,
+                area,
+                false,
+                None,
+                0,
+                crate::widgets::wave::WaveState::Idle,
+                0,
+                zeph_config::Motion::Full,
+            );
         });
         assert_snapshot!(output);
     }
@@ -207,7 +379,17 @@ mod tests {
     fn input_busy_shows_spinner() {
         let app = make_app();
         let output = render_to_string(60, 5, |frame, area| {
-            super::render(&app, frame, area, true, Some("Thinking..."), 0);
+            super::render(
+                &app,
+                frame,
+                area,
+                true,
+                Some("Thinking..."),
+                0,
+                crate::widgets::wave::WaveState::Swell,
+                0,
+                zeph_config::Motion::Minimal,
+            );
         });
         assert!(
             output.contains("esc to interrupt"),
@@ -219,7 +401,17 @@ mod tests {
     fn input_idle_width_80() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            super::render(&app, frame, area, false, None, 0);
+            super::render(
+                &app,
+                frame,
+                area,
+                false,
+                None,
+                0,
+                crate::widgets::wave::WaveState::Idle,
+                0,
+                zeph_config::Motion::Full,
+            );
         });
         assert_snapshot!(output);
     }
@@ -228,7 +420,17 @@ mod tests {
     fn input_busy_width_40() {
         let app = make_app();
         let output = render_to_string(40, 5, |frame, area| {
-            super::render(&app, frame, area, true, Some("Thinking..."), 0);
+            super::render(
+                &app,
+                frame,
+                area,
+                true,
+                Some("Thinking..."),
+                0,
+                crate::widgets::wave::WaveState::Swell,
+                0,
+                zeph_config::Motion::Minimal,
+            );
         });
         // On a 40-column terminal the full "esc to interrupt" hint may be truncated;
         // humanize() lowercases the verb, so check for "thinking" (lowercase).
@@ -242,7 +444,17 @@ mod tests {
     fn input_busy_width_80() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            super::render(&app, frame, area, true, Some("Thinking..."), 0);
+            super::render(
+                &app,
+                frame,
+                area,
+                true,
+                Some("Thinking..."),
+                0,
+                crate::widgets::wave::WaveState::Swell,
+                0,
+                zeph_config::Motion::Minimal,
+            );
         });
         assert!(
             output.contains("esc to interrupt"),
@@ -257,7 +469,17 @@ mod tests {
             crate::event::AgentEvent::ContextEstimate(14_200),
         ));
         let output = render_to_string(80, 5, |frame, area| {
-            super::render(&app, frame, area, false, None, 0);
+            super::render(
+                &app,
+                frame,
+                area,
+                false,
+                None,
+                0,
+                crate::widgets::wave::WaveState::Idle,
+                0,
+                zeph_config::Motion::Full,
+            );
         });
         assert!(
             output.contains("14.2k tokens"),
@@ -269,7 +491,17 @@ mod tests {
     fn input_hides_token_estimate_when_zero() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            super::render(&app, frame, area, false, None, 0);
+            super::render(
+                &app,
+                frame,
+                area,
+                false,
+                None,
+                0,
+                crate::widgets::wave::WaveState::Idle,
+                0,
+                zeph_config::Motion::Full,
+            );
         });
         assert!(
             !output.contains("tokens"),

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -33,7 +33,7 @@ fn push_label_spans<'a>(
     let symbol = if animated {
         breeze_frame(u64::from(spinner_idx), app.is_ascii_only())
     } else {
-        // Static glyph — frame-invariant under Motion::Off.
+        // Static glyph — no animated symbol under Motion::Off; other separator content (token estimate, label) still reflects live state.
         "·"
     };
     if let Some(label) = activity_label {
@@ -75,6 +75,7 @@ fn build_full_busy_sep<'a>(
     wave_state: WaveState,
     wave_tick: u64,
     theme: &'a Theme,
+    wave_buf: &mut Vec<Span<'static>>,
 ) -> Vec<Span<'static>> {
     const PROMPT_W: u16 = 2; // "› " width
 
@@ -109,21 +110,16 @@ fn build_full_busy_sep<'a>(
         spans.push(Span::raw(" ")); // gutter
         let color_mode = app.effective_color_mode();
         let ascii = app.is_ascii_only();
-        // wave_buf is borrowed mutably from App in draw.rs via app.wave_buf — but here we
-        // own the call through `&App` read access. We allocate a local buffer because the
-        // caller already has a `&App` borrow and `wave_buf` is `pub(crate)`. The cost is
-        // one Vec allocation per busy frame in Full mode; acceptable (amortized by capacity).
-        let mut local_buf: Vec<Span<'static>> = Vec::with_capacity(wave_w as usize);
         glyphs(
             wave_state,
             u32::from(wave_w),
             wave_tick,
             color_mode,
             ascii,
-            &mut local_buf,
+            wave_buf,
             theme,
         );
-        spans.extend(local_buf);
+        spans.extend_from_slice(wave_buf);
     }
 
     spans
@@ -164,7 +160,14 @@ fn build_spinner_busy_sep<'a>(
     if app.editing_queued() {
         spans.push(Span::styled("  [editing queued]", theme.highlight));
     }
-    push_label_spans(&mut spans, spinner_idx, activity_label, app, theme, animated);
+    push_label_spans(
+        &mut spans,
+        spinner_idx,
+        activity_label,
+        app,
+        theme,
+        animated,
+    );
     spans
 }
 
@@ -273,6 +276,7 @@ pub fn render(
     wave_state: WaveState,
     wave_tick: u64,
     motion: Motion,
+    wave_buf: &mut Vec<Span<'static>>,
 ) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -289,13 +293,12 @@ pub fn render(
                 wave_state,
                 wave_tick,
                 theme,
+                wave_buf,
             ),
             Motion::Minimal => {
                 build_spinner_busy_sep(spinner_idx, activity_label, app, theme, true)
             }
-            Motion::Off => {
-                build_spinner_busy_sep(spinner_idx, activity_label, app, theme, false)
-            }
+            Motion::Off => build_spinner_busy_sep(spinner_idx, activity_label, app, theme, false),
         }
     } else {
         build_idle_sep(app, theme)
@@ -331,11 +334,39 @@ mod tests {
         App::new(user_tx, agent_rx)
     }
 
+    /// Thin wrapper so existing tests don't need to manage `wave_buf` themselves.
+    #[allow(clippy::too_many_arguments)]
+    fn render_input(
+        app: &App,
+        frame: &mut ratatui::Frame,
+        area: ratatui::layout::Rect,
+        busy: bool,
+        activity_label: Option<&str>,
+        spinner_idx: u8,
+        wave_state: crate::widgets::wave::WaveState,
+        wave_tick: u64,
+        motion: zeph_config::Motion,
+    ) {
+        let mut buf = Vec::new();
+        super::render(
+            app,
+            frame,
+            area,
+            busy,
+            activity_label,
+            spinner_idx,
+            wave_state,
+            wave_tick,
+            motion,
+            &mut buf,
+        );
+    }
+
     #[test]
     fn input_insert_mode() {
         let app = make_app();
         let output = render_to_string(40, 5, |frame, area| {
-            super::render(
+            render_input(
                 &app,
                 frame,
                 area,
@@ -360,7 +391,7 @@ mod tests {
             ),
         ));
         let output = render_to_string(40, 5, |frame, area| {
-            super::render(
+            render_input(
                 &app,
                 frame,
                 area,
@@ -379,7 +410,7 @@ mod tests {
     fn input_busy_shows_spinner() {
         let app = make_app();
         let output = render_to_string(60, 5, |frame, area| {
-            super::render(
+            render_input(
                 &app,
                 frame,
                 area,
@@ -401,7 +432,7 @@ mod tests {
     fn input_idle_width_80() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            super::render(
+            render_input(
                 &app,
                 frame,
                 area,
@@ -420,7 +451,7 @@ mod tests {
     fn input_busy_width_40() {
         let app = make_app();
         let output = render_to_string(40, 5, |frame, area| {
-            super::render(
+            render_input(
                 &app,
                 frame,
                 area,
@@ -444,7 +475,7 @@ mod tests {
     fn input_busy_width_80() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            super::render(
+            render_input(
                 &app,
                 frame,
                 area,
@@ -469,7 +500,7 @@ mod tests {
             crate::event::AgentEvent::ContextEstimate(14_200),
         ));
         let output = render_to_string(80, 5, |frame, area| {
-            super::render(
+            render_input(
                 &app,
                 frame,
                 area,
@@ -491,7 +522,7 @@ mod tests {
     fn input_hides_token_estimate_when_zero() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            super::render(
+            render_input(
                 &app,
                 frame,
                 area,
@@ -540,5 +571,100 @@ mod tests {
             format!("~{}", zeph_common::text::format_tokens(100_000)),
             "~100.0k"
         );
+    }
+
+    // C2: Motion::Full busy-path tests (wave render integration)
+
+    #[test]
+    fn input_busy_full_streaming_width_80() {
+        let app = make_app();
+        let output = render_to_string(80, 5, |frame, area| {
+            render_input(
+                &app,
+                frame,
+                area,
+                true,
+                Some("Streaming..."),
+                0,
+                crate::widgets::wave::WaveState::Streaming,
+                5,
+                zeph_config::Motion::Full,
+            );
+        });
+        // Separator must have the prompt glyph and label.
+        assert!(
+            output.contains('›'),
+            "prompt glyph must appear in Full+busy; got: {output:?}"
+        );
+        assert!(
+            output.contains("esc to interrupt"),
+            "interrupt hint must appear; got: {output:?}"
+        );
+        // Wave glyphs OR the label fills the row — no block-element crash check.
+        assert!(
+            !output.is_empty(),
+            "render must not produce empty output; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn input_busy_full_narrow_wave_skipped() {
+        // width=20 is narrow enough that wave_w saturates to 0 after prompt (2) + label (~18).
+        let app = make_app();
+        let output = render_to_string(20, 5, |frame, area| {
+            render_input(
+                &app,
+                frame,
+                area,
+                true,
+                None,
+                0,
+                crate::widgets::wave::WaveState::Swell,
+                0,
+                zeph_config::Motion::Full,
+            );
+        });
+        // No wave block characters when wave_w == 0.
+        for glyph in &["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] {
+            assert!(
+                !output.contains(glyph),
+                "no wave glyphs should appear on narrow terminal; got: {output:?}"
+            );
+        }
+        // Label must still be present.
+        assert!(
+            output.contains('›'),
+            "prompt glyph must appear even on narrow terminal; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn input_busy_motion_off() {
+        let app = make_app();
+        let output = render_to_string(80, 5, |frame, area| {
+            render_input(
+                &app,
+                frame,
+                area,
+                true,
+                Some("Streaming..."),
+                0,
+                crate::widgets::wave::WaveState::Streaming,
+                5,
+                zeph_config::Motion::Off,
+            );
+        });
+        // Interrupt hint must be present.
+        assert!(
+            output.contains("esc to interrupt"),
+            "interrupt hint must appear in Off mode; got: {output:?}"
+        );
+        // No block-element wave glyphs.
+        for glyph in &["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] {
+            assert!(
+                !output.contains(glyph),
+                "no wave glyphs should appear under Motion::Off; got: {output:?}"
+            );
+        }
     }
 }

--- a/crates/zeph-tui/src/widgets/mod.rs
+++ b/crates/zeph-tui/src/widgets/mod.rs
@@ -27,3 +27,4 @@ pub mod status_verbs;
 pub mod subagents;
 pub mod task_registry;
 pub mod tool_view;
+pub mod wave;

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -31,8 +31,12 @@ enum Priority {
 
 struct Segment {
     spans: Vec<Span<'static>>,
+    /// Abbreviated form shown under space pressure. `None` = no short form (full or drop).
+    short_spans: Option<Vec<Span<'static>>>,
     priority: Priority,
     width: u16,
+    /// Pre-computed display width of [`Segment::short_spans`], or 0 if absent.
+    short_width: u16,
 }
 
 struct SegmentList {
@@ -52,14 +56,108 @@ impl SegmentList {
         });
         self.segments.push(Segment {
             spans,
+            short_spans: None,
             priority,
             width,
+            short_width: 0,
         });
     }
 
-    /// Iteratively drop the last-pushed segment among those with the highest (lowest importance)
-    /// priority level until total fits within `max_width`, never dropping Critical.
+    /// Push a segment with an abbreviated form used under space pressure.
+    ///
+    /// When `total > max_width`, Phase A of [`SegmentList::layout`] abbreviates `full_spans`
+    /// to `short_spans` before Phase B drops segments entirely. Critical segments with a short
+    /// form are abbreviated but never dropped.
+    fn push_abbrev(
+        &mut self,
+        priority: Priority,
+        full_spans: Vec<Span<'static>>,
+        short_spans: Vec<Span<'static>>,
+    ) {
+        let width: u16 = full_spans.iter().fold(0u16, |acc, s| {
+            acc.saturating_add(u16::try_from(s.content.width()).unwrap_or(u16::MAX))
+        });
+        let short_width: u16 = short_spans.iter().fold(0u16, |acc, s| {
+            acc.saturating_add(u16::try_from(s.content.width()).unwrap_or(u16::MAX))
+        });
+        self.segments.push(Segment {
+            spans: full_spans,
+            short_spans: Some(short_spans),
+            priority,
+            width,
+            short_width,
+        });
+    }
+
+    /// Convenience for the common single-span case.
+    fn push_abbrev_styled(
+        &mut self,
+        priority: Priority,
+        full: String,
+        short: String,
+        style: ratatui::style::Style,
+    ) {
+        self.push_abbrev(
+            priority,
+            vec![Span::styled(full, style)],
+            vec![Span::styled(short, style)],
+        );
+    }
+
+    /// Apply the three-rung pressure ladder and return a flat span list.
+    ///
+    /// - **Phase A** — abbreviate: while over budget, switch the worst-priority, last-pushed
+    ///   segment that still shows its full form AND has a short form to its abbreviated
+    ///   version. Segments where `short_width >= width` (no savings) are skipped — this
+    ///   prevents an infinite loop when a short form is the same width as the full form.
+    /// - **Phase B** — drop: if still over budget, drop segments LIFO by worst priority
+    ///   (Critical exempt).
+    /// - **Phase C** — truncate: if Critical segments alone overflow, truncate the last span.
     fn layout(mut self, max_width: u16) -> Vec<Span<'static>> {
+        // Phase A — abbreviate under pressure.
+        loop {
+            let total: u16 = self
+                .segments
+                .iter()
+                .fold(0u16, |a, s| a.saturating_add(s.width));
+            if total <= max_width {
+                break;
+            }
+            // Find the worst priority among segments that can be abbreviated (have a short
+            // form that actually saves space — skip if short_width >= width).
+            let worst = self
+                .segments
+                .iter()
+                .filter(|s| s.short_spans.is_some() && s.short_width < s.width)
+                .map(|s| s.priority)
+                .max();
+            let Some(worst_priority) = worst else {
+                break;
+            };
+            // Abbreviate the last-pushed (LIFO) abbreviatable segment at that priority.
+            let abbrev_idx = self
+                .segments
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, s)| {
+                    s.priority == worst_priority
+                        && s.short_spans.is_some()
+                        && s.short_width < s.width
+                })
+                .map(|(i, _)| i);
+            if let Some(idx) = abbrev_idx {
+                let seg = &mut self.segments[idx];
+                if let Some(short) = seg.short_spans.take() {
+                    seg.width = seg.short_width;
+                    seg.spans = short;
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Phase B — drop under pressure.
         loop {
             let total: u16 = self
                 .segments
@@ -123,6 +221,28 @@ impl SegmentList {
 impl Segment {
     fn into_spans(self) -> Vec<Span<'static>> {
         self.spans
+    }
+}
+
+/// Shorten token counts to the minimal non-ambiguous abbreviation.
+///
+/// Mirrors `format_tokens` but drops the label prefix, e.g. `12.3k` instead of `Tokens: 12.3k`.
+fn short_tokens(total: u64, reasoning: u64) -> String {
+    use zeph_common::format_tokens;
+    if reasoning > 0 {
+        format!(" {}(R:{})", format_tokens(total), format_tokens(reasoning))
+    } else {
+        format!(" {}", format_tokens(total))
+    }
+}
+
+/// Short form for uptime: minutes only when ≥1 min, seconds otherwise.
+fn short_uptime(secs: u64) -> String {
+    let m = secs / 60;
+    if m > 0 {
+        format!(" {m}m")
+    } else {
+        format!(" {secs}s")
     }
 }
 
@@ -211,22 +331,25 @@ fn push_medium_segments(
             )],
         );
     }
-    list.push(
+    list.push_abbrev_styled(
         Priority::Medium,
-        vec![Span::styled(
-            format!(
-                " | Skills: {} active / {} loaded",
-                metrics.active_skills.len(),
-                metrics.total_skills,
-            ),
-            theme.status_bar,
-        )],
+        format!(
+            " | Skills: {} active / {} loaded",
+            metrics.active_skills.len(),
+            metrics.total_skills,
+        ),
+        format!(
+            " Sk {}/{}",
+            metrics.active_skills.len(),
+            metrics.total_skills
+        ),
+        theme.status_bar,
     );
 }
 
 #[allow(clippy::too_many_lines)]
 fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapshot, theme: &Theme) {
-    let token_str = if metrics.reasoning_tokens > 0 {
+    let token_full = if metrics.reasoning_tokens > 0 {
         format!(
             " | Tokens: {} (R: {})",
             format_tokens(metrics.total_tokens),
@@ -235,32 +358,31 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
     } else {
         format!(" | Tokens: {}", format_tokens(metrics.total_tokens))
     };
-    list.push(
-        Priority::Low,
-        vec![Span::styled(token_str, theme.status_bar)],
+    let token_short = format!(
+        " |{}",
+        short_tokens(metrics.total_tokens, metrics.reasoning_tokens)
     );
+    list.push_abbrev_styled(Priority::Low, token_full, token_short, theme.status_bar);
+
     if metrics.cost_spent_cents > 0.0 {
-        list.push(
+        list.push_abbrev_styled(
             Priority::Low,
-            vec![Span::styled(
-                format!(" | ${:.4}", metrics.cost_spent_cents / 100.0),
-                theme.status_bar,
-            )],
+            format!(" | ${:.4}", metrics.cost_spent_cents / 100.0),
+            format!(" ${:.2}", metrics.cost_spent_cents / 100.0),
+            theme.status_bar,
         );
     }
-    list.push(
+    list.push_abbrev_styled(
         Priority::Low,
-        vec![Span::styled(
-            format!(" | API: {}", metrics.api_calls),
-            theme.status_bar,
-        )],
+        format!(" | API: {}", metrics.api_calls),
+        format!(" A{}", metrics.api_calls),
+        theme.status_bar,
     );
-    list.push(
+    list.push_abbrev_styled(
         Priority::Low,
-        vec![Span::styled(
-            format!(" | {}", format_uptime(metrics.uptime_seconds)),
-            theme.status_bar,
-        )],
+        format!(" | {}", format_uptime(metrics.uptime_seconds)),
+        short_uptime(metrics.uptime_seconds),
+        theme.status_bar,
     );
     if !metrics.shell_background_runs.is_empty() {
         list.push(
@@ -852,5 +974,119 @@ mod tests {
             !text.contains("BBBBBBBBBB"),
             "Low must be dropped: {text:?}"
         );
+    }
+
+    #[test]
+    fn phase_a_abbreviates_before_phase_b_drops() {
+        let theme = Theme::default();
+        let mut list = SegmentList::new();
+        // Critical: 10 chars — never dropped or abbreviated here (no short form).
+        list.push(
+            Priority::Critical,
+            vec![Span::styled("0123456789", theme.status_bar)],
+        );
+        // Low with short form: full=10, short=3 — abbreviatable.
+        list.push_abbrev(
+            Priority::Low,
+            vec![Span::styled("AAAAAAAAAA", theme.status_bar)],
+            vec![Span::styled("AAA", theme.status_bar)],
+        );
+        // Low without short form: 10 chars — drops in Phase B.
+        list.push(
+            Priority::Low,
+            vec![Span::styled("BBBBBBBBBB", theme.status_bar)],
+        );
+        // max_width = 23: Critical(10) + short_A(3) + B(10) = 23 — Phase A abbreviates A,
+        // then total = 23 which fits. B must NOT be dropped.
+        let spans = list.layout(23);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("0123456789"), "Critical must survive");
+        assert!(text.contains("AAA"), "abbreviated A must appear");
+        assert!(
+            !text.contains("AAAAAAAAAA"),
+            "full A must be replaced by short form"
+        );
+        assert!(
+            text.contains("BBBBBBBBBB"),
+            "B must survive — Phase A was enough"
+        );
+    }
+
+    #[test]
+    fn phase_a_skips_segment_where_short_equals_full_width() {
+        let theme = Theme::default();
+        let mut list = SegmentList::new();
+        list.push(
+            Priority::Critical,
+            vec![Span::styled("0123456789", theme.status_bar)],
+        );
+        // short_width == width — no savings, must be skipped by Phase A and dropped in Phase B.
+        list.push_abbrev(
+            Priority::Low,
+            vec![Span::styled("AAAA", theme.status_bar)],
+            vec![Span::styled("BBBB", theme.status_bar)], // same width = 4
+        );
+        // max_width = 10: only Critical fits. The abbrev segment has no savings so Phase A
+        // skips it; Phase B drops it.
+        let spans = list.layout(10);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("0123456789"), "Critical must survive");
+        assert!(
+            !text.contains("AAAA") && !text.contains("BBBB"),
+            "no-savings abbrev segment must be dropped in Phase B"
+        );
+    }
+
+    #[test]
+    fn phase_a_lifo_order_among_abbreviatable_at_same_priority() {
+        let theme = Theme::default();
+        let mut list = SegmentList::new();
+        list.push(
+            Priority::Critical,
+            vec![Span::styled("CRIT______", theme.status_bar)],
+        ); // 10
+        // Two Low abbreviatable: first pushed = A, last pushed = B.
+        // Phase A should abbreviate B first (LIFO).
+        list.push_abbrev(
+            Priority::Low,
+            vec![Span::styled("FULL_A____", theme.status_bar)], // 10
+            vec![Span::styled("sA", theme.status_bar)],         // 2
+        );
+        list.push_abbrev(
+            Priority::Low,
+            vec![Span::styled("FULL_B____", theme.status_bar)], // 10
+            vec![Span::styled("sB", theme.status_bar)],         // 2
+        );
+        // Total = 30. max_width = 22: need to save 8. Abbreviating B saves 8 (10→2). Fits.
+        let spans = list.layout(22);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("CRIT______"), "Critical must survive");
+        assert!(
+            text.contains("FULL_A____"),
+            "A must stay full — last pushed (B) abbreviated first"
+        );
+        assert!(text.contains("sB"), "B must be abbreviated (LIFO)");
+        assert!(!text.contains("FULL_B____"), "full B must not appear");
+    }
+
+    #[test]
+    fn short_tokens_no_reasoning() {
+        // Just checks the helper function used to build abbreviations.
+        assert_eq!(short_tokens(4200, 0), " 4.2k");
+    }
+
+    #[test]
+    fn short_tokens_with_reasoning() {
+        assert_eq!(short_tokens(4200, 1000), " 4.2k(R:1.0k)");
+    }
+
+    #[test]
+    fn short_uptime_seconds() {
+        assert_eq!(short_uptime(45), " 45s");
+    }
+
+    #[test]
+    fn short_uptime_minutes() {
+        assert_eq!(short_uptime(135), " 2m");
     }
 }

--- a/crates/zeph-tui/src/widgets/wave.rs
+++ b/crates/zeph-tui/src/widgets/wave.rs
@@ -1,0 +1,540 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic wave animation for the input separator row (#5096).
+//!
+//! The wave is a pure function of `(state, width, t)` where `t` is a monotonic
+//! `u64` tick counter owned by `App`. No wall-clock reads happen here — all
+//! time-dependence flows through the explicit `t` argument so snapshot tests
+//! and property tests stay bit-identical.
+//!
+//! # Architecture
+//!
+//! - [`WaveState`] — discriminates the 6 visual modes; derived in `App::wave_state()`.
+//! - [`sample`] — pure math: maps `(state, x, t)` to a glyph bucket `0..=7`.
+//! - [`glyphs`] — converts a row width to a `Vec<Span<'static>>` using the bucket ramp.
+//!
+//! The caller owns a reused `Vec<Span<'static>>` buffer (`wave_buf`) and passes a `&mut` to
+//! [`glyphs`] so the per-frame allocation is amortized to zero after the first frame.
+
+use std::f32::consts::TAU;
+
+use ratatui::style::{Color, Style};
+use ratatui::text::Span;
+
+use crate::theme::{EffectiveColorMode, Theme};
+
+// ---------------------------------------------------------------------------
+// Glyph ramps
+// ---------------------------------------------------------------------------
+
+/// Block-element gradient from thin (index 0) to full (index 7).
+/// `[&'static str; 8]` so `Span::styled(WAVE_GLYPHS[b], style)` borrows a `&'static str`
+/// — no per-glyph String allocation.
+const WAVE_GLYPHS: [&str; 8] = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+
+/// ASCII fallback ramp for `TERM=dumb` terminals.
+const ASCII_GLYPHS: [&str; 8] = [".", ".", "-", "-", "~", "~", "=", "="];
+
+// ---------------------------------------------------------------------------
+// WaveState
+// ---------------------------------------------------------------------------
+
+/// Discriminates the wave animation mode for the input separator row.
+///
+/// Derived once per render frame by [`crate::app::App::wave_state`] from live
+/// agent state. The renderer receives a `WaveState` value — it never inspects
+/// wall-clock time directly so snapshot tests remain deterministic.
+///
+/// # Variants
+///
+/// | Variant | When shown |
+/// |---------|-----------|
+/// | `Idle` | Agent is not busy — flat `▁` baseline |
+/// | `Swell` | Busy, awaiting first token — high amplitude, slow roll |
+/// | `Streaming` | Token stream active — medium amplitude, medium ω |
+/// | `Tool` | Tool execution in progress — choppy short-λ wave |
+/// | `Parallel` | ≥2 background tasks inflight — superposed sines |
+/// | `Stalled` | No progress for >`stall_threshold` — flat + error tint |
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaveState {
+    /// Agent idle — renders a static thin baseline.
+    Idle,
+    /// Busy, waiting for the first token.
+    Swell,
+    /// Token stream active (fixed ω; tps modulation deferred to v2).
+    ///
+    /// `// TODO(#5096-tps): modulate omega by live tok/s once a per-turn rate metric exists`
+    Streaming,
+    /// Tool execution in progress.
+    Tool,
+    /// ≥2 background tasks inflight; `sines` is clamped to `2..=3`.
+    Parallel {
+        /// Number of superposed sine waves; clamped to `2..=3`.
+        sines: u8,
+    },
+    /// No progress for longer than the stall threshold.
+    Stalled,
+}
+
+// ---------------------------------------------------------------------------
+// Wave parameters
+// ---------------------------------------------------------------------------
+
+/// Per-state wave parameters passed to [`sample`].
+///
+/// `amplitude`, `wavelength`, and `omega` are tuned for the 250 ms tick rate
+/// (4 fps). Per-tick phase step = `omega`; per-column spatial frequency = 2π/λ.
+/// Nyquist constraint: omega < π, λ ≥ ~8 columns.
+#[derive(Debug, Clone, Copy)]
+struct WaveParams {
+    /// Peak displacement in `[0, 1]`.
+    amplitude: f32,
+    /// Spatial wavelength in columns.
+    wavelength: f32,
+    /// Phase advance per tick (radians).
+    omega: f32,
+    /// Whether to apply a choppy short-λ secondary component.
+    choppy: bool,
+    /// Number of parallel sines to superpose (only for `Parallel`).
+    sines: u8,
+}
+
+impl WaveState {
+    /// Return the render parameters for this state.
+    fn params(self) -> WaveParams {
+        match self {
+            // Idle and Stalled both render a flat line (amplitude=0); colour tint is
+            // applied by `glyphs()` based on the WaveState variant, not params.
+            WaveState::Idle | WaveState::Stalled => WaveParams {
+                amplitude: 0.0,
+                wavelength: 1.0, // unused (A=0)
+                omega: 0.0,
+                choppy: false,
+                sines: 1,
+            },
+            WaveState::Swell => WaveParams {
+                amplitude: 0.9,
+                wavelength: 40.0, // long roll
+                omega: 0.25,
+                choppy: false,
+                sines: 1,
+            },
+            WaveState::Streaming => WaveParams {
+                amplitude: 0.6,
+                wavelength: 12.0,
+                omega: 0.7,
+                choppy: false,
+                sines: 1,
+            },
+            WaveState::Tool => WaveParams {
+                amplitude: 0.5,
+                wavelength: 4.0, // short choppy
+                omega: 1.0,
+                choppy: true,
+                sines: 1,
+            },
+            WaveState::Parallel { sines } => WaveParams {
+                amplitude: 0.5,
+                wavelength: 14.0, // primary λ
+                omega: 0.6,
+                choppy: false,
+                sines: sines.clamp(2, 3),
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core math
+// ---------------------------------------------------------------------------
+
+/// Return the glyph bucket index `0..=7` for column `x` at tick `t`.
+///
+/// This function is pure — given identical `(state, x, t)` arguments it always
+/// returns the same value. Use it directly in snapshot and property tests.
+///
+/// The `u64 → f32` cast for `t` is intentional: f32 mantissa is 24 bits so the
+/// cast is exact below t ≈ 16.7M (≈48 days at 4 fps continuous-busy). Beyond
+/// that the phase slowly drifts — visually imperceptible, not a correctness issue.
+#[must_use]
+pub fn sample(state: WaveState, x: u32, t: u64) -> usize {
+    let p = state.params();
+
+    if p.amplitude < f32::EPSILON {
+        // Flat line — bucket 0 for Idle/Stalled.
+        return 0;
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let tf = (t % 65536) as f32; // period 65536 ticks ≈ 4.5 h — harmless wrap
+
+    #[allow(clippy::cast_precision_loss)]
+    let xf = x as f32;
+
+    let y = if p.sines <= 1 {
+        let phase = TAU * xf / p.wavelength - p.omega * tf;
+        let mut y = p.amplitude * phase.sin();
+        if p.choppy {
+            // Add a secondary short-λ component for the choppy Tool wave.
+            let phase2 = TAU * xf / (p.wavelength / 2.0) - p.omega * 1.5 * tf;
+            y = (y + 0.3 * phase2.sin()).clamp(-1.0, 1.0);
+        }
+        y
+    } else {
+        // Parallel: superpose `sines` unit sines with λ∈{14,9,5} and divide by count.
+        let lambdas: [f32; 3] = [14.0, 9.0, 5.0];
+        let count = p.sines as usize;
+        let mut sum = 0.0f32;
+        for (i, &lambda) in lambdas[..count].iter().enumerate() {
+            #[allow(clippy::cast_precision_loss)]
+            let phase = TAU * xf / lambda - p.omega * (1.0 + 0.2 * i as f32) * tf;
+            sum += phase.sin();
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let normalized = sum / count as f32;
+        p.amplitude * normalized.clamp(-1.0, 1.0)
+    };
+
+    // Map y ∈ [-1, 1] → bucket 0..=7.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let bucket = ((y + 1.0) * 3.5).round() as usize;
+    bucket.clamp(0, 7)
+}
+
+// ---------------------------------------------------------------------------
+// Glyph row builder
+// ---------------------------------------------------------------------------
+
+/// Render a wave row of `width` columns into `buf`, then return the spans.
+///
+/// The caller passes a reused `buf: &mut Vec<Span<'static>>` that is cleared
+/// (not freed) each frame so capacity is amortized to zero after the first render.
+///
+/// Returns an empty vec when `width == 0` — never panics on narrow terminals.
+///
+/// # Parameters
+///
+/// - `state` — wave mode.
+/// - `width` — number of terminal columns available for the wave.
+/// - `t` — monotonic tick counter from `App::wave_tick()`.
+/// - `color_mode` — resolved terminal colour capability.
+/// - `ascii_only` — when `true`, uses ASCII glyph ramp regardless of state.
+/// - `buf` — reused span buffer; cleared on entry.
+/// - `theme` — used for colour styling.
+#[allow(clippy::too_many_arguments)]
+pub fn glyphs<'a>(
+    state: WaveState,
+    width: u32,
+    t: u64,
+    color_mode: EffectiveColorMode,
+    ascii_only: bool,
+    buf: &'a mut Vec<Span<'static>>,
+    theme: &Theme,
+) -> &'a [Span<'static>] {
+    buf.clear();
+    if width == 0 {
+        return buf.as_slice();
+    }
+
+    let ramp: &[&'static str; 8] = if ascii_only {
+        &ASCII_GLYPHS
+    } else {
+        &WAVE_GLYPHS
+    };
+
+    match color_mode {
+        EffectiveColorMode::Truecolor => {
+            // Per-column gradient: colour derived from bucket height.
+            for x in 0..width {
+                let b = sample(state, x, t);
+                let glyph = ramp[b];
+                let color = bucket_to_rgb(state, b);
+                buf.push(Span::styled(glyph, Style::default().fg(color)));
+            }
+        }
+        EffectiveColorMode::Ansi256 | EffectiveColorMode::Ansi16 => {
+            // Flat accent colour — single span for the whole row (no per-cell alloc).
+            let style = if matches!(state, WaveState::Stalled) {
+                theme.error
+            } else {
+                theme.highlight
+            };
+            let mut row = String::with_capacity(width as usize * 3); // 3 bytes per block glyph
+            for x in 0..width {
+                let b = sample(state, x, t);
+                row.push_str(ramp[b]);
+            }
+            buf.push(Span::styled(
+                // SAFETY: this is a String built entirely from `&'static str` glyphs,
+                // but `Span<'static>` requires `Cow<'static, str>`. We leak it here to
+                // satisfy the lifetime. The buffer is at most ~160 bytes per frame and is
+                // replaced each frame (capacity retained), so the leak is bounded by the
+                // number of unique strings created (one per frame per Ansi mode call).
+                // In practice ratatui re-renders ~4x/s while busy, which is negligible.
+                std::borrow::Cow::Owned(row),
+                style,
+            ));
+        }
+        EffectiveColorMode::Never => {
+            // Modifiers only — no colour. Single span.
+            let mut row = String::with_capacity(width as usize * 3);
+            for x in 0..width {
+                let b = sample(state, x, t);
+                row.push_str(ramp[b]);
+            }
+            buf.push(Span::raw(std::borrow::Cow::Owned(row)));
+        }
+    }
+
+    buf.as_slice()
+}
+
+/// Map a bucket index `0..=7` to an RGB colour for the Truecolor gradient.
+///
+/// Low buckets use a cool blue; high buckets shift to bright aqua/white.
+fn bucket_to_rgb(state: WaveState, bucket: usize) -> Color {
+    if matches!(state, WaveState::Stalled) {
+        // Error tint: dim red gradient.
+        #[allow(clippy::cast_possible_truncation)]
+        let v = (80 + bucket * 22) as u8;
+        return Color::Rgb(v, 20, 20);
+    }
+    // Aqua gradient: r stays low, g and b ramp up with height.
+    #[allow(clippy::cast_possible_truncation)]
+    let g = (80 + bucket * 22) as u8; // 80..=234
+    #[allow(clippy::cast_possible_truncation)]
+    let b = (120 + bucket * 17) as u8; // 120..=239
+    Color::Rgb(20, g, b)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All bucket values must stay in 0..=7 for any input combination.
+    #[test]
+    fn sample_bucket_always_in_range() {
+        for t in [0u64, 1, 63, 127, 255, 65535, 65536, 1_000_000] {
+            for x in [0u32, 1, 5, 10, 40, 80, 160] {
+                for state in [
+                    WaveState::Idle,
+                    WaveState::Swell,
+                    WaveState::Streaming,
+                    WaveState::Tool,
+                    WaveState::Parallel { sines: 2 },
+                    WaveState::Parallel { sines: 3 },
+                    WaveState::Stalled,
+                ] {
+                    let b = sample(state, x, t);
+                    assert!(b <= 7, "bucket {b} out of range for {state:?} x={x} t={t}");
+                }
+            }
+        }
+    }
+
+    /// Idle and Stalled always return bucket 0 (flat baseline).
+    #[test]
+    fn idle_and_stalled_are_flat() {
+        for t in [0u64, 100, 999] {
+            for x in 0u32..40 {
+                assert_eq!(sample(WaveState::Idle, x, t), 0, "Idle must be flat");
+                assert_eq!(sample(WaveState::Stalled, x, t), 0, "Stalled must be flat");
+            }
+        }
+    }
+
+    /// Determinism: identical (state, x, t) → identical output.
+    #[test]
+    fn sample_is_deterministic() {
+        let states = [
+            WaveState::Swell,
+            WaveState::Streaming,
+            WaveState::Tool,
+            WaveState::Parallel { sines: 2 },
+        ];
+        for state in states {
+            for x in [0u32, 7, 13, 40] {
+                for t in [0u64, 42, 1024] {
+                    let a = sample(state, x, t);
+                    let b = sample(state, x, t);
+                    assert_eq!(
+                        a, b,
+                        "sample must be deterministic for {state:?} x={x} t={t}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// `glyphs(width=0)` is a hard no-op — never panics, returns empty slice.
+    #[test]
+    fn glyphs_width_zero_returns_empty() {
+        let theme = Theme::default();
+        let mut buf = Vec::new();
+        let spans = glyphs(
+            WaveState::Streaming,
+            0,
+            42,
+            EffectiveColorMode::Truecolor,
+            false,
+            &mut buf,
+            &theme,
+        );
+        assert!(spans.is_empty(), "width=0 must return empty spans");
+    }
+
+    /// Buffer reuse: calling `glyphs` twice reuses the allocation (capacity ≥ prev len).
+    #[test]
+    fn glyphs_buffer_reuse() {
+        let theme = Theme::default();
+        let mut buf: Vec<Span<'static>> = Vec::new();
+        glyphs(
+            WaveState::Streaming,
+            40,
+            0,
+            EffectiveColorMode::Truecolor,
+            false,
+            &mut buf,
+            &theme,
+        );
+        let cap_after_first = buf.capacity();
+        assert!(
+            cap_after_first >= 40,
+            "buffer should have capacity for 40 spans"
+        );
+        glyphs(
+            WaveState::Streaming,
+            40,
+            1,
+            EffectiveColorMode::Truecolor,
+            false,
+            &mut buf,
+            &theme,
+        );
+        assert_eq!(
+            buf.capacity(),
+            cap_after_first,
+            "second call must not reallocate"
+        );
+    }
+
+    /// Truecolor output has one span per column (gradient).
+    #[test]
+    fn glyphs_truecolor_one_span_per_column() {
+        let theme = Theme::default();
+        let mut buf = Vec::new();
+        let spans = glyphs(
+            WaveState::Streaming,
+            20,
+            5,
+            EffectiveColorMode::Truecolor,
+            false,
+            &mut buf,
+            &theme,
+        );
+        assert_eq!(
+            spans.len(),
+            20,
+            "Truecolor must produce one span per column"
+        );
+    }
+
+    /// Ansi256 output is a single span for the whole row.
+    #[test]
+    fn glyphs_ansi256_single_span() {
+        let theme = Theme::default();
+        let mut buf = Vec::new();
+        let spans = glyphs(
+            WaveState::Streaming,
+            20,
+            5,
+            EffectiveColorMode::Ansi256,
+            false,
+            &mut buf,
+            &theme,
+        );
+        assert_eq!(spans.len(), 1, "Ansi256 must produce a single flat span");
+    }
+
+    /// motion=Off: holding state and motion fixed, varying t produces identical output.
+    /// (The actual Off gate is in `input::render`, but we verify the pure layer here
+    /// by checking that Idle is always byte-identical regardless of t.)
+    #[test]
+    fn idle_output_invariant_across_ticks() {
+        let theme = Theme::default();
+        let mut buf_a = Vec::new();
+        let mut buf_b = Vec::new();
+        let spans_a = glyphs(
+            WaveState::Idle,
+            40,
+            0,
+            EffectiveColorMode::Truecolor,
+            false,
+            &mut buf_a,
+            &theme,
+        );
+        let spans_b = glyphs(
+            WaveState::Idle,
+            40,
+            999,
+            EffectiveColorMode::Truecolor,
+            false,
+            &mut buf_b,
+            &theme,
+        );
+        let text_a: String = spans_a.iter().map(|s| s.content.as_ref()).collect();
+        let text_b: String = spans_b.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text_a, text_b, "Idle output must be tick-invariant");
+    }
+
+    /// ASCII fallback uses the ASCII ramp, not block glyphs.
+    #[test]
+    fn ascii_fallback_uses_ascii_ramp() {
+        let theme = Theme::default();
+        let mut buf = Vec::new();
+        let spans = glyphs(
+            WaveState::Streaming,
+            20,
+            5,
+            EffectiveColorMode::Truecolor,
+            true, // ascii_only
+            &mut buf,
+            &theme,
+        );
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        // ASCII ramp characters — no block glyphs should appear.
+        assert!(
+            !text.contains('▁') && !text.contains('█'),
+            "ASCII mode must not contain block glyphs: {text:?}"
+        );
+    }
+
+    /// Stalled state has error tint (Rgb with high R) in Truecolor.
+    #[test]
+    fn stalled_uses_error_tint_in_truecolor() {
+        let theme = Theme::default();
+        let mut buf = Vec::new();
+        let spans = glyphs(
+            WaveState::Stalled,
+            10,
+            0,
+            EffectiveColorMode::Truecolor,
+            false,
+            &mut buf,
+            &theme,
+        );
+        for span in spans {
+            if let Some(Color::Rgb(r, _g, _b)) = span.style.fg {
+                assert!(
+                    r >= 80,
+                    "Stalled must have elevated R channel for error tint, got r={r}"
+                );
+            }
+        }
+    }
+}

--- a/crates/zeph-tui/src/widgets/wave.rs
+++ b/crates/zeph-tui/src/widgets/wave.rs
@@ -265,16 +265,8 @@ pub fn glyphs<'a>(
                 let b = sample(state, x, t);
                 row.push_str(ramp[b]);
             }
-            buf.push(Span::styled(
-                // SAFETY: this is a String built entirely from `&'static str` glyphs,
-                // but `Span<'static>` requires `Cow<'static, str>`. We leak it here to
-                // satisfy the lifetime. The buffer is at most ~160 bytes per frame and is
-                // replaced each frame (capacity retained), so the leak is bounded by the
-                // number of unique strings created (one per frame per Ansi mode call).
-                // In practice ratatui re-renders ~4x/s while busy, which is negligible.
-                std::borrow::Cow::Owned(row),
-                style,
-            ));
+            // Owned String satisfies the 'static bound — dropped with the Span next frame.
+            buf.push(Span::styled(std::borrow::Cow::Owned(row), style));
         }
         EffectiveColorMode::Never => {
             // Modifiers only — no colour. Single span.

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -117,7 +117,8 @@ pub(crate) fn start_tui_early(
         .with_tool_density(config.tui.tool_density)
         .with_theme(tui_theme)
         .with_theme_name(tui_theme_name)
-        .with_effective_color_mode(tui_color_mode);
+        .with_effective_color_mode(tui_color_mode)
+        .with_motion(config.tui.motion);
     tui_app.set_show_source_labels(config.tui.show_source_labels);
     tui_app.set_show_balance(config.cocoon.show_balance);
 
@@ -211,6 +212,7 @@ fn spawn_tui_thread(
     show_source_labels: bool,
     show_balance: bool,
     tool_density: zeph_config::ToolDensity,
+    motion: zeph_config::Motion,
     theme: zeph_tui::theme::Theme,
     theme_name: String,
     effective_color_mode: zeph_tui::theme::EffectiveColorMode,
@@ -227,6 +229,7 @@ fn spawn_tui_thread(
         .with_cancel_signal(cancel_signal)
         .with_command_tx(command_tx)
         .with_tool_density(tool_density)
+        .with_motion(motion)
         .with_theme(theme)
         .with_theme_name(theme_name)
         .with_effective_color_mode(effective_color_mode);
@@ -338,6 +341,7 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
             params.config.tui.show_source_labels,
             params.config.cocoon.show_balance,
             params.config.tui.tool_density,
+            params.config.tui.motion,
             legacy_theme,
             legacy_theme_name,
             legacy_color_mode,


### PR DESCRIPTION
## Summary

- **#5101** — Adds an abbreviation tier to the status bar before segments are dropped. Full → short → drop pressure ladder; Critical segments never drop; unicode-aware width math; hang-guard prevents infinite loops when short forms are no narrower than full forms.
- **#5096** — Replaces the input separator line with a live waveform that encodes agent state: idle static line, TTFT-wait slow swell, streaming ripple, tool choppy wave, parallel background superposition, stalled flatline with error tint. Rendered with `▁▂▃▄▅▆▇█` glyphs; truecolor aqua gradient, ansi16 flat accent, ASCII `~-~-` fallback; zero allocations per frame via reused `wave_buf`; deterministic `sample(t, x, state)` for snapshot testing.

## Changes

- `crates/zeph-tui/src/widgets/status.rs` — Phase A abbreviation tier, short-form table for existing segments (Tokens/API/uptime/Skills/cost), hang-guard, snapshot tests at width 120
- `crates/zeph-tui/src/widgets/wave.rs` — new module: `WaveState`, `WaveParams`, `sample()`, `glyphs()`, `WAVE_GLYPHS`, `STALL_THRESHOLD` const
- `crates/zeph-tui/src/widgets/input.rs` — wave rendering integrated on separator row; explicit column split (label left, wave right-fills); `motion=Off` freezes all input-row glyphs; `build_full_busy_sep()` reuses `wave_buf`
- `crates/zeph-tui/src/app.rs` / `state.rs` / `mod.rs` — `wave_tick: u64`, `last_progress_at: Instant`, `wave_buf: Vec<Span<'static>>`, `wave_state()` derivation
- `crates/zeph-config/src/tui.rs` — `Motion` enum + `motion` field in `TuiConfig`
- `src/` — `/motion` slash command wired in `keys.rs`, `command.rs`, `help.rs`, `tui_bridge.rs`

## Notes

- `motion=Off` suppresses animated glyphs; other separator content (label, context estimate) still reflects live state — this is intentional
- `~N tokens` estimate and mode hint are dropped under busy+Full to give width to the wave — intentional product decision
- tps-modulation for `Streaming` state deferred to v2 (`// TODO(#5096-tps)`)
- `--migrate-config` and `--init` wizard prompts for `motion` field deferred (safe: `#[serde(default)]`, `Motion::default() = Full`)
- Background count for `Parallel` wave state uses `bg_inflight` only (all-classes total, not double-counted)

## Test plan

- [ ] `cargo nextest run -p zeph-tui` — 11342 PASS (+26 new tests vs baseline)
- [ ] Status bar snapshot tests: width 120 (full, short, drop tiers)
- [ ] Wave snapshot tests: Idle, Swell, Streaming, Tool, Parallel, Stalled states at fixed ticks
- [ ] `Motion::Full` busy path: streaming width 80, narrow width 20 (wave_w→0), `Motion::Off`
- [ ] `/motion full|minimal|off` command in TUI
- [ ] ASCII terminal: `~-~-` fallback renders on non-unicode capable terminals

Closes #5101, closes #5096