### PR TITLE
feat(tui): TUI design polish — status bar redesign and input prompt glyph update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(ci)`: unblock the workspace lint/build/doc gates. Pin `ollama-rs` back to 0.3.4 (an
+  accidental 0.3.5 bump deprecated `Ollama::new_with_client`, failing `zeph-llm` under
+  `-D warnings` and cascading to every downstream job) and resolve two pedantic clippy findings
+  surfaced once `zeph-llm` compiled again: `cast_precision_loss` in `context_gauge::build_bar`
+  and `format_push_string` in `resources.rs` (now `write!` into the buffer).
+
 - `fix(tui)`: keep the equalizer animating during LLM streaming and background activity.
   The render loop now drains at most `AGENT_DRAIN_BATCH` (64) agent events per iteration instead
   of the whole backlog, so a fast token stream repaints smoothly (was: frozen until the backlog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `fix(tui)`: correct and de-clutter the input separator row. The Insert-mode hint now reads
+  `esc for normal mode` (Esc switches Insert→Normal; it does not cancel input). The busy verb is
+  no longer duplicated on this row — it already appears in the bottom status bar and the side-panel
+  wave — so the separator shows only the prompt glyph, mode hint, token estimate, spinner, and the
+  interrupt hint. A status change (sub-agent start/complete, file indexing) now refreshes the
+  progress clock so the wave animates instead of reading as `Stalled` (a flat line). See
+  `crates/zeph-tui/src/widgets/input.rs`, `app/events.rs`, `app/keys.rs`.
+
 ### Added
 
 - `feat(tui)`: move the inference visualiser from the input separator to the right-panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `feat(tui)`: give background/external requests a visually distinct equalizer wave. The
+  `WaveState::Parallel` variant is replaced by `WaveState::Network`, which now triggers on any
+  in-flight task-supervisor work (`bg_inflight >= 1` plus background shell runs) instead of only
+  `>= 2`. It renders in a **violet** gradient (vs the teal of foreground `Swell`/`Streaming`/`Tool`)
+  so concurrent background activity is separable at a glance, and the equalizer slot stays visible
+  while background requests run even when the agent itself is idle. See
+  `crates/zeph-tui/src/widgets/wave.rs` and `app/state.rs` (`wave_state`, `background_inflight`).
+
 - `fix(tui)`: correct and de-clutter the input separator row. The Insert-mode hint now reads
   `esc for normal mode` (Esc switches Insert→Normal; it does not cancel input). The busy verb is
   no longer duplicated on this row — it already appears in the bottom status bar and the side-panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- `feat(tui)`: move equalizer widget from input separator to the right-panel dashboard —
-  a 4-row animated VU-meter slot is carved from the bottom of the subagents panel while the
-  agent is busy; the slot collapses when idle. `Motion::Full` busy mode now shows an animated
-  spinner in the input row (same as `Minimal`). `TuiCommand::ToggleEqualizer` / `app:equalizer`
-  command hides or shows the panel slot. Removes `EQ_ROWS`/`EQ_W_MAX` constants (relocated).
-  See `crates/zeph-tui/src/widgets/wave.rs` and `crates/zeph-tui/src/app/draw.rs`.
+- `feat(tui)`: move the inference visualiser from the input separator to the right-panel
+  dashboard and redesign it as an animated braille waveform — a continuous wave mirrored about
+  the centre axis (rendered with `U+2800` braille for 2×4 sub-pixel resolution) that jerks up
+  and down in time to a sharp beat envelope, with a teal gradient brightening toward the peaks.
+  A 4-row slot is carved from the bottom of the subagents panel while the agent is busy and
+  collapses when idle. `Motion::Full` busy mode now shows an animated spinner in the input row
+  (same as `Minimal`). `TuiCommand::ToggleEqualizer` / `app:equalizer` hides or shows the slot.
+  Removes `EQ_ROWS`/`EQ_W_MAX` constants. See `crates/zeph-tui/src/widgets/wave.rs` and
+  `crates/zeph-tui/src/app/draw.rs`.
 
 ### Research
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `feat(tui)`: move equalizer widget from input separator to the right-panel dashboard —
+  a 4-row animated VU-meter slot is carved from the bottom of the subagents panel while the
+  agent is busy; the slot collapses when idle. `Motion::Full` busy mode now shows an animated
+  spinner in the input row (same as `Minimal`). `TuiCommand::ToggleEqualizer` / `app:equalizer`
+  command hides or shows the panel slot. Removes `EQ_ROWS`/`EQ_W_MAX` constants (relocated).
+  See `crates/zeph-tui/src/widgets/wave.rs` and `crates/zeph-tui/src/app/draw.rs`.
+
 ### Research
 
 - `docs(cocoon)`: add stable non-positional threat IDs (`T-BIN-SUBST`, `T-COMP-ATTEST`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(tui)`: keep the equalizer animating during LLM streaming and background activity.
