### PR TITLE
refactor(bench): extract write_atomic, add tracing spans to tau2_bench driver and envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `refactor(bench)`: extract shared `write_atomic` helper into `zeph_bench::utils` and remove the
+  byte-for-byte duplicate copies from `baseline.rs` and `results.rs`. Closes #5314.
+
+- `feat(bench)`: add `#[tracing::instrument]` spans to the tau2-bench multi-turn driver
+  (`bench.tau2.drive`, `bench.tau2.generate_user_message`, `bench.tau2.call_simulator`) so
+  per-turn and LLM-call latency are visible in local Chrome JSON / Perfetto traces. Closes #5315.
+
+- `feat(bench)`: add `#[tracing::instrument]` spans to the tau2-bench domain environments
+  (`bench.tau2.airline.replay_actions`, `bench.tau2.airline.execute_tool_call`,
+  `bench.tau2.retail.replay_actions`, `bench.tau2.retail.execute_tool_call`) so tool-dispatch
+  latency is visible in traces. Closes #5316.
+
 ### Fixed
 
 - `fix(tui)`: remove duplicate `last_assistant_content` / `last_assistant_code_blocks`

--- a/crates/zeph-bench/src/baseline.rs
+++ b/crates/zeph-bench/src/baseline.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::utils::write_atomic;
 use crate::{BenchError, BenchRun};
 
 /// Score delta for a single scenario between memory-on and memory-off runs.
@@ -197,14 +198,6 @@ impl BaselineComparison {
         file.write_all(section.as_bytes())?;
         Ok(())
     }
-}
-
-/// Write `data` to `path` atomically via a `.tmp` sibling + rename.
-fn write_atomic(path: &Path, data: &[u8]) -> Result<(), std::io::Error> {
-    let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, data)?;
-    std::fs::rename(&tmp, path)?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/zeph-bench/src/lib.rs
+++ b/crates/zeph-bench/src/lib.rs
@@ -76,6 +76,7 @@ pub mod loaders;
 pub mod results;
 pub mod runner;
 pub mod scenario;
+pub(crate) mod utils;
 
 pub use baseline::{BaselineComparison, ScenarioDelta};
 pub use channel::BenchmarkChannel;

--- a/crates/zeph-bench/src/loaders/tau2_bench/driver.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/driver.rs
@@ -28,6 +28,7 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider as _, Message, Role};
 
 use crate::error::BenchError;
+use tracing::instrument;
 
 use super::data::StructuredUserInstructions;
 
@@ -120,6 +121,7 @@ impl MultiTurnDriver {
     ///
     /// Returns [`BenchError`] if the simulator LLM fails on both the initial attempt
     /// and the single retry, or if `agent_turn` returns an error.
+    #[instrument(skip_all, name = "bench.tau2.drive")]
     pub async fn drive<F, Fut>(&self, mut agent_turn: F) -> Result<MultiTurnResult, BenchError>
     where
         F: FnMut(String) -> Fut,
@@ -162,6 +164,7 @@ impl MultiTurnDriver {
     /// Call the simulator LLM to generate the next user message.
     ///
     /// Retries once on any error before propagating.
+    #[instrument(skip_all, name = "bench.tau2.generate_user_message")]
     async fn generate_user_message(
         &self,
         history: &[Turn],
@@ -180,6 +183,7 @@ impl MultiTurnDriver {
         }
     }
 
+    #[instrument(skip_all, name = "bench.tau2.call_simulator")]
     async fn call_simulator(&self, messages: &[Message]) -> Result<String, BenchError> {
         self.simulator_provider
             .chat(messages)

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use serde::Deserialize;
+use tracing::instrument;
 use zeph_common::ToolName;
 use zeph_tools::ToolExecutor;
 use zeph_tools::executor::{ToolCall, ToolError, ToolOutput};
@@ -169,6 +170,7 @@ impl AirlineEnv {
     /// # Errors
     ///
     /// Returns [`BenchError`] if a gold action fails to execute in the env.
+    #[instrument(skip_all, name = "bench.tau2.airline.replay_actions")]
     pub async fn replay_actions(&self, actions: &[Action]) -> Result<(), BenchError> {
         for action in actions {
             if action.requestor != "assistant" {
@@ -199,6 +201,7 @@ impl ToolExecutor for AirlineEnv {
         super::tools::airline_definitions()
     }
 
+    #[instrument(skip_all, name = "bench.tau2.airline.execute_tool_call")]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         {
             let mut t = self.trace.lock().expect("trace mutex poisoned");

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use serde::Deserialize;
+use tracing::instrument;
 use zeph_common::ToolName;
 use zeph_tools::ToolExecutor;
 use zeph_tools::executor::{ToolCall, ToolError, ToolOutput};
@@ -188,6 +189,7 @@ impl RetailEnv {
     /// # Errors
     ///
     /// Returns [`BenchError`] if a gold action fails to execute in the env.
+    #[instrument(skip_all, name = "bench.tau2.retail.replay_actions")]
     pub async fn replay_actions(&self, actions: &[Action]) -> Result<(), BenchError> {
         for action in actions {
             if action.requestor != "assistant" {
@@ -219,6 +221,7 @@ impl ToolExecutor for RetailEnv {
         super::tools::retail_definitions()
     }
 
+    #[instrument(skip_all, name = "bench.tau2.retail.execute_tool_call")]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         // Record before dispatching (lock held only for push, never across .await).
         {

--- a/crates/zeph-bench/src/results.rs
+++ b/crates/zeph-bench/src/results.rs
@@ -9,11 +9,12 @@
 
 use std::collections::HashSet;
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::BenchError;
+use crate::utils::write_atomic;
 
 /// Status of a benchmark run serialized into `results.json`.
 ///
@@ -428,14 +429,6 @@ impl ResultWriter {
         write_atomic(&self.summary_path(), md.as_bytes())?;
         Ok(())
     }
-}
-
-/// Write `data` to `path` using a temp file + rename for atomicity.
-fn write_atomic(path: &Path, data: &[u8]) -> Result<(), std::io::Error> {
-    let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, data)?;
-    std::fs::rename(&tmp, path)?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/zeph-bench/src/utils.rs
+++ b/crates/zeph-bench/src/utils.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::path::Path;
+
+/// Write `data` to `path` atomically via a `.tmp` sibling and rename.
+///
+/// Creates a sibling file with a `.tmp` extension, writes all bytes to it, then
+/// renames it over `path`. The rename is atomic on most filesystems, so readers
+/// never observe a partial write.
+///
+/// # Errors
+///
+/// Returns [`std::io::Error`] if the write or rename fails.
+pub(crate) fn write_atomic(path: &Path, data: &[u8]) -> Result<(), std::io::Error> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, data)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Extract the duplicated `write_atomic` helper into a shared `crate::utils` module, removing byte-for-byte copies from `baseline.rs` and `results.rs` (#5314)
- Add `#[tracing::instrument]` spans to `TauBenchDriver::drive`, `generate_user_message`, `call_simulator` in `driver.rs` following the existing `bench.*` naming convention (#5315)
- Add `#[tracing::instrument]` spans to `AirlineEnv` and `RetailEnv` `replay_actions` / `execute_tool_call` methods (#5316)

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo clippy --profile ci -p zeph-bench --all-targets -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11437 passed
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-bench` — no new errors

Closes #5314, #5315, #5316