### PR TITLE
fix(orchestration): raise recursion limit to fix release build overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the combination previously made `check_graph_completion` see no ready/running tasks and
   falsely report a scheduler deadlock, marking the graph `Failed` and cancelling already-completed
   work. Closes #5403.
+- `fix(orchestration)`: `cargo build --release` no longer fails on `zeph-orchestration` with
+  `error: queries overflow the depth limit!` while computing the layout of
+  `durable::journal_budget()`'s async state machine. Release-profile layout computation walks
+  deeper than debug builds through the generic/trait-object nesting in `zeph_durable`'s
+  `DurableContext::step`, exceeding rustc's default 128 query-depth limit. Added
+  `#![recursion_limit = "256"]` to `zeph-orchestration`, the same precedented fix already applied
+  to `zeph-acp` for the identical error class. Closes #5395.
 - `fix(knowledge)`: `zeph knowledge ingest` no longer fails on a fresh Qdrant instance.
   `build_ingest_resources` now probes the embedding dimension and calls
   `QdrantOps::ensure_collection` for the documents collection before constructing the

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -1,6 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+// Release-profile layout computation for `durable::journal_budget()`'s async state machine
+// exceeds rustc's default 128 query-depth limit due to the generic/trait-object nesting in
+// `zeph_durable`'s `DurableContext::step`. Same class of issue as zeph-acp (see commit
+// 076c7fb3); dev/debug builds are unaffected.
+#![recursion_limit = "256"]
+
 //! Multi-model task orchestration: DAG execution, failure propagation, and persistence.
 //!
 //! `zeph-orchestration` decomposes a user goal into a directed acyclic graph (DAG)


### PR DESCRIPTION
## Summary
- `cargo build --release` (and `--release --features full`) fails unconditionally on `zeph-orchestration` with a rustc query-depth overflow computing the layout of `durable::journal_budget()`'s async state machine. This blocks the actual release CI workflow, which builds with `--release --features full`.
- Root cause: release-profile layout computation walks deeper than debug builds through the generic/trait-object nesting in `zeph_durable`'s `DurableContext::step`, exceeding rustc's default 128 query-depth limit.
- Fix: add `#![recursion_limit = "256"]` to `zeph-orchestration`, matching the identical precedent already applied to `zeph-acp` (076c7fb3) and five other crates in the workspace for the same error class.

## Verification
- `cargo build --release --bin zeph` (default features) — succeeds
- `cargo build --release --features full --bin zeph` — succeeds
- `cargo build --release -p zeph-subagent` — succeeds (also calls `DurableContext::step`, confirmed it does not independently need the attribute)
- `cargo nextest run -p zeph-orchestration` — 399/399 passed
- `cargo nextest run -p zeph-durable` — 100 passed, 2 skipped (pre-existing, unrelated)
- `cargo +nightly fmt --check` and `cargo clippy --profile ci -p zeph-orchestration --all-targets -- -D warnings` — clean

## Follow-up (out of scope for this PR)
During validation, a separate pre-existing gap was found: `crates/zeph-acp/tests/integration.rs` independently hits the same recursion-overflow error class under `cargo build --release --workspace --all-targets` (test binaries compile as separate crate roots and don't inherit `zeph-acp/src/lib.rs`'s `recursion_limit` attribute). This is unrelated to and not caused by this fix; filing as a separate follow-up issue.

## Test plan
- [x] `cargo build --release` (default features) succeeds
- [x] `cargo build --release --features full` succeeds
- [x] `cargo nextest run -p zeph-orchestration` and `-p zeph-durable` pass with no regressions
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --profile ci -p zeph-orchestration` passes with no warnings