### PR TITLE
feat(tracing): instrument async fns in zeph-mcp manager/ and zeph-context summarization

### DIFF
--- a/crates/zeph-context/src/summarization.rs
+++ b/crates/zeph-context/src/summarization.rs
@@ -243,7 +243,7 @@ async fn run_chunk_summaries(
             })
     }
     .instrument(tracing::info_span!(
-        "context.summarization.chunk_summaries",
+        "context.summarization.chunk",
         chunk_count,
     ))
     .await
@@ -318,7 +318,7 @@ async fn try_structured_consolidation(deps: &SummarizationDeps, numbered: &str) 
             }
         }
     }
-    .instrument(tracing::info_span!("context.summarization.structured_consolidation"))
+    .instrument(tracing::info_span!("context.summarization.consolidate_structured"))
     .await
 }
 
@@ -347,7 +347,7 @@ async fn prose_consolidation(
             .await
             .map_err(|_| zeph_llm::LlmError::Timeout)?
     }
-    .instrument(tracing::info_span!("context.summarization.prose_consolidation"))
+    .instrument(tracing::info_span!("context.summarization.consolidate_prose"))
     .await
 }
 

--- a/crates/zeph-mcp/src/manager/connect.rs
+++ b/crates/zeph-mcp/src/manager/connect.rs
@@ -67,6 +67,7 @@ impl McpManager {
         std::time::Duration::from_secs(secs)
     }
 
