### PR TITLE
feat(tui): dashboard restyle and tracing instrumentation (#5093, #5233)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,6 +247,7 @@ profiling = [
     "zeph-skills/profiling",
     "zeph-mcp/profiling",
     "zeph-channels/profiling",
+    "zeph-tui?/profiling",
 ]
 profiling-alloc = ["profiling", "zeph-core/profiling-alloc"]
 profiling-pyroscope = ["profiling", "otel", "dep:pprof"]

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -65,6 +65,7 @@ tokio-util.workspace = true
 default = ["clipboard", "sqlite"]
 clipboard = ["dep:arboard"]
 cocoon = []
+profiling = []
 # `zeph-memory`/`zeph-db` require a backend to compile; default to `sqlite` so this crate
 # builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
 sqlite = ["zeph-memory/sqlite"]

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -147,35 +147,65 @@ impl App {
         layout: &AppLayout,
         effective: [bool; 4],
     ) {
+        use ratatui::layout::{Constraint, Direction, Layout};
+
+        let focused_panel = self.active_panel;
+
         if effective[0] {
-            self.render_collapsed_summary(frame, layout.skills, "Skills");
+            self.render_collapsed_summary(
+                frame,
+                layout.skills,
+                "skills",
+                focused_panel == super::Panel::Skills,
+            );
+        } else if focused_panel == super::Panel::Skills {
+            self.render_section_header(frame, layout.skills, "skills");
+            let inner = shrink_top(layout.skills, 1);
+            widgets::skills::render(&self.metrics, frame, inner, &self.theme);
         } else {
             widgets::skills::render(&self.metrics, frame, layout.skills, &self.theme);
         }
 
         if effective[1] {
-            self.render_collapsed_summary(frame, layout.memory, "Memory");
+            self.render_collapsed_summary(
+                frame,
+                layout.memory,
+                "memory",
+                focused_panel == super::Panel::Memory,
+            );
+        } else if focused_panel == super::Panel::Memory {
+            self.render_section_header(frame, layout.memory, "memory");
+            let inner = shrink_top(layout.memory, 1);
+            widgets::memory::render(&self.metrics, frame, inner, &self.theme);
         } else {
             widgets::memory::render(&self.metrics, frame, layout.memory, &self.theme);
         }
 
         if effective[2] {
-            self.render_collapsed_summary(frame, layout.resources, "Resources");
+            self.render_collapsed_summary(
+                frame,
+                layout.resources,
+                "resources",
+                focused_panel == super::Panel::Resources,
+            );
         } else {
-            // Split the resources area into: context gauge (3 rows), compaction badge (3 rows),
-            // and the remaining resources panel. Each gauge/badge needs at least its border rows.
-            use ratatui::layout::{Constraint, Direction, Layout};
-            let context_split = Layout::default()
+            let resources_area = if focused_panel == super::Panel::Resources {
+                self.render_section_header(frame, layout.resources, "resources");
+                shrink_top(layout.resources, 1)
+            } else {
+                layout.resources
+            };
+            let splits = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
                     Constraint::Length(3),
                     Constraint::Length(3),
                     Constraint::Min(0),
                 ])
-                .split(layout.resources);
-            widgets::context_gauge::render(&self.metrics, frame, context_split[0]);
-            widgets::compaction_badge::render(&self.metrics, frame, context_split[1]);
-            widgets::resources::render(&self.metrics, frame, context_split[2], &self.theme);
+                .split(resources_area);
+            widgets::context_gauge::render(&self.metrics, frame, splits[0]);
+            widgets::compaction_badge::render(&self.metrics, frame, splits[1]);
+            widgets::resources::render(&self.metrics, frame, splits[2], &self.theme);
         }
 
         let tick = self.throbber_state.index().cast_unsigned();
