### PR TITLE
build(db): upgrade sqlx 0.8.6 to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `build(db)`: upgrade `sqlx` 0.8.6 → 0.9.0. The `runtime-tokio-rustls` feature was split into
+  `runtime-tokio` + `tls-rustls` in `zeph-db`, `zeph-memory`, `zeph-index`, and `zeph-scheduler`.
+  The new `SqlSafeStr` bound on `query`/`query_as`/`query_scalar` requires runtime-built SQL
+  strings to be wrapped in `sqlx::AssertSqlSafe`; all 67 dynamic-SQL call sites (assembled only
+  from machine-generated placeholders, boolean-selected static clause fragments, and dialect
+  constants — never unvalidated input) were audited and wrapped. `zeph-db`'s `FullDriver` bound
+  updated for the now-lifetime-free `Database::Arguments` associated type
+  (`crates/zeph-db/src/bounds.rs`). `zeph-durable` gained `#![recursion_limit = "256"]`
+  (`crates/zeph-durable/src/lib.rs`) — sqlx 0.9's larger generated future types pushed the
+  generic `step` wrapper past the default depth limit, matching the existing precedent in
+  `zeph-core`/`zeph-acp`/`zeph-bench`/`zeph-scheduler`/`src/main.rs`.
+
 - `refactor(tests)`: migrate 772 `assert!(matches!(...))` calls to the stabilized
   `assert_matches!` macro (MSRV 1.96). The new macro prints the actual value on failure,
   making test output more informative. Added `#[derive(Debug)]` to 12 types that lacked it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
  "base64 0.21.7",
  "chacha20poly1305",
  "cookie-factory",
- "hkdf",
+ "hkdf 0.12.4",
  "io_tee",
  "nom 7.1.3",
  "rand 0.8.6",
@@ -615,7 +615,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -1946,7 +1946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2361,17 +2360,6 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "etcetera"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
@@ -2668,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3278,8 +3266,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3309,11 +3295,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3364,6 +3350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3507,7 +3502,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4156,9 +4151,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "libc"
@@ -4198,10 +4190,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.13.0",
  "libc",
- "plain",
- "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -4279,7 +4268,7 @@ dependencies = [
  "indexmap 2.14.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "nom 8.0.0",
  "rand 0.10.1",
  "rangemap",
@@ -4380,6 +4369,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4711,22 +4710,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -5177,7 +5160,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -5244,15 +5227,6 @@ dependencies = [
  "postscript",
  "type1-encoding-parser",
  "unicode-normalization",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -5475,17 +5449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5500,12 +5463,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -6390,15 +6347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6506,7 +6454,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -6632,26 +6580,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -7300,6 +7228,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7526,9 +7465,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -7539,12 +7478,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "crc",
  "crossbeam-queue",
  "either",
@@ -7553,12 +7493,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap 2.14.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
@@ -7570,14 +7509,14 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7588,15 +7527,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -7606,56 +7545,42 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.118",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "serde",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -7663,23 +7588,21 @@ dependencies = [
  "byteorder",
  "crc",
  "dotenvy",
- "etcetera 0.8.0",
+ "etcetera",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac 0.12.1",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7690,12 +7613,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -7705,7 +7629,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -8287,7 +8210,7 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera 0.11.0",
+ "etcetera",
  "ferroid",
  "futures",
  "http",
@@ -9151,7 +9074,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -9387,7 +9310,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -9535,12 +9458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9664,15 +9581,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
@@ -9772,13 +9680,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"
@@ -9943,15 +9847,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -9999,21 +9894,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -10066,12 +9946,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -10090,12 +9964,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -10111,12 +9979,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10150,12 +10012,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -10171,12 +10027,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10198,12 +10048,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -10219,12 +10063,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ serial_test = "3.5.0"
 sha2 = "0.11"
 shell-words = "1.1.1"
 similar = "3.1.1"
-sqlx = { version = "0.8.6", default-features = false }
+sqlx = { version = "0.9.0", default-features = false }
 subtle = "2.6"
 symphonia = { version = "0.6.0", default-features = false }
 sysinfo = { version = "0.39.5", default-features = false }

--- a/crates/zeph-db/Cargo.toml
+++ b/crates/zeph-db/Cargo.toml
@@ -25,7 +25,7 @@ test-utils = ["dep:testcontainers", "dep:testcontainers-modules", "postgres"]
 [dependencies]
 regex = { workspace = true }
 # "macros" required for sqlx::migrate! in driver implementations.
-sqlx = { workspace = true, features = ["macros", "migrate", "runtime-tokio-rustls"] }
+sqlx = { workspace = true, features = ["macros", "migrate", "runtime-tokio", "tls-rustls"] }
 testcontainers = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, features = ["postgres"], optional = true }
 thiserror.workspace = true

--- a/crates/zeph-db/src/bounds.rs
+++ b/crates/zeph-db/src/bounds.rs
@@ -6,14 +6,13 @@
 use crate::DatabaseDriver;
 
 /// Marker trait automatically implemented for all [`DatabaseDriver`] types
-/// whose `Database` supports standard Rust types in queries (sqlx 0.8 bounds).
+/// whose `Database` supports standard Rust types in queries (sqlx 0.9 bounds).
 ///
 /// This trait exists solely to reduce bound repetition on generic impl blocks.
 /// It is sealed: all impls are inside this crate.
 pub trait FullDriver: DatabaseDriver
 where
