### PR TITLE
refactor(llm): extract ASI coherence helper and replace cascade expect() with Result

### DIFF
--- a/crates/zeph-llm/src/router/chat.rs
+++ b/crates/zeph-llm/src/router/chat.rs
@@ -150,11 +150,11 @@ impl RouterProvider {
         let cfg = self
             .cascade_config
             .as_ref()
-            .expect("cascade_config must be set");
+            .ok_or_else(|| LlmError::Other("cascade_config not set".into()))?;
         let cascade_state = self
             .cascade_state
             .as_ref()
-            .expect("cascade_state must be set");
+            .ok_or_else(|| LlmError::Other("cascade_state not set".into()))?;
 
         let mut escalations_remaining = cfg.max_escalations;
         let mut best: Option<(String, f64)> = None; // (response, score)
@@ -291,11 +291,11 @@ impl RouterProvider {
         let cfg = self
             .cascade_config
             .as_ref()
-            .expect("cascade_config must be set");
+            .ok_or_else(|| LlmError::Other("cascade_config not set".into()))?;
         let cascade_state = self
             .cascade_state
             .as_ref()
-            .expect("cascade_state must be set");
+            .ok_or_else(|| LlmError::Other("cascade_state not set".into()))?;
 
         let mut escalations_remaining = cfg.max_escalations;
         let mut tokens_used: u32 = 0;

--- a/crates/zeph-llm/src/router/select.rs
+++ b/crates/zeph-llm/src/router/select.rs
@@ -23,6 +23,35 @@ use crate::ema::EmaTracker;
 use crate::provider::LlmProvider;
 
 impl RouterProvider {
+    /// Emit a rate-limited warn (once per 60 s) when a provider's ASI coherence drops below
+    /// threshold. Falls back to a trace-level message while the rate limit is active.
+    fn maybe_warn_asi_coherence(provider: &str, coherence: f32, threshold: f32) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or(std::time::Duration::MAX)
+            .as_secs();
+        let last = ASI_WARN_LAST_SECS.load(Ordering::Relaxed);
+        if now.saturating_sub(last) >= 60
+            && ASI_WARN_LAST_SECS
+                .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            tracing::warn!(
+                provider,
+                coherence,
+                threshold,
+                "asi: coherence below threshold"
+            );
+        } else {
+            tracing::trace!(
+                provider,
+                coherence,
+                threshold,
+                "asi: coherence below threshold (warn rate-limited)"
+            );
+        }
+    }
+
     /// Hash a query string to a `u64` cache key.
     fn query_hash(query: &str) -> u64 {
         use std::hash::{Hash as _, Hasher as _};
@@ -261,30 +290,11 @@ impl RouterProvider {
                 .map(|(idx, p)| {
                     let coherence = asi.coherence(p.name());
                     if coherence < asi_cfg.coherence_threshold {
-                        let now = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or(std::time::Duration::MAX)
-                            .as_secs();
-                        let last = ASI_WARN_LAST_SECS.load(Ordering::Relaxed);
-                        if now.saturating_sub(last) >= 60
-                            && ASI_WARN_LAST_SECS
-                                .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
-                                .is_ok()
-                        {
-                            tracing::warn!(
-                                provider = p.name(),
-                                coherence,
-                                threshold = asi_cfg.coherence_threshold,
-                                "asi: coherence below threshold"
-                            );
-                        } else {
-                            tracing::trace!(
-                                provider = p.name(),
-                                coherence,
-                                threshold = asi_cfg.coherence_threshold,
-                                "asi: coherence below threshold (warn rate-limited)"
-                            );
-                        }
+                        Self::maybe_warn_asi_coherence(
+                            p.name(),
+                            coherence,
+                            asi_cfg.coherence_threshold,
+                        );
                     }
                     let base_score = snap
                         .as_ref()
@@ -353,35 +363,11 @@ impl RouterProvider {
                     if let (Some(asi), Some(asi_cfg)) = (&asi_guard, &self.asi_config) {
                         let coherence = asi.coherence(name);
                         if coherence < asi_cfg.coherence_threshold {
-                            let now = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or(std::time::Duration::MAX)
-                                .as_secs();
-                            let last = ASI_WARN_LAST_SECS.load(Ordering::Relaxed);
-                            if now.saturating_sub(last) >= 60
-                                && ASI_WARN_LAST_SECS
-                                    .compare_exchange(
-                                        last,
-                                        now,
-                                        Ordering::Relaxed,
-                                        Ordering::Relaxed,
-                                    )
-                                    .is_ok()
-                            {
-                                tracing::warn!(
-                                    provider = name.as_str(),
-                                    coherence,
-                                    threshold = asi_cfg.coherence_threshold,
-                                    "asi: coherence below threshold"
-                                );
-                            } else {
-                                tracing::trace!(
-                                    provider = name.as_str(),
-                                    coherence,
-                                    threshold = asi_cfg.coherence_threshold,
-                                    "asi: coherence below threshold (warn rate-limited)"
-                                );
-                            }
+                            Self::maybe_warn_asi_coherence(
+                                name.as_str(),
+                                coherence,
+                                asi_cfg.coherence_threshold,
+                            );
                             let deficit = asi_cfg.coherence_threshold - coherence;
                             let penalty = f64::from(asi_cfg.penalty_weight * deficit);
                             beta += penalty;


### PR DESCRIPTION
## Summary

- **#5288** — Extract the duplicated rate-limited `warn`/`trace` block from `ema_ordered_providers` and `thompson_ordered_providers` in `router/select.rs` into a single private helper `maybe_warn_asi_coherence(provider, coherence, threshold)`. Removes ~40 lines of near-identical inline code.
- **#5289** — Replace four `.expect()` calls in `cascade_chat` and `cascade_chat_stream` (`router/chat.rs`) with `.ok_or_else(|| LlmError::Other(...))?`. Both functions already return `Result<_, LlmError>`, so a builder-invariant violation now produces a recoverable error instead of a hard panic.

Also closes #5286 (duplicate of #5288) and #5287 (duplicate of #5289).

## Notes

`LlmError::Internal` does not exist in the enum — `LlmError::Other` was used instead. A follow-up P3 issue to add `LlmError::Internal(String)` and migrate these four sites is recommended by the reviewer.

## Test plan

- `cargo +nightly fmt --check`: clean
- `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`: 0 warnings
- `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins`: 11411 passed, 0 failed
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`: clean