### PR TITLE
docs(cocoon): add threat IDs, attestation monitoring checklist, and spec gap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Research
+
+- `docs(cocoon)`: add stable non-positional threat IDs (`T-BIN-SUBST`, `T-COMP-ATTEST`,
+  `T-LOCAL-INTERCEPT`, `T-QDRANT-EXFIL`, `T-BALANCE-SIDE`, `T-CRED-EXFIL`, `T-CRASH-LOOP`,
+  `T-STALE-ATTEST`) to `threat-model.md` §4 table; cross-reference SG-7 (§2) and Challenge 1
+  (§3) to `T-COMP-ATTEST`; correct #4650's positional "row T-4" reference to stable ID (#4650)
+- `docs(cocoon)`: add compound attestation monitoring checklist §15.5 to `spec.md` — defines
+  signals to watch in Cocoon releases (attestation endpoints, release-note keywords, capability
+  fields), trigger→action flow for filing P2 implementation issue, and cross-ref to CI
+  dependency-watch loop; #4650 is the open tracking anchor (#4650)
+- `docs(cocoon)`: qualify E2E Option B for containerised deployments in §16.2 — "no security
+  over RA-TLS" claim qualified to bare-metal/loopback topology; in Docker Compose / Kubernetes
+  topologies where the Zeph→sidecar hop is a real network segment, Option B provides additional
+  protection; Option A remains preferred; add containerised topology open question to §17 (#3677)
+- `docs(cocoon)`: add TaskSupervisor AC requirement and cross-reference in §16.1 — managed
+  sidecar MUST use `TaskSupervisor::spawn_restartable` with circuit breaker (spec-039); designate
+  `cocoon doctor --start` as the managed entry point; add cross-ref: #4650 resolution weakens
+  trust-boundary objection to managed mode (#3676)
+- `docs(cocoon)`: add GA/experimental open questions for E2E encryption maturity and Option A
+  support to §17; annotate §16.2 perf claims as unmeasured; note reserved config stanzas are
+  intentionally commented until supervisor-backed implementations land (#3677)
+
 ### Changed
 
 - `fix(channels)`: add `// EXEMPT` annotation and `tracing::warn!` to the raw `tokio::spawn` in

--- a/specs/055-cocoon/spec.md
+++ b/specs/055-cocoon/spec.md
@@ -605,6 +605,60 @@ Add the following to Section 11 "Key Invariants":
 >   because managing the sidecar lifecycle makes Zeph part of the trusted
 >   compute base and weakens TEE attestation guarantees
 
+### 15.5 Compound Attestation Monitoring Checklist
+
+**Tracking issue:** #4650 (P2, upstream-blocked). This section defines the
+monitoring criteria that determine when #4650 becomes implementable. The issue
+remains open as the canonical tracking anchor — do not close it until all
+criteria below are resolved and an implementation PR is merged.
+
+**Cross-ref:** threat `T-COMP-ATTEST` in [[055-cocoon/threat-model]] §4;
+SG-7 in §2; Challenge 1 in §3. Also tracked in the CI dependency-watch loop
+(`.claude/rules/continuous-improvement.md`, "Dependency Monitoring" section).
+
+#### What to watch in Cocoon releases
+
+Monitor Cocoon sidecar release notes and API documentation for any of the
+following signals:
+
+| Signal | What it means |
+|--------|---------------|
+| New endpoint `GET /attestation` or `GET /attestation/evidence` | Sidecar exposes TDX quote and/or proxy certificate chain directly |
+| `GET /health` or `GET /stats` response gains a `tdx_quote` or `attestation` field | Attestation evidence embedded in existing health endpoint |
+| `GET /stats` response gains a `proxy_cert_chain` or `pcr_values` field | Proxy certificate chain or platform configuration registers exposed |
+| Release note mentions "attestation evidence", "TDX quote", "compound attestation", "PCK cert", "remote attestation API", or "quote forwarding" | Protocol-level capability landing |
+| New sidecar capability negotiation field (version handshake, capability flags) | May indicate E2E or attestation feature availability |
+
+#### Trigger → action
+
+When **any** of the above signals appear in a Cocoon release:
+
+1. Comment on issue #4650 with the Cocoon version, the signal observed, and
+   a link to the release notes or API diff.
+2. File a new P2 implementation issue: `feat(cocoon): implement compound
+   attestation verification (#4650 follow-up)`. Body must include:
+   - The attestation evidence endpoint and response schema
+   - Implementation plan: fetch TDX quote + PCK cert chain; validate quote
+     signature against Intel root CA; surface pass/fail in `cocoon doctor`
+     output; add config flag `cocoon.verify_attestation_chain` (default `false`
+     until validation is battle-tested)
+   - Integration: add `cocoon attestation verify` CLI subcommand; TUI status
+     indicator; tracing span `llm.cocoon.attestation`
+3. Re-read §11 "Never" invariants before implementing — the constraint
+   "NEVER implement compound attestation verification without upstream Cocoon
+   sidecar support" becomes satisfiable once the endpoint exists.
+
+#### What NOT to do
+
+- Do not implement attestation verification by screen-scraping `cocoon doctor`
+  CLI output — require a machine-readable API endpoint.
+- Do not assert `proxy_connected = true` is equivalent to attestation — it is
+  an informational signal from the sidecar itself, not an independently
+  verifiable cryptographic proof (see §15.3).
+- Do not embed this checklist as the recurring trigger mechanism — the CI
+  dependency-watch loop in `.claude/rules/continuous-improvement.md` watches
+  sidecar dependency updates; cross-link #4650 there so automated cycles flag it.
+
 ---
 
 ## 16. Deferred Features — Research Findings
@@ -645,14 +699,34 @@ The current model — user starts the sidecar independently, Zeph connects to it
 # cocoon_args = []                 # extra args passed to sidecar at spawn
 ```
 
+> [!note]
+> The config stanzas above are intentionally kept commented-out. Promoting them
+> to live schema without the supervisor-backed implementation would create a
+> half-wired feature flag that violates the MVP "no half-finished implementations"
+> rule (CLAUDE.md). These keys remain reserved; do not add deserialization or
+> validation until the full #3676 implementation lands.
+
 **Future implementation acceptance criteria (post-v1.0.0):**
 - GIVEN `cocoon_managed = true` and `cocoon_binary_path` set
 - WHEN Zeph starts and `/stats` is unreachable
-- THEN Zeph spawns the binary, waits for health, and registers a SIGTERM hook
-  for clean shutdown; exponential backoff with max 3 retries before giving up
+- THEN Zeph spawns the binary via `TaskSupervisor::spawn_restartable` (per
+  `zeph_common::task_supervisor`, spec-039) with a `RestartPolicy` providing
+  exponential backoff and a circuit breaker (max 3 retries before giving up);
+  registers a SIGTERM hook for clean shutdown
+- Designated managed entry point: `cocoon doctor --start` (explicit operator
+  action; avoids implicit spawn at startup which would weaken the trust-boundary
+  argument; operator-initiated makes the trust decision explicit)
 - Platform: Unix-only initially; Windows deferred
 - MUST document in operator guide that `cocoon_managed = true` weakens TEE
   attestation guarantees
+- MUST NOT use a raw `tokio::spawn` — all lifecycle management MUST go through
+  `TaskSupervisor::spawn_restartable` (spec-039 "NEVER" constraint)
+
+> [!note] Cross-reference with #4650
+> If compound attestation (#4650) lands before this feature is implemented, the
+> trust-boundary objection to `cocoon_managed` weakens: Zeph could cryptographically
+> verify the sidecar's attestation chain even when it spawned the sidecar.
+> Re-evaluate the deferral at that point.
 
 ### 16.2 End-to-End Payload Encryption (Issue #3677)
 
@@ -685,15 +759,42 @@ multi-operator proxy network.
 encryption is performed by the Cocoon sidecar on behalf of the client, or
 by Zeph directly before sending to the sidecar — must be resolved with the
 Cocoon upstream before implementation. Option A (Zeph encrypts, sidecar passes
-opaque ciphertext) is the stronger model; Option B (sidecar encrypts after
-receiving plaintext from Zeph) provides no security improvement over RA-TLS
-alone since localhost plaintext exposure remains.
+opaque ciphertext) is the stronger model and the recommended path.
+
+Option B (sidecar encrypts after receiving plaintext from Zeph) provides no
+security improvement over RA-TLS alone **when Zeph and the sidecar share a
+loopback interface (the supported default for bare-metal deployments)**. However,
+this reasoning does not hold universally: in containerised deployments where
+Zeph and the sidecar run in separate containers on a real container network
+(see §15.2 Limitation #3 — Docker Compose with separate services, or Kubernetes
+with separate pods), the Zeph→sidecar hop is NOT a trusted loopback and Option B
+WOULD provide additional protection for that segment. Option A remains preferred
+because it protects all topologies; Option B is not ruled out for containerised
+threat models where the topology diverges from the bare-metal default.
+
+**Open question:** Is client-side E2E (Option A) supported by the current
+Cocoon sidecar API, or is it experimental/unimplemented? This must be confirmed
+with upstream before implementation begins.
+
+**Performance note:** The latency overhead of asymmetric Ed25519/X25519 per
+request for typical prompt sizes is expected to be negligible; SSE per-chunk
+AEAD streaming is more complex (see deferred challenges below). These claims are
+**not measured** — no live sidecar or benchmarks are available. Performance
+impact MUST be benchmarked at implementation time; do not treat qualitative
+assessments here as measured results.
 
 **Config interface reserved (not implemented):**
 
 ```toml
 # cocoon_e2e_encryption = false    # default; enable Ed25519 E2E encryption if supported by sidecar
 ```
+
+> [!note]
+> `cocoon_e2e_encryption` is intentionally kept commented-out until the upstream
+> Option-A question is resolved and a full implementation is ready. Promoting it
+> to live schema now would create a half-wired flag with no consumer, violating
+> the MVP rule. The vault key slot `ZEPH_COCOON_E2E_PRIVATE_KEY` is also reserved
+> but not wired; do not add vault lookup until #3677 implementation begins.
 
 **Vault key reserved:**
 
@@ -712,8 +813,14 @@ alone since localhost plaintext exposure remains.
 - WHEN Zeph sends a chat or embed request
 - THEN the Ed25519 public key is included in the request header and the
   response is decrypted before deserialisation
-- MUST verify with Cocoon upstream which encryption point (sidecar vs. client)
-  is supported before starting implementation
+- MUST confirm with Cocoon upstream that Option A (client-side encryption) is
+  supported and at GA maturity before starting implementation (see §17 open
+  questions: "E2E encryption point" and "E2E encryption maturity")
+- MUST benchmark Ed25519/X25519 overhead and SSE streaming AEAD per-chunk cost
+  at implementation time; no performance estimates are asserted in this spec
+- MUST address containerised topology interaction (§17 "Containerised topology
+  interaction with E2E") if the deployment topology differs from the
+  bare-metal default
 
 ---
 
@@ -728,10 +835,22 @@ alone since localhost plaintext exposure remains.
 >   mechanism or a way to detect schema drift?
 > - **Attestation evidence endpoint**: Does the Cocoon sidecar expose
 >   attestation chain information (proxy certificate details, TDX quote)? This
->   would enable partial compound attestation verification from Zeph.
-> - **E2E encryption point**: Does the current Cocoon sidecar support E2E
->   encryption at the client level (Zeph encrypts before sending) or only at
->   the sidecar level? This determines which Option (A vs. B) is viable for #3677.
+>   would enable partial compound attestation verification from Zeph. See §15.5
+>   for the monitoring checklist; tracking issue #4650.
+> - **E2E encryption point (Option A vs. B)**: Does the current Cocoon sidecar
+>   support E2E encryption at the client level (Zeph encrypts before sending —
+>   Option A) or only at the sidecar level (Option B)? This determines which
+>   option is viable for #3677. Option A is the security-positive path; Option B
+>   provides no protection in the default bare-metal topology (see §16.2).
+> - **E2E encryption maturity (GA vs. experimental)**: Even if Option A is
+>   supported by the sidecar protocol, is this feature generally available or
+>   experimental/unstable in the current Cocoon release? Must be confirmed with
+>   upstream before starting #3677 implementation.
+> - **Containerised topology interaction with E2E**: In Docker Compose or
+>   Kubernetes deployments where Zeph and the sidecar are in separate network
+>   namespaces (§15.2 Limitation #3), does the Cocoon sidecar support Option A
+>   E2E encryption for the inter-container hop? Does the deployment guide
+>   address this topology?
 > - **Streaming E2E**: If E2E encryption is added, what cipher mode does Cocoon
 >   use for SSE streaming chunks? Per-chunk AEAD, or a session cipher with
 >   stream continuity?

--- a/specs/055-cocoon/threat-model.md
+++ b/specs/055-cocoon/threat-model.md
@@ -63,7 +63,7 @@ arXiv:2605.03213 defines nine security goals for confidential AI agents.
 | SG-4 | **Confidentiality of agent memory** | Not met | Qdrant and SQLite run outside TEE; embeddings and retrieved context cross trust boundary in plaintext |
 | SG-5 | **Integrity of tool execution** | Not met | `zeph-tools` and `zeph-mcp` run outside TEE; tool results are plaintext in L4 |
 | SG-6 | **Auditability of agent actions** | Partial | `zeph-agent-feedback`, tool audit log, tracing spans provide auditability; none is TEE-sealed |
-| SG-7 | **Compound attestation (end-to-end)** | Not met | Zeph cannot verify the full Zeph → sidecar → proxy → worker attestation chain; sidecar is trusted implicitly |
+| SG-7 | **Compound attestation (end-to-end)** | Not met | Zeph cannot verify the full Zeph → sidecar → proxy → worker attestation chain; sidecar is trusted implicitly (see threat `T-COMP-ATTEST` in §4, Challenge 1 in §3, and §15.5 of parent spec) |
 | SG-8 | **Side-channel resistance** | Partial | TDX provides L6 hardware isolation; `ton_balance` in TUI is an application-level side-channel; no mitigations for timing or cache side-channels at L1–L5 |
 | SG-9 | **Secure multi-agent coordination** | Partial | Subagents (`zeph-subagent`) each independently connect to the sidecar; no shared TEE session or cross-agent attestation |
 
@@ -75,6 +75,8 @@ arXiv:2605.03213 identifies three open challenges for confidential AI agent
 systems. Below is their applicability to Zeph/Cocoon.
 
 ### Challenge 1: Compound Attestation
+
+**Threat table ID:** `T-COMP-ATTEST` (§4). Cross-ref: SG-7 (§2), #4650, §15.5 of parent spec.
 
 **Paper definition:** Verifying that the entire agent pipeline — from user
 input through every layer to the inference backend — operates within a
@@ -93,15 +95,15 @@ sidecar itself — not independently verifiable attestation evidence.
 **Gap severity:** High for operators with strong confidentiality requirements;
 acceptable for operators who trust their own host environment.
 
-**Recommended action:** File a P2 issue to investigate whether the Cocoon
-sidecar exposes attestation evidence (TDX quote, proxy certificate chain) via
-an API endpoint. If so, implement a `cocoon attestation verify` command that
-fetches and validates this evidence. This is blocked on upstream Cocoon
-protocol support.
+**Recommended action:** File a P2 implementation issue when the Cocoon sidecar
+gains an attestation evidence endpoint exposing TDX quote and proxy certificate
+chain. See §15.5 of the parent spec for the monitoring checklist that defines
+exactly what to watch for in Cocoon releases. This is currently upstream-blocked;
+tracking issue is #4650.
 
-**Status of issue #3692:** Documented as a known limitation. A dedicated P2
-follow-up issue should be filed if the sidecar gains attestation evidence
-exposure in a future Cocoon release.
+**Status:** Known limitation documented in spec §15.2 Limitation #1. Issue #4650
+is the open tracking anchor; it stays open until upstream attestation-evidence
+support lands.
 
 ### Challenge 2: TEE-Backed RAG Isolation
 
@@ -147,16 +149,21 @@ visible to operators.
 
 ## 4. Threat Table
 
-| Threat | Current Mitigation | Gap | Recommended Action |
-|--------|-------------------|-----|-------------------|
-| **Sidecar binary substitution** — attacker replaces the Cocoon C++ binary on the operator's host | Operator is responsible for binary integrity; out of scope for Zeph | No binary hash verification, no TEE attestation of the sidecar itself | Document as operator responsibility; consider adding a `zeph cocoon verify-binary` command once Cocoon publishes signed release hashes |
-| **Compromised proxy (RA-TLS termination attack)** — proxy terminates RA-TLS and inspects/modifies prompts without TEE | RA-TLS attestation verified by sidecar before connecting | Zeph cannot verify this verification occurred | Compound attestation (Challenge 1 above); partial mitigation via E2E encryption (#3677) |
-| **Localhost interception** — process on same host intercepts Zeph ↔ sidecar HTTP | Localhost-only URL validation; OS network isolation | plaintext localhost segment | Document as known limitation; E2E encryption (#3677) is the only mitigation |
-| **Memory exfiltration from Qdrant** — attacker with host access reads Qdrant data | Qdrant access control (API key if configured); network firewall | Qdrant not TEE-protected | Document as known limitation; full mitigation requires TEE-backed vector store |
-| **Side-channel via `ton_balance` TUI display** — shared-screen observer infers usage volume | None | `ton_balance` visible to anyone with TUI access | Recommend opt-in or redactable balance display (see Section 15.2 of parent spec) |
-| **Credential exfiltration via LLM prompt injection** — malicious tool output or web content triggers prompt that leaks `ZEPH_COCOON_ACCESS_HASH` | `zeph-sanitizer` exfiltration guard, PII filtering | Sanitizer is heuristic, not TEE-sealed | Rely on sanitizer; enforce `ZEPH_COCOON_ACCESS_HASH` stays in vault (never in context) |
-| **Sidecar crash loop under `cocoon_managed = true`** (deferred feature) | Feature deferred; not implemented | If implemented without circuit breaker, Zeph could hang retrying indefinitely | Acceptance criteria for #3676 implementation require exponential backoff + circuit breaker |
-| **Stale attestation** — sidecar reconnects to a different proxy after initial health check passes | `proxy_connected` checked once at `cocoon doctor` | No continuous re-attestation | Document; `cocoon doctor` is a point-in-time check, not continuous monitoring |
+Threat IDs are stable and non-positional — they are mnemonic slugs, not row numbers. Reordering rows
+does not change IDs. Cross-references in issues and other documents should use these IDs (e.g.
+`T-COMP-ATTEST`), not row positions. Issue #4650 originally referenced "row T-4 (compound attestation
+gap)"; the correct stable ID is `T-COMP-ATTEST` as defined below.
+
+| ID | Threat | Current Mitigation | Gap | Recommended Action |
+|----|--------|-------------------|-----|-------------------|
+| **T-BIN-SUBST** | **Sidecar binary substitution** — attacker replaces the Cocoon C++ binary on the operator's host | Operator is responsible for binary integrity; out of scope for Zeph | No binary hash verification, no TEE attestation of the sidecar itself | Document as operator responsibility; consider adding a `zeph cocoon verify-binary` command once Cocoon publishes signed release hashes |
+| **T-COMP-ATTEST** | **Compromised proxy / compound attestation** — proxy terminates RA-TLS and inspects/modifies prompts without TEE; or the attestation chain is opaque to Zeph (see SG-7, Challenge 1) | RA-TLS attestation verified by sidecar before connecting | Zeph cannot verify this verification occurred; compound attestation chain is opaque | Compound attestation (Challenge 1 above); partial mitigation via E2E encryption (#3677); see §15.5 for monitoring checklist |
+| **T-LOCAL-INTERCEPT** | **Localhost interception** — process on same host intercepts Zeph ↔ sidecar HTTP | Localhost-only URL validation; OS network isolation | plaintext localhost segment | Document as known limitation; E2E encryption (#3677) is the only mitigation |
+| **T-QDRANT-EXFIL** | **Memory exfiltration from Qdrant** — attacker with host access reads Qdrant data | Qdrant access control (API key if configured); network firewall | Qdrant not TEE-protected | Document as known limitation; full mitigation requires TEE-backed vector store |
+| **T-BALANCE-SIDE** | **Side-channel via `ton_balance` TUI display** — shared-screen observer infers usage volume | None | `ton_balance` visible to anyone with TUI access | Recommend opt-in or redactable balance display (see Section 15.2 of parent spec) |
+| **T-CRED-EXFIL** | **Credential exfiltration via LLM prompt injection** — malicious tool output or web content triggers prompt that leaks `ZEPH_COCOON_ACCESS_HASH` | `zeph-sanitizer` exfiltration guard, PII filtering | Sanitizer is heuristic, not TEE-sealed | Rely on sanitizer; enforce `ZEPH_COCOON_ACCESS_HASH` stays in vault (never in context) |
+| **T-CRASH-LOOP** | **Sidecar crash loop under `cocoon_managed = true`** (deferred feature) | Feature deferred; not implemented | If implemented without circuit breaker, Zeph could hang retrying indefinitely | Acceptance criteria for #3676 implementation require exponential backoff + circuit breaker via `TaskSupervisor::spawn_restartable` |
+| **T-STALE-ATTEST** | **Stale attestation** — sidecar reconnects to a different proxy after initial health check passes | `proxy_connected` checked once at `cocoon doctor` | No continuous re-attestation | Document; `cocoon doctor` is a point-in-time check, not continuous monitoring |
 
 ---
 
@@ -167,14 +174,16 @@ visible to operators.
 | #3692 | P3/research | Open | arXiv:2605.03213 threat model analysis — resolved by this document |
 | #3676 | P3 | Open | Sidecar lifecycle management — DEFERRED (see Section 16.1 of parent spec) |
 | #3677 | P3 | Open | E2E payload encryption — DEFERRED (see Section 16.2 of parent spec) |
+| #4650 | P2/research | Open | Compound attestation monitoring (threat `T-COMP-ATTEST`) — UPSTREAM-BLOCKED; monitoring checklist in §15.5 of parent spec defines the trigger for implementation |
 
 **Recommended follow-up issues:**
 
-1. **Compound attestation investigation (P2)**: File if the Cocoon sidecar
+1. **Compound attestation implementation (P2)**: File when the Cocoon sidecar
    gains an attestation evidence endpoint in a future release. The issue should
    request: fetch TDX quote + proxy certificate chain via sidecar API; validate
    quote signature; surface result in `cocoon doctor` output. Do not file until
-   upstream capability is confirmed.
+   upstream capability is confirmed (see §15.5 of parent spec for monitoring
+   criteria and the T-COMP-ATTEST threat row above).
 
 2. **`ton_balance` opt-in display (P3)**: File a UX improvement issue to make
    the balance display in the TUI sidebar opt-in. This is a low-priority privacy


### PR DESCRIPTION
## Summary

Research cluster for three Cocoon subsystem issues: #4650 (compound attestation tracking), #3676 (sidecar lifecycle), #3677 (E2E encryption). This PR is docs-only — no Rust source files were changed.

- **threat-model.md**: Added 8 stable non-positional threat IDs (`T-COMP-ATTEST`, `T-BIN-SUBST`, `T-LOCAL-INTERCEPT`, `T-QDRANT-EXFIL`, `T-BALANCE-SIDE`, `T-CRED-EXFIL`, `T-CRASH-LOOP`, `T-STALE-ATTEST`). Corrects the dangling "row T-4" reference in #4650 — compound attestation is now unambiguously `T-COMP-ATTEST`.
- **spec.md §15.5**: New compound attestation monitoring checklist with 5 watch signals (endpoint names, keywords, release-note patterns), trigger-to-action flow, and #4650 as the tracking anchor.
- **spec.md §16.1** (sidecar lifecycle): Added `TaskSupervisor::spawn_restartable` + circuit-breaker to future AC; designated `cocoon doctor --start` as managed entry point; cross-reference noting that resolving #4650 weakens the trust-boundary objection to managed mode.
- **spec.md §16.2** (E2E encryption): Qualified the Option B dismissal for containerised deployments where Zeph and sidecar are in separate containers (Docker Compose / Kubernetes); added GA/experimental open question; annotated perf claims as unmeasured.
- **spec.md §17**: Added 3 open questions scoping future implementation.
- **CHANGELOG.md**: Research findings documented in `[Unreleased] ### Research`.

## Implementation sub-issues filed

- #5338 — `feat(cocoon): implement E2E payload encryption (Option A, client-side Ed25519)` (from #3677)
- #5339 — `feat(cocoon): implement managed sidecar lifecycle (cocoon_managed config + TaskSupervisor)` (from #3676)

## Status of original issues

- #3676, #3677 — closed (research complete, findings in spec, implementation sub-issues filed)
- #4650 — remains open as upstream-blocked tracking issue (no Cocoon attestation evidence API yet)

## Test plan

- [ ] Spec files render correctly (Markdown)
- [ ] No src/ files changed — confirm with `git diff --name-only origin/main`
- [ ] `cargo +nightly fmt --check` passes
- [ ] `gh issue view 5338` and `gh issue view 5339` exist and reference correct parent issues