### PR TITLE
fix(tools): expand leading ~ in diagnostics, cwd, and search-code path arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tools)`: expand a leading `~` in LLM-supplied paths for `DiagnosticsExecutor::validate_path`,
+  `SetCwdExecutor::execute_tool_call` (`set_working_directory` tool), and the `allowed_paths`
+  constructor argument of `DiagnosticsExecutor::new`/`SearchCodeExecutor::new`, mirroring the
+  `FileExecutor` fix below (#5413). Previously a `~/...` argument was treated as a literal path
+  component instead of being resolved to the user's home directory. Closes #5415.
 - `fix(plugins)`: the plugin auto-update path (`apply_staged_update`,
   `crates/zeph-plugins/src/manager/registry.rs`) now enforces the same manifest validation as
   initial install (`PluginManager::add()`) — dependency count/name validation

--- a/crates/zeph-tools/src/cwd.rs
+++ b/crates/zeph-tools/src/cwd.rs
@@ -11,6 +11,7 @@ use zeph_common::ToolName;
 use crate::executor::{
     ClaimSource, ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params,
 };
+use crate::file::expand_tilde;
 use crate::registry::{InvocationHint, ToolDef};
 
 const TOOL_NAME: &str = "set_working_directory";
@@ -40,7 +41,7 @@ impl ToolExecutor for SetCwdExecutor {
             return Ok(None);
         }
         let params: SetCwdParams = deserialize_params(&call.params)?;
-        let target = PathBuf::from(&params.path);
+        let target = expand_tilde(PathBuf::from(&params.path));
 
         // Resolve relative paths against current cwd before changing.
         let resolved = if target.is_absolute() {
@@ -122,6 +123,37 @@ mod tests {
         // The returned summary is the new cwd.
         let new_cwd = std::env::current_dir().unwrap();
         assert_eq!(out.summary, new_cwd.display().to_string());
+        // Restore cwd so parallel tests are not affected.
+        let _ = std::env::set_current_dir(&original_cwd);
+    }
+
+    // --- tilde expansion regression (#5415) ---
+
+    #[tokio::test]
+    async fn set_cwd_expands_tilde_in_runtime_argument() {
+        // Regression for #5415: a `~`-prefixed path coming from an LLM tool
+        // call must resolve to the real home directory, mirroring the fix
+        // for `DiagnosticsExecutor::validate_path`.
+        let original_cwd = std::env::current_dir().unwrap();
+        let home = dirs::home_dir().expect("home dir must be resolvable in test env");
+        let subdir = tempfile::Builder::new()
+            .prefix("zeph_test_cwd_tilde_")
+            .tempdir_in(&home)
+            .expect("failed to create temp dir under home");
+        let dir_name = subdir.path().file_name().unwrap().to_str().unwrap();
+
+        let executor = SetCwdExecutor;
+        let call = make_call(&format!("~/{dir_name}"));
+        let result = executor.execute_tool_call(&call).await.unwrap();
+        assert!(result.is_some());
+
+        let new_cwd = std::env::current_dir().unwrap();
+        assert_eq!(new_cwd, subdir.path().canonicalize().unwrap());
+        assert!(
+            !new_cwd.to_string_lossy().contains('~'),
+            "tilde must not appear in resolved cwd: {new_cwd:?}"
+        );
+
         // Restore cwd so parallel tests are not affected.
         let _ = std::env::set_current_dir(&original_cwd);
     }

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use zeph_common::ToolName;
 
 use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params};
+use crate::file::expand_tilde;
 use crate::registry::{InvocationHint, ToolDef};
 
 /// Cargo diagnostics level.
@@ -46,7 +47,7 @@ impl DiagnosticsExecutor {
         let paths = if allowed_paths.is_empty() {
             vec![std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))]
         } else {
-            allowed_paths
+            allowed_paths.into_iter().map(expand_tilde).collect()
         };
         Self {
             allowed_paths: paths
@@ -64,8 +65,9 @@ impl DiagnosticsExecutor {
     }
 
     fn validate_path(&self, path: &Path) -> Result<PathBuf, ToolError> {
+        let path = expand_tilde(path.to_path_buf());
         let resolved = if path.is_absolute() {
-            path.to_path_buf()
+            path
         } else {
             std::env::current_dir()
                 .unwrap_or_else(|_| PathBuf::from("."))
@@ -406,6 +408,44 @@ mod tests {
         let p: DiagnosticsParams = serde_json::from_str(r"{}").unwrap();
         assert!(p.path.is_none());
         assert_eq!(p.level, DiagnosticsLevel::Check);
+    }
+
+    // --- tilde expansion regression (#5415) ---
+
+    #[tokio::test]
+    async fn validate_path_expands_tilde_in_runtime_argument() {
+        // Regression for #5415: a `~`-prefixed workspace path coming from an LLM
+        // tool call must resolve to the real home directory, mirroring the fix
+        // for `FileExecutor::validate_path` in #5410.
+        let home = dirs::home_dir().expect("home dir must be resolvable in test env");
+        let subdir = tempfile::Builder::new()
+            .prefix("zeph_test_diagnostics_tilde_")
+            .tempdir_in(&home)
+            .expect("failed to create temp dir under home");
+        let dir_name = subdir.path().file_name().unwrap().to_str().unwrap();
+
+        let exec = DiagnosticsExecutor::new(vec![home.clone()]);
+        let canonical = exec
+            .validate_path(Path::new(&format!("~/{dir_name}")))
+            .unwrap();
+
+        assert_eq!(canonical, subdir.path().canonicalize().unwrap());
+        assert!(
+            !canonical.to_string_lossy().contains('~'),
+            "tilde must not appear in normalized runtime path: {canonical:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_path_absolute_path_unchanged() {
+        // Non-regression: absolute paths without a leading `~` must still
+        // resolve exactly as before the tilde-expansion fix.
+        let dir = tempfile::tempdir().unwrap();
+        let exec = DiagnosticsExecutor::new(vec![dir.path().to_path_buf()]);
+
+        let canonical = exec.validate_path(dir.path()).unwrap();
+
+        assert_eq!(canonical, dir.path().canonicalize().unwrap());
     }
 
     // CR-14: verify that level=clippy maps to "clippy" subcommand string

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -104,7 +104,7 @@ pub struct FileExecutor {
     read_allow_globs: Option<globset::GlobSet>,
 }
 
-fn expand_tilde(path: PathBuf) -> PathBuf {
+pub(crate) fn expand_tilde(path: PathBuf) -> PathBuf {
     let s = path.to_string_lossy();
     if let Some(rest) = s
         .strip_prefix("~/")

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -15,6 +15,7 @@ use zeph_common::ToolName;
 use crate::executor::{
     ClaimSource, ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params,
 };
+use crate::file::expand_tilde;
 use crate::registry::{InvocationHint, ToolDef};
 
 // ---------------------------------------------------------------------------
@@ -218,7 +219,7 @@ impl SearchCodeExecutor {
         let paths = if allowed_paths.is_empty() {
             vec![std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))]
         } else {
-            allowed_paths
+            allowed_paths.into_iter().map(expand_tilde).collect()
         };
         Self {
             allowed_paths: paths


### PR DESCRIPTION
## Summary

- `DiagnosticsExecutor::validate_path` did not expand a leading `~` in an LLM-supplied path before validation, unlike `FileExecutor::validate_path` (fixed in #5413). Made `expand_tilde` `pub(crate)` and applied it, mirroring the file-tool fix.
- Adversarial critique of the initial fix surfaced two related gaps that were fixed in this same PR:
  - `SetCwdExecutor` (`set_working_directory` tool, `crates/zeph-tools/src/cwd.rs`) had the identical bug and, unlike `DiagnosticsExecutor`, is confirmed wired into the live agent (`src/agent_setup.rs`, `src/daemon.rs`, `src/acp.rs`) — this was the actual live user-facing instance of the bug class.
  - `DiagnosticsExecutor::new`/`SearchCodeExecutor::new` did not tilde-expand their `allowed_paths` constructor argument, unlike `FileExecutor::new`, creating a runtime-expanded vs. allowlist-literal mismatch.
- Full unification of the four path validators into one shared helper was considered and deliberately left out of scope as a follow-up (the validators have intentionally different existence/canonicalization semantics).

Closes #5415.

## Test plan

- [x] `cargo build -p zeph-tools`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo +nightly fmt --check`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11588 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression tests: tilde expansion for `DiagnosticsExecutor::validate_path` (2 tests) and `SetCwdExecutor::execute_tool_call` (1 test), all exercising the real integration point under a temp dir in `$HOME`