### PR TITLE
fix(channels,tracing): annotate guest proxy spawn + instrument runner startup fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `fix(channels)`: add `// EXEMPT` annotation and `tracing::warn!` to the raw `tokio::spawn` in
+  `spawn_guest_proxy()` (`crates/zeph-channels/src/telegram.rs`), matching the documentation
+  pattern used by the three other untracked Telegram spawn sites. The guest proxy is a singleton
+  axum server bound to an ephemeral port; TaskSupervisor routing is not feasible because restart
+  would require rebinding the port and re-pointing `bot.set_api_url()`. Closes #5309.
+
+- `feat(tracing)`: add `#[tracing::instrument]` to four startup-path async functions in
+  `src/runner.rs` — `build_typed_pages_state`, `load_rl_head`, `resolve_rl_embed_dim`, and
+  `run_experiment_report` — making their latency visible in Perfetto/Jaeger traces. Closes #5199.
+
 - `refactor(bench)`: extract shared `write_atomic` helper into `zeph_bench::utils` and remove the
   byte-for-byte duplicate copies from `baseline.rs` and `results.rs`. Closes #5314.
 

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -701,6 +701,13 @@ fn spawn_guest_proxy(
         ChannelError::Other(format!("guest proxy: TcpListener conversion failed: {e}"))
     })?;
 
+    // EXEMPT: guest proxy is a singleton loopback axum server bound to an ephemeral port;
+    // restarting via TaskSupervisor would require rebinding the port and re-pointing
+    // bot.set_api_url() — the JoinHandle is stored in TelegramChannel and tied to its lifetime.
+    tracing::warn!(
+        "guest proxy spawned without TaskSupervisor — singleton task, lifecycle bound to \
+         TelegramChannel; handle is tracked via guest_proxy_handle field"
+    );
     let handle = tokio::spawn(async move {
         if let Err(e) = axum::serve(listener, app).await {
             tracing::warn!("guest proxy axum serve error: {e}");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -173,6 +173,7 @@ fn check_legacy_artifact_paths(config: &Config) {
 /// read from the agent's configuration file, which already requires file-system write access.
 /// No canonicalization or prefix-check is performed because the threat model does not include
 /// less-privileged config editing. Do not propagate this path from end-user input.
+#[tracing::instrument(name = "runner.build_typed_pages_state", skip_all)]
 async fn build_typed_pages_state(
     config: &Config,
     supervisor: Option<&zeph_common::TaskSupervisor>,
@@ -3746,6 +3747,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
 /// Load persisted RL routing head weights from memory store.
 ///
 /// Returns `None` when no weights are stored yet (cold start) or on any DB error.
+#[tracing::instrument(name = "runner.load_rl_head", skip_all)]
 pub(crate) async fn load_rl_head(
     memory: &zeph_memory::semantic::SemanticMemory,
 ) -> Option<zeph_skills::rl_head::RoutingHead> {
@@ -3782,6 +3784,7 @@ pub(crate) async fn load_rl_head(
 /// embedding provider with a single empty-string call to determine the actual
 /// output dimension at runtime. Falls back to 1536 with a WARN when the probe
 /// also fails, instructing the operator to set `skills.rl_embed_dim` explicitly.
+#[tracing::instrument(name = "runner.resolve_rl_embed_dim", skip_all)]
 pub(crate) async fn resolve_rl_embed_dim(
     skills_config: &zeph_core::config::SkillsConfig,
     embedding_provider: &LlmAnyProvider,
@@ -3821,6 +3824,7 @@ pub(crate) async fn resolve_rl_embed_dim(
 /// # Errors
 ///
 /// Returns an error if the database cannot be opened or the query fails.
+#[tracing::instrument(name = "runner.run_experiment_report", skip_all)]
 async fn run_experiment_report(app: &crate::bootstrap::AppBuilder) -> anyhow::Result<()> {
     use zeph_memory::store::SqliteStore;
 


### PR DESCRIPTION
## Summary

- **#5309** — Add `// EXEMPT` annotation and `tracing::warn!` to the raw `tokio::spawn` in `spawn_guest_proxy()` (`crates/zeph-channels/src/telegram.rs:704`). The guest proxy is a singleton axum server bound to an ephemeral port; routing through `TaskSupervisor` is not feasible because restart would require rebinding the port and re-pointing `bot.set_api_url()`. This matches the documentation pattern used by the three other untracked Telegram spawn sites (lines 298, 352, 442).
- **#5199** — Add `#[tracing::instrument(name = "runner.<fn>", skip_all)]` to four startup-path async functions in `src/runner.rs`: `build_typed_pages_state`, `load_rl_head`, `resolve_rl_embed_dim`, `run_experiment_report`. Startup latency contributions are now visible in Perfetto/Jaeger traces.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11437 passed (matches baseline)
- [ ] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [ ] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 10 passed

Closes #5309, #5199