### PR TITLE
feat(tracing): instrument hot-path async fns in zeph-memory qdrant/embed-registry/graph-retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `feat(tracing)`: add `#[tracing::instrument]` to 21 async fns in `zeph-memory`
+  (`qdrant_ops.rs`, `embedding_registry.rs`, `graph/retrieval.rs`) using
+  `memory.qdrant.*`, `memory.embed_registry.*`, `memory.graph.retrieval.*` span
+  prefixes; `BoxFuture` trait methods instrumented via `.instrument(debug_span!(...))`;
+  private helpers use `level = "debug"` (closes #5226, #5228, #5229).
 - `feat(tracing)`: add `#[tracing::instrument]` to 13 hot-path async fns across
   `zeph-core` learning pipeline (`write_skill_file`, `arise_trace_task`,
   `arise_check_domain_gate`, `arise_store_version`, `stem_detection_task`,

--- a/crates/zeph-memory/src/embedding_registry.rs
+++ b/crates/zeph-memory/src/embedding_registry.rs
@@ -168,6 +168,7 @@ impl EmbeddingRegistry {
     /// # Errors
     ///
     /// Returns [`EmbeddingRegistryError`] on Qdrant or embedding failures.
+    #[tracing::instrument(name = "memory.embed_registry.sync", skip_all, err)]
     pub async fn sync<T: Embeddable>(
         &mut self,
         items: &[T],
@@ -286,6 +287,7 @@ impl EmbeddingRegistry {
     /// Returns [`EmbeddingRegistryError::DimensionProbe`] when the query vector dimension does not
     /// match the stored collection dimension.  Returns [`EmbeddingRegistryError::Embedding`] if the
     /// embed function fails, or [`EmbeddingRegistryError::VectorStore`] on Qdrant search failure.
+    #[tracing::instrument(name = "memory.embed_registry.search_raw", skip_all, err)]
     pub async fn search_raw(
         &self,
         query: &str,
@@ -383,6 +385,12 @@ impl EmbeddingRegistry {
         uuid::Uuid::new_v5(&self.namespace, key.as_bytes()).to_string()
     }
 
+    #[tracing::instrument(
+        name = "memory.embed_registry.ensure_collection",
+        skip_all,
+        err,
+        level = "debug"
+    )]
     async fn ensure_collection(
         &self,
         embed_fn: &impl Fn(&str) -> EmbedFuture,
@@ -468,10 +476,21 @@ impl EmbeddingRegistry {
     }
 
     /// Store `dim` in the dimension cache so `search_raw` can validate without a Qdrant round-trip.
+    #[tracing::instrument(
+        name = "memory.embed_registry.set_cached_dim",
+        skip_all,
+        level = "debug"
+    )]
     async fn set_cached_dim(&self, dim: u64) {
         *self.cached_dim.write().await = Some(dim);
     }
 
+    #[tracing::instrument(
+        name = "memory.embed_registry.probe_vector_size",
+        skip_all,
+        err,
+        level = "debug"
+    )]
     async fn probe_vector_size(
         &self,
         embed_fn: &impl Fn(&str) -> EmbedFuture,
@@ -483,6 +502,12 @@ impl EmbeddingRegistry {
         Ok(probe.len() as u64)
     }
 
+    #[tracing::instrument(
+        name = "memory.embed_registry.recreate_collection",
+        skip_all,
+        err,
+        level = "debug"
+    )]
     async fn recreate_collection(
         &self,
         embed_fn: &impl Fn(&str) -> EmbedFuture,
@@ -542,8 +567,6 @@ fn build_work_set<'a, T: Embeddable>(
 
 /// Await each pre-created embed future and collect the resulting Qdrant points.
 ///
-/// Await each pre-created embed future and collect the resulting Qdrant points.
-///
 /// `work_items` is `(key, hash, embed_future, point_id, item_payload)` — point IDs and payloads
 /// must be pre-computed to avoid a double-borrow on the `EmbeddingRegistry` when `hashes` is
 /// mutably borrowed.
@@ -552,6 +575,12 @@ fn build_work_set<'a, T: Embeddable>(
 /// after each successful embed.  Updates `stats.added`/`stats.updated` and `hashes` in place.
 ///
 /// Returns a `Vec<PointStruct>` ready for upsert, or an error if payload serialization fails.
+#[tracing::instrument(
+    name = "memory.embed_registry.embed_and_collect_points",
+    skip_all,
+    err,
+    level = "debug"
+)]
 #[allow(clippy::too_many_arguments)]
 async fn embed_and_collect_points(
     work_items: Vec<(String, String, EmbedFuture, String, serde_json::Value)>,

--- a/crates/zeph-memory/src/graph/retrieval.rs
+++ b/crates/zeph-memory/src/graph/retrieval.rs
@@ -35,6 +35,7 @@ use super::types::{EdgeType, GraphFact};
 /// # Errors
 ///
 /// Returns an error if any database query fails.
+#[tracing::instrument(name = "memory.graph.retrieval.graph_recall", skip_all, err)]
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)] // complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
 pub async fn graph_recall(
     store: &GraphStore,
@@ -205,6 +206,11 @@ pub async fn graph_recall(
 ///
 /// Returns `false` when `embed()` fails (caller should return empty seeds).
 /// On search failure: logs warning and leaves map empty (caller continues normally).
+#[tracing::instrument(
+    name = "memory.graph.retrieval.seed_embedding_fallback",
+    skip_all,
+    level = "debug"
+)]
 async fn seed_embedding_fallback(
     store: &GraphStore,
     emb_store: &EmbeddingStore,
@@ -250,6 +256,12 @@ async fn seed_embedding_fallback(
     true
 }
 
+#[tracing::instrument(
+    name = "memory.graph.retrieval.find_seed_entities",
+    skip_all,
+    err,
+    level = "debug"
+)]
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) async fn find_seed_entities(
     store: &GraphStore,
@@ -400,6 +412,7 @@ pub(crate) async fn find_seed_entities(
 /// # Errors
 ///
 /// Returns an error if any database query fails.
+#[tracing::instrument(name = "memory.graph.retrieval.graph_recall_activated", skip_all, err)]
 #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
 pub async fn graph_recall_activated(
     store: &GraphStore,

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -68,6 +68,7 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error if Qdrant cannot be reached or collection creation fails.
+    #[tracing::instrument(name = "memory.qdrant.ensure_collection", skip_all, err)]
     pub async fn ensure_collection(&self, collection: &str, vector_size: u64) -> QdrantResult<()> {
         if self
             .client
@@ -110,6 +111,12 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error only on hard Qdrant communication failures.
+    #[tracing::instrument(
+        name = "memory.qdrant.get_collection_vector_size",
+        skip_all,
+        err,
+        level = "debug"
+    )]
     pub(crate) async fn get_collection_vector_size(
         &self,
         collection: &str,
@@ -138,6 +145,7 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error if Qdrant cannot be reached.
+    #[tracing::instrument(name = "memory.qdrant.collection_exists", skip_all, err)]
     pub async fn collection_exists(&self, collection: &str) -> QdrantResult<bool> {
         self.client
             .collection_exists(collection)
@@ -150,6 +158,7 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error if the collection cannot be deleted.
+    #[tracing::instrument(name = "memory.qdrant.delete_collection", skip_all, err)]
     pub async fn delete_collection(&self, collection: &str) -> QdrantResult<()> {
         self.client
             .delete_collection(collection)
@@ -163,6 +172,7 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error if the upsert fails.
+    #[tracing::instrument(name = "memory.qdrant.upsert", skip_all, err)]
     pub async fn upsert(&self, collection: &str, points: Vec<PointStruct>) -> QdrantResult<()> {
         self.client
             .upsert_points(UpsertPointsBuilder::new(collection, points).wait(true))
@@ -179,6 +189,7 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error if the search fails.
+    #[tracing::instrument(name = "memory.qdrant.search", skip_all, err)]
     pub async fn search(
         &self,
         collection: &str,
@@ -202,6 +213,7 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error if the deletion fails.
+    #[tracing::instrument(name = "memory.qdrant.delete_by_ids", skip_all, err)]
     pub async fn delete_by_ids(&self, collection: &str, ids: Vec<PointId>) -> QdrantResult<()> {
         if ids.is_empty() {
             return Ok(());
@@ -224,6 +236,7 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error if the scroll operation fails.
+    #[tracing::instrument(name = "memory.qdrant.scroll_all", skip_all, err)]
     pub async fn scroll_all(
         &self,
         collection: &str,
@@ -278,6 +291,7 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error if the scroll operation fails.
+    #[tracing::instrument(name = "memory.qdrant.scroll_all_with_point_ids", skip_all, err)]
     pub async fn scroll_all_with_point_ids(
         &self,
         collection: &str,
@@ -336,6 +350,11 @@ impl QdrantOps {
     /// # Errors
     ///
     /// Returns an error if any Qdrant operation fails.
+    #[tracing::instrument(
+        name = "memory.qdrant.ensure_collection_with_quantization",
+        skip_all,
+        err
+    )]
     pub async fn ensure_collection_with_quantization(
         &self,
         collection: &str,
@@ -528,13 +547,19 @@ impl crate::vector_store::VectorStore for QdrantOps {
     }
 
     fn health_check(&self) -> BoxFuture<'_, Result<bool, crate::VectorStoreError>> {
-        Box::pin(async move {
-            self.client
-                .health_check()
-                .await
-                .map(|_| true)
-                .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))
-        })
+        use tracing::Instrument as _;
+        Box::pin(
+            async move {
+                match self.client.health_check().await {
+                    Ok(_) => Ok(true),
+                    Err(e) => {
+                        tracing::warn!(err = %e, "health_check failed");
+                        Err(crate::VectorStoreError::Collection(e.to_string()))
+                    }
+                }
+            }
+            .instrument(tracing::debug_span!("memory.qdrant.health_check")),
+        )
     }
 
     fn create_keyword_indexes(
@@ -543,21 +568,25 @@ impl crate::vector_store::VectorStore for QdrantOps {
         fields: &[&str],
     ) -> BoxFuture<'_, Result<(), crate::VectorStoreError>> {
         use qdrant_client::qdrant::{CreateFieldIndexCollectionBuilder, FieldType};
+        use tracing::Instrument as _;
         let collection = collection.to_owned();
         let fields: Vec<String> = fields.iter().map(|f| (*f).to_owned()).collect();
-        Box::pin(async move {
-            for field in &fields {
-                self.client
-                    .create_field_index(CreateFieldIndexCollectionBuilder::new(
-                        &collection,
-                        field.as_str(),
-                        FieldType::Keyword,
-                    ))
-                    .await
-                    .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?;
+        Box::pin(
+            async move {
+                for field in &fields {
+                    self.client
+                        .create_field_index(CreateFieldIndexCollectionBuilder::new(
+                            &collection,
+                            field.as_str(),
+                            FieldType::Keyword,
+                        ))
+                        .await
+                        .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?;
+                }
+                Ok(())
             }
-            Ok(())
-        })
+            .instrument(tracing::debug_span!("memory.qdrant.create_keyword_indexes")),
+        )
     }
 
     fn get_points(
@@ -565,48 +594,55 @@ impl crate::vector_store::VectorStore for QdrantOps {
         collection: &str,
         ids: Vec<String>,
     ) -> BoxFuture<'_, Result<Vec<crate::VectorPoint>, crate::VectorStoreError>> {
+        use tracing::Instrument as _;
         let collection = collection.to_owned();
-        Box::pin(async move {
-            if ids.is_empty() {
-                return Ok(Vec::new());
-            }
-            let point_ids: Vec<PointId> = ids.into_iter().map(PointId::from).collect();
-            let response = self
-                .client
-                .get_points(
-                    GetPointsBuilder::new(&collection, point_ids)
-                        .with_vectors(true)
-                        .with_payload(true),
-                )
-                .await
-                .map_err(|e| crate::VectorStoreError::Search(e.to_string()))?;
+        Box::pin(
+            async move {
+                if ids.is_empty() {
+                    return Ok(Vec::new());
+                }
+                let point_ids: Vec<PointId> = ids.into_iter().map(PointId::from).collect();
+                let response = self
+                    .client
+                    .get_points(
+                        GetPointsBuilder::new(&collection, point_ids)
+                            .with_vectors(true)
+                            .with_payload(true),
+                    )
+                    .await
+                    .map_err(|e| {
+                        tracing::error!(err = %e, "get_points failed");
+                        crate::VectorStoreError::Search(e.to_string())
+                    })?;
 
-            let mut result = Vec::with_capacity(response.result.len());
-            for point in response.result {
-                let Some(id_str) = point_id_to_string(point.id) else {
-                    continue;
-                };
-                // Use VectorsOutput::get_vector() to extract the default dense vector.
-                let vector = match point.vectors.and_then(|v| v.get_vector()) {
-                    Some(VectorVariant::Dense(dv)) => dv.data,
-                    _ => continue,
-                };
-                let payload: HashMap<String, serde_json::Value> = point
-                    .payload
-                    .into_iter()
-                    .filter_map(|(k, v)| {
-                        let json = qdrant_value_to_json(v.kind?)?;
-                        Some((k, json))
-                    })
-                    .collect();
-                result.push(crate::VectorPoint {
-                    id: id_str,
-                    vector,
-                    payload,
-                });
+                let mut result = Vec::with_capacity(response.result.len());
+                for point in response.result {
+                    let Some(id_str) = point_id_to_string(point.id) else {
+                        continue;
+                    };
+                    // Use VectorsOutput::get_vector() to extract the default dense vector.
+                    let vector = match point.vectors.and_then(|v| v.get_vector()) {
+                        Some(VectorVariant::Dense(dv)) => dv.data,
+                        _ => continue,
+                    };
+                    let payload: HashMap<String, serde_json::Value> = point
+                        .payload
+                        .into_iter()
+                        .filter_map(|(k, v)| {
+                            let json = qdrant_value_to_json(v.kind?)?;
+                            Some((k, json))
+                        })
+                        .collect();
+                    result.push(crate::VectorPoint {
+                        id: id_str,
+                        vector,
+                        payload,
+                    });
+                }
+                Ok(result)
             }
-            Ok(result)
-        })
+            .instrument(tracing::debug_span!("memory.qdrant.get_points")),
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Instruments 21 async fns across three previously-invisible `zeph-memory` modules, closing the final gap in memory crate tracing coverage.

- `qdrant_ops.rs`: 10 inherent async fns + 3 `BoxFuture` trait methods via `.instrument(debug_span!(...))`
- `embedding_registry.rs`: 7 async fns including `embed_and_collect_points` (hot loop of the sync path)
- `graph/retrieval.rs`: 4 async fns (`graph_recall`, `graph_recall_activated`, `find_seed_entities`, `seed_embedding_fallback`)

Naming: `memory.qdrant.*`, `memory.embed_registry.*`, `memory.graph.retrieval.*`. Private helpers use `level = "debug"`. No `profiling` feature gate — spans are always active.

Closes #5226, #5228, #5229.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11316 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (2 pre-existing private-item warnings, not broken links)
- [x] `cargo nextest run -p zeph-memory` — 1509 passed, 27 skipped, 0 failed