### PR TITLE
feat(hooks): add conditional if filter and agent context to hook payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `feat(hooks)`: add optional `if` conditional field to `HookDef` with `tool:<token>` DSL — hooks
+  now fire only when `ZEPH_TOOL_NAME` contains the token (case-sensitive substring, fail-closed for
+  all error cases: no colon, unknown key, empty token, empty tool name, `None` tool context).
+  Configured in TOML as `if = "tool:shell"`. Hooks without `if` fire unconditionally. A `warn!`
+  is emitted once at startup when a `tool:` condition is placed on a non-tool event
+  (`cwd_changed`, `file_changed`, `turn_complete`). Closes #3088 (partial).
+
+- `feat(hooks)`: inject `ZEPH_AGENT_TYPE` (`"main"` or `"subagent"`) and `ZEPH_AGENT_ID` into
+  all hook env maps at every lifecycle event. Sub-agent path (`zeph-subagent`) sets
+  `ZEPH_AGENT_TYPE=subagent` and `ZEPH_AGENT_ID=<task_id>` in `make_hook_env`. Main agent path
+  (`zeph-core`) injects both vars via new `insert_main_agent_ctx` helper in `hooks_dispatch.rs`,
+  called from `check_cwd_changed`, `handle_file_changed`, `mod.rs` (turn_complete), and
+  `tier_loop.rs` (pre/post-tool-use, permission_denied). `ZEPH_AGENT_ID` is omitted when no
+  conversation has been bound yet. Closes #3088 (partial).
+
+- `feat(hooks)`: extend `PostToolUseHookInput` stdin JSON with `agent_id` and `agent_type` fields
+  for `PostToolUse` and `PostToolUseFailure` events. `agent_id` is omitted when `None`
+  (`skip_serializing_if`); `agent_type` is always present. Both the main agent and sub-agent
+  populate these fields in their respective `PostToolUseHookInput` construction sites. Closes #3088.
+
 - `fix(channels)`: add `// EXEMPT` annotation and `tracing::warn!` to the raw `tokio::spawn` in
   `spawn_guest_proxy()` (`crates/zeph-channels/src/telegram.rs`), matching the documentation
   pattern used by the three other untracked Telegram spawn sites. The guest proxy is a singleton

--- a/crates/zeph-config/src/hooks.rs
+++ b/crates/zeph-config/src/hooks.rs
@@ -180,6 +180,7 @@ mod tests {
             },
             timeout_secs: 10,
             fail_closed: false,
+            r#if: None,
         }
     }
 
@@ -458,5 +459,56 @@ severity = "high"
             HookAction::McpTool { server, tool, .. } if server == "policy" && tool == "audit"
         ));
         assert!(!cfg.is_empty());
+    }
+
+    // ── HookDef `if` field serde ──────────────────────────────────────────────
+
+    #[test]
+    fn hook_def_if_none_omits_field_in_toml() {
+        let hook = cmd_hook("echo hi");
+        // r#if: None must not serialize the `if` key.
+        let serialized = toml::to_string(&hook).unwrap();
+        assert!(
+            !serialized.contains("if"),
+            "unexpected `if` key: {serialized}"
+        );
+    }
+
+    #[test]
+    fn hook_def_if_some_roundtrips_via_toml() {
+        use crate::subagent::HookAction;
+        use crate::subagent::HookDef;
+        let hook = HookDef {
+            action: HookAction::Command {
+                command: "echo hi".into(),
+            },
+            timeout_secs: 10,
+            fail_closed: false,
+            r#if: Some("tool:shell".to_owned()),
+        };
+        let serialized = toml::to_string(&hook).unwrap();
+        assert!(
+            serialized.contains("if = \"tool:shell\""),
+            "missing `if` key: {serialized}"
+        );
+        let deserialized: HookDef = toml::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.r#if.as_deref(), Some("tool:shell"));
+    }
+
+    #[test]
+    fn hook_def_if_condition_parses_from_toml() {
+        let toml = r#"
+[[post_tool_use]]
+matcher = "Shell"
+[[post_tool_use.hooks]]
+type = "command"
+command = "echo shell"
+timeout_secs = 5
+fail_closed = false
+if = "tool:shell"
+"#;
+        let cfg: HooksConfig = toml::from_str(toml).unwrap();
+        let hook = &cfg.post_tool_use[0].hooks[0];
+        assert_eq!(hook.r#if.as_deref(), Some("tool:shell"));
     }
 }

