### PR TITLE
refactor(llm): replace expect() with recoverable errors and extract ASI coherence DRY helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   in `trace_extractor.rs` (always-on); `miner::embed_existing` retains its
   existing `profiling`-gated span. Closes #5290, #5291.
 
+- `refactor(llm)`: replace 4 `expect()` calls in `cascade_chat` and
+  `cascade_chat_stream` with `ok_or_else(|| LlmError::Other(...))?`, converting
+  unreachable-in-practice panics into recoverable errors that propagate through
+  the normal error path. Closes #5287.
+
+- `refactor(llm)`: extract the duplicated ~20-line rate-limited ASI coherence
+  warn/trace block from `ema_ordered_providers` and `thompson_ordered_providers`
+  in `router/select.rs` into a private `maybe_warn_asi_coherence()` helper,
+  reducing the duplication and making future changes to the warn logic a
+  one-place edit. Closes #5286.
+
 ### Added
 
 - `feat(tracing)`: add `#[tracing::instrument]` to 13 hot-path async fns across

--- a/crates/zeph-llm/src/router/chat.rs
+++ b/crates/zeph-llm/src/router/chat.rs
@@ -150,11 +150,11 @@ impl RouterProvider {
         let cfg = self
             .cascade_config
             .as_ref()
-            .expect("cascade_config must be set");
+            .ok_or_else(|| LlmError::Other("cascade_config not set".into()))?;
         let cascade_state = self
             .cascade_state
             .as_ref()
-            .expect("cascade_state must be set");
+            .ok_or_else(|| LlmError::Other("cascade_state not set".into()))?;
 
         let mut escalations_remaining = cfg.max_escalations;
         let mut best: Option<(String, f64)> = None; // (response, score)
@@ -291,11 +291,11 @@ impl RouterProvider {
         let cfg = self
             .cascade_config
             .as_ref()
-            .expect("cascade_config must be set");
+            .ok_or_else(|| LlmError::Other("cascade_config not set".into()))?;
         let cascade_state = self
             .cascade_state
             .as_ref()
-            .expect("cascade_state must be set");
+            .ok_or_else(|| LlmError::Other("cascade_state not set".into()))?;
 
         let mut escalations_remaining = cfg.max_escalations;
         let mut tokens_used: u32 = 0;

--- a/crates/zeph-llm/src/router/select.rs
+++ b/crates/zeph-llm/src/router/select.rs
@@ -22,6 +22,35 @@ use crate::any::AnyProvider;
 use crate::ema::EmaTracker;
 use crate::provider::LlmProvider;
 
+/// Emit a rate-limited `warn!` (at most once per 60 s) and an always-on `trace!`
+/// when a provider's ASI coherence falls below the configured threshold.
+fn maybe_warn_asi_coherence(provider: &str, coherence: f32, threshold: f32) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::MAX)
+        .as_secs();
+    let last = ASI_WARN_LAST_SECS.load(Ordering::Relaxed);
+    if now.saturating_sub(last) >= 60
+        && ASI_WARN_LAST_SECS
+            .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    {
+        tracing::warn!(
+            provider,
+            coherence,
+            threshold,
+            "asi: coherence below threshold"
+        );
+    } else {
+        tracing::trace!(
+            provider,
+            coherence,
+            threshold,
+            "asi: coherence below threshold (warn rate-limited)"
+        );
+    }
+}
+
 impl RouterProvider {
     /// Hash a query string to a `u64` cache key.
     fn query_hash(query: &str) -> u64 {
@@ -261,30 +290,7 @@ impl RouterProvider {
                 .map(|(idx, p)| {
                     let coherence = asi.coherence(p.name());
                     if coherence < asi_cfg.coherence_threshold {
-                        let now = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or(std::time::Duration::MAX)
-                            .as_secs();
-                        let last = ASI_WARN_LAST_SECS.load(Ordering::Relaxed);
-                        if now.saturating_sub(last) >= 60
-                            && ASI_WARN_LAST_SECS
-                                .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
-                                .is_ok()
-                        {
-                            tracing::warn!(
-                                provider = p.name(),
-                                coherence,
-                                threshold = asi_cfg.coherence_threshold,
-                                "asi: coherence below threshold"
-                            );
-                        } else {
-                            tracing::trace!(
-                                provider = p.name(),
-                                coherence,
-                                threshold = asi_cfg.coherence_threshold,
-                                "asi: coherence below threshold (warn rate-limited)"
-                            );
-                        }
+                        maybe_warn_asi_coherence(p.name(), coherence, asi_cfg.coherence_threshold);
                     }
                     let base_score = snap
                         .as_ref()
@@ -353,35 +359,11 @@ impl RouterProvider {
                     if let (Some(asi), Some(asi_cfg)) = (&asi_guard, &self.asi_config) {
                         let coherence = asi.coherence(name);
                         if coherence < asi_cfg.coherence_threshold {
-                            let now = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or(std::time::Duration::MAX)
-                                .as_secs();
-                            let last = ASI_WARN_LAST_SECS.load(Ordering::Relaxed);
-                            if now.saturating_sub(last) >= 60
-                                && ASI_WARN_LAST_SECS
-                                    .compare_exchange(
-                                        last,
-                                        now,
-                                        Ordering::Relaxed,
-                                        Ordering::Relaxed,
-                                    )
-                                    .is_ok()
-                            {
-                                tracing::warn!(
-                                    provider = name.as_str(),
-                                    coherence,
-                                    threshold = asi_cfg.coherence_threshold,
-                                    "asi: coherence below threshold"
-                                );
-                            } else {
-                                tracing::trace!(
-                                    provider = name.as_str(),
-                                    coherence,
-                                    threshold = asi_cfg.coherence_threshold,
-                                    "asi: coherence below threshold (warn rate-limited)"
-                                );
-                            }
+                            maybe_warn_asi_coherence(
+                                name.as_str(),
+                                coherence,
+                                asi_cfg.coherence_threshold,
+                            );
                             let deficit = asi_cfg.coherence_threshold - coherence;
                             let penalty = f64::from(asi_cfg.penalty_weight * deficit);
                             beta += penalty;


### PR DESCRIPTION
## Summary

- Replace 4 `expect()` calls in `cascade_chat` and `cascade_chat_stream` (`router/chat.rs`) with `ok_or_else(|| LlmError::Other(...))?`. The panics are unreachable in practice due to builder invariants in `with_cascade()`, but converting them to propagated errors makes future refactors safe and removes hard panics from the async hot path. Closes #5287.
- Extract the duplicated ~20-line rate-limited ASI coherence warn/trace block from `ema_ordered_providers` and `thompson_ordered_providers` (`router/select.rs`) into a private `maybe_warn_asi_coherence(provider, coherence, threshold)` helper. Reduces net LOC by 18 lines; any future changes to the warn rate-limit logic are now a single-site edit. Closes #5286.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11432 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [ ] LLM serialization gate: not triggered (changes are in routing/selection logic, not serialization paths)