### PR TITLE
feat(tracing): add missing instrument spans in experiments, gateway, and index

### DIFF
--- a/crates/zeph-experiments/src/engine.rs
+++ b/crates/zeph-experiments/src/engine.rs
@@ -362,6 +362,7 @@ impl ExperimentEngine {
     /// # Errors
     ///
     /// Returns [`EvalError::Storage`] if the `SQLite` insert fails.
+    #[tracing::instrument(name = "experiments.engine.persist_result", skip_all)]
     #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
     async fn persist_result(
         &self,

--- a/crates/zeph-gateway/src/handlers.rs
+++ b/crates/zeph-gateway/src/handlers.rs
@@ -181,6 +181,7 @@ pub(crate) async fn health_handler(State(state): State<AppState>) -> impl IntoRe
 /// | 200 | Registry encoded successfully; `Content-Type: application/openmetrics-text; version=1.0.0; charset=utf-8` |
 /// | 500 | Registry encoding failed (logged as error) |
 #[cfg(feature = "prometheus")]
+#[tracing::instrument(name = "gateway.metrics", skip_all)]
 pub(crate) async fn metrics_handler(
     axum::extract::State(registry): axum::extract::State<
         std::sync::Arc<prometheus_client::registry::Registry>,

--- a/crates/zeph-gateway/src/server.rs
+++ b/crates/zeph-gateway/src/server.rs
@@ -300,6 +300,7 @@ impl GatewayServer {
     ///   permission denied, etc.).
     /// - [`GatewayError::Server`] — the server encountered a fatal I/O error
     ///   after binding.
+    #[tracing::instrument(name = "gateway.serve", skip_all)]
     pub async fn serve(self) -> Result<(), GatewayError> {
         let state = AppState {
             webhook_tx: self.webhook_tx,

--- a/crates/zeph-index/src/mcp_server.rs
+++ b/crates/zeph-index/src/mcp_server.rs
@@ -398,6 +398,7 @@ fn run_module_summary(index: &SymbolIndex, params: &ModuleSummaryParams) -> serd
 // ── ToolExecutor impl ──────────────────────────────────────────────────────────
 
 impl ToolExecutor for IndexMcpServer {
+    #[tracing::instrument(name = "index.mcp_server.execute", skip_all)]
     async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
         Ok(None)
     }
@@ -411,6 +412,7 @@ impl ToolExecutor for IndexMcpServer {
         ]
     }
 
+    #[tracing::instrument(name = "index.mcp_server.execute_tool_call", skip_all)]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         let result = if call.tool_id == "find_text_references" {
             // `run_find_text_references` calls `std::fs::read_to_string` in a loop.


### PR DESCRIPTION
## Summary

- `ExperimentEngine::persist_result` (`experiments.engine.persist_result`) — SQLite insert on every accepted/rejected variation was invisible to tracing; closes #5215
- `GatewayServer::serve` (`gateway.serve`) and `metrics_handler` (`gateway.metrics`) — gateway lifecycle and metrics scrape path were rootless in traces; closes #5216
- `IndexMcpServer::execute` and `execute_tool_call` (`index.mcp_server.execute`, `index.mcp_server.execute_tool_call`) — MCP tool dispatch through the in-process code navigation server was invisible; closes #5246

All attributes follow the `#[tracing::instrument(name = "<subsystem>.<module>.<fn>", skip_all)]` convention already used in each crate.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11366 passed, 23 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (no new errors)