+  The render loop now drains at most `AGENT_DRAIN_BATCH` (64) agent events per iteration instead
+  of the whole backlog, so a fast token stream repaints smoothly (was: frozen until the backlog
+  fully drained, then a jump) and the animation/input arms are serviced between batches. The
+  internal 100 ms interval now advances the wave clock as a heartbeat independent of the
+  `EventReader`, and the `AnimationOnly` redraw gate also fires while background/external requests
+  are inflight (`background_inflight() > 0`) — previously gated on `is_agent_busy()` alone, which
+  left the violet `Network` wave frozen when the agent itself was idle. See `crates/zeph-tui/src/lib.rs`.
+
 ### Changed
 
 - `feat(tui)`: give background/external requests a visually distinct equalizer wave. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -1323,7 +1323,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2090,7 +2090,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2346,7 +2346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3529,7 +3529,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4677,7 +4677,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4823,7 +4823,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -4955,9 +4955,9 @@ dependencies = [
 
 [[package]]
 name = "ollama-rs"
-version = "0.3.5"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22839a9841aacb7bcd70a3f73575945b89ffaa7a5532c8a85cf2fee85d919b8c"
+checksum = "f647d8676b95a6b6205e11453c9fac338d73c9cdcc011c94d1ba9c9bfea582cd"
 dependencies = [
  "async-stream",
  "log",
@@ -6011,7 +6011,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6049,9 +6049,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6769,7 +6769,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6837,7 +6837,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8185,7 +8185,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9785,7 +9785,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d176a10d4cb06e0262a738c3c5bf21ff0968db13a666e31cbca94a3d3d72e7c"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -134,7 +134,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "strum 0.28.0",
+ "strum",
  "tracing",
 ]
 
@@ -252,9 +252,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "aquamarine"
@@ -267,14 +276,14 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
 dependencies = [
  "object",
 ]
@@ -301,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -316,9 +325,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "assert-json-diff"
@@ -332,15 +341,15 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
+checksum = "08648fef353ab39a9d26f909ad53fc4f071be4c91853b78523f5cc3d9e5ebffd"
 dependencies = [
- "filetime",
  "futures-core",
  "libc",
  "portable-atomic",
  "rustc-hash 2.1.2",
+ "rustix 0.38.44",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -371,7 +380,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -402,7 +411,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -417,7 +426,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -442,7 +451,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -459,7 +468,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -662,7 +671,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -769,9 +778,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -807,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -853,7 +862,7 @@ checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -896,8 +905,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic 0.14.6",
  "tonic-prost",
  "ureq",
@@ -912,7 +921,7 @@ dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -930,13 +939,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -944,6 +953,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytecount"
@@ -968,7 +983,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -985,9 +1000,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "candle-core"
@@ -999,7 +1014,7 @@ dependencies = [
  "candle-kernels",
  "candle-metal-kernels",
  "candle-ug",
- "cudarc 0.19.7",
+ "cudarc 0.19.8",
  "float8",
  "gemm 0.19.0",
  "half",
@@ -1015,7 +1030,7 @@ dependencies = [
  "safetensors 0.7.0",
  "thiserror 2.0.18",
  "tokenizers 0.22.2",
- "yoke 0.8.2",
+ "yoke 0.8.3",
  "zip",
 ]
 
@@ -1117,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1158,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1182,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1263,7 +1278,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1556,6 +1571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "cron"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,13 +1637,13 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1705,7 +1726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1719,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "cudaforge"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7a0d45b139b5beeeb1c34188717e12241c44a0120afb498815ce7f5373c691"
+checksum = "8d475ff95b9e4096878f47fe0ca5dbad0e23849a79fc225305ea06c2f25771cd"
 dependencies = [
  "anyhow",
  "fs2",
@@ -1748,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.7"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "float8",
  "half",
@@ -1780,7 +1801,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1820,7 +1841,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1833,7 +1854,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1844,7 +1865,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1855,7 +1876,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1937,7 +1958,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1959,7 +1979,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1969,7 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1998,7 +2018,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -2012,7 +2032,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -2046,7 +2066,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -2079,7 +2099,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
@@ -2091,7 +2111,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2254,7 +2274,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2274,7 +2294,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2300,7 +2320,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2450,6 +2470,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -2678,7 +2704,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2814,7 +2840,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2981,7 +3007,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "paste",
- "pulp 0.22.2",
+ "pulp 0.22.3",
  "raw-cpuid",
  "rayon",
  "seq-macro",
@@ -3101,7 +3127,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link",
 ]
 
@@ -3143,16 +3169,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -3193,9 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3370,9 +3394,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -3415,9 +3439,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -3472,7 +3496,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3577,7 +3601,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unic-langid",
 ]
 
@@ -3591,7 +3615,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3627,7 +3651,7 @@ dependencies = [
  "displaydoc",
  "potential_utf",
  "utf8_iter",
- "yoke 0.8.2",
+ "yoke 0.8.3",
  "zerofrom",
  "zerovec",
 ]
@@ -3694,17 +3718,11 @@ dependencies = [
  "displaydoc",
  "icu_locale_core",
  "writeable",
- "yoke 0.8.2",
+ "yoke 0.8.3",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -3735,9 +3753,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -3808,9 +3826,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "993f007684f2e9727160da8b960ec161264703bfd1af084fd2e34d040c9a0dd4"
 dependencies = [
  "console",
  "portable-atomic",
@@ -3834,7 +3852,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -3860,9 +3878,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -3880,7 +3898,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4008,7 +4026,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4027,7 +4045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4042,13 +4060,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -4102,7 +4119,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -4131,12 +4148,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -4176,7 +4187,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.8.1",
@@ -4199,8 +4210,14 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4231,9 +4248,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lopdf"
@@ -4242,7 +4259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
 dependencies = [
  "aes",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cbc",
  "ecb",
  "encoding_rs",
@@ -4261,15 +4278,6 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "weezl",
-]
-
-[[package]]
-name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4366,15 +4374,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -4410,7 +4418,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -4513,7 +4521,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4566,7 +4574,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4579,7 +4587,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4621,7 +4629,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -4651,7 +4659,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4746,7 +4754,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4852,7 +4860,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -4864,7 +4872,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -4875,7 +4883,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -4894,7 +4902,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -4917,7 +4925,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4928,7 +4936,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2",
  "dispatch2",
  "objc2",
@@ -4947,9 +4955,9 @@ dependencies = [
 
 [[package]]
 name = "ollama-rs"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f647d8676b95a6b6205e11453c9fac338d73c9cdcc011c94d1ba9c9bfea582cd"
+checksum = "22839a9841aacb7bcd70a3f73575945b89ffaa7a5532c8a85cf2fee85d919b8c"
 dependencies = [
  "async-stream",
  "log",
@@ -4982,7 +4990,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -5012,13 +5020,12 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.3.5"
+version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
 dependencies = [
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -5051,7 +5058,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost 0.14.4",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.14.6",
@@ -5066,7 +5073,7 @@ checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic 0.14.6",
  "tonic-prost",
 ]
@@ -5124,6 +5131,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,7 +5205,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5188,12 +5219,6 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
@@ -5267,7 +5292,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5373,7 +5398,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5386,7 +5411,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5424,7 +5449,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5517,7 +5542,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5534,7 +5559,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5629,7 +5654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5660,7 +5685,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5706,7 +5731,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5717,7 +5742,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -5750,12 +5775,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -5775,7 +5800,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -5789,7 +5814,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5802,20 +5827,20 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5838,11 +5863,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -5870,7 +5895,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -5899,9 +5924,9 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -5916,9 +5941,9 @@ dependencies = [
 
 [[package]]
 name = "pulp-wasm-simd-flag"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "pxfm"
@@ -5975,9 +6000,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5995,9 +6020,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -6031,9 +6056,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -6088,8 +6113,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -6184,41 +6209,45 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
- "indoc",
+ "critical-section",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.16.4",
- "strum 0.27.2",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -6227,9 +6256,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -6239,19 +6268,30 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
+name = "ratatui-termina"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -6259,18 +6299,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.12.1",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "serde",
+ "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -6282,7 +6323,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6346,7 +6387,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6355,7 +6396,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6386,14 +6427,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6420,9 +6461,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -6466,7 +6507,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -6554,9 +6595,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6583,15 +6624,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6650,7 +6691,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.117",
+ "syn 2.0.118",
  "walkdir",
 ]
 
@@ -6707,22 +6748,35 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6911,7 +6965,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6922,9 +6976,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrape-core"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03decc97c1ae50e724aad570ad9408f980a28dfba41c4826871c1ff9d7f8a574"
+checksum = "50e7d3340e8233885563cf1fcbe829f80ef58d421cedf007b2b5b278f2590823"
 dependencies = [
  "cssparser",
  "html5ever",
@@ -6984,7 +7038,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7007,7 +7061,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cssparser",
  "derive_more 2.1.1",
  "log",
@@ -7074,7 +7128,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7085,7 +7139,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7143,7 +7197,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7169,9 +7223,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7189,14 +7243,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7221,7 +7275,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7391,9 +7445,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -7528,7 +7582,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7550,7 +7604,7 @@ dependencies = [
  "sqlx-core",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tokio",
  "url",
 ]
@@ -7563,7 +7617,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "crc",
@@ -7604,7 +7658,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -7757,7 +7811,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7768,16 +7822,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7786,19 +7831,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "strum_macros",
 ]
 
 [[package]]
@@ -7810,7 +7843,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7913,7 +7946,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "lazy_static",
  "log",
@@ -7971,9 +8004,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7997,7 +8030,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8006,7 +8039,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -8016,9 +8049,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
 dependencies = [
  "libc",
  "memchr",
@@ -8034,7 +8067,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -8104,7 +8137,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7a34ca8e971fa892e633858c07547fe138ef4a02e4a4eaa1d35e517d6e0bc4"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytes",
  "chrono",
  "derive_more 1.0.0",
@@ -8139,7 +8172,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8149,9 +8182,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -8163,6 +8196,19 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8194,7 +8240,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
@@ -8294,7 +8340,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8305,7 +8351,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8319,9 +8365,9 @@ dependencies = [
 
 [[package]]
 name = "throbber-widgets-tui"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e6941f74491a80911cb8821cb1f55f7e13bca867b28a2b14e5a1daaf691eb3"
+checksum = "0b0452e418faaa263a742d94e5c2f9f50c777a0ae5b3ec53ce754d917d568e36"
 dependencies = [
  "ratatui",
 ]
@@ -8357,12 +8403,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -8374,15 +8419,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8515,7 +8560,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8701,7 +8746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic 0.14.6",
 ]
 
@@ -8711,8 +8756,8 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic 0.14.6",
 ]
 
@@ -8761,7 +8806,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -8820,7 +8865,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8908,7 +8953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8923,9 +8968,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
 dependencies = [
  "cc",
  "regex",
@@ -8957,9 +9002,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-highlight"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fbfa3f35520ff730da507e2c9a526a98156f417e0008c73de873741d7e4ecc"
+checksum = "51d5c68e5dba9c2818166330961143812b22a286e51a107a0733766b50dfc87d"
 dependencies = [
  "regex",
  "streaming-iterator",
@@ -9325,7 +9370,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -9379,12 +9424,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "atomic",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "sha1_smol",
@@ -9417,7 +9462,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9465,20 +9510,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -9489,9 +9525,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9502,9 +9538,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9512,9 +9548,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9522,46 +9558,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -9591,22 +9605,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.12.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9624,9 +9626,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
@@ -9636,9 +9638,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9649,14 +9651,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9747,7 +9749,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix",
+ "rustix 1.1.4",
  "winsafe",
 ]
 
@@ -9863,7 +9865,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9874,7 +9876,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9936,6 +9938,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -10259,97 +10270,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.12.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -10364,7 +10287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -10393,7 +10316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -10410,9 +10333,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive 0.8.2",
@@ -10427,7 +10350,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -10439,7 +10362,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -11075,7 +10998,7 @@ dependencies = [
  "dashmap",
  "futures",
  "insta",
- "lru 0.18.0",
+ "lru",
  "metrics",
  "parking_lot",
  "pdf-extract",
@@ -11188,7 +11111,7 @@ dependencies = [
  "chrono",
  "cron",
  "reqwest 0.13.4",
- "rustix",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_json",
@@ -11401,22 +11324,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11436,15 +11359,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "serde",
  "zeroize_derive",
@@ -11452,13 +11375,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11468,7 +11391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
- "yoke 0.8.2",
+ "yoke 0.8.3",
  "zerofrom",
 ]
 
@@ -11479,7 +11402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
- "yoke 0.8.2",
+ "yoke 0.8.3",
  "zerofrom",
  "zerovec-derive",
 ]
@@ -11492,7 +11415,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -143,7 +143,7 @@ impl App {
         );
 
         let line = Line::from(vec![
-            Span::styled("⬡ ", theme.user_message),
+            Span::styled("≈ ", theme.user_message),
             Span::styled("zeph", brand_style),
             Span::styled(meta, meta_style),
         ]);
@@ -328,7 +328,7 @@ impl App {
             } else {
                 let theme = &self.theme;
                 let header = Line::from(vec![
-                    Span::styled("⬡ ", theme.highlight),
+                    Span::styled("≈ ", theme.highlight),
                     Span::styled("tasks  supervisor not available", theme.system_message),
                 ]);
                 frame.render_widget(Paragraph::new(header), area);
@@ -354,7 +354,7 @@ impl App {
         }
         let line = if focused {
             Line::from(vec![
-                Span::styled("⬡ ", self.theme.highlight),
+                Span::styled("≈ ", self.theme.highlight),
                 Span::styled(label, self.theme.highlight),
             ])
         } else {
@@ -380,7 +380,7 @@ impl App {
             return;
         }
         let line = Line::from(vec![
-            Span::styled("⬡ ", self.theme.highlight),
+            Span::styled("≈ ", self.theme.highlight),
             Span::styled(label, self.theme.highlight),
         ]);
         frame.render_widget(Paragraph::new(line), area);

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -51,28 +51,28 @@ impl App {
         }
         self.draw_separator(frame, layout.separator);
 
-        // Carve the equalizer slot from the bottom of the subagents area.
-        // The slot only appears while the agent is busy and the user hasn't hidden it.
+        // Carve the equalizer slot from the bottom of the subagents area. The slot
+        // appears while the agent is busy OR background/external requests are inflight
+        // (so concurrent background work is visible), unless the user has hidden it.
         let wave_state = self.wave_state();
         let wave_tick = self.wave_tick();
-        let eq_area = if self.show_equalizer
-            && self.is_agent_busy()
-            && layout.subagents.height > EQ_PANEL_H + 2
-        {
-            let sub_h = layout.subagents.height - EQ_PANEL_H;
-            let eq = Rect {
-                y: layout.subagents.y + sub_h,
-                height: EQ_PANEL_H,
-                ..layout.subagents
+        let wave_active = self.is_agent_busy() || self.background_inflight() > 0;
+        let eq_area =
+            if self.show_equalizer && wave_active && layout.subagents.height > EQ_PANEL_H + 2 {
+                let sub_h = layout.subagents.height - EQ_PANEL_H;
+                let eq = Rect {
+                    y: layout.subagents.y + sub_h,
+                    height: EQ_PANEL_H,
+                    ..layout.subagents
+                };
+                layout.subagents = Rect {
+                    height: sub_h,
+                    ..layout.subagents
+                };
+                eq
+            } else {
+                Rect::default()
             };
-            layout.subagents = Rect {
-                height: sub_h,
-                ..layout.subagents
-            };
-            eq
-        } else {
-            Rect::default()
-        };
 
         self.draw_side_panel(frame, &layout, collapsed);
 

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -143,7 +143,8 @@ impl App {
         );
 
         let line = Line::from(vec![
-            Span::styled("⬡ zeph", brand_style),
+            Span::styled("⬡ ", theme.user_message),
+            Span::styled("zeph", brand_style),
             Span::styled(meta, meta_style),
         ]);
 

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -11,6 +11,9 @@ use super::{App, Panel};
 
 impl App {
     pub fn draw(&mut self, frame: &mut ratatui::Frame) {
+        // Height of the equalizer slot carved from the bottom of the subagents panel.
+        const EQ_PANEL_H: u16 = 4;
+
         let collapsed = self.effective_collapsed();
         let mut layout = AppLayout::compute(
             frame.area(),
@@ -50,7 +53,6 @@ impl App {
 
         // Carve the equalizer slot from the bottom of the subagents area.
         // The slot only appears while the agent is busy and the user hasn't hidden it.
-        const EQ_PANEL_H: u16 = 4;
         let wave_state = self.wave_state();
         let wave_tick = self.wave_tick();
         let eq_area = if self.show_equalizer
@@ -89,19 +91,8 @@ impl App {
 
         let spinner_idx = self.throbber_state().index().cast_unsigned();
         let busy = self.is_agent_busy();
-        let activity_label = self.status_label().map(str::to_owned);
-        let supervisor_label = self.supervisor_activity_label();
-        let effective_label = activity_label.or(supervisor_label);
         let motion = self.motion();
-        widgets::input::render(
-            self,
-            frame,
-            layout.input,
-            busy,
-            effective_label.as_deref(),
-            spinner_idx,
-            motion,
-        );
+        widgets::input::render(self, frame, layout.input, busy, spinner_idx, motion);
         widgets::status::render(self, &self.metrics, frame, layout.status);
 
         if let Some(state) = &self.file_picker_state {

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -1,15 +1,18 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use ratatui::layout::Rect;
+
 use crate::layout::AppLayout;
 use crate::widgets;
+use crate::widgets::wave::EqualizerWidget;
 
 use super::{App, Panel};
 
 impl App {
     pub fn draw(&mut self, frame: &mut ratatui::Frame) {
         let collapsed = self.effective_collapsed();
-        let layout = AppLayout::compute(
+        let mut layout = AppLayout::compute(
             frame.area(),
             self.show_side_panels,
             self.desired_input_height(),
@@ -44,14 +47,51 @@ impl App {
                 self.sessions.current().scroll_offset.min(max_scroll);
         }
         self.draw_separator(frame, layout.separator);
+
+        // Carve the equalizer slot from the bottom of the subagents area.
+        // The slot only appears while the agent is busy and the user hasn't hidden it.
+        const EQ_PANEL_H: u16 = 4;
+        let wave_state = self.wave_state();
+        let wave_tick = self.wave_tick();
+        let eq_area = if self.show_equalizer
+            && self.is_agent_busy()
+            && layout.subagents.height > EQ_PANEL_H + 2
+        {
+            let sub_h = layout.subagents.height - EQ_PANEL_H;
+            let eq = Rect {
+                y: layout.subagents.y + sub_h,
+                height: EQ_PANEL_H,
+                ..layout.subagents
+            };
+            layout.subagents = Rect {
+                height: sub_h,
+                ..layout.subagents
+            };
+            eq
+        } else {
+            Rect::default()
+        };
+
         self.draw_side_panel(frame, &layout, collapsed);
+
+        if eq_area.height > 0 {
+            frame.render_widget(
+                EqualizerWidget {
+                    state: wave_state,
+                    tick: wave_tick,
+                    theme: &self.theme,
+                    color_mode: self.effective_color_mode(),
+                    ascii_only: self.is_ascii_only(),
+                },
+                eq_area,
+            );
+        }
+
         let spinner_idx = self.throbber_state().index().cast_unsigned();
         let busy = self.is_agent_busy();
         let activity_label = self.status_label().map(str::to_owned);
         let supervisor_label = self.supervisor_activity_label();
         let effective_label = activity_label.or(supervisor_label);
-        let wave_state = self.wave_state();
-        let wave_tick = self.wave_tick();
         let motion = self.motion();
         widgets::input::render(
             self,
@@ -60,8 +100,6 @@ impl App {
             busy,
             effective_label.as_deref(),
             spinner_idx,
-            wave_state,
-            wave_tick,
             motion,
         );
         widgets::status::render(self, &self.metrics, frame, layout.status);

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -223,13 +223,13 @@ impl App {
             let splits = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Length(3),
-                    Constraint::Length(3),
+                    Constraint::Length(1),
+                    Constraint::Length(1),
                     Constraint::Min(0),
                 ])
                 .split(resources_area);
-            widgets::context_gauge::render(&self.metrics, frame, splits[0]);
-            widgets::compaction_badge::render(&self.metrics, frame, splits[1]);
+            widgets::context_gauge::render(&self.metrics, frame, splits[0], &self.theme);
+            widgets::compaction_badge::render(&self.metrics, frame, splits[1], &self.theme);
             widgets::resources::render(&self.metrics, frame, splits[2], &self.theme);
         }
 

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -53,9 +53,6 @@ impl App {
         let wave_state = self.wave_state();
         let wave_tick = self.wave_tick();
         let motion = self.motion();
-        // Take the reuse buffer out of self before the shared &App borrow starts so that
-        // build_full_busy_sep can write into it without conflicting with &self below.
-        let mut wave_buf = std::mem::take(&mut self.wave_buf);
         widgets::input::render(
             self,
             frame,
@@ -66,9 +63,7 @@ impl App {
             wave_state,
             wave_tick,
             motion,
-            &mut wave_buf,
         );
-        self.wave_buf = wave_buf;
         widgets::status::render(self, &self.metrics, frame, layout.status);
 
         if let Some(state) = &self.file_picker_state {

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -236,6 +236,8 @@ impl App {
             AgentEvent::ForegroundSubagentStarted { id, name } => {
                 self.sessions.current_mut().status_label =
                     Some(format!("Sub-agent '{name}' running..."));
+                // Status change counts as progress so the wave animates (never reads Stalled).
+                self.last_progress_at = Instant::now();
                 self.set_view_target(super::AgentViewTarget::SubAgent { id, name });
             }
             AgentEvent::ForegroundSubagentCompleted { id, name, success } => {
@@ -250,6 +252,8 @@ impl App {
                     format!("Sub-agent '{name}' failed")
                 };
                 self.sessions.current_mut().status_label = Some(label.clone());
+                // Status change counts as progress so the wave animates (never reads Stalled).
+                self.last_progress_at = Instant::now();
                 self.sessions
                     .current_mut()
                     .messages

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -1046,6 +1046,8 @@ impl App {
         let needs_rebuild = self.file_index.as_ref().is_none_or(FileIndex::is_stale);
         if needs_rebuild && self.pending_file_index.is_none() {
             self.sessions.current_mut().status_label = Some("indexing files...".to_owned());
+            // Status change counts as progress so the wave animates (never reads Stalled).
+            self.last_progress_at = std::time::Instant::now();
             let pending = if let Some(sup) = &self.task_supervisor {
                 let handle = sup.spawn_blocking(Arc::from("tui.file_index.build"), move || {
                     FileIndex::build(&root)

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -480,9 +480,11 @@ pub struct App {
     /// — otherwise the first frame after a long idle gap would falsely read as `Stalled`.
     pub(crate) last_progress_at: Instant,
 
-    /// Reusable buffer for wave glyph spans, allocated once and passed into
-    /// [`crate::widgets::wave::glyphs`] each busy frame to avoid per-frame `Vec` allocation.
-    pub(crate) wave_buf: Vec<ratatui::text::Span<'static>>,
+    /// Whether the compact equalizer widget is visible in the busy separator row.
+    ///
+    /// Toggled via [`crate::command::TuiCommand::ToggleEqualizer`].
+    /// Defaults to `true`. Ignored when `Motion` is not `Full`.
+    pub(crate) show_equalizer: bool,
 
     // --- Micro-delights (#5104) ---
     /// Individual feature toggles sourced from `[tui.delights]` in config.

--- a/crates/zeph-tui/src/app/reducer.rs
+++ b/crates/zeph-tui/src/app/reducer.rs
@@ -665,6 +665,10 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
                     let cur = app.mouse_enabled;
                     return reduce(app, Action::SetMouse(!cur));
                 }
+                TuiCommand::ToggleEqualizer => {
+                    app.show_equalizer = !app.show_equalizer;
+                    return vec![];
+                }
 
                 // ── Group A — pure state mutations ──────────────────────────────
                 TuiCommand::NewSession => {

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -105,7 +105,7 @@ impl App {
             motion: zeph_config::Motion::Full,
             wave_tick: 0,
             last_progress_at: Instant::now(),
-            wave_buf: Vec::new(),
+            show_equalizer: true,
             delights: zeph_config::DelightsConfig::default(),
             stream_rate: crate::delights::StreamRate::new(),
             toasts: crate::delights::ToastQueue::new(),

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -1156,28 +1156,32 @@ impl App {
     pub fn wave_state(&self) -> crate::widgets::wave::WaveState {
         use crate::widgets::wave::WaveState;
 
-        if !self.is_agent_busy() {
+        let foreground = self.is_agent_busy();
+        let bg = self.background_inflight();
+
+        // Nothing running at all → flat baseline.
+        if !foreground && bg == 0 {
             return WaveState::Idle;
         }
 
-        // Stalled: no progress for longer than the threshold.
-        if self.last_progress_at.elapsed() > STALL_THRESHOLD {
+        // Stalled: a foreground turn with no progress past the threshold. Checked
+        // before background so a genuinely hung turn still surfaces the warning.
+        if foreground && self.last_progress_at.elapsed() > STALL_THRESHOLD {
             return WaveState::Stalled;
         }
 
-        // Tool execution.
-        if self.has_running_tool() {
+        // Foreground tool execution takes priority over background requests.
+        if foreground && self.has_running_tool() {
             return WaveState::Tool;
         }
 
-        // Parallel background tasks.
-        // Use bg_inflight (all-classes total) — avoids double-counting since
-        // bg_enrichment_inflight and bg_telemetry_inflight are already included in bg_inflight.
-        let bg = self.metrics.bg_inflight;
-        if bg >= 2 {
+        // External/background requests (task-supervisor work: enrichment, telemetry,
+        // MCP, egress, background shell). Rendered in violet so concurrent background
+        // activity is visually distinct from the agent's own foreground turn.
+        if bg >= 1 {
             #[allow(clippy::cast_possible_truncation)]
-            return WaveState::Parallel {
-                sines: (bg as u8).clamp(2, 3),
+            return WaveState::Network {
+                sines: (bg as u8).clamp(1, 3),
             };
         }
 
@@ -1194,6 +1198,18 @@ impl App {
 
         // Swell: busy but awaiting first token.
         WaveState::Swell
+    }
+
+    /// Count in-flight background/external requests for the wave equalizer.
+    ///
+    /// Combines the task-supervisor inflight gauge (`bg_inflight` — all classes,
+    /// already includes enrichment + telemetry) with in-flight background shell
+    /// runs. Used by [`Self::wave_state`] to drive the violet `Network` wave and
+    /// by the draw loop to keep the equalizer visible while background work runs
+    /// even when the agent itself is idle.
+    #[must_use]
+    pub fn background_inflight(&self) -> u64 {
+        self.metrics.bg_inflight + self.metrics.shell_background_runs.len() as u64
     }
 
     /// Advance all micro-delight animations by one tick.

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -1042,6 +1042,17 @@ impl App {
         self.wave_tick
     }
 
+    /// Advance the wave animation clock by one tick.
+    ///
+    /// Called from the render loop's internal interval as an animation heartbeat
+    /// that is independent of the `EventReader`'s `AppEvent::Tick`s, so the
+    /// equalizer keeps moving even when the event channel is briefly starved by a
+    /// streaming burst. Only the wave counter is advanced here — the throbber and
+    /// micro-delights stay driven by `AppEvent::Tick`.
+    pub fn advance_wave_tick(&mut self) {
+        self.wave_tick = self.wave_tick.saturating_add(1);
+    }
+
     /// Apply micro-delight configuration (#5104).
     ///
     /// Called at construction time from `tui_bridge` to propagate `[tui.delights]` config.

--- a/crates/zeph-tui/src/app/tests.rs
+++ b/crates/zeph-tui/src/app/tests.rs
@@ -2601,6 +2601,36 @@ fn supervisor_activity_label_no_supervisor_returns_none() {
     assert!(app.supervisor_activity_label().is_none());
 }
 
+#[test]
+fn wave_state_idle_when_nothing_running() {
+    use crate::widgets::wave::WaveState;
+    let (app, _rx, _tx) = make_app();
+    assert_eq!(app.wave_state(), WaveState::Idle);
+    assert_eq!(app.background_inflight(), 0);
+}
+
+#[test]
+fn wave_state_network_when_background_inflight_without_foreground() {
+    use crate::widgets::wave::WaveState;
+    let (mut app, _rx, _tx) = make_app();
+    // No status label and no streaming message → not foreground-busy.
+    assert!(!app.is_agent_busy());
+    app.metrics.bg_inflight = 1;
+    assert_eq!(app.background_inflight(), 1);
+    assert!(
+        matches!(app.wave_state(), WaveState::Network { .. }),
+        "background request must drive the Network wave even when the agent is idle"
+    );
+}
+
+#[test]
+fn wave_state_network_sines_scale_with_concurrency() {
+    use crate::widgets::wave::WaveState;
+    let (mut app, _rx, _tx) = make_app();
+    app.metrics.bg_inflight = 5; // clamps to 3
+    assert_eq!(app.wave_state(), WaveState::Network { sines: 3 });
+}
+
 #[tokio::test]
 async fn supervisor_activity_label_single_active_task() {
     use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -152,6 +152,8 @@ pub enum TuiCommand {
     SetMouse(bool),
     /// Toggle the current mouse capture state.
     ToggleMouse,
+    /// Toggle the compact equalizer widget in the busy separator row.
+    ToggleEqualizer,
     // SubAgent sidebar navigation (used by decode_normal_key → Action::Dispatch)
     /// Move the subagent list selection down by one.
     SubagentSidebarDown,
@@ -376,6 +378,13 @@ fn build_app_commands() -> Vec<CommandEntry> {
             category: "app",
             shortcut: None,
             command: TuiCommand::ToggleMouse,
+        },
+        CommandEntry {
+            id: "app:equalizer",
+            label: "Toggle equalizer (compact VU-meter in busy separator)",
+            category: "app",
+            shortcut: None,
+            command: TuiCommand::ToggleEqualizer,
         },
     ]
 }
@@ -984,7 +993,7 @@ mod tests {
 
     #[test]
     fn registry_has_correct_count() {
-        assert_eq!(command_registry().len(), 26);
+        assert_eq!(command_registry().len(), 27);
     }
 
     #[test]

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -148,6 +148,13 @@ enum DirtyState {
     Full,
 }
 
+/// Maximum agent events drained per render-loop iteration.
+///
+/// Bounds how long a streaming burst can run before the loop repaints and
+/// services the animation/input arms again. Sized well above a typical
+/// per-frame chunk count so normal streaming drains fully in one pass.
+const AGENT_DRAIN_BATCH: u16 = 64;
+
 #[cfg_attr(
     feature = "profiling",
     tracing::instrument(name = "tui.lib.tui_loop", skip_all)
@@ -157,7 +164,8 @@ async fn tui_loop(
     event_rx: &mut mpsc::Receiver<AppEvent>,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
 ) -> Result<(), TuiError> {
-    let mut tick = tokio::time::interval(std::time::Duration::from_millis(250));
+    // 100 ms ≈ 10 fps animation heartbeat, matching the EventReader tick rate.
+    let mut tick = tokio::time::interval(std::time::Duration::from_millis(100));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut dirty = DirtyState::Clean;
     let mut first_draw_done = false;
@@ -172,8 +180,21 @@ async fn tui_loop(
             agent_poll = app.poll_agent_event() => {
                 if let Some(agent_event) = agent_poll {
                     app.handle_agent_event(agent_event);
-                    while let Ok(ev) = app.try_recv_agent_event() {
-                        app.handle_agent_event(ev);
+                    // Drain a bounded batch per iteration. An unbounded drain lets a
+                    // fast LLM stream monopolise the loop: tokens only repaint once the
+                    // whole backlog is consumed (looks frozen, then jumps) and the wave
+                    // tick (event_rx arm) is starved meanwhile. Capping returns control
+                    // to `select!` regularly so streaming repaints smoothly and the
+                    // animation clock keeps ticking.
+                    let mut drained = 0u16;
+                    while drained < AGENT_DRAIN_BATCH {
+                        match app.try_recv_agent_event() {
+                            Ok(ev) => {
+                                app.handle_agent_event(ev);
+                                drained += 1;
+                            }
+                            Err(_) => break,
+                        }
                     }
                 } else {
                     // Agent channel closed: agent exited. Quit the TUI.
@@ -182,9 +203,10 @@ async fn tui_loop(
                 dirty = DirtyState::Full;
             }
             _ = tick.tick() => {
-                // Tick: only upgrade to AnimationOnly if no full redraw is
-                // already scheduled, so a burst of agent events is not
-                // downgraded.
+                // The internal interval is an animation heartbeat independent of the
+                // EventReader's `AppEvent::Tick`s, so the wave keeps moving even when
+                // the event channel is briefly starved by a streaming burst.
+                app.advance_wave_tick();
                 if dirty == DirtyState::Clean {
                     dirty = DirtyState::AnimationOnly;
                 }
@@ -220,7 +242,10 @@ async fn tui_loop(
 
         let should_draw = match dirty {
             DirtyState::Clean => false,
-            DirtyState::AnimationOnly => app.is_agent_busy(),
+            // Animate while the agent is busy OR background/external requests are
+            // inflight, so the violet Network wave keeps moving even when the agent
+            // itself is idle.
+            DirtyState::AnimationOnly => app.is_agent_busy() || app.background_inflight() > 0,
             DirtyState::Full => true,
         };
 

--- a/crates/zeph-tui/src/widgets/compaction_badge.rs
+++ b/crates/zeph-tui/src/widgets/compaction_badge.rs
@@ -11,51 +11,39 @@
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::Paragraph;
 
 use crate::metrics::MetricsSnapshot;
+use crate::theme::Theme;
 
 /// Render the compaction badge into `area`.
 ///
-/// Shows `"Last: {before}k→{after}k ({saved}k freed) {elapsed}"`.
-/// Hidden (renders an empty block) when no compaction has occurred or `area` has zero height.
-pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
-    if area.height == 0 {
+/// Shows `compaction  {before}k→{after}k (-{saved}k)  {elapsed}` on a single line.
+/// Renders nothing when no compaction has occurred or `area` has zero height.
+pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &Theme) {
+    if area.height == 0 || metrics.compaction_last_at_ms == 0 {
         return;
     }
 
-    let at_ms = metrics.compaction_last_at_ms;
     let before = metrics.compaction_last_before;
     let after = metrics.compaction_last_after;
-
-    let block = Block::default().borders(Borders::ALL).title("Compaction");
-
-    if at_ms == 0 {
-        // No compaction yet — render empty block.
-        frame.render_widget(block, area);
-        return;
-    }
-
     let saved = before.saturating_sub(after);
-    let elapsed = format_elapsed(at_ms);
+    let elapsed = format_elapsed(metrics.compaction_last_at_ms);
 
-    let text = format!(
-        "{}k→{}k (-{}k) {}",
+    let detail = format!(
+        "{}k→{}k (-{}k)  {elapsed}",
         before / 1000,
         after / 1000,
         saved / 1000,
-        elapsed,
     );
 
-    let paragraph = Paragraph::new(Line::from(vec![Span::styled(
-        text,
-        Style::default().fg(Color::Cyan),
-    )]))
-    .block(block);
+    let line = Line::from(vec![
+        Span::styled("compaction  ", theme.system_message),
+        Span::styled(detail, theme.status_bar),
+    ]);
 
-    frame.render_widget(paragraph, area);
+    frame.render_widget(Paragraph::new(line), area);
 }
 
 /// Format elapsed time since `at_ms` (Unix epoch ms) as a human-readable string.

--- a/crates/zeph-tui/src/widgets/context_gauge.rs
+++ b/crates/zeph-tui/src/widgets/context_gauge.rs
@@ -56,7 +56,11 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &
 
 /// Build a block-character bar string of the given `width` (number of cells).
 fn build_bar(ratio: f64, width: usize) -> String {
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
     let filled = (ratio.clamp(0.0, 1.0) * width as f64).round() as usize;
     let empty = width.saturating_sub(filled);
     format!("[{}{}]", "█".repeat(filled), "░".repeat(empty))

--- a/crates/zeph-tui/src/widgets/context_gauge.rs
+++ b/crates/zeph-tui/src/widgets/context_gauge.rs
@@ -3,24 +3,26 @@
 
 //! Context fill gauge for the TUI side panel.
 //!
-//! Renders a [`ratatui::widgets::Gauge`] showing the fraction of the provider's context window
-//! currently in use. Color changes from green to yellow to red as the window fills.
-//! When `context_max_tokens == 0` (pre-init or unknown provider window), the gauge label
-//! renders `"—"` and the bar stays at 0 — no divide-by-zero.
+//! Renders a single-line inline bar `context  [████████░░]  Nk / Nk · N%`
+//! using block characters in the `info` palette color (via `theme.code_inline`).
+//! When `context_max_tokens == 0` (pre-init or unknown provider window), the label
+//! renders `Nk / —` and the bar stays empty — no divide-by-zero.
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Style};
-use ratatui::text::Span;
-use ratatui::widgets::{Block, Borders, Gauge};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
 
 use crate::metrics::MetricsSnapshot;
+use crate::theme::Theme;
 
 /// Render the context fill gauge into `area`.
 ///
-/// Color thresholds: green below 70%, yellow 70–90%, red above 90%.
-/// Hidden (renders an empty block) when `area` has zero height.
-pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
+/// Shows a single row: `context  [████████░░]  Nk / Nk · N%`.
+/// Bar color: `theme.code_inline` fg (maps to palette `info` = `#6FDCD2`).
+/// Hidden when `area` has zero height.
+pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &Theme) {
     if area.height == 0 {
         return;
     }
@@ -29,35 +31,35 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     let used = metrics.context_tokens;
 
     let (ratio, label) = if max == 0 {
-        // Unknown provider window — display placeholder rather than divide-by-zero.
-        (0.0_f64, format!("Context: {}k / —", used / 1000))
+        (0.0_f64, format!("{}k / —", used / 1000))
     } else {
         let clamped = used.min(max);
         #[allow(clippy::cast_precision_loss)]
         let r = clamped as f64 / max as f64;
-        // r is in [0.0, 1.0], so r * 100.0 is in [0.0, 100.0] — no truncation or sign loss.
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let pct = (r * 100.0) as u64;
-        let label = format!("Context: {}k / {}k ({pct}%)", used / 1000, max / 1000);
-        (r, label)
+        (r, format!("{}k / {}k · {pct}%", used / 1000, max / 1000))
     };
 
+    let bar = build_bar(ratio, 10);
+    let bar_style =
+        Style::default().fg(theme.code_inline.fg.unwrap_or(ratatui::style::Color::Cyan));
+
+    let line = Line::from(vec![
+        Span::styled("context  ", theme.system_message),
+        Span::styled(bar, bar_style),
+        Span::styled(format!("  {label}"), theme.status_bar),
+    ]);
+
+    frame.render_widget(Paragraph::new(line), area);
+}
+
+/// Build a block-character bar string of the given `width` (number of cells).
+fn build_bar(ratio: f64, width: usize) -> String {
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let pct_u16 = (ratio * 100.0).clamp(0.0, 100.0) as u16;
-
-    let color = match pct_u16 {
-        0..=69 => Color::Green,
-        70..=89 => Color::Yellow,
-        _ => Color::Red,
-    };
-
-    let gauge = Gauge::default()
-        .block(Block::default().borders(Borders::ALL).title("Context"))
-        .gauge_style(Style::default().fg(color))
-        .ratio(ratio)
-        .label(Span::raw(label));
-
-    frame.render_widget(gauge, area);
+    let filled = (ratio.clamp(0.0, 1.0) * width as f64).round() as usize;
+    let empty = width.saturating_sub(filled);
+    format!("[{}{}]", "█".repeat(filled), "░".repeat(empty))
 }
 
 #[cfg(test)]
@@ -65,7 +67,6 @@ mod tests {
     use super::*;
     use crate::metrics::MetricsSnapshot;
 
-    /// Returns a zero-sized rect so render is a no-op — we are only testing the label logic.
     fn make_metrics(context_tokens: u64, context_max_tokens: u64) -> MetricsSnapshot {
         MetricsSnapshot {
             context_tokens,
@@ -77,7 +78,6 @@ mod tests {
     #[test]
     fn ratio_zero_when_max_is_zero() {
         let m = make_metrics(1000, 0);
-        // When max is 0 ratio must be 0.0 — no divide-by-zero.
         let max = m.context_max_tokens;
         let used = m.context_tokens;
         let ratio: f64 = if max == 0 {
@@ -104,35 +104,17 @@ mod tests {
     }
 
     #[test]
-    fn color_green_below_70_percent() {
-        let pct: u16 = 50;
-        let color = match pct {
-            0..=69 => Color::Green,
-            70..=89 => Color::Yellow,
-            _ => Color::Red,
-        };
-        assert_eq!(color, Color::Green);
+    fn build_bar_empty_at_zero() {
+        assert_eq!(build_bar(0.0, 10), "[░░░░░░░░░░]");
     }
 
     #[test]
-    fn color_yellow_70_to_89_percent() {
-        let pct: u16 = 80;
-        let color = match pct {
-            0..=69 => Color::Green,
-            70..=89 => Color::Yellow,
-            _ => Color::Red,
-        };
-        assert_eq!(color, Color::Yellow);
+    fn build_bar_full_at_one() {
+        assert_eq!(build_bar(1.0, 10), "[██████████]");
     }
 
     #[test]
-    fn color_red_above_90_percent() {
-        let pct: u16 = 95;
-        let color = match pct {
-            0..=69 => Color::Green,
-            70..=89 => Color::Yellow,
-            _ => Color::Red,
-        };
-        assert_eq!(color, Color::Red);
+    fn build_bar_half() {
+        assert_eq!(build_bar(0.5, 10), "[█████░░░░░]");
     }
 }

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -12,7 +12,7 @@ use crate::app::{App, InputMode};
 use crate::theme::Theme;
 use crate::widgets::spinner::breeze_frame;
 use crate::widgets::status_verbs::humanize;
-use crate::widgets::wave::{WaveState, glyphs};
+use crate::widgets::wave::{EQ_ROWS, EQ_W_MAX, EqualizerWidget, WaveState};
 use zeph_common::text::format_tokens;
 
 /// Prompt glyph shown at the beginning of the separator line.
@@ -56,48 +56,6 @@ fn push_label_spans<'a>(
         spans.push(Span::styled(format!("  {symbol}"), theme.highlight));
     }
     spans.push(Span::styled("  esc to interrupt", theme.system_message));
-}
-
-/// Build the busy separator row for `Motion::Full`.
-///
-/// Layout (left → right):
-/// 1. `you ▸ ` prompt glyph (6 columns, always present).
-/// 2. Wave fills the remaining columns — no label text (the busy verb is already
-///    in the status bar §6; duplicating it here clutters the input area).
-fn build_full_busy_sep<'a>(
-    area_width: u16,
-    app: &'a App,
-    wave_state: WaveState,
-    wave_tick: u64,
-    theme: &'a Theme,
-    wave_buf: &mut Vec<Span<'static>>,
-) -> Vec<Span<'static>> {
-    const PROMPT_W: u16 = 6; // "you ▸ " width
-
-    let wave_w = area_width.saturating_sub(PROMPT_W);
-
-    let mut spans: Vec<Span<'static>> = Vec::new();
-    spans.push(Span::styled(
-        format!("{PROMPT_GLYPH} "),
-        theme.system_message,
-    ));
-
-    if wave_w > 0 {
-        let color_mode = app.effective_color_mode();
-        let ascii = app.is_ascii_only();
-        glyphs(
-            wave_state,
-            u32::from(wave_w),
-            wave_tick,
-            color_mode,
-            ascii,
-            wave_buf,
-            theme,
-        );
-        spans.extend_from_slice(wave_buf);
-    }
-
-    spans
 }
 
 /// Build the busy separator row for `Motion::Minimal` (animated) and `Motion::Off` (static).
@@ -251,7 +209,6 @@ pub fn render(
     wave_state: WaveState,
     wave_tick: u64,
     motion: Motion,
-    wave_buf: &mut Vec<Span<'static>>,
 ) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -259,35 +216,84 @@ pub fn render(
 
     let theme = &app.theme;
 
-    let sep_spans: Vec<Span<'_>> = if busy {
-        match motion {
-            Motion::Full => {
-                build_full_busy_sep(area.width, app, wave_state, wave_tick, theme, wave_buf)
+    if busy && matches!(motion, Motion::Full) && app.show_equalizer {
+        // Compact 2-row equalizer: prompt glyph on row 0, then EqualizerWidget.
+        const PROMPT_W: u16 = 6; // "you ▸ " width
+        let sep_height = EQ_ROWS.min(area.height.saturating_sub(1));
+        if sep_height > 0 {
+            // Prompt glyph on the first row only.
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    format!("{PROMPT_GLYPH} "),
+                    theme.system_message,
+                ))),
+                Rect {
+                    x: area.x,
+                    y: area.y,
+                    width: PROMPT_W,
+                    height: 1,
+                },
+            );
+            // Bounded equalizer to the right of the prompt.
+            let eq_x = area.x.saturating_add(PROMPT_W);
+            let eq_avail = area.width.saturating_sub(PROMPT_W);
+            #[allow(clippy::cast_possible_truncation)]
+            let eq_w = eq_avail.min(EQ_W_MAX as u16);
+            if eq_w > 0 {
+                frame.render_widget(
+                    EqualizerWidget {
+                        state: wave_state,
+                        tick: wave_tick,
+                        theme,
+                        color_mode: app.effective_color_mode(),
+                        ascii_only: app.is_ascii_only(),
+                    },
+                    Rect {
+                        x: eq_x,
+                        y: area.y,
+                        width: eq_w,
+                        height: sep_height,
+                    },
+                );
             }
-            Motion::Minimal => {
-                build_spinner_busy_sep(spinner_idx, activity_label, app, theme, true)
-            }
-            Motion::Off => build_spinner_busy_sep(spinner_idx, activity_label, app, theme, false),
         }
+        render_text_area(
+            app,
+            frame,
+            Rect {
+                y: area.y.saturating_add(sep_height),
+                height: area.height.saturating_sub(sep_height),
+                ..area
+            },
+            busy,
+        );
     } else {
-        build_idle_sep(app, theme)
-    };
+        let sep_spans: Vec<Span<'_>> = if busy {
+            match motion {
+                Motion::Minimal => {
+                    build_spinner_busy_sep(spinner_idx, activity_label, app, theme, true)
+                }
+                _ => build_spinner_busy_sep(spinner_idx, activity_label, app, theme, false),
+            }
+        } else {
+            build_idle_sep(app, theme)
+        };
 
-    frame.render_widget(
-        Paragraph::new(Line::from(sep_spans)),
-        Rect { height: 1, ..area },
-    );
-
-    render_text_area(
-        app,
-        frame,
-        Rect {
-            y: area.y.saturating_add(1),
-            height: area.height.saturating_sub(1),
-            ..area
-        },
-        busy,
-    );
+        frame.render_widget(
+            Paragraph::new(Line::from(sep_spans)),
+            Rect { height: 1, ..area },
+        );
+        render_text_area(
+            app,
+            frame,
+            Rect {
+                y: area.y.saturating_add(1),
+                height: area.height.saturating_sub(1),
+                ..area
+            },
+            busy,
+        );
+    }
 }
 
 #[cfg(test)]
@@ -304,7 +310,6 @@ mod tests {
         App::new(user_tx, agent_rx)
     }
 
-    /// Thin wrapper so existing tests don't need to manage `wave_buf` themselves.
     #[allow(clippy::too_many_arguments)]
     fn render_input(
         app: &App,
@@ -317,7 +322,6 @@ mod tests {
         wave_tick: u64,
         motion: zeph_config::Motion,
     ) {
-        let mut buf = Vec::new();
         super::render(
             app,
             frame,
@@ -328,7 +332,6 @@ mod tests {
             wave_state,
             wave_tick,
             motion,
-            &mut buf,
         );
     }
 
@@ -628,12 +631,11 @@ mod tests {
             output.contains("esc to interrupt"),
             "interrupt hint must appear in Off mode; got: {output:?}"
         );
-        // No block-element wave glyphs.
-        for glyph in &["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] {
-            assert!(
-                !output.contains(glyph),
-                "no wave glyphs should appear under Motion::Off; got: {output:?}"
-            );
-        }
+        // No lit dot-matrix bullet — Off mode uses the spinner/label path only.
+        // Note: `·` (middle-dot) is the static spinner symbol and may appear legitimately.
+        assert!(
+            !output.contains('•'),
+            "no dot-matrix bullet should appear under Motion::Off; got: {output:?}"
+        );
     }
 }

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -16,7 +16,7 @@ use crate::widgets::wave::{WaveState, glyphs};
 use zeph_common::text::format_tokens;
 
 /// Prompt glyph shown at the beginning of the separator line.
-const PROMPT_GLYPH: &str = "›";
+const PROMPT_GLYPH: &str = "you ▸";
 
 /// Append human-voice label spans to the separator line (no animated glyph).
 ///
@@ -61,7 +61,7 @@ fn push_label_spans<'a>(
 /// Build the busy separator row for `Motion::Full`.
 ///
 /// Layout (left → right):
-/// 1. `› ` prompt glyph (2 columns, always present).
+/// 1. `you ▸ ` prompt glyph (6 columns, always present).
 /// 2. Activity label: `verb · detail  esc to interrupt` — measured via unicode width.
 /// 3. Wave right-fills the remaining columns (`wave_w = width - prompt_w - label_w - 1`).
 ///    The `+1` is a space gutter between label and wave. `wave_w = 0` → wave skipped.
@@ -77,7 +77,7 @@ fn build_full_busy_sep<'a>(
     theme: &'a Theme,
     wave_buf: &mut Vec<Span<'static>>,
 ) -> Vec<Span<'static>> {
-    const PROMPT_W: u16 = 2; // "› " width
+    const PROMPT_W: u16 = 6; // "you ▸ " width
 
     // Build the human-voice label text first so we can measure it.
     let label_text: String = if let Some(label) = activity_label {
@@ -103,7 +103,10 @@ fn build_full_busy_sep<'a>(
 
     // Build spans — all 'static lifetime via owned Strings.
     let mut spans: Vec<Span<'static>> = Vec::new();
-    spans.push(Span::styled(format!("{PROMPT_GLYPH} "), theme.highlight));
+    spans.push(Span::styled(
+        format!("{PROMPT_GLYPH} "),
+        theme.system_message,
+    ));
     spans.push(Span::styled(label_text, theme.system_message));
 
     if wave_w > 0 {
@@ -147,7 +150,7 @@ fn build_spinner_busy_sep<'a>(
         String::new()
     };
     let mut spans: Vec<Span<'_>> = vec![
-        Span::styled(format!("{PROMPT_GLYPH} "), theme.highlight),
+        Span::styled(format!("{PROMPT_GLYPH} "), theme.system_message),
         Span::styled(mode_hint, theme.system_message),
         Span::styled(meta, theme.system_message),
     ];
@@ -184,7 +187,7 @@ fn build_idle_sep<'a>(app: &'a App, theme: &'a Theme) -> Vec<Span<'a>> {
         String::new()
     };
     let mut spans: Vec<Span<'_>> = vec![
-        Span::styled(format!("{PROMPT_GLYPH} "), theme.highlight),
+        Span::styled(format!("{PROMPT_GLYPH} "), theme.system_message),
         Span::styled(mode_hint, theme.system_message),
         Span::styled(meta, theme.system_message),
     ];
@@ -593,7 +596,7 @@ mod tests {
         });
         // Separator must have the prompt glyph and label.
         assert!(
-            output.contains('›'),
+            output.contains("you ▸"),
             "prompt glyph must appear in Full+busy; got: {output:?}"
         );
         assert!(
@@ -633,7 +636,7 @@ mod tests {
         }
         // Label must still be present.
         assert!(
-            output.contains('›'),
+            output.contains("you ▸"),
             "prompt glyph must appear even on narrow terminal; got: {output:?}"
         );
     }

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -11,20 +11,21 @@ use zeph_config::Motion;
 use crate::app::{App, InputMode};
 use crate::theme::Theme;
 use crate::widgets::spinner::breeze_frame;
-use crate::widgets::status_verbs::humanize;
 use zeph_common::text::format_tokens;
 
 /// Prompt glyph shown at the beginning of the separator line.
 const PROMPT_GLYPH: &str = "you ▸";
 
-/// Append human-voice label spans to the separator line (no animated glyph).
+/// Append the animated spinner glyph and interrupt hint to a busy separator row.
 ///
-/// Used by `Motion::Minimal` (breeze spinner) and `Motion::Off` (static).
-/// Callers pass `animated_glyph = false` for `Off`.
-fn push_label_spans<'a>(
+/// No activity label is shown here — the busy verb already lives in the bottom
+/// status bar ([`crate::widgets::status`]) and the wave equalizer in the side
+/// panel, so duplicating it on this row would be redundant.
+///
+/// Used by `Motion::Minimal` (breeze spinner) and `Motion::Off` (static `·`).
+fn push_busy_tail<'a>(
     spans: &mut Vec<Span<'a>>,
     spinner_idx: u8,
-    activity_label: Option<&'a str>,
     app: &App,
     theme: &'a Theme,
     animated: bool,
@@ -32,46 +33,34 @@ fn push_label_spans<'a>(
     let symbol = if animated {
         breeze_frame(u64::from(spinner_idx), app.is_ascii_only())
     } else {
-        // Static glyph — no animated symbol under Motion::Off; other separator content (token estimate, label) still reflects live state.
         "·"
     };
-    if let Some(label) = activity_label {
-        let phrase = humanize(label);
-        if phrase.verb.is_empty() {
-            spans.push(Span::styled(format!("  {symbol}"), theme.highlight));
-        } else {
-            spans.push(Span::styled(
-                format!("  {symbol} {}", phrase.verb),
-                theme.highlight,
-            ));
-            if !phrase.detail.is_empty() {
-                spans.push(Span::styled(
-                    format!(" · {}", phrase.detail),
-                    theme.system_message,
-                ));
-            }
-        }
-    } else {
-        spans.push(Span::styled(format!("  {symbol}"), theme.highlight));
-    }
+    spans.push(Span::styled(format!("  {symbol}"), theme.highlight));
     spans.push(Span::styled("  esc to interrupt", theme.system_message));
+}
+
+/// Mode hint shown on the separator row, accurate to what the keys actually do.
+///
+/// `Normal` → press `i` to start typing; `Insert` → `Esc` switches back to
+/// Normal mode (it does not cancel input or interrupt the agent).
+fn mode_hint(app: &App) -> &'static str {
+    match app.input_mode() {
+        InputMode::Normal => "press 'i' to type",
+        InputMode::Insert => "esc for normal mode",
+    }
 }
 
 /// Build the busy separator row for `Motion::Minimal` (animated) and `Motion::Off` (static).
 ///
-/// Both modes share the same layout — prompt glyph + mode hint + token estimate + queued badge
-/// + activity label. The only difference is whether the label glyph animates (`animated = true`).
+/// Layout: prompt glyph + mode hint + token estimate + queued badge + spinner +
+/// interrupt hint. The only difference between modes is whether the spinner glyph
+/// animates (`animated = true`).
 fn build_spinner_busy_sep<'a>(
     spinner_idx: u8,
-    activity_label: Option<&'a str>,
     app: &'a App,
     theme: &'a Theme,
     animated: bool,
 ) -> Vec<Span<'a>> {
-    let mode_hint = match app.input_mode() {
-        InputMode::Normal => "press 'i' to type",
-        InputMode::Insert => "esc to cancel",
-    };
     let estimate = app.context_token_estimate();
     let meta = if estimate > 0 {
         format!("  ~{} tokens", format_tokens(estimate as u64))
@@ -80,7 +69,7 @@ fn build_spinner_busy_sep<'a>(
     };
     let mut spans: Vec<Span<'_>> = vec![
         Span::styled(format!("{PROMPT_GLYPH} "), theme.system_message),
-        Span::styled(mode_hint, theme.system_message),
+        Span::styled(mode_hint(app), theme.system_message),
         Span::styled(meta, theme.system_message),
     ];
     if app.queued_count() > 0 {
@@ -92,23 +81,12 @@ fn build_spinner_busy_sep<'a>(
     if app.editing_queued() {
         spans.push(Span::styled("  [editing queued]", theme.highlight));
     }
-    push_label_spans(
-        &mut spans,
-        spinner_idx,
-        activity_label,
-        app,
-        theme,
-        animated,
-    );
+    push_busy_tail(&mut spans, spinner_idx, app, theme, animated);
     spans
 }
 
 /// Build the idle separator row (agent not busy, all motion modes share this layout).
 fn build_idle_sep<'a>(app: &'a App, theme: &'a Theme) -> Vec<Span<'a>> {
-    let mode_hint = match app.input_mode() {
-        InputMode::Normal => "press 'i' to type",
-        InputMode::Insert => "esc to cancel",
-    };
     let estimate = app.context_token_estimate();
     let meta = if estimate > 0 {
         format!("  ~{} tokens", format_tokens(estimate as u64))
@@ -117,7 +95,7 @@ fn build_idle_sep<'a>(app: &'a App, theme: &'a Theme) -> Vec<Span<'a>> {
     };
     let mut spans: Vec<Span<'_>> = vec![
         Span::styled(format!("{PROMPT_GLYPH} "), theme.system_message),
-        Span::styled(mode_hint, theme.system_message),
+        Span::styled(mode_hint(app), theme.system_message),
         Span::styled(meta, theme.system_message),
     ];
     if app.queued_count() > 0 {
@@ -202,7 +180,6 @@ pub fn render(
     frame: &mut Frame,
     area: Rect,
     busy: bool,
-    activity_label: Option<&str>,
     spinner_idx: u8,
     motion: Motion,
 ) {
@@ -214,8 +191,8 @@ pub fn render(
 
     let sep_spans: Vec<Span<'_>> = if busy {
         match motion {
-            Motion::Off => build_spinner_busy_sep(spinner_idx, activity_label, app, theme, false),
-            _ => build_spinner_busy_sep(spinner_idx, activity_label, app, theme, true),
+            Motion::Off => build_spinner_busy_sep(spinner_idx, app, theme, false),
+            _ => build_spinner_busy_sep(spinner_idx, app, theme, true),
         }
     } else {
         build_idle_sep(app, theme)
@@ -256,18 +233,17 @@ mod tests {
         frame: &mut ratatui::Frame,
         area: ratatui::layout::Rect,
         busy: bool,
-        activity_label: Option<&str>,
         spinner_idx: u8,
         motion: zeph_config::Motion,
     ) {
-        super::render(app, frame, area, busy, activity_label, spinner_idx, motion);
+        super::render(app, frame, area, busy, spinner_idx, motion);
     }
 
     #[test]
     fn input_insert_mode() {
         let app = make_app();
         let output = render_to_string(40, 5, |frame, area| {
-            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
+            render_input(&app, frame, area, false, 0, zeph_config::Motion::Full);
         });
         assert_snapshot!(output);
     }
@@ -282,7 +258,7 @@ mod tests {
             ),
         ));
         let output = render_to_string(40, 5, |frame, area| {
-            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
+            render_input(&app, frame, area, false, 0, zeph_config::Motion::Full);
         });
         assert_snapshot!(output);
     }
@@ -291,15 +267,7 @@ mod tests {
     fn input_busy_shows_spinner() {
         let app = make_app();
         let output = render_to_string(60, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                true,
-                Some("Thinking..."),
-                0,
-                zeph_config::Motion::Minimal,
-            );
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
         });
         assert!(
             output.contains("esc to interrupt"),
@@ -311,7 +279,7 @@ mod tests {
     fn input_idle_width_80() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
+            render_input(&app, frame, area, false, 0, zeph_config::Motion::Full);
         });
         assert_snapshot!(output);
     }
@@ -320,21 +288,17 @@ mod tests {
     fn input_busy_width_40() {
         let app = make_app();
         let output = render_to_string(40, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                true,
-                Some("Thinking..."),
-                0,
-                zeph_config::Motion::Minimal,
-            );
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
         });
-        // On a 40-column terminal the full "esc to interrupt" hint may be truncated;
-        // humanize() lowercases the verb, so check for "thinking" (lowercase).
+        // The busy verb is NOT duplicated here (it lives in the status bar); the
+        // separator shows the prompt glyph + mode hint, which fit at width 40.
         assert!(
-            output.contains("thinking"),
-            "activity label must appear when busy; got: {output:?}"
+            output.contains("you ▸"),
+            "prompt glyph must appear when busy; got: {output:?}"
+        );
+        assert!(
+            !output.contains("thinking"),
+            "activity label must NOT be duplicated in the input separator; got: {output:?}"
         );
     }
 
@@ -342,15 +306,7 @@ mod tests {
     fn input_busy_width_80() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                true,
-                Some("Thinking..."),
-                0,
-                zeph_config::Motion::Minimal,
-            );
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
         });
         assert!(
             output.contains("esc to interrupt"),
@@ -365,7 +321,7 @@ mod tests {
             crate::event::AgentEvent::ContextEstimate(14_200),
         ));
         let output = render_to_string(80, 5, |frame, area| {
-            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
+            render_input(&app, frame, area, false, 0, zeph_config::Motion::Full);
         });
         assert!(
             output.contains("14.2k tokens"),
@@ -377,7 +333,7 @@ mod tests {
     fn input_hides_token_estimate_when_zero() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
+            render_input(&app, frame, area, false, 0, zeph_config::Motion::Full);
         });
         assert!(
             !output.contains("tokens"),
@@ -424,15 +380,7 @@ mod tests {
         // The equalizer is rendered in the side panel, not in the input area.
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                true,
-                Some("Streaming..."),
-                0,
-                zeph_config::Motion::Full,
-            );
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Full);
         });
         assert!(
             output.contains("you ▸"),
@@ -448,7 +396,7 @@ mod tests {
     fn input_busy_full_narrow() {
         let app = make_app();
         let output = render_to_string(20, 5, |frame, area| {
-            render_input(&app, frame, area, true, None, 0, zeph_config::Motion::Full);
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Full);
         });
         assert!(
             output.contains("you ▸"),
@@ -464,15 +412,7 @@ mod tests {
     fn input_busy_motion_off() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                true,
-                Some("Streaming..."),
-                0,
-                zeph_config::Motion::Off,
-            );
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Off);
         });
         assert!(
             output.contains("esc to interrupt"),

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -12,7 +12,6 @@ use crate::app::{App, InputMode};
 use crate::theme::Theme;
 use crate::widgets::spinner::breeze_frame;
 use crate::widgets::status_verbs::humanize;
-use crate::widgets::wave::{EQ_ROWS, EQ_W_MAX, EqualizerWidget, WaveState};
 use zeph_common::text::format_tokens;
 
 /// Prompt glyph shown at the beginning of the separator line.
@@ -198,7 +197,6 @@ fn render_text_area(app: &App, frame: &mut Frame, text_area: Rect, busy: bool) {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn render(
     app: &App,
     frame: &mut Frame,
@@ -206,8 +204,6 @@ pub fn render(
     busy: bool,
     activity_label: Option<&str>,
     spinner_idx: u8,
-    wave_state: WaveState,
-    wave_tick: u64,
     motion: Motion,
 ) {
     if area.width == 0 || area.height == 0 {
@@ -216,84 +212,29 @@ pub fn render(
 
     let theme = &app.theme;
 
-    if busy && matches!(motion, Motion::Full) && app.show_equalizer {
-        // Compact 2-row equalizer: prompt glyph on row 0, then EqualizerWidget.
-        const PROMPT_W: u16 = 6; // "you ▸ " width
-        let sep_height = EQ_ROWS.min(area.height.saturating_sub(1));
-        if sep_height > 0 {
-            // Prompt glyph on the first row only.
-            frame.render_widget(
-                Paragraph::new(Line::from(Span::styled(
-                    format!("{PROMPT_GLYPH} "),
-                    theme.system_message,
-                ))),
-                Rect {
-                    x: area.x,
-                    y: area.y,
-                    width: PROMPT_W,
-                    height: 1,
-                },
-            );
-            // Bounded equalizer to the right of the prompt.
-            let eq_x = area.x.saturating_add(PROMPT_W);
-            let eq_avail = area.width.saturating_sub(PROMPT_W);
-            #[allow(clippy::cast_possible_truncation)]
-            let eq_w = eq_avail.min(EQ_W_MAX as u16);
-            if eq_w > 0 {
-                frame.render_widget(
-                    EqualizerWidget {
-                        state: wave_state,
-                        tick: wave_tick,
-                        theme,
-                        color_mode: app.effective_color_mode(),
-                        ascii_only: app.is_ascii_only(),
-                    },
-                    Rect {
-                        x: eq_x,
-                        y: area.y,
-                        width: eq_w,
-                        height: sep_height,
-                    },
-                );
-            }
+    let sep_spans: Vec<Span<'_>> = if busy {
+        match motion {
+            Motion::Off => build_spinner_busy_sep(spinner_idx, activity_label, app, theme, false),
+            _ => build_spinner_busy_sep(spinner_idx, activity_label, app, theme, true),
         }
-        render_text_area(
-            app,
-            frame,
-            Rect {
-                y: area.y.saturating_add(sep_height),
-                height: area.height.saturating_sub(sep_height),
-                ..area
-            },
-            busy,
-        );
     } else {
-        let sep_spans: Vec<Span<'_>> = if busy {
-            match motion {
-                Motion::Minimal => {
-                    build_spinner_busy_sep(spinner_idx, activity_label, app, theme, true)
-                }
-                _ => build_spinner_busy_sep(spinner_idx, activity_label, app, theme, false),
-            }
-        } else {
-            build_idle_sep(app, theme)
-        };
+        build_idle_sep(app, theme)
+    };
 
-        frame.render_widget(
-            Paragraph::new(Line::from(sep_spans)),
-            Rect { height: 1, ..area },
-        );
-        render_text_area(
-            app,
-            frame,
-            Rect {
-                y: area.y.saturating_add(1),
-                height: area.height.saturating_sub(1),
-                ..area
-            },
-            busy,
-        );
-    }
+    frame.render_widget(
+        Paragraph::new(Line::from(sep_spans)),
+        Rect { height: 1, ..area },
+    );
+    render_text_area(
+        app,
+        frame,
+        Rect {
+            y: area.y.saturating_add(1),
+            height: area.height.saturating_sub(1),
+            ..area
+        },
+        busy,
+    );
 }
 
 #[cfg(test)]
@@ -310,7 +251,6 @@ mod tests {
         App::new(user_tx, agent_rx)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn render_input(
         app: &App,
         frame: &mut ratatui::Frame,
@@ -318,38 +258,16 @@ mod tests {
         busy: bool,
         activity_label: Option<&str>,
         spinner_idx: u8,
-        wave_state: crate::widgets::wave::WaveState,
-        wave_tick: u64,
         motion: zeph_config::Motion,
     ) {
-        super::render(
-            app,
-            frame,
-            area,
-            busy,
-            activity_label,
-            spinner_idx,
-            wave_state,
-            wave_tick,
-            motion,
-        );
+        super::render(app, frame, area, busy, activity_label, spinner_idx, motion);
     }
 
     #[test]
     fn input_insert_mode() {
         let app = make_app();
         let output = render_to_string(40, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                false,
-                None,
-                0,
-                crate::widgets::wave::WaveState::Idle,
-                0,
-                zeph_config::Motion::Full,
-            );
+            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
         });
         assert_snapshot!(output);
     }
@@ -364,17 +282,7 @@ mod tests {
             ),
         ));
         let output = render_to_string(40, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                false,
-                None,
-                0,
-                crate::widgets::wave::WaveState::Idle,
-                0,
-                zeph_config::Motion::Full,
-            );
+            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
         });
         assert_snapshot!(output);
     }
@@ -390,8 +298,6 @@ mod tests {
                 true,
                 Some("Thinking..."),
                 0,
-                crate::widgets::wave::WaveState::Swell,
-                0,
                 zeph_config::Motion::Minimal,
             );
         });
@@ -405,17 +311,7 @@ mod tests {
     fn input_idle_width_80() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                false,
-                None,
-                0,
-                crate::widgets::wave::WaveState::Idle,
-                0,
-                zeph_config::Motion::Full,
-            );
+            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
         });
         assert_snapshot!(output);
     }
@@ -430,8 +326,6 @@ mod tests {
                 area,
                 true,
                 Some("Thinking..."),
-                0,
-                crate::widgets::wave::WaveState::Swell,
                 0,
                 zeph_config::Motion::Minimal,
             );
@@ -455,8 +349,6 @@ mod tests {
                 true,
                 Some("Thinking..."),
                 0,
-                crate::widgets::wave::WaveState::Swell,
-                0,
                 zeph_config::Motion::Minimal,
             );
         });
@@ -473,17 +365,7 @@ mod tests {
             crate::event::AgentEvent::ContextEstimate(14_200),
         ));
         let output = render_to_string(80, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                false,
-                None,
-                0,
-                crate::widgets::wave::WaveState::Idle,
-                0,
-                zeph_config::Motion::Full,
-            );
+            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
         });
         assert!(
             output.contains("14.2k tokens"),
@@ -495,17 +377,7 @@ mod tests {
     fn input_hides_token_estimate_when_zero() {
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                false,
-                None,
-                0,
-                crate::widgets::wave::WaveState::Idle,
-                0,
-                zeph_config::Motion::Full,
-            );
+            render_input(&app, frame, area, false, None, 0, zeph_config::Motion::Full);
         });
         assert!(
             !output.contains("tokens"),
@@ -546,10 +418,10 @@ mod tests {
         );
     }
 
-    // C2: Motion::Full busy-path tests (wave render integration)
-
     #[test]
-    fn input_busy_full_streaming_width_80() {
+    fn input_busy_full_shows_spinner() {
+        // Motion::Full busy path — shows animated spinner same as Minimal.
+        // The equalizer is rendered in the side panel, not in the input area.
         let app = make_app();
         let output = render_to_string(80, 5, |frame, area| {
             render_input(
@@ -559,51 +431,29 @@ mod tests {
                 true,
                 Some("Streaming..."),
                 0,
-                crate::widgets::wave::WaveState::Streaming,
-                5,
                 zeph_config::Motion::Full,
             );
         });
-        // In Full mode the wave row shows prompt glyph + wave animation only.
-        // The busy verb is in the status bar (§6), not duplicated here.
         assert!(
             output.contains("you ▸"),
             "prompt glyph must appear in Full+busy; got: {output:?}"
         );
-        // "esc to interrupt" must NOT appear in Full mode — only in Minimal/Off.
         assert!(
-            !output.contains("esc to interrupt"),
-            "Full mode must not show interrupt hint in wave row; got: {output:?}"
-        );
-        assert!(
-            !output.is_empty(),
-            "render must not produce empty output; got: {output:?}"
+            output.contains("esc to interrupt"),
+            "interrupt hint must appear in Full+busy mode; got: {output:?}"
         );
     }
 
     #[test]
-    fn input_busy_full_narrow_wave_appears() {
-        // width=20: wave_w = 20 - 6 = 14, wave appears right after the prompt glyph.
-        // No label text competes for space — the whole remaining width is wave.
+    fn input_busy_full_narrow() {
         let app = make_app();
         let output = render_to_string(20, 5, |frame, area| {
-            render_input(
-                &app,
-                frame,
-                area,
-                true,
-                None,
-                0,
-                crate::widgets::wave::WaveState::Swell,
-                0,
-                zeph_config::Motion::Full,
-            );
+            render_input(&app, frame, area, true, None, 0, zeph_config::Motion::Full);
         });
         assert!(
             output.contains("you ▸"),
             "prompt glyph must appear on narrow terminal; got: {output:?}"
         );
-        // Text area is blank when busy (no placeholder).
         assert!(
             !output.contains("Type a message"),
             "placeholder must be hidden when busy; got: {output:?}"
@@ -621,18 +471,13 @@ mod tests {
                 true,
                 Some("Streaming..."),
                 0,
-                crate::widgets::wave::WaveState::Streaming,
-                5,
                 zeph_config::Motion::Off,
             );
         });
-        // Interrupt hint must be present.
         assert!(
             output.contains("esc to interrupt"),
             "interrupt hint must appear in Off mode; got: {output:?}"
         );
-        // No lit dot-matrix bullet — Off mode uses the spinner/label path only.
-        // Note: `·` (middle-dot) is the static spinner symbol and may appear legitimately.
         assert!(
             !output.contains('•'),
             "no dot-matrix bullet should appear under Motion::Off; got: {output:?}"

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -62,15 +62,10 @@ fn push_label_spans<'a>(
 ///
 /// Layout (left → right):
 /// 1. `you ▸ ` prompt glyph (6 columns, always present).
-/// 2. Activity label: `verb · detail  esc to interrupt` — measured via unicode width.
-/// 3. Wave right-fills the remaining columns (`wave_w = width - prompt_w - label_w - 1`).
-///    The `+1` is a space gutter between label and wave. `wave_w = 0` → wave skipped.
-///
-/// The `~N tokens` estimate and mode hint are deliberately omitted while busy+Full to
-/// free width for the wave.
+/// 2. Wave fills the remaining columns — no label text (the busy verb is already
+///    in the status bar §6; duplicating it here clutters the input area).
 fn build_full_busy_sep<'a>(
     area_width: u16,
-    activity_label: Option<&'a str>,
     app: &'a App,
     wave_state: WaveState,
     wave_tick: u64,
@@ -79,38 +74,15 @@ fn build_full_busy_sep<'a>(
 ) -> Vec<Span<'static>> {
     const PROMPT_W: u16 = 6; // "you ▸ " width
 
-    // Build the human-voice label text first so we can measure it.
-    let label_text: String = if let Some(label) = activity_label {
-        let phrase = humanize(label);
-        if phrase.verb.is_empty() {
-            "  esc to interrupt".to_owned()
-        } else if phrase.detail.is_empty() {
-            format!("  {} · esc to interrupt", phrase.verb)
-        } else {
-            format!("  {} · {}  esc to interrupt", phrase.verb, phrase.detail)
-        }
-    } else {
-        "  esc to interrupt".to_owned()
-    };
+    let wave_w = area_width.saturating_sub(PROMPT_W);
 
-    #[allow(clippy::cast_possible_truncation)]
-    let label_w = label_text.width() as u16;
-
-    let wave_w = area_width
-        .saturating_sub(PROMPT_W)
-        .saturating_sub(label_w)
-        .saturating_sub(1); // gutter
-
-    // Build spans — all 'static lifetime via owned Strings.
     let mut spans: Vec<Span<'static>> = Vec::new();
     spans.push(Span::styled(
         format!("{PROMPT_GLYPH} "),
         theme.system_message,
     ));
-    spans.push(Span::styled(label_text, theme.system_message));
 
     if wave_w > 0 {
-        spans.push(Span::raw(" ")); // gutter
         let color_mode = app.effective_color_mode();
         let ascii = app.is_ascii_only();
         glyphs(
@@ -204,7 +176,7 @@ fn build_idle_sep<'a>(app: &'a App, theme: &'a Theme) -> Vec<Span<'a>> {
 }
 
 /// Render the editable text area and update the terminal cursor position.
-fn render_text_area(app: &App, frame: &mut Frame, text_area: Rect) {
+fn render_text_area(app: &App, frame: &mut Frame, text_area: Rect, busy: bool) {
     let theme = &app.theme;
     let block = Block::default();
 
@@ -238,7 +210,7 @@ fn render_text_area(app: &App, frame: &mut Frame, text_area: Rect) {
             .style(theme.system_message)
             .scroll((scroll, 0))
             .wrap(Wrap { trim: false })
-    } else if app.input().is_empty() && matches!(app.input_mode(), InputMode::Insert) {
+    } else if app.input().is_empty() && matches!(app.input_mode(), InputMode::Insert) && !busy {
         Paragraph::new("Type a message, / for commands, @ to mention")
             .block(block)
             .style(theme.system_message)
@@ -289,15 +261,9 @@ pub fn render(
 
     let sep_spans: Vec<Span<'_>> = if busy {
         match motion {
-            Motion::Full => build_full_busy_sep(
-                area.width,
-                activity_label,
-                app,
-                wave_state,
-                wave_tick,
-                theme,
-                wave_buf,
-            ),
+            Motion::Full => {
+                build_full_busy_sep(area.width, app, wave_state, wave_tick, theme, wave_buf)
+            }
             Motion::Minimal => {
                 build_spinner_busy_sep(spinner_idx, activity_label, app, theme, true)
             }
@@ -320,6 +286,7 @@ pub fn render(
             height: area.height.saturating_sub(1),
             ..area
         },
+        busy,
     );
 }
 
@@ -594,16 +561,17 @@ mod tests {
                 zeph_config::Motion::Full,
             );
         });
-        // Separator must have the prompt glyph and label.
+        // In Full mode the wave row shows prompt glyph + wave animation only.
+        // The busy verb is in the status bar (§6), not duplicated here.
         assert!(
             output.contains("you ▸"),
             "prompt glyph must appear in Full+busy; got: {output:?}"
         );
+        // "esc to interrupt" must NOT appear in Full mode — only in Minimal/Off.
         assert!(
-            output.contains("esc to interrupt"),
-            "interrupt hint must appear; got: {output:?}"
+            !output.contains("esc to interrupt"),
+            "Full mode must not show interrupt hint in wave row; got: {output:?}"
         );
-        // Wave glyphs OR the label fills the row — no block-element crash check.
         assert!(
             !output.is_empty(),
             "render must not produce empty output; got: {output:?}"
@@ -611,8 +579,9 @@ mod tests {
     }
 
     #[test]
-    fn input_busy_full_narrow_wave_skipped() {
-        // width=20 is narrow enough that wave_w saturates to 0 after prompt (2) + label (~18).
+    fn input_busy_full_narrow_wave_appears() {
+        // width=20: wave_w = 20 - 6 = 14, wave appears right after the prompt glyph.
+        // No label text competes for space — the whole remaining width is wave.
         let app = make_app();
         let output = render_to_string(20, 5, |frame, area| {
             render_input(
@@ -627,17 +596,14 @@ mod tests {
                 zeph_config::Motion::Full,
             );
         });
-        // No wave block characters when wave_w == 0.
-        for glyph in &["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] {
-            assert!(
-                !output.contains(glyph),
-                "no wave glyphs should appear on narrow terminal; got: {output:?}"
-            );
-        }
-        // Label must still be present.
         assert!(
             output.contains("you ▸"),
-            "prompt glyph must appear even on narrow terminal; got: {output:?}"
+            "prompt glyph must appear on narrow terminal; got: {output:?}"
+        );
+        // Text area is blank when busy (no placeholder).
+        assert!(
+            !output.contains("Type a message"),
+            "placeholder must be hidden when busy; got: {output:?}"
         );
     }
 

--- a/crates/zeph-tui/src/widgets/memory.rs
+++ b/crates/zeph-tui/src/widgets/memory.rs
@@ -86,16 +86,24 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &
         )),
         Line::from(format!("  sqlite: {} msgs", metrics.sqlite_message_count)),
     ];
-    if metrics.qdrant_available {
-        mem_lines.push(Line::from(format!(
-            "  vector: {} (connected)",
-            metrics.vector_backend
-        )));
-    } else if !metrics.vector_backend.is_empty() {
-        mem_lines.push(Line::from(format!(
-            "  vector: {} (offline)",
-            metrics.vector_backend
-        )));
+    if !metrics.vector_backend.is_empty() {
+        if metrics.qdrant_available {
+            mem_lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {} ", metrics.vector_backend),
+                    theme.system_message,
+                ),
+                Span::styled("connected", theme.tool_success),
+            ]));
+        } else {
+            mem_lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {} ", metrics.vector_backend),
+                    theme.system_message,
+                ),
+                Span::styled("offline", theme.error),
+            ]));
+        }
     }
     mem_lines.push(Line::from(format!(
         "  conv id: {}",

--- a/crates/zeph-tui/src/widgets/memory.rs
+++ b/crates/zeph-tui/src/widgets/memory.rs
@@ -79,54 +79,58 @@ fn render_probe_last_line<'a>(metrics: &'a MetricsSnapshot, lines: &mut Vec<Line
 }
 
 pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let mut mem_lines = vec![
-        Line::from(Span::styled(
-            "memory",
-            theme.system_message.add_modifier(Modifier::BOLD),
-        )),
-        Line::from(format!("  sqlite: {} msgs", metrics.sqlite_message_count)),
-    ];
+    let mut mem_lines = vec![Line::from(Span::styled(
+        "memory",
+        theme.system_message.add_modifier(Modifier::BOLD),
+    ))];
+
+    // sqlite: message count · conv #N
+    {
+        let conv_id = metrics
+            .sqlite_conversation_id
+            .map_or_else(|| "—".to_string(), |id| format!("#{id}"));
+        mem_lines.push(Line::from(vec![
+            Span::styled("  sqlite  ", theme.system_message),
+            Span::styled(
+                format!("{} msgs · conv {conv_id}", metrics.sqlite_message_count),
+                theme.status_bar,
+            ),
+        ]));
+    }
+
+    // vector backend: connected / offline
     if !metrics.vector_backend.is_empty() {
         if metrics.qdrant_available {
             mem_lines.push(Line::from(vec![
                 Span::styled(
-                    format!("  {} ", metrics.vector_backend),
+                    format!("  {}  ", metrics.vector_backend),
                     theme.system_message,
                 ),
                 Span::styled("connected", theme.tool_success),
+                Span::styled(
+                    format!(" · {} vec", metrics.embeddings_generated),
+                    theme.status_bar,
+                ),
             ]));
         } else {
             mem_lines.push(Line::from(vec![
                 Span::styled(
-                    format!("  {} ", metrics.vector_backend),
+                    format!("  {}  ", metrics.vector_backend),
                     theme.system_message,
                 ),
                 Span::styled("offline", theme.error),
             ]));
         }
     }
-    mem_lines.push(Line::from(format!(
-        "  conv id: {}",
-        metrics
-            .sqlite_conversation_id
-            .map_or_else(|| "---".to_string(), |id| id.to_string())
-    )));
-    mem_lines.push(Line::from(format!(
-        "  embeddings: {}",
-        metrics.embeddings_generated
-    )));
-    {
-        mem_lines.push(Line::from(format!(
-            "  graph: {} entities, {} edges, {} communities",
-            metrics.graph_entities_total,
-            metrics.graph_edges_total,
-            metrics.graph_communities_total,
-        )));
-        mem_lines.push(Line::from(format!(
-            "  graph extractions: {} ok, {} failed",
-            metrics.graph_extraction_count, metrics.graph_extraction_failures,
-        )));
+
+    // summaries (only when non-zero)
+    if metrics.embeddings_generated > 0 && metrics.vector_backend.is_empty() {
+        mem_lines.push(Line::from(vec![
+            Span::styled("  embeds  ", theme.system_message),
+            Span::styled(metrics.embeddings_generated.to_string(), theme.status_bar),
+        ]));
     }
+
     let total_probes = metrics.compaction_probe_passes
         + metrics.compaction_probe_soft_failures
         + metrics.compaction_probe_failures

--- a/crates/zeph-tui/src/widgets/resources.rs
+++ b/crates/zeph-tui/src/widgets/resources.rs
@@ -12,6 +12,8 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
+use std::fmt::Write as _;
+
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use crate::layout::truncate_to_width;
@@ -45,7 +47,7 @@ fn append_tokens_line(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, them
     use zeph_common::format_tokens;
     let mut detail = format_tokens(metrics.total_tokens);
     if metrics.reasoning_tokens > 0 {
-        detail.push_str(&format!("  R:{}", format_tokens(metrics.reasoning_tokens)));
+        let _ = write!(detail, "  R:{}", format_tokens(metrics.reasoning_tokens));
     }
     lines.push(Line::from(vec![
         Span::styled("  tokens  ", theme.system_message),
@@ -57,7 +59,7 @@ fn append_tokens_line(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, them
 fn append_api_line(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
     let mut detail = format!("{} calls", metrics.api_calls);
     if metrics.last_llm_latency_ms > 0 {
-        detail.push_str(&format!("  · {}ms last", metrics.last_llm_latency_ms));
+        let _ = write!(detail, "  · {}ms last", metrics.last_llm_latency_ms);
     }
     lines.push(Line::from(vec![
         Span::styled("  api     ", theme.system_message),

--- a/crates/zeph-tui/src/widgets/resources.rs
+++ b/crates/zeph-tui/src/widgets/resources.rs
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Resources side-panel widget.
+//!
+//! Shows a compact summary of LLM routing, session token usage, and API calls:
+//! `tokens`, `api`, `route` — matching design spec §4. Extra lines (cache,
+//! MCP, latency, background shell, classifiers) appear only when they carry
+//! non-zero data, so the panel stays quiet during idle sessions.
+
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::Modifier;
@@ -11,147 +18,116 @@ use crate::layout::truncate_to_width;
 use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
 
+/// Render the resources panel into `area`.
+///
+/// Layout (spec §4): section title · tokens · api · route, with optional
+/// cache, MCP, background-shell, and turn-latency lines when non-zero.
 pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let collapsed = area.height < 30;
     let mut lines: Vec<Line<'_>> = vec![Line::from(Span::styled(
         "resources",
         theme.system_message.add_modifier(Modifier::BOLD),
     ))];
-    append_llm_section(&mut lines, metrics);
-    append_session_section(&mut lines, metrics, collapsed);
-    append_infra_section(&mut lines, metrics, collapsed);
+
+    append_tokens_line(&mut lines, metrics, theme);
+    append_api_line(&mut lines, metrics, theme);
+    append_route_line(&mut lines, metrics, theme);
+    append_cache_line(&mut lines, metrics, theme);
+    append_mcp_line(&mut lines, metrics, theme);
     append_shell_background_section(&mut lines, metrics);
     append_turn_latency_section(&mut lines, metrics);
-    append_classifier_section(&mut lines, metrics);
+
     let resources = Paragraph::new(lines).block(Block::default().borders(Borders::NONE));
     frame.render_widget(resources, area);
 }
 
-fn append_llm_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
-    lines.push(Line::from("  LLM"));
-    lines.push(Line::from(format!(
-        "    Provider: {}",
-        metrics.provider_name
-    )));
-    lines.push(Line::from(format!("    Model: {}", metrics.model_name)));
+/// `tokens  Nk` (with reasoning suffix when non-zero).
+fn append_tokens_line(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
+    use zeph_common::format_tokens;
+    let mut detail = format_tokens(metrics.total_tokens);
+    if metrics.reasoning_tokens > 0 {
+        detail.push_str(&format!("  R:{}", format_tokens(metrics.reasoning_tokens)));
+    }
+    lines.push(Line::from(vec![
+        Span::styled("  tokens  ", theme.system_message),
+        Span::styled(detail, theme.status_bar),
+    ]));
+}
+
+/// `api  N calls [· Nms last]`.
+fn append_api_line(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
+    let mut detail = format!("{} calls", metrics.api_calls);
+    if metrics.last_llm_latency_ms > 0 {
+        detail.push_str(&format!("  · {}ms last", metrics.last_llm_latency_ms));
+    }
+    lines.push(Line::from(vec![
+        Span::styled("  api     ", theme.system_message),
+        Span::styled(detail, theme.status_bar),
+    ]));
+}
+
+/// `route  provider/model` (or just `model` when provider is empty).
+fn append_route_line(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
+    if metrics.model_name.is_empty() {
+        return;
+    }
+    let route = if metrics.provider_name.is_empty() {
+        metrics.model_name.clone()
+    } else {
+        format!("{}/{}", metrics.provider_name, metrics.model_name)
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  route   ", theme.system_message),
+        Span::styled(route, theme.status_bar),
+    ]));
     if !metrics.embedding_model.is_empty() {
-        lines.push(Line::from(format!(
-            "    Embed: {}",
-            metrics.embedding_model
-        )));
-    }
-    lines.push(Line::from(format!(
-        "    Context: {} | Latency: {}ms",
-        metrics.context_tokens, metrics.last_llm_latency_ms
-    )));
-    if metrics.extended_context {
-        lines.push(Line::from("    Max context: 1M"));
+        lines.push(Line::from(vec![
+            Span::styled("  embed   ", theme.system_message),
+            Span::styled(metrics.embedding_model.clone(), theme.status_bar),
+        ]));
     }
 }
 
-fn append_session_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, collapsed: bool) {
-    if collapsed {
-        lines.push(Line::from(format!(
-            "  Session: {} tok | {} calls",
-            metrics.total_tokens, metrics.api_calls
-        )));
+/// `cache  W:N R:N` — only when there is cache activity.
+fn append_cache_line(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
+    if metrics.cache_creation_tokens == 0 && metrics.cache_read_tokens == 0 {
         return;
     }
-    lines.push(Line::from("  Session"));
-    lines.push(Line::from(format!(
-        "    Tokens: {} | API: {}",
-        metrics.total_tokens, metrics.api_calls
-    )));
-    if let Some(budget) = metrics.token_budget {
-        if let Some(threshold) = metrics.compaction_threshold {
-            lines.push(Line::from(format!(
-                "    Budget: {budget} | Compact: {threshold}"
-            )));
-        } else {
-            lines.push(Line::from(format!("    Budget: {budget}")));
-        }
-    }
-    if metrics.cache_creation_tokens > 0 || metrics.cache_read_tokens > 0 {
-        lines.push(Line::from(format!(
-            "    Cache W:{} R:{}",
-            metrics.cache_creation_tokens, metrics.cache_read_tokens
-        )));
-    }
-    if metrics.filter_applications > 0 {
-        #[allow(clippy::cast_precision_loss)]
-        let hit_pct = if metrics.filter_total_commands > 0 {
-            metrics.filter_filtered_commands as f64 / metrics.filter_total_commands as f64 * 100.0
-        } else {
-            0.0
-        };
-        lines.push(Line::from(format!(
-            "    Filter: {}/{} ({hit_pct:.0}% hit)",
-            metrics.filter_filtered_commands, metrics.filter_total_commands,
-        )));
-        #[allow(clippy::cast_precision_loss)]
-        let pct = if metrics.filter_raw_tokens > 0 {
-            metrics.filter_saved_tokens as f64 / metrics.filter_raw_tokens as f64 * 100.0
-        } else {
-            0.0
-        };
-        lines.push(Line::from(format!(
-            "    Filter saved: {} tok ({pct:.0}%)",
-            metrics.filter_saved_tokens,
-        )));
-    }
+    lines.push(Line::from(vec![
+        Span::styled("  cache   ", theme.system_message),
+        Span::styled(
+            format!(
+                "W:{} R:{}",
+                metrics.cache_creation_tokens, metrics.cache_read_tokens
+            ),
+            theme.status_bar,
+        ),
+    ]));
 }
 
-fn append_infra_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, collapsed: bool) {
-    if collapsed {
-        let mut infra_parts: Vec<String> = Vec::new();
-        if !metrics.vault_backend.is_empty() {
-            infra_parts.push(format!("vault:{}", metrics.vault_backend));
-        }
-        if !metrics.active_channel.is_empty() {
-            infra_parts.push(format!("ch:{}", metrics.active_channel));
-        }
-        if !infra_parts.is_empty() {
-            lines.push(Line::from(format!("  Infra: {}", infra_parts.join(" | "))));
-        }
+/// `mcp  N/N connected, N tools` — only when MCP servers are configured.
+fn append_mcp_line(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
+    if metrics.mcp_server_count == 0 {
         return;
     }
-    lines.push(Line::from("  Infra"));
-    match (
-        metrics.vault_backend.as_str(),
-        metrics.active_channel.as_str(),
-    ) {
-        ("", "") => {}
-        (v, "") => lines.push(Line::from(format!("    Vault: {v}"))),
-        ("", c) => lines.push(Line::from(format!("    Channel: {c}"))),
-        (v, c) => lines.push(Line::from(format!("    Vault: {v} | Channel: {c}"))),
-    }
-    let mut flags: Vec<&str> = Vec::new();
-    if metrics.self_learning_enabled {
-        flags.push("Learning: ON");
-    }
-    if metrics.cache_enabled {
-        flags.push("Cache: ON");
-    }
-    if metrics.autosave_enabled {
-        flags.push("Autosave: ON");
-    }
-    if !flags.is_empty() {
-        lines.push(Line::from(format!("    {}", flags.join(" | "))));
-    }
-    if metrics.mcp_server_count > 0 {
-        lines.push(Line::from(format!(
-            "    MCP: {}/{} connected, {} tools",
-            metrics.mcp_connected_count, metrics.mcp_server_count, metrics.mcp_tool_count
-        )));
-    }
+    lines.push(Line::from(vec![
+        Span::styled("  mcp     ", theme.system_message),
+        Span::styled(
+            format!(
+                "{}/{} connected, {} tools",
+                metrics.mcp_connected_count, metrics.mcp_server_count, metrics.mcp_tool_count
+            ),
+            theme.status_bar,
+        ),
+    ]));
 }
 
+/// Background shell runs — only when present.
 fn append_shell_background_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
     if metrics.shell_background_runs.is_empty() {
         return;
     }
     lines.push(Line::from(format!(
-        "  Background Shell ({})",
+        "  shell ({} bg)",
         metrics.shell_background_runs.len()
     )));
     for run in &metrics.shell_background_runs {
@@ -166,52 +142,16 @@ fn append_shell_background_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsS
     }
 }
 
+/// Turn latency breakdown — only when timing samples exist.
 fn append_turn_latency_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
     if metrics.timing_sample_count == 0 {
         return;
     }
     let last = &metrics.last_turn_timings;
-    let avg = &metrics.avg_turn_timings;
-    let max = &metrics.max_turn_timings;
-    lines.push(Line::from("  Turn Latency"));
     lines.push(Line::from(format!(
-        "    ctx:{}ms llm:{}ms tool:{}ms persist:{}ms",
-        last.prepare_context_ms, last.llm_chat_ms, last.tool_exec_ms, last.persist_message_ms,
+        "  latency  ctx:{}ms llm:{}ms",
+        last.prepare_context_ms, last.llm_chat_ms,
     )));
-    if metrics.timing_sample_count > 1 {
-        lines.push(Line::from(format!(
-            "    avg ctx:{}ms llm:{}ms (n={})",
-            avg.prepare_context_ms, avg.llm_chat_ms, metrics.timing_sample_count,
-        )));
-        lines.push(Line::from(format!(
-            "    max ctx:{}ms llm:{}ms tool:{}ms",
-            max.prepare_context_ms, max.llm_chat_ms, max.tool_exec_ms,
-        )));
-    }
-}
-
-fn append_classifier_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
-    let clf = &metrics.classifier;
-    let has_data =
-        clf.injection.call_count > 0 || clf.pii.call_count > 0 || clf.feedback.call_count > 0;
-    if !has_data {
-        return;
-    }
-    lines.push(Line::from("  Classifiers"));
-    for (name, snap) in [
-        ("injection", &clf.injection),
-        ("pii", &clf.pii),
-        ("feedback", &clf.feedback),
-    ] {
-        if snap.call_count > 0 {
-            lines.push(Line::from(format!(
-                "    [{name}] calls:{} p50:{}ms p95:{}ms",
-                snap.call_count,
-                snap.p50_ms.unwrap_or(0),
-                snap.p95_ms.unwrap_or(0),
-            )));
-        }
-    }
 }
 
 #[cfg(test)]
@@ -221,45 +161,32 @@ mod tests {
     use crate::metrics::MetricsSnapshot;
     use crate::test_utils::render_to_string;
 
+    fn theme() -> crate::theme::Theme {
+        crate::theme::Theme::default()
+    }
+
     #[test]
-    fn resources_with_provider() {
+    fn resources_shows_tokens_api_route() {
         let metrics = MetricsSnapshot {
             provider_name: "claude".into(),
             model_name: "opus-4".into(),
-            context_tokens: 8000,
-            total_tokens: 12000,
+            total_tokens: 12_500,
             api_calls: 5,
             last_llm_latency_ms: 250,
             ..MetricsSnapshot::default()
         };
-
-        let output = render_to_string(35, 12, |frame, area| {
-            let theme = crate::theme::Theme::default();
-            super::render(&metrics, frame, area, &theme);
-        });
-        assert_snapshot!(output);
-    }
-
-    #[test]
-    fn resources_with_extended_context() {
-        let metrics = MetricsSnapshot {
-            provider_name: "claude".into(),
-            model_name: "claude-sonnet-4-6".into(),
-            context_tokens: 50000,
-            total_tokens: 75000,
-            api_calls: 3,
-            last_llm_latency_ms: 400,
-            extended_context: true,
-            ..MetricsSnapshot::default()
-        };
-
-        let output = render_to_string(35, 13, |frame, area| {
-            let theme = crate::theme::Theme::default();
-            super::render(&metrics, frame, area, &theme);
+        let output = render_to_string(35, 8, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
         });
         assert!(
-            output.contains("Max context: 1M"),
-            "resources panel must contain 'Max context: 1M' when extended_context is true; got: {output:?}"
+            output.contains("tokens"),
+            "must show tokens; got: {output:?}"
+        );
+        assert!(output.contains("api"), "must show api; got: {output:?}");
+        assert!(output.contains("route"), "must show route; got: {output:?}");
+        assert!(
+            output.contains("claude/opus-4"),
+            "route must be provider/model; got: {output:?}"
         );
         assert_snapshot!(output);
     }
@@ -267,104 +194,81 @@ mod tests {
     #[test]
     fn resources_shows_embedding_model_when_set() {
         let metrics = MetricsSnapshot {
+            provider_name: "ollama".into(),
+            model_name: "qwen3:8b".into(),
             embedding_model: "nomic-embed-text".into(),
             ..MetricsSnapshot::default()
         };
-        let output = render_to_string(35, 30, |frame, area| {
-            let theme = crate::theme::Theme::default();
-            super::render(&metrics, frame, area, &theme);
+        let output = render_to_string(35, 10, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
         });
         assert!(
-            output.contains("Embed: nomic-embed-text"),
-            "resources panel must contain embedding model; got: {output:?}"
+            output.contains("nomic-embed-text"),
+            "must show embed model; got: {output:?}"
         );
     }
 
     #[test]
     fn resources_omits_embedding_model_when_empty() {
         let metrics = MetricsSnapshot::default();
-        let output = render_to_string(35, 30, |frame, area| {
-            let theme = crate::theme::Theme::default();
-            super::render(&metrics, frame, area, &theme);
+        let output = render_to_string(35, 8, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
         });
         assert!(
-            !output.contains("Embed:"),
-            "resources panel must not contain Embed: when embedding_model is empty; got: {output:?}"
+            !output.contains("embed"),
+            "must not show embed when empty; got: {output:?}"
         );
     }
 
     #[test]
-    fn resources_shows_token_budget_with_compaction_threshold_none() {
+    fn resources_shows_cache_when_nonzero() {
         let metrics = MetricsSnapshot {
-            token_budget: Some(200_000),
+            cache_creation_tokens: 1000,
+            cache_read_tokens: 500,
             ..MetricsSnapshot::default()
         };
-        let output = render_to_string(35, 30, |frame, area| {
-            let theme = crate::theme::Theme::default();
-            super::render(&metrics, frame, area, &theme);
+        let output = render_to_string(40, 8, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
         });
+        assert!(output.contains("cache"), "must show cache; got: {output:?}");
         assert!(
-            output.contains("Budget: 200000"),
-            "resources panel must show token budget; got: {output:?}"
+            output.contains("W:1000"),
+            "must show write tokens; got: {output:?}"
+        );
+        assert!(
+            output.contains("R:500"),
+            "must show read tokens; got: {output:?}"
         );
     }
 
     #[test]
-    fn resources_shows_self_learning_flag() {
-        let metrics = MetricsSnapshot {
-            self_learning_enabled: true,
-            ..MetricsSnapshot::default()
-        };
-        let output = render_to_string(35, 30, |frame, area| {
-            let theme = crate::theme::Theme::default();
-            super::render(&metrics, frame, area, &theme);
+    fn resources_omits_cache_when_zero() {
+        let metrics = MetricsSnapshot::default();
+        let output = render_to_string(35, 8, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
         });
         assert!(
-            output.contains("Learning: ON"),
-            "resources panel must show 'Learning: ON' when self_learning_enabled; got: {output:?}"
+            !output.contains("cache"),
+            "must not show cache when zero; got: {output:?}"
         );
     }
 
     #[test]
-    fn resources_with_full_infra() {
+    fn resources_shows_mcp_when_configured() {
         let metrics = MetricsSnapshot {
-            provider_name: "claude".into(),
-            model_name: "claude-sonnet-4-6".into(),
-            context_tokens: 10000,
-            total_tokens: 15000,
-            api_calls: 7,
-            last_llm_latency_ms: 180,
-            embedding_model: "nomic-embed-text".into(),
-            token_budget: Some(200_000),
-            compaction_threshold: Some(120_000),
-            vault_backend: "age".into(),
-            active_channel: "tui".into(),
-            self_learning_enabled: true,
-            cache_enabled: true,
-            autosave_enabled: true,
             mcp_server_count: 2,
             mcp_connected_count: 2,
             mcp_tool_count: 14,
             ..MetricsSnapshot::default()
         };
-
-        let output = render_to_string(40, 30, |frame, area| {
-            let theme = crate::theme::Theme::default();
-            super::render(&metrics, frame, area, &theme);
+        let output = render_to_string(40, 8, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
         });
+        assert!(output.contains("mcp"), "must show mcp; got: {output:?}");
         assert!(
-            output.contains("Vault: age"),
-            "expected vault backend; got: {output:?}"
+            output.contains("14 tools"),
+            "must show tool count; got: {output:?}"
         );
-        assert!(
-            output.contains("Channel: tui"),
-            "expected channel; got: {output:?}"
-        );
-        assert!(
-            output.contains("Learning: ON"),
-            "expected learning flag; got: {output:?}"
-        );
-        assert_snapshot!(output);
     }
 
     #[test]
@@ -379,41 +283,36 @@ mod tests {
             }],
             ..MetricsSnapshot::default()
         };
-        let output = render_to_string(50, 30, |frame, area| {
-            let theme = crate::theme::Theme::default();
-            super::render(&metrics, frame, area, &theme);
+        let output = render_to_string(50, 10, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
         });
         assert!(
-            output.contains("Background Shell"),
-            "resources panel must show Background Shell header; got: {output:?}"
+            output.contains("shell"),
+            "must show shell header; got: {output:?}"
         );
         assert!(
             output.contains("a1b2c3d"),
-            "resources panel must show run_id prefix; got: {output:?}"
+            "must show run_id; got: {output:?}"
         );
         assert!(
             output.contains("01:15"),
-            "resources panel must show elapsed mm:ss; got: {output:?}"
+            "must show elapsed mm:ss; got: {output:?}"
         );
     }
 
     #[test]
-    fn resources_collapsed_when_small_height() {
+    fn resources_shows_reasoning_tokens_when_nonzero() {
         let metrics = MetricsSnapshot {
-            provider_name: "claude".into(),
-            model_name: "claude-sonnet-4-6".into(),
-            vault_backend: "age".into(),
-            active_channel: "tui".into(),
+            total_tokens: 10_000,
+            reasoning_tokens: 2_000,
             ..MetricsSnapshot::default()
         };
-
-        let output = render_to_string(40, 20, |frame, area| {
-            let theme = crate::theme::Theme::default();
-            super::render(&metrics, frame, area, &theme);
+        let output = render_to_string(40, 8, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
         });
         assert!(
-            output.contains("vault:age"),
-            "collapsed mode should show vault inline; got: {output:?}"
+            output.contains("R:"),
+            "must show reasoning label; got: {output:?}"
         );
     }
 }

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_idle_width_80.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_idle_width_80.snap
@@ -2,5 +2,5 @@
 source: crates/zeph-tui/src/widgets/input.rs
 expression: output
 ---
-› esc to cancel                                                                 
+you ▸ esc to cancel                                                             
 Type a message, / for commands, @ to mention

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_idle_width_80.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_idle_width_80.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/zeph-tui/src/widgets/input.rs
+assertion_line: 284
 expression: output
 ---
-you ▸ esc to cancel                                                             
+you ▸ esc for normal mode                                                       
 Type a message, / for commands, @ to mention

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_insert_mode.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_insert_mode.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/zeph-tui/src/widgets/input.rs
+assertion_line: 248
 expression: output
 ---
-you ▸ esc to cancel                     
+you ▸ esc for normal mode               
 Type a message, / for commands, @ to    
 mention

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_insert_mode.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_insert_mode.snap
@@ -2,6 +2,6 @@
 source: crates/zeph-tui/src/widgets/input.rs
 expression: output
 ---
-› esc to cancel                         
+you ▸ esc to cancel                     
 Type a message, / for commands, @ to    
 mention

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_normal_mode.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_normal_mode.snap
@@ -2,4 +2,4 @@
 source: crates/zeph-tui/src/widgets/input.rs
 expression: output
 ---
-› press 'i' to type
+you ▸ press 'i' to type

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__memory_with_guidelines.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__memory_with_guidelines.snap
@@ -1,11 +1,8 @@
 ---
 source: crates/zeph-tui/src/widgets/memory.rs
+assertion_line: 209
 expression: output
 ---
 memory                                            
-  sqlite: 10 msgs                                 
-  conv id: ---                                    
-  embeddings: 0                                   
-  graph: 0 entities, 0 edges, 0 communities       
-  graph extractions: 0 ok, 0 failed               
+  sqlite  10 msgs · conv —                        
   guidelines: v3 (2026-03-15T17:00:00.000Z)

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__memory_with_stats.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__memory_with_stats.snap
@@ -1,11 +1,8 @@
 ---
 source: crates/zeph-tui/src/widgets/memory.rs
+assertion_line: 192
 expression: output
 ---
 memory                        
-  sqlite: 42 msgs             
-  qdrant connected            
-  conv id: ---                
-  embeddings: 10              
-  graph: 0 entities, 0 edges, 
-  graph extractions: 0 ok, 0 f
+  sqlite  42 msgs · conv —    
+  qdrant  connected · 10 vec

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__memory_with_stats.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__memory_with_stats.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 memory                        
   sqlite: 42 msgs             
-  vector: qdrant (connected)  
+  qdrant connected            
   conv id: ---                
   embeddings: 10              
   graph: 0 entities, 0 edges, 

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__probe_error_verdict_shows_no_score.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__probe_error_verdict_shows_no_score.snap
@@ -1,12 +1,9 @@
 ---
 source: crates/zeph-tui/src/widgets/memory.rs
+assertion_line: 308
 expression: output
 ---
 memory                                            
-  sqlite: 5 msgs                                  
-  conv id: ---                                    
-  embeddings: 0                                   
-  graph: 0 entities, 0 edges, 0 communities       
-  graph extractions: 0 ok, 0 failed               
+  sqlite  5 msgs · conv —                         
   probe: P 50% S 0% H 0% E 50%                    
   Last: Error

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__probe_lines_hidden_when_no_probes.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__probe_lines_hidden_when_no_probes.snap
@@ -1,10 +1,7 @@
 ---
 source: crates/zeph-tui/src/widgets/memory.rs
+assertion_line: 290
 expression: output
 ---
 memory                                            
-  sqlite: 5 msgs                                  
-  conv id: ---                                    
-  embeddings: 0                                   
-  graph: 0 entities, 0 edges, 0 communities       
-  graph extractions: 0 ok, 0 failed
+  sqlite  5 msgs · conv —

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__probe_lines_visible_when_probes_ran.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__probe_lines_visible_when_probes_ran.snap
@@ -1,12 +1,9 @@
 ---
 source: crates/zeph-tui/src/widgets/memory.rs
+assertion_line: 229
 expression: output
 ---
 memory                                            
-  sqlite: 5 msgs                                  
-  conv id: ---                                    
-  embeddings: 0                                   
-  graph: 0 entities, 0 edges, 0 communities       
-  graph extractions: 0 ok, 0 failed               
+  sqlite  5 msgs · conv —                         
   probe: P 87% S 10% H 2% E 1%                    
   Last: Pass (0.91)

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__probe_lines_with_category_scores.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__probe_lines_with_category_scores.snap
@@ -1,12 +1,9 @@
 ---
 source: crates/zeph-tui/src/widgets/memory.rs
+assertion_line: 270
 expression: output
 ---
 memory                                                                
-  sqlite: 5 msgs                                                      
-  conv id: ---                                                        
-  embeddings: 0                                                       
-  graph: 0 entities, 0 edges, 0 communities                           
-  graph extractions: 0 ok, 0 failed                                   
+  sqlite  5 msgs · conv —                                             
   probe: P 100% S 0% H 0% E 0%                                        
   Last: Pass (0.72) Rec:0.90 Art:0.50 Con:0.80 Dec:0.60

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__resources__tests__resources_shows_tokens_api_route.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__resources__tests__resources_shows_tokens_api_route.snap
@@ -1,0 +1,9 @@
+---
+source: crates/zeph-tui/src/widgets/resources.rs
+assertion_line: 188
+expression: output
+---
+resources                          
+  tokens  12.5k                    
+  api     5 calls  · 250ms last    
+  route   claude/opus-4

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_full_width_120.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_full_width_120.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/zeph-tui/src/widgets/status.rs
-assertion_line: 782
+assertion_line: 1012
 expression: output
 ---
- [Insert] | claude-sonnet-4-6 | ctx:8% | ? for help | Skills: 1 active / 3 loaded | Tokens: 12.5k | API: 7 | 5m 00s
+ INSERT  · claude-sonnet-4-6 · skills 1/3 · tokens 12.5k · api 7                                                ↑ 5m 00s

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_full_width_120.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_full_width_120.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/zeph-tui/src/widgets/status.rs
-assertion_line: 1012
+assertion_line: 979
 expression: output
 ---
- INSERT  · claude-sonnet-4-6 · skills 1/3 · tokens 12.5k · api 7                                                ↑ 5m 00s
+ INSERT  · skills 1/3 · tokens 12.5k · api 7                                                                    ↑ 5m 00s

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_snapshot.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/zeph-tui/src/widgets/status.rs
-assertion_line: 589
+assertion_line: 801
 expression: output
 ---
- [Insert] | ? for help | Skills: 2 active / 5 loaded | Tokens: 4.2k | API: 12 | 2m 15s
+ INSERT  · skills 2/5 · tokens 4.2k · api 12                                                ↑ 2m 15s

--- a/crates/zeph-tui/src/widgets/splash.rs
+++ b/crates/zeph-tui/src/widgets/splash.rs
@@ -15,7 +15,8 @@ use ratatui::widgets::Paragraph;
 use crate::delights::shimmer_brightness;
 use crate::theme::{EffectiveColorMode, map_color};
 
-// Aqua (#22d3ee) and ice (#e0f2fe) — gradient endpoints for the `zeph` letters.
+// Aqua (#22d3ee) and ice (#e0f2fe) — splash wordmark gradient only; intentionally
+// distinct from palette.accent (#1FB9A8) used everywhere else in chrome.
 const AQUA: (u8, u8, u8) = (0x22, 0xd3, 0xee);
 const ICE: (u8, u8, u8) = (0xe0, 0xf2, 0xfe);
 

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -276,7 +276,6 @@ fn build_segment_lists(
     let mut list = SegmentList::new();
 
     push_mode_chip(&mut list, mode, theme);
-    push_model_segment(&mut list, metrics, theme);
 
     if app.is_agent_busy() {
         push_busy_segment(&mut list, app, theme);
@@ -315,19 +314,6 @@ fn push_mode_chip(list: &mut SegmentList, mode: InputMode, theme: &Theme) {
             chip_text,
             Style::default().fg(surface_bg).bg(chip_bg),
         )],
-    );
-}
-
-fn push_model_segment(list: &mut SegmentList, metrics: &MetricsSnapshot, theme: &Theme) {
-    if metrics.model_name.is_empty() {
-        return;
-    }
-    list.push(
-        Priority::Critical,
-        vec![
-            Span::styled(" · ", theme.system_message),
-            Span::styled(metrics.model_name.clone(), theme.status_bar),
-        ],
     );
 }
 
@@ -879,31 +865,6 @@ mod tests {
         assert!(
             !output.contains("ch:tui"),
             "channel must not appear in redesigned status bar; got: {output:?}"
-        );
-    }
-
-    #[test]
-    fn status_bar_shows_model_name_when_set() {
-        use tokio::sync::mpsc;
-
-        use crate::app::App;
-        use crate::metrics::MetricsSnapshot;
-        use crate::test_utils::render_to_string;
-
-        let (user_tx, _) = mpsc::channel(1);
-        let (_, agent_rx) = mpsc::channel(1);
-        let app = App::new(user_tx, agent_rx);
-        let metrics = MetricsSnapshot {
-            model_name: "claude-sonnet-4-6".into(),
-            ..MetricsSnapshot::default()
-        };
-
-        let output = render_to_string(180, 1, |frame, area| {
-            super::render(&app, &metrics, frame, area);
-        });
-        assert!(
-            output.contains("claude-sonnet-4-6"),
-            "expected model name in status bar; got: {output:?}"
         );
     }
 

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -515,13 +515,6 @@ fn push_extra_low_segments(
             )],
         );
     }
-
-    if app.is_agent_busy() && app.input_mode() == InputMode::Normal {
-        list.push(
-            Priority::Low,
-            vec![Span::styled(" · [Esc to cancel]", theme.status_bar)],
-        );
-    }
 }
 
 fn build_cocoon_spans(

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -224,85 +224,140 @@ impl Segment {
     }
 }
 
-/// Shorten token counts to the minimal non-ambiguous abbreviation.
-///
-/// Mirrors `format_tokens` but drops the label prefix, e.g. `12.3k` instead of `Tokens: 12.3k`.
-fn short_tokens(total: u64, reasoning: u64) -> String {
-    use zeph_common::format_tokens;
+/// Compact token display: `4.2k` or `4.2k(R:1.0k)` when reasoning tokens > 0.
+fn compact_tokens(total: u64, reasoning: u64) -> String {
     if reasoning > 0 {
-        format!(" {}(R:{})", format_tokens(total), format_tokens(reasoning))
+        format!("{}(R:{})", format_tokens(total), format_tokens(reasoning))
     } else {
-        format!(" {}", format_tokens(total))
-    }
-}
-
-/// Short form for uptime: minutes only when ≥1 min, seconds otherwise.
-fn short_uptime(secs: u64) -> String {
-    let m = secs / 60;
-    if m > 0 {
-        format!(" {m}m")
-    } else {
-        format!(" {secs}s")
+        format_tokens(total)
     }
 }
 
 pub fn render(app: &App, metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     let theme = &app.theme;
-    let list = build_segment_list(app, metrics, theme);
-    let spans = list.layout(area.width);
-    let line = Line::from(spans);
+    let (left_list, right_spans) = build_segment_lists(app, metrics, theme);
+
+    let right_width: u16 = right_spans.iter().fold(0u16, |acc, s| {
+        acc.saturating_add(u16::try_from(s.content.width()).unwrap_or(u16::MAX))
+    });
+
+    let left_budget = area.width.saturating_sub(right_width);
+    let left_spans = left_list.layout(left_budget);
+    let left_width: u16 = left_spans.iter().fold(0u16, |acc, s| {
+        acc.saturating_add(u16::try_from(s.content.width()).unwrap_or(u16::MAX))
+    });
+
+    let padding = area
+        .width
+        .saturating_sub(left_width)
+        .saturating_sub(right_width);
+
+    let mut all_spans = left_spans;
+    if !right_spans.is_empty() {
+        if padding > 0 {
+            all_spans.push(Span::styled(" ".repeat(padding as usize), theme.status_bar));
+        }
+        all_spans.extend(right_spans);
+    }
+
+    let line = Line::from(all_spans);
     let paragraph = Paragraph::new(line).style(theme.status_bar);
     frame.render_widget(paragraph, area);
 }
 
-fn build_segment_list(app: &App, metrics: &MetricsSnapshot, theme: &Theme) -> SegmentList {
-    let mode = match app.input_mode() {
-        InputMode::Normal => "Normal",
-        InputMode::Insert => "Insert",
-    };
-
+/// Build the left segment list and right (uptime) spans separately so the caller
+/// can right-align the uptime by computing the padding between them.
+fn build_segment_lists(
+    app: &App,
+    metrics: &MetricsSnapshot,
+    theme: &Theme,
+) -> (SegmentList, Vec<Span<'static>>) {
+    let mode = app.input_mode();
     let mut list = SegmentList::new();
 
-    push_critical_segments(&mut list, metrics, mode, theme);
-    list.push(
-        Priority::High,
-        vec![Span::styled(" | ? for help", theme.status_bar)],
-    );
-    push_medium_segments(&mut list, app, metrics, theme);
-    push_low_segments(&mut list, app, metrics, theme);
+    push_mode_chip(&mut list, mode, theme);
+    push_model_segment(&mut list, metrics, theme);
 
-    list
-}
+    if app.is_agent_busy() {
+        push_busy_segment(&mut list, app, theme);
+    }
 
-fn push_critical_segments(
-    list: &mut SegmentList,
-    metrics: &MetricsSnapshot,
-    mode: &str,
-    theme: &Theme,
-) {
-    list.push(
-        Priority::Critical,
-        vec![Span::styled(format!(" [{mode}]"), theme.status_bar)],
-    );
-    if !metrics.model_name.is_empty() {
+    push_plan_subagent_segments(&mut list, app, metrics, theme);
+    push_skills_segment(&mut list, metrics, theme);
+    push_tokens_segment(&mut list, metrics, theme);
+
+    if metrics.sanitizer_injection_flags > 0 {
         list.push(
-            Priority::Critical,
+            Priority::Low,
             vec![Span::styled(
-                format!(" | {}", metrics.model_name),
-                theme.status_bar,
+                format!(" · SEC {} ⚑", metrics.sanitizer_injection_flags),
+                theme.highlight,
             )],
         );
     }
-    if metrics.context_max_tokens > 0 {
-        let pct = context_pct(metrics.context_tokens, metrics.context_max_tokens);
+
+    push_api_segment(&mut list, metrics, theme);
+    push_extra_low_segments(&mut list, app, metrics, theme);
+
+    let uptime_spans = build_uptime_spans(metrics, theme);
+    (list, uptime_spans)
+}
+
+fn push_mode_chip(list: &mut SegmentList, mode: InputMode, theme: &Theme) {
+    let surface_bg = theme.status_bar.bg.unwrap_or(Color::Black);
+    let (chip_text, chip_bg) = match mode {
+        InputMode::Insert => (" INSERT ", theme.user_message.fg.unwrap_or(Color::Cyan)),
+        InputMode::Normal => (" NORMAL ", theme.panel_border.fg.unwrap_or(Color::Gray)),
+    };
+    list.push(
+        Priority::Critical,
+        vec![Span::styled(
+            chip_text,
+            Style::default().fg(surface_bg).bg(chip_bg),
+        )],
+    );
+}
+
+fn push_model_segment(list: &mut SegmentList, metrics: &MetricsSnapshot, theme: &Theme) {
+    if metrics.model_name.is_empty() {
+        return;
+    }
+    list.push(
+        Priority::Critical,
+        vec![
+            Span::styled(" · ", theme.system_message),
+            Span::styled(metrics.model_name.clone(), theme.status_bar),
+        ],
+    );
+}
+
+fn push_busy_segment(list: &mut SegmentList, app: &App, theme: &Theme) {
+    let verb = app.status_label().unwrap_or("thinking").to_owned();
+    if app.motion == zeph_config::Motion::Off {
         list.push(
-            Priority::Critical,
-            vec![Span::styled(format!(" | ctx:{pct}%"), theme.status_bar)],
+            Priority::High,
+            vec![
+                Span::styled(" · ", theme.system_message),
+                Span::styled("·", theme.system_message),
+                Span::styled(format!(" {verb}"), theme.system_message),
+            ],
+        );
+    } else {
+        const BRAILLE: &str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏";
+        let idx = app.throbber_state().index().cast_unsigned() as usize % 10;
+        let spinner_char = BRAILLE.chars().nth(idx).unwrap_or('⠋').to_string();
+        list.push(
+            Priority::High,
+            vec![
+                Span::styled(" · ", theme.system_message),
+                Span::styled(spinner_char, theme.highlight),
+                Span::styled(format!(" {verb}"), theme.system_message),
+            ],
         );
     }
 }
 
-fn push_medium_segments(
+fn push_plan_subagent_segments(
     list: &mut SegmentList,
     app: &App,
     metrics: &MetricsSnapshot,
@@ -322,73 +377,80 @@ fn push_medium_segments(
             vec![Span::styled(subagent_seg, theme.status_bar)],
         );
     }
-    if !metrics.active_channel.is_empty() {
-        list.push(
-            Priority::Medium,
-            vec![Span::styled(
-                format!(" | ch:{}", metrics.active_channel),
-                theme.status_bar,
-            )],
-        );
-    }
-    list.push_abbrev_styled(
+}
+
+fn push_skills_segment(list: &mut SegmentList, metrics: &MetricsSnapshot, theme: &Theme) {
+    let active = metrics.active_skills.len();
+    let total = metrics.total_skills;
+    list.push_abbrev(
         Priority::Medium,
-        format!(
-            " | Skills: {} active / {} loaded",
-            metrics.active_skills.len(),
-            metrics.total_skills,
-        ),
-        format!(
-            " Sk {}/{}",
-            metrics.active_skills.len(),
-            metrics.total_skills
-        ),
-        theme.status_bar,
+        vec![
+            Span::styled(" · ", theme.system_message),
+            Span::styled("skills ", theme.system_message),
+            Span::styled(format!("{active}/{total}"), theme.status_bar),
+        ],
+        vec![
+            Span::styled(" Sk ", theme.system_message),
+            Span::styled(format!("{active}/{total}"), theme.status_bar),
+        ],
     );
 }
 
-#[allow(clippy::too_many_lines)]
-fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapshot, theme: &Theme) {
-    let token_full = if metrics.reasoning_tokens > 0 {
-        format!(
-            " | Tokens: {} (R: {})",
-            format_tokens(metrics.total_tokens),
-            format_tokens(metrics.reasoning_tokens)
-        )
-    } else {
-        format!(" | Tokens: {}", format_tokens(metrics.total_tokens))
-    };
-    let token_short = format!(
-        " |{}",
-        short_tokens(metrics.total_tokens, metrics.reasoning_tokens)
+fn push_tokens_segment(list: &mut SegmentList, metrics: &MetricsSnapshot, theme: &Theme) {
+    let compact = compact_tokens(metrics.total_tokens, metrics.reasoning_tokens);
+    list.push_abbrev(
+        Priority::Low,
+        vec![
+            Span::styled(" · ", theme.system_message),
+            Span::styled("tokens ", theme.system_message),
+            Span::styled(compact.clone(), theme.status_bar),
+        ],
+        vec![Span::styled(format!(" t:{compact}"), theme.status_bar)],
     );
-    list.push_abbrev_styled(Priority::Low, token_full, token_short, theme.status_bar);
+}
 
+fn push_api_segment(list: &mut SegmentList, metrics: &MetricsSnapshot, theme: &Theme) {
+    list.push_abbrev(
+        Priority::Low,
+        vec![
+            Span::styled(" · ", theme.system_message),
+            Span::styled("api ", theme.system_message),
+            Span::styled(metrics.api_calls.to_string(), theme.status_bar),
+        ],
+        vec![Span::styled(
+            format!(" A{}", metrics.api_calls),
+            theme.status_bar,
+        )],
+    );
+}
+
+fn build_uptime_spans(metrics: &MetricsSnapshot, theme: &Theme) -> Vec<Span<'static>> {
+    vec![Span::styled(
+        format!(" ↑ {}", format_uptime(metrics.uptime_seconds)),
+        theme.status_bar,
+    )]
+}
+
+#[allow(clippy::too_many_lines)]
+fn push_extra_low_segments(
+    list: &mut SegmentList,
+    app: &App,
+    metrics: &MetricsSnapshot,
+    theme: &Theme,
+) {
     if metrics.cost_spent_cents > 0.0 {
         list.push_abbrev_styled(
             Priority::Low,
-            format!(" | ${:.4}", metrics.cost_spent_cents / 100.0),
+            format!(" · ${:.4}", metrics.cost_spent_cents / 100.0),
             format!(" ${:.2}", metrics.cost_spent_cents / 100.0),
             theme.status_bar,
         );
     }
-    list.push_abbrev_styled(
-        Priority::Low,
-        format!(" | API: {}", metrics.api_calls),
-        format!(" A{}", metrics.api_calls),
-        theme.status_bar,
-    );
-    list.push_abbrev_styled(
-        Priority::Low,
-        format!(" | {}", format_uptime(metrics.uptime_seconds)),
-        short_uptime(metrics.uptime_seconds),
-        theme.status_bar,
-    );
     if !metrics.shell_background_runs.is_empty() {
         list.push(
             Priority::Low,
             vec![Span::styled(
-                format!(" | sh:{}", metrics.shell_background_runs.len()),
+                format!(" · sh:{}", metrics.shell_background_runs.len()),
                 theme.status_bar,
             )],
         );
@@ -401,7 +463,7 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
             Priority::Low,
             vec![Span::styled(
                 format!(
-                    " | bg: {} enrich, {} telem",
+                    " · bg: {} enrich, {} telem",
                     metrics.bg_enrichment_inflight, metrics.bg_telemetry_inflight,
                 ),
                 theme.status_bar,
@@ -412,7 +474,7 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
         list.push(
             Priority::Low,
             vec![
-                Span::styled(" | ", theme.status_bar),
+                Span::styled(" · ", theme.system_message),
                 Span::styled(
                     format!("[SC: {}]", metrics.server_compaction_events),
                     Style::default().fg(Color::Cyan),
@@ -429,7 +491,7 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
             vec![Span::styled(build_filter_text(metrics), theme.status_bar)],
         );
     }
-    let security_spans = build_security_spans(metrics, theme);
+    let security_spans = build_exfil_guardrail_spans(metrics, theme);
     if !security_spans.is_empty() {
         list.push(Priority::Low, security_spans);
     }
@@ -443,7 +505,7 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
             let rate_int = rate as u32;
             list.push_abbrev_styled(
                 Priority::Low,
-                format!(" | {}", crate::delights::format_toks(rate)),
+                format!(" · {}", crate::delights::format_toks(rate)),
                 format!(" {rate_int}t/s"),
                 theme.status_bar,
             );
@@ -451,7 +513,7 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
         if let Some(ttft_ms) = app.stream_rate.ttft_ms() {
             list.push_abbrev_styled(
                 Priority::Low,
-                format!(" | {}", crate::delights::format_ttft(ttft_ms)),
+                format!(" · {}", crate::delights::format_ttft(ttft_ms)),
                 format!(" {ttft_ms}ms"),
                 theme.status_bar,
             );
@@ -462,7 +524,7 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
         list.push(
             Priority::Low,
             vec![Span::styled(
-                " | mouse on (Shift+drag selects)",
+                " · mouse on (Shift+drag selects)",
                 theme.status_bar,
             )],
         );
@@ -471,17 +533,9 @@ fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapsho
     if app.is_agent_busy() && app.input_mode() == InputMode::Normal {
         list.push(
             Priority::Low,
-            vec![Span::styled(" | [Esc to cancel]", theme.status_bar)],
+            vec![Span::styled(" · [Esc to cancel]", theme.status_bar)],
         );
     }
-}
-
-fn context_pct(context_tokens: u64, context_max_tokens: u64) -> u64 {
-    #[allow(clippy::cast_precision_loss)]
-    let ratio = (context_tokens as f64 / context_max_tokens as f64 * 100.0).clamp(0.0, 100.0);
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let pct = ratio as u64;
-    pct
 }
 
 fn build_cocoon_spans(
@@ -493,7 +547,7 @@ fn build_cocoon_spans(
         None => None,
         Some(true) => {
             let mut text = format!(
-                " | Cocoon: healthy ({} models, {} workers)",
+                " · Cocoon: healthy ({} models, {} workers)",
                 metrics.cocoon_model_count, metrics.cocoon_worker_count,
             );
             if let Some(balance) = metrics.cocoon_ton_balance {
@@ -506,7 +560,7 @@ fn build_cocoon_spans(
             Some(vec![Span::styled(text, theme.status_bar)])
         }
         Some(false) => Some(vec![Span::styled(
-            " | Cocoon: sidecar unreachable".to_owned(),
+            " · Cocoon: sidecar unreachable".to_owned(),
             theme.status_bar,
         )]),
     }
@@ -528,39 +582,29 @@ fn build_goal_spans(snap: &crate::metrics::GoalSnapshot, theme: &Theme) -> Vec<S
         format!(" {icon} {truncated}")
     };
     vec![
-        Span::styled(" | ", theme.status_bar),
+        Span::styled(" · ", theme.system_message),
         Span::styled(label, Style::default().fg(color)),
     ]
 }
 
-fn build_security_spans(metrics: &MetricsSnapshot, theme: &Theme) -> Vec<Span<'static>> {
-    let injection_flags = metrics.sanitizer_injection_flags;
+/// Spans for exfiltration blocked count and guardrail status.
+/// Injection flags are handled separately as `SEC N ⚑` in the main field list.
+fn build_exfil_guardrail_spans(metrics: &MetricsSnapshot, theme: &Theme) -> Vec<Span<'static>> {
     let exfil_total = metrics.exfiltration_images_blocked
         + metrics.exfiltration_tool_urls_flagged
         + metrics.exfiltration_memory_guards;
 
     let mut spans: Vec<Span<'static>> = Vec::new();
 
-    if injection_flags > 0 || exfil_total > 0 {
-        spans.push(Span::styled(" | ", theme.status_bar));
-        if injection_flags > 0 {
-            spans.push(Span::styled(
-                format!("SEC: {injection_flags} flags"),
-                Style::default().fg(Color::Yellow),
-            ));
-        }
-        if exfil_total > 0 {
-            if injection_flags > 0 {
-                spans.push(Span::styled(" ", theme.status_bar));
-            }
-            spans.push(Span::styled(
-                format!("{exfil_total} blocked"),
-                Style::default().fg(Color::Red),
-            ));
-        }
+    if exfil_total > 0 {
+        spans.push(Span::styled(" · ", theme.system_message));
+        spans.push(Span::styled(
+            format!("{exfil_total} blocked"),
+            Style::default().fg(Color::Red),
+        ));
     }
     if metrics.guardrail_enabled {
-        spans.push(Span::styled(" | ", theme.status_bar));
+        spans.push(Span::styled(" · ", theme.system_message));
         let (label, color) = if metrics.guardrail_warn_mode {
             ("GRD:warn", Color::Yellow)
         } else {
@@ -574,7 +618,7 @@ fn build_security_spans(metrics: &MetricsSnapshot, theme: &Theme) -> Vec<Span<'s
 
 fn subagent_view_segment(app: &App) -> String {
     if let Some(name) = app.view_target().subagent_name() {
-        format!(" | Viewing: {name}")
+        format!(" · Viewing: {name}")
     } else {
         String::new()
     }
@@ -587,9 +631,9 @@ fn plan_mode_segment<'a>(app: &App, metrics: &MetricsSnapshot) -> &'a str {
         .is_some_and(|s| !s.is_stale())
     {
         if app.plan_view_active() {
-            " | [Agents]"
+            " · [Agents]"
         } else {
-            " | [Plan]"
+            " · [Plan]"
         }
     } else {
         ""
@@ -604,7 +648,7 @@ fn build_filter_text(metrics: &MetricsSnapshot) -> String {
         0.0
     };
     format!(
-        " | Filters: {}/{} ({savings:.0}% saved)",
+        " · Filters: {}/{} ({savings:.0}% saved)",
         metrics.filter_filtered_commands, metrics.filter_total_commands,
     )
 }
@@ -622,6 +666,15 @@ fn format_uptime(secs: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn short_uptime(secs: u64) -> String {
+        let m = secs / 60;
+        if m > 0 {
+            format!(" {m}m")
+        } else {
+            format!(" {secs}s")
+        }
+    }
 
     #[test]
     fn format_tokens_small() {
@@ -774,8 +827,8 @@ mod tests {
             super::render(&app, &metrics, frame, area);
         });
         assert!(
-            output.contains("SEC: 2 flags"),
-            "expected SEC indicator with flag count"
+            output.contains("SEC 2 ⚑"),
+            "expected SEC indicator with flag count; got: {output:?}"
         );
     }
 
@@ -805,7 +858,7 @@ mod tests {
     }
 
     #[test]
-    fn status_bar_shows_channel_when_active_channel_set() {
+    fn status_bar_omits_channel() {
         use tokio::sync::mpsc;
 
         use crate::app::App;
@@ -824,8 +877,8 @@ mod tests {
             super::render(&app, &metrics, frame, area);
         });
         assert!(
-            output.contains("ch:tui"),
-            "expected ch:tui in status bar; got: {output:?}"
+            !output.contains("ch:tui"),
+            "channel must not appear in redesigned status bar; got: {output:?}"
         );
     }
 
@@ -930,7 +983,7 @@ mod tests {
             super::render(&app, &metrics, frame, area);
         });
         assert!(
-            !output.contains("SEC:"),
+            !output.contains("SEC"),
             "SEC indicator must be hidden when all counters are zero"
         );
     }
@@ -1105,17 +1158,6 @@ mod tests {
     }
 
     #[test]
-    fn short_tokens_no_reasoning() {
-        // Just checks the helper function used to build abbreviations.
-        assert_eq!(short_tokens(4200, 0), " 4.2k");
-    }
-
-    #[test]
-    fn short_tokens_with_reasoning() {
-        assert_eq!(short_tokens(4200, 1000), " 4.2k(R:1.0k)");
-    }
-
-    #[test]
     fn short_uptime_seconds() {
         assert_eq!(short_uptime(45), " 45s");
     }
@@ -1123,6 +1165,38 @@ mod tests {
     #[test]
     fn short_uptime_minutes() {
         assert_eq!(short_uptime(135), " 2m");
+    }
+
+    #[test]
+    fn motion_off_shows_static_busy_not_braille() {
+        use tokio::sync::mpsc;
+
+        use crate::app::App;
+        use crate::metrics::MetricsSnapshot;
+        use crate::test_utils::render_to_string;
+
+        let (user_tx, _) = mpsc::channel(1);
+        let (_, agent_rx) = mpsc::channel(1);
+        let mut app = App::new(user_tx, agent_rx);
+        app.motion = zeph_config::Motion::Off;
+        app.sessions.current_mut().status_label = Some("thinking".to_owned());
+
+        let metrics = MetricsSnapshot::default();
+        let output = render_to_string(200, 1, |frame, area| {
+            super::render(&app, &metrics, frame, area);
+        });
+
+        let contains_braille = output
+            .chars()
+            .any(|c| ('\u{2800}'..='\u{28FF}').contains(&c));
+        assert!(
+            !contains_braille,
+            "motion=Off must not show braille spinner; got: {output:?}"
+        );
+        assert!(
+            output.contains("thinking"),
+            "motion=Off must still show verb; got: {output:?}"
+        );
     }
 
     /// Off-state byte-identity: motion=Off must suppress tok/s and TTFT segments

--- a/crates/zeph-tui/src/widgets/subagents.rs
+++ b/crates/zeph-tui/src/widgets/subagents.rs
@@ -137,7 +137,7 @@ pub fn render_interactive(
 
     if metrics.sub_agents.is_empty() {
         let header = Line::from(vec![
-            Span::styled("⬡ ", theme.highlight),
+            Span::styled("≈ ", theme.highlight),
             Span::styled(
                 "agents · none  [j/k=nav  Esc=close]",
                 theme.highlight.add_modifier(Modifier::BOLD),
@@ -160,7 +160,7 @@ pub fn render_interactive(
         .collect();
 
     let header = Line::from(vec![
-        Span::styled("⬡ ", theme.highlight),
+        Span::styled("≈ ", theme.highlight),
         Span::styled(
             format!(
                 "agents · {}  [j/k=nav  Enter=view  Esc=close]",

--- a/crates/zeph-tui/src/widgets/wave.rs
+++ b/crates/zeph-tui/src/widgets/wave.rs
@@ -28,18 +28,18 @@ use crate::theme::{EffectiveColorMode, Theme};
 // Glyph ramps
 // ---------------------------------------------------------------------------
 
-/// Thin horizontal-line ramp: dim dash → solid thin → solid thick at wave peak.
+/// Uniform thin horizontal line — all buckets use the same glyph `─`.
 ///
-/// Each glyph sits in the *middle* of the cell so the wave appears as a single
-/// thin horizontal line whose brightness oscillates with the sine. Color (see
-/// [`bucket_to_rgb`]) fades from near-invisible at the trough to full accent
-/// `#1FB9A8` at the crest — replicating the CSS
-/// `background: linear-gradient(90deg, transparent, accent, transparent)` sweep
-/// from the design mock.
-const WAVE_GLYPHS: [&str; 8] = ["╌", "╌", "─", "─", "─", "━", "━", "━"];
+/// The wave effect is produced entirely by color: [`bucket_to_rgb`] fades from
+/// near-invisible at the trough to full accent `#1FB9A8` at the crest.
+/// Using one glyph avoids per-bucket character-width variation and produces a
+/// smooth gradient sweep, matching the CSS
+/// `background: linear-gradient(90deg, transparent, #1FB9A8, transparent)`
+/// animation in the design mock.
+const WAVE_GLYPHS: [&str; 8] = ["─", "─", "─", "─", "─", "─", "─", "─"];
 
 /// ASCII fallback for `TERM=dumb` terminals.
-const ASCII_GLYPHS: [&str; 8] = [".", ".", "-", "-", "-", "=", "=", "="];
+const ASCII_GLYPHS: [&str; 8] = ["-", "-", "-", "-", "-", "-", "-", "-"];
 
 // ---------------------------------------------------------------------------
 // WaveState

--- a/crates/zeph-tui/src/widgets/wave.rs
+++ b/crates/zeph-tui/src/widgets/wave.rs
@@ -1,26 +1,30 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Deterministic wave animation for the input separator row (#5096).
+//! Deterministic wave animation and equalizer widget for the TUI dashboard (#5096).
 //!
-//! The wave is a pure function of `(state, width, t)` where `t` is a monotonic
+//! All renderers are pure functions of `(state, width, t)` where `t` is a monotonic
 //! `u64` tick counter owned by `App`. No wall-clock reads happen here — all
 //! time-dependence flows through the explicit `t` argument so snapshot tests
-//! and property tests stay bit-identical.
+//! stay bit-identical.
 //!
 //! # Architecture
 //!
 //! - [`WaveState`] — discriminates the 6 visual modes; derived in `App::wave_state()`.
-//! - [`sample`] — pure math: maps `(state, x, t)` to a glyph bucket `0..=7`.
-//! - [`glyphs`] — converts a row width to a `Vec<Span<'static>>` using the bucket ramp.
-//!
-//! The caller owns a reused `Vec<Span<'static>>` buffer (`wave_buf`) and passes a `&mut` to
-//! [`glyphs`] so the per-frame allocation is amortized to zero after the first frame.
+//! - [`band_value`] — pure math: maps `(state, band, t)` to a normalised `[0.0, 1.0]` amplitude.
+//! - [`sample`] — maps `(state, x, t)` to a glyph bucket `0..=7` (delegates to [`band_value`]).
+//! - [`glyphs`] — single-row span builder used in compact-motion paths.
+//! - [`EqualizerWidget`] — full ratatui [`Widget`] for the busy separator; writes `▄` blocks
+//!   directly into the [`Buffer`] with a per-row teal gradient.
 
 use std::f32::consts::TAU;
 
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Style};
+use ratatui::symbols;
 use ratatui::text::Span;
+use ratatui::widgets::Widget;
 
 use crate::theme::{EffectiveColorMode, Theme};
 
@@ -28,18 +32,32 @@ use crate::theme::{EffectiveColorMode, Theme};
 // Glyph ramps
 // ---------------------------------------------------------------------------
 
-/// Uniform thin horizontal line — all buckets use the same glyph `─`.
+/// Equalizer bar ramp from silent (▁) to full (█).
 ///
-/// The wave effect is produced entirely by color: [`bucket_to_rgb`] fades from
-/// near-invisible at the trough to full accent `#1FB9A8` at the crest.
-/// Using one glyph avoids per-bucket character-width variation and produces a
-/// smooth gradient sweep, matching the CSS
-/// `background: linear-gradient(90deg, transparent, #1FB9A8, transparent)`
-/// animation in the design mock.
-const WAVE_GLYPHS: [&str; 8] = ["─", "─", "─", "─", "─", "─", "─", "─"];
+/// Each column's bar height is determined by [`sample`] (sine math per `WaveState`).
+/// Different states produce visually distinct patterns:
+/// Swell → slow tall columns; Streaming → medium ripple; Tool → choppy spikes;
+/// Parallel → complex superposed pattern. Color is a vertical gradient from dim
+/// accent at the base to full `#1FB9A8` at the peak (see [`bucket_to_rgb`]).
+const WAVE_GLYPHS: [&str; 8] = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
 
 /// ASCII fallback for `TERM=dumb` terminals.
-const ASCII_GLYPHS: [&str; 8] = ["-", "-", "-", "-", "-", "-", "-", "-"];
+const ASCII_GLYPHS: [&str; 8] = [".", ".", "-", "-", "~", "~", "=", "="];
+
+// ---------------------------------------------------------------------------
+// Equalizer constants
+// ---------------------------------------------------------------------------
+
+/// Maximum width (terminal columns) of the compact equalizer area.
+///
+/// Bands beyond this width are not rendered — keeps the equalizer visually
+/// compact even on ultra-wide terminals.
+pub const EQ_W_MAX: u32 = 48;
+
+/// Number of rows occupied by the compact [`EqualizerWidget`] in the input area.
+///
+/// Two rows give a readable VU-meter look while consuming minimal screen space.
+pub const EQ_ROWS: u16 = 2;
 
 // ---------------------------------------------------------------------------
 // WaveState
@@ -86,22 +104,19 @@ pub enum WaveState {
 // Wave parameters
 // ---------------------------------------------------------------------------
 
-/// Per-state wave parameters passed to [`sample`].
+/// Per-state equalizer parameters passed to [`sample`].
 ///
-/// `amplitude`, `wavelength`, and `omega` are tuned for the 250 ms tick rate
-/// (4 fps). Per-tick phase step = `omega`; per-column spatial frequency = 2π/λ.
-/// Nyquist constraint: omega < π, λ ≥ ~8 columns.
+/// Tuned for the 250 ms tick rate (4 fps). `omega` is the phase advance per tick
+/// in radians; one full vertical cycle takes `2π / omega` ticks.
 #[derive(Debug, Clone, Copy)]
 struct WaveParams {
     /// Peak displacement in `[0, 1]`.
     amplitude: f32,
-    /// Spatial wavelength in columns.
-    wavelength: f32,
-    /// Phase advance per tick (radians).
+    /// Phase advance per tick (radians). Higher → faster vertical oscillation.
     omega: f32,
-    /// Whether to apply a choppy short-λ secondary component.
+    /// Whether to superpose a secondary component for erratic spikes (Tool state).
     choppy: bool,
-    /// Number of parallel sines to superpose (only for `Parallel`).
+    /// Number of superposed sines (only for `Parallel`).
     sines: u8,
 }
 
@@ -109,40 +124,38 @@ impl WaveState {
     /// Return the render parameters for this state.
     fn params(self) -> WaveParams {
         match self {
-            // Idle and Stalled both render a flat line (amplitude=0); colour tint is
-            // applied by `glyphs()` based on the WaveState variant, not params.
+            // Idle and Stalled both render a flat baseline (amplitude=0).
             WaveState::Idle | WaveState::Stalled => WaveParams {
                 amplitude: 0.0,
-                wavelength: 1.0, // unused (A=0)
                 omega: 0.0,
                 choppy: false,
                 sines: 1,
             },
+            // Slow breathing: bars rise and fall lazily.
             WaveState::Swell => WaveParams {
                 amplitude: 0.9,
-                wavelength: 40.0, // long roll
-                omega: 0.25,
+                omega: 0.35,
                 choppy: false,
                 sines: 1,
             },
+            // Medium pace: energetic activity during token streaming.
             WaveState::Streaming => WaveParams {
-                amplitude: 0.6,
-                wavelength: 12.0,
-                omega: 0.7,
+                amplitude: 0.85,
+                omega: 1.1,
                 choppy: false,
                 sines: 1,
             },
+            // Fast erratic: short spikes during tool execution.
             WaveState::Tool => WaveParams {
-                amplitude: 0.5,
-                wavelength: 4.0, // short choppy
-                omega: 1.0,
+                amplitude: 0.7,
+                omega: 2.3,
                 choppy: true,
                 sines: 1,
             },
+            // Mixed pace: superposed sines create complex pattern.
             WaveState::Parallel { sines } => WaveParams {
-                amplitude: 0.5,
-                wavelength: 14.0, // primary λ
-                omega: 0.6,
+                amplitude: 0.7,
+                omega: 0.85,
                 choppy: false,
                 sines: sines.clamp(2, 3),
             },
@@ -150,60 +163,86 @@ impl WaveState {
     }
 }
 
+/// Number of terminal columns per equalizer bar (band width).
+///
+/// Columns within one band share the same phase so they act as a single
+/// bar — visually distinct bars oscillate independently.
+const BAND_W: u32 = 3;
+
 // ---------------------------------------------------------------------------
 // Core math
 // ---------------------------------------------------------------------------
 
-/// Return the glyph bucket index `0..=7` for column `x` at tick `t`.
+/// Return the normalised amplitude `[0.0, 1.0]` for equalizer band `band_idx` at tick `t`.
 ///
-/// This function is pure — given identical `(state, x, t)` arguments it always
-/// returns the same value. Use it directly in snapshot and property tests.
+/// This function is the shared oscillation core used by both [`sample`] and [`EqualizerWidget`].
+/// Given identical `(state, band_idx, t)` it always returns the same value.
 ///
-/// The `u64 → f32` cast for `t` is intentional: f32 mantissa is 24 bits so the
-/// cast is exact below t ≈ 16.7M (≈48 days at 4 fps continuous-busy). Beyond
-/// that the phase slowly drifts — visually imperceptible, not a correctness issue.
+/// # Band-oscillation model
+///
+/// Each band receives a unique phase offset via the golden ratio (`0.618034`), so
+/// adjacent bands oscillate independently — producing the classic audio equalizer
+/// aesthetic where every bar moves up and down on its own schedule.
+///
+/// A squaring step (`y_norm²`) concentrates energy near the trough: bars spend
+/// most time low and spike briefly to full height ("резко поднимаются").
+///
+/// # `u64 → f32` note
+///
+/// f32 mantissa is 24 bits; the cast is exact below t ≈ 16.7 M (≈48 days at
+/// 4 fps). Beyond that the phase drifts slowly — visually imperceptible.
 #[must_use]
-pub fn sample(state: WaveState, x: u32, t: u64) -> usize {
+pub fn band_value(state: WaveState, band_idx: u32, t: u64) -> f32 {
     let p = state.params();
 
     if p.amplitude < f32::EPSILON {
-        // Flat line — bucket 0 for Idle/Stalled.
-        return 0;
+        return 0.0; // Idle / Stalled → flat baseline
     }
 
     #[allow(clippy::cast_precision_loss)]
-    let tf = (t % 65536) as f32; // period 65536 ticks ≈ 4.5 h — harmless wrap
-
+    let tf = (t % 65536) as f32; // harmless wrap after ≈4.5 h
     #[allow(clippy::cast_precision_loss)]
-    let xf = x as f32;
+    let bar_phase = (band_idx as f32 * 0.618_034).fract() * TAU;
 
     let y = if p.sines <= 1 {
-        let phase = TAU * xf / p.wavelength - p.omega * tf;
-        let mut y = p.amplitude * phase.sin();
+        let mut v = p.amplitude * (p.omega * tf + bar_phase).sin();
         if p.choppy {
-            // Add a secondary short-λ component for the choppy Tool wave.
-            let phase2 = TAU * xf / (p.wavelength / 2.0) - p.omega * 1.5 * tf;
-            y = (y + 0.3 * phase2.sin()).clamp(-1.0, 1.0);
-        }
-        y
-    } else {
-        // Parallel: superpose `sines` unit sines with λ∈{14,9,5} and divide by count.
-        let lambdas: [f32; 3] = [14.0, 9.0, 5.0];
-        let count = p.sines as usize;
-        let mut sum = 0.0f32;
-        for (i, &lambda) in lambdas[..count].iter().enumerate() {
+            // Secondary component (tribonacci ratio) for erratic Tool spikes.
             #[allow(clippy::cast_precision_loss)]
-            let phase = TAU * xf / lambda - p.omega * (1.0 + 0.2 * i as f32) * tf;
-            sum += phase.sin();
+            let bar_phase2 = (band_idx as f32 * 1.324_718).fract() * TAU;
+            v = (v + 0.4 * p.amplitude * (p.omega * 1.7 * tf + bar_phase2).sin())
+                .clamp(-p.amplitude, p.amplitude);
+        }
+        v
+    } else {
+        // Parallel: superpose sines at golden-ratio omega multiples.
+        let omegas: [f32; 3] = [1.0, 1.618_034, 2.414_214];
+        let count = p.sines as usize;
+        let mut sum = 0.0_f32;
+        for (i, &om) in omegas[..count].iter().enumerate() {
+            #[allow(clippy::cast_precision_loss)]
+            let phase = (band_idx as f32 * (0.618_034 + i as f32 * 0.381_966)).fract() * TAU;
+            sum += (p.omega * om * tf + phase).sin();
         }
         #[allow(clippy::cast_precision_loss)]
-        let normalized = sum / count as f32;
-        p.amplitude * normalized.clamp(-1.0, 1.0)
+        {
+            p.amplitude * (sum / count as f32).clamp(-1.0, 1.0)
+        }
     };
 
-    // Map y ∈ [-1, 1] → bucket 0..=7.
+    // Normalise to [0, 1] then square: bars mostly low, spiking sharply to peak.
+    let y_norm = (y.clamp(-p.amplitude, p.amplitude) / p.amplitude + 1.0) / 2.0;
+    y_norm.powi(2)
+}
+
+/// Return the glyph bucket index `0..=7` for column `x` at tick `t`.
+///
+/// Delegates to [`band_value`] — `x` is mapped to a band via `x / BAND_W`.
+#[must_use]
+pub fn sample(state: WaveState, x: u32, t: u64) -> usize {
+    let band = x / BAND_W;
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let bucket = ((y + 1.0) * 3.5).round() as usize;
+    let bucket = (band_value(state, band, t) * 7.0).round() as usize;
     bucket.clamp(0, 7)
 }
 
@@ -285,6 +324,153 @@ pub fn glyphs<'a>(
     }
 
     buf.as_slice()
+}
+
+/// Compact VU-meter equalizer widget for the TUI input separator.
+///
+/// Renders animated frequency bands directly into a ratatui [`Buffer`] using `▄`
+/// (U+2584, lower half block) characters with a teal gradient that runs from near-black
+/// at the bottom row to the full Zeph accent colour (`#1FB9A8`) at the top.
+///
+/// Band phases are distributed via the golden ratio so adjacent bars oscillate
+/// independently, producing the classic audio equalizer aesthetic where each bar
+/// moves up and down on its own schedule.
+///
+/// Inspired by the [`tui-equalizer`](https://github.com/ratatui/tui-widgets/tree/main/tui-equalizer)
+/// reference widget, adapted for the Zeph teal design language.
+///
+/// # Examples
+///
+/// ```no_run
+/// use ratatui::layout::Rect;
+/// use zeph_tui::widgets::wave::{EqualizerWidget, WaveState};
+/// use zeph_tui::theme::{EffectiveColorMode, Theme};
+///
+/// let widget = EqualizerWidget {
+///     state: WaveState::Streaming,
+///     tick: 42,
+///     theme: &Theme::default(),
+///     color_mode: EffectiveColorMode::Truecolor,
+///     ascii_only: false,
+/// };
+/// // frame.render_widget(widget, area);
+/// ```
+pub struct EqualizerWidget<'a> {
+    /// Current wave animation state.
+    pub state: WaveState,
+    /// Monotonic tick counter from `App::wave_tick()`.
+    pub tick: u64,
+    /// Theme reference for ANSI colour fallback.
+    pub theme: &'a Theme,
+    /// Resolved terminal colour capability.
+    pub color_mode: EffectiveColorMode,
+    /// When `true`, uses ASCII-safe `|` instead of `▄`.
+    pub ascii_only: bool,
+}
+
+impl Widget for EqualizerWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        let n_bands = area.width / BAND_W as u16;
+        if n_bands == 0 {
+            return;
+        }
+        let effective_w = n_bands * BAND_W as u16;
+        let eq_area = Rect {
+            width: effective_w,
+            ..area
+        };
+
+        let band_areas =
+            Layout::horizontal(vec![Constraint::Length(BAND_W as u16); n_bands as usize])
+                .split(eq_area);
+
+        for (idx, &band_area) in band_areas.iter().enumerate() {
+            #[allow(clippy::cast_possible_truncation)]
+            let value = band_value(self.state, idx as u32, self.tick);
+            render_eq_band(
+                band_area,
+                value,
+                self.state,
+                self.color_mode,
+                self.theme,
+                self.ascii_only,
+                buf,
+            );
+        }
+    }
+}
+
+/// Render one equalizer band into the buffer.
+///
+/// Fills from the bottom up: lit rows receive `▄` in the gradient colour;
+/// unlit rows are left untouched (transparent background).
+fn render_eq_band(
+    area: Rect,
+    value: f32,
+    state: WaveState,
+    color_mode: EffectiveColorMode,
+    theme: &Theme,
+    ascii_only: bool,
+    buf: &mut Buffer,
+) {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let lit_rows = (value.clamp(0.0, 1.0) * area.height as f32) as u16;
+    let symbol = if ascii_only { "|" } else { symbols::bar::HALF };
+
+    for row in 0..lit_rows {
+        let y = area.bottom().saturating_sub(row + 1);
+        let color = eq_row_color(row, area.height, state, color_mode, theme);
+        for x in area.left()..area.right() {
+            buf[(x, y)].set_fg(color).set_symbol(symbol);
+        }
+    }
+}
+
+/// Compute the foreground colour for a single lit row of an equalizer band.
+///
+/// `row_from_bottom = 0` is the lowest (darkest) lit row; increasing values move
+/// toward the top (brightest). In Truecolor mode a smooth teal gradient is applied;
+/// ANSI modes fall back to the theme highlight or error colour.
+fn eq_row_color(
+    row_from_bottom: u16,
+    total_height: u16,
+    state: WaveState,
+    color_mode: EffectiveColorMode,
+    theme: &Theme,
+) -> Color {
+    match color_mode {
+        EffectiveColorMode::Truecolor => {
+            let v = if total_height <= 1 {
+                1.0_f32
+            } else {
+                row_from_bottom as f32 / (total_height - 1) as f32
+            };
+            if matches!(state, WaveState::Stalled) {
+                // Error tint: dark red at bottom → bright red at top.
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                return Color::Rgb((80.0 + v * 175.0) as u8, 10, 10);
+            }
+            // Teal gradient: #0A191E (bottom) → #1FB9A8 (top / accent).
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            Color::Rgb(
+                (10.0 + v * 21.0) as u8,  // 10 → 31
+                (25.0 + v * 160.0) as u8, // 25 → 185
+                (30.0 + v * 138.0) as u8, // 30 → 168
+            )
+        }
+        EffectiveColorMode::Ansi256 | EffectiveColorMode::Ansi16 => {
+            if matches!(state, WaveState::Stalled) {
+                theme.error.fg.unwrap_or(Color::Red)
+            } else {
+                theme.highlight.fg.unwrap_or(Color::Yellow)
+            }
+        }
+        EffectiveColorMode::Never => Color::Reset,
+    }
 }
 
 /// Map a bucket index `0..=7` to an RGB colour for the Truecolor thin-line wave.

--- a/crates/zeph-tui/src/widgets/wave.rs
+++ b/crates/zeph-tui/src/widgets/wave.rs
@@ -14,15 +14,14 @@
 //! - [`band_value`] — pure math: maps `(state, band, t)` to a normalised `[0.0, 1.0]` amplitude.
 //! - [`sample`] — maps `(state, x, t)` to a glyph bucket `0..=7` (delegates to [`band_value`]).
 //! - [`glyphs`] — single-row span builder used in compact-motion paths.
-//! - [`EqualizerWidget`] — full ratatui [`Widget`] for the busy separator; writes `▄` blocks
-//!   directly into the [`Buffer`] with a per-row teal gradient.
+//! - [`EqualizerWidget`] — full ratatui [`Widget`] for the side-panel slot; writes braille
+//!   characters directly into the [`Buffer`] with 4× sub-pixel resolution and a teal gradient.
 
 use std::f32::consts::TAU;
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Style};
-use ratatui::symbols;
 use ratatui::text::Span;
 use ratatui::widgets::Widget;
 
@@ -148,11 +147,8 @@ impl WaveState {
     }
 }
 
-/// Number of terminal columns per equalizer bar (band width).
-///
-/// Columns within one band share the same phase so they act as a single
-/// bar — visually distinct bars oscillate independently.
-const BAND_W: u32 = 3;
+/// Terminal columns per equalizer band. One column = one independent bar.
+const BAND_W: u32 = 1;
 
 // ---------------------------------------------------------------------------
 // Core math
@@ -313,14 +309,16 @@ pub fn glyphs<'a>(
 
 /// VU-meter equalizer widget rendered in the dashboard side panel during active inference.
 ///
-/// Renders animated frequency bands directly into a ratatui [`Buffer`] using `▄`
-/// (U+2584, lower half block) characters with a teal gradient that runs from near-black
-/// at the bottom row to the full Zeph accent colour (`#1FB9A8`) at the top.
+/// Each terminal column is one independent bar. Bars are rendered with braille characters
+/// (U+2800 range), giving 4× sub-pixel vertical resolution compared to half-block chars:
+/// each terminal row can represent 4 fill levels (`⣀` → `⣤` → `⣶` → `⣿`).
 ///
-/// Band phases are distributed via the golden ratio so adjacent bars oscillate
-/// independently, producing the classic audio equalizer aesthetic where each bar
-/// moves up and down on its own schedule. The number of lit rows per band is
-/// proportional to `area.height`, so the widget scales naturally to any allocated rect.
+/// A teal gradient runs from near-black (`#0A191E`) at the bottom to the full Zeph accent
+/// colour (`#1FB9A8`) at the top. Band phases are distributed via the golden ratio so
+/// adjacent bars oscillate independently — the classic audio equalizer look.
+///
+/// Scales to any rect: `area.width` columns = that many bands; `area.height` rows ×4 =
+/// total sub-pixel resolution.
 ///
 /// Inspired by the [`tui-equalizer`](https://github.com/ratatui/tui-widgets/tree/main/tui-equalizer)
 /// reference widget, adapted for the Zeph teal design language.
@@ -390,10 +388,17 @@ impl Widget for EqualizerWidget<'_> {
     }
 }
 
-/// Render one equalizer band into the buffer.
+/// Render one equalizer band into the buffer using braille sub-pixel filling.
 ///
-/// Fills from the bottom up: lit rows receive `▄` in the gradient colour;
-/// unlit rows are left untouched (transparent background).
+/// Each terminal row contains one braille character whose dots are filled from
+/// the bottom row up, giving 4× the vertical resolution of half-block characters:
+///
+/// | Dots lit (bottom → top) | Char |
+/// |-------------------------|------|
+/// | 1/4 (dots 7, 8)         | ⣀    |
+/// | 2/4 (+ dots 3, 6)       | ⣤    |
+/// | 3/4 (+ dots 2, 5)       | ⣶    |
+/// | 4/4 (+ dots 1, 4)       | ⣿    |
 fn render_eq_band(
     area: Rect,
     value: f32,
@@ -403,13 +408,39 @@ fn render_eq_band(
     ascii_only: bool,
     buf: &mut Buffer,
 ) {
+    // Total sub-pixels = terminal rows × 4 braille dot rows per character.
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let lit_rows = (value.clamp(0.0, 1.0) * area.height as f32) as u16;
-    let symbol = if ascii_only { "|" } else { symbols::bar::HALF };
+    let total_sub = area.height as f32 * 4.0;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let lit_sub = (value.clamp(0.0, 1.0) * total_sub).round() as u16;
 
-    for row in 0..lit_rows {
-        let y = area.bottom().saturating_sub(row + 1);
-        let color = eq_row_color(row, area.height, state, color_mode, theme);
+    for row_from_bottom in 0..area.height {
+        let y = area.bottom().saturating_sub(row_from_bottom + 1);
+        let sub_base = row_from_bottom * 4;
+        let lit_in_cell = lit_sub.saturating_sub(sub_base).min(4) as u8;
+
+        if lit_in_cell == 0 {
+            continue;
+        }
+
+        let color = eq_row_color(row_from_bottom, area.height, state, color_mode, theme);
+        let symbol = if ascii_only {
+            "|"
+        } else {
+            // Braille dot layout (Unicode):
+            //   row 1 top  → bits 0 (left), 3 (right) = 0x01 | 0x08 = 0x09
+            //   row 2      → bits 1, 4 = 0x12
+            //   row 3      → bits 2, 5 = 0x24
+            //   row 4 bot  → bits 6, 7 = 0xC0
+            // Fill bottom-up: 0xC0 → 0xC0|0x24 → 0xC0|0x24|0x12 → 0xFF
+            match lit_in_cell {
+                1 => "⣀", // U+28C0
+                2 => "⣤", // U+28E4
+                3 => "⣶", // U+28F6
+                _ => "⣿", // U+28FF
+            }
+        };
+
         for x in area.left()..area.right() {
             buf[(x, y)].set_fg(color).set_symbol(symbol);
         }

--- a/crates/zeph-tui/src/widgets/wave.rs
+++ b/crates/zeph-tui/src/widgets/wave.rs
@@ -45,21 +45,6 @@ const WAVE_GLYPHS: [&str; 8] = ["▁", "▂", "▃", "▄", "▅", "▆", "▇",
 const ASCII_GLYPHS: [&str; 8] = [".", ".", "-", "-", "~", "~", "=", "="];
 
 // ---------------------------------------------------------------------------
-// Equalizer constants
-// ---------------------------------------------------------------------------
-
-/// Maximum width (terminal columns) of the compact equalizer area.
-///
-/// Bands beyond this width are not rendered — keeps the equalizer visually
-/// compact even on ultra-wide terminals.
-pub const EQ_W_MAX: u32 = 48;
-
-/// Number of rows occupied by the compact [`EqualizerWidget`] in the input area.
-///
-/// Two rows give a readable VU-meter look while consuming minimal screen space.
-pub const EQ_ROWS: u16 = 2;
-
-// ---------------------------------------------------------------------------
 // WaveState
 // ---------------------------------------------------------------------------
 
@@ -326,7 +311,7 @@ pub fn glyphs<'a>(
     buf.as_slice()
 }
 
-/// Compact VU-meter equalizer widget for the TUI input separator.
+/// VU-meter equalizer widget rendered in the dashboard side panel during active inference.
 ///
 /// Renders animated frequency bands directly into a ratatui [`Buffer`] using `▄`
 /// (U+2584, lower half block) characters with a teal gradient that runs from near-black
@@ -334,7 +319,8 @@ pub fn glyphs<'a>(
 ///
 /// Band phases are distributed via the golden ratio so adjacent bars oscillate
 /// independently, producing the classic audio equalizer aesthetic where each bar
-/// moves up and down on its own schedule.
+/// moves up and down on its own schedule. The number of lit rows per band is
+/// proportional to `area.height`, so the widget scales naturally to any allocated rect.
 ///
 /// Inspired by the [`tui-equalizer`](https://github.com/ratatui/tui-widgets/tree/main/tui-equalizer)
 /// reference widget, adapted for the Zeph teal design language.

--- a/crates/zeph-tui/src/widgets/wave.rs
+++ b/crates/zeph-tui/src/widgets/wave.rs
@@ -36,8 +36,8 @@ use crate::theme::{EffectiveColorMode, Theme};
 /// Each column's bar height is determined by [`sample`] (sine math per `WaveState`).
 /// Different states produce visually distinct patterns:
 /// Swell → slow tall columns; Streaming → medium ripple; Tool → choppy spikes;
-/// Parallel → complex superposed pattern. Color is a vertical gradient from dim
-/// accent at the base to full `#1FB9A8` at the peak (see [`bucket_to_rgb`]).
+/// Network → complex superposed pattern. Colour is a vertical gradient (see
+/// [`bucket_to_rgb`]): teal for foreground work, violet for `Network`.
 const WAVE_GLYPHS: [&str; 8] = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
 
 /// ASCII fallback for `TERM=dumb` terminals.
@@ -55,14 +55,20 @@ const ASCII_GLYPHS: [&str; 8] = [".", ".", "-", "-", "~", "~", "=", "="];
 ///
 /// # Variants
 ///
-/// | Variant | When shown |
-/// |---------|-----------|
-/// | `Idle` | Agent is not busy — flat `▁` baseline |
-/// | `Swell` | Busy, awaiting first token — high amplitude, slow roll |
-/// | `Streaming` | Token stream active — medium amplitude, medium ω |
-/// | `Tool` | Tool execution in progress — choppy short-λ wave |
-/// | `Parallel` | ≥2 background tasks inflight — superposed sines |
-/// | `Stalled` | No progress for >`stall_threshold` — flat + error tint |
+/// | Variant | When shown | Colour |
+/// |---------|-----------|--------|
+/// | `Idle` | Agent is not busy — flat `▁` baseline | teal |
+/// | `Swell` | Busy, awaiting first token — high amplitude, slow roll | teal |
+/// | `Streaming` | Token stream active — medium amplitude, medium ω | teal |
+/// | `Tool` | Tool execution in progress — choppy short-λ wave | teal |
+/// | `Network` | External/background requests inflight — superposed sines | violet |
+/// | `Stalled` | No progress for >`stall_threshold` — flat + error tint | red |
+///
+/// Foreground agent work (`Swell`/`Streaming`/`Tool`) renders in the teal accent;
+/// [`WaveState::Network`] — background/external requests run by the task supervisor
+/// (memory enrichment, telemetry, MCP, egress, background shell) — renders in a distinct
+/// **violet** gradient so concurrent background activity is visually separable from the
+/// agent's own turn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WaveState {
     /// Agent idle — renders a static thin baseline.
@@ -75,9 +81,11 @@ pub enum WaveState {
     Streaming,
     /// Tool execution in progress.
     Tool,
-    /// ≥2 background tasks inflight; `sines` is clamped to `2..=3`.
-    Parallel {
-        /// Number of superposed sine waves; clamped to `2..=3`.
+    /// External/background requests inflight (task-supervisor work: enrichment,
+    /// telemetry, MCP, egress, background shell). Rendered in violet to set it
+    /// apart from foreground agent work. `sines` is clamped to `1..=3`.
+    Network {
+        /// Number of superposed sine waves; clamped to `1..=3` by concurrency.
         sines: u8,
     },
     /// No progress for longer than the stall threshold.
@@ -100,7 +108,7 @@ struct WaveParams {
     omega: f32,
     /// Whether to superpose a secondary component for erratic spikes (Tool state).
     choppy: bool,
-    /// Number of superposed sines (only for `Parallel`).
+    /// Number of superposed sines (only for `Network`).
     sines: u8,
 }
 
@@ -136,12 +144,13 @@ impl WaveState {
                 choppy: true,
                 sines: 1,
             },
-            // Mixed pace: superposed sines create complex pattern.
-            WaveState::Parallel { sines } => WaveParams {
-                amplitude: 0.7,
-                omega: 0.85,
+            // Background/external requests: superposed sines create a complex pattern,
+            // distinct violet colour applied in `wave_color` / `bucket_to_rgb`.
+            WaveState::Network { sines } => WaveParams {
+                amplitude: 0.75,
+                omega: 0.95,
                 choppy: false,
-                sines: sines.clamp(2, 3),
+                sines: sines.clamp(1, 3),
             },
         }
     }
@@ -196,7 +205,7 @@ pub fn band_value(state: WaveState, band_idx: u32, t: u64) -> f32 {
         }
         v
     } else {
-        // Parallel: superpose sines at golden-ratio omega multiples.
+        // Network: superpose sines at golden-ratio omega multiples.
         let omegas: [f32; 3] = [1.0, 1.618_034, 2.414_214];
         let count = p.sines as usize;
         let mut sum = 0.0_f32;
@@ -488,8 +497,9 @@ fn ascii_density(bits: u8) -> char {
 ///
 /// `intensity` (`0.0..=1.0`) is the cell's distance from the centre axis: peaks
 /// (`1.0`) get the full accent, the quiet centre (`0.0`) stays dim. In Truecolor
-/// mode a smooth teal gradient is applied; ANSI modes fall back to the theme
-/// highlight (or error colour for `Stalled`).
+/// mode a smooth gradient is applied — teal for foreground agent work, **violet**
+/// for [`WaveState::Network`] (background/external requests), red for `Stalled`.
+/// ANSI modes fall back to theme colours (magenta for `Network`).
 fn wave_color(
     intensity: f32,
     state: WaveState,
@@ -504,6 +514,15 @@ fn wave_color(
                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                 return Color::Rgb((80.0 + v * 175.0) as u8, 10, 10);
             }
+            if matches!(state, WaveState::Network { .. }) {
+                // Violet gradient: #14102C (centre) → #8B5CF6 (peaks).
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                return Color::Rgb(
+                    (20.0 + v * 119.0) as u8, // 20 → 139
+                    (16.0 + v * 76.0) as u8,  // 16 → 92
+                    (44.0 + v * 202.0) as u8, // 44 → 246
+                );
+            }
             // Teal gradient: #0A191E (centre) → #1FB9A8 (peaks / accent).
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             Color::Rgb(
@@ -512,13 +531,11 @@ fn wave_color(
                 (30.0 + v * 138.0) as u8, // 30 → 168
             )
         }
-        EffectiveColorMode::Ansi256 | EffectiveColorMode::Ansi16 => {
-            if matches!(state, WaveState::Stalled) {
-                theme.error.fg.unwrap_or(Color::Red)
-            } else {
-                theme.highlight.fg.unwrap_or(Color::Yellow)
-            }
-        }
+        EffectiveColorMode::Ansi256 | EffectiveColorMode::Ansi16 => match state {
+            WaveState::Stalled => theme.error.fg.unwrap_or(Color::Red),
+            WaveState::Network { .. } => Color::Magenta,
+            _ => theme.highlight.fg.unwrap_or(Color::Yellow),
+        },
         EffectiveColorMode::Never => Color::Reset,
     }
 }
@@ -535,9 +552,19 @@ fn bucket_to_rgb(state: WaveState, bucket: usize) -> Color {
         let v = (80 + bucket * 22) as u8;
         return Color::Rgb(v, 15, 15);
     }
-    // Quadratic fade: 0 → dark (#0A191E), 7 → accent (#1FB9A8).
+    // Quadratic fade keeps low buckets dark so the peak stands out.
     #[allow(clippy::cast_precision_loss)]
     let t = (bucket as f32 / 7.0).powi(2);
+    if matches!(state, WaveState::Network { .. }) {
+        // Violet fade: 0 → dark (#14102C), 7 → #8B5CF6.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        return Color::Rgb(
+            (20.0_f32 + t * 119.0) as u8,
+            (16.0_f32 + t * 76.0) as u8,
+            (44.0_f32 + t * 202.0) as u8,
+        );
+    }
+    // Teal fade: 0 → dark (#0A191E), 7 → accent (#1FB9A8).
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let r = (10.0_f32 + t * 21.0) as u8; // 10..=31
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -565,8 +592,8 @@ mod tests {
                     WaveState::Swell,
                     WaveState::Streaming,
                     WaveState::Tool,
-                    WaveState::Parallel { sines: 2 },
-                    WaveState::Parallel { sines: 3 },
+                    WaveState::Network { sines: 2 },
+                    WaveState::Network { sines: 3 },
                     WaveState::Stalled,
                 ] {
                     let b = sample(state, x, t);
@@ -594,7 +621,7 @@ mod tests {
             WaveState::Swell,
             WaveState::Streaming,
             WaveState::Tool,
-            WaveState::Parallel { sines: 2 },
+            WaveState::Network { sines: 2 },
         ];
         for state in states {
             for x in [0u32, 7, 13, 40] {
@@ -882,5 +909,49 @@ mod tests {
         assert_eq!(ascii_density(0x0F), ':'); // 4 dots
         assert_eq!(ascii_density(0x3F), '+'); // 6 dots
         assert_eq!(ascii_density(0xFF), '#'); // 8 dots
+    }
+
+    /// Network peaks are violet (blue-dominant) while foreground work is teal
+    /// (green-dominant) — the two activity classes must be colour-separable.
+    #[test]
+    fn network_wave_color_is_violet_distinct_from_teal() {
+        let theme = Theme::default();
+        let net = wave_color(
+            1.0,
+            WaveState::Network { sines: 2 },
+            EffectiveColorMode::Truecolor,
+            &theme,
+        );
+        let teal = wave_color(
+            1.0,
+            WaveState::Streaming,
+            EffectiveColorMode::Truecolor,
+            &theme,
+        );
+        let Color::Rgb(nr, ng, nb) = net else {
+            panic!("expected Rgb for Network peak, got {net:?}");
+        };
+        let Color::Rgb(_tr, tg, tb) = teal else {
+            panic!("expected Rgb for Streaming peak, got {teal:?}");
+        };
+        assert!(
+            nb > ng && nb > nr,
+            "Network peak must be blue-dominant (violet); got r={nr} g={ng} b={nb}"
+        );
+        assert!(tg > tb, "Streaming (teal) peak must be green-dominant");
+        assert_ne!(net, teal, "Network and foreground colours must differ");
+    }
+
+    /// ANSI mode maps `Network` to magenta, distinct from the foreground highlight.
+    #[test]
+    fn network_wave_color_ansi_is_magenta() {
+        let theme = Theme::default();
+        let net = wave_color(
+            1.0,
+            WaveState::Network { sines: 1 },
+            EffectiveColorMode::Ansi16,
+            &theme,
+        );
+        assert_eq!(net, Color::Magenta);
     }
 }

--- a/crates/zeph-tui/src/widgets/wave.rs
+++ b/crates/zeph-tui/src/widgets/wave.rs
@@ -28,13 +28,18 @@ use crate::theme::{EffectiveColorMode, Theme};
 // Glyph ramps
 // ---------------------------------------------------------------------------
 
-/// Block-element gradient from thin (index 0) to full (index 7).
-/// `[&'static str; 8]` so `Span::styled(WAVE_GLYPHS[b], style)` borrows a `&'static str`
-/// — no per-glyph String allocation.
-const WAVE_GLYPHS: [&str; 8] = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+/// Thin horizontal-line ramp: dim dash → solid thin → solid thick at wave peak.
+///
+/// Each glyph sits in the *middle* of the cell so the wave appears as a single
+/// thin horizontal line whose brightness oscillates with the sine. Color (see
+/// [`bucket_to_rgb`]) fades from near-invisible at the trough to full accent
+/// `#1FB9A8` at the crest — replicating the CSS
+/// `background: linear-gradient(90deg, transparent, accent, transparent)` sweep
+/// from the design mock.
+const WAVE_GLYPHS: [&str; 8] = ["╌", "╌", "─", "─", "─", "━", "━", "━"];
 
-/// ASCII fallback ramp for `TERM=dumb` terminals.
-const ASCII_GLYPHS: [&str; 8] = [".", ".", "-", "-", "~", "~", "=", "="];
+/// ASCII fallback for `TERM=dumb` terminals.
+const ASCII_GLYPHS: [&str; 8] = [".", ".", "-", "-", "-", "=", "=", "="];
 
 // ---------------------------------------------------------------------------
 // WaveState
@@ -282,22 +287,27 @@ pub fn glyphs<'a>(
     buf.as_slice()
 }
 
-/// Map a bucket index `0..=7` to an RGB colour for the Truecolor gradient.
+/// Map a bucket index `0..=7` to an RGB colour for the Truecolor thin-line wave.
 ///
-/// Low buckets use a cool blue; high buckets shift to bright aqua/white.
+/// Trough (bucket 0) → near-invisible on dark bg. Crest (bucket 7) → full
+/// accent `#1FB9A8`, matching the CSS gradient in the design mock.
+/// Quadratic curve keeps low buckets dark so the peak stands out.
 fn bucket_to_rgb(state: WaveState, bucket: usize) -> Color {
     if matches!(state, WaveState::Stalled) {
-        // Error tint: dim red gradient.
+        // Error tint: low-to-mid red gradient along the flat line.
         #[allow(clippy::cast_possible_truncation)]
         let v = (80 + bucket * 22) as u8;
-        return Color::Rgb(v, 20, 20);
+        return Color::Rgb(v, 15, 15);
     }
-    // Aqua gradient: r stays low, g and b ramp up with height.
-    #[allow(clippy::cast_possible_truncation)]
-    let g = (80 + bucket * 22) as u8; // 80..=234
-    #[allow(clippy::cast_possible_truncation)]
-    let b = (120 + bucket * 17) as u8; // 120..=239
-    Color::Rgb(20, g, b)
+    // Quadratic fade: 0 → dark (#0A191E), 7 → accent (#1FB9A8).
+    let t = (bucket as f32 / 7.0).powi(2);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let r = (10.0_f32 + t * 21.0) as u8; // 10..=31
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let g = (25.0_f32 + t * 160.0) as u8; // 25..=185
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let b = (30.0_f32 + t * 138.0) as u8; // 30..=168
+    Color::Rgb(r, g, b)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/zeph-tui/src/widgets/wave.rs
+++ b/crates/zeph-tui/src/widgets/wave.rs
@@ -14,13 +14,13 @@
 //! - [`band_value`] — pure math: maps `(state, band, t)` to a normalised `[0.0, 1.0]` amplitude.
 //! - [`sample`] — maps `(state, x, t)` to a glyph bucket `0..=7` (delegates to [`band_value`]).
 //! - [`glyphs`] — single-row span builder used in compact-motion paths.
-//! - [`EqualizerWidget`] — full ratatui [`Widget`] for the side-panel slot; writes braille
-//!   characters directly into the [`Buffer`] with 4× sub-pixel resolution and a teal gradient.
+//! - [`EqualizerWidget`] — full ratatui [`Widget`] for the side-panel slot; draws a braille
+//!   waveform (mirrored about the centre axis) that jerks in time to a sharp beat envelope.
 
 use std::f32::consts::TAU;
 
 use ratatui::buffer::Buffer;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::Span;
 use ratatui::widgets::Widget;
@@ -212,7 +212,7 @@ pub fn band_value(state: WaveState, band_idx: u32, t: u64) -> f32 {
     };
 
     // Normalise to [0, 1] then square: bars mostly low, spiking sharply to peak.
-    let y_norm = (y.clamp(-p.amplitude, p.amplitude) / p.amplitude + 1.0) / 2.0;
+    let y_norm = f32::midpoint(y.clamp(-p.amplitude, p.amplitude) / p.amplitude, 1.0);
     y_norm.powi(2)
 }
 
@@ -307,18 +307,18 @@ pub fn glyphs<'a>(
     buf.as_slice()
 }
 
-/// VU-meter equalizer widget rendered in the dashboard side panel during active inference.
+/// Animated braille waveform rendered in the dashboard side panel during active inference.
 ///
-/// Each terminal column is one independent bar. Bars are rendered with braille characters
-/// (U+2800 range), giving 4× sub-pixel vertical resolution compared to half-block chars:
-/// each terminal row can represent 4 fill levels (`⣀` → `⣤` → `⣶` → `⣿`).
+/// Instead of discrete bars, the widget draws a single continuous waveform mirrored about
+/// the horizontal centre axis — like an audio waveform display. It is rendered with braille
+/// characters (U+2800 range), giving 2× horizontal and 4× vertical sub-pixel resolution.
 ///
-/// A teal gradient runs from near-black (`#0A191E`) at the bottom to the full Zeph accent
-/// colour (`#1FB9A8`) at the top. Band phases are distributed via the golden ratio so
-/// adjacent bars oscillate independently — the classic audio equalizer look.
+/// The outline is a travelling superposition of sines (so it ripples across the width),
+/// multiplied by a sharp beat envelope (instant attack, cubic decay) so the whole wave
+/// jerks up and down "in time to the music". A teal gradient brightens toward the wave
+/// peaks (`#1FB9A8`), staying dim near the quiet centre axis.
 ///
-/// Scales to any rect: `area.width` columns = that many bands; `area.height` rows ×4 =
-/// total sub-pixel resolution.
+/// `Idle` and `Stalled` collapse the wave to a flat centre line (`Stalled` tinted red).
 ///
 /// Inspired by the [`tui-equalizer`](https://github.com/ratatui/tui-widgets/tree/main/tui-equalizer)
 /// reference widget, adapted for the Zeph teal design language.
@@ -348,9 +348,24 @@ pub struct EqualizerWidget<'a> {
     pub theme: &'a Theme,
     /// Resolved terminal colour capability.
     pub color_mode: EffectiveColorMode,
-    /// When `true`, uses ASCII-safe `|` instead of `▄`.
+    /// When `true`, renders the wave with ASCII density characters instead of braille.
     pub ascii_only: bool,
 }
+
+/// Braille dot bit for each `(sub_col, sub_row)`, where `sub_row = 0` is the top.
+///
+/// Unicode braille (`U+2800` base) dot numbering:
+///
+/// ```text
+///   (1)(4)
+///   (2)(5)
+///   (3)(6)
+///   (7)(8)
+/// ```
+const BRAILLE_DOT: [[u8; 4]; 2] = [
+    [0x01, 0x02, 0x04, 0x40], // left column  → dots 1, 2, 3, 7
+    [0x08, 0x10, 0x20, 0x80], // right column → dots 4, 5, 6, 8
+];
 
 impl Widget for EqualizerWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
@@ -358,120 +373,138 @@ impl Widget for EqualizerWidget<'_> {
             return;
         }
 
-        let n_bands = area.width / BAND_W as u16;
-        if n_bands == 0 {
-            return;
-        }
-        let effective_w = n_bands * BAND_W as u16;
-        let eq_area = Rect {
-            width: effective_w,
-            ..area
-        };
+        let w = usize::from(area.width);
+        let sub_w = area.width * 2; // 2 braille dot columns per terminal cell
+        let sub_h = area.height * 4; // 4 braille dot rows per terminal cell
+        let center = f32::from(sub_h) / 2.0;
+        let max_half = (center - 1.0).max(0.0);
 
-        let band_areas =
-            Layout::horizontal(vec![Constraint::Length(BAND_W as u16); n_bands as usize])
-                .split(eq_area);
-
-        for (idx, &band_area) in band_areas.iter().enumerate() {
-            #[allow(clippy::cast_possible_truncation)]
-            let value = band_value(self.state, idx as u32, self.tick);
-            render_eq_band(
-                band_area,
-                value,
-                self.state,
-                self.color_mode,
-                self.theme,
-                self.ascii_only,
-                buf,
-            );
-        }
-    }
-}
-
-/// Render one equalizer band into the buffer using braille sub-pixel filling.
-///
-/// Each terminal row contains one braille character whose dots are filled from
-/// the bottom row up, giving 4× the vertical resolution of half-block characters:
-///
-/// | Dots lit (bottom → top) | Char |
-/// |-------------------------|------|
-/// | 1/4 (dots 7, 8)         | ⣀    |
-/// | 2/4 (+ dots 3, 6)       | ⣤    |
-/// | 3/4 (+ dots 2, 5)       | ⣶    |
-/// | 4/4 (+ dots 1, 4)       | ⣿    |
-fn render_eq_band(
-    area: Rect,
-    value: f32,
-    state: WaveState,
-    color_mode: EffectiveColorMode,
-    theme: &Theme,
-    ascii_only: bool,
-    buf: &mut Buffer,
-) {
-    // Total sub-pixels = terminal rows × 4 braille dot rows per character.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let total_sub = area.height as f32 * 4.0;
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let lit_sub = (value.clamp(0.0, 1.0) * total_sub).round() as u16;
-
-    for row_from_bottom in 0..area.height {
-        let y = area.bottom().saturating_sub(row_from_bottom + 1);
-        let sub_base = row_from_bottom * 4;
-        let lit_in_cell = lit_sub.saturating_sub(sub_base).min(4) as u8;
-
-        if lit_in_cell == 0 {
-            continue;
-        }
-
-        let color = eq_row_color(row_from_bottom, area.height, state, color_mode, theme);
-        let symbol = if ascii_only {
-            "|"
-        } else {
-            // Braille dot layout (Unicode):
-            //   row 1 top  → bits 0 (left), 3 (right) = 0x01 | 0x08 = 0x09
-            //   row 2      → bits 1, 4 = 0x12
-            //   row 3      → bits 2, 5 = 0x24
-            //   row 4 bot  → bits 6, 7 = 0xC0
-            // Fill bottom-up: 0xC0 → 0xC0|0x24 → 0xC0|0x24|0x12 → 0xFF
-            match lit_in_cell {
-                1 => "⣀", // U+28C0
-                2 => "⣤", // U+28E4
-                3 => "⣶", // U+28F6
-                _ => "⣿", // U+28FF
+        // Accumulate braille dot bits per terminal cell, then write once.
+        let mut cells = vec![0u8; w * usize::from(area.height)];
+        for sx in 0..sub_w {
+            let amp = wave_profile(self.state, sx, sub_w, self.tick);
+            let half = amp * max_half;
+            // `center ± half` is bounded to `[0, sub_h]`, which fits u16.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let top = (center - half).round().clamp(0.0, f32::from(sub_h - 1)) as u16;
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let bot = (center + half).round().clamp(0.0, f32::from(sub_h - 1)) as u16;
+            let col = usize::from(sx / 2);
+            let sub_col = usize::from(sx % 2);
+            for sy in top..=bot {
+                let row = usize::from(sy / 4);
+                let sub_row = usize::from(sy % 4);
+                cells[row * w + col] |= BRAILLE_DOT[sub_col][sub_row];
             }
-        };
+        }
 
-        for x in area.left()..area.right() {
-            buf[(x, y)].set_fg(color).set_symbol(symbol);
+        // Brightness rises toward the wave extremes (peaks = brightest accent).
+        let mid_row = (f32::from(area.height) - 1.0) / 2.0;
+        let mut utf8 = [0u8; 4];
+        for row in 0..area.height {
+            for col in 0..area.width {
+                let bits = cells[usize::from(row) * w + usize::from(col)];
+                if bits == 0 {
+                    continue;
+                }
+                let intensity = if mid_row <= 0.0 {
+                    1.0
+                } else {
+                    ((f32::from(row) - mid_row).abs() / mid_row).clamp(0.0, 1.0)
+                };
+                let color = wave_color(intensity, self.state, self.color_mode, self.theme);
+                let symbol = if self.ascii_only {
+                    ascii_density(bits)
+                } else {
+                    // 0x2800..=0x28FF are all valid braille code points.
+                    char::from_u32(0x2800 + u32::from(bits)).unwrap_or(' ')
+                };
+                buf[(area.left() + col, area.top() + row)]
+                    .set_fg(color)
+                    .set_symbol(symbol.encode_utf8(&mut utf8));
+            }
         }
     }
 }
 
-/// Compute the foreground colour for a single lit row of an equalizer band.
+/// Vertical half-amplitude (`0.0..=1.0` of the half-height) of the braille
+/// waveform at sub-column `sx` and tick `t`.
 ///
-/// `row_from_bottom = 0` is the lowest (darkest) lit row; increasing values move
-/// toward the top (brightest). In Truecolor mode a smooth teal gradient is applied;
-/// ANSI modes fall back to the theme highlight or error colour.
-fn eq_row_color(
-    row_from_bottom: u16,
-    total_height: u16,
+/// The outline is a travelling superposition of sines (so it ripples across the
+/// width), multiplied by a sharp beat envelope (instant attack, cubic decay,
+/// floored so it pulses without fully dying). `Idle` / `Stalled` return `0.0`,
+/// collapsing the wave to a flat centre line.
+fn wave_profile(state: WaveState, sx: u16, sub_w: u16, t: u64) -> f32 {
+    let p = state.params();
+    if p.amplitude < f32::EPSILON {
+        return 0.0;
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let tf = (t % 65536) as f32; // harmless wrap after ≈4.5 h
+    #[allow(clippy::cast_precision_loss)]
+    let u = if sub_w <= 1 {
+        0.0
+    } else {
+        f32::from(sx) / f32::from(sub_w - 1)
+    };
+
+    // Travelling waveform: superposed sines drifting across the width.
+    let mut s = (u * TAU * 1.5 + p.omega * tf).sin();
+    let mut denom = 1.0_f32;
+    s += 0.6 * (u * TAU * 3.0 - p.omega * 1.6 * tf).sin();
+    denom += 0.6;
+    if p.choppy {
+        s += 0.4 * (u * TAU * 5.0 + p.omega * 2.3 * tf).sin();
+        denom += 0.4;
+    }
+    if p.sines > 1 {
+        s += 0.5 * (u * TAU * 2.3 + p.omega * 1.27 * tf).sin();
+        denom += 0.5;
+    }
+    let shape = (s / denom).abs();
+
+    // Sharp beat envelope: instant attack, cubic decay, floored at 0.3.
+    let beat_phase = (p.omega * 0.18 * tf).fract();
+    let energy = 0.3 + 0.7 * (1.0 - beat_phase).powi(3);
+
+    (p.amplitude * energy * shape).clamp(0.0, 1.0)
+}
+
+/// ASCII density glyph for a braille cell, chosen by how many dots are lit.
+///
+/// Used when the terminal cannot render braille (`ascii_only`).
+fn ascii_density(bits: u8) -> char {
+    match bits.count_ones() {
+        0 => ' ',
+        1..=2 => '.',
+        3..=4 => ':',
+        5..=6 => '+',
+        _ => '#',
+    }
+}
+
+/// Foreground colour for a braille wave cell.
+///
+/// `intensity` (`0.0..=1.0`) is the cell's distance from the centre axis: peaks
+/// (`1.0`) get the full accent, the quiet centre (`0.0`) stays dim. In Truecolor
+/// mode a smooth teal gradient is applied; ANSI modes fall back to the theme
+/// highlight (or error colour for `Stalled`).
+fn wave_color(
+    intensity: f32,
     state: WaveState,
     color_mode: EffectiveColorMode,
     theme: &Theme,
 ) -> Color {
     match color_mode {
         EffectiveColorMode::Truecolor => {
-            let v = if total_height <= 1 {
-                1.0_f32
-            } else {
-                row_from_bottom as f32 / (total_height - 1) as f32
-            };
+            let v = intensity.clamp(0.0, 1.0);
             if matches!(state, WaveState::Stalled) {
-                // Error tint: dark red at bottom → bright red at top.
+                // Error tint: dark red at centre → bright red at the peaks.
                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                 return Color::Rgb((80.0 + v * 175.0) as u8, 10, 10);
             }
-            // Teal gradient: #0A191E (bottom) → #1FB9A8 (top / accent).
+            // Teal gradient: #0A191E (centre) → #1FB9A8 (peaks / accent).
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             Color::Rgb(
                 (10.0 + v * 21.0) as u8,  // 10 → 31
@@ -503,6 +536,7 @@ fn bucket_to_rgb(state: WaveState, bucket: usize) -> Color {
         return Color::Rgb(v, 15, 15);
     }
     // Quadratic fade: 0 → dark (#0A191E), 7 → accent (#1FB9A8).
+    #[allow(clippy::cast_precision_loss)]
     let t = (bucket as f32 / 7.0).powi(2);
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let r = (10.0_f32 + t * 21.0) as u8; // 10..=31
@@ -741,5 +775,112 @@ mod tests {
                 );
             }
         }
+    }
+
+    // --- EqualizerWidget (braille waveform) ---------------------------------
+
+    /// Count terminal rows that contain at least one non-blank cell.
+    fn non_blank_rows(buf: &Buffer, area: Rect) -> usize {
+        (0..area.height)
+            .filter(|&row| {
+                (0..area.width).any(|col| {
+                    let s = buf[(area.left() + col, area.top() + row)].symbol();
+                    !s.trim().is_empty()
+                })
+            })
+            .count()
+    }
+
+    /// Idle collapses the wave to a single flat centre line — exactly one row lit.
+    #[test]
+    fn wave_widget_idle_is_flat_line() {
+        let theme = Theme::default();
+        let area = Rect::new(0, 0, 12, 4);
+        let mut buf = Buffer::empty(area);
+        EqualizerWidget {
+            state: WaveState::Idle,
+            tick: 123,
+            theme: &theme,
+            color_mode: EffectiveColorMode::Truecolor,
+            ascii_only: false,
+        }
+        .render(area, &mut buf);
+        assert_eq!(
+            non_blank_rows(&buf, area),
+            1,
+            "Idle must render a single flat centre line"
+        );
+    }
+
+    /// A busy state spreads the wave across more than one terminal row for at
+    /// least one tick (mirrored amplitude above/below the centre axis).
+    #[test]
+    fn wave_widget_busy_spreads_vertically() {
+        let theme = Theme::default();
+        let area = Rect::new(0, 0, 16, 4);
+        let spread = (0u64..40).any(|tick| {
+            let mut buf = Buffer::empty(area);
+            EqualizerWidget {
+                state: WaveState::Streaming,
+                tick,
+                theme: &theme,
+                color_mode: EffectiveColorMode::Truecolor,
+                ascii_only: false,
+            }
+            .render(area, &mut buf);
+            non_blank_rows(&buf, area) > 1
+        });
+        assert!(spread, "busy wave must span >1 row for some tick");
+    }
+
+    /// Rendering into a degenerate 1×1 area must never panic.
+    #[test]
+    fn wave_widget_tiny_area_no_panic() {
+        let theme = Theme::default();
+        let area = Rect::new(0, 0, 1, 1);
+        let mut buf = Buffer::empty(area);
+        EqualizerWidget {
+            state: WaveState::Tool,
+            tick: 7,
+            theme: &theme,
+            color_mode: EffectiveColorMode::Truecolor,
+            ascii_only: false,
+        }
+        .render(area, &mut buf);
+    }
+
+    /// ASCII mode emits only density characters, never braille code points.
+    #[test]
+    fn wave_widget_ascii_has_no_braille() {
+        let theme = Theme::default();
+        let area = Rect::new(0, 0, 16, 4);
+        let mut buf = Buffer::empty(area);
+        EqualizerWidget {
+            state: WaveState::Swell,
+            tick: 11,
+            theme: &theme,
+            color_mode: EffectiveColorMode::Ansi256,
+            ascii_only: true,
+        }
+        .render(area, &mut buf);
+        for row in 0..area.height {
+            for col in 0..area.width {
+                let s = buf[(area.left() + col, area.top() + row)].symbol();
+                assert!(
+                    s.chars().all(|c| !('\u{2800}'..='\u{28FF}').contains(&c)),
+                    "ASCII mode must not emit braille: {s:?}"
+                );
+            }
+        }
+    }
+
+    /// `ascii_density` maps dot-count buckets to increasing ink density.
+    #[test]
+    fn ascii_density_buckets() {
+        assert_eq!(ascii_density(0x00), ' ');
+        assert_eq!(ascii_density(0x01), '.'); // 1 dot
+        assert_eq!(ascii_density(0x0F), ':'); // 4 dots
+        assert_eq!(ascii_density(0x3F), '+'); // 6 dots
+        assert_eq!(ascii_density(0xFF), '#'); // 8 dots
     }
 }


### PR DESCRIPTION
## Summary

- **Status bar** (§6 of design spec): mode chip with explicit fg/bg color swap (INSERT on accent, NORMAL on border), `·` separators in muted color, braille spinner cycle gated on `motion != Off`, fields reordered to chip · model · spinner+verb · skills N/M · tokens Nk · SEC N ⚑ · api N, uptime right-aligned. Removed `? for help`, `ch:channel`, `ctx:N%`.
- **Input prompt** (§5 of design spec): `›` replaced with `you ▸` in `theme.system_message` (muted). PROMPT_W updated from 2 → 6 columns.
- **Header glyph**: `⬡ ` tinted in `theme.user_message` (accent), separate from the bold brand name.
- **Splash comment**: documents the AQUA/ICE gradient color boundary vs palette accent.

## Changes

- `crates/zeph-tui/src/widgets/status.rs` — full redesign + new `motion_off_shows_static_busy_not_braille` test
- `crates/zeph-tui/src/widgets/input.rs` — PROMPT_GLYPH and PROMPT_W updated
- `crates/zeph-tui/src/app/draw.rs` — header glyph accent tint
- `crates/zeph-tui/src/widgets/splash.rs` — gradient boundary comment
- 5 insta snapshots updated

## Test plan

- [ ] `cargo nextest run -p zeph-tui --lib` — 802 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Run with `--tui` and verify status bar layout at narrow (80 col) and wide (120+ col) terminals
- [ ] Verify braille spinner animates in INSERT mode when busy
- [ ] Verify `motion=Off` shows static `·` instead of braille