### PR TITLE
fix: prevent stack overflow crash in zeph --daemon startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `DurableContext::step`, exceeding rustc's default 128 query-depth limit. Added
   `#![recursion_limit = "256"]` to `zeph-orchestration`, the same precedented fix already applied
   to `zeph-acp` for the identical error class. Closes #5395.
+- `fix`: `zeph --daemon` no longer crashes with a stack overflow on startup. `main()` used to
+  run the whole async runtime (via `#[tokio::main]`) directly on the OS main thread, whose stack
+  size is governed by the caller's `ulimit -s` (default 8 MiB on macOS); the large
+  `Config::deserialize` frame (43 top-level fields) stacked on top of the already-large
+  `runner::run`/`run_daemon` async-fn frames could exceed that default. `main()` now spawns a
+  dedicated `"zeph-main"` OS thread with a 32 MiB stack and drives a manually built
+  `tokio::runtime::Builder::new_multi_thread().enable_all()` runtime from it, so daemon startup
+  no longer depends on the caller's shell `ulimit`. Closes #5394.
 - `fix(knowledge)`: `zeph knowledge ingest` no longer fails on a fresh Qdrant instance.
   `build_ingest_resources` now probes the embedding dimension and calls
   `QdrantOps::ensure_collection` for the documents collection before constructing the

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,9 +135,29 @@ mod url_scheme;
 use clap::Parser;
 use cli::Cli;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    Box::pin(runner::run(Cli::parse())).await
+// `Config`'s derive-generated `Deserialize` visitor (43 top-level fields,
+// `crates/zeph-config/src/root.rs`) produces a very large single stack frame in
+// unoptimized debug builds. Stacked on top of the similarly large `runner::run`/
+// `run_daemon` async-fn frames, this can exceed the OS main thread's default stack
+// size (8 MiB on macOS/Linux, entirely governed by the caller's `ulimit -s`). Driving
+// the runtime from a dedicated thread with an explicit, generous stack removes the
+// dependency on the invoking shell/service manager's default (see #5394).
+// 32 MiB is a 2x margin over the 16 MiB confirmed sufficient during root-cause
+// debugging, leaving headroom as `Config` grows new fields over time.
+const MAIN_THREAD_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+fn main() -> anyhow::Result<()> {
+    std::thread::Builder::new()
+        .name("zeph-main".into())
+        .stack_size(MAIN_THREAD_STACK_SIZE)
+        .spawn(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?
+                .block_on(Box::pin(runner::run(Cli::parse())))
+        })?
+        .join()
+        .expect("zeph-main thread panicked")
 }
 
 #[cfg(test)]