@@ -187,79 +217,132 @@ impl App {
         let panel_focused = self.active_panel == Panel::SubAgents;
 
         if effective[3] {
-            self.render_collapsed_summary(frame, layout.subagents, "Agents");
+            self.render_collapsed_summary(
+                frame,
+                layout.subagents,
+                "agents",
+                focused_panel == Panel::SubAgents,
+            );
         } else {
-            // When SubAgents panel is focused (`a` key), always show the interactive sidebar.
-            // Otherwise: auto-show plan when graph active, security events, or subagents list.
-            if panel_focused {
-                widgets::subagents::render_interactive(
-                    &self.metrics,
-                    &mut self.subagent_sidebar,
-                    frame,
-                    layout.subagents,
+            self.render_subagents_slot(
+                frame,
+                layout.subagents,
+                tick,
+                ascii,
+                panel_focused,
+                has_graph,
+            );
+        }
+    }
+
+    fn render_subagents_slot(
+        &mut self,
+        frame: &mut ratatui::Frame,
+        area: ratatui::layout::Rect,
+        tick: u8,
+        ascii: bool,
+        panel_focused: bool,
+        has_graph: bool,
+    ) {
+        use ratatui::text::{Line, Span};
+        use ratatui::widgets::Paragraph;
+
+        // When SubAgents panel is focused (`a` key), always show the interactive sidebar.
+        // Otherwise: auto-show plan when graph active, security events, or subagents list.
+        if panel_focused {
+            widgets::subagents::render_interactive(
+                &self.metrics,
+                &mut self.subagent_sidebar,
+                frame,
+                area,
+                tick,
+                &self.theme,
+                ascii,
+            );
+        } else if has_graph && !self.sessions.current().plan_view_active {
+            widgets::plan_view::render(&self.metrics, frame, area, tick, ascii, &self.theme);
+        } else if self.has_recent_security_events() {
+            widgets::security::render(&self.metrics, frame, area, &self.theme);
+        } else {
+            widgets::subagents::render(&self.metrics, frame, area, &self.theme);
+        }
+
+        // Overlay fleet panel over the subagents slot when `f` key is active (#3884).
+        if self.active_panel == Panel::Fleet {
+            widgets::fleet::render(
+                &self.fleet_snapshot,
+                frame,
+                area,
+                &mut self.fleet_list_state,
+                &self.theme,
+            );
+        }
+
+        // Overlay durable panel over the subagents slot when `D` key is active (spec-064, #4949).
+        if self.active_panel == Panel::Durable {
+            widgets::durable::render(
+                &self.durable_snapshot,
+                frame,
+                area,
+                &mut self.durable_list_state,
+                &self.theme,
+            );
+        }
+
+        // Overlay task registry over the subagents slot when `/tasks` is toggled.
+        if self.show_task_panel {
+            if self.task_supervisor.is_some() {
+                widgets::task_registry::render(
+                    &self.cached_task_snapshots,
                     tick,
+                    area,
+                    frame,
                     &self.theme,
                     ascii,
                 );
-            } else if has_graph && !self.sessions.current().plan_view_active {
-                widgets::plan_view::render(&self.metrics, frame, layout.subagents, tick, ascii);
-            } else if self.has_recent_security_events() {
-                widgets::security::render(&self.metrics, frame, layout.subagents, &self.theme);
             } else {
-                widgets::subagents::render(&self.metrics, frame, layout.subagents, &self.theme);
-            }
-
-            // Overlay fleet panel over the subagents slot when `f` key is active (#3884).
-            if self.active_panel == Panel::Fleet {
-                widgets::fleet::render(
-                    &self.fleet_snapshot,
-                    frame,
-                    layout.subagents,
-                    &mut self.fleet_list_state,
-                    &self.theme,
-                );
-            }
-
-            // Overlay durable panel over the subagents slot when `D` key is active (spec-064, #4949).
-            if self.active_panel == Panel::Durable {
-                widgets::durable::render(
-                    &self.durable_snapshot,
-                    frame,
-                    layout.subagents,
-                    &mut self.durable_list_state,
-                    &self.theme,
-                );
-            }
-
-            // Overlay task registry over the subagents slot when `/tasks` is toggled.
-            if self.show_task_panel {
-                if self.task_supervisor.is_some() {
-                    widgets::task_registry::render(
-                        &self.cached_task_snapshots,
-                        tick,
-                        layout.subagents,
-                        frame,
-                        &self.theme,
-                        ascii,
-                    );
-                } else {
-                    use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
-                    let theme = &self.theme;
-                    let block = Block::default()
-                        .borders(Borders::ALL)
-                        .border_style(theme.panel_border)
-                        .title(" Tasks ");
-                    let paragraph = Paragraph::new(" Task supervisor not available.")
-                        .block(block)
-                        .wrap(Wrap { trim: true });
-                    frame.render_widget(paragraph, layout.subagents);
-                }
+                let theme = &self.theme;
+                let header = Line::from(vec![
+                    Span::styled("⬡ ", theme.highlight),
+                    Span::styled("tasks  supervisor not available", theme.system_message),
+                ]);
+                frame.render_widget(Paragraph::new(header), area);
             }
         }
     }
 
     /// Render a single-row collapsed summary bar for the given panel label.
+    ///
+    /// When `focused` is true the brand glyph prefix and accent color replace the muted style.
     fn render_collapsed_summary(
+        &self,
+        frame: &mut ratatui::Frame,
+        area: ratatui::layout::Rect,
+        label: &str,
+        focused: bool,
+    ) {
+        use ratatui::text::{Line, Span};
+        use ratatui::widgets::Paragraph;
+
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+        let line = if focused {
+            Line::from(vec![
+                Span::styled("⬡ ", self.theme.highlight),
+                Span::styled(label, self.theme.highlight),
+            ])
+        } else {
+            Line::from(vec![
+                Span::styled("▸ ", self.theme.panel_border),
+                Span::styled(label, self.theme.panel_title),
+            ])
+        };
+        frame.render_widget(Paragraph::new(line), area);
+    }
+
+    /// Render a single-row focused section header (brand glyph + accent color).
+    fn render_section_header(
         &self,
         frame: &mut ratatui::Frame,
         area: ratatui::layout::Rect,
@@ -272,9 +355,27 @@ impl App {
             return;
         }
         let line = Line::from(vec![
-            Span::styled("▸ ", self.theme.panel_border),
-            Span::styled(label, self.theme.panel_title),
+            Span::styled("⬡ ", self.theme.highlight),
+            Span::styled(label, self.theme.highlight),
         ]);
         frame.render_widget(Paragraph::new(line), area);
+    }
+}
+
+/// Return `area` with the top `n` rows removed.
+fn shrink_top(area: ratatui::layout::Rect, n: u16) -> ratatui::layout::Rect {
+    if n >= area.height {
+        return ratatui::layout::Rect {
+            x: area.x,
+            y: area.y + area.height,
+            width: area.width,
+            height: 0,
+        };
+    }
+    ratatui::layout::Rect {
+        x: area.x,
+        y: area.y + n,
+        width: area.width,
+        height: area.height - n,
     }
 }

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -121,6 +121,10 @@ impl TuiChannel {
 }
 
 impl Channel for TuiChannel {
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.recv", skip_all)
+    )]
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
         match self.user_input_rx.recv().await {
             Some(text) => {
@@ -148,6 +152,10 @@ impl Channel for TuiChannel {
         })
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.send", skip_all)
+    )]
     async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
         // Full message is the final rendered response for a turn; losing it leaves the chat
         // panel blank. Use a bounded timeout rather than try_send.
