### PR TITLE
fix(tui,worktree): offload blocking std::fs I/O to spawn_blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tui)`: offload user theme file I/O to `tokio::task::spawn_blocking` in `apply_theme`
+  to prevent the `tui_loop` from stalling on `std::fs::symlink_metadata` / `File::open` calls.
+  Built-in presets are still applied synchronously (no I/O). User file results arrive via an
+  `oneshot` channel polled on each tick. Cancels any in-flight load when switching to a preset.
+  Closes #5308.
+
+- `fix(worktree)`: make `WorktreeManager::new` async and wrap the `canonicalize_root` call
+  (`create_dir_all` + `canonicalize`) in `tokio::task::spawn_blocking` to prevent blocking
+  the async executor at agent startup. Matches the pattern already used in `WorktreeManager::create`.
+  Closes #5312.
+
 - `fix(index)`: wrap `embed_batch` in `tokio::time::timeout` in `FileIndexWorker::index_file`
   (`indexer.rs:572`). Previously the call had no timeout guard, meaning a slow or hung
   embedding provider could stall the indexer pipeline indefinitely. Adds

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -3477,7 +3477,7 @@ mod worktree_cleanup_guard_tests {
 
     use crate::manager::worktree::WorktreeCleanupGuard;
 
-    fn make_dummy_wm() -> (TempDir, Arc<DefaultWorktreeManager>) {
+    async fn make_dummy_wm() -> (TempDir, Arc<DefaultWorktreeManager>) {
         let dir = TempDir::new().unwrap();
         std::fs::create_dir_all(dir.path().join(".git")).unwrap();
         let config = WorktreeConfig {
@@ -3487,6 +3487,7 @@ mod worktree_cleanup_guard_tests {
         };
         let wm =
             DefaultWorktreeManager::new(dir.path().to_path_buf(), config, DefaultGitRunner::new())
+                .await
                 .unwrap();
         (dir, Arc::new(wm))
     }
@@ -3505,7 +3506,11 @@ mod worktree_cleanup_guard_tests {
     /// even outside a tokio runtime.
     #[test]
     fn cleanup_skipped_when_disabled() {
-        let (_dir, wm) = make_dummy_wm();
+        // Build manager inside a temporary runtime; then drop the runtime so the
+        // subsequent WorktreeCleanupGuard drop is intentionally outside a runtime.
+        let (_dir, wm) = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(make_dummy_wm());
         let dir2 = TempDir::new().unwrap();
         let handle = dummy_handle(&dir2);
         // Drop must not panic even without a tokio runtime.
@@ -3521,7 +3526,9 @@ mod worktree_cleanup_guard_tests {
     /// This covers the `Handle::try_current` → `Err` branch.
     #[test]
     fn cleanup_logs_error_without_runtime() {
-        let (_dir, wm) = make_dummy_wm();
+        let (_dir, wm) = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(make_dummy_wm());
         let dir2 = TempDir::new().unwrap();
         let handle = dummy_handle(&dir2);
         // No tokio runtime active — must not panic, must log error instead.
@@ -3538,7 +3545,7 @@ mod worktree_cleanup_guard_tests {
     /// is a no-op or logs a warning — either outcome is acceptable here).
     #[tokio::test]
     async fn cleanup_spawns_remove_with_runtime() {
-        let (_dir, wm) = make_dummy_wm();
+        let (_dir, wm) = make_dummy_wm().await;
         let dir2 = TempDir::new().unwrap();
         let handle = dummy_handle(&dir2);
         drop(WorktreeCleanupGuard {

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -165,11 +165,15 @@ impl App {
             TuiCommand::SetTheme(name) => {
                 let name = name.clone();
                 match self.apply_theme(&name) {
-                    Ok(()) => {
+                    Ok(true) => {
+                        // Preset applied immediately.
                         self.push_system_message(format!(
                             "Theme switched to: {}",
                             self.active_theme_name()
                         ));
+                    }
+                    Ok(false) => {
+                        // User file load dispatched; confirmation arrives via poll_pending_theme.
                     }
                     Err(e) => {
                         self.push_system_message(format!("Theme error: {e}"));

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -400,6 +400,15 @@ pub struct App {
     hyperlinks: Vec<HyperlinkSpan>,
     cancel_signal: Option<Arc<Notify>>,
     pending_file_index: Option<oneshot::Receiver<FileIndex>>,
+    /// Pending user-theme load: fired by `apply_theme` when the name resolves to a
+    /// user file on disk rather than a built-in preset.  The background thread reads
+    /// and parses `~/.config/zeph/themes/<name>.toml`; the result is installed by
+    /// `poll_pending_theme` on the next tick.
+    pending_theme: Option<
+        oneshot::Receiver<Result<super::theme::SemanticPalette, super::theme::ThemeLoadError>>,
+    >,
+    /// Theme name paired with `pending_theme` so the poll handler can update `theme_name`.
+    pending_theme_name: Option<String>,
     /// Interactive selection state for the subagent sidebar (stays global per arch v2 E5).
     pub subagent_sidebar: SubAgentSidebarState,
     /// Optional handle to the `TaskSupervisor` for the task registry panel.

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -85,6 +85,8 @@ impl App {
             hyperlinks: Vec::new(),
             cancel_signal: None,
             pending_file_index: None,
+            pending_theme: None,
+            pending_theme_name: None,
             subagent_sidebar: SubAgentSidebarState::new(),
             task_supervisor: None,
             show_task_panel: false,
@@ -200,16 +202,18 @@ impl App {
         self.theme_generation
     }
 
-    /// Apply a named theme preset or user file, updating the active theme and bumping
-    /// the generation counter so that all session render caches are invalidated.
+    /// Apply a named theme preset or user file.
     ///
-    /// On success the new theme name is stored for cycle tracking.
-    /// On error the existing theme is left unchanged.
+    /// Returns `Ok(true)` when the theme was applied immediately (built-in preset).
+    /// Returns `Ok(false)` when the user file load was dispatched asynchronously; the
+    /// result will be installed by `poll_pending_theme` on the next tick.
+    ///
+    /// Cancels any in-flight user-file load when switching to a preset, so the earlier
+    /// async result cannot silently revert the newer choice.
     ///
     /// # Errors
     ///
-    /// Returns [`crate::theme::ThemeLoadError`] if the name fails validation or the
-    /// palette file cannot be parsed.
+    /// Returns [`crate::theme::ThemeLoadError`] for empty or path-unsafe names.
     ///
     /// # Examples
     ///
@@ -224,20 +228,79 @@ impl App {
     /// let _ = app.apply_theme("zephyr-light");
     /// assert!(app.theme_generation() > gen_before);
     /// ```
-    pub fn apply_theme(&mut self, name: &str) -> Result<(), crate::theme::ThemeLoadError> {
-        use crate::theme::{Theme, ThemeLoadError, resolve_palette};
+    pub fn apply_theme(&mut self, name: &str) -> Result<bool, crate::theme::ThemeLoadError> {
+        use crate::theme::{Theme, ThemeLoadError, presets};
         // Reject empty names — always routes to listing, never implicit preset resolution.
         if name.is_empty() {
             return Err(ThemeLoadError::UnsafeName(String::new()));
         }
-        let palette = resolve_palette(name)?;
-        let new_theme = Theme::from_palette_with_mode(&palette, self.effective_color_mode);
-        self.theme = new_theme;
-        name.clone_into(&mut self.theme_name);
-        self.theme_generation += 1;
-        // Invalidate render caches for ALL sessions (theme is global, not per-session).
-        self.clear_all_render_caches();
-        Ok(())
+        // Validate name before any I/O so callers get immediate feedback on bad input.
+        presets::validate_theme_name_pub(name)?;
+
+        // Built-in presets are compile-time constants — no I/O, apply synchronously.
+        if let Some(preset) = presets::Preset::from_name(name) {
+            // Cancel any in-flight user-file load so it cannot revert this newer choice.
+            self.pending_theme = None;
+            self.pending_theme_name = None;
+            let palette = preset.palette();
+            let new_theme = Theme::from_palette_with_mode(&palette, self.effective_color_mode);
+            self.theme = new_theme;
+            name.clone_into(&mut self.theme_name);
+            self.theme_generation += 1;
+            self.clear_all_render_caches();
+            return Ok(true);
+        }
+
+        // User file: offload blocking I/O to a spawn_blocking thread.
+        // The result is installed by `poll_pending_theme` on the next tick.
+        let name_owned = name.to_owned();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::task::spawn_blocking(move || {
+            let _ = tx.send(presets::load_user_theme(&name_owned));
+        });
+        self.pending_theme = Some(rx);
+        self.pending_theme_name = Some(name.to_owned());
+        Ok(false)
+    }
+
+    /// Install a pending user-theme load result if the background task has completed.
+    ///
+    /// Must be called once per tick from `tui_loop` (alongside `poll_pending_file_index`).
+    pub fn poll_pending_theme(&mut self) {
+        use crate::theme::Theme;
+
+        let Some(rx) = self.pending_theme.as_mut() else {
+            return;
+        };
+        match rx.try_recv() {
+            Ok(result) => {
+                self.pending_theme = None;
+                let name = self.pending_theme_name.take().unwrap_or_default();
+                match result {
+                    Ok(palette) => {
+                        let new_theme =
+                            Theme::from_palette_with_mode(&palette, self.effective_color_mode);
+                        self.theme = new_theme;
+                        name.clone_into(&mut self.theme_name);
+                        self.theme_generation += 1;
+                        self.clear_all_render_caches();
+                        self.push_system_message_pub(format!("Theme switched to: {name}"));
+                    }
+                    Err(e) => {
+                        self.push_system_message_pub(format!("Theme error: {e}"));
+                    }
+                }
+            }
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                // Not ready yet — keep waiting.
+            }
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                // Sender dropped without sending (spawn_blocking panicked).
+                self.pending_theme = None;
+                self.pending_theme_name = None;
+                tracing::warn!("pending theme load task dropped without result");
+            }
+        }
     }
 
     /// Cycle to the next preset in the fixed cycle list `["zephyr", "zephyr-light", "high-contrast"]`.
@@ -265,7 +328,7 @@ impl App {
             .unwrap_or(0);
         let next = CYCLE[(pos + 1) % CYCLE.len()];
         if let Err(e) = self.apply_theme(next) {
-            tracing::warn!("cycle_theme: failed to load '{}': {e}", next);
+            tracing::warn!("cycle_theme: failed to apply '{}': {e}", next);
         }
     }
 

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -215,6 +215,7 @@ async fn tui_loop(
         app.poll_metrics();
         app.poll_pending_file_index();
         app.poll_pending_transcript();
+        app.poll_pending_theme();
         app.refresh_task_snapshots();
 
         let should_draw = match dirty {

--- a/crates/zeph-tui/src/theme/presets.rs
+++ b/crates/zeph-tui/src/theme/presets.rs
@@ -150,6 +150,13 @@ pub fn resolve_palette(name: &str) -> Result<SemanticPalette, ThemeLoadError> {
 }
 
 /// Validate a theme name for path safety (M3).
+///
+/// Exposed as `pub(crate)` so callers that split the preset/user-file fast path can
+/// validate the name before dispatching without going through `resolve_palette`.
+pub(crate) fn validate_theme_name_pub(name: &str) -> Result<(), ThemeLoadError> {
+    validate_theme_name(name)
+}
+
 fn validate_theme_name(name: &str) -> Result<(), ThemeLoadError> {
     if name.is_empty() {
         return Ok(()); // empty → zephyr default
@@ -171,11 +178,14 @@ fn validate_theme_name(name: &str) -> Result<(), ThemeLoadError> {
 
 /// Load a user-defined theme from `~/.config/zeph/themes/<name>.toml`.
 ///
+/// This is a synchronous, blocking function — call it only from a
+/// `tokio::task::spawn_blocking` context, never directly on an async executor thread.
+///
 /// # Errors
 ///
 /// Returns [`ThemeLoadError`] if the name is not found, the file is too large, or
 /// the TOML cannot be parsed.
-fn load_user_theme(name: &str) -> Result<SemanticPalette, ThemeLoadError> {
+pub(crate) fn load_user_theme(name: &str) -> Result<SemanticPalette, ThemeLoadError> {
     use std::io::Read;
 
     const MAX_SIZE: u64 = 64 * 1024; // 64 KiB

--- a/crates/zeph-worktree/src/lib.rs
+++ b/crates/zeph-worktree/src/lib.rs
@@ -34,7 +34,7 @@
 //! let runner = DefaultGitRunner::new();
 //! probe_capabilities(&runner, &repo).await?;
 //!
-//! let mgr = DefaultWorktreeManager::new(repo, WorktreeConfig::default(), DefaultGitRunner::new())?;
+//! let mgr = DefaultWorktreeManager::new(repo, WorktreeConfig::default(), DefaultGitRunner::new()).await?;
 //! let handle = mgr.create("agent-42").await?;
 //! println!("Worktree at {:?}", handle.path);
 //! mgr.remove(&handle, false).await?;

--- a/crates/zeph-worktree/src/manager.rs
+++ b/crates/zeph-worktree/src/manager.rs
@@ -49,7 +49,10 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// Creates a new manager, validating the repository root and canonicalising
     /// the worktree root directory.
     ///
-    /// The worktree root directory is created if it does not yet exist.
+    /// The worktree root directory is created if it does not yet exist.  The
+    /// underlying filesystem calls (`create_dir_all`, `canonicalize`) are
+    /// offloaded to `tokio::task::spawn_blocking` so the async executor is
+    /// never stalled.
     ///
     /// # Errors
     ///
@@ -64,24 +67,27 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// use zeph_config::WorktreeConfig;
     /// use zeph_worktree::{DefaultWorktreeManager, git_runner::DefaultGitRunner};
     ///
-    /// # fn main() -> Result<(), zeph_worktree::WorktreeError> {
+    /// # async fn example() -> Result<(), zeph_worktree::WorktreeError> {
     /// let mgr = DefaultWorktreeManager::new(
     ///     PathBuf::from("/path/to/repo"),
     ///     WorktreeConfig::default(),
     ///     DefaultGitRunner::new(),
-    /// )?;
+    /// ).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new(
+    pub async fn new(
         repo_root: PathBuf,
         config: WorktreeConfig,
         runner: R,
     ) -> Result<Self, WorktreeError> {
         // Validate the root now so bootstrap fails fast rather than at first spawn.
-        let root = Path::new(&config.root);
-        // canonicalize_root creates the directory if needed.
-        let _ = canonicalize_root(root, &repo_root)?;
+        // Offload blocking I/O (create_dir_all + canonicalize) to a dedicated thread.
+        let root = PathBuf::from(&config.root);
+        let repo = repo_root.clone();
+        tokio::task::spawn_blocking(move || canonicalize_root(&root, &repo))
+            .await
+            .map_err(|e| WorktreeError::Io(std::io::Error::other(e)))??;
 
         Ok(Self {
             repo_root,
@@ -575,11 +581,13 @@ mod tests {
         dir
     }
 
-    fn make_manager(
+    async fn make_manager(
         dir: &tempfile::TempDir,
         runner: FakeGitRunner,
     ) -> WorktreeManager<FakeGitRunner> {
-        WorktreeManager::new(dir.path().to_path_buf(), test_config(), runner).unwrap()
+        WorktreeManager::new(dir.path().to_path_buf(), test_config(), runner)
+            .await
+            .unwrap()
     }
 
     // --- probe_capabilities ---
@@ -630,7 +638,7 @@ mod tests {
         // worktree add → success
         runner.push_ok(b"" as &[u8]);
 
-        let mgr = make_manager(&dir, runner);
+        let mgr = make_manager(&dir, runner).await;
 
         // The path doesn't actually get created since FakeGitRunner doesn't
         // invoke git, so we just verify the call args.
@@ -657,7 +665,7 @@ mod tests {
     async fn create_rejects_invalid_branch_component() {
         let dir = make_repo();
         let runner = FakeGitRunner::new();
-        let mgr = make_manager(&dir, runner);
+        let mgr = make_manager(&dir, runner).await;
         let err = mgr.create("../escape").await.unwrap_err();
         assert!(matches!(err, WorktreeError::InvalidBranchName(_)));
     }
@@ -666,7 +674,7 @@ mod tests {
     async fn create_rejects_leading_dash() {
         let dir = make_repo();
         let runner = FakeGitRunner::new();
-        let mgr = make_manager(&dir, runner);
+        let mgr = make_manager(&dir, runner).await;
         let err = mgr.create("-bad-id").await.unwrap_err();
         assert!(matches!(err, WorktreeError::InvalidBranchName(_)));
     }
@@ -692,7 +700,9 @@ mod tests {
             branch_prefix: "agent/".to_string(),
             ..WorktreeConfig::default()
         };
-        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner).unwrap();
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
 
         let result = mgr.create("agent-fresh").await;
         match result {
@@ -716,7 +726,9 @@ mod tests {
             branch_prefix: "agent/".to_string(),
             ..WorktreeConfig::default()
         };
-        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner).unwrap();
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
         let err = mgr.create("agent-fresh").await.unwrap_err();
         assert!(matches!(err, WorktreeError::GitCommand { .. }));
     }
@@ -736,7 +748,9 @@ mod tests {
             branch_prefix: "agent/".to_string(),
             ..WorktreeConfig::default()
         };
-        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner).unwrap();
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
         let err = mgr.create("agent-fresh").await.unwrap_err();
         assert!(matches!(err, WorktreeError::BaseRefUnresolved { .. }));
     }
@@ -750,7 +764,7 @@ mod tests {
         // worktree remove → success
         runner.push_ok(b"" as &[u8]);
 
-        let mgr = make_manager(&dir, runner);
+        let mgr = make_manager(&dir, runner).await;
         let handle = WorktreeHandle {
             path: dir.path().join("worktrees/agent-99"),
             branch_name: "agent/agent-99".to_string(),
@@ -771,7 +785,7 @@ mod tests {
         // branch -D
         runner.push_ok(b"" as &[u8]);
 
-        let mgr = make_manager(&dir, runner);
+        let mgr = make_manager(&dir, runner).await;
         let handle = WorktreeHandle {
             path: dir.path().join("worktrees/agent-99"),
             branch_name: "agent/agent-99".to_string(),
@@ -795,7 +809,7 @@ mod tests {
         );
         runner.push_ok(porcelain.into_bytes());
 
-        let mgr = make_manager(&dir, runner);
+        let mgr = make_manager(&dir, runner).await;
         let stale = mgr.reconcile().await.unwrap();
         // The main worktree (repo_root) is filtered out; only agent worktrees remain.
         assert_eq!(stale.len(), 1);
@@ -830,6 +844,7 @@ mod tests {
         // Use Arc<FakeGitRunner> as the runner.
         let mgr =
             WorktreeManager::new(dir.path().to_path_buf(), test_config(), Arc::clone(&runner))
+                .await
                 .unwrap();
 
         let handle = WorktreeHandle {
@@ -866,7 +881,7 @@ mod tests {
         // This is fine — we only verify dirty-tree check doesn't abort early.
         runner.push_err(b"fake error\n" as &[u8]);
 
-        let mgr = make_manager(&dir, runner);
+        let mgr = make_manager(&dir, runner).await;
         let result = mgr.create("dirty-agent").await;
         // Result is an error because the fake runner returns an error for `worktree add`,
         // but we reached that point — meaning check_dirty_tree did NOT abort.

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -36,7 +36,7 @@ pub(crate) async fn handle_worktree_command(
     let timeout_secs = config.worktree.git_timeout_secs.max(1);
     let runner = DefaultGitRunner::with_timeout(std::time::Duration::from_secs(timeout_secs));
     probe_capabilities(&runner, &repo_root).await?;
-    let wm = DefaultWorktreeManager::new(repo_root, config.worktree.clone(), runner)?;
+    let wm = DefaultWorktreeManager::new(repo_root, config.worktree.clone(), runner).await?;
 
     match cmd {
         WorktreeCommand::List => {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2986,6 +2986,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                 agents_config.worktree.clone(),
                 runner,
             )
+            .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
             mgr.set_worktree_manager(std::sync::Arc::new(wm));
             tracing::info!("worktree subsystem initialised");


### PR DESCRIPTION
## Summary

- **#5308 (tui)**: `load_user_theme` called `std::fs::symlink_metadata` / `std::fs::File::open` synchronously from the async `tui_loop`, stalling the render loop and key handling on every `/theme <user-file>` invocation. Fixed by dispatching the user-file load via `tokio::task::spawn_blocking` + an oneshot channel polled in the tui_loop tick. Preset applies remain synchronous (no I/O); they now clear `pending_theme` before applying to prevent an in-flight load from silently reverting a newer preset choice.
- **#5312 (worktree)**: `WorktreeManager::new()` called `canonicalize_root` (which uses `std::fs::create_dir_all` + `std::fs::canonicalize`) synchronously on the async executor thread during startup. Made `new` async and wrapped `canonicalize_root` in `tokio::task::spawn_blocking`, mirroring the pattern already in `create()`. All 7 callers updated.

## Test plan

- [ ] `cargo +nightly fmt --check` — PASS
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — PASS
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11433 PASS, 23 skipped
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — PASS
- [ ] All 7 `WorktreeManager::new()` callers use `.await`
- [ ] `pending_theme` cleared on preset apply (race fix confirmed by reviewer)
- [ ] CHANGELOG `[Unreleased]` entries for both fixes

Closes #5308, closes #5312.