### PR TITLE
feat(tracing): add instrument spans to zeph-llm, zeph-subagent, zeph-plugins

### DIFF
--- a/crates/zeph-llm/src/router/chat.rs
+++ b/crates/zeph-llm/src/router/chat.rs
@@ -86,6 +86,10 @@ struct CascadeEvalResult {
 
 /// Evaluate a cascade response: score it, record the verdict in shared state, and
 /// compute whether the token budget is exhausted.
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(name = "llm.router.cascade.evaluate_response", skip_all)
+)]
 async fn cascade_evaluate_response(
     provider_name: &str,
     response: &str,
@@ -281,6 +285,10 @@ impl RouterProvider {
     /// occurs, the user experiences: cheap model's full response time + expensive model's
     /// TTFT. This is strictly worse than direct routing to the expensive model for
     /// hard queries. Acceptable for v1; see CRIT-01 in critic handoff for alternatives.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "llm.router.cascade.chat_stream", skip_all)
+    )]
     #[allow(clippy::too_many_lines)] // sequential cascade semantics: buffer→classify→escalate
     pub(crate) async fn cascade_chat_stream(
         &self,

--- a/crates/zeph-plugins/src/manager/install.rs
+++ b/crates/zeph-plugins/src/manager/install.rs
@@ -177,6 +177,7 @@ impl PluginManager {
     /// - [`PluginError::NotFound`] — plugin is not installed.
     /// - [`PluginError::DependencyRequired`] — at least one enabled plugin depends on this one.
     /// - [`PluginError::Io`] — the plugin directory cannot be removed.
+    #[tracing::instrument(name = "plugins.install.remove", skip_all)]
     pub fn remove(&self, name: &str) -> Result<RemoveResult, PluginError> {
         validate_plugin_name(name)?;
         let plugin_dir = self.plugins_dir.join(name);
@@ -241,6 +242,7 @@ impl PluginManager {
     /// - [`PluginError::MissingDependency`] — a declared dependency is not installed.
     /// - [`PluginError::DependencyCycle`] — the dependency graph contains a cycle.
     /// - [`PluginError::Io`] — the `.disabled` marker cannot be removed.
+    #[tracing::instrument(name = "plugins.install.enable", skip_all)]
     pub fn enable(&self, name: &str) -> Result<(), PluginError> {
         validate_plugin_name(name)?;
         let mut visiting: Vec<String> = Vec::new();
@@ -353,6 +355,7 @@ impl PluginManager {
     /// # Ok(())
     /// # }
     /// ```
+    #[tracing::instrument(name = "plugins.install.disable", skip_all)]
     pub fn disable(&self, name: &str, force: bool) -> Result<DisableResult, PluginError> {
         validate_plugin_name(name)?;
         let plugin_dir = self.plugins_dir.join(name);

--- a/crates/zeph-plugins/src/manager/security.rs
+++ b/crates/zeph-plugins/src/manager/security.rs
@@ -52,6 +52,7 @@ impl PluginManager {
     ///     Ok(())
     /// }
     /// ```
+    #[tracing::instrument(name = "plugins.security.scan_targets", skip_all)]
     pub fn scan_targets(&self, source: &str) -> Result<Vec<SkillScanInput>, PluginError> {
         // Cap per-file reads to prevent memory DoS when scanning untrusted plugin archives.
         const MAX_SKILL_MD_READ_BYTES: u64 = 512 * 1024; // 512 KiB

--- a/crates/zeph-plugins/src/manager/store.rs
+++ b/crates/zeph-plugins/src/manager/store.rs
@@ -19,6 +19,7 @@ impl PluginManager {
     /// # Errors
     ///
     /// Returns [`PluginError`] if the plugins directory cannot be read.
+    #[tracing::instrument(name = "plugins.store.list_installed", skip_all)]
     pub fn list_installed(&self) -> Result<Vec<InstalledPlugin>, PluginError> {
         if !self.plugins_dir.exists() {
             return Ok(Vec::new());

--- a/crates/zeph-subagent/src/manager/mod.rs
+++ b/crates/zeph-subagent/src/manager/mod.rs
@@ -535,6 +535,7 @@ impl SubAgentManager {
     /// # Errors
     ///
     /// Returns [`SubAgentError`] if a CLI-sourced definition file fails to parse.
+    #[tracing::instrument(name = "subagent.manager.load_definitions_with_sources", skip_all)]
     pub async fn load_definitions_with_sources(
         &mut self,
         ordered_paths: &[PathBuf],

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -275,6 +275,7 @@ pub(crate) fn apply_constraint_propagation(def: &mut SubAgentDef, ctx: &SpawnCon
 /// directory path is provided as a soft boundary via the system prompt instruction.
 /// Known limitation: agents may use Read/Write/Edit beyond the memory directory.
 /// See issue #1152 for future `FilteredToolExecutor` path-restriction enhancement.
+#[tracing::instrument(name = "subagent.manager.build_system_prompt_with_memory", skip_all)]
 #[cfg_attr(test, allow(dead_code))]
 pub(crate) async fn build_system_prompt_with_memory(
     def: &mut SubAgentDef,
@@ -1151,6 +1152,7 @@ impl SubAgentManager {
     ///
     /// Panics if the internal agent entry is missing after a successful `spawn` call.
     /// This is a programming error and should never occur in normal operation.
+    #[tracing::instrument(name = "subagent.manager.spawn_for_task", skip_all)]
     #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
     pub async fn spawn_for_task<F>(
         &mut self,

--- a/crates/zeph-subagent/src/memory.rs
+++ b/crates/zeph-subagent/src/memory.rs
@@ -114,6 +114,7 @@ pub fn resolve_memory_dir(scope: MemoryScope, agent_name: &str) -> Result<PathBu
 ///
 /// Returns [`SubAgentError::Invalid`] if the agent name is invalid.
 /// Returns [`SubAgentError::Memory`] if the directory cannot be created.
+#[tracing::instrument(name = "subagent.memory.ensure_memory_dir", skip_all)]
 pub async fn ensure_memory_dir(
     scope: MemoryScope,
     agent_name: &str,
@@ -150,6 +151,7 @@ pub async fn ensure_memory_dir(
 /// - Opens the canonical path after the boundary check (no TOCTOU window).
 /// - Rejects files larger than 256 KiB.
 /// - Rejects files containing null bytes.
+#[tracing::instrument(name = "subagent.memory.load_memory_content", skip_all)]
 pub async fn load_memory_content(dir: &Path) -> Option<String> {
     let memory_path = dir.join("MEMORY.md");
 


### PR DESCRIPTION
## Summary

Add `#[tracing::instrument]` annotations to 11 hot-path functions across three crates that were invisible in local Chrome JSON traces and Perfetto profiles. Pure annotation additions — no logic changes.

### zeph-llm (#5323)

`crates/zeph-llm/src/router/chat.rs` — profiling feature gate (`#[cfg_attr(feature = "profiling", tracing::instrument(...))]`), matching the pattern on `cascade_chat` and `bandit_chat`:

- `cascade_evaluate_response` → `llm.router.cascade.evaluate_response`
- `cascade_chat_stream` → `llm.router.cascade.chat_stream`

### zeph-subagent (#5322)

Plain `#[tracing::instrument(name = "...", skip_all)]` (no profiling gate — crate has none):

- `ensure_memory_dir` → `subagent.memory.ensure_memory_dir`
- `load_memory_content` → `subagent.memory.load_memory_content`
- `load_definitions_with_sources` → `subagent.manager.load_definitions_with_sources`
- `build_system_prompt_with_memory` → `subagent.manager.build_system_prompt_with_memory`
- `spawn_for_task` → `subagent.manager.spawn_for_task`

### zeph-plugins (#5311)

Sync public methods — plain `#[tracing::instrument(name = "...", skip_all)]`:

- `PluginManager::remove` → `plugins.install.remove`
- `PluginManager::enable` → `plugins.install.enable`
- `PluginManager::disable` → `plugins.install.disable`
- `PluginManager::list_installed` → `plugins.store.list_installed`
- `PluginManager::scan_targets` → `plugins.security.scan_targets`

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11437 PASS (+4 vs baseline)
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean

Closes #5323, #5322, #5311