### PR TITLE
refactor(memory,index): extract shared probe+ensure_collection helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   union, replacing the previous text-only extraction at every MCP tool-result call site
   (`zeph-mcp` executor/manager, `zeph-core` hooks dispatch, `zeph-acp` LSP provider,
   `src/agent_setup.rs`). MCP Tasks API support is explicitly out of scope (zero existing usage).
+- `refactor(memory,index)`: extract the duplicated "probe embedding dimension, then
+  `ensure_collection`" sequence into shared helpers instead of 6+ independent
+  re-implementations. New `zeph_memory::probe_vector_size` (`crates/zeph-memory/src/embed_probe.rs`)
+  awaits an already-invoked embed future (optionally bounded by a timeout) and returns the
+  vector's dimension, used by `EmbeddingRegistry::ensure_collection`, `zeph-index`'s
+  `Indexer::ensure_collection_for_provider` (preserving its existing 15s startup timeout), and
+  `src/commands/knowledge.rs::build_ingest_resources`. New
+  `EmbeddingStore::ensure_collection_for_vector` (`crates/zeph-memory/src/embedding_store.rs`)
+  derives the dimension from an already-computed vector and ensures the collection in one call,
+  used by `admission.rs`, `semantic/recall.rs` (5 call sites), and `semantic/summarization.rs`,
+  which each already hold a real embedding rather than a throwaway probe. No behavior change.
 
 ### Fixed
 

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -310,19 +310,21 @@ impl CodeIndexer {
     #[tracing::instrument(name = "index.indexer.ensure_collection", skip_all)]
     async fn ensure_collection_for_provider(&self) -> Result<()> {
         const STARTUP_EMBED_TIMEOUT_SECS: u64 = 15;
-        let probe = tokio::time::timeout(
-            Duration::from_secs(STARTUP_EMBED_TIMEOUT_SECS),
+        let vector_size = zeph_memory::probe_vector_size(
             self.provider.embed("probe"),
+            Some(Duration::from_secs(STARTUP_EMBED_TIMEOUT_SECS)),
         )
         .await
-        .map_err(|_| {
-            tracing::warn!(
-                timeout_secs = STARTUP_EMBED_TIMEOUT_SECS,
-                "embedding provider timed out during startup"
-            );
-            crate::error::IndexError::EmbedTimeout(STARTUP_EMBED_TIMEOUT_SECS)
-        })??;
-        let vector_size = u64::try_from(probe.len())?;
+        .map_err(|e| match e {
+            zeph_memory::ProbeError::Timeout(_) => {
+                tracing::warn!(
+                    timeout_secs = STARTUP_EMBED_TIMEOUT_SECS,
+                    "embedding provider timed out during startup"
+                );
+                crate::error::IndexError::EmbedTimeout(STARTUP_EMBED_TIMEOUT_SECS)
+            }
+            zeph_memory::ProbeError::Embed(err) => crate::error::IndexError::from(err),
+        })?;
         self.store.ensure_collection(vector_size).await
     }
 

--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -381,10 +381,7 @@ async fn compute_semantic_novelty(
             return 1.0;
         }
     };
-    let Ok(vector_size) = u64::try_from(vector.len()) else {
-        return 1.0;
-    };
-    if let Err(e) = store.ensure_collection(vector_size).await {
+    if let Err(e) = store.ensure_collection_for_vector(&vector).await {
         tracing::debug!(error = %e, "A-MAC: collection not ready for novelty check");
         return 1.0;
     }

--- a/crates/zeph-memory/src/embed_probe.rs
+++ b/crates/zeph-memory/src/embed_probe.rs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared embedding-dimension probe helper.
+//!
+//! Several ingest and memory subsystems need to learn an embedding provider's output
+//! dimension before creating a Qdrant collection: they call the provider once with a
+//! throwaway probe string and use the resulting vector's length as the collection's
+//! vector size. [`probe_vector_size`] centralizes that sequence (including an optional
+//! timeout) so callers stop re-implementing it inline.
+
+use std::future::Future;
+use std::time::Duration;
+
+/// Error surfaced by [`probe_vector_size`].
+#[derive(Debug, thiserror::Error)]
+pub enum ProbeError<E> {
+    /// The probe embedding call exceeded `timeout`.
+    #[error("embedding probe timed out after {0:?}")]
+    Timeout(Duration),
+    /// The probe embedding call itself returned an error.
+    #[error("{0}")]
+    Embed(E),
+}
+
+/// Learn an embedding provider's output dimension.
+///
+/// Awaits `embed_fut` — the caller's already-invoked embed call for a throwaway probe string —
+/// and returns the length of the resulting vector. When `timeout` is `Some`, the await is
+/// bounded by it; pass `None` to await unconditionally.
+///
+/// Taking the future itself (rather than a `Fn(&str) -> Fut` closure) sidesteps the higher-rank
+/// lifetime that a borrowing `embed(&self, text: &str)` call would otherwise require, and lets
+/// each caller keep its own probe string literal.
+///
+/// This function only performs the probe — pair the returned size with the caller's own
+/// `ensure_collection` (or `ensure_collection_with_quantization`) call, since collection setup
+/// differs across call sites (plain vs. quantized, fixed vs. caller-supplied collection name).
+///
+/// # Errors
+///
+/// Returns [`ProbeError::Timeout`] if `timeout` elapses, or [`ProbeError::Embed`] if the probe
+/// call fails.
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+/// use zeph_memory::embed_probe::probe_vector_size;
+///
+/// # async fn probe() -> Result<(), Box<dyn std::error::Error>> {
+/// let embed_fut = async { Ok::<_, std::convert::Infallible>(vec![0.0_f32; 384]) };
+/// let size = probe_vector_size(embed_fut, Some(Duration::from_secs(15))).await?;
+/// assert_eq!(size, 384);
+/// # Ok(())
+/// # }
+/// ```
+#[tracing::instrument(
+    name = "memory.embed_probe.probe_vector_size",
+    skip_all,
+    err,
+    level = "debug"
+)]
+pub async fn probe_vector_size<Fut, E>(
+    embed_fut: Fut,
+    timeout: Option<Duration>,
+) -> Result<u64, ProbeError<E>>
+where
+    Fut: Future<Output = Result<Vec<f32>, E>>,
+    E: std::fmt::Display,
+{
+    let vector = match timeout {
+        Some(d) => tokio::time::timeout(d, embed_fut)
+            .await
+            .map_err(|_| ProbeError::Timeout(d))?
+            .map_err(ProbeError::Embed)?,
+        None => embed_fut.await.map_err(ProbeError::Embed)?,
+    };
+    // Safe: a Vec<f32> with 4B+ elements is impossible in practice on any 64-bit platform.
+    Ok(vector.len() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+
+    #[tokio::test]
+    async fn probe_vector_size_returns_length() {
+        let size = probe_vector_size(async { Ok::<_, Infallible>(vec![0.0_f32; 128]) }, None)
+            .await
+            .unwrap();
+        assert_eq!(size, 128);
+    }
+
+    #[tokio::test]
+    async fn probe_vector_size_propagates_embed_error() {
+        let result = probe_vector_size(async { Err::<Vec<f32>, _>("boom") }, None).await;
+        assert!(matches!(result, Err(ProbeError::Embed("boom"))));
+    }
+
+    #[tokio::test]
+    async fn probe_vector_size_times_out() {
+        let result = probe_vector_size(
+            async {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                Ok::<_, Infallible>(vec![0.0_f32; 4])
+            },
+            Some(Duration::from_millis(1)),
+        )
+        .await;
+        assert!(matches!(result, Err(ProbeError::Timeout(_))));
+    }
+
+    #[tokio::test]
+    async fn probe_vector_size_no_timeout_awaits_unconditionally() {
+        let size = probe_vector_size(
+            async {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                Ok::<_, Infallible>(vec![0.0_f32; 7])
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(size, 7);
+    }
+}

--- a/crates/zeph-memory/src/embedding_registry.rs
+++ b/crates/zeph-memory/src/embedding_registry.rs
@@ -91,6 +91,19 @@ fn normalize_model_name(name: &str) -> &str {
     name.strip_suffix(":latest").unwrap_or(name)
 }
 
+/// Probe the embedding dimension via [`crate::embed_probe::probe_vector_size`], adapting its
+/// error into [`EmbeddingRegistryError::DimensionProbe`].
+///
+/// No timeout is applied here — `EmbeddingRegistry` has never bounded this call, unlike
+/// `zeph-index`'s indexer (which has its own 15s startup timeout).
+async fn probe_dimension(
+    embed_fn: &impl Fn(&str) -> EmbedFuture,
+) -> Result<u64, EmbeddingRegistryError> {
+    crate::embed_probe::probe_vector_size(embed_fn("dimension probe"), None)
+        .await
+        .map_err(|e| EmbeddingRegistryError::DimensionProbe(e.to_string()))
+}
+
 /// Returns `true` when any stored point uses a model name that is semantically different
 /// from `config_model` after normalizing `:latest` suffixes.
 ///
@@ -404,7 +417,7 @@ impl EmbeddingRegistry {
             })?
         {
             // Collection does not exist — probe once and create.
-            let vector_size = self.probe_vector_size(embed_fn).await?;
+            let vector_size = probe_dimension(embed_fn).await?;
             self.ops
                 .ensure_collection(&self.collection, vector_size)
                 .await
@@ -440,7 +453,7 @@ impl EmbeddingRegistry {
                 qdrant_client::qdrant::vectors_config::Config::ParamsMap(_) => None,
             });
 
-        let vector_size = self.probe_vector_size(embed_fn).await?;
+        let vector_size = probe_dimension(embed_fn).await?;
 
         if existing_size == Some(vector_size) {
             self.set_cached_dim(vector_size).await;
@@ -483,23 +496,6 @@ impl EmbeddingRegistry {
     )]
     async fn set_cached_dim(&self, dim: u64) {
         *self.cached_dim.write().await = Some(dim);
-    }
-
-    #[tracing::instrument(
-        name = "memory.embed_registry.probe_vector_size",
-        skip_all,
-        err,
-        level = "debug"
-    )]
-    async fn probe_vector_size(
-        &self,
-        embed_fn: &impl Fn(&str) -> EmbedFuture,
-    ) -> Result<u64, EmbeddingRegistryError> {
-        let probe = embed_fn("dimension probe")
-            .await
-            .map_err(|e| EmbeddingRegistryError::DimensionProbe(e.to_string()))?;
-        // Safe: a Vec<f32> with 4B+ elements is impossible in practice on any 64-bit platform.
-        Ok(probe.len() as u64)
     }
 
     #[tracing::instrument(

--- a/crates/zeph-memory/src/embedding_store.rs
+++ b/crates/zeph-memory/src/embedding_store.rs
@@ -172,6 +172,21 @@ impl EmbeddingStore {
         Ok(())
     }
 
+    /// Ensure the collection exists with a vector dimension matching an already-computed
+    /// `vector`.
+    ///
+    /// Callers that already hold an embedding (e.g. from embedding real content for search or
+    /// storage) use this instead of duplicating `vector.len() as u64` followed by a call to
+    /// [`Self::ensure_collection`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if Qdrant cannot be reached or collection creation fails.
+    pub async fn ensure_collection_for_vector(&self, vector: &[f32]) -> Result<(), MemoryError> {
+        // Safe: a Vec<f32> with 4B+ elements is impossible in practice on any 64-bit platform.
+        self.ensure_collection(vector.len() as u64).await
+    }
+
     /// Store a vector in Qdrant with additional tool execution metadata as payload fields.
     ///
     /// Metadata fields (`tool_name`, `exit_code`, `timestamp`) are stored as Qdrant payload

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -87,6 +87,7 @@ pub mod tiered_retrieval;
 pub mod tiers;
 
 pub mod db_vector_store;
+pub mod embed_probe;
 pub mod embedding_registry;
 pub mod embedding_store;
 pub mod error;
@@ -136,6 +137,7 @@ pub use document::{
     Chunk, Document, DocumentError, DocumentLoader, DocumentMetadata, IngestionPipeline,
     SplitterConfig, TextLoader, TextSplitter,
 };
+pub use embed_probe::{ProbeError, probe_vector_size};
 pub use embedding_registry::{
     EmbedFuture, Embeddable, EmbeddingRegistry, EmbeddingRegistryError, SyncStats,
 };

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -130,8 +130,7 @@ async fn embed_and_store_regular_bg(args: EmbedBgArgs) {
     let Some(first) = vectors.first() else {
         return;
     };
-    let vector_size = first.len() as u64;
-    if let Err(e) = qdrant.ensure_collection(vector_size).await {
+    if let Err(e) = qdrant.ensure_collection_for_vector(first).await {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -197,24 +196,23 @@ async fn embed_chunks_with_tool_context_bg(args: EmbedBgArgs, embed_ctx: EmbedCo
         }
     };
 
-    if let Some(first) = vectors.first() {
-        let vector_size = first.len() as u64;
-        if let Err(e) = qdrant.ensure_collection(vector_size).await {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            let last = last_qdrant_warn.load(Ordering::Relaxed);
-            if now.saturating_sub(last) >= 10 {
-                last_qdrant_warn.store(now, Ordering::Relaxed);
-                tracing::warn!("bg embed_tool: failed to ensure Qdrant collection: {e:#}");
-            } else {
-                tracing::debug!(
-                    "bg embed_tool: failed to ensure Qdrant collection (suppressed): {e:#}"
-                );
-            }
-            return;
+    if let Some(first) = vectors.first()
+        && let Err(e) = qdrant.ensure_collection_for_vector(first).await
+    {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let last = last_qdrant_warn.load(Ordering::Relaxed);
+        if now.saturating_sub(last) >= 10 {
+            last_qdrant_warn.store(now, Ordering::Relaxed);
+            tracing::warn!("bg embed_tool: failed to ensure Qdrant collection: {e:#}");
+        } else {
+            tracing::debug!(
+                "bg embed_tool: failed to ensure Qdrant collection (suppressed): {e:#}"
+            );
         }
+        return;
     }
 
     for (chunk_index, vector) in vectors.into_iter().enumerate() {
@@ -288,8 +286,7 @@ async fn embed_and_store_with_category_bg(args: EmbedBgArgs, category: Option<St
     let Some(first) = vectors.first() else {
         return;
     };
-    let vector_size = first.len() as u64;
-    if let Err(e) = qdrant.ensure_collection(vector_size).await {
+    if let Err(e) = qdrant.ensure_collection_for_vector(first).await {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -774,8 +771,7 @@ impl SemanticMemory {
                 }
             };
             let query_vector = self.apply_query_bias(query, query_vector).await;
-            let vector_size = u64::try_from(query_vector.len()).unwrap_or(896);
-            qdrant.ensure_collection(vector_size).await?;
+            qdrant.ensure_collection_for_vector(&query_vector).await?;
             qdrant
                 .search(&query_vector, self.effective_depth(limit), filter)
                 .await?
@@ -843,8 +839,7 @@ impl SemanticMemory {
             }
         };
         let query_vector = self.apply_query_bias(query, query_vector).await;
-        let vector_size = u64::try_from(query_vector.len()).unwrap_or(896);
-        qdrant.ensure_collection(vector_size).await?;
+        qdrant.ensure_collection_for_vector(&query_vector).await?;
         qdrant
             .search(&query_vector, self.effective_depth(limit), filter)
             .await

--- a/crates/zeph-memory/src/semantic/summarization.rs
+++ b/crates/zeph-memory/src/semantic/summarization.rs
@@ -152,8 +152,7 @@ impl SemanticMemory {
             .await
             {
                 Ok(Ok(vector)) => {
-                    let vector_size = u64::try_from(vector.len()).unwrap_or(896);
-                    if let Err(e) = qdrant.ensure_collection(vector_size).await {
+                    if let Err(e) = qdrant.ensure_collection_for_vector(&vector).await {
                         tracing::warn!("Failed to ensure Qdrant collection: {e:#}");
                     } else if let Err(e) = qdrant
                         .store(

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -436,20 +436,22 @@ async fn build_ingest_resources(
     };
 
     // Probe the embedding dimension and pre-create the documents collection so a fresh
-    // Qdrant instance doesn't fail on the first upsert (mirrors EmbeddingRegistry::ensure_collection).
-    let vector_size = tokio::time::timeout(
-        std::time::Duration::from_secs(DIMENSION_PROBE_TIMEOUT_SECS),
+    // Qdrant instance doesn't fail on the first upsert (same probe helper used by
+    // EmbeddingRegistry::ensure_collection and zeph-index's indexer).
+    let vector_size = zeph_memory::probe_vector_size(
         provider.embed("dimension probe"),
+        Some(std::time::Duration::from_secs(DIMENSION_PROBE_TIMEOUT_SECS)),
     )
     .await
-    .map_err(|_| {
-        anyhow::anyhow!(
+    .map_err(|e| match e {
+        zeph_memory::ProbeError::Timeout(_) => anyhow::anyhow!(
             "embedding dimension probe timed out after {DIMENSION_PROBE_TIMEOUT_SECS}s: \
              provider is unresponsive"
-        )
-    })?
-    .map(|v| v.len() as u64)
-    .map_err(|e| anyhow::anyhow!("failed to probe embedding dimension: {e}"))?;
+        ),
+        zeph_memory::ProbeError::Embed(err) => {
+            anyhow::anyhow!("failed to probe embedding dimension: {err}")
+        }
+    })?;
     qdrant
         .ensure_collection(&collection, vector_size)
         .await


### PR DESCRIPTION
## Summary
- Extract the duplicated "probe embedding dimension, then `ensure_collection`" sequence into two shared helpers instead of 9 independent inline re-implementations across `zeph-memory`, `zeph-index`, and `src/commands/knowledge.rs`.
- New `zeph_memory::probe_vector_size` (`crates/zeph-memory/src/embed_probe.rs`) awaits an already-invoked embed future, optionally timeout-bounded, for the 3 throwaway-probe call sites (`EmbeddingRegistry::ensure_collection`, `zeph-index`'s `Indexer::ensure_collection_for_provider` — preserving its existing 15s startup timeout — and `knowledge.rs::build_ingest_resources`).
- New `EmbeddingStore::ensure_collection_for_vector` (`crates/zeph-memory/src/embedding_store.rs`) derives the dimension from an already-computed real embedding for the 7 sites in `admission.rs`, `semantic/recall.rs` (5 sites), and `semantic/summarization.rs` that already hold a vector for real work rather than a throwaway probe.
- No behavior change: per-site error mapping, control flow, and the 15s timeout are preserved exactly; verified independently by both an adversarial critic and a testing pass, plus reviewer re-read of the full diff.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11558 passed
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory -p zeph-index --features testing` — 1625 passed, includes 4 new `embed_probe` unit tests + 1 doc-test
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] Rustdoc gate for touched published crates (`zeph-memory`, `zeph-index`)
- [x] `indexer::tests::ensure_collection_timeout_returns_embed_timeout_error` still asserts the 15s timeout fires through the new shared helper

Closes #5388