### PR TITLE
fix(index): add embed_batch timeout and ensure_collection tracing span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(index)`: wrap `embed_batch` in `tokio::time::timeout` in `FileIndexWorker::index_file`
+  (`indexer.rs:572`). Previously the call had no timeout guard, meaning a slow or hung
+  embedding provider could stall the indexer pipeline indefinitely. Adds
+  `embed_batch_timeout_secs` (default 60 s) to `IndexerConfig`, consistent with the
+  existing `embed_timeout_secs` pattern in `RetrieverConfig`. Exceeding the timeout
+  returns `IndexError::EmbedTimeout` and skips the batch. Closes #5293.
+
+- `fix(index)`: add `#[tracing::instrument(name = "index.store.ensure_collection",
+  skip_all)]` to `CodeStore::ensure_collection` (`store.rs:177`). The function was the
+  only uninstrumented public async fn in `CodeStore`, making Qdrant collection-creation
+  timing and errors invisible in traces. Closes #5292.
+
 ### Changed
 
 - `refactor(skills)`: extract shared `embed_skills_with_timeout` free function

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -97,6 +97,14 @@ pub struct IndexerConfig {
     /// resolution happens in the binary bootstrap before this struct is constructed.
     /// Setting this field does not change which provider is used.
     pub embedding_provider: String,
+    /// Timeout in seconds for a single `embed_batch` call. Default: 60.
+    ///
+    /// Batch embedding calls cover an entire file's worth of chunks and can take
+    /// longer than a single-query embed, so this is set higher than the retriever's
+    /// `embed_timeout_secs` (10 s). Exceeding the timeout yields
+    /// [`crate::error::IndexError::EmbedTimeout`] and skips the batch rather than
+    /// blocking the indexer indefinitely.
+    pub embed_batch_timeout_secs: u64,
 }
 
 impl Default for IndexerConfig {
@@ -109,6 +117,7 @@ impl Default for IndexerConfig {
             max_file_bytes: 512 * 1024,
             embed_concurrency: 1,
             embedding_provider: String::new(),
+            embed_batch_timeout_secs: 60,
         }
     }
 }
@@ -563,7 +572,19 @@ impl FileIndexWorker {
         let embedding_texts: Vec<String> =
             new_chunks.iter().map(contextualize_for_embedding).collect();
         let text_refs: Vec<&str> = embedding_texts.iter().map(String::as_str).collect();
-        let vectors = self.provider.embed_batch(&text_refs).await?;
+        let vectors = tokio::time::timeout(
+            Duration::from_secs(self.config.embed_batch_timeout_secs),
+            self.provider.embed_batch(&text_refs),
+        )
+        .await
+        .map_err(|_| {
+            tracing::warn!(
+                embed_batch_timeout_secs = self.config.embed_batch_timeout_secs,
+                chunks = new_chunks.len(),
+                "embed_batch timed out, skipping batch"
+            );
+            IndexError::EmbedTimeout(self.config.embed_batch_timeout_secs)
+        })??;
 
         let batch: Vec<(ChunkInsert<'_>, Vec<f32>)> = new_chunks
             .iter()
@@ -726,6 +747,7 @@ mod tests {
         assert_eq!(config.batch_size, 16);
         assert_eq!(config.embed_concurrency, 1);
         assert_eq!(config.embedding_provider, "");
+        assert_eq!(config.embed_batch_timeout_secs, 60);
     }
 
     #[test]
@@ -956,6 +978,67 @@ mod tests {
         match result {
             Err(crate::error::IndexError::EmbedTimeout(secs)) => {
                 assert_eq!(secs, 15, "timeout value must be the configured 15 s");
+            }
+            other => panic!("expected IndexError::EmbedTimeout, got: {other:?}"),
+        }
+    }
+
+    /// Verify that `index_file` returns `IndexError::EmbedTimeout` when `embed_batch`
+    /// exceeds `embed_batch_timeout_secs`.
+    ///
+    /// Uses a tiny real-wall-clock timeout (1 s) paired with a mock provider that sleeps
+    /// for 3 s, so the test finishes in ~1 s without requiring `tokio::time::pause` (which
+    /// is process-global and causes `PoolTimedOut` in concurrently running `SQLite` tests).
+    #[tokio::test]
+    async fn index_file_embed_batch_timeout_returns_embed_timeout_error() {
+        use std::sync::Arc;
+        use tempfile::TempDir;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_memory::QdrantOps;
+
+        let dir = TempDir::new().unwrap();
+        let rs_path = dir.path().join("slow.rs");
+        std::fs::write(&rs_path, "pub fn slow() -> u32 { 42 }\n").unwrap();
+
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_string(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap();
+
+        // embed_delay_ms (3 000) > embed_batch_timeout_secs (1 s).
+        // The test waits at most ~1 s wall-clock time — acceptable in CI.
+        let slow_provider = Arc::new(AnyProvider::Mock(
+            MockProvider::default()
+                .with_embed_delay(3_000) // 3 s > 1 s timeout
+                .with_embedding(vec![0.0_f32; 384]),
+        ));
+
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        let store = crate::store::CodeStore::with_ops(ops, pool);
+        let config = IndexerConfig {
+            embed_batch_timeout_secs: 1,
+            ..IndexerConfig::default()
+        };
+        // Call FileIndexWorker::index_file directly to avoid remove_file_chunks (SQLite)
+        // so the test does not touch the DB after construction.
+        let worker = super::FileIndexWorker {
+            store,
+            provider: Arc::clone(&slow_provider),
+            config,
+            spawner: None,
+        };
+        let result = worker.index_file(&rs_path, "slow.rs").await;
+
+        match result {
+            Err(crate::error::IndexError::EmbedTimeout(secs)) => {
+                assert_eq!(
+                    secs, 1,
+                    "timeout value must match configured embed_batch_timeout_secs"
+                );
             }
             other => panic!("expected IndexError::EmbedTimeout, got: {other:?}"),
         }

--- a/crates/zeph-index/src/store.rs
+++ b/crates/zeph-index/src/store.rs
@@ -174,6 +174,7 @@ impl CodeStore {
     /// # Errors
     ///
     /// Returns an error if `Qdrant` operations fail.
+    #[tracing::instrument(name = "index.store.ensure_collection", skip_all)]
     pub async fn ensure_collection(&self, vector_size: u64) -> Result<()> {
         self.ops
             .ensure_collection_with_quantization(


### PR DESCRIPTION
## Summary

- **#5293** — `embed_batch` in `FileIndexWorker::index_file` (`indexer.rs:572`) previously had no timeout guard, allowing a slow or hung embedding provider to stall the indexer pipeline indefinitely. Adds `IndexerConfig::embed_batch_timeout_secs` (default 60 s) and wraps the call in `tokio::time::timeout`, consistent with the `RetrieverConfig::embed_timeout_secs` pattern in `retriever.rs`. On timeout returns `IndexError::EmbedTimeout` and skips the batch.
- **#5292** — `CodeStore::ensure_collection` (`store.rs:177`) was the only uninstrumented public async fn in `CodeStore`. Adds `#[tracing::instrument(name = "index.store.ensure_collection", skip_all)]` so Qdrant collection-creation timing and errors are visible in traces.

## Test plan

- [x] `cargo +nightly fmt --check` — PASS
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — PASS
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-index` — 109/109 PASS (new test `index_file_embed_batch_timeout_returns_embed_timeout_error` verifies timeout path; stable ×3 runs)
- [x] `cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` with `-D warnings` + `--deny rustdoc::broken_intra_doc_links` — PASS

## Notes

- `embed_batch_timeout_secs` uses a 60 s default (vs 10 s for single-query `embed_timeout_secs`) because batch calls cover a full file's chunks and warrant a higher bound.
- The field is not yet exposed via `config.toml` — it matches the existing `RetrieverConfig::embed_timeout_secs` precedent. Follow-up to promote both index timeouts to user-configurable `IndexConfig` fields.

Closes #5293, #5292