### PR TITLE
fix(knowledge): thread --provider through notes-sink ingest and accept batch-id prefixes in rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the combination previously made `check_graph_completion` see no ready/running tasks and
   falsely report a scheduler deadlock, marking the graph `Failed` and cancelling already-completed
   work. Closes #5403.
+- `fix(knowledge)`: `zeph knowledge ingest --provider <PROVIDER>` no longer silently ignores the
+  override for notes-sink sources (`specs`, `changelog`, `handoff`, `coverage`, `git-log`). The
+  CLI override now threads through `run_ingest` into `build_ingest_resources` via a new
+  `resolve_notes_embed_provider` helper that honours only the explicit `--provider` flag (falling
+  back to primary otherwise). This is intentionally a separate, narrower resolution policy from
+  the graph-sink's `resolve_graph_extraction_provider` (CLI override → `knowledge.ingest_provider`
+  → `memory.graph.extract_provider` → primary): the notes sink only ever calls `.embed()`, while
+  `knowledge.ingest_provider` / `memory.graph.extract_provider` select the Phase-2
+  LLM-extraction provider, so folding the extraction chain into the embedding path would silently
+  risk an embedding-model/dimension mismatch against the existing `documents` Qdrant collection.
+  Closes #5396.
+- `fix(knowledge)`: `zeph knowledge rollback --batch-id` now accepts the 8-character batch id
+  prefix printed by `zeph knowledge status`, resolving it git-style against the ledger: an exact
+  match wins immediately, a unique prefix resolves to the full id, an ambiguous prefix lists every
+  matching batch, and no match keeps the existing "not found" error. An empty or whitespace-only
+  `--batch-id` is now rejected up front instead of matching (and silently rolling back) every
+  batch in a single-batch ledger. New `IngestLedger::resolve_batch_id` / `BatchIdResolution` in
+  `zeph-memory`. Closes #5399.
 - `fix(orchestration)`: `cargo build --release` no longer fails on `zeph-orchestration` with
   `error: queries overflow the depth limit!` while computing the layout of
   `durable::journal_budget()`'s async state machine. Release-profile layout computation walks

--- a/crates/zeph-memory/src/graph/ingest/ledger.rs
+++ b/crates/zeph-memory/src/graph/ingest/ledger.rs
@@ -46,6 +46,21 @@ use zeph_db::{DbPool, query, query_as, query_scalar, sql};
 
 use crate::MemoryError;
 
+/// Outcome of resolving a (possibly abbreviated) batch id prefix against the ledger.
+///
+/// Returned by [`IngestLedger::resolve_batch_id`] to support git-style unambiguous prefix
+/// matching for `zeph knowledge rollback --batch-id`, since `zeph knowledge status` only
+/// prints an 8-character prefix of each `import_batch_id`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BatchIdResolution {
+    /// Exactly one batch id matches the supplied prefix (or matches it exactly).
+    Resolved(String),
+    /// More than one batch id shares the supplied prefix; lists every match.
+    Ambiguous(Vec<String>),
+    /// No batch id in the ledger starts with the supplied prefix.
+    NotFound,
+}
+
 /// A single row from the `knowledge_ingest_ledger` table.
 ///
 /// Returned by [`IngestLedger::summary`] to back `zeph knowledge status`.
