### PR TITLE
fix(ci): add full bundle check and fix compile errors under --features full

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,9 +402,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bundle: [desktop, ide, server, chat, ml, bench]
+        bundle: [desktop, ide, server, chat, ml, bench, full]
         include:
           - bundle: ml
+            allow_failure: true
+          - bundle: full
             allow_failure: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -519,7 +519,9 @@ pub fn spawn_cocoon_health_checks(
         supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
             name: "core.provider_factory.cocoon_health_check",
             restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || async move {
+            factory: move || {
+                let client = client.clone();
+                async move {
                 match client.health_check().await {
                     Ok(h) => {
                         tracing::info!(
@@ -535,6 +537,7 @@ pub fn spawn_cocoon_health_checks(
                              inference requests will return LlmError::Unavailable until the sidecar is running"
                         );
                     }
+                }
                 }
             },
         });

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -16,6 +16,7 @@ use crate::tui_bridge::forward_status_to_stderr;
 use crate::tui_bridge::{
     TuiRunParams, forward_index_progress_to_tui, run_tui_agent, start_tui_early,
 };
+use tracing::Instrument as _;
 
 use crate::bootstrap::find_repo_root;
 use crate::bootstrap::load_config_or_default;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -16,6 +16,7 @@ use crate::tui_bridge::forward_status_to_stderr;
 use crate::tui_bridge::{
     TuiRunParams, forward_index_progress_to_tui, run_tui_agent, start_tui_early,
 };
+#[cfg(feature = "cocoon")]
 use tracing::Instrument as _;
 
 use crate::bootstrap::find_repo_root;


### PR DESCRIPTION
## Summary

- `provider_factory.rs`: cocoon health-check factory closure was `FnOnce` because it moved `Arc<CocoonClient>` into an `async move` block. Fixed by cloning the `Arc` inside the outer closure so each invocation gets its own handle — satisfying `TaskSupervisor::spawn`'s `Fn` bound.
- `runner.rs`: `tracing::Instrument` trait was not in scope for the `.instrument(span)` call on the cocoon poll path. Added missing `use tracing::Instrument as _` import.
- `ci.yml`: added `full` to the `bundle-check` matrix (`allow_failure: true`) so future feature-combination compile errors are caught before release builds.

## Root cause

The standard CI feature set (`desktop,ide,server,chat,pdf,scheduler`) does not include `cocoon` or `candle`, so the broken code was never compiled in CI. The `full` bundle compiles all feature flags and would have caught both errors immediately.

## Test plan

- [x] `cargo build -p zeph --release --features full` passes locally
- [x] `cargo +nightly fmt --check` passes
- [ ] CI bundle-check/full passes in this PR