--- a/tests/daemon_boot.rs
+++ b/tests/daemon_boot.rs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression coverage for #5394: `zeph --daemon` used to stack-overflow on startup
+//! because the whole async runtime ran on the OS main thread, whose stack size is
+//! governed by the caller's `ulimit -s` (8 MiB default on macOS/Linux). See
+//! `src/main.rs` for the fix (dedicated 32 MiB-stack thread).
+
+/// Kills the wrapped child process (and waits briefly for it to exit) on drop, so the
+/// daemon is never left running after a test completes or an assertion panics mid-test.
+struct KillOnDrop(std::process::Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Reproduces a constrained OS main-thread stack ulimit — the class of environment that
+/// crashed every `--daemon` invocation before the fix (originally reported at the macOS/
+/// Linux default of `ulimit -s 8192`, 8 MiB) — and asserts the daemon is still alive a few
+/// seconds after startup instead of having aborted with SIGSEGV/SIGABRT (exit 134,
+/// "thread 'main' has overflowed its stack").
+///
+/// Uses `ulimit -s 4096` (4 MiB) rather than the originally-reported 8 MiB: empirically,
+/// the exact crash threshold shifts with the compiled feature set (`Config`'s frame size
+/// depends on which feature-gated sub-configs are compiled in), and 8 MiB does not
+/// reliably reproduce the crash under every feature combination this test may be built
+/// with. 4 MiB reproduced the pre-fix crash reliably across all feature sets tested,
+/// while comfortably fitting under the fix's 32 MiB dedicated-thread stack (8x margin) —
+/// and after the fix the OS main thread's own footprint is negligible (it only spawns and
+/// joins the worker thread), so the exact ulimit no longer matters.
+#[cfg(all(unix, feature = "a2a"))]
+#[test]
+fn daemon_boots_under_constrained_stack_ulimit() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let config_path = tmp.path().join("daemon-boot.toml");
+
+    // `Config`'s top-level fields have no struct-wide `#[serde(default)]`, so a
+    // partial TOML document fails to parse once the file exists on disk (only a
+    // *missing* file falls back to `Config::default()`). Start from a full dump
+    // of the defaults and patch only the paths that must stay inside the tempdir.
+    let mut doc: toml_edit::DocumentMut = zeph_core::config::Config::dump_defaults()
+        .expect("dump default config")
+        .parse()
+        .expect("parse default config toml");
+    doc["memory"]["sqlite_path"] =
+        toml_edit::value(tmp.path().join("zeph.db").display().to_string());
+    doc["daemon"]["pid_file"] = toml_edit::value(tmp.path().join("zeph.pid").display().to_string());
+    doc["skills"]["paths"] = toml_edit::value(toml_edit::Array::from_iter([tmp
+        .path()
+        .join("skills")
+        .display()
+        .to_string()]));
+    std::fs::write(&config_path, doc.to_string()).expect("write test config");
+
+    let bin = env!("CARGO_BIN_EXE_zeph");
+    let child = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "ulimit -s 4096 && exec {bin} --config {config} --daemon --bare",
+            bin = shell_escape(bin),
+            config = shell_escape(&config_path.display().to_string()),
+        ))
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn zeph --daemon under bash");
+    let mut child = KillOnDrop(child);
+
+    std::thread::sleep(std::time::Duration::from_secs(3));
+
+    match child.0.try_wait().expect("try_wait") {
+        None => {} // still running — the crash under investigation never happens
+        Some(status) => panic!(
+            "daemon exited early with {status:?} instead of staying up \
+             (pre-fix symptom: stack overflow, exit 134)"
+        ),
+    }
+}
+
+/// Cheap tripwire against reintroducing `#[tokio::main]` on the OS main thread, which
+/// would silently drop the stack-size safety margin added for #5394.
+#[test]
+fn main_rs_drives_runtime_from_dedicated_stack_thread() {
+    let main_rs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/main.rs"))
+        .expect("read src/main.rs");
+    assert!(
+        main_rs.contains("stack_size("),
+        "src/main.rs must spawn the runtime on a thread with an explicit stack_size (see #5394)"
+    );
+    assert!(
+        !main_rs.contains("#[tokio::main]"),
+        "src/main.rs must not run the async runtime via #[tokio::main] on the OS main \
+         thread — its stack size is bounded by the caller's ulimit -s and can overflow \
+         (see #5394); use the dedicated stack_size thread instead"
+    );
+}
+
+/// Minimal single-quote shell escaping for interpolating paths into the `bash -c` string.
+#[cfg(all(unix, feature = "a2a"))]
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}

--- a/tests/daemon_boot.rs
+++ b/tests/daemon_boot.rs
@@ -8,8 +8,10 @@
 
 /// Kills the wrapped child process (and waits briefly for it to exit) on drop, so the
 /// daemon is never left running after a test completes or an assertion panics mid-test.
+#[cfg(all(unix, feature = "a2a"))]
 struct KillOnDrop(std::process::Child);
 
+#[cfg(all(unix, feature = "a2a"))]
 impl Drop for KillOnDrop {
     fn drop(&mut self) {
         let _ = self.0.kill();

--- a/tests/daemon_boot.rs
+++ b/tests/daemon_boot.rs
@@ -57,12 +57,12 @@ fn daemon_boots_under_constrained_stack_ulimit() {
         .to_string()]));
     std::fs::write(&config_path, doc.to_string()).expect("write test config");
 