@@ -167,6 +175,10 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.send_chunk", skip_all)
+    )]
     async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
         self.accumulated.push_str(chunk);
         // Non-critical: dropping a chunk loses partial streaming output but agent continues.
@@ -176,18 +188,30 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.flush_chunks", skip_all)
+    )]
     async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
         // Non-critical: visual signal that streaming ended.
         let _ = self.agent_event_tx.try_send(AgentEvent::Flush);
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.send_typing", skip_all)
+    )]
     async fn send_typing(&mut self) -> Result<(), ChannelError> {
         // Non-critical: throbber hint only.
         let _ = self.agent_event_tx.try_send(AgentEvent::Typing);
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.send_status", skip_all)
+    )]
     async fn send_status(&mut self, text: &str) -> Result<(), ChannelError> {
         // Non-critical: informational status text.
         let _ = self
@@ -196,12 +220,20 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.send_queue_count", skip_all)
+    )]
     async fn send_queue_count(&mut self, count: usize) -> Result<(), ChannelError> {
         // Non-critical: display-only counter.
         let _ = self.agent_event_tx.try_send(AgentEvent::QueueCount(count));
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.send_context_estimate", skip_all)
+    )]
     async fn send_context_estimate(&mut self, tokens: usize) -> Result<(), ChannelError> {
         // Non-critical: informational estimate shown in the input block title.
         let _ = self
@@ -210,6 +242,10 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.send_diff", skip_all)
+    )]
     async fn send_diff(
         &mut self,
         diff: zeph_core::DiffData,
@@ -236,6 +272,10 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.send_tool_start", skip_all)
+    )]
     async fn send_tool_start(&mut self, event: ToolStartEvent) -> Result<(), ChannelError> {
         let command = event
             .params
@@ -257,6 +297,10 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.send_tool_output", skip_all)
+    )]
     async fn send_tool_output(&mut self, event: ToolOutputEvent) -> Result<(), ChannelError> {
         tracing::debug!(
             tool_name = %event.tool_name.as_str(),
@@ -293,6 +337,10 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.confirm", skip_all)
+    )]
     async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.agent_event_tx
