### PR TITLE
test(ci): wire zeph-memory/zeph-index postgres integration tests into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,30 @@ jobs:
           name: nextest-archive-zeph-db-postgres
           path: nextest-archive-zeph-db-postgres.tar.zst
           retention-days: 1
+      - name: Build and archive zeph-memory postgres integration tests
+        # zeph-memory's sqlite/postgres features are additive (unlike zeph-db's
+        # mutually-exclusive default), so default features stay on here — building
+        # with --no-default-features would disable the "sqlite" feature and turn
+        # unrelated sqlite-only test helpers into dead-code errors under -D warnings.
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci -p zeph-memory --features test-utils --tests --archive-file nextest-archive-zeph-memory-postgres.tar.zst
+      - name: Upload zeph-memory postgres test archive
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: nextest-archive-zeph-memory-postgres
+          path: nextest-archive-zeph-memory-postgres.tar.zst
+          retention-days: 1
+      - name: Build and archive zeph-index postgres integration tests
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci -p zeph-index --features test-utils --tests --archive-file nextest-archive-zeph-index-postgres.tar.zst
+      - name: Upload zeph-index postgres test archive
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: nextest-archive-zeph-index-postgres
+          path: nextest-archive-zeph-index-postgres.tar.zst
+          retention-days: 1
       - name: Upload binary
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -308,6 +332,24 @@ jobs:
           name: nextest-archive-zeph-db-postgres
       - name: Run postgres integration tests (testcontainers)
         run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive-zeph-db-postgres.tar.zst --workspace-remap . --profile ci --run-ignored ignored-only
+      - name: Download zeph-memory postgres test archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nextest-archive-zeph-memory-postgres
+      - name: Run zeph-memory postgres integration tests (testcontainers)
+        # Scoped to the postgres_integration binary: zeph-memory's archive also
+        # contains hela_spreading_activation.rs (SQLite `:memory:` ignored tests,
+        # unrelated to postgres). Both sqlite and postgres are enabled in this
+        # archive (see the archive step's comment in build-tests), so DbConfig::connect
+        # gives postgres cfg-priority for the whole crate; running crate-wide would
+        # route those unrelated :memory: tests through connect_postgres and fail them.
+        run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive-zeph-memory-postgres.tar.zst --workspace-remap . --profile ci --run-ignored ignored-only -E 'binary(postgres_integration)'
+      - name: Download zeph-index postgres test archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nextest-archive-zeph-index-postgres
+      - name: Run zeph-index postgres integration tests (testcontainers)
+        run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive-zeph-index-postgres.tar.zst --workspace-remap . --profile ci --run-ignored ignored-only -E 'binary(postgres_integration)'
       - name: Run Qdrant integration tests (testcontainers)
         run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive.tar.zst --workspace-remap . --profile ci --run-ignored ignored-only -E 'binary(qdrant_integration)'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   emitted the same `IngestProgress::FileDone { chunks: 0, .. }` event as a legitimate zero-chunk
   success, printing `[done] ... → 0 chunk(s)`; a new `IngestProgress::FileError { uri, msg }`
   variant is now sent instead, printed as `[ERR] {uri}: {msg}`. Closes #5382.