-    let bin = env!("CARGO_BIN_EXE_zeph");
+    let bin = zeph_bin_path();
     let child = std::process::Command::new("bash")
         .arg("-c")
         .arg(format!(
             "ulimit -s 4096 && exec {bin} --config {config} --daemon --bare",
-            bin = shell_escape(bin),
+            bin = shell_escape(&bin),
             config = shell_escape(&config_path.display().to_string()),
         ))
         .stdout(std::process::Stdio::null())
@@ -98,6 +98,22 @@ fn main_rs_drives_runtime_from_dedicated_stack_thread() {
          thread — its stack size is bounded by the caller's ulimit -s and can overflow \
          (see #5394); use the dedicated stack_size thread instead"
     );
+}
+
+/// Resolves the path to the built `zeph` binary at runtime rather than baking it in via the
+/// `CARGO_BIN_EXE_zeph` compile-time macro, which breaks under `cargo nextest`'s
+/// archive-and-restore CI flow (the path is captured at build time on a different runner and
+/// is no longer valid after `--workspace-remap`). `NEXTEST_BIN_EXE_zeph` is nextest's
+/// archive-aware runtime variable; `CARGO_BIN_EXE_zeph` read as a runtime env var (not via
+/// `env!`) is the fallback for plain `cargo test`/`cargo nextest run` without an archive.
+#[cfg(all(unix, feature = "a2a"))]
+fn zeph_bin_path() -> String {
+    std::env::var("NEXTEST_BIN_EXE_zeph")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_zeph"))
+        .expect(
+            "NEXTEST_BIN_EXE_zeph or CARGO_BIN_EXE_zeph must be set by the test runner \
+             (cargo test / cargo nextest run / cargo nextest run --archive-file)",
+        )
 }
 
 /// Minimal single-quote shell escaping for interpolating paths into the `bash -c` string.


### PR DESCRIPTION
## Summary

- `zeph --daemon` crashed with a stack overflow on every invocation, before any daemon functionality could run. Root cause: `main()` ran the whole async runtime via `#[tokio::main]` directly on the OS main thread, whose stack size is governed by the caller's `ulimit -s` (default 8 MiB on macOS); the `Config::deserialize` frame (43-field struct) stacked on the already-large `runner::run`/`run_daemon` async-fn frames exceeded that default.
- `main()` now spawns a dedicated OS thread with a 32 MiB stack and drives a manually built `tokio::runtime::Builder::new_multi_thread().enable_all()` runtime from it, removing the dependency on the caller's shell `ulimit` for every subcommand (not just `--daemon`, which had the thinnest margin).
- Added `tests/daemon_boot.rs`: a process-level smoke test that boots the built binary under a constrained `ulimit -s 4096` (verified to reliably crash pre-fix, pass post-fix), plus a source-text tripwire asserting the dedicated-stack-thread pattern stays in place.

## Known follow-ups (out of scope for this PR, not blocking)

- Tokio worker/blocking threads still default to ~2 MiB stack. Not exploitable by this bug (daemon boot and config hot-reload both run inline on the new 32 MiB thread), but any future heavy-stack work moved onto a spawned task could hit the same class of issue. Worth a P3 tracking note.
- Sibling bin `crates/zeph-skills/src/bin/miner.rs` still uses `#[tokio::main]` unprotected — low risk since it doesn't load the full `Config`, but same underlying pattern.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11565 passed
- [x] `cargo nextest run --config-file .github/nextest.toml --features "desktop,ide,server,chat,pdf,scheduler,testing" --test daemon_boot` — 2 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing unrelated warnings only)
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Manual verification: `./target/debug/zeph --config .local/config/testing.toml --daemon --bare` boots through `Config::load`, loads skills, starts the A2A server, and shuts down cleanly on SIGTERM under the default (unmodified) `ulimit -s`