### PR TITLE
feat(tracing): instrument hot-path async fns in zeph-mcp, zeph-channels, zeph-vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `feat(tracing)`: add `#[tracing::instrument]` to 13 hot-path async fns across
+  three crates. `zeph-mcp` `connect.rs`: `spawn_non_oauth_connections`,
+  `process_connect_results`, `commit_connect_outputs`, `handle_connect_result`
+  (with `server_id` field), `spawn_oauth_connections`, `process_oauth_results`,
+  `commit_oauth_outputs` — MCP connect pipeline inner latency now visible in
+  traces. `zeph-channels` `discord/gateway.rs`: `gateway_loop`, `run_session`,
+  `ack_interaction`; `slack/events.rs`: `handle_event` — WebSocket reconnect
+  loop and event handling now traced. `zeph-vault` `age.rs`: `load_async`,
+  `save_async` — vault startup path now visible. All spans unconditional, use
+  `skip_all` to prevent sensitive args from leaking into traces. Closes #5203,
+  #5189, #5210.
+
 - `feat(tracing)`: add `#[tracing::instrument]` to hot-path async fns in
   `zeph-sanitizer` (9 fns across `causal_ipi`, `sanitizer`, `ipi_filter`,
   `quarantine`), `zeph-a2a` client and discovery (11 fns), and

--- a/crates/zeph-channels/src/discord/gateway.rs
+++ b/crates/zeph-channels/src/discord/gateway.rs
@@ -98,6 +98,7 @@ pub fn spawn_gateway(
     }
 }
 
