### PR TITLE
refactor(tracing): add instrument spans to memory and skills hot paths

### DIFF
--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -79,6 +79,7 @@ pub use zeph_common::config::memory::ConsolidationConfig;
 /// The loop exits immediately if `config.enabled = false`.
 ///
 /// Database and LLM errors are logged but do not stop the loop.
+#[tracing::instrument(name = "memory.consolidation.start_loop", skip_all)]
 pub async fn start_consolidation_loop(
     store: Arc<SqliteStore>,
     provider: AnyProvider,
@@ -165,6 +166,7 @@ pub async fn run_consolidation_sweep(
 ///
 /// Loads candidates, embeds them, clusters by similarity, and applies topology ops.
 /// Returns early (without error) if embeddings are unavailable or too few candidates exist.
+#[tracing::instrument(name = "memory.consolidation.process_conversation", skip_all, fields(conv_id = %conv_id))]
 async fn process_conversation(
     store: &SqliteStore,
     provider: &AnyProvider,
@@ -261,6 +263,7 @@ async fn embed_candidates(
 /// Asks the LLM to produce a `TopologyOp` for the cluster and, if accepted, applies it
 /// via the store. Updates `result` counters in place; individual op failures are logged
 /// and do not propagate.
+#[tracing::instrument(name = "memory.consolidation.apply_topology_op", skip_all, fields(cluster_size = cluster.len()))]
 async fn apply_topology_op(
     store: &SqliteStore,
     provider: &AnyProvider,

--- a/crates/zeph-memory/src/eviction.rs
+++ b/crates/zeph-memory/src/eviction.rs
@@ -176,6 +176,7 @@ fn parse_sqlite_timestamp_secs(s: &str) -> Option<u64> {
 /// # Errors (non-fatal)
 ///
 /// Database and Qdrant errors are logged but do not stop the loop.
+#[tracing::instrument(name = "memory.eviction.start_loop", skip_all)]
 pub async fn start_eviction_loop(
     store: Arc<SqliteStore>,
     embedding: Option<Arc<EmbeddingStore>>,

--- a/crates/zeph-memory/src/tiered_retrieval.rs
+++ b/crates/zeph-memory/src/tiered_retrieval.rs
@@ -31,7 +31,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use tracing::Instrument as _;
 pub use zeph_config::memory::TieredRetrievalConfig;
 use zeph_llm::any::AnyProvider;
 
@@ -188,6 +187,7 @@ pub async fn recall_tiered(
 /// Iterates through tiers starting at `initial_intent`, retrieving candidates and
 /// validating evidence quality. Escalates to heavier tiers when validation indicates
 /// insufficient evidence.
+#[tracing::instrument(name = "memory.tiered.escalation_loop", skip_all, fields(initial_intent = %initial_intent, max_escalations = config.max_escalations))]
 async fn escalation_loop(
     memory: &SemanticMemory,
     query: &str,
@@ -202,13 +202,9 @@ async fn escalation_loop(
     let mut tier_escalated = false;
 
     loop {
-        let raw_candidates = retrieve_tier(memory, query, conversation_id, intent, config)
-            .instrument(tracing::debug_span!("memory.tiered.retrieve_tier", tier = %intent))
-            .await?;
+        let raw_candidates = retrieve_tier(memory, query, conversation_id, intent, config).await?;
 
-        let candidates = score_candidates(memory, query, raw_candidates, config)
-            .instrument(tracing::debug_span!("memory.tiered.score_candidates", tier = %intent))
-            .await?;
+        let candidates = score_candidates(memory, query, raw_candidates, config).await?;
 
         let (messages, tokens_used) = assemble_within_budget(candidates, effective_budget);
 
@@ -225,7 +221,6 @@ async fn escalation_loop(
                 config.validation_threshold,
                 config.validator_timeout_secs,
             )
-            .instrument(tracing::debug_span!("memory.tiered.validate"))
             .await;
             if !sufficient {
                 tracing::debug!(
@@ -254,6 +249,7 @@ async fn escalation_loop(
 ///
 /// For `DeepReasoning` when `config.deep_reasoning_query_conditioned = true`, routes through
 /// query-conditioned graph recall (HELA spreading activation) instead of static-weight BFS (#3994).
+#[tracing::instrument(name = "memory.tiered.retrieve_tier", skip_all, fields(intent = %intent))]
 async fn retrieve_tier(
     memory: &SemanticMemory,
     query: &str,
@@ -576,6 +572,7 @@ fn assemble_within_budget(
 ///
 /// Returns `true` when the validator's confidence is >= `threshold` or when the
 /// call fails (fail-open: prefer serving potentially incomplete evidence over blocking).
+#[tracing::instrument(name = "memory.tiered.validate_evidence", skip_all, fields(threshold, timeout_secs, evidence_count = messages.len()))]
 async fn validate_evidence(
     provider: &Arc<AnyProvider>,
     query: &str,

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -13,7 +13,6 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use tracing::Instrument as _;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 
@@ -183,6 +182,10 @@ impl SkillMiner {
     }
 
     /// Pre-compute embeddings for existing skill descriptions.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.miner.embed_existing", skip(self, skills), fields(count = skills.len()))
+    )]
     async fn embed_existing(&self, skills: &[SkillMeta]) -> Vec<(SkillMeta, SkillEmbedding)> {
         let mut embeddings = Vec::with_capacity(skills.len());
         let timeout = Duration::from_millis(self.config.generation_timeout_ms);
@@ -211,6 +214,10 @@ impl SkillMiner {
 
     /// Process a single repo: generate skill, dedup, write.
     #[allow(clippy::too_many_lines)]
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.miner.process_repo", skip(self, repo, existing_embeddings), fields(repo = %repo.full_name, is_dry_run))
+    )]
     async fn process_repo(
         &self,
         repo: &RepoCandidate,
@@ -342,22 +349,19 @@ impl SkillMiner {
     /// # Errors
     ///
     /// Returns `SkillError::Other` on timeout or provider failure.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.miner.embed_candidate", skip(self, skill), fields(candidate = %skill.name))
+    )]
     async fn embed_candidate(&self, skill: &GeneratedSkill) -> Result<SkillEmbedding, SkillError> {
-        async move {
-            tokio::time::timeout(
-                Duration::from_millis(self.config.generation_timeout_ms),
-                self.embed_provider.embed(&skill.meta.description),
-            )
-            .await
-            .map_err(|_| SkillError::Timeout(self.config.generation_timeout_ms))?
-            .map(SkillEmbedding::from_raw)
-            .map_err(|e| SkillError::Other(format!("embed failed: {e}")))
-        }
-        .instrument(tracing::info_span!(
-            "skills.miner.embed",
-            candidate = %skill.name,
-        ))
+        tokio::time::timeout(
+            Duration::from_millis(self.config.generation_timeout_ms),
+            self.embed_provider.embed(&skill.meta.description),
+        )
         .await
+        .map_err(|_| SkillError::Timeout(self.config.generation_timeout_ms))?
+        .map(SkillEmbedding::from_raw)
+        .map_err(|e| SkillError::Other(format!("embed failed: {e}")))
     }
 
     /// Call the LLM merge prompt and write the merged skill to disk.
@@ -366,6 +370,10 @@ impl SkillMiner {
     ///
     /// Returns `SkillError` when the merge LLM call fails, the result fails to parse,
     /// or injection is detected in the merged output.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skills.miner.merge_candidate", skip(self, candidate, existing_skill_dir), fields(existing = existing_name, next_version = existing_version + 1))
+    )]
     async fn merge_candidate(
         &self,
         candidate: &GeneratedSkill,
@@ -373,54 +381,46 @@ impl SkillMiner {
         existing_version: u32,
         existing_skill_dir: &Path,
     ) -> Result<(), SkillError> {
-        async move {
-            let existing_body = tokio::fs::read_to_string(existing_skill_dir.join("SKILL.md"))
-                .await
-                .unwrap_or_else(|_| {
-                    format!("---\nname: {existing_name}\nversion: {existing_version}\n---\n")
-                });
+        let existing_body = tokio::fs::read_to_string(existing_skill_dir.join("SKILL.md"))
+            .await
+            .unwrap_or_else(|_| {
+                format!("---\nname: {existing_name}\nversion: {existing_version}\n---\n")
+            });
 
-            let messages = build_merge_messages(
-                &existing_body,
-                &candidate.content,
+        let messages = build_merge_messages(
+            &existing_body,
+            &candidate.content,
+            existing_name,
+            existing_version + 1,
+        );
+
+        let timeout = Duration::from_millis(self.config.generation_timeout_ms);
+        let raw = tokio::time::timeout(timeout, self.generator.provider.chat(&messages))
+            .await
+            .map_err(|_| SkillError::Timeout(self.config.generation_timeout_ms))?
+            .map_err(|e| SkillError::Other(format!("merge LLM failed: {e}")))?;
+
+        let content = extract_skill_md_pub(raw.trim());
+
+        let scan = scan_skill_body(&content);
+        if scan.has_matches() {
+            return Err(SkillError::Invalid(format!(
+                "merged skill '{}' failed injection scan: {}",
                 existing_name,
-                existing_version + 1,
-            );
-
-            let timeout = Duration::from_millis(self.config.generation_timeout_ms);
-            let raw = tokio::time::timeout(timeout, self.generator.provider.chat(&messages))
-                .await
-                .map_err(|_| SkillError::Timeout(self.config.generation_timeout_ms))?
-                .map_err(|e| SkillError::Other(format!("merge LLM failed: {e}")))?;
-
-            let content = extract_skill_md_pub(raw.trim());
-
-            let scan = scan_skill_body(&content);
-            if scan.has_matches() {
-                return Err(SkillError::Invalid(format!(
-                    "merged skill '{}' failed injection scan: {}",
-                    existing_name,
-                    scan.matched_patterns.join(", ")
-                )));
-            }
-
-            let merged = parse_and_validate_pub(&content)?;
-            self.generator.approve_and_save(&merged).await?;
-
-            tracing::info!(
-                existing = existing_name,
-                next_version = existing_version + 1,
-                "miner: merged skill written to disk"
-            );
-
-            Ok(())
+                scan.matched_patterns.join(", ")
+            )));
         }
-        .instrument(tracing::info_span!(
-            "skills.miner.merge",
+
+        let merged = parse_and_validate_pub(&content)?;
+        self.generator.approve_and_save(&merged).await?;
+
+        tracing::info!(
             existing = existing_name,
-            skill_dir = %existing_skill_dir.display(),
-        ))
-        .await
+            next_version = existing_version + 1,
+            "miner: merged skill written to disk"
+        );
+
+        Ok(())
     }
 
     /// Search GitHub for repositories matching `query`.


### PR DESCRIPTION
## Summary

- **`zeph-memory/tiered_retrieval.rs`**: add `#[tracing::instrument]` to `escalation_loop`, `retrieve_tier`, and `validate_evidence`; remove redundant call-site `.instrument()` wrappers and the now-unused `Instrument` import
- **`zeph-memory/consolidation.rs`**: add `#[tracing::instrument]` to `start_consolidation_loop`, `process_conversation`, and `apply_topology_op`
- **`zeph-memory/eviction.rs`**: add `#[tracing::instrument]` to `start_eviction_loop`
- **`zeph-skills/miner.rs`**: add `#[cfg_attr(feature = "profiling", tracing::instrument(...))]` to `embed_existing`, `process_repo`, `embed_candidate`, and `merge_candidate`; replace the inner `async move { ... }.instrument(...)` pattern with a function-level attribute and remove the unused `Instrument` import

Closes #5230, #5232

Note: #5188 was already fixed in #5250/#5257 and has been closed without code changes.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory -p zeph-skills --lib --bins` — 2047 passed
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-memory -p zeph-skills` — clean