### PR TITLE
fix(knowledge): create Qdrant documents collection before ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(knowledge)`: `zeph knowledge ingest` no longer fails on a fresh Qdrant instance.
+  `build_ingest_resources` now probes the embedding dimension and calls
+  `QdrantOps::ensure_collection` for the documents collection before constructing the
+  `IngestionPipeline` (mirroring `EmbeddingRegistry::ensure_collection`), instead of assuming
+  the collection already exists. Also fixed misleading progress output: a failed file previously
+  emitted the same `IngestProgress::FileDone { chunks: 0, .. }` event as a legitimate zero-chunk
+  success, printing `[done] ... → 0 chunk(s)`; a new `IngestProgress::FileError { uri, msg }`
+  variant is now sent instead, printed as `[ERR] {uri}: {msg}`. Closes #5382.
 - `fix(acp)`: `zeph acp model-config show` now loads the resolved config and marks the active
   `[acp.model_config].default_temperature_preset` in its output (e.g. `balanced   temperature =
   0.7  (default)`), instead of only printing the static preset table with a generic pointer to

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -60,13 +60,16 @@ pub(crate) enum IngestProgress {
     Discovered { source: String, files: usize },
     /// A file is about to be embedded (pre-write signal for TUI spinner: `Ingesting knowledge: <uri>…`).
     Ingesting { uri: String },
-    /// All chunks for a file have been processed (or the file failed).
+    /// All chunks for a file were successfully processed (or skipped as unchanged).
     FileDone {
         uri: String,
         chunks: usize,
         /// `true` when the ledger skipped this file (unchanged content).
         skipped: bool,
     },
+    /// A file failed to ingest; distinct from `FileDone` so the printer doesn't
+    /// misreport a failure as a successful zero-chunk ingest.
+    FileError { uri: String, msg: String },
     /// The run is complete.
     Finished,
 }
@@ -429,6 +432,19 @@ async fn build_ingest_resources(
             Box::pin(async move { p.embed(&owned).await })
         }
     };
+
+    // Probe the embedding dimension and pre-create the documents collection so a fresh
+    // Qdrant instance doesn't fail on the first upsert (mirrors EmbeddingRegistry::ensure_collection).
+    let vector_size = provider
+        .embed("dimension probe")
+        .await
+        .map(|v| v.len() as u64)
+        .map_err(|e| anyhow::anyhow!("failed to probe embedding dimension: {e}"))?;
+    qdrant
+        .ensure_collection(&collection, vector_size)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to ensure Qdrant collection '{collection}': {e}"))?;
+
     let pipeline = IngestionPipeline::new(
         TextSplitter::new(SplitterConfig::default()),
         qdrant,
@@ -478,6 +494,9 @@ async fn run_ingest(
                         println!("  [done] {uri} → {chunks} chunk(s)");
                     }
                 }
+                IngestProgress::FileError { uri, msg } => {
+                    println!("  [ERR] {uri}: {msg}");
+                }
                 IngestProgress::Finished => break,
             }
         }
@@ -523,12 +542,8 @@ async fn run_ingest(
                 });
             }
             IngestOneResult::Error(msg) => {
-                failures.push((uri.clone(), msg));
-                let _ = progress_tx.send(IngestProgress::FileDone {
-                    uri,
-                    chunks: 0,
-                    skipped: false,
-                });
+                failures.push((uri.clone(), msg.clone()));
+                let _ = progress_tx.send(IngestProgress::FileError { uri, msg });
             }
         }
     }
@@ -1731,6 +1746,44 @@ mod tests {
         assert!(
             matches!(second, IngestProgress::FileDone { skipped: true, .. }),
             "FileDone(skipped) must follow Ingesting"
+        );
+    }
+
+    // ── IngestProgress channel: failed ingest emits FileError, not FileDone (#5382) ──
+
+    #[tokio::test]
+    async fn progress_channel_emits_file_error_for_failed_ingest() {
+        // Simulate the IngestOneResult::Error branch of run_ingest's loop body
+        // (run_ingest itself needs a live Qdrant pipeline and can't be called here).
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<IngestProgress>();
+
+        let uri = "specs/README.md@abc1234".to_owned();
+        let msg = "embedding provider returned 500".to_owned();
+
+        let _ = tx.send(IngestProgress::Ingesting { uri: uri.clone() });
+        let _ = tx.send(IngestProgress::FileError {
+            uri: uri.clone(),
+            msg: msg.clone(),
+        });
+        let _ = tx.send(IngestProgress::Finished);
+        drop(tx);
+
+        let first = rx.recv().await.expect("first event");
+        assert!(
+            matches!(first, IngestProgress::Ingesting { uri: ref u } if u == &uri),
+            "Ingesting must fire before the terminal event"
+        );
+
+        let second = rx.recv().await.expect("second event");
+        assert!(
+            matches!(second, IngestProgress::FileError { uri: ref got_uri, msg: ref got_msg }
+                if got_uri == &uri && got_msg == &msg),
+            "#5382: a failed ingest must emit FileError{{uri, msg}}, not FileDone{{chunks:0}}, \
+             so the CLI prints [ERR] instead of misreporting [done]"
+        );
+        assert!(
+            !matches!(second, IngestProgress::FileDone { .. }),
+            "#5382 regression guard: must never fall back to FileDone on error"
         );
     }
 


### PR DESCRIPTION
## Summary

- `zeph knowledge ingest` was completely non-functional against a fresh Qdrant instance: `build_ingest_resources()` never called `ensure_collection` for the documents collection, so every file failed at the Qdrant upsert step with `Collection doesn't exist`. It now probes the embedding dimension and ensures the collection exists before constructing the ingestion pipeline, mirroring `EmbeddingRegistry`'s existing pattern.
- The per-file progress printer misreported failures as `[done] ... -> 0 chunk(s)` because errors were sent as the same `IngestProgress::FileDone` event used for a legitimate zero-chunk success. Added a dedicated `IngestProgress::FileError { uri, msg }` variant, printed as `[ERR] {uri}: {msg}`, so failures are visible inline instead of only in the final summary.

Closes #5382.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11554 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — builds clean (pre-existing unrelated warnings in zeph-bench/zeph-channels/zeph-tui only)
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all pass
- [x] Added regression test `progress_channel_emits_file_error_for_failed_ingest` covering the FileError/FileDone distinction
- [x] Manual live verification: ran `zeph knowledge ingest --source specs` against a fresh Qdrant collection that did not previously exist; confirmed the collection was auto-created (1536-dim cosine) and ingest completed successfully (55 chunks/points written) instead of failing at `qdrant.upsert(...)`