+#[tracing::instrument(name = "channels.discord.gateway_loop", skip_all)]
 async fn gateway_loop(token: String, tx: mpsc::Sender<IncomingMessage>) {
     loop {
         match run_session(&token, &tx).await {
@@ -112,6 +113,7 @@ async fn gateway_loop(token: String, tx: mpsc::Sender<IncomingMessage>) {
     }
 }
 
+#[tracing::instrument(name = "channels.discord.run_session", skip_all)]
 async fn run_session(
     token: &str,
     tx: &mpsc::Sender<IncomingMessage>,
@@ -262,6 +264,7 @@ fn parse_interaction_create(d: &Value) -> Option<(IncomingMessage, InteractionAc
 ///
 /// Uses type 5 (`DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE`) so Discord shows a thinking indicator
 /// while the agent processes the command and sends a follow-up message.
+#[tracing::instrument(name = "channels.discord.ack_interaction", skip_all, err)]
 async fn ack_interaction(
     ack: &InteractionAck,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/crates/zeph-channels/src/slack/events.rs
+++ b/crates/zeph-channels/src/slack/events.rs
@@ -115,6 +115,7 @@ pub fn spawn_event_server(
     }
 }
 
+#[tracing::instrument(name = "channels.slack.handle_event", skip_all)]
 async fn handle_event(
     State(state): State<EventState>,
     headers: HeaderMap,

--- a/crates/zeph-mcp/src/manager/connect.rs
+++ b/crates/zeph-mcp/src/manager/connect.rs
@@ -221,6 +221,7 @@ impl McpManager {
         (all_tools, outcomes)
     }
 
+    #[tracing::instrument(name = "mcp.manager.spawn_non_oauth_connections", skip_all)]
     async fn spawn_non_oauth_connections(
         &self,
         last_refresh: &Arc<DashMap<String, Instant>>,
@@ -274,6 +275,7 @@ impl McpManager {
         join_set
     }
 
+    #[tracing::instrument(name = "mcp.manager.process_connect_results", skip_all)]
     async fn process_connect_results(
         &self,
         raw: Vec<(String, Result<McpClient, McpError>)>,
@@ -289,6 +291,7 @@ impl McpManager {
         outputs
     }
 
+    #[tracing::instrument(name = "mcp.manager.commit_connect_outputs", skip_all)]
     async fn commit_connect_outputs(
         &self,
         outputs: Vec<ConnectOutput>,
@@ -372,6 +375,7 @@ impl McpManager {
         self.log_tool_collisions(&all_tools).await;
     }
 
+    #[tracing::instrument(name = "mcp.manager.spawn_oauth_connections", skip_all)]
     async fn spawn_oauth_connections(
         &self,
         last_refresh: &Arc<DashMap<String, Instant>>,
@@ -441,6 +445,7 @@ impl McpManager {
         join_set
     }
 
+    #[tracing::instrument(name = "mcp.manager.process_oauth_results", skip_all)]
     async fn process_oauth_results(
         &self,
         raw: Vec<(String, Result<McpClient, String>)>,
@@ -475,6 +480,7 @@ impl McpManager {
         outputs
     }
 
+    #[tracing::instrument(name = "mcp.manager.commit_oauth_outputs", skip_all)]
     async fn commit_oauth_outputs(&self, outputs: Vec<ConnectOutput>) {
         // Batch-commit to shared maps in separate guarded blocks — never hold one
         // lock across another .await (same pattern as connect_all).
@@ -552,6 +558,7 @@ impl McpManager {
     /// Returns a [`ConnectOutput`] with all owned data the caller must commit to the
     /// shared maps. The caller is responsible for inserting this data under a write
     /// guard after all async work completes.
+    #[tracing::instrument(name = "mcp.manager.handle_connect_result", skip_all, fields(server_id = %server_id))]
     async fn handle_connect_result(
         &self,
         server_id: String,

--- a/crates/zeph-vault/src/age.rs
+++ b/crates/zeph-vault/src/age.rs
@@ -214,6 +214,7 @@ impl AgeVaultProvider {
     /// # Ok(())
     /// # }
     /// ```
+    #[tracing::instrument(name = "vault.age.load_async", skip_all, err)]
     pub async fn load_async(key_path: &Path, vault_path: &Path) -> Result<Self, AgeVaultError> {
         let key_path = key_path.to_owned();
         let vault_path = vault_path.to_owned();
@@ -286,6 +287,7 @@ impl AgeVaultProvider {
     /// # Ok(())
     /// # }
     /// ```
+    #[tracing::instrument(name = "vault.age.save_async", skip_all, err)]
     pub async fn save_async(&self) -> Result<(), AgeVaultError> {
         let key_path = self.key_path.clone();
         let vault_path = self.vault_path.clone();


### PR DESCRIPTION
## Summary

- **zeph-mcp `connect.rs`**: Add `#[tracing::instrument]` to 7 private async functions (`spawn_non_oauth_connections`, `process_connect_results`, `commit_connect_outputs`, `handle_connect_result`, `spawn_oauth_connections`, `process_oauth_results`, `commit_oauth_outputs`). Only `connect_all` had a span before; the internal fan-out/per-server/commit pipeline was entirely invisible.
- **zeph-channels `discord/gateway.rs`**: Instrument `gateway_loop`, `run_session`, `ack_interaction` (with `err`). WebSocket reconnect loop and HTTP interaction latency were absent from all traces.
- **zeph-channels `slack/events.rs`**: Instrument `handle_event`. Incoming webhook handling was untraced.
- **zeph-vault `age.rs`**: Add spans to `load_async` and `save_async` (with `err`). The async wrappers were missed when PR #5153 added spans to the sync `load`/`save` variants.

All 13 new spans are unconditional (not behind `#[cfg_attr(feature = "profiling", ...)]`), use `skip_all` to prevent sensitive parameters (Discord token, Slack signing secret, vault key paths) from leaking into trace output, and follow the `<crate>.<module>.<fn>` naming convention.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11411/11411 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] impl-critic audit: approved, 2 non-blocking findings (orphaned spans in non-profiling builds tied to open #5121; empty `connect_all` fields — out of scope)
- [x] Code review: approved

Closes #5203, #5189, #5210.