### PR TITLE
feat(deep-link): add 30s timeout to lsregister in url-scheme commands

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -690,8 +690,16 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             use crate::cli::UrlSchemeCommand;
             use crate::url_scheme::register;
             return match url_scheme_cmd {
-                UrlSchemeCommand::Register => register::handle_url_scheme_register(),
-                UrlSchemeCommand::Unregister => register::handle_url_scheme_unregister(),
+                UrlSchemeCommand::Register => {
+                    tokio::task::spawn_blocking(register::handle_url_scheme_register)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("spawn_blocking panicked: {e}"))?
+                }
+                UrlSchemeCommand::Unregister => {
+                    tokio::task::spawn_blocking(register::handle_url_scheme_unregister)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("spawn_blocking panicked: {e}"))?
+                }
                 UrlSchemeCommand::Status { check } => {
                     let stale = register::handle_url_scheme_status();
                     if check && stale {

--- a/src/url_scheme/register.rs
+++ b/src/url_scheme/register.rs
@@ -399,13 +399,12 @@ fn register_macos(exe_str: &str) -> anyhow::Result<()> {
     println!("Wrote: {}", bundle.display());
 
     // Register with LaunchServices.
-    let ls_result = std::process::Command::new("/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister")
-        .args(["-f", &bundle.to_string_lossy()])
-        .status();
-    match ls_result {
-        Ok(s) if s.success() => println!("lsregister: registered"),
-        Ok(s) => println!("lsregister exited with status {s}; registration may be incomplete"),
-        Err(e) => println!("lsregister not found or failed: {e}; registration may be incomplete"),
+    match lsregister_with_timeout(&["-f", &bundle.to_string_lossy()]) {
+        Ok(true) => println!("lsregister: registered"),
+        Ok(false) => {
+            println!("lsregister exited with non-zero status; registration may be incomplete");
+        }
+        Err(e) => println!("lsregister failed: {e}; registration may be incomplete"),
     }
 
     println!("Registered zeph:// scheme → {exe_str}");
@@ -421,13 +420,10 @@ fn unregister_macos() -> anyhow::Result<()> {
     }
 
     // Unregister from LaunchServices before removing files.
-    let ls_result = std::process::Command::new("/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister")
-        .args(["-u", &bundle.to_string_lossy()])
-        .status();
-    match ls_result {
-        Ok(s) if s.success() => println!("lsregister: unregistered"),
-        Ok(s) => println!("lsregister -u exited with status {s}"),
-        Err(e) => println!("lsregister not found or failed: {e}"),
+    match lsregister_with_timeout(&["-u", &bundle.to_string_lossy()]) {
+        Ok(true) => println!("lsregister: unregistered"),
+        Ok(false) => println!("lsregister -u exited with non-zero status"),
+        Err(e) => println!("lsregister failed: {e}"),
     }
 
     std::fs::remove_dir_all(&bundle)?;
@@ -526,6 +522,48 @@ fn scheme_status_macos(current_exe: Option<&std::path::Path>) -> SchemeStatus {
         ));
     }
     SchemeStatus::Ok
+}
+
+/// Invoke `lsregister` with the given arguments and a 30-second wall-clock timeout.
+///
+/// Returns `Ok(true)` when `lsregister` exits with status 0, `Ok(false)` on a non-zero exit
+/// code, and `Err` on spawn failure or timeout. On timeout the child process is killed before
+/// the error is returned so it cannot linger in the background.
+///
+/// # Errors
+///
+/// - `lsregister` could not be spawned (binary not found or permission denied).
+/// - `lsregister` did not exit within 30 seconds. The error message includes the recovery
+///   command to rebuild the `LaunchServices` database.
+#[cfg(target_os = "macos")]
+fn lsregister_with_timeout(args: &[&str]) -> anyhow::Result<bool> {
+    const LSREGISTER: &str = "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+    let mut child = std::process::Command::new(LSREGISTER)
+        .args(args)
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("failed to spawn lsregister: {e}"))?;
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status.success()),
+            Ok(None) if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                anyhow::bail!(
+                    "lsregister timed out after 30s — LaunchServices database may be corrupted. \
+                     Run: {LSREGISTER} -kill -r -domain local -domain system -domain user"
+                );
+            }
+            Ok(None) => std::thread::sleep(POLL_INTERVAL),
+            Err(e) => {
+                let _ = child.kill();
+                return Err(anyhow::anyhow!("lsregister wait failed: {e}"));
+            }
+        }
+    }
 }
 
 // ── Windows ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Introduces `lsregister_with_timeout()` in `src/url_scheme/register.rs` that polls `try_wait()` every 100ms for up to 30 seconds, kills the child on timeout, and returns a clear error with the LaunchServices database recovery command
- On `try_wait()` error the child is also killed before propagating, preventing process leaks
- Wraps `handle_url_scheme_register`/`handle_url_scheme_unregister` call sites in `tokio::task::spawn_blocking` to avoid blocking a tokio worker thread during the polling loop

Closes #5064

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11411 passed
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [ ] Manual: `zeph url-scheme register` completes normally on a healthy system
- [ ] Timeout path covered by open #5063 (deep-link test gaps, P3)