### PR TITLE
feat(tui): micro-delights — stream metrics, toasts, completion flash, smooth scroll, splash shimmer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `feat(tui)`: micro-delights — five opt-in animation enhancements gated by
+  `[tui.delights]` config block and master-controlled by `tui.motion` (#5104):
+  - **Stream metrics**: tok/s rolling-window estimate (Low priority, status bar,
+    visible while streaming) and TTFT in milliseconds/seconds (shown after each turn).
+  - **Ephemeral toasts**: transient overlay notifications (cap 3, ~3s TTL, tick-
+    deterministic expiry); shown on tool-group completion when `completion_flash`
+    and `toasts` are both enabled.
+  - **Completion flash**: accent tint applied to all spans in a fully-resolved
+    tool-message group for ~400ms (4 ticks) after the last tool output arrives.
+  - **Smooth scroll**: ease-out-cubic interpolation (3 ticks, ~300ms) on
+    `PageUp`/`PageDown` and Insert-mode page scroll; single-line j/k scrolls
+    bypass animation; `motion = Off` falls back to instant offset change.
+  - **Splash shimmer**: one-shot bell-curve brightness sweep across the `zeph`
+    wordmark on each new splash show (~1.2s, 12 ticks); resets on rising edge of
+    `show_splash`; `shimmer_phase = None` is byte-identical to pre-feature baseline.
+  - All five features individually toggleable via `[tui.delights]` TOML fields
+    (all default `true`); `motion = Minimal` reduces to 1-tick flash / instant
+    scroll / single-frame shimmer; `motion = Off` suppresses all animation.
+  - Migration step 67 injects advisory `[tui.delights]` comment block into
+    existing configs that have a `[tui]` section (idempotent, 3-case unit-tested).
+  - Interactive wizard (`--init`) includes a `step_tui_delights` Confirm prompt.
+  - `FlashState` and `ScrollAnim` placed on `SessionSlot` (session-scoped) to
+    prevent cross-session bleed; `ToastQueue` and `SplashShimmer` on `App`.
+
 ### Changed
 
 - `feat(tracing)`: add `#[tracing::instrument]` to 21 async fns in `zeph-memory`

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -193,8 +193,8 @@ pub use telemetry::{TelemetryBackend, TelemetryConfig};
 pub use tools::{AuditDestination, SandboxBackend, ToolCompressionConfig};
 pub use ui::{
     AcpAuthMethod, AcpConfig, AcpLspConfig, AcpSubagentsConfig, AcpTimeoutsConfig, AcpTransport,
-    AdditionalDir, AdditionalDirError, ColorMode, FleetConfig, Motion, SubagentPresetConfig,
-    ThemeConfig, ToolDensity, TuiConfig,
+    AdditionalDir, AdditionalDirError, ColorMode, DelightsConfig, FleetConfig, Motion,
+    SubagentPresetConfig, ThemeConfig, ToolDensity, TuiConfig,
 };
 pub use ui::{DiagnosticSeverity, DiagnosticsConfig, HoverConfig, LspConfig};
 pub use vigil::VigilConfig;

--- a/crates/zeph-config/src/migrate/features.rs
+++ b/crates/zeph-config/src/migrate/features.rs
@@ -11,6 +11,87 @@ use regex::Regex;
 
 use super::{MigrateError, MigrationResult};
 
+/// Regex matching the `[tui]` section header line (used by step 67).
+static TUI_HEADER_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"(?m)^[ \t]*\[tui\][ \t]*(?:#[^\r\n]*)?\r?\n").expect("static pattern")
+});
+
+/// Inject a commented-out `[tui.delights]` advisory block when absent (#5104).
+///
+/// No-op when `[tui]` is absent (config doesn't use TUI at all) or when
+/// `[tui.delights]` already exists (active or commented) — idempotent.
+///
+/// # Errors
+///
+/// Returns `MigrateError::TomlParse` if the input is not valid TOML; infallible otherwise.
+pub fn migrate_tui_delights(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // No [tui] section → no-op.
+    if !toml_src.contains("[tui]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Idempotency: scan for [tui.delights] already present (active or commented-out).
+    let already_present = toml_src.lines().any(|l| {
+        let t = l.trim().trim_start_matches('#').trim();
+        t == "[tui.delights]" || t.starts_with("[tui.delights]")
+    });
+    if already_present {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Normalise trailing newline so the regex always matches.
+    let owned;
+    let src = if toml_src.ends_with('\n') {
+        toml_src
+    } else {
+        owned = format!("{toml_src}\n");
+        &owned
+    };
+
+    if !TUI_HEADER_RE.is_match(src) {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let advisory = "\n# [tui.delights] — micro-delight toggles (all default true, #5104).\n\
+         # motion = off acts as a master kill-switch regardless of individual settings.\n\
+         # [tui.delights]\n\
+         # stream_metrics   = true  # tok/s during streaming + TTFT after turn in status bar\n\
+         # toasts           = true  # ephemeral overlay notifications (theme switch, copy, etc.)\n\
+         # completion_flash = true  # accent tint on a finished tool group for ~400 ms\n\
+         # smooth_scroll    = true  # eased multi-frame interpolation on page-up / page-down\n\
+         # splash_shimmer   = true  # one-shot gradient sweep across the wordmark at startup\n";
+
+    let output = TUI_HEADER_RE
+        .replacen(src, 1, |caps: &regex::Captures| {
+            format!("{}{advisory}", &caps[0])
+        })
+        .into_owned();
+
+    let changed = output != toml_src;
+    let changed_count = usize::from(changed);
+    Ok(MigrationResult {
+        output,
+        changed_count,
+        sections_changed: if changed {
+            vec!["tui.delights".to_owned()]
+        } else {
+            Vec::new()
+        },
+    })
+}
+
 /// Strip any existing `[memory.compression.predictor]` section from the config (#3251).
 ///
 /// The compression predictor feature was removed. This migration cleans up both active

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -23,7 +23,8 @@ pub use features::{
     migrate_autodream_config, migrate_caveman_config, migrate_compression_predictor_config,
     migrate_deep_link_config, migrate_five_signal_config, migrate_goals_config,
     migrate_knowledge_config, migrate_magic_docs_config, migrate_microcompact_config,
-    migrate_orchestration_persistence, migrate_tui_theme_config, migrate_tui_theme_defaults,
+    migrate_orchestration_persistence, migrate_tui_delights, migrate_tui_theme_config,
+    migrate_tui_theme_defaults,
 };
 pub use infra::*;
 /// Advisory `GonkaGate` migration is crate-internal (registered via the [`MIGRATIONS`] registry).
@@ -613,11 +614,11 @@ use steps::{
     MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellCheckpointsConfig,
     MigrateShellTransactional, MigrateSttToProvider, MigrateSupervisorConfig,
     MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateTraceMetadata,
-    MigrateTuiThemeConfig, MigrateTuiThemeDefaults, MigrateVigilConfig, MigrateWorktreeConfig,
-    MigrateWorktreeGitTimeout,
+    MigrateTuiDelights, MigrateTuiThemeConfig, MigrateTuiThemeDefaults, MigrateVigilConfig,
+    MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–66).
+/// Ordered registry of all sequential migration steps (steps 1–67).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -732,6 +733,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateTuiThemeConfig),
             // Step 66 — insert active name/color_mode defaults into [tui.theme] (#5091)
             Box::new(MigrateTuiThemeDefaults),
+            // Step 67 — add [tui.delights] advisory block (#5104)
+            Box::new(MigrateTuiDelights),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -56,9 +56,9 @@ use super::{
     migrate_session_persist_provider_overrides, migrate_session_provider_persistence,
     migrate_session_recap_config, migrate_shell_checkpoints_config, migrate_shell_transactional,
     migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
-    migrate_tools_compression_config, migrate_trace_metadata, migrate_tui_theme_config,
-    migrate_tui_theme_defaults, migrate_vigil_config, migrate_worktree_config,
-    migrate_worktree_git_timeout,
+    migrate_tools_compression_config, migrate_trace_metadata, migrate_tui_delights,
+    migrate_tui_theme_config, migrate_tui_theme_defaults, migrate_vigil_config,
+    migrate_worktree_config, migrate_worktree_git_timeout,
 };
 
 // ── Wrapper structs for all 64 sequential migration steps ───────────────────────────────────────
@@ -786,5 +786,16 @@ impl Migration for MigrateTuiThemeDefaults {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_tui_theme_defaults(toml_src)
+    }
+}
+
+pub(super) struct MigrateTuiDelights;
+impl Migration for MigrateTuiDelights {
+    fn name(&self) -> &'static str {
+        "migrate_tui_delights"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_tui_delights(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        66,
-        "MIGRATIONS registry must contain all 66 sequential steps"
+        67,
+        "MIGRATIONS registry must contain all 67 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1645,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 66);
+    assert_eq!(MIGRATIONS.len(), 67);
 }
 
 #[test]
@@ -1752,6 +1752,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_policy_provider_and_utility_window",
         "migrate_tui_theme_config",
         "migrate_tui_theme_defaults",
+        "migrate_tui_delights",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -2891,5 +2892,50 @@ fn step_66_inserts_only_missing_key_when_one_present() {
         result.output.matches("name").count(),
         1,
         "name must appear exactly once"
+    );
+}
+
+// ── Step 67 — migrate_tui_delights (#5104) ────────────────────────────────
+
+#[test]
+fn step_67_injects_delights_block_when_tui_present_and_no_delights() {
+    let src = "[tui]\nmotion = \"full\"\n";
+    let result = migrate_tui_delights(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result.output.contains("[tui.delights]"),
+        "advisory block must be injected"
+    );
+    assert!(
+        result.output.contains("stream_metrics"),
+        "stream_metrics key must be in advisory"
+    );
+    assert_eq!(result.sections_changed, vec!["tui.delights"]);
+}
+
+#[test]
+fn step_67_noop_when_tui_delights_already_present() {
+    let src = "[tui]\nmotion = \"full\"\n\n[tui.delights]\nstream_metrics = false\n";
+    let result = migrate_tui_delights(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_67_noop_when_no_tui_section() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_tui_delights(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_67_idempotent_on_commented_delights() {
+    // Simulate a config where the advisory was already injected (commented-out header present).
+    let src = "[tui]\nmotion = \"full\"\n\n# [tui.delights]\n# stream_metrics = true\n";
+    let result = migrate_tui_delights(src).expect("migrate");
+    assert_eq!(
+        result.changed_count, 0,
+        "must not inject twice when commented-out delights already present"
     );
 }

--- a/crates/zeph-config/src/ui.rs
+++ b/crates/zeph-config/src/ui.rs
@@ -406,6 +406,53 @@ pub enum Motion {
     Off,
 }
 
+/// Micro-delight toggles for the TUI dashboard (#5104).
+///
+/// All features default to `true`. The `motion = off` setting in [`TuiConfig`]
+/// acts as a master kill-switch that overrides every individual toggle.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [tui.delights]
+/// stream_metrics   = true   # tok/s during streaming + TTFT in status bar
+/// toasts           = true   # ephemeral overlay notifications
+/// completion_flash = true   # accent tint on finished tool groups
+/// smooth_scroll    = true   # eased multi-frame scroll on page jumps
+/// splash_shimmer   = true   # one-shot gradient sweep across the wordmark
+/// ```
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DelightsConfig {
+    /// Show tok/s during streaming and TTFT after each turn in the status bar.
+    #[serde(default = "default_true")]
+    pub stream_metrics: bool,
+    /// Ephemeral toast notifications (theme switched, copied, task done).
+    #[serde(default = "default_true")]
+    pub toasts: bool,
+    /// One-frame accent tint when a tool group finishes.
+    #[serde(default = "default_true")]
+    pub completion_flash: bool,
+    /// Eased multi-frame interpolation on page scroll.
+    #[serde(default = "default_true")]
+    pub smooth_scroll: bool,
+    /// One-shot gradient shimmer across the splash wordmark at startup.
+    #[serde(default = "default_true")]
+    pub splash_shimmer: bool,
+}
+
+impl Default for DelightsConfig {
+    fn default() -> Self {
+        Self {
+            stream_metrics: true,
+            toasts: true,
+            completion_flash: true,
+            smooth_scroll: true,
+            splash_shimmer: true,
+        }
+    }
+}
+
 /// TUI (terminal user interface) configuration, nested under `[tui]` in TOML.
 ///
 /// # Example (TOML)
@@ -419,6 +466,13 @@ pub enum Motion {
 /// [tui.theme]
 /// name = "zephyr"
 /// color_mode = "auto"
+///
+/// [tui.delights]
+/// stream_metrics   = true
+/// toasts           = true
+/// completion_flash = true
+/// smooth_scroll    = true
+/// splash_shimmer   = true
 /// ```
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct TuiConfig {
@@ -443,6 +497,11 @@ pub struct TuiConfig {
     /// Theme and colour capability configuration.
     #[serde(default)]
     pub theme: ThemeConfig,
+    /// Micro-delight toggles (tok/s, toasts, flash, scroll, shimmer). All default `true`.
+    ///
+    /// `motion = off` overrides all toggles regardless of their individual values.
+    #[serde(default)]
+    pub delights: DelightsConfig,
 }
 
 /// Configuration for the TUI fleet panel (#3884).

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -16,9 +16,26 @@ impl App {
             collapsed,
         );
 
+        // Micro-delight state is advanced in tick_delights() (called on AppEvent::Tick).
+        // draw() only reads the current state for rendering.
+        let now = self.anim_tick();
+        let cur_show_splash = self.sessions.current().show_splash;
+        let shimmer_enabled =
+            self.motion != zeph_config::Motion::Off && self.delights.splash_shimmer;
+
         self.draw_header(frame, layout.header);
-        if self.sessions.current().show_splash {
-            widgets::splash::render(frame, layout.chat, self.effective_color_mode());
+        if cur_show_splash {
+            let shimmer_phase = if shimmer_enabled {
+                self.splash_shimmer.phase(now)
+            } else {
+                None
+            };
+            widgets::splash::render(
+                frame,
+                layout.chat,
+                self.effective_color_mode(),
+                shimmer_phase,
+            );
         } else {
             let mut cache = std::mem::take(&mut self.sessions.current_mut().render_cache);
             let max_scroll = widgets::chat::render(self, frame, layout.chat, &mut cache);
@@ -65,6 +82,11 @@ impl App {
         if let Some(state) = &self.reverse_search {
             let history = self.sessions.current().input_history.clone();
             widgets::reverse_search::render(state, &history, frame, layout.input, &self.theme);
+        }
+
+        // Render toasts above the input, below modal overlays.
+        if self.motion != zeph_config::Motion::Off && self.delights.toasts {
+            widgets::toast::render(&self.toasts, frame, layout.chat, &self.theme, now);
         }
 
         if let Some(state) = &self.confirm_state {

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -19,6 +19,7 @@ impl App {
             AppEvent::Tick => {
                 self.throbber_state.calc_next();
                 self.wave_tick = self.wave_tick.saturating_add(1);
+                self.tick_delights();
             }
             AppEvent::Resize(_, _) => {
                 self.sessions.current_mut().render_cache.clear();
@@ -73,6 +74,9 @@ impl App {
                         .push(ChatMessage::new(MessageRole::Assistant, text).streaming());
                     self.trim_messages();
                 }
+                // Micro-delight: update streaming rate estimate with current completion tokens.
+                let completion_tokens = self.metrics.completion_tokens;
+                self.stream_rate.on_token_chunk(completion_tokens);
                 // No explicit cache invalidation needed: the cache key includes
                 // content_hash, so new chunk content causes a natural cache miss.
                 self.auto_scroll();
@@ -105,6 +109,8 @@ impl App {
                 self.sessions.current_mut().status_label = Some("thinking...".to_owned());
                 // Turn begins — initialize the stall clock so the first frame is Swell, not Stalled.
                 self.last_progress_at = Instant::now();
+                // Micro-delight: reset streaming rate tracker for this new turn.
+                self.stream_rate.on_turn_start();
             }
             AgentEvent::Status(text) => {
                 self.sessions.current_mut().status_label =
@@ -376,6 +382,60 @@ impl App {
             msg.filter_stats = filter_stats;
         }
         self.auto_scroll();
+        self.maybe_flash_completed_group();
+    }
+
+    /// If the most recently completed tool message belongs to a fully-resolved group,
+    /// trigger a completion flash for that group (#5104).
+    ///
+    /// Groups are defined as a contiguous run of [`MessageRole::Tool`] messages in the
+    /// transcript. We scan backward from the last Tool message to find the group's
+    /// `start_idx`, then verify that every message in the run is no longer streaming.
+    fn maybe_flash_completed_group(&mut self) {
+        if self.motion == zeph_config::Motion::Off || !self.delights.completion_flash {
+            return;
+        }
+
+        let messages = &self.sessions.current().messages;
+
+        // Find the last Tool message index.
+        let Some(last_tool_pos) = messages.iter().rposition(|m| m.role == MessageRole::Tool) else {
+            return;
+        };
+
+        // Walk backward to find the start of the contiguous Tool run.
+        let mut start_idx = last_tool_pos;
+        while start_idx > 0 && messages[start_idx - 1].role == MessageRole::Tool {
+            start_idx -= 1;
+        }
+
+        // Check that every message in this run is finalized (not streaming).
+        let all_done = messages[start_idx..=last_tool_pos]
+            .iter()
+            .all(|m| !m.streaming && m.success.is_some());
+        if !all_done {
+            return;
+        }
+
+        // Avoid re-flashing a group that already flashed this tick cycle.
+        if self.sessions.current().flashed_groups.contains(&start_idx) {
+            return;
+        }
+
+        let group_size = last_tool_pos - start_idx + 1;
+        let now = self.anim_tick();
+        self.sessions.current_mut().flashed_groups.insert(start_idx);
+        self.sessions.current_mut().flash.insert(start_idx, now);
+
+        // Show a transient success toast when the toasts delight is also enabled.
+        if self.delights.toasts {
+            let text = if group_size == 1 {
+                "Tool done".to_owned()
+            } else {
+                format!("{group_size} tools done")
+            };
+            self.push_toast(text, crate::delights::ToastKind::Success);
+        }
     }
 
     #[must_use]

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -931,18 +931,20 @@ impl App {
                     self.sessions.current().scroll_offset.saturating_sub(1);
             }
             KeyCode::PageUp => {
-                self.sessions.current_mut().scroll_offset = self
+                let to = self
                     .sessions
                     .current()
                     .scroll_offset
                     .saturating_add(SCROLL_STEP_PAGE);
+                self.begin_scroll(to);
             }
             KeyCode::PageDown => {
-                self.sessions.current_mut().scroll_offset = self
+                let to = self
                     .sessions
                     .current()
                     .scroll_offset
                     .saturating_sub(SCROLL_STEP_PAGE);
+                self.begin_scroll(to);
             }
             KeyCode::Home => {
                 self.sessions.current_mut().scroll_offset =
@@ -1127,18 +1129,20 @@ impl App {
     fn handle_insert_scroll_keys(&mut self, key: KeyEvent) -> bool {
         match key.code {
             KeyCode::PageUp => {
-                self.sessions.current_mut().scroll_offset = self
+                let to = self
                     .sessions
                     .current()
                     .scroll_offset
                     .saturating_add(SCROLL_STEP_PAGE);
+                self.begin_scroll(to);
             }
             KeyCode::PageDown => {
-                self.sessions.current_mut().scroll_offset = self
+                let to = self
                     .sessions
                     .current()
                     .scroll_offset
                     .saturating_sub(SCROLL_STEP_PAGE);
+                self.begin_scroll(to);
             }
             _ => return false,
         }

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -451,7 +451,7 @@ pub struct App {
 
     /// Monotonic tick counter for the wave animation phase.
     ///
-    /// Incremented once per `AppEvent::Tick` (250 ms). `u64` never wraps within
+    /// Incremented once per `AppEvent::Tick` (100 ms). `u64` never wraps within
     /// a session lifetime. Used as the explicit `t` argument to [`crate::widgets::wave::sample`]
     /// so that the wave renderer stays purely deterministic.
     pub(crate) wave_tick: u64,
@@ -465,6 +465,16 @@ pub struct App {
     /// Reusable buffer for wave glyph spans, allocated once and passed into
     /// [`crate::widgets::wave::glyphs`] each busy frame to avoid per-frame `Vec` allocation.
     pub(crate) wave_buf: Vec<ratatui::text::Span<'static>>,
+
+    // --- Micro-delights (#5104) ---
+    /// Individual feature toggles sourced from `[tui.delights]` in config.
+    pub(crate) delights: zeph_config::DelightsConfig,
+    /// Approximate streaming rate and TTFT for the status bar.
+    pub(crate) stream_rate: crate::delights::StreamRate,
+    /// Ephemeral toast queue rendered as an overlay above the chat area.
+    pub(crate) toasts: crate::delights::ToastQueue,
+    /// One-shot shimmer state for the splash wordmark.
+    pub(crate) splash_shimmer: crate::delights::SplashShimmer,
 }
 
 mod draw;

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -104,6 +104,10 @@ impl App {
             wave_tick: 0,
             last_progress_at: Instant::now(),
             wave_buf: Vec::new(),
+            delights: zeph_config::DelightsConfig::default(),
+            stream_rate: crate::delights::StreamRate::new(),
+            toasts: crate::delights::ToastQueue::new(),
+            splash_shimmer: crate::delights::SplashShimmer::new(),
         }
     }
 
@@ -972,6 +976,107 @@ impl App {
         self.wave_tick
     }
 
+    /// Apply micro-delight configuration (#5104).
+    ///
+    /// Called at construction time from `tui_bridge` to propagate `[tui.delights]` config.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tokio::sync::mpsc;
+    /// use zeph_tui::App;
+    /// use zeph_config::DelightsConfig;
+    ///
+    /// let (tx, _) = mpsc::channel(1);
+    /// let (_, rx) = mpsc::channel(1);
+    /// let app = App::new(tx, rx).with_delights(DelightsConfig::default());
+    /// ```
+    #[must_use]
+    pub fn with_delights(mut self, delights: zeph_config::DelightsConfig) -> Self {
+        self.delights = delights;
+        self
+    }
+
+    /// Return the current animation tick counter.
+    ///
+    /// Aliased from `wave_tick` so animation code can read it by an intent-revealing name.
+    /// Free-running at ~10fps (100ms/tick via `EventReader`). Never pauses.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tokio::sync::mpsc;
+    /// use zeph_tui::App;
+    ///
+    /// let (tx, _) = mpsc::channel(1);
+    /// let (_, rx) = mpsc::channel(1);
+    /// let app = App::new(tx, rx);
+    /// assert_eq!(app.anim_tick(), 0);
+    /// ```
+    #[must_use]
+    pub fn anim_tick(&self) -> u64 {
+        self.wave_tick
+    }
+
+    /// Begin an animated scroll to `target_offset` for the current session.
+    ///
+    /// When smooth-scroll is disabled (`motion = Off` or `delights.smooth_scroll = false`),
+    /// the offset is set directly. Single-line scrolls (j/k) bypass this and write
+    /// `scroll_offset` directly — animation is reserved for page-sized jumps.
+    pub(crate) fn begin_scroll(&mut self, target_offset: usize) {
+        let smooth = self.motion != zeph_config::Motion::Off && self.delights.smooth_scroll;
+        if smooth {
+            // Use the in-flight animation's destination as the starting point so that
+            // two rapid PageDown presses chain correctly instead of producing identical
+            // animations from the same stale scroll_offset.
+            let cur = self.sessions.current();
+            let from = cur.scroll_anim.as_ref().map_or(cur.scroll_offset, |a| a.to);
+            let now = self.anim_tick();
+            self.sessions.current_mut().scroll_anim = Some(crate::session::ScrollAnim {
+                from,
+                to: target_offset,
+                start_tick: now,
+            });
+        } else {
+            self.sessions.current_mut().scroll_offset = target_offset;
+        }
+    }
+
+    /// Enqueue an ephemeral toast notification.
+    ///
+    /// **MUST** be called only from the render thread (inside `handle_event` /
+    /// `handle_agent_event`). Off-thread origins must be routed as `AgentEvent` or
+    /// `AppEvent` variants — never mutate the queue cross-thread.
+    pub(crate) fn push_toast(&mut self, text: impl Into<String>, kind: crate::delights::ToastKind) {
+        let tick = self.anim_tick();
+        self.toasts.push(text, kind, tick);
+    }
+
+    /// Whether any animation-driven feature is currently active.
+    ///
+    /// Provided as an optional future hook for a deferred CPU-optimization issue
+    /// (suppress idle redraws when nothing animates). NOT wired to the redraw gate
+    /// in this PR — the `EventReader` already drives 10fps unconditionally.
+    #[must_use]
+    pub fn wants_animation_frame(&self) -> bool {
+        if self.motion == zeph_config::Motion::Off {
+            return false;
+        }
+        let t = self.anim_tick();
+        let flash_active = self
+            .sessions
+            .current()
+            .flash
+            .pending
+            .values()
+            .any(|&born| t.saturating_sub(born) < crate::session::FLASH_TICKS);
+        let scroll_active = self.sessions.current().scroll_anim.is_some();
+        self.toasts.has_active(t)
+            || flash_active
+            || scroll_active
+            || self.splash_shimmer.is_active(t)
+    }
+
     /// Derive the current wave animation state from live agent state.
     ///
     /// Stalled is checked first so a hung turn never reads as Streaming or Swell.
@@ -1023,6 +1128,44 @@ impl App {
 
         // Swell: busy but awaiting first token.
         WaveState::Swell
+    }
+
+    /// Advance all micro-delight animations by one tick.
+    ///
+    /// Called from [`crate::app::events`] on every `AppEvent::Tick` so that
+    /// animation state advances unconditionally, regardless of whether a draw
+    /// frame is suppressed by `DirtyState::AnimationOnly`.
+    pub(crate) fn tick_delights(&mut self) {
+        let now = self.anim_tick();
+
+        // Prune expired toasts.
+        self.toasts.prune(now);
+
+        // Advance current session's scroll animation.
+        if let Some(ref anim) = self.sessions.current().scroll_anim {
+            let (offset, done) = anim.current_offset(now);
+            self.sessions.current_mut().scroll_offset = offset;
+            if done {
+                self.sessions.current_mut().scroll_anim = None;
+            }
+        }
+
+        // Prune expired flash entries for the current session.
+        self.sessions.current_mut().flash.prune(now);
+
+        // Detect show_splash rising edge (false → true) → reset shimmer for fresh sweep.
+        let cur_show_splash = self.sessions.current().show_splash;
+        if cur_show_splash && !self.sessions.current().prev_show_splash {
+            self.splash_shimmer.reset();
+        }
+        self.sessions.current_mut().prev_show_splash = cur_show_splash;
+
+        // Activate shimmer on first splash frame.
+        let shimmer_enabled =
+            self.motion != zeph_config::Motion::Off && self.delights.splash_shimmer;
+        if shimmer_enabled && cur_show_splash {
+            self.splash_shimmer.activate(now);
+        }
     }
 }
 

--- a/crates/zeph-tui/src/app/tests.rs
+++ b/crates/zeph-tui/src/app/tests.rs
@@ -2844,6 +2844,8 @@ fn paste_state_consumed_on_submit() {
 #[test]
 fn insert_mode_page_up_scrolls_transcript() {
     let (mut app, _rx, _tx) = make_app();
+    // Disable smooth scroll so offset changes are immediate (no animation needed).
+    app.motion = zeph_config::Motion::Off;
     app.sessions.current_mut().input_mode = InputMode::Insert;
     app.sessions.current_mut().scroll_offset = 0;
     app.handle_event(AppEvent::Key(KeyEvent::new(
@@ -2860,6 +2862,7 @@ fn insert_mode_page_up_scrolls_transcript() {
 #[test]
 fn insert_mode_page_down_scrolls_transcript() {
     let (mut app, _rx, _tx) = make_app();
+    app.motion = zeph_config::Motion::Off;
     app.sessions.current_mut().input_mode = InputMode::Insert;
     app.sessions.current_mut().scroll_offset = 20;
     app.handle_event(AppEvent::Key(KeyEvent::new(
@@ -2876,6 +2879,7 @@ fn insert_mode_page_down_scrolls_transcript() {
 #[test]
 fn insert_mode_page_down_saturates_at_zero() {
     let (mut app, _rx, _tx) = make_app();
+    app.motion = zeph_config::Motion::Off;
     app.sessions.current_mut().input_mode = InputMode::Insert;
     app.sessions.current_mut().scroll_offset = 5;
     app.handle_event(AppEvent::Key(KeyEvent::new(
@@ -3057,4 +3061,90 @@ fn collapse_slot3_with_subagents_panel_focused_force_expands() {
     app.active_panel = Panel::SubAgents;
     let eff = app.effective_collapsed();
     assert!(!eff[3], "SubAgents focus must force-expand slot 3");
+}
+
+// ── M2: wants_animation_frame unit tests (#5104) ─────────────────────────────
+
+#[test]
+fn wants_animation_frame_false_when_motion_off() {
+    let (mut app, _rx, _tx) = make_app();
+    app.motion = zeph_config::Motion::Off;
+
+    // Inject active toast — must still return false under motion=Off.
+    app.toasts
+        .push("hello", crate::delights::ToastKind::Success, 0);
+    // Inject active shimmer.
+    app.splash_shimmer.activate(0);
+    // Inject active flash.
+    app.sessions.current_mut().flash.insert(0, 0);
+    // Inject active scroll animation.
+    app.sessions.current_mut().scroll_anim = Some(crate::session::ScrollAnim {
+        from: 0,
+        to: 10,
+        start_tick: 0,
+    });
+
+    assert!(
+        !app.wants_animation_frame(),
+        "motion=Off must suppress all animation frames"
+    );
+}
+
+#[test]
+fn wants_animation_frame_false_when_all_idle() {
+    let (app, _rx, _tx) = make_app();
+    // Fresh app: no toasts, no flash, no scroll anim, no shimmer.
+    assert!(
+        !app.wants_animation_frame(),
+        "idle app must not want animation frames"
+    );
+}
+
+#[test]
+fn wants_animation_frame_true_while_toast_active() {
+    let (mut app, _rx, _tx) = make_app();
+    let tick = app.anim_tick();
+    app.toasts
+        .push("msg", crate::delights::ToastKind::Success, tick);
+    assert!(
+        app.wants_animation_frame(),
+        "active toast must trigger animation frame"
+    );
+}
+
+#[test]
+fn wants_animation_frame_true_while_flash_active() {
+    let (mut app, _rx, _tx) = make_app();
+    let tick = app.anim_tick();
+    app.sessions.current_mut().flash.insert(0, tick);
+    assert!(
+        app.wants_animation_frame(),
+        "active flash must trigger animation frame"
+    );
+}
+
+#[test]
+fn wants_animation_frame_true_while_scroll_active() {
+    let (mut app, _rx, _tx) = make_app();
+    let tick = app.anim_tick();
+    app.sessions.current_mut().scroll_anim = Some(crate::session::ScrollAnim {
+        from: 0,
+        to: 5,
+        start_tick: tick,
+    });
+    assert!(
+        app.wants_animation_frame(),
+        "active scroll animation must trigger animation frame"
+    );
+}
+
+#[test]
+fn wants_animation_frame_true_while_shimmer_active() {
+    let (mut app, _rx, _tx) = make_app();
+    let tick = app.anim_tick();
+    app.splash_shimmer.activate(tick);
+    assert!(
+        app.wants_animation_frame(),
+        "active shimmer must trigger animation frame"
+    );
 }

--- a/crates/zeph-tui/src/delights.rs
+++ b/crates/zeph-tui/src/delights.rs
@@ -1,0 +1,374 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Micro-delight state types for the TUI dashboard (#5104).
+//!
+//! All animation math is a pure function of `(state, anim_tick)` — deterministic
+//! and snapshot-testable. Wall-clock (`Instant`) is used only for the streaming
+//! rate estimate, which is display-only and never fed into layout math.
+
+use std::collections::VecDeque;
+use std::time::Instant;
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/// Lifetime of a toast in animation ticks. ≈3s at 10fps (100ms/tick).
+pub(crate) const TOAST_TTL_TICKS: u64 = 30;
+
+/// Number of samples kept for the tok/s rolling window.
+const RATE_SAMPLES: usize = 8;
+
+/// Maximum number of toasts displayed simultaneously.
+const TOAST_CAP: usize = 3;
+
+/// Duration of the splash shimmer sweep in animation ticks. ≈1.2s at 10fps.
+pub(crate) const SHIMMER_TICKS: u64 = 12;
+
+// ── StreamRate ───────────────────────────────────────────────────────────────
+
+/// Approximate streaming rate and TTFT for the status bar.
+///
+/// Tracks chunk-arrival times (not per-token), so tok/s is an estimate.
+/// Display-only — never fed into layout math or persisted.
+pub(crate) struct StreamRate {
+    /// Rolling window: `(sample_instant, cumulative_completion_tokens)`.
+    samples: VecDeque<(Instant, u64)>,
+    /// TTFT from the last completed turn (milliseconds).
+    pub(crate) last_ttft_ms: Option<u64>,
+    /// When the current agent turn started (set on `AgentEvent::Typing`).
+    pub(crate) turn_start: Option<Instant>,
+    /// When the first streaming token of the current turn arrived.
+    pub(crate) first_token_at: Option<Instant>,
+}
+
+impl StreamRate {
+    pub(crate) fn new() -> Self {
+        Self {
+            samples: VecDeque::with_capacity(RATE_SAMPLES),
+            last_ttft_ms: None,
+            turn_start: None,
+            first_token_at: None,
+        }
+    }
+
+    /// Called at turn-start (`AgentEvent::Typing`).
+    pub(crate) fn on_turn_start(&mut self) {
+        self.turn_start = Some(Instant::now());
+        self.first_token_at = None;
+        self.samples.clear();
+    }
+
+    /// Called on each streaming chunk with the current cumulative completion token count.
+    pub(crate) fn on_token_chunk(&mut self, completion_tokens: u64) {
+        let now = Instant::now();
+        if self.first_token_at.is_none() {
+            self.first_token_at = Some(now);
+            if let Some(start) = self.turn_start {
+                #[allow(clippy::cast_possible_truncation)]
+                let ttft = now.duration_since(start).as_millis() as u64;
+                self.last_ttft_ms = Some(ttft);
+            }
+        }
+        if self.samples.len() == RATE_SAMPLES {
+            self.samples.pop_front();
+        }
+        self.samples.push_back((now, completion_tokens));
+    }
+
+    /// TTFT (time-to-first-token) from the last completed turn, in milliseconds.
+    ///
+    /// Returns `None` when no turn has completed since the rate tracker was created.
+    #[must_use]
+    pub(crate) fn ttft_ms(&self) -> Option<u64> {
+        self.last_ttft_ms
+    }
+
+    /// Compute current tok/s using the rolling window (EMA-smoothed over window).
+    ///
+    /// Returns `None` when fewer than 2 samples are available.
+    #[must_use]
+    pub(crate) fn tokens_per_sec(&self) -> Option<f32> {
+        if self.samples.len() < 2 {
+            return None;
+        }
+        let (t0, c0) = &self.samples[0];
+        let (tn, cn) = self.samples.back()?;
+        let dt = tn.duration_since(*t0).as_secs_f32();
+        if dt < 0.001 {
+            return None;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let tokens = cn.saturating_sub(*c0) as f32;
+        Some(tokens / dt)
+    }
+}
+
+// ── ToastKind ────────────────────────────────────────────────────────────────
+
+/// Visual category of a toast notification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToastKind {
+    /// Informational notice (default colour).
+    #[allow(dead_code)]
+    Info,
+    /// Success / completion notice (green tint).
+    Success,
+    /// Warning notice (yellow tint).
+    #[allow(dead_code)]
+    Warn,
+}
+
+// ── Toast + ToastQueue ───────────────────────────────────────────────────────
+
+pub(crate) struct Toast {
+    pub(crate) text: String,
+    pub(crate) kind: ToastKind,
+    /// `anim_tick` when this toast was enqueued — drives deterministic expiry.
+    pub(crate) born_tick: u64,
+}
+
+/// Queue of ephemeral overlay toasts, capped at [`TOAST_CAP`].
+///
+/// `push_toast` is render-thread-only — never call from background tasks.
+/// Off-thread toast origins must be routed as `AgentEvent`/`AppEvent` variants
+/// and enqueued inside the event handler.
+pub(crate) struct ToastQueue {
+    items: VecDeque<Toast>,
+}
+
+impl ToastQueue {
+    pub(crate) fn new() -> Self {
+        Self {
+            items: VecDeque::with_capacity(TOAST_CAP),
+        }
+    }
+
+    /// Enqueue a new toast. When the queue is full, the oldest entry is dropped.
+    pub(crate) fn push(&mut self, text: impl Into<String>, kind: ToastKind, born_tick: u64) {
+        if self.items.len() == TOAST_CAP {
+            self.items.pop_front();
+        }
+        self.items.push_back(Toast {
+            text: text.into(),
+            kind,
+            born_tick,
+        });
+    }
+
+    /// Whether any toast is still within its TTL.
+    #[must_use]
+    pub(crate) fn has_active(&self, now: u64) -> bool {
+        self.items
+            .iter()
+            .any(|t| now.saturating_sub(t.born_tick) < TOAST_TTL_TICKS)
+    }
+
+    /// Remove all expired toasts. Called once per draw frame.
+    pub(crate) fn prune(&mut self, now: u64) {
+        self.items
+            .retain(|t| now.saturating_sub(t.born_tick) < TOAST_TTL_TICKS);
+    }
+
+    /// Iterate active (non-expired) toasts.
+    pub(crate) fn active_items(&self, now: u64) -> impl Iterator<Item = &Toast> {
+        self.items
+            .iter()
+            .filter(move |t| now.saturating_sub(t.born_tick) < TOAST_TTL_TICKS)
+    }
+}
+
+// ── SplashShimmer ────────────────────────────────────────────────────────────
+
+/// One-shot shimmer state for the splash wordmark (#5104).
+///
+/// `start_tick` is set on the first draw frame where `show_splash` is `true`.
+/// Cleared on the rising edge of `show_splash` (false → true) so each new
+/// splash show gets a fresh sweep.
+pub(crate) struct SplashShimmer {
+    pub(crate) start_tick: Option<u64>,
+}
+
+impl SplashShimmer {
+    pub(crate) fn new() -> Self {
+        Self { start_tick: None }
+    }
+
+    /// Whether the shimmer is still sweeping.
+    #[must_use]
+    pub(crate) fn is_active(&self, now: u64) -> bool {
+        self.start_tick
+            .is_some_and(|s| now.saturating_sub(s) < SHIMMER_TICKS)
+    }
+
+    /// Phase `(0..SHIMMER_TICKS)` of the sweep, or `None` when inactive.
+    #[must_use]
+    pub(crate) fn phase(&self, now: u64) -> Option<u64> {
+        let start = self.start_tick?;
+        let elapsed = now.saturating_sub(start);
+        if elapsed < SHIMMER_TICKS {
+            Some(elapsed)
+        } else {
+            None
+        }
+    }
+
+    /// Record the start tick on first splash frame.
+    pub(crate) fn activate(&mut self, now: u64) {
+        if self.start_tick.is_none() {
+            self.start_tick = Some(now);
+        }
+    }
+
+    /// Reset so the next splash show gets a fresh sweep.
+    pub(crate) fn reset(&mut self) {
+        self.start_tick = None;
+    }
+}
+
+// ── Pure math helpers (snapshot-testable) ────────────────────────────────────
+
+/// Format tok/s for the status bar (e.g. `"42 tok/s"`, `"1.2k tok/s"`).
+#[must_use]
+pub(crate) fn format_toks(rate: f32) -> String {
+    if rate >= 1000.0 {
+        format!("{:.1}k tok/s", rate / 1000.0)
+    } else {
+        format!("{rate:.0} tok/s")
+    }
+}
+
+/// Format TTFT milliseconds for the status bar (e.g. `"TTFT 234ms"`, `"TTFT 1.2s"`).
+#[must_use]
+pub(crate) fn format_ttft(ms: u64) -> String {
+    if ms >= 1000 {
+        #[allow(clippy::cast_precision_loss)]
+        let secs = ms as f32 / 1000.0;
+        format!("TTFT {secs:.1}s")
+    } else {
+        format!("TTFT {ms}ms")
+    }
+}
+
+/// Brightness boost multiplier for the shimmer highlight at letter index `i`.
+///
+/// Returns a value in `[0.0, 1.0]` where 1.0 is peak brightness.
+/// The sweep front passes each letter at `phase * letters_per_tick`.
+#[must_use]
+pub(crate) fn shimmer_brightness(letter_idx: usize, n_letters: usize, phase: u64) -> f32 {
+    if n_letters == 0 {
+        return 0.0;
+    }
+    // Map phase [0..SHIMMER_TICKS] to a sweep position across all letters.
+    #[allow(clippy::cast_precision_loss)]
+    let sweep_pos = phase as f32 / SHIMMER_TICKS as f32 * (n_letters + 2) as f32 - 1.0;
+    #[allow(clippy::cast_precision_loss)]
+    let dist = (letter_idx as f32 - sweep_pos).abs();
+    // Bell curve: peak at 0 distance, falls to ~0 at distance ≥ 1.5 letters.
+    let brightness = (-dist * dist * 2.0).exp();
+    brightness.clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_toks_below_1k() {
+        assert_eq!(format_toks(42.0), "42 tok/s");
+    }
+
+    #[test]
+    fn format_toks_above_1k() {
+        let s = format_toks(1200.0);
+        assert!(s.contains("tok/s"), "got: {s}");
+        assert!(s.starts_with("1.2k"), "got: {s}");
+    }
+
+    #[test]
+    fn format_ttft_ms() {
+        assert_eq!(format_ttft(234), "TTFT 234ms");
+    }
+
+    #[test]
+    fn format_ttft_seconds() {
+        let s = format_ttft(1200);
+        assert!(s.starts_with("TTFT 1.2s"), "got: {s}");
+    }
+
+    #[test]
+    fn shimmer_peak_at_sweep_front() {
+        // Phase 6 out of 12 ticks → sweep at mid-point (letter 2 of 4).
+        let brightness = shimmer_brightness(2, 4, 6);
+        assert!(
+            brightness > 0.5,
+            "brightness at sweep front must be > 0.5, got {brightness}"
+        );
+    }
+
+    #[test]
+    fn shimmer_zero_when_far_from_front() {
+        // Phase 0 → sweep front at beginning; letter 3 (far away) should be dim.
+        let brightness = shimmer_brightness(3, 4, 0);
+        assert!(
+            brightness < 0.2,
+            "brightness far from front must be < 0.2, got {brightness}"
+        );
+    }
+
+    #[test]
+    fn toast_queue_caps_at_3() {
+        let mut q = ToastQueue::new();
+        for i in 0..5u64 {
+            q.push(format!("t{i}"), ToastKind::Info, i);
+        }
+        assert_eq!(q.items.len(), 3);
+        // Oldest (0,1) dropped; remaining are 2,3,4.
+        assert_eq!(q.items[0].born_tick, 2);
+    }
+
+    #[test]
+    fn toast_prune_removes_expired() {
+        let mut q = ToastQueue::new();
+        q.push("old", ToastKind::Info, 0);
+        q.push("new", ToastKind::Info, 50);
+        q.prune(TOAST_TTL_TICKS + 5); // old expired; new still alive
+        assert_eq!(q.items.len(), 1);
+        assert_eq!(q.items[0].born_tick, 50);
+    }
+
+    #[test]
+    fn splash_shimmer_activate_and_phase() {
+        let mut s = SplashShimmer::new();
+        assert!(!s.is_active(5));
+        s.activate(10);
+        assert!(s.is_active(10));
+        assert_eq!(s.phase(10), Some(0));
+        assert_eq!(s.phase(15), Some(5));
+        assert!(!s.is_active(10 + SHIMMER_TICKS));
+    }
+
+    #[test]
+    fn splash_shimmer_reset() {
+        let mut s = SplashShimmer::new();
+        s.activate(10);
+        s.reset();
+        assert!(!s.is_active(10));
+    }
+
+    #[test]
+    fn scroll_anim_ease_out() {
+        use crate::session::ScrollAnim;
+        let anim = ScrollAnim {
+            from: 0,
+            to: 100,
+            start_tick: 0,
+        };
+        let (mid, done) = anim.current_offset(1);
+        assert!(!done);
+        // After 1 of 3 ticks ease-out-cubic gives ≈1-(2/3)^3 ≈ 0.704 → ~70 rows.
+        assert!(
+            mid > 50,
+            "ease-out should be past midpoint at t=1/3, got {mid}"
+        );
+    }
+}

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -41,6 +41,7 @@ pub mod app;
 pub mod channel;
 pub mod clipboard;
 pub mod command;
+pub(crate) mod delights;
 pub mod error;
 pub mod event;
 pub mod file_picker;

--- a/crates/zeph-tui/src/session.rs
+++ b/crates/zeph-tui/src/session.rs
@@ -6,11 +6,98 @@
 //! Phase-1: always exactly one [`SessionSlot`] owned by [`SessionRegistry`].
 //! Phase-2 will add `SessionNew` and multi-slot rendering.
 
+use std::collections::HashMap;
+
 use tokio::sync::oneshot;
 
 use crate::app::{AgentViewTarget, TranscriptCache, TuiTranscriptEntry};
 use crate::render_cache::RenderCache;
 use crate::types::{ChatMessage, InputMode, PasteState};
+
+/// Duration (in animation ticks) for the completion flash tint. ≈400ms at 10fps.
+pub(crate) const FLASH_TICKS: u64 = 4;
+
+/// Duration (in animation ticks) for the smooth-scroll easing. ≈300ms at 10fps.
+pub(crate) const SCROLL_ANIM_TICKS: u64 = 3;
+
+/// Per-session flash state for tool-group completion tints (#5104).
+///
+/// Keyed by `start_idx` (the group's first message index within this session's
+/// transcript) so flashes from different groups don't interfere. Session-scoped to
+/// prevent cross-session bleed when the user switches between [`SessionSlot`]s.
+pub(crate) struct FlashState {
+    /// `start_idx → born_tick`: groups currently mid-flash.
+    pub(crate) pending: HashMap<usize, u64>,
+}
+
+impl FlashState {
+    pub(crate) fn new() -> Self {
+        Self {
+            pending: HashMap::new(),
+        }
+    }
+
+    /// Record a new flash for `start_idx` at the given tick.
+    pub(crate) fn insert(&mut self, start_idx: usize, born_tick: u64) {
+        self.pending.insert(start_idx, born_tick);
+    }
+
+    /// Collect all currently active `start_idx` values as a set.
+    pub(crate) fn active_set(&self, now: u64) -> std::collections::HashSet<usize> {
+        self.pending
+            .iter()
+            .filter(|&(_, &born)| now.saturating_sub(born) < FLASH_TICKS)
+            .map(|(&idx, _)| idx)
+            .collect()
+    }
+
+    /// Evict all expired flashes.
+    pub(crate) fn prune(&mut self, now: u64) {
+        self.pending
+            .retain(|_, &mut born| now.saturating_sub(born) < FLASH_TICKS);
+    }
+}
+
+/// Per-session smooth-scroll animation state (#5104).
+///
+/// Session-scoped alongside `scroll_offset` to prevent one session's easing from
+/// bleeding into another when the user switches [`SessionSlot`]s.
+pub(crate) struct ScrollAnim {
+    pub(crate) from: usize,
+    pub(crate) to: usize,
+    pub(crate) start_tick: u64,
+}
+
+impl ScrollAnim {
+    /// Compute the eased integer offset at the current tick.
+    ///
+    /// Uses ease-out-cubic: fast start, decelerates near target.
+    /// Returns `to` (and marks completion) when `elapsed >= SCROLL_ANIM_TICKS`.
+    #[must_use]
+    pub(crate) fn current_offset(&self, now: u64) -> (usize, bool) {
+        let elapsed = now.saturating_sub(self.start_tick);
+        if elapsed >= SCROLL_ANIM_TICKS {
+            return (self.to, true);
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let t = elapsed as f32 / SCROLL_ANIM_TICKS as f32;
+        // Ease-out cubic: 1 - (1-t)^3
+        let eased = 1.0_f32 - (1.0 - t).powi(3);
+        #[allow(
+            clippy::cast_sign_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_precision_loss
+        )]
+        let offset = if self.from <= self.to {
+            let delta = self.to - self.from;
+            self.from + (delta as f32 * eased).round() as usize
+        } else {
+            let delta = self.from - self.to;
+            self.from - (delta as f32 * eased).round() as usize
+        };
+        (offset, false)
+    }
+}
 
 /// Maximum number of chat messages retained per session slot.
 pub(crate) const MAX_TUI_MESSAGES: usize = 2000;
@@ -63,6 +150,18 @@ pub(crate) struct SessionSlot {
     pub show_splash: bool,
     pub plan_view_active: bool,
     pub status_label: Option<String>,
+
+    // Micro-delight state — session-scoped to prevent cross-session bleed (#5104).
+    pub(crate) flash: FlashState,
+    pub(crate) scroll_anim: Option<ScrollAnim>,
+    /// Set of `start_idx` values that have already had their flash triggered,
+    /// preventing re-fires on re-render of an old completed group.
+    pub(crate) flashed_groups: std::collections::HashSet<usize>,
+    /// Previous `show_splash` value used for rising-edge detection (shimmer reset).
+    ///
+    /// Kept on `SessionSlot` (not `App`) so that switching sessions in phase-2
+    /// multi-slot mode correctly re-triggers the shimmer for each slot independently.
+    pub(crate) prev_show_splash: bool,
 }
 
 impl SessionSlot {
@@ -87,19 +186,28 @@ impl SessionSlot {
             show_splash: true,
             plan_view_active: false,
             status_label: None,
+            flash: FlashState::new(),
+            scroll_anim: None,
+            flashed_groups: std::collections::HashSet::new(),
+            prev_show_splash: false,
         }
     }
 
     /// Evict oldest messages when the buffer exceeds `MAX_TUI_MESSAGES`.
     ///
     /// Shifts the render cache to match the drained messages, preserving cached renders
-    /// for the remaining entries.
+    /// for the remaining entries. Flash state is cleared entirely because all `start_idx`
+    /// keys are invalidated after the drain — stale indices in `flashed_groups` would
+    /// permanently suppress the flash on a recycled group.
     pub fn trim_messages(&mut self) {
         if self.messages.len() > MAX_TUI_MESSAGES {
             let excess = self.messages.len() - MAX_TUI_MESSAGES;
             self.messages.drain(0..excess);
             self.render_cache.shift(excess);
             self.scroll_offset = self.scroll_offset.saturating_sub(excess);
+            // All start_idx values are now stale; reset to avoid index-aliasing bugs.
+            self.flash.pending.clear();
+            self.flashed_groups.clear();
         }
     }
 }
@@ -321,5 +429,30 @@ mod tests {
         }
         slot.trim_messages();
         assert_eq!(slot.messages.len(), MAX_TUI_MESSAGES);
+    }
+
+    #[test]
+    fn trim_messages_clears_flash_state() {
+        let mut slot = SessionSlot::new(SlotId::FIRST, "test");
+        for i in 0..(MAX_TUI_MESSAGES + 5) {
+            slot.messages
+                .push(ChatMessage::new(MessageRole::User, format!("msg {i}")));
+        }
+        // Inject stale flash entries using old start_idx values.
+        slot.flash.insert(0, 42);
+        slot.flash.insert(3, 43);
+        slot.flashed_groups.insert(1);
+        slot.flashed_groups.insert(2);
+
+        slot.trim_messages();
+
+        assert!(
+            slot.flash.pending.is_empty(),
+            "flash.pending must be cleared after trim"
+        );
+        assert!(
+            slot.flashed_groups.is_empty(),
+            "flashed_groups must be cleared after trim"
+        );
     }
 }

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -49,6 +49,14 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, cache: &mut RenderCa
     let messages = app.visible_messages();
     let truncation_info = app.transcript_truncation_info();
 
+    let flash_enabled = app.motion != zeph_config::Motion::Off && app.delights.completion_flash;
+    let flash_groups = if flash_enabled {
+        app.sessions.current().flash.active_set(app.anim_tick())
+    } else {
+        std::collections::HashSet::new()
+    };
+    let flash_style = app.theme.tool_accent;
+
     let (mut lines, all_md_links) = collect_message_lines_from(
         &messages,
         truncation_info.as_deref(),
@@ -62,6 +70,8 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, cache: &mut RenderCa
         usize::try_from(app.throbber_state().index().rem_euclid(6)).unwrap_or(0),
         app.is_ascii_only(),
         app.theme_generation(),
+        &flash_groups,
+        flash_style,
     );
 
     let total = lines.len();
@@ -119,6 +129,8 @@ fn collect_message_lines_from(
     throbber_idx: usize,
     ascii: bool,
     theme_generation: u64,
+    flash_groups: &std::collections::HashSet<usize>,
+    flash_style: ratatui::style::Style,
 ) -> (Vec<Line<'static>>, Vec<MdLink>) {
     let mut lines: Vec<Line<'static>> = Vec::new();
     let mut all_md_links: Vec<MdLink> = Vec::new();
@@ -261,7 +273,13 @@ fn collect_message_lines_from(
                     rendered
                 };
 
+                let flash_active = flash_groups.contains(start_idx);
                 for mut line in group_lines {
+                    if flash_active {
+                        for span in &mut line.spans {
+                            span.style = span.style.patch(flash_style);
+                        }
+                    }
                     line.spans.insert(0, Span::raw("  "));
                     lines.push(line);
                 }
@@ -1705,6 +1723,8 @@ mod tests {
             0,
             false,
             0,
+            &std::collections::HashSet::new(),
+            ratatui::style::Style::default(),
         );
         let all_text: String = lines
             .iter()
@@ -1764,6 +1784,8 @@ mod tests {
             0,
             false,
             0,
+            &std::collections::HashSet::new(),
+            ratatui::style::Style::default(),
         );
         let has_bg = lines
             .iter()
@@ -2218,6 +2240,8 @@ mod tests {
             0,
             false,
             0,
+            &std::collections::HashSet::new(),
+            ratatui::style::Style::default(),
         );
         let text: String = lines
             .iter()

--- a/crates/zeph-tui/src/widgets/mod.rs
+++ b/crates/zeph-tui/src/widgets/mod.rs
@@ -26,5 +26,6 @@ pub mod status;
 pub mod status_verbs;
 pub mod subagents;
 pub mod task_registry;
+pub mod toast;
 pub mod tool_view;
 pub mod wave;

--- a/crates/zeph-tui/src/widgets/splash.rs
+++ b/crates/zeph-tui/src/widgets/splash.rs
@@ -12,6 +12,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+use crate::delights::shimmer_brightness;
 use crate::theme::{EffectiveColorMode, map_color};
 
 // Aqua (#22d3ee) and ice (#e0f2fe) — gradient endpoints for the `zeph` letters.
@@ -45,18 +46,30 @@ const QUICK_HINTS: &[(&str, &str)] = &[
 /// - ≥ 8 rows: full layout (wordmark + slogan + version + hints).
 /// - 3–7 rows: two-line compact layout.
 /// - < 3 rows: single wordmark line.
-pub fn render(frame: &mut Frame, area: Rect, color_mode: EffectiveColorMode) {
+///
+/// `shimmer_phase` drives the one-shot highlight sweep across the wordmark (#5104).
+/// Pass `None` to render the static gradient (off-state, byte-identical to pre-feature).
+pub fn render(
+    frame: &mut Frame,
+    area: Rect,
+    color_mode: EffectiveColorMode,
+    shimmer_phase: Option<u64>,
+) {
     if area.width == 0 || area.height == 0 {
         return;
     }
 
-    let lines = build_lines(area.height, color_mode);
+    let lines = build_lines(area.height, color_mode, shimmer_phase);
     let paragraph = Paragraph::new(lines).alignment(Alignment::Center);
     frame.render_widget(paragraph, area);
 }
 
-fn build_lines(height: u16, mode: EffectiveColorMode) -> Vec<Line<'static>> {
-    let wordmark = wordmark_line(mode);
+fn build_lines(
+    height: u16,
+    mode: EffectiveColorMode,
+    shimmer_phase: Option<u64>,
+) -> Vec<Line<'static>> {
+    let wordmark = wordmark_line(mode, shimmer_phase);
     let hints = hints_line(mode);
 
     if height < 3 {
@@ -65,7 +78,7 @@ fn build_lines(height: u16, mode: EffectiveColorMode) -> Vec<Line<'static>> {
 
     if height < 8 {
         // Compact: wordmark + slogan on one line, hints on the next.
-        let compact = compact_wordmark_line(mode);
+        let compact = compact_wordmark_line(mode, shimmer_phase);
         return vec![compact, hints];
     }
 
@@ -86,10 +99,10 @@ fn build_lines(height: u16, mode: EffectiveColorMode) -> Vec<Line<'static>> {
 }
 
 /// Single-line wordmark: `≈ zeph` (or `~ zeph` in ASCII mode) with gradient or plain colour.
-fn wordmark_line(mode: EffectiveColorMode) -> Line<'static> {
+fn wordmark_line(mode: EffectiveColorMode, shimmer_phase: Option<u64>) -> Line<'static> {
     match mode {
         EffectiveColorMode::Truecolor | EffectiveColorMode::Ansi256 => {
-            gradient_wordmark_line("≈ ", mode)
+            gradient_wordmark_line("≈ ", mode, shimmer_phase)
         }
         EffectiveColorMode::Ansi16 => {
             Line::from(Span::styled("≈ zeph", Style::default().fg(ACCENT)))
@@ -99,10 +112,10 @@ fn wordmark_line(mode: EffectiveColorMode) -> Line<'static> {
 }
 
 /// Compact single-line: `≈ zeph  think further.` for 3–7 row layouts.
-fn compact_wordmark_line(mode: EffectiveColorMode) -> Line<'static> {
+fn compact_wordmark_line(mode: EffectiveColorMode, shimmer_phase: Option<u64>) -> Line<'static> {
     match mode {
         EffectiveColorMode::Truecolor | EffectiveColorMode::Ansi256 => {
-            let mut spans = gradient_wordmark_spans("≈ ", mode);
+            let mut spans = gradient_wordmark_spans("≈ ", mode, shimmer_phase);
             spans.push(Span::styled(
                 format!("  {SLOGAN}"),
                 Style::default().fg(MUTED),
@@ -140,42 +153,69 @@ fn hints_line(mode: EffectiveColorMode) -> Line<'static> {
 }
 
 /// Build a `Line` with the gradient wordmark (full-layout version).
-fn gradient_wordmark_line(prefix: &'static str, mode: EffectiveColorMode) -> Line<'static> {
-    Line::from(gradient_wordmark_spans(prefix, mode))
+fn gradient_wordmark_line(
+    prefix: &'static str,
+    mode: EffectiveColorMode,
+    shimmer_phase: Option<u64>,
+) -> Line<'static> {
+    Line::from(gradient_wordmark_spans(prefix, mode, shimmer_phase))
 }
 
 /// Build the gradient wordmark spans: prefix in accent, `zeph` in interpolated colours.
 ///
+/// When `shimmer_phase` is `Some(tick)`, each letter's brightness is boosted by a bell-curve
+/// envelope centred on the shimmer position, producing a moving highlight sweep (#5104).
+/// When `shimmer_phase` is `None` the output is byte-identical to the pre-feature baseline.
+///
 /// Colors are passed through [`map_color`] so that `Ansi256` terminals receive indexed
 /// colors instead of truecolor RGB escape sequences.
-fn gradient_wordmark_spans(prefix: &'static str, mode: EffectiveColorMode) -> Vec<Span<'static>> {
+fn gradient_wordmark_spans(
+    prefix: &'static str,
+    mode: EffectiveColorMode,
+    shimmer_phase: Option<u64>,
+) -> Vec<Span<'static>> {
     let accent_style = Style::default().fg(map_color(ACCENT, mode));
     let letters: &[char] = &['z', 'e', 'p', 'h'];
-    let n = letters.len();
+    let n_letters = letters.len();
 
-    let mut spans: Vec<Span<'static>> = Vec::with_capacity(1 + n);
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(1 + n_letters);
     spans.push(Span::styled(prefix, accent_style));
 
-    for (i, ch) in letters.iter().enumerate() {
+    for (letter_pos, ch) in letters.iter().enumerate() {
         #[allow(clippy::cast_precision_loss)]
-        let t = if n <= 1 {
+        let interp = if n_letters <= 1 {
             0.0_f32
         } else {
-            i as f32 / (n - 1) as f32
+            letter_pos as f32 / (n_letters - 1) as f32
         };
-        let color = map_color(lerp_rgb(AQUA, ICE, t), mode);
+        let (red, green, blue) = lerp_rgb_components(AQUA, ICE, interp);
+
+        // Apply shimmer brightness boost per letter when shimmer is active.
+        let (red, green, blue) = if let Some(phase) = shimmer_phase {
+            let boost = shimmer_brightness(letter_pos, n_letters, phase);
+            boost_rgb(red, green, blue, boost)
+        } else {
+            (red, green, blue)
+        };
+
+        let color = map_color(Color::Rgb(red, green, blue), mode);
         spans.push(Span::styled(ch.to_string(), Style::default().fg(color)));
     }
 
     spans
 }
 
-/// Linear interpolation between two RGB colours.
-fn lerp_rgb((r1, g1, b1): (u8, u8, u8), (r2, g2, b2): (u8, u8, u8), t: f32) -> Color {
-    let r = lerp_channel(r1, r2, t);
-    let g = lerp_channel(g1, g2, t);
-    let b = lerp_channel(b1, b2, t);
-    Color::Rgb(r, g, b)
+/// Linear interpolation between two RGB colours, returning components.
+fn lerp_rgb_components(
+    (r1, g1, b1): (u8, u8, u8),
+    (r2, g2, b2): (u8, u8, u8),
+    t: f32,
+) -> (u8, u8, u8) {
+    (
+        lerp_channel(r1, r2, t),
+        lerp_channel(g1, g2, t),
+        lerp_channel(b1, b2, t),
+    )
 }
 
 fn lerp_channel(a: u8, b: u8, t: f32) -> u8 {
@@ -183,6 +223,16 @@ fn lerp_channel(a: u8, b: u8, t: f32) -> u8 {
     {
         (f32::from(a) + (f32::from(b) - f32::from(a)) * t).round() as u8
     }
+}
+
+/// Boost RGB channels towards white by `amount` in [0, 1].
+fn boost_rgb(r: u8, g: u8, b: u8, amount: f32) -> (u8, u8, u8) {
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    let boost = |c: u8| -> u8 {
+        let boosted = f32::from(c) + (255.0 - f32::from(c)) * amount;
+        boosted.min(255.0) as u8
+    };
+    (boost(r), boost(g), boost(b))
 }
 
 #[cfg(test)]
@@ -194,7 +244,7 @@ mod tests {
 
     fn render(width: u16, height: u16, mode: EffectiveColorMode) -> String {
         render_to_string(width, height, |frame, area| {
-            super::render(frame, area, mode);
+            super::render(frame, area, mode, None);
         })
     }
 
@@ -274,7 +324,30 @@ mod tests {
     fn splash_zero_area_no_panic() {
         // Must not panic on a zero-size area.
         render_to_string(0, 0, |frame, area| {
-            super::render(frame, area, EffectiveColorMode::Truecolor);
+            super::render(frame, area, EffectiveColorMode::Truecolor, None);
         });
+    }
+
+    #[test]
+    fn splash_shimmer_none_matches_baseline() {
+        // `shimmer_phase = None` must produce byte-identical output to pre-feature baseline.
+        let without_shimmer = render(60, 20, EffectiveColorMode::Truecolor);
+        let with_none = render_to_string(60, 20, |frame, area| {
+            super::render(frame, area, EffectiveColorMode::Truecolor, None);
+        });
+        assert_eq!(
+            without_shimmer, with_none,
+            "shimmer_phase=None must be byte-identical to baseline (off-state)"
+        );
+    }
+
+    #[test]
+    fn splash_shimmer_active_does_not_panic() {
+        // Active shimmer must not panic for any phase in [0, SHIMMER_TICKS).
+        for phase in 0..crate::delights::SHIMMER_TICKS {
+            render_to_string(60, 20, |frame, area| {
+                super::render(frame, area, EffectiveColorMode::Truecolor, Some(phase));
+            });
+        }
     }
 }

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -433,6 +433,31 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
     if !security_spans.is_empty() {
         list.push(Priority::Low, security_spans);
     }
+    // Stream metrics: tok/s while streaming, TTFT after turn completes (#5104).
+    // Suppressed entirely when motion=Off (master kill-switch, same as all other delights).
+    if app.motion != zeph_config::Motion::Off && app.delights.stream_metrics {
+        if app.is_agent_busy()
+            && let Some(rate) = app.stream_rate.tokens_per_sec()
+        {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let rate_int = rate as u32;
+            list.push_abbrev_styled(
+                Priority::Low,
+                format!(" | {}", crate::delights::format_toks(rate)),
+                format!(" {rate_int}t/s"),
+                theme.status_bar,
+            );
+        }
+        if let Some(ttft_ms) = app.stream_rate.ttft_ms() {
+            list.push_abbrev_styled(
+                Priority::Low,
+                format!(" | {}", crate::delights::format_ttft(ttft_ms)),
+                format!(" {ttft_ms}ms"),
+                theme.status_bar,
+            );
+        }
+    }
+
     if app.is_agent_busy() && app.input_mode() == InputMode::Normal {
         list.push(
             Priority::Low,
@@ -1088,5 +1113,38 @@ mod tests {
     #[test]
     fn short_uptime_minutes() {
         assert_eq!(short_uptime(135), " 2m");
+    }
+
+    /// Off-state byte-identity: motion=Off must suppress tok/s and TTFT segments
+    /// even when `stream_rate` holds live data.  This is the test that would have
+    /// caught the missing guard in M1.
+    #[test]
+    fn motion_off_suppresses_stream_metrics_segments() {
+        use tokio::sync::mpsc;
+
+        use crate::app::App;
+        use crate::metrics::MetricsSnapshot;
+        use crate::test_utils::render_to_string;
+
+        let (user_tx, _) = mpsc::channel(1);
+        let (_, agent_rx) = mpsc::channel(1);
+        let mut app = App::new(user_tx, agent_rx);
+        app.motion = zeph_config::Motion::Off;
+        // Inject synthetic TTFT so the render path would include it if the guard is absent.
+        app.stream_rate.last_ttft_ms = Some(123);
+
+        let metrics = MetricsSnapshot::default();
+        let output = render_to_string(200, 1, |frame, area| {
+            super::render(&app, &metrics, frame, area);
+        });
+
+        assert!(
+            !output.contains("TTFT"),
+            "motion=Off must suppress TTFT segment; got: {output:?}"
+        );
+        assert!(
+            !output.contains("tok/s") && !output.contains("t/s"),
+            "motion=Off must suppress tok/s segment; got: {output:?}"
+        );
     }
 }

--- a/crates/zeph-tui/src/widgets/toast.rs
+++ b/crates/zeph-tui/src/widgets/toast.rs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Ephemeral toast overlay widget (#5104).
+//!
+//! Renders a stack of transient notifications anchored to the bottom of the
+//! chat area (above the input line, below modal overlays).
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Clear, Paragraph};
+
+use crate::delights::{ToastKind, ToastQueue};
+use crate::theme::Theme;
+
+/// Render active toasts into the bottom of `chat_area`.
+///
+/// Toasts are stacked newest-at-bottom, max 3 visible. Each toast occupies
+/// one row. The overlay lives entirely within `chat_area` so it never obscures
+/// the input slot (which is a separate layout area below `chat_area`).
+pub(crate) fn render(
+    toasts: &ToastQueue,
+    frame: &mut Frame,
+    chat_area: Rect,
+    theme: &Theme,
+    now: u64,
+) {
+    let active: Vec<_> = toasts.active_items(now).collect();
+    if active.is_empty() || chat_area.height == 0 || chat_area.width == 0 {
+        return;
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    let n = active.len().min(3) as u16;
+    let y_start = chat_area.y + chat_area.height.saturating_sub(n);
+
+    for (i, toast) in active.iter().rev().take(3).enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        let y = y_start + i as u16;
+        if y >= chat_area.y + chat_area.height {
+            break;
+        }
+        let toast_area = Rect {
+            x: chat_area.x,
+            y,
+            width: chat_area.width,
+            height: 1,
+        };
+        let style = toast_style(toast.kind, theme);
+        let text = format!(" {} ", toast.text);
+        let line = Line::from(Span::styled(text, style));
+        frame.render_widget(Clear, toast_area);
+        frame.render_widget(Paragraph::new(line), toast_area);
+    }
+}
+
+fn toast_style(kind: ToastKind, theme: &Theme) -> Style {
+    match kind {
+        ToastKind::Info => theme.status_bar,
+        ToastKind::Success => Style::default().fg(Color::Green),
+        ToastKind::Warn => Style::default().fg(Color::Yellow),
+    }
+}

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -294,6 +294,8 @@ pub(crate) struct WizardState {
     pub(crate) tui_theme_name: String,
     /// Terminal colour mode override.
     pub(crate) tui_color_mode: zeph_config::ColorMode,
+    /// Whether TUI micro-delights are enabled (tok/s, toasts, flash, scroll, shimmer).
+    pub(crate) tui_delights_enabled: bool,
 }
 
 impl Default for WizardState {
@@ -487,6 +489,7 @@ impl Default for WizardState {
             deep_link_confirm_before_prompt: true,
             tui_theme_name: "zephyr".to_owned(),
             tui_color_mode: zeph_config::ColorMode::Auto,
+            tui_delights_enabled: true,
         }
     }
 }
@@ -562,6 +565,7 @@ pub fn run(output: Option<PathBuf>) -> anyhow::Result<()> {
     #[cfg(feature = "deep-link")]
     step_deep_link(&mut state)?;
     step_tui_theme(&mut state)?;
+    step_tui_delights(&mut state)?;
     step_quality(&mut state)?;
     step_review_and_write(&state, output)?;
 
@@ -1215,6 +1219,17 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     config.tui.theme.name.clone_from(&state.tui_theme_name);
     config.tui.theme.color_mode = state.tui_color_mode;
 
+    // Apply TUI delights (#5104).
+    if !state.tui_delights_enabled {
+        config.tui.delights = zeph_config::DelightsConfig {
+            stream_metrics: false,
+            toasts: false,
+            completion_flash: false,
+            smooth_scroll: false,
+            splash_shimmer: false,
+        };
+    }
+
     config
 }
 
@@ -1790,6 +1805,29 @@ fn step_deep_link(state: &mut WizardState) -> anyhow::Result<()> {
 /// # Errors
 ///
 /// Returns an error if the terminal prompt interaction fails.
+fn step_tui_delights(state: &mut WizardState) -> anyhow::Result<()> {
+    use dialoguer::Confirm;
+    println!("== TUI Micro-Delights ==\n");
+    println!("Enable animated micro-delights in the TUI dashboard:");
+    println!("  • tok/s and TTFT in the status bar during/after LLM turns");
+    println!("  • ephemeral toast notifications (theme switch, copy, etc.)");
+    println!("  • completion flash on finished tool groups");
+    println!("  • smooth scroll on page jumps");
+    println!("  • one-shot shimmer on the splash wordmark");
+    println!();
+    println!("All are controlled by [tui.delights] in config.toml.");
+    println!("motion = off acts as a master kill-switch regardless.\n");
+
+    let enabled = Confirm::new()
+        .with_prompt("Enable TUI micro-delights?")
+        .default(true)
+        .interact()?;
+
+    state.tui_delights_enabled = enabled;
+    println!();
+    Ok(())
+}
+
 fn step_tui_theme(state: &mut WizardState) -> anyhow::Result<()> {
     use dialoguer::Select;
 

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -118,7 +118,8 @@ pub(crate) fn start_tui_early(
         .with_theme(tui_theme)
         .with_theme_name(tui_theme_name)
         .with_effective_color_mode(tui_color_mode)
-        .with_motion(config.tui.motion);
+        .with_motion(config.tui.motion)
+        .with_delights(config.tui.delights.clone());
     tui_app.set_show_source_labels(config.tui.show_source_labels);
     tui_app.set_show_balance(config.cocoon.show_balance);
 
@@ -213,6 +214,7 @@ fn spawn_tui_thread(
     show_balance: bool,
     tool_density: zeph_config::ToolDensity,
     motion: zeph_config::Motion,
+    delights: zeph_config::DelightsConfig,
     theme: zeph_tui::theme::Theme,
     theme_name: String,
     effective_color_mode: zeph_tui::theme::EffectiveColorMode,
@@ -230,6 +232,7 @@ fn spawn_tui_thread(
         .with_command_tx(command_tx)
         .with_tool_density(tool_density)
         .with_motion(motion)
+        .with_delights(delights)
         .with_theme(theme)
         .with_theme_name(theme_name)
         .with_effective_color_mode(effective_color_mode);
@@ -342,6 +345,7 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
             params.config.cocoon.show_balance,
             params.config.tui.tool_density,
             params.config.tui.motion,
+            params.config.tui.delights.clone(),
             legacy_theme,
             legacy_theme_name,
             legacy_color_mode,


### PR DESCRIPTION
## Summary

Five individually-toggleable TUI micro-delights under `[tui].delights`, each default-on and master-gated by `motion = off` (closes #5104, part of epic #5086):

- **stream_metrics**: tok/s rolling window + TTFT in the status bar as Low-priority segments during streaming / after turn (TUI-local computation, no changes to `zeph-core`)
- **toasts**: ephemeral 3s overlays for transient notices — tool done, theme switched, clipboard copy; cap-3, oldest dropped, never obscures input line
- **completion_flash**: 4-tick accent tint on a fully-resolved tool group line
- **smooth_scroll**: ease-out-cubic interpolation over 3 ticks for PageUp/PageDown; j/k bypasses for key-repeat responsiveness
- **splash_shimmer**: one-shot bell-curve brightness sweep across the wordmark on first render per session

## Architecture

- **10fps tick base** (`EventReader` at 100ms, `tui_bridge.rs:107`) — all duration constants derived accordingly (toast 30 ticks ≈ 3s, flash 4 ≈ 400ms, scroll 3 ≈ 300ms, shimmer 12 ≈ 1.2s)
- **`draw()` is a pure reader** — all animation state mutations extracted to `tick_delights()` called on `AppEvent::Tick`; prevents animation stalls when `DirtyState::AnimationOnly` skips draws
- **Session-scoped state** — `FlashState`, `ScrollAnim`, `SplashShimmer`, and `prev_show_splash` live on `SessionSlot`, not `App`, preventing cross-session bleed
- **`lib.rs` redraw gate untouched** — idle frames already flow at 10fps; `wants_animation_frame()` ships as an unwired hook for a future idle-redraw suppression (deferred P3 perf issue)
- **`push_toast` is render-thread-only** — off-thread origins routed as `AppEvent`/`AgentEvent` variants

## Config

```toml
[tui]
# All default true; master-gated by motion = off
[tui.delights]
stream_metrics = true
toasts = true
completion_flash = true
smooth_scroll = true
splash_shimmer = true
```

CLI flag: config-only for this PR — delights are visual preferences, not operational commands. The existing `motion = off` config key kills all delights and is already wirable via `--migrate-config`.

## Migration

Migration step 67 (`MigrateTuiDelights`) injects commented advisory block into existing `[tui]` sections. Includes 4 unit tests (inject / present no-op / no-`[tui]` no-op / commented no-op). Wizard `step_tui_delights` adds a single confirm prompt.

## Testing

- 11411 tests pass (+10 new: migration ×4, `wants_animation_frame` ×6, `trim_messages_clears_flash`, streaming-off status bar snapshot, shimmer baseline)
- Off-state byte-identity snapshot covers idle **and** streaming states
- `trim_messages` now clears `flash.pending` + `flashed_groups` to prevent stale `start_idx` suppression after buffer trim

## Related issues

- Closes #5104
- Part of epic #5086
- Filed #5277 (P3): `trim_messages` start_idx stability (index-shift rather than full-clear, deferred)