+- `fix(ci)`: wire the 19 `zeph-memory` + 2 `zeph-index` Postgres integration tests added by
+  #5376 into `.github/workflows/ci.yml`, mirroring the existing `zeph-db` postgres archive/run
+  job pattern (`nextest-archive-{zeph-memory,zeph-index}-postgres.tar.zst`). These tests, added
+  to catch the dynamic-SQL dialect regressions behind #5364, compiled behind the crates'
+  `test-utils` feature but were never built or run in CI, so a reintroduced regression would
+  have silently passed. The new run steps scope execution to
+  `-E 'binary(postgres_integration)'` rather than the crate-wide `--ignored` set, since enabling
+  `test-utils` (which adds `postgres` on top of the crate's default `sqlite` feature) makes
+  `zeph-db::DbConfig::connect()` route every `SqliteStore::new(":memory:")` call in the same
+  crate through `connect_postgres` (documented at the cfg-priority site in
+  `crates/zeph-db/src/pool.rs`), which would otherwise break unrelated ignored tests
+  (`hela_spreading_activation.rs`). Also corrected both files' module doc-comments, which
+  recommended the crate-wide command that triggers that exact failure. Closes #5377.
 - `fix(acp)`: `zeph acp model-config show` now loads the resolved config and marks the active
   `[acp.model_config].default_temperature_preset` in its output (e.g. `balanced   temperature =
   0.7  (default)`), instead of only printing the static preset table with a generic pointer to

--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -33,6 +33,15 @@ impl DbConfig {
     /// # Errors
     ///
     /// Returns [`DbError`] if connection or migration fails.
+    // `postgres` takes cfg-priority over `sqlite` when both are enabled on a crate
+    // (documented in this crate's Cargo.toml `[features]` comment). This is safe for
+    // `zeph-db` in isolation, but a downstream crate that enables both (e.g. via a
+    // `test-utils` feature that adds `postgres` on top of a default `sqlite`) will have
+    // every `SqliteStore::new(":memory:")` call silently routed through
+    // `connect_postgres`, which fails to parse the bare `:memory:` string as a Postgres
+    // URL. See #5377: this bit `zeph-memory`/`zeph-index`'s crate-wide
+    // `--features test-utils --ignored` test runs; the fix there was to scope test
+    // execution to the Postgres-only test binary rather than changing this priority.
     #[tracing::instrument(name = "db.pool.connect", skip_all, err)]
     pub async fn connect(&self) -> Result<DbPool, DbError> {
         #[cfg(all(feature = "sqlite", not(feature = "postgres")))]

--- a/crates/zeph-index/tests/postgres_integration.rs
+++ b/crates/zeph-index/tests/postgres_integration.rs
@@ -3,10 +3,10 @@
 
 //! `PostgreSQL` integration tests for `zeph-index`.
 //!
-//! These tests require Docker to be running and are skipped in CI unless the
-//! `test-postgres` CI job is active. Run locally with:
+//! These tests require Docker to be running. They run in CI as part of the
+//! `build-tests`/`integration` jobs in `.github/workflows/ci.yml`. Run locally with:
 //! ```bash
-//! cargo nextest run -p zeph-index --features test-utils --ignored
+//! cargo nextest run -p zeph-index --features test-utils --test postgres_integration --run-ignored ignored-only
 //! ```
 
 #[cfg(feature = "test-utils")]

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -3,11 +3,17 @@
 
 //! `PostgreSQL` integration tests for `zeph-memory`.
 //!
-//! These tests require Docker to be running and are skipped in CI unless the
-//! `test-postgres` CI job is active. Run locally with:
+//! These tests require Docker to be running. They run in CI as part of the
+//! `build-tests`/`integration` jobs in `.github/workflows/ci.yml`. Run locally with:
 //! ```bash
-//! cargo nextest run -p zeph-memory --features test-utils --ignored
+//! cargo nextest run -p zeph-memory --features test-utils --test postgres_integration --run-ignored ignored-only
 //! ```
+//! Scoping to `--test postgres_integration` matters: `test-utils` enables the `postgres`
+//! feature alongside the crate's default `sqlite` feature, and `DbConfig::connect()` gives
+//! `postgres` cfg-priority whenever both are enabled (see `zeph-db/src/pool.rs`). Running the
+//! crate-wide `--ignored` command instead would route unrelated `SqliteStore::new(":memory:")`
+//! calls in other ignored tests (e.g. `hela_spreading_activation.rs`) through `connect_postgres`
+//! and fail them with a `RelativeUrlWithoutBase` error.
 //!
 //! Regression coverage for issue #5364: several dynamic-SQL call sites in
 //! `zeph-memory` built `IN (...)` lists and `INSERT ... ON CONFLICT` statements with


### PR DESCRIPTION
## Summary
- Adds archive/run steps in `.github/workflows/ci.yml` for the 19 zeph-memory + 2 zeph-index Postgres integration tests added in #5376 (previously gated behind `test-utils` but never built or executed by any CI job), mirroring the existing zeph-db postgres job.
- Scopes the new steps with a nextest filter (`binary(postgres_integration)` + `--run-ignored ignored-only`) instead of `--no-default-features`, since the latter fails to compile under `-D warnings` for these two crates (dead_code in sqlite-only test helpers), and avoids the sqlite/postgres cfg-priority interaction that silently misroutes `:memory:` connections in unrelated ignored tests in the same crate.
- Documents the cfg-priority interaction at its source in `zeph-db::DbConfig::connect()` and fixes both crates' module doc-comments, which previously recommended a crate-wide test command that triggers the footgun.
- Updates `CHANGELOG.md`.

A compile-time guard against enabling `sqlite`+`postgres` together was considered and deliberately not added — `test-utils` legitimately needs both features active at once, and the spec's edge-case analysis scopes the general (production-facing) footgun fix out of this issue. Filing a separate P3 follow-up for that is recommended (not done here).

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11553 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `fy lint .github/workflows/ci.yml` (0 errors)
- [x] Verified locally that `cargo nextest archive -p zeph-memory --features test-utils --tests` and `-p zeph-index` compile cleanly and that the new filter selects exactly the 19+2 target tests, no bleed from unrelated ignored tests
- [ ] First real CI run: watch for resource/flakiness from 21 tests each spinning up their own Postgres testcontainer in parallel (not verifiable locally)

Closes #5377