### PR TITLE
fix(a2a): close SSRF DNS-rebinding TOCTOU and redirect bypass, replace boolean-blind with_security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `fix(a2a)!`: `A2aClient::with_security` no longer takes two positional bools (transposing
+  `with_security(true, false)` vs. `with_security(false, true)` was a silent foot-gun). It now
+  takes a `SecurityPolicy { require_tls, ssrf_protection }` struct, with `SecurityPolicy::hardened()`
+  / `SecurityPolicy::permissive()` presets. Closes #5381.
 - `feat(mcp)!`: upgrade `rmcp` from 1.8.0 to 2.0.0. **Breaking dependency change**:
   `RawContent`/`Content`/`Annotated<RawContent>` are removed in favor of a unified
   `ContentBlock` enum (`Text`/`Image`/`Audio`/`Resource`/`ResourceLink`); elicitation types
@@ -83,6 +87,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `crates/zeph-db/src/pool.rs`), which would otherwise break unrelated ignored tests
   (`hela_spreading_activation.rs`). Also corrected both files' module doc-comments, which
   recommended the crate-wide command that triggers that exact failure. Closes #5377.
+- `fix(a2a)`: close two SSRF gaps in `A2aClient`. (1) DNS-rebinding TOCTOU — `validate_endpoint`
+  resolved and validated the hostname but discarded the address, letting the underlying
+  `reqwest::Client` re-resolve independently at connect time; requests now pin the connection to
+  the validated address via `resolve_to_addrs`, so a DNS answer that changes between the check
+  and the connect can no longer redirect to a private/internal address. (2) redirect-based
+  bypass — the client's redirect policy (`Policy::limited(10)`) followed a malicious `3xx`
+  response toward a private address or an `https`→`http` downgrade with no re-validation;
+  requests through a client with any `SecurityPolicy` flag enabled now use `Policy::none()`
+  (and `https_only(true)` when `require_tls` is set), so the raw redirect is surfaced as an
+  error instead of being followed. The shared resolve+validate loop was factored out to
+  `zeph_common::net::resolve_and_validate` and is now used by both `zeph-a2a` and
+  `zeph-tools`'s `scrape.rs`. The TUI-remote client (`src/tui_remote.rs`) now wires
+  `SecurityPolicy` from `config.a2a.require_tls`/`.ssrf_protection` (both default `true`)
+  instead of running with no security applied — the only production call site was previously
+  unprotected despite the config defaulting to hardened. Closes #5380.
 - `fix(acp)`: `zeph acp model-config show` now loads the resolved config and marks the active
   `[acp.model_config].default_temperature_preset` in its output (e.g. `balanced   temperature =
   0.7  (default)`), instead of only printing the static preset table with a generic pointer to

--- a/crates/zeph-a2a/Cargo.toml
+++ b/crates/zeph-a2a/Cargo.toml
@@ -25,7 +25,7 @@ futures.workspace = true
 futures-core.workspace = true
 hex.workspace = true
 hmac = { workspace = true, optional = true }
-reqwest = { workspace = true, features = ["json", "stream"] }
+reqwest = { workspace = true, features = ["json", "rustls", "stream"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2 = { workspace = true, optional = true }

--- a/crates/zeph-a2a/src/client.rs
+++ b/crates/zeph-a2a/src/client.rs
@@ -3,6 +3,7 @@
 
 //! A2A protocol HTTP client with optional TLS enforcement and SSRF protection.
 
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::time::Duration;
 
@@ -10,7 +11,7 @@ use eventsource_stream::Eventsource;
 use futures_core::Stream;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio_stream::StreamExt;
-use zeph_common::net::is_private_ip;
+use zeph_common::net::resolve_and_validate;
 
 use crate::error::A2aError;
 use crate::jsonrpc::{
@@ -40,6 +41,88 @@ pub enum TaskEvent {
     ArtifactUpdate(TaskArtifactUpdateEvent),
 }
 
+/// Security posture applied to outbound [`A2aClient`] requests.
+///
+/// Named fields eliminate the transposition hazard of a two-bool builder method
+/// (`with_security(true, false)` vs. `with_security(false, true)` are easy to swap
+/// by accident) and group the security boundary as one reviewable unit.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_a2a::{A2aClient, SecurityPolicy};
+///
+/// // Recommended for production: reject HTTP and private/loopback targets.
+/// let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy::hardened());
+///
+/// // Partial policy via named fields — no ambiguity about which flag is which.
+/// let tls_only = SecurityPolicy {
+///     require_tls: true,
+///     ssrf_protection: false,
+/// };
+/// let _ = client.with_security(tls_only);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SecurityPolicy {
+    /// Reject any endpoint that does not start with `https://`, and build requests with
+    /// `https_only(true)` so a redirect cannot silently downgrade the connection to `http://`.
+    pub require_tls: bool,
+    /// Resolve the endpoint hostname via DNS, reject private/loopback/link-local ranges,
+    /// and pin the validated address for the actual connection so it cannot be re-resolved
+    /// to a different (attacker-controlled) address between the check and the connect.
+    pub ssrf_protection: bool,
+}
+
+impl SecurityPolicy {
+    /// Both protections enabled. The recommended posture for production deployments
+    /// that talk to untrusted or third-party A2A endpoints.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_a2a::SecurityPolicy;
+    ///
+    /// let policy = SecurityPolicy::hardened();
+    /// assert!(policy.require_tls);
+    /// assert!(policy.ssrf_protection);
+    /// ```
+    #[must_use]
+    pub const fn hardened() -> Self {
+        Self {
+            require_tls: true,
+            ssrf_protection: true,
+        }
+    }
+
+    /// Both protections disabled. Suitable only for local development against
+    /// trusted, non-adversarial endpoints (e.g. `http://localhost`).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_a2a::SecurityPolicy;
+    ///
+    /// let policy = SecurityPolicy::permissive();
+    /// assert!(!policy.require_tls);
+    /// assert!(!policy.ssrf_protection);
+    /// ```
+    #[must_use]
+    pub const fn permissive() -> Self {
+        Self {
+            require_tls: false,
+            ssrf_protection: false,
+        }
+    }
+}
+
+/// A DNS-validated hostname and its resolved addresses, used to pin the actual HTTP
+/// connection to the exact addresses that passed SSRF validation (see [`SecurityPolicy`]).
+#[derive(Debug)]
+struct PinnedTarget {
+    host: String,
+    addrs: Vec<SocketAddr>,
+}
+
 /// HTTP client for the A2A protocol.
 ///
 /// `A2aClient` wraps a `reqwest::Client` and provides typed methods for the four
@@ -49,19 +132,19 @@ pub enum TaskEvent {
 /// # Security
 ///
 /// Use [`with_security`](A2aClient::with_security) to harden the client for
-/// production deployments:
-/// - `require_tls = true` rejects any `http://` endpoint before connecting.
-/// - `ssrf_protection = true` resolves the endpoint's hostname via DNS and rejects
-///   addresses in private/loopback ranges (10/8, 172.16/12, 192.168/16, 127/8, etc.).
+/// production deployments — see [`SecurityPolicy`]. When either flag is enabled,
+/// each request is sent through a dedicated per-request `reqwest::Client` with
+/// redirects disabled and, when `ssrf_protection` is on, the connection pinned to
+/// the exact addresses that were validated (no re-resolution at connect time).
 ///
 /// # Examples
 ///
 /// ```rust,no_run
-/// use zeph_a2a::{A2aClient, SendMessageParams, Message};
+/// use zeph_a2a::{A2aClient, SecurityPolicy, SendMessageParams, Message};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = A2aClient::new(reqwest::Client::new())
-///     .with_security(true, true); // require HTTPS, block SSRF
+///     .with_security(SecurityPolicy::hardened());
 ///
 /// let params = SendMessageParams {
 ///     message: Message::user_text("Summarize this page."),
@@ -74,8 +157,7 @@ pub enum TaskEvent {
 /// ```
 pub struct A2aClient {
     client: reqwest::Client,
-    require_tls: bool,
-    ssrf_protection: bool,
+    security: SecurityPolicy,
     /// Per-request timeout applied to `rpc_call` (send + JSON parse) and to the initial
     /// `send()` in `stream_message`. The SSE body stream itself is not bounded — that
     /// is the caller's responsibility.
@@ -95,32 +177,27 @@ impl A2aClient {
     pub fn new(client: reqwest::Client) -> Self {
         Self {
             client,
-            require_tls: false,
-            ssrf_protection: false,
+            security: SecurityPolicy::permissive(),
             request_timeout: Duration::from_secs(30),
         }
     }
 
-    /// Configure TLS enforcement and SSRF protection for this client.
+    /// Configure the [`SecurityPolicy`] for this client.
     ///
-    /// Both flags default to `false`. This method uses the builder pattern and
-    /// can be chained directly after [`new`](Self::new).
-    ///
-    /// - `require_tls`: reject any endpoint that does not start with `https://`.
-    /// - `ssrf_protection`: resolve the endpoint hostname via DNS and reject private IP ranges.
+    /// Defaults to [`SecurityPolicy::permissive()`] (no restrictions). This method
+    /// uses the builder pattern and can be chained directly after [`new`](Self::new).
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use zeph_a2a::A2aClient;
+    /// use zeph_a2a::{A2aClient, SecurityPolicy};
     ///
     /// let client = A2aClient::new(reqwest::Client::new())
-    ///     .with_security(true, true);
+    ///     .with_security(SecurityPolicy::hardened());
     /// ```
     #[must_use]
-    pub fn with_security(mut self, require_tls: bool, ssrf_protection: bool) -> Self {
-        self.require_tls = require_tls;
-        self.ssrf_protection = ssrf_protection;
+    pub fn with_security(mut self, policy: SecurityPolicy) -> Self {
+        self.security = policy;
         self
     }
 
@@ -158,9 +235,10 @@ impl A2aClient {
         params: SendMessageParams,
         token: Option<&str>,
     ) -> Result<TaskEventStream, A2aError> {
-        self.validate_endpoint(endpoint).await?;
+        let pinned = self.validate_endpoint(endpoint).await?;
+        let request_client = self.request_client(pinned.as_ref())?;
         let request = JsonRpcRequest::new(METHOD_SEND_STREAMING_MESSAGE, params);
-        let mut req = self.client.post(endpoint).json(&request);
+        let mut req = request_client.post(endpoint).json(&request);
         if let Some(t) = token {
             req = req.bearer_auth(t);
         }
@@ -234,40 +312,87 @@ impl A2aClient {
             .await
     }
 
+    /// Validates `endpoint` against the configured [`SecurityPolicy`] and, when
+    /// `ssrf_protection` is enabled, resolves its hostname once and returns the
+    /// validated addresses to be pinned for the actual connection.
+    ///
+    /// Returning `Ok(None)` means either security is off for that check, or the
+    /// endpoint has no host (validation is skipped, matching prior behavior).
     #[tracing::instrument(name = "a2a.client.validate_endpoint", skip_all, err)]
-    async fn validate_endpoint(&self, endpoint: &str) -> Result<(), A2aError> {
-        if self.require_tls && !endpoint.starts_with("https://") {
+    async fn validate_endpoint(&self, endpoint: &str) -> Result<Option<PinnedTarget>, A2aError> {
+        if self.security.require_tls && !endpoint.starts_with("https://") {
             return Err(A2aError::Security(format!(
                 "TLS required but endpoint uses HTTP: {endpoint}"
             )));
         }
 
-        if self.ssrf_protection {
-            let url: url::Url = endpoint
-                .parse()
-                .map_err(|e| A2aError::Security(format!("invalid URL: {e}")))?;
-
-            if let Some(host) = url.host_str() {
-                let addrs = tokio::net::lookup_host(format!(
-                    "{}:{}",
-                    host,
-                    url.port_or_known_default().unwrap_or(443)
-                ))
-                .await
-                .map_err(|e| A2aError::Security(format!("DNS resolution failed: {e}")))?;
-
-                for addr in addrs {
-                    if is_private_ip(addr.ip()) {
-                        return Err(A2aError::Security(format!(
-                            "SSRF protection: private IP {} for host {host}",
-                            addr.ip()
-                        )));
-                    }
-                }
-            }
+        if !self.security.ssrf_protection {
+            return Ok(None);
         }
 
-        Ok(())
+        let url: url::Url = endpoint
+            .parse()
+            .map_err(|e| A2aError::Security(format!("invalid URL: {e}")))?;
+
+        let Some(host) = url.host_str() else {
+            return Ok(None);
+        };
+        let port = url.port_or_known_default().unwrap_or(443);
+        let addrs = resolve_and_validate(host, port)
+            .await
+            .map_err(|e| A2aError::Security(e.to_string()))?;
+
+        Ok(Some(PinnedTarget {
+            host: host.to_owned(),
+            addrs,
+        }))
+    }
+
+    /// Returns `true` when either half of the [`SecurityPolicy`] requires requests
+    /// to be sent through a dedicated per-request client instead of `self.client`.
+    fn needs_hardened_client(&self) -> bool {
+        self.security.require_tls || self.security.ssrf_protection
+    }
+
+    /// Selects the `reqwest::Client` to use for a single request: the shared
+    /// injected client when no security is configured, or a fresh hardened client
+    /// (redirects disabled, optionally TLS-enforced and address-pinned) otherwise.
+    fn request_client(&self, pinned: Option<&PinnedTarget>) -> Result<reqwest::Client, A2aError> {
+        if self.needs_hardened_client() {
+            self.build_hardened_client(pinned)
+        } else {
+            Ok(self.client.clone())
+        }
+    }
+
+    /// Builds a per-request client hardened per the configured [`SecurityPolicy`].
+    ///
+    /// Redirects are always disabled (`Policy::none()`) so a malicious `3xx` response
+    /// cannot silently redirect the connection to a private address or downgrade to
+    /// `http://` — the caller (`rpc_call`/`stream_message`) treats any non-2xx or
+    /// unparseable response as an error instead of following it. When `pinned` is
+    /// `Some`, the client is additionally locked to the exact addresses that passed
+    /// SSRF validation via `resolve_to_addrs`, so reqwest cannot re-resolve the
+    /// hostname to a different address at connect time (closing the DNS-rebinding
+    /// TOCTOU window).
+    fn build_hardened_client(
+        &self,
+        pinned: Option<&PinnedTarget>,
+    ) -> Result<reqwest::Client, A2aError> {
+        let mut builder = reqwest::Client::builder()
+            .user_agent(concat!("zeph-a2a/", env!("CARGO_PKG_VERSION")))
+            .redirect(reqwest::redirect::Policy::none());
+
+        if self.security.require_tls {
+            builder = builder.https_only(true);
+        }
+        if let Some(target) = pinned {
+            builder = builder.resolve_to_addrs(&target.host, &target.addrs);
+        }
+
+        builder
+            .build()
+            .map_err(|e| A2aError::Security(format!("failed to build hardened client: {e}")))
     }
 
     #[tracing::instrument(name = "a2a.client.rpc_call", skip_all, err)]
@@ -278,9 +403,10 @@ impl A2aClient {
         params: P,
         token: Option<&str>,
     ) -> Result<R, A2aError> {
-        self.validate_endpoint(endpoint).await?;
+        let pinned = self.validate_endpoint(endpoint).await?;
+        let request_client = self.request_client(pinned.as_ref())?;
         let request = JsonRpcRequest::new(method, params);
-        let mut req = self.client.post(endpoint).json(&request);
+        let mut req = request_client.post(endpoint).json(&request);
         if let Some(t) = token {
             req = req.bearer_auth(t);
         }
@@ -301,6 +427,8 @@ mod tests {
     use std::net::IpAddr;
 
     use super::*;
+    use zeph_common::net::is_private_ip;
+
     use crate::jsonrpc::{JsonRpcError, JsonRpcResponse};
     use crate::types::{
         Artifact, Message, Part, Task, TaskArtifactUpdateEvent, TaskState, TaskStatus,
@@ -427,7 +555,10 @@ mod tests {
 
     #[tokio::test]
     async fn tls_enforcement_rejects_http() {
-        let client = A2aClient::new(reqwest::Client::new()).with_security(true, false);
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: true,
+            ssrf_protection: false,
+        });
         let result = client.validate_endpoint("http://example.com/rpc").await;
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -437,14 +568,20 @@ mod tests {
 
     #[tokio::test]
     async fn tls_enforcement_allows_https() {
-        let client = A2aClient::new(reqwest::Client::new()).with_security(true, false);
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: true,
+            ssrf_protection: false,
+        });
         let result = client.validate_endpoint("https://example.com/rpc").await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn ssrf_protection_rejects_localhost() {
-        let client = A2aClient::new(reqwest::Client::new()).with_security(false, true);
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: false,
+            ssrf_protection: true,
+        });
         let result = client.validate_endpoint("http://127.0.0.1:8080/rpc").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("SSRF"));
@@ -563,7 +700,10 @@ mod tests {
 
     #[tokio::test]
     async fn stream_message_tls_required_rejects_http() {
-        let client = A2aClient::new(reqwest::Client::new()).with_security(true, false);
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: true,
+            ssrf_protection: false,
+        });
         let params = SendMessageParams {
             message: Message::user_text("hello"),
             configuration: None,
@@ -579,7 +719,10 @@ mod tests {
 
     #[tokio::test]
     async fn send_message_tls_required_rejects_http() {
-        let client = A2aClient::new(reqwest::Client::new()).with_security(true, false);
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: true,
+            ssrf_protection: false,
+        });
         let params = SendMessageParams {
             message: Message::user_text("hello"),
             configuration: None,
@@ -593,7 +736,10 @@ mod tests {
 
     #[tokio::test]
     async fn get_task_tls_required_rejects_http() {
-        let client = A2aClient::new(reqwest::Client::new()).with_security(true, false);
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: true,
+            ssrf_protection: false,
+        });
         let params = TaskIdParams {
             id: "t-1".into(),
             history_length: None,
@@ -607,7 +753,10 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_task_tls_required_rejects_http() {
-        let client = A2aClient::new(reqwest::Client::new()).with_security(true, false);
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: true,
+            ssrf_protection: false,
+        });
         let params = TaskIdParams {
             id: "t-1".into(),
             history_length: None,
@@ -621,7 +770,10 @@ mod tests {
 
     #[tokio::test]
     async fn validate_endpoint_invalid_url_with_ssrf() {
-        let client = A2aClient::new(reqwest::Client::new()).with_security(false, true);
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: false,
+            ssrf_protection: true,
+        });
         let result = client.validate_endpoint("not-a-url").await;
         assert!(result.is_err());
         assert_matches!(result.unwrap_err(), A2aError::Security(_));
@@ -629,16 +781,43 @@ mod tests {
 
     #[test]
     fn with_security_returns_configured_client() {
-        let client = A2aClient::new(reqwest::Client::new()).with_security(true, true);
-        assert!(client.require_tls);
-        assert!(client.ssrf_protection);
+        let client =
+            A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy::hardened());
+        assert!(client.security.require_tls);
+        assert!(client.security.ssrf_protection);
     }
 
     #[test]
     fn default_client_no_security() {
         let client = A2aClient::new(reqwest::Client::new());
-        assert!(!client.require_tls);
-        assert!(!client.ssrf_protection);
+        assert!(!client.security.require_tls);
+        assert!(!client.security.ssrf_protection);
+    }
+
+    #[test]
+    fn needs_hardened_client_reflects_policy() {
+        assert!(!A2aClient::new(reqwest::Client::new()).needs_hardened_client());
+        assert!(
+            A2aClient::new(reqwest::Client::new())
+                .with_security(SecurityPolicy {
+                    require_tls: true,
+                    ssrf_protection: false,
+                })
+                .needs_hardened_client()
+        );
+        assert!(
+            A2aClient::new(reqwest::Client::new())
+                .with_security(SecurityPolicy {
+                    require_tls: false,
+                    ssrf_protection: true,
+                })
+                .needs_hardened_client()
+        );
+        assert!(
+            A2aClient::new(reqwest::Client::new())
+                .with_security(SecurityPolicy::hardened())
+                .needs_hardened_client()
+        );
     }
 
     #[test]
@@ -753,7 +932,7 @@ mod wiremock_tests {
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use crate::client::A2aClient;
+    use crate::client::{A2aClient, PinnedTarget, SecurityPolicy};
     use crate::jsonrpc::{SendMessageParams, TaskIdParams};
     use crate::testing::*;
     use crate::types::Message;
@@ -945,6 +1124,112 @@ mod wiremock_tests {
         assert!(
             matches!(result.unwrap_err(), crate::error::A2aError::Timeout(_)),
             "expected Timeout error"
+        );
+    }
+
+    /// Proves the DNS-rebinding TOCTOU is closed: `resolve_to_addrs` pins the connection to
+    /// the address validated by `resolve_and_validate`, so reqwest never re-resolves `fake_host`
+    /// (a hostname reserved by RFC 2606 and guaranteed to never resolve via real DNS) at connect
+    /// time. If the client re-resolved instead of using the pinned address, this request would
+    /// fail with a DNS lookup error rather than reaching the mock server.
+    #[tokio::test]
+    async fn hardened_client_pins_connection_bypassing_dns() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+            .mount(&server)
+            .await;
+
+        let addr = *server.address();
+        let fake_host = "zeph-a2a-pin-test.invalid";
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: false,
+            ssrf_protection: true,
+        });
+        let pinned = PinnedTarget {
+            host: fake_host.to_owned(),
+            addrs: vec![addr],
+        };
+        let hardened = client.build_hardened_client(Some(&pinned)).unwrap();
+
+        let resp = hardened
+            .get(format!("http://{fake_host}:{}/", addr.port()))
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("pinned request to unresolvable host failed: {e}"));
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.text().await.unwrap(), "ok");
+    }
+
+    /// Proves the redirect-based SSRF bypass is closed: the hardened client does not
+    /// automatically follow a `3xx` response, even when `Location` points at a private
+    /// address. `rpc_call`/`stream_message` treat the raw redirect response as a normal
+    /// (non-2xx) response and surface an error instead of connecting to `Location`.
+    #[tokio::test]
+    async fn hardened_client_does_not_auto_follow_redirect_to_private_ip() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(302).insert_header("Location", "http://127.0.0.1:9/internal"),
+            )
+            .mount(&server)
+            .await;
+
+        let addr = *server.address();
+        let fake_host = "zeph-a2a-redirect-test.invalid";
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: false,
+            ssrf_protection: true,
+        });
+        let pinned = PinnedTarget {
+            host: fake_host.to_owned(),
+            addrs: vec![addr],
+        };
+        let hardened = client.build_hardened_client(Some(&pinned)).unwrap();
+
+        let resp = hardened
+            .get(format!("http://{fake_host}:{}/start", addr.port()))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::FOUND);
+        assert_eq!(
+            resp.headers().get(reqwest::header::LOCATION).unwrap(),
+            "http://127.0.0.1:9/internal"
+        );
+    }
+
+    /// Proves TLS enforcement holds even on the hardened per-request client: `https_only(true)`
+    /// rejects a plaintext `http://` connection outright, closing the https-to-http downgrade
+    /// gap that an unvalidated redirect could otherwise exploit.
+    #[tokio::test]
+    async fn hardened_client_with_require_tls_rejects_plaintext_connection() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let addr = *server.address();
+        let fake_host = "zeph-a2a-tls-test.invalid";
+        let client = A2aClient::new(reqwest::Client::new()).with_security(SecurityPolicy {
+            require_tls: true,
+            ssrf_protection: true,
+        });
+        let pinned = PinnedTarget {
+            host: fake_host.to_owned(),
+            addrs: vec![addr],
+        };
+        let hardened = client.build_hardened_client(Some(&pinned)).unwrap();
+
+        let result = hardened
+            .get(format!("http://{fake_host}:{}/", addr.port()))
+            .send()
+            .await;
+        assert!(
+            result.is_err(),
+            "https_only(true) must reject a plain http:// URL"
         );
     }
 }

--- a/crates/zeph-a2a/src/lib.rs
+++ b/crates/zeph-a2a/src/lib.rs
@@ -82,7 +82,7 @@ mod testing;
 pub const A2A_PROTOCOL_VERSION: &str = "0.2.1";
 
 pub use card::AgentCardBuilder;
-pub use client::{A2aClient, TaskEvent, TaskEventStream};
+pub use client::{A2aClient, SecurityPolicy, TaskEvent, TaskEventStream};
 pub use discovery::AgentRegistry;
 pub use error::A2aError;
 pub use ibct::{Ibct, IbctError, IbctKey};

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -36,7 +36,7 @@ serde = { workspace = true, features = ["derive", "rc"] }
 subtle = { workspace = true, optional = true }
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util.workspace = true
 tracing.workspace = true
 tree-sitter = { workspace = true, optional = true }

--- a/crates/zeph-common/src/net.rs
+++ b/crates/zeph-common/src/net.rs
@@ -3,7 +3,11 @@
 
 //! Network utilities shared across crates.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+/// Timeout applied to the DNS lookup performed by [`resolve_and_validate`].
+const RESOLVE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Returns `true` if `addr` is a non-routable or private IP address that
 /// should be blocked for outbound connections (SSRF defense).
@@ -43,6 +47,75 @@ pub fn is_private_ip(addr: IpAddr) -> bool {
                 || (ip.segments()[0] & 0xffc0) == 0xfe80 // fe80::/10 link-local
         }
     }
+}
+
+/// Error returned by [`resolve_and_validate`] when a hostname cannot be safely resolved.
+///
+/// Callers map this into their own error type — it carries enough context (the timeout,
+/// the underlying I/O error, or the offending address) to build a user-facing message.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ResolveError {
+    /// DNS resolution did not complete within the lookup timeout.
+    #[error("DNS resolution timed out after {0:?}")]
+    Timeout(Duration),
+    /// The DNS lookup itself failed (NXDOMAIN, network error, etc.).
+    #[error("DNS resolution failed: {0}")]
+    Lookup(std::io::Error),
+    /// A resolved address falls in a private/loopback/link-local range.
+    #[error("SSRF protection: private IP {addr} for host {host}")]
+    PrivateAddress {
+        /// The hostname that was being resolved.
+        host: String,
+        /// The rejected private/loopback address.
+        addr: IpAddr,
+    },
+}
+
+/// Resolves `host:port` via DNS and rejects the result if any resolved address is
+/// private, loopback, link-local, or otherwise non-routable per [`is_private_ip`].
+///
+/// Returns the full set of resolved [`SocketAddr`]s on success so the caller can pin
+/// an HTTP client to them (e.g. via `reqwest::ClientBuilder::resolve_to_addrs`),
+/// eliminating the TOCTOU window between this check and the actual connection —
+/// resolving again at connect time could return a different (attacker-controlled)
+/// address for the same hostname (DNS rebinding).
+///
+/// # Errors
+///
+/// Returns [`ResolveError::Timeout`] if the lookup exceeds 10 seconds,
+/// [`ResolveError::Lookup`] if DNS resolution fails, or
+/// [`ResolveError::PrivateAddress`] if any resolved address is private/loopback.
+///
+/// # Examples
+///
+/// ```rust
+/// # async fn example() {
+/// use zeph_common::net::resolve_and_validate;
+///
+/// // A private hostname is rejected before any connection is attempted.
+/// let result = resolve_and_validate("localhost", 443).await;
+/// assert!(result.is_err());
+/// # }
+/// ```
+pub async fn resolve_and_validate(host: &str, port: u16) -> Result<Vec<SocketAddr>, ResolveError> {
+    let addrs: Vec<SocketAddr> =
+        tokio::time::timeout(RESOLVE_TIMEOUT, tokio::net::lookup_host((host, port)))
+            .await
+            .map_err(|_| ResolveError::Timeout(RESOLVE_TIMEOUT))?
+            .map_err(ResolveError::Lookup)?
+            .collect();
+
+    for addr in &addrs {
+        if is_private_ip(addr.ip()) {
+            return Err(ResolveError::PrivateAddress {
+                host: host.to_owned(),
+                addr: addr.ip(),
+            });
+        }
+    }
+
+    Ok(addrs)
 }
 
 #[cfg(test)]
@@ -107,5 +180,18 @@ mod tests {
     #[test]
     fn ipv6_public() {
         assert!(!is_private_ip("2001:4860:4860::8888".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn resolve_and_validate_rejects_loopback_hostname() {
+        let err = resolve_and_validate("localhost", 443).await.unwrap_err();
+        assert!(matches!(err, ResolveError::PrivateAddress { .. }));
+        assert!(err.to_string().contains("SSRF protection"));
+    }
+
+    #[tokio::test]
+    async fn resolve_and_validate_rejects_loopback_ip_literal() {
+        let err = resolve_and_validate("127.0.0.1", 443).await.unwrap_err();
+        assert!(matches!(err, ResolveError::PrivateAddress { .. }));
     }
 }

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -1132,29 +1132,32 @@ fn is_private_host(host: &url::Host<&str>) -> bool {
 ///
 /// Returning the addresses allows the caller to pin the HTTP client to these exact
 /// addresses, eliminating TOCTOU between DNS validation and the actual connection.
+///
+/// Delegates the actual lookup+validation loop to the shared
+/// [`zeph_common::net::resolve_and_validate`] helper (also used by `zeph-a2a`'s client)
+/// and maps its neutral error into this crate's [`ToolError`].
 #[tracing::instrument(name = "tools.scrape.dns.resolve", skip(url), fields(host = url.host_str().unwrap_or("")))]
 async fn resolve_and_validate(url: &Url) -> Result<(String, Vec<SocketAddr>), ToolError> {
     let Some(host) = url.host_str() else {
         return Ok((String::new(), vec![]));
     };
     let port = url.port_or_known_default().unwrap_or(443);
-    let addrs: Vec<SocketAddr> = tokio::time::timeout(
-        Duration::from_secs(10),
-        tokio::net::lookup_host(format!("{host}:{port}")),
-    )
-    .await
-    .map_err(|_| ToolError::Timeout { timeout_secs: 10 })?
-    .map_err(|e| ToolError::Blocked {
-        command: format!("DNS resolution failed: {e}"),
-    })?
-    .collect();
-    for addr in &addrs {
-        if is_private_ip(addr.ip()) {
-            return Err(ToolError::Blocked {
-                command: format!("SSRF protection: private IP {} for host {host}", addr.ip()),
-            });
-        }
-    }
+    let addrs = zeph_common::net::resolve_and_validate(host, port)
+        .await
+        .map_err(|e| match e {
+            zeph_common::net::ResolveError::Timeout(timeout) => ToolError::Timeout {
+                timeout_secs: timeout.as_secs(),
+            },
+            zeph_common::net::ResolveError::Lookup(io_err) => ToolError::Blocked {
+                command: format!("DNS resolution failed: {io_err}"),
+            },
+            zeph_common::net::ResolveError::PrivateAddress { host, addr } => ToolError::Blocked {
+                command: format!("SSRF protection: private IP {addr} for host {host}"),
+            },
+            other => ToolError::Blocked {
+                command: format!("DNS resolution failed: {other}"),
+            },
+        })?;
     Ok((host.to_owned(), addrs))
 }
 

--- a/specs/014-a2a/spec.md
+++ b/specs/014-a2a/spec.md
@@ -112,9 +112,64 @@ Terminal states: `completed | failed | canceled | rejected`
 - History is append-only — never reorder or delete entries
 - Artifacts are immutable once created — no in-place updates
 - SSE stream must emit `[DONE]` on completion — clients depend on this terminator
-- SSRF protection: DNS lookup + IP check post-fetch (prevents DNS rebinding attacks)
-- TLS enforcement: if `require_tls` enabled, `http://` URLs must be rejected
+- SSRF protection: the address validated by DNS lookup + private-IP check MUST be the exact
+  address the client connects to — no re-resolution between validation and connect (see
+  Client Security Posture below)
+- TLS enforcement: if `require_tls` enabled, `http://` URLs must be rejected, including via redirect
 - Server feature (`zeph-a2a?/server`) is independent of client — can run one without the other
+
+---
+
+## Client Security Posture
+
+`A2aClient` accepts a [`SecurityPolicy`] (`crates/zeph-a2a/src/client.rs`) with two independent
+flags: `require_tls` and `ssrf_protection`. `SecurityPolicy::hardened()` enables both;
+`SecurityPolicy::permissive()` (the `A2aClient::new` default) disables both, for local/dev use
+against trusted endpoints.
+
+### SSRF invariant: validated address == connected address
+
+`validate_endpoint` resolves the endpoint hostname via DNS once and returns the resolved
+`SocketAddr` list alongside the hostname (`PinnedTarget`). When `ssrf_protection` is on, every
+`rpc_call`/`stream_message` request is sent through a per-request `reqwest::Client` built with
+`.resolve_to_addrs(host, addrs)`, pinning the connection to those exact addresses. reqwest never
+re-resolves the hostname at connect time, so a DNS answer that changes between the check and the
+connect (DNS rebinding) cannot redirect the connection to a private/internal address.
+
+**NEVER** discard the resolved addresses after validation and let the underlying HTTP client
+re-resolve the hostname independently — that reintroduces the TOCTOU window this invariant closes.
+
+### Redirect policy
+
+Whenever `require_tls` or `ssrf_protection` is enabled, the per-request client is built with
+`.redirect(Policy::none())`. A malicious `3xx` response with `Location` pointing at a private
+address or downgrading to `http://` is never followed automatically — `rpc_call` (which always
+calls `.json()` on the raw response) and `stream_message` (which checks `status.is_success()`)
+both surface the unfollowed redirect as an error instead of connecting to `Location`.
+
+### TLS enforcement across hops
+
+`require_tls` rejects any endpoint that does not start with `https://` before the request is
+sent, and additionally builds the per-request client with `.https_only(true)`. Combined with the
+redirect policy above, a hop cannot downgrade an `https://` connection to `http://` — `https_only`
+rejects the plaintext connection outright rather than silently allowing it.
+
+### Secure-by-default config wiring
+
+`A2aServerConfig.require_tls` / `.ssrf_protection` (`crates/zeph-config/src/channels.rs`) both
+default to `true` and are env-overridable (`ZEPH_A2A_REQUIRE_TLS`, `ZEPH_A2A_SSRF_PROTECTION`).
+The TUI-remote client (`src/tui_remote.rs`) builds its `A2aClient` with
+`SecurityPolicy { require_tls: config.a2a.require_tls, ssrf_protection: config.a2a.ssrf_protection }`,
+so production deployments are hardened by default through existing config — no separate
+client-side security config section exists, and none should be added (avoid config sprawl; the
+server config's flags already express the intended security posture for outbound A2A traffic).
+
+### Shared resolution helper
+
+The DNS-resolve-then-validate loop lives in `zeph_common::net::resolve_and_validate` (used by both
+`zeph-a2a`'s client and `zeph-tools`'s `scrape.rs` web-fetch executor) — do not duplicate this
+loop in a new call site; add a caller that maps `zeph_common::net::ResolveError` into the local
+error type instead.
 
 ---
 

--- a/src/tui_remote.rs
+++ b/src/tui_remote.rs
@@ -19,7 +19,12 @@ pub(crate) async fn run_tui_remote(
     config.validate()?;
     let auth_token = config.a2a.auth_token.clone();
 
-    let client = zeph_a2a::A2aClient::new(zeph_core::http::default_client());
+    let client = zeph_a2a::A2aClient::new(zeph_core::http::default_client()).with_security(
+        zeph_a2a::SecurityPolicy {
+            require_tls: config.a2a.require_tls,
+            ssrf_protection: config.a2a.ssrf_protection,
+        },
+    );
 
     // user_tx is passed to App; App sends user text through it.
     // We receive on user_rx and forward to the A2A SSE pump.


### PR DESCRIPTION
## Summary

- Closes a DNS-rebinding TOCTOU bypass in `A2aClient`: `validate_endpoint` resolved and validated the target hostname but discarded the address, letting the underlying `reqwest::Client` re-resolve DNS independently at connect time. Requests now pin the connection to the validated address via `resolve_to_addrs`.
- Closes a related redirect-based SSRF/TLS-downgrade bypass (found during audit, not in the original issue): the client's redirect policy followed a malicious `3xx` response toward a private address or an `https`->`http` downgrade with no re-validation. Any client with a `SecurityPolicy` flag enabled now uses `Policy::none()` (plus `https_only` when `require_tls` is set), surfacing the redirect as an error.
- The only production call site (`src/tui_remote.rs`, `--connect`) previously never enabled either protection; it now wires `SecurityPolicy` from `config.a2a.require_tls`/`.ssrf_protection` (both already default `true`), so `--connect` is hardened by default.
- Replaces the boolean-blind `with_security(require_tls: bool, ssrf_protection: bool)` with a `SecurityPolicy { require_tls, ssrf_protection }` struct (`hardened()`/`permissive()` presets), eliminating the transposition foot-gun. Breaking change, no deprecated shim (pre-v1.0.0).
- Factored the shared resolve+validate loop into `zeph_common::net::resolve_and_validate`, now shared by `zeph-a2a` and `zeph-tools`'s `scrape.rs` (removes a third copy of the same loop).
- Extended `specs/014-a2a/spec.md` with a "Client Security Posture" section and corrected a stale invariant describing the old buggy behavior.

Closes #5380, closes #5381.

## Follow-up issues recommended (not blocking, to be filed after merge)

- IPv6 transition-mechanism ranges (6to4/Teredo/NAT64) not decoded by `is_private_ip` — exotic, realistic cloud-metadata vectors already covered.
- `A2aServerConfig.require_tls`/`.ssrf_protection` now govern both inbound server and outbound client posture — a conscious but coupled reuse, worth a dedicated client-side config knob if it causes confusion.
- `zeph-a2a` lacks `scrape.rs`'s pre-resolution hostname-suffix block (`.localhost`/`.internal`/`.local`) for defense-in-depth parity.
- Per-request hardened `reqwest::Client` rebuild cost (TLS root store reload) — matches existing `scrape.rs` precedent, only act on if profiling shows it matters.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11560 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc -p zeph-a2a -p zeph-common -p zeph-tools`
- [x] New wiremock tests proving: DNS pinning survives independent resolution (RFC 2606 `.invalid` hostname), redirect-to-private-IP is not auto-followed, plaintext connection rejected under `require_tls`
- [x] Testing playbook + coverage-status row added (`.local/testing/playbooks/a2a-client-security.md`)