### PR TITLE
fix(plugins): enforce dependency and skill-path validation parity in auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(plugins)`: the plugin auto-update path (`apply_staged_update`,
+  `crates/zeph-plugins/src/manager/registry.rs`) now enforces the same manifest validation as
+  initial install (`PluginManager::add()`) — dependency count/name validation
+  (`MAX_DEPENDENCIES`, per-dependency `validate_plugin_name`) and `[[skills]] path` traversal
+  validation (rejecting any skill path that canonicalizes outside the plugin source root).
+  Previously the auto-update path skipped both checks despite its doc comment claiming parity
+  with `add()`, so a compromised auto-update URL (registry compromise, DNS hijack, or a
+  malicious plugin author shipping a benign v1 then a malicious v2) could bypass validations
+  that would have blocked the same manifest content at initial install time. Both checks are
+  now unified in a single shared `validate_manifest_for_install` (`crates/zeph-plugins/src/
+  manager/security.rs`) called by both `add()` and `apply_staged_update()`, so the two paths
+  cannot silently diverge again. Closes #5401.
 - `fix(tools)`: file-tool calls (`write`, `edit`, `create_directory`, and every other
   `FileExecutor` handler) now expand a leading `~` in the LLM-supplied `path` argument to the
   real home directory before sandbox checks run, instead of treating it as a literal `~`

--- a/crates/zeph-plugins/src/manager/install.rs
+++ b/crates/zeph-plugins/src/manager/install.rs
@@ -11,14 +11,9 @@ use crate::manifest::PluginManifest;
 use super::{
     AddResult, DisableResult, PluginManager, RemoveResult, check_allowed_commands_overlay_effect,
     collect_skill_names, copy_dir_all, load_installed_manifest, scan_skill_entries,
-    strip_bundled_markers, validate_mcp_commands, validate_overlay_keys, validate_plugin_name,
+    strip_bundled_markers, validate_manifest_for_install, validate_mcp_commands,
+    validate_overlay_keys, validate_plugin_name,
 };
-
-/// Maximum number of entries allowed in `plugin.dependencies`.
-///
-/// Prevents a malicious manifest from triggering a fan-out `DoS` via recursive `enable()` calls
-/// across an unbounded dependency graph.
-const MAX_DEPENDENCIES: usize = 64;
 
 impl PluginManager {
     /// Install a plugin from a local directory path.
@@ -51,40 +46,8 @@ impl PluginManager {
 
         // Name validity is enforced by PluginName deserialization; no separate call needed.
 
-        // Validate dependency list: enforce count limit and name format.
-        if manifest.plugin.dependencies.len() > MAX_DEPENDENCIES {
-            return Err(PluginError::InvalidManifest(format!(
-                "plugin declares {} dependencies; maximum allowed is {MAX_DEPENDENCIES}",
-                manifest.plugin.dependencies.len()
-            )));
-        }
-        for dep in &manifest.plugin.dependencies {
-            validate_plugin_name(dep)?;
-        }
-
-        // Validate each [[skills]] entry: path must stay within source root and SKILL.md must exist.
-        for entry in &manifest.skills {
-            let skill_path = source_path.join(&entry.path);
-            // Reject path traversal: resolved path must be inside source_path.
-            let canonical_source = source_path.canonicalize().map_err(|e| PluginError::Io {
-                path: source_path.clone(),
-                source: e,
-            })?;
-            let canonical_skill = skill_path.canonicalize().map_err(|e| PluginError::Io {
-                path: skill_path.clone(),
-                source: e,
-            })?;
-            if !canonical_skill.starts_with(&canonical_source) {
-                return Err(PluginError::InvalidSource {
-                    path: entry.path.clone(),
-                    reason: "skill path escapes plugin source root".to_owned(),
-                });
-            }
-            // Ensure the skill directory contains a SKILL.md file.
-            if !skill_path.join("SKILL.md").is_file() {
-                return Err(PluginError::SkillEntryMissing { path: skill_path });
-            }
-        }
+        // Validate dependency list and [[skills]] path entries (shared with apply_staged_update).
+        validate_manifest_for_install(&source_path, &manifest)?;
 
         // Validate config overlay keys.
         validate_overlay_keys(&manifest.config)?;

--- a/crates/zeph-plugins/src/manager/mod.rs
+++ b/crates/zeph-plugins/src/manager/mod.rs
@@ -241,7 +241,8 @@ pub(crate) use security::extract_archive;
 pub use security::validate_url_scheme_ephemeral;
 pub(crate) use security::{
     check_allowed_commands_overlay_effect, extract_archive_safe, scan_skill_entries,
-    validate_mcp_commands, validate_overlay_keys, validate_plugin_name, validate_url_scheme,
+    validate_manifest_for_install, validate_mcp_commands, validate_overlay_keys,
+    validate_plugin_name, validate_url_scheme,
 };
 pub(crate) use store::{
     collect_skill_names, copy_dir_all, load_installed_manifest, parse_frontmatter_meta,

--- a/crates/zeph-plugins/src/manager/registry.rs
+++ b/crates/zeph-plugins/src/manager/registry.rs
@@ -8,8 +8,8 @@ use crate::PluginError;
 use super::{
     AddResult, AutoUpdateResult, AutoUpdateStatus, InstalledPlugin, PluginManager, PluginSource,
     collect_skill_names, extract_archive_safe, scan_skill_entries, strip_bundled_markers,
-    validate_mcp_commands, validate_overlay_keys, validate_url_scheme,
-    validate_url_scheme_ephemeral,
+    validate_manifest_for_install, validate_mcp_commands, validate_overlay_keys,
+    validate_url_scheme, validate_url_scheme_ephemeral,
 };
 
 impl PluginManager {
@@ -657,7 +657,16 @@ pub(crate) fn apply_staged_update(
         ));
     }
 
-    // Run the full validation pipeline — same checks as `add()`.
+    // Run the full validation pipeline — same checks as `add()` (issue #5401: this must call
+    // the shared `validate_manifest_for_install` helper, not just the overlay/MCP/skill-conflict
+    // checks, or a compromised auto-update URL can bypass the dependency and skill-path-traversal
+    // guards that `add()` enforces).
+    if let Err(e) = validate_manifest_for_install(staging, &manifest) {
+        let _ = std::fs::remove_dir_all(staging);
+        return Err(format!(
+            "staged manifest failed dependency/skill-path validation: {e}"
+        ));
+    }
     if let Err(e) = validate_overlay_keys(&manifest.config) {
         let _ = std::fs::remove_dir_all(staging);
         return Err(format!(

--- a/crates/zeph-plugins/src/manager/security.rs
+++ b/crates/zeph-plugins/src/manager/security.rs
@@ -10,7 +10,7 @@ use zeph_skills::registry::SkillRegistry;
 use zeph_skills::scanner::scan_skill_body;
 
 use crate::PluginError;
-use crate::manifest::PluginMcpServer;
+use crate::manifest::{PluginManifest, PluginMcpServer};
 
 use super::{PluginManager, SkillScanInput, parse_frontmatter_meta};
 
@@ -21,6 +21,80 @@ const CONFIG_SAFELIST: &[&str] = &[
     "tools.allowed_commands",
     "skills.disambiguation_threshold",
 ];
+
+/// Maximum number of entries allowed in `plugin.dependencies`.
+///
+/// Prevents a malicious manifest from triggering a fan-out `DoS` via recursive `enable()` calls
+/// across an unbounded dependency graph.
+const MAX_DEPENDENCIES: usize = 64;
+
+/// Validate a manifest's dependency list and `[[skills]] path` entries before it is installed.
+///
+/// # Security invariant
+///
+/// This is the single shared checkpoint for two checks that must run on **every** manifest
+/// before its declared skills are ever interpreted by
+/// [`super::collect_skill_names`]/`SkillRegistry::load`:
+///
+/// 1. **Dependency bound** — rejects manifests with more than [`MAX_DEPENDENCIES`] entries or a
+///    malformed dependency name, bounding the fan-out of recursive `enable()` calls.
+/// 2. **Skill path traversal** — each `[[skills]] path` entry is canonicalized and must resolve
+///    inside `source_path`. [`extract_archive_safe`]'s tar-slip protection only guards *tar
+///    entry paths* during extraction; it does not protect against a manifest `path` value
+///    (e.g. `"../../etc"`) that is interpreted later, after extraction, by
+///    `collect_skill_names`/`SkillRegistry::load`.
+///
+/// [`PluginManager::add`] (fresh installs) and `apply_staged_update` (the auto-update path) both
+/// write a manifest's declared skills to disk and must call this function so the two call sites
+/// cannot silently diverge again — see issue #5401, where `apply_staged_update` re-ran the
+/// overlay/MCP/skill-conflict checks but skipped both of these, letting a compromised
+/// auto-update URL bypass validation that `add()` would have enforced.
+///
+/// # Errors
+///
+/// - [`PluginError::InvalidManifest`] — dependency count exceeds [`MAX_DEPENDENCIES`].
+/// - [`PluginError::InvalidName`] — a dependency name fails [`validate_plugin_name`].
+/// - [`PluginError::Io`] — `source_path` or a skill path cannot be canonicalized.
+/// - [`PluginError::InvalidSource`] — a `[[skills]] path` entry resolves outside `source_path`.
+/// - [`PluginError::SkillEntryMissing`] — a `[[skills]] path` entry has no `SKILL.md`.
+pub(crate) fn validate_manifest_for_install(
+    source_path: &Path,
+    manifest: &PluginManifest,
+) -> Result<(), PluginError> {
+    if manifest.plugin.dependencies.len() > MAX_DEPENDENCIES {
+        return Err(PluginError::InvalidManifest(format!(
+            "plugin declares {} dependencies; maximum allowed is {MAX_DEPENDENCIES}",
+            manifest.plugin.dependencies.len()
+        )));
+    }
+    for dep in &manifest.plugin.dependencies {
+        validate_plugin_name(dep)?;
+    }
+
+    for entry in &manifest.skills {
+        let skill_path = source_path.join(&entry.path);
+        // Reject path traversal: resolved path must be inside source_path.
+        let canonical_source = source_path.canonicalize().map_err(|e| PluginError::Io {
+            path: source_path.to_path_buf(),
+            source: e,
+        })?;
+        let canonical_skill = skill_path.canonicalize().map_err(|e| PluginError::Io {
+            path: skill_path.clone(),
+            source: e,
+        })?;
+        if !canonical_skill.starts_with(&canonical_source) {
+            return Err(PluginError::InvalidSource {
+                path: entry.path.clone(),
+                reason: "skill path escapes plugin source root".to_owned(),
+            });
+        }
+        // Ensure the skill directory contains a SKILL.md file.
+        if !skill_path.join("SKILL.md").is_file() {
+            return Err(PluginError::SkillEntryMissing { path: skill_path });
+        }
+    }
+    Ok(())
+}
 
 impl PluginManager {
     /// Collect [`SkillScanInput`] entries for each skill in the plugin at `source`.

--- a/crates/zeph-plugins/src/manager/tests.rs
+++ b/crates/zeph-plugins/src/manager/tests.rs
@@ -2152,3 +2152,121 @@ fn strip_bundled_markers_removes_marker_files() {
         "regular files must not be affected by strip_bundled_markers"
     );
 }
+
+// --- regression: #5401 apply_staged_update validation parity with add() ---
+
+#[test]
+fn apply_staged_update_rejects_too_many_dependencies() {
+    use super::registry::apply_staged_update;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let plugins_dir = tmp.path().join("plugins");
+    let managed_dir = tmp.path().join("managed");
+    std::fs::create_dir_all(&plugins_dir).unwrap();
+
+    let deps: Vec<String> = (0..=64).map(|i| format!("dep-{i:02}")).collect();
+    let deps_toml = deps
+        .iter()
+        .map(|d| format!("\"{d}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let manifest = format!(
+        "[plugin]\nname = \"update-target\"\nversion = \"0.2.0\"\ndependencies = [{deps_toml}]\n"
+    );
+    let src = tmp.path().join("staged-src");
+    write_plugin(&src, "update-target", &manifest, &[]);
+    let archive = build_tar_gz(&src);
+
+    let dest = plugins_dir.join("update-target");
+    let staging = plugins_dir.join(".staging-update-target");
+    let backup = plugins_dir.join(".backup-update-target");
+    let integrity_path = plugins_dir.join(".plugin-integrity.toml");
+
+    let err = apply_staged_update(
+        &archive,
+        "https://example.com/update-target.tar.gz",
+        &dest,
+        &staging,
+        &backup,
+        "update-target",
+        &[],
+        &managed_dir,
+        &plugins_dir,
+        &integrity_path,
+        &[],
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("maximum allowed"),
+        "expected too-many-dependencies rejection, got {err}"
+    );
+    assert!(
+        !staging.exists(),
+        "staging dir must be cleaned up after a rejected update"
+    );
+    assert!(
+        !dest.exists(),
+        "dest must not be touched when the staged manifest fails validation"
+    );
+}
+
+#[test]
+fn apply_staged_update_rejects_skill_path_traversal() {
+    use super::registry::apply_staged_update;
+
+    let tmp = tempfile::tempdir().unwrap();
+    // Canonicalize so the traversal guard's prefix check works on macOS (/tmp -> /private/tmp).
+    let real_tmp = tmp.path().canonicalize().unwrap();
+    let plugins_dir = real_tmp.join("plugins");
+    let managed_dir = real_tmp.join("managed");
+    std::fs::create_dir_all(&plugins_dir).unwrap();
+
+    // Pre-create a real directory outside the staging root so canonicalize resolves it —
+    // this is what the traversal guard must catch, not a plain IO NotFound.
+    std::fs::create_dir_all(plugins_dir.join("outside-skill")).unwrap();
+
+    let manifest = r#"[plugin]
+name = "traversal-update"
+version = "0.2.0"
+description = "test"
+
+[[skills]]
+path = "../outside-skill"
+"#;
+    let src = real_tmp.join("staged-src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(src.join("plugin.toml"), manifest).unwrap();
+    let archive = build_tar_gz(&src);
+
+    let dest = plugins_dir.join("traversal-update");
+    let staging = plugins_dir.join(".staging-traversal-update");
+    let backup = plugins_dir.join(".backup-traversal-update");
+    let integrity_path = plugins_dir.join(".plugin-integrity.toml");
+
+    let err = apply_staged_update(
+        &archive,
+        "https://example.com/traversal-update.tar.gz",
+        &dest,
+        &staging,
+        &backup,
+        "traversal-update",
+        &[],
+        &managed_dir,
+        &plugins_dir,
+        &integrity_path,
+        &[],
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("escapes plugin source root"),
+        "expected skill path traversal rejection, got {err}"
+    );
+    assert!(
+        !staging.exists(),
+        "staging dir must be cleaned up after a rejected update"
+    );
+    assert!(
+        !dest.exists(),
+        "dest must not be touched when the staged manifest fails validation"
+    );
+}


### PR DESCRIPTION
## Summary

- `apply_staged_update()` (`crates/zeph-plugins/src/manager/registry.rs`, the plugin auto-update path) claimed to run "the full validation pipeline — same checks as `add()`" but actually skipped two security-relevant checks that `PluginManager::add()` enforces at initial install: dependency count/name validation (`MAX_DEPENDENCIES` = 64, per-dependency `validate_plugin_name`) and `[[skills]] path` traversal validation (canonicalize and reject any skill path resolving outside the plugin source root).
- A compromised auto-update source (registry compromise, DNS hijack, or a malicious plugin author shipping a benign v1 then a malicious v2) could bypass validations that would have blocked the same manifest content at initial `add()` time.
- Both checks are now unified in a single shared `validate_manifest_for_install(source_path, manifest)` (`crates/zeph-plugins/src/manager/security.rs`), called by both `add()` and `apply_staged_update()`, so the two install paths cannot silently diverge again.

## Known non-blocking limitation

`check_allowed_commands_overlay_effect` (an advisory-only warning check in `add()`) has no counterpart in the auto-update path. This is out of scope for this fix — it is not a blocking/security check (the blocking `validate_overlay_keys` guard already runs in both paths) — and is noted here rather than expanded into this PR per reviewer/critic recommendation.

## Test plan

- [x] `cargo nextest run -p zeph-plugins` — 119/119 passed (117 pre-existing + 2 new regression tests)
- [x] New regression test: `apply_staged_update` rejects a staged manifest with >64 dependencies
- [x] New regression test: `apply_staged_update` rejects a staged manifest with a `[[skills]] path` that escapes the plugin source root via traversal
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11587/11587 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `cargo test --doc -p zeph-plugins` — 9/9 passed
- [x] Adversarial critique (rust-critic) — APPROVED, confirmed validation runs against the correct staged root, before the atomic dest swap, with real end-to-end tests (no mocking)
- [x] Code review (rust-code-reviewer) — approved, independently reproduced all CI-matching checks

Closes #5401