@@ -191,6 +206,49 @@ impl IngestLedger {
         .fetch_optional(&self.pool)
         .await?;
         Ok(exists.is_some())
+    }
+
+    /// Resolves a (possibly abbreviated) `batch_id` prefix to a full `import_batch_id`.
+    ///
+    /// Mirrors git's unambiguous short-hash resolution: an exact match on a full id wins
+    /// immediately; otherwise a prefix that uniquely identifies one batch resolves to it, a
+    /// prefix shared by several batches is reported as [`BatchIdResolution::Ambiguous`], and a
+    /// prefix matching no batch is reported as [`BatchIdResolution::NotFound`]. This lets
+    /// `zeph knowledge rollback --batch-id` accept the 8-character prefix printed by
+    /// `zeph knowledge status` (#5399).
+    ///
+    /// An empty (or whitespace-only) `prefix` always resolves to [`BatchIdResolution::NotFound`],
+    /// even when the ledger is non-empty — every id trivially `starts_with("")`, so without this
+    /// guard a blank prefix (e.g. an unset `--batch-id "$VAR"` shell substitution) would silently
+    /// resolve to the sole batch in a single-batch ledger instead of being rejected.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Sqlx`] on database failure.
+    pub async fn resolve_batch_id(&self, prefix: &str) -> Result<BatchIdResolution, MemoryError> {
+        if prefix.trim().is_empty() {
+            return Ok(BatchIdResolution::NotFound);
+        }
+
+        let ids: Vec<String> = query_scalar(sql!(
+            "SELECT DISTINCT import_batch_id FROM knowledge_ingest_ledger"
+        ))
+        .fetch_all(&self.pool)
+        .await?;
+
+        if ids.iter().any(|id| id == prefix) {
+            return Ok(BatchIdResolution::Resolved(prefix.to_owned()));
+        }
+
+        let mut matches: Vec<String> = ids
+            .into_iter()
+            .filter(|id| id.starts_with(prefix))
+            .collect();
+        match matches.len() {
+            0 => Ok(BatchIdResolution::NotFound),
+            1 => Ok(BatchIdResolution::Resolved(matches.remove(0))),
+            _ => Ok(BatchIdResolution::Ambiguous(matches)),
+        }
     }
 
     /// Deletes all ledger rows for the given `import_batch_id`.