--- a/crates/zeph-config/src/subagent.rs
+++ b/crates/zeph-config/src/subagent.rs
@@ -154,6 +154,14 @@ fn default_hook_timeout() -> u64 {
 /// command = "echo changed to $ZEPH_NEW_CWD"
 /// timeout_secs = 10
 /// fail_closed = false
+///
+/// # Conditional hook — only fires when the triggering tool name contains "shell":
+/// [[hooks.post_tool_use]]
+/// matcher = "Shell"
+/// [[hooks.post_tool_use.hooks]]
+/// type = "command"
+/// command = "echo shell ran"
+/// if = "tool:shell"
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HookDef {
@@ -172,6 +180,24 @@ pub struct HookDef {
     /// fail-open at the agent level; the tool executes regardless of hook outcomes.
     #[serde(default)]
     pub fail_closed: bool,
+    /// Optional condition that must match for this hook to fire.
+    ///
+    /// When `None` (the default), the hook fires unconditionally at every matching lifecycle
+    /// event. When `Some`, the value is a `key:value` filter string. Supported keys:
+    ///
+    /// - `tool:<token>` — the hook fires only when `ZEPH_TOOL_NAME` **contains** `<token>`
+    ///   (case-sensitive substring, same rule as `HookMatcher`). An empty token
+    ///   (`tool:`) always evaluates to `false` (fail-closed).
+    ///
+    /// Unknown keys and malformed values (no `:`) also evaluate to `false` so that a
+    /// misconfigured condition silently skips the hook rather than firing unconditionally.
+    ///
+    /// **Note:** `tool:` conditions on `file_changed`, `cwd_changed`, and `turn_complete`
+    /// events will never match because those events carry no triggering-tool context.
+    /// The hook will be permanently skipped in those positions (a `warn!` is emitted once
+    /// when the hook config is first evaluated).
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "if")]
+    pub r#if: Option<String>,
 }
 
 /// Tool-name matcher with associated hooks.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1532,6 +1532,29 @@ impl<C: Channel> Agent<C> {
     /// from the current process cwd at call time (the project root).
     #[must_use]
     pub fn with_hooks_config(mut self, config: &zeph_config::HooksConfig) -> Self {
+        // Warn about `if = "tool:..."` conditions on events that carry no tool context.
+        // These hooks will never fire because ZEPH_TOOL_NAME is absent at those events.
+        let no_tool_hooks: Vec<&zeph_config::HookDef> = config
+            .cwd_changed
+            .iter()
+            .chain(config.turn_complete.iter())
+            .chain(config.file_changed.iter().flat_map(|fc| fc.hooks.iter()))
+            .collect();
+        for hook in no_tool_hooks {
+            if hook
+                .r#if
+                .as_deref()
+                .is_some_and(|cond| cond.starts_with("tool:"))
+            {
+                tracing::warn!(
+                    condition = hook.r#if.as_deref().unwrap_or(""),
+                    "hook `if` uses `tool:` filter on an event with no tool context \
+                     (cwd_changed, file_changed, turn_complete) — \
+                     this hook will never fire"
+                );
+            }
+        }
+
         self.services
             .session
             .hooks_config

--- a/crates/zeph-core/src/agent/hooks_dispatch.rs
+++ b/crates/zeph-core/src/agent/hooks_dispatch.rs
@@ -12,6 +12,18 @@ use std::sync::Arc;
 use super::Agent;
 use crate::channel::Channel;
 
+/// Inject `ZEPH_AGENT_TYPE = "main"` and (when present) `ZEPH_AGENT_ID` into a hook
+/// environment map. Mirrors how `ZEPH_SESSION_ID` is conditionally inserted at each site.
+pub(crate) fn insert_main_agent_ctx(
+    env: &mut std::collections::HashMap<String, String>,
+    conv_id: Option<&str>,
+) {
+    env.insert("ZEPH_AGENT_TYPE".to_owned(), "main".to_owned());
+    if let Some(id) = conv_id {
+        env.insert("ZEPH_AGENT_ID".to_owned(), id.to_owned());
+    }
+}
+
 impl<C: Channel> Agent<C> {
     /// Return an `McpDispatch` adapter backed by the agent's MCP manager, if present.
     pub(super) fn mcp_dispatch(&self) -> Option<McpManagerDispatch> {
@@ -61,6 +73,13 @@ impl<C: Channel> Agent<C> {
             let mut env = std::collections::HashMap::new();
             env.insert("ZEPH_OLD_CWD".to_owned(), old_cwd.display().to_string());
             env.insert("ZEPH_NEW_CWD".to_owned(), current.display().to_string());
+            let conv_id_str = self
+                .services
+                .memory
+                .persistence
+                .conversation_id
+                .map(|id| id.0.to_string());
+            insert_main_agent_ctx(&mut env, conv_id_str.as_deref());
             let dispatch = self.mcp_dispatch();
             let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
                 .as_ref()
@@ -102,6 +121,13 @@ impl<C: Channel> Agent<C> {
                 "ZEPH_CHANGED_PATH".to_owned(),
                 event.path.display().to_string(),
             );
+            let conv_id_str = self
+                .services
+                .memory
+                .persistence
+                .conversation_id
+                .map(|id| id.0.to_string());
+            insert_main_agent_ctx(&mut env, conv_id_str.as_deref());
             let dispatch = self.mcp_dispatch();
             let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
                 .as_ref()
@@ -153,5 +179,39 @@ impl zeph_subagent::McpDispatch for McpManagerDispatch {
                 })
                 .map_err(|e| e.to_string())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::insert_main_agent_ctx;
+
+    #[test]
+    fn insert_main_agent_ctx_always_sets_agent_type() {
+        let mut env = HashMap::new();
+        insert_main_agent_ctx(&mut env, None);
+        assert_eq!(env.get("ZEPH_AGENT_TYPE").map(String::as_str), Some("main"));
+    }
+
+    #[test]
+    fn insert_main_agent_ctx_sets_agent_id_when_some() {
+        let mut env = HashMap::new();
+        insert_main_agent_ctx(&mut env, Some("conv-abc"));
+        assert_eq!(
+            env.get("ZEPH_AGENT_ID").map(String::as_str),
+            Some("conv-abc")
+        );
+    }
+
+    #[test]
+    fn insert_main_agent_ctx_omits_agent_id_when_none() {
+        let mut env = HashMap::new();
+        insert_main_agent_ctx(&mut env, None);
+        assert!(
+            !env.contains_key("ZEPH_AGENT_ID"),
+            "ZEPH_AGENT_ID must be absent when conv_id is None"
+        );
     }
 }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1417,6 +1417,13 @@ impl<C: Channel> Agent<C> {
                 "ZEPH_TURN_LLM_REQUESTS".to_owned(),
                 summary.llm_requests.to_string(),
             );
+            let conv_id_str = self
+                .services
+                .memory
+                .persistence
+                .conversation_id
+                .map(|id| id.0.to_string());
+            crate::agent::hooks_dispatch::insert_main_agent_ctx(&mut env, conv_id_str.as_deref());
             let dispatch = self.mcp_dispatch();
             let _span = tracing::info_span!("core.agent.turn_hooks").entered();
             let _accepted = self.runtime.lifecycle.supervisor.spawn(

--- a/crates/zeph-core/src/agent/tool_execution/tests/hook_block_cap_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/hook_block_cap_tests.rs
@@ -26,6 +26,7 @@ fn fail_closed_hook() -> HookDef {
         },
         timeout_secs: 5,
         fail_closed: true,
+        r#if: None,
     }
 }
 
@@ -36,6 +37,7 @@ fn fail_open_hook() -> HookDef {
         },
         timeout_secs: 5,
         fail_closed: false,
+        r#if: None,
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -26,6 +26,7 @@ fn make_tool_hook_env(
     if let Some(sid) = session_id {
         env.insert("ZEPH_SESSION_ID".to_owned(), sid.to_owned());
     }
+    crate::agent::hooks_dispatch::insert_main_agent_ctx(&mut env, session_id);
     env
 }
 
@@ -1490,6 +1491,14 @@ impl<C: Channel> Agent<C> {
         let mut env = std::collections::HashMap::new();
         env.insert("ZEPH_DENIED_TOOL".to_owned(), tc.name.to_string());
         env.insert("ZEPH_DENY_REASON".to_owned(), reason.to_owned());
+        env.insert("ZEPH_TOOL_NAME".to_owned(), tc.name.to_string());
+        let conv_id_str = self
+            .services
+            .memory
+            .persistence
+            .conversation_id
+            .map(|id| id.0.to_string());
+        crate::agent::hooks_dispatch::insert_main_agent_ctx(&mut env, conv_id_str.as_deref());
         let dispatch = self.mcp_dispatch();
         let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
             .as_ref()
@@ -1876,6 +1885,8 @@ impl<C: Channel> Agent<C> {
                         duration_ms,
                         tool_output: tool_output_text,
                         tool_error: tool_error_text.as_deref(),
+                        agent_id: conv_id_str.as_deref(),
+                        agent_type: "main",
                     };
                     let stdin_bytes = serde_json::to_vec(&hook_input).ok();
 
@@ -2834,6 +2845,7 @@ mod tests {
             },
             timeout_secs: 5,
             fail_closed: false,
+            r#if: None,
         };
         // A wildcard-style matcher that matches any tool name token.
         let matchers = vec![HookMatcher {

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -36,6 +36,7 @@ fn make_hook_env(
     let mut env = make_base_hook_env(tool_name, tool_input);
     env.insert("ZEPH_AGENT_ID".to_owned(), task_id.to_owned());
     env.insert("ZEPH_AGENT_NAME".to_owned(), agent_name.to_owned());
+    env.insert("ZEPH_AGENT_TYPE".to_owned(), "subagent".to_owned());
     env
 }
 
@@ -579,6 +580,8 @@ async fn handle_tool_step(
                             duration_ms,
                             tool_output: tool_output_text,
                             tool_error: tool_error_text.as_deref(),
+                            agent_id: Some(task_id),
+                            agent_type: "subagent",
                         };
                         let stdin_bytes = serde_json::to_vec(&hook_input).ok();
                         // MCP dispatch is not available in the subagent execution path.
@@ -833,6 +836,10 @@ mod make_hook_env_tests {
         let env = make_hook_env("task-1", "bot", "Edit", &serde_json::Value::Null);
         assert_eq!(env.get("ZEPH_AGENT_ID").map(String::as_str), Some("task-1"));
         assert_eq!(env.get("ZEPH_AGENT_NAME").map(String::as_str), Some("bot"));
+        assert_eq!(
+            env.get("ZEPH_AGENT_TYPE").map(String::as_str),
+            Some("subagent")
+        );
     }
 
     #[test]

--- a/crates/zeph-subagent/src/hooks.rs
+++ b/crates/zeph-subagent/src/hooks.rs
@@ -67,6 +67,7 @@
 //!         action: HookAction::Command { command: "true".to_owned() },
 //!         timeout_secs: 5,
 //!         fail_closed: false,
+//!         r#if: None,
 //!     }];
 //!     fire_hooks(&hooks, &HashMap::new(), None, None).await.unwrap();
 //! }
@@ -115,6 +116,15 @@ pub struct HookRunResult {
 /// The `tool_output` field is present for success events; `tool_error` is present
 /// for failure events. Both are `Option` with `skip_serializing_if` so only the
 /// relevant field appears in the JSON written to stdin.
+///
+/// # Payload consistency contract
+///
+/// Agent context is delivered **two ways**:
+/// - **All hook events**: `ZEPH_AGENT_TYPE` and (when available) `ZEPH_AGENT_ID` env vars.
+/// - **`PostToolUse` only**: `agent_id` and `agent_type` fields in this stdin JSON object.
+///
+/// `file_changed`, `cwd_changed`, and `turn_complete` hooks receive agent context via env
+/// vars only — no stdin JSON is written for those events.
 #[derive(Debug, Serialize)]
 pub struct PostToolUseHookInput<'a> {
     /// Name of the tool that was invoked.
@@ -132,6 +142,12 @@ pub struct PostToolUseHookInput<'a> {
     /// Tool error text (failure path). Absent for success events.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_error: Option<&'a str>,
+    /// The agent's stable identifier: `conversation_id` for the main agent,
+    /// `task_id` for sub-agents. Absent when no conversation has been bound yet.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<&'a str>,
+    /// Discriminator for the agent that fired this hook: `"main"` or `"subagent"`.
+    pub agent_type: &'a str,
 }
 
 /// Maximum number of bytes read from hook stdout before truncation.
@@ -159,6 +175,67 @@ pub trait McpDispatch: Send + Sync {
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>,
     >;
+}
+
+// ── Conditional `if` filter ───────────────────────────────────────────────────
+
+/// Evaluate a `HookDef.r#if` condition string against the triggering tool name.
+///
+/// The condition must be a `key:value` string. Only the `tool` key is supported:
+/// `tool:<token>` matches when `tool_name` is `Some` and **contains** `<token>`.
+///
+/// Returns `false` (fail-closed) in all of these cases:
+/// - The condition has no `:` separator.
+/// - The key is not `tool`.
+/// - The token after `tool:` is empty.
+/// - `tool_name` is `None` (no tool context at this event).
+/// - `tool_name` is `Some("")` (start/stop lifecycle events pass an empty tool name).
+///
+/// A `warn!` is emitted once for unknown keys and malformed conditions so that
+/// misconfigured hooks surface in logs without aborting hook dispatch.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_subagent::hook_if_matches;
+///
+/// assert!(hook_if_matches("tool:shell", Some("shell")));
+/// assert!(hook_if_matches("tool:sh", Some("shell")));  // substring rule
+/// assert!(!hook_if_matches("tool:shell", Some("python")));
+/// assert!(!hook_if_matches("tool:shell", None));       // no tool context
+/// assert!(!hook_if_matches("tool:", Some("shell")));   // empty token → fail-closed
+/// assert!(!hook_if_matches("bad", Some("shell")));     // no colon → fail-closed
+/// ```
+#[must_use]
+pub fn hook_if_matches(condition: &str, tool_name: Option<&str>) -> bool {
+    let Some((key, value)) = condition.split_once(':') else {
+        tracing::warn!(
+            condition,
+            "hook `if` condition has no `:` separator — skipping hook (fail-closed)"
+        );
+        return false;
+    };
+
+    match key {
+        "tool" => {
+            if value.is_empty() {
+                tracing::warn!(
+                    condition,
+                    "hook `if` condition has empty token after `tool:` — skipping hook (fail-closed)"
+                );
+                return false;
+            }
+            tool_name.is_some_and(|t| !t.is_empty() && t.contains(value))
+        }
+        unknown => {
+            tracing::warn!(
+                key = unknown,
+                condition,
+                "hook `if` condition uses unknown key — skipping hook (fail-closed)"
+            );
+            false
+        }
+    }
 }
 
 // ── Error ─────────────────────────────────────────────────────────────────────
@@ -212,7 +289,7 @@ pub enum HookError {
 /// ```rust
 /// use zeph_subagent::{HookDef, HookAction, HookMatcher, matching_hooks};
 ///
-/// let hook = HookDef { action: HookAction::Command { command: "echo hi".to_owned() }, timeout_secs: 30, fail_closed: false };
+/// let hook = HookDef { action: HookAction::Command { command: "echo hi".to_owned() }, timeout_secs: 30, fail_closed: false, r#if: None };
 /// let matchers = vec![HookMatcher { matcher: "Edit|Write".to_owned(), hooks: vec![hook] }];
 ///
 /// assert_eq!(matching_hooks(&matchers, "Edit").len(), 1);
@@ -318,8 +395,23 @@ pub async fn fire_hooks<S: BuildHasher>(
     mcp: Option<&dyn McpDispatch>,
     stdin_json: Option<&[u8]>,
 ) -> Result<HookRunResult, HookError> {
+    let tool_name = env.get("ZEPH_TOOL_NAME").map(String::as_str);
     let mut run_result = HookRunResult::default();
     for hook in hooks {
+        // Evaluate the optional `if` condition before dispatching.
+        if hook.r#if.as_ref().is_some_and(|cond| {
+            let matches = hook_if_matches(cond, tool_name);
+            if !matches {
+                tracing::debug!(
+                    condition = cond.as_str(),
+                    "hook `if` condition did not match — skipping"
+                );
+            }
+            !matches
+        }) {
+            continue;
+        }
+
         // For chaining: pass the already-replaced output as the new stdin so each
         // subsequent hook sees the current (potentially substituted) output.
         let effective_stdin = run_result
@@ -536,6 +628,7 @@ mod tests {
             },
             timeout_secs,
             fail_closed,
+            r#if: None,
         }
     }
 
@@ -676,6 +769,7 @@ mod tests {
             },
             timeout_secs: 5,
             fail_closed: false,
+            r#if: None,
         }];
         let env = HashMap::new();
         // fail_open: should succeed even though MCP is unavailable
@@ -692,6 +786,7 @@ mod tests {
             },
             timeout_secs: 5,
             fail_closed: true,
+            r#if: None,
         }];
         let env = HashMap::new();
         let result = fire_hooks(&hooks, &env, None, None).await;
@@ -730,6 +825,7 @@ mod tests {
             },
             timeout_secs: 5,
             fail_closed: true,
+            r#if: None,
         }];
         let env = HashMap::new();
         let result = fire_hooks(&hooks, &env, Some(&dispatch), None).await;
@@ -891,5 +987,146 @@ PreToolUse:
             matches!(result, Err(HookError::Timeout { .. })),
             "expected HookError::Timeout, got: {result:?}"
         );
+    }
+
+    // ── hook_if_matches ───────────────────────────────────────────────────────
+
+    #[test]
+    fn hook_if_matches_tool_positive() {
+        assert!(hook_if_matches("tool:shell", Some("shell")));
+    }
+
+    #[test]
+    fn hook_if_matches_tool_substring() {
+        assert!(hook_if_matches("tool:shell", Some("subshell")));
+    }
+
+    #[test]
+    fn hook_if_matches_tool_negative() {
+        assert!(!hook_if_matches("tool:shell", Some("python")));
+    }
+
+    #[test]
+    fn hook_if_matches_no_tool_name() {
+        assert!(!hook_if_matches("tool:shell", None));
+    }
+
+    #[test]
+    fn hook_if_matches_empty_token_fail_closed() {
+        // M2: empty token after `tool:` must return false (fail-closed), never fire on everything.
+        assert!(!hook_if_matches("tool:", Some("shell")));
+    }
+
+    #[test]
+    fn hook_if_matches_empty_tool_name_fail_closed() {
+        // M1: start/stop sites pass Some("") — must behave like "no tool context", not match.
+        assert!(!hook_if_matches("tool:shell", Some("")));
+    }
+
+    #[test]
+    fn hook_if_matches_empty_token_with_empty_tool_fail_closed() {
+        assert!(!hook_if_matches("tool:", Some("")));
+    }
+
+    #[test]
+    fn hook_if_matches_unknown_key_fail_closed() {
+        assert!(!hook_if_matches("badkey:value", Some("x")));
+    }
+
+    #[test]
+    fn hook_if_matches_no_colon_fail_closed() {
+        assert!(!hook_if_matches("no-colon", Some("x")));
+    }
+
+    // ── `if` filter integration with fire_hooks ───────────────────────────────
+
+    #[tokio::test]
+    async fn fire_hooks_if_condition_matches_fires() {
+        // hook with `if = "tool:shell"` and env ZEPH_TOOL_NAME=shell → must fire
+        let hook = HookDef {
+            action: HookAction::Command {
+                command: "true".to_owned(),
+            },
+            timeout_secs: 5,
+            fail_closed: true,
+            r#if: Some("tool:shell".to_owned()),
+        };
+        let mut env = HashMap::new();
+        env.insert("ZEPH_TOOL_NAME".to_owned(), "shell".to_owned());
+        assert!(fire_hooks(&[hook], &env, None, None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn fire_hooks_if_condition_does_not_match_skips() {
+        // hook with `if = "tool:shell"` and env ZEPH_TOOL_NAME=python → must NOT fire
+        // Use fail_closed=true and `false` exit to prove skipping (no error = skipped).
+        let hook = HookDef {
+            action: HookAction::Command {
+                command: "exit 1".to_owned(),
+            },
+            timeout_secs: 5,
+            fail_closed: true,
+            r#if: Some("tool:shell".to_owned()),
+        };
+        let mut env = HashMap::new();
+        env.insert("ZEPH_TOOL_NAME".to_owned(), "python".to_owned());
+        // Would return Err if the hook ran (fail_closed=true, exit 1). Instead it should be Ok.
+        assert!(fire_hooks(&[hook], &env, None, None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn fire_hooks_no_if_always_fires() {
+        let hook = cmd_hook("true", false, 5);
+        let env = HashMap::new();
+        assert!(fire_hooks(&[hook], &env, None, None).await.is_ok());
+    }
+
+    // ── PostToolUseHookInput agent fields ────────────────────────────────────
+
+    #[test]
+    fn post_tool_use_input_serializes_agent_fields() {
+        let input = PostToolUseHookInput {
+            tool_name: "Shell",
+            tool_args: &serde_json::Value::Null,
+            session_id: None,
+            duration_ms: 42,
+            tool_output: Some("out"),
+            tool_error: None,
+            agent_id: Some("conv-1"),
+            agent_type: "main",
+        };
+        let json = serde_json::to_value(&input).unwrap();
+        assert_eq!(json["agent_type"], "main");
+        assert_eq!(json["agent_id"], "conv-1");
+    }
+
+    #[test]
+    fn post_tool_use_input_omits_agent_id_when_none() {
+        let input = PostToolUseHookInput {
+            tool_name: "Shell",
+            tool_args: &serde_json::Value::Null,
+            session_id: None,
+            duration_ms: 42,
+            tool_output: None,
+            tool_error: None,
+            agent_id: None,
+            agent_type: "main",
+        };
+        let json = serde_json::to_value(&input).unwrap();
+        assert_eq!(json["agent_type"], "main");
+        assert!(json.get("agent_id").is_none() || json["agent_id"].is_null());
+        let text = serde_json::to_string(&input).unwrap();
+        assert!(
+            !text.contains("agent_id"),
+            "agent_id must not appear when None"
+        );
+    }
+
+    // ── make_base_hook_env agent_type env var (subagent path) ────────────────
+
+    #[test]
+    fn make_base_hook_env_sets_tool_name() {
+        let env = make_base_hook_env("Edit", &serde_json::Value::Null);
+        assert_eq!(env.get("ZEPH_TOOL_NAME").map(String::as_str), Some("Edit"));
     }
 }

--- a/crates/zeph-subagent/src/lib.rs
+++ b/crates/zeph-subagent/src/lib.rs
@@ -70,8 +70,8 @@ pub use fleet::{FleetRegistry, FleetSessionInfo, FleetSessionStatus, SharedFleet
 pub use grants::{Grant, GrantKind, PermissionGrants, SecretRequest};
 pub use hooks::{
     HookAction, HookDef, HookError, HookMatcher, HookOutput, HookRunResult, McpDispatch,
-    PostToolUseHookInput, SubagentHooks, TOOL_ARGS_JSON_LIMIT, fire_hooks, make_base_hook_env,
-    matching_hooks,
+    PostToolUseHookInput, SubagentHooks, TOOL_ARGS_JSON_LIMIT, fire_hooks, hook_if_matches,
+    make_base_hook_env, matching_hooks,
 };
 pub use manager::{SpawnContext, SubAgentHandle, SubAgentManager, SubAgentStatus};
 pub use memory::{ensure_memory_dir, load_memory_content};

--- a/crates/zeph-subagent/src/manager/secrets.rs
+++ b/crates/zeph-subagent/src/manager/secrets.rs
@@ -17,6 +17,7 @@ pub(crate) fn make_hook_env(
     let mut env = HashMap::new();
     env.insert("ZEPH_AGENT_ID".to_owned(), task_id.to_owned());
     env.insert("ZEPH_AGENT_NAME".to_owned(), agent_name.to_owned());
+    env.insert("ZEPH_AGENT_TYPE".to_owned(), "subagent".to_owned());
     env.insert("ZEPH_TOOL_NAME".to_owned(), tool_name.to_owned());
     env
 }
@@ -111,5 +112,28 @@ impl SubAgentManager {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::make_hook_env;
+
+    #[test]
+    fn make_hook_env_sets_agent_type_subagent() {
+        let env = make_hook_env("task-42", "my-agent", "Shell");
+        assert_eq!(
+            env.get("ZEPH_AGENT_TYPE").map(String::as_str),
+            Some("subagent")
+        );
+        assert_eq!(
+            env.get("ZEPH_AGENT_ID").map(String::as_str),
+            Some("task-42")
+        );
+        assert_eq!(
+            env.get("ZEPH_AGENT_NAME").map(String::as_str),
+            Some("my-agent")
+        );
+        assert_eq!(env.get("ZEPH_TOOL_NAME").map(String::as_str), Some("Shell"));
     }
 }


### PR DESCRIPTION
## Summary

Implements #3088: two orthogonal additions to the Zeph hooks system, parity with Claude Code v2.1.x hook capabilities.

- Add optional `if` field on hook entries with a `tool:<token>` DSL for conditional firing
- Inject `ZEPH_AGENT_TYPE` / `ZEPH_AGENT_ID` into all hook env maps and extend `PostToolUseHookInput` with agent context fields

## Changes

**zeph-config** (`hooks.rs`, `subagent.rs`):
- `HookDef.r#if: Option<String>` with `#[serde(skip_serializing_if = "Option::is_none", rename = "if")]`
- Supports `tool:<token>` DSL; absent field = unconditional (backward compatible)

**zeph-subagent** (`hooks.rs`, `agent_loop.rs`, `manager/secrets.rs`, `lib.rs`):
- `hook_if_matches(condition, tool_name) -> bool` — fail-closed for empty token, unknown key, no colon, absent tool context
- `ZEPH_AGENT_TYPE = "subagent"` added to both `make_hook_env` variants
- `ZEPH_AGENT_ID = task_id` always set for subagents
- `PostToolUseHookInput` extended with `agent_id: Option<String>` and `agent_type: String`

**zeph-core** (`hooks_dispatch.rs`, `builder.rs`, `tier_loop.rs`, `mod.rs`):
- `insert_main_agent_ctx(env, conv_id)` helper — sets `ZEPH_AGENT_TYPE = "main"`, `ZEPH_AGENT_ID` when `conv_id` is `Some`
- All 6 main-agent dispatch sites call `insert_main_agent_ctx`
- `ZEPH_TOOL_NAME` set at pre/post/permission_denied sites
- Startup `warn!` when `tool:` filter is placed on events with no tool context (`cwd_changed`, `file_changed`, `turn_complete`)

## Payload contract

- **All hook events**: `ZEPH_AGENT_TYPE`, `ZEPH_AGENT_ID` (when available) in env vars
- **PostToolUse**: additionally `agent_id`/`agent_type` in stdin JSON
- **`tool:` filter on file_changed/cwd_changed/turn_complete**: documented no-op with startup warning (no triggering-tool context at those events)

## Tests

21 new unit tests (+4 vs initial implementation after review fixes):
- 9 `hook_if_matches` branches (positive, negative, empty token, empty tool name, no colon, unknown key)
- 3 serde round-trips for `HookDef.r#if`
- 3 `fire_hooks` integration tests
- 2 `PostToolUseHookInput` JSON serialization
- 3 `insert_main_agent_ctx` unit tests (type always present, id conditional)
- 1 `sets_agent_id_and_name` assertion for `ZEPH_AGENT_TYPE`
- 1 `make_hook_env_sets_agent_type_subagent` for secrets.rs variant

**Test suite: 11500 PASS** (baseline 11478, +22 net after skips)

## Checklist

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` passes
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11500 PASS
- [x] `cargo doc --no-deps --workspace` — no errors
- [x] CHANGELOG.md updated
- [x] All new `pub` items have doc comments
- [x] Unrelated working-tree changes excluded from commit