### PR TITLE
feat(tracing): add missing instrument spans to scheduler, worktree, and commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `command_tx` arms, clipboard duplicates, `prefill_input` arms, session-switch arms.
   Closes #5298.
 
+- `feat(tracing)`: promote `CommandRegistry::dispatch` in `zeph-commands` from
+  `#[cfg_attr(feature = "profiling", tracing::instrument(...))]` to an unconditional
+  `#[tracing::instrument(name = "commands.dispatch", skip(self, ctx))]` so slash-command
+  dispatch latency is visible in all production traces. Closes #5201.
+
+- `feat(tracing)`: add `#[tracing::instrument]` spans to `Scheduler::init`
+  (`sched.scheduler.init`) and `daemon_status` (`sched.daemon.status`) in `zeph-scheduler`
+  so scheduler startup and status-query paths are visible in local Chrome JSON traces.
+  Closes #5328.
+
+- `feat(tracing)`: add `#[tracing::instrument]` spans to `verify_commitish`,
+  `git_worktree_add`, and `probe_capabilities` in `zeph-worktree` so worktree creation
+  and bootstrap paths are visible in trace analysis. Closes #5313.
+
 ### Fixed
 
 - `fix(tui)`: remove duplicate `last_assistant_content` / `last_assistant_code_blocks`

--- a/crates/zeph-commands/src/lib.rs
+++ b/crates/zeph-commands/src/lib.rs
@@ -304,14 +304,7 @@ impl<Ctx: ?Sized> CommandRegistry<Ctx> {
     /// # Errors
     ///
     /// Returns `Some(Err(_))` when authorization fails or the matched handler returns an error.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "commands.dispatch",
-            skip_all,
-            fields(input = tracing::field::Empty, matched = tracing::field::Empty)
-        )
-    )]
+    #[tracing::instrument(name = "commands.dispatch", skip(self, ctx))]
     pub async fn dispatch(
         &self,
         ctx: &mut Ctx,

--- a/crates/zeph-scheduler/src/daemon.rs
+++ b/crates/zeph-scheduler/src/daemon.rs
@@ -258,6 +258,7 @@ pub fn detach_and_run(cfg: &DaemonConfig, extra_args: &[&str]) -> Result<(), Sch
 /// # Errors
 ///
 /// Returns [`SchedulerError`] if the job store cannot be opened or queried.
+#[tracing::instrument(name = "sched.daemon.status", skip_all, err)]
 pub async fn daemon_status(
     cfg: &DaemonConfig,
     store_url: &str,

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -256,6 +256,7 @@ impl Scheduler {
     ///
     /// Returns an error if DB init, upsert, `next_run` persistence, or job listing fails.
     #[allow(clippy::too_many_lines)]
+    #[tracing::instrument(name = "sched.scheduler.init", skip_all, err)]
     pub async fn init(&mut self) -> Result<(), SchedulerError> {
         self.store.init().await?;
         let now = Utc::now();

--- a/crates/zeph-worktree/src/manager.rs
+++ b/crates/zeph-worktree/src/manager.rs
@@ -442,6 +442,7 @@ impl<R: GitRunner> WorktreeManager<R> {
     }
 
     /// Runs `git rev-parse --verify {commitish}` to confirm it is resolvable.
+    #[instrument(name = "worktree.verify_commitish", skip(self), err)]
     async fn verify_commitish(&self, commitish: &str) -> Result<(), WorktreeError> {
         let out = self
             .runner
@@ -460,6 +461,7 @@ impl<R: GitRunner> WorktreeManager<R> {
     }
 
     /// Runs `git worktree add -b {branch} -- {path} {commitish}`.
+    #[instrument(name = "worktree.git_worktree_add", skip(self), err)]
     async fn git_worktree_add(
         &self,
         branch: &str,
@@ -510,6 +512,7 @@ impl<R: GitRunner> WorktreeManager<R> {
 /// # Ok(())
 /// # }
 /// ```
+#[instrument(name = "worktree.probe_capabilities", skip(runner), err)]
 pub async fn probe_capabilities<R: GitRunner>(
     runner: &R,
     repo_root: &Path,


### PR DESCRIPTION
## Summary

- Promotes `CommandRegistry::dispatch` in `zeph-commands` from `#[cfg_attr(feature = "profiling", tracing::instrument(...))]` to an unconditional `#[tracing::instrument(name = "commands.dispatch", skip(self, ctx))]` — slash-command dispatch latency is now visible in all production traces without enabling the `profiling` feature flag. The old empty `fields(input = Empty, matched = Empty)` that were never `span.record()`-ed are removed.
- Adds `#[tracing::instrument(name = "sched.scheduler.init", skip_all, err)]` to `Scheduler::init` and `#[tracing::instrument(name = "sched.daemon.status", skip_all, err)]` to `daemon_status` in `zeph-scheduler`.
- Adds `#[tracing::instrument]` spans to `verify_commitish` (`worktree.verify_commitish`), `git_worktree_add` (`worktree.git_worktree_add`), and `probe_capabilities` (`worktree.probe_capabilities`) in `zeph-worktree`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11437 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean

Closes #5328, #5313, #5201