@@ -413,5 +471,87 @@ mod tests {
         let ledger = test_ledger().await;
         let removed = ledger.delete_batch("ghost-batch").await.unwrap();
         assert_eq!(removed, 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_batch_id_not_found_when_no_match() {
+        let ledger = test_ledger().await;
+        ledger
+            .mark_ingested("a", "h1", "01234567-aaaa", 0, 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            ledger.resolve_batch_id("ghost").await.unwrap(),
+            BatchIdResolution::NotFound
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_batch_id_empty_prefix_is_not_found_even_with_a_single_batch() {
+        let ledger = test_ledger().await;
+        ledger
+            .mark_ingested("a", "h1", "01234567-aaaa", 0, 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            ledger.resolve_batch_id("").await.unwrap(),
+            BatchIdResolution::NotFound
+        );
+        assert_eq!(
+            ledger.resolve_batch_id("   ").await.unwrap(),
+            BatchIdResolution::NotFound
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_batch_id_exact_match_wins_even_if_also_a_prefix() {
+        let ledger = test_ledger().await;
+        ledger.mark_ingested("a", "h1", "0123", 0, 0).await.unwrap();
+        ledger
+            .mark_ingested("b", "h2", "01234567", 0, 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            ledger.resolve_batch_id("0123").await.unwrap(),
+            BatchIdResolution::Resolved("0123".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_batch_id_unique_prefix_resolves_to_full_id() {
+        let ledger = test_ledger().await;
+        ledger
+            .mark_ingested("a", "h1", "01234567-aaaa-bbbb-cccc", 0, 0)
+            .await
+            .unwrap();
+        ledger
+            .mark_ingested("b", "h2", "89abcdef-aaaa-bbbb-cccc", 0, 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            ledger.resolve_batch_id("012345").await.unwrap(),
+            BatchIdResolution::Resolved("01234567-aaaa-bbbb-cccc".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_batch_id_ambiguous_prefix_lists_candidates() {
+        let ledger = test_ledger().await;
+        ledger
+            .mark_ingested("a", "h1", "01234567-aaaa", 0, 0)
+            .await
+            .unwrap();
+        ledger
+            .mark_ingested("b", "h2", "01234567-bbbb", 0, 0)
+            .await
+            .unwrap();
+        let resolution = ledger.resolve_batch_id("01234567").await.unwrap();
+        match resolution {
+            BatchIdResolution::Ambiguous(mut candidates) => {
+                candidates.sort();
+                assert_eq!(candidates, ["01234567-aaaa", "01234567-bbbb"]);
+            }
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
     }
 }

--- a/crates/zeph-memory/src/graph/ingest/mod.rs
+++ b/crates/zeph-memory/src/graph/ingest/mod.rs
@@ -26,5 +26,5 @@ pub use adapter::{
     ClaudeCodeJsonl, CodexJsonl, IngestSourceAdapter, SubagentJsonl, TranscriptEntry,
 };
 pub use document::{IngestDocument, IngestSourceKind};
-pub use ledger::{IngestLedger, LedgerEntry};
+pub use ledger::{BatchIdResolution, IngestLedger, LedgerEntry};
 pub use report::{HubDegree, ImportBatchId, IngestFailure, IngestProgress, IngestReport};

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -160,9 +160,9 @@ pub use forgetting::{ForgettingConfig, ForgettingResult, start_forgetting_loop};
 pub use graph::EntityLockManager;
 pub use graph::experience::{EvolutionSweepStats, ExperienceStore};
 pub use graph::ingest::{
-    ClaudeCodeJsonl, CodexJsonl, HubDegree, ImportBatchId, IngestDocument, IngestFailure,
-    IngestLedger, IngestProgress, IngestReport, IngestSourceAdapter, IngestSourceKind, LedgerEntry,
-    SubagentJsonl, TranscriptEntry,
+    BatchIdResolution, ClaudeCodeJsonl, CodexJsonl, HubDegree, ImportBatchId, IngestDocument,
+    IngestFailure, IngestLedger, IngestProgress, IngestReport, IngestSourceAdapter,
+    IngestSourceKind, LedgerEntry, SubagentJsonl, TranscriptEntry,
 };
 pub use graph::{
     BeliefMemConfig, BeliefRevisionConfig, BeliefStore, Community, Edge, EdgeType, Entity,

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -34,13 +34,16 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use serde_json::Value as JsonValue;
+use zeph_core::config::Config;
 use zeph_core::vault::Secret;
+use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider;
 use zeph_memory::graph::ingest::IngestProgress as GraphIngestProgress;
 use zeph_memory::{
-    ClaudeCodeJsonl, CodexJsonl, Document, DocumentMetadata, GraphStore, ImportBatchId,
-    IngestBatchConfig, IngestLedger, IngestSourceAdapter, IngestionPipeline, QdrantOps,
-    SharedPostExtractValidator, SplitterConfig, SubagentJsonl, TextSplitter, store::DbStore,
+    BatchIdResolution, ClaudeCodeJsonl, CodexJsonl, Document, DocumentMetadata, GraphStore,
+    ImportBatchId, IngestBatchConfig, IngestLedger, IngestSourceAdapter, IngestionPipeline,
+    QdrantOps, SharedPostExtractValidator, SplitterConfig, SubagentJsonl, TextSplitter,
+    store::DbStore,
 };
 
 use crate::bootstrap::{AppBuilder, create_named_provider, find_repo_root};
@@ -214,6 +217,7 @@ async fn handle_ingest(
                 discovery_errors,
                 per_source_counts,
                 config_path,
+                provider_override.as_deref(),
             ))
             .await?;
         }
@@ -411,8 +415,119 @@ fn run_dry_run(source_items: &[SourceItem], total_files: usize, discovery_errors
     println!("Dry run complete. Run without --dry-run to ingest.");
 }
 
+/// Pure name-selection logic for the notes-sink **embedding** provider (#5396).
+///
+/// Returns only an explicit CLI `--provider` override (non-empty); never consults
+/// `knowledge.ingest_provider` / `memory.graph.extract_provider`. See
+/// [`resolve_notes_embed_provider`] for why the notes sink deliberately does not share the
+/// graph-sink's fallback chain. Split out from the async resolver so the selection policy is
+/// unit-testable without `AppBuilder`/async (#5396 regression coverage).
+fn select_notes_embed_provider_name(provider_override: Option<&str>) -> Option<&str> {
+    provider_override.filter(|s| !s.is_empty())
+}
+
+/// Resolve the notes-sink **embedding** provider for `zeph knowledge ingest` (#5396).
+///
+/// Only honours an explicit CLI `--provider` override, falling back to the primary provider
+/// otherwise. Deliberately does **not** fall through `knowledge.ingest_provider` /
+/// `memory.graph.extract_provider` — those two config fields select the Phase-2
+/// **LLM-extraction** provider (see [`resolve_graph_extraction_provider`] and the doc contract on
+/// `KnowledgeConfig::ingest_provider` in `crates/zeph-config/src/knowledge.rs`, which states the
+/// notes sink "does not perform LLM calls; this field is ... ignored" by it). The notes sink only
+/// ever calls `.embed()` (see [`build_ingest_resources`]), so folding in the extraction chain
+/// would silently point notes embeddings at a provider entry that may use a different embedding
+/// model/dimension than the primary provider the existing `documents` Qdrant collection was built
+/// with — the same silent embed-dimension-mismatch bug class this fix must not reintroduce.
+async fn resolve_notes_embed_provider(
+    provider_override: Option<&str>,
+    config: &Config,
+    app: &AppBuilder,
+) -> anyhow::Result<Arc<AnyProvider>> {
+    let Some(name) = select_notes_embed_provider_name(provider_override) else {
+        let (p, _, _) = app.build_provider().await?;
+        return Ok(Arc::new(p));
+    };
+
+    let provider = match create_named_provider(name, config) {
+        Ok(p) => {
+            tracing::debug!(
+                provider = name,
+                "using named provider for knowledge ingest (notes)"
+            );
+            Arc::new(p)
+        }
+        Err(e) => {
+            tracing::warn!(
+                provider = name,
+                "named provider resolution failed ({e:#}); falling back to primary"
+            );
+            let (p, _, _) = app.build_provider().await?;
+            Arc::new(p)
+        }
+    };
+    Ok(provider)
+}
+
+/// Pure name-selection logic for the graph-sink **LLM-extraction** provider (FR-041): CLI
+/// override → `knowledge.ingest_provider` → `memory.graph.extract_provider` → `None` (caller
+/// falls back to primary).
+///
+/// Split out from the async resolver so the fallback-chain policy is unit-testable without
+/// `AppBuilder`/async (#5396 regression coverage).
+fn select_graph_extraction_provider_name<'a>(
+    provider_override: Option<&'a str>,
+    config: &'a Config,
+) -> Option<&'a str> {
+    provider_override
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            let p = config.knowledge.ingest_provider.as_str();
+            if p.is_empty() { None } else { Some(p) }
+        })
+        .or_else(|| {
+            let p = config.memory.graph.extract_provider.as_str();
+            if p.is_empty() { None } else { Some(p) }
+        })
+}
+
+/// Resolve the graph-sink **LLM-extraction** provider for `zeph knowledge ingest` (FR-041): CLI
+/// override → `knowledge.ingest_provider` → `memory.graph.extract_provider` → primary.
+///
+/// Used exclusively by [`run_graph_ingest`] (`--source subagents`), where the resolved provider
+/// drives entity/edge extraction chat calls. Must not be reused for the notes-sink embedding path
+/// — see [`resolve_notes_embed_provider`] for why the two are separate resolution policies.
+async fn resolve_graph_extraction_provider(
+    provider_override: Option<&str>,
+    config: &Config,
+    app: &AppBuilder,
+) -> anyhow::Result<Arc<AnyProvider>> {
+    let provider_name = select_graph_extraction_provider_name(provider_override, config);
+
+    let provider = if let Some(name) = provider_name {
+        match create_named_provider(name, config) {
+            Ok(p) => {
+                tracing::debug!(provider = name, "using named provider for graph ingest");
+                Arc::new(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = name,
+                    "named provider resolution failed ({e:#}); falling back to primary"
+                );
+                let (p, _, _) = app.build_provider().await?;
+                Arc::new(p)
+            }
+        }
+    } else {
+        let (p, _, _) = app.build_provider().await?;
+        Arc::new(p)
+    };
+    Ok(provider)
+}
+
 async fn build_ingest_resources(
     config_path: Option<&Path>,
+    provider_override: Option<&str>,
 ) -> anyhow::Result<(IngestionPipeline, IngestLedger, String, String)> {
     const DIMENSION_PROBE_TIMEOUT_SECS: u64 = 15;
 
@@ -424,8 +539,7 @@ async fn build_ingest_resources(
     )
     .map_err(|e| anyhow::anyhow!("failed to connect to Qdrant: {e}"))?;
     let collection = config.memory.documents.collection.clone();
-    let (provider, _status_tx, _status_rx) = app.build_provider().await?;
-    let provider = Arc::new(provider);
+    let provider = resolve_notes_embed_provider(provider_override, config, &app).await?;
     let embed_fn = {
         let p = Arc::clone(&provider);
         move |text: &str| -> zeph_llm::provider::EmbedFuture {
@@ -478,9 +592,10 @@ async fn run_ingest(
     discovery_errors: Vec<IngestError>,
     per_source_counts: Vec<(&'static str, usize)>,
     config_path: Option<&Path>,
+    provider_override: Option<&str>,
 ) -> anyhow::Result<()> {
     let (pipeline, ledger, batch_id, collection) =
-        Box::pin(build_ingest_resources(config_path)).await?;
+        Box::pin(build_ingest_resources(config_path, provider_override)).await?;
 
     // FR-014: create a dedicated progress channel and spawn a CLI printer consumer.
     let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel::<IngestProgress>();
@@ -820,39 +935,10 @@ async fn run_graph_ingest(
         println!();
     }
 
-    // Resolve LLM provider (FR-041): CLI override → knowledge.ingest_provider →
+    // Resolve LLM-extraction provider (FR-041): CLI override → knowledge.ingest_provider →
     // memory.graph.extract_provider → primary.
-    let provider_name = provider_override
-        .as_deref()
-        .filter(|s| !s.is_empty())
-        .or_else(|| {
-            let p = config.knowledge.ingest_provider.as_str();
-            if p.is_empty() { None } else { Some(p) }
-        })
-        .or_else(|| {
-            let p = config.memory.graph.extract_provider.as_str();
-            if p.is_empty() { None } else { Some(p) }
-        });
-
-    let provider = if let Some(name) = provider_name {
-        match create_named_provider(name, config) {
-            Ok(p) => {
-                tracing::debug!(provider = name, "using named provider for graph ingest");
-                Arc::new(p)
-            }
-            Err(e) => {
-                tracing::warn!(
-                    provider = name,
-                    "named provider resolution failed ({e:#}); falling back to primary"
-                );
-                let (p, _, _) = app.build_provider().await?;
-                Arc::new(p)
-            }
-        }
-    } else {
-        let (p, _, _) = app.build_provider().await?;
-        Arc::new(p)
-    };
+    let provider =
+        resolve_graph_extraction_provider(provider_override.as_deref(), config, &app).await?;
 
     let kn_sup2 = zeph_common::TaskSupervisor::new(tokio_util::sync::CancellationToken::new());
     let memory = app.build_memory(&provider, &kn_sup2).await?;
@@ -1444,9 +1530,31 @@ async fn handle_rollback(
     let pool = store.pool().clone();
     let ledger = IngestLedger::new(pool.clone());
 
-    if !ledger.batch_exists(batch_id).await? {
-        anyhow::bail!("batch '{batch_id}' not found in the ingest ledger — nothing to roll back");
+    // Reject an empty/whitespace `--batch-id` (e.g. an unset `$VAR` shell substitution) up front
+    // with an unambiguous message, rather than letting it fall through to `resolve_batch_id`'s
+    // generic "not found" (#5399 F2: an unguarded empty prefix would otherwise match every batch).
+    if batch_id.trim().is_empty() {
+        anyhow::bail!("--batch-id must not be empty");
     }
+
+    // Git-style unambiguous prefix resolution (#5399): `zeph knowledge status` prints only an
+    // 8-char prefix of `import_batch_id`, so a caller pasting that prefix must still resolve.
+    let batch_id = match ledger.resolve_batch_id(batch_id).await? {
+        BatchIdResolution::Resolved(full_id) => full_id,
+        BatchIdResolution::Ambiguous(candidates) => {
+            anyhow::bail!(
+                "batch id '{batch_id}' is ambiguous, matches {} batches: {}",
+                candidates.len(),
+                candidates.join(", ")
+            );
+        }
+        BatchIdResolution::NotFound => {
+            anyhow::bail!(
+                "batch '{batch_id}' not found in the ingest ledger — nothing to roll back"
+            );
+        }
+    };
+    let batch_id = batch_id.as_str();
 
     if !yes {
         print!(
@@ -1620,6 +1728,82 @@ mod tests {
         assert_eq!(source_label(&KnowledgeSource::GitLog), "git-log");
         assert_eq!(source_label(&KnowledgeSource::ClaudeCode), "claude-code");
         assert_eq!(source_label(&KnowledgeSource::Codex), "codex");
+    }
+
+    // ── provider name selection (#5396) ───────────────────────────────────────
+    //
+    // Pure sync tests for select_notes_embed_provider_name / select_graph_extraction_provider_name
+    // — no AppBuilder/async required. These pin the exact regression #5396 fixed (the CLI
+    // --provider override reaching the notes-sink path) and the F1 fix (the notes-sink embed
+    // provider must NOT fall through knowledge.ingest_provider / memory.graph.extract_provider).
+
+    #[test]
+    fn notes_embed_provider_name_uses_cli_override_when_present() {
+        assert_eq!(select_notes_embed_provider_name(Some("fast")), Some("fast"));
+    }
+
+    #[test]
+    fn notes_embed_provider_name_none_when_no_override() {
+        assert_eq!(select_notes_embed_provider_name(None), None);
+    }
+
+    #[test]
+    fn notes_embed_provider_name_treats_empty_override_as_absent() {
+        assert_eq!(select_notes_embed_provider_name(Some("")), None);
+    }
+
+    #[test]
+    fn graph_extraction_provider_name_cli_override_wins_over_both_config_fields() {
+        let mut config = Config::default();
+        config.knowledge.ingest_provider = "from-knowledge".to_owned();
+        config.memory.graph.extract_provider = "from-graph".into();
+        assert_eq!(
+            select_graph_extraction_provider_name(Some("cli"), &config),
+            Some("cli")
+        );
+    }
+
+    #[test]
+    fn graph_extraction_provider_name_knowledge_ingest_provider_wins_when_no_cli_override() {
+        let mut config = Config::default();
+        config.knowledge.ingest_provider = "from-knowledge".to_owned();
+        config.memory.graph.extract_provider = "from-graph".into();
+        assert_eq!(
+            select_graph_extraction_provider_name(None, &config),
+            Some("from-knowledge")
+        );
+    }
+
+    #[test]
+    fn graph_extraction_provider_name_falls_back_to_memory_graph_extract_provider() {
+        let mut config = Config::default();
+        config.memory.graph.extract_provider = "from-graph".into();
+        assert_eq!(
+            select_graph_extraction_provider_name(None, &config),
+            Some("from-graph")
+        );
+    }
+
+    #[test]
+    fn graph_extraction_provider_name_none_when_everything_empty() {
+        let config = Config::default();
+        assert_eq!(select_graph_extraction_provider_name(None, &config), None);
+    }
+
+    #[test]
+    fn graph_extraction_provider_name_does_not_leak_into_notes_embed_selection() {
+        // The critic's F1 regression scenario: knowledge.ingest_provider / extract_provider set
+        // (the documented multi-model best practice), no CLI --provider. The notes-sink embed
+        // path must resolve to None (-> primary), not fall through to either config field.
+        let mut config = Config::default();
+        config.knowledge.ingest_provider = "from-knowledge".to_owned();
+        config.memory.graph.extract_provider = "from-graph".into();
+        assert_eq!(select_notes_embed_provider_name(None), None);
+        assert_eq!(
+            select_graph_extraction_provider_name(None, &config),
+            Some("from-knowledge"),
+            "sanity: the graph-sink chain should still resolve the config field"
+        );
     }
 
     // ── ingest_one skip gate (FR-012) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `zeph knowledge ingest --provider` was silently ignored for notes-sink sources (`specs`, `changelog`, `handoff`, `coverage`, `git-log`). It now resolves through a dedicated embedding-only policy (CLI override -> primary), kept intentionally separate from the graph-sink's LLM-extraction fallback chain (`knowledge.ingest_provider` -> `memory.graph.extract_provider` -> primary) so notes embeddings can never silently pick up an extraction-role provider with a different embedding model/dimension than the primary provider the existing `documents` Qdrant collection was built with. Closes #5396.
- `zeph knowledge rollback --batch-id` now accepts the 8-character batch id prefix printed by `zeph knowledge status`, resolving it git-style against the ledger: exact match wins, a unique prefix resolves to the full id, an ambiguous prefix lists every matching batch, no match keeps the existing error. An empty or whitespace-only `--batch-id` is rejected up front (previously it would match every batch in a single-batch ledger and could silently roll it back with `-y`). Closes #5399.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11582 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New unit tests: `IngestLedger::resolve_batch_id` (exact match, unique prefix, ambiguous prefix, not found, empty prefix) and the notes-embed vs. graph-extraction provider name selectors (including a regression test pinning the embedding/extraction role separation)
- [x] Independent re-review re-ran the full check suite from a forced recompile and did a security sanity pass on the rollback delete path (parameterized exact-match delete on the resolved full id only, no TOCTOU/prefix-confusion path)