### PR TITLE
refactor(memory): finish probe-then-ensure_collection dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   derives the dimension from an already-computed vector and ensures the collection in one call,
   used by `admission.rs`, `semantic/recall.rs` (5 call sites), and `semantic/summarization.rs`,
   which each already hold a real embedding rather than a throwaway probe. No behavior change.
+- `refactor(memory)`: finish the probe-then-ensure_collection dedup started above. New
+  `EmbeddingStore::ensure_named_collection_for_vector` (`crates/zeph-memory/src/embedding_store.rs`)
+  replaces 8 remaining inline `ensure_named_collection(vector.len())` call sites across
+  `episodic_consolidation.rs`, `graph/resolver/mod.rs`, and `semantic/{summarization,cross_session,
+  corrections}.rs`, eliminating a dead-fallback default (`1536`/`896`/`384`) that had already
+  diverged across the inline copies. `src/bootstrap/mod.rs`'s reasoning-strategies collection probe
+  now also calls `zeph_memory::probe_vector_size` directly instead of its own inline throwaway
+  probe. No behavior change. Closes #5393.
 
 ### Fixed
 

--- a/crates/zeph-memory/src/embedding_store.rs
+++ b/crates/zeph-memory/src/embedding_store.rs
@@ -187,6 +187,26 @@ impl EmbeddingStore {
         self.ensure_collection(vector.len() as u64).await
     }
 
+    /// Ensure a named collection exists with a vector dimension matching an already-computed
+    /// `vector`.
+    ///
+    /// Callers that already hold an embedding for a non-default collection (e.g. graph entity
+    /// resolution, session summaries) use this instead of duplicating `vector.len() as u64`
+    /// followed by a call to [`Self::ensure_named_collection`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if Qdrant cannot be reached or collection creation fails.
+    pub async fn ensure_named_collection_for_vector(
+        &self,
+        name: &str,
+        vector: &[f32],
+    ) -> Result<(), MemoryError> {
+        // Safe: a Vec<f32> with 4B+ elements is impossible in practice on any 64-bit platform.
+        self.ensure_named_collection(name, vector.len() as u64)
+            .await
+    }
+
     /// Store a vector in Qdrant with additional tool execution metadata as payload fields.
     ///
     /// Metadata fields (`tool_name`, `exit_code`, `timestamp`) are stored as Qdrant payload

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -601,9 +601,8 @@ async fn promote_fact(
 
     // Upsert into Qdrant `zeph_key_facts` when a pre-computed embedding is available.
     if let (Some(qdrant), Some(vector)) = (qdrant, embedding) {
-        let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         if let Err(e) = qdrant
-            .ensure_named_collection(KEY_FACTS_COLLECTION, vector_size)
+            .ensure_named_collection_for_vector(KEY_FACTS_COLLECTION, &vector)
             .await
         {
             tracing::warn!(error = %e, "episodic consolidation: failed to ensure key_facts collection");

--- a/crates/zeph-memory/src/graph/resolver/mod.rs
+++ b/crates/zeph-memory/src/graph/resolver/mod.rs
@@ -711,15 +711,14 @@ impl<'a> EntityResolver<'a> {
     ) {
         // Ensure the Qdrant collection exists exactly once per resolver lifetime.
         // All entity embeddings use the same model dimension, so the first call's
-        // vector_size wins — subsequent entities share the same collection.
+        // vector dimension wins — subsequent entities share the same collection.
         // On error the cell stays unset, so the next entity retries — transient
         // network failures do not permanently disable embedding storage.
-        let vector_size = u64::try_from(vector.len()).unwrap_or(384);
         let collection_ensured = Arc::clone(&self.collection_ensured);
         if let Err(err) = collection_ensured
             .get_or_try_init(|| async {
                 emb_store
-                    .ensure_named_collection(ENTITY_COLLECTION, vector_size)
+                    .ensure_named_collection_for_vector(ENTITY_COLLECTION, vector)
                     .await
             })
             .await

--- a/crates/zeph-memory/src/semantic/corrections.rs
+++ b/crates/zeph-memory/src/semantic/corrections.rs
@@ -39,9 +39,8 @@ impl SemanticMemory {
                 return Ok(());
             }
         };
-        let vector_size = u64::try_from(embedding.len()).unwrap_or(896);
         store
-            .ensure_named_collection(CORRECTIONS_COLLECTION, vector_size)
+            .ensure_named_collection_for_vector(CORRECTIONS_COLLECTION, &embedding)
             .await?;
         let payload = serde_json::json!({ "correction_id": correction_id });
         store
@@ -85,9 +84,8 @@ impl SemanticMemory {
                 return Ok(vec![]);
             }
         };
-        let vector_size = u64::try_from(embedding.len()).unwrap_or(896);
         store
-            .ensure_named_collection(CORRECTIONS_COLLECTION, vector_size)
+            .ensure_named_collection_for_vector(CORRECTIONS_COLLECTION, &embedding)
             .await?;
         let scored = store
             .search_collection(CORRECTIONS_COLLECTION, &embedding, limit, None)

--- a/crates/zeph-memory/src/semantic/cross_session.rs
+++ b/crates/zeph-memory/src/semantic/cross_session.rs
@@ -111,9 +111,8 @@ impl SemanticMemory {
                 return Ok(());
             }
         };
-        let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         qdrant
-            .ensure_named_collection(SESSION_SUMMARIES_COLLECTION, vector_size)
+            .ensure_named_collection_for_vector(SESSION_SUMMARIES_COLLECTION, &vector)
             .await?;
 
         let point_id = {
@@ -175,9 +174,8 @@ impl SemanticMemory {
                 return Ok(Vec::new());
             }
         };
-        let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         qdrant
-            .ensure_named_collection(SESSION_SUMMARIES_COLLECTION, vector_size)
+            .ensure_named_collection_for_vector(SESSION_SUMMARIES_COLLECTION, &vector)
             .await?;
 
         let filter = exclude_conversation_id.map(|cid| VectorFilter {

--- a/crates/zeph-memory/src/semantic/summarization.rs
+++ b/crates/zeph-memory/src/semantic/summarization.rs
@@ -277,9 +277,8 @@ impl SemanticMemory {
                 return;
             }
         };
-        let vector_size = u64::try_from(first_vector.len()).unwrap_or(896);
         if let Err(e) = qdrant
-            .ensure_named_collection(KEY_FACTS_COLLECTION, vector_size)
+            .ensure_named_collection_for_vector(KEY_FACTS_COLLECTION, &first_vector)
             .await
         {
             tracing::warn!("Failed to ensure key_facts collection: {e:#}");
@@ -397,9 +396,8 @@ impl SemanticMemory {
                 return Ok(Vec::new());
             }
         };
-        let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         qdrant
-            .ensure_named_collection(KEY_FACTS_COLLECTION, vector_size)
+            .ensure_named_collection_for_vector(KEY_FACTS_COLLECTION, &vector)
             .await?;
 
         let points = qdrant

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -628,9 +628,10 @@ impl AppBuilder {
             // Ensure the reasoning_strategies collection exists with the correct vector size.
             // Best-effort: a failure here is logged and Qdrant falls back to SQLite-only mode.
             if probe_provider.supports_embeddings() {
-                match probe_provider.embed("dimension probe").await {
-                    Ok(probe) => {
-                        let vector_size = u64::try_from(probe.len()).unwrap_or(1536);
+                match zeph_memory::probe_vector_size(probe_provider.embed("dimension probe"), None)
+                    .await
+                {
+                    Ok(vector_size) => {
                         if let Err(e) = ops
                             .ensure_collection(
                                 zeph_memory::reasoning::REASONING_COLLECTION,


### PR DESCRIPTION
## Summary

- Adds `EmbeddingStore::ensure_named_collection_for_vector` (`crates/zeph-memory/src/embedding_store.rs`), analogous to the existing `ensure_collection_for_vector` added in #5392, and migrates the 8 remaining inline `ensure_named_collection(vector.len())` call sites to it across `episodic_consolidation.rs`, `graph/resolver/mod.rs`, and `semantic/{summarization,cross_session,corrections}.rs`.
- Migrates `src/bootstrap/mod.rs`'s reasoning-strategies collection probe to call `zeph_memory::probe_vector_size` directly instead of its own inline throwaway probe, matching the 3 sites #5392 already migrated.
- Eliminates a dead-fallback default (`1536`/`896`/`384`) that had already diverged across the 8 inline copies — `u64::try_from(usize)` is infallible on every real platform, so these fallbacks were unreachable, but the divergence itself was evidence of drift the shared helper now prevents.
- Pure dedup — no behavior change.

Closes #5393 (follow-up to #5388/#5392).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11565 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-memory`
- [x] Reviewed by adversarial critic (verdict: minor, no behavioral drift) and code reviewer (verdict: approved after one comment-wording fix)