### PR TITLE
ci: run release-build check only on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
   release-build:
     name: Release Build Check
     needs: detect-changes
-    if: needs.detect-changes.outputs.run-full-ci == 'true'
+    if: needs.detect-changes.outputs.run-full-ci == 'true' && github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `ci`: gate the `Release Build Check` job (`.github/workflows/ci.yml`) behind
+  `github.event_name == 'push'` in addition to the existing `run-full-ci` condition, so it only
+  runs post-merge on `main` instead of on every `pull_request` push. It is the most expensive
+  job in the workflow (`cargo build --release --workspace --all-targets` with
+  `lto = true, codegen-units = 1`), and `main` already re-verifies every change after merge, so
+  gating every feature/fix branch push behind it was wasteful. `ci-status` already treats
+  `skipped` as passing, so this does not weaken the gate for `push` runs.
 - `fix(a2a)!`: `A2aClient::with_security` no longer takes two positional bools (transposing
   `with_security(true, false)` vs. `with_security(false, true)` was a silent foot-gun). It now
   takes a `SecurityPolicy { require_tls, ssrf_protection }` struct, with `SecurityPolicy::hardened()`


### PR DESCRIPTION
## Summary
- `release-build` (Release Build Check) is the most expensive job in the workflow — a full `cargo build --release --workspace --all-targets` with `lto = true, codegen-units = 1` (up to ~45 min, mitigated by sccache).
- It was running on every `pull_request` push in addition to `main` pushes, since its `if:` condition only checked `run-full-ci`.
- Gate it behind `github.event_name == 'push'` as well, so it only runs post-merge on `main`, which already re-verifies the full release build after every merge.
- `ci-status` already treats `skipped` as passing, so PR runs are unaffected by the gate.

## Test plan
- [x] Validated `.github/workflows/ci.yml` with `actionlint` — no findings
- [x] Confirmed `ci-status`'s pass/fail check treats `skipped` as success for `release-build`
- [x] Updated `CHANGELOG.md` under `[Unreleased] / Changed`