### PR TITLE
fix(config): correct SchedulerConfig doc-comment and add cron/run_at validation

### DIFF
--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -1037,8 +1037,8 @@ impl Default for SchedulerSecurityConfig {
 /// [[scheduler.tasks]]
 /// name = "daily-summary"
 /// cron = "0 9 * * *"
-/// kind = "prompt"
-/// prompt = "Summarize what was accomplished today."
+/// kind = "custom"
+/// config = { prompt = "Summarize what was accomplished today." }
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SchedulerConfig {

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -81,6 +81,7 @@ impl Config {
         self.validate_llm_and_skills()?;
         self.validate_provider_names()?;
         self.validate_mcp_misc()?;
+        self.validate_scheduler()?;
         Ok(())
     }
 
@@ -388,6 +389,28 @@ impl Config {
                  use forward_output_schema = false to disable forwarding",
                 self.mcp.output_schema_hint_bytes
             )));
+        }
+        Ok(())
+    }
+
+    /// Validate that each `[[scheduler.tasks]]` entry has exactly one of `cron` or `run_at` set.
+    fn validate_scheduler(&self) -> Result<(), ConfigError> {
+        for task in &self.scheduler.tasks {
+            match (&task.cron, &task.run_at) {
+                (Some(_), Some(_)) => {
+                    return Err(ConfigError::Validation(format!(
+                        "scheduler task {:?}: only one of `cron` or `run_at` may be set, not both",
+                        task.name
+                    )));
+                }
+                (None, None) => {
+                    return Err(ConfigError::Validation(format!(
+                        "scheduler task {:?}: either `cron` or `run_at` must be set",
+                        task.name
+                    )));
+                }
+                _ => {}
+            }
         }
         Ok(())
     }
@@ -1014,5 +1037,55 @@ weight = 0.3
         let mut cfg = Config::default();
         cfg.agent.focus.auto_consolidate_min_window = 1;
         assert!(cfg.validate().is_ok());
+    }
+
+    fn task_with(cron: Option<&str>, run_at: Option<&str>) -> crate::features::ScheduledTaskConfig {
+        crate::features::ScheduledTaskConfig {
+            name: "test-task".into(),
+            cron: cron.map(Into::into),
+            run_at: run_at.map(Into::into),
+            kind: crate::features::ScheduledTaskKind::HealthCheck,
+            config: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn scheduler_task_valid_cron() {
+        let mut cfg = Config::default();
+        cfg.scheduler.tasks.push(task_with(Some("0 9 * * *"), None));
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn scheduler_task_valid_run_at() {
+        let mut cfg = Config::default();
+        cfg.scheduler
+            .tasks
+            .push(task_with(None, Some("2025-01-01T09:00:00Z")));
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn scheduler_task_neither_cron_nor_run_at_rejected() {
+        let mut cfg = Config::default();
+        cfg.scheduler.tasks.push(task_with(None, None));
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("either `cron` or `run_at` must be set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn scheduler_task_both_cron_and_run_at_rejected() {
+        let mut cfg = Config::default();
+        cfg.scheduler
+            .tasks
+            .push(task_with(Some("0 9 * * *"), Some("2025-01-01T09:00:00Z")));
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("only one of `cron` or `run_at` may be set"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix incorrect `SchedulerConfig` doc-comment example that used non-existent `kind = "prompt"` variant and a `prompt` field not present on `ScheduledTaskConfig`. The example now uses `kind = "custom"` with `config = { prompt = "..." }` per the actual API.
- Add `Config::validate_scheduler()` called from `Config::validate()` that rejects any `[[scheduler.tasks]]` entry where both `cron` and `run_at` are absent, or both are present simultaneously. Previously this constraint was enforced only at runtime via silent `tracing::warn` + task skip in `src/scheduler.rs`; users now get a clear startup error before the agent loop begins.

## Test plan

- [ ] `cargo nextest run -p zeph-config --lib` — 4 new tests cover all scheduler validation branches (valid cron, valid run_at, neither set, both set)
- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11436 passed
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean

Closes #5302, #5303