### PR TITLE
feat(acp): add model_config temperature option and cancel_request bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   rejecting an unknown tool name to verify the client -> server leg), plus a
   `tools/list_changed` notification asserting `ToolListChangedHandler::on_tool_list_changed`
   emits a `ToolRefreshEvent`. See `crates/zeph-mcp/src/client.rs`.
+- `feat(acp)`: adopt the `model_config` `session/set_config_option` category (schema 1.1.0) for
+  per-session sampling-temperature control, independent of the `model` selector. New
+  `config_id="temperature"` option (presets `precise` 0.2 / `balanced` 0.7 / `creative` 1.0,
+  applied via `zeph_llm::GenerationOverrides`); new `[acp.model_config]` config section
+  (`default_temperature_preset`); new `zeph acp model-config show` CLI subcommand; new `--init`
+  wizard prompt. `default_temperature_preset` is now primed into the session's effective
+  provider at session creation (`do_new_session`/`do_load_session`/`do_fork_session`/
+  `do_resume_session`), not just advertised in the IDE dropdown, so the configured default is
+  effective from the very first prompt without an explicit `session/set_config_option` call.
+  Closes #5361.
+- `feat(acp)`: wire the real ACP `$/cancel_request` protocol notification onto the existing
+  `cancel_signal: Arc<Notify>`. New `unstable-cancel-request` Cargo feature on `zeph-acp` (not in
+  `default`) mapping to `agent-client-protocol/unstable_cancel_request`; `session/prompt` now
+  bridges `Responder::cancellation()`, scoped to that specific JSON-RPC request, onto the same
+  signal `session/cancel` already notifies. The bridge's watcher select is `biased` with prompt
+  completion checked first, and `drain_agent_events` drains a stale `cancel_signal` permit before
+  its main loop, so a cancellation resolving at/after prompt completion can no longer leak into
+  the next, unrelated prompt on the same session (also hardens the equivalent pre-existing
+  `session/cancel` race when no prompt is in flight). Closes #5362.
+- `test(acp)`: add live JSON-RPC round-trip coverage for the 8 previously-untested
+  `zeph-acp` handler files (`authenticate`, `close_session`, `delete_session`, `fork_session`,
+  `logout`, `resume_session`, `set_session_config_option`, `set_session_mode`), plus coverage for
+  the new `model_config`/temperature option and the `$/cancel_request` bridge, plus regression
+  tests for the two fixes above. Note: `resume_session` coverage exercises only the in-memory
+  early-return path; the store-backed reconstruction path remains untested (tracked in #5374).
+  Closes #5367.
 
 ### Changed
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -989,6 +989,12 @@ max_workspace_symbols = 50
 # Timeout in seconds for LSP extension method calls
 request_timeout_secs = 10
 
+[acp.model_config]
+# Default sampling-temperature preset advertised to IDE clients via the model_config
+# session/set_config_option category (config_id = "temperature"): "precise" (0.2),
+# "balanced" (0.7), or "creative" (1.0)
+default_temperature_preset = "balanced"
+
 [acp.subagents]
 # Enable ACP sub-agent delegation (allows `zeph acp run-agent` to spawn child ACP agents)
 enabled = false

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -40,6 +40,9 @@ unstable-llm-providers = ["dep:agent-client-protocol-schema", "agent-client-prot
 unstable-logout = []
 unstable-auth-methods = ["agent-client-protocol/unstable_auth_methods"]
 unstable-boolean-config = ["agent-client-protocol/unstable_boolean_config"]
+# Wires the real $/cancel_request protocol notification (agent-client-protocol crate level,
+# available since SDK 0.15.1) onto the existing internal cancel_signal. Not in `default` — see #5362.
+unstable-cancel-request = ["agent-client-protocol/unstable_cancel_request"]
 # message-id stabilized in acp 0.14.0; no upstream feature gate needed
 unstable-message-id = []
 # session-add-dirs stabilized in acp 0.14.0; no upstream feature gate needed
@@ -87,6 +90,7 @@ axum = { workspace = true, features = ["ws"] }
 tempfile.workspace = true
 tokio-tungstenite = { workspace = true, features = ["connect"] }
 tower = { workspace = true, features = ["util"] }
+zeph-llm = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/zeph-acp/src/agent/handlers/cancel_request.rs
+++ b/crates/zeph-acp/src/agent/handlers/cancel_request.rs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Low-level observability handler for the real ACP `$/cancel_request` protocol notification.
+//!
+//! `$/cancel_request` carries only a JSON-RPC `request_id`, not a `session_id`, so it cannot be
+//! mapped to a `SessionEntry::cancel_signal` here. The SDK already updates per-request
+//! cancellation markers automatically once `unstable_cancel_request` is enabled — registering a
+//! handler does not replace that built-in behavior, it only adds visibility. The functional
+//! bridge onto `cancel_signal` lives in `handlers/prompt.rs`, scoped to the `session/prompt`
+//! request via `Responder::cancellation()`, which already knows the originating session.
+
+use std::sync::Arc;
+
+use agent_client_protocol as acp;
+
+use crate::agent::ZephAcpAgentState;
+
+/// Observe an incoming `$/cancel_request` notification for tracing purposes.
+pub(crate) async fn handle_cancel_request(
+    notif: acp::schema::v1::CancelRequestNotification,
+    _cx: acp::ConnectionTo<acp::Client>,
+    _state: Arc<ZephAcpAgentState>,
+) -> acp::Result<()> {
+    tracing::debug!(request_id = ?notif.request_id, "received $/cancel_request");
+    Ok(())
+}

--- a/crates/zeph-acp/src/agent/handlers/mod.rs
+++ b/crates/zeph-acp/src/agent/handlers/mod.rs
@@ -3,6 +3,8 @@
 
 pub(crate) mod authenticate;
 pub(crate) mod cancel;
+#[cfg(feature = "unstable-cancel-request")]
+pub(crate) mod cancel_request;
 pub(crate) mod close_session;
 pub(crate) mod delete_session;
 pub(crate) mod dispatch;

--- a/crates/zeph-acp/src/agent/handlers/prompt.rs
+++ b/crates/zeph-acp/src/agent/handlers/prompt.rs
@@ -10,12 +10,64 @@ use agent_client_protocol as acp;
 use crate::agent::ZephAcpAgentState;
 
 /// Handle an ACP `prompt` request.
+///
+/// When the `unstable-cancel-request` feature is enabled, this bridges the real ACP
+/// `$/cancel_request` protocol notification (scoped to this specific JSON-RPC request via
+/// [`acp::Responder::cancellation`]) onto the session's existing `cancel_signal: Arc<Notify>` —
+/// the same signal `session/cancel` notifies. A short-lived watcher task races the cancellation
+/// marker against prompt completion so it never outlives this request.
 pub(crate) async fn handle_prompt(
     req: acp::schema::v1::PromptRequest,
     responder: acp::Responder<acp::schema::v1::PromptResponse>,
-    _cx: acp::ConnectionTo<acp::Client>,
+    #[cfg_attr(not(feature = "unstable-cancel-request"), allow(unused_variables))]
+    cx: acp::ConnectionTo<acp::Client>,
     state: Arc<ZephAcpAgentState>,
 ) -> acp::Result<()> {
+    #[cfg(feature = "unstable-cancel-request")]
+    let cancel_request_bridge = spawn_cancel_request_bridge(&req, &responder, &cx, &state);
+
     let resp = state.do_prompt(req).await?;
+
+    #[cfg(feature = "unstable-cancel-request")]
+    drop(cancel_request_bridge);
+
     responder.respond(resp)
+}
+
+/// Spawn a watcher that notifies `entry.cancel_signal` if the IDE sends `$/cancel_request` for
+/// this `session/prompt` request before it completes.
+///
+/// Returns a guard whose [`Drop`] unblocks the watcher once the prompt finishes normally, so the
+/// watcher task never lives beyond this single request even when cancellation never fires.
+#[cfg(feature = "unstable-cancel-request")]
+fn spawn_cancel_request_bridge(
+    req: &acp::schema::v1::PromptRequest,
+    responder: &acp::Responder<acp::schema::v1::PromptResponse>,
+    cx: &acp::ConnectionTo<acp::Client>,
+    state: &Arc<ZephAcpAgentState>,
+) -> tokio::sync::oneshot::Sender<()> {
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+    if let Some(cancel_signal) = state.session_cancel_signal(&req.session_id) {
+        let cancellation = responder.cancellation();
+        // Infallible by construction: never returns Err, so a misbehaving watcher can never
+        // bring down the whole connection (per `ConnectionTo::spawn` contract).
+        let spawn_result = cx.spawn(async move {
+            tokio::select! {
+                // `done_rx` is checked first so prompt completion deterministically wins once
+                // it's ready, even if `cancellation` also becomes ready in the same poll (e.g.
+                // a `$/cancel_request` arriving right as the prompt finishes) — otherwise an
+                // unbiased pick could call `notify_one()` after this watcher's job is already
+                // done, leaking a stale permit onto the session's shared `cancel_signal` that
+                // would silently cancel the *next*, unrelated prompt.
+                biased;
+                _ = done_rx => {}
+                () = cancellation.cancelled() => cancel_signal.notify_one(),
+            }
+            Ok(())
+        });
+        if let Err(e) = spawn_result {
+            tracing::debug!(error = %e, "failed to spawn $/cancel_request watcher for prompt");
+        }
+    }
+    done_tx
 }

--- a/crates/zeph-acp/src/agent/helpers.rs
+++ b/crates/zeph-acp/src/agent/helpers.rs
@@ -5,6 +5,7 @@
 use acp::schema::v1::*;
 use agent_client_protocol as acp;
 use zeph_common::text::xml_escape;
+use zeph_config::AcpTemperaturePreset;
 
 use zeph_core::LoopbackEvent;
 
@@ -173,15 +174,19 @@ pub(super) fn build_mode_state(current_mode_id: &SessionModeId) -> SessionModeSt
     SessionModeState::new(current_mode_id.clone(), available_session_modes())
 }
 
-/// Build all session config options: model selector, thinking toggle, and auto-approve level.
+/// Build all session config options: model selector, model parameters, thinking toggle, and
+/// auto-approve level.
 ///
 /// `current_model` is the currently selected model key; empty string means use the first.
-/// `thinking_enabled` and `auto_approve` reflect the current per-session values.
+/// `thinking_enabled`, `auto_approve`, and `temperature_preset` reflect the current per-session
+/// values. The `temperature` option (category `model_config`) is only advertised alongside the
+/// `model` selector since both require the provider factory / `available_models` machinery.
 pub(super) fn build_config_options(
     available_models: &[String],
     current_model: &str,
     thinking_enabled: bool,
     auto_approve: &str,
+    temperature_preset: AcpTemperaturePreset,
 ) -> Vec<SessionConfigOption> {
     let mut opts = Vec::new();
 
@@ -198,6 +203,19 @@ pub(super) fn build_config_options(
         opts.push(
             SessionConfigOption::select("model", "Model", current_value, model_options)
                 .category(SessionConfigOptionCategory::Model),
+        );
+        opts.push(
+            SessionConfigOption::select(
+                "temperature",
+                "Temperature",
+                temperature_preset.as_str().to_owned(),
+                vec![
+                    SessionConfigSelectOption::new("precise".to_owned(), "Precise".to_owned()),
+                    SessionConfigSelectOption::new("balanced".to_owned(), "Balanced".to_owned()),
+                    SessionConfigSelectOption::new("creative".to_owned(), "Creative".to_owned()),
+                ],
+            )
+            .category(SessionConfigOptionCategory::ModelConfig),
         );
     }
 

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use parking_lot::{Mutex, RwLock};
 
 use agent_client_protocol as acp;
-use futures::StreamExt as _;
+use futures::{FutureExt as _, StreamExt as _};
 use tokio::sync::{mpsc, oneshot};
 #[cfg(feature = "unstable-elicitation")]
 use tokio::task::JoinHandle;
@@ -34,7 +34,7 @@ use zeph_core::{
     StopHint,
 };
 use zeph_llm::any::AnyProvider;
-use zeph_llm::provider::LlmProvider as _;
+use zeph_llm::provider::{GenerationOverrides, LlmProvider as _};
 use zeph_mcp::McpManager;
 use zeph_mcp::manager::ServerEntry;
 use zeph_memory::ConversationId;
@@ -401,6 +401,9 @@ pub(crate) struct SessionEntry {
     thinking_enabled: AtomicBool,
     /// Auto-approve level for this session ("suggest" | "auto-edit" | "full-auto").
     auto_approve_level: Mutex<String>,
+    /// Sampling-temperature preset for this session, advertised under the `model_config`
+    /// `session/set_config_option` category (`config_id = "temperature"`).
+    temperature_preset: Mutex<zeph_config::AcpTemperaturePreset>,
     /// Shell executor for this session, retained so the event loop can release terminals
     /// after `tool_call_update` notifications are sent (ACP requires the terminal to
     /// remain alive until after the notification that embeds it).
@@ -497,6 +500,8 @@ pub struct ZephAcpAgentState {
     auth_methods_config: Vec<zeph_core::config::AcpAuthMethod>,
     /// Timeout configuration for ACP operations (terminal, elicitation, MCP bridge).
     pub(crate) timeouts: zeph_config::AcpTimeoutsConfig,
+    /// Model-related configuration parameters (from `[acp.model_config]`).
+    pub(crate) model_config: zeph_config::AcpModelConfigConfig,
     /// Injection-detection-only sanitizer for advisory scanning of inbound ACP prompts.
     ///
     /// Spotlight wrapping is explicitly disabled: operator-typed prompts must not be
@@ -557,6 +562,7 @@ impl ZephAcpAgentState {
             additional_directories_allow: Vec::new(),
             auth_methods_config: vec![zeph_core::config::AcpAuthMethod::Agent],
             timeouts: zeph_config::AcpTimeoutsConfig::default(),
+            model_config: zeph_config::AcpModelConfigConfig::default(),
             prompt_injection_detector: ContentSanitizer::new(&ContentIsolationConfig {
                 spotlight_untrusted: false,
                 ..ContentIsolationConfig::default()
@@ -596,6 +602,13 @@ impl ZephAcpAgentState {
     #[must_use]
     pub fn with_timeouts(mut self, timeouts: zeph_config::AcpTimeoutsConfig) -> Self {
         self.timeouts = timeouts;
+        self
+    }
+
+    /// Configure model-related configuration parameters (`[acp.model_config]`).
+    #[must_use]
+    pub fn with_model_config(mut self, model_config: zeph_config::AcpModelConfigConfig) -> Self {
+        self.model_config = model_config;
         self
     }
 
@@ -641,6 +654,21 @@ impl ZephAcpAgentState {
             .into_iter()
             .next()
             .unwrap_or_default()
+    }
+
+    /// Returns the `cancel_signal` for `session_id`, if the session is currently in memory.
+    ///
+    /// Used to bridge the real ACP `$/cancel_request` protocol notification onto the same
+    /// internal signal `session/cancel` already notifies (see `handlers/prompt.rs`).
+    #[cfg(feature = "unstable-cancel-request")]
+    pub(crate) fn session_cancel_signal(
+        &self,
+        session_id: &acp::schema::v1::SessionId,
+    ) -> Option<Arc<tokio::sync::Notify>> {
+        self.sessions
+            .lock()
+            .get(session_id)
+            .map(|entry| Arc::clone(&entry.cancel_signal))
     }
 
     #[must_use]
@@ -1248,8 +1276,13 @@ impl ZephAcpAgentState {
         initial_model: &str,
     ) -> acp::schema::v1::NewSessionResponse {
         let available_models = self.available_models_snapshot();
-        let config_options =
-            build_config_options(&available_models, initial_model, false, "suggest");
+        let config_options = build_config_options(
+            &available_models,
+            initial_model,
+            false,
+            "suggest",
+            self.model_config.default_temperature_preset,
+        );
         let default_mode_id = acp::schema::v1::SessionModeId::new(DEFAULT_MODE_ID);
         let mut resp = acp::schema::v1::NewSessionResponse::new(session_id)
             .modes(build_mode_state(&default_mode_id));
@@ -1320,6 +1353,7 @@ impl ZephAcpAgentState {
             .await;
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
+        self.prime_provider_override(&provider_override, &initial_model);
         #[cfg_attr(not(feature = "unstable-elicitation"), allow(unused_mut))]
         let mut entry = Self::make_session_entry(
             handle,
@@ -1327,6 +1361,7 @@ impl ZephAcpAgentState {
             session_cwd.clone(),
             shell_executor,
             provider_override,
+            self.model_config.default_temperature_preset,
         );
         #[cfg(feature = "unstable-elicitation")]
         {
@@ -1611,12 +1646,14 @@ impl ZephAcpAgentState {
             .await;
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
+        self.prime_provider_override(&provider_override, &initial_model);
         let entry = Self::make_session_entry(
             handle,
             initial_model,
             session_cwd.clone(),
             shell_executor,
             provider_override,
+            self.model_config.default_temperature_preset,
         );
 
         Self::spawn_notify_drainer(&entry, cx)?;
@@ -1779,12 +1816,14 @@ impl ZephAcpAgentState {
             .await;
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
+        self.prime_provider_override(&provider_override, &initial_model);
         let entry = Self::make_session_entry(
             handle,
             initial_model.clone(),
             args.cwd.clone(),
             shell_executor,
             provider_override,
+            self.model_config.default_temperature_preset,
         );
 
         Self::spawn_notify_drainer(&entry, cx)?;
@@ -1807,8 +1846,13 @@ impl ZephAcpAgentState {
         );
 
         let available_models = self.available_models_snapshot();
-        let config_options =
-            build_config_options(&available_models, &initial_model, false, "suggest");
+        let config_options = build_config_options(
+            &available_models,
+            &initial_model,
+            false,
+            "suggest",
+            self.model_config.default_temperature_preset,
+        );
         let default_mode_id = acp::schema::v1::SessionModeId::new(DEFAULT_MODE_ID);
         let mut resp = acp::schema::v1::ForkSessionResponse::new(new_id)
             .modes(build_mode_state(&default_mode_id));
@@ -1887,12 +1931,14 @@ impl ZephAcpAgentState {
             .await;
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
+        self.prime_provider_override(&provider_override, &initial_model);
         let entry = Self::make_session_entry(
             handle,
             initial_model,
             args.cwd.clone(),
             shell_executor,
             provider_override,
+            self.model_config.default_temperature_preset,
         );
 
         Self::spawn_notify_drainer(&entry, cx)?;
@@ -1936,7 +1982,7 @@ impl ZephAcpAgentState {
         };
         let value: &str = &value_str;
 
-        let (current_model, thinking, auto_approve) = {
+        let (current_model, thinking, auto_approve, temperature_preset) = {
             let sessions = self.sessions.lock();
             let entry = sessions
                 .get(&args.session_id)
@@ -1948,6 +1994,7 @@ impl ZephAcpAgentState {
                 entry.current_model.lock().clone(),
                 entry.thinking_enabled.load(Ordering::Relaxed),
                 entry.auto_approve_level.lock().clone(),
+                *entry.temperature_preset.lock(),
             )
         };
 
@@ -1956,6 +2003,7 @@ impl ZephAcpAgentState {
             &current_model,
             thinking,
             &auto_approve,
+            temperature_preset,
         );
 
         let changed_option = config_options.iter().find(|o| o.id.0 == config_id).cloned();
@@ -2066,19 +2114,36 @@ impl ZephAcpAgentState {
     ) -> acp::Result<()> {
         match config_id {
             "model" => {
-                let Some(ref factory) = self.provider_factory else {
-                    return Err(acp::Error::internal_error().data("model switching not configured"));
-                };
                 let available_models = self.available_models_snapshot();
                 if !available_models.iter().any(|m| m == value) {
                     return Err(acp::Error::invalid_request().data("model not in allowed list"));
                 }
-                let Some(new_provider) = factory(value) else {
-                    return Err(acp::Error::invalid_request().data("unknown model"));
-                };
+                let temperature_preset = *entry.temperature_preset.lock();
+                let new_provider = self.provider_with_temperature(value, temperature_preset)?;
                 *entry.provider_override.write() = Some(new_provider);
                 value.clone_into(&mut *entry.current_model.lock());
                 tracing::debug!(session_id = %session_id, model = %value, "ACP model switched");
+            }
+            "temperature" => {
+                let preset: zeph_config::AcpTemperaturePreset = value.parse().map_err(|()| {
+                    acp::Error::invalid_request()
+                        .data("temperature must be precise, balanced, or creative")
+                })?;
+                let model_key = {
+                    let current = entry.current_model.lock().clone();
+                    if current.is_empty() {
+                        self.initial_model()
+                    } else {
+                        current
+                    }
+                };
+                if model_key.is_empty() {
+                    return Err(acp::Error::internal_error().data("model switching not configured"));
+                }
+                let new_provider = self.provider_with_temperature(&model_key, preset)?;
+                *entry.provider_override.write() = Some(new_provider);
+                *entry.temperature_preset.lock() = preset;
+                tracing::debug!(session_id = %session_id, temperature = %preset.as_str(), "ACP temperature preset changed");
             }
             "thinking" => {
                 let enabled = match value {
@@ -2106,6 +2171,49 @@ impl ZephAcpAgentState {
             }
         }
         Ok(())
+    }
+
+    /// Build a provider for `model_key` with `preset`'s sampling temperature applied.
+    ///
+    /// Shared by the `model` and `temperature` `model_config` config options so switching
+    /// either one preserves the other's current setting.
+    fn provider_with_temperature(
+        &self,
+        model_key: &str,
+        preset: zeph_config::AcpTemperaturePreset,
+    ) -> acp::Result<AnyProvider> {
+        let Some(ref factory) = self.provider_factory else {
+            return Err(acp::Error::internal_error().data("model switching not configured"));
+        };
+        let Some(provider) = factory(model_key) else {
+            return Err(acp::Error::invalid_request().data("unknown model"));
+        };
+        Ok(provider.with_generation_overrides(GenerationOverrides {
+            temperature: Some(preset.temperature()),
+            ..Default::default()
+        }))
+    }
+
+    /// Prime a freshly created session's `provider_override` with the configured default
+    /// `[acp.model_config].default_temperature_preset`, so that preset is the *effective*
+    /// sampling temperature from the session's very first prompt — not just the value
+    /// advertised in the IDE dropdown until an explicit `session/set_config_option` call.
+    ///
+    /// No-op (leaves `provider_override` as `None`, falling back to the spawner's own
+    /// provider) when model switching isn't configured (`provider_factory` unset) or
+    /// `initial_model` doesn't resolve to a known provider — mirrors
+    /// `provider_with_temperature`'s error cases, which are expected outside model-switching
+    /// setups.
+    fn prime_provider_override(
+        &self,
+        provider_override: &Arc<RwLock<Option<AnyProvider>>>,
+        initial_model: &str,
+    ) {
+        if let Ok(provider) = self
+            .provider_with_temperature(initial_model, self.model_config.default_temperature_preset)
+        {
+            *provider_override.write() = Some(provider);
+        }
     }
 
     /// Dispatch a slash command, returning a short-circuit `PromptResponse`.
@@ -2437,6 +2545,15 @@ impl ZephAcpAgentState {
         // Per-turn token totals for PromptResponse.usage (separate from session accumulator).
         #[cfg(feature = "unstable-session-usage")]
         let mut turn_usage = TurnUsage::default();
+        if let Some(ref signal) = cancel_signal {
+            // Drain a stale permit left on the shared per-session `Notify` by a cancellation
+            // that resolved after the *previous* prompt on this session had already finished
+            // (`do_cancel`'s `notify_one()`, or the `$/cancel_request` bridge in
+            // `handlers/prompt.rs`) — without this, that leftover permit would be consumed by
+            // this prompt's very first `signal.notified()` check below and silently cancel an
+            // unrelated, brand-new prompt.
+            signal.notified().now_or_never();
+        }
         loop {
             let event = if let Some(ref signal) = cancel_signal {
                 tokio::select! {
@@ -2702,6 +2819,7 @@ impl ZephAcpAgentState {
         cwd: PathBuf,
         shell_executor: Option<AcpShellExecutor>,
         provider_override: Arc<RwLock<Option<AnyProvider>>>,
+        temperature_preset: zeph_config::AcpTemperaturePreset,
     ) -> SessionEntry {
         // Bounded: prevents a misbehaving IDE from buffering notifications without limit.
         // 256 slots cover any realistic burst between drainer loop iterations.
@@ -2729,6 +2847,7 @@ impl ZephAcpAgentState {
             title: Mutex::new(None),
             thinking_enabled: AtomicBool::new(false),
             auto_approve_level: Mutex::new("suggest".to_owned()),
+            temperature_preset: Mutex::new(temperature_preset),
             shell_executor,
             #[cfg(feature = "unstable-elicitation")]
             elicitation_bridge_handle: None,
@@ -3088,6 +3207,11 @@ pub async fn run_agent(
         req_handler!(state, logout::handle_logout),
         acp::on_receive_request!(),
     );
+    #[cfg(feature = "unstable-cancel-request")]
+    let builder = builder.on_receive_notification(
+        notif_handler!(state, handlers::cancel_request::handle_cancel_request),
+        acp::on_receive_notification!(),
+    );
 
     builder
         .on_receive_dispatch(
@@ -3151,6 +3275,7 @@ mod notify_timeout_tests {
             std::path::PathBuf::from("."),
             None,
             provider_override,
+            zeph_config::AcpTemperaturePreset::default(),
         );
         // Insert without starting the drainer — no ack will ever be sent.
         agent.sessions.lock().insert(session_id.clone(), entry);

--- a/crates/zeph-acp/src/transport/mod.rs
+++ b/crates/zeph-acp/src/transport/mod.rs
@@ -128,6 +128,8 @@ pub struct AcpServerConfig {
     pub message_ids_enabled: bool,
     /// Per-request timeout configuration for elicitation, terminal, and MCP operations.
     pub timeouts: zeph_config::AcpTimeoutsConfig,
+    /// Model-related configuration parameters (`[acp.model_config]`).
+    pub model_config: zeph_config::AcpModelConfigConfig,
 }
 
 impl Clone for AcpServerConfig {
@@ -153,6 +155,7 @@ impl Clone for AcpServerConfig {
             auth_methods: self.auth_methods.clone(),
             message_ids_enabled: self.message_ids_enabled,
             timeouts: self.timeouts.clone(),
+            model_config: self.model_config.clone(),
         }
     }
 }
@@ -180,6 +183,7 @@ impl Default for AcpServerConfig {
             auth_methods: vec![zeph_core::config::AcpAuthMethod::Agent],
             message_ids_enabled: true,
             timeouts: zeph_config::AcpTimeoutsConfig::default(),
+            model_config: zeph_config::AcpModelConfigConfig::default(),
         }
     }
 }

--- a/crates/zeph-acp/src/transport/stdio.rs
+++ b/crates/zeph-acp/src/transport/stdio.rs
@@ -107,6 +107,7 @@ pub(crate) async fn build_agent_state(
         agent = agent.with_auth_methods(server_config.auth_methods);
     }
     agent = agent.with_timeouts(server_config.timeouts);
+    agent = agent.with_model_config(server_config.model_config);
 
     let state = Arc::new(agent);
     state.start_idle_reaper();

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -36,6 +36,20 @@ fn echo_spawner() -> AgentSpawner {
     })
 }
 
+/// Like `echo_spawner`, but loops to handle multiple sequential `session/prompt` turns on the
+/// same session instead of returning (and dropping the channel) after the first one.
+fn multi_turn_echo_spawner() -> AgentSpawner {
+    Arc::new(|mut channel, _ctx, _session| {
+        Box::pin(async move {
+            while let Ok(Some(_)) = channel.recv().await {
+                if channel.flush_chunks().await.is_err() {
+                    break;
+                }
+            }
+        })
+    })
+}
+
 /// Spawner that sends N text chunks then flushes.
 fn text_chunks_spawner(chunks: Vec<&'static str>) -> AgentSpawner {
     Arc::new(move |mut channel, _ctx, _session| {
@@ -56,6 +70,27 @@ fn test_config(name: &str) -> AcpServerConfig {
         agent_name: name.to_owned(),
         agent_version: "0.0.1".to_owned(),
         max_sessions: 8,
+        ..AcpServerConfig::default()
+    }
+}
+
+/// Server config with a provider factory and `available_models`, required for `model` /
+/// `temperature` `session/set_config_option` coverage. Every model key resolves to a fresh
+/// `MockProvider`.
+fn test_config_with_models(name: &str, models: Vec<&str>) -> AcpServerConfig {
+    let factory: zeph_acp::ProviderFactory = Arc::new(|_key: &str| {
+        Some(zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default(),
+        ))
+    });
+    AcpServerConfig {
+        agent_name: name.to_owned(),
+        agent_version: "0.0.1".to_owned(),
+        max_sessions: 8,
+        provider_factory: Some(factory),
+        available_models: Arc::new(parking_lot::RwLock::new(
+            models.into_iter().map(str::to_owned).collect(),
+        )),
         ..AcpServerConfig::default()
     }
 }
@@ -84,6 +119,16 @@ fn duplex_pair() -> (
 /// Creates a temporary working directory for tests that need a real filesystem path.
 fn temp_workdir() -> TempDir {
     tempfile::tempdir().expect("failed to create temp dir")
+}
+
+/// Extracts the current selected value from a `model` / `temperature` (`Select`-kind)
+/// `SessionConfigOption`. Panics if the option is not a `Select`.
+fn select_current_value(option: &acp::schema::v1::SessionConfigOption) -> &str {
+    match &option.kind {
+        acp::schema::v1::SessionConfigKind::Select(select) => select.current_value.0.as_ref(),
+        #[allow(unreachable_patterns)]
+        other => panic!("expected a Select config option, got {other:?}"),
+    }
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -416,23 +461,25 @@ async fn drain_until_stop_collects_text_chunks() {
 /// AC #10: `session/cancel` prior to prompt causes the prompt to complete with
 /// `StopReason::Cancelled`.
 ///
-/// `do_cancel` stores its signal via `cancel_signal.notify_one()`. The `drain_agent_events`
-/// biased select checks `signal.notified()` before reading events, so a cancel sent
-/// immediately before (or during) the prompt causes `cancelled = true` and the
-/// `PromptResponse` carries `StopReason::Cancelled`.
+/// `do_cancel` stores its signal via `cancel_signal.notify_one()`. `drain_agent_events` now
+/// drains any stale permit on this shared per-session `Notify` *before* its main loop starts
+/// (hardening against the same leftover-permit race fixed for the `$/cancel_request` bridge —
+/// see `late_cancel_after_prompt_completion_does_not_affect_next_prompt`), so a cancel that
+/// arrives while no prompt is in flight on this session is a no-op rather than retroactively
+/// cancelling whichever prompt happens to be sent next. `session/cancel` has no request id to
+/// scope it to a specific turn, so there is no well-defined "current turn" for it to cancel
+/// when none is running.
 ///
-/// This test sends `CancelNotification` before `PromptRequest` so that the signal
-/// is already armed when the server's drain loop starts. The biased select inside
-/// `drain_agent_events` picks it up on the first poll.
+/// This test sends `CancelNotification` before any `PromptRequest` on a brand-new session and
+/// asserts the upcoming prompt completes normally — i.e. the early cancel notification is
+/// dropped, not retroactively applied.
 #[tokio::test(flavor = "current_thread")]
-async fn cancel_before_prompt_returns_cancelled() {
+async fn cancel_before_prompt_is_a_no_op() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            // echo_spawner reads the message and flushes, but drain exits immediately because
-            // cancel_signal is already notified (biased select fires the cancel arm first).
             let server_fut = serve_connection(echo_spawner(), test_config("test-agent"), sw, sr);
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
@@ -447,7 +494,7 @@ async fn cancel_before_prompt_returns_cancelled() {
                     .await?
                     .session_id;
 
-                // Send cancel BEFORE the prompt so the signal is armed when drain starts.
+                // Cancel notification arrives with no prompt in flight on this session.
                 cx.send_notification(acp::schema::v1::CancelNotification::new(session_id.clone()))?;
 
                 let content = vec![acp::schema::v1::ContentBlock::Text(
@@ -460,8 +507,9 @@ async fn cancel_before_prompt_returns_cancelled() {
 
                 assert_eq!(
                     resp.stop_reason,
-                    acp::schema::v1::StopReason::Cancelled,
-                    "expected Cancelled when cancel is sent before prompt, got {:?}",
+                    acp::schema::v1::StopReason::EndTurn,
+                    "a cancel notification sent before any prompt is in flight must not \
+                     retroactively cancel the next prompt, got {:?}",
                     resp.stop_reason,
                 );
                 Ok(())
@@ -470,6 +518,687 @@ async fn cancel_before_prompt_returns_cancelled() {
                 res = server_fut => panic!("server exited before client: {res:?}"),
                 result = client_fut => {
                     assert!(result.is_ok(), "cancel_before_prompt test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// Regression test for the fixed `drain_agent_events` stale-permit race (review S-C2): a
+/// cancellation that resolves once a prompt has *already finished* — e.g. a `session/cancel`
+/// notification, or a late `$/cancel_request` racing the bridge in `handlers/prompt.rs` —
+/// must not silently cancel the next, unrelated prompt on the same session via a leftover
+/// permit on the shared `cancel_signal: Arc<Notify>`.
+///
+/// Simulated deterministically via the public `CancelNotification` protocol message (which
+/// notifies the very same `cancel_signal` `do_cancel` and the `$/cancel_request` bridge both
+/// use) sent strictly *after* the first prompt's response has already been received.
+#[tokio::test(flavor = "current_thread")]
+async fn late_cancel_after_prompt_completion_does_not_affect_next_prompt() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut =
+                serve_connection(multi_turn_echo_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                let first_content = vec![acp::schema::v1::ContentBlock::Text(
+                    acp::schema::v1::TextContent::new("first"),
+                )];
+                let first = cx
+                    .send_request(acp::schema::v1::PromptRequest::new(
+                        session_id.clone(),
+                        first_content,
+                    ))
+                    .block_task()
+                    .await?;
+                assert_eq!(
+                    first.stop_reason,
+                    acp::schema::v1::StopReason::EndTurn,
+                    "first prompt must complete normally before the late cancel arrives"
+                );
+
+                // No prompt is in flight at this point — this notify leaves a permit on the
+                // shared `cancel_signal` that must be drained before the next prompt's
+                // `drain_agent_events` loop starts.
+                cx.send_notification(acp::schema::v1::CancelNotification::new(session_id.clone()))?;
+
+                let second_content = vec![acp::schema::v1::ContentBlock::Text(
+                    acp::schema::v1::TextContent::new("second"),
+                )];
+                let second = cx
+                    .send_request(acp::schema::v1::PromptRequest::new(
+                        session_id,
+                        second_content,
+                    ))
+                    .block_task()
+                    .await?;
+                assert_eq!(
+                    second.stop_reason,
+                    acp::schema::v1::StopReason::EndTurn,
+                    "a cancel notification that arrives between two prompts must not cancel \
+                     the next, unrelated prompt, got {:?}",
+                    second.stop_reason,
+                );
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "late cancel regression test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `authenticate` is a no-op (vault-based auth) but must round-trip successfully (#5367).
+#[tokio::test(flavor = "current_thread")]
+async fn authenticate_returns_default_response() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                cx.send_request(acp::schema::v1::AuthenticateRequest::new("agent"))
+                    .block_task()
+                    .await?;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "authenticate failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `logout` is a no-op (vault-based auth) but must round-trip successfully (#5367).
+#[tokio::test(flavor = "current_thread")]
+async fn logout_returns_default_response() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                cx.send_request(acp::schema::v1::LogoutRequest::new())
+                    .block_task()
+                    .await?;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "logout failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/close` flushes and removes the session: a subsequent `session/load` for the same
+/// id must fail since no store is configured and the in-memory entry is gone (#5367).
+#[tokio::test(flavor = "current_thread")]
+async fn close_session_removes_session_from_memory() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                cx.send_request(acp::schema::v1::CloseSessionRequest::new(
+                    session_id.clone(),
+                ))
+                .block_task()
+                .await?;
+
+                let load_err = cx
+                    .send_request(acp::schema::v1::LoadSessionRequest::new(
+                        session_id,
+                        workdir.path(),
+                    ))
+                    .block_task()
+                    .await;
+                assert!(
+                    load_err.is_err(),
+                    "loading a closed session must fail when no store is configured"
+                );
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "close_session test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/delete` removes the session from `session/list` (#5367).
+#[tokio::test(flavor = "current_thread")]
+async fn delete_session_removes_session_from_list() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                cx.send_request(acp::schema::v1::DeleteSessionRequest::new(
+                    session_id.clone(),
+                ))
+                .block_task()
+                .await?;
+
+                let resp = cx
+                    .send_request(acp::schema::v1::ListSessionsRequest::new())
+                    .block_task()
+                    .await?;
+                let ids: Vec<&acp::schema::v1::SessionId> =
+                    resp.sessions.iter().map(|s| &s.session_id).collect();
+                assert!(
+                    !ids.contains(&&session_id),
+                    "deleted session must not appear in session/list: {ids:?}"
+                );
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "delete_session test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/fork` creates a new session with a distinct id from the source (#5367).
+#[cfg(feature = "unstable-session-fork")]
+#[tokio::test(flavor = "current_thread")]
+async fn fork_session_creates_distinct_session_id() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let source_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                let forked = cx
+                    .send_request(acp::schema::v1::ForkSessionRequest::new(
+                        source_id.clone(),
+                        workdir.path(),
+                    ))
+                    .block_task()
+                    .await?;
+
+                assert_ne!(
+                    forked.session_id, source_id,
+                    "forked session must have a distinct id from the source"
+                );
+                assert!(!forked.session_id.0.is_empty());
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "fork_session test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/resume` reconnects to an in-memory session by id (#5367).
+#[tokio::test(flavor = "current_thread")]
+async fn resume_session_reconnects_to_existing_session() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                cx.send_request(acp::schema::v1::ResumeSessionRequest::new(
+                    session_id,
+                    workdir.path(),
+                ))
+                .block_task()
+                .await?;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "resume_session test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/set_mode` switches the active mode and is reflected in subsequent requests (#5367).
+#[tokio::test(flavor = "current_thread")]
+async fn set_session_mode_switches_mode() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                cx.send_request(acp::schema::v1::SetSessionModeRequest::new(
+                    session_id,
+                    "architect",
+                ))
+                .block_task()
+                .await?;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "set_session_mode test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/set_config_option` with `config_id="model"` switches the active model and echoes
+/// it back in `config_options` (#5367 coverage; pre-existing handler, previously untested).
+#[tokio::test(flavor = "current_thread")]
+async fn set_session_config_option_model_switches_active_model() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config_with_models("test-agent", vec!["claude:sonnet", "ollama:llama3"]),
+                sw,
+                sr,
+            );
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                let resp = cx
+                    .send_request(acp::schema::v1::SetSessionConfigOptionRequest::new(
+                        session_id,
+                        "model",
+                        "ollama:llama3",
+                    ))
+                    .block_task()
+                    .await?;
+
+                let model_option = resp
+                    .config_options
+                    .iter()
+                    .find(|o| o.id.0.as_ref() == "model")
+                    .expect("model option must be present");
+                assert_eq!(
+                    select_current_value(model_option),
+                    "ollama:llama3",
+                    "model option must reflect the switched model"
+                );
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "set_config_option model test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/set_config_option` with `config_id="temperature"` (`model_config` category, #5361)
+/// switches the sampling-temperature preset and echoes it back in `config_options`.
+#[tokio::test(flavor = "current_thread")]
+async fn set_session_config_option_temperature_preset_changes() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config_with_models("test-agent", vec!["claude:sonnet"]),
+                sw,
+                sr,
+            );
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_resp = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?;
+                let session_id = session_resp.session_id;
+
+                // The default preset ("balanced") must already be advertised on session creation.
+                let initial_temperature = session_resp
+                    .config_options
+                    .unwrap_or_default()
+                    .into_iter()
+                    .find(|o| o.id.0.as_ref() == "temperature")
+                    .expect("temperature option must be advertised in new_session response");
+                assert_eq!(select_current_value(&initial_temperature), "balanced");
+
+                let resp = cx
+                    .send_request(acp::schema::v1::SetSessionConfigOptionRequest::new(
+                        session_id,
+                        "temperature",
+                        "creative",
+                    ))
+                    .block_task()
+                    .await?;
+
+                let temperature_option = resp
+                    .config_options
+                    .iter()
+                    .find(|o| o.id.0.as_ref() == "temperature")
+                    .expect("temperature option must be present");
+                assert_eq!(
+                    select_current_value(temperature_option),
+                    "creative",
+                    "temperature option must reflect the switched preset"
+                );
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "set_config_option temperature test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// Regression test for review finding S-C1: `[acp.model_config].default_temperature_preset`
+/// must be primed into the session's *effective* provider at session creation
+/// (`prime_provider_override` in `agent/mod.rs`) — not just advertised as the `temperature`
+/// config option's current value in the IDE dropdown — even when no
+/// `session/set_config_option` call is ever made.
+///
+/// Verified via `MockProvider::with_overrides_capture`: the test-only `ProviderFactory` shares
+/// one capture slot across every provider it builds, so it observes whatever
+/// `GenerationOverrides` production code applied internally during `new_session`.
+#[tokio::test(flavor = "current_thread")]
+async fn default_temperature_preset_is_primed_at_session_creation() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+
+            let captured: Arc<std::sync::Mutex<Option<zeph_llm::provider::GenerationOverrides>>> =
+                Arc::new(std::sync::Mutex::new(None));
+            let captured_for_factory = Arc::clone(&captured);
+            let factory: zeph_acp::ProviderFactory = Arc::new(move |_key: &str| {
+                Some(zeph_llm::any::AnyProvider::Mock(
+                    zeph_llm::mock::MockProvider::default()
+                        .with_overrides_capture(Arc::clone(&captured_for_factory)),
+                ))
+            });
+
+            let mut config = test_config_with_models("test-agent", vec!["claude:sonnet"]);
+            config.provider_factory = Some(factory);
+            config.model_config = zeph_config::AcpModelConfigConfig {
+                default_temperature_preset: zeph_config::AcpTemperaturePreset::Creative,
+            };
+
+            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                // No session/set_config_option call is made — the default preset must already
+                // be effective from session creation alone.
+                cx.send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "client connection failed: {result:?}");
+                }
+            }
+
+            let applied_temperature = captured
+                .lock()
+                .expect("capture mutex poisoned")
+                .as_ref()
+                .and_then(|o| o.temperature);
+            assert_eq!(
+                applied_temperature,
+                Some(zeph_config::AcpTemperaturePreset::Creative.temperature()),
+                "default_temperature_preset must be primed into the effective provider at \
+                 session creation, with no session/set_config_option call made"
+            );
+        })
+        .await;
+}
+
+/// `session/set_config_option` with an unrecognized `config_id` must error, not silently
+/// succeed (#5367 coverage).
+#[tokio::test(flavor = "current_thread")]
+async fn set_session_config_option_unknown_config_id_errors() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                let err = cx
+                    .send_request(acp::schema::v1::SetSessionConfigOptionRequest::new(
+                        session_id,
+                        "nonexistent_option",
+                        "whatever",
+                    ))
+                    .block_task()
+                    .await;
+                assert!(err.is_err(), "unknown config_id must return an error");
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "client connection failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// The real `$/cancel_request` protocol notification (#5362), sent for the in-flight
+/// `session/prompt` JSON-RPC request, cancels the prompt the same way `session/cancel` does.
+#[cfg(feature = "unstable-cancel-request")]
+#[tokio::test(flavor = "current_thread")]
+async fn cancel_request_during_prompt_cancels() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            // echo_spawner reads the message and flushes; the $/cancel_request watcher in
+            // handle_prompt notifies the same cancel_signal session/cancel uses.
+            let server_fut = serve_connection(echo_spawner(), test_config("test-agent"), sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                let content = vec![acp::schema::v1::ContentBlock::Text(
+                    acp::schema::v1::TextContent::new("go"),
+                )];
+                let request =
+                    cx.send_request(acp::schema::v1::PromptRequest::new(session_id, content));
+                // Cancel the specific in-flight session/prompt JSON-RPC request via the real
+                // protocol-level $/cancel_request notification (distinct from session/cancel).
+                request.cancel()?;
+
+                let resp = request.block_task().await;
+                // Cooperative cancellation: the handler may still finish with EndTurn if the
+                // watcher loses the race, or return the standard cancellation error, or
+                // (when the cancel_signal wins inside drain_agent_events) complete with
+                // StopReason::Cancelled. All three are valid SDK-documented outcomes; the
+                // assertion only rules out a hang or panic.
+                match resp {
+                    Ok(r) => {
+                        assert!(matches!(
+                            r.stop_reason,
+                            acp::schema::v1::StopReason::EndTurn
+                                | acp::schema::v1::StopReason::Cancelled
+                        ));
+                    }
+                    Err(e) => {
+                        assert_eq!(
+                            i32::from(e.code),
+                            -32800,
+                            "expected request_cancelled error"
+                        );
+                    }
+                }
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "cancel_request test failed: {result:?}");
                 }
             }
         })

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -192,9 +192,10 @@ pub use subagent::{
 pub use telemetry::{TelemetryBackend, TelemetryConfig};
 pub use tools::{AuditDestination, SandboxBackend, ToolCompressionConfig};
 pub use ui::{
-    AcpAuthMethod, AcpConfig, AcpLspConfig, AcpSubagentsConfig, AcpTimeoutsConfig, AcpTransport,
-    AdditionalDir, AdditionalDirError, ColorMode, DelightsConfig, FleetConfig, Motion,
-    SubagentPresetConfig, ThemeConfig, ToolDensity, TuiConfig,
+    AcpAuthMethod, AcpConfig, AcpLspConfig, AcpModelConfigConfig, AcpSubagentsConfig,
+    AcpTemperaturePreset, AcpTimeoutsConfig, AcpTransport, AdditionalDir, AdditionalDirError,
+    ColorMode, DelightsConfig, FleetConfig, Motion, SubagentPresetConfig, ThemeConfig, ToolDensity,
+    TuiConfig,
 };
 pub use ui::{DiagnosticSeverity, DiagnosticsConfig, HoverConfig, LspConfig};
 pub use vigil::VigilConfig;

--- a/crates/zeph-config/src/ui.rs
+++ b/crates/zeph-config/src/ui.rs
@@ -683,6 +683,10 @@ pub struct AcpConfig {
     /// Timeout configuration for ACP operations (`[acp.timeouts]`).
     #[serde(default)]
     pub timeouts: AcpTimeoutsConfig,
+    /// Model-related configuration parameters (`[acp.model_config]`), advertised to IDE
+    /// clients via the `model_config` `session/set_config_option` category (schema 1.1.0+).
+    #[serde(default)]
+    pub model_config: AcpModelConfigConfig,
 }
 
 impl Default for AcpConfig {
@@ -706,6 +710,7 @@ impl Default for AcpConfig {
             message_ids_enabled: true,
             subagents: AcpSubagentsConfig::default(),
             timeouts: AcpTimeoutsConfig::default(),
+            model_config: AcpModelConfigConfig::default(),
         }
     }
 }
@@ -734,8 +739,80 @@ impl std::fmt::Debug for AcpConfig {
             .field("message_ids_enabled", &self.message_ids_enabled)
             .field("subagents", &self.subagents)
             .field("timeouts", &self.timeouts)
+            .field("model_config", &self.model_config)
             .finish()
     }
+}
+
+/// Sampling-temperature preset for ACP `model_config` session options.
+///
+/// Maps a discrete, IDE-friendly selector (`"precise"` | `"balanced"` | `"creative"`) onto a
+/// concrete sampling temperature, since the ACP `SessionConfigOption` select type only
+/// supports discrete values, not a free-form numeric input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcpTemperaturePreset {
+    /// Low temperature (0.2) — more deterministic, focused completions.
+    Precise,
+    /// Moderate temperature (0.7) — balanced determinism and variety. Default.
+    #[default]
+    Balanced,
+    /// High temperature (1.0) — more varied, exploratory completions.
+    Creative,
+}
+
+impl AcpTemperaturePreset {
+    /// Returns the concrete sampling temperature for this preset.
+    #[must_use]
+    pub fn temperature(self) -> f64 {
+        match self {
+            Self::Precise => 0.2,
+            Self::Balanced => 0.7,
+            Self::Creative => 1.0,
+        }
+    }
+
+    /// Returns the ACP wire identifier for this preset (`"precise"` | `"balanced"` | `"creative"`).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Precise => "precise",
+            Self::Balanced => "balanced",
+            Self::Creative => "creative",
+        }
+    }
+}
+
+impl std::str::FromStr for AcpTemperaturePreset {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "precise" => Ok(Self::Precise),
+            "balanced" => Ok(Self::Balanced),
+            "creative" => Ok(Self::Creative),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Model-related configuration parameters configuration, nested under `[acp.model_config]`.
+///
+/// Backs the ACP `model_config` `session/set_config_option` category (schema 1.1.0+), which is
+/// distinct from the `model` category: `model` selects which model is active, `model_config`
+/// adjusts a parameter (e.g. sampling temperature) of the currently selected model.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [acp.model_config]
+/// default_temperature_preset = "balanced"
+/// ```
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct AcpModelConfigConfig {
+    /// Default sampling-temperature preset applied to new ACP sessions. Default: `"balanced"`.
+    #[serde(default)]
+    pub default_temperature_preset: AcpTemperaturePreset,
 }
 
 /// Timeout configuration for ACP operations.

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -53,6 +53,10 @@ pub struct MockProvider {
     peak_concurrent: Arc<std::sync::atomic::AtomicUsize>,
     /// Per-call delay sequence. Each `chat()` call pops from the front; when empty, falls back to `delay_ms`.
     per_call_delays: Arc<Mutex<VecDeque<u64>>>,
+    /// Captures the most recent [`GenerationOverrides`] applied via
+    /// [`MockProvider::with_generation_overrides`]. Shared with the test via
+    /// [`MockProvider::with_overrides_capture`] — the mock otherwise ignores overrides entirely.
+    captured_overrides: Arc<Mutex<Option<GenerationOverrides>>>,
 }
 
 impl Default for MockProvider {
@@ -79,6 +83,7 @@ impl Default for MockProvider {
             in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             peak_concurrent: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             per_call_delays: Arc::new(Mutex::new(VecDeque::new())),
+            captured_overrides: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -173,8 +178,40 @@ impl MockProvider {
     }
 
     #[must_use]
-    pub fn with_generation_overrides(self, _overrides: GenerationOverrides) -> Self {
-        // No-op: mock provider ignores generation overrides.
+    pub fn with_generation_overrides(self, overrides: GenerationOverrides) -> Self {
+        // Functionally a no-op (the mock never applies overrides to a response), but records
+        // the value into `captured_overrides` so tests can assert what was applied — see
+        // `with_overrides_capture`.
+        if let Ok(mut guard) = self.captured_overrides.lock() {
+            *guard = Some(overrides);
+        }
+        self
+    }
+
+    /// Share `slot` as this provider's `captured_overrides` sink, so a test can read back the
+    /// [`GenerationOverrides`] most recently applied via [`MockProvider::with_generation_overrides`]
+    /// — including overrides applied by production code *after* the provider left the test's
+    /// hands (e.g. by a `ProviderFactory` closure that rebuilds providers internally).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::{Arc, Mutex};
+    /// use zeph_llm::mock::MockProvider;
+    /// use zeph_llm::provider::GenerationOverrides;
+    ///
+    /// let slot = Arc::new(Mutex::new(None));
+    /// let provider = MockProvider::default()
+    ///     .with_overrides_capture(Arc::clone(&slot))
+    ///     .with_generation_overrides(GenerationOverrides {
+    ///         temperature: Some(0.2),
+    ///         ..Default::default()
+    ///     });
+    /// assert_eq!(slot.lock().unwrap().as_ref().unwrap().temperature, Some(0.2));
+    /// ```
+    #[must_use]
+    pub fn with_overrides_capture(mut self, slot: Arc<Mutex<Option<GenerationOverrides>>>) -> Self {
+        self.captured_overrides = slot;
         self
     }
 

--- a/specs/013-acp/spec.md
+++ b/specs/013-acp/spec.md
@@ -8,7 +8,7 @@ tags:
   - protocol
   - acp
 created: 2026-04-08
-updated: 2026-06-30
+updated: 2026-07-01
 status: approved
 related:
   - "[[MOC-specs]]"
@@ -30,6 +30,8 @@ related:
 | 1.2 | 2026-05-29 | sdd | Mark Providers API, Elicitation protocol, Session Usage, and session/delete as implemented; update SDK to 0.12.1; wire IDE-provided MCP servers into do_new_session; add blocking-await timeout note |
 | 1.3 | 2026-06-06 | sdd | ACP 0.14.0 protocol bump: bumped core 0.12.1→0.14.0, schema pinned =0.13.6; removed session/set_model RPC (model switching preserved via set_config_option); removed inbound message-id echo feature; renamed provider ext-method types to singular; stabilized delete/logout/resume/add-dirs feature flags; renamed session-usage upstream gate; added elicitation core passthrough; documented MessageId newtype change |
 | 1.4 | 2026-06-30 | developer | ACP 1.0.1 schema-path migration: bumped core 0.14.0→1.0.1, schema pinned =1.1.0; mechanical `schema::X` → `schema::v1::X` reorg (root re-export removed upstream), `ProtocolVersion`/`MaybeUndefined`/`IntoOption`/`IntoMaybeUndefined` stay flat; removed root re-exports `cookbook`/`handler`/`jsonrpcmsg`/six message enums; deleted 5 long-dead `#[cfg(any())]` test modules (153 unverifiable sites); no handler/transport/builder logic changed; `unstable_cancel_request` and `model_config` evaluated and deferred to follow-up issues |
+| 1.5 | 2026-07-01 | developer | Adopt `model_config` option category (#5361): new `config_id="temperature"` `session/set_config_option`, presets precise/balanced/creative, `[acp.model_config]` config section, CLI + wizard integration. Wire `unstable_cancel_request` (#5362): new `unstable-cancel-request` Cargo feature (not in `default`), `$/cancel_request` bridged onto `cancel_signal: Arc<Notify>` via `Responder::cancellation()` in `session/prompt`, plus a low-level tracing-only `CancelRequestNotification` handler in the `Agent.builder()` chain. Added test coverage for the 8 previously-untested handler files (#5367). |
+| 1.6 | 2026-07-01 | developer | Review fix pass on #5361/#5362: (S-C1) `default_temperature_preset` is now primed into the effective `provider_override` at session creation (`do_new_session`/`do_load_session`/`do_fork_session`/`do_resume_session`), not just advertised in the IDE dropdown; (S-C2) the `$/cancel_request` watcher select is now `biased` with prompt completion checked first, and `drain_agent_events` drains a stale `cancel_signal` permit before its main loop, so a cancellation resolving at/after prompt completion can no longer leak into the next, unrelated prompt (also hardens the pre-existing `session/cancel` no-active-prompt race — `cancel_before_prompt_returns_cancelled` renamed to `cancel_before_prompt_is_a_no_op` to reflect the corrected semantics). Documented fork/resume reset behavior for `temperature_preset` (#5373 tracking issue filed); filed #5374 for the untested `resume_session` store-backed path. |
 
 ---
 
@@ -300,7 +302,7 @@ exposing tools over ACP.
 | `unstable-logout` | **tombstone** `= []` | Stabilized — logout handler is unconditional in core 1.0.1 (since the 0.14.0 bump). Flag retained as no-op. |
 | `unstable-session-add-dirs` | **tombstone** `= []` | Stabilized — `additional_directories` field is plain `Vec<PathBuf>`, unconditional since schema 0.13.6 (now schema 1.1.0). Flag retained as no-op. |
 | `unstable-message-id` | **tombstone** `= []` | Removed — `PromptRequest.message_id` and `PromptResponse.user_message_id` deleted upstream. Entire inbound echo feature removed. Flag retained as no-op for workspace forwarding. |
-| `unstable_cancel_request` | **not adopted** | Available at the ACP-crate level since SDK 0.15.1 (predates Zeph's 0.14.0 baseline; not "new in 1.0.1" relative to upstream, only relative to Zeph's prior pin). Exposes `RequestCancellation` + `is_cancel_request_notification`. Zeph does **not** define an `unstable-cancel-request` Cargo feature and does **not** wire a `$/cancel_request` handler — deferred to a follow-up issue; today cancellation is handled entirely via the internal `cancel_signal: Arc<Notify>` in `agent/handlers/cancel.rs` (`session/cancel`). |
+| `unstable-cancel-request` | **active** | Implemented (#5362). Maps to upstream `agent-client-protocol/unstable_cancel_request` (available at the ACP-crate level since SDK 0.15.1). Not in `default` — opt-in only. The `session/prompt` handler (`agent/handlers/prompt.rs`) bridges `Responder::cancellation()`, scoped to that specific JSON-RPC request, onto the session's existing `cancel_signal: Arc<Notify>` (the same signal `session/cancel` notifies in `agent/handlers/cancel.rs`) via a short-lived watcher task that races cancellation against prompt completion. A low-level `CancelRequestNotification` handler is also registered in the `Agent.builder()` chain (`agent/mod.rs`) for tracing-only observability — the SDK updates per-request cancellation markers automatically regardless of whether a handler is registered. |
 | `unstable-session-model` | **DELETED** | Removed entirely — `session/set_model` RPC deleted upstream. Feature name removed from Cargo.toml and root `Cargo.toml`. Model switching survives via `set_config_option`. |
 
 > **Tombstone flags** are `= []` no-ops retained solely so root `Cargo.toml` feature forwarding
@@ -329,6 +331,33 @@ concept, NOT a replacement for model switching. Mode and model are independent.
 
 > **NEVER** describe the removal of `session/set_model` as a capability loss. Model switching
 > survives unconditionally via `session/set_config_option`.
+
+### Model Parameters (`model_config` category)
+
+**Status: implemented** (#5361)
+
+Distinct from the `model` selector above, `session/set_config_option` with `config_id="temperature"`
+(category `SessionConfigOptionCategory::ModelConfig`, stabilized unconditionally in schema 1.1.0)
+adjusts a parameter of the *currently selected* model rather than switching models. Zeph exposes
+one preset-based parameter today:
+
+- **Sampling temperature** — discrete presets `precise` (0.2) / `balanced` (0.7, default) /
+  `creative` (1.0), since the ACP `SessionConfigOption` select type only supports discrete values,
+  not free-form numeric input. Applied via `zeph_llm::provider::GenerationOverrides` on top of the
+  provider returned by `provider_factory(model_key)` — the same rebuild-on-switch mechanism the
+  `model` option already used, so switching either option preserves the other's current setting.
+
+Configured via `[acp.model_config].default_temperature_preset` (applies to new sessions); shown
+to IDE clients alongside the `model` option (only when `available_models` is non-empty, since
+both require the provider-factory machinery); changeable per-session via `set_config_option`.
+Applied to the session's *effective* provider (not just the advertised dropdown value) from the
+session's very first prompt, via the same `provider_with_temperature` rebuild mechanism used for
+explicit switches.
+
+`session/fork` and `session/resume` reset `temperature_preset` to the configured default rather
+than inheriting the source session's current value, consistent with the pre-existing
+`thinking_enabled`/`auto_approve_level` reset behavior — see #5373 for a tracking issue covering
+inheritance/persistence of all four session-config fields on fork/resume.
 
 ---
 
@@ -551,7 +580,7 @@ without `_` prefix are rejected).
 | Schema crate `1.1.0` removed the flat `pub use v1::*` root re-export (schema types now live only under `schema::v1::`); ACP crate `1.0.1` mirrors this in `schema/mod.rs` | Mechanical `acp::schema::X` → `acp::schema::v1::X` reorg across `crates/zeph-acp/src/**` and `crates/zeph-acp/tests/**` (~506 live sites); `ProtocolVersion`, `MaybeUndefined`, `IntoOption`, `IntoMaybeUndefined` stay flat at crate root — explicitly excluded from the reorg | **Resolved** |
 | Root re-exports `cookbook`, `handler`, `jsonrpcmsg`, and the six root enum re-exports (`AgentRequest`/`AgentResponse`/`AgentNotification`/`ClientRequest`/`ClientResponse`/`ClientNotification`) removed from the ACP crate root | Zeph used none of `cookbook`/`handler`/`jsonrpcmsg`; the only root-enum use site (`tests/integration.rs` `acp::ClientRequest::ExtMethodRequest`) repointed to `acp::schema::v1::ClientRequest::ExtMethodRequest` | **Resolved** |
 | `Builder`/`ConnectionTo`/`Dispatch`/`Responder`/`ByteStreams`/`on_receive_request!`/`on_receive_dispatch!` builder API | Byte-identical between 0.14.0 and 1.0.1 for the methods Zeph uses — no handler, transport, or builder-chain code changed shape | **Resolved — no action** |
-| Feature flags: ACP crate `[features]` add only `unstable_cancel_request`; schema `[features]` unchanged | No renames affecting Zeph's existing `unstable-*` feature mappings; `unstable_cancel_request` evaluated and deferred (#5362), not adopted in this PR | **Resolved — no action** |
+| Feature flags: ACP crate `[features]` add only `unstable_cancel_request`; schema `[features]` unchanged | No renames affecting Zeph's existing `unstable-*` feature mappings; `unstable_cancel_request` evaluated and deferred in this PR, since adopted via the `unstable-cancel-request` Zeph feature (#5362) | **Resolved** |
 | `model_config` option category stabilized in schema 1.1.0 (reachable, schema 1.2.0 stabilizes `unstable_cancel_request` but is **not** reachable — ACP 1.0.1 pins schema `=1.1.0` exactly) | Evaluated and deferred to a follow-up issue (#5361) to keep this PR a clean mechanical bump | **Deferred — not capability loss** |
 | 5 long-dead `#[cfg(any())]` test modules (153 of 616 `acp::schema::` src sites, pre-dating ACP 0.11) were unreachable by any feature toggle and contained stale pre-0.14.0 root-path references that didn't even compile | Deleted entirely: `terminal.rs`, `custom.rs`, `fs.rs`, `mcp_bridge.rs` (inline dead `mod tests`), `agent/mod.rs` + external `agent/tests.rs` (dead `mod tests;` declaration) — removes false-green risk where a sed-rewritten but type-unchecked block would silently mask path errors | **Resolved** |
 
@@ -581,8 +610,8 @@ without `_` prefix are rejected).
 | I18 | Re-point `unstable-session-usage` gate | **Implemented** | ✓ Done | — |
 | I19 | Add elicitation core passthrough | **Implemented** | ✓ Done | — |
 | I20 | SDK upgrade 0.14.0 → 1.0.1 (schema-path reorg) | **Implemented** (this PR) | ✓ Done | — |
-| I21 | Adopt `model_config` option category | Deferred — schema 1.1.0 stabilizes it but Zeph does not expose it | Follow-up issue #5361 | P3 |
-| I22 | Wire `unstable_cancel_request` ($/cancel_request handler) | Deferred — feature flag not added, no handler wired | Follow-up issue #5362 | P3 |
+| I21 | Adopt `model_config` option category | **Implemented** (#5361) | ✓ Done | — |
+| I22 | Wire `unstable_cancel_request` ($/cancel_request handler) | **Implemented** (#5362) | ✓ Done | — |
 
 ---
 
@@ -684,8 +713,8 @@ require Zeph adaptation when stabilized:
 - Meta-propagation
 
 `unstable_cancel_request` has graduated out of this list — it is implemented (not just RFD) at
-the ACP-crate level since SDK 0.15.1, see "Feature Flags" above; Zeph has evaluated and deferred
-adoption (#5362), it is not blocked on upstream availability.
+the ACP-crate level since SDK 0.15.1, and Zeph adopted it via the `unstable-cancel-request`
+feature (#5362); see "Feature Flags" above.
 
 No action needed now. Monitor upstream v2 progress at https://github.com/agentclientprotocol/rust-sdk.
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -184,6 +184,8 @@ struct SharedAgentDeps {
     acp_message_ids_enabled: bool,
     /// ACP timeout configuration (elicitation, terminal, MCP).
     acp_timeouts: zeph_config::AcpTimeoutsConfig,
+    /// ACP model-related configuration parameters (`[acp.model_config]`).
+    acp_model_config: zeph_config::AcpModelConfigConfig,
     /// Resolves current per-plugin skill dirs at hot-reload time.
     plugin_dirs_supplier: std::sync::Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>,
 
@@ -673,6 +675,7 @@ async fn build_acp_deps(
         acp_auth_methods: config.acp.auth_methods.clone(),
         acp_message_ids_enabled: config.acp.message_ids_enabled,
         acp_timeouts: config.acp.timeouts.clone(),
+        acp_model_config: config.acp.model_config.clone(),
         plugin_dirs_supplier: std::sync::Arc::new(plugin_dirs_supplier),
         #[cfg(feature = "scheduler")]
         scheduler_executor,
@@ -1443,6 +1446,7 @@ pub(crate) async fn run_acp_server(
         auth_methods: effective_auth_methods,
         message_ids_enabled: effective_message_ids,
         timeouts: deps.acp_timeouts.clone(),
+        model_config: deps.acp_model_config.clone(),
     };
 
     let shared = Arc::new(deps);
@@ -1512,6 +1516,7 @@ pub(crate) async fn run_acp_http_server(
         auth_methods: app.config().acp.auth_methods.clone(),
         message_ids_enabled: app.config().acp.message_ids_enabled,
         timeouts: app.config().acp.timeouts.clone(),
+        model_config: app.config().acp.model_config.clone(),
     };
     let shared_deps: Arc<RwLock<Option<Arc<SharedAgentDeps>>>> = Arc::new(RwLock::new(None));
     let shared_deps_for_spawner = Arc::clone(&shared_deps);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -614,6 +614,11 @@ pub(crate) enum AcpCommand {
         #[command(subcommand)]
         command: AcpSubagentCommand,
     },
+    /// Model-related configuration parameters (`[acp.model_config]`)
+    ModelConfig {
+        #[command(subcommand)]
+        command: AcpModelConfigCommand,
+    },
 }
 
 /// Sub-agent preset subcommands.
@@ -622,6 +627,14 @@ pub(crate) enum AcpCommand {
 pub(crate) enum AcpSubagentCommand {
     /// List configured sub-agent presets
     List,
+}
+
+/// Model-config subcommands.
+#[cfg(feature = "acp")]
+#[derive(Subcommand)]
+pub(crate) enum AcpModelConfigCommand {
+    /// Show available sampling-temperature presets and the configured default
+    Show,
 }
 
 /// Database subcommands.

--- a/src/commands/acp.rs
+++ b/src/commands/acp.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Context as _;
 
-use crate::cli::{AcpCommand, AcpSubagentCommand};
+use crate::cli::{AcpCommand, AcpModelConfigCommand, AcpSubagentCommand};
 
 /// Handle `zeph acp <subcommand>`.
 ///
@@ -57,6 +57,27 @@ pub(crate) async fn handle_acp_command(cmd: AcpCommand) -> anyhow::Result<()> {
             // Config is not loaded at this point; report that presets must be configured.
             println!("Sub-agent presets are configured under [acp.subagents] in config.toml.");
             println!("Use `zeph acp run-agent --command <CMD> --prompt <TEXT>` for one-shot runs.");
+            Ok(())
+        }
+        AcpCommand::ModelConfig {
+            command: AcpModelConfigCommand::Show,
+        } => {
+            // Config is not loaded at this point; report the static preset table and pointer.
+            println!(
+                "ACP model_config presets (session/set_config_option, config_id=\"temperature\"):"
+            );
+            for preset in [
+                zeph_config::AcpTemperaturePreset::Precise,
+                zeph_config::AcpTemperaturePreset::Balanced,
+                zeph_config::AcpTemperaturePreset::Creative,
+            ] {
+                println!(
+                    "  {:<10} temperature = {}",
+                    preset.as_str(),
+                    preset.temperature()
+                );
+            }
+            println!("Default preset is configured under [acp.model_config] in config.toml.");
             Ok(())
         }
     }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -74,6 +74,7 @@ pub(crate) struct WizardState {
     pub(crate) acp_auth_methods: Vec<zeph_config::AcpAuthMethod>,
     pub(crate) acp_message_ids_enabled: bool,
     pub(crate) acp_subagents_enabled: bool,
+    pub(crate) acp_default_temperature_preset: zeph_config::AcpTemperaturePreset,
     pub(crate) thinking: Option<ThinkingConfig>,
     pub(crate) enable_extended_context: bool,
     pub(crate) agents_default_permission_mode: Option<PermissionMode>,
@@ -341,6 +342,7 @@ impl Default for WizardState {
             acp_auth_methods: vec![zeph_config::AcpAuthMethod::Agent],
             acp_message_ids_enabled: true,
             acp_subagents_enabled: false,
+            acp_default_temperature_preset: zeph_config::AcpTemperaturePreset::default(),
             thinking: None,
             enable_extended_context: false,
             agents_default_permission_mode: None,
@@ -1276,6 +1278,9 @@ fn apply_acp_config(config: &mut Config, state: &WizardState) {
                 enabled: state.acp_subagents_enabled,
                 ..zeph_config::AcpSubagentsConfig::default()
             },
+            model_config: zeph_config::AcpModelConfigConfig {
+                default_temperature_preset: state.acp_default_temperature_preset,
+            },
             ..AcpConfig::default()
         };
     }
@@ -1402,6 +1407,28 @@ fn step_acp(state: &mut WizardState) -> anyhow::Result<()> {
             )
             .default(false)
             .interact()?;
+
+        let temperature_presets = [
+            zeph_config::AcpTemperaturePreset::Precise,
+            zeph_config::AcpTemperaturePreset::Balanced,
+            zeph_config::AcpTemperaturePreset::Creative,
+        ];
+        let labels: Vec<String> = temperature_presets
+            .iter()
+            .map(|p| format!("{} (temperature {})", p.as_str(), p.temperature()))
+            .collect();
+        let default_idx = temperature_presets
+            .iter()
+            .position(|p| *p == state.acp_default_temperature_preset)
+            .unwrap_or(1);
+        let idx = Select::new()
+            .with_prompt(
+                "Default model_config sampling-temperature preset advertised to IDE clients",
+            )
+            .items(&labels)
+            .default(default_idx)
+            .interact()?;
+        state.acp_default_temperature_preset = temperature_presets[idx];
     }
 
     println!();


### PR DESCRIPTION
## Summary

- Adds the ACP `model_config` `session/set_config_option` category for per-session sampling-
  temperature control (presets precise/balanced/creative), independent of the `model` selector,
  configured via `[acp.model_config].default_temperature_preset` (closes #5361). The configured
  default is now primed into the session's effective provider at session creation itself (not
  just advertised in the IDE dropdown), so it is in effect from the very first prompt.
- Wires the real ACP `$/cancel_request` protocol notification onto the existing
  `cancel_signal: Arc<Notify>`, behind a new opt-in `unstable-cancel-request` Cargo feature
  (closes #5362). The watcher and the session's drain loop are hardened against a race where a
  cancellation resolving at/after prompt completion could leak a stale permit onto the next,
  unrelated prompt — this also hardens the pre-existing `session/cancel` no-active-prompt path,
  which is now a deterministic no-op instead of retroactively cancelling whichever prompt is sent
  next.
- Adds test coverage for 8 previously-untested `zeph-acp` handler files plus the two features
  above (closes #5367).
- Follow-ups filed (non-blocking): #5373 (fork/resume does not inherit session-config fields —
  product decision needed), #5374 (`resume_session` store-backed reconstruction path untested).

### Accepted debt (intentionally not addressed in this PR)
- `cancel_request_during_prompt_cancels` is a true-race test that only rules out hang/panic, not
  a strict regression check (writing a deterministic variant requires a spawner that blocks until
  cancelled — deferred).
- The `model`/`temperature` config-option tests assert the echoed dropdown value rather than the
  functional provider effect directly (the new temperature-priming test does assert the
  functional effect, narrowing this gap).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo clippy --profile ci -p zeph-acp --all-targets --features "unstable-cancel-request,acp-http" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11540 passed)
- [x] `cargo nextest run -p zeph-acp --features "unstable-cancel-request,acp-http"` (164/164 passed)
- [x] `cargo nextest run -p zeph-acp` (default features, 101/101 passed)
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] LLM serialization gate: live OpenAI round-trip with `GenerationOverrides.temperature` set, verifying the exact mechanism the new temperature option routes through