@@ -305,6 +353,10 @@ impl Channel for TuiChannel {
         rx.await.map_err(|_| ChannelError::ConfirmCancelled)
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.elicit", skip_all)
+    )]
     async fn elicit(
         &mut self,
         request: ElicitationRequest,
@@ -320,6 +372,10 @@ impl Channel for TuiChannel {
         rx.await.map_err(|_| ChannelError::ChannelClosed)
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.notify_foreground_subagent_started", skip_all)
+    )]
     async fn notify_foreground_subagent_started(
         &mut self,
         id: &str,
@@ -335,6 +391,10 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.notify_foreground_subagent_completed", skip_all)
+    )]
     async fn notify_foreground_subagent_completed(
         &mut self,
         id: &str,

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -100,6 +100,10 @@ pub use types::{ChatMessage, InputMode, MessageRole, PasteState};
 ///     run_tui(app, event_rx).await
 /// }
 /// ```
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(name = "tui.lib.run_tui", skip_all)
+)]
 pub async fn run_tui(mut app: App, mut event_rx: mpsc::Receiver<AppEvent>) -> Result<(), TuiError> {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -142,6 +146,10 @@ enum DirtyState {
     Full,
 }
 
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(name = "tui.lib.tui_loop", skip_all)
+)]
 async fn tui_loop(
     app: &mut App,
     event_rx: &mut mpsc::Receiver<AppEvent>,

--- a/crates/zeph-tui/src/widgets/durable.rs
+++ b/crates/zeph-tui/src/widgets/durable.rs
@@ -10,10 +10,10 @@
 //! missing) the panel shows the [`STATUS_UNAVAILABLE`] message.
 
 use ratatui::Frame;
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
 
 use crate::theme::Theme;
 
@@ -72,31 +72,29 @@ pub fn render(
     list_state: &mut ListState,
     theme: &Theme,
 ) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(theme.panel_border)
-        .title(Span::styled(
-            " Durable [D] ",
-            Style::default().add_modifier(Modifier::BOLD),
-        ));
+    let exec_count = snapshot.executions.len();
+    let header_text = format!("durable · {exec_count}  [D]");
+    let header = Line::from(Span::styled(
+        header_text,
+        theme.system_message.add_modifier(Modifier::BOLD),
+    ));
+    let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
+    frame.render_widget(Paragraph::new(header), splits[0]);
 
-    let placeholder = if !snapshot.available {
-        Some((STATUS_UNAVAILABLE, Color::Yellow))
-    } else if snapshot.executions.is_empty() {
-        Some(("No durable executions recorded.", Color::DarkGray))
-    } else {
-        None
-    };
-
-    if let Some((text, color)) = placeholder {
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
-        let msg = ratatui::widgets::Paragraph::new(text).style(Style::default().fg(color));
-        frame.render_widget(msg, inner);
+    if !snapshot.available {
+        let msg = Paragraph::new(STATUS_UNAVAILABLE).style(Style::default().fg(Color::Yellow));
+        frame.render_widget(msg, splits[1]);
         return;
     }
 
-    let header = ListItem::new(Line::from(vec![Span::styled(
+    if snapshot.executions.is_empty() {
+        let msg = Paragraph::new("No durable executions recorded.")
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(msg, splits[1]);
+        return;
+    }
+
+    let col_header = ListItem::new(Line::from(vec![Span::styled(
         format!(
             " {:<10}  {:<16}{:<10}{:>6}  {:>6}",
             "ID", "KIND", "STATUS", "STEPS", "AGE"
@@ -104,7 +102,7 @@ pub fn render(
         Style::default().add_modifier(Modifier::BOLD),
     )]));
 
-    let mut items: Vec<ListItem> = vec![header];
+    let mut items: Vec<ListItem> = vec![col_header];
     for (i, row) in snapshot.executions.iter().enumerate() {
         let selected = list_state.selected() == Some(i + 1);
         let base = if selected {
@@ -123,10 +121,8 @@ pub fn render(
         items.push(ListItem::new(line));
     }
 
-    let list = List::new(items)
-        .block(block)
-        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
-    frame.render_stateful_widget(list, area, list_state);
+    let list = List::new(items).highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_stateful_widget(list, splits[1], list_state);
 }
 
 #[cfg(test)]

--- a/crates/zeph-tui/src/widgets/fleet.rs
+++ b/crates/zeph-tui/src/widgets/fleet.rs
@@ -4,10 +4,10 @@
 //! TUI fleet panel: shows a live table of all agent sessions (#3884).
 
 use ratatui::Frame;
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
 use zeph_common::format_tokens;
 use zeph_memory::store::agent_sessions::{AgentSessionRow, SessionStatus};
 
@@ -78,24 +78,30 @@ pub fn render(
     list_state: &mut ListState,
     theme: &Theme,
 ) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(theme.panel_border)
-        .title(Span::styled(
-            " Fleet [f] ",
-            Style::default().add_modifier(Modifier::BOLD),
-        ));
+    let header_text = format!(
+        "fleet · {} session{}  [f]",
+        snapshot.sessions.len(),
+        if snapshot.sessions.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+    );
+    let header = Line::from(Span::styled(
+        header_text,
+        theme.system_message.add_modifier(Modifier::BOLD),
+    ));
+    let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
+    frame.render_widget(Paragraph::new(header), splits[0]);
 
     if snapshot.sessions.is_empty() {
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
-        let msg = ratatui::widgets::Paragraph::new("No agent sessions recorded.")
+        let msg = Paragraph::new("No agent sessions recorded.")
             .style(Style::default().fg(Color::DarkGray));
-        frame.render_widget(msg, inner);
+        frame.render_widget(msg, splits[1]);
         return;
     }
 
-    let header = ListItem::new(Line::from(vec![Span::styled(
+    let col_header = ListItem::new(Line::from(vec![Span::styled(
         format!(
             " {:<8}  {:<12}{:<11}{:<5}{:<22}{:>5}  {:<15}{}",
             "ID", "KIND", "STATUS", "CH", "MODEL", "TURNS", "P/C TOKENS", "COST"
@@ -103,16 +109,14 @@ pub fn render(
         Style::default().add_modifier(Modifier::BOLD),
     )]));
 
-    let mut items: Vec<ListItem> = vec![header];
+    let mut items: Vec<ListItem> = vec![col_header];
     for (i, row) in snapshot.sessions.iter().enumerate() {
         let selected = list_state.selected() == Some(i + 1);
         items.push(build_session_item(row, selected));
     }
 
-    let list = List::new(items)
-        .block(block)
-        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
-    frame.render_stateful_widget(list, area, list_state);
+    let list = List::new(items).highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_stateful_widget(list, splits[1], list_state);
 }
 
 #[cfg(test)]

--- a/crates/zeph-tui/src/widgets/plan_view.rs
+++ b/crates/zeph-tui/src/widgets/plan_view.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Rect};
-use ratatui::style::{Color, Style};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+use ratatui::widgets::{Cell, Paragraph, Row, Table};
 
 use crate::metrics::MetricsSnapshot;
 use crate::widgets::spinner::breeze_frame;
@@ -22,12 +22,16 @@ fn status_color(status: &str) -> Color {
     }
 }
 
-fn render_placeholder(frame: &mut Frame, area: Rect) {
-    let block = Block::default().borders(Borders::ALL).title("Plan");
+fn render_placeholder(frame: &mut Frame, area: Rect, theme: &crate::theme::Theme) {
+    let header = Line::from(Span::styled(
+        "plan · idle",
+        theme.system_message.add_modifier(Modifier::BOLD),
+    ));
+    let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
+    frame.render_widget(Paragraph::new(header), splits[0]);
     let para = Paragraph::new("No active plan. Use /plan <goal> to create one.")
-        .block(block)
         .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(para, area);
+    frame.render_widget(para, splits[1]);
 }
 
 fn build_task_row(task: &crate::metrics::TaskSnapshotRow, tick: u8, ascii: bool) -> Row<'static> {
@@ -105,47 +109,55 @@ fn build_task_row(task: &crate::metrics::TaskSnapshotRow, tick: u8, ascii: bool)
 /// * `area` — terminal rect to render into.
 /// * `tick` — current animation tick.
 /// * `ascii` — when `true`, uses ASCII-only spinner frames for terminals without Unicode support.
-pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, tick: u8, ascii: bool) {
+pub fn render(
+    metrics: &MetricsSnapshot,
+    frame: &mut Frame,
+    area: Rect,
+    tick: u8,
+    ascii: bool,
+    theme: &crate::theme::Theme,
+) {
     let Some(ref snapshot) = metrics.orchestration_graph else {
-        render_placeholder(frame, area);
+        render_placeholder(frame, area, theme);
         return;
     };
 
     // Stale snapshots (completed/failed/canceled >30s ago) show as empty.
     if snapshot.is_stale() {
-        render_placeholder(frame, area);
+        render_placeholder(frame, area, theme);
         return;
     }
 
     let any_running = snapshot.tasks.iter().any(|t| t.status == "running");
 
-    let title = match snapshot.status.as_str() {
-        "created" => format!(
-            " Plan [pending confirmation]: {} ",
-            truncate_goal(&snapshot.goal, 30)
-        ),
-        "running" => format!(
-            " Plan {} [running…]: {} ",
-            breeze_frame(u64::from(tick), ascii),
-            truncate_goal(&snapshot.goal, 30)
-        ),
-        "completed" => format!(" Plan [completed]: {} ", truncate_goal(&snapshot.goal, 30)),
-        "failed" => format!(" Plan [failed]: {} ", truncate_goal(&snapshot.goal, 30)),
-        "paused" => format!(" Plan [paused]: {} ", truncate_goal(&snapshot.goal, 30)),
-        "canceled" => format!(" Plan [canceled]: {} ", truncate_goal(&snapshot.goal, 30)),
-        _ => format!(" Plan: {} ", truncate_goal(&snapshot.goal, 30)),
+    let status_tag = match snapshot.status.as_str() {
+        "created" => "pending",
+        "running" => {
+            if any_running {
+                breeze_frame(u64::from(tick), ascii)
+            } else {
+                "running"
+            }
+        }
+        "completed" => "completed",
+        "failed" => "failed",
+        "paused" => "paused",
+        "canceled" => "canceled",
+        _ => "active",
     };
-
-    // Show a spinner in the title when tasks are actively running.
-    let title_span = if any_running {
-        Span::styled(title, Style::default().fg(Color::Yellow))
+    let goal_short = truncate_goal(&snapshot.goal, 30);
+    let header_text = format!("plan · {status_tag} · {goal_short}");
+    let header_style = if any_running {
+        theme
+            .system_message
+            .add_modifier(Modifier::BOLD)
+            .fg(Color::Yellow)
     } else {
-        Span::raw(title)
+        theme.system_message.add_modifier(Modifier::BOLD)
     };
-
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .title(Line::from(title_span));
+    let header = Line::from(Span::styled(header_text, header_style));
+    let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
+    frame.render_widget(Paragraph::new(header), splits[0]);
 
     let widths = [
         Constraint::Length(4),  // spinner or status icon (3 cells + 1 padding)
@@ -156,7 +168,7 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, tick: u8
         Constraint::Length(8),  // duration
     ];
 
-    let header = Row::new([
+    let col_header = Row::new([
         Cell::from(""),
         Cell::from("#").style(Style::default().fg(Color::DarkGray)),
         Cell::from("Title").style(Style::default().fg(Color::DarkGray)),
@@ -172,11 +184,10 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, tick: u8
         .collect();
 
     let table = Table::new(rows, widths)
-        .header(header)
-        .block(block)
+        .header(col_header)
         .column_spacing(1);
 
-    frame.render_widget(table, area);
+    frame.render_widget(table, splits[1]);
 }
 
 fn truncate_goal(goal: &str, max: usize) -> String {
@@ -222,7 +233,14 @@ mod tests {
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                render(metrics, frame, area, 0, false);
+                render(
+                    metrics,
+                    frame,
+                    area,
+                    0,
+                    false,
+                    &crate::theme::Theme::default(),
+                );
             })
             .unwrap();
         let buffer = terminal.backend().buffer().clone();

--- a/crates/zeph-tui/src/widgets/security.rs
+++ b/crates/zeph-tui/src/widgets/security.rs
@@ -2,23 +2,28 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use ratatui::Frame;
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{List, ListItem, Paragraph};
 
 use crate::metrics::{MetricsSnapshot, SecurityEventCategory};
 use crate::theme::Theme;
 
 pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let block = Block::default()
-        .title(" Security ")
-        .borders(Borders::ALL)
-        .style(theme.panel_border);
+    let event_count = metrics.security_events.len();
+    let header_text = format!(
+        "security · {event_count} event{}",
+        if event_count == 1 { "" } else { "s" }
+    );
+    let header = Line::from(Span::styled(
+        header_text,
+        theme.system_message.add_modifier(Modifier::BOLD),
+    ));
+    let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
+    frame.render_widget(Paragraph::new(header), splits[0]);
 
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
+    let inner = splits[1];
     if inner.height == 0 {
         return;
     }

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__task_registry__tests__render_multiple_tasks_snapshot.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__task_registry__tests__render_multiple_tasks_snapshot.snap
@@ -1,13 +1,9 @@
 ---
 source: crates/zeph-tui/src/widgets/task_registry.rs
-assertion_line: 225
+assertion_line: 230
 expression: output
 ---
-┌ Tasks (3) ─────────────────────────────────────────────────────────┐
-│ ▸▸▹ config-watcher      Running       00:00:00  ↺0                 │
-│     memory-loop         Completed     00:00:00  ↺1                 │
-│     scheduler           Failed        00:00:00  ↺3                 │
-│                                                                    │
-│                                                                    │
-│                                                                    │
-└────────────────────────────────────────────────────────────────────┘
+tasks · 3                                                             
+ ▸▸▹ config-watcher      Running       00:00:00  ↺0                   
+     memory-loop         Completed     00:00:00  ↺1                   
+     scheduler           Failed        00:00:00  ↺3

--- a/crates/zeph-tui/src/widgets/subagents.rs
+++ b/crates/zeph-tui/src/widgets/subagents.rs
@@ -76,15 +76,22 @@ fn build_agent_list_item<'a>(
 
 /// Non-interactive render (used when `SubAgents` panel is not focused).
 pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &Theme) {
+    use ratatui::text::Span;
+
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+
     if metrics.sub_agents.is_empty() {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(theme.panel_border)
-            .title(" Sub-Agents ");
-        let paragraph = Paragraph::new(" No sub-agents. Use /agent spawn <name> to create one.")
-            .block(block)
-            .wrap(Wrap { trim: true });
-        frame.render_widget(paragraph, area);
+        let header = Line::from(Span::styled(
+            "agents · none",
+            theme.system_message.add_modifier(Modifier::BOLD),
+        ));
+        let body = Paragraph::new(vec![
+            header,
+            Line::from("  No sub-agents. Use /agent spawn <name> to create one."),
+        ]);
+        frame.render_widget(body, area);
         return;
     }
 
@@ -96,13 +103,19 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &
         .map(|sa| build_agent_list_item(sa, 0, false, false))
         .collect();
 
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(theme.panel_border)
-            .title(format!(" Sub-Agents ({}) ", metrics.sub_agents.len())),
-    );
-    frame.render_widget(list, area);
+    let header = Line::from(Span::styled(
+        format!("agents · {}", metrics.sub_agents.len()),
+        theme.system_message.add_modifier(Modifier::BOLD),
+    ));
+
+    // Render header, then the list below it.
+    if area.height <= 1 {
+        frame.render_widget(Paragraph::new(vec![header]), area);
+        return;
+    }
+    let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
+    frame.render_widget(Paragraph::new(vec![header]), splits[0]);
+    frame.render_widget(List::new(items), splits[1]);
 }
 
 /// Interactive render: shows selection highlight and spinner animation.
@@ -116,15 +129,25 @@ pub fn render_interactive(
     theme: &Theme,
     ascii: bool,
 ) {
+    use ratatui::text::Span;
+
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+
     if metrics.sub_agents.is_empty() {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(theme.highlight)
-            .title(" Sub-Agents [focused] ");
-        let paragraph = Paragraph::new(" No sub-agents. Use /agent spawn <name> to create one.")
-            .block(block)
-            .wrap(Wrap { trim: true });
-        frame.render_widget(paragraph, area);
+        let header = Line::from(vec![
+            Span::styled("⬡ ", theme.highlight),
+            Span::styled(
+                "agents · none  [j/k=nav  Esc=close]",
+                theme.highlight.add_modifier(Modifier::BOLD),
+            ),
+        ]);
+        let body = Paragraph::new(vec![
+            header,
+            Line::from("  No sub-agents. Use /agent spawn <name> to create one."),
+        ]);
+        frame.render_widget(body, area);
         return;
     }
 
@@ -136,16 +159,24 @@ pub fn render_interactive(
         .map(|(i, sa)| build_agent_list_item(sa, tick, selected == Some(i), ascii))
         .collect();
 
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(theme.highlight)
-            .title(format!(
-                " Sub-Agents ({}) [j/k=nav  Enter=view  Esc=close] ",
+    let header = Line::from(vec![
+        Span::styled("⬡ ", theme.highlight),
+        Span::styled(
+            format!(
+                "agents · {}  [j/k=nav  Enter=view  Esc=close]",
                 metrics.sub_agents.len()
-            )),
-    );
-    frame.render_stateful_widget(list, area, &mut sidebar.list_state);
+            ),
+            theme.highlight.add_modifier(Modifier::BOLD),
+        ),
+    ]);
+
+    if area.height <= 1 {
+        frame.render_widget(Paragraph::new(vec![header]), area);
+        return;
+    }
+    let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
+    frame.render_widget(Paragraph::new(vec![header]), splits[0]);
+    frame.render_stateful_widget(List::new(items), splits[1], &mut sidebar.list_state);
 }
 
 // ── Definition manager ────────────────────────────────────────────────────────
@@ -1006,8 +1037,8 @@ mod tests {
             super::render(&metrics, frame, area, &theme);
         });
         assert!(
-            output.contains("Sub-Agents") && output.contains("No sub-agents"),
-            "expected placeholder text, got: {output:?}"
+            output.contains("agents") && output.contains("No sub-agents"),
+            "expected placeholder text with data-first header, got: {output:?}"
         );
     }
 
@@ -1044,7 +1075,10 @@ mod tests {
             let theme = crate::theme::Theme::default();
             super::render(&metrics, frame, area, &theme);
         });
-        assert!(output.contains("Sub-Agents"));
+        assert!(
+            output.contains("agents"),
+            "expected data-first header; got: {output:?}"
+        );
         assert!(output.contains("code-reviewer"));
         assert!(output.contains("test-writer"));
         assert!(output.contains("[dont_ask]"));

--- a/crates/zeph-tui/src/widgets/task_registry.rs
+++ b/crates/zeph-tui/src/widgets/task_registry.rs
@@ -19,10 +19,10 @@
 use std::time::Instant;
 
 use ratatui::Frame;
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{List, ListItem, Paragraph};
 use zeph_common::task_supervisor::{TaskSnapshot, TaskStatus};
 
 use crate::theme::Theme;
@@ -109,17 +109,18 @@ pub fn render(
     theme: &Theme,
     ascii: bool,
 ) {
-    let title = format!(" Tasks ({}) ", snapshots.len());
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(theme.panel_border)
-        .title(title);
+    let header_text = format!("tasks · {}", snapshots.len());
+    let header = Line::from(Span::styled(
+        header_text,
+        theme.system_message.add_modifier(Modifier::BOLD),
+    ));
+    let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
+    frame.render_widget(Paragraph::new(header), splits[0]);
 
     if snapshots.is_empty() {
-        let paragraph = Paragraph::new(" No supervised tasks registered yet.")
-            .block(block)
-            .wrap(Wrap { trim: true });
-        frame.render_widget(paragraph, area);
+        let paragraph =
+            Paragraph::new("No supervised tasks registered yet.").style(theme.system_message);
+        frame.render_widget(paragraph, splits[1]);
         return;
     }
 
@@ -127,8 +128,8 @@ pub fn render(
         .iter()
         .map(|s| build_list_item(s, tick, ascii))
         .collect();
-    let list = List::new(items).block(block);
-    frame.render_widget(list, area);
+    let list = List::new(items);
+    frame.render_widget(list, splits[1]);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Replace `Borders::ALL` with data-first section headers across all dashboard and overlay panels in `zeph-tui`
- Add `#[tracing::instrument]` annotations to `run_tui`, `tui_loop`, and all 15 async `TuiChannel` trait methods (gated behind `profiling` feature)

## Changes

**Dashboard restyle (#5093):**
- `widgets/subagents.rs`: "agents · N" section header, border removed
- `widgets/fleet.rs`: "fleet · N sessions  [f]" header
- `widgets/durable.rs`: "durable · N  [D]" header
- `widgets/security.rs`: "security · N events" header
- `widgets/plan_view.rs`: "plan · {status} · {goal}" header (yellow when running); `theme` param added
- `widgets/task_registry.rs`: "tasks · N" header; snapshot updated
- `app/draw.rs`: focused panels show `⬡` brand glyph + accent color; `render_subagents_slot` extracted; `else-if` chains flattened; `use` imports hoisted (pedantic); Resources `Layout::split` de-duplicated

**Tracing instrumentation (#5233):**
- `lib.rs`: `run_tui` and `tui_loop` instrumented (`tui.lib.*`)
- `channel.rs`: all 15 async `TuiChannel` trait methods instrumented (`tui.channel.*`)
- `zeph-tui/Cargo.toml`: `profiling = []` feature added
- workspace `Cargo.toml`: `zeph-tui?/profiling` wired into profiling bundle

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler,testing -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features desktop,ide,server,chat,pdf,scheduler --lib --bins` — 11386/11386 pass
- [x] Snapshot test updated for `task_registry` panel header change
- [x] `cargo check --features desktop,profiling` — clean (tracing annotations compile correctly)

Closes #5093
Closes #5233