### PR TITLE
fix: expand ~ in file-tool paths, allow durable --reveal without key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tools)`: file-tool calls (`write`, `edit`, `create_directory`, and every other
+  `FileExecutor` handler) now expand a leading `~` in the LLM-supplied `path` argument to the
+  real home directory before sandbox checks run, instead of treating it as a literal `~`
+  directory relative to the current working directory. `FileExecutor::validate_path`
+  (`crates/zeph-tools/src/file.rs`) now applies the existing `expand_tilde` helper — previously
+  only used for the `allowed_paths` sandbox policy config — to the runtime path argument as
+  well, since every handler funnels through this single entry point. Closes #5410.
+- `fix(durable)`: `zeph durable show --reveal` (and `inspect --reveal`) no longer requires
+  `ZEPH_DURABLE_KEY` in the vault when `[durable] encrypt_payload = false` (the documented
+  dev-only plaintext override). `open_backend` (`src/commands/durable.rs`) now only loads the
+  AEAD cipher when `reveal && config.durable.encrypt_payload`; with encryption disabled, no
+  cipher is attached and the already-plaintext payload bytes are returned as-is. Encrypted
+  deployments (`encrypt_payload = true`, the default) still require the key as before. Closes
+  #5404.
 - `fix(worktree)`: `WorktreeManager::remove()` no longer leaves a stale handle in the in-memory
   session list when the worktree directory itself was already deleted but the subsequent branch
   prune (`git branch -D`, `prune_branch = true`) fails. The handle is now dropped from

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -181,8 +181,9 @@ impl FileExecutor {
     }
 
     fn validate_path(&self, path: &Path) -> Result<PathBuf, ToolError> {
+        let path = expand_tilde(path.to_path_buf());
         let resolved = if path.is_absolute() {
-            path.to_path_buf()
+            path
         } else {
             std::env::current_dir()
                 .unwrap_or_else(|_| PathBuf::from("."))
@@ -1616,6 +1617,26 @@ mod tests {
             !exec.allowed_paths[0].to_string_lossy().starts_with('~'),
             "bare tilde was not expanded: {:?}",
             exec.allowed_paths[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_path_expands_tilde_in_runtime_argument() {
+        // Regression for #5410: a `~`-prefixed path coming from an LLM tool call
+        // (write/edit/create_directory) must resolve to the real home directory,
+        // not be treated as a literal `~` directory relative to cwd.
+        let home = dirs::home_dir().expect("home dir must be resolvable in test env");
+        let exec = FileExecutor::new(vec![home.clone()]);
+        let canonical = exec
+            .validate_path(Path::new("~/zeph_test_tilde_marker_regression"))
+            .unwrap();
+        assert!(
+            canonical.ends_with("zeph_test_tilde_marker_regression"),
+            "expected path ending in zeph_test_tilde_marker_regression, got {canonical:?}"
+        );
+        assert!(
+            !canonical.to_string_lossy().contains('~'),
+            "tilde must not appear in normalized runtime path: {canonical:?}"
         );
     }
 

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -58,7 +58,10 @@ fn load_durable_cipher() -> anyhow::Result<XChaCha20Poly1305Cipher> {
         .map_err(|e| anyhow::anyhow!("invalid ZEPH_DURABLE_KEY: {e}"))
 }
 
-/// Open the local durable backend, attaching the AEAD cipher when `reveal` is set.
+/// Open the local durable backend, attaching the AEAD cipher when `reveal` is set and payloads are
+/// actually encrypted (`config.durable.encrypt_payload`). When `encrypt_payload` is `false` (the
+/// documented dev-only override), stored payloads are already plaintext, so `--reveal` must not
+/// require `ZEPH_DURABLE_KEY` to be present in the vault.
 ///
 /// Returns `Ok(None)` when no journal file exists yet (a friendly signal that durable execution has
 /// not run on this deployment), so the caller can print guidance instead of creating an empty file.
@@ -78,7 +81,7 @@ async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<Lo
         .init()
         .await
         .map_err(|e| anyhow::anyhow!("failed to initialize durable schema: {e}"))?;
-    if reveal {
+    if reveal && config.durable.encrypt_payload {
         let cipher = load_durable_cipher()?;
         Ok(Some(backend.with_cipher(Arc::new(cipher))))
     } else {
@@ -320,6 +323,7 @@ fn print_revealed(entries: &[zeph_durable::JournalEntry]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn durable_db_is_sibling_of_sqlite_path() {
@@ -338,5 +342,60 @@ mod tests {
     #[test]
     fn fmt_ts_formats_epoch_millis_as_utc() {
         assert_eq!(fmt_ts(0), "1970-01-01 00:00:00");
+    }
+
+    /// Regression for #5404: `--reveal` must not require `ZEPH_DURABLE_KEY` when
+    /// `encrypt_payload = false` — stored payloads are already plaintext.
+    #[tokio::test]
+    async fn open_backend_reveal_succeeds_without_key_when_encrypt_payload_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.encrypt_payload = false;
+
+        let url = resolve_durable_db_url(&config);
+        std::fs::write(&url, []).unwrap();
+
+        let backend = open_backend(&config, true)
+            .await
+            .expect("--reveal must succeed without ZEPH_DURABLE_KEY when encrypt_payload=false");
+        assert!(backend.is_some());
+    }
+
+    /// Regression for #5404: `--reveal` must still require `ZEPH_DURABLE_KEY` when
+    /// `encrypt_payload = true` (the default, encrypted-at-rest posture).
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial]
+    async fn open_backend_reveal_requires_key_when_encrypt_payload_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.encrypt_payload = true;
+
+        let url = resolve_durable_db_url(&config);
+        std::fs::write(&url, []).unwrap();
+
+        // Point the vault dir at an empty temp dir so no real ZEPH_DURABLE_KEY is found,
+        // regardless of what happens to be configured on the machine running this test.
+        let vault_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", vault_dir.path());
+        }
+
+        let result = open_backend(&config, true).await;
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            result.is_err(),
+            "expected --reveal to fail without ZEPH_DURABLE_KEY when encrypt_payload=true"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two small, independent bug fixes bundled into one PR (triaged together — same priority tier, both simple and localized):

- **#5410** — `write`/`edit`/`create_directory` (and every other `FileExecutor` handler) did not expand a leading `~` in an LLM-supplied path, creating a literal `~` directory relative to the working directory instead of resolving to the user's home directory. `FileExecutor::validate_path` now applies the existing `expand_tilde` helper to the runtime path argument, matching how it already applies to the `allowed_paths` sandbox config. All handlers funnel through this single choke point, so the fix requires no per-call-site duplication.
- **#5404** — `zeph durable show --reveal` unconditionally required `ZEPH_DURABLE_KEY` in the vault, even when `[durable] encrypt_payload = false` (the documented dev-only plaintext override), where payloads are already stored unencrypted. `open_backend` now only loads the AEAD cipher when `reveal && config.durable.encrypt_payload`; encrypted deployments (`encrypt_payload = true`, the default) are unaffected and still require the key.

## Test plan

- [x] Regression test `validate_path_expands_tilde_in_runtime_argument` (crates/zeph-tools/src/file.rs) — fails without the fix
- [x] Regression tests `open_backend_reveal_succeeds_without_key_when_encrypt_payload_disabled` / `open_backend_reveal_requires_key_when_encrypt_payload_enabled` (src/commands/durable.rs)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11572 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] CHANGELOG.md updated under `[Unreleased] / Fixed`
- [x] `.local/testing/playbooks/filesystem-access.md` (Scenario 8) and `.local/testing/playbooks/durable.md` (Scenario C6.2b) updated with live-test scenarios; `.local/testing/coverage-status.md` rows added/updated (status: Untested, pending a live CI session)

Note: `cargo doc --all-features -p <crate>` (per-crate doc gate) hits a pre-existing, unrelated failure — enabling both the `sqlite` and `postgres` backend features simultaneously on `zeph-memory` causes a dual-backend type conflict. Verified this reproduces identically on a clean `main` checkout, so it predates this change; the workspace-level doc build with the CI feature set (above) passes cleanly.

Closes #5410
Closes #5404