### PR TITLE
fix(durable): attach AEAD cipher on write paths when encrypt_payload=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   now unified in a single shared `validate_manifest_for_install` (`crates/zeph-plugins/src/
   manager/security.rs`) called by both `add()` and `apply_staged_update()`, so the two paths
   cannot silently diverge again. Closes #5401.
+- `fix(durable)`: `[durable] encrypt_payload = true` (the default, encrypted-at-rest posture)
+  now actually attaches an AEAD cipher on every durable-journal *write* path, not just the
+  `--reveal` read path (#5404/#5413). Previously `runner.rs` unconditionally passed
+  `cipher=None` to `with_durable_orchestration`, and `scheduler_daemon.rs` opened its
+  `LocalBackend` with no cipher at all, so a deployment believing its payloads were encrypted
+  at rest was silently storing plaintext. New shared helper
+  `load_write_cipher` (`src/commands/durable.rs`) resolves the vault-backed
+  `ZEPH_DURABLE_KEY` and gates cipher construction on `encrypt_payload`, mirroring the existing
+  `open_backend`/`load_durable_cipher` read-path pattern; it fails closed (errors out) instead
+  of silently falling back to plaintext when the key is missing. Wired into `runner.rs`
+  (durable orchestration write path) and `scheduler_daemon.rs` (scheduler durable write path).
+  The TUI's `durable_poll_task` (`src/tui_bridge.rs`) is unaffected — it only lists execution
+  metadata and never reads or writes payload bytes, so it never needed a cipher. Closes #5414.
 - `fix(tools)`: file-tool calls (`write`, `edit`, `create_directory`, and every other
   `FileExecutor` handler) now expand a leading `~` in the LLM-supplied `path` argument to the
   real home directory before sandbox checks run, instead of treating it as a literal `~`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10219,6 +10219,7 @@ dependencies = [
  "async-trait",
  "axum 0.8.9",
  "blake3",
+ "bytes",
  "chrono",
  "clap",
  "cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,6 +348,7 @@ zeph-worktree.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
+bytes.workspace = true
 insta.workspace = true
 serial_test.workspace = true
 sqlx.workspace = true

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -58,6 +58,24 @@ fn load_durable_cipher() -> anyhow::Result<XChaCha20Poly1305Cipher> {
         .map_err(|e| anyhow::anyhow!("invalid ZEPH_DURABLE_KEY: {e}"))
 }
 
+/// Resolve the AEAD payload cipher to attach on a durable *write* path when
+/// `config.durable.encrypt_payload` is enabled (INV-5).
+///
+/// Returns `Ok(None)` when encryption is disabled — the documented dev-only override where
+/// payloads are stored as plaintext, so no cipher is attached and writes stay unchanged.
+/// Returns `Ok(Some(cipher))` when encryption is enabled and `ZEPH_DURABLE_KEY` resolves from
+/// the vault. Fails closed (`Err`) when encryption is enabled but the key is missing: a write
+/// path must never silently persist plaintext while the config declares payloads encrypted.
+pub(crate) fn load_write_cipher(
+    config: &Config,
+) -> anyhow::Result<Option<Arc<dyn zeph_durable::PayloadCipher>>> {
+    if !config.durable.encrypt_payload {
+        return Ok(None);
+    }
+    let cipher = load_durable_cipher()?;
+    Ok(Some(Arc::new(cipher)))
+}
+
 /// Open the local durable backend, attaching the AEAD cipher when `reveal` is set and payloads are
 /// actually encrypted (`config.durable.encrypt_payload`). When `encrypt_payload` is `false` (the
 /// documented dev-only override), stored payloads are already plaintext, so `--reveal` must not
@@ -397,5 +415,116 @@ mod tests {
             result.is_err(),
             "expected --reveal to fail without ZEPH_DURABLE_KEY when encrypt_payload=true"
         );
+    }
+
+    /// End-to-end regression for #5414: `encrypt_payload = true` must actually attach a cipher
+    /// on the write path (`load_write_cipher`, consumed by `runner.rs` and
+    /// `scheduler_daemon.rs`), not just gate `--reveal` on the read path. Writes a step result
+    /// through the real backend using the cipher `load_write_cipher` resolves from a real vault
+    /// key, then reads the raw `durable_journal.payload` column directly (bypassing decryption)
+    /// and asserts it is neither the plaintext bytes nor valid JSON — i.e., genuinely ciphertext
+    /// at rest, mirroring the issue's reproduction steps.
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial]
+    async fn write_path_attaches_cipher_and_seals_payload_when_encrypt_payload_enabled() {
+        use zeph_durable::{
+            EffectClass, EntryKind, ExecutionKind, IdempotencyKey, JournalEntry, StepId,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.encrypt_payload = true;
+
+        // Point the vault dir at a fresh temp dir and seed a real ZEPH_DURABLE_KEY, mirroring
+        // what `zeph --init` does (src/init/durable.rs::store_durable_key).
+        let vault_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", vault_dir.path());
+        }
+
+        let vault_root = zeph_core::vault::default_vault_dir();
+        zeph_core::vault::AgeVaultProvider::init_vault(&vault_root).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
+        provider.set_secret_mut(
+            "ZEPH_DURABLE_KEY".to_owned(),
+            zeph_core::durable::generate_durable_key_b64(),
+        );
+        provider.save().unwrap();
+
+        // Exercise the exact glue the write paths (runner.rs, scheduler_daemon.rs) call.
+        let cipher = load_write_cipher(&config)
+            .expect("cipher load must succeed with a real vault key")
+            .expect("encrypt_payload=true must produce a cipher");
+
+        let url = resolve_durable_db_url(&config);
+        let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
+            .await
+            .unwrap()
+            .with_cipher(cipher);
+        backend.init().await.unwrap();
+
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let step_id = StepId::new(0);
+        let plaintext: &[u8] = br#"{"secret":"token-value"}"#;
+        backend
+            .append(JournalEntry {
+                seq: None,
+                execution_id: exec,
+                kind: ExecutionKind::AgentTurn,
+                step_id,
+                entry: EntryKind::StepResult {
+                    idempotency_key: IdempotencyKey::derive(exec, step_id, b"tool:test"),
+                    payload: bytes::Bytes::copy_from_slice(plaintext),
+                    effect: EffectClass::Idempotent,
+                    payload_version: 1,
+                },
+                created_at_ms: 0,
+            })
+            .await
+            .unwrap();
+
+        let (stored,): (Option<Vec<u8>>,) = zeph_db::query_as(zeph_db::sql!(
+            "SELECT payload FROM durable_journal WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        let stored = stored.expect("payload present");
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert_ne!(
+            stored.as_slice(),
+            plaintext,
+            "payload must not be stored verbatim when encrypt_payload=true"
+        );
+        assert!(
+            serde_json::from_slice::<serde_json::Value>(&stored).is_err(),
+            "sealed payload must not parse as plaintext JSON"
+        );
+
+        // Round-trips back to plaintext through the same cipher-attached backend.
+        let entries = backend.read_execution(exec).await.unwrap();
+        match &entries[0].entry {
+            EntryKind::StepResult { payload, .. } => assert_eq!(payload.as_ref(), plaintext),
+            other => panic!("unexpected entry kind: {other:?}"),
+        }
     }
 }

--- a/src/commands/scheduler_daemon.rs
+++ b/src/commands/scheduler_daemon.rs
@@ -145,41 +145,7 @@ async fn run_foreground(
         config.scheduler.security.attenuate_after_external_read,
     );
 
-    if config.durable.enabled && config.durable.scheduler {
-        let durable_url = crate::commands::durable::resolve_durable_db_url(config);
-        let local =
-            zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
-                .await
-                .context("failed to open scheduler durable backend")?;
-        local
-            .init()
-            .await
-            .context("failed to init scheduler durable schema")?;
-        let local = std::sync::Arc::new(local);
-        let backend = std::sync::Arc::new(zeph_durable::DurableBackendEnum::Local(local.clone()));
-        let durable_cfg = std::sync::Arc::new(config.durable.clone());
-        let (writer_actor, writer_handle) = zeph_durable::JournalWriter::new(local, &durable_cfg);
-        {
-            let writer_fut = writer_actor.run();
-            let cell = std::sync::Arc::new(parking_lot::Mutex::new(Some(writer_fut)));
-            sched_supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "journal_writer",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    let f = cell.lock().take();
-                    async move {
-                        if let Some(f) = f {
-                            f.await;
-                        }
-                    }
-                },
-            });
-        }
-        let adapter = zeph_scheduler::durable::SchedulerDurableAdapter::new(
-            backend,
-            writer_handle,
-            durable_cfg,
-        );
+    if let Some(adapter) = build_durable_adapter(config, &sched_supervisor).await? {
         scheduler = scheduler.with_durable(adapter);
     }
 
@@ -204,6 +170,66 @@ async fn run_foreground(
         .shutdown_all(std::time::Duration::from_secs(5))
         .await;
     result
+}
+
+/// Open the scheduler's durable backend, attach the write-path AEAD cipher when
+/// `[durable] encrypt_payload = true`, and spawn its journal-writer task under `sched_supervisor`.
+///
+/// Returns `Ok(None)` when durable execution is disabled for the scheduler
+/// (`[durable] enabled = false` or `[durable] scheduler = false`), so the caller runs without
+/// durable execution unchanged.
+///
+/// # Errors
+///
+/// Returns an error if the durable backend cannot be opened or initialized, or if the AEAD
+/// cipher cannot be resolved when `encrypt_payload = true` — this fails closed instead of
+/// silently falling back to plaintext.
+async fn build_durable_adapter(
+    config: &zeph_core::config::Config,
+    sched_supervisor: &zeph_common::TaskSupervisor,
+) -> anyhow::Result<Option<zeph_scheduler::durable::SchedulerDurableAdapter>> {
+    if !(config.durable.enabled && config.durable.scheduler) {
+        return Ok(None);
+    }
+    let durable_url = crate::commands::durable::resolve_durable_db_url(config);
+    let local = zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
+        .await
+        .context("failed to open scheduler durable backend")?;
+    local
+        .init()
+        .await
+        .context("failed to init scheduler durable schema")?;
+    let cipher = crate::commands::durable::load_write_cipher(config)?;
+    let local = if let Some(cipher) = cipher {
+        local.with_cipher(cipher)
+    } else {
+        local
+    };
+    let local = std::sync::Arc::new(local);
+    let backend = std::sync::Arc::new(zeph_durable::DurableBackendEnum::Local(local.clone()));
+    let durable_cfg = std::sync::Arc::new(config.durable.clone());
+    let (writer_actor, writer_handle) = zeph_durable::JournalWriter::new(local, &durable_cfg);
+    {
+        let writer_fut = writer_actor.run();
+        let cell = std::sync::Arc::new(parking_lot::Mutex::new(Some(writer_fut)));
+        sched_supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "journal_writer",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                let f = cell.lock().take();
+                async move {
+                    if let Some(f) = f {
+                        f.await;
+                    }
+                }
+            },
+        });
+    }
+    Ok(Some(zeph_scheduler::durable::SchedulerDurableAdapter::new(
+        backend,
+        writer_handle,
+        durable_cfg,
+    )))
 }
 
 fn print_status_human(status: &zeph_scheduler::DaemonStatus) {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2996,7 +2996,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         let agent = agent.with_orchestration(config.orchestration.clone(), agents_config, mgr);
         if config.durable.enabled && config.durable.orchestration {
             let durable_url = crate::commands::durable::resolve_durable_db_url(config);
-            agent.with_durable_orchestration(config.durable.clone(), durable_url, None)
+            let cipher = crate::commands::durable::load_write_cipher(config)?;
+            agent.with_durable_orchestration(config.durable.clone(), durable_url, cipher)
         } else {
             agent
         }


### PR DESCRIPTION
## Summary
- `[durable] encrypt_payload = true` never attached an AEAD cipher on any write path — only the `--reveal` read path (#5404/#5413) did — so durable journal payloads were stored as plaintext at rest regardless of config.
- Adds `load_write_cipher` (`src/commands/durable.rs`), mirroring the existing `open_backend`/`load_durable_cipher` read-path pattern, and wires it into both real write-path call sites: `src/runner.rs` (durable-orchestration agent build) and `src/commands/scheduler_daemon.rs` (scheduler durable backend, via a new `build_durable_adapter` helper extracted to stay under the `clippy::too_many_lines` limit).
- Fails closed: if `encrypt_payload=true` but the vault key is missing, the write path errors out instead of silently falling back to plaintext.
- `src/tui_bridge.rs` intentionally untouched — `durable_poll_task` only lists execution metadata and never reads/writes the `payload` column, so it never needed a cipher (verified independently by both the adversarial critic and the reviewer).

## Test plan
- [x] New e2e regression test `write_path_attaches_cipher_and_seals_payload_when_encrypt_payload_enabled` (`src/commands/durable.rs`): seeds a real vault key, writes through the actual backend, reads the raw `durable_journal.payload` column directly, asserts genuine ciphertext (not plaintext/valid JSON), and round-trips through decrypt.
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11586 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`

## Notes for reviewers
- The regression test exercises `load_write_cipher` + the backend's `with_cipher`/`append` directly rather than invoking `runner.rs`/`scheduler_daemon.rs` themselves, so it guards the cipher mechanism but not the two call-site wirings specifically — flagged during adversarial critique as acceptable (not worth a heavier integration test for two one-line call sites) but noted here for visibility.
- `crates/zeph-durable/src/config.rs::encryption_gate` (INV-8, shared-DB/Restate AEAD-required validation) has zero runtime callers — a separate, pre-existing gap unrelated to this fix's scope (both fixed paths are local SQLite, `shared_db=false`, so the gate's absence doesn't weaken this fix). Worth a follow-up issue.

Closes #5414