### PR TITLE
feat(llm): add profiling tracing spans to private async fns in claude/openai/ollama backends

### DIFF
--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -446,6 +446,10 @@ impl ClaudeProvider {
     /// # Panics
     ///
     /// Panics if the hardcoded Anthropic API URL cannot be parsed (impossible in practice).
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.claude.list_models_remote", skip_all)
+    )]
     pub async fn list_models_remote(
         &self,
     ) -> Result<Vec<crate::model_cache::RemoteModelInfo>, LlmError> {
@@ -830,6 +834,10 @@ impl ClaudeProvider {
         req.header("content-type", "application/json").json(&body)
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.claude.send_request", skip_all)
+    )]
     async fn send_request(&self, messages: &[Message]) -> Result<String, LlmError> {
         let mut retried = false;
         loop {
@@ -981,6 +989,10 @@ impl ClaudeProvider {
         }
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.claude.send_stream_request", skip_all)
+    )]
     async fn send_stream_request(
         &self,
         messages: &[Message],

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -165,6 +165,10 @@ impl OllamaProvider {
     /// # Errors
     ///
     /// Returns an error if the request fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.ollama.fetch_model_info", skip_all)
+    )]
     pub async fn fetch_model_info(&self) -> Result<ModelInfo, LlmError> {
         let info = self
             .client
@@ -195,6 +199,10 @@ impl OllamaProvider {
     /// # Errors
     ///
     /// Returns an error if the connection to Ollama fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.ollama.health_check", skip_all)
+    )]
     pub async fn health_check(&self) -> Result<(), LlmError> {
         self.client
             .list_local_models()
@@ -210,6 +218,10 @@ impl OllamaProvider {
     /// # Errors
     ///
     /// Returns an error if the Ollama API request fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.ollama.list_models_remote", skip_all)
+    )]
     pub async fn list_models_remote(
         &self,
     ) -> Result<Vec<crate::model_cache::RemoteModelInfo>, LlmError> {
@@ -239,6 +251,10 @@ impl OllamaProvider {
     /// # Errors
     ///
     /// Returns an error if the warmup request fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.ollama.warmup", skip_all)
+    )]
     pub async fn warmup(&self) -> Result<(), LlmError> {
         let request =
             ChatMessageRequest::new(self.model.clone(), vec![ChatMessage::user("hi".to_owned())]);

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -446,6 +446,10 @@ impl OpenAiProvider {
     /// # Errors
     ///
     /// Returns an error if the API request fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.openai.list_models_remote", skip_all)
+    )]
     pub async fn list_models_remote(
         &self,
     ) -> Result<Vec<crate::model_cache::RemoteModelInfo>, LlmError> {
@@ -519,6 +523,10 @@ impl OpenAiProvider {
         );
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.openai.send_request", skip_all)
+    )]
     async fn send_request(&self, messages: &[Message]) -> Result<String, LlmError> {
         let reasoning = self
             .reasoning_effort
@@ -583,6 +591,10 @@ impl OpenAiProvider {
             })
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.openai.send_stream_request", skip_all)
+    )]
     async fn send_stream_request(
         &self,
         messages: &[Message],


### PR DESCRIPTION
## Summary

- Added `#[cfg_attr(feature = "profiling", tracing::instrument(skip_all, name = "..."))]` to 10 async functions across three LLM backend files that were opaque to trace analysis
- `claude/mod.rs`: `list_models_remote`, `send_request`, `send_stream_request`
- `openai/mod.rs`: `list_models_remote`, `send_request`, `send_stream_request`
- `ollama.rs`: `fetch_model_info`, `health_check`, `list_models_remote`, `warmup`

Span names follow the `llm.<backend>.<operation>` convention consistent with existing instrumented trait methods. `skip_all` is used for functions handling large or sensitive arguments (`&[Message]`, API keys, raw HTTP responses). No behavior change — annotation only, no-op when `profiling` feature is disabled.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11433 passed
- [x] `cargo nextest run -p zeph-llm --features profiling` — 906 passed with profiling feature enabled
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean

Closes #5304, #5305, #5306