### PR TITLE
fix(knowledge): bound embed-provider calls with a timeout in ingest path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `SecurityPolicy` from `config.a2a.require_tls`/`.ssrf_protection` (both default `true`)
   instead of running with no security applied — the only production call site was previously
   unprotected despite the config defaulting to hardened. Closes #5380.
+- `fix(knowledge)`: `zeph knowledge ingest` no longer hangs indefinitely on an unresponsive
+  embedding provider. Both the dimension-probe `embed()` call in `build_ingest_resources` and
+  the per-chunk `embed_fn` call in `IngestionPipeline::ingest` are now wrapped in a 15s
+  `tokio::time::timeout`, mirroring the existing pattern in
+  `zeph_index::indexer::ensure_collection_for_provider`. A per-chunk timeout surfaces as a
+  clear per-file `[ERR] <uri>: ...` error via the existing collect-and-continue reporting
+  instead of blocking the whole ingest run. Closes #5387.
 - `fix(acp)`: `zeph acp model-config show` now loads the resolved config and marks the active
   `[acp.model_config].default_temperature_preset` in its output (e.g. `balanced   temperature =
   0.7  (default)`), instead of only printing the static preset table with a generic pointer to

--- a/crates/zeph-memory/src/document/pipeline.rs
+++ b/crates/zeph-memory/src/document/pipeline.rs
@@ -34,8 +34,10 @@ impl IngestionPipeline {
     ///
     /// # Errors
     ///
-    /// Returns an error if embedding or Qdrant storage fails.
+    /// Returns an error if embedding, embedding timeout, or Qdrant storage fails.
     pub async fn ingest(&self, document: Document) -> Result<usize, DocumentError> {
+        const CHUNK_EMBED_TIMEOUT_SECS: u64 = 15;
+
         let chunks = self.splitter.split(&document);
         if chunks.is_empty() {
             return Ok(0);
@@ -43,7 +45,19 @@ impl IngestionPipeline {
 
         let mut points = Vec::with_capacity(chunks.len());
         for chunk in &chunks {
-            let vector = (self.embed_fn)(&chunk.content).await?;
+            let vector = tokio::time::timeout(
+                std::time::Duration::from_secs(CHUNK_EMBED_TIMEOUT_SECS),
+                (self.embed_fn)(&chunk.content),
+            )
+            .await
+            .map_err(|_| {
+                tracing::warn!(
+                    timeout_secs = CHUNK_EMBED_TIMEOUT_SECS,
+                    source = %chunk.metadata.source,
+                    "embedding provider timed out during chunk ingest"
+                );
+                zeph_llm::LlmError::Timeout
+            })??;
             let payload = QdrantOps::json_to_payload(json!({
                 "source": chunk.metadata.source,
                 "content_type": chunk.metadata.content_type,
@@ -115,6 +129,20 @@ mod tests {
         })
     }
 
+    /// Embed fn that sleeps longer than `IngestionPipeline::ingest`'s 15 s
+    /// `CHUNK_EMBED_TIMEOUT_SECS`, used to exercise the timeout path without a real wall-clock
+    /// wait (paired with `#[tokio::test(start_paused = true)]`).
+    fn stalled_embed(
+        delay_secs: u64,
+    ) -> Box<dyn Fn(&str) -> zeph_llm::provider::EmbedFuture + Send + Sync> {
+        Box::new(move |_text: &str| {
+            Box::pin(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                Ok(vec![0.0f32; 4])
+            })
+        })
+    }
+
     #[tokio::test]
     async fn ingest_empty_document_returns_zero() {
         // Empty document should short-circuit before calling Qdrant.
@@ -138,5 +166,24 @@ mod tests {
         let doc = make_document("hello world, this is test content for embedding");
         let result = pipeline.ingest(doc).await;
         assert!(result.is_err(), "expected error from embedding failure");
+    }
+
+    /// Regression for #5387: an embed provider that never responds must not hang `ingest`
+    /// indefinitely. The per-chunk embed call is bounded by a 15 s timeout that surfaces as
+    /// `DocumentError::Embedding(LlmError::Timeout)`. Uses `start_paused` + a sleeping `embed_fn`
+    /// so the timeout fires against virtual time instead of a real 15 s wait.
+    #[tokio::test(start_paused = true)]
+    async fn ingest_embed_timeout_returns_error_without_hanging() {
+        let qdrant = crate::QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        let splitter = TextSplitter::new(SplitterConfig::default());
+        let pipeline = IngestionPipeline::new(splitter, qdrant, "col", stalled_embed(16));
+
+        let doc = make_document("hello world, this is test content for embedding");
+        let result = pipeline.ingest(doc).await;
+
+        match result {
+            Err(DocumentError::Embedding(zeph_llm::LlmError::Timeout)) => {}
+            other => panic!("expected DocumentError::Embedding(LlmError::Timeout), got {other:?}"),
+        }
     }
 }

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -414,6 +414,8 @@ fn run_dry_run(source_items: &[SourceItem], total_files: usize, discovery_errors
 async fn build_ingest_resources(
     config_path: Option<&Path>,
 ) -> anyhow::Result<(IngestionPipeline, IngestLedger, String, String)> {
+    const DIMENSION_PROBE_TIMEOUT_SECS: u64 = 15;
+
     let app = AppBuilder::new(config_path, None, None, None).await?;
     let config = app.config();
     let qdrant = QdrantOps::new(
@@ -435,11 +437,19 @@ async fn build_ingest_resources(
 
     // Probe the embedding dimension and pre-create the documents collection so a fresh
     // Qdrant instance doesn't fail on the first upsert (mirrors EmbeddingRegistry::ensure_collection).
-    let vector_size = provider
-        .embed("dimension probe")
-        .await
-        .map(|v| v.len() as u64)
-        .map_err(|e| anyhow::anyhow!("failed to probe embedding dimension: {e}"))?;
+    let vector_size = tokio::time::timeout(
+        std::time::Duration::from_secs(DIMENSION_PROBE_TIMEOUT_SECS),
+        provider.embed("dimension probe"),
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "embedding dimension probe timed out after {DIMENSION_PROBE_TIMEOUT_SECS}s: \
+             provider is unresponsive"
+        )
+    })?
+    .map(|v| v.len() as u64)
+    .map_err(|e| anyhow::anyhow!("failed to probe embedding dimension: {e}"))?;
     qdrant
         .ensure_collection(&collection, vector_size)
         .await


### PR DESCRIPTION
## Summary
- `build_ingest_resources`'s dimension-probe `embed()` call and `IngestionPipeline::ingest`'s per-chunk `embed_fn` call now wrap the embedding-provider await in a 15s `tokio::time::timeout`, mirroring the existing pattern in `zeph_index::indexer::ensure_collection_for_provider`.
- An unresponsive embedding provider previously hung `zeph knowledge ingest` indefinitely with no diagnostic output; a per-chunk timeout now surfaces as a clear per-file `[ERR] <uri>: ...` error through the existing collect-and-continue reporting instead of blocking the whole run.
- Scope is intentionally limited to the two embed-provider await sites named in the issue. Adjacent unbounded Qdrant awaits (`ensure_collection`, `upsert`, ledger writes) and the broader duplicated "probe dimension" pattern across 6+ call sites are tracked separately (#5388) and left untouched.

Closes #5387

## Test plan
- [x] `cargo nextest run -p zeph-memory --features test-utils -E 'test(pipeline)'` — 3/3 PASS, including new `ingest_embed_timeout_returns_error_without_hanging` (`#[tokio::test(start_paused = true)]`, no real wall-clock delay)
- [x] `cargo nextest run -p zeph --features "desktop,ide,server,chat,pdf,scheduler,testing" -E 'test(knowledge)'` — 30/30 PASS, no regressions
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci -p zeph-memory -p zeph --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] rustdoc builds clean on `zeph-memory` (2 pre-existing unrelated warnings only)
- [ ] Live-session verification of the `build_ingest_resources` dimension-probe timeout (stalled provider endpoint) — documented as a gap: no `AppBuilder`-backed test harness exists anywhere in the codebase; manual repro steps added to `.local/testing/playbooks/knowledge-ingest.md` (S-19)