-    for<'q> <Self::Database as sqlx::Database>::Arguments<'q>:
-        sqlx::IntoArguments<'q, Self::Database>,
+    <Self::Database as sqlx::Database>::Arguments: sqlx::IntoArguments<Self::Database>,
     for<'c> &'c mut <Self::Database as sqlx::Database>::Connection:
         sqlx::Executor<'c, Database = Self::Database>,
     i64: for<'q> sqlx::Encode<'q, Self::Database> + sqlx::Type<Self::Database>,

--- a/crates/zeph-durable/src/lib.rs
+++ b/crates/zeph-durable/src/lib.rs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+// sqlx 0.9 increases the generated Future type depth in generic async step
+// wrappers (handle.rs) beyond the default limit of 128.
+#![recursion_limit = "256"]
+
 //! Native durable execution layer for Zeph.
 //!
 //! `zeph-durable` is a Layer-0 infrastructure crate — analogous to `zeph-db` and `zeph-common` —

--- a/crates/zeph-index/Cargo.toml
+++ b/crates/zeph-index/Cargo.toml
@@ -44,7 +44,7 @@ zeph-tools.workspace = true
 
 [dev-dependencies]
 serial_test.workspace = true
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "sqlite"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 zeph-llm = { workspace = true, features = ["testing"] }

--- a/crates/zeph-index/src/store.rs
+++ b/crates/zeph-index/src/store.rs
@@ -377,7 +377,7 @@ impl CodeStore {
             let sql = format!(
                 "SELECT content_hash FROM chunk_metadata WHERE content_hash IN ({placeholders})"
             );
-            let mut query = zeph_db::query_scalar::<_, String>(&sql);
+            let mut query = zeph_db::query_scalar::<_, String>(zeph_db::sqlx::AssertSqlSafe(sql));
             for hash in chunk {
                 query = query.bind(*hash);
             }

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -29,7 +29,7 @@ schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true
-sqlx = { workspace = true, features = ["macros", "runtime-tokio-rustls", "sqlite", "migrate"] } # TODO(#2385-phase3): audit and remove direct sqlx dep once #[derive(sqlx::Type)] is resolved
+sqlx = { workspace = true, features = ["macros", "runtime-tokio", "tls-rustls", "sqlite", "migrate"] } # TODO(#2385-phase3): audit and remove direct sqlx dep once #[derive(sqlx::Type)] is resolved
 thiserror.workspace = true
 tiktoken-rs.workspace = true
 tokio = { workspace = true, features = ["rt"] }

--- a/crates/zeph-memory/src/db_vector_store.rs
+++ b/crates/zeph-memory/src/db_vector_store.rs
@@ -83,7 +83,7 @@ impl VectorStore for DbVectorStore {
                 <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
                 <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
             );
-            zeph_db::query(&sql)
+            zeph_db::query(sqlx::AssertSqlSafe(sql))
                 .bind(&collection)
                 .execute(&self.pool)
                 .await

--- a/crates/zeph-memory/src/embedding_store.rs
+++ b/crates/zeph-memory/src/embedding_store.rs
@@ -680,7 +680,7 @@ impl EmbeddingStore {
              JOIN vector_points vp ON vp.id = em.qdrant_point_id \
              WHERE em.message_id IN ({placeholders}) AND em.chunk_index = 0"
         );
-        let mut q = zeph_db::query_as::<_, (MessageId, Vec<u8>)>(&query);
+        let mut q = zeph_db::query_as::<_, (MessageId, Vec<u8>)>(sqlx::AssertSqlSafe(query));
         for &id in ids {
             q = q.bind(id);
         }
@@ -733,7 +733,7 @@ impl EmbeddingStore {
              FROM embeddings_metadata \
              WHERE message_id IN ({placeholders}) AND chunk_index = 0"
         );
-        let mut q = zeph_db::query_as::<_, (MessageId, String)>(&query);
+        let mut q = zeph_db::query_as::<_, (MessageId, String)>(sqlx::AssertSqlSafe(query));
         for &id in ids {
             q = q.bind(id);
         }
@@ -796,7 +796,7 @@ impl EmbeddingStore {
         let query = format!(
             "SELECT qdrant_point_id FROM embeddings_metadata WHERE message_id IN ({placeholders})"
         );
-        let mut q = zeph_db::query_as::<_, (String,)>(&query);
+        let mut q = zeph_db::query_as::<_, (String,)>(sqlx::AssertSqlSafe(query));
         for &id in ids {
             q = q.bind(id);
         }

--- a/crates/zeph-memory/src/episodic_graph.rs
+++ b/crates/zeph-memory/src/episodic_graph.rs
@@ -338,7 +338,7 @@ pub async fn store_events(
              RETURNING id"
         );
         let sql = zeph_db::rewrite_placeholders(&raw);
-        let id = sqlx::query_scalar::<_, i64>(&sql)
+        let id = sqlx::query_scalar::<_, i64>(sqlx::AssertSqlSafe(sql))
             .bind(event.session_id.as_str())
             .bind(event.message_id.0)
             .bind(&event.event_type)
@@ -375,7 +375,7 @@ pub async fn store_links(store: &SqliteStore, links: &[CausalLink]) -> Result<()
              ON CONFLICT (cause_event_id, effect_event_id) DO NOTHING"
         );
         let sql = zeph_db::rewrite_placeholders(&raw);
-        sqlx::query(&sql)
+        sqlx::query(sqlx::AssertSqlSafe(sql))
             .bind(link.cause_event_id)
             .bind(link.effect_event_id)
             .bind(link.strength)
@@ -471,7 +471,7 @@ pub async fn recall_episodic_causal(
                    AND effect_event_id NOT IN ({visited_ph})"
             );
 
-            let mut q = sqlx::query_scalar::<_, i64>(&query);
+            let mut q = sqlx::query_scalar::<_, i64>(sqlx::AssertSqlSafe(query));
             for &id in &frontier {
                 q = q.bind(id);
             }
@@ -500,7 +500,9 @@ pub async fn recall_episodic_causal(
              ORDER BY created_at ASC"
         );
 
-        let mut q = sqlx::query_as::<_, (i64, String, i64, String, String, i64)>(&query);
+        let mut q = sqlx::query_as::<_, (i64, String, i64, String, String, i64)>(
+            sqlx::AssertSqlSafe(query),
+        );
         for &id in &visited {
             q = q.bind(id);
         }

--- a/crates/zeph-memory/src/five_signal/access_frequency.rs
+++ b/crates/zeph-memory/src/five_signal/access_frequency.rs
@@ -68,7 +68,7 @@ impl AccessFrequencyCache {
              GROUP BY fact_id"
         );
 
-        let mut q = sqlx::query(&sql).bind(session_id);
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(sql)).bind(session_id);
         for id in &ids {
             q = q.bind(id);
         }

--- a/crates/zeph-memory/src/graph/implicit_conflict.rs
+++ b/crates/zeph-memory/src/graph/implicit_conflict.rs
@@ -233,7 +233,7 @@ pub async fn annotate_conflicts(
                AND (edge_a_id IN ({placeholders}) OR edge_b_id IN ({placeholders}))",
         );
 
-        let mut q = sqlx::query(&query_str);
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(query_str));
         for id in chunk {
             q = q.bind(id);
         }

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -256,7 +256,7 @@ impl GraphStore {
              LIMIT ?",
             <ActiveDialect as zeph_db::dialect::Dialect>::COLLATE_NOCASE,
         );
-        let rows: Vec<EntityRow> = zeph_db::query_as(&search_sql)
+        let rows: Vec<EntityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(search_sql))
             .bind(&fts_query)
             .bind(format!(
                 "%{}%",
@@ -331,7 +331,7 @@ impl GraphStore {
             <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
             <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
         );
-        zeph_db::query(&insert_alias_sql)
+        zeph_db::query(sqlx::AssertSqlSafe(insert_alias_sql))
             .bind(entity_id)
             .bind(alias_name)
             .execute(&self.pool)
@@ -364,7 +364,7 @@ impl GraphStore {
              LIMIT 1",
             <ActiveDialect as zeph_db::dialect::Dialect>::COLLATE_NOCASE,
         );
-        let row: Option<EntityRow> = zeph_db::query_as(&alias_typed_sql)
+        let row: Option<EntityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(alias_typed_sql))
             .bind(alias_name)
             .bind(type_str)
             .fetch_optional(&self.pool)
@@ -709,7 +709,7 @@ impl GraphStore {
         };
 
         // Bind entity IDs twice (source IN and target IN clauses) then edge types.
-        let mut query = zeph_db::query_as::<_, EdgeRow>(&sql);
+        let mut query = zeph_db::query_as::<_, EdgeRow>(sqlx::AssertSqlSafe(sql));
         for id in entity_ids {
             query = query.bind(*id);
         }
@@ -754,7 +754,7 @@ impl GraphStore {
              WHERE valid_to IS NULL{origin_filter}
                AND (source_entity_id = ? OR target_entity_id = ?)"
         );
-        let rows: Vec<EdgeRow> = zeph_db::query_as::<_, EdgeRow>(&sql)
+        let rows: Vec<EdgeRow> = zeph_db::query_as::<_, EdgeRow>(sqlx::AssertSqlSafe(sql))
             .bind(entity_id)
             .bind(entity_id)
             .fetch_all(&self.pool)
@@ -1227,7 +1227,7 @@ impl GraphStore {
 
         let limit_i64 = i64::try_from(limit)?;
         let ranked_fts_sql = build_ranked_fts_sql();
-        let rows: Vec<EntityFtsRow> = zeph_db::query_as(&ranked_fts_sql)
+        let rows: Vec<EntityFtsRow> = zeph_db::query_as(sqlx::AssertSqlSafe(ranked_fts_sql))
             .bind(&fts_query)
             .bind(format!(
                 "%{}%",
@@ -1296,7 +1296,7 @@ impl GraphStore {
                  GROUP BY entity_id"
             );
 
-            let mut query = zeph_db::query_as::<_, (i64, i64, i64)>(&sql);
+            let mut query = zeph_db::query_as::<_, (i64, i64, i64)>(sqlx::AssertSqlSafe(sql));
             // Bind chunk three times (three IN clauses)
             for id in chunk {
                 query = query.bind(*id);
@@ -1361,7 +1361,7 @@ impl GraphStore {
             let placeholders = placeholder_list(1, chunk.len());
 
             let community_sql = community_ids_sql(&placeholders);
-            let mut query = zeph_db::query_as::<_, (i64, i64)>(&community_sql);
+            let mut query = zeph_db::query_as::<_, (i64, i64)>(sqlx::AssertSqlSafe(community_sql));
             for id in chunk {
                 query = query.bind(*id);
             }
@@ -1393,7 +1393,7 @@ impl GraphStore {
                      last_retrieved_at = {epoch_now} \
                  WHERE id IN ({edge_placeholders})"
             );
-            let mut q = zeph_db::query(&retrieval_sql);
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(retrieval_sql));
             for id in chunk {
                 q = q.bind(*id);
             }
@@ -1437,7 +1437,7 @@ impl GraphStore {
                  WHERE id IN ({edge_placeholders}) \
                    AND valid_to IS NULL"
             );
-            let mut q = zeph_db::query(&sql);
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(sql));
             q = q.bind(f64::from(delta));
             for id in chunk {
                 q = q.bind(*id);
@@ -1466,7 +1466,7 @@ impl GraphStore {
         for chunk in ids.chunks(MAX_BATCH) {
             let placeholders = zeph_db::placeholder_list(1, chunk.len());
             let sql = format!("SELECT id FROM graph_entities WHERE id IN ({placeholders})");
-            let mut q = zeph_db::query_as::<_, (i64,)>(&sql);
+            let mut q = zeph_db::query_as::<_, (i64,)>(sqlx::AssertSqlSafe(sql));
             for id in chunk {
                 q = q.bind(*id);
             }
@@ -1504,7 +1504,7 @@ impl GraphStore {
                  WHERE id IN ({placeholders}) \
                    AND qdrant_point_id IS NOT NULL"
             );
-            let mut q = zeph_db::query_as::<_, (i64, String)>(&sql);
+            let mut q = zeph_db::query_as::<_, (i64, String)>(sqlx::AssertSqlSafe(sql));
             for id in chunk {
                 q = q.bind(*id);
             }
@@ -1539,7 +1539,7 @@ impl GraphStore {
                AND (last_retrieved_at IS NULL OR last_retrieved_at < {epoch_now_decay} - ?)"
         );
         let decay_sql = zeph_db::rewrite_placeholders(&decay_raw);
-        let result = zeph_db::query(&decay_sql)
+        let result = zeph_db::query(sqlx::AssertSqlSafe(decay_sql))
             .bind(decay_lambda)
             .bind(i64::try_from(interval_secs).unwrap_or(i64::MAX))
             .execute(&self.pool)
@@ -1973,7 +1973,7 @@ impl GraphStore {
                  WHERE {edge_filter}
                    AND (source_entity_id IN ({ph2}) OR target_entity_id IN ({ph3}))"
             );
-            let mut q = zeph_db::query_scalar::<_, i64>(&neighbour_sql);
+            let mut q = zeph_db::query_scalar::<_, i64>(sqlx::AssertSqlSafe(neighbour_sql));
             for id in &frontier {
                 q = q.bind(*id);
             }
@@ -2064,7 +2064,7 @@ impl GraphStore {
                    AND (source_entity_id IN ({fp2}) OR target_entity_id IN ({fp3}))"
             );
 
-            let mut q = zeph_db::query_scalar::<_, i64>(&neighbour_sql);
+            let mut q = zeph_db::query_scalar::<_, i64>(sqlx::AssertSqlSafe(neighbour_sql));
             // Bind types first
             for t in &type_strs {
                 q = q.bind(*t);
@@ -2155,7 +2155,7 @@ impl GraphStore {
                AND source_entity_id IN ({ph_ids1})
                AND target_entity_id IN ({ph_ids2})"
         );
-        let mut edge_query = zeph_db::query_as::<_, EdgeRow>(&edge_sql);
+        let mut edge_query = zeph_db::query_as::<_, EdgeRow>(sqlx::AssertSqlSafe(edge_sql));
         for t in type_strs {
             edge_query = edge_query.bind(*t);
         }
@@ -2176,7 +2176,7 @@ impl GraphStore {
              FROM graph_entities WHERE id IN ({ph})",
             ph = placeholder_list(1, visited_ids.len()),
         );
-        let mut entity_query = zeph_db::query_as::<_, EntityRow>(&entity_sql2);
+        let mut entity_query = zeph_db::query_as::<_, EntityRow>(sqlx::AssertSqlSafe(entity_sql2));
         for id in &visited_ids {
             entity_query = entity_query.bind(*id);
         }
@@ -2235,7 +2235,7 @@ impl GraphStore {
                AND source_entity_id IN ({ph_ids1})
                AND target_entity_id IN ({ph_ids2})"
         );
-        let mut edge_query = zeph_db::query_as::<_, EdgeRow>(&edge_sql);
+        let mut edge_query = zeph_db::query_as::<_, EdgeRow>(sqlx::AssertSqlSafe(edge_sql));
         for id in &visited_ids {
             edge_query = edge_query.bind(*id);
         }
@@ -2252,7 +2252,7 @@ impl GraphStore {
              FROM graph_entities WHERE id IN ({ph})",
             ph = placeholder_list(1, n),
         );
-        let mut entity_query = zeph_db::query_as::<_, EntityRow>(&entity_sql);
+        let mut entity_query = zeph_db::query_as::<_, EntityRow>(sqlx::AssertSqlSafe(entity_sql));
         for id in &visited_ids {
             entity_query = entity_query.bind(*id);
         }
@@ -2291,7 +2291,7 @@ impl GraphStore {
              LIMIT 5",
             cn = <ActiveDialect as zeph_db::dialect::Dialect>::COLLATE_NOCASE,
         );
-        let rows: Vec<EntityRow> = zeph_db::query_as(&find_by_name_sql)
+        let rows: Vec<EntityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(find_by_name_sql))
             .bind(name)
             .bind(name)
             .fetch_all(&self.pool)
@@ -2368,7 +2368,7 @@ impl GraphStore {
             let placeholders = placeholder_list(1, chunk.len());
             let sql =
                 format!("UPDATE messages SET graph_processed = 1 WHERE id IN ({placeholders})");
-            let mut query = zeph_db::query(&sql);
+            let mut query = zeph_db::query(sqlx::AssertSqlSafe(sql));
             for id in chunk {
                 query = query.bind(id.0);
             }
@@ -3018,7 +3018,8 @@ impl GraphStore {
             "SELECT id, episode_id FROM graph_edges \
              WHERE id IN ({placeholders}) AND episode_id IS NOT NULL"
         );
-        let mut q = zeph_db::query_as::<_, (i64, crate::types::MessageId)>(&sql);
+        let mut q =
+            zeph_db::query_as::<_, (i64, crate::types::MessageId)>(sqlx::AssertSqlSafe(sql));
         for &eid in edge_ids {
             q = q.bind(eid);
         }
@@ -3087,7 +3088,7 @@ impl GraphStore {
              LIMIT 200"
         );
 
-        let mut q = zeph_db::query_as::<_, EdgeRow>(&sql);
+        let mut q = zeph_db::query_as::<_, EdgeRow>(sqlx::AssertSqlSafe(sql));
         for t in &type_strs {
             q = q.bind(*t);
         }
@@ -3108,7 +3109,7 @@ impl GraphStore {
             let ph2 = placeholder_list(1, chunk.len());
             let name_sql =
                 format!("SELECT id, canonical_name FROM graph_entities WHERE id IN ({ph2})");
-            let mut nq = zeph_db::query_as::<_, (i64, String)>(&name_sql);
+            let mut nq = zeph_db::query_as::<_, (i64, String)>(sqlx::AssertSqlSafe(name_sql));
             for &id in chunk {
                 nq = nq.bind(id);
             }

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -3366,7 +3366,7 @@ async fn decay_edge_retrieval_counts_respects_interval() {
          VALUES (?, ?, 'knows', 'A knows B', 0.9, CURRENT_TIMESTAMP, 5, {epoch_now})"
     );
     let insert_sql = zeph_db::rewrite_placeholders(&insert_raw);
-    sqlx::query(&insert_sql)
+    sqlx::query(sqlx::AssertSqlSafe(insert_sql))
         .bind(a)
         .bind(b)
         .execute(store.pool())

--- a/crates/zeph-memory/src/reasoning.rs
+++ b/crates/zeph-memory/src/reasoning.rs
@@ -224,7 +224,7 @@ impl ReasoningMemory {
                embedded_at = EXCLUDED.embedded_at"
         );
         let sql = zeph_db::rewrite_placeholders(&raw);
-        zeph_db::query(&sql)
+        zeph_db::query(sqlx::AssertSqlSafe(sql))
             .bind(&strategy.id)
             .bind(&strategy.summary)
             .bind(strategy.outcome.as_str())
@@ -255,7 +255,7 @@ impl ReasoningMemory {
                 let update_sql = zeph_db::rewrite_placeholders(&format!(
                     "UPDATE reasoning_strategies SET embedded_at = {epoch_now} WHERE id = ?"
                 ));
-                if let Err(e) = zeph_db::query(&update_sql)
+                if let Err(e) = zeph_db::query(sqlx::AssertSqlSafe(update_sql))
                     .bind(&strategy.id)
                     .execute(&self.pool)
                     .await
@@ -331,7 +331,7 @@ impl ReasoningMemory {
                  SET use_count = use_count + 1, last_used_at = {epoch_now} \
                  WHERE id IN ({ph})"
             );
-            let mut q = zeph_db::query(&sql);
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(sql));
             for id in chunk {
                 q = q.bind(id.as_str());
             }
@@ -433,7 +433,7 @@ impl ReasoningMemory {
             let mut q = zeph_db::query_as::<
                 _,
                 (String, String, String, String, i64, i64, i64, Option<i64>),
-            >(&sql);
+            >(sqlx::AssertSqlSafe(sql));
             for id in chunk {
                 q = q.bind(id.as_str());
             }
@@ -481,7 +481,10 @@ impl ReasoningMemory {
              )"
         );
         let sql = zeph_db::rewrite_placeholders(&raw);
-        let result = zeph_db::query(&sql).bind(limit).execute(&self.pool).await?;
+        let result = zeph_db::query(sqlx::AssertSqlSafe(sql))
+            .bind(limit)
+            .execute(&self.pool)
+            .await?;
         Ok(usize::try_from(result.rows_affected()).unwrap_or(0))
     }
 
@@ -496,7 +499,10 @@ impl ReasoningMemory {
                      ORDER BY last_used_at ASC LIMIT ? \
                    )";
         let sql = zeph_db::rewrite_placeholders(raw);
-        let result = zeph_db::query(&sql).bind(limit).execute(&self.pool).await?;
+        let result = zeph_db::query(sqlx::AssertSqlSafe(sql))
+            .bind(limit)
+            .execute(&self.pool)
+            .await?;
         Ok(usize::try_from(result.rows_affected()).unwrap_or(0))
     }
 }

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -1121,7 +1121,7 @@ impl SemanticMemory {
             let sql = format!(
                 "SELECT id, created_at FROM messages WHERE id IN ({placeholders}) AND deleted_at IS NULL"
             );
-            let mut q = sqlx::query(&sql);
+            let mut q = sqlx::query(sqlx::AssertSqlSafe(sql));
             for id in &id_vals {
                 q = q.bind(id);
             }

--- a/crates/zeph-memory/src/snapshot.rs
+++ b/crates/zeph-memory/src/snapshot.rs
@@ -110,10 +110,11 @@ pub async fn export_snapshot(sqlite: &SqliteStore) -> Result<MemorySnapshot, Mem
             "SELECT id, role, content, parts, {epoch_expr} \
             FROM messages WHERE conversation_id = ? ORDER BY id ASC"
         ));
-        let msg_rows: Vec<(i64, String, String, String, i64)> = zeph_db::query_as(&msg_sql)
-            .bind(cid)
-            .fetch_all(sqlite.pool())
-            .await?;
+        let msg_rows: Vec<(i64, String, String, String, i64)> =
+            zeph_db::query_as(sqlx::AssertSqlSafe(msg_sql))
+                .bind(cid)
+                .fetch_all(sqlite.pool())
+                .await?;
 
         let messages = msg_rows
             .into_iter()
@@ -209,7 +210,7 @@ pub async fn import_snapshot(
                 <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
                 <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
             );
-            let result = zeph_db::query(&msg_sql)
+            let result = zeph_db::query(sqlx::AssertSqlSafe(msg_sql))
                 .bind(msg.id)
                 .bind(msg.conversation_id)
                 .bind(&msg.role)
@@ -231,7 +232,7 @@ pub async fn import_snapshot(
                 <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
                 <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
             );
-            let result = zeph_db::query(&sum_sql)
+            let result = zeph_db::query(sqlx::AssertSqlSafe(sum_sql))
                 .bind(sum.id)
                 .bind(sum.conversation_id)
                 .bind(&sum.content)

--- a/crates/zeph-memory/src/store/acp_sessions.rs
+++ b/crates/zeph-memory/src/store/acp_sessions.rs
@@ -34,7 +34,7 @@ impl SqliteStore {
             <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
             <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
         );
-        zeph_db::query(&sql)
+        zeph_db::query(sqlx::AssertSqlSafe(sql))
             .bind(session_id)
             .execute(&self.pool)
             .await?;
@@ -273,7 +273,7 @@ impl SqliteStore {
             <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
             <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
         );
-        zeph_db::query(&sql)
+        zeph_db::query(sqlx::AssertSqlSafe(sql))
             .bind(session_id)
             .bind(conversation_id)
             .execute(&self.pool)

--- a/crates/zeph-memory/src/store/admission_training.rs
+++ b/crates/zeph-memory/src/store/admission_training.rs
@@ -120,7 +120,7 @@ impl SqliteStore {
              SET was_recalled = 1, updated_at = datetime('now') \
              WHERE message_id IN ({placeholders})"
         );
-        let mut q = zeph_db::query(&query);
+        let mut q = zeph_db::query(sqlx::AssertSqlSafe(query));
         for id in message_ids {
             q = q.bind(id.0);
         }

--- a/crates/zeph-memory/src/store/compression_guidelines.rs
+++ b/crates/zeph-memory/src/store/compression_guidelines.rs
@@ -381,7 +381,7 @@ impl SqliteStore {
         let query = format!(
             "UPDATE compression_failure_pairs SET used_in_update = 1 WHERE id IN ({placeholders})"
         );
-        let mut q = zeph_db::query(&query);
+        let mut q = zeph_db::query(sqlx::AssertSqlSafe(query));
         for id in ids {
             q = q.bind(id);
         }

--- a/crates/zeph-memory/src/store/mem_scenes.rs
+++ b/crates/zeph-memory/src/store/mem_scenes.rs
@@ -80,7 +80,7 @@ impl SqliteStore {
             <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
         );
         for &msg_id in member_ids {
-            zeph_db::query(&member_sql)
+            zeph_db::query(sqlx::AssertSqlSafe(member_sql.as_str()))
                 .bind(scene_id)
                 .bind(msg_id.0)
                 .execute(&mut *tx)

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -422,7 +422,7 @@ impl SqliteStore {
             let sql = format!(
                 "UPDATE messages SET fidelity_tag = CASE id {case_arms} END WHERE id IN ({in_list})"
             );
-            let mut q = zeph_db::query(&sql);
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(sql));
             for &(id, tag) in chunk {
                 q = q.bind(id.0).bind(i32::from(tag));
             }
@@ -641,7 +641,8 @@ impl SqliteStore {
             "SELECT id, role, content, parts FROM messages \
              WHERE id IN ({placeholders}) AND visibility != 'user_only' AND deleted_at IS NULL"
         );
-        let mut q = zeph_db::query_as::<_, (MessageId, String, String, String)>(&query);
+        let mut q =
+            zeph_db::query_as::<_, (MessageId, String, String, String)>(sqlx::AssertSqlSafe(query));
         for &id in ids {
             q = q.bind(id);
         }
@@ -882,7 +883,8 @@ impl SqliteStore {
              LIMIT ?"
         );
 
-        let mut q = zeph_db::query_as::<_, (MessageId, f64)>(&sql).bind(&safe_query);
+        let mut q =
+            zeph_db::query_as::<_, (MessageId, f64)>(sqlx::AssertSqlSafe(sql)).bind(&safe_query);
         if let Some(a) = after {
             q = q.bind(a);
         }
@@ -919,7 +921,7 @@ impl SqliteStore {
         let query = format!(
             "SELECT id, {epoch_expr} FROM messages WHERE id IN ({placeholders}) AND deleted_at IS NULL"
         );
-        let mut q = zeph_db::query_as::<_, (MessageId, i64)>(&query);
+        let mut q = zeph_db::query_as::<_, (MessageId, i64)>(sqlx::AssertSqlSafe(query));
         for &id in ids {
             q = q.bind(id);
         }
@@ -1065,7 +1067,7 @@ impl SqliteStore {
                              AND m.id <= s.last_message_id \
                         )"
             );
-            let mut q = zeph_db::query_as::<_, (MessageId,)>(&sql);
+            let mut q = zeph_db::query_as::<_, (MessageId,)>(sqlx::AssertSqlSafe(sql));
             for &id in chunk {
                 q = q.bind(id);
             }
@@ -1111,7 +1113,7 @@ impl SqliteStore {
         let query = format!(
             "SELECT id, importance_score FROM messages WHERE id IN ({placeholders}) AND deleted_at IS NULL"
         );
-        let mut q = zeph_db::query_as::<_, (MessageId, f64)>(&query);
+        let mut q = zeph_db::query_as::<_, (MessageId, f64)>(sqlx::AssertSqlSafe(query));
         for &id in ids {
             q = q.bind(id);
         }
@@ -1135,7 +1137,7 @@ impl SqliteStore {
             "UPDATE messages SET access_count = access_count + 1, last_accessed = CURRENT_TIMESTAMP \
              WHERE id IN ({placeholders})"
         );
-        let mut q = zeph_db::query(&query);
+        let mut q = zeph_db::query(sqlx::AssertSqlSafe(query));
         for &id in ids {
             q = q.bind(id);
         }
@@ -1165,7 +1167,7 @@ impl SqliteStore {
         let query = format!(
             "SELECT id, access_count FROM messages WHERE id IN ({placeholders}) AND deleted_at IS NULL"
         );
-        let mut q = zeph_db::query_as::<_, (MessageId, i64)>(&query);
+        let mut q = zeph_db::query_as::<_, (MessageId, i64)>(sqlx::AssertSqlSafe(query));
         for &id in ids {
             q = q.bind(id);
         }
@@ -1296,7 +1298,7 @@ impl SqliteStore {
              RETURNING id"
         );
         let promote_insert_sql = zeph_db::rewrite_placeholders(&promote_insert_raw);
-        let row: (MessageId,) = zeph_db::query_as(&promote_insert_sql)
+        let row: (MessageId,) = zeph_db::query_as(sqlx::AssertSqlSafe(promote_insert_sql))
             .bind(conversation_id)
             .bind(merged_content)
             .fetch_one(&mut *tx)
@@ -1341,7 +1343,7 @@ impl SqliteStore {
         let manual_promote_sql = zeph_db::rewrite_placeholders(&manual_promote_raw);
         let mut count = 0usize;
         for &id in ids {
-            let result = zeph_db::query(&manual_promote_sql)
+            let result = zeph_db::query(sqlx::AssertSqlSafe(manual_promote_sql.as_str()))
                 .bind(id)
                 .execute(&self.pool)
                 .await?;
@@ -1391,7 +1393,7 @@ impl SqliteStore {
         let query = format!(
             "SELECT id, tier FROM messages WHERE id IN ({placeholders}) AND deleted_at IS NULL"
         );
-        let mut q = zeph_db::query_as::<_, (MessageId, String)>(&query);
+        let mut q = zeph_db::query_as::<_, (MessageId, String)>(sqlx::AssertSqlSafe(query));
         for &id in ids {
             q = q.bind(id);
         }
@@ -1524,7 +1526,7 @@ impl SqliteStore {
             <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
         );
         for &source_id in source_ids {
-            zeph_db::query(&consol_sql)
+            zeph_db::query(sqlx::AssertSqlSafe(consol_sql.as_str()))
                 .bind(consolidated_id)
                 .bind(source_id)
                 .execute(&mut *tx)
@@ -1582,7 +1584,7 @@ impl SqliteStore {
             <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
         );
         for &source_id in additional_source_ids {
-            zeph_db::query(&consol_sql)
+            zeph_db::query(sqlx::AssertSqlSafe(consol_sql.as_str()))
                 .bind(target_id)
                 .bind(source_id)
                 .execute(&mut *tx)
@@ -1717,7 +1719,7 @@ impl SqliteStore {
                 "UPDATE messages SET importance_score = importance_score * (1.0 - {decay}) \
                  WHERE id IN ({placeholders})"
             );
-            let mut q = zeph_db::query(&downscale_sql);
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(downscale_sql));
             for &(id,) in &candidate_ids {
                 q = q.bind(id);
             }
@@ -1745,7 +1747,7 @@ impl SqliteStore {
                      OR access_count >= ?\
                  )"
             );
-            let mut rq = zeph_db::query(&replay_sql);
+            let mut rq = zeph_db::query(sqlx::AssertSqlSafe(replay_sql));
             for &(id,) in &candidate_ids {
                 rq = rq.bind(id);
             }
@@ -1773,7 +1775,7 @@ impl SqliteStore {
              ) \
              AND access_count < ?"
         );
-        let prune_result = zeph_db::query(&prune_sql)
+        let prune_result = zeph_db::query(sqlx::AssertSqlSafe(prune_sql))
             .bind(protect_hours)
             .bind(protect_min_access)
             .execute(&mut *tx)

--- a/crates/zeph-scheduler/Cargo.toml
+++ b/crates/zeph-scheduler/Cargo.toml
@@ -41,7 +41,7 @@ zeph-durable.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [dev-dependencies]
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "sqlite"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wiremock.workspace = true

--- a/specs/031-database-abstraction/spec.md
+++ b/specs/031-database-abstraction/spec.md
@@ -1094,7 +1094,7 @@ postgres = ["sqlx/postgres"]
 [dependencies]
 # NOTE: "macros" deliberately excluded — zeph-db uses query() not query!().
 # This saves ~5-15s on cold builds by avoiding sqlx-macros proc-macro compilation.
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "migrate"] }
 regex = { workspace = true }  # for redact_url()
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt"] }
@@ -1108,7 +1108,7 @@ Each crate that currently depends on `sqlx` directly changes to depend on `zeph-
 ```toml
 # crates/zeph-memory/Cargo.toml
 [dependencies]
-# REMOVE: sqlx = { workspace = true, features = ["macros", "runtime-tokio-rustls", "sqlite", "migrate"] }
+# REMOVE: sqlx = { workspace = true, features = ["macros", "runtime-tokio", "tls-rustls", "sqlite", "migrate"] }
 # ADD:
 zeph-db.workspace = true
 ```


### PR DESCRIPTION
## Summary

- Upgrades `sqlx` 0.8.6 -> 0.9.0 across the workspace, adapting to the major release's breaking changes.
- Splits the deprecated `runtime-tokio-rustls` feature into `runtime-tokio` + `tls-rustls` in `zeph-db`, `zeph-memory`, `zeph-index`, and `zeph-scheduler` (identical rustls/webpki backend, verified at the feature-graph level).
- Wraps all 67 dynamic-SQL call sites in `zeph-memory`/`zeph-index` with `sqlx::AssertSqlSafe` to satisfy the new `SqlSafeStr` bound on `query`/`query_as`/`query_scalar`. Every site was individually audited: SQL text is built only from machine-generated placeholders, boolean-selected static clause fragments, and dialect constants -- runtime values always go through `.bind()`, never interpolated into SQL text. `sql!()`-macro-based static query sites (~120, already `&'static str`) and `migrate.rs` (no affected Migrator APIs in use) needed no changes.
- Fixes `zeph-db`'s `FullDriver` bound for sqlx 0.9's lifetime-free `Database::Arguments`/`IntoArguments`.
- Adds `recursion_limit = 256` to `zeph-durable`, matching existing precedent in `zeph-core`/`zeph-acp`/`zeph-bench`/`zeph-scheduler`/`src/main.rs` (sqlx 0.9's larger generated future types pushed the generic `step` wrapper past the compiler's default depth limit).

## Process

Run through the `refactoring` chain of `/rust-agents:team-develop`: architect produced a plan that was initially **rejected by the critic** for finding only 8 of the 65 planned `AssertSqlSafe` sites (missed the `zeph_db::query*` re-export form); the revised plan (65 sites, full injection audit) was approved on re-review. The developer's implementation found 2 further sites only the compiler caught (67 total) plus unplanned fallout (`FullDriver` bound, `zeph-durable` recursion limit), all flagged transparently rather than silently folded in. Both the tester and impl-critic independently re-verified the diff; the reviewer gave a final `approved` with no changes requested.

## Known non-blocking follow-ups (not introduced by this PR)

- The 67 `AssertSqlSafe`-wrapped dynamic-SQL sites are runtime-exercised by the test suite only against SQLite; there is no Postgres-runtime coverage for `zeph-memory`/`zeph-index`'s dynamic query paths anywhere in the workspace (pre-existing gap, worth a follow-up issue).
- The developer's handoff cites `nfr_de_07_append_throughput_ge_1000_per_sec` (zeph-durable) as a pre-existing failure; the tester could not reproduce this on either branch in this environment. Noting for the record rather than treating it as settled.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` -- 11526 passed, 0 failed, 23 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` -- 33/33 ok
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo check -p {zeph-db,zeph-memory,zeph-index,zeph-scheduler} --features postgres`
- [x] `cargo deny check advisories` -- 2 pre-existing unmaintained-crate findings, unrelated to sqlx
- [x] Docker-gated Postgres integration tests (`crates/zeph-db/tests/postgres_integration.rs`) -- 4/4 passed
- [x] `.local/testing/playbooks/sqlx-0-9-upgrade.md` added; `.local/testing/coverage-status.md` rows updated in place