+    #[tracing::instrument(name = "mcp.manager.handler_cfg_for", skip_all)]
     pub(super) async fn handler_cfg_for(
         &self,
         entry: &ServerEntry,
@@ -528,6 +529,7 @@ impl McpManager {
     /// claimed by a higher-trust tool. When trust levels are equal, the first-registered
     /// tool wins dispatch. Either way the collision is a misconfiguration and must be logged
     /// so the operator can disambiguate (MF-1 / SF-6 fix).
+    #[tracing::instrument(name = "mcp.manager.log_tool_collisions", skip_all)]
     pub(super) async fn log_tool_collisions(&self, tools: &[McpTool]) {
         use crate::tool::detect_collisions;
 
@@ -659,6 +661,7 @@ impl McpManager {
     ///
     /// Returns `Ok(())` if the probe passes or no prober is configured.
     /// Returns `Err` and calls `client.shutdown()` if the probe blocks the server.
+    #[tracing::instrument(name = "mcp.manager.run_probe", skip_all, fields(server_id = %server_id), err)]
     pub(super) async fn run_probe(
         &self,
         server_id: &str,
@@ -691,6 +694,7 @@ impl McpManager {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[tracing::instrument(name = "mcp.manager.run_oauth_handshake", skip_all, fields(server_id = %server_id))]
 async fn run_oauth_handshake(
     server_id: String,
     url: String,
@@ -776,6 +780,7 @@ async fn run_oauth_handshake(
     (server_id, client_result)
 }
 
+#[tracing::instrument(name = "mcp.manager.drain_connect_results", skip_all)]
 async fn drain_connect_results(
     mut join_set: JoinSet<(String, Result<McpClient, McpError>)>,
 ) -> Vec<(String, Result<McpClient, McpError>)> {
@@ -794,6 +799,7 @@ async fn drain_connect_results(
     raw_results
 }
 
+#[tracing::instrument(name = "mcp.manager.drain_oauth_results", skip_all)]
 async fn drain_oauth_results(
     mut join_set: JoinSet<(String, Result<McpClient, String>)>,
 ) -> Vec<(String, Result<McpClient, String>)> {
@@ -814,6 +820,7 @@ async fn drain_oauth_results(
 /// - Warns if a URI does not use `file://` scheme.
 /// - Warns if the path does not exist on the filesystem.
 /// - Filters out roots with non-`file://` URIs (MCP spec requires filesystem roots).
+#[tracing::instrument(name = "mcp.manager.validate_roots", skip_all, fields(server_id = %server_id))]
 pub(super) async fn validate_roots(
     roots: &[rmcp::model::Root],
     server_id: &str,

--- a/crates/zeph-mcp/src/manager/ingest.rs
+++ b/crates/zeph-mcp/src/manager/ingest.rs
@@ -24,6 +24,7 @@ use super::{
 /// After applying penalties, loads the updated score and demotes the server's runtime
 /// trust level when `recommended_trust_level()` is more restrictive than the current
 /// level (as measured by `restriction_level()`). Auto-promotion never happens.
+#[tracing::instrument(name = "mcp.manager.apply_injection_penalties", skip_all, fields(server_id = %server_id))]
 pub(super) async fn apply_injection_penalties(
     trust_store: Option<&Arc<TrustScoreStore>>,
     server_id: &str,

--- a/crates/zeph-mcp/src/manager/retry.rs
+++ b/crates/zeph-mcp/src/manager/retry.rs
@@ -88,6 +88,7 @@ pub(super) fn is_retryable_connect_error(err: &McpError) -> bool {
 ///
 /// `retry_backoff_base_ms` is the base delay in milliseconds; the actual delay doubles
 /// with each attempt, capped at 8 000 ms. See [`connect_retry_backoff`] for details.
+#[tracing::instrument(name = "mcp.manager.retry_loop", skip_all, fields(server_id = %server_id, max_attempts), err)]
 pub(super) async fn retry_loop<F, Fut>(
     server_id: &str,
     max_attempts: u8,
@@ -164,6 +165,7 @@ where
 /// This is a thin shim over [`retry_loop`] that binds [`connect_entry`] as the attempt
 /// function. `add_server` uses [`connect_entry`] directly (single-attempt, no retry).
 #[allow(clippy::too_many_arguments)]
+#[tracing::instrument(name = "mcp.manager.connect_with_retry", skip_all, fields(server_id = %entry.id), err)]
 pub(super) async fn connect_with_retry(
     entry: &ServerEntry,
     allowed_commands: &[String],
@@ -201,7 +203,9 @@ pub(super) async fn connect_with_retry(
     .await
 }
 
-#[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
+#[allow(clippy::too_many_arguments)]
+// function with many required inputs; a *Params struct would be more verbose without simplifying the call site
+#[tracing::instrument(name = "mcp.manager.connect_entry", skip_all, fields(server_id = %entry.id), err)]
 pub(super) async fn connect_entry(
     entry: &ServerEntry,
     allowed_commands: &[String],

--- a/crates/zeph-mcp/src/manager/server.rs
+++ b/crates/zeph-mcp/src/manager/server.rs
@@ -77,7 +77,7 @@ impl McpManager {
     ///
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.manager.add_server", skip(self, entry), fields(server_id = %entry.id))
+        tracing::instrument(name = "mcp.manager.add_server", skip(self, entry), fields(server_id = %entry.id), err)
     )]
     pub async fn add_server(&self, entry: &ServerEntry) -> Result<Vec<McpTool>, McpError> {
         self.check_not_already_connected(&entry.id).await?;
@@ -142,6 +142,7 @@ impl McpManager {
         Ok(tools)
     }
 
+    #[tracing::instrument(name = "mcp.manager.check_not_already_connected", skip(self), fields(server_id = %server_id), err)]
     async fn check_not_already_connected(&self, server_id: &str) -> Result<(), McpError> {
         let clients = self.clients.read().await;
         if clients.contains_key(server_id) {
@@ -152,6 +153,7 @@ impl McpManager {
         Ok(())
     }
 
+    #[tracing::instrument(name = "mcp.manager.connect_and_list_tools", skip(self), err)]
     async fn connect_and_list_tools(
         &self,
         entry: &ServerEntry,
@@ -190,6 +192,7 @@ impl McpManager {
         Ok((client, raw_tools))
     }
 
+    #[tracing::instrument(name = "mcp.manager.probe_or_cleanup", skip(self), err)]
     async fn probe_or_cleanup(
         &self,
         entry: &ServerEntry,
@@ -202,6 +205,7 @@ impl McpManager {
         Ok(())
     }
 
+    #[tracing::instrument(name = "mcp.manager.store_server_instructions", skip(self))]
     async fn store_server_instructions(&self, entry: &ServerEntry, client: &McpClient) {
         if let Some(ref instructions) = client.server_instructions() {
             let truncated = crate::sanitize::truncate_instructions(
@@ -216,6 +220,7 @@ impl McpManager {
         }
     }
 
+    #[tracing::instrument(name = "mcp.manager.commit_added_server", skip(self), err)]
     pub(super) async fn commit_added_server(
         &self,
         entry: &ServerEntry,
@@ -275,7 +280,12 @@ impl McpManager {
     ///
     #[cfg_attr(
         feature = "profiling",
-        tracing::instrument(name = "mcp.manager.remove_server", skip(self), fields(server_id))
+        tracing::instrument(
+            name = "mcp.manager.remove_server",
+            skip(self),
+            fields(server_id),
+            err
+        )
     )]
     pub async fn remove_server(&self, server_id: &str) -> Result<(), McpError> {
         // Serialize with commit_added_server to prevent orphaned trust/tools entries.


### PR DESCRIPTION
## Summary

- Add `#[tracing::instrument]` to 16 async fns in `zeph-mcp/src/manager/` (connect.rs ×7, server.rs ×5, retry.rs ×3, ingest.rs ×1) following `mcp.manager.<fn>` span naming convention; `err` added on all `Result`-returning fns including `add_server` and `remove_server`
- Fix 3 inner span name divergences in `zeph-context/src/summarization.rs` to match `context.summarization.*` convention (`chunk`, `consolidate_structured`, `consolidate_prose`); no outer `#[tracing::instrument]` added since the file already wraps function bodies with `.instrument(info_span!(...))`

Closes #5325, #5156

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [ ] `cargo nextest run` — 11437 passed, 0 failed (baseline maintained)
- [ ] `cargo doc` rustdoc gate — clean
- [ ] No `.entered()`-across-`.await` anti-patterns introduced
- [ ] No double-nested spans (verified by adversarial critique + code review)