### PR TITLE
fix(acp): add recursion_limit to zeph-acp test crate root; add release-build CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,6 +460,33 @@ jobs:
         continue-on-error: ${{ matrix.allow_failure == true }}
         run: cargo check --features ${{ matrix.bundle }}
 
+  release-build:
+    name: Release Build Check
+    needs: detect-changes
+    if: needs.detect-changes.outputs.run-full-ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-targets: "false"
+          shared-key: "release-build"
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: cargo build (release, --all-targets)
+        # `cargo check --release` does not reproduce the release-profile query-depth overflow
+        # class of bug fixed by #5407/#5408 (verified empirically: it passes even without the
+        # `#![recursion_limit]` fix) because it skips codegen/LTO layout finalization. Only a
+        # real `cargo build --release` with this workspace's `[profile.release]` (lto = true,
+        # codegen-units = 1) exercises the same query depth CI is meant to gate on.
+        run: cargo build --release --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing,deep-link"
+
   build-postgres:
     name: Build (postgres)
     needs: detect-changes
@@ -517,7 +544,7 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    needs: [cla, lint-shellcheck, lint-fmt, lint-clippy, msrv, build-tests, test, integration, coverage, docker-build-and-scan, bundle-check, validate-specs, build-postgres, rustdoc]
+    needs: [cla, lint-shellcheck, lint-fmt, lint-clippy, msrv, build-tests, test, integration, coverage, docker-build-and-scan, bundle-check, validate-specs, build-postgres, rustdoc, release-build]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
@@ -538,6 +565,7 @@ jobs:
             "${{ needs.validate-specs.result }}"
             "${{ needs.build-postgres.result }}"
             "${{ needs.rustdoc.result }}"
+            "${{ needs.release-build.result }}"
           )
           for r in "${results[@]}"; do
             if [[ "$r" != "success" && "$r" != "skipped" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `ci`: add a `Release Build Check` job to `.github/workflows/ci.yml` that runs
+  `cargo build --release --workspace --all-targets --features
+  desktop,ide,server,chat,pdf,scheduler,testing,deep-link` on every PR and push to `main`.
+  Previously `cargo build --release` only ran at an actual release cut
+  (`.github/workflows/release.yml`), so release-profile-only regressions — such as the
+  query-depth overflow behind #5395/#5407/#5408 — were invisible to the normal commit/PR gate.
+  `cargo check --release` was evaluated and rejected: it does not reproduce this bug class
+  because it skips the codegen/LTO layout finalization where the overflow occurs, so only a
+  real `cargo build --release` (which exercises this workspace's `lto = true`,
+  `codegen-units = 1` release profile) closes the gap. Wired into the `ci-status` gate.
+  Closes #5409.
 - `test(mcp)`: add an in-process duplex-transport integration test for `McpClient` /
   `ToolListChangedHandler`, covering a full `initialize -> tools/list -> tools/call`
   round-trip through the real rmcp wire serialization path over `tokio::io::duplex`
@@ -156,6 +167,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   dedicated `"zeph-main"` OS thread with a 32 MiB stack and drives a manually built
   `tokio::runtime::Builder::new_multi_thread().enable_all()` runtime from it, so daemon startup
   no longer depends on the caller's shell `ulimit`. Closes #5394.
+- `fix(acp)`: `cargo build --release --workspace --all-targets` no longer fails on
+  `crates/zeph-acp/tests/integration.rs` with the same `queries overflow the depth limit!`
+  error already fixed in `zeph-acp/src/lib.rs` (see 076c7fb3) and `zeph-orchestration`
+  (#5395/#5407). Each file directly under a crate's `tests/` directory is compiled by Cargo as
+  its own crate root and does not inherit `#![recursion_limit]` from `src/lib.rs`, so the
+  attribute has to be repeated per test-binary crate root (same precedent already applied to
+  `zeph-core/tests/turn_lifecycle.rs`). Added `#![recursion_limit = "256"]` to
+  `zeph-acp/tests/integration.rs`; a workspace-wide sweep of the remaining top-level
+  `crates/*/tests/*.rs` files found no other file exceeding the default depth limit under
+  `cargo build --release --workspace --features full --all-targets`. Closes #5408.
 - `fix(knowledge)`: `zeph knowledge ingest` no longer fails on a fresh Qdrant instance.
   `build_ingest_resources` now probes the embedding dimension and calls
   `QdrantOps::ensure_collection` for the documents collection before constructing the

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -1,5 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// Raised from 128: async-fn state machine chain through serve_connection/run_agent handlers
+// deepens past the default depth limit under release-profile query evaluation.
+#![recursion_limit = "256"]
 
 //! Integration tests for the ACP 0.11 server (`zeph-acp`) using in-process loopback transports.
 //!


### PR DESCRIPTION
## Summary

- Fixes #5408: `crates/zeph-acp/tests/integration.rs` hit the same rustc release-profile query-depth overflow already fixed in `zeph-acp/src/lib.rs` (076c7fb3) and `zeph-orchestration` (#5395/#5407) — added `#![recursion_limit = "256"]` to that file. Files directly under a crate's `tests/` directory are independent crate roots and don't inherit `src/lib.rs` attributes. A workspace-wide sweep of the remaining top-level `crates/*/tests/*.rs` files (16 others) found no other file affected.
- Fixes #5409: added a `release-build` job to `.github/workflows/ci.yml` running `cargo build --release --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler,testing,deep-link`, so release-profile-only regressions are caught on the normal commit/PR gate instead of only surfacing at an actual release cut.
- `cargo check --release` was evaluated and rejected for the new CI job: verified empirically (by temporarily reverting the `#5408` fix) that it does not reproduce this bug class, since it skips the codegen/LTO layout finalization where the overflow occurs. Only a real `cargo build --release`, matching this workspace's `lto = true, codegen-units = 1` release profile, closes the gap.

## Known scope limitation (not fixed in this PR)

The new `release-build` CI job's feature set (`desktop,ide,server,chat,pdf,scheduler,testing,deep-link`) intentionally excludes `full`/`ml`/`candle`, matching this repo's existing posture of treating `candle`/`ml` as best-effort/`allow_failure: true` elsewhere in CI. `.github/workflows/release.yml` (the actual shipped-artifact build) does use `--features full`, which includes `candle`. This means a release-profile regression inside `candle`/`ml`-gated code would still be invisible to this new CI gate and would only surface at an actual release cut — a narrower instance of the same failure mode #5409 closes for every other feature slice. The job is also gated only behind `detect-changes`, unlike the heavier lint-gated job group, so a trivially-broken PR still burns the full ~40-minute runner.

Filed as follow-up: #5418 (proposes a non-blocking `continue-on-error` full-featured variant plus tightening the `needs:` gate).

## Test plan

- [x] `cargo build --release --workspace --features full --all-targets` — passes clean (41m51s, zero errors); confirms #5408 is fully closed and no other `tests/*.rs` file needs the attribute
- [x] `cargo check --release -p zeph-acp --all-targets` — fast targeted spot-check, passes
- [x] `fy lint .github/workflows/ci.yml` — 0 errors (pre-existing style warnings only)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing"` — clean, 0 warnings
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11572 passed, 0 failed
- [x] rustdoc gate (`RUSTFLAGS=-D warnings RUSTDOCFLAGS=--deny rustdoc::broken_intra_doc_links cargo doc --no-deps --workspace`) — clean
- [x] `RUSTFLAGS=-D warnings cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean