### PR TITLE
fix(acp): load resolved config in model-config show, inherit session-config on fork/resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(acp)`: `zeph acp model-config show` now loads the resolved config and marks the active
+  `[acp.model_config].default_temperature_preset` in its output (e.g. `balanced   temperature =
+  0.7  (default)`), instead of only printing the static preset table with a generic pointer to
+  `config.toml`. Closes #5379.
+- `fix(acp)`: `session/fork` and `session/resume` now inherit the source session's current
+  `model`, `temperature_preset`, `thinking_enabled`, and `auto_approve_level` instead of always
+  resetting to configured defaults. Resolution order: the source session's live in-memory state
+  (fork's common case), then a persisted close-time snapshot written by `session/close` (new
+  `current_model`/`temperature_preset`/`thinking_enabled`/`auto_approve_level` columns on
+  `acp_sessions`, migration `105_acp_session_config`), then configured defaults (source was
+  evicted rather than closed, or predates the snapshot migration). An inherited model no longer
+  present in `available_models` falls back to the current default instead of a dangling model
+  key. Closes #5373.
 - `fix(db,memory,index)`: fix the remaining `PostgreSQL` runtime defects in `zeph-memory`/
   `zeph-index` surfaced by actually running the new `postgres_integration.rs` suites against a
   real Postgres container (22 tests now pass against live Postgres — 19 `zeph-memory` +

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -372,6 +372,16 @@ struct DrainResult {
     turn_usage: TurnUsage,
 }
 
+/// Per-session config fields seeded into a fresh `SessionEntry` (#5373).
+///
+/// Callers pass either configured defaults (new/loaded session) or values inherited from a
+/// source session (fork/resume of an existing session) — see `inherited_session_config`.
+struct SessionConfigSeed {
+    thinking_enabled: bool,
+    auto_approve_level: String,
+    temperature_preset: zeph_config::AcpTemperaturePreset,
+}
+
 pub(crate) struct SessionEntry {
     pub(crate) input_tx: mpsc::Sender<ChannelMessage>,
     /// Receiver is owned solely by the `prompt()` handler.
@@ -1353,7 +1363,11 @@ impl ZephAcpAgentState {
             .await;
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
-        self.prime_provider_override(&provider_override, &initial_model);
+        self.prime_provider_override(
+            &provider_override,
+            &initial_model,
+            self.model_config.default_temperature_preset,
+        );
         #[cfg_attr(not(feature = "unstable-elicitation"), allow(unused_mut))]
         let mut entry = Self::make_session_entry(
             handle,
@@ -1361,7 +1375,11 @@ impl ZephAcpAgentState {
             session_cwd.clone(),
             shell_executor,
             provider_override,
-            self.model_config.default_temperature_preset,
+            SessionConfigSeed {
+                thinking_enabled: false,
+                auto_approve_level: "suggest".to_owned(),
+                temperature_preset: self.model_config.default_temperature_preset,
+            },
         );
         #[cfg(feature = "unstable-elicitation")]
         {
@@ -1569,8 +1587,26 @@ impl ZephAcpAgentState {
                 }
             }
         }
-        if let Some(entry) = self.sessions.lock().remove(&args.session_id) {
+        let removed = self.sessions.lock().remove(&args.session_id);
+        if let Some(entry) = removed {
             entry.cancel_signal.notify_one();
+            // Snapshot the session's config fields (#5373) so a later `session/resume` or
+            // `session/fork` of this now-evicted session can inherit them instead of
+            // resetting to configured defaults.
+            if let Some(ref store) = self.store {
+                let snapshot = zeph_memory::store::AcpSessionConfigSnapshot {
+                    current_model: entry.current_model.lock().clone(),
+                    temperature_preset: (*entry.temperature_preset.lock()).as_str().to_owned(),
+                    thinking_enabled: entry.thinking_enabled.load(Ordering::Relaxed),
+                    auto_approve_level: entry.auto_approve_level.lock().clone(),
+                };
+                if let Err(e) = store
+                    .save_session_config(&args.session_id.to_string(), &snapshot)
+                    .await
+                {
+                    tracing::warn!(error = %e, "failed to persist session config snapshot on close");
+                }
+            }
         }
         Ok(acp::schema::v1::CloseSessionResponse::default())
     }
@@ -1646,14 +1682,22 @@ impl ZephAcpAgentState {
             .await;
         let shell_executor = acp_ctx.shell_executor.clone();
         let initial_model = self.initial_model();
-        self.prime_provider_override(&provider_override, &initial_model);
+        self.prime_provider_override(
+            &provider_override,
+            &initial_model,
+            self.model_config.default_temperature_preset,
+        );
         let entry = Self::make_session_entry(
             handle,
             initial_model,
             session_cwd.clone(),
             shell_executor,
             provider_override,
-            self.model_config.default_temperature_preset,
+            SessionConfigSeed {
+                thinking_enabled: false,
+                auto_approve_level: "suggest".to_owned(),
+                temperature_preset: self.model_config.default_temperature_preset,
+            },
         );
 
         Self::spawn_notify_drainer(&entry, cx)?;
@@ -1742,6 +1786,76 @@ impl ZephAcpAgentState {
         Ok(acp::schema::v1::ListSessionsResponse::new(sessions_vec))
     }
 
+    /// Resolve the config a new `SessionEntry` should inherit from `source_id` (#5373).
+    ///
+    /// Order of precedence: the source session's live in-memory state (source still resident
+    /// in the LRU cache — the common case for `session/fork`), then the persisted close-time
+    /// snapshot (source was gracefully closed — the common case for `session/resume`), then
+    /// configured defaults (no snapshot available: the source was evicted rather than closed,
+    /// or predates the config-snapshot migration).
+    ///
+    /// Returns `(model, thinking_enabled, auto_approve_level, temperature_preset)`.
+    async fn inherited_session_config(
+        &self,
+        source_id: &acp::schema::v1::SessionId,
+    ) -> (String, bool, String, zeph_config::AcpTemperaturePreset) {
+        let inherited = if let Some(entry) = self.sessions.lock().get(source_id) {
+            Some((
+                entry.current_model.lock().clone(),
+                entry.thinking_enabled.load(Ordering::Relaxed),
+                entry.auto_approve_level.lock().clone(),
+                *entry.temperature_preset.lock(),
+            ))
+        } else if let Some(ref store) = self.store {
+            store
+                .get_session_config(&source_id.to_string())
+                .await
+                .ok()
+                .flatten()
+                .map(|snapshot| {
+                    let preset = snapshot
+                        .temperature_preset
+                        .parse()
+                        .unwrap_or(self.model_config.default_temperature_preset);
+                    (
+                        snapshot.current_model,
+                        snapshot.thinking_enabled,
+                        snapshot.auto_approve_level,
+                        preset,
+                    )
+                })
+        } else {
+            None
+        };
+
+        let (model, thinking_enabled, auto_approve_level, temperature_preset) = inherited
+            .unwrap_or_else(|| {
+                (
+                    self.initial_model(),
+                    false,
+                    "suggest".to_owned(),
+                    self.model_config.default_temperature_preset,
+                )
+            });
+
+        // The inherited model may no longer be configured (removed from the provider list
+        // since the source session was created) — fall back to the current default rather
+        // than handing the spawner a dangling model key.
+        let available_models = self.available_models_snapshot();
+        let model = if model.is_empty() || available_models.iter().any(|m| m == &model) {
+            model
+        } else {
+            self.initial_model()
+        };
+
+        (
+            model,
+            thinking_enabled,
+            auto_approve_level,
+            temperature_preset,
+        )
+    }
+
     #[cfg(feature = "unstable-session-fork")]
     #[allow(dead_code, clippy::too_many_lines)]
     #[tracing::instrument(skip_all, name = "acp.handler.fork_session")]
@@ -1771,6 +1885,11 @@ impl ZephAcpAgentState {
                 }
             }
         }
+
+        // Captured before the LRU eviction pass below, since (pre-existing behavior) that
+        // pass does not exclude the fork source and could otherwise evict it out from under us.
+        let (inherited_model, inherited_thinking, inherited_auto_approve, inherited_preset) =
+            self.inherited_session_config(&args.session_id).await;
 
         if self.sessions.lock().len() >= self.max_sessions {
             let evict_id = {
@@ -1815,15 +1934,19 @@ impl ZephAcpAgentState {
             )
             .await;
         let shell_executor = acp_ctx.shell_executor.clone();
-        let initial_model = self.initial_model();
-        self.prime_provider_override(&provider_override, &initial_model);
+        let initial_model = inherited_model;
+        self.prime_provider_override(&provider_override, &initial_model, inherited_preset);
         let entry = Self::make_session_entry(
             handle,
             initial_model.clone(),
             args.cwd.clone(),
             shell_executor,
             provider_override,
-            self.model_config.default_temperature_preset,
+            SessionConfigSeed {
+                thinking_enabled: inherited_thinking,
+                auto_approve_level: inherited_auto_approve.clone(),
+                temperature_preset: inherited_preset,
+            },
         );
 
         Self::spawn_notify_drainer(&entry, cx)?;
@@ -1849,9 +1972,9 @@ impl ZephAcpAgentState {
         let config_options = build_config_options(
             &available_models,
             &initial_model,
-            false,
-            "suggest",
-            self.model_config.default_temperature_preset,
+            inherited_thinking,
+            &inherited_auto_approve,
+            inherited_preset,
         );
         let default_mode_id = acp::schema::v1::SessionModeId::new(DEFAULT_MODE_ID);
         let mut resp = acp::schema::v1::ForkSessionResponse::new(new_id)
@@ -1889,6 +2012,13 @@ impl ZephAcpAgentState {
         if !exists {
             return Err(acp::Error::internal_error().data("session not found"));
         }
+
+        // Resolved from the persisted close-time snapshot (#5373) — by construction the
+        // session is not in memory here (the early return above handles that case), so this
+        // always reads through to the store, falling back to config defaults if no snapshot
+        // was ever saved for this session.
+        let (inherited_model, inherited_thinking, inherited_auto_approve, inherited_preset) =
+            self.inherited_session_config(&args.session_id).await;
 
         if self.sessions.lock().len() >= self.max_sessions {
             let evict_id = {
@@ -1930,15 +2060,19 @@ impl ZephAcpAgentState {
             )
             .await;
         let shell_executor = acp_ctx.shell_executor.clone();
-        let initial_model = self.initial_model();
-        self.prime_provider_override(&provider_override, &initial_model);
+        let initial_model = inherited_model;
+        self.prime_provider_override(&provider_override, &initial_model, inherited_preset);
         let entry = Self::make_session_entry(
             handle,
             initial_model,
             args.cwd.clone(),
             shell_executor,
             provider_override,
-            self.model_config.default_temperature_preset,
+            SessionConfigSeed {
+                thinking_enabled: inherited_thinking,
+                auto_approve_level: inherited_auto_approve,
+                temperature_preset: inherited_preset,
+            },
         );
 
         Self::spawn_notify_drainer(&entry, cx)?;
@@ -2194,10 +2328,12 @@ impl ZephAcpAgentState {
         }))
     }
 
-    /// Prime a freshly created session's `provider_override` with the configured default
-    /// `[acp.model_config].default_temperature_preset`, so that preset is the *effective*
-    /// sampling temperature from the session's very first prompt — not just the value
-    /// advertised in the IDE dropdown until an explicit `session/set_config_option` call.
+    /// Prime a freshly created session's `provider_override` with `temperature_preset`, so
+    /// that preset is the *effective* sampling temperature from the session's very first
+    /// prompt — not just the value advertised in the IDE dropdown until an explicit
+    /// `session/set_config_option` call. Callers pass the configured
+    /// `[acp.model_config].default_temperature_preset` for new/loaded sessions, or a preset
+    /// inherited from a source session for fork/resume (#5373).
     ///
     /// No-op (leaves `provider_override` as `None`, falling back to the spawner's own
     /// provider) when model switching isn't configured (`provider_factory` unset) or
@@ -2208,10 +2344,9 @@ impl ZephAcpAgentState {
         &self,
         provider_override: &Arc<RwLock<Option<AnyProvider>>>,
         initial_model: &str,
+        temperature_preset: zeph_config::AcpTemperaturePreset,
     ) {
-        if let Ok(provider) = self
-            .provider_with_temperature(initial_model, self.model_config.default_temperature_preset)
-        {
+        if let Ok(provider) = self.provider_with_temperature(initial_model, temperature_preset) {
             *provider_override.write() = Some(provider);
         }
     }
@@ -2812,14 +2947,14 @@ impl ZephAcpAgentState {
         }
     }
 
-    /// Build a fresh `SessionEntry` from a `LoopbackHandle`.
+    /// Build a fresh `SessionEntry` from a `LoopbackHandle`, seeded with `config` (#5373).
     fn make_session_entry(
         handle: LoopbackHandle,
         initial_model: String,
         cwd: PathBuf,
         shell_executor: Option<AcpShellExecutor>,
         provider_override: Arc<RwLock<Option<AnyProvider>>>,
-        temperature_preset: zeph_config::AcpTemperaturePreset,
+        config: SessionConfigSeed,
     ) -> SessionEntry {
         // Bounded: prevents a misbehaving IDE from buffering notifications without limit.
         // 256 slots cover any realistic burst between drainer loop iterations.
@@ -2845,9 +2980,9 @@ impl ZephAcpAgentState {
             current_mode: Mutex::new(acp::schema::v1::SessionModeId::new(DEFAULT_MODE_ID)),
             first_prompt_done: AtomicBool::new(false),
             title: Mutex::new(None),
-            thinking_enabled: AtomicBool::new(false),
-            auto_approve_level: Mutex::new("suggest".to_owned()),
-            temperature_preset: Mutex::new(temperature_preset),
+            thinking_enabled: AtomicBool::new(config.thinking_enabled),
+            auto_approve_level: Mutex::new(config.auto_approve_level),
+            temperature_preset: Mutex::new(config.temperature_preset),
             shell_executor,
             #[cfg(feature = "unstable-elicitation")]
             elicitation_bridge_handle: None,
@@ -3275,7 +3410,11 @@ mod notify_timeout_tests {
             std::path::PathBuf::from("."),
             None,
             provider_override,
-            zeph_config::AcpTemperaturePreset::default(),
+            SessionConfigSeed {
+                thinking_enabled: false,
+                auto_approve_level: "suggest".to_owned(),
+                temperature_preset: zeph_config::AcpTemperaturePreset::default(),
+            },
         );
         // Insert without starting the drainer — no ack will ever be sent.
         agent.sessions.lock().insert(session_id.clone(), entry);
@@ -3288,6 +3427,66 @@ mod notify_timeout_tests {
         assert!(
             result.is_err(),
             "send_notification must fail when ack does not arrive within the timeout"
+        );
+    }
+}
+
+/// Regression tests for #5373: `inherited_session_config`'s fallback when the inherited model
+/// is no longer configured.
+#[cfg(test)]
+mod inherited_session_config_tests {
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use zeph_core::channel::LoopbackChannel;
+    use zeph_llm::any::AnyProvider;
+
+    use super::*;
+
+    /// The inherited model must fall back to `initial_model()` when it is absent from
+    /// `available_models_snapshot()` (e.g. removed from `[[llm.providers]]`/`available_models`
+    /// since the source session was created), rather than handing the spawner a dangling model
+    /// key (#5373).
+    #[tokio::test]
+    async fn falls_back_to_initial_model_when_inherited_model_not_available() {
+        let spawner: AgentSpawner = Arc::new(|_ch, _ctx, _sc| Box::pin(async {}));
+        let agent = ZephAcpAgent::new(spawner, 4, 1800, None).with_provider_factory(
+            Arc::new(|_key: &str| None),
+            Arc::new(RwLock::new(vec!["claude:sonnet".to_owned()])),
+        );
+
+        let session_id = acp::schema::v1::SessionId::new("source-session".to_owned());
+        let (_, handle) = LoopbackChannel::pair(4);
+        let provider_override = Arc::new(RwLock::new(None::<AnyProvider>));
+        let entry = ZephAcpAgent::make_session_entry(
+            handle,
+            "claude:opus".to_owned(),
+            std::path::PathBuf::from("."),
+            None,
+            provider_override,
+            SessionConfigSeed {
+                thinking_enabled: true,
+                auto_approve_level: "auto-edit".to_owned(),
+                temperature_preset: zeph_config::AcpTemperaturePreset::Creative,
+            },
+        );
+        agent.sessions.lock().insert(session_id.clone(), entry);
+
+        let (model, thinking_enabled, auto_approve_level, temperature_preset) =
+            agent.inherited_session_config(&session_id).await;
+
+        assert_eq!(
+            model,
+            agent.initial_model(),
+            "model no longer in available_models must fall back to initial_model()"
+        );
+        // Non-model fields are unaffected by the model-availability check — they still carry
+        // through from the source session.
+        assert!(thinking_enabled);
+        assert_eq!(auto_approve_level, "auto-edit");
+        assert_eq!(
+            temperature_preset,
+            zeph_config::AcpTemperaturePreset::Creative
         );
     }
 }

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -961,6 +961,185 @@ async fn resume_session_reconstructs_from_store_after_restart() {
         .await;
 }
 
+/// `session/fork` inherits the source session's current `temperature`, `thinking`, and
+/// `auto_approve` config from its live in-memory state, rather than resetting to configured
+/// defaults (#5373).
+#[cfg(feature = "unstable-session-fork")]
+#[tokio::test(flavor = "current_thread")]
+async fn fork_session_inherits_config_from_in_memory_source() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            // Configured default is "balanced" — the source session will be switched away
+            // from it so the test can distinguish "inherited" from "reset to default".
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config_with_models("test-agent", vec!["claude:sonnet"]),
+                sw,
+                sr,
+            );
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let source_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                cx.send_request(acp::schema::v1::SetSessionConfigOptionRequest::new(
+                    source_id.clone(),
+                    "temperature",
+                    "creative",
+                ))
+                .block_task()
+                .await?;
+                cx.send_request(acp::schema::v1::SetSessionConfigOptionRequest::new(
+                    source_id.clone(),
+                    "thinking",
+                    "on",
+                ))
+                .block_task()
+                .await?;
+                cx.send_request(acp::schema::v1::SetSessionConfigOptionRequest::new(
+                    source_id.clone(),
+                    "auto_approve",
+                    "auto-edit",
+                ))
+                .block_task()
+                .await?;
+
+                let forked = cx
+                    .send_request(acp::schema::v1::ForkSessionRequest::new(
+                        source_id,
+                        workdir.path(),
+                    ))
+                    .block_task()
+                    .await?;
+
+                let options = forked.config_options.unwrap_or_default();
+                let get = |id: &str| {
+                    select_current_value(options.iter().find(|o| o.id.0.as_ref() == id).unwrap())
+                        .to_owned()
+                };
+                assert_eq!(
+                    get("temperature"),
+                    "creative",
+                    "forked session must inherit the source's temperature preset, not reset to \
+                     the configured default"
+                );
+                assert_eq!(
+                    get("thinking"),
+                    "on",
+                    "forked session must inherit the source's thinking toggle"
+                );
+                assert_eq!(
+                    get("auto_approve"),
+                    "auto-edit",
+                    "forked session must inherit the source's auto-approve level"
+                );
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "fork inheritance test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/resume` of a session that was gracefully closed inherits its persisted config
+/// snapshot (temperature preset applied to the effective provider) rather than resetting to
+/// the configured default (#5373).
+#[tokio::test(flavor = "current_thread")]
+async fn resume_session_inherits_temperature_preset_after_close() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+
+            let captured: Arc<std::sync::Mutex<Option<zeph_llm::provider::GenerationOverrides>>> =
+                Arc::new(std::sync::Mutex::new(None));
+            let captured_for_factory = Arc::clone(&captured);
+            let factory: zeph_acp::ProviderFactory = Arc::new(move |_key: &str| {
+                Some(zeph_llm::any::AnyProvider::Mock(
+                    zeph_llm::mock::MockProvider::default()
+                        .with_overrides_capture(Arc::clone(&captured_for_factory)),
+                ))
+            });
+
+            let mut config = test_config_with_models("test-agent", vec!["claude:sonnet"]);
+            config.provider_factory = Some(factory);
+            config.sqlite_path = Some(":memory:".to_owned());
+
+            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                // Switch away from the configured default ("balanced") before closing.
+                cx.send_request(acp::schema::v1::SetSessionConfigOptionRequest::new(
+                    session_id.clone(),
+                    "temperature",
+                    "creative",
+                ))
+                .block_task()
+                .await?;
+
+                cx.send_request(acp::schema::v1::CloseSessionRequest::new(
+                    session_id.clone(),
+                ))
+                .block_task()
+                .await?;
+
+                cx.send_request(acp::schema::v1::ResumeSessionRequest::new(
+                    session_id,
+                    workdir.path(),
+                ))
+                .block_task()
+                .await?;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "resume inheritance test failed: {result:?}");
+                }
+            }
+
+            let applied_temperature = captured
+                .lock()
+                .expect("capture mutex poisoned")
+                .as_ref()
+                .and_then(|o| o.temperature);
+            assert_eq!(
+                applied_temperature,
+                Some(zeph_config::AcpTemperaturePreset::Creative.temperature()),
+                "resumed session must inherit the closed source's persisted temperature preset, \
+                 not reset to the configured default"
+            );
+        })
+        .await;
+}
+
 /// `session/set_mode` switches the active mode and is reflected in subsequent requests (#5367).
 #[tokio::test(flavor = "current_thread")]
 async fn set_session_mode_switches_mode() {

--- a/crates/zeph-db/migrations/postgres/105_acp_session_config.sql
+++ b/crates/zeph-db/migrations/postgres/105_acp_session_config.sql
@@ -1,0 +1,9 @@
+-- Snapshot of per-session config fields (#5373), persisted on graceful `session/close` so a
+-- later `session/resume` or `session/fork` of a session no longer resident in memory can inherit
+-- its last-known values instead of resetting to configured defaults. NULL means no snapshot
+-- exists yet (session was never closed gracefully, or predates this migration) — callers fall
+-- back to config defaults in that case.
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS current_model TEXT;
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS temperature_preset TEXT;
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS thinking_enabled BOOLEAN;
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS auto_approve_level TEXT;

--- a/crates/zeph-db/migrations/sqlite/105_acp_session_config.sql
+++ b/crates/zeph-db/migrations/sqlite/105_acp_session_config.sql
@@ -1,0 +1,9 @@
+-- Snapshot of per-session config fields (#5373), persisted on graceful `session/close` so a
+-- later `session/resume` or `session/fork` of a session no longer resident in memory can inherit
+-- its last-known values instead of resetting to configured defaults. NULL means no snapshot
+-- exists yet (session was never closed gracefully, or predates this migration) — callers fall
+-- back to config defaults in that case.
+ALTER TABLE acp_sessions ADD COLUMN current_model TEXT;
+ALTER TABLE acp_sessions ADD COLUMN temperature_preset TEXT;
+ALTER TABLE acp_sessions ADD COLUMN thinking_enabled INTEGER;
+ALTER TABLE acp_sessions ADD COLUMN auto_approve_level TEXT;

--- a/crates/zeph-memory/src/store/acp_sessions.rs
+++ b/crates/zeph-memory/src/store/acp_sessions.rs
@@ -22,6 +22,16 @@ pub struct AcpSessionInfo {
     pub message_count: i64,
 }
 
+/// Snapshot of per-session config fields (#5373), taken on graceful `session/close` so a later
+/// `session/resume` or `session/fork` can inherit these values instead of resetting to
+/// configured defaults.
+pub struct AcpSessionConfigSnapshot {
+    pub current_model: String,
+    pub temperature_preset: String,
+    pub thinking_enabled: bool,
+    pub auto_approve_level: String,
+}
+
 impl SqliteStore {
     /// Create a new ACP session record.
     ///
@@ -244,6 +254,69 @@ impl SqliteStore {
         Ok(result.rows_affected() > 0)
     }
 
+    /// Persist a snapshot of the session's current config fields (#5373).
+    ///
+    /// Called on graceful `session/close` so a later `session/resume` or `session/fork` of a
+    /// session no longer resident in memory can inherit these values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database write fails.
+    pub async fn save_session_config(
+        &self,
+        session_id: &str,
+        snapshot: &AcpSessionConfigSnapshot,
+    ) -> Result<(), MemoryError> {
+        zeph_db::query(sql!(
+            "UPDATE acp_sessions SET current_model = ?, temperature_preset = ?, \
+             thinking_enabled = ?, auto_approve_level = ? WHERE id = ?"
+        ))
+        .bind(&snapshot.current_model)
+        .bind(&snapshot.temperature_preset)
+        .bind(snapshot.thinking_enabled)
+        .bind(&snapshot.auto_approve_level)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Load the persisted config snapshot for a session, if one was saved (#5373).
+    ///
+    /// Returns `None` when the session has no snapshot yet — either it was never closed
+    /// gracefully, or it predates the config-snapshot migration. Callers should fall back to
+    /// configured defaults in that case.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn get_session_config(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<AcpSessionConfigSnapshot>, MemoryError> {
+        let row = zeph_db::query_as::<
+            _,
+            (Option<String>, Option<String>, Option<bool>, Option<String>),
+        >(sql!(
+            "SELECT current_model, temperature_preset, thinking_enabled, auto_approve_level \
+                 FROM acp_sessions WHERE id = ?"
+        ))
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.and_then(
+            |(current_model, temperature_preset, thinking_enabled, auto_approve_level)| {
+                Some(AcpSessionConfigSnapshot {
+                    current_model: current_model?,
+                    temperature_preset: temperature_preset?,
+                    thinking_enabled: thinking_enabled?,
+                    auto_approve_level: auto_approve_level?,
+                })
+            },
+        ))
+    }
+
     /// Check whether an ACP session record exists.
     ///
     /// # Errors
@@ -379,6 +452,45 @@ mod tests {
         store.create_acp_session("sess-1").await.unwrap();
         assert!(store.acp_session_exists("sess-1").await.unwrap());
         assert!(!store.acp_session_exists("sess-2").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn session_config_round_trips() {
+        let store = make_store().await;
+        store.create_acp_session("sess-1").await.unwrap();
+        let snapshot = AcpSessionConfigSnapshot {
+            current_model: "claude:opus".to_owned(),
+            temperature_preset: "creative".to_owned(),
+            thinking_enabled: true,
+            auto_approve_level: "auto-edit".to_owned(),
+        };
+        store
+            .save_session_config("sess-1", &snapshot)
+            .await
+            .unwrap();
+
+        let loaded = store
+            .get_session_config("sess-1")
+            .await
+            .unwrap()
+            .expect("snapshot must be present after save");
+        assert_eq!(loaded.current_model, "claude:opus");
+        assert_eq!(loaded.temperature_preset, "creative");
+        assert!(loaded.thinking_enabled);
+        assert_eq!(loaded.auto_approve_level, "auto-edit");
+    }
+
+    #[tokio::test]
+    async fn session_config_missing_snapshot_returns_none() {
+        let store = make_store().await;
+        store.create_acp_session("sess-1").await.unwrap();
+        assert!(store.get_session_config("sess-1").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn session_config_unknown_session_returns_none() {
+        let store = make_store().await;
+        assert!(store.get_session_config("no-such").await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/zeph-memory/src/store/mod.rs
+++ b/crates/zeph-memory/src/store/mod.rs
@@ -56,7 +56,7 @@ use zeph_db::{DbConfig, DbPool};
 
 use crate::error::MemoryError;
 
-pub use acp_sessions::{AcpSessionEvent, AcpSessionInfo};
+pub use acp_sessions::{AcpSessionConfigSnapshot, AcpSessionEvent, AcpSessionInfo};
 pub use agent_sessions::{AgentSessionRow, SessionChannel, SessionKind, SessionStatus};
 pub use memory_tree::MemoryTreeRow;
 pub use messages::role_str;

--- a/specs/013-acp/spec.md
+++ b/specs/013-acp/spec.md
@@ -32,6 +32,7 @@ related:
 | 1.4 | 2026-06-30 | developer | ACP 1.0.1 schema-path migration: bumped core 0.14.0→1.0.1, schema pinned =1.1.0; mechanical `schema::X` → `schema::v1::X` reorg (root re-export removed upstream), `ProtocolVersion`/`MaybeUndefined`/`IntoOption`/`IntoMaybeUndefined` stay flat; removed root re-exports `cookbook`/`handler`/`jsonrpcmsg`/six message enums; deleted 5 long-dead `#[cfg(any())]` test modules (153 unverifiable sites); no handler/transport/builder logic changed; `unstable_cancel_request` and `model_config` evaluated and deferred to follow-up issues |
 | 1.5 | 2026-07-01 | developer | Adopt `model_config` option category (#5361): new `config_id="temperature"` `session/set_config_option`, presets precise/balanced/creative, `[acp.model_config]` config section, CLI + wizard integration. Wire `unstable_cancel_request` (#5362): new `unstable-cancel-request` Cargo feature (not in `default`), `$/cancel_request` bridged onto `cancel_signal: Arc<Notify>` via `Responder::cancellation()` in `session/prompt`, plus a low-level tracing-only `CancelRequestNotification` handler in the `Agent.builder()` chain. Added test coverage for the 8 previously-untested handler files (#5367). |
 | 1.6 | 2026-07-01 | developer | Review fix pass on #5361/#5362: (S-C1) `default_temperature_preset` is now primed into the effective `provider_override` at session creation (`do_new_session`/`do_load_session`/`do_fork_session`/`do_resume_session`), not just advertised in the IDE dropdown; (S-C2) the `$/cancel_request` watcher select is now `biased` with prompt completion checked first, and `drain_agent_events` drains a stale `cancel_signal` permit before its main loop, so a cancellation resolving at/after prompt completion can no longer leak into the next, unrelated prompt (also hardens the pre-existing `session/cancel` no-active-prompt race — `cancel_before_prompt_returns_cancelled` renamed to `cancel_before_prompt_is_a_no_op` to reflect the corrected semantics). Documented fork/resume reset behavior for `temperature_preset` (#5373 tracking issue filed); filed #5374 for the untested `resume_session` store-backed path. |
+| 1.7 | 2026-07-01 | developer | Fixed #5379: `zeph acp model-config show` now loads the resolved config and marks the active `[acp.model_config].default_temperature_preset` in its output, instead of only printing the static preset table. Resolved #5373: `session/fork` and `session/resume` now inherit `model`/`temperature_preset`/`thinking_enabled`/`auto_approve_level` from the source session (live in-memory state, falling back to a persisted close-time snapshot, falling back to configured defaults) instead of always resetting to defaults — new `acp_sessions` columns via migration `105_acp_session_config`; see "Fork/Resume Config Inheritance" below. |
 
 ---
 
@@ -354,10 +355,53 @@ Applied to the session's *effective* provider (not just the advertised dropdown 
 session's very first prompt, via the same `provider_with_temperature` rebuild mechanism used for
 explicit switches.
 
-`session/fork` and `session/resume` reset `temperature_preset` to the configured default rather
-than inheriting the source session's current value, consistent with the pre-existing
-`thinking_enabled`/`auto_approve_level` reset behavior — see #5373 for a tracking issue covering
-inheritance/persistence of all four session-config fields on fork/resume.
+`session/fork` and `session/resume` inherit `model`, `temperature_preset`, `thinking_enabled`,
+and `auto_approve_level` from the source session rather than resetting to configured defaults
+(#5373) — see "Fork/Resume Config Inheritance" below for the resolution order and edge cases.
+
+---
+
+## Fork/Resume Config Inheritance (#5373)
+
+**Status: implemented**
+
+`session/fork` and `session/resume` inherit the source session's current `model`,
+`temperature_preset`, `thinking_enabled`, and `auto_approve_level` rather than resetting to
+`[acp.model_config].default_temperature_preset` / the built-in `thinking_enabled=false` /
+`auto_approve_level="suggest"` defaults. `session/new` and `session/load` are unaffected — they
+have no "source" session to inherit from and continue to seed configured defaults.
+
+Resolution order (`ZephAcpAgent::inherited_session_config`), in `crates/zeph-acp/src/agent/mod.rs`:
+
+1. **Live in-memory state** — if the source session is still resident in the `AcpSessionManager`
+   LRU cache (the common case for `session/fork`, and for `session/resume` when the source was
+   never evicted), its current `SessionEntry` fields are read directly.
+2. **Persisted close-time snapshot** — if not in memory, the session's `acp_sessions` row is
+   checked for a config snapshot (`current_model`, `temperature_preset`, `thinking_enabled`,
+   `auto_approve_level` columns, migration `105_acp_session_config`). The snapshot is written by
+   `do_close_session` immediately before the in-memory entry is removed, so a session closed via
+   `session/close` and later resumed inherits its last-known config even across process restarts.
+3. **Configured defaults** — if neither is available (the source was evicted rather than closed
+   gracefully — LRU capacity pressure or the idle reaper — or predates the snapshot migration),
+   inheritance falls back to the same defaults `session/new` uses.
+
+Additionally, an inherited `model` that is no longer present in the current
+`available_models_snapshot()` (e.g. removed from `[[llm.providers]]` since the source session was
+created) falls back to `initial_model()` rather than handing the spawner a dangling model key.
+
+### Key Invariants
+
+- Eviction paths (idle reaper timeout, LRU capacity eviction in `session/new`, `session/fork`, and
+  `session/resume`) do **not** write a config snapshot — only graceful `session/close` does. A
+  session that was evicted rather than closed falls back to configured defaults on later
+  resume/fork; this is a known, documented boundary, not a bug.
+- The snapshot is best-effort: a write failure is logged (`tracing::warn!`) and does not fail
+  `session/close`, since losing the config snapshot is far less severe than failing to close the
+  session.
+- `session/fork`'s inheritance lookup runs before the LRU capacity-eviction pass in the same
+  handler, since that pass does not exclude the fork source from eviction candidates (pre-existing
+  behavior, unchanged by this feature) — reading inheritance first avoids a race where forking
+  could otherwise evict the very session it inherits from.
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1019,6 +1019,21 @@ mod tests {
 
     use super::Cli;
 
+    #[cfg(feature = "acp")]
+    #[test]
+    fn cli_parses_acp_model_config_show() {
+        use super::{AcpCommand, AcpModelConfigCommand, Command};
+        let cli = Cli::try_parse_from(["zeph", "acp", "model-config", "show"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Acp {
+                command: AcpCommand::ModelConfig {
+                    command: AcpModelConfigCommand::Show
+                }
+            })
+        ));
+    }
+
     #[cfg(feature = "scheduler")]
     #[test]
     fn cli_parses_schedule_list() {

--- a/src/commands/acp.rs
+++ b/src/commands/acp.rs
@@ -1,8 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::path::Path;
+
 use anyhow::Context as _;
 
+use crate::bootstrap::{load_config_or_default, resolve_config_path};
 use crate::cli::{AcpCommand, AcpModelConfigCommand, AcpSubagentCommand};
 
 /// Handle `zeph acp <subcommand>`.
@@ -11,7 +14,10 @@ use crate::cli::{AcpCommand, AcpModelConfigCommand, AcpSubagentCommand};
 ///
 /// Returns an error if the sub-agent fails to spawn, the handshake fails, or the
 /// prompt round-trip times out.
-pub(crate) async fn handle_acp_command(cmd: AcpCommand) -> anyhow::Result<()> {
+pub(crate) async fn handle_acp_command(
+    cmd: AcpCommand,
+    config_path: Option<&Path>,
+) -> anyhow::Result<()> {
     match cmd {
         AcpCommand::RunAgent {
             command,
@@ -62,23 +68,132 @@ pub(crate) async fn handle_acp_command(cmd: AcpCommand) -> anyhow::Result<()> {
         AcpCommand::ModelConfig {
             command: AcpModelConfigCommand::Show,
         } => {
-            // Config is not loaded at this point; report the static preset table and pointer.
-            println!(
-                "ACP model_config presets (session/set_config_option, config_id=\"temperature\"):"
-            );
-            for preset in [
-                zeph_config::AcpTemperaturePreset::Precise,
-                zeph_config::AcpTemperaturePreset::Balanced,
-                zeph_config::AcpTemperaturePreset::Creative,
-            ] {
-                println!(
-                    "  {:<10} temperature = {}",
-                    preset.as_str(),
-                    preset.temperature()
-                );
-            }
-            println!("Default preset is configured under [acp.model_config] in config.toml.");
+            let config_file = resolve_config_path(config_path);
+            let config = load_config_or_default(&config_file);
+            print!("{}", render_model_config_table(&config, &config_file));
             Ok(())
+        }
+    }
+}
+
+/// Render the `zeph acp model-config show` table: the three sampling-temperature presets with
+/// `(default)` marked on whichever one matches `config.acp.model_config.default_temperature_preset`,
+/// plus a pointer to the config file and key that controls it.
+///
+/// Extracted as a pure function (rather than inlined `println!` calls) so the #5379 regression
+/// test can assert on the exact rendered text instead of only that the handler returns `Ok(())`.
+fn render_model_config_table(config: &zeph_core::config::Config, config_path: &Path) -> String {
+    use std::fmt::Write as _;
+
+    let default_preset = config.acp.model_config.default_temperature_preset;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "ACP model_config presets (session/set_config_option, config_id=\"temperature\"):"
+    );
+    for preset in [
+        zeph_config::AcpTemperaturePreset::Precise,
+        zeph_config::AcpTemperaturePreset::Balanced,
+        zeph_config::AcpTemperaturePreset::Creative,
+    ] {
+        let marker = if preset == default_preset {
+            "  (default)"
+        } else {
+            ""
+        };
+        let _ = writeln!(
+            out,
+            "  {:<10} temperature = {}{marker}",
+            preset.as_str(),
+            preset.temperature()
+        );
+    }
+    let _ = writeln!(
+        out,
+        "Config: {} — [acp.model_config].default_temperature_preset",
+        config_path.display()
+    );
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{handle_acp_command, render_model_config_table};
+    use crate::cli::{AcpCommand, AcpModelConfigCommand};
+
+    /// `model-config show` must load the resolved config without error (#5379) — this
+    /// exercises the `resolve_config_path` + `load_config_or_default` wiring end to end.
+    /// Marker-placement correctness is asserted separately below against
+    /// `render_model_config_table` directly, since capturing `stdout` from this handler in a
+    /// test is fragile — the pure render function exists specifically to avoid that.
+    #[tokio::test]
+    async fn model_config_show_loads_config_without_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = zeph_core::config::Config::default();
+        config.acp.model_config.default_temperature_preset =
+            zeph_config::AcpTemperaturePreset::Creative;
+        let toml = toml::to_string_pretty(&config).expect("serialize config");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml).expect("write config");
+
+        let result = handle_acp_command(
+            AcpCommand::ModelConfig {
+                command: AcpModelConfigCommand::Show,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(result.is_ok(), "model-config show failed: {result:?}");
+    }
+
+    /// The `(default)` marker must land specifically on the `creative` line when
+    /// `default_temperature_preset = "creative"` is configured — a regression that drops the
+    /// marker entirely, or misplaces it on another preset, must fail this test (#5379).
+    #[test]
+    fn render_marks_configured_creative_preset_as_default() {
+        let mut config = zeph_core::config::Config::default();
+        config.acp.model_config.default_temperature_preset =
+            zeph_config::AcpTemperaturePreset::Creative;
+        let table = render_model_config_table(&config, std::path::Path::new("config.toml"));
+
+        let creative_line = table
+            .lines()
+            .find(|l| l.contains("creative"))
+            .expect("creative line present");
+        assert!(
+            creative_line.contains("(default)"),
+            "creative line must carry the marker: {creative_line:?}"
+        );
+        for other in ["precise", "balanced"] {
+            let line = table.lines().find(|l| l.contains(other)).unwrap();
+            assert!(
+                !line.contains("(default)"),
+                "{other} line must not carry the marker: {line:?}"
+            );
+        }
+    }
+
+    /// With no `[acp.model_config]` override, the built-in default (`balanced`) must carry the
+    /// marker — not `precise`/`creative` (#5379).
+    #[test]
+    fn render_marks_balanced_as_default_when_unconfigured() {
+        let config = zeph_core::config::Config::default();
+        let table = render_model_config_table(&config, std::path::Path::new("config.toml"));
+
+        let balanced_line = table
+            .lines()
+            .find(|l| l.contains("balanced"))
+            .expect("balanced line present");
+        assert!(
+            balanced_line.contains("(default)"),
+            "balanced line must carry the marker: {balanced_line:?}"
+        );
+        for other in ["precise", "creative"] {
+            let line = table.lines().find(|l| l.contains(other)).unwrap();
+            assert!(
+                !line.contains("(default)"),
+                "{other} line must not carry the marker: {line:?}"
+            );
         }
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -539,7 +539,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         }
         #[cfg(feature = "acp")]
         Some(Command::Acp { command: acp_cmd }) => {
-            return handle_acp_command(acp_cmd).await;
+            return handle_acp_command(acp_cmd, cli.config.as_deref()).await;
         }
         #[cfg(feature = "acp")]
         Some(Command::Sessions { command: sess_cmd }) => {


### PR DESCRIPTION
## Summary
- `zeph acp model-config show` now loads the resolved config and marks the active `[acp.model_config].default_temperature_preset` in its output (e.g. `balanced   temperature = 0.7  (default)`), instead of always printing the same static preset table with a generic pointer to `config.toml`.
- `session/fork` and `session/resume` now inherit the source session's current `model`, `temperature_preset`, `thinking_enabled`, and `auto_approve_level` instead of always resetting to configured defaults. Resolution order: the source's live in-memory state (fork's common case) → a persisted close-time snapshot (new columns on `acp_sessions` via migration `105_acp_session_config`, written by `session/close`) → configured defaults. An inherited model no longer present in `available_models` falls back to the current default instead of a dangling model key.
- Eviction paths (idle-reaper timeout, LRU capacity) do not persist a snapshot — this is a documented boundary in `specs/013-acp/spec.md`, not a regression; only graceful close snapshots for later resume.

Closes #5379
Closes #5373

## Notes for reviewers
- Migration number `105` is now claimed by `105_acp_session_config.sql` (both dialects). `specs/068-session-persistence/spec.md` (#2807/#3102, not yet implemented) had also planned to use `105` for unrelated `acp_sessions` columns — that future work will need to renumber to `106+`.
- Two follow-up P3 issues were suggested during review but intentionally left out of scope for this PR (happy to file if wanted): reaper-snapshot coverage for the eviction-path gap above, and `session/resume`'s response not populating `config_options`/`modes` like `session/fork` does (pre-existing, from the ACP 1.0.1 migration, not a regression here).

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11553 PASS
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New unit/integration tests: `render_marks_configured_creative_preset_as_default`, `render_marks_balanced_as_default_when_unconfigured`, `fork_session_inherits_config_from_in_memory_source`, `resume_session_inherits_temperature_preset_after_close`, `falls_back_to_initial_model_when_inherited_model_not_available`, plus 3 new `zeph-memory` unit tests for the snapshot store.
- [x] `CHANGELOG.md`, `specs/013-acp/spec.md`, and the mandatory testing artifacts (`.local/testing/playbooks/acp.md` Scenarios 8-9, `.local/testing/coverage-status.md` rows 636/638) updated in the main repo.