### PR TITLE
refactor(skills): extract embed_skills_with_timeout and add tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `refactor(skills)`: extract shared `embed_skills_with_timeout` free function
+  into `crates/zeph-skills/src/embedding.rs`, eliminating the duplicate
+  `embed_existing` body in `miner.rs` and `trace_extractor.rs`. Adds
+  `#[tracing::instrument]` spans to `save_quarantined` and `embed_existing`
+  in `trace_extractor.rs` (always-on); `miner::embed_existing` retains its
+  existing `profiling`-gated span. Closes #5290, #5291.
+
 ### Added
 
 - `feat(tracing)`: add `#[tracing::instrument]` to 13 hot-path async fns across

--- a/crates/zeph-skills/src/embedding.rs
+++ b/crates/zeph-skills/src/embedding.rs
@@ -24,7 +24,12 @@
 //! assert!(SkillEmbedding::new(vec![1.0, 0.0], 3).is_err());
 //! ```
 
+use std::time::Duration;
+
+use zeph_llm::provider::LlmProvider;
+
 use crate::error::SkillError;
+use crate::loader::SkillMeta;
 
 /// Validated embedding vector for skill matching.
 ///
@@ -92,7 +97,9 @@ impl SkillEmbedding {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
+    /// use zeph_skills::embedding::SkillEmbedding;
+    ///
     /// // At the provider boundary: dimension is whatever the model returns.
     /// let raw = vec![0.1_f32, 0.2, 0.3];
     /// let emb = SkillEmbedding::from_raw(raw);
@@ -107,7 +114,9 @@ impl SkillEmbedding {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
+    /// use zeph_skills::embedding::SkillEmbedding;
+    ///
     /// let emb = SkillEmbedding::from_raw(vec![0.0; 768]);
     /// assert_eq!(emb.dim(), 768);
     /// ```
@@ -120,7 +129,9 @@ impl SkillEmbedding {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
+    /// use zeph_skills::embedding::SkillEmbedding;
+    ///
     /// let v = vec![1.0_f32, 2.0, 3.0];
     /// let emb = SkillEmbedding::from_raw(v.clone());
     /// assert_eq!(emb.into_inner(), v);
@@ -135,6 +146,53 @@ impl AsRef<[f32]> for SkillEmbedding {
     fn as_ref(&self) -> &[f32] {
         &self.0
     }
+}
+
+/// Compute embeddings for a skill slice, skipping skills that fail or time out.
+///
+/// Each skill description is embedded independently with a per-call `timeout`. Skills whose
+/// embed call times out or returns an error are skipped with a `tracing::warn!` and are not
+/// included in the returned vector. The caller receives only successfully embedded skills.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::Duration;
+/// use zeph_skills::embedding::{embed_skills_with_timeout, SkillEmbedding};
+/// use zeph_skills::loader::SkillMeta;
+///
+/// # async fn example(skills: &[SkillMeta], provider: &impl zeph_llm::provider::LlmProvider) {
+/// let pairs = embed_skills_with_timeout(skills, provider, Duration::from_secs(5)).await;
+/// assert!(pairs.len() <= skills.len());
+/// # }
+/// ```
+#[tracing::instrument(
+    name = "skills.embed_skills_with_timeout",
+    skip_all,
+    fields(skill_count = skills.len())
+)]
+pub async fn embed_skills_with_timeout(
+    skills: &[SkillMeta],
+    embed_provider: &impl LlmProvider,
+    timeout: Duration,
+) -> Vec<(SkillMeta, SkillEmbedding)> {
+    let mut result = Vec::with_capacity(skills.len());
+    for skill in skills {
+        match tokio::time::timeout(timeout, embed_provider.embed(&skill.description)).await {
+            Ok(Ok(emb)) => result.push((skill.clone(), SkillEmbedding::from_raw(emb))),
+            Ok(Err(e)) => {
+                tracing::warn!(skill = %skill.name, error = %e, "embed failed, skipping skill");
+            }
+            Err(_) => {
+                tracing::warn!(
+                    skill = %skill.name,
+                    timeout_ms = timeout.as_millis(),
+                    "embed timed out, skipping skill"
+                );
+            }
+        }
+    }
+    result
 }
 
 #[cfg(test)]

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -18,7 +18,7 @@ use zeph_llm::provider::{LlmProvider, Message, Role};
 
 use zeph_common::secret::Secret;
 
-use crate::embedding::SkillEmbedding;
+use crate::embedding::{SkillEmbedding, embed_skills_with_timeout};
 use crate::error::SkillError;
 use crate::generator::{
     GeneratedSkill, SkillGenerator, extract_skill_md_pub, parse_and_validate_pub,
@@ -187,29 +187,8 @@ impl SkillMiner {
         tracing::instrument(name = "skills.miner.embed_existing", skip(self, skills), fields(count = skills.len()))
     )]
     async fn embed_existing(&self, skills: &[SkillMeta]) -> Vec<(SkillMeta, SkillEmbedding)> {
-        let mut embeddings = Vec::with_capacity(skills.len());
         let timeout = Duration::from_millis(self.config.generation_timeout_ms);
-        for skill in skills {
-            let embed_fut = self.embed_provider.embed(&skill.description);
-            match tokio::time::timeout(timeout, embed_fut).await {
-                Ok(Ok(emb)) => embeddings.push((skill.clone(), SkillEmbedding::from_raw(emb))),
-                Ok(Err(e)) => {
-                    tracing::warn!(
-                        skill = %skill.name,
-                        error = %e,
-                        "failed to embed existing skill for dedup"
-                    );
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        skill = %skill.name,
-                        timeout_ms = self.config.generation_timeout_ms,
-                        "embed timed out, skipping skill for dedup"
-                    );
-                }
-            }
-        }
-        embeddings
+        embed_skills_with_timeout(skills, &self.embed_provider, timeout).await
     }
 
     /// Process a single repo: generate skill, dedup, write.

--- a/crates/zeph-skills/src/trace_extractor.rs
+++ b/crates/zeph-skills/src/trace_extractor.rs
@@ -33,7 +33,7 @@ use tracing::Instrument as _;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 
-use crate::embedding::SkillEmbedding;
+use crate::embedding::{SkillEmbedding, embed_skills_with_timeout};
 use crate::error::SkillError;
 use crate::generator::{
     GeneratedSkill, SkillGenerator, extract_skill_md_pub, parse_and_validate_pub,
@@ -425,6 +425,7 @@ impl TraceExtractor {
     }
 
     /// Write a candidate skill to the quarantine directory. Logs on failure.
+    #[tracing::instrument(name = "skills.trace_extraction.save_quarantined", skip_all, fields(skill = %skill.name, session_id))]
     async fn save_quarantined(&self, skill: &GeneratedSkill, session_id: &str) {
         match self.generator.write_quarantined(skill).await {
             Ok(path) => tracing::info!(
@@ -520,36 +521,12 @@ impl TraceExtractor {
         }
     }
 
-    /// Compute embeddings for existing skills (same as miner, used for callers that assemble
-    /// `existing_embeddings` lazily).
+    /// Compute embeddings for existing skills, used for dedup before skill extraction.
     ///
-    /// # Errors
-    ///
-    /// Returns `SkillError::Other` if the embed provider fails catastrophically.
-    /// Skills that time out are skipped with a warning.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "skills.trace_extractor.embed_existing", skip(self, skills), fields(skill_count = skills.len()))
-    )]
+    /// Skills that time out or fail are skipped with a warning.
+    #[tracing::instrument(name = "skills.trace_extractor.embed_existing", skip_all, fields(skill_count = skills.len()))]
     pub async fn embed_existing(&self, skills: &[SkillMeta]) -> Vec<(SkillMeta, SkillEmbedding)> {
-        let mut result = Vec::with_capacity(skills.len());
-        for skill in skills {
-            match tokio::time::timeout(
-                self.llm_timeout,
-                self.embed_provider.embed(&skill.description),
-            )
-            .await
-            {
-                Ok(Ok(emb)) => result.push((skill.clone(), SkillEmbedding::from_raw(emb))),
-                Ok(Err(e)) => {
-                    tracing::warn!(skill = %skill.name, error = %e, "trace_extractor: embed failed");
-                }
-                Err(_) => {
-                    tracing::warn!(skill = %skill.name, "trace_extractor: embed timed out");
-                }
-            }
-        }
-        result
+        embed_skills_with_timeout(skills, &self.embed_provider, self.llm_timeout).await
     }
 }
 


### PR DESCRIPTION
## Summary

- Extracts shared `embed_skills_with_timeout` free function into new `crates/zeph-skills/src/embedding.rs`, eliminating the near-identical `embed_existing` bodies in `miner.rs` and `trace_extractor.rs`
- Adds `#[tracing::instrument]` to `save_quarantined` and `embed_existing` in `trace_extractor.rs` (always-on spans); shared helper carries span `skills.embed_skills_with_timeout` with `skill_count` field
- `miner::embed_existing` retains its existing profiling-gated span unchanged

`merge_candidate` duplication was assessed and intentionally left — the two variants differ in write target, injection scan, and `session_id` param.

**Note:** Default builds now emit `skills.embed_skills_with_timeout` and `skills.trace_extractor.embed_existing` spans that were previously absent (or profiling-gated). This is intentional and spec-aligned with the continuous-improvement instrumentation rule.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — 0 errors
- [x] `cargo nextest run -p zeph-skills --lib --bins` — 538 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace` — clean

Closes #5290, #5291.