### PR TITLE
fix(core,plugins): remove match_same_arms and enforce PluginName at deserialization

### DIFF
--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1342,7 +1342,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                         .await
                         .ok()
                         .and_then(|s| toml::from_str::<zeph_plugins::PluginManifest>(&s).ok())
-                        .map(|m| m.plugin.name)
+                        .map(|m| m.plugin.name.to_string())
                 });
                 join_all(futs).await.into_iter().flatten().collect()
             };

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1540,7 +1540,6 @@ impl<C: Channel> Agent<C> {
                 zeph_sanitizer::InjectionVerdict::Suspicious => {
                     tracing::warn!("injection_classifier soft_signal on user input");
                 }
-                zeph_sanitizer::InjectionVerdict::Clean => {}
                 _ => {}
             }
         }

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -228,7 +228,6 @@ impl<C: Channel> Agent<C> {
                     );
                     self.update_metrics(|m| m.classifier_tool_suspicious += 1);
                 }
-                zeph_sanitizer::InjectionVerdict::Clean => {}
                 _ => {}
             }
         }

--- a/crates/zeph-plugins/src/manager/install.rs
+++ b/crates/zeph-plugins/src/manager/install.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 
 use crate::PluginError;
 use crate::manifest::PluginManifest;
-use crate::types::PluginName;
 
 use super::{
     AddResult, DisableResult, PluginManager, RemoveResult, check_allowed_commands_overlay_effect,
@@ -50,8 +49,7 @@ impl PluginManager {
         let manifest: PluginManifest = toml::from_str(&manifest_str)
             .map_err(|e| PluginError::InvalidManifest(format!("{e}")))?;
 
-        // Validate plugin name.
-        validate_plugin_name(&manifest.plugin.name)?;
+        // Name validity is enforced by PluginName deserialization; no separate call needed.
 
         // Validate dependency list: enforce count limit and name format.
         if manifest.plugin.dependencies.len() > MAX_DEPENDENCIES {
@@ -96,14 +94,14 @@ impl PluginManager {
         scan_skill_entries(
             source_path.as_path(),
             &manifest.skills,
-            &manifest.plugin.name,
+            manifest.plugin.name.as_str(),
         );
 
         let mut warnings: Vec<String> = Vec::new();
         if let Some(msg) = check_allowed_commands_overlay_effect(
             &manifest.config,
             &self.base_allowed_commands,
-            &manifest.plugin.name,
+            manifest.plugin.name.as_str(),
         ) {
             tracing::warn!(plugin = %manifest.plugin.name, "{msg}");
             warnings.push(msg);
@@ -116,9 +114,9 @@ impl PluginManager {
         let skill_names = collect_skill_names(&source_path, &manifest);
 
         // Check for name conflicts.
-        self.check_skill_conflicts(&skill_names, &manifest.plugin.name)?;
+        self.check_skill_conflicts(&skill_names, manifest.plugin.name.as_str())?;
 
-        let dest = self.plugins_dir.join(&manifest.plugin.name);
+        let dest = self.plugins_dir.join(manifest.plugin.name.as_str());
 
         // Copy source to destination.
         copy_dir_all(&source_path, &dest)?;
@@ -138,7 +136,7 @@ impl PluginManager {
         // plugin with no registry entry — it will load unverified until reinstalled (M4).
         let mut registry = crate::integrity::IntegrityRegistry::load(&self.integrity_registry_path);
         if let Err(e) = registry
-            .record(&manifest.plugin.name, &installed_manifest_path)
+            .record(manifest.plugin.name.as_str(), &installed_manifest_path)
             .and_then(|()| registry.save(&self.integrity_registry_path))
         {
             tracing::warn!(plugin = %manifest.plugin.name, error = %e, "failed to update integrity registry after install");
@@ -155,8 +153,7 @@ impl PluginManager {
         );
 
         Ok(AddResult {
-            // validate_plugin_name already verified the name above; TryFrom is infallible here.
-            name: PluginName::try_from(manifest.plugin.name)?,
+            name: manifest.plugin.name,
             plugin_root: dest,
             installed_skills: skill_names,
             mcp_server_ids,
@@ -431,7 +428,7 @@ impl PluginManager {
                 continue;
             }
             if manifest.plugin.dependencies.iter().any(|d| d == name) {
-                dependents.push(manifest.plugin.name);
+                dependents.push(manifest.plugin.name.to_string());
             }
         }
         dependents.sort();

--- a/crates/zeph-plugins/src/manager/registry.rs
+++ b/crates/zeph-plugins/src/manager/registry.rs
@@ -8,7 +8,7 @@ use crate::PluginError;
 use super::{
     AddResult, AutoUpdateResult, AutoUpdateStatus, InstalledPlugin, PluginManager, PluginSource,
     collect_skill_names, extract_archive_safe, scan_skill_entries, strip_bundled_markers,
-    validate_mcp_commands, validate_overlay_keys, validate_plugin_name, validate_url_scheme,
+    validate_mcp_commands, validate_overlay_keys, validate_url_scheme,
     validate_url_scheme_ephemeral,
 };
 
@@ -648,10 +648,7 @@ pub(crate) fn apply_staged_update(
         toml::from_str(&manifest_str).map_err(|e| format!("staged plugin.toml invalid: {e}"))?;
 
     // Reject name changes: an update must not rename the plugin.
-    if let Err(e) = validate_plugin_name(&manifest.plugin.name) {
-        let _ = std::fs::remove_dir_all(staging);
-        return Err(format!("staged manifest has invalid plugin name: {e}"));
-    }
+    // Name validity is enforced by PluginName deserialization above.
     if manifest.plugin.name != installed_plugin_name {
         let _ = std::fs::remove_dir_all(staging);
         return Err(format!(
@@ -690,7 +687,7 @@ pub(crate) fn apply_staged_update(
     }
 
     // Advisory SKILL.md scan (non-blocking — logs warnings only).
-    scan_skill_entries(staging, &manifest.skills, &manifest.plugin.name);
+    scan_skill_entries(staging, &manifest.skills, manifest.plugin.name.as_str());
 
     // Write the normalised .plugin.toml and strip bundled markers.
     let installed_manifest_toml =
@@ -716,7 +713,7 @@ pub(crate) fn apply_staged_update(
     let installed_manifest_path = dest.join(".plugin.toml");
     let mut registry = crate::integrity::IntegrityRegistry::load(integrity_registry_path);
     if let Err(e) = registry
-        .record(&manifest.plugin.name, &installed_manifest_path)
+        .record(manifest.plugin.name.as_str(), &installed_manifest_path)
         .and_then(|()| registry.save(integrity_registry_path))
     {
         tracing::warn!(

--- a/crates/zeph-plugins/src/manager/store.rs
+++ b/crates/zeph-plugins/src/manager/store.rs
@@ -10,7 +10,6 @@ use zeph_skills::registry::SkillRegistry;
 
 use crate::PluginError;
 use crate::manifest::PluginManifest;
-use crate::types::PluginName;
 
 use super::{InstalledPlugin, PluginManager};
 
@@ -51,11 +50,8 @@ impl PluginManager {
             };
             let skill_names = collect_skill_names(&path, &manifest);
             let auto_update = manifest.plugin.auto_update;
-            let Ok(name) = PluginName::try_from(manifest.plugin.name) else {
-                continue;
-            };
             plugins.push(InstalledPlugin {
-                name,
+                name: manifest.plugin.name,
                 version: manifest.plugin.version,
                 description: manifest.plugin.description,
                 path,

--- a/crates/zeph-plugins/src/manifest.rs
+++ b/crates/zeph-plugins/src/manifest.rs
@@ -5,6 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::PluginName;
+
 fn default_config_table() -> toml::Value {
     toml::Value::Table(toml::map::Map::new())
 }
@@ -50,7 +52,7 @@ pub struct PluginManifest {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PluginMeta {
     /// Canonical plugin name. Must be a valid identifier: `[a-z0-9][a-z0-9-]*`.
-    pub name: String,
+    pub name: PluginName,
     /// Plugin version (informational).
     pub version: String,
     /// Short description shown in `zeph plugin list`.

--- a/crates/zeph-plugins/src/overlay.rs
+++ b/crates/zeph-plugins/src/overlay.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use zeph_config::Config;
 
 use crate::PluginError;
-use crate::manager::{validate_overlay_keys, validate_plugin_name};
+use crate::manager::validate_overlay_keys;
 use crate::manifest::PluginManifest;
 
 /// Summary of the overlay applied to a [`Config`] by [`apply_plugin_config_overlays`].
@@ -210,16 +210,6 @@ fn process_plugin_entry(
         }
     }
 
-    // Security: validate plugin name before using it in logs/data structures to prevent
-    // log injection via a post-install-tampered manifest.
-    if let Err(e) = validate_plugin_name(&manifest.plugin.name) {
-        tracing::warn!(
-            path = %path.display(),
-            "plugin overlay skipped: invalid plugin name ({e})"
-        );
-        return;
-    }
-
     // M2: re-run install-time safelist check as defence-in-depth against post-install tampering.
     if let Err(e) = validate_overlay_keys(&manifest.config) {
         out.skipped_plugins.push(format!(
@@ -231,7 +221,7 @@ fn process_plugin_entry(
 
     let contributed = merge_manifest_overlay(&manifest, out, blocked_set, allowed_accum, threshold);
     if contributed {
-        out.source_plugins.push(manifest.plugin.name);
+        out.source_plugins.push(manifest.plugin.name.to_string());
     }
 }
 


### PR DESCRIPTION
## Summary

- **#5318**: Remove redundant `InjectionVerdict::Clean => {}` arms in `sanitize.rs` and `agent/mod.rs`. `InjectionVerdict` is `#[non_exhaustive]`, so the wildcard is required and the duplicate arm was dead code flagged by `clippy::match_same_arms` under `--features full`.
- **#5310**: Change `PluginMeta.name` from `String` to `PluginName` in `manifest.rs`. `PluginName` has a custom `Deserialize` impl that validates naming rules, so any path that deserializes `PluginManifest` now automatically enforces the constraint — removing the need for manual `validate_plugin_name` calls at each call site.

## Changes

- `crates/zeph-core/src/agent/mod.rs` — remove duplicate match arm
- `crates/zeph-core/src/agent/tool_execution/sanitize.rs` — remove duplicate match arm
- `crates/zeph-plugins/src/manifest.rs` — `pub name: String` → `pub name: PluginName`
- `crates/zeph-plugins/src/manager/install.rs` — remove redundant `validate_plugin_name` call, update call sites
- `crates/zeph-plugins/src/manager/registry.rs` — remove redundant `validate_plugin_name` call, update call sites
- `crates/zeph-plugins/src/manager/store.rs` — simplify `InstalledPlugin` construction
- `crates/zeph-plugins/src/overlay.rs` — remove redundant `validate_plugin_name` call
- `crates/zeph-core/src/agent/agent_access_impl.rs` — `.to_string()` on `PluginName` for `Vec<String>` return

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features full -- -D warnings` — clean (this is the specific check #5318 targeted)
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11433 passed

Closes #5318
Closes #5310