### PR TITLE
fix(memory): replace .entered() guard with .instrument(span) in ingest_documents

### DIFF
--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -1142,14 +1142,13 @@ impl SemanticMemory {
             IngestSourceKind,
         };
 
-        let _span = tracing::info_span!(
+        let span = tracing::info_span!(
             "memory.ingest.batch",
             batch_id = %batch_id,
             doc_count = documents.len(),
             concurrency = concurrency,
             dry_run = config.dry_run,
-        )
-        .entered();
+        );
 
         let send_progress = |evt: IngestProgress| {
             if let Some(ref tx) = progress {
@@ -1364,7 +1363,11 @@ impl SemanticMemory {
         });
 
         // Collect outcomes with bounded concurrency.
-        let outcomes: Vec<DocOutcome> = stream.buffer_unordered(concurrency).collect().await;
+        let outcomes: Vec<DocOutcome> = stream
+            .buffer_unordered(concurrency)
+            .collect()
+            .instrument(span)
+            .await;
 
         // Build the report.
         let mut report = IngestReport {


### PR DESCRIPTION
## Summary

Fixes #5279.

`SemanticMemory::ingest_documents` in `crates/zeph-memory/src/semantic/graph.rs` held a synchronous tracing span guard (`.entered()`) across `stream.buffer_unordered(concurrency).collect().await`, violating the tracing contract per `.claude/rules/rust-code.md` Await Discipline §4.

A sync `entered()` guard propagates span context via thread-locals — this breaks when `buffer_unordered` migrates tasks across worker threads, causing incorrect trace attribution (span context leaks into unrelated futures).

## Change

- Remove `.entered()` call; keep `let span = tracing::info_span!(...)` as a plain (non-entered) span
- Wrap the terminal future with `.instrument(span)` so the span correctly enters and exits on each poll, surviving cross-thread scheduling in `buffer_unordered`

Same pattern applied previously in `bench` (#5214) and `runner.rs` (#5237).

Adversarial audit confirmed no other `.entered()`-across-`.await` violations in `zeph-memory` (8 other sites verified sync-safe).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11411 passed
- [x] Rustdoc gate — clean