### PR TITLE
feat(tracing): add tracing instrumentation to sanitizer, a2a, and candle crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `feat(tracing)`: add `#[tracing::instrument]` to hot-path async fns in
+  `zeph-sanitizer` (9 fns across `causal_ipi`, `sanitizer`, `ipi_filter`,
+  `quarantine`), `zeph-a2a` client and discovery (11 fns), and
+  `zeph-llm` `CandleProvider` (4 fns, `profiling`-gated). Sanitizer and A2A
+  spans use `skip_all` to prevent leaking sensitive content into traces;
+  CandleProvider follows the `#[cfg_attr(feature = "profiling", ...)]`
+  pattern consistent with `ollama` and `openai` providers. Closes #5211,
+  #5235, #5221.
+
 - `feat(tui)`: micro-delights — five opt-in animation enhancements gated by
   `[tui.delights]` config block and master-controlled by `tui.motion` (#5104):
   - **Stream metrics**: tok/s rolling-window estimate (Low priority, status bar,

--- a/crates/zeph-a2a/src/client.rs
+++ b/crates/zeph-a2a/src/client.rs
@@ -138,6 +138,7 @@ impl A2aClient {
     /// # Errors
     /// Returns `A2aError` on network, JSON, or JSON-RPC errors, or `A2aError::Timeout`
     /// if the request exceeds the configured `request_timeout`.
+    #[tracing::instrument(name = "a2a.client.send_message", skip_all, err)]
     pub async fn send_message(
         &self,
         endpoint: &str,
@@ -150,6 +151,7 @@ impl A2aClient {
 
     /// # Errors
     /// Returns `A2aError` on network failure or if the SSE connection cannot be established.
+    #[tracing::instrument(name = "a2a.client.stream_message", skip_all, err)]
     pub async fn stream_message(
         &self,
         endpoint: &str,
@@ -207,6 +209,7 @@ impl A2aClient {
     /// # Errors
     /// Returns `A2aError` on network, JSON, or JSON-RPC errors, or `A2aError::Timeout`
     /// if the request exceeds the configured `request_timeout`.
+    #[tracing::instrument(name = "a2a.client.get_task", skip_all, err)]
     pub async fn get_task(
         &self,
         endpoint: &str,
@@ -220,6 +223,7 @@ impl A2aClient {
     /// # Errors
     /// Returns `A2aError` on network, JSON, or JSON-RPC errors, or `A2aError::Timeout`
     /// if the request exceeds the configured `request_timeout`.
+    #[tracing::instrument(name = "a2a.client.cancel_task", skip_all, err)]
     pub async fn cancel_task(
         &self,
         endpoint: &str,
@@ -230,6 +234,7 @@ impl A2aClient {
             .await
     }
 
+    #[tracing::instrument(name = "a2a.client.validate_endpoint", skip_all, err)]
     async fn validate_endpoint(&self, endpoint: &str) -> Result<(), A2aError> {
         if self.require_tls && !endpoint.starts_with("https://") {
             return Err(A2aError::Security(format!(
@@ -265,6 +270,7 @@ impl A2aClient {
         Ok(())
     }
 
+    #[tracing::instrument(name = "a2a.client.rpc_call", skip_all, err)]
     async fn rpc_call<P: Serialize, R: DeserializeOwned>(
         &self,
         endpoint: &str,

--- a/crates/zeph-a2a/src/discovery.rs
+++ b/crates/zeph-a2a/src/discovery.rs
@@ -88,6 +88,7 @@ impl AgentRegistry {
     ///
     /// Returns [`A2aError`] wrapping an HTTP transport failure, or a [`A2aError`] discovery
     /// variant on non-2xx HTTP status or JSON parse failure.
+    #[tracing::instrument(name = "a2a.discovery.discover", skip_all, err)]
     pub async fn discover(&self, base_url: &str) -> Result<AgentCard, A2aError> {
         let url = format!("{}{WELL_KNOWN_PATH}", base_url.trim_end_matches('/'));
         let card: AgentCard = tokio::time::timeout(self.request_timeout, async {
@@ -129,6 +130,7 @@ impl AgentRegistry {
     ///
     /// Returns [`A2aError`] if the cached entry is expired and the re-fetch via
     /// [`discover`](Self::discover) fails.
+    #[tracing::instrument(name = "a2a.discovery.get_or_discover", skip_all, err)]
     pub async fn get_or_discover(&self, base_url: &str) -> Result<AgentCard, A2aError> {
         {
             let cache = self.cache.read().await;
@@ -147,6 +149,7 @@ impl AgentRegistry {
     /// fetched and will not expire until `ttl` has elapsed from the time of this call.
     ///
     /// Useful when the card is already known (e.g., loaded from config) or in tests.
+    #[tracing::instrument(name = "a2a.discovery.register", skip_all)]
     pub async fn register(&self, base_url: String, card: AgentCard) {
         let mut cache = self.cache.write().await;
         cache.insert(
@@ -162,6 +165,7 @@ impl AgentRegistry {
     ///
     /// This does not trigger any eviction or re-fetch. Call [`evict_stale`](Self::evict_stale)
     /// first if you only want cards that are still within their TTL.
+    #[tracing::instrument(name = "a2a.discovery.all", skip_all)]
     pub async fn all(&self) -> Vec<AgentCard> {
         let cache = self.cache.read().await;
         cache.values().map(|e| e.card.clone()).collect()
@@ -171,6 +175,7 @@ impl AgentRegistry {
     ///
     /// Intended for periodic background cleanup. The A2A server does not call this
     /// automatically — callers should schedule it as needed (e.g., via a periodic task).
+    #[tracing::instrument(name = "a2a.discovery.evict_stale", skip_all)]
     pub async fn evict_stale(&self) {
         let mut cache = self.cache.write().await;
         cache.retain(|_, entry| entry.fetched_at.elapsed() < self.ttl);

--- a/crates/zeph-llm/src/candle_provider/mod.rs
+++ b/crates/zeph-llm/src/candle_provider/mod.rs
@@ -227,6 +227,14 @@ impl CandleProvider {
     ///
     /// Applies `inference_timeout` to both the channel send and the oneshot recv.
     /// Maps `RecvError` (worker panic / drop) to `LlmError::Inference`.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.candle.dispatch",
+            skip_all,
+            fields(provider = self.name(), device = self.device_name())
+        )
+    )]
     async fn dispatch(&self, messages: Vec<Message>) -> Result<String, LlmError> {
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         let req = InferenceRequest {
@@ -253,6 +261,14 @@ impl CandleProvider {
 }
 
 impl LlmProvider for CandleProvider {
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.candle.chat",
+            skip_all,
+            fields(provider = self.name(), device = self.device_name())
+        )
+    )]
     async fn chat(&self, messages: &[Message]) -> Result<String, LlmError> {
         self.dispatch(messages.to_vec()).await
     }
@@ -260,6 +276,14 @@ impl LlmProvider for CandleProvider {
     // NOTE: MVP fake streaming — generates all tokens then chunks into 32-byte slices.
     // No spawn needed: text is fully available before streaming begins, so we yield
     // pre-built chunks via tokio_stream::iter (structured concurrency, no JoinHandle).
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.candle.chat_stream",
+            skip_all,
+            fields(provider = self.name(), device = self.device_name())
+        )
+    )]
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, LlmError> {
         let text = self.dispatch(messages.to_vec()).await?;
         let mut chunks: Vec<Result<StreamChunk, LlmError>> = Vec::new();
@@ -279,6 +303,14 @@ impl LlmProvider for CandleProvider {
         true
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "llm.candle.embed",
+            skip_all,
+            fields(provider = self.name(), device = self.device_name())
+        )
+    )]
     async fn embed(&self, text: &str) -> Result<Vec<f32>, LlmError> {
         let Some(ref embed_model) = self.embed_model else {
             return Err(LlmError::EmbedUnsupported {

--- a/crates/zeph-sanitizer/src/causal_ipi.rs
+++ b/crates/zeph-sanitizer/src/causal_ipi.rs
@@ -161,6 +161,7 @@ impl TurnCausalAnalyzer {
     ///
     /// Returns `CausalIpiError::LlmError` on provider failure, `CausalIpiError::Timeout`
     /// on probe timeout.
+    #[tracing::instrument(name = "sanitizer.causal_ipi.probe", skip_all, err)]
     pub async fn probe(&self, context_summary: &str) -> Result<String, CausalIpiError> {
         let content = format!("{context_summary}\n\n{PROBE_QUESTION}");
         self.call_probe(&content).await
@@ -181,6 +182,7 @@ impl TurnCausalAnalyzer {
     ///
     /// Returns `CausalIpiError::LlmError` on provider failure, `CausalIpiError::Timeout`
     /// on probe timeout.
+    #[tracing::instrument(name = "sanitizer.causal_ipi.post_probe", skip_all, err)]
     pub async fn post_probe(
         &self,
         context_summary: &str,

--- a/crates/zeph-sanitizer/src/ipi_filter.rs
+++ b/crates/zeph-sanitizer/src/ipi_filter.rs
@@ -263,6 +263,7 @@ impl IpiFilter {
     /// assert_eq!(verdict.score, 0.0);
     /// # }
     /// ```
+    #[tracing::instrument(name = "sanitizer.ipi_filter.filter_async", skip_all, err)]
     pub async fn filter_async(&self, text: String) -> Result<IpiVerdict, tokio::task::JoinError> {
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.filter(&text)).await

--- a/crates/zeph-sanitizer/src/quarantine.rs
+++ b/crates/zeph-sanitizer/src/quarantine.rs
@@ -163,6 +163,7 @@ impl QuarantinedSummarizer {
     /// - [`QuarantineError::Timeout`] — the provider did not respond within `timeout_ms`.
     /// - [`QuarantineError::LlmError`] — the provider call failed (network error, etc.).
     /// - [`QuarantineError::EmptyResponse`] — the provider returned an empty string.
+    #[tracing::instrument(name = "sanitizer.quarantine.extract_facts", skip_all, err)]
     pub async fn extract_facts(
         &self,
         input: &SanitizedContent,

--- a/crates/zeph-sanitizer/src/sanitizer.rs
+++ b/crates/zeph-sanitizer/src/sanitizer.rs
@@ -309,6 +309,7 @@ impl ContentSanitizer {
     ///
     /// Returns `LlmError` if the underlying model fails.
     #[cfg(feature = "classifiers")]
+    #[tracing::instrument(name = "sanitizer.sanitizer.detect_pii", skip_all, err)]
     pub async fn detect_pii(
         &self,
         text: &str,
@@ -602,6 +603,7 @@ impl ContentSanitizer {
     /// Returns [`BinaryStageOutcome::Final`] on classifier error or timeout; the
     /// verdict is the regex fallback and the caller **must not** invoke Stage 2.
     #[cfg(feature = "classifiers")]
+    #[tracing::instrument(name = "sanitizer.sanitizer.run_binary_stage", skip_all)]
     async fn run_binary_stage(
         &self,
         backend: &dyn zeph_llm::classifier::ClassifierBackend,
@@ -647,6 +649,7 @@ impl ContentSanitizer {
     /// classifier timeout, `MisalignedInstruction`, `Unknown`, or
     /// `AlignedInstruction` below threshold.
     #[cfg(feature = "classifiers")]
+    #[tracing::instrument(name = "sanitizer.sanitizer.refine_with_three_class", skip_all)]
     async fn refine_with_three_class(
         &self,
         text: &str,
@@ -714,6 +717,7 @@ impl ContentSanitizer {
     ///
     /// When no classifier backend is attached, also falls back to regex detection.
     #[cfg(feature = "classifiers")]
+    #[tracing::instrument(name = "sanitizer.sanitizer.classify_injection", skip_all)]
     pub async fn classify_injection(&self, text: &str) -> InjectionVerdict {
         if !self.enabled {
             return self.regex_fallback_verdict(text);


### PR DESCRIPTION
## Summary

- **zeph-sanitizer** (#5211): add `#[tracing::instrument]` to 9 async hot-path functions across `causal_ipi`, `sanitizer`, `ipi_filter`, and `quarantine` modules. Uses `skip_all` to prevent PII/sensitive content from leaking into trace fields.
- **zeph-a2a** (#5235): instrument 11 async functions in `client.rs` (send_message, stream_message, get_task, cancel_task, validate_endpoint, rpc_call) and `discovery.rs` (discover, get_or_discover, register, all, evict_stale). Pattern matches existing `a2a.server.handlers` spans.
- **zeph-llm CandleProvider** (#5221): instrument 4 async methods (dispatch, chat, chat_stream, embed) using `#[cfg_attr(feature = "profiling", tracing::instrument(...))]` to match the existing pattern in `ollama` and `openai` providers.

## Feature-gating

- Sanitizer and A2A use direct `#[tracing::instrument]` (always-on, coarse per-request spans)
- CandleProvider uses `profiling` gate — consistent with `ollama.rs` and `openai/mod.rs`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — 0 warnings
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11411/11411 passed (matches CI-1106 baseline)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean

Closes #5211, #5235, #5221