### PR TITLE
fix(llm): make tracing instrument spans unconditional in zeph-llm backends and router

### DIFF
--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -139,6 +139,7 @@ impl AnyProvider {
     /// # Errors
     ///
     /// Returns an error if the provider fails or the response cannot be parsed.
+    #[tracing::instrument(name = "llm.any.chat_typed_erased", skip_all)]
     pub async fn chat_typed_erased<T>(&self, messages: &[Message]) -> Result<T, crate::LlmError>
     where
         T: DeserializeOwned + JsonSchema + 'static,
@@ -154,6 +155,7 @@ impl AnyProvider {
     /// # Errors
     ///
     /// Returns an error if the remote request fails.
+    #[tracing::instrument(name = "llm.any.list_models_remote", skip_all)]
     pub async fn list_models_remote(
         &self,
     ) -> Result<Vec<crate::model_cache::RemoteModelInfo>, crate::LlmError> {
@@ -210,6 +212,7 @@ impl AnyProvider {
     ///
     /// Saves Thompson, reputation, and bandit state concurrently using
     /// [`tokio::task::spawn_blocking`]. No-op for all other provider variants.
+    #[tracing::instrument(name = "llm.any.save_router_state", skip_all)]
     pub async fn save_router_state(&self) {
         if let Self::Router(p) = self {
             // Run all three saves concurrently — each is independent I/O.
@@ -259,6 +262,7 @@ impl AnyProvider {
     /// # Errors
     ///
     /// Returns an error if the provider does not support tool streaming or the HTTP request fails.
+    #[tracing::instrument(name = "llm.any.chat_with_tools_stream", skip_all)]
     pub async fn chat_with_tools_stream(
         &self,
         messages: &[crate::provider::Message],

--- a/crates/zeph-llm/src/classifier/llm.rs
+++ b/crates/zeph-llm/src/classifier/llm.rs
@@ -90,6 +90,7 @@ impl LlmClassifier {
     /// # Errors
     ///
     /// Returns `LlmError` if the provider call fails or the response cannot be parsed.
+    #[tracing::instrument(name = "llm.classifier.classify_feedback", skip_all)]
     pub async fn classify_feedback(
         &self,
         user_message: &str,

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -446,10 +446,7 @@ impl ClaudeProvider {
     /// # Panics
     ///
     /// Panics if the hardcoded Anthropic API URL cannot be parsed (impossible in practice).
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.claude.list_models_remote", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.claude.list_models_remote", skip_all)]
     pub async fn list_models_remote(
         &self,
     ) -> Result<Vec<crate::model_cache::RemoteModelInfo>, LlmError> {
@@ -834,10 +831,7 @@ impl ClaudeProvider {
         req.header("content-type", "application/json").json(&body)
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.claude.send_request", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.claude.send_request", skip_all)]
     async fn send_request(&self, messages: &[Message]) -> Result<String, LlmError> {
         let mut retried = false;
         loop {
@@ -907,13 +901,10 @@ impl ClaudeProvider {
     /// # Errors
     ///
     /// Returns an error if the HTTP request fails or the API returns a non-2xx status.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.claude.tools_stream",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.claude.tools_stream",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     pub async fn chat_with_tools_stream(
         &self,
@@ -989,10 +980,7 @@ impl ClaudeProvider {
         }
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.claude.send_stream_request", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.claude.send_stream_request", skip_all)]
     async fn send_stream_request(
         &self,
         messages: &[Message],
@@ -1053,25 +1041,19 @@ impl LlmProvider for ClaudeProvider {
         }
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat(&self, messages: &[Message]) -> Result<String, LlmError> {
         self.send_request(messages).await
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_stream",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_stream",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, LlmError> {
         let response = self.send_stream_request(messages).await?;
@@ -1082,13 +1064,10 @@ impl LlmProvider for ClaudeProvider {
         true
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.embed",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.embed",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn embed(&self, _text: &str) -> Result<Vec<f32>, LlmError> {
         Err(LlmError::EmbedUnsupported {
@@ -1310,13 +1289,10 @@ impl LlmProvider for ClaudeProvider {
             .unwrap_or_else(|e| serde_json::json!({ "serialization_error": e.to_string() }))
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_with_tools",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_with_tools",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
     )]
     async fn chat_with_tools(
         &self,

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -209,13 +209,10 @@ impl LlmProvider for CompatibleProvider {
         self.inner.context_window()
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat(&self, messages: &[Message]) -> Result<String, LlmError> {
         self.inner.chat(messages).await
@@ -228,13 +225,10 @@ impl LlmProvider for CompatibleProvider {
         self.inner.chat_with_extras(messages).await
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_stream",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_stream",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, LlmError> {
         self.inner.chat_stream(messages).await
@@ -244,25 +238,19 @@ impl LlmProvider for CompatibleProvider {
         self.inner.supports_streaming()
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.embed",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.embed",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn embed(&self, text: &str) -> Result<Vec<f32>, LlmError> {
         self.inner.embed(text).await
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.embed_batch",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.embed_batch",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
         self.inner.embed_batch(texts).await
@@ -296,13 +284,10 @@ impl LlmProvider for CompatibleProvider {
         self.inner.chat_typed(messages).await
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_with_tools",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_with_tools",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
     )]
     async fn chat_with_tools(
         &self,

--- a/crates/zeph-llm/src/extractor.rs
+++ b/crates/zeph-llm/src/extractor.rs
@@ -69,6 +69,7 @@ impl<'a, P: LlmProvider> Extractor<'a, P> {
     /// # Errors
     ///
     /// Returns an error if the provider fails or the response cannot be parsed after the retry.
+    #[tracing::instrument(name = "llm.extractor.extract", skip_all)]
     pub async fn extract<T>(&self, input: &str) -> Result<T, LlmError>
     where
         T: DeserializeOwned + JsonSchema + 'static,

--- a/crates/zeph-llm/src/gemini/mod.rs
+++ b/crates/zeph-llm/src/gemini/mod.rs
@@ -1192,25 +1192,19 @@ impl LlmProvider for GeminiProvider {
         }
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat(&self, messages: &[Message]) -> Result<String, LlmError> {
         self.send_request(messages).await
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_stream",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_stream",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, LlmError> {
         let response = self.send_stream_request(messages).await?;
@@ -1221,13 +1215,10 @@ impl LlmProvider for GeminiProvider {
         true
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_with_tools",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_with_tools",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
     )]
     async fn chat_with_tools(
         &self,
@@ -1237,13 +1228,10 @@ impl LlmProvider for GeminiProvider {
         self.send_tool_request(messages, tools).await
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.embed",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.embed",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn embed(&self, text: &str) -> Result<Vec<f32>, LlmError> {
         use crate::embed::truncate_for_embed;

--- a/crates/zeph-llm/src/model_cache.rs
+++ b/crates/zeph-llm/src/model_cache.rs
@@ -100,6 +100,7 @@ impl ModelCache {
     /// # Errors
     ///
     /// Returns an error only on JSON parse failure (corrupt file).
+    #[tracing::instrument(name = "llm.model_cache.load_async", skip_all)]
     pub async fn load_async(&self) -> Result<Option<Vec<RemoteModelInfo>>, LlmError> {
         let path = self.path.clone();
         tokio::task::spawn_blocking(move || {
@@ -118,6 +119,7 @@ impl ModelCache {
     /// Offloads the blocking file read to `spawn_blocking`. Prefer this over
     /// [`Self::is_stale`] when calling from `async fn`.
     #[must_use]
+    #[tracing::instrument(name = "llm.model_cache.is_stale_async", skip_all)]
     pub async fn is_stale_async(&self) -> bool {
         let path = self.path.clone();
         tokio::task::spawn_blocking(move || {
@@ -145,6 +147,7 @@ impl ModelCache {
     /// # Errors
     ///
     /// Returns an error if the directory cannot be created or the file cannot be written.
+    #[tracing::instrument(name = "llm.model_cache.save", skip_all)]
     pub async fn save(&self, models: &[RemoteModelInfo]) -> Result<(), LlmError> {
         let path = self.path.clone();
         let models = models.to_vec();

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -165,10 +165,7 @@ impl OllamaProvider {
     /// # Errors
     ///
     /// Returns an error if the request fails.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.ollama.fetch_model_info", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.ollama.fetch_model_info", skip_all)]
     pub async fn fetch_model_info(&self) -> Result<ModelInfo, LlmError> {
         let info = self
             .client
@@ -199,10 +196,7 @@ impl OllamaProvider {
     /// # Errors
     ///
     /// Returns an error if the connection to Ollama fails.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.ollama.health_check", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.ollama.health_check", skip_all)]
     pub async fn health_check(&self) -> Result<(), LlmError> {
         self.client
             .list_local_models()
@@ -218,10 +212,7 @@ impl OllamaProvider {
     /// # Errors
     ///
     /// Returns an error if the Ollama API request fails.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.ollama.list_models_remote", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.ollama.list_models_remote", skip_all)]
     pub async fn list_models_remote(
         &self,
     ) -> Result<Vec<crate::model_cache::RemoteModelInfo>, LlmError> {
@@ -251,10 +242,7 @@ impl OllamaProvider {
     /// # Errors
     ///
     /// Returns an error if the warmup request fails.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.ollama.warmup", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.ollama.warmup", skip_all)]
     pub async fn warmup(&self) -> Result<(), LlmError> {
         let request =
             ChatMessageRequest::new(self.model.clone(), vec![ChatMessage::user("hi".to_owned())]);
@@ -275,13 +263,10 @@ impl LlmProvider for OllamaProvider {
         true
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat(&self, messages: &[Message]) -> Result<String, LlmError> {
         let has_images = messages
@@ -322,13 +307,10 @@ impl LlmProvider for OllamaProvider {
         Ok((self.chat(messages).await?, ChatExtras::default()))
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_stream",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_stream",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, LlmError> {
         let has_images = messages
@@ -419,13 +401,10 @@ impl LlmProvider for OllamaProvider {
             .unwrap_or_else(|e| serde_json::json!({ "serialization_error": e.to_string() }))
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_with_tools",
-            skip_all,
-            fields(model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_with_tools",
+        skip_all,
+        fields(model = self.model_identifier())
     )]
     async fn chat_with_tools(
         &self,
@@ -495,13 +474,10 @@ impl LlmProvider for OllamaProvider {
         })
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.embed",
-            skip_all,
-            fields(provider = self.name(), model = self.embedding_model)
-        )
+    #[tracing::instrument(
+        name = "llm.embed",
+        skip_all,
+        fields(provider = self.name(), model = self.embedding_model)
     )]
     async fn embed(&self, text: &str) -> Result<Vec<f32>, LlmError> {
         use crate::embed::truncate_for_embed;
@@ -527,13 +503,10 @@ impl LlmProvider for OllamaProvider {
             })
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.embed_batch",
-            skip_all,
-            fields(provider = self.name(), model = self.embedding_model)
-        )
+    #[tracing::instrument(
+        name = "llm.embed_batch",
+        skip_all,
+        fields(provider = self.name(), model = self.embedding_model)
     )]
     async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
         use crate::embed::truncate_for_embed;

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -446,10 +446,7 @@ impl OpenAiProvider {
     /// # Errors
     ///
     /// Returns an error if the API request fails.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.openai.list_models_remote", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.openai.list_models_remote", skip_all)]
     pub async fn list_models_remote(
         &self,
     ) -> Result<Vec<crate::model_cache::RemoteModelInfo>, LlmError> {
@@ -523,10 +520,7 @@ impl OpenAiProvider {
         );
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.openai.send_request", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.openai.send_request", skip_all)]
     async fn send_request(&self, messages: &[Message]) -> Result<String, LlmError> {
         let reasoning = self
             .reasoning_effort
@@ -591,10 +585,7 @@ impl OpenAiProvider {
             })
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.openai.send_stream_request", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.openai.send_stream_request", skip_all)]
     async fn send_stream_request(
         &self,
         messages: &[Message],
@@ -672,13 +663,10 @@ impl LlmProvider for OpenAiProvider {
         }
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat(&self, messages: &[Message]) -> Result<String, LlmError> {
         self.send_request(messages).await
@@ -691,13 +679,10 @@ impl LlmProvider for OpenAiProvider {
         Ok((self.send_request(messages).await?, ChatExtras::default()))
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_stream",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_stream",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, LlmError> {
         let response = self.send_stream_request(messages).await?;
@@ -708,13 +693,10 @@ impl LlmProvider for OpenAiProvider {
         true
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.embed",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.embed",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn embed(&self, text: &str) -> Result<Vec<f32>, LlmError> {
         use crate::embed::truncate_for_embed;
@@ -764,13 +746,10 @@ impl LlmProvider for OpenAiProvider {
             })
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.embed_batch",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
-        )
+    #[tracing::instrument(
+        name = "llm.embed_batch",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier())
     )]
     async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
         use crate::embed::truncate_for_embed;
@@ -1006,13 +985,10 @@ impl LlmProvider for OpenAiProvider {
         true
     }
 
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(
-            name = "llm.chat_with_tools",
-            skip_all,
-            fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
-        )
+    #[tracing::instrument(
+        name = "llm.chat_with_tools",
+        skip_all,
+        fields(provider = self.name(), model = self.model_identifier(), tool_count = tools.len())
     )]
     async fn chat_with_tools(
         &self,

--- a/crates/zeph-llm/src/provider_dyn.rs
+++ b/crates/zeph-llm/src/provider_dyn.rs
@@ -321,6 +321,7 @@ impl<T: LlmProvider + std::fmt::Debug + Send + Sync + 'static> LlmProviderDyn fo
 /// # Ok(())
 /// # }
 /// ```
+#[tracing::instrument(name = "llm.provider_dyn.chat_typed_dyn", skip_all)]
 pub async fn chat_typed_dyn<T, P>(provider: &P, messages: &[Message]) -> Result<T, LlmError>
 where
     T: DeserializeOwned + schemars::JsonSchema + 'static,

--- a/crates/zeph-llm/src/router/chat.rs
+++ b/crates/zeph-llm/src/router/chat.rs
@@ -20,10 +20,7 @@ use crate::provider::{ChatStream, LlmProvider, Message, StatusTx};
 
 impl RouterProvider {
     /// Bandit `chat()` implementation: select provider, call, record reward.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.bandit_chat", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.router.bandit_chat", skip_all)]
     pub(crate) async fn bandit_chat(
         &self,
         messages: &[Message],
@@ -86,10 +83,7 @@ struct CascadeEvalResult {
 
 /// Evaluate a cascade response: score it, record the verdict in shared state, and
 /// compute whether the token budget is exhausted.
-#[cfg_attr(
-    feature = "profiling",
-    tracing::instrument(name = "llm.router.cascade.evaluate_response", skip_all)
-)]
+#[tracing::instrument(name = "llm.router.cascade.evaluate_response", skip_all)]
 async fn cascade_evaluate_response(
     provider_name: &str,
     response: &str,
@@ -140,10 +134,7 @@ impl RouterProvider {
     /// Cascade chat: try providers in order, escalate on degenerate output.
     ///
     /// Returns the best-seen response if all providers fail or budget is exhausted.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.cascade_chat", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.router.cascade_chat", skip_all)]
     #[allow(clippy::too_many_lines)] // cascade loop: per-provider error/ok/budget/escalation branches are tightly coupled — extracting would obscure the control flow
     pub(crate) async fn cascade_chat(
         &self,
@@ -285,10 +276,7 @@ impl RouterProvider {
     /// occurs, the user experiences: cheap model's full response time + expensive model's
     /// TTFT. This is strictly worse than direct routing to the expensive model for
     /// hard queries. Acceptable for v1; see CRIT-01 in critic handoff for alternatives.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.cascade.chat_stream", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.router.cascade.chat_stream", skip_all)]
     #[allow(clippy::too_many_lines)] // sequential cascade semantics: buffer→classify→escalate
     pub(crate) async fn cascade_chat_stream(
         &self,

--- a/crates/zeph-llm/src/router/provider_impl.rs
+++ b/crates/zeph-llm/src/router/provider_impl.rs
@@ -60,7 +60,6 @@ impl LlmProvider for RouterProvider {
         let status_tx = self.status_tx.clone();
         let messages = messages.to_vec();
         let router = self.clone();
-        #[cfg(feature = "profiling")]
         let model = self.model_identifier().to_owned();
         // NOTE: `chat` and `chat_stream` share error-path logic via `record_fallback_error`.
         // Their success paths diverge (quality gate + CoE vs. plain stream-open), so a
@@ -218,12 +217,10 @@ impl LlmProvider for RouterProvider {
 
             Err(LlmError::NoProviders)
         });
-        #[cfg(feature = "profiling")]
-        let fut = {
+        {
             use tracing::Instrument as _;
             fut.instrument(tracing::info_span!("llm.router.chat", model = model))
-        };
-        fut
+        }
     }
 
     fn chat_stream(
@@ -233,7 +230,6 @@ impl LlmProvider for RouterProvider {
         let status_tx = self.status_tx.clone();
         let messages = messages.to_vec();
         let router = self.clone();
-        #[cfg(feature = "profiling")]
         let model = self.model_identifier().to_owned();
         let fut = Box::pin(async move {
             // NOTE: see DRY design decision above `chat()` — error path shared via
@@ -290,12 +286,10 @@ impl LlmProvider for RouterProvider {
             }
             Err(LlmError::NoProviders)
         });
-        #[cfg(feature = "profiling")]
-        let fut = {
+        {
             use tracing::Instrument as _;
             fut.instrument(tracing::info_span!("llm.router.chat_stream", model = model))
-        };
-        fut
+        }
     }
 
     fn supports_streaming(&self) -> bool {
@@ -315,7 +309,6 @@ impl LlmProvider for RouterProvider {
         let text = text.to_owned();
         let router = self.clone();
         let embed_timeout_ms = self.embed_timeout_ms;
-        #[cfg(feature = "profiling")]
         let model = self.model_identifier().to_owned();
         let fut = Box::pin(async move {
             for p in &providers {
@@ -410,12 +403,10 @@ impl LlmProvider for RouterProvider {
             }
             Err(LlmError::NoProviders)
         });
-        #[cfg(feature = "profiling")]
-        let fut = {
+        {
             use tracing::Instrument as _;
             fut.instrument(tracing::info_span!("llm.router.embed", model = model))
-        };
-        fut
+        }
     }
 
     fn embed_batch(
@@ -427,7 +418,6 @@ impl LlmProvider for RouterProvider {
         let owned = owned_strs(texts);
         let router = self.clone();
         let semaphore = self.state.embed_semaphore.clone();
-        #[cfg(feature = "profiling")]
         let model = self.model_identifier().to_owned();
         let fut = Box::pin(async move {
             // Acquire embed semaphore permit before any HTTP work to cap concurrency.
@@ -513,12 +503,10 @@ impl LlmProvider for RouterProvider {
             }
             Err(LlmError::NoProviders)
         });
-        #[cfg(feature = "profiling")]
-        let fut = {
+        {
             use tracing::Instrument as _;
             fut.instrument(tracing::info_span!("llm.router.embed_batch", model = model))
-        };
-        fut
+        }
     }
 
     fn supports_embeddings(&self) -> bool {
@@ -560,12 +548,10 @@ impl LlmProvider for RouterProvider {
         tools: &[ToolDefinition],
     ) -> impl std::future::Future<Output = Result<ChatResponse, LlmError>> + Send {
         let messages = messages.to_vec();
-        #[cfg(feature = "profiling")]
         let tool_count = tools.len();
         let tools = tools.to_vec();
         let status_tx = self.status_tx.clone();
         let router = self.clone();
-        #[cfg(feature = "profiling")]
         let model = self.model_identifier().to_owned();
         let fut = Box::pin(async move {
             // Bandit routing for tool calls: select a single provider, no quality escalation.
@@ -638,16 +624,14 @@ impl LlmProvider for RouterProvider {
             }
             Err(LlmError::NoProviders)
         });
-        #[cfg(feature = "profiling")]
-        let fut = {
+        {
             use tracing::Instrument as _;
             fut.instrument(tracing::info_span!(
                 "llm.router.chat_with_tools",
                 model = model,
                 tool_count = tool_count
             ))
-        };
-        fut
+        }
     }
 
     fn debug_request_json(

--- a/crates/zeph-llm/src/router/select.rs
+++ b/crates/zeph-llm/src/router/select.rs
@@ -66,10 +66,7 @@ impl RouterProvider {
     /// - No embedding provider is configured.
     /// - The embedding call exceeds `embedding_timeout_ms`.
     /// - The embedding is shorter than `dim` or is all-zero.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.bandit_features", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.router.bandit_features", skip_all)]
     pub(crate) async fn bandit_features(&self, query: &str) -> Option<Vec<f32>> {
         let cfg = self.bandit_config.as_ref()?;
         let key = Self::query_hash(query);
@@ -115,10 +112,7 @@ impl RouterProvider {
     /// Falls through to Thompson or first available provider when bandit cannot decide.
     /// Budget enforcement via global `CostTracker` is handled at the caller level.
     /// Per-provider budget fractions are intentionally NOT implemented (scope creep, see #2230).
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.bandit_select_provider", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.router.bandit_select_provider", skip_all)]
     pub(crate) async fn bandit_select_provider(&self, query: &str) -> Option<AnyProvider> {
         let Some(ref bandit_arc) = self.bandit else {
             return self.state.providers.first().cloned();
@@ -465,10 +459,7 @@ impl RouterProvider {
     ///
     /// For `ClassifierMode::Judge`, calls the summary provider and falls back to heuristic
     /// on any error or timeout. For `ClassifierMode::Heuristic`, evaluates synchronously.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.evaluate_quality", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.router.evaluate_quality", skip_all)]
     pub(crate) async fn evaluate_quality(
         response: &str,
         threshold: f64,
@@ -517,10 +508,7 @@ impl RouterProvider {
     /// Checks `cache` before calling the underlying provider. On a cache hit, increments
     /// `embed_cache_hits`; on a miss, embeds via `self.embed()` and populates the cache.
     /// Either way, `embed_call_count` is incremented for observability.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "llm.router.embed_cached", skip_all)
-    )]
+    #[tracing::instrument(name = "llm.router.embed_cached", skip_all)]
     pub(crate) async fn embed_cached(
         &self,
         text: &str,


### PR DESCRIPTION
## Summary

- Removes ~42 `#[cfg_attr(feature = "profiling", tracing::instrument(...))]` gates across `claude/mod.rs`, `openai/mod.rs`, `ollama.rs`, `compatible.rs`, `gemini/mod.rs`, `router/chat.rs`, `router/select.rs`, and `router/provider_impl.rs` (closes #5336)
- Adds unconditional `#[tracing::instrument]` to 10 previously untraced `pub async fn`s in `any.rs`, `extractor.rs`, `classifier/llm.rs`, `provider_dyn.rs`, and `model_cache.rs` (closes #5337)
- Follows the same approach applied to `candle_provider/` in PR #5335

**Note:** `cocoon/client.rs` was intentionally left unchanged — its 4 async fns are already instrumented via inline `.instrument(info_span!("llm.cocoon.*"))` calls, which is equivalent to unconditional `#[tracing::instrument]`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11482 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `grep 'feature = "profiling"' crates/zeph-llm/src/` (excl. candle) → empty
- [x] All `#[tracing::instrument]` attributes verified to include `skip_all` — no sensitive args exposed in tracing output