### PR TITLE
fix(orchestration): stop populating verify_predicate when the gate is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(orchestration)`: `/plan confirm` no longer deadlocks and discards completed work when the
+  LLM planner attaches a `verify_criteria` acceptance criterion to a task under the default
+  config (`orchestration.verify_predicate_enabled = false`). `convert_response` (planner.rs) now
+  only populates `TaskNode::verify_predicate` when the flag is enabled, so a disabled predicate
+  gate no longer leaves a completed parent's dependents permanently blocked in
+  `dag::all_parents_predicate_clear` while nothing ever evaluates the predicate to clear it —
+  the combination previously made `check_graph_completion` see no ready/running tasks and
+  falsely report a scheduler deadlock, marking the graph `Failed` and cancelling already-completed
+  work. Closes #5403.
 - `fix(knowledge)`: `zeph knowledge ingest` no longer fails on a fresh Qdrant instance.
   `build_ingest_resources` now probes the embedding dimension and calls
   `QdrantOps::ensure_collection` for the documents collection before constructing the

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -971,6 +971,7 @@ impl<C: crate::channel::Channel> Agent<C> {
 
         let topology_hint = self.compute_topology_hint(goal).await;
 
+        let cfg = &self.services.orchestration.orchestration_config;
         let planner_provider = self
             .services
             .orchestration
@@ -978,23 +979,16 @@ impl<C: crate::channel::Channel> Agent<C> {
             .as_ref()
             .unwrap_or(&self.provider)
             .clone();
-        let planner = LlmPlanner::new(
-            planner_provider,
-            &self.services.orchestration.orchestration_config,
-        );
+        let planner = LlmPlanner::new(planner_provider, cfg);
         let embed_model = self.services.skill.embedding_model.clone();
-        let max_tasks = self.services.orchestration.orchestration_config.max_tasks;
+        let max_tasks = cfg.max_tasks;
+        let verify_predicate_enabled = cfg.verify_predicate_enabled;
         let (graph, planner_usage) = {
             use zeph_orchestration::Planner as _;
             let use_cache = topology_hint
                 .as_ref()
                 .is_none_or(|h| h.prompt_sentence().is_none());
-            let planner_timeout = std::time::Duration::from_secs(
-                self.services
-                    .orchestration
-                    .orchestration_config
-                    .planner_timeout_secs,
-            );
+            let planner_timeout = std::time::Duration::from_secs(cfg.planner_timeout_secs);
             let result = if use_cache {
                 plan_with_cache(
                     &planner,
@@ -1006,6 +1000,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                     &available_agents,
                     max_tasks,
                     planner_timeout,
+                    verify_predicate_enabled,
                 )
                 .await
             } else {

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -481,6 +481,7 @@ pub async fn plan_with_cache<P>(
     available_agents: &[SubAgentDef],
     max_tasks: u32,
     planner_timeout: Duration,
+    verify_predicate_enabled: bool,
 ) -> Result<(TaskGraph, Option<(u64, u64)>), OrchestrationError>
 where
     P: super::planner::Planner,
@@ -502,6 +503,7 @@ where
                     available_agents,
                     max_tasks,
                     planner_timeout,
+                    verify_predicate_enabled,
                 )
                 .await
                 {
@@ -537,6 +539,7 @@ where
 /// Returns `OrchestrationError::PlanningFailed` if the LLM call fails, times out, or the
 /// adapted graph fails DAG validation.
 #[tracing::instrument(name = "orchestration.plan_cache.adapt", skip_all, fields(goal_len = goal.len()))]
+#[allow(clippy::too_many_arguments)]
 async fn adapt_plan(
     provider: &impl LlmProvider,
     goal: &str,
@@ -544,6 +547,7 @@ async fn adapt_plan(
     available_agents: &[SubAgentDef],
     max_tasks: u32,
     timeout: Duration,
+    verify_predicate_enabled: bool,
 ) -> Result<(TaskGraph, Option<(u64, u64)>), OrchestrationError> {
     use zeph_subagent::ToolPolicy;
 
@@ -598,7 +602,13 @@ async fn adapt_plan(
 
     let usage = provider.last_usage();
 
-    let graph = convert_response_pub(response, goal, available_agents, max_tasks)?;
+    let graph = convert_response_pub(
+        response,
+        goal,
+        available_agents,
+        max_tasks,
+        verify_predicate_enabled,
+    )?;
 
     dag::validate(&graph.tasks, max_tasks as usize)?;
 
@@ -980,6 +990,7 @@ mod tests {
             &[],
             20,
             Duration::from_mins(2),
+            false,
         )
         .await
         .unwrap();
@@ -1030,6 +1041,7 @@ mod tests {
             &[],
             20,
             Duration::from_mins(2),
+            false,
         )
         .await
         .unwrap();
@@ -1081,6 +1093,7 @@ mod tests {
             &[],
             20,
             Duration::from_mins(2),
+            false,
         )
         .await
         .unwrap();

--- a/crates/zeph-orchestration/src/planner.rs
+++ b/crates/zeph-orchestration/src/planner.rs
@@ -93,6 +93,12 @@ pub struct LlmPlanner<P: LlmProvider> {
     /// Default failure strategy applied to every graph produced by this planner,
     /// unless a per-task `failure_strategy` override is set by the LLM.
     default_failure_strategy: FailureStrategy,
+    /// Whether the predicate gate is enabled (`config.verify_predicate_enabled`).
+    ///
+    /// When `false`, `verify_criteria` from the LLM response is dropped instead of
+    /// being attached to the graph node, so the scheduler never waits on a predicate
+    /// outcome that nothing will ever produce.
+    verify_predicate_enabled: bool,
 }
 
 impl<P: LlmProvider> LlmPlanner<P> {
@@ -109,6 +115,7 @@ impl<P: LlmProvider> LlmPlanner<P> {
             max_tasks: config.max_tasks,
             timeout: Duration::from_secs(config.planner_timeout_secs),
             default_failure_strategy: config.default_failure_strategy,
+            verify_predicate_enabled: config.verify_predicate_enabled,
         }
     }
 }
@@ -188,7 +195,13 @@ impl<P: LlmProvider + Send + Sync> Planner for LlmPlanner<P> {
                 .map_err(|_| OrchestrationError::PlanningFailed("planner timed out".into()))?
                 .map_err(|e| OrchestrationError::PlanningFailed(e.to_string()))?;
         let usage = self.provider.last_usage();
-        let mut graph = convert_response(response, goal, available_agents, self.max_tasks)?;
+        let mut graph = convert_response(
+            response,
+            goal,
+            available_agents,
+            self.max_tasks,
+            self.verify_predicate_enabled,
+        )?;
         graph.default_failure_strategy = self.default_failure_strategy;
         dag::validate(&graph.tasks, self.max_tasks as usize)?;
         Ok((graph, usage))
@@ -217,7 +230,13 @@ impl<P: LlmProvider + Send + Sync> Planner for LlmPlanner<P> {
         // Capture usage right after the API call, before any fallible post-processing.
         let usage = self.provider.last_usage();
 
-        let mut graph = convert_response(response, goal, available_agents, self.max_tasks)?;
+        let mut graph = convert_response(
+            response,
+            goal,
+            available_agents,
+            self.max_tasks,
+            self.verify_predicate_enabled,
+        )?;
         graph.default_failure_strategy = self.default_failure_strategy;
 
         dag::validate(&graph.tasks, self.max_tasks as usize)?;
@@ -318,8 +337,15 @@ pub(crate) fn convert_response_pub(
     goal: &str,
     available_agents: &[SubAgentDef],
     max_tasks: u32,
+    verify_predicate_enabled: bool,
 ) -> Result<TaskGraph, OrchestrationError> {
-    convert_response(response, goal, available_agents, max_tasks)
+    convert_response(
+        response,
+        goal,
+        available_agents,
+        max_tasks,
+        verify_predicate_enabled,
+    )
 }
 
 fn convert_response(
@@ -327,6 +353,7 @@ fn convert_response(
     goal: &str,
     available_agents: &[SubAgentDef],
     max_tasks: u32,
+    verify_predicate_enabled: bool,
 ) -> Result<TaskGraph, OrchestrationError> {
     let planned = response.tasks;
 
@@ -413,7 +440,7 @@ fn convert_response(
             node.execution_mode = mode;
         }
 
-        if let Some(criteria) = &pt.verify_criteria {
+        if verify_predicate_enabled && let Some(criteria) = &pt.verify_criteria {
             let trimmed = criteria.trim();
             if !trimmed.is_empty() {
                 let criterion: String = trimmed.chars().take(1024).collect();
@@ -483,7 +510,7 @@ mod tests {
                 make_planned("task-c", "Task C", &["task-b"], None),
             ],
         };
-        let graph = convert_response(response, "linear goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "linear goal", &agents(), 20, true).unwrap();
         assert_eq!(graph.tasks.len(), 3);
         assert_eq!(graph.tasks[0].id, TaskId(0));
         assert_eq!(graph.tasks[1].depends_on, vec![TaskId(0)]);
@@ -501,7 +528,7 @@ mod tests {
                 make_planned("d", "D", &["b", "c"], None),
             ],
         };
-        let graph = convert_response(response, "diamond", &agents(), 20).unwrap();
+        let graph = convert_response(response, "diamond", &agents(), 20, true).unwrap();
         assert_eq!(graph.tasks[3].depends_on, vec![TaskId(1), TaskId(2)]);
     }
 
@@ -514,7 +541,7 @@ mod tests {
                 make_planned("t3", "T3", &[], None),
             ],
         };
-        let graph = convert_response(response, "parallel", &agents(), 20).unwrap();
+        let graph = convert_response(response, "parallel", &agents(), 20, true).unwrap();
         for node in &graph.tasks {
             assert!(node.depends_on.is_empty());
         }
@@ -523,7 +550,7 @@ mod tests {
     #[test]
     fn test_convert_empty_tasks_rejected() {
         let response = PlannerResponse { tasks: vec![] };
-        let err = convert_response(response, "goal", &agents(), 20).unwrap_err();
+        let err = convert_response(response, "goal", &agents(), 20, true).unwrap_err();
         assert_matches!(err, OrchestrationError::PlanningFailed(_));
     }
 
@@ -533,7 +560,7 @@ mod tests {
             .map(|i| make_planned(&format!("task-{i}"), &format!("T{i}"), &[], None))
             .collect();
         let response = PlannerResponse { tasks };
-        let err = convert_response(response, "goal", &agents(), 3).unwrap_err();
+        let err = convert_response(response, "goal", &agents(), 3, true).unwrap_err();
         assert_matches!(err, OrchestrationError::PlanningFailed(_));
     }
 
@@ -547,7 +574,7 @@ mod tests {
                 make_planned("dup", "Second", &[], None),
             ],
         };
-        let err = convert_response(response, "goal", &agents(), 20).unwrap_err();
+        let err = convert_response(response, "goal", &agents(), 20, true).unwrap_err();
         assert_matches!(err, OrchestrationError::PlanningFailed(_));
     }
 
@@ -556,7 +583,7 @@ mod tests {
         let response = PlannerResponse {
             tasks: vec![make_planned("task-a", "A", &["nonexistent"], None)],
         };
-        let err = convert_response(response, "goal", &agents(), 20).unwrap_err();
+        let err = convert_response(response, "goal", &agents(), 20, true).unwrap_err();
         assert_matches!(err, OrchestrationError::PlanningFailed(_));
     }
 
@@ -565,7 +592,7 @@ mod tests {
         let response = PlannerResponse {
             tasks: vec![make_planned("task-a", "A", &[], Some("unknown-agent"))],
         };
-        let graph = convert_response(response, "goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "goal", &agents(), 20, true).unwrap();
         assert!(graph.tasks[0].agent_hint.is_none());
     }
 
@@ -574,7 +601,7 @@ mod tests {
         let response = PlannerResponse {
             tasks: vec![make_planned("task-a", "A", &[], Some("agent-a"))],
         };
-        let graph = convert_response(response, "goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "goal", &agents(), 20, true).unwrap();
         assert_eq!(graph.tasks[0].agent_hint.as_deref(), Some("agent-a"));
     }
 
@@ -603,7 +630,7 @@ mod tests {
                     verify_criteria: None,
                 }],
             };
-            let err = convert_response(response, "goal", &agents(), 20).unwrap_err();
+            let err = convert_response(response, "goal", &agents(), 20, true).unwrap_err();
             assert!(
                 matches!(err, OrchestrationError::PlanningFailed(_)),
                 "expected PlanningFailed for task_id '{bad_id}'"
@@ -628,7 +655,7 @@ mod tests {
         ]}"#;
         let response: PlannerResponse = serde_json::from_str(json).unwrap();
         assert!(response.tasks[0].failure_strategy.is_none());
-        let graph = convert_response(response, "goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "goal", &agents(), 20, true).unwrap();
         assert!(graph.tasks[0].failure_strategy.is_none());
     }
 
@@ -643,7 +670,7 @@ mod tests {
             response.tasks[0].failure_strategy,
             Some(FailureStrategy::Skip)
         );
-        let graph = convert_response(response, "goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "goal", &agents(), 20, true).unwrap();
         assert_eq!(graph.tasks[0].failure_strategy, Some(FailureStrategy::Skip));
     }
 
@@ -652,7 +679,7 @@ mod tests {
         let response = PlannerResponse {
             tasks: vec![make_planned("t1", "T1", &[], None)],
         };
-        let graph = convert_response(response, "my goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "my goal", &agents(), 20, true).unwrap();
         assert_eq!(graph.goal, "my goal");
     }
 
@@ -666,7 +693,7 @@ mod tests {
         let response = PlannerResponse {
             tasks: vec![make_planned("t1", "T1", &[], None)],
         };
-        let graph = convert_response(response, "goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "goal", &agents(), 20, true).unwrap();
         assert_eq!(
             graph.default_failure_strategy,
             FailureStrategy::Abort,
@@ -788,7 +815,7 @@ mod tests {
                 verify_criteria: None,
             }],
         };
-        let graph = convert_response(response, "goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "goal", &agents(), 20, true).unwrap();
         assert_eq!(graph.tasks[0].execution_mode, ExecutionMode::Parallel);
     }
 
@@ -806,7 +833,7 @@ mod tests {
                 verify_criteria: None,
             }],
         };
-        let graph = convert_response(response, "goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "goal", &agents(), 20, true).unwrap();
         assert_eq!(graph.tasks[0].execution_mode, ExecutionMode::Sequential);
     }
 
@@ -815,8 +842,49 @@ mod tests {
         let response = PlannerResponse {
             tasks: vec![make_planned("t1", "T1", &[], None)],
         };
-        let graph = convert_response(response, "goal", &agents(), 20).unwrap();
+        let graph = convert_response(response, "goal", &agents(), 20, true).unwrap();
         assert_eq!(graph.tasks[0].execution_mode, ExecutionMode::Parallel);
+    }
+
+    // --- verify_predicate gating tests (#5403 regression) ---
+
+    #[test]
+    fn test_convert_verify_predicate_disabled_drops_criteria_with_dependent() {
+        // Regression for #5403: a parent task with verify_criteria and a downstream
+        // dependent must NOT get a verify_predicate when the flag is disabled, or the
+        // dependent is permanently blocked by dag::all_parents_predicate_clear, causing
+        // a false scheduler deadlock.
+        let response = PlannerResponse {
+            tasks: vec![
+                PlannedTask {
+                    verify_criteria: Some("output must be valid JSON".to_string()),
+                    ..make_planned("a", "A", &[], None)
+                },
+                make_planned("b", "B", &["a"], None),
+            ],
+        };
+        let graph = convert_response(response, "goal", &agents(), 20, false).unwrap();
+        assert_eq!(graph.tasks[0].verify_predicate, None);
+    }
+
+    #[test]
+    fn test_convert_verify_predicate_enabled_sets_predicate_with_dependent() {
+        let response = PlannerResponse {
+            tasks: vec![
+                PlannedTask {
+                    verify_criteria: Some("output must be valid JSON".to_string()),
+                    ..make_planned("a", "A", &[], None)
+                },
+                make_planned("b", "B", &["a"], None),
+            ],
+        };
+        let graph = convert_response(response, "goal", &agents(), 20, true).unwrap();
+        assert_eq!(
+            graph.tasks[0].verify_predicate,
+            Some(VerifyPredicate::Natural(
+                "output must be valid JSON".to_string()
+            ))
+        );
     }
 
     #[test]
@@ -990,6 +1058,7 @@ mod tests {
                 max_tasks: 20,
                 timeout: Duration::from_millis(50),
                 default_failure_strategy: FailureStrategy::Abort,
+                verify_predicate_enabled: false,
             };
             let err = planner.plan("some goal", &agents()).await.unwrap_err();
             assert!(

--- a/crates/zeph-orchestration/src/scheduler/tick/tests.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/tests.rs
@@ -112,6 +112,99 @@ fn test_completion_event_marks_deps_ready() {
 }
 
 #[test]
+fn test_plan_with_verify_criteria_and_predicate_disabled_reaches_completed() {
+    // End-to-end regression for #5403: a planner response where a task has a
+    // verify_criteria acceptance check and a downstream dependent, converted with
+    // verify_predicate_enabled = false (the reported bug's default config), must
+    // dispatch the dependent once the parent completes and drive the graph to
+    // GraphStatus::Completed instead of a false scheduler deadlock.
+    use crate::graph::PlanSlug;
+    use crate::planner::{PlannedTask, PlannerResponse, convert_response_pub};
+
+    let response = PlannerResponse {
+        tasks: vec![
+            PlannedTask {
+                task_id: PlanSlug::from("parent"),
+                title: "Parent".to_string(),
+                description: "do parent work".to_string(),
+                agent_hint: None,
+                depends_on: vec![],
+                failure_strategy: None,
+                execution_mode: None,
+                verify_criteria: Some("output must be valid JSON".to_string()),
+            },
+            PlannedTask {
+                task_id: PlanSlug::from("child"),
+                title: "Child".to_string(),
+                description: "do child work".to_string(),
+                agent_hint: None,
+                depends_on: vec![PlanSlug::from("parent")],
+                failure_strategy: None,
+                execution_mode: None,
+                verify_criteria: None,
+            },
+        ],
+    };
+    let graph = convert_response_pub(response, "goal", &[make_def("worker")], 20, false).unwrap();
+    assert!(
+        graph.tasks[0].verify_predicate.is_none(),
+        "verify_predicate must be dropped when verify_predicate_enabled is false"
+    );
+
+    let mut scheduler = make_scheduler(graph);
+
+    // Tick 1: parent has no dependencies, should be dispatched.
+    let actions = scheduler.tick();
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a, SchedulerAction::Spawn { task_id, .. } if *task_id == TaskId(0)))
+    );
+    scheduler.record_spawn(TaskId(0), "handle-parent".to_string(), "worker".to_string());
+    scheduler.buffered_events.push_back(TaskEvent {
+        task_id: TaskId(0),
+        agent_handle_id: "handle-parent".to_string(),
+        outcome: TaskOutcome::Completed {
+            output: "parent done".to_string(),
+            artifacts: vec![],
+        },
+    });
+
+    // Tick 2: parent completion processed; child must be dispatched, not blocked by a
+    // dangling verify_predicate gate.
+    let actions = scheduler.tick();
+    assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Completed);
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a, SchedulerAction::Spawn { task_id, .. } if *task_id == TaskId(1))),
+        "child must be dispatched once its only dependency completes"
+    );
+    scheduler.record_spawn(TaskId(1), "handle-child".to_string(), "worker".to_string());
+    scheduler.buffered_events.push_back(TaskEvent {
+        task_id: TaskId(1),
+        agent_handle_id: "handle-child".to_string(),
+        outcome: TaskOutcome::Completed {
+            output: "child done".to_string(),
+            artifacts: vec![],
+        },
+    });
+
+    // Tick 3: graph must reach Completed, not a false deadlock/Failed.
+    let actions = scheduler.tick();
+    assert!(
+        actions.iter().any(|a| matches!(
+            a,
+            SchedulerAction::Done {
+                status: GraphStatus::Completed
+            }
+        )),
+        "graph should complete successfully, not deadlock"
+    );
+    assert_eq!(scheduler.graph.status, GraphStatus::Completed);
+}
+
+#[test]
 fn test_failure_abort_cancels_running() {
     let graph = graph_from_nodes(vec![
         make_node(0, &[]),


### PR DESCRIPTION
## Summary

- `/plan confirm` deterministically false-deadlocked and discarded completed sub-agent work whenever the LLM planner attached a `verify_criteria` acceptance criterion to a task with downstream dependents, under the default config (`orchestration.verify_predicate_enabled = false`).
- `convert_response` (planner.rs) now only populates `TaskNode::verify_predicate` when `verify_predicate_enabled` is `true`, threaded through `LlmPlanner`, `plan_cache`'s `adapt_plan`/`plan_with_cache`, and the real call site in `crates/zeph-core/src/agent/plan.rs`. With the flag at its default, a task carries no predicate at all, so dependents become `Ready` as soon as the parent completes — matching pre-regression behavior.
- An additional defensive change to `check_graph_completion`'s deadlock-avoidance guard was implemented and then reverted after adversarial review found it traded the loud, terminal false-`Failed` for a silent, non-terminal, permanent hang in an out-of-scope config-drift scenario (no timeout would ever rescue it). `crates/zeph-orchestration/src/scheduler/planner.rs` is unchanged versus `origin/main`.

Closes #5403

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-orchestration` — 402/402 passed (399 pre-existing + 2 unit tests for the disabled/enabled `verify_predicate` gating + 1 end-to-end scheduler-tick test reproducing the original bug and asserting `GraphStatus::Completed`)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — full workspace suite green
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — 0 warnings
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — rustdoc gate clean
- [x] Manually confirmed `git diff origin/main -- crates/zeph-orchestration/src/scheduler/planner.rs` is empty (defensive fix cleanly reverted)