### PR TITLE
feat(tracing): instrument hot-path async fns in learning, agent-context, and skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `feat(tracing)`: add `#[tracing::instrument]` to 13 hot-path async fns across
+  `zeph-core` learning pipeline (`write_skill_file`, `arise_trace_task`,
+  `arise_check_domain_gate`, `arise_store_version`, `stem_detection_task`,
+  `stem_generate_skill`, `erl_reflection_task`), `zeph-agent-context` deferred
+  summarization (`maybe_summarize_tool_pair`, `flush_deferred_summaries`), and
+  `zeph-skills` trace extraction (`process_candidate`, `apply_decision`,
+  `call_extract_llm`, `embed_candidate`) using `core.learning.*`,
+  `agent_context.summarization.*`, and `skills.trace_extraction.*` span prefixes
+  (closes #5176, #5196, #5171).
+
 - `feat(tracing)`: instrument 17 hot-path async fns in `zeph-core` agent module
   (`tool_execution/mod.rs`, `autodream.rs`, `hooks_dispatch.rs`,
   `context/summarization/{scheduling,compaction,deferred}.rs`) with

--- a/crates/zeph-agent-context/src/summarization/deferred.rs
+++ b/crates/zeph-agent-context/src/summarization/deferred.rs
@@ -125,6 +125,10 @@ pub fn count_deferred_summaries(messages: &[Message]) -> usize {
 /// # Errors
 ///
 /// This function is infallible — LLM errors and timeouts are logged and the batch stops.
+#[tracing::instrument(
+    name = "agent_context.summarization.maybe_summarize_tool_pair",
+    skip_all
+)]
 pub(crate) async fn maybe_summarize_tool_pair(
     summ: &mut ContextSummarizationView<'_>,
     providers: &ProviderHandles,
@@ -279,6 +283,10 @@ pub(crate) fn apply_deferred_summaries(summ: &mut ContextSummarizationView<'_>) 
 ///
 /// Returns `ContextError::Memory` if the `SQLite` call fails. Both deferred queues are
 /// always cleared regardless of the outcome so the agent can continue.
+#[tracing::instrument(
+    name = "agent_context.summarization.flush_deferred_summaries",
+    skip_all
+)]
 pub(crate) async fn flush_deferred_summaries(
     summ: &mut ContextSummarizationView<'_>,
 ) -> Result<(), ContextError> {

--- a/crates/zeph-core/src/agent/learning/background.rs
+++ b/crates/zeph-core/src/agent/learning/background.rs
@@ -24,6 +24,7 @@ pub(super) fn defer_clear_status(
     ClearStatusOnDrop(tx)
 }
 
+#[tracing::instrument(name = "core.learning.write_skill_file", skip_all, level = "debug")]
 pub(super) async fn write_skill_file(
     skill_paths: &[PathBuf],
     skill_name: &str,
@@ -84,6 +85,7 @@ pub(super) struct AriseTaskArgs {
     pub status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
 }
 
+#[tracing::instrument(name = "core.learning.arise_trace_task", skip_all, level = "debug")]
 pub(super) async fn arise_trace_task(args: AriseTaskArgs) {
     let _clear_status = defer_clear_status(args.status_tx.clone());
     let prompt = zeph_skills::evolution::build_trace_improvement_prompt(
@@ -128,6 +130,11 @@ pub(super) async fn arise_trace_task(args: AriseTaskArgs) {
     arise_store_version(args, generated).await;
 }
 
+#[tracing::instrument(
+    name = "core.learning.arise_check_domain_gate",
+    skip_all,
+    level = "debug"
+)]
 async fn arise_check_domain_gate(args: &AriseTaskArgs, generated: &str) -> bool {
     if !args.domain_success_gate {
         return true;
@@ -163,6 +170,7 @@ async fn arise_check_domain_gate(args: &AriseTaskArgs, generated: &str) -> bool 
     }
 }
 
+#[tracing::instrument(name = "core.learning.arise_store_version", skip_all, level = "debug")]
 async fn arise_store_version(args: AriseTaskArgs, generated: String) {
     let active = match args
         .memory
@@ -266,6 +274,7 @@ pub(super) struct StemTaskArgs {
     pub status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
 }
 
+#[tracing::instrument(name = "core.learning.stem_detection_task", skip_all, level = "debug")]
 pub(super) async fn stem_detection_task(args: StemTaskArgs) {
     let _clear_status = defer_clear_status(args.status_tx.clone());
     if let Err(e) = args
@@ -318,6 +327,7 @@ pub(super) async fn stem_detection_task(args: StemTaskArgs) {
     }
 }
 
+#[tracing::instrument(name = "core.learning.stem_generate_skill", skip_all, level = "debug")]
 async fn stem_generate_skill(
     args: &StemTaskArgs,
     seq: &str,
@@ -391,6 +401,7 @@ pub(super) struct ErlTaskArgs {
     pub status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
 }
 
+#[tracing::instrument(name = "core.learning.erl_reflection_task", skip_all, level = "debug")]
 pub(super) async fn erl_reflection_task(args: ErlTaskArgs) {
     let _clear_status = defer_clear_status(args.status_tx.clone());
     let prompt = zeph_skills::erl::build_reflection_extract_prompt(

--- a/crates/zeph-skills/src/trace_extractor.rs
+++ b/crates/zeph-skills/src/trace_extractor.rs
@@ -237,6 +237,11 @@ impl TraceExtractor {
     }
 
     /// Process a single raw candidate string through the parse → scan → embed → decide pipeline.
+    #[tracing::instrument(
+        name = "skills.trace_extraction.process_candidate",
+        skip_all,
+        fields(session_id)
+    )]
     async fn process_candidate(
         &self,
         raw_candidate: &str,
@@ -290,6 +295,11 @@ impl TraceExtractor {
         .await;
     }
 
+    #[tracing::instrument(
+        name = "skills.trace_extraction.apply_decision",
+        skip_all,
+        fields(session_id)
+    )]
     async fn apply_decision(
         &self,
         skill: &GeneratedSkill,
@@ -381,23 +391,18 @@ impl TraceExtractor {
     /// # Errors
     ///
     /// Returns `SkillError::Other` on timeout or LLM failure.
+    #[tracing::instrument(name = "skills.trace_extraction.call_extract_llm", skip_all)]
     async fn call_extract_llm(&self, prompt_text: &str) -> Result<String, SkillError> {
-        async move {
-            let messages = vec![
-                Message::from_legacy(Role::System, EXTRACTION_SYSTEM_PROMPT),
-                Message::from_legacy(Role::User, prompt_text),
-            ];
-            tokio::time::timeout(self.llm_timeout, self.extract_provider.chat(&messages))
-                .await
-                .map_err(|_| {
-                    SkillError::Timeout(
-                        u64::try_from(self.llm_timeout.as_millis()).unwrap_or(u64::MAX),
-                    )
-                })?
-                .map_err(|e| SkillError::Other(format!("extraction LLM failed: {e}")))
-        }
-        .instrument(tracing::info_span!("skills.trace_extraction.llm_call"))
-        .await
+        let messages = vec![
+            Message::from_legacy(Role::System, EXTRACTION_SYSTEM_PROMPT),
+            Message::from_legacy(Role::User, prompt_text),
+        ];
+        tokio::time::timeout(self.llm_timeout, self.extract_provider.chat(&messages))
+            .await
+            .map_err(|_| {
+                SkillError::Timeout(u64::try_from(self.llm_timeout.as_millis()).unwrap_or(u64::MAX))
+            })?
+            .map_err(|e| SkillError::Other(format!("extraction LLM failed: {e}")))
     }
 
     /// Embed a candidate skill description for similarity check.
@@ -405,24 +410,18 @@ impl TraceExtractor {
     /// # Errors
     ///
     /// Returns `SkillError::Other` on timeout or provider failure.
+    #[tracing::instrument(name = "skills.trace_extraction.embed_candidate", skip(self, skill), fields(candidate = %skill.name))]
     async fn embed_candidate(&self, skill: &GeneratedSkill) -> Result<SkillEmbedding, SkillError> {
-        async move {
-            tokio::time::timeout(
-                self.llm_timeout,
-                self.embed_provider.embed(&skill.meta.description),
-            )
-            .await
-            .map_err(|_| {
-                SkillError::Timeout(u64::try_from(self.llm_timeout.as_millis()).unwrap_or(u64::MAX))
-            })?
-            .map(SkillEmbedding::from_raw)
-            .map_err(|e| SkillError::Other(format!("embed failed: {e}")))
-        }
-        .instrument(tracing::info_span!(
-            "skills.trace_extraction.embed",
-            candidate = %skill.name,
-        ))
+        tokio::time::timeout(
+            self.llm_timeout,
+            self.embed_provider.embed(&skill.meta.description),
+        )
         .await
+        .map_err(|_| {
+            SkillError::Timeout(u64::try_from(self.llm_timeout.as_millis()).unwrap_or(u64::MAX))
+        })?
+        .map(SkillEmbedding::from_raw)
+        .map_err(|e| SkillError::Other(format!("embed failed: {e}")))
     }
 
     /// Write a candidate skill to the quarantine directory. Logs on failure.


### PR DESCRIPTION
## Summary

- Add `#[tracing::instrument]` to 7 async fns in `zeph-core` self-learning pipeline (`core.learning.*` span prefix): `write_skill_file`, `arise_trace_task`, `arise_check_domain_gate`, `arise_store_version`, `stem_detection_task`, `stem_generate_skill`, `erl_reflection_task`
- Add `#[tracing::instrument]` to 2 async fns in `zeph-agent-context` deferred summarization (`agent_context.summarization.*`): `maybe_summarize_tool_pair`, `flush_deferred_summaries`
- Add `#[tracing::instrument]` to 4 async fns in `zeph-skills` trace extraction (`skills.trace_extraction.*`): `process_candidate`, `apply_decision`, `call_extract_llm`, `embed_candidate` — the last two also have their manual `.instrument()` wrapper removed in favour of the attribute form

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11361 passed (matches baseline)
- [ ] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 10 passed
- [ ] rustdoc gate — no errors

Closes #5176, #5196, #5171