### PR TITLE
feat(session)!: implement session persistence, event log replay, and zeph serve mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,433 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `feat(session)`: add the `zeph-session` crate foundation (spec-068 P0, #5343) — an append-only
+  JSONL event log (`SessionEventLog`) as the durable source of truth for a conversation, the
+  `SessionEvent` schema (reusing `zeph_llm::provider::MessagePart` and
+  `zeph_common::memory::AnchoredSummary`), `SessionStore` (metadata CRUD over the existing
+  `acp_sessions` table, promoted from ACP-only to channel-agnostic per spec-068 Decision D1),
+  `ReplayEngine` (deterministic fold of an event log into agent-ready messages — never calls the
+  LLM or a tool executor), and the `Condenser` trait contract with the INV-SP-4 non-overlap guard
+  (`validate_non_overlap`). New migration `106_session_persistence.sql` (SQLite + PostgreSQL) adds
+  `last_seq`/`event_count`/`forked_from`/`forked_at_seq`/`status`/`last_condensed_seq` to
+  `acp_sessions`. New `session` Cargo feature (added to the `desktop`/`server` bundles).
+
+- `feat(session)`: wire the durable JSONL event log into the live agent turn loop (spec-068 P1,
+  #5343). New `zeph_agent_persistence::SessionSink` dual-writes every persisted user/assistant
+  message to the session's `events.jsonl` **before** the `SQLite` `messages` projection
+  (INV-SP-1), called from `Agent::persist_message` — the single choke point already shared by
+  every channel and every tool-loop persistence call site. `[session]` config gains `enabled`
+  (default `true`), `data_dir` (default `.zeph/sessions`), `encrypt` (deferred, default `false`),
+  `max_event_log_mb`, and a new `[session.condense]` block (`condense_provider`, `threshold`,
+  `keep_recent`) — `--migrate-config` step 70 surfaces the new keys as commented advisories.
+  CLI/TUI/Telegram channels mint (and reuse, across restarts, keyed by `conversation_id`) a
+  session id in `runner.rs`; ACP sessions reuse their existing ACP session id directly, with no
+  separate minting step.
+
+  **Write-path cutover** (critic-flagged correction): retired both live per-turn writers to the
+  legacy `acp_session_events` table in `crates/zeph-acp/src/agent/mod.rs` —
+  `persist_user_message_async` (an unsupervised `tokio::spawn`, `EXEMPT #5144`) and the
+  notify-drainer's per-`SessionUpdate` write (also `EXEMPT #5144`) — since the same content now
+  reaches the JSONL log through the shared `Agent::persist_message` path once a `SessionSink` is
+  attached. `SessionSink` is the sole live writer for conversation-session history; no partial
+  double-write to `acp_session_events` survives. Removes two unsupervised `tokio::spawn` sites
+  (net positive against the CI spawn-baseline tracked in `.claude/rules/continuous-improvement.md`).
+  Dead code this cutover exposed (`session_update_to_event`, `content_chunk_text` in
+  `crates/zeph-acp/src/agent/helpers.rs`) removed rather than `#[allow(dead_code)]`-suppressed.
+
+  **Known gap** (tracked for the spec §12.3 read-handler thinning follow-up, out of scope for this
+  cutover): `do_load_session`'s replay of historical `SessionUpdate`s (`agent_thought`,
+  `tool_call_update` deltas, `config_option_update` — variants with no `SessionEvent` equivalent)
+  now has nothing new to replay for sessions created after this cutover, since it still reads the
+  now-frozen `acp_session_events` table.
+
+- `feat(session)`: replay-based `MessageState` hydration for ACP session resume/load/fork (spec-068
+  P1, #5343). Every ACP session spawned via `spawn_acp_agent` (`src/acp.rs`) — `do_new_session`,
+  `do_load_session`, `do_fork_session`, `do_resume_session` all share this one spawner — now folds
+  its `events.jsonl` (if non-empty) via `ReplayEngine::fold` and seeds `MessageState` from the
+  result, via a new `AgentBuilder::with_preloaded_messages` builder method, **before** the existing
+  `SQLite`-based `Agent::load_history()` call. `load_history()` gained an explicit
+  `MessageState::history_preloaded` guard (not a `messages.is_empty()` check — `Agent::new` always
+  seeds `messages` with the system-prompt message, so emptiness never distinguishes "already
+  hydrated" from "not yet loaded") so it becomes a safe no-op once replay has already populated
+  history, rather than duplicating every message (`PersistenceService::load_history` appends, it
+  does not replace). A session with an empty/absent JSONL log (brand-new sessions, and legacy
+  sessions that predate this feature) falls through unchanged to the existing `SQLite` path — no
+  retroactive synthesis, matching spec §18's legacy-session decision.
+
+- `feat(cli)`: enrich `zeph sessions` (spec-068 P1, #5343). `sessions list` now shows
+  `status`/`event_count`/`forked_from` columns sourced from `zeph_session::SessionStore`. New
+  `sessions show <id> [--from N] [--to N] [--events]` prints session metadata (status, timestamps,
+  conversation id, `last_seq`, `event_count`, `last_condensed_seq`, fork provenance) and, with
+  `--events`, the session's JSONL event log (optionally sliced by `seq` range). `sessions resume
+  <id>` gained a `--print` flag that dumps the JSONL event log (replacing the old
+  `acp_session_events`-sourced dump — the source of truth moved to JSONL). The `Sessions` CLI
+  command is no longer gated behind the `acp` feature alone — it's now available under
+  `any(feature = "acp", feature = "session")`, since the underlying data (`acp_sessions`) is
+  channel-agnostic as of spec-068 Decision D1, not ACP-specific.
+
+- `feat(session)`: INV-SP-3 projection reconciliation (spec-068 §13, #5343). New
+  `zeph_agent_persistence::reconcile_projection`, called from `spawn_acp_agent` alongside the
+  replay-hydration wiring: when `acp_sessions.event_count` trails the session's JSONL event log
+  (e.g. a crash between the log append and the `SQLite` write of the same turn), rebuilds the
+  missing `messages` rows forward from the log. Deliberately conservative — reconciles only a gap
+  containing exclusively `UserMessage`/`AssistantMessage` events; any gap containing a
+  `ToolCall`/`ToolResult`/`Condensation`/`Compaction`/`ForkPoint` event is left stale (logged, not
+  guessed at) rather than risk writing an incorrect row. Not correctness-critical for
+  resume/load/fork itself (which already sources conversation history from the JSONL log directly
+  when it has content); keeps other features that read `messages` directly (semantic search,
+  history displays) in sync with the log after a crash.
+
+- `feat(session)`: `ForkEngine` — eager-copy session forking (spec-068 P2 §7, #5343). New
+  `zeph_session::ForkEngine::fork(data_dir, src_id, new_id, at_seq, store)`: copies parent events
+  `[0, at_seq)` (or the whole log when `at_seq` is `None`) into a caller-allocated child session's
+  own, fully self-contained JSONL log, prefixed with a synthetic `SessionStarted { forked_from:
+  Some((src_id, at_seq)) }` header; creates the child's `acp_sessions` row via
+  `SessionStore::record_fork`; appends a `ForkPoint` provenance event to the parent's log.
+  Copy-on-write forking is explicitly deferred (spec §15 NEVER) in favor of eager copy for MVP
+  simplicity and independence from the parent's subsequent condensation. `new_id` is
+  caller-supplied (not minted internally) since ACP's `do_fork_session` needs the id before the
+  fork call completes, to construct the session's in-memory entry.
+
+- `feat(acp)`: `do_fork_session` delegates to `ForkEngine::fork` when `[session] enabled = true`
+  (spec-068 P2, #5343). New `AcpServerConfig.session_data_dir` /
+  `ZephAcpAgentState.session_data_dir` (threaded through `build_agent_state`) gate the new path.
+  `fork_conversation` now forks the durable JSONL log via `ForkEngine::fork` and links the new
+  `SQLite` conversation to the `acp_sessions` row `ForkEngine::fork` already created (via
+  `record_fork`) rather than creating a second row — the legacy `acp_session_events`
+  `import_acp_events`/`load_acp_events` copy is retired for new forks (the JSONL log is now the
+  sole source of truth for forked history, matching the P1 write-path cutover's philosophy). The
+  `SQLite` `messages`/`conversations` copy (`copy_conversation`) is unchanged. When persistence is
+  disabled, behavior is unchanged from before spec-068.
+
+- `feat(cli)`: `sessions fork/export/import` (spec-068 P2, #5343). `sessions fork <id> [--at
+  <seq>]` mints a new session id and delegates to `ForkEngine::fork`. `sessions export <id>
+  <path.jsonl>` copies a session's validated (INV-SP-2 torn-tail-truncated) event log to a file.
+  `sessions import <path.jsonl>` restores a previously-exported log as a brand-new session (fresh
+  id, no `forked_from` provenance — an import is a restore, not a fork).
+
+- `feat(session)`: `LlmCondenser` — the default `Condenser` implementation (spec-068 P2 §8,
+  #5343). New `zeph_session::LlmCondenser`, reusing
+  `zeph_context::summarization::summarize_structured` (`zeph-session` now depends on
+  `zeph-context` — confirmed `cargo tree` still excludes `zeph-durable`/`zeph-memory`/`zeph-core`,
+  INV-1 preserved). `should_condense` triggers once `budget_used_fraction` reaches a configurable
+  threshold and there are more than `keep_recent` messages; `condense` keeps the last
+  `keep_recent` messages un-summarized, folds the rest via `ReplayEngine::fold`, and summarizes
+  via the LLM, enforcing INV-SP-4 (`validate_non_overlap`) on the computed `replaced_range`. New
+  `SessionError::Llm` variant for summarization failures.
+
+- `feat(session)`: `Compaction` event hook (spec-068 P2 §8.1, #5343). New
+  `SessionSink::record_compaction(tier, cleared_count)`, called from `Agent::maybe_compact`
+  (`crates/zeph-core/src/agent/context/summarization/scheduling.rs`) whenever live in-memory
+  compaction actually pruned messages this turn — makes the prune replayable
+  (`ReplayEngine::fold` already handled `Compaction` events conservatively since P0). **Known
+  limitation**: emitted with `summary: None` — the LLM-produced hard-compaction summary text is
+  produced deep inside `zeph-agent-context`'s `do_hard_compaction`/`compact_context` and is not
+  currently surfaced to the `Agent<C>` call site that has `session_sink` access; `tier`/
+  `cleared_count` alone are recorded for now, tracked as a follow-up to fully close AC-6.
+
+- `feat(config)`: `[serve]` config section for `zeph serve` (spec-068 P3 §9, #5343). New
+  `zeph_config::ServeConfig` (`http_addr`, `require_auth`, `auth_token_vault_key`, `max_sessions`,
+  `session_idle_ttl_secs`, `max_queued_prompts`) — the bearer token itself is never stored inline
+  (only the age-vault key name to resolve it from at startup, per the vault-only secrets policy).
+  New `--migrate-config` step 71 adds a commented-out `[serve]` block for discoverability;
+  `config/default.toml` documents all fields.
+
+- `feat(core)`: `SessionActor` + `LiveSessionRegistry` for `zeph serve` (spec-068 P3 §9.2-9.3,
+  #5343). New `zeph_core::serve` module: `SessionCommand` (`Prompt`/`Cancel`/`Shutdown`),
+  `SessionOutput` (`Token`/`ToolCall`/`ToolResult`/`TurnComplete`/`Error`), and
+  `SessionActor::drive` — a single `tokio::select!` loop (no raw `tokio::spawn`) bridging an
+  `mpsc::Receiver<SessionCommand>` into an `Agent<LoopbackChannel>`'s channel input and forwarding
+  channel output as `SessionOutput` over a `broadcast::Sender`, while concurrently driving
+  `agent.run()` to completion. Graceful shutdown (explicit `Shutdown` command, or the
+  `TaskSupervisor`'s `CancellationToken` cancelling) drops the channel's input sender, letting
+  `Agent::run`'s `next_event()` observe closure and exit on its own rather than aborting mid-turn.
+  Also new `LiveSessionRegistry` (spec §9.3): pure bookkeeping
+  (`HashMap<SessionId, SessionActorHandle>` behind a `parking_lot::Mutex`, never held across
+  `.await`) with `get`/`insert`/`remove`/`idle_candidates` (no attached broadcast subscribers +
+  TTL-expired `last_active`, for a future `serve.evict` task).
+
+  `SessionActor::spawn` — the production entry point — registers a *coordinator* task under
+  `TaskSupervisor` via `spawn_oneshot(name: Arc<str>, factory)` (architect ruling D-7): a dynamic
+  `serve.session.<id>` name and `RestartPolicy::RunOnce` (no auto-restart after a crash —
+  re-driving a torn turn/replay in place is unsafe; recovery is a fresh spawn that replays the
+  durable log from the last committed `seq`). `Agent<C>`'s futures are `!Send` (same constraint
+  `zeph-acp`'s `serve_stdio` documents), and `Agent<LoopbackChannel>` itself cannot cross *any*
+  thread boundary, so `spawn` takes a `Send`-safe agent-construction factory
+  (architect ruling D-8: `FnOnce(LoopbackChannel) -> Agent<LoopbackChannel> + Send + 'static`,
+  mirroring `zeph-acp`'s `SendAgentSpawner`) rather than an already-built `Agent` — the factory
+  runs *inside* a dedicated OS thread with its own `current_thread` runtime and `LocalSet`,
+  mirroring `serve_stdio`'s exact pattern (only `Send`-safe state crosses the thread boundary; the
+  `Agent` is constructed entirely inside it). The `spawn_oneshot` task itself is a thin
+  coordinator that never touches the `!Send` `Agent` — it awaits the thread's completion signal
+  and, on process-wide supervisor shutdown, forwards cancellation onto a **per-session**
+  `CancellationToken` (new `SessionActorHandle.cancel` field, distinct from the supervisor's
+  process-wide token) so idle eviction (`serve.evict`, spec §9.3) can cancel exactly one session
+  without tearing down every live actor, while `drive` only ever selects on one cancellation
+  source regardless of trigger.
+
+- `feat(cli)`: `zeph serve-sessions` — process lifecycle for `zeph serve` (spec-068 §9, #5343).
+  New root-binary `src/serve/` module and `Command::ServeSessions` CLI variant (new `session`
+  Cargo feature dependency: `dep:axum`, `zeph-common/http-middleware`). **Naming note**: named
+  `serve-sessions` rather than the spec's literal `serve` — `Command::Serve` already names the
+  scheduler's foreground daemon (`#[cfg(all(unix, feature = "scheduler"))]`), and both features
+  can be enabled simultaneously, so a second command claiming the same top-level name isn't
+  viable; documented in the module doc and CLI help text. Implements: config resolution
+  (`--http-addr`/`--max-sessions` CLI overrides `[serve]` config), TCP bind, an unauthenticated
+  `GET /health` endpoint (status/uptime/live-session-count), and graceful shutdown — SIGTERM
+  (Unix) or Ctrl-C triggers `axum::serve`'s `with_graceful_shutdown`, cancels the process's
+  `TaskSupervisor` `CancellationToken`, then calls `shutdown_all(30s)`. Live-tested: bind, `curl
+  /health` (`{"status":"ok","uptime_secs":1,"live_sessions":0}`), SIGTERM, clean exit — verified
+  manually against the built binary. Also implements `serve.evict` (spec §9.3): a
+  `TaskSupervisor`-registered task (`RestartPolicy::Restart { max: 5, .. }`) that scans
+  `LiveSessionRegistry::idle_candidates` every minute and cancels each idle session's own
+  `SessionActorHandle::cancel` token — uses `registry.remove` rather than `registry.get` so the
+  eviction scan itself never resets the `last_active` timer it is reading. Selects on the
+  supervisor's `CancellationToken` so it exits immediately on shutdown rather than forcing
+  `shutdown_all`'s full grace-period timeout (live-tested: shutdown completed in 0s, not the 30s
+  fallback). Implements a first slice of the `/sessions*` REST surface (spec §9.4):
+  `POST /sessions` (create), `GET /sessions` (list live ids), `DELETE /sessions/:id` (end a
+  session — same `SessionActorHandle::cancel` mechanism `serve.evict` uses, caller-initiated
+  instead of TTL-triggered), backed by a new `src/serve/deps.rs` (`ServeAgentDeps`,
+  `build_serve_deps`) and `src/serve/agent_factory.rs` (`build_agent_factory`) that assemble a
+  working `Agent<LoopbackChannel>` — provider, embedding provider, skill registry/matcher,
+  memory, a core shell/file/web/cwd tool set (with sandbox + audit wired the same way ACP does),
+  and `SessionSink` durable persistence when `[session] enabled = true`. Deliberately **not** a
+  reuse of `src/acp.rs`'s `SharedAgentDeps`/`build_acp_deps` — that struct carries ~15
+  ACP-transport-only fields (permission files, ACP model-switching provider factory, auth bearer
+  tokens) that don't apply to a plain HTTP session; `ServeAgentDeps` calls the same underlying
+  `AppBuilder`/`zeph_tools`/`zeph_mcp` constructors but stops before MCP, the scheduler, and every
+  ACP-only field, at the cost of some orchestration-call duplication with `build_acp_deps`.
+  `POST /sessions` enforces `[serve] max_sessions` (`503` when at capacity). Because a live
+  session can execute shell/file/web tools and bearer-auth enforcement is not implemented yet,
+  `handle_serve_sessions_command` now refuses to start when `[serve] require_auth = true`
+  (the default) and the bind address is not loopback, rather than silently exposing
+  unauthenticated tool execution to the network. Live-tested end-to-end against a local Ollama
+  provider: `POST /sessions` → `201` with a durable `events.jsonl` written under `[session]
+  data_dir`, `GET /sessions` reflects the new id, filling `[serve] max_sessions` (5) then a 6th
+  create correctly returns `503`, `DELETE /sessions/:id` returns `204` and a repeat `DELETE`
+  returns `404`, and SIGTERM with 5 live sessions registered shuts down cleanly (`shutdown_all`
+  gated on all 6 supervised tasks — 5 session coordinators + `serve.evict` — reaching
+  `active_count() == 0`, not the 30s force-abort fallback). New `LiveSessionRegistry::ids()`
+  accessor (1 new unit test) backs the list endpoint.
+  MCP tools, the scheduler executor, and skill/config hot-reload are not wired into
+  `ServeAgentDeps`. `--acp` (running the ACP transport alongside HTTP/SSE) and `require_auth`'s
+  vault-token resolution are also not yet wired.
+
+- `feat(cli)`: `POST /sessions/:id/prompt` and `GET /sessions/:id/events` — the conversational
+  surface of `/sessions*` (spec §9.4). `prompt_session_handler` sends `SessionCommand::Prompt`
+  over the session's mailbox (fire-and-forget; `202` once queued, `404` if not live, `410` if the
+  mailbox already closed). `events_session_handler` subscribes to the session's
+  `SessionActorHandle::tx_out` broadcast and streams it as SSE via `axum::response::sse`; multiple
+  concurrent subscribers are supported (broadcast fan-out) and a lagged subscriber has missed
+  events dropped rather than the connection closed (the durable log is the source of truth for
+  anything missed). `SessionOutput` gained `Serialize` (adjacently tagged —
+  `{"type": "token", "data": "..."}` — since `Token`/`Error` wrap a bare `String` that can't
+  flatten into an internally tagged object). New `tokio-stream` dependency (`sync` feature, gated
+  behind the `session` Cargo feature) for `BroadcastStream`. Live-tested end-to-end against a
+  local Ollama provider: created a session, subscribed to its SSE stream, posted a prompt, and
+  received `{"type":"token","data":"PONG"}` followed by `{"type":"turn_complete"}` — a real
+  model round-trip, not a mock. The durable event log correctly recorded the user message at
+  `seq 0`; the persisted `assistant_message` at `seq 1` had empty `parts: []` even though the
+  correct content streamed over SSE — this looks like a pre-existing gap in `SessionSink`'s
+  dual-write content capture (P1/P2 work, not part of this REST-endpoint change) rather than
+  something introduced here; filed #5419 rather than fixing blind since it's outside this
+  change's scope.
+
+- `feat(cli)`: `GET /sessions/:id` — durable session metadata (spec §9.4). Returns
+  `zeph_session::SessionMetadata` (now `Serialize`, as is `SessionStatus`) flattened alongside a
+  `live: bool` computed from `LiveSessionRegistry`. `404` only when the session is neither live
+  nor known to `SessionStore` — a session whose actor has ended (idle eviction, explicit delete,
+  process restart) still returns its metadata with `live: false`, since the durable log allows it
+  to be resumed. Live-tested: a live session returns `live: true`; an unknown id returns `404`;
+  after `DELETE`, the same id still returns its metadata with `live: false` — matching the
+  documented resumability semantics exactly.
+
+- `feat(cli)`: `POST /sessions/:id/fork` — completes spec §9.4's `/sessions*` surface. Reuses
+  `zeph_session::ForkEngine::fork` (P2) to eager-copy the source session's durable log up to an
+  optional `at_seq` into a fresh child id, then immediately spawns a live `SessionActor` for the
+  child (a fresh `ConversationId`, same as `POST /sessions`) so the fork is usable via
+  `/prompt`+`/events` right away rather than only durably persisted. `404` when the source has no
+  durable log, `400` when `at_seq` exceeds the source log's event count, `503` at
+  `[serve] max_sessions` (the child counts as a new live session). Live-tested end-to-end against
+  a local Ollama provider: prompted a source session to completion, forked it, confirmed the
+  child's metadata shows `forked_from`/`forked_at_seq` pointing at the source and `live: true`,
+  and both the parent's and child's `events.jsonl` on disk reflect the fork correctly (child gets
+  the copied events plus a fresh `SessionStarted` header; parent gets a `ForkPoint` provenance
+  record per spec §7.2 step 8). Also verified `404` (unknown source) and `400`
+  (`at_seq` too large) against the running binary.
+
+- `feat(cli)`: wire `[serve] require_auth` / `auth_token_vault_key` bearer-auth enforcement
+  (spec §9.4) — the last major security gap flagged when `zeph serve-sessions` first landed.
+  `build_serve_deps` resolves the token from the vault at startup (`AppBuilder::vault()`,
+  extracted into `resolve_auth_token`/`build_tool_executor` helpers to stay under clippy's
+  `too_many_lines`) and returns it separately from `ServeAgentDeps` (server-level config, not an
+  agent-construction dependency). Every `/sessions*` route (not `/health`) is now layered with
+  `zeph_common::http_middleware::auth_middleware` via `AuthConfig`, the same pattern
+  `zeph-gateway`'s router uses. **Refined the earlier loopback-only bind guard**: now that auth
+  can actually be enforced, a non-loopback bind is only refused when `require_auth = true` *and*
+  no token was resolved (which would otherwise mean the API is reachable over the network while
+  rejecting every single request — a footgun, not a protection); a non-loopback bind with a
+  resolved token is legitimately safe and now allowed. Live-tested against a local Ollama
+  provider with `require_auth = true`: `/health` still succeeds unauthenticated (200);
+  `POST /sessions` without a bearer token now returns `401` (confirmed via
+  `zeph_common::http_middleware`'s own `require_auth=true but no auth_token configured,
+  rejecting request` log line); binding `0.0.0.0` with no vault token resolved correctly refuses
+  to start with a clear error message. The `require_auth = false` (default) path was already
+  exercised unauthenticated across every prior live test in this session (create/list/
+  get/delete/prompt/events/fork).
+
+- `feat(cli)`: `/conv [list | show <id>]` slash command (spec-068, #5343) — browse durable
+  conversation-sessions from inside an already-running agent, channel-agnostic by construction
+  (works identically in CLI, TUI, and Telegram, matching `/model`/`/undo`'s
+  `CommandHandler`/`AgentAccess` pattern rather than a TUI-only command). Mirrors
+  `zeph serve-sessions`'s `GET /sessions`/`GET /sessions/:id` REST endpoints, reading through the
+  same `zeph_session::SessionStore` — metadata only (title/status/event count/`forked_from`/
+  timestamps); use `zeph sessions show --events <id>` on the CLI for a full event-log dump. New
+  `AgentAccess::handle_conv` trait method (default: "not enabled in this context" message,
+  matching `handle_undo`'s pattern) with the real implementation in
+  `crates/zeph-core/src/agent/agent_access_impl.rs`, registered in the agent command registry
+  alongside `/undo`/`/redo`. New `ConvCommand` in `crates/zeph-commands/src/handlers/conv.rs`.
+  Live-tested via the interactive CLI against the shared production SQLite database: `/conv list`
+  printed the full session table (confirmed a session created by an earlier `zeph serve-sessions`
+  live test in this same session appears correctly); `/conv show <id>` printed full metadata for
+  an existing session and a clear "not found" message for an unknown one; an unrecognized
+  subcommand (`/conv bogus`) printed a usage hint rather than silently failing.
+
+- `fix(session)`: **#5419** — `SessionSink::record_message`'s `Role::Assistant` branch used only
+  `parts` and ignored `content` entirely, but the real production call sites
+  (`Agent::persist_message` from `crates/zeph-core/src/agent/tool_execution/tier_loop.rs:2435,
+  2659`) always pass an empty `parts` slice and put the response text in `content` — this was the
+  universal path for every assistant turn, not an edge case, so every durably persisted assistant
+  message had empty `parts` in production. Undermined AC-1 (resume shows empty assistant turns),
+  AC-5 (crash reconciliation reconstructs empty assistant messages), and `ReplayEngine`'s fold
+  logic for the common case. Fixed in `crates/zeph-agent-persistence/src/session_sink.rs`: when
+  `parts` is empty and `content` is non-empty, wrap `content` into a single `MessagePart::Text`;
+  an explicitly provided non-empty `parts` is used as-is and never overwritten by `content`. Two
+  new regression tests mirror both call shapes
+  (`record_assistant_message_wraps_content_when_parts_empty` for the real production shape,
+  `record_assistant_message_prefers_explicit_parts_over_content` to guard the pre-existing
+  explicit-`parts` shape against regressing). Re-verified against the exact live-Ollama repro from
+  #5419: the durable log now shows `{"seq":1,...,"kind":{"type":"assistant_message","parts":
+  [{"kind":"text","text":"PONG"}]}}` instead of empty `parts: []`.
+
+- `feat(cli)`: `zeph serve-sessions --acp` now fails fast with a clear error naming the correct
+  alternative, instead of silently logging a warning and running HTTP/SSE-only. Researched
+  in-process combination before implementing: `src/acp.rs`'s `run_acp_server`/
+  `run_acp_http_server` each build a complete, independent `SharedAgentDeps` (own
+  `SemanticMemory`/`SQLite` pool, provider, `McpManager`, skill registry, `TaskSupervisor`) with
+  no existing path to share those with `ServeAgentDeps` — running both in one process would mean
+  two independent `SQLite` connection pools writing the same database file concurrently (a real
+  contention/correctness risk, not just wasted resources) plus duplicate MCP subprocess spawning.
+  Rather than build that silently, `--acp` now errors naming the workaround (run `zeph --acp` /
+  `zeph --acp-http` as a separate process alongside `zeph serve-sessions`). Filed **#5420** for
+  proper in-process support: refactor `build_acp_deps` to accept prebuilt shared resources, the
+  same pattern it already uses for the MCP manager (`prebuilt_mcp_manager`) — real design work
+  deserving its own attention rather than being squeezed into this PR.
+
+- `feat(cli)`: `/conv resume <id>` and `/conv fork <id>` (spec-068, #5343, architect ruling D-9)
+  — mid-session live conversation swap on the CLI/TUI's single running agent. Architect ruling:
+  the "needs new live-swap machinery" estimate for descoping these was checked against code and
+  was wrong — the machinery already exists (`reset_conversation`/`/new` IS the live-swap
+  precedent; `AgentBuilder::with_preloaded_messages` IS the replay-hydration precedent; slash
+  commands already dispatch with `&mut self` between turns). New
+  `Agent::load_and_resume_conversation` (`crates/zeph-core/src/agent/context/assembly.rs`,
+  sibling to `reset_conversation`, same reset shape) sets `conversation_id` from the
+  `SessionId`<->`ConversationId` bijection (spec §5.2, resolving or minting+linking one via
+  `SessionStore`) instead of minting a fresh empty one, and applies `ReplayEngine::replay`'s
+  output to `msg.messages` (same "append replayed messages" shape as `with_preloaded_messages`,
+  the D-6 startup path). Sends `"Replaying conversation..."` over the existing TUI status
+  channel during the swap (AC-10). **Critical, explicitly-flagged bit**: re-points
+  `SessionState::session_sink` to the resumed/forked session's own `SessionEventLog` — without
+  this, `reset_conversation`'s conversation_id-only swap would leave subsequent turns silently
+  appending to the *previous* session's `events.jsonl` (INV-SP-1 accounting corruption). New
+  `SessionState::session_persistence_config` field + `AgentBuilder::with_session_persistence_config`
+  retain the `[session]` config snapshot (previously only consumed at construction via
+  `with_session_sink`) so the resume/fork swap can locate `data_dir` later; wired into all three
+  agent-construction call sites (`spawn_acp_agent`, the CLI/TUI bootstrap in `src/runner.rs`, and
+  `src/serve/agent_factory.rs`). `handle_conv_resume`/`handle_conv_fork` on `Agent<C>`
+  (`agent_access_impl.rs`) wire this into the existing `ConvCommand`/`handle_conv` dispatcher
+  (`resume <id>`/`fork <id>` subcommands, alongside `list`/`show`) rather than adding separate
+  `AgentAccess` trait methods — `ConvCommand` already forwards raw args to one entry point, so a
+  second dispatch layer would just duplicate subcommand parsing. `/conv fork <id>` reuses
+  `ForkEngine::fork` (P2) then the same resume-swap into the child — same effect as
+  `POST /sessions/:id/fork` but for the current CLI/TUI session instead of spawning a new
+  `SessionActor`. New `AgentError::Session(#[from] zeph_session::SessionError)` variant.
+  Live-tested end-to-end against a local Ollama provider: created a session via
+  `zeph serve-sessions` with real content ("the secret word is BANANA"), `/conv resume <id>` in
+  a plain CLI session showed the "Replaying conversation..." status, confirmed "2 event(s)
+  replayed", and a follow-up question correctly recalled "BANANA" via `memory_search` — proving
+  the replayed history is genuinely usable, not just cosmetically loaded. Verified the SessionSink
+  re-point specifically: new turns after resume correctly appended to the *resumed* session's
+  `events.jsonl` (seq 2-4), not a stale one. `/conv fork <id>` copied 5 events into a fresh child
+  session, immediately became the active conversation, and both logs were verified on disk (child
+  gained a `session_started` header with `forked_from`, parent gained a `fork_point` record).
+
+- `feat(session)`: legacy session lazy-bootstrap (spec-068 §18, P4). Existing installs have
+  `SQLite` `messages` rows for conversations that predate durable event-log persistence — these
+  are **not** retroactively synthesized into full event logs (lossy: no tool-call/result
+  granularity survives in the old projection). Instead, new `zeph_agent_persistence::
+  bootstrap_legacy_session` (`crates/zeph-agent-persistence/src/legacy_bootstrap.rs`) runs on
+  the first resume of such a session: no-ops if the event log already has events (already
+  bootstrapped, or #5343-native) or if the linked conversation has zero `SQLite` messages
+  (genuinely new session — `SessionSink` writes its own `SessionStarted` on the first real turn
+  instead); otherwise writes a `SessionStarted` header plus a single `Condensation`-style
+  "imported history" event (`replaced_seq_range: (0, 0)`) summarizing the pre-existing message
+  count, so `ReplayEngine::fold`'s existing (unmodified) logic produces one system message
+  representing the imported history — verified this replays correctly using the existing
+  `replace_range` fallback path (inserts the summary even when no prior in-log messages match
+  the range) rather than needing new replay logic. Old sessions cannot be forked or replayed at
+  an arbitrary historical `seq` predating this import boundary. Wired into both resume paths:
+  ACP's `spawn_acp_agent` (`src/acp.rs`, additive — inserted before the existing resume-hydration
+  read, not a restructure) and the new `/conv resume`/`Agent::load_and_resume_conversation`
+  (`crates/zeph-core/src/agent/context/assembly.rs`). Extracted a shared `reset_swap_state`
+  helper (steps 4-9 of `reset_conversation`) used by `load_and_resume_conversation` — did **not**
+  refactor `reset_conversation` itself to call it, since `reset_conversation`'s `keep_plan`
+  parameter conditionally skips the plan-cancellation step in a way `load_and_resume_conversation`
+  never needs to (resume/fork always fully resets); sharing the helper both ways would have
+  required either dropping that conditional (behavior change to the tested `/new --keep-plan`
+  path) or adding a parameter neither caller other than `/new` needs. 3 new unit tests
+  (no-op-with-existing-events, no-op-with-no-messages, bootstraps-and-is-idempotent). Live-tested
+  regression: created a normal (non-legacy, already has real session-persistence events) session
+  via `zeph serve-sessions`, then `/conv resume`d it via CLI — confirmed the bootstrap correctly
+  no-ops (event count stayed at 2, not 4) and the existing resume flow is unaffected.
+
+- `feat(cli)`: `--init` wizard steps for `[session]` and `[serve]` (spec-068, #5343, P4). New
+  `src/init/session.rs`: `step_session` prompts whether to enable durable session persistence and
+  its event-log directory; `step_serve` gates `zeph serve-sessions`'s `[serve]` settings
+  (bind address, bearer-auth requirement + vault key name, max concurrent sessions, idle eviction
+  TTL) behind a single "customize now?" confirmation rather than a per-field prompt cascade, since
+  `[serve]` has no `enabled` toggle of its own (the command is opt-in by virtue of being a
+  separate CLI subcommand) — declining leaves `ServeConfig::default()` values in place. New
+  `WizardState` fields for both, wired into `build_config()`. 2 new unit tests verifying
+  `build_config` output matches `SessionConfig`/`ServeConfig`'s own `Default` impls when the user
+  declines customization, and correctly applies overrides when they don't. Smoke-tested: `zeph
+  init` starts and reaches the first prompt without a compile or runtime crash (full interactive
+  drive-through of a wizard with ~40 prior steps was impractical to script; correctness of the
+  actual generated config is covered by the `build_config` unit tests, matching how every other
+  wizard step in this file is verified — individual `dialoguer` prompts aren't unit-tested
+  anywhere in this wizard, only their effect on the resulting `Config`).
+
+- `docs`: mdBook chapters for session persistence (spec-068, #5343) — the last P4 deliverable.
+  New `book/src/advanced/session-persistence.md` ("Session Persistence and Resume": the durable
+  JSONL event log, `SessionId`<->`ConversationId` bijection, `/conv`/`sessions` verbs, forking,
+  condensation, crash-safety invariants in plain language, legacy session lazy-bootstrap) and
+  `book/src/advanced/serve-mode.md` ("`zeph serve` — Persistent Agent Service": the REST+SSE API,
+  `SessionActor` isolation model, `serve.evict`, bearer-auth + the loopback-bind safety guard, and
+  the explicit `--acp` non-goal with a link to running ACP as a separate process). Both linked
+  from `book/src/SUMMARY.md` under "Advanced". Updated `book/src/reference/cli.md`'s `zeph
+  sessions` section (was still describing the old ACP-only, print-events-by-default behavior) with
+  the current verb set (`show`, `resume` [live agent by default, `--print` for the old behavior],
+  `fork`, `export`, `import`) plus new `zeph serve-sessions` and `/conv` entries. Updated
+  `book/src/reference/configuration.md` with `[session]`/`[session.condense]`/`[serve]` — also
+  fixed a pre-existing bug found while editing the adjacent block: `[session.provider_persistence]
+  enabled = true` was documented as a nested table, but `provider_persistence` is a plain `bool`
+  field directly on `[session]` in `zeph_config::SessionConfig`; corrected to
+  `[session] provider_persistence = true`. `mdbook build book/` succeeds with only a pre-existing,
+  unrelated warning in `changelog.md` (an unclosed HTML tag from an earlier entry, not touched by
+  this change). No `mdbook-linkcheck` preprocessor is configured, so all cross-reference links
+  added in the new/updated pages were verified manually against `SUMMARY.md`'s existing entries.
+
 - `test(mcp)`: add an in-process duplex-transport integration test for `McpClient` /
   `ToolListChangedHandler`, covering a full `initialize -> tools/list -> tools/call`
   round-trip through the real rmcp wire serialization path over `tokio::io::duplex`
@@ -51,6 +478,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `feat(cli)!`: `zeph sessions resume <id>` no longer dumps events to stdout by default (spec-068,
+  #5343) — it now launches a **live interactive agent** bound to that session's conversation,
+  replaying its JSONL event log to reconstruct history before accepting the next prompt (spec §10,
+  architect ruling D-6). Pass `--print` for the old dump behavior (now sourced from the JSONL
+  event log rather than the legacy `acp_session_events` table). Implementation: `Cli` gained a new
+  internal `resume_session_id` field; `runner::run` intercepts `Sessions{Resume{id, print: false}}`
+  before the one-shot command dispatch and falls through to the normal interactive bootstrap
+  (mirroring the existing `UrlOpen` dispatch precedent), then resolves `conversation_id` via
+  `SessionStore::get(id).conversation_id` instead of `latest_conversation_id()` at the single
+  point `runner.rs` resolves it — every downstream step (replay, hydrate, `SessionSink`,
+  continuation loop) was already wired for the interactive path in the P1 slice and needed no
+  changes. A session with no linked `conversation_id` (a legacy session with no recorded history)
+  errors with a message pointing at `--print`. Dead `resume_summary` (the interim hydration-summary
+  dump this replaces) removed.
 - `fix(a2a)!`: `A2aClient::with_security` no longer takes two positional bools (transposing
   `with_security(true, false)` vs. `with_security(false, true)` was a silent foot-gun). It now
   takes a `SecurityPolicy { require_tls, ssrf_protection }` struct, with `SecurityPolicy::hardened()`
@@ -72,6 +513,170 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(session)`: resume-time durable condensation (D-11) only fired on `/conv resume`, not on
+  the other three session-open paths — CLI `sessions resume`, ACP `spawn_acp_agent`, or `zeph
+  serve` reactivation (impl-critic re-verify finding N3, architect ruling D-13). The original
+  scope decision assumed those three sites had no live `Agent` to source a condenser/token
+  counter/budget from; that premise was wrong — `maybe_condense_on_resume` never took an `Agent`
+  parameter, and `condenser`/`context_window` are both resolvable from config + the provider
+  registry before agent construction at every site (the same "sounds harder than it is" pattern
+  as D-6/D-9). New `zeph_agent_persistence::hydrate_and_condense` centralizes
+  `hydrate_from_event_log` + `maybe_condense_on_resume` into one call so all four resume paths
+  share it instead of each carrying its own inline copy (same centralization principle as D-10).
+  New `resume_budget_fraction(messages, token_counter, window)` computes `budget_used_fraction`
+  without a live `Agent`; new `zeph_core::provider_factory::{resolve_named_provider,
+  build_resume_condenser}` resolve `[session.condense].condense_provider` and build the
+  `LlmCondenser` from config alone. CLI/ACP/`zeph serve` now all call `hydrate_and_condense`,
+  built once at deps-construction time for ACP/serve (`SharedAgentDeps::resume_condenser`,
+  `ServeAgentDeps::resume_condenser`) since their per-session code only receives pre-decomposed
+  config, not the raw `Config`. `/conv resume` itself was refactored onto the same shared call.
+  New end-to-end regression test drives `SessionSink::record_message` through
+  `hydrate_and_condense` and asserts both a `Condensation` event is appended and
+  `last_condensed_seq` advances; fails without the fix.
+- `chore(session)`: added `tracing::instrument` spans across the session-persistence subsystem
+  (`zeph-session`'s log/replay/condenser/store/fork operations, `zeph-agent-persistence`'s
+  hydrate/condense/reconcile/legacy-bootstrap/session-sink functions, `zeph-core`'s
+  `LiveSessionRegistry::get_or_reactivate`, and every `src/serve/handlers.rs` HTTP handler) —
+  the code-review pass on #5343 found the entire new subsystem had zero instrumentation despite
+  `.claude/rules/continuous-improvement.md`'s mandatory coverage requirement for I/O, DB, and LLM
+  round-trip paths. 33 spans added (`session.*`/`persistence.*`/`core.serve.*`/
+  `serve.handlers.*` naming), covering every fsync'd log append, `SessionStore` query, the
+  `LlmCondenser::condense` LLM round-trip, and each REST endpoint.
+- `fix(acp)`: `GET /sessions/{id}/messages` (the `acp-http` transport's own REST surface, distinct
+  from `zeph serve-sessions`) now reads the durable JSONL event log instead of the legacy
+  `acp_session_events` table — same bug class and fix shape as `do_load_session`/
+  `do_list_sessions` (S1), for the one legacy-table read S1 left out of scope pending
+  `session_data_dir` plumbing. No new config plumbing was actually needed: `AcpHttpState`
+  already carries the full `AcpServerConfig` (including `session_data_dir`) via its existing
+  `server_config` field, so the fix reads `state.server_config.session_data_dir` directly rather
+  than duplicating the field. New `session_event_envelope_to_dtos` maps each durable
+  `SessionEvent` to the endpoint's existing `SessionEventDto` shape (`user_message`/
+  `agent_message`/`tool_call`/`tool_result`, timestamps formatted to match the legacy column's
+  `datetime('now')` format for API-consumer compatibility). Fixed the same-class false-green
+  test this endpoint had (seeded the legacy table via the retired `save_acp_event` instead of
+  the JSONL log the handler now actually reads).
+- `fix(serve)`: close a durable-log corruption race in D-12's reactivation (impl-critic
+  re-verify finding N1, gated merge). `reactivate_session`'s check→hydrate→spawn→register
+  sequence was not atomic: two concurrent requests for the same evicted-but-durable session
+  (e.g. two `/prompt` calls, or a `/prompt` racing a `/events` subscribe) could both miss the
+  registry's fast-path `get`, both independently open and replay the *same* `SessionEventLog`,
+  and both spawn a live `SessionActor` writing to it — violating INV-D2 (single-writer) and
+  risking duplicate `seq` numbers or a non-trailing torn line, corrupting the durable log. New
+  `LiveSessionRegistry::get_or_reactivate` makes this atomic: a fast, lock-free path when the
+  session is already live, and a `tokio::sync::Mutex`-guarded double-checked-locking slow path
+  otherwise — the loser of a concurrent race never runs its `reactivate` closure at all, it just
+  observes the winner's `insert`. A genuine concurrency regression test (8 real `tokio::spawn`
+  tasks racing `get_or_reactivate` for the same id, each yielding inside its closure to force
+  real interleaving — not a sequential table-driven test) asserts exactly one reactivation runs;
+  it fails (`left: 8, right: 1`) without the fix. Live end-to-end verified with two genuinely
+  concurrent `curl` requests against a real evicted session: `GET /health` showed exactly one
+  live session afterward (not two), and the event log shows both prompts correctly serialized
+  through the single actor's mailbox with no duplicate or out-of-order `seq`.
+- `fix(session)`: durable resume-time condensation (D-11) could only ever fire once per session
+  (impl-critic re-verify finding N2). `LlmCondenser::condense` computed its boundaries over the
+  *full* event list passed in, not just the events after `last_condensed_seq` — so on any resume
+  after the first condensation, the caller's full-log re-pass made the proposed range start back
+  near `seq 0`, which `validate_non_overlap` correctly rejected as overlapping the (now
+  non-zero) watermark. `condense` now filters to `seq > last_condensed_seq` before computing
+  boundaries, so a session that stays over budget across many resumes keeps condensing instead
+  of silently falling back to per-turn live compaction after the first pass. New regression test
+  drives two condensations against a growing log (matching how `maybe_condense_on_resume` is
+  actually called on repeated resumes) and asserts the second succeeds with a range strictly
+  after the first's; fails with the exact `CondensationOverlap` error the bug produced in
+  production before the fix.
+- `fix(serve)`: `POST /sessions/:id/prompt` and `GET /sessions/:id/events` no longer return `404`
+  forever once a session's actor ends (idle eviction, explicit `DELETE`, or a process restart) —
+  they now reactivate it: look up the durable `acp_sessions` row, replay its event log via the
+  D-10 hydration pipeline, and spawn+register a fresh `SessionActor`, exactly as `POST /sessions`
+  does for a new one (architect ruling D-12, spec §9.3: "connect to absent session: replay → spawn
+  SessionActor → register → attach"). Before this, `[serve] session_idle_ttl_secs` eviction was a
+  one-way trip — a durably-intact session became permanently unpromptable over HTTP after its TTL,
+  contradicting `GET /sessions/:id`'s own documented claim that "the durable log allows it to be
+  resumed" (impl-critic finding S2). `build_agent_factory`/`SessionActor::spawn` now always route
+  through `hydrate_from_event_log` (a brand-new session's empty log makes this a no-op there), so
+  create and reactivate share one code path. Also fixed a gap this surfaced: `POST /sessions`
+  never linked the minted session to its `conversation_id` in `SessionStore` at all — reactivation
+  couldn't have found a conversation to replay for *any* serve-created session without it. Live
+  end-to-end verified: create → prompt (establish context) → `DELETE` (ends the live actor, keeps
+  the durable record) → prompt again → session reactivates and correctly recalls the earlier
+  context from the replayed log; the event log's `seq` continues (2, 3, ...) rather than
+  restarting, confirming the reactivated actor writes to the same durable log, not a fresh one.
+- `fix(serve)`: a session's `LiveSessionRegistry` entry could survive its actor's death forever
+  when no `serve.evict` TTL eviction ever ran for it (e.g. a lingering `GET /sessions/:id/events`
+  SSE subscriber, which `idle_candidates`' `receiver_count() == 0` check requires) — leaving
+  `POST /sessions/:id/prompt` returning `410 Gone` permanently for a session D-12 reactivation
+  should otherwise be able to recover (impl-critic finding M1). `SessionActor`'s coordinator now
+  reaps its own registry entry unconditionally once the dedicated thread signals completion,
+  regardless of cause (panic, normal exit, or supervisor shutdown) — via a new
+  `LiveSessionRegistry::remove_if_current`, not a plain key-based `remove`, so a stale coordinator
+  racing a concurrent D-12 reactivation under the same session id can never evict the *new* live
+  entry (verified by a dedicated regression test simulating exactly that race).
+- `fix(session)`: wire `zeph_session::LlmCondenser` into the `/conv resume` path — durable
+  resume-time condensation (#3102, spec §8.1) was fully built but never invoked from any
+  production call site, so `[session.condense]` config was dead and `last_condensed_seq` never
+  advanced (impl-critic finding S3). New `zeph_agent_persistence::maybe_condense_on_resume`
+  triggers `LlmCondenser` when the replayed context exceeds the configured budget threshold,
+  emitting a durable `Condensation` event and advancing the `INV-SP-4` non-overlap watermark
+  (architect ruling D-11). Also fixed the M2 fold-in this exposed: `SessionSink::record_compaction`
+  now also advances `last_condensed_seq`, so live in-memory compaction and durable condensation
+  share the same non-overlap ledger and cannot overlap each other's ranges. **Not yet wired** into
+  ACP or CLI resume — both happen during agent *construction*, before a live `Agent` (and its
+  `build_condense_deps`/`ContextBudget`/token counter) exists, an architectural asymmetry `/conv
+  resume` (a mid-session swap on an already-built agent) doesn't have; tracked as a follow-up.
+- `fix(session)`: `INV-SP-4`'s non-overlap check (`validate_non_overlap`) rejected the very first
+  condensation of every session — discovered only once `LlmCondenser` was actually invoked
+  end-to-end (previous entry). `acp_sessions.last_condensed_seq` defaults to `0` (migration 106),
+  which collided with `0` also being a valid real event `seq` (logs are 0-indexed), so any
+  proposed range starting at `seq == 0` — the *only* possible starting point for a session's first
+  condensation — was rejected as "overlapping the default". Fixed by treating
+  `last_condensed_seq == 0` as the "nothing condensed yet" sentinel; documented residual gap (a
+  condensation whose range happens to end at `seq == 0` is indistinguishable from "never
+  condensed", narrow enough in practice to defer a full `Option<u64>` schema fix).
+- `fix(session)!`: unify CLI `sessions resume`, `/conv resume`/`fork`, and ACP resume/load/fork
+  behind one shared hydration pipeline, `zeph_agent_persistence::hydrate_from_event_log`
+  (architect ruling D-10, spec-068 §12.3/§13). Previously each path had its own inline copy of
+  "legacy bootstrap → `ReplayEngine` fold → `SQLite` projection reconcile", and they had already
+  diverged: CLI `sessions resume` (`src/runner.rs`) never replayed the JSONL log or reconciled
+  the projection at all — it silently fell back to stale `SQLite` history only, breaking AC-1/
+  AC-2/AC-5 on the exact user-facing path AC-1 names (impl-critic finding C1). `/conv resume`/
+  `fork` (`crates/zeph-core/src/agent/context/assembly.rs`) replayed but never called
+  `reconcile_projection` (finding C2). Both now route through the same helper ACP already used,
+  so the three pipelines cannot silently diverge again. Live-verified: `sessions resume <id>`
+  correctly replays prior turns into the LLM context (confirmed via debug dump) and new turns
+  append to the resumed session's own `events.jsonl` at the correct `seq`, not a fresh log.
+  **Breaking**: `zeph_agent_persistence::reconcile_projection`'s signature drops its
+  `session_store: &SessionStore` parameter (no longer needed — see the `INV-SP-3` fix below).
+- `fix(session)`: `INV-SP-3` projection reconciliation (`reconcile_projection`) could never
+  actually detect the crash gap it exists to close. It compared the log's event count against
+  `acp_sessions.event_count` — but `SessionSink::record_message` advances that column
+  immediately after the durable log append, *before* the corresponding `SQLite` `messages` write
+  runs (INV-SP-1's log-first ordering), so `event_count` races ahead of `SQLite` on every single
+  turn, not just a crashed one. The gap-detection watermark now reads the real `SQLite` message
+  count (`SqliteStore::count_messages`) instead. Added a regression test
+  (`crash_after_session_sink_write_is_reconciled_on_resume`) that writes through the real
+  `SessionSink::record_message` primitive (not a raw log append) and confirms the `SQLite`
+  projection is rebuilt correctly on resume — this test failed before the fix, confirming the
+  bug was real and not just theoretical.
+- `fix(acp)`: `session/load` and `session/list` now replay a session's durable JSONL event log
+  (spec-068 §12.3) instead of the legacy `acp_session_events` table, which the P1 write cutover
+  (#5343) leaves permanently empty for every session created after it — an IDE loading a
+  post-cutover session previously saw an empty transcript, and `session/list`'s `message_count`
+  was always `0`. `do_load_session` now reads the session's `events.jsonl` via
+  `zeph_session::SessionEventLog` and maps each `SessionEvent` to the corresponding ACP
+  `SessionUpdate` (new pure helper `session_event_to_updates`, unit-tested directly).
+  `zeph_memory::store::acp_sessions::{list_acp_sessions, get_acp_session_info}` now read
+  `acp_sessions.event_count` (kept current by `SessionSink`/`SessionStore::update_seq`) instead
+  of a `COUNT(*)` subquery against the emptied table. Also fixed a related regression this
+  surfaced: `SessionStore::update_seq` never bumped `acp_sessions.updated_at` (previously done
+  only by an `AFTER INSERT ON acp_session_events` trigger that no longer fires post-cutover), so
+  `session/list`'s "ordered by last activity" silently degraded to "ordered by creation time" for
+  every post-cutover session — `update_seq` now sets `updated_at` explicitly via a new
+  `Dialect::NOW` cross-backend SQL fragment. The false-green test at
+  `crates/zeph-acp/src/transport/tests.rs` that asserted `message_count == 1` only because it
+  called the retired `save_acp_event` directly now drives the fixture through
+  `SessionStore::update_seq`, the real write primitive; a new integration test
+  (`load_session_succeeds_from_event_log_with_no_legacy_rows`) seeds only the JSONL log and
+  confirms `session/load` succeeds via the store-backed reconstruction path with zero legacy rows.
 - `fix(knowledge)`: `zeph knowledge ingest` no longer fails on a fresh Qdrant instance.
   `build_ingest_resources` now probes the embedding dimension and calls
   `QdrantOps::ensure_collection` for the documents collection before constructing the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8496,6 +8496,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -10245,6 +10246,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "toml_edit",
@@ -10257,6 +10259,8 @@ dependencies = [
  "uuid",
  "zeph-a2a",
  "zeph-acp",
+ "zeph-agent-context",
+ "zeph-agent-persistence",
  "zeph-bench",
  "zeph-channels",
  "zeph-common",
@@ -10275,6 +10279,7 @@ dependencies = [
  "zeph-plugins",
  "zeph-sanitizer",
  "zeph-scheduler",
+ "zeph-session",
  "zeph-skills",
  "zeph-subagent",
  "zeph-tools",
@@ -10351,6 +10356,7 @@ dependencies = [
  "zeph-llm",
  "zeph-mcp",
  "zeph-memory",
+ "zeph-session",
  "zeph-tools",
 ]
 
@@ -10398,14 +10404,17 @@ version = "0.21.4"
 dependencies = [
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "zeph-common",
  "zeph-config",
  "zeph-context",
+ "zeph-db",
  "zeph-llm",
  "zeph-memory",
+ "zeph-session",
 ]
 
 [[package]]
@@ -10627,6 +10636,7 @@ dependencies = [
  "zeph-orchestration",
  "zeph-plugins",
  "zeph-sanitizer",
+ "zeph-session",
  "zeph-skills",
  "zeph-subagent",
  "zeph-tools",
@@ -10973,6 +10983,23 @@ dependencies = [
  "zeph-config",
  "zeph-db",
  "zeph-durable",
+]
+
+[[package]]
+name = "zeph-session"
+version = "0.21.4"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "zeph-common",
+ "zeph-context",
+ "zeph-db",
+ "zeph-llm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.21.4" }
 zeph-plugins = { path = "crates/zeph-plugins", version = "0.21.4" }
 zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.21.4" }
 zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.21.4" }
+zeph-session = { path = "crates/zeph-session", default-features = false, version = "0.21.4" }
 zeph-skills = { path = "crates/zeph-skills", version = "0.21.4" }
 zeph-subagent = { path = "crates/zeph-subagent", version = "0.21.4" }
 zeph-tools = { path = "crates/zeph-tools", version = "0.21.4" }
@@ -209,9 +210,9 @@ readme = "README.md"
 default = ["scheduler", "sqlite"]
 
 # === Use-case bundles ===
-desktop = ["tui", "deep-link"]
+desktop = ["tui", "deep-link", "session"]
 ide     = ["acp", "acp-http"]
-server  = ["gateway", "a2a", "otel", "prometheus"]
+server  = ["gateway", "a2a", "otel", "prometheus", "session"]
 chat    = ["discord", "slack"]
 ml      = ["candle", "pdf"]
 full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "sandbox", "gonka", "cocoon", "sqlite", "testing"]
@@ -234,6 +235,11 @@ slack = ["zeph-channels/slack"]
 gateway = ["dep:zeph-gateway"]
 prometheus = ["gateway", "dep:prometheus-client", "zeph-gateway/prometheus"]
 scheduler = ["dep:zeph-scheduler", "dep:blake3", "dep:cron", "dep:schemars", "zeph-core/scheduler", "zeph-scheduler/daemon", "zeph-memory/scheduler"]
+# Session persistence, event-log replay, and `zeph serve` (spec-068, #5343). Independent of `acp`:
+# `acp` gates ACP protocol transports, `session` gates the persistence CLI verbs and `zeph serve`.
+# The `zeph-session` crate/agent-loop dual-write is always compiled and config-gated
+# (`[session] enabled`). `dep:axum` backs `zeph serve-sessions`'s HTTP/SSE API — see `src/serve/`.
+session = ["dep:axum", "dep:tokio-stream", "zeph-common/http-middleware"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
 pdf = ["zeph-memory/pdf"]
 profiling = [
@@ -267,6 +273,8 @@ sqlite = [
     "zeph-scheduler?/sqlite",
     "zeph-core/sqlite",
     "zeph-durable/sqlite",
+    "zeph-session/sqlite",
+    "zeph-agent-persistence/sqlite",
 ]
 postgres = [
     "zeph-db/postgres",
@@ -278,6 +286,8 @@ postgres = [
     "zeph-scheduler?/postgres",
     "zeph-core/postgres",
     "zeph-durable/postgres",
+    "zeph-session/postgres",
+    "zeph-agent-persistence/postgres",
 ]
 
 [dependencies]
@@ -310,6 +320,7 @@ sysinfo = { workspace = true, optional = true }
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-stream = { workspace = true, features = ["sync"], optional = true }
 tokio-util.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
@@ -322,6 +333,8 @@ url.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 zeph-a2a = { workspace = true, optional = true }
 zeph-acp = { workspace = true, optional = true }
+zeph-agent-context.workspace = true
+zeph-agent-persistence.workspace = true
 zeph-bench = { workspace = true, optional = true }
 zeph-channels.workspace = true
 zeph-common.workspace = true
@@ -340,6 +353,7 @@ zeph-orchestration.workspace = true
 zeph-plugins.workspace = true
 zeph-sanitizer.workspace = true
 zeph-scheduler = { workspace = true, optional = true }
+zeph-session.workspace = true
 zeph-skills.workspace = true
 zeph-subagent.workspace = true
 zeph-tools.workspace = true

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -69,6 +69,8 @@
 - [TUI Dashboard](advanced/tui.md)
 - [HTTP Gateway](advanced/gateway.md)
 - [Daemon & Scheduler](advanced/daemon.md)
+- [Session Persistence and Resume](advanced/session-persistence.md)
+- [zeph serve — Persistent Agent Service](advanced/serve-mode.md)
 - [Document Loaders](advanced/document-loaders.md)
 - [Observability & Cost](advanced/observability.md)
 - [Channels](advanced/channels.md)

--- a/book/src/advanced/serve-mode.md
+++ b/book/src/advanced/serve-mode.md
@@ -1,0 +1,108 @@
+# zeph serve — Persistent Agent Service
+
+`zeph serve-sessions` runs Zeph as a long-lived process exposing durable [conversation
+sessions](session-persistence.md) over an HTTP/SSE API — create sessions, stream responses, and
+manage them remotely without an interactive terminal.
+
+> **Naming note**: the command is `zeph serve-sessions`, not the bare `zeph serve` you might
+> expect. `zeph serve` already names the [scheduler's foreground daemon](daemon.md) — both
+> features can be enabled in the same build, so a second command claiming the same name wasn't
+> viable.
+
+```bash
+cargo build --release --features session
+zeph serve-sessions
+```
+
+## REST + SSE API
+
+All routes except `/health` operate on the same durable event log described in [Session
+Persistence and Resume](session-persistence.md) — a session created here can be resumed later via
+`/conv resume` or `zeph sessions resume` in any other channel, and vice versa.
+
+| Method & Path | Purpose |
+|---|---|
+| `GET /health` | Unauthenticated liveness check — status, uptime, live session count |
+| `POST /sessions` | Create a session |
+| `GET /sessions` | List live session ids |
+| `GET /sessions/:id` | Durable metadata + live status (works even for a session whose actor has ended — it's still resumable) |
+| `DELETE /sessions/:id` | End a live session |
+| `POST /sessions/:id/prompt` | Submit a prompt (fire-and-forget; `202 Accepted` once queued) |
+| `GET /sessions/:id/events` | Server-Sent Events stream of the session's output (tokens, tool calls, tool results, turn completion) |
+| `POST /sessions/:id/fork` | Eager-copy the session into a fresh child, which becomes immediately usable |
+
+```bash
+# Create a session and stream its output
+SID=$(curl -s -X POST http://127.0.0.1:8420/sessions | jq -r .session_id)
+curl -N "http://127.0.0.1:8420/sessions/$SID/events" &
+curl -X POST "http://127.0.0.1:8420/sessions/$SID/prompt" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Summarize this repository."}'
+```
+
+## Session Actors
+
+Each live session runs as an independent `SessionActor` — the agent that owns it runs on a
+dedicated OS thread with its own async runtime, isolated from every other session and from the
+HTTP server's own request-handling. Multiple SSE clients (or an SSE client and a TUI attaching to
+the same session) can subscribe to one session's output concurrently; a subscriber that falls
+behind has its own missed events dropped, never the connection — the durable log is always there
+to catch up from.
+
+## Idle Eviction
+
+A background task (`serve.evict`) periodically scans for sessions with no attached output
+subscribers whose activity has gone stale past `session_idle_ttl_secs`, and ends them —
+freeing the OS thread and in-memory state. The session itself isn't deleted: its durable log
+remains on disk and it can be resumed again later (via this API, `/conv resume`, or `zeph
+sessions resume`), which spins up a fresh `SessionActor` and replays the log.
+
+## Authentication
+
+`/sessions*` routes can execute shell, file, and web tools on behalf of any caller that reaches
+the port — treat this API with the same care as a shell. Bearer-token authentication is
+controlled by `require_auth` (`true` by default) and `auth_token_vault_key`: the token itself is
+never written to `config.toml` — only the *name* of the vault key it's resolved from at startup.
+
+```bash
+zeph vault set ZEPH_SERVE_AUTH_TOKEN "$(openssl rand -hex 32)"
+```
+
+If `require_auth = true` but no token can be resolved from the configured vault key, `zeph
+serve-sessions` refuses to bind any address other than loopback — an unauthenticated API on a
+non-loopback address is a real risk, not a warning to skip past. Set `require_auth = false` only
+on a network you fully trust.
+
+## `--acp`
+
+The `--acp` flag does **not** run the ACP protocol transport in the same process as
+`zeph serve-sessions` — combining them would mean two independent database connection pools
+writing the same session-store file concurrently. Run ACP separately instead:
+
+```bash
+zeph serve-sessions &
+zeph --acp        # or --acp-http, in a second process
+```
+
+Both processes share the same durable event logs on disk (via `[session] data_dir`), so sessions
+created in one are visible and resumable from the other.
+
+## Configuration
+
+```toml
+[serve]
+http_addr = "127.0.0.1:8420"              # bind address
+require_auth = true                        # require a bearer token on /sessions* (not /health)
+auth_token_vault_key = "ZEPH_SERVE_AUTH_TOKEN"  # vault key name to resolve the token from
+max_sessions = 50                          # maximum concurrent live sessions
+session_idle_ttl_secs = 1800               # idle eviction TTL (30 minutes)
+max_queued_prompts = 8                     # per-session prompt mailbox capacity
+```
+
+## See Also
+
+- [Session Persistence and Resume](session-persistence.md) — the durable event log every session
+  here is backed by.
+- [Daemon and Scheduler](daemon.md) — `zeph serve` (the scheduler's foreground daemon, a
+  different command).
+- [ACP (Agent Client Protocol)](acp.md) — the transport `--acp` runs as a separate process.

--- a/book/src/advanced/session-persistence.md
+++ b/book/src/advanced/session-persistence.md
@@ -1,0 +1,140 @@
+# Session Persistence and Resume
+
+Every conversation-session in Zeph (CLI, TUI, Telegram, Discord, Slack, ACP, or `zeph
+serve-sessions`) can maintain a durable, replayable event log — a crash-safe, forkable record of
+everything that happened in that session, independent of the `SQLite` `messages` table used for
+search and recall.
+
+## Why a Separate Event Log?
+
+The existing `SQLite` `messages` projection is optimized for semantic search and context
+assembly, not for exact replay. It doesn't capture tool-call/result pairing precisely enough to
+reconstruct a conversation byte-for-byte after a crash, and it has no concept of "this session was
+forked from that one at this exact point."
+
+The event log (`zeph-session` crate) exists specifically to answer: *what exactly happened in this
+session, in order, and can I replay it deterministically?*
+
+## The Event Log
+
+Each session writes to its own append-only JSONL file:
+
+```text
+<data_dir>/sessions/<session_id>/events.jsonl
+```
+
+Every line is one `SessionEvent` — `SessionStarted`, `UserMessage`, `AssistantMessage`,
+`ToolCall`, `ToolResult`, `Condensation`, `Compaction`, or `ForkPoint` — tagged with a sequence
+number (`seq`), a timestamp, and (for tool events) a turn ID. The log is the source of truth;
+the `SQLite` projection is reconciled from it, not the other way around.
+
+**Crash safety**: an event is durably appended and flushed *before* the corresponding `SQLite`
+write happens, never after. If the process crashes between the two, the log is ahead — on next
+open, a torn trailing write (partial JSON from a crash mid-append) is detected and truncated
+cleanly rather than causing a parse error, and the `SQLite` projection is reconciled forward from
+the log to catch up.
+
+## `SessionId` and `ConversationId`
+
+Every session has a `SessionId` (a UUID string) linked one-to-one with a `ConversationId` (the
+existing `SQLite` conversation primary key). Looking up a session by id resolves its linked
+conversation, and vice versa — this bijection is what lets `/conv resume`/`/conv fork` swap the
+active conversation on a running agent without losing the connection between the durable log and
+the searchable `SQLite` history.
+
+## Browsing and Resuming Sessions
+
+### `/conv` — In-Conversation Slash Command
+
+```text
+/conv list                  # table of all sessions: id, title, status, event count, updated
+/conv show <id>             # one session's metadata
+/conv resume <id>           # swap the CURRENT conversation onto <id>, replaying its history
+/conv fork <id>             # copy <id> into a fresh session, then swap onto the copy
+```
+
+`/conv` is a channel-agnostic slash command — it works identically whether typed in the CLI, the
+TUI, or a chat channel, because it's implemented once against the shared `AgentAccess` interface
+rather than per-channel.
+
+`/conv resume` and `/conv fork` perform a **live, mid-session swap**: the agent's message history,
+active `ConversationId`, and durable-log target all switch to the resumed/forked session between
+turns — no restart required. In the TUI, a "Replaying conversation…" status indicator shows while
+the swap is in progress.
+
+### `zeph sessions` — CLI Subcommand
+
+```bash
+zeph sessions list                      # table of all sessions
+zeph sessions show <id> [--events]      # metadata, or full event-log dump with --events
+zeph sessions resume <id>               # launch a live interactive agent bound to <id>
+zeph sessions resume <id> --print       # dump events to stdout instead (no agent started)
+zeph sessions fork <id> [--at N]        # eager-copy <id> into a fresh session
+zeph sessions export <id> <path>        # write the event log to a file
+zeph sessions import <path>             # load an exported event log as a new session
+```
+
+## Forking
+
+Forking eager-copies a session's event log up to a cut point (`--at N`, or the full log by
+default) into a fresh session with its own id:
+
+- The child's log opens with a `SessionStarted` event recording `forked_from: (parent_id, seq)`.
+- The parent's log gets a non-destructive `ForkPoint` provenance record — forking never mutates
+  the parent's own history.
+- The child gets its own `ConversationId`, independent of the parent.
+
+A session can only be forked at a point *within its own logged history* — old sessions predating
+event-log persistence (see [Legacy Sessions](#legacy-sessions) below) can only be forked at the
+import boundary, not at an arbitrary historical point, since granular tool-call replay isn't
+available before that boundary.
+
+## Condensation
+
+Distinct from live, in-memory context compaction (see [Context
+Budgets](../concepts/context-budgets.md)), *condensation* operates at the event-log level: when a
+session's durable history grows large, a `Condenser` (the default implementation,
+`LlmCondenser`, reuses the same summarization pipeline as in-memory compaction) replaces a range
+of events with a single `Condensation` event carrying a structured summary. Replay folds a
+`Condensation` event into one system message representing everything it replaced — a later
+condensation is guaranteed not to overlap an earlier one's replaced range.
+
+## Legacy Sessions
+
+Installs upgrading from before session persistence existed have `SQLite` message history for
+conversations with no event log at all. That history is **not** retroactively synthesized into a
+full log — tool-call/result pairing isn't recoverable from the old projection, so any attempt
+would be lossy and potentially misleading.
+
+Instead, the first time such a session is resumed (via `/conv resume`, `zeph sessions resume`, or
+an ACP client reconnecting), Zeph writes a `SessionStarted` header plus a single event
+summarizing "this session had N prior messages before durable logging existed," then proceeds
+normally — every turn after that point is logged in full detail. A session bootstrapped this way
+can be forked and replayed from that import boundary onward, just not from before it.
+
+## Configuration
+
+```toml
+[session]
+enabled = true               # maintain a durable event log per session (default: true)
+data_dir = ".zeph/sessions"  # directory under which event logs are stored
+encrypt = false               # opt-in AEAD encryption — reserved, not yet implemented
+max_event_log_mb = 256        # size guard that triggers condensation
+
+[session.condense]
+condense_provider = "fast"    # provider name from [[llm.providers]]; empty = primary provider
+threshold = 0.85               # fraction of context budget that triggers condensation
+keep_recent = 20               # minimum recent events preserved after condensation
+```
+
+When `[session] enabled = false`, only the `SQLite` `messages` projection is written — the
+pre-session-persistence behavior. `encrypt` is a placeholder for a future AEAD implementation; the
+current protection for event-log files is OS file permissions (`0o600` on Unix).
+
+## See Also
+
+- [`zeph serve` — Persistent Agent Service](serve-mode.md) — exposes durable sessions over
+  HTTP/SSE, backed by the same event log described here.
+- [Migrate Config](../guides/migrate-config.md) — `--migrate-config` adds `[session]`/`[serve]`
+  sections to existing config files.
+- [CLI Reference](../reference/cli.md) — full `zeph sessions` and `/conv` syntax.

--- a/book/src/reference/cli.md
+++ b/book/src/reference/cli.md
@@ -462,19 +462,43 @@ Model files are cached in `~/.cache/huggingface/hub/`. Run this before starting 
 
 ### `zeph sessions`
 
-Manage ACP session history. Requires the `acp` feature.
+Manage durable conversation-session event logs (see [Session Persistence and
+Resume](../advanced/session-persistence.md)). Requires the `session` or `acp` feature.
 
 | Subcommand | Description |
 |------------|-------------|
-| `sessions list` | List recent ACP sessions with ID, timestamp, and turn count |
-| `sessions resume <ID>` | Print all events from a past session to stdout |
-| `sessions delete <ID>` | Delete a session and its events from the database |
+| `sessions list` | List sessions — ID, title, status, event count, last updated |
+| `sessions show <ID> [--events]` | Session metadata, or the full event-log dump with `--events` |
+| `sessions resume <ID>` | Launch a live interactive agent bound to `<ID>`, replaying its history |
+| `sessions resume <ID> --print` | Print all events from the session to stdout instead (no agent started; matches the pre-session-persistence `resume` behavior) |
+| `sessions fork <ID> [--at N]` | Eager-copy the session into a fresh one, optionally cut at event `N` |
+| `sessions export <ID> <path>` | Write the session's event log to a file |
+| `sessions import <path>` | Load an exported event log as a new session |
+| `sessions delete <ID>` | Delete a session and its event log |
 
 ```bash
 zeph sessions list
-zeph sessions resume abc123
+zeph sessions show abc123 --events
+zeph sessions resume abc123               # live interactive agent
+zeph sessions resume abc123 --print       # dump events, no agent
+zeph sessions fork abc123 --at 40
+zeph sessions export abc123 backup.jsonl
+zeph sessions import backup.jsonl
 zeph sessions delete abc123
 ```
+
+### `zeph serve-sessions`
+
+Run Zeph as a long-lived process exposing durable sessions over HTTP/SSE. See [zeph serve —
+Persistent Agent Service](../advanced/serve-mode.md) for the full REST API. Requires the
+`session` feature.
+
+```bash
+zeph serve-sessions [--http-addr ADDR] [--max-sessions N]
+```
+
+`--acp` is not supported here — it errors with guidance to run `zeph --acp` (or `--acp-http`) as
+a separate process instead of combining transports in one process.
 
 ## Interactive Commands
 
@@ -650,6 +674,26 @@ Generate an on-demand summary of the current conversation. Useful for understand
 ```
 
 Configuration: Set `[session.recap]` in your config to control which LLM provider and whether to auto-recap on session resume.
+
+### `/conv`
+
+Browse, resume, or fork durable conversation-sessions (see [Session Persistence and
+Resume](../advanced/session-persistence.md)). Works identically in the CLI, TUI, and chat
+channels.
+
+| Subcommand | Description |
+|------------|-------------|
+| `/conv` or `/conv list` | List sessions — ID, title, status, event count, last updated |
+| `/conv show <id>` | One session's metadata |
+| `/conv resume <id>` | Live-swap the current conversation onto `<id>`, replaying its history |
+| `/conv fork <id>` | Eager-copy `<id>` into a fresh session, then swap onto the copy |
+
+```bash
+> /conv list
+> /conv show abc123
+> /conv resume abc123
+> /conv fork abc123
+```
 
 ## Global Options
 

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -463,15 +463,36 @@ edge_history_limit = 100               # Max historical edge versions per source
 # contradiction_risk_threshold = 0.7           # Graph edge conflict risk (default: 0.7)
 # Fail-open contract: embed/LLM/graph errors yield neutral defaults. Requires graph memory for contradiction scoring.
 
+[session]
+# Durable, replayable event log per conversation-session — see "Session Persistence and Resume"
+# in the mdBook guide (advanced/session-persistence.md).
+enabled = true                 # Maintain a durable JSONL event log per session (default: true)
+data_dir = ".zeph/sessions"    # Directory under which per-session event logs are stored
+encrypt = false                # Opt-in AEAD encryption — reserved, not yet implemented (default: false)
+max_event_log_mb = 256         # Event-log size (MB) that triggers condensation (default: 256)
+provider_persistence = true    # Persist channel-level provider overrides across restarts (default: true)
+persist_provider_overrides = true  # Store reasoning_effort per session; requires provider_persistence (default: true)
+
+[session.condense]
+# condense_provider = ""       # Provider name from [[llm.providers]] for condensation; empty = primary (default: "fast")
+threshold = 0.85               # Fraction of the context budget that triggers condensation (default: 0.85)
+keep_recent = 20               # Minimum recent events preserved after condensation (default: 20)
+
 [session.recap]
 on_resume = true              # Auto-generate recap when resuming a stored conversation (default: true)
 # recap_provider = ""           # Provider name for recap generation; empty = primary provider (default: "")
 max_tokens = 500              # Max tokens for the recap summary (default: 500)
 max_input_messages = 50       # Max messages included in recap context (default: 50)
 
-[session.provider_persistence]
-enabled = true                # Persist channel-level provider overrides across restarts (default: true)
-# persist_provider_overrides = true  # Store reasoning_effort per session (default: true)
+[serve]
+# Settings for `zeph serve-sessions` — see advanced/serve-mode.md. Independent of whether you
+# ever run the command; only takes effect when you do.
+http_addr = "127.0.0.1:8420"              # Bind address for the HTTP/SSE API (default)
+require_auth = true                        # Require a bearer token on /sessions* (/health is always open) (default: true)
+auth_token_vault_key = "ZEPH_SERVE_AUTH_TOKEN"  # Vault key name to resolve the bearer token from (default)
+max_sessions = 50                          # Maximum concurrent live sessions (default: 50)
+session_idle_ttl_secs = 1800               # Idle session eviction TTL in seconds (default: 1800 = 30 min)
+max_queued_prompts = 8                     # Per-session prompt mailbox capacity (default: 8)
 
 [tools]
 enabled = true

--- a/config/default.toml
+++ b/config/default.toml
@@ -1462,6 +1462,18 @@ autonomous_turn_delay_ms = 500
 # Set to false to always start with the configured primary provider.
 provider_persistence = true
 
+# Maintain a durable, replayable JSONL event log per conversation-session (spec-068, #5343).
+# When true (default), every channel mints a session id on first turn and appends events to
+# <data_dir>/sessions/<session_id>/events.jsonl — the source of truth for crash-safe resume
+# and fork. When false, only the SQLite `messages` projection is written (pre-#5343 behavior).
+# enabled = true
+# Directory for per-session event logs; default is a sibling of memory.sqlite_path's parent.
+# data_dir = ".zeph/sessions"
+# Opt-in AEAD encryption of session event logs (deferred to a post-MVP implementation).
+# encrypt = false
+# Event-log size (MB) that guards a rotate/condense trigger.
+# max_event_log_mb = 256
+
 # [session.recap] — session recap on resume (#3064)
 # [session.recap]
 # Show a recap of the previous session when resuming a conversation (requires a persisted digest)
@@ -1472,6 +1484,30 @@ provider_persistence = true
 # provider = ""
 # Maximum recent messages included for fresh-generation path (no cached digest)
 # max_input_messages = 20
+
+# [session.condense] — durable context condensation policy (spec-068 §8, #5343)
+# [session.condense]
+# Provider name from [[llm.providers]] for condensation calls; empty = primary provider
+# condense_provider = "fast"
+# Fraction of the context budget that triggers condensation on resume/mid-session
+# threshold = 0.85
+# Minimum recent events preserved after condensation
+# keep_recent = 20
+
+# [serve] — `zeph serve` persistent agent service (spec-068 §9, #5343)
+# [serve]
+# HTTP/SSE API bind address
+# http_addr = "127.0.0.1:8420"
+# Require a bearer token on /sessions* endpoints (/health is always unauthenticated)
+# require_auth = true
+# Zeph age-vault key name to resolve the bearer token from at startup
+# auth_token_vault_key = "ZEPH_SERVE_AUTH_TOKEN"
+# Maximum number of concurrent live sessions LiveSessionRegistry will hold
+# max_sessions = 50
+# Seconds of no attached broadcast receivers before an idle SessionActor is evicted
+# session_idle_ttl_secs = 1800
+# Bounded mpsc capacity for a SessionActor's prompt mailbox; full mailbox -> HTTP 429
+# max_queued_prompts = 8
 
 # ── Lifecycle hooks ────────────────────────────────────────────────────────────
 # Hooks fire at named lifecycle points. Each hook specifies an action (shell

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -24,8 +24,8 @@ default = [
 ]
 # `zeph-memory`/`zeph-db` require a backend to compile; default to `sqlite` so this crate
 # builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
-sqlite = ["zeph-memory/sqlite"]
-postgres = ["zeph-memory/postgres"]
+sqlite = ["zeph-memory/sqlite", "zeph-session/sqlite"]
+postgres = ["zeph-memory/postgres", "zeph-session/postgres"]
 acp-http = ["dep:axum", "dep:blake3", "dep:dashmap", "dep:async-stream", "dep:tower-http", "dep:subtle", "dep:tower", "zeph-common/deep-link"]
 # session/close and session/delete stabilized in acp 0.14.0; no upstream feature gate needed
 unstable-session-delete = []
@@ -82,6 +82,7 @@ zeph-core.workspace = true
 zeph-llm.workspace = true
 zeph-mcp.workspace = true
 zeph-memory.workspace = true
+zeph-session = { workspace = true, default-features = false }
 zeph-tools.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 

--- a/crates/zeph-acp/src/agent/helpers.rs
+++ b/crates/zeph-acp/src/agent/helpers.rs
@@ -9,46 +9,6 @@ use zeph_config::AcpTemperaturePreset;
 
 use zeph_core::LoopbackEvent;
 
-pub(super) fn content_chunk_text(chunk: &ContentChunk) -> String {
-    match &chunk.content {
-        ContentBlock::Text(t) => t.text.clone(),
-        _ => String::new(),
-    }
-}
-
-pub(super) fn session_update_to_event(update: &SessionUpdate) -> (&'static str, String) {
-    match update {
-        SessionUpdate::UserMessageChunk(c) => ("user_message", content_chunk_text(c)),
-        SessionUpdate::AgentMessageChunk(c) => ("agent_message", content_chunk_text(c)),
-        SessionUpdate::AgentThoughtChunk(c) => ("agent_thought", content_chunk_text(c)),
-        SessionUpdate::ToolCall(tc) => {
-            let payload = match serde_json::to_string(tc) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to serialize ToolCall for persistence");
-                    String::new()
-                }
-            };
-            ("tool_call", payload)
-        }
-        SessionUpdate::ToolCallUpdate(tcu) => {
-            let payload = match serde_json::to_string(tcu) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to serialize ToolCallUpdate for persistence");
-                    String::new()
-                }
-            };
-            ("tool_call_update", payload)
-        }
-        SessionUpdate::ConfigOptionUpdate(u) => {
-            let payload = serde_json::to_string(u).unwrap_or_default();
-            ("config_option_update", payload)
-        }
-        _ => ("unknown", String::new()),
-    }
-}
-
 /// Returns `true` if `text` looks like a raw tool-use marker that should not be
 /// forwarded to the IDE (e.g. `[tool_use: bash (toolu_abc123)]`).
 pub(super) fn is_tool_use_marker(text: &str) -> bool {

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -481,6 +481,9 @@ pub struct ZephAcpAgentState {
     max_sessions: usize,
     idle_timeout: std::time::Duration,
     pub(crate) store: Option<SqliteStore>,
+    /// Directory for durable per-session JSONL event logs (spec-068, #5343). `Some` when
+    /// `[session] enabled = true`; enables `ForkEngine`-based forking in `fork_conversation`.
+    pub(crate) session_data_dir: Option<std::path::PathBuf>,
     permission_file: Option<std::path::PathBuf>,
     /// IDE capabilities received during `initialize()`; used by `build_acp_context`.
     pub(crate) client_caps: RwLock<acp::schema::v1::ClientCapabilities>,
@@ -557,6 +560,7 @@ impl ZephAcpAgentState {
             max_sessions,
             idle_timeout: std::time::Duration::from_secs(session_idle_timeout_secs),
             store: None,
+            session_data_dir: None,
             permission_file,
             client_caps: RwLock::new(acp::schema::v1::ClientCapabilities::default()),
             provider_factory: None,
@@ -634,6 +638,13 @@ impl ZephAcpAgentState {
     #[must_use]
     pub fn with_store(mut self, store: SqliteStore) -> Self {
         self.store = Some(store);
+        self
+    }
+
+    /// Set the durable per-session JSONL event-log directory (spec-068, #5343).
+    #[must_use]
+    pub fn with_session_data_dir(mut self, data_dir: std::path::PathBuf) -> Self {
+        self.session_data_dir = Some(data_dir);
         self
     }
 
@@ -1441,20 +1452,15 @@ impl ZephAcpAgentState {
         Ok((entry.input_tx.clone(), rx))
     }
 
-    /// Fire-and-forget: persist `text` as a `user_message` ACP event for `session_id`.
-    fn persist_user_message_async(&self, session_id: &acp::schema::v1::SessionId, text: String) {
-        if let Some(ref store) = self.store {
-            let sid = session_id.to_string();
-            let store = store.clone();
-            // EXEMPT(#5144): short-lived independent DB write; many fire concurrently —
-            // unique-named supervisor entries would flood the registry with no lifecycle benefit.
-            tokio::spawn(async move {
-                if let Err(e) = store.save_acp_event(&sid, "user_message", &text).await {
-                    tracing::warn!(error = %e, "failed to persist user message");
-                }
-            });
-        }
-    }
+    // `persist_user_message_async` (an unsupervised fire-and-forget `tokio::spawn` writing
+    // `user_message` rows to `acp_session_events`, EXEMPT #5144) was retired here (spec-068
+    // P1, #5343): every ACP session's underlying `zeph_core::agent::Agent` now carries a
+    // `SessionSink` (wired in `spawn_acp_agent`, `src/acp.rs`), so the same user-message text
+    // is already durably appended to the session's JSONL event log — before the SQLite
+    // `messages` projection — by `Agent::persist_message`'s existing INV-SP-1 dual-write, the
+    // moment the prompt reaches the agent loop via `input_tx.send(...)` below. A second,
+    // unordered write to the legacy `acp_session_events` table would only reintroduce the
+    // double-write this cutover removes; `SessionSink` is the sole live writer.
 
     #[tracing::instrument(skip_all, name = "acp.handler.prompt", fields(session_id = %args.session_id))]
     pub(crate) async fn do_prompt(
@@ -1498,8 +1504,6 @@ impl ZephAcpAgentState {
                 "injection patterns detected in ACP prompt"
             );
         }
-
-        self.persist_user_message_async(&args.session_id, text.clone());
 
         input_tx
             .send(ChannelMessage {
@@ -1654,13 +1658,12 @@ impl ZephAcpAgentState {
             return Err(acp::Error::internal_error().data("session not found"));
         }
 
-        let events = store
-            .load_acp_events(&args.session_id.to_string())
-            .await
-            .map_err(|e| {
-                tracing::warn!(error = %e, session_id = %args.session_id, "failed to load ACP session events");
-                acp::Error::internal_error().data("internal error")
-            })?;
+        // spec-068 §12.3 / D-2: the legacy `acp_session_events` table is emptied by the write-path
+        // cutover — post-cutover sessions must replay from the durable JSONL event log instead
+        // (`self.session_data_dir`, wired the same way `do_fork_session` already reads it).
+        let events = self
+            .load_session_replay_events(&args.session_id.to_string())
+            .await;
 
         let session_cwd = args.cwd.clone();
         let conversation_id = resolve_conversation_id(store, &args.session_id).await;
@@ -2761,18 +2764,21 @@ impl ZephAcpAgentState {
                 None
             };
             for update in loopback_event_to_updates(event) {
-                if let Some(ref store) = self.store {
-                    let sid = session_id.to_string();
-                    let (event_type, payload) = session_update_to_event(&update);
-                    let store = store.clone();
-                    // EXEMPT(#5144): high-frequency per-event DB write; supervising each unique
-                    // task floods the registry — independent, short-lived, errors are logged.
-                    tokio::spawn(async move {
-                        if let Err(e) = store.save_acp_event(&sid, event_type, &payload).await {
-                            tracing::warn!(error = %e, "failed to persist session event");
-                        }
-                    });
-                }
+                // The unsupervised fire-and-forget `tokio::spawn` write to `acp_session_events`
+                // that used to live here (EXEMPT #5144) was retired (spec-068 P1, #5343):
+                // assistant/tool-call/tool-result content reaching the IDE via `update` here
+                // is the same content the underlying `Agent::persist_message` already durably
+                // appended to the session's JSONL event log via `SessionSink` (INV-SP-1,
+                // ordered ahead of the SQLite `messages` projection). `SessionSink` is now the
+                // sole live writer for conversation-history events.
+                //
+                // KNOWN GAP (tracked for the §12.3 read-handler thinning follow-up): finer-grained
+                // `SessionUpdate` variants that never reach `Agent::persist_message` at all
+                // (`agent_thought`, `tool_call_update` deltas, `config_option_update`) are no
+                // longer persisted anywhere. `do_load_session`'s `replay_session_events` call
+                // (which reads `load_acp_events`) still exists but has nothing new to replay for
+                // sessions created after this cutover, until it is migrated to
+                // `ReplayEngine::replay` alongside the other read handlers.
                 let notification =
                     acp::schema::v1::SessionNotification::new(session_id.clone(), update);
                 if let Err(e) = self.send_notification(session_id, notification).await {
@@ -2806,9 +2812,20 @@ impl ZephAcpAgentState {
 
     /// Create a forked conversation for `new_id` from `source_id`.
     ///
-    /// Copies ACP events and conversation history from the source session synchronously before
-    /// the agent loop is spawned to eliminate race conditions where the agent starts
-    /// `load_history()` before the copy completes.
+    /// Copies conversation history from the source session synchronously before the agent loop
+    /// is spawned to eliminate race conditions where the agent starts `load_history()` before the
+    /// copy completes.
+    ///
+    /// Session persistence (spec-068 P2, #5343): when `[session] enabled = true`
+    /// (`self.session_data_dir` is `Some`), also forks the durable JSONL event log via
+    /// [`zeph_session::ForkEngine::fork`] and links the new `SQLite` conversation to the
+    /// `acp_sessions` row `ForkEngine::fork` already created (via `record_fork`) — rather than
+    /// creating a second row. This retires the legacy `acp_session_events`
+    /// `import_acp_events`/`load_acp_events` copy for new forks: `zeph-acp` no longer needs a
+    /// second source of forked history once the JSONL log is the source of truth, matching the P1
+    /// write-path cutover's philosophy. When persistence is disabled, behavior is unchanged from
+    /// before spec-068 (`SQLite` `messages`/`conversations` copy only, `acp_sessions` row created
+    /// directly).
     #[allow(dead_code)]
     async fn fork_conversation(
         &self,
@@ -2818,19 +2835,25 @@ impl ZephAcpAgentState {
         let Some(s) = &self.store else {
             return Ok(None);
         };
-        let source_events = s
-            .load_acp_events(&source_id.to_string())
-            .await
-            .map_err(|e| {
-                tracing::warn!(error = %e, "failed to load ACP session events for fork");
-                acp::Error::internal_error().data("internal error")
-            })?;
-
         let new_id_str = new_id.to_string();
-        let pairs: Vec<(&str, &str)> = source_events
-            .iter()
-            .map(|ev| (ev.event_type.as_str(), ev.payload.as_str()))
-            .collect();
+
+        if let Some(ref data_dir) = self.session_data_dir {
+            let session_store = zeph_session::SessionStore::new(s.pool().clone());
+            if let Err(e) = zeph_session::ForkEngine::fork(
+                data_dir,
+                &source_id.to_string(),
+                &new_id_str,
+                None,
+                &session_store,
+            )
+            .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    "failed to fork session event log; SQLite-only fork continues"
+                );
+            }
+        }
 
         match s.create_conversation().await {
             Ok(forked_cid) => {
@@ -2838,14 +2861,23 @@ impl ZephAcpAgentState {
                     .get_acp_session_conversation_id(&source_id.to_string())
                     .await
                     .unwrap_or(None);
-                if let Err(e) = s
+                if self.session_data_dir.is_some() {
+                    // `ForkEngine::fork` above already created the `acp_sessions` row (via
+                    // `record_fork`) with `forked_from`/`forked_at_seq` set but no
+                    // `conversation_id` — link it now rather than attempting a second
+                    // (INSERT-IGNORE, silently-skipped) row creation.
+                    let session_store = zeph_session::SessionStore::new(s.pool().clone());
+                    if let Err(e) = session_store
+                        .link_conversation(&new_id_str, forked_cid.0)
+                        .await
+                    {
+                        tracing::warn!(error = %e, "failed to link conversation to forked session");
+                    }
+                } else if let Err(e) = s
                     .create_acp_session_with_conversation(&new_id_str, forked_cid)
                     .await
                 {
                     tracing::warn!(error = %e, "failed to persist forked ACP session mapping");
-                }
-                if let Err(e) = s.import_acp_events(&new_id_str, &pairs).await {
-                    tracing::warn!(error = %e, "failed to import events for forked session");
                 }
                 if let Some(src_cid) = forked_from_cid
                     && let Err(e) = s.copy_conversation(src_cid, forked_cid).await
@@ -2856,11 +2888,10 @@ impl ZephAcpAgentState {
             }
             Err(e) => {
                 tracing::warn!(error = %e, "failed to create conversation for forked session; history will not be copied");
-                if let Err(e2) = s.create_acp_session(&new_id_str).await {
+                if self.session_data_dir.is_none()
+                    && let Err(e2) = s.create_acp_session(&new_id_str).await
+                {
                     tracing::warn!(error = %e2, "failed to persist forked ACP session");
-                }
-                if let Err(e2) = s.import_acp_events(&new_id_str, &pairs).await {
-                    tracing::warn!(error = %e2, "failed to import events for forked session");
                 }
                 Ok(None)
             }
@@ -2991,44 +3022,46 @@ impl ZephAcpAgentState {
         }
     }
 
-    /// Replay stored `AcpSessionEvent` records as ACP notifications for the session.
+    /// Read a session's durable JSONL event log for ACP replay (spec-068 §12.3, D-2).
+    ///
+    /// Returns an empty `Vec` (logging a warning, never erroring the caller) when
+    /// `self.session_data_dir` is unset (`[session] enabled = false`) or the log can't be opened —
+    /// matching `replay_session_events`'s existing tolerance of missing/legacy history: a session
+    /// with no durable log still loads, it just has no client-visible replay.
+    async fn load_session_replay_events(
+        &self,
+        session_id: &str,
+    ) -> Vec<zeph_session::SessionEventEnvelope> {
+        let Some(ref data_dir) = self.session_data_dir else {
+            return Vec::new();
+        };
+        let session_path = zeph_session::session_dir(data_dir, session_id);
+        match zeph_session::SessionEventLog::open(&session_path).await {
+            Ok(log) => log.read_all().await.unwrap_or_else(|e| {
+                tracing::warn!(error = %e, session_id, "failed to read session event log for replay");
+                Vec::new()
+            }),
+            Err(e) => {
+                tracing::warn!(error = %e, session_id, "failed to open session event log for replay");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Replay a session's durable `SessionEvent` log as ACP notifications (spec-068 §12.3, D-2).
     async fn replay_session_events(
         &self,
         session_id: &acp::schema::v1::SessionId,
-        events: Vec<zeph_memory::store::AcpSessionEvent>,
+        events: Vec<zeph_session::SessionEventEnvelope>,
     ) {
-        for ev in events {
-            let update = match ev.event_type.as_str() {
-                "user_message" => acp::schema::v1::SessionUpdate::UserMessageChunk(
-                    acp::schema::v1::ContentChunk::new(ev.payload.into()),
-                ),
-                "agent_message" => acp::schema::v1::SessionUpdate::AgentMessageChunk(
-                    acp::schema::v1::ContentChunk::new(ev.payload.into()),
-                ),
-                "agent_thought" => acp::schema::v1::SessionUpdate::AgentThoughtChunk(
-                    acp::schema::v1::ContentChunk::new(ev.payload.into()),
-                ),
-                "tool_call" => match serde_json::from_str::<acp::schema::v1::ToolCall>(&ev.payload)
-                {
-                    Ok(tc) => acp::schema::v1::SessionUpdate::ToolCall(tc),
-                    Err(e) => {
-                        tracing::warn!(error = %e, "failed to deserialize tool call event during replay");
-                        continue;
-                    }
-                },
-                other => {
-                    tracing::debug!(
-                        event_type = other,
-                        "skipping unknown event type during replay"
-                    );
-                    continue;
+        for envelope in events {
+            for update in session_event_to_updates(envelope.kind) {
+                let notification =
+                    acp::schema::v1::SessionNotification::new(session_id.clone(), update);
+                if let Err(e) = self.send_notification(session_id, notification).await {
+                    tracing::warn!(error = %e, "failed to replay notification");
+                    return;
                 }
-            };
-            let notification =
-                acp::schema::v1::SessionNotification::new(session_id.clone(), update);
-            if let Err(e) = self.send_notification(session_id, notification).await {
-                tracing::warn!(error = %e, "failed to replay notification");
-                break;
             }
         }
     }
@@ -3134,6 +3167,75 @@ impl ZephAcpAgentState {
     }
 }
 
+/// Map one durable [`zeph_session::SessionEvent`] to the ACP `SessionUpdate`(s) it replays as
+/// (spec-068 §12.3, D-2's ACP read-handler cutover).
+///
+/// `SessionStarted`/`ForkPoint`/`Condensation`/`Compaction`/`ModelChanged`/`SessionEnded` are
+/// session-log bookkeeping, not turn content — they produce no client-visible notification.
+/// `ToolCall`/`ToolResult` are handled for schema completeness even though no production write
+/// path currently emits them (today, tool use/results are embedded as `MessagePart::ToolUse`/text
+/// inside `AssistantMessage`/`UserMessage` via `persist_message`).
+///
+/// Pure and side-effect-free so the event-to-notification mapping is unit-testable without the
+/// full `serve_connection` ACP harness — see `tests::session_event_to_updates_*` below.
+fn session_event_to_updates(
+    event: zeph_session::SessionEvent,
+) -> Vec<acp::schema::v1::SessionUpdate> {
+    match event {
+        zeph_session::SessionEvent::UserMessage { text, .. } => {
+            vec![acp::schema::v1::SessionUpdate::UserMessageChunk(
+                acp::schema::v1::ContentChunk::new(text.into()),
+            )]
+        }
+        zeph_session::SessionEvent::AssistantMessage { parts } => parts
+            .into_iter()
+            .filter_map(|part| match part {
+                zeph_llm::provider::MessagePart::ToolUse { id, name, input } => {
+                    Some(acp::schema::v1::SessionUpdate::ToolCall(
+                        acp::schema::v1::ToolCall::new(id, name).raw_input(input),
+                    ))
+                }
+                other => other.as_plain_text().map(|text| {
+                    acp::schema::v1::SessionUpdate::AgentMessageChunk(
+                        acp::schema::v1::ContentChunk::new(text.to_owned().into()),
+                    )
+                }),
+            })
+            .collect(),
+        zeph_session::SessionEvent::ToolCall { id, name, input } => {
+            vec![acp::schema::v1::SessionUpdate::ToolCall(
+                acp::schema::v1::ToolCall::new(id, name).raw_input(input),
+            )]
+        }
+        zeph_session::SessionEvent::ToolResult {
+            id,
+            output,
+            is_error,
+            ..
+        } => {
+            let status = if is_error {
+                acp::schema::v1::ToolCallStatus::Failed
+            } else {
+                acp::schema::v1::ToolCallStatus::Completed
+            };
+            vec![acp::schema::v1::SessionUpdate::ToolCallUpdate(
+                acp::schema::v1::ToolCallUpdate::new(
+                    id,
+                    acp::schema::v1::ToolCallUpdateFields::new()
+                        .status(status)
+                        .content(vec![output.into()]),
+                ),
+            )]
+        }
+        zeph_session::SessionEvent::SessionStarted { .. }
+        | zeph_session::SessionEvent::ForkPoint { .. }
+        | zeph_session::SessionEvent::Condensation { .. }
+        | zeph_session::SessionEvent::Compaction { .. }
+        | zeph_session::SessionEvent::ModelChanged { .. }
+        | zeph_session::SessionEvent::SessionEnded { .. } => Vec::new(),
+    }
+}
+
 /// Returns `true` when `trimmed_text` is an ACP-native slash command that should
 /// be handled by [`ZephAcpAgentState::handle_slash_command`] rather than forwarded
 /// to the agent loop.
@@ -3204,7 +3306,6 @@ pub(super) mod helpers;
 use helpers::{
     DEFAULT_MODE_ID, DIAGNOSTICS_MIME_TYPE, build_available_commands, build_config_options,
     build_mode_state, format_diagnostics_block, loopback_event_to_updates, mime_to_ext, model_meta,
-    session_update_to_event,
 };
 use zeph_common::text::xml_escape;
 
@@ -3540,6 +3641,146 @@ mod prompt_injection_detection_tests {
         assert_eq!(
             result.body, clean,
             "clean prompt must be returned unmodified"
+        );
+    }
+}
+
+/// Regression coverage for S1 (spec-068 §12.3 / D-2): `session_event_to_updates` is the mapping
+/// `do_load_session` now uses to replay the durable JSONL event log instead of the emptied
+/// `acp_session_events` table. Exercised directly (no ACP client/server harness needed) since the
+/// function is pure.
+#[cfg(test)]
+mod session_event_replay_tests {
+    use super::*;
+
+    #[test]
+    fn user_message_becomes_user_message_chunk() {
+        let updates = session_event_to_updates(zeph_session::SessionEvent::UserMessage {
+            text: "hello".to_owned(),
+            image_refs: Vec::new(),
+        });
+        assert_eq!(updates.len(), 1);
+        assert!(matches!(
+            updates[0],
+            acp::schema::v1::SessionUpdate::UserMessageChunk(_)
+        ));
+    }
+
+    #[test]
+    fn assistant_text_part_becomes_agent_message_chunk() {
+        let updates = session_event_to_updates(zeph_session::SessionEvent::AssistantMessage {
+            parts: vec![zeph_llm::provider::MessagePart::Text {
+                text: "hi there".to_owned(),
+            }],
+        });
+        assert_eq!(updates.len(), 1);
+        assert!(matches!(
+            updates[0],
+            acp::schema::v1::SessionUpdate::AgentMessageChunk(_)
+        ));
+    }
+
+    #[test]
+    fn assistant_tool_use_part_becomes_tool_call() {
+        let updates = session_event_to_updates(zeph_session::SessionEvent::AssistantMessage {
+            parts: vec![zeph_llm::provider::MessagePart::ToolUse {
+                id: "call_0".to_owned(),
+                name: "shell".to_owned(),
+                input: serde_json::json!({"cmd": "ls"}),
+            }],
+        });
+        assert_eq!(updates.len(), 1);
+        assert!(matches!(
+            updates[0],
+            acp::schema::v1::SessionUpdate::ToolCall(_)
+        ));
+    }
+
+    #[test]
+    fn assistant_message_maps_each_part_independently() {
+        let updates = session_event_to_updates(zeph_session::SessionEvent::AssistantMessage {
+            parts: vec![
+                zeph_llm::provider::MessagePart::ToolUse {
+                    id: "call_0".to_owned(),
+                    name: "shell".to_owned(),
+                    input: serde_json::json!({}),
+                },
+                zeph_llm::provider::MessagePart::Text {
+                    text: "done".to_owned(),
+                },
+            ],
+        });
+        assert_eq!(updates.len(), 2);
+        assert!(matches!(
+            updates[0],
+            acp::schema::v1::SessionUpdate::ToolCall(_)
+        ));
+        assert!(matches!(
+            updates[1],
+            acp::schema::v1::SessionUpdate::AgentMessageChunk(_)
+        ));
+    }
+
+    #[test]
+    fn tool_result_becomes_tool_call_update_with_status() {
+        let updates = session_event_to_updates(zeph_session::SessionEvent::ToolResult {
+            id: "call_0".to_owned(),
+            name: "shell".to_owned(),
+            output: "ok".to_owned(),
+            is_error: false,
+            duration_ms: 10,
+        });
+        assert_eq!(updates.len(), 1);
+        let acp::schema::v1::SessionUpdate::ToolCallUpdate(update) = &updates[0] else {
+            panic!("expected ToolCallUpdate");
+        };
+        assert_eq!(
+            update.fields.status,
+            Some(acp::schema::v1::ToolCallStatus::Completed)
+        );
+    }
+
+    #[test]
+    fn failed_tool_result_maps_to_failed_status() {
+        let updates = session_event_to_updates(zeph_session::SessionEvent::ToolResult {
+            id: "call_0".to_owned(),
+            name: "shell".to_owned(),
+            output: "boom".to_owned(),
+            is_error: true,
+            duration_ms: 10,
+        });
+        let acp::schema::v1::SessionUpdate::ToolCallUpdate(update) = &updates[0] else {
+            panic!("expected ToolCallUpdate");
+        };
+        assert_eq!(
+            update.fields.status,
+            Some(acp::schema::v1::ToolCallStatus::Failed)
+        );
+    }
+
+    #[test]
+    fn bookkeeping_events_produce_no_client_visible_update() {
+        assert!(
+            session_event_to_updates(zeph_session::SessionEvent::SessionStarted {
+                session_id: "s1".to_owned(),
+                cwd: "/tmp".to_owned(),
+                provider_name: "claude".to_owned(),
+                model: "opus".to_owned(),
+                forked_from: None,
+            })
+            .is_empty()
+        );
+        assert!(
+            session_event_to_updates(zeph_session::SessionEvent::ForkPoint {
+                new_session_id: "s2".to_owned(),
+            })
+            .is_empty()
+        );
+        assert!(
+            session_event_to_updates(zeph_session::SessionEvent::SessionEnded {
+                reason: "user_quit".to_owned(),
+            })
+            .is_empty()
         );
     }
 }

--- a/crates/zeph-acp/src/transport/http.rs
+++ b/crates/zeph-acp/src/transport/http.rs
@@ -564,6 +564,13 @@ pub async fn list_sessions_handler(
 
 /// `GET /sessions/{id}/messages` — retrieve all events for a persisted ACP session.
 ///
+/// Reads `session_id`'s durable JSONL event log (`state.server_config.session_data_dir`) instead
+/// of the legacy `acp_session_events` table (spec-068 §12.3 / D-2), which the P1 write cutover
+/// leaves permanently empty for every post-cutover session — same bug class and fix shape as
+/// `do_load_session`/`do_list_sessions` in `crates/zeph-acp/src/agent/mod.rs` (S1). Returns an
+/// empty array (not an error) when `[session] data_dir` isn't configured or the log can't be
+/// read — matching `do_load_session`'s replay tolerance of missing durable history.
+///
 /// # Errors
 ///
 /// Returns `503 Service Unavailable` if no `SQLite` store is configured.
@@ -593,18 +600,106 @@ pub async fn session_messages_handler(
         return Err(StatusCode::NOT_FOUND);
     }
 
-    let events = store.load_acp_events(&session_id).await.map_err(|e| {
-        tracing::warn!(error = %e, "failed to load ACP session events");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    let dtos: Vec<SessionEventDto> = events
-        .into_iter()
-        .map(|e| SessionEventDto {
-            event_type: e.event_type,
-            payload: e.payload,
-            created_at: e.created_at,
-        })
-        .collect();
+    let dtos = load_session_event_dtos(&state, &session_id).await;
     Ok(Json(dtos))
+}
+
+/// Read `session_id`'s durable event log and map each event to a [`SessionEventDto`] row.
+///
+/// Soft-fails to an empty `Vec` (logging a warning) when `session_data_dir` is unset or the log
+/// can't be opened/read — mirrors `crates/zeph-acp/src/agent/mod.rs`'s
+/// `load_session_replay_events` tolerance for the same scenario.
+#[cfg(feature = "acp-http")]
+async fn load_session_event_dtos(state: &AcpHttpState, session_id: &str) -> Vec<SessionEventDto> {
+    let Some(ref data_dir) = state.server_config.session_data_dir else {
+        return Vec::new();
+    };
+    let session_path = zeph_session::session_dir(data_dir, session_id);
+    let log = match zeph_session::SessionEventLog::open(&session_path).await {
+        Ok(log) => log,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to open session event log for HTTP messages endpoint");
+            return Vec::new();
+        }
+    };
+    let events = match log.read_all().await {
+        Ok(events) => events,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to read session event log for HTTP messages endpoint");
+            return Vec::new();
+        }
+    };
+    events
+        .into_iter()
+        .flat_map(session_event_envelope_to_dtos)
+        .collect()
+}
+
+/// Map one durable [`zeph_session::SessionEventEnvelope`] to the [`SessionEventDto`] row(s) it
+/// surfaces as. `SessionStarted`/`ForkPoint`/`Condensation`/`Compaction`/`ModelChanged`/
+/// `SessionEnded` are session-log bookkeeping, not turn content — they produce no row, matching
+/// `session_event_to_updates`'s equivalent bookkeeping carve-out for the ACP JSON-RPC path.
+#[cfg(feature = "acp-http")]
+fn session_event_envelope_to_dtos(
+    envelope: zeph_session::SessionEventEnvelope,
+) -> Vec<SessionEventDto> {
+    let created_at = chrono::DateTime::from_timestamp_millis(envelope.ts_ms).map_or_else(
+        || envelope.ts_ms.to_string(),
+        |dt| dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+    );
+    match envelope.kind {
+        zeph_session::SessionEvent::UserMessage { text, .. } => vec![SessionEventDto {
+            event_type: "user_message".to_owned(),
+            payload: text,
+            created_at,
+        }],
+        zeph_session::SessionEvent::AssistantMessage { parts } => parts
+            .into_iter()
+            .filter_map(|part| match part {
+                zeph_llm::provider::MessagePart::ToolUse { id, name, input } => {
+                    serde_json::to_string(&serde_json::json!({
+                        "id": id,
+                        "name": name,
+                        "input": input,
+                    }))
+                    .ok()
+                    .map(|payload| SessionEventDto {
+                        event_type: "tool_call".to_owned(),
+                        payload,
+                        created_at: created_at.clone(),
+                    })
+                }
+                other => other.as_plain_text().map(|text| SessionEventDto {
+                    event_type: "agent_message".to_owned(),
+                    payload: text.to_owned(),
+                    created_at: created_at.clone(),
+                }),
+            })
+            .collect(),
+        zeph_session::SessionEvent::ToolCall { id, name, input } => {
+            serde_json::to_string(&serde_json::json!({ "id": id, "name": name, "input": input }))
+                .ok()
+                .map(|payload| {
+                    vec![SessionEventDto {
+                        event_type: "tool_call".to_owned(),
+                        payload,
+                        created_at,
+                    }]
+                })
+                .unwrap_or_default()
+        }
+        zeph_session::SessionEvent::ToolResult { id, output, .. } => {
+            vec![SessionEventDto {
+                event_type: "tool_result".to_owned(),
+                payload: serde_json::json!({ "id": id, "output": output }).to_string(),
+                created_at,
+            }]
+        }
+        zeph_session::SessionEvent::SessionStarted { .. }
+        | zeph_session::SessionEvent::ForkPoint { .. }
+        | zeph_session::SessionEvent::Condensation { .. }
+        | zeph_session::SessionEvent::Compaction { .. }
+        | zeph_session::SessionEvent::ModelChanged { .. }
+        | zeph_session::SessionEvent::SessionEnded { .. } => Vec::new(),
+    }
 }

--- a/crates/zeph-acp/src/transport/mod.rs
+++ b/crates/zeph-acp/src/transport/mod.rs
@@ -118,6 +118,12 @@ pub struct AcpServerConfig {
     /// When set, the agent persists session events and loads conversation history
     /// from this database. When `None`, sessions are in-memory only.
     pub sqlite_path: Option<String>,
+    /// Directory for durable per-session JSONL event logs (spec-068, #5343).
+    ///
+    /// `Some` when `[session] enabled = true`; enables `ForkEngine`-based session forking in
+    /// `do_fork_session`. `None` (the default when `[session] enabled = false`) falls back to the
+    /// pre-#5343 `SQLite`-only fork path (`messages`/`conversations` copy, no JSONL log).
+    pub session_data_dir: Option<std::path::PathBuf>,
     /// Optional startup notification emitted as the first stdio JSON-RPC frame.
     pub ready_notification: Option<ReadyNotification>,
     /// Canonicalized allowlist of directories ACP clients may reference in session requests.
@@ -150,6 +156,7 @@ impl Clone for AcpServerConfig {
             title_max_chars: self.title_max_chars,
             max_history: self.max_history,
             sqlite_path: self.sqlite_path.clone(),
+            session_data_dir: self.session_data_dir.clone(),
             ready_notification: self.ready_notification.clone(),
             additional_directories: self.additional_directories.clone(),
             auth_methods: self.auth_methods.clone(),
@@ -178,6 +185,7 @@ impl Default for AcpServerConfig {
             title_max_chars: 60,
             max_history: 100,
             sqlite_path: None,
+            session_data_dir: None,
             ready_notification: None,
             additional_directories: Vec::new(),
             auth_methods: vec![zeph_core::config::AcpAuthMethod::Agent],

--- a/crates/zeph-acp/src/transport/stdio.rs
+++ b/crates/zeph-acp/src/transport/stdio.rs
@@ -91,6 +91,9 @@ pub(crate) async fn build_agent_state(
             Err(e) => tracing::warn!(error = %e, "failed to open ACP SQLite store"),
         }
     }
+    if let Some(data_dir) = server_config.session_data_dir {
+        agent = agent.with_session_data_dir(data_dir);
+    }
     if let Some(factory) = server_config.provider_factory {
         agent = agent.with_provider_factory(factory, server_config.available_models);
     }

--- a/crates/zeph-acp/src/transport/tests.rs
+++ b/crates/zeph-acp/src/transport/tests.rs
@@ -56,6 +56,33 @@ fn test_state() -> AcpHttpState {
     .with_ready(true)
 }
 
+fn test_state_with_session_data_dir(data_dir: std::path::PathBuf) -> AcpHttpState {
+    AcpHttpState::new(
+        noop_spawner(),
+        AcpServerConfig {
+            agent_name: "test".into(),
+            agent_version: "0.0.1".into(),
+            max_sessions: 4,
+            session_idle_timeout_secs: 1800,
+            permission_file: None,
+            provider_factory: None,
+            available_models: shared_models(vec![]),
+            mcp_manager: None,
+            auth_bearer_token: None,
+            discovery_enabled: true,
+            terminal_timeout_secs: 120,
+            project_rules: vec![],
+            title_max_chars: 60,
+            max_history: 100,
+            sqlite_path: None,
+            session_data_dir: Some(data_dir),
+            ready_notification: None,
+            ..Default::default()
+        },
+    )
+    .with_ready(true)
+}
+
 fn state_with_max_sessions(max: usize) -> AcpHttpState {
     AcpHttpState::new(
         noop_spawner(),
@@ -810,10 +837,13 @@ async fn list_sessions_returns_session_data() {
         .await
         .expect("SqliteStore::new");
     store.create_acp_session("sess-1").await.unwrap();
-    store
-        .save_acp_event("sess-1", "user", "hello")
-        .await
-        .unwrap();
+    // Regression guard for the S1 false-green (spec-068 §12.3 / D-2): `list_acp_sessions`
+    // now derives `message_count` from `acp_sessions.event_count`, so the fixture must drive
+    // it through `zeph_session::SessionStore::update_seq` — the same primitive
+    // `SessionSink::record_message` calls in production — not the retired `save_acp_event`,
+    // which only ever populated the now-permanently-empty `acp_session_events` table.
+    let session_store = zeph_session::SessionStore::new(store.pool().clone());
+    session_store.update_seq("sess-1", 0, 1).await.unwrap();
     store
         .update_session_title("sess-1", "Test Session")
         .await
@@ -901,12 +931,28 @@ async fn session_messages_returns_events_for_known_session() {
         .expect("SqliteStore::new");
     let session_id = "00000000-0000-0000-0000-000000000001";
     store.create_acp_session(session_id).await.unwrap();
-    store
-        .save_acp_event(session_id, "user_message", "hello")
+
+    // Regression guard for the S1-class false-green: message_messages_handler now reads the
+    // durable JSONL event log (spec-068 §12.3 / D-2), not the legacy acp_session_events table —
+    // seed the log directly instead of the retired save_acp_event write path.
+    let dir = tempfile::tempdir().unwrap();
+    let session_path = zeph_session::session_dir(dir.path(), session_id);
+    let log = zeph_session::SessionEventLog::open(&session_path)
         .await
         .unwrap();
+    log.append(
+        None,
+        None,
+        zeph_session::SessionEvent::UserMessage {
+            text: "hello".to_owned(),
+            image_refs: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    drop(log);
 
-    let state = test_state().with_store(store);
+    let state = test_state_with_session_data_dir(dir.path().to_path_buf()).with_store(store);
     let router = acp_router(state);
 
     let req = Request::builder()

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -815,6 +815,128 @@ async fn fork_session_creates_distinct_session_id() {
         .await;
 }
 
+/// `session/fork` copies the source session's durable JSONL event log into a new,
+/// self-contained child log when `[session] enabled = true` (spec-068 P2, #5343).
+///
+/// The mock spawner used by this test harness never runs a real `zeph_core::Agent` (that only
+/// happens in the root binary's `spawn_acp_agent`), so it cannot generate turns through the
+/// normal `SessionSink` path. Instead this test seeds the source session's `events.jsonl`
+/// directly via `zeph_session::SessionEventLog`, exercising exactly the `fork_conversation` /
+/// `ForkEngine::fork` wiring under test without needing the full agent-loop integration.
+#[cfg(feature = "unstable-session-fork")]
+#[tokio::test(flavor = "current_thread")]
+async fn fork_session_copies_event_log_when_persistence_enabled() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let db_dir = tempfile::tempdir().expect("failed to create temp db dir");
+            let sqlite_path = db_dir
+                .path()
+                .join("acp-fork-test.db")
+                .to_string_lossy()
+                .into_owned();
+            let session_data_dir = db_dir.path().join("sessions");
+
+            let (sw, sr, cw, cr) = duplex_pair();
+            let config = AcpServerConfig {
+                sqlite_path: Some(sqlite_path),
+                session_data_dir: Some(session_data_dir.clone()),
+                ..test_config("test-agent")
+            };
+            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let source_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                // Seed the source session's event log directly (simulating turns that a real
+                // agent loop would have appended via SessionSink).
+                let source_dir =
+                    zeph_session::session_dir(&session_data_dir, &source_id.to_string());
+                let log = zeph_session::SessionEventLog::open(&source_dir)
+                    .await
+                    .expect("open source event log");
+                log.append(
+                    None,
+                    None,
+                    zeph_session::SessionEvent::SessionStarted {
+                        session_id: source_id.to_string(),
+                        cwd: workdir.path().to_string_lossy().into_owned(),
+                        provider_name: "claude".to_owned(),
+                        model: "opus".to_owned(),
+                        forked_from: None,
+                    },
+                )
+                .await
+                .expect("append SessionStarted");
+                log.append(
+                    None,
+                    None,
+                    zeph_session::SessionEvent::UserMessage {
+                        text: "hello".to_owned(),
+                        image_refs: vec![],
+                    },
+                )
+                .await
+                .expect("append UserMessage");
+
+                let forked = cx
+                    .send_request(acp::schema::v1::ForkSessionRequest::new(
+                        source_id.clone(),
+                        workdir.path(),
+                    ))
+                    .block_task()
+                    .await?;
+
+                let child_dir =
+                    zeph_session::session_dir(&session_data_dir, &forked.session_id.to_string());
+                let child_log = zeph_session::SessionEventLog::open(&child_dir)
+                    .await
+                    .expect("open child event log");
+                let events = child_log.read_all().await.expect("read child event log");
+                // 1 synthesized SessionStarted header (forked_from) + the 2 seeded events.
+                assert_eq!(events.len(), 3, "child log must contain the copied events");
+                assert!(matches!(
+                    events[0].kind,
+                    zeph_session::SessionEvent::SessionStarted {
+                        forked_from: Some(_),
+                        ..
+                    }
+                ));
+
+                let parent_log = zeph_session::SessionEventLog::open(&source_dir)
+                    .await
+                    .expect("reopen source event log");
+                let parent_events = parent_log.read_all().await.expect("read source event log");
+                assert!(
+                    matches!(
+                        parent_events.last().expect("parent has events").kind,
+                        zeph_session::SessionEvent::ForkPoint { .. }
+                    ),
+                    "parent log must record a ForkPoint provenance event"
+                );
+
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "fork_session persistence test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
 /// `session/resume` reconnects to an in-memory session by id (#5367).
 #[tokio::test(flavor = "current_thread")]
 async fn resume_session_reconnects_to_existing_session() {
@@ -955,6 +1077,106 @@ async fn resume_session_reconstructs_from_store_after_restart() {
                         result.is_ok(),
                         "store-backed resume_session test failed: {result:?}"
                     );
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/load` replays from the durable JSONL event log (spec-068 §12.3 / D-2), not the
+/// legacy `acp_session_events` table, which the P1 write cutover leaves permanently empty for
+/// post-cutover sessions (S1 regression fix). This test seeds only the JSONL log — never
+/// `save_acp_event` — so a `session/load` that still reached into the legacy table would find
+/// nothing there while this test's event still proves the store-backed reconstruction branch
+/// (fresh connection, empty in-memory `sessions` map) can load the session at all.
+#[tokio::test(flavor = "current_thread")]
+async fn load_session_succeeds_from_event_log_with_no_legacy_rows() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let db_dir = tempfile::tempdir().expect("failed to create temp db dir");
+            let sqlite_path = db_dir
+                .path()
+                .join("acp-load-test.db")
+                .to_string_lossy()
+                .into_owned();
+            let session_data_dir = db_dir.path().join("sessions");
+
+            let session_id = {
+                let (sw, sr, cw, cr) = duplex_pair();
+                let config = AcpServerConfig {
+                    sqlite_path: Some(sqlite_path.clone()),
+                    session_data_dir: Some(session_data_dir.clone()),
+                    ..test_config("test-agent")
+                };
+                let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+                let client_fut =
+                    acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                        cx.send_request(acp::schema::v1::InitializeRequest::new(
+                            acp::schema::ProtocolVersion::LATEST,
+                        ))
+                        .block_task()
+                        .await?;
+
+                        let session_id = cx
+                            .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                            .block_task()
+                            .await?
+                            .session_id;
+                        Ok(session_id)
+                    });
+                tokio::select! {
+                    res = server_fut => panic!("server exited before client: {res:?}"),
+                    result = client_fut => result.expect("session/new failed"),
+                }
+            };
+
+            // Seed only the durable JSONL log (as SessionSink would in production) — no
+            // acp_session_events legacy rows exist for this session at all.
+            let session_dir = zeph_session::session_dir(&session_data_dir, &session_id.to_string());
+            let log = zeph_session::SessionEventLog::open(&session_dir)
+                .await
+                .expect("open event log");
+            log.append(
+                None,
+                None,
+                zeph_session::SessionEvent::UserMessage {
+                    text: "hello".to_owned(),
+                    image_refs: vec![],
+                },
+            )
+            .await
+            .expect("append UserMessage");
+
+            // Fresh connection: empty in-memory `sessions` map, so `session/load` can only
+            // succeed via the store-backed reconstruction branch.
+            let (sw, sr, cw, cr) = duplex_pair();
+            let config = AcpServerConfig {
+                sqlite_path: Some(sqlite_path),
+                session_data_dir: Some(session_data_dir),
+                ..test_config("test-agent")
+            };
+            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                cx.send_request(acp::schema::v1::LoadSessionRequest::new(
+                    session_id,
+                    workdir.path(),
+                ))
+                .block_task()
+                .await?;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "session/load from event log failed: {result:?}");
                 }
             }
         })

--- a/crates/zeph-agent-persistence/Cargo.toml
+++ b/crates/zeph-agent-persistence/Cargo.toml
@@ -23,10 +23,16 @@ zeph-config.workspace = true
 zeph-context.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
+zeph-session = { workspace = true, default-features = false }
+
+[dev-dependencies]
+tempfile.workspace = true
+zeph-db = { workspace = true, default-features = false, features = ["sqlite"] }
+zeph-llm = { workspace = true, features = ["testing"] }
 
 [features]
-sqlite = ["zeph-memory/sqlite"]
-postgres = ["zeph-memory/postgres"]
+sqlite = ["zeph-memory/sqlite", "zeph-session/sqlite"]
+postgres = ["zeph-memory/postgres", "zeph-session/postgres"]
 default = ["sqlite"]
 
 [lints]

--- a/crates/zeph-agent-persistence/src/condense.rs
+++ b/crates/zeph-agent-persistence/src/condense.rs
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Resume-time durable condensation trigger (spec-068 §8.1, architect rulings D-11/D-13).
+//!
+//! #3102 durable condensation is one of spec §1's three co-equal headline features. Before D-11,
+//! [`zeph_session::LlmCondenser`] was fully built but never invoked from any production call
+//! site — `[session.condense]` config was dead and `last_condensed_seq` never advanced.
+//! [`maybe_condense_on_resume`] is the missing wiring: called immediately after
+//! [`crate::hydrate_from_event_log`] on a resume path, it checks whether the replayed state
+//! exceeds the condenser's threshold and, if so, durably condenses the session's tail.
+//!
+//! [`hydrate_and_condense`] (D-13) is the single entry point every session-open path should use
+//! instead: it wraps [`crate::hydrate_from_event_log`] and folds in the
+//! `maybe_condense_on_resume` call automatically, so condensation cannot be wired into some
+//! resume paths and silently forgotten on others.
+
+use zeph_context::summarization::MessageTokenCounter;
+use zeph_llm::provider::Message;
+use zeph_session::{
+    Condenser, ReconstructedState, SessionEvent, SessionEventEnvelope, SessionEventLog,
+    SessionStore,
+};
+
+use crate::error::PersistenceError;
+
+/// Run resume-time durable condensation (spec §8.1) if `condenser.should_condense` returns
+/// `true` for the replayed `state` at `budget_used_fraction`. No-op otherwise.
+///
+/// On trigger: reads the session's current `last_condensed_seq` (the INV-SP-4 non-overlap
+/// watermark), asks `condenser` to summarize everything up to its `keep_recent` cutoff, appends
+/// the resulting [`SessionEvent::Condensation`] event to `log`, and advances
+/// `acp_sessions.last_condensed_seq` to match.
+///
+/// # Errors
+///
+/// Returns [`PersistenceError`] if reading session metadata, condensing, appending the
+/// `Condensation` event, or advancing `last_condensed_seq` fails. A condensation failure (e.g.
+/// the LLM call errors, or `events` is too short) must not fail the resume itself — callers
+/// should log and continue, matching [`crate::bootstrap_legacy_session`]'s established
+/// soft-fail contract for optional resume-time work.
+#[tracing::instrument(
+    name = "persistence.condense.maybe_run",
+    skip_all,
+    level = "debug",
+    fields(session_id, budget_used_fraction)
+)]
+pub async fn maybe_condense_on_resume<C: Condenser>(
+    condenser: &C,
+    log: &SessionEventLog,
+    store: &SessionStore,
+    session_id: &str,
+    state: &ReconstructedState,
+    events: &[SessionEventEnvelope],
+    budget_used_fraction: f64,
+) -> Result<(), PersistenceError> {
+    if !condenser.should_condense(state, budget_used_fraction).await {
+        return Ok(());
+    }
+
+    let Some(meta) = store.get(session_id).await? else {
+        return Ok(());
+    };
+
+    let result = condenser.condense(events, meta.last_condensed_seq).await?;
+
+    log.append(
+        None,
+        None,
+        SessionEvent::Condensation {
+            replaced_seq_range: result.replaced_range,
+            summary: result.summary,
+            tokens_before: result.tokens_before,
+            tokens_after: result.tokens_after,
+        },
+    )
+    .await?;
+
+    // M2 (spec §8.3 INV-SP-4): advance the same non-overlap ledger live Compaction
+    // (`SessionSink::record_compaction`) also participates in, so a later condensation or
+    // compaction pass cannot overlap the range just condensed.
+    store
+        .set_condensed_seq(session_id, result.replaced_range.1)
+        .await?;
+
+    tracing::info!(
+        session_id,
+        replaced_range = ?result.replaced_range,
+        tokens_before = result.tokens_before,
+        tokens_after = result.tokens_after,
+        "spec-068 §8.1: durable condensation ran on resume"
+    );
+
+    Ok(())
+}
+
+/// Fraction of `window` tokens `messages` consumes — the `budget_used_fraction` input
+/// [`Condenser::should_condense`] expects (spec §8.1, architect ruling D-13).
+///
+/// Deliberately Agent-free: needs only a token counter and a window size, both resolvable at
+/// agent-construction time (before a live `Agent`'s `ContextBudget` exists) — see
+/// [`hydrate_and_condense`]'s module-level rationale for why this was the one piece D-11
+/// mistakenly assumed required a live `Agent`.
+///
+/// Returns `0.0` if `window == 0` (a misconfigured or not-yet-resolved budget) rather than
+/// dividing by zero — this only suppresses condensation from firing, never panics.
+#[must_use]
+pub fn resume_budget_fraction(
+    messages: &[Message],
+    token_counter: &dyn MessageTokenCounter,
+    window: usize,
+) -> f64 {
+    if window == 0 {
+        return 0.0;
+    }
+    let tokens: usize = messages
+        .iter()
+        .map(|m| token_counter.count_message_tokens(m))
+        .sum();
+    #[allow(clippy::cast_precision_loss)]
+    let fraction = tokens as f64 / window as f64;
+    fraction
+}
+
+/// [`crate::hydrate_from_event_log`] (D-10) plus resume-time durable condensation (D-11),
+/// centralized so all four session-open paths (ACP, CLI `sessions resume`, `/conv resume`/
+/// `fork`, `zeph serve` reactivation) get condensation automatically instead of each needing
+/// its own inline `maybe_condense_on_resume` call — the same "one shared pipeline, not N
+/// diverging copies" principle D-10 already established for hydration itself (architect ruling
+/// D-13, spec-068 N3).
+///
+/// D-13's key correction: [`maybe_condense_on_resume`] takes no `Agent` parameter — `condenser`
+/// is buildable from config + the provider registry (both resolved before agent construction at
+/// every call site) and `budget_used_fraction` is `resume_budget_fraction`'s plain arithmetic
+/// over the just-replayed messages. There is no path that structurally *cannot* call this; the
+/// three non-`/conv` sites simply didn't have a live `Agent`'s convenience accessors
+/// (`ContextBudget`, `resolve_background_provider`) to reach for and mistakenly concluded
+/// condensation needed one.
+///
+/// Soft-fails condensation exactly like [`maybe_condense_on_resume`] itself — a condensation
+/// failure never fails the resume; only [`crate::hydrate_from_event_log`]'s own hard-error
+/// conditions (log open/read failure) propagate.
+///
+/// # Errors
+///
+/// Returns [`PersistenceError`] under the same conditions as
+/// [`crate::hydrate_from_event_log`] — condensation failures are logged and swallowed, not
+/// propagated.
+#[allow(clippy::too_many_arguments)] // hydrate_from_event_log's 6 params + condenser/token_counter/context_window
+#[tracing::instrument(
+    name = "persistence.condense.hydrate_and_condense",
+    skip_all,
+    level = "info",
+    fields(session_id, context_window)
+)]
+pub async fn hydrate_and_condense<C: Condenser>(
+    session_path: &std::path::Path,
+    store: &SessionStore,
+    session_id: &str,
+    conversation_id: zeph_memory::types::ConversationId,
+    memory: &zeph_memory::semantic::SemanticMemory,
+    up_to: Option<u64>,
+    condenser: &C,
+    token_counter: &dyn MessageTokenCounter,
+    context_window: usize,
+) -> Result<crate::hydrate::Hydrated, PersistenceError> {
+    let hydrated = crate::hydrate::hydrate_from_event_log(
+        session_path,
+        store,
+        session_id,
+        conversation_id,
+        memory,
+        up_to,
+    )
+    .await?;
+
+    if !hydrated.messages.is_empty() {
+        let budget_used_fraction =
+            resume_budget_fraction(&hydrated.messages, token_counter, context_window);
+        let state = ReconstructedState {
+            messages: hydrated.messages.clone(),
+            ..Default::default()
+        };
+        if let Err(e) = maybe_condense_on_resume(
+            condenser,
+            &hydrated.log,
+            store,
+            session_id,
+            &state,
+            &hydrated.events,
+            budget_used_fraction,
+        )
+        .await
+        {
+            tracing::warn!(error = %e, session_id, "spec-068 §8.1: resume-time condensation failed");
+        }
+    }
+
+    Ok(hydrated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use zeph_context::summarization::{MessageTokenCounter, SummarizationDeps};
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+    use zeph_llm::provider::{Message, MessagePart, Role};
+    use zeph_session::LlmCondenser;
+
+    struct WordCountTokenCounter;
+    impl MessageTokenCounter for WordCountTokenCounter {
+        fn count_message_tokens(&self, msg: &Message) -> usize {
+            msg.content.split_whitespace().count().max(1)
+        }
+    }
+
+    fn make_condenser(response: &str) -> LlmCondenser {
+        let deps = SummarizationDeps {
+            provider: AnyProvider::Mock(MockProvider::with_responses(vec![response.to_owned()])),
+            llm_timeout: Duration::from_secs(5),
+            token_counter: std::sync::Arc::new(WordCountTokenCounter),
+            structured_summaries: true,
+            on_anchored_summary: None,
+        };
+        LlmCondenser::new(deps, 0.5, 1)
+    }
+
+    fn summary_json() -> String {
+        serde_json::json!({
+            "session_intent": "implement feature X",
+            "files_modified": ["src/lib.rs"],
+            "decisions_made": ["used approach A"],
+            "open_questions": [],
+            "next_steps": ["write tests"],
+        })
+        .to_string()
+    }
+
+    async fn make_store(pool: zeph_db::DbPool) -> SessionStore {
+        let store = SessionStore::new(pool);
+        store.create("s1").await.unwrap();
+        store
+    }
+
+    #[tokio::test]
+    async fn below_threshold_is_a_noop() {
+        let condenser = make_condenser(&summary_json());
+        let config = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        };
+        let pool = config.connect().await.unwrap();
+        zeph_db::run_migrations(&pool).await.unwrap();
+        let store = make_store(pool).await;
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+
+        let state = ReconstructedState {
+            messages: vec![Message::from_parts(
+                Role::User,
+                vec![MessagePart::Text {
+                    text: "hi".to_owned(),
+                }],
+            )],
+            ..Default::default()
+        };
+
+        maybe_condense_on_resume(&condenser, &log, &store, "s1", &state, &[], 0.1)
+            .await
+            .unwrap();
+
+        let meta = store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.last_condensed_seq, 0);
+        assert!(log.read_all().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn above_threshold_condenses_and_advances_watermark() {
+        let condenser = make_condenser(&summary_json());
+        let config = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        };
+        let pool = config.connect().await.unwrap();
+        zeph_db::run_migrations(&pool).await.unwrap();
+        let store = make_store(pool).await;
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+
+        // 3 message events; keep_recent=1 means the first 2 are condensed.
+        let mut events = Vec::new();
+        for i in 0..3 {
+            let envelope = log
+                .append(
+                    None,
+                    None,
+                    SessionEvent::UserMessage {
+                        text: format!("message {i}"),
+                        image_refs: Vec::new(),
+                    },
+                )
+                .await
+                .unwrap();
+            events.push(envelope);
+        }
+
+        let state = ReconstructedState {
+            messages: vec![
+                Message::from_parts(
+                    Role::User,
+                    vec![MessagePart::Text {
+                        text: "a".to_owned(),
+                    }],
+                ),
+                Message::from_parts(
+                    Role::User,
+                    vec![MessagePart::Text {
+                        text: "b".to_owned(),
+                    }],
+                ),
+                Message::from_parts(
+                    Role::User,
+                    vec![MessagePart::Text {
+                        text: "c".to_owned(),
+                    }],
+                ),
+            ],
+            ..Default::default()
+        };
+
+        maybe_condense_on_resume(&condenser, &log, &store, "s1", &state, &events, 0.9)
+            .await
+            .unwrap();
+
+        let meta = store.get("s1").await.unwrap().unwrap();
+        assert_eq!(
+            meta.last_condensed_seq, 1,
+            "condensed through seq 1 (2 of 3 events)"
+        );
+
+        let all_events = log.read_all().await.unwrap();
+        assert_eq!(
+            all_events.len(),
+            4,
+            "3 original events + 1 Condensation event"
+        );
+        assert!(matches!(
+            all_events.last().unwrap().kind,
+            SessionEvent::Condensation { .. }
+        ));
+    }
+
+    /// D-13 regression (spec-068 §8.1, N3): `hydrate_and_condense` must actually condense, not
+    /// just hydrate — this is the exact wiring CLI/ACP/`zeph serve` construction sites now
+    /// depend on (previously only `/conv resume`'s hand-inlined copy was exercised, and that
+    /// copy is gone post-D-13 refactor). Drives the real production write path
+    /// (`SessionSink::record_message`, not raw `log.append`) through `hydrate_and_condense` in
+    /// one call and asserts both effects: the durable log gained a `Condensation` event and the
+    /// returned `Hydrated.messages` still reflects the full pre-condensation replay (callers
+    /// preload the complete history; condensation is a log-level side effect, not a truncation
+    /// of what's handed back here).
+    #[tokio::test]
+    async fn hydrate_and_condense_triggers_condensation_end_to_end() {
+        let memory = zeph_memory::semantic::SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            None,
+            AnyProvider::Mock(MockProvider::default()),
+            "test-model",
+        )
+        .await
+        .unwrap();
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let store = SessionStore::new(memory.sqlite().pool().clone());
+        store.create("s1").await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        let log = std::sync::Arc::new(SessionEventLog::open(dir.path()).await.unwrap());
+        let sink = crate::SessionSink::new(
+            std::sync::Arc::clone(&log),
+            SessionStore::new(memory.sqlite().pool().clone()),
+            zeph_common::SessionId::new("s1"),
+        );
+        // keep_recent=1 (make_condenser's fixed value): 3 messages condenses the first 2.
+        sink.record_message(Role::User, "message zero", &[])
+            .await
+            .unwrap();
+        sink.record_message(Role::User, "message one", &[])
+            .await
+            .unwrap();
+        sink.record_message(Role::User, "message two", &[])
+            .await
+            .unwrap();
+        drop(sink);
+        drop(log);
+
+        let condenser = make_condenser(&summary_json());
+        let token_counter = WordCountTokenCounter;
+        // 3 messages x 2 words = 6 tokens; window=10 => budget_used_fraction=0.6, over the 0.5
+        // threshold `make_condenser` sets.
+        let hydrated = hydrate_and_condense(
+            dir.path(),
+            &store,
+            "s1",
+            cid,
+            &memory,
+            None,
+            &condenser,
+            &token_counter,
+            10,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            hydrated.messages.len(),
+            3,
+            "hydrate_and_condense must still return the full pre-condensation replay"
+        );
+
+        let meta = store.get("s1").await.unwrap().unwrap();
+        assert_eq!(
+            meta.last_condensed_seq, 1,
+            "condensation must have fired and advanced the watermark through seq 1"
+        );
+
+        let all_events = hydrated.log.read_all().await.unwrap();
+        assert_eq!(
+            all_events.len(),
+            4,
+            "3 original message events + 1 Condensation event appended by hydrate_and_condense"
+        );
+        assert!(matches!(
+            all_events.last().unwrap().kind,
+            SessionEvent::Condensation { .. }
+        ));
+    }
+}

--- a/crates/zeph-agent-persistence/src/error.rs
+++ b/crates/zeph-agent-persistence/src/error.rs
@@ -28,4 +28,8 @@ pub enum PersistenceError {
     /// Failed to serialize message parts to JSON.
     #[error("serialization error: {0}")]
     Serialize(#[from] serde_json::Error),
+
+    /// `zeph-session` event log or `SessionStore` operation failed (spec-068, #5343).
+    #[error("session persistence error: {0}")]
+    Session(#[from] zeph_session::SessionError),
 }

--- a/crates/zeph-agent-persistence/src/hydrate.rs
+++ b/crates/zeph-agent-persistence/src/hydrate.rs
@@ -1,0 +1,266 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared session-open hydration pipeline (spec-068 §12.3/§13, architect ruling D-10).
+//!
+//! Before D-10, three call sites (ACP resume/load/fork, CLI `sessions resume`, `/conv resume`)
+//! each open the event log and decide independently whether to run
+//! [`crate::bootstrap_legacy_session`], fold it via [`zeph_session::ReplayEngine`], and reconcile
+//! the `SQLite` projection. The CLI copy never did the fold/reconcile steps at all — a real
+//! regression (impl-critic finding C1: `sessions resume` silently fell back to stale `SQLite`
+//! history instead of the durable log). [`hydrate_from_event_log`] is the single pipeline every
+//! session-open path must route through, so "which pipeline does resume use" cannot diverge
+//! again.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use zeph_llm::provider::Message;
+use zeph_memory::semantic::SemanticMemory;
+use zeph_memory::types::ConversationId;
+use zeph_session::{ReplayEngine, SessionEventEnvelope, SessionEventLog, SessionStore};
+
+use crate::error::PersistenceError;
+use crate::legacy_bootstrap::bootstrap_legacy_session;
+use crate::reconcile::reconcile_projection;
+
+/// Result of [`hydrate_from_event_log`]: the replayed message history plus the opened log,
+/// ready for the caller to wrap into a [`crate::SessionSink`] and/or feed to a builder.
+pub struct Hydrated {
+    /// Replayed message history — empty for a brand-new session or a legacy session with no
+    /// recorded log yet (spec §18: legacy sessions are not retroactively synthesized here).
+    pub messages: Vec<Message>,
+    /// The full, unfolded event list read from the log — needed by
+    /// [`crate::maybe_condense_on_resume`] (D-11), which condenses over a `seq` range rather
+    /// than the already-folded `messages`. Empty for a brand-new or legacy-unbootstrapped
+    /// session, matching `messages`.
+    pub events: Vec<SessionEventEnvelope>,
+    /// The session's opened durable event log. Returned so the caller doesn't have to reopen it
+    /// to construct a [`crate::SessionSink`] — [`zeph_session::SessionEventLog`] has no
+    /// multi-writer story (INV-D2), so callers must reuse this handle rather than opening a
+    /// second one.
+    pub log: Arc<SessionEventLog>,
+}
+
+/// Open `session_id`'s durable event log at `session_path`, run legacy bootstrap, fold it into
+/// agent-ready messages, and reconcile the `SQLite` projection forward (INV-SP-3) — the single
+/// pipeline every session-open path (ACP resume/load/fork, CLI `sessions resume`, `/conv
+/// resume`/`fork`) routes through (spec-068 D-10).
+///
+/// `up_to` bounds the fold to events with `seq < up_to` (fork's partial-history case); pass
+/// `None` for a full replay (the common resume/load case).
+///
+/// # Errors
+///
+/// Returns [`PersistenceError`] if the log can't be opened or read, legacy bootstrap fails, or
+/// projection reconciliation fails.
+///
+/// # Examples
+///
+/// ```no_run
+/// # async fn example(
+/// #     session_path: &std::path::Path,
+/// #     store: &zeph_session::SessionStore,
+/// #     memory: &zeph_memory::semantic::SemanticMemory,
+/// #     conversation_id: zeph_memory::types::ConversationId,
+/// # ) -> Result<(), zeph_agent_persistence::PersistenceError> {
+/// let hydrated = zeph_agent_persistence::hydrate_from_event_log(
+///     session_path,
+///     store,
+///     "session-id",
+///     conversation_id,
+///     memory,
+///     None,
+/// )
+/// .await?;
+/// // hydrated.messages is ready for `AgentBuilder::with_preloaded_messages`;
+/// // hydrated.log is ready for `SessionSink::new`.
+/// # Ok(())
+/// # }
+/// ```
+#[tracing::instrument(
+    name = "persistence.hydrate.run",
+    skip_all,
+    level = "info",
+    fields(session_id)
+)]
+pub async fn hydrate_from_event_log(
+    session_path: &Path,
+    store: &SessionStore,
+    session_id: &str,
+    conversation_id: ConversationId,
+    memory: &SemanticMemory,
+    up_to: Option<u64>,
+) -> Result<Hydrated, PersistenceError> {
+    let log = SessionEventLog::open(session_path).await?;
+
+    // Legacy session lazy-bootstrap (spec §18): no-op unless this session predates durable
+    // event-log persistence (has SQLite history but an empty log). Soft-fail like
+    // `bootstrap_legacy_session`'s own doc contract: a failure here must not prevent the log
+    // itself from being replayed and wrapped into a SessionSink below.
+    if let Err(e) = bootstrap_legacy_session(&log, store, session_id, conversation_id, memory).await
+    {
+        tracing::warn!(error = %e, session_id, "legacy session lazy-bootstrap failed");
+    }
+
+    let events = log.read_all().await?;
+    let messages = if events.is_empty() {
+        Vec::new()
+    } else {
+        let state = ReplayEngine::fold(events.clone(), up_to);
+        // INV-SP-3 (spec-068 §13): rebuild the SQLite `messages` projection forward from the log
+        // when it trails the log's validated content (e.g. a crash between the JSONL append and
+        // the SQLite write of the same turn). Not correctness-critical for `messages` (already
+        // sourced from the log directly) — keeps other features that read `messages` directly
+        // (semantic search, history displays) in sync. Soft-fail: a reconcile error must not
+        // throw away the successfully-replayed `messages`.
+        if let Err(e) = reconcile_projection(memory, conversation_id, session_id, &events).await {
+            tracing::warn!(error = %e, session_id, "INV-SP-3 projection reconciliation failed");
+        }
+        state.messages
+    };
+
+    Ok(Hydrated {
+        messages,
+        events,
+        log: Arc::new(log),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::provider::{MessagePart, Role};
+    use zeph_session::SessionEvent;
+
+    async fn make_memory() -> SemanticMemory {
+        SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            None,
+            AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            "test-model",
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn empty_log_returns_no_messages() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let store = SessionStore::new(memory.sqlite().pool().clone());
+        store.create("s1").await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        let hydrated = hydrate_from_event_log(dir.path(), &store, "s1", cid, &memory, None)
+            .await
+            .unwrap();
+
+        assert!(hydrated.messages.is_empty());
+        assert!(hydrated.log.last_seq().is_none());
+    }
+
+    /// D-10's mandated end-to-end regression test: `SessionSink::record_message` (the real
+    /// production write primitive `Agent::persist_message` calls, not a raw `log.append`) →
+    /// simulate a crash in the INV-SP-1 window by never running the corresponding `SQLite`
+    /// `messages` write → resume via `hydrate_from_event_log` → confirm both the replayed
+    /// `messages` AND the reconciled `SQLite` projection reflect the durable log. Matches the
+    /// #5419 lesson (green units + unexercised integration = this bug class) by going through
+    /// `SessionSink` itself instead of directly appending to the log.
+    #[tokio::test]
+    async fn crash_after_session_sink_write_is_reconciled_on_resume() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let store = SessionStore::new(memory.sqlite().pool().clone());
+        store.create("s1").await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        // Simulates the live agent loop up to (and including) the durable log write, then a
+        // crash before `PersistenceService::persist_message`'s SQLite write for the same turn
+        // — the exact INV-SP-1 gap the reconcile mechanism exists to close.
+        let log = Arc::new(SessionEventLog::open(dir.path()).await.unwrap());
+        let sink = crate::SessionSink::new(
+            Arc::clone(&log),
+            SessionStore::new(memory.sqlite().pool().clone()),
+            zeph_common::SessionId::new("s1"),
+        );
+        sink.record_message(Role::User, "hello", &[]).await.unwrap();
+        sink.record_message(Role::Assistant, "hi there", &[])
+            .await
+            .unwrap();
+        drop(sink);
+        drop(log);
+
+        // No SQLite messages exist yet for this conversation — confirms the crash was
+        // faithfully simulated (only the log + acp_sessions bookkeeping advanced).
+        let before = memory.sqlite().load_history(cid, 10).await.unwrap();
+        assert!(before.is_empty(), "SQLite must be empty before reconcile");
+
+        let hydrated = hydrate_from_event_log(dir.path(), &store, "s1", cid, &memory, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hydrated.messages.len(),
+            2,
+            "replay must recover both turns from the log"
+        );
+
+        let after = memory.sqlite().load_history(cid, 10).await.unwrap();
+        assert_eq!(
+            after.len(),
+            2,
+            "INV-SP-3 reconcile must rebuild the SQLite projection from the log on resume"
+        );
+    }
+
+    #[tokio::test]
+    async fn replays_events_and_reconciles_projection() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let store = SessionStore::new(memory.sqlite().pool().clone());
+        store.create("s1").await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        // Seed the log directly, as SessionSink would in production, WITHOUT updating
+        // acp_sessions.event_count — simulating the exact crash-recovery gap INV-SP-3 covers.
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "hello".to_owned(),
+                image_refs: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::AssistantMessage {
+                parts: vec![MessagePart::Text {
+                    text: "hi there".to_owned(),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        drop(log);
+
+        let hydrated = hydrate_from_event_log(dir.path(), &store, "s1", cid, &memory, None)
+            .await
+            .unwrap();
+
+        assert_eq!(hydrated.messages.len(), 2);
+        assert_eq!(hydrated.messages[0].role, Role::User);
+        assert_eq!(hydrated.messages[1].role, Role::Assistant);
+
+        // INV-SP-3: the SQLite projection was reconciled forward even though this call never
+        // wrote through SessionSink/PersistenceService.
+        let history = memory.sqlite().load_history(cid, 10).await.unwrap();
+        assert_eq!(history.len(), 2);
+    }
+}

--- a/crates/zeph-agent-persistence/src/legacy_bootstrap.rs
+++ b/crates/zeph-agent-persistence/src/legacy_bootstrap.rs
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Legacy session lazy-bootstrap (spec-068 §18, #5343, P4).
+//!
+//! Existing installs upgrading to #5343 have `messages` rows (the `SQLite` projection) for
+//! conversations that predate durable event-log persistence. Event logs are **not**
+//! retroactively synthesized from that projection — lossy, since no tool-call/result granularity
+//! survives in the projection. Instead, on the first resume of such a session, this writes a
+//! [`SessionEvent::SessionStarted`] header plus a single [`SessionEvent::Condensation`]-style
+//! "imported history" event summarizing the pre-existing history, after which new turns append
+//! to the log normally. Old sessions cannot be forked or replayed at an arbitrary historical
+//! `seq` predating this import boundary — documented in `sessions show --events` output.
+
+use zeph_common::memory::AnchoredSummary;
+use zeph_memory::ConversationId;
+use zeph_memory::semantic::SemanticMemory;
+use zeph_session::{SessionEvent, SessionEventLog, SessionStore};
+
+use crate::error::PersistenceError;
+
+/// Bootstraps a legacy session's durable event log if it doesn't have one yet and has
+/// pre-existing `SQLite` message history for `conversation_id`.
+///
+/// No-op (returns `Ok(())` without writing anything) when:
+/// - the session's event log already has events (`log.last_seq().is_some()`) — already
+///   bootstrapped, or a session that was always #5343-native.
+/// - the linked conversation has zero `SQLite` messages — a genuinely new session, not a legacy
+///   one; the caller's own [`crate::SessionSink`] writes its own `SessionStarted` on the first
+///   real turn instead.
+///
+/// # Errors
+///
+/// Returns [`PersistenceError`] if the message count query, log append, or [`SessionStore`]
+/// update fails.
+#[tracing::instrument(
+    name = "persistence.legacy_bootstrap.run",
+    skip_all,
+    level = "debug",
+    fields(session_id)
+)]
+pub async fn bootstrap_legacy_session(
+    log: &SessionEventLog,
+    store: &SessionStore,
+    session_id: &str,
+    conversation_id: ConversationId,
+    memory: &SemanticMemory,
+) -> Result<(), PersistenceError> {
+    if log.last_seq().is_some() {
+        return Ok(());
+    }
+
+    let message_count = memory.sqlite().count_messages(conversation_id).await?;
+    if message_count <= 0 {
+        return Ok(());
+    }
+
+    log.append(
+        None,
+        None,
+        SessionEvent::SessionStarted {
+            session_id: session_id.to_owned(),
+            cwd: String::new(),
+            provider_name: String::new(),
+            model: String::new(),
+            forked_from: None,
+        },
+    )
+    .await?;
+
+    let summary = AnchoredSummary {
+        session_intent: format!(
+            "Imported from pre-existing conversation history ({message_count} message(s)) that \
+             predates durable session-log persistence (spec-068, #5343). Granular tool-call/\
+             result replay is not available for this range — only the SQLite projection existed."
+        ),
+        files_modified: Vec::new(),
+        decisions_made: Vec::new(),
+        open_questions: Vec::new(),
+        next_steps: Vec::new(),
+    };
+    log.append(
+        None,
+        None,
+        SessionEvent::Condensation {
+            replaced_seq_range: (0, 0),
+            summary,
+            tokens_before: 0,
+            tokens_after: 0,
+        },
+    )
+    .await?;
+
+    let last_seq = log.last_seq().unwrap_or(1);
+    store.update_seq(session_id, last_seq, last_seq + 1).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_llm::any::AnyProvider;
+
+    async fn make_env() -> (SemanticMemory, SessionStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let memory = SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            None,
+            AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            "test-model",
+        )
+        .await
+        .unwrap();
+        let store = SessionStore::new(memory.sqlite().pool().clone());
+        (memory, store, dir)
+    }
+
+    #[tokio::test]
+    async fn noop_when_log_already_has_events() {
+        let (memory, store, dir) = make_env().await;
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "hi".to_owned(),
+                image_refs: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        store.create("s1").await.unwrap();
+
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        bootstrap_legacy_session(&log, &store, "s1", cid, &memory)
+            .await
+            .unwrap();
+
+        // Still just the one UserMessage — no bootstrap events appended.
+        let events = log.read_all().await.unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn noop_when_conversation_has_no_messages() {
+        let (memory, store, dir) = make_env().await;
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        store.create("s1").await.unwrap();
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        bootstrap_legacy_session(&log, &store, "s1", cid, &memory)
+            .await
+            .unwrap();
+
+        assert!(log.read_all().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn bootstraps_when_legacy_messages_exist() {
+        let (memory, store, dir) = make_env().await;
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        store.create("s1").await.unwrap();
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        memory
+            .sqlite()
+            .save_message(cid, "user", "legacy message")
+            .await
+            .unwrap();
+
+        bootstrap_legacy_session(&log, &store, "s1", cid, &memory)
+            .await
+            .unwrap();
+
+        let events = log.read_all().await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0].kind,
+            SessionEvent::SessionStarted { .. }
+        ));
+        let SessionEvent::Condensation {
+            replaced_seq_range,
+            ref summary,
+            ..
+        } = events[1].kind
+        else {
+            panic!("expected Condensation");
+        };
+        assert_eq!(replaced_seq_range, (0, 0));
+        assert!(summary.session_intent.contains("Imported"));
+
+        let meta = store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.event_count, 2);
+
+        // Idempotent: calling again is a no-op since the log now has events.
+        bootstrap_legacy_session(&log, &store, "s1", cid, &memory)
+            .await
+            .unwrap();
+        assert_eq!(log.read_all().await.unwrap().len(), 2);
+    }
+}

--- a/crates/zeph-agent-persistence/src/lib.rs
+++ b/crates/zeph-agent-persistence/src/lib.rs
@@ -24,15 +24,25 @@
 //! # TODO(critic): consolidate MockChannel/MockToolExecutor into shared zeph-agent-test-helpers
 //! crate; tracked separately from #3515/#3516
 
+pub mod condense;
 pub mod embed;
 pub mod error;
 pub mod graph;
+pub mod hydrate;
+pub mod legacy_bootstrap;
+pub mod reconcile;
 pub mod request;
 pub mod sanitize;
 pub mod service;
+pub mod session_sink;
 pub mod state;
 
+pub use condense::{hydrate_and_condense, maybe_condense_on_resume, resume_budget_fraction};
 pub use error::PersistenceError;
+pub use hydrate::{Hydrated, hydrate_from_event_log};
+pub use legacy_bootstrap::bootstrap_legacy_session;
+pub use reconcile::reconcile_projection;
 pub use request::{LoadHistoryOutcome, PersistMessageOutcome, PersistMessageRequest};
 pub use service::{LoadHistoryParams, PersistenceService};
+pub use session_sink::SessionSink;
 pub use state::{MemoryPersistenceView, MetricsView, ProviderHandles, SecurityView};

--- a/crates/zeph-agent-persistence/src/reconcile.rs
+++ b/crates/zeph-agent-persistence/src/reconcile.rs
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! INV-SP-3: projection reconcile-from-log on open (spec-068 §13, #5343).
+//!
+//! When a session is opened (resume, load, fork) and the `SQLite` `messages` projection trails
+//! the durable JSONL event log's validated content, [`reconcile_projection`] rebuilds the missing
+//! rows forward from the log.
+
+use zeph_memory::semantic::SemanticMemory;
+use zeph_memory::types::ConversationId;
+use zeph_session::{SessionEvent, SessionEventEnvelope};
+
+use crate::error::PersistenceError;
+
+/// Rebuild the `SQLite` `messages` projection forward from the event log when it trails the
+/// log's validated content.
+///
+/// The watermark is the real `SQLite` `messages` row count for `conversation_id`
+/// ([`zeph_memory::store::SqliteStore::count_messages`]), **not** `acp_sessions.event_count`:
+/// [`crate::SessionSink::record_message`] advances `event_count` immediately after the durable
+/// log append, deliberately *before* the caller's separate `SQLite` `messages` write runs
+/// (INV-SP-1's log-first ordering) — so `event_count` races ahead of `SQLite` on every turn, not
+/// just a crashed one, and can never observe the gap this function exists to close. Reading the
+/// actual row count is the only watermark that reflects what `SQLite` has really committed.
+///
+/// Deliberately conservative: only reconciles a gap that contains **exclusively**
+/// `UserMessage`/`AssistantMessage` events from the first un-committed message onward — if a
+/// `ToolCall`/`ToolResult`/`Condensation`/`Compaction`/`ForkPoint` event appears anywhere at or
+/// after that point, the whole reconcile is skipped rather than guessed at. An
+/// incorrectly-reconstructed row in the `messages` table is worse than a stale projection, and
+/// the resume/load/fork hydration path itself does not depend on this projection being current
+/// (it sources conversation history from the JSONL log directly when the log has content — see
+/// [`crate::hydrate_from_event_log`]).
+///
+/// `events` must already be the full, INV-SP-2-validated event list for the session (as returned
+/// by [`zeph_session::SessionEventLog::read_all`]).
+///
+/// # Errors
+///
+/// Returns an error if a `SQLite` read or write fails. Rows written before a mid-loop failure
+/// are not rolled back — matches [`crate::service::PersistenceService::load_history`]'s existing
+/// non-transactional pattern for the same table.
+#[tracing::instrument(
+    name = "persistence.reconcile.run",
+    skip_all,
+    level = "debug",
+    fields(session_id, event_count = events.len())
+)]
+pub async fn reconcile_projection(
+    memory: &SemanticMemory,
+    conversation_id: ConversationId,
+    session_id: &str,
+    events: &[SessionEventEnvelope],
+) -> Result<(), PersistenceError> {
+    let is_message = |kind: &SessionEvent| {
+        matches!(
+            kind,
+            SessionEvent::UserMessage { .. } | SessionEvent::AssistantMessage { .. }
+        )
+    };
+
+    let committed =
+        usize::try_from(memory.sqlite().count_messages(conversation_id).await?).unwrap_or(0);
+
+    let message_events: Vec<&SessionEventEnvelope> =
+        events.iter().filter(|e| is_message(&e.kind)).collect();
+    if message_events.len() <= committed {
+        return Ok(());
+    }
+    let missing = &message_events[committed..];
+
+    // Bail if any non-message event appears at or after the first un-committed message's
+    // position — a mixed gap (tool call, condensation, fork, ...) is too complex to safely
+    // auto-reconcile from message events alone.
+    let first_missing_seq = missing[0].seq;
+    if events
+        .iter()
+        .any(|e| e.seq >= first_missing_seq && !is_message(&e.kind))
+    {
+        tracing::warn!(
+            session_id,
+            gap = missing.len(),
+            "INV-SP-3 reconciliation skipped: gap contains a tool call, condensation, or fork \
+             event — too complex to auto-reconcile safely; leaving the SQLite projection stale"
+        );
+        return Ok(());
+    }
+
+    for envelope in missing {
+        match &envelope.kind {
+            SessionEvent::UserMessage { text, .. } => {
+                memory
+                    .sqlite()
+                    .save_message(conversation_id, "user", text)
+                    .await?;
+            }
+            SessionEvent::AssistantMessage { parts } => {
+                let flattened = zeph_llm::provider::Message::from_parts(
+                    zeph_llm::provider::Role::Assistant,
+                    parts.clone(),
+                );
+                let parts_json = serde_json::to_string(parts)?;
+                memory
+                    .sqlite()
+                    .save_message_with_parts(
+                        conversation_id,
+                        "assistant",
+                        &flattened.content,
+                        &parts_json,
+                    )
+                    .await?;
+            }
+            // SessionStarted/ModelChanged/SessionEnded carry no `messages` row; excluded from
+            // `message_events` above so they never appear here.
+            _ => {}
+        }
+    }
+
+    // acp_sessions.event_count/last_seq already reflect the full log (SessionSink keeps them
+    // current on every append, ahead of SQLite by design) — nothing to update here; this
+    // function's only job is catching SQLite up to what the log and acp_sessions already agree
+    // on.
+
+    tracing::info!(
+        session_id,
+        reconciled = missing.len(),
+        "INV-SP-3: SQLite projection reconciled forward from the session event log"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::provider::MessagePart;
+    use zeph_session::SessionEventLog;
+
+    async fn make_memory() -> SemanticMemory {
+        SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            None,
+            AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            "test-model",
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn reconciles_trailing_plain_messages() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "hello".to_owned(),
+                image_refs: vec![],
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::AssistantMessage {
+                parts: vec![MessagePart::Text {
+                    text: "hi there".to_owned(),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        let events = log.read_all().await.unwrap();
+
+        // Simulates the INV-SP-1 crash window: the log has 2 events, but SQLite `messages` has
+        // none yet (a real `SessionSink` would have already bumped `acp_sessions.event_count`
+        // to 2 at this point too — irrelevant here since reconcile no longer reads that column).
+        reconcile_projection(&memory, cid, "s1", &events)
+            .await
+            .unwrap();
+
+        let history = memory
+            .sqlite()
+            .load_history_filtered(cid, 50, Some(true), None)
+            .await
+            .unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].content, "hello");
+        assert_eq!(history[1].content, "hi there");
+    }
+
+    #[tokio::test]
+    async fn skips_when_no_gap() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "hello".to_owned(),
+                image_refs: vec![],
+            },
+        )
+        .await
+        .unwrap();
+        let events = log.read_all().await.unwrap();
+
+        // SQLite already has the one message the log records — nothing to reconcile.
+        memory
+            .sqlite()
+            .save_message(cid, "user", "hello")
+            .await
+            .unwrap();
+
+        reconcile_projection(&memory, cid, "s1", &events)
+            .await
+            .unwrap();
+
+        // No duplicate row was written.
+        let history = memory
+            .sqlite()
+            .load_history_filtered(cid, 50, Some(true), None)
+            .await
+            .unwrap();
+        assert_eq!(history.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn skips_gap_containing_a_tool_call() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "run ls".to_owned(),
+                image_refs: vec![],
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::ToolCall {
+                id: "t1".to_owned(),
+                name: "shell".to_owned(),
+                input: serde_json::json!({}),
+            },
+        )
+        .await
+        .unwrap();
+        let events = log.read_all().await.unwrap();
+
+        reconcile_projection(&memory, cid, "s1", &events)
+            .await
+            .unwrap();
+
+        // Bailed out safely: no rows written.
+        let history = memory
+            .sqlite()
+            .load_history_filtered(cid, 50, Some(true), None)
+            .await
+            .unwrap();
+        assert!(history.is_empty());
+    }
+
+    /// A tool call that precedes the un-committed message gap must not block reconciliation —
+    /// only complex events AT OR AFTER the first missing message matter.
+    #[tokio::test]
+    async fn tool_call_before_the_gap_does_not_block_reconciliation() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "run ls".to_owned(),
+                image_refs: vec![],
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::ToolCall {
+                id: "t1".to_owned(),
+                name: "shell".to_owned(),
+                input: serde_json::json!({}),
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::AssistantMessage {
+                parts: vec![MessagePart::Text {
+                    text: "done".to_owned(),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        let events = log.read_all().await.unwrap();
+
+        // Only the first message ("run ls") is already in SQLite; the tool call has no
+        // `messages` row and sits entirely before the un-committed "done" message.
+        memory
+            .sqlite()
+            .save_message(cid, "user", "run ls")
+            .await
+            .unwrap();
+
+        reconcile_projection(&memory, cid, "s1", &events)
+            .await
+            .unwrap();
+
+        let history = memory
+            .sqlite()
+            .load_history_filtered(cid, 50, Some(true), None)
+            .await
+            .unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[1].content, "done");
+    }
+}

--- a/crates/zeph-agent-persistence/src/session_sink.rs
+++ b/crates/zeph-agent-persistence/src/session_sink.rs
@@ -1,0 +1,320 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`SessionSink`]: dual-write of turn messages into the durable session event log.
+//!
+//! Implements INV-SP-1 (spec-068 §13): a turn's `SessionEvent`s must be appended to
+//! `events.jsonl` and durably flushed **before** the `SQLite` `messages` projection or
+//! `acp_sessions.last_seq` are updated — the projection must never lead the log. Callers
+//! (`zeph-core`'s `Agent::persist_message` shim) MUST invoke [`SessionSink::record_message`]
+//! before calling `PersistenceService::persist_message`, not after.
+
+use std::sync::Arc;
+
+use zeph_common::SessionId;
+use zeph_llm::provider::{MessagePart, Role};
+use zeph_session::{CompactionTier, SessionError, SessionEvent, SessionEventLog, SessionStore};
+
+/// Dual-writes turn messages to the durable JSONL event log ahead of the `SQLite` projection.
+///
+/// One `SessionSink` is constructed per live conversation-session and held for its lifetime
+/// (mirrors `zeph_session`'s single-writer precondition, INV-D2 — only one `SessionSink` may
+/// hold a given session's [`SessionEventLog`] at a time).
+pub struct SessionSink {
+    log: Arc<SessionEventLog>,
+    store: SessionStore,
+    session_id: SessionId,
+}
+
+impl SessionSink {
+    /// Wrap an already-opened [`SessionEventLog`] and [`SessionStore`] for `session_id`.
+    #[must_use]
+    pub fn new(log: Arc<SessionEventLog>, store: SessionStore, session_id: SessionId) -> Self {
+        Self {
+            log,
+            store,
+            session_id,
+        }
+    }
+
+    /// The session this sink writes to.
+    #[must_use]
+    pub fn session_id(&self) -> &SessionId {
+        &self.session_id
+    }
+
+    /// Record one persisted message as a `SessionEvent`, then update `acp_sessions.last_seq`.
+    ///
+    /// `role == Role::System` (and any future non-exhaustive `Role` variant) is a no-op:
+    /// system-role `persist_message` calls carry live in-memory compaction summaries, which map
+    /// to the `Compaction` event emitted separately by the compaction hook (spec §8.1), not to a
+    /// generic system message — there is no `SessionEvent` variant for an untyped system message.
+    ///
+    /// For `Role::Assistant`, the real production call sites
+    /// (`Agent::persist_message` from `crates/zeph-core/src/agent/tool_execution/tier_loop.rs`)
+    /// always pass the response text via `content` and an empty `parts` slice — `parts` is only
+    /// populated in a handful of tests that construct it explicitly. When `parts` is empty and
+    /// `content` is non-empty, `content` is wrapped into a single [`MessagePart::Text`] so the
+    /// durable log captures the real response either way; an explicitly provided `parts` is used
+    /// as-is (never overwritten by `content`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError`] if the log append or the `last_seq` update fails. Callers should
+    /// log and continue rather than fail the turn — a dropped session-log write only means that
+    /// turn is absent from replay, not that agent state is corrupted (`SQLite` projection write
+    /// still proceeds independently after this call in the caller's turn-persistence path).
+    #[tracing::instrument(
+        name = "persistence.session_sink.record_message",
+        skip_all,
+        level = "debug"
+    )]
+    pub async fn record_message(
+        &self,
+        role: Role,
+        content: &str,
+        parts: &[MessagePart],
+    ) -> Result<(), SessionError> {
+        let event = match role {
+            Role::User => SessionEvent::UserMessage {
+                text: content.to_owned(),
+                image_refs: Vec::new(),
+            },
+            Role::Assistant => {
+                let parts = if parts.is_empty() && !content.is_empty() {
+                    vec![MessagePart::Text {
+                        text: content.to_owned(),
+                    }]
+                } else {
+                    parts.to_vec()
+                };
+                SessionEvent::AssistantMessage { parts }
+            }
+            _ => return Ok(()),
+        };
+
+        let envelope = self.log.append(None, None, event).await?;
+        let event_count = envelope.seq + 1;
+        self.store
+            .update_seq(self.session_id.as_str(), envelope.seq, event_count)
+            .await?;
+        Ok(())
+    }
+
+    /// Record that live in-memory compaction fired (spec §8.1), making it replayable.
+    ///
+    /// Unlike [`crate::reconcile_projection`]'s `Condensation` event (event-log-driven, carries a
+    /// precise `replaced_seq_range`), `Compaction` reflects a live, in-memory prune the agent
+    /// already applied to `MessageState.messages` — its schema has no `replaced_seq_range`
+    /// ([`zeph_session::replay::ReplayEngine::fold`] folds it conservatively: a recorded summary
+    /// replaces everything folded so far). `summary` is `None` for now — the LLM-produced
+    /// hard-compaction summary text is not yet surfaced from `zeph-agent-context`'s internal
+    /// state to this call site; `tier`/`cleared_count` alone are enough to make replay aware a
+    /// compaction happened.
+    ///
+    /// A no-op when `cleared_count == 0` (nothing was actually pruned this turn).
+    ///
+    /// M2 (spec §8.3, `INV-SP-4`): also advances `acp_sessions.last_condensed_seq` to this
+    /// event's `seq` — live compaction and durable condensation
+    /// ([`zeph_agent_persistence::maybe_condense_on_resume`](crate::maybe_condense_on_resume))
+    /// share the same non-overlap ledger (`zeph_session::condenser::validate_non_overlap`), so a
+    /// later resume-condensation cannot re-summarize a range compaction already pruned live.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError`] if the log append or either `SessionStore` update fails. Callers
+    /// should log and continue rather than fail the turn, matching [`Self::record_message`].
+    #[tracing::instrument(
+        name = "persistence.session_sink.record_compaction",
+        skip_all,
+        level = "debug",
+        fields(cleared_count)
+    )]
+    pub async fn record_compaction(
+        &self,
+        tier: CompactionTier,
+        cleared_count: u32,
+    ) -> Result<(), SessionError> {
+        if cleared_count == 0 {
+            return Ok(());
+        }
+        let event = SessionEvent::Compaction {
+            tier,
+            cleared_count,
+            summary: None,
+        };
+        let envelope = self.log.append(None, None, event).await?;
+        let event_count = envelope.seq + 1;
+        self.store
+            .update_seq(self.session_id.as_str(), envelope.seq, event_count)
+            .await?;
+        self.store
+            .set_condensed_seq(self.session_id.as_str(), envelope.seq)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_sink(session_id: &str) -> (SessionSink, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let log = Arc::new(SessionEventLog::open(dir.path()).await.unwrap());
+
+        let config = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        };
+        let pool = config.connect().await.unwrap();
+        zeph_db::run_migrations(&pool).await.unwrap();
+        let store = SessionStore::new(pool);
+        store.create(session_id).await.unwrap();
+
+        let sink = SessionSink::new(log, store, SessionId::new(session_id));
+        (sink, dir)
+    }
+
+    #[tokio::test]
+    async fn record_user_message_appends_event_and_updates_seq() {
+        let (sink, _dir) = make_sink("s1").await;
+        sink.record_message(Role::User, "hello", &[]).await.unwrap();
+
+        let meta = sink.store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.last_seq, 0);
+        assert_eq!(meta.event_count, 1);
+
+        let events = sink.log.read_all().await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].kind, SessionEvent::UserMessage { .. }));
+    }
+
+    #[tokio::test]
+    async fn record_assistant_message_carries_parts() {
+        let (sink, _dir) = make_sink("s1").await;
+        let parts = vec![MessagePart::Text {
+            text: "hi there".to_owned(),
+        }];
+        sink.record_message(Role::Assistant, "hi there", &parts)
+            .await
+            .unwrap();
+
+        let events = sink.log.read_all().await.unwrap();
+        assert_eq!(events.len(), 1);
+        let SessionEvent::AssistantMessage { parts: got } = &events[0].kind else {
+            panic!("expected AssistantMessage");
+        };
+        assert_eq!(got.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn record_assistant_message_wraps_content_when_parts_empty() {
+        // Mirrors the real production call shape (`Agent::persist_message` from
+        // `crates/zeph-core/src/agent/tool_execution/tier_loop.rs`): content set, parts empty —
+        // not `record_assistant_message_carries_parts`'s shape above, which only a handful of
+        // tests use. Regression test for #5419.
+        let (sink, _dir) = make_sink("s1").await;
+        sink.record_message(Role::Assistant, "the real response text", &[])
+            .await
+            .unwrap();
+
+        let events = sink.log.read_all().await.unwrap();
+        assert_eq!(events.len(), 1);
+        let SessionEvent::AssistantMessage { parts: got } = &events[0].kind else {
+            panic!("expected AssistantMessage");
+        };
+        assert_eq!(got.len(), 1);
+        let MessagePart::Text { text } = &got[0] else {
+            panic!("expected MessagePart::Text");
+        };
+        assert_eq!(text, "the real response text");
+    }
+
+    #[tokio::test]
+    async fn record_assistant_message_prefers_explicit_parts_over_content() {
+        // When parts is explicitly non-empty, content must not be used to overwrite it.
+        let (sink, _dir) = make_sink("s1").await;
+        let parts = vec![MessagePart::Text {
+            text: "explicit part".to_owned(),
+        }];
+        sink.record_message(Role::Assistant, "ignored content", &parts)
+            .await
+            .unwrap();
+
+        let events = sink.log.read_all().await.unwrap();
+        let SessionEvent::AssistantMessage { parts: got } = &events[0].kind else {
+            panic!("expected AssistantMessage");
+        };
+        assert_eq!(got.len(), 1);
+        let MessagePart::Text { text } = &got[0] else {
+            panic!("expected MessagePart::Text");
+        };
+        assert_eq!(text, "explicit part");
+    }
+
+    #[tokio::test]
+    async fn record_system_message_is_noop() {
+        let (sink, _dir) = make_sink("s1").await;
+        sink.record_message(Role::System, "compaction summary", &[])
+            .await
+            .unwrap();
+
+        let events = sink.log.read_all().await.unwrap();
+        assert!(events.is_empty());
+        let meta = sink.store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.event_count, 0);
+    }
+
+    #[tokio::test]
+    async fn sequential_messages_increment_seq() {
+        let (sink, _dir) = make_sink("s1").await;
+        sink.record_message(Role::User, "a", &[]).await.unwrap();
+        sink.record_message(Role::Assistant, "b", &[])
+            .await
+            .unwrap();
+
+        let meta = sink.store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.last_seq, 1);
+        assert_eq!(meta.event_count, 2);
+    }
+
+    #[tokio::test]
+    async fn record_compaction_appends_event_and_updates_seq() {
+        let (sink, _dir) = make_sink("s1").await;
+        sink.record_compaction(CompactionTier::Hard, 6)
+            .await
+            .unwrap();
+
+        let events = sink.log.read_all().await.unwrap();
+        assert_eq!(events.len(), 1);
+        let SessionEvent::Compaction {
+            tier,
+            cleared_count,
+            summary,
+        } = &events[0].kind
+        else {
+            panic!("expected Compaction");
+        };
+        assert_eq!(*tier, CompactionTier::Hard);
+        assert_eq!(*cleared_count, 6);
+        assert!(summary.is_none());
+
+        let meta = sink.store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.event_count, 1);
+        // M2 (spec §8.3 INV-SP-4): live compaction advances the same non-overlap ledger
+        // resume-time condensation reads, so a later condensation cannot overlap this range.
+        assert_eq!(meta.last_condensed_seq, 0);
+    }
+
+    #[tokio::test]
+    async fn record_compaction_zero_cleared_is_noop() {
+        let (sink, _dir) = make_sink("s1").await;
+        sink.record_compaction(CompactionTier::Soft, 0)
+            .await
+            .unwrap();
+
+        let events = sink.log.read_all().await.unwrap();
+        assert!(events.is_empty());
+    }
+}

--- a/crates/zeph-commands/src/handlers/conv.rs
+++ b/crates/zeph-commands/src/handlers/conv.rs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `/conv` slash command handler — browse durable conversation-sessions (spec-068, #5343).
+//!
+//! Channel-agnostic by construction (the `CommandHandler`/`ChannelSink` pattern): works
+//! identically whether typed in the CLI, TUI, or Telegram, mirroring `zeph serve-sessions`'s
+//! `GET /sessions`/`GET /sessions/:id` REST endpoints but reading through
+//! [`crate::AgentAccess::handle_conv`] instead of HTTP.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::context::CommandContext;
+use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
+
+/// List, inspect, resume, or fork durable conversation-sessions
+/// (`acp_sessions` / `[session] data_dir`).
+///
+/// Syntax: `/conv` or `/conv list` — list sessions; `/conv show <id>` — one session's metadata;
+/// `/conv resume <id>` — live-swap this conversation onto an existing session, replaying its
+/// durable log; `/conv fork <id>` — eager-copy `id` into a fresh session and swap onto it
+/// (spec-068 §9, D-9).
+pub struct ConvCommand;
+
+impl CommandHandler<CommandContext<'_>> for ConvCommand {
+    fn name(&self) -> &'static str {
+        "/conv"
+    }
+
+    fn description(&self) -> &'static str {
+        "List, inspect, resume, or fork durable conversation-sessions"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "[list | show <id> | resume <id> | fork <id>]"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn feature_gate(&self) -> Option<&'static str> {
+        Some("session")
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        use tracing::Instrument as _;
+        let span = tracing::info_span!("commands.conv.handle");
+        Box::pin(
+            async move {
+                let result = ctx.agent.handle_conv(args).await?;
+                Ok(CommandOutput::Message(result))
+            }
+            .instrument(span),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
+    use crate::sink::NullSink;
+
+    #[test]
+    fn conv_name_and_description() {
+        assert_eq!(ConvCommand.name(), "/conv");
+        assert!(!ConvCommand.description().is_empty());
+    }
+
+    #[tokio::test]
+    async fn conv_not_supported_returns_ok_message() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+        let result = ConvCommand.handle(&mut ctx, "").await;
+        assert!(result.is_ok());
+        if let Ok(CommandOutput::Message(msg)) = result {
+            assert!(!msg.is_empty());
+        }
+    }
+}

--- a/crates/zeph-commands/src/handlers/mod.rs
+++ b/crates/zeph-commands/src/handlers/mod.rs
@@ -17,6 +17,7 @@ pub mod checkpoint;
 #[cfg(feature = "cocoon")]
 pub mod cocoon;
 pub mod compaction;
+pub mod conv;
 pub mod debug;
 pub mod experiment;
 pub mod goal;

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -564,6 +564,27 @@ pub trait AgentAccess: Send {
         let _ = args;
         Box::pin(async move { Ok(String::new()) })
     }
+
+    // ----- /conv -----
+
+    /// Execute `/conv [list]` or `/conv show <id>` (spec-068, #5343).
+    ///
+    /// `args` is everything after `/conv`. Empty string and `"list"` both list durable
+    /// conversation-sessions; `"show <id>"` returns one session's metadata. Mirrors
+    /// `zeph serve-sessions`'s `GET /sessions`/`GET /sessions/:id` REST endpoints, reading
+    /// through the same `zeph_session::SessionStore`.
+    ///
+    /// Returns a formatted response string. The default returns a "not supported" message —
+    /// only channels backed by an `Agent` with `[session] enabled = true` override this.
+    fn handle_conv<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let _ = args;
+        Box::pin(async move {
+            Ok("Conversation-session persistence is not enabled in this context.".to_owned())
+        })
+    }
 }
 
 /// A no-op [`AgentAccess`] implementation.

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -103,6 +103,7 @@ pub mod rate_limit;
 pub mod root;
 pub mod sanitizer;
 pub mod security;
+pub mod serve;
 pub mod session;
 pub mod subagent;
 pub mod telemetry;
@@ -184,6 +185,7 @@ pub use security::{
     CapabilityScopesConfig, PatternStrictness, ScannerConfig, ScopeConfig, SecurityConfig,
     ShadowSentinelConfig, TimeoutConfig, TrajectorySentinelConfig, TrustConfig,
 };
+pub use serve::ServeConfig;
 pub use session::{RecapConfig, SessionConfig};
 pub use subagent::{
     HookAction, HookDef, HookMatcher, MemoryScope, PermissionMode, SkillFilter, SubagentHooks,

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -16,6 +16,7 @@ mod infra;
 mod llm;
 mod mcp;
 mod memory;
+mod serve;
 mod session;
 mod tools;
 
@@ -32,6 +33,7 @@ pub(crate) use llm::migrate_gonkagate_to_gonka;
 pub use llm::*;
 pub use mcp::*;
 pub use memory::*;
+pub use serve::migrate_serve_config;
 pub use session::*;
 pub use tools::*;
 
@@ -611,15 +613,15 @@ use steps::{
     MigrateOrchestratorProvider, MigrateOtelFilter, MigratePlannerModelToProvider,
     MigratePolicyProviderAndUtilityWindow, MigrateProviderMaxConcurrent, MigrateQdrantApiKey,
     MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
-    MigrateSessionPersistProviderOverrides, MigrateSessionProviderPersistence,
-    MigrateSessionRecapConfig, MigrateShellCheckpointsConfig, MigrateShellTransactional,
-    MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
-    MigrateToolsCompressionConfig, MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse,
-    MigrateTuiThemeConfig, MigrateTuiThemeDefaults, MigrateVigilConfig, MigrateWorktreeConfig,
-    MigrateWorktreeGitTimeout,
+    MigrateServeConfig, MigrateSessionPersistProviderOverrides, MigrateSessionPersistenceConfig,
+    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellCheckpointsConfig,
+    MigrateShellTransactional, MigrateSttToProvider, MigrateSupervisorConfig,
+    MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateTraceMetadata,
+    MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig, MigrateTuiThemeDefaults,
+    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–69).
+/// Ordered registry of all sequential migration steps (steps 1–71).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -740,6 +742,10 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateTuiMouse),
             // Step 69 — add default_asset_sensitivity advisory comment under [orchestration] (spec-068, #3934)
             Box::new(MigrateOrchestrationAssetSensitivity),
+            // Step 70 — add session-persistence keys + [session.condense] advisory block (#5343)
+            Box::new(MigrateSessionPersistenceConfig),
+            // Step 71 — add [serve] advisory block for `zeph serve` (spec-068 §9, #5343)
+            Box::new(MigrateServeConfig),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/serve.rs
+++ b/crates/zeph-config/src/migrate/serve.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `[serve]` config migration step (spec-068 §9, #5343).
+
+use super::{MigrateError, MigrationResult};
+
+/// Append a commented-out `[serve]` block if the config lacks it (spec-068 §9, #5343).
+///
+/// `ServeConfig` uses `#[serde(default)]` so existing configs without this section parse fine
+/// (the `zeph serve` command is opt-in via the CLI subcommand regardless of config presence).
+/// This step is discoverability-only, mirroring
+/// [`super::session::migrate_acp_subagents_config`].
+///
+/// Idempotent: skipped when `[serve]` (active or commented) is already present.
+///
+/// # Errors
+///
+/// Infallible in practice; `Result` matches the migration convention.
+pub fn migrate_serve_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src
+        .lines()
+        .any(|l| l.trim() == "[serve]" || l.trim() == "# [serve]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [serve] — `zeph serve` persistent agent service (spec-068 §9, #5343).\n\
+         # [serve]\n\
+         # http_addr = \"127.0.0.1:8420\"          # HTTP/SSE API bind address\n\
+         # require_auth = true                    # require a bearer token on /sessions* endpoints\n\
+         # auth_token_vault_key = \"ZEPH_SERVE_AUTH_TOKEN\"  # age-vault key name for the bearer token\n\
+         # max_sessions = 50                       # concurrent live sessions LiveSessionRegistry holds\n\
+         # session_idle_ttl_secs = 1800            # idle SessionActor eviction threshold\n\
+         # max_queued_prompts = 8                  # per-session prompt mailbox capacity\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["serve".to_owned()],
+    })
+}

--- a/crates/zeph-config/src/migrate/session.rs
+++ b/crates/zeph-config/src/migrate/session.rs
@@ -242,3 +242,55 @@ pub fn migrate_session_persist_provider_overrides(
         sections_changed: vec!["session".to_owned()],
     })
 }
+
+/// Splice the session-persistence keys (`enabled`, `data_dir`, `encrypt`, `max_event_log_mb`)
+/// into an existing `[session]` block and append a commented-out `[session.condense]` block
+/// (spec-068, #5343).
+///
+/// `SessionConfig`/`CondenseConfig` use `#[serde(default)]` so existing configs without these
+/// keys parse fine (event-log persistence defaults to enabled). This step is
+/// discoverability-only, mirroring [`migrate_session_persist_provider_overrides`].
+///
+/// Idempotent: skipped when `max_event_log_mb` is already present (commented or live), or when
+/// there is no `[session]` section yet (a prior run of
+/// [`migrate_session_provider_persistence`] creates the block itself).
+///
+/// # Errors
+///
+/// Infallible in practice; `Result` matches the migration convention.
+pub fn migrate_session_persistence_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("max_event_log_mb") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+    if !toml_src.lines().any(|l| l.trim() == "[session]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let session_keys = "# enabled = true  \
+        # maintain a durable, replayable JSONL event log per session (spec-068, #5343)\n\
+        # data_dir = \".zeph/sessions\"  # directory for per-session event logs\n\
+        # encrypt = false  # opt-in AEAD encryption of session event logs (deferred to post-MVP)\n\
+        # max_event_log_mb = 256  # event-log size (MB) that guards a rotate/condense trigger\n";
+    let output = toml_src.replacen("[session]\n", &format!("[session]\n{session_keys}"), 1);
+
+    let condense_block = "\n# [session.condense] — durable context condensation policy (spec-068 §8, #5343).\n\
+         # [session.condense]\n\
+         # condense_provider = \"fast\"  # [[llm.providers]] name; empty falls back to the primary provider\n\
+         # threshold = 0.85            # fraction of context budget that triggers condensation\n\
+         # keep_recent = 20            # minimum recent events preserved after condensation\n";
+    let output = format!("{output}{condense_block}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["session".to_owned(), "session.condense".to_owned()],
+    })
+}

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -25,7 +25,12 @@
 //! step 63 adds `recall_include_imported` to `[memory.graph]` (#5015);
 //! step 64 adds `policy_provider` and `utility_window` advisory comments (#5067);
 //! step 65 adds `[tui.theme]` advisory block (Theme System 2.0, #5087);
-//! step 66 inserts active `name`/`color_mode` defaults into `[tui.theme]` (#5091).
+//! step 66 inserts active `name`/`color_mode` defaults into `[tui.theme]` (#5091);
+//! step 67 adds `[tui] delights` advisory comment;
+//! step 68 adds `mouse = false` advisory comment under `[tui]` (#5103);
+//! step 69 adds `default_asset_sensitivity` advisory comment under `[orchestration]` (spec-068, #3934);
+//! step 70 adds session-persistence keys and a `[session.condense]` advisory block (spec-068, #5343);
+//! step 71 adds a `[serve]` advisory block for `zeph serve` (spec-068 §9, #5343).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -52,13 +57,14 @@ use super::{
     migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
     migrate_policy_provider_and_utility_window, migrate_provider_max_concurrent,
     migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
-    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
-    migrate_session_persist_provider_overrides, migrate_session_provider_persistence,
-    migrate_session_recap_config, migrate_shell_checkpoints_config, migrate_shell_transactional,
-    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
-    migrate_tools_compression_config, migrate_trace_metadata, migrate_tui_delights,
-    migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults, migrate_vigil_config,
-    migrate_worktree_config, migrate_worktree_git_timeout,
+    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config, migrate_serve_config,
+    migrate_session_persist_provider_overrides, migrate_session_persistence_config,
+    migrate_session_provider_persistence, migrate_session_recap_config,
+    migrate_shell_checkpoints_config, migrate_shell_transactional, migrate_stt_to_provider,
+    migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
+    migrate_trace_metadata, migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config,
+    migrate_tui_theme_defaults, migrate_vigil_config, migrate_worktree_config,
+    migrate_worktree_git_timeout,
 };
 
 // ── Wrapper structs for all 69 sequential migration steps ───────────────────────────────────────
@@ -821,5 +827,30 @@ impl Migration for MigrateOrchestrationAssetSensitivity {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_orchestration_asset_sensitivity(toml_src)
+    }
+}
+
+/// Step 70 — add session-persistence keys and a `[session.condense]` advisory block
+/// (spec-068-session-persistence, #5343).
+pub(super) struct MigrateSessionPersistenceConfig;
+impl Migration for MigrateSessionPersistenceConfig {
+    fn name(&self) -> &'static str {
+        "migrate_session_persistence_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_session_persistence_config(toml_src)
+    }
+}
+
+/// Step 71 — add a `[serve]` advisory block for `zeph serve` (spec-068 §9, #5343).
+pub(super) struct MigrateServeConfig;
+impl Migration for MigrateServeConfig {
+    fn name(&self) -> &'static str {
+        "migrate_serve_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_serve_config(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        69,
-        "MIGRATIONS registry must contain all 69 sequential steps"
+        71,
+        "MIGRATIONS registry must contain all 71 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1645,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 69);
+    assert_eq!(MIGRATIONS.len(), 71);
 }
 
 #[test]
@@ -1684,7 +1684,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–69).
+    // Names must follow the documented step order (steps 1–71).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1755,6 +1755,8 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_tui_delights",
         "migrate_tui_mouse",
         "migrate_orchestration_asset_sensitivity",
+        "migrate_session_persistence_config",
+        "migrate_serve_config",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -3024,6 +3026,91 @@ fn step_69_idempotent_on_own_output() {
     let first = migrate_orchestration_asset_sensitivity(src).expect("first migrate");
     assert_eq!(first.changed_count, 1);
     let second = migrate_orchestration_asset_sensitivity(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
+    );
+}
+
+// ── Step 70 — migrate_session_persistence_config (spec-068-session-persistence, #5343) ──
+
+#[test]
+fn step_70_injects_session_persistence_keys_when_session_present() {
+    let src = "[session]\nprovider_persistence = true\n";
+    let result = migrate_session_persistence_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("max_event_log_mb"));
+    assert!(result.output.contains("[session.condense]"));
+    assert_eq!(
+        result.sections_changed,
+        vec!["session".to_owned(), "session.condense".to_owned()]
+    );
+}
+
+#[test]
+fn step_70_noop_when_no_session_section() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_session_persistence_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_70_noop_when_key_already_present() {
+    let src = "[session]\nmax_event_log_mb = 256\n";
+    let result = migrate_session_persistence_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_70_idempotent_on_own_output() {
+    let src = "[session]\nprovider_persistence = true\n";
+    let first = migrate_session_persistence_config(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_session_persistence_config(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
+    );
+}
+
+// ── Step 71 — migrate_serve_config (spec-068 §9, #5343) ──
+
+#[test]
+fn step_71_adds_serve_block_when_absent() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_serve_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("# [serve]"));
+    assert!(result.output.contains("http_addr"));
+    assert_eq!(result.sections_changed, vec!["serve".to_owned()]);
+}
+
+#[test]
+fn step_71_noop_when_serve_section_already_active() {
+    let src = "[serve]\nhttp_addr = \"127.0.0.1:8420\"\n";
+    let result = migrate_serve_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_71_noop_when_serve_comment_already_present() {
+    let src = "# [serve]\n# http_addr = \"127.0.0.1:8420\"\n";
+    let result = migrate_serve_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_71_idempotent_on_own_output() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let first = migrate_serve_config(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_serve_config(&first.output).expect("second migrate");
     assert_eq!(second.changed_count, 0, "second run must be a no-op");
     assert_eq!(
         second.output, first.output,

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -115,6 +115,9 @@ pub struct Config {
     /// Session UX settings (recap-on-resume, etc.).
     #[serde(default)]
     pub session: crate::session::SessionConfig,
+    /// `zeph serve` persistent agent service settings (spec-068 §9).
+    #[serde(default)]
+    pub serve: crate::serve::ServeConfig,
     /// Session-scoped CLI overrides (bare mode, JSON output, auto-approve).
     #[serde(default)]
     pub cli: CliConfig,
@@ -349,6 +352,7 @@ impl Default for Config {
             telemetry: TelemetryConfig::default(),
             metrics: MetricsConfig::default(),
             session: crate::session::SessionConfig::default(),
+            serve: crate::serve::ServeConfig::default(),
             cli: CliConfig::default(),
             quality: crate::quality::QualityConfig::default(),
             notifications: NotificationsConfig::default(),

--- a/crates/zeph-config/src/serve.rs
+++ b/crates/zeph-config/src/serve.rs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `[serve]` config: settings for the `zeph serve` persistent agent service (spec-068 §9).
+//!
+//! `zeph serve` runs a long-lived process exposing sessions over an HTTP/SSE API and (optionally)
+//! ACP, backed by the same durable JSONL event log as every other channel. This module only
+//! declares the config surface — see `crates/zeph-core` for `SessionActor`/`LiveSessionRegistry`
+//! and `src/serve/` for the HTTP handlers.
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level `[serve]` config block (spec-068 §9).
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [serve]
+/// http_addr = "127.0.0.1:8420"
+/// require_auth = true
+/// auth_token_vault_key = "ZEPH_SERVE_AUTH_TOKEN"
+/// max_sessions = 50
+/// session_idle_ttl_secs = 1800
+/// max_queued_prompts = 8
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ServeConfig {
+    /// Address the HTTP/SSE API binds to. Default: `"127.0.0.1:8420"`.
+    pub http_addr: String,
+    /// Require a bearer token on all `/sessions*` endpoints (`/health` is always
+    /// unauthenticated). Default: `true`.
+    ///
+    /// Per CLAUDE.md's vault-only secrets policy, the token itself is never stored in this
+    /// config file — only the vault key name to resolve it from (`auth_token_vault_key`).
+    pub require_auth: bool,
+    /// Zeph age-vault key name to resolve the bearer token from at startup (spec-068 NFR-S4).
+    /// Default: `"ZEPH_SERVE_AUTH_TOKEN"`.
+    pub auth_token_vault_key: String,
+    /// Maximum number of concurrent live sessions the `LiveSessionRegistry` will hold.
+    /// Default: `50`.
+    pub max_sessions: usize,
+    /// Seconds of no attached broadcast receivers before `serve.evict` shuts down and removes a
+    /// session's `SessionActor` (spec-068 §9.3). Default: `1800` (30 minutes).
+    pub session_idle_ttl_secs: u64,
+    /// Bounded mpsc capacity for a `SessionActor`'s prompt mailbox; a full mailbox returns HTTP
+    /// 429 to the caller rather than blocking (spec-068 §9.2). Default: `8`.
+    pub max_queued_prompts: usize,
+}
+
+impl Default for ServeConfig {
+    fn default() -> Self {
+        Self {
+            http_addr: "127.0.0.1:8420".to_owned(),
+            require_auth: true,
+            auth_token_vault_key: "ZEPH_SERVE_AUTH_TOKEN".to_owned(),
+            max_sessions: 50,
+            session_idle_ttl_secs: 1800,
+            max_queued_prompts: 8,
+        }
+    }
+}

--- a/crates/zeph-config/src/session.rs
+++ b/crates/zeph-config/src/session.rs
@@ -13,6 +13,7 @@ use crate::providers::ProviderName;
 /// Top-level `[session]` config block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
+#[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 pub struct SessionConfig {
     /// Recap-on-resume settings.
     pub recap: RecapConfig,
@@ -30,6 +31,26 @@ pub struct SessionConfig {
     /// `provider_persistence` is also `true` — overrides are meaningless without a persisted
     /// provider to apply them to. Default: `true`.
     pub persist_provider_overrides: bool,
+    /// Whether to maintain a durable, replayable JSONL event log per conversation-session
+    /// (spec-068, #5343). Default: `true`.
+    ///
+    /// When `true`, every channel (CLI, TUI, Telegram, ACP) mints a
+    /// [`zeph_common::SessionId`] on first turn and appends
+    /// `SessionEvent`s to `<data_dir>/sessions/<session_id>/events.jsonl`. When `false`, only the
+    /// existing `messages` `SQLite` projection is written (pre-#5343 behavior).
+    pub enabled: bool,
+    /// Directory under which per-session event logs are stored (spec-068 §4.1).
+    ///
+    /// Default: `.zeph/sessions` (sibling of `memory.sqlite_path`'s parent directory).
+    pub data_dir: String,
+    /// Opt-in AEAD encryption of session event logs. Deferred to a post-MVP implementation
+    /// (spec-068 §4.3) — currently has no effect. Default: `false`.
+    pub encrypt: bool,
+    /// Event-log size (in MB) that acts as a rotate/condense trigger guard (spec-068 §17).
+    /// Default: `256`.
+    pub max_event_log_mb: u64,
+    /// Durable context condensation settings (spec-068 §8).
+    pub condense: CondenseConfig,
 }
 
 impl Default for SessionConfig {
@@ -38,6 +59,39 @@ impl Default for SessionConfig {
             recap: RecapConfig::default(),
             provider_persistence: true,
             persist_provider_overrides: true,
+            enabled: true,
+            data_dir: ".zeph/sessions".to_owned(),
+            encrypt: false,
+            max_event_log_mb: 256,
+            condense: CondenseConfig::default(),
+        }
+    }
+}
+
+/// `[session.condense]` — durable context condensation policy (spec-068 §8).
+///
+/// Distinct from live in-memory compaction (`zeph-context`): condensation operates at the
+/// event-log level and is recorded as a replayable `Condensation` event.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct CondenseConfig {
+    /// Provider name from `[[llm.providers]]` for condensation LLM calls.
+    ///
+    /// An empty [`ProviderName`] falls back to the primary provider. Default: `"fast"`.
+    pub condense_provider: ProviderName,
+    /// Fraction of the context budget that triggers condensation on resume/mid-session.
+    /// Default: `0.85`.
+    pub threshold: f64,
+    /// Minimum number of recent events to preserve after condensation. Default: `20`.
+    pub keep_recent: usize,
+}
+
+impl Default for CondenseConfig {
+    fn default() -> Self {
+        Self {
+            condense_provider: ProviderName::from("fast"),
+            threshold: 0.85,
+            keep_recent: 20,
         }
     }
 }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -22,11 +22,11 @@ cocoon = ["zeph-llm/cocoon", "zeph-commands/cocoon"]
 index = ["zeph-agent-context/index"]
 metal = ["zeph-llm/metal"]
 mock = ["zeph-vault/mock"]
-postgres = ["zeph-db/postgres", "zeph-agent-context/postgres", "zeph-agent-persistence/postgres", "zeph-durable/postgres"]
+postgres = ["zeph-db/postgres", "zeph-agent-context/postgres", "zeph-agent-persistence/postgres", "zeph-durable/postgres", "zeph-session/postgres"]
 profiling = ["dep:tracing-subscriber", "zeph-commands/profiling"]
 profiling-alloc = ["profiling"]
 scheduler  = []
-sqlite = ["zeph-db/sqlite", "zeph-agent-context/sqlite", "zeph-agent-persistence/sqlite", "zeph-durable/sqlite"]
+sqlite = ["zeph-db/sqlite", "zeph-agent-context/sqlite", "zeph-agent-persistence/sqlite", "zeph-durable/sqlite", "zeph-session/sqlite"]
 sysinfo = ["dep:sysinfo"]
 
 [dependencies]
@@ -81,6 +81,7 @@ zeph-memory.workspace = true
 zeph-orchestration.workspace = true
 zeph-plugins.workspace = true
 zeph-sanitizer.workspace = true
+zeph-session = { workspace = true, default-features = false }
 zeph-skills = { workspace = true, features = ["qdrant"] }
 zeph-subagent.workspace = true
 zeph-tools.workspace = true

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1707,6 +1707,207 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
             Ok(out)
         })
     }
+
+    // ----- /conv -----
+
+    fn handle_conv<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let args_owned = args.trim().to_owned();
+        Box::pin(async move {
+            // `resume`/`fork` need `&mut self` (mid-session live conversation swap, D-9) —
+            // handled first so `self` isn't already borrowed by the `list`/`show` path below.
+            if let Some(id) = args_owned.strip_prefix("resume ") {
+                return self.handle_conv_resume(id.trim()).await;
+            }
+            if let Some(id) = args_owned.strip_prefix("fork ") {
+                return self.handle_conv_fork(id.trim()).await;
+            }
+
+            let Some(memory) = self.services.memory.persistence.memory.clone() else {
+                return Ok(
+                    "Conversation-session persistence requires memory to be enabled ([memory] enabled = true)."
+                        .to_owned(),
+                );
+            };
+            let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+
+            if let Some(id) = args_owned.strip_prefix("show ") {
+                return handle_conv_show(&store, id.trim()).await;
+            }
+            if args_owned.is_empty() || args_owned == "list" {
+                return handle_conv_list(&store).await;
+            }
+            Ok(format!(
+                "Unknown /conv subcommand '{args_owned}'. Usage: /conv [list | show <id> | resume <id> | fork <id>]"
+            ))
+        })
+    }
+}
+
+impl<C: Channel> Agent<C> {
+    /// `/conv resume <id>` (spec-068, #5343, D-9): mid-session live swap onto an existing
+    /// durable session. Resolves `conversation_id` via the `SessionId`<->`ConversationId`
+    /// bijection (spec §5.2) — reuses the session's existing linked conversation if one exists,
+    /// otherwise mints one and links it (a session created via the HTTP API's `POST /sessions`,
+    /// or a legacy session, may not have one yet).
+    async fn handle_conv_resume(&mut self, id: &str) -> Result<String, CommandError> {
+        if id.is_empty() {
+            return Ok("Usage: /conv resume <id>".to_owned());
+        }
+        let Some(memory) = self.services.memory.persistence.memory.clone() else {
+            return Ok(
+                "Conversation-session persistence requires memory to be enabled ([memory] enabled = true)."
+                    .to_owned(),
+            );
+        };
+        let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+        let Some(metadata) = store
+            .get(id)
+            .await
+            .map_err(|e| CommandError::new(e.to_string()))?
+        else {
+            return Ok(format!("Session '{id}' not found."));
+        };
+
+        let conversation_id = if let Some(cid) = metadata.conversation_id {
+            zeph_memory::ConversationId(cid)
+        } else {
+            let cid = memory
+                .sqlite()
+                .create_conversation()
+                .await
+                .map_err(|e| CommandError::new(e.to_string()))?;
+            store
+                .link_conversation(id, cid.0)
+                .await
+                .map_err(|e| CommandError::new(e.to_string()))?;
+            cid
+        };
+
+        let session_id = zeph_common::SessionId::new(id);
+        self.load_and_resume_conversation(&session_id, conversation_id)
+            .await
+            .map_err(|e| CommandError::new(e.to_string()))?;
+
+        Ok(format!(
+            "Resumed session {id} ({} event(s) replayed).",
+            metadata.event_count
+        ))
+    }
+
+    /// `/conv fork <id>` (spec-068, #5343, D-9): eager-copies `id`'s durable log into a fresh
+    /// child session via `ForkEngine::fork` (P2), then immediately live-swaps onto the child —
+    /// same effect as `POST /sessions/:id/fork` (spec §9.4) but for the current CLI/TUI session
+    /// instead of spawning a new `SessionActor`.
+    async fn handle_conv_fork(&mut self, id: &str) -> Result<String, CommandError> {
+        if id.is_empty() {
+            return Ok("Usage: /conv fork <id>".to_owned());
+        }
+        let Some(memory) = self.services.memory.persistence.memory.clone() else {
+            return Ok(
+                "Conversation-session persistence requires memory to be enabled ([memory] enabled = true)."
+                    .to_owned(),
+            );
+        };
+        let Some(session_persistence_config) =
+            self.services.session.session_persistence_config.clone()
+        else {
+            return Ok(
+                "Conversation-session persistence is not enabled ([session] enabled = true)."
+                    .to_owned(),
+            );
+        };
+        let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+        let data_dir = std::path::PathBuf::from(&session_persistence_config.data_dir);
+        let new_id = zeph_common::SessionId::generate();
+
+        let fork_result =
+            zeph_session::ForkEngine::fork(&data_dir, id, new_id.as_str(), None, &store)
+                .await
+                .map_err(|e| CommandError::new(e.to_string()))?;
+
+        let conversation_id = memory
+            .sqlite()
+            .create_conversation()
+            .await
+            .map_err(|e| CommandError::new(e.to_string()))?;
+
+        self.load_and_resume_conversation(&new_id, conversation_id)
+            .await
+            .map_err(|e| CommandError::new(e.to_string()))?;
+
+        Ok(format!(
+            "Forked session {id} -> {} ({} event(s) copied); now the active conversation.",
+            fork_result.new_session_id, fork_result.events_copied
+        ))
+    }
+}
+
+/// Formats `/conv list` — mirrors `sessions list`'s CLI table layout
+/// (`src/commands/sessions.rs`) and `zeph serve-sessions`'s `GET /sessions`.
+async fn handle_conv_list(store: &zeph_session::SessionStore) -> Result<String, CommandError> {
+    use std::fmt::Write as _;
+
+    let sessions = store
+        .list(&zeph_session::SessionFilter::default())
+        .await
+        .map_err(|e| CommandError::new(format!("failed to list sessions: {e}")))?;
+
+    if sessions.is_empty() {
+        return Ok("No conversation-sessions found.".to_owned());
+    }
+
+    let mut out = format!(
+        "{:<38} {:<30} {:<9} {:>6} {:<24}\n",
+        "ID", "TITLE", "STATUS", "EVENTS", "UPDATED"
+    );
+    out.push_str(&"-".repeat(110));
+    out.push('\n');
+    for s in &sessions {
+        let title = s.title.as_deref().unwrap_or("(untitled)");
+        let _ = writeln!(
+            out,
+            "{:<38} {:<30} {:<9} {:>6} {:<24}",
+            s.session_id,
+            crate::text::truncate_to_chars(title, 30),
+            s.status.as_str(),
+            s.event_count,
+            s.updated_at
+        );
+    }
+    Ok(out.trim_end().to_owned())
+}
+
+/// Formats `/conv show <id>` — one session's metadata, mirroring `zeph serve-sessions`'s
+/// `GET /sessions/:id` (metadata only; use `zeph sessions show --events <id>` on the CLI for a
+/// full event-log dump).
+async fn handle_conv_show(
+    store: &zeph_session::SessionStore,
+    id: &str,
+) -> Result<String, CommandError> {
+    if id.is_empty() {
+        return Ok("Usage: /conv show <id>".to_owned());
+    }
+    let metadata = store
+        .get(id)
+        .await
+        .map_err(|e| CommandError::new(format!("failed to read session metadata: {e}")))?;
+    let Some(m) = metadata else {
+        return Ok(format!("Session '{id}' not found."));
+    };
+    Ok(format!(
+        "Session {}\n  title: {}\n  status: {}\n  events: {} (last_seq={})\n  forked_from: {}\n  created: {}\n  updated: {}",
+        m.session_id,
+        m.title.as_deref().unwrap_or("(untitled)"),
+        m.status.as_str(),
+        m.event_count,
+        m.last_seq,
+        m.forked_from.as_deref().unwrap_or("-"),
+        m.created_at,
+        m.updated_at
+    ))
 }
 
 type GoalStore = crate::goal::GoalStore;

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -139,6 +139,53 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Attach the durable session event-log dual-writer (spec-068, #5343).
+    ///
+    /// `None` when `[session] enabled = false` — the agent then persists only the `SQLite`
+    /// `messages` projection, matching pre-#5343 behavior.
+    #[must_use]
+    pub fn with_session_sink(
+        mut self,
+        session_sink: Option<Arc<zeph_agent_persistence::SessionSink>>,
+    ) -> Self {
+        self.services.session.session_sink = session_sink;
+        self
+    }
+
+    /// Retain the `[session]` config snapshot (spec-068, #5343, D-9) so a mid-session
+    /// `/conv resume`/`/conv fork` swap can locate `data_dir` later — unlike
+    /// [`Self::with_session_sink`], this config is not consumed at construction time.
+    #[must_use]
+    pub fn with_session_persistence_config(
+        mut self,
+        config: Option<zeph_config::SessionConfig>,
+    ) -> Self {
+        self.services.session.session_persistence_config = config;
+        self
+    }
+
+    /// Seed `MessageState` directly from a durable event-log replay (spec-068, #5343), bypassing
+    /// the `SQLite`-based [`Self::load_history`] path.
+    ///
+    /// Appends `messages` after `Agent::new`'s system-prompt message (never replaces it — the
+    /// system prompt is not part of the replayed conversation history). No-op (aside from
+    /// marking history as preloaded) when `messages` is empty — callers should only pass a
+    /// non-empty `Vec` once they've confirmed the replay produced content.
+    ///
+    /// Call this **before** [`Self::load_history`] (or not at all if the caller intends to load
+    /// from `SQLite`) — once called, `load_history` becomes a no-op (gated on the
+    /// `history_preloaded` flag this method sets), since `PersistenceService::load_history`
+    /// appends rather than replaces and would otherwise duplicate every message.
+    #[must_use]
+    pub fn with_preloaded_messages(
+        mut self,
+        mut messages: Vec<zeph_llm::provider::Message>,
+    ) -> Self {
+        self.msg.messages.append(&mut messages);
+        self.msg.history_preloaded = true;
+        self
+    }
+
     /// Configure autosave behaviour for assistant messages.
     #[must_use]
     pub fn with_autosave_config(mut self, autosave_assistant: bool, min_length: usize) -> Self {

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -399,6 +399,185 @@ impl<C: Channel> Agent<C> {
         Ok((old_conversation_id, new_conversation_id))
     }
 
+    /// Mid-session live conversation swap for `/conv resume <id>` / `/conv fork <id>`
+    /// (spec-068, #5343, architect ruling D-9).
+    ///
+    /// Sibling to [`Self::reset_conversation`] (`/new`) — same reset shape (clear message
+    /// history/queues/caches, keep cross-session state like memory/MCP/providers/skills intact)
+    /// — but instead of minting a fresh empty `ConversationId`, it sets `conversation_id` to the
+    /// resumed/forked session's own id (spec §5.2 bijection) and replays that session's durable
+    /// event log into `msg.messages` (same "append replayed messages" shape as
+    /// [`super::super::builder::AgentBuilder::with_preloaded_messages`], the D-6 startup path).
+    ///
+    /// Also re-points [`crate::agent::state::SessionState::session_sink`] to the resumed/forked
+    /// session's own [`zeph_session::SessionEventLog`] — `reset_conversation` swaps
+    /// `conversation_id` but has no equivalent concept, since `/new` always keeps writing to the
+    /// *same* session's log. Skipping this re-point here would mean subsequent turns silently
+    /// keep appending to the *previous* session's `events.jsonl` (INV-SP-1 accounting
+    /// corruption) instead of the resumed one.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if minting the pre-reset digest's memory lookup, opening the resumed
+    /// session's [`zeph_session::SessionEventLog`], or replaying it fails. On error, no agent
+    /// state has been mutated yet (the replay happens before any reset step).
+    pub(in crate::agent) async fn load_and_resume_conversation(
+        &mut self,
+        session_id: &zeph_common::SessionId,
+        conversation_id: zeph_memory::ConversationId,
+    ) -> Result<(), super::super::error::AgentError> {
+        let Some(session_persistence_config) =
+            self.services.session.session_persistence_config.clone()
+        else {
+            return Err(super::super::error::AgentError::ContextError(
+                "session persistence is not enabled for this agent".to_owned(),
+            ));
+        };
+        let data_dir = PathBuf::from(&session_persistence_config.data_dir);
+        let session_path = zeph_session::session_dir(&data_dir, session_id.as_str());
+
+        let Some(memory) = self.services.memory.persistence.memory.clone() else {
+            return Err(super::super::error::AgentError::ContextError(
+                "session persistence requires semantic memory to be enabled".to_owned(),
+            ));
+        };
+        let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+
+        // D-10 (spec-068 §12.3/§13): route through the shared hydration pipeline (legacy
+        // bootstrap + ReplayEngine fold + INV-SP-3 reconcile) instead of the previous inline
+        // copy, which never called `reconcile_projection` at all (impl-critic finding C2) and
+        // opened the event log up to three separate times (bootstrap, replay, sink re-point).
+        // D-13 (spec-068 §8.1, N3): `hydrate_and_condense` additionally folds in resume-time
+        // durable condensation — `condenser`/`token_counter`/`context_window` are all resolvable
+        // here without touching anything construction-time-only, exactly as they are at the
+        // other three resume paths (CLI/ACP/serve), which is what makes centralizing this call
+        // possible instead of each site carrying its own inline condensation block.
+        //
+        // Replay BEFORE mutating any agent state (fail-fast, matching reset_conversation's
+        // "mint id first" ordering) — if this fails, the agent keeps its current conversation.
+        let condense_config = &session_persistence_config.condense;
+        let condenser = zeph_session::LlmCondenser::new(
+            self.build_condense_deps(&condense_config.condense_provider),
+            condense_config.threshold,
+            condense_config.keep_recent,
+        );
+        let context_window = self
+            .context_manager
+            .budget
+            .as_ref()
+            .map_or(0, zeph_context::budget::ContextBudget::max_tokens);
+        let token_counter_adapter = zeph_agent_context::memory_backend::TokenCounterAdapter::new(
+            Arc::clone(&self.runtime.metrics.token_counter),
+        );
+
+        let hydrated = zeph_agent_persistence::hydrate_and_condense(
+            &session_path,
+            &store,
+            session_id.as_str(),
+            conversation_id,
+            &memory,
+            None,
+            &condenser,
+            &token_counter_adapter,
+            context_window,
+        )
+        .await
+        .map_err(|e| super::super::error::AgentError::ContextError(e.to_string()))?;
+
+        if let Some(ref tx) = self.services.session.status_tx {
+            let _ = tx.send("Replaying conversation...".to_string());
+        }
+
+        let old_conversation_id = self.services.memory.persistence.conversation_id;
+        self.spawn_outgoing_digest(old_conversation_id);
+        self.reset_swap_state();
+
+        // --- Apply the replayed history (same shape as `with_preloaded_messages`, D-6) ---
+        let mut messages = hydrated.messages;
+        self.msg.messages.append(&mut messages);
+        self.msg.history_preloaded = true;
+
+        // --- Set conversation_id from the resumed/forked session, not a freshly minted one ---
+        self.services.memory.persistence.conversation_id = Some(conversation_id);
+        self.services.memory.persistence.unsummarized_count = 0;
+        self.services.memory.compaction.cached_session_digest = None;
+        if let Some(ref acc) = self.services.memory.extraction.memcot_accumulator {
+            acc.reset_session_counters().await;
+        }
+
+        // --- Re-point SessionSink to the resumed/forked session's own event log, reusing the
+        // handle `hydrate_from_event_log` opened above (INV-D2: only one open
+        // `SessionEventLog` per session at a time) instead of opening the file again. ---
+        if session_persistence_config.enabled {
+            let sink = Arc::new(zeph_agent_persistence::SessionSink::new(
+                hydrated.log,
+                store,
+                session_id.clone(),
+            ));
+            self.services.session.session_sink = Some(sink);
+        }
+
+        if let Some(ref tx) = self.services.session.status_tx {
+            let _ = tx.send(String::new());
+        }
+
+        Ok(())
+    }
+
+    /// Clears message history/queues/caches shared by [`Self::reset_conversation`] (`/new`) and
+    /// [`Self::load_and_resume_conversation`] (`/conv resume`/`/conv fork`, D-9) — the parts of
+    /// a conversation swap that don't depend on where the new `conversation_id`/message history
+    /// comes from (mirrors `reset_conversation`'s steps 4-9).
+    fn reset_swap_state(&mut self) {
+        if let Some(h) = self.services.compression.pending_task_goal.take() {
+            h.abort();
+        }
+        if let Some(h) = self.services.compression.pending_sidequest_result.take() {
+            h.abort();
+        }
+        if let Some(h) = self.services.compression.pending_subgoal.take() {
+            h.abort();
+        }
+        self.services.compression.current_task_goal = None;
+        self.services.compression.task_goal_user_msg_hash = None;
+        self.services.compression.subgoal_registry = zeph_agent_context::SubgoalRegistry::default();
+        self.services.compression.subgoal_user_msg_hash = None;
+
+        if let Some(token) = self.services.orchestration.plan_cancel_token.take() {
+            token.cancel();
+        }
+        self.services.orchestration.pending_graph = None;
+        self.services.orchestration.pending_goal_embedding = None;
+        if let Some(ref mut mgr) = self.services.orchestration.subagent_manager {
+            mgr.shutdown_all();
+        }
+
+        self.clear_history();
+        self.tool_orchestrator.clear_cache();
+        let discarded = self.clear_queue();
+        if discarded > 0 {
+            tracing::debug!(
+                discarded,
+                "conversation swap: discarded queued messages that arrived during reset"
+            );
+        }
+        self.msg.pending_image_parts.clear();
+
+        self.services.security.user_provided_urls.write().clear();
+        self.services.security.flagged_urls.clear();
+
+        self.context_manager.reset_compaction();
+        self.services.focus.reset();
+        self.services.sidequest.reset();
+
+        self.runtime.debug.iteration_counter = 0;
+        self.msg.last_persisted_message_id = None;
+        self.msg.deferred_db_hide_ids.clear();
+        self.msg.deferred_db_summaries.clear();
+        self.services.tool_state.cached_filtered_tool_ids = None;
+        self.runtime.providers.cached_prompt_tokens = 0;
+    }
+
     /// Gather context from all memory sources and inject into the message window.
     ///
     /// Delegates to [`zeph_agent_context::ContextService::prepare_context`] and then

--- a/crates/zeph-core/src/agent/context/summarization/mod.rs
+++ b/crates/zeph-core/src/agent/context/summarization/mod.rs
@@ -54,6 +54,36 @@ impl<C: Channel> Agent<C> {
         }
     }
 
+    /// Build the `SummarizationDeps` used by durable event-log condensation (spec-068 §8,
+    /// architect ruling D-11) — `LlmCondenser` reuses the same `summarize_structured` machinery
+    /// as live compaction, so the only difference from [`Self::build_summarization_deps`] is
+    /// resolving `[session.condense] condense_provider` instead of `compaction_provider`.
+    /// `structured_summaries` is shared with the compaction setting rather than adding a
+    /// dedicated condense-specific toggle.
+    pub(in crate::agent) fn build_condense_deps(
+        &self,
+        condense_provider: &zeph_common::ProviderName,
+    ) -> SummarizationDeps {
+        let token_counter = Arc::clone(&self.runtime.metrics.token_counter);
+        let token_counter_adapter: std::sync::Arc<
+            dyn zeph_context::summarization::MessageTokenCounter,
+        > = std::sync::Arc::new(
+            zeph_agent_context::memory_backend::TokenCounterAdapter::new(token_counter),
+        );
+        let provider = if condense_provider.is_empty() {
+            self.summary_or_primary_provider().clone()
+        } else {
+            self.resolve_background_provider(condense_provider.as_str())
+        };
+        SummarizationDeps {
+            provider,
+            llm_timeout: std::time::Duration::from_secs(self.runtime.config.timeouts.llm_seconds),
+            token_counter: token_counter_adapter,
+            structured_summaries: self.services.memory.compaction.structured_summaries,
+            on_anchored_summary: None,
+        }
+    }
+
     /// Load the current compression guidelines from `SQLite` if the feature is enabled.
     ///
     /// Returns an empty string when the feature is disabled, memory is not initialized,

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -67,6 +67,23 @@ impl<C: Channel> Agent<C> {
             });
         }
 
+        // Session persistence (spec-068 §8.1, #5343): record the compaction as a replayable
+        // `Compaction` event when it actually pruned messages this turn.
+        if compacted && let Some(sink) = self.services.session.session_sink.clone() {
+            let tier = if hard_fired {
+                zeph_session::CompactionTier::Hard
+            } else {
+                zeph_session::CompactionTier::Soft
+            };
+            let cleared_count =
+                u32::try_from(msg_count_before.saturating_sub(msg_count_after)).unwrap_or(u32::MAX);
+            tracing::debug!("maybe_compact: session_sink.record_compaction start");
+            if let Err(e) = sink.record_compaction(tier, cleared_count).await {
+                tracing::warn!(error = %e, "failed to record Compaction session event");
+            }
+            tracing::debug!("maybe_compact: session_sink.record_compaction done");
+        }
+
         Ok(())
     }
 

--- a/crates/zeph-core/src/agent/error.rs
+++ b/crates/zeph-core/src/agent/error.rs
@@ -116,6 +116,11 @@ pub enum AgentError {
     /// A database operation in the agent subsystem failed.
     #[error(transparent)]
     Db(#[from] zeph_db::DbError),
+
+    /// A durable session event-log operation failed (spec-068, #5343) — event log replay, fork,
+    /// or `SessionStore` metadata read/write.
+    #[error(transparent)]
+    Session(#[from] zeph_session::SessionError),
 }
 
 impl AgentError {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -324,6 +324,7 @@ impl<C: Channel> Agent<C> {
                 last_persisted_message_id: None,
                 deferred_db_hide_ids: Vec::new(),
                 deferred_db_summaries: Vec::new(),
+                history_preloaded: false,
             },
             context_manager: context_manager::ContextManager::new(),
             tool_orchestrator: tool_orchestrator::ToolOrchestrator::new(),
@@ -591,6 +592,7 @@ impl<C: Channel> Agent<C> {
                     caveman::CavemanCommand,
                     checkpoint::{RedoCommand, UndoCommand},
                     compaction::{CompactCommand, NewConversationCommand, RecapCommand},
+                    conv::ConvCommand,
                     experiment::ExperimentCommand,
                     goal::GoalCommand,
                     loop_cmd::LoopCommand,
@@ -652,6 +654,7 @@ impl<C: Channel> Agent<C> {
                 agent_reg.register(GoalCommand);
                 agent_reg.register(UndoCommand);
                 agent_reg.register(RedoCommand);
+                agent_reg.register(ConvCommand);
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut agent_null_sink,

--- a/crates/zeph-core/src/agent/persistence/history.rs
+++ b/crates/zeph-core/src/agent/persistence/history.rs
@@ -29,6 +29,17 @@ impl<C: Channel> Agent<C> {
     /// casts that saturate to zero on overflow; they cannot panic.
     #[tracing::instrument(name = "core.persist.load_history", skip_all, level = "debug", err)]
     pub async fn load_history(&mut self) -> Result<(), super::super::error::AgentError> {
+        // Idempotency guard (spec-068, #5343): a session already hydrated from the durable JSONL
+        // event log via `AgentBuilder::with_preloaded_messages` (see `spawn_acp_agent`,
+        // `src/acp.rs`) must not also load from `SQLite` — `PersistenceService::load_history`
+        // appends rather than replaces, so calling both would duplicate every message. Gated on
+        // the explicit `history_preloaded` flag, not `messages.is_empty()`: `Agent::new` always
+        // seeds `messages` with the system-prompt message, so emptiness never distinguishes
+        // "already hydrated" from "not yet loaded."
+        if self.msg.history_preloaded {
+            return Ok(());
+        }
+
         let (Some(memory), Some(cid)) = (
             self.services.memory.persistence.memory.as_ref(),
             self.services.memory.persistence.conversation_id,

--- a/crates/zeph-core/src/agent/persistence/store.rs
+++ b/crates/zeph-core/src/agent/persistence/store.rs
@@ -48,6 +48,18 @@ impl<C: Channel> Agent<C> {
             );
         }
 
+        // INV-SP-1 (spec-068 §13): the durable event log must be appended and flushed before the
+        // SQLite `messages` projection is written — the projection must never lead the log. A
+        // failed session-log write is logged and the turn proceeds; a crash between the two
+        // leaves the log ahead of the projection, which INV-SP-3 reconciles on next open.
+        if let Some(sink) = self.services.session.session_sink.clone() {
+            tracing::debug!("persist_message: session_sink.record_message start");
+            if let Err(e) = sink.record_message(role, content, parts).await {
+                tracing::warn!(error = %e, "failed to append session event log entry");
+            }
+            tracing::debug!("persist_message: session_sink.record_message done");
+        }
+
         let req = PersistMessageRequest::from_borrowed(role, content, parts, has_injection_flags);
 
         let mut unsummarized = self.services.memory.persistence.unsummarized_count;

--- a/crates/zeph-core/src/agent/persistence/tests.rs
+++ b/crates/zeph-core/src/agent/persistence/tests.rs
@@ -131,6 +131,52 @@ async fn load_history_with_empty_store_returns_ok() {
 }
 
 #[tokio::test]
+async fn with_preloaded_messages_makes_load_history_a_noop() {
+    // Regression test for spec-068/#5343: `Agent::new` always seeds `messages` with the
+    // system-prompt message, so `load_history`'s SQLite-skip guard must key off the explicit
+    // `history_preloaded` flag, not `messages.is_empty()` — an emptiness check is never true at
+    // this point and would either always skip (dropping SQLite history) or never skip
+    // (duplicating replayed history), depending on which way the bug goes.
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let memory = test_memory(&AnyProvider::Mock(zeph_llm::mock::MockProvider::default())).await;
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+    memory
+        .sqlite()
+        .save_message(cid, "user", "from sqlite, should not be loaded")
+        .await
+        .unwrap();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+        std::sync::Arc::new(memory),
+        cid,
+        50,
+        5,
+        100,
+    );
+    let messages_before = agent.msg.messages.len(); // system prompt only, at this point
+
+    let replayed = vec![zeph_llm::provider::Message::from_legacy(
+        zeph_llm::provider::Role::User,
+        "from replay",
+    )];
+    agent = agent.with_preloaded_messages(replayed);
+
+    // Preload appended after the system prompt, not in place of it.
+    assert_eq!(agent.msg.messages.len(), messages_before + 1);
+    assert_eq!(agent.msg.messages.last().unwrap().content, "from replay");
+
+    agent.load_history().await.unwrap();
+
+    // load_history must not have added the SQLite message — no duplication, no clobbering.
+    assert_eq!(agent.msg.messages.len(), messages_before + 1);
+    assert_eq!(agent.msg.messages.last().unwrap().content, "from replay");
+}
+
+#[tokio::test]
 async fn load_history_increments_session_count_for_existing_messages() {
     let provider = mock_provider(vec![]);
     let channel = MockChannel::new(vec![]);

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -837,6 +837,18 @@ pub(crate) struct SessionState {
     /// `/caveman [on|off]`. Preserved across `/new` (session resets do not clear style flags —
     /// only process restart returns to `default_on`).
     pub(crate) caveman_active: bool,
+    /// Durable JSONL event-log dual-writer for this conversation-session (spec-068, #5343).
+    ///
+    /// `Some` when `[session] enabled = true`; the session has minted a
+    /// [`zeph_common::SessionId`](zeph_common::SessionId) and opened its event log. `None` when
+    /// session persistence is disabled — in which case only the `SQLite` `messages` projection
+    /// is written (pre-#5343 behavior).
+    pub(crate) session_sink: Option<std::sync::Arc<zeph_agent_persistence::SessionSink>>,
+    /// `[session]` config snapshot (spec-068, #5343, D-9) — retained (not just consumed at
+    /// construction) so a mid-session `/conv resume`/`/conv fork` swap can locate `data_dir` to
+    /// replay a different session's event log and re-point [`Self::session_sink`] to it.
+    /// `None` when session persistence is disabled.
+    pub(crate) session_persistence_config: Option<zeph_config::SessionConfig>,
 }
 
 /// Extracted hook lists from `[hooks]` config, stored in `SessionState`.
@@ -875,6 +887,13 @@ pub(crate) struct MessageState {
     pub(crate) deferred_db_hide_ids: Vec<i64>,
     /// Summary texts pending insertion after deferred tool pair summarization.
     pub(crate) deferred_db_summaries: Vec<String>,
+    /// Set by `AgentBuilder::with_preloaded_messages` (spec-068, #5343) when `messages` was
+    /// seeded from a durable event-log replay rather than the default single system-prompt
+    /// message `Agent::new` always seeds. Makes [`super::super::Agent::load_history`]'s
+    /// `SQLite`-skip guard precise — `messages.is_empty()` is never true at that point in the
+    /// normal flow (the system prompt is always present), so a plain emptiness check cannot
+    /// distinguish "already hydrated from the log" from "not yet loaded."
+    pub(crate) history_preloaded: bool,
 }
 
 impl McpState {
@@ -1205,6 +1224,8 @@ impl SessionState {
             durable_subagent: false,
             durable_turn_replayed: false,
             caveman_active: false,
+            session_sink: None,
+            session_persistence_config: None,
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -55,6 +55,7 @@ fn make_message_state() -> MessageState {
         last_persisted_message_id: None,
         deferred_db_hide_ids: Vec::new(),
         deferred_db_summaries: Vec::new(),
+        history_preloaded: false,
     }
 }
 
@@ -74,6 +75,8 @@ fn make_session_state() -> SessionState {
         durable_ctx: None,
         durable_subagent: false,
         durable_turn_replayed: false,
+        session_sink: None,
+        session_persistence_config: None,
     }
 }
 

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -91,6 +91,7 @@ pub mod project;
 pub mod provider_factory;
 pub mod quality;
 pub mod redact;
+pub mod serve;
 #[cfg(feature = "sysinfo")]
 pub mod system_metrics;
 

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -140,6 +140,91 @@ pub fn build_provider_from_entry(
     }
 }
 
+/// Resolve a provider by name from `config.llm.providers`, falling back to `primary` when
+/// `name` is empty, not found, or fails to build.
+///
+/// The Agent-free counterpart to `Agent::resolve_background_provider` (`crates/zeph-core/src/
+/// agent/learning/arise.rs`) — that method looks up an *already-built* provider from the live
+/// `Agent`'s `provider_pool` cache; this one builds fresh from `config.llm.providers` via
+/// [`build_provider_from_entry`] for callers that run *before* an `Agent` (and its pool) exists
+/// — e.g. resume-time condensation at CLI/ACP/`zeph serve` construction sites (spec-068
+/// architect ruling D-13, spec §8.1). Fresh-build cost is a non-issue here: this only runs on
+/// session resume, not the hot per-turn path.
+#[must_use]
+pub fn resolve_named_provider(config: &Config, primary: &AnyProvider, name: &str) -> AnyProvider {
+    if name.is_empty() {
+        return primary.clone();
+    }
+    let Some(entry) = config
+        .llm
+        .providers
+        .iter()
+        .find(|e| e.effective_name().eq_ignore_ascii_case(name))
+    else {
+        tracing::warn!(
+            provider = name,
+            "provider not found in [[llm.providers]], falling back to primary"
+        );
+        return primary.clone();
+    };
+    match build_provider_from_entry(entry, config) {
+        Ok(provider) => provider,
+        Err(e) => {
+            tracing::warn!(error = %e, provider = name, "failed to build named provider, falling back to primary");
+            primary.clone()
+        }
+    }
+}
+
+/// Build the [`zeph_session::LlmCondenser`] + token counter D-13's Agent-free resume-time
+/// condensation needs, shared by every construction-time session-open path (CLI `sessions
+/// resume`, ACP `spawn_acp_agent`, `zeph serve`'s `hydrate_session_sink`) so they cannot drift
+/// from each other on `[session.condense]` field mapping — the same divergence risk D-10 named
+/// for the hydration pipeline itself, applied here to condenser construction.
+///
+/// Returns the condenser plus a standalone `Arc<TokenCounterAdapter>` for
+/// [`zeph_agent_persistence::resume_budget_fraction`]'s own token-counting need (distinct from
+/// the counter embedded in the condenser's `SummarizationDeps`, which the LLM-summarization path
+/// uses) — cheap to construct twice: [`zeph_memory::TokenCounter::new`] is backed by a
+/// process-scoped `OnceLock`, so only the first call anywhere in the process pays for loading
+/// the BPE tokenizer.
+#[must_use]
+pub fn build_resume_condenser(
+    config: &Config,
+    primary_provider: &AnyProvider,
+) -> (
+    zeph_session::LlmCondenser,
+    std::sync::Arc<zeph_agent_context::memory_backend::TokenCounterAdapter>,
+) {
+    let condense_config = &config.session.condense;
+    let condense_provider = resolve_named_provider(
+        config,
+        primary_provider,
+        condense_config.condense_provider.as_str(),
+    );
+    let token_counter_adapter = std::sync::Arc::new(
+        zeph_agent_context::memory_backend::TokenCounterAdapter::new(std::sync::Arc::new(
+            zeph_memory::TokenCounter::new(),
+        )),
+    );
+    let condenser = zeph_session::LlmCondenser::new(
+        zeph_context::summarization::SummarizationDeps {
+            provider: condense_provider,
+            llm_timeout: std::time::Duration::from_secs(config.timeouts.llm_seconds),
+            token_counter: std::sync::Arc::new(
+                zeph_agent_context::memory_backend::TokenCounterAdapter::new(std::sync::Arc::new(
+                    zeph_memory::TokenCounter::new(),
+                )),
+            ),
+            structured_summaries: config.memory.structured_summaries,
+            on_anchored_summary: None,
+        },
+        condense_config.threshold,
+        condense_config.keep_recent,
+    );
+    (condenser, token_counter_adapter)
+}
+
 fn build_ollama_provider(entry: &ProviderEntry, config: &Config) -> AnyProvider {
     let base_url = entry
         .base_url

--- a/crates/zeph-core/src/serve.rs
+++ b/crates/zeph-core/src/serve.rs
@@ -1,0 +1,865 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `SessionActor` and `LiveSessionRegistry` for `zeph serve` (spec-068 §9, #5343).
+//!
+//! Each live conversation-session under `zeph serve` is a [`SessionActor`] task: it owns an
+//! [`Agent<LoopbackChannel>`](crate::agent::Agent) exclusively, bridges [`SessionCommand`]s into
+//! the agent's channel input, and forwards the channel's output as [`SessionOutput`] over a
+//! broadcast channel any number of HTTP/SSE or TUI attachments can subscribe to.
+//!
+//! [`LiveSessionRegistry`] is pure bookkeeping (a `HashMap` behind a `parking_lot::Mutex`, never
+//! held across `.await`) — it does not itself supervise tasks. [`SessionActor::spawn`] registers
+//! a *coordinator* task under `TaskSupervisor` via `spawn_oneshot(name: Arc<str>, factory)`
+//! (architect ruling D-7): the dynamic `serve.session.<id>` name and non-restarting `RunOnce`
+//! policy are exactly right for a session actor (re-driving a torn turn/replay after a crash is
+//! unsafe; recovery is a fresh spawn that replays the durable log from the last committed `seq`).
+//!
+//! `Agent<C>`'s futures are `!Send` (documented precedent: `crates/zeph-acp/src/transport/
+//! stdio.rs`, "Agent futures are `!Send` and deeply nested") and `Agent<LoopbackChannel>` itself
+//! cannot cross *any* thread boundary — not just `spawn_oneshot`'s `Send` bound but a
+//! `std::thread::spawn` one too. [`SessionActor::spawn`] resolves this exactly as `zeph-acp`'s
+//! `serve_stdio`/`transport/http.rs` do (architect ruling D-8): the `Agent` is constructed and
+//! driven entirely inside a dedicated OS thread with its own `current_thread` runtime and
+//! `LocalSet` — only `Send`-safe state (a `FnOnce(LoopbackChannel) -> Agent<LoopbackChannel>`
+//! factory, mirroring `zeph-acp`'s `SendAgentSpawner`) crosses into that thread. The
+//! `spawn_oneshot` task is a *thin coordinator*, never the agent driver itself: it awaits the
+//! thread's completion signal and, on process-wide supervisor shutdown, forwards cancellation
+//! onto the session's own [`CancellationToken`] (distinct from the supervisor's) so idle
+//! eviction (spec §9.3) can cancel exactly one session without tearing down every live actor,
+//! while `drive` only ever needs to select on a single cancellation source regardless of trigger.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
+use zeph_common::SessionId;
+use zeph_common::task_supervisor::{BlockingHandle, TaskSupervisor};
+
+use crate::agent::Agent;
+use crate::channel::{ChannelMessage, LoopbackChannel, LoopbackEvent, LoopbackHandle};
+
+/// Stack size for the dedicated per-session thread — mirrors `zeph-acp`'s
+/// `ACP_AGENT_STACK_SIZE` (Agent futures are deeply nested, ~512 KiB measured on overflow with
+/// the default 2 MiB worker-thread stack).
+const SESSION_ACTOR_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+/// Buffer capacity for the `LoopbackChannel` constructed inside [`SessionActor::spawn`]'s
+/// dedicated thread — matches the buffer used by every other headless `LoopbackChannel` consumer
+/// (e.g. `zeph-acp`'s A2A bridge).
+const LOOPBACK_CHANNEL_CAPACITY: usize = 8;
+
+/// A command sent to a live [`SessionActor`] (spec §9.2).
+#[derive(Debug)]
+pub enum SessionCommand {
+    /// Submit a new user prompt for this turn.
+    Prompt {
+        /// The prompt text.
+        text: String,
+    },
+    /// Interrupt the agent's current operation (mirrors the existing `LoopbackHandle` cancel
+    /// signal used by every other headless channel consumer).
+    Cancel,
+    /// Gracefully end the actor: closes the agent's channel input, letting `Agent::run` observe
+    /// channel closure and exit its loop on its own rather than being aborted mid-turn.
+    Shutdown,
+}
+
+/// An event streamed out of a live [`SessionActor`] (spec §9.2).
+///
+/// `Serialize`s as an adjacently tagged JSON object (`{"type": "token", "data": "..."}`) for
+/// `GET /sessions/:id/events`'s SSE stream (spec §9.4) — adjacent rather than internal tagging
+/// because [`Self::Token`] and [`Self::Error`] wrap a bare `String`, which cannot be flattened
+/// into an internally tagged object.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum SessionOutput {
+    /// A streamed or full-message text chunk from the agent's response.
+    Token(String),
+    /// A tool call started.
+    ToolCall {
+        /// Name of the tool being invoked.
+        tool_name: String,
+        /// Opaque tool call ID assigned by the LLM.
+        tool_call_id: String,
+    },
+    /// A tool call produced output.
+    ToolResult {
+        /// Name of the tool that produced this output.
+        tool_name: String,
+        /// Human-readable output text.
+        display: String,
+    },
+    /// The current turn finished.
+    TurnComplete,
+    /// The agent loop ended with an error.
+    Error(String),
+}
+
+/// Default broadcast channel capacity for [`SessionOutput`] — generous enough to absorb a burst
+/// of streamed tokens between a slow subscriber's polls without lagging.
+const OUTPUT_CHANNEL_CAPACITY: usize = 256;
+
+/// Owns a live [`Agent<LoopbackChannel>`](crate::agent::Agent) for one conversation-session
+/// (spec §9.2).
+///
+/// This is a driver, not a stored value — [`SessionActor::spawn`] returns a
+/// [`SessionActorHandle`] (cheap to clone, holds only channel senders) for
+/// [`LiveSessionRegistry`] to track; the actor's own state lives entirely inside the spawned
+/// task.
+pub struct SessionActor;
+
+impl SessionActor {
+    /// Spawn a new `SessionActor` under `supervisor` (architect ruling D-8).
+    ///
+    /// `build_agent` is called *inside* a dedicated thread (see the module doc) with a freshly
+    /// constructed `LoopbackChannel`, and must return the `Agent<LoopbackChannel>` built from it
+    /// — never pass an already-built `Agent` in, since `Agent<LoopbackChannel>` is `!Send` and
+    /// cannot cross the thread boundary. Mirrors `zeph-acp`'s `SendAgentSpawner`
+    /// (`Arc<dyn Fn(...) -> Agent + Send + Sync>`): typical callers wrap an existing
+    /// `AgentBuilder` pipeline (the same one used for CLI/TUI/Telegram/ACP sessions) in a closure
+    /// capturing only `Send`-safe dependencies (provider, skill registry, tool executor, the
+    /// session's `Arc<SessionEventLog>`, session id — all `Send`/`Sync`). `Agent::new` is sync,
+    /// so `build_agent` is a plain sync closure — no async-construction-in-thread complexity.
+    ///
+    /// Registers a *coordinator* task under the dynamic name `serve.session.<id>` via
+    /// [`TaskSupervisor::spawn_oneshot`] — visible through `supervisor.snapshot()`. The
+    /// coordinator never touches the `!Send` `Agent`; it only awaits the dedicated thread's
+    /// completion signal and, if the supervisor's own `CancellationToken` fires first (process
+    /// shutdown), forwards cancellation onto the session's own token so [`Self::drive`] observes
+    /// exactly one cancellation source regardless of trigger. Session actors intentionally do not
+    /// auto-restart on panic or unexpected exit (`spawn_oneshot`'s `RestartPolicy::RunOnce`):
+    /// re-driving a torn turn or replay in place is unsafe. Recovery is a fresh spawn (re-attach)
+    /// that replays the durable log from the last committed `seq`, not an in-place restart.
+    ///
+    /// Returns the [`SessionActorHandle`] for [`LiveSessionRegistry`] plus the raw
+    /// [`BlockingHandle`] — callers that need a forced-abort fallback (e.g. if a `serve.evict`
+    /// idle-eviction task's cancellation overruns its TTL grace) should hold onto the latter. The
+    /// graceful paths are sending [`SessionCommand::Shutdown`] over [`SessionActorHandle::tx`],
+    /// or cancelling [`SessionActorHandle::cancel`] directly (what idle eviction uses, spec §9.3,
+    /// to target exactly this session without affecting any other live actor).
+    #[must_use]
+    pub fn spawn<F>(
+        supervisor: &TaskSupervisor,
+        registry: &Arc<LiveSessionRegistry>,
+        session_id: &SessionId,
+        build_agent: F,
+        mailbox_capacity: usize,
+    ) -> (SessionActorHandle, BlockingHandle<()>)
+    where
+        F: FnOnce(LoopbackChannel) -> Agent<LoopbackChannel> + Send + 'static,
+    {
+        let (cmd_tx, cmd_rx) = mpsc::channel(mailbox_capacity.max(1));
+        let (tx_out, _first_subscriber) = broadcast::channel(OUTPUT_CHANNEL_CAPACITY);
+        let tx_out_for_actor = tx_out.clone();
+        let id_str = session_id.as_str().to_owned();
+
+        // Per-session cancellation, distinct from the supervisor's process-wide token, so idle
+        // eviction can target exactly this session (spec §9.3) without tearing down every live
+        // actor. The coordinator forwards a supervisor-wide shutdown onto this same token.
+        let session_cancel = CancellationToken::new();
+        let session_cancel_for_thread = session_cancel.clone();
+        let session_cancel_for_coordinator = session_cancel.clone();
+
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+        let thread_name = format!("serve-session-{id_str}");
+        let thread_session_id = id_str.clone();
+        let spawn_result = std::thread::Builder::new()
+            .name(thread_name)
+            .stack_size(SESSION_ACTOR_STACK_SIZE)
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        tracing::error!(
+                            session_id = %thread_session_id,
+                            error = %e,
+                            "failed to build session actor tokio runtime"
+                        );
+                        let _ = done_tx.send(());
+                        return;
+                    }
+                };
+                let (channel, handle) = LoopbackChannel::pair(LOOPBACK_CHANNEL_CAPACITY);
+                let agent = build_agent(channel);
+                let local = tokio::task::LocalSet::new();
+                rt.block_on(local.run_until(Self::drive(
+                    agent,
+                    handle,
+                    cmd_rx,
+                    tx_out_for_actor,
+                    session_cancel_for_thread,
+                )));
+                let _ = done_tx.send(());
+            });
+
+        if let Err(e) = spawn_result {
+            tracing::error!(error = %e, "failed to spawn dedicated session actor thread");
+        }
+
+        let name: Arc<str> = Arc::from(format!("serve.session.{id_str}"));
+        let supervisor_cancel = supervisor.cancellation_token();
+        let registry_for_coordinator = Arc::clone(registry);
+        let session_id_for_coordinator = session_id.clone();
+        let tx_for_coordinator = cmd_tx.clone();
+        let blocking_handle = supervisor.spawn_oneshot(name, move || {
+            Self::coordinate(
+                done_rx,
+                supervisor_cancel,
+                session_cancel_for_coordinator,
+                registry_for_coordinator,
+                session_id_for_coordinator,
+                tx_for_coordinator,
+            )
+        });
+
+        (
+            SessionActorHandle {
+                tx: cmd_tx,
+                tx_out,
+                last_active: Instant::now(),
+                cancel: session_cancel,
+            },
+            blocking_handle,
+        )
+    }
+
+    /// Thin `Send`-safe coordinator handed to [`TaskSupervisor::spawn_oneshot`]: never touches
+    /// the `!Send` `Agent` — only a thread-completion signal and cancellation tokens. Forwards a
+    /// process-wide supervisor shutdown onto the session's own [`CancellationToken`] so
+    /// [`Self::drive`] (running on the dedicated thread) only ever needs to select on one
+    /// cancellation source.
+    ///
+    /// M1 (impl-critic finding): reaps `registry`'s entry for `session_id` unconditionally once
+    /// the dedicated thread signals completion — regardless of *why* it ended (agent panic,
+    /// normal exit, or supervisor shutdown). Before this, [`LiveSessionRegistry::idle_candidates`]
+    /// was the *only* reap path, and it requires `receiver_count() == 0`; a lingering `GET
+    /// /sessions/:id/events` SSE subscriber (or a crashed actor whose stream simply stops
+    /// emitting, never closing) could pin a dead session in the registry forever, so
+    /// `POST /sessions/:id/prompt` would return `410 Gone` for it permanently with no path back
+    /// to a live actor even under D-12's reactivation. Uses
+    /// [`LiveSessionRegistry::remove_if_current`] (not a plain key-based `remove`) so a
+    /// concurrent reactivation that has already `insert`ed a fresh handle under the same
+    /// `session_id` is never evicted by this now-dead coordinator.
+    async fn coordinate(
+        done_rx: tokio::sync::oneshot::Receiver<()>,
+        supervisor_cancel: CancellationToken,
+        session_cancel: CancellationToken,
+        registry: Arc<LiveSessionRegistry>,
+        session_id: SessionId,
+        tx: mpsc::Sender<SessionCommand>,
+    ) {
+        let mut done_rx = done_rx;
+        tokio::select! {
+            _ = &mut done_rx => {}
+            () = supervisor_cancel.cancelled() => {
+                session_cancel.cancel();
+                let _ = done_rx.await;
+            }
+        }
+        registry.remove_if_current(&session_id, &tx);
+    }
+
+    /// Bridge `cmd_rx` into the agent's `LoopbackChannel` input and forward the channel's output
+    /// as [`SessionOutput`] over `tx_out`, while concurrently driving `agent.run()` to
+    /// completion. A single `tokio::select!` loop — no raw `tokio::spawn` — per the non-blocking
+    /// contract (CLAUDE.md Async & Background Tasks).
+    ///
+    /// Must run inside a `tokio::task::LocalSet` (or be `.await`ed directly, never spawned via
+    /// a `Send`-bound spawner) because `Agent<C>`'s futures are `!Send`.
+    ///
+    /// `cancel` cancelling (via `TaskSupervisor::shutdown_all`) is treated the same as
+    /// [`SessionCommand::Shutdown`] — a graceful flush (drop the channel's input sender, let
+    /// `Agent::run` observe closure and exit, drain buffered output) rather than the abrupt
+    /// task-abort `shutdown_all` would otherwise apply. Abrupt abort is still safe (INV-SP-2
+    /// torn-tail truncation covers a torn trailing write) but an explicit flush avoids leaving a
+    /// truncated trailing event on every shutdown.
+    async fn drive(
+        mut agent: Agent<LoopbackChannel>,
+        handle: LoopbackHandle,
+        mut cmd_rx: mpsc::Receiver<SessionCommand>,
+        tx_out: broadcast::Sender<SessionOutput>,
+        cancel: CancellationToken,
+    ) {
+        let LoopbackHandle {
+            input_tx,
+            mut output_rx,
+            cancel_signal,
+        } = handle;
+        let mut input_tx = Some(input_tx);
+
+        let mut agent_run = std::pin::pin!(agent.run());
+        let mut agent_done = false;
+
+        while !agent_done {
+            tokio::select! {
+                biased;
+                result = &mut agent_run => {
+                    agent_done = true;
+                    if let Err(e) = result {
+                        tracing::warn!(error = %e, "session actor: agent run ended with error");
+                        let _ = tx_out.send(SessionOutput::Error(e.to_string()));
+                    }
+                }
+                Some(event) = output_rx.recv() => {
+                    if let Some(output) = translate_loopback_event(event) {
+                        let _ = tx_out.send(output);
+                    }
+                }
+                () = cancel.cancelled(), if input_tx.is_some() => {
+                    tracing::info!("session actor: supervisor shutdown, flushing and exiting");
+                    input_tx = None;
+                }
+                cmd = cmd_rx.recv() => {
+                    match cmd {
+                        Some(SessionCommand::Prompt { text }) => {
+                            if let Some(tx) = &input_tx {
+                                let msg = ChannelMessage {
+                                    text,
+                                    attachments: Vec::new(),
+                                    is_guest_context: false,
+                                    is_from_bot: false,
+                                };
+                                tracing::debug!("session actor: forwarding prompt to agent channel");
+                                let _ = tx.send(msg).await;
+                                tracing::debug!("session actor: prompt forwarded");
+                            }
+                        }
+                        Some(SessionCommand::Cancel) => cancel_signal.notify_one(),
+                        Some(SessionCommand::Shutdown) | None => {
+                            // Drop the sender: `Agent::run`'s `next_event()` observes the closed
+                            // channel and returns `Ok(None)`, ending the loop gracefully (see
+                            // `crates/zeph-core/src/agent/mod.rs::next_event` doc comment).
+                            input_tx = None;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Drain any output events buffered just before the agent loop ended.
+        while let Ok(event) = output_rx.try_recv() {
+            if let Some(output) = translate_loopback_event(event) {
+                let _ = tx_out.send(output);
+            }
+        }
+    }
+}
+
+/// Maps a [`LoopbackEvent`] to a [`SessionOutput`], or `None` for event kinds not yet part of
+/// the spec §9.2 `SessionOutput` schema (`Status`/`ThinkingChunk`/`Usage`/`SessionTitle`/`Plan`/
+/// `Stop`) — dropped rather than guessed at an ad hoc extension.
+fn translate_loopback_event(event: LoopbackEvent) -> Option<SessionOutput> {
+    match event {
+        LoopbackEvent::Chunk(text) | LoopbackEvent::FullMessage(text) => {
+            Some(SessionOutput::Token(text))
+        }
+        LoopbackEvent::Flush => Some(SessionOutput::TurnComplete),
+        LoopbackEvent::ToolStart(ev) => Some(SessionOutput::ToolCall {
+            tool_name: ev.tool_name.to_string(),
+            tool_call_id: ev.tool_call_id,
+        }),
+        LoopbackEvent::ToolOutput(ev) => Some(SessionOutput::ToolResult {
+            tool_name: ev.tool_name.to_string(),
+            display: ev.display,
+        }),
+        _ => None,
+    }
+}
+
+/// Bookkeeping handle for one live session, held by [`LiveSessionRegistry`] (spec §9.3).
+///
+/// Cheap to clone — `tx`/`tx_out` are `Arc`-backed channel senders.
+#[derive(Clone)]
+pub struct SessionActorHandle {
+    /// Mailbox for [`SessionCommand`]s; same-session prompts are serialized by this mpsc's FIFO
+    /// ordering (spec §9.2 concurrency policy — no separate turn-lock needed).
+    pub tx: mpsc::Sender<SessionCommand>,
+    /// Broadcast source new subscribers (SSE connections, TUI attach) subscribe to.
+    pub tx_out: broadcast::Sender<SessionOutput>,
+    /// Updated by [`LiveSessionRegistry::get`] on every lookup; read by
+    /// [`LiveSessionRegistry::idle_candidates`] for TTL eviction.
+    pub last_active: Instant,
+    /// Cancelling this token ends exactly this session's actor gracefully — the same effect as
+    /// sending [`SessionCommand::Shutdown`], but usable without an owned mpsc permit. What
+    /// `serve.evict` idle eviction (spec §9.3) calls to target one session without affecting any
+    /// other live actor. Distinct from the process-wide `TaskSupervisor` cancellation token.
+    pub cancel: CancellationToken,
+}
+
+/// Registry of live [`SessionActor`]s for `zeph serve` (spec §9.3).
+///
+/// Distinct from the TUI's own `SessionRegistry`/`SlotId` tab-switching abstraction
+/// (`zeph-tui/src/session.rs`) — this is `zeph serve`-specific bookkeeping only. The internal
+/// `sessions` mutex is never held across `.await`; [`Self::get_or_reactivate`]'s
+/// `reactivation_lock` is a separate `tokio::sync::Mutex` deliberately held across `.await` for
+/// its entire critical section — see that method's doc comment.
+#[derive(Default)]
+pub struct LiveSessionRegistry {
+    sessions: Mutex<HashMap<SessionId, SessionActorHandle>>,
+    /// Serializes [`Self::get_or_reactivate`]'s check-build-insert critical section (N1,
+    /// impl-critic re-verify finding): without it, two concurrent requests for the same
+    /// evicted-but-durable session both miss the fast-path `get`, both independently replay and
+    /// spawn a `SessionActor` over the *same* `SessionEventLog` file, and the second `insert`
+    /// silently orphans the first — two live writers on one INV-D2 single-writer log, corrupting
+    /// it (duplicate `seq`s, a torn line that isn't the trailing one). A single process-wide lock
+    /// (not a per-session map) is deliberate: reactivation is a rare recovery path, not the hot
+    /// `get()` path every prompt/events call takes first — serializing distinct sessions'
+    /// reactivations against each other is an acceptable trade for not needing to manage a
+    /// second, dynamically-growing lock table's own cleanup/eviction lifecycle.
+    reactivation_lock: tokio::sync::Mutex<()>,
+}
+
+impl LiveSessionRegistry {
+    /// Construct an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up a live session by id, refreshing its `last_active` timestamp on hit.
+    #[must_use]
+    pub fn get(&self, id: &SessionId) -> Option<SessionActorHandle> {
+        let mut sessions = self.sessions.lock();
+        let handle = sessions.get_mut(id)?;
+        handle.last_active = Instant::now();
+        Some(handle.clone())
+    }
+
+    /// Register a freshly spawned actor's handle, replacing (and dropping, without aborting) any
+    /// prior entry under the same id.
+    pub fn insert(&self, id: SessionId, handle: SessionActorHandle) {
+        self.sessions.lock().insert(id, handle);
+    }
+
+    /// Look up a live session, reactivating it via `reactivate` if it isn't currently live —
+    /// atomically, so two concurrent callers for the same absent `id` can never both win and
+    /// double-spawn a `SessionActor` over the same durable log (N1, impl-critic re-verify
+    /// finding: `SessionEventLog` is single-writer per INV-D2, and a plain `get()`-miss-then-
+    /// spawn-then-`insert()` sequence has no such guarantee under concurrency).
+    ///
+    /// Fast path (the common case — session already live): a plain `get()`, no lock contention
+    /// with any in-flight reactivation elsewhere. Slow path (session absent): acquires
+    /// `reactivation_lock`, then re-checks `get()` *under the lock* — if a concurrent caller won
+    /// the race and already reactivated `id` while this caller was waiting for the lock, that
+    /// caller's `insert` is visible here and `reactivate` is never invoked a second time. Only
+    /// the loser of the race skips calling `reactivate`; the winner runs it exactly once.
+    ///
+    /// `reactivate` is expected to build+spawn the actor and `insert` it into `self` before
+    /// resolving — it runs to completion holding `reactivation_lock`, so its own `insert` is
+    /// safely serialized against any other concurrent `get_or_reactivate` call for the same
+    /// (or a different) id.
+    #[tracing::instrument(
+        name = "core.serve.registry.get_or_reactivate",
+        skip_all,
+        level = "debug",
+        fields(session_id = id.as_str())
+    )]
+    pub async fn get_or_reactivate<F, Fut>(
+        &self,
+        id: &SessionId,
+        reactivate: F,
+    ) -> Option<SessionActorHandle>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Option<SessionActorHandle>>,
+    {
+        if let Some(handle) = self.get(id) {
+            return Some(handle);
+        }
+        let _guard = self.reactivation_lock.lock().await;
+        if let Some(handle) = self.get(id) {
+            return Some(handle);
+        }
+        reactivate().await
+    }
+
+    /// Remove `id`'s entry only if it is still the exact handle identified by `tx` (compared via
+    /// [`mpsc::Sender::same_channel`], which is `true` iff both senders share the same underlying
+    /// channel).
+    ///
+    /// Used by [`SessionActor`]'s coordinator (M1) to reap its own registry entry on completion
+    /// without racing a concurrent reactivation (D-12) that has already `insert`ed a *fresh*
+    /// handle under the same id — a plain `remove(id)` there would delete the new entry too, an
+    /// unconditional key-based removal cannot tell "my own now-dead entry" from "a different,
+    /// live entry that happens to share this id".
+    pub fn remove_if_current(
+        &self,
+        id: &SessionId,
+        tx: &mpsc::Sender<SessionCommand>,
+    ) -> Option<SessionActorHandle> {
+        let mut sessions = self.sessions.lock();
+        if sessions.get(id).is_some_and(|h| h.tx.same_channel(tx)) {
+            sessions.remove(id)
+        } else {
+            None
+        }
+    }
+
+    /// Remove a session's handle (used by idle eviction and explicit shutdown), returning it if
+    /// present.
+    pub fn remove(&self, id: &SessionId) -> Option<SessionActorHandle> {
+        self.sessions.lock().remove(id)
+    }
+
+    /// Session ids with no attached broadcast receivers (`receiver_count() == 0`) whose
+    /// `last_active` is at least `ttl` old — eviction candidates for a `serve.evict` task
+    /// (spec §9.3).
+    #[must_use]
+    pub fn idle_candidates(&self, ttl: Duration) -> Vec<SessionId> {
+        let sessions = self.sessions.lock();
+        let now = Instant::now();
+        sessions
+            .iter()
+            .filter(|(_, handle)| {
+                handle.tx_out.receiver_count() == 0 && now.duration_since(handle.last_active) >= ttl
+            })
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    /// Ids of all live sessions currently tracked, in arbitrary order.
+    #[must_use]
+    pub fn ids(&self) -> Vec<SessionId> {
+        self.sessions.lock().keys().cloned().collect()
+    }
+
+    /// Number of live sessions currently tracked.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.sessions.lock().len()
+    }
+
+    /// `true` when no sessions are tracked.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn make_handle() -> SessionActorHandle {
+        let (tx, _rx) = mpsc::channel(4);
+        let (tx_out, _sub) = broadcast::channel(4);
+        SessionActorHandle {
+            tx,
+            tx_out,
+            last_active: Instant::now(),
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    #[test]
+    fn registry_insert_and_get_round_trips() {
+        let registry = LiveSessionRegistry::new();
+        let id = SessionId::new("s1");
+        registry.insert(id.clone(), make_handle());
+        assert!(registry.get(&id).is_some());
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn registry_get_missing_returns_none() {
+        let registry = LiveSessionRegistry::new();
+        assert!(registry.get(&SessionId::new("nope")).is_none());
+    }
+
+    #[test]
+    fn registry_remove_drops_entry() {
+        let registry = LiveSessionRegistry::new();
+        let id = SessionId::new("s1");
+        registry.insert(id.clone(), make_handle());
+        assert!(registry.remove(&id).is_some());
+        assert!(registry.get(&id).is_none());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn registry_remove_if_current_drops_matching_entry() {
+        let registry = LiveSessionRegistry::new();
+        let id = SessionId::new("s1");
+        let handle = make_handle();
+        let tx = handle.tx.clone();
+        registry.insert(id.clone(), handle);
+
+        assert!(registry.remove_if_current(&id, &tx).is_some());
+        assert!(registry.get(&id).is_none());
+    }
+
+    /// M1 regression: a stale coordinator's `remove_if_current` (its own now-dead handle's `tx`)
+    /// must NOT evict a fresh entry a concurrent reactivation (D-12) already `insert`ed under the
+    /// same id — the exact race a plain key-based `remove` would lose.
+    #[test]
+    fn registry_remove_if_current_ignores_stale_tx_after_reactivation() {
+        let registry = LiveSessionRegistry::new();
+        let id = SessionId::new("s1");
+        let stale_handle = make_handle();
+        let stale_tx = stale_handle.tx.clone();
+        registry.insert(id.clone(), stale_handle);
+
+        // A concurrent reactivation replaces the entry with a fresh handle under the same id.
+        registry.insert(id.clone(), make_handle());
+
+        // The stale coordinator's reap call must be a no-op — the fresh entry survives.
+        assert!(registry.remove_if_current(&id, &stale_tx).is_none());
+        assert!(
+            registry.get(&id).is_some(),
+            "a stale coordinator must never evict a concurrently-reactivated entry"
+        );
+    }
+
+    /// N1 regression (impl-critic re-verify finding): a genuine concurrency test, not a
+    /// sequential table-driven one — real `tokio::spawn` tasks race `get_or_reactivate` for the
+    /// same absent session id, each `.await`ing a `yield_now()` inside its `reactivate` closure
+    /// so they actually interleave (without the yield, the first task could run its whole
+    /// closure to completion before the second is even polled, defeating the point of the test).
+    /// Before the `reactivation_lock`, every task's fast-path `get()` would miss and every task
+    /// would run its `reactivate` closure — spawning N independent `SessionActorHandle`s that
+    /// each `insert` under the same id, the exact double-spawn-over-one-log scenario N1
+    /// describes. With the fix, exactly one task's closure must run to completion.
+    #[tokio::test]
+    async fn get_or_reactivate_serializes_concurrent_reactivation_for_the_same_id() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let registry = Arc::new(LiveSessionRegistry::new());
+        let id = SessionId::new("race-test");
+        let reactivate_calls = Arc::new(AtomicUsize::new(0));
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let registry = Arc::clone(&registry);
+            let id = id.clone();
+            let reactivate_calls = Arc::clone(&reactivate_calls);
+            tasks.push(tokio::spawn(async move {
+                registry
+                    .get_or_reactivate(&id, || {
+                        let registry = Arc::clone(&registry);
+                        let id = id.clone();
+                        let reactivate_calls = Arc::clone(&reactivate_calls);
+                        async move {
+                            // Force a real interleaving window — without this, tasks could
+                            // resolve strictly in spawn order without ever actually contending
+                            // for `reactivation_lock`.
+                            tokio::task::yield_now().await;
+                            reactivate_calls.fetch_add(1, Ordering::SeqCst);
+                            let handle = make_handle();
+                            registry.insert(id, handle.clone());
+                            Some(handle)
+                        }
+                    })
+                    .await
+            }));
+        }
+
+        for task in tasks {
+            assert!(
+                task.await.unwrap().is_some(),
+                "every concurrent caller must resolve to a live handle, win or lose the race"
+            );
+        }
+
+        assert_eq!(
+            reactivate_calls.load(Ordering::SeqCst),
+            1,
+            "exactly one concurrent caller may run the reactivation closure — a second run means \
+             two SessionActors would have been spawned over the same durable log (N1)"
+        );
+    }
+
+    #[test]
+    fn registry_ids_lists_all_tracked_sessions() {
+        let registry = LiveSessionRegistry::new();
+        assert!(registry.ids().is_empty());
+        registry.insert(SessionId::new("s1"), make_handle());
+        registry.insert(SessionId::new("s2"), make_handle());
+        let mut ids: Vec<String> = registry
+            .ids()
+            .into_iter()
+            .map(|id| id.as_str().to_owned())
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["s1".to_owned(), "s2".to_owned()]);
+    }
+
+    #[test]
+    fn registry_idle_candidates_requires_no_subscribers_and_expired_ttl() {
+        let registry = LiveSessionRegistry::new();
+        let id = SessionId::new("s1");
+        let mut handle = make_handle();
+        // No subscriber to tx_out, but last_active is "now" — not yet past a long TTL.
+        handle.last_active = Instant::now();
+        registry.insert(id.clone(), handle);
+        assert!(registry.idle_candidates(Duration::from_hours(1)).is_empty());
+    }
+
+    #[test]
+    fn registry_idle_candidates_skips_sessions_with_active_subscribers() {
+        let registry = LiveSessionRegistry::new();
+        let id = SessionId::new("s1");
+        let mut handle = make_handle();
+        handle.last_active = Instant::now()
+            .checked_sub(Duration::from_secs(9999))
+            .unwrap();
+        let _subscriber = handle.tx_out.subscribe();
+        registry.insert(id, handle);
+        assert!(registry.idle_candidates(Duration::from_secs(1)).is_empty());
+    }
+
+    #[test]
+    fn registry_idle_candidates_returns_expired_unattached_sessions() {
+        let registry = LiveSessionRegistry::new();
+        let id = SessionId::new("s1");
+        let mut handle = make_handle();
+        handle.last_active = Instant::now()
+            .checked_sub(Duration::from_secs(9999))
+            .unwrap();
+        registry.insert(id.clone(), handle);
+        let candidates = registry.idle_candidates(Duration::from_secs(1));
+        assert_eq!(candidates, vec![id]);
+    }
+
+    #[tokio::test]
+    async fn session_actor_drive_shuts_down_cleanly_on_command() {
+        use crate::agent::Agent;
+        use crate::agent::agent_tests::{MockToolExecutor, create_test_registry, mock_provider};
+
+        // `LoopbackChannel::pair` gives exactly the (channel, handle) split `SessionActor::drive`
+        // bridges between — the same split every other headless channel consumer (A2A) uses.
+        let (channel, handle) = LoopbackChannel::pair(8);
+        let provider = mock_provider(vec!["ok".to_owned()]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let agent: Agent<LoopbackChannel> =
+            Agent::new(provider, channel, registry, None, 5, executor);
+
+        let (cmd_tx, cmd_rx) = mpsc::channel::<SessionCommand>(4);
+        let (tx_out, _sub) = broadcast::channel::<SessionOutput>(16);
+
+        // `Agent<C>`'s futures are `!Send` (see the module doc), so `drive`'s future cannot be
+        // handed to `tokio::spawn`. Pre-queue both commands into the bounded mpsc buffer, then
+        // `.await` `drive` directly in this test task — no cross-thread Send requirement applies
+        // to a future that is only ever polled in place, never spawned.
+        cmd_tx
+            .send(SessionCommand::Prompt {
+                text: "hello".to_owned(),
+            })
+            .await
+            .unwrap();
+        cmd_tx.send(SessionCommand::Shutdown).await.unwrap();
+        drop(cmd_tx);
+
+        // `drive`'s future embeds the whole `Agent` state (large) — box it per
+        // `clippy::large_futures` rather than growing this test task's stack.
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            Box::pin(SessionActor::drive(
+                agent,
+                handle,
+                cmd_rx,
+                tx_out,
+                CancellationToken::new(),
+            )),
+        )
+        .await
+        .expect("drive must finish within the timeout");
+    }
+
+    #[tokio::test]
+    async fn session_actor_spawn_runs_on_dedicated_thread_and_shuts_down() {
+        use crate::agent::Agent;
+        use crate::agent::agent_tests::{MockToolExecutor, create_test_registry, mock_provider};
+
+        let supervisor = TaskSupervisor::new(CancellationToken::new());
+        let registry = Arc::new(LiveSessionRegistry::new());
+        let session_id = SessionId::new("spawn-test");
+
+        // `build_agent` is `Send` (captures only `Send`-safe test doubles); the `Agent` it
+        // constructs is built *inside* the dedicated thread `spawn` creates from the
+        // caller-supplied `LoopbackChannel`, never crossing a thread boundary itself.
+        let (handle, blocking_handle) = SessionActor::spawn(
+            &supervisor,
+            &registry,
+            &session_id,
+            move |channel| {
+                let provider = mock_provider(vec!["ok".to_owned()]);
+                let registry = create_test_registry();
+                let executor = MockToolExecutor::no_tools();
+                let agent: Agent<LoopbackChannel> =
+                    Agent::new(provider, channel, registry, None, 5, executor);
+                agent
+            },
+            4,
+        );
+
+        handle
+            .tx
+            .send(SessionCommand::Prompt {
+                text: "hello".to_owned(),
+            })
+            .await
+            .unwrap();
+        handle.tx.send(SessionCommand::Shutdown).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(10), blocking_handle.join())
+            .await
+            .expect("session actor must finish within the timeout")
+            .expect("session actor task must not panic or be aborted");
+
+        // M1 (impl-critic finding): the coordinator must reap its own registry entry once the
+        // dedicated thread signals completion, not only via `idle_candidates`'s
+        // `receiver_count() == 0` TTL path — otherwise a session whose actor died with no
+        // eviction ever running stays permanently registered as "live" with a dead mailbox.
+        assert!(
+            registry.get(&session_id).is_none(),
+            "registry entry must be reaped once the session actor's coordinator completes"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_actor_handle_cancel_shuts_down_without_supervisor_shutdown() {
+        use crate::agent::Agent;
+        use crate::agent::agent_tests::{MockToolExecutor, create_test_registry, mock_provider};
+
+        // Regression test for the D-8 per-session cancellation path: `serve.evict` idle eviction
+        // cancels one session's own `SessionActorHandle::cancel` — it must terminate that actor
+        // without the supervisor's own token ever being cancelled (i.e. without a process-wide
+        // shutdown), proving the two cancellation sources are genuinely independent.
+        let supervisor = TaskSupervisor::new(CancellationToken::new());
+        let registry = Arc::new(LiveSessionRegistry::new());
+        let session_id = SessionId::new("cancel-test");
+
+        let (handle, blocking_handle) = SessionActor::spawn(
+            &supervisor,
+            &registry,
+            &session_id,
+            move |channel| {
+                let provider = mock_provider(vec!["ok".to_owned()]);
+                let registry = create_test_registry();
+                let executor = MockToolExecutor::no_tools();
+                Agent::new(provider, channel, registry, None, 5, executor)
+            },
+            4,
+        );
+
+        // No `SessionCommand::Shutdown` sent — cancel the per-session token directly, as idle
+        // eviction would.
+        handle.cancel.cancel();
+
+        tokio::time::timeout(Duration::from_secs(10), blocking_handle.join())
+            .await
+            .expect("session actor must finish within the timeout after its own token cancels")
+            .expect("session actor task must not panic or be aborted");
+    }
+}

--- a/crates/zeph-db/migrations/postgres/106_session_persistence.sql
+++ b/crates/zeph-db/migrations/postgres/106_session_persistence.sql
@@ -1,0 +1,21 @@
+-- Promotes `acp_sessions` (migration 013) from ACP-only to the channel-agnostic
+-- conversation-session index backing the JSONL event log (spec-068 §5.1, #5343). Non-ACP
+-- channels (CLI, TUI, Telegram) mint an ACP-style SessionId and share this same table
+-- (Decision D1 — no new `sessions` table).
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS last_seq            BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS event_count         BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS forked_from         TEXT;
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS forked_at_seq       BIGINT;
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS status              TEXT NOT NULL DEFAULT 'idle'
+                                              CHECK(status IN ('active', 'idle', 'archived'));
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS last_condensed_seq  BIGINT NOT NULL DEFAULT 0;
+
+-- Enforces the SessionId <-> ConversationId bijection (spec §5.2). Permits multiple NULLs
+-- (legacy rows without a conversation link, or rows never associated with one).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_acp_sessions_conversation_id
+    ON acp_sessions(conversation_id)
+    WHERE conversation_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_status      ON acp_sessions(status);
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_updated     ON acp_sessions(updated_at);
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_forked_from ON acp_sessions(forked_from);

--- a/crates/zeph-db/migrations/sqlite/106_session_persistence.sql
+++ b/crates/zeph-db/migrations/sqlite/106_session_persistence.sql
@@ -1,0 +1,21 @@
+-- Promotes `acp_sessions` (migration 013) from ACP-only to the channel-agnostic
+-- conversation-session index backing the JSONL event log (spec-068 §5.1, #5343). Non-ACP
+-- channels (CLI, TUI, Telegram) mint an ACP-style SessionId and share this same table
+-- (Decision D1 — no new `sessions` table).
+ALTER TABLE acp_sessions ADD COLUMN last_seq            INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE acp_sessions ADD COLUMN event_count         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE acp_sessions ADD COLUMN forked_from         TEXT;
+ALTER TABLE acp_sessions ADD COLUMN forked_at_seq       INTEGER;
+ALTER TABLE acp_sessions ADD COLUMN status              TEXT NOT NULL DEFAULT 'idle'
+                                   CHECK(status IN ('active', 'idle', 'archived'));
+ALTER TABLE acp_sessions ADD COLUMN last_condensed_seq  INTEGER NOT NULL DEFAULT 0;
+
+-- Enforces the SessionId <-> ConversationId bijection (spec §5.2). Permits multiple NULLs
+-- (legacy rows without a conversation link, or rows never associated with one).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_acp_sessions_conversation_id
+    ON acp_sessions(conversation_id)
+    WHERE conversation_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_status      ON acp_sessions(status);
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_updated     ON acp_sessions(updated_at);
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_forked_from ON acp_sessions(forked_from);

--- a/crates/zeph-db/src/dialect.rs
+++ b/crates/zeph-db/src/dialect.rs
@@ -36,6 +36,13 @@ pub trait Dialect: Send + Sync + 'static {
     /// `PostgreSQL`: `EXTRACT(EPOCH FROM NOW())::BIGINT`
     const EPOCH_NOW: &'static str;
 
+    /// Current timestamp expression, for direct assignment into a `TEXT`/`TIMESTAMPTZ`
+    /// `updated_at`-style column (as opposed to [`Self::EPOCH_NOW`], which yields an integer).
+    ///
+    /// `SQLite`: `datetime('now')`
+    /// `PostgreSQL`: `NOW()`
+    const NOW: &'static str;
+
     /// Case-insensitive comparison expression for a column.
     ///
     /// `SQLite`: `{col} COLLATE NOCASE`
@@ -112,6 +119,7 @@ impl Dialect for Sqlite {
     const CONFLICT_NOTHING: &'static str = "";
     const COLLATE_NOCASE: &'static str = "COLLATE NOCASE";
     const EPOCH_NOW: &'static str = "unixepoch('now')";
+    const NOW: &'static str = "datetime('now')";
     const JSON_CAST: &'static str = "";
     const GREATEST_FN: &'static str = "MAX";
     const LEAST_FN: &'static str = "MIN";
@@ -138,6 +146,7 @@ impl Dialect for Postgres {
     const CONFLICT_NOTHING: &'static str = "ON CONFLICT DO NOTHING";
     const COLLATE_NOCASE: &'static str = "";
     const EPOCH_NOW: &'static str = "EXTRACT(EPOCH FROM NOW())::BIGINT";
+    const NOW: &'static str = "NOW()";
     const JSON_CAST: &'static str = "::jsonb";
     const GREATEST_FN: &'static str = "GREATEST";
     const LEAST_FN: &'static str = "LEAST";
@@ -177,6 +186,11 @@ mod tests {
         #[test]
         fn epoch_now() {
             assert_eq!(Sqlite::EPOCH_NOW, "unixepoch('now')");
+        }
+
+        #[test]
+        fn now() {
+            assert_eq!(Sqlite::NOW, "datetime('now')");
         }
 
         #[test]
@@ -231,6 +245,11 @@ mod tests {
         #[test]
         fn epoch_now() {
             assert_eq!(Postgres::EPOCH_NOW, "EXTRACT(EPOCH FROM NOW())::BIGINT");
+        }
+
+        #[test]
+        fn now() {
+            assert_eq!(Postgres::NOW, "NOW()");
         }
 
         #[test]

--- a/crates/zeph-memory/src/store/acp_sessions.rs
+++ b/crates/zeph-memory/src/store/acp_sessions.rs
@@ -130,9 +130,12 @@ impl SqliteStore {
         // LIMIT -1 in SQLite means no limit; cast limit=0 sentinel to -1.
         #[allow(clippy::cast_possible_wrap)]
         let sql_limit: i64 = if limit == 0 { -1 } else { limit as i64 };
+        // spec-068 §12.3 / D-2: `acp_sessions.event_count` (migration 106, kept current by
+        // `SessionStore::update_seq` on every turn flush per INV-SP-1) replaces the subquery
+        // against `acp_session_events`, which the P1 write cutover leaves permanently empty for
+        // post-cutover sessions.
         let rows = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
-            "SELECT s.id, s.title, s.created_at, s.updated_at, \
-             (SELECT COUNT(*) FROM acp_session_events WHERE session_id = s.id) AS message_count \
+            "SELECT s.id, s.title, s.created_at, s.updated_at, s.event_count AS message_count \
              FROM acp_sessions s \
              ORDER BY s.updated_at DESC \
              LIMIT ?",
@@ -166,9 +169,10 @@ impl SqliteStore {
         &self,
         session_id: &str,
     ) -> Result<Option<AcpSessionInfo>, MemoryError> {
+        // spec-068 §12.3 / D-2: see `list_acp_sessions` — `event_count` replaces the emptied
+        // `acp_session_events` subquery.
         let row = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
-            "SELECT s.id, s.title, s.created_at, s.updated_at, \
-             (SELECT COUNT(*) FROM acp_session_events WHERE session_id = s.id) AS message_count \
+            "SELECT s.id, s.title, s.created_at, s.updated_at, s.event_count AS message_count \
              FROM acp_sessions s \
              WHERE s.id = ?",
         )
@@ -446,6 +450,25 @@ mod tests {
             .expect("SqliteStore::new")
     }
 
+    /// Bump `acp_sessions.event_count` and `updated_at`, mirroring the `UPDATE`
+    /// `zeph_session::SessionStore::update_seq` issues in production (spec-068 §12.3 / D-2).
+    /// `list_acp_sessions`/`get_acp_session_info` read `event_count`, not the legacy
+    /// `acp_session_events` table that `save_acp_event` populates — tests asserting on
+    /// `message_count` (or activity ordering, which depends on `updated_at`) must drive both
+    /// through this column directly rather than the retired write path.
+    async fn bump_event_count(store: &SqliteStore, session_id: &str, event_count: i64) {
+        let stmt = zeph_db::rewrite_placeholders(&format!(
+            "UPDATE acp_sessions SET event_count = ?, updated_at = {} WHERE id = ?",
+            <ActiveDialect as zeph_db::dialect::Dialect>::NOW,
+        ));
+        zeph_db::query(sqlx::AssertSqlSafe(stmt))
+            .bind(event_count)
+            .bind(session_id)
+            .execute(store.pool())
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn create_and_exists() {
         let store = make_store().await;
@@ -546,11 +569,7 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
 
         store.create_acp_session("sess-a").await.unwrap();
-        store.save_acp_event("sess-a", "user", "hi").await.unwrap();
-        store
-            .save_acp_event("sess-a", "agent", "hello")
-            .await
-            .unwrap();
+        bump_event_count(&store, "sess-a", 2).await;
         store
             .update_session_title("sess-a", "My Chat")
             .await
@@ -618,10 +637,7 @@ mod tests {
     async fn get_acp_session_info_returns_data() {
         let store = make_store().await;
         store.create_acp_session("sess-x").await.unwrap();
-        store
-            .save_acp_event("sess-x", "user", "hello")
-            .await
-            .unwrap();
+        bump_event_count(&store, "sess-x", 1).await;
         store.update_session_title("sess-x", "Test").await.unwrap();
 
         let info = store.get_acp_session_info("sess-x").await.unwrap().unwrap();

--- a/crates/zeph-session/Cargo.toml
+++ b/crates/zeph-session/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "zeph-session"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+description = "Conversation-session persistence: append-only JSONL event log, replay, and fork engine"
+readme = "README.md"
+
+[features]
+default = ["sqlite"]
+sqlite = ["zeph-db/sqlite"]
+postgres = ["zeph-db/postgres"]
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sqlx = { workspace = true, features = ["macros"] }
+thiserror.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt", "sync", "time"] }
+tracing.workspace = true
+zeph-common.workspace = true
+zeph-context.workspace = true
+zeph-db = { workspace = true, default-features = false }
+zeph-llm.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+zeph-llm = { workspace = true, features = ["testing"] }
+
+[lints]
+workspace = true

--- a/crates/zeph-session/README.md
+++ b/crates/zeph-session/README.md
@@ -1,0 +1,38 @@
+# zeph-session
+
+[![Crates.io](https://img.shields.io/crates/v/zeph-session)](https://crates.io/crates/zeph-session)
+[![docs.rs](https://img.shields.io/docsrs/zeph-session)](https://docs.rs/zeph-session)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+
+Conversation-session persistence for [Zeph](https://github.com/bug-ops/zeph): an append-only JSONL
+event log, deterministic replay, and fork engine, shared by every channel (CLI, TUI, Telegram, ACP,
+`zeph serve`).
+
+> [!IMPORTANT]
+> This crate is **under active construction** (spec-068, issue
+> [#5343](https://github.com/bug-ops/zeph/issues/5343)). The foundation — `SessionEvent` schema,
+> the JSONL event log with torn-append recovery, the `acp_sessions` metadata store, the replay
+> engine, and the `Condenser` trait contract — has landed. The fork engine, the default
+> `LlmCondenser`, agent-loop wiring (`SessionSink`), `zeph serve`, and the `/conv` TUI commands
+> land in follow-up phases of the plan.
+
+## Overview
+
+Every conversation-session's history is appended as one line per event to
+`<data_dir>/sessions/<session_id>/events.jsonl` — the source of truth. The existing `acp_sessions`
+table (promoted from ACP-only to channel-agnostic, per spec-068 Decision D1) tracks lightweight
+queryable metadata (`last_seq`, `status`, fork provenance) so `sessions list` and reconciliation on
+open don't require replaying every log.
+
+Replay never calls the LLM or a tool executor: it folds previously recorded events into
+agent-ready `Message`s, which is the correctness guarantee behind byte-identical resume and fork.
+
+## Architectural placement
+
+`zeph-session` mirrors the append-only journal design of `zeph-durable` (sequential ordering,
+single-writer actor model) but is a **separate** crate — the two record different concerns
+(task/step effect-idempotency vs. conversation semantics) at different abstraction levels and use
+different storage formats. `zeph-session` does not depend on `zeph-durable`, and vice versa.
+
+See `specs/068-session-persistence/spec.md` and `plan.md` for the full design and phased rollout.

--- a/crates/zeph-session/src/condenser.rs
+++ b/crates/zeph-session/src/condenser.rs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The [`Condenser`] contract for durable, replayable context condensation (spec §8).
+//!
+//! Condensation is distinct from live in-memory compaction (owned by `zeph-context`): it
+//! operates at the event-log level and is recorded as a [`crate::event::SessionEvent::Condensation`]
+//! event so replay can fold the same summary deterministically. This module defines the trait
+//! contract and the [`INV-SP-4`](validate_non_overlap) non-overlap guard; see
+//! [`crate::llm_condenser::LlmCondenser`] for the default implementation.
+
+use zeph_common::memory::AnchoredSummary;
+
+use crate::error::SessionError;
+use crate::event::SessionEventEnvelope;
+use crate::replay::ReconstructedState;
+
+/// The outcome of one condensation pass: the `seq` range it replaced and the resulting summary.
+#[derive(Debug, Clone)]
+pub struct CondensationResult {
+    /// `[inclusive, inclusive]` seq range replaced by `summary`.
+    pub replaced_range: (u64, u64),
+    pub summary: AnchoredSummary,
+    pub tokens_before: u32,
+    pub tokens_after: u32,
+}
+
+/// Computes whether and how to durably condense a session's event log.
+///
+/// Implementors MUST respect INV-SP-4 (spec §8.3): the range returned by [`Self::condense`] must
+/// start strictly after the caller's `last_condensed_seq` — see [`validate_non_overlap`].
+pub trait Condenser: Send + Sync {
+    /// Returns `true` if the reconstructed context has grown enough (relative to
+    /// `budget_used_fraction`, the fraction of the context budget currently consumed) to warrant
+    /// a condensation pass.
+    fn should_condense(
+        &self,
+        state: &ReconstructedState,
+        budget_used_fraction: f64,
+    ) -> impl Future<Output = bool> + Send;
+
+    /// Condense `events` (typically the tail since `last_condensed_seq`), producing a
+    /// [`CondensationResult`] whose `replaced_range` starts strictly after `last_condensed_seq`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if summarization fails or the computed range would violate INV-SP-4.
+    fn condense(
+        &self,
+        events: &[SessionEventEnvelope],
+        last_condensed_seq: u64,
+    ) -> impl Future<Output = Result<CondensationResult, SessionError>> + Send;
+}
+
+/// Enforce INV-SP-4: a proposed `(lo, hi)` range must start strictly after `last_condensed_seq`.
+///
+/// Callers (the `Condenser` implementation and `zeph-agent-persistence`'s live-compaction hook)
+/// must call this immediately before emitting a `Condensation`/`Compaction` event, using the
+/// `last_condensed_seq` read from `acp_sessions` at the start of the computation — not a
+/// stale/cached value — to close the read-then-write race the invariant depends on.
+///
+/// `last_condensed_seq == 0` is treated as the sentinel "nothing has ever been condensed" rather
+/// than "seq 0 was already condensed" — event logs are 0-indexed (a session's first event is
+/// `seq == 0`, matching `acp_sessions.last_condensed_seq`'s migration-106 `DEFAULT 0`), so
+/// without this carve-out the very first condensation of every session — which necessarily wants
+/// to start at `lo == 0` — would be permanently rejected as "overlapping" the default. Verified
+/// empirically: `LlmCondenser::condense`'s own doc-mandated caller pattern hit exactly this
+/// before the carve-out was added (spec-068 D-11 end-to-end wiring). Residual gap: a
+/// condensation whose range happens to end exactly at `hi == 0` (only possible when
+/// `keep_recent` leaves just one message event past position 0) leaves `last_condensed_seq == 0`
+/// again, indistinguishable from "never condensed" — narrow enough in practice that resolving it
+/// properly needs an `Option<u64>` schema change; tracked as a follow-up, not blocking here.
+///
+/// # Errors
+///
+/// Returns [`SessionError::CondensationOverlap`] if `last_condensed_seq > 0 && lo <=
+/// last_condensed_seq`.
+pub fn validate_non_overlap(
+    last_condensed_seq: u64,
+    proposed_range: (u64, u64),
+) -> Result<(), SessionError> {
+    let (lo, hi) = proposed_range;
+    if last_condensed_seq > 0 && lo <= last_condensed_seq {
+        return Err(SessionError::CondensationOverlap(format!(
+            "proposed range ({lo}, {hi}) overlaps or precedes last_condensed_seq={last_condensed_seq}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_inv_sp4_no_overlap() {
+        // First condensation over (1, 10) is fine when nothing has been condensed yet.
+        validate_non_overlap(0, (1, 10)).unwrap();
+
+        // A second condensation must start strictly after the first one's end.
+        validate_non_overlap(10, (11, 20)).unwrap();
+
+        // Overlapping or regressive ranges are rejected.
+        assert!(validate_non_overlap(10, (5, 15)).is_err());
+        assert!(validate_non_overlap(10, (10, 20)).is_err());
+    }
+
+    /// Regression test for the sentinel carve-out: the very first condensation of a session
+    /// necessarily starts at `seq == 0` (event logs are 0-indexed) and must not be rejected just
+    /// because `last_condensed_seq`'s default is also `0`.
+    #[test]
+    fn first_ever_condensation_may_start_at_seq_zero() {
+        validate_non_overlap(0, (0, 5)).unwrap();
+    }
+}

--- a/crates/zeph-session/src/error.rs
+++ b/crates/zeph-session/src/error.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Crate-wide error type for `zeph-session`.
+
+use thiserror::Error;
+
+/// Errors produced by the session persistence, replay, and fork engines.
+#[derive(Debug, Error)]
+pub enum SessionError {
+    /// Filesystem I/O failed while reading or appending to an event log.
+    #[error("session event log I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A `SessionEvent` line failed to (de)serialize.
+    #[error("session event (de)serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    /// The `acp_sessions` metadata store returned a database error.
+    #[error("session store database error: {0}")]
+    Db(#[from] zeph_db::SqlxError),
+
+    /// A lookup by [`zeph_common::SessionId`] found no matching session.
+    #[error("session not found: {0}")]
+    NotFound(String),
+
+    /// A fork was requested at a `seq` beyond the source session's `last_seq`.
+    #[error("invalid fork point: {0}")]
+    InvalidForkPoint(String),
+
+    /// A condensation or compaction range overlapped a previously replaced range (INV-SP-4).
+    #[error("condensation range overlap: {0}")]
+    CondensationOverlap(String),
+
+    /// Condensation summarization failed (LLM call error or timeout).
+    #[error("condensation summarization failed: {0}")]
+    Llm(#[from] zeph_llm::LlmError),
+}

--- a/crates/zeph-session/src/event.rs
+++ b/crates/zeph-session/src/event.rs
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The `SessionEvent` schema and its on-disk envelope.
+//!
+//! Every line appended to a session's `events.jsonl` is one JSON-encoded
+//! [`SessionEventEnvelope`]. `seq` is the source of truth for ordering (see INV-SP-1/INV-SP-2 in
+//! `specs/068-session-persistence/spec.md` §13); `ts_ms` is informational only.
+
+use serde::{Deserialize, Serialize};
+use zeph_common::memory::AnchoredSummary;
+use zeph_llm::provider::MessagePart;
+
+/// One line of a session's `events.jsonl` append-only log.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_session::event::{SessionEvent, SessionEventEnvelope};
+///
+/// let envelope = SessionEventEnvelope::new(
+///     0,
+///     None,
+///     None,
+///     SessionEvent::UserMessage { text: "hello".to_owned(), image_refs: vec![] },
+/// );
+/// let line = serde_json::to_string(&envelope).expect("serializable");
+/// let round_tripped: SessionEventEnvelope =
+///     serde_json::from_str(&line).expect("deserializable");
+/// assert_eq!(round_tripped.seq, 0);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionEventEnvelope {
+    /// Monotonic, gap-free, per-session sequence number starting at 0.
+    pub seq: u64,
+    /// Wall-clock milliseconds (UTC) at append time. Informational only — `seq` orders events.
+    pub ts_ms: i64,
+    /// Groups events emitted within one agent turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<u64>,
+    /// Fork provenance: set only on the first event of a forked child log, referencing the
+    /// parent's `seq` at the fork point.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_seq: Option<u64>,
+    /// The tagged event payload, nested under the `kind` key (spec §4.2).
+    pub kind: SessionEvent,
+}
+
+impl SessionEventEnvelope {
+    /// Construct an envelope with `ts_ms` set to the current wall-clock time.
+    #[must_use]
+    pub fn new(
+        seq: u64,
+        turn_id: Option<u64>,
+        parent_seq: Option<u64>,
+        kind: SessionEvent,
+    ) -> Self {
+        Self {
+            seq,
+            ts_ms: now_ms(),
+            turn_id,
+            parent_seq,
+            kind,
+        }
+    }
+}
+
+/// Current wall-clock time in milliseconds since the Unix epoch, saturating on overflow.
+#[must_use]
+pub fn now_ms() -> i64 {
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    i64::try_from(dur.as_millis()).unwrap_or(i64::MAX)
+}
+
+/// The kind of a persisted conversation-session event.
+///
+/// See `specs/068-session-persistence/spec.md` §4.3 for the full contract. `MessagePart` is
+/// reused from [`zeph_llm::provider`] and `AnchoredSummary` from [`zeph_common::memory`] — this
+/// enum MUST NOT redefine either.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionEvent {
+    /// First event of a session's log; also written as the header line of a forked child log.
+    SessionStarted {
+        session_id: String,
+        cwd: String,
+        provider_name: String,
+        model: String,
+        /// `(parent_session_id, parent_seq_at_fork)`, set only for forked sessions.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        forked_from: Option<(String, u64)>,
+    },
+    /// A user turn.
+    UserMessage {
+        text: String,
+        /// Content-hash refs into the session's `blobs/` directory.
+        #[serde(default)]
+        image_refs: Vec<String>,
+    },
+    /// An assistant turn.
+    AssistantMessage { parts: Vec<MessagePart> },
+    /// A model-initiated tool invocation.
+    ToolCall {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    /// The result of a [`SessionEvent::ToolCall`]. Replay never re-executes tools; it folds this
+    /// recorded output.
+    ToolResult {
+        id: String,
+        name: String,
+        output: String,
+        is_error: bool,
+        duration_ms: u64,
+    },
+    /// Durable, replayable condensation of a `seq` range (distinct from live in-memory
+    /// compaction; see spec §8.1).
+    Condensation {
+        /// `[inclusive, inclusive]` seq range replaced by `summary`.
+        replaced_seq_range: (u64, u64),
+        summary: AnchoredSummary,
+        tokens_before: u32,
+        tokens_after: u32,
+    },
+    /// Recorded when live hard-compaction fires during a turn, so replay can fold the same
+    /// prune/summary deterministically.
+    Compaction {
+        tier: CompactionTier,
+        cleared_count: u32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        summary: Option<AnchoredSummary>,
+    },
+    /// Non-destructive provenance record appended to the **parent** log when a child session is
+    /// forked from it.
+    ForkPoint { new_session_id: String },
+    /// The active provider/model changed mid-session.
+    ModelChanged {
+        provider_name: String,
+        model: String,
+    },
+    /// The session ended; `reason` is one of `user_quit` | `idle_ttl` | `shutdown` | `error`.
+    SessionEnded { reason: String },
+}
+
+/// Which compaction threshold fired for a [`SessionEvent::Compaction`] event.
+///
+/// Mirrors `zeph_context::manager::CompactionTier` (soft 70% / hard 90% budget thresholds) but is
+/// redefined here rather than imported: `zeph-context` is a context-assembly crate the session
+/// event schema should not need to pull in just for this one enum, and the two enums are kept in
+/// sync manually since compaction tiers change rarely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompactionTier {
+    /// Soft threshold (~70% of budget): a light prune.
+    Soft,
+    /// Hard threshold (~90% of budget): an aggressive prune.
+    Hard,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_round_trips_through_json() {
+        let envelope = SessionEventEnvelope::new(
+            5,
+            Some(2),
+            None,
+            SessionEvent::ToolResult {
+                id: "t1".to_owned(),
+                name: "shell".to_owned(),
+                output: "ok".to_owned(),
+                is_error: false,
+                duration_ms: 12,
+            },
+        );
+        let json = serde_json::to_string(&envelope).unwrap();
+        let back: SessionEventEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.seq, 5);
+        assert_eq!(back.turn_id, Some(2));
+        assert!(back.parent_seq.is_none());
+        assert!(matches!(back.kind, SessionEvent::ToolResult { .. }));
+    }
+
+    #[test]
+    fn session_started_forked_from_round_trips() {
+        let envelope = SessionEventEnvelope::new(
+            0,
+            None,
+            Some(41),
+            SessionEvent::SessionStarted {
+                session_id: "child".to_owned(),
+                cwd: "/tmp".to_owned(),
+                provider_name: "claude".to_owned(),
+                model: "opus".to_owned(),
+                forked_from: Some(("parent".to_owned(), 41)),
+            },
+        );
+        let json = serde_json::to_string(&envelope).unwrap();
+        let back: SessionEventEnvelope = serde_json::from_str(&json).unwrap();
+        let SessionEvent::SessionStarted { forked_from, .. } = back.kind else {
+            panic!("expected SessionStarted");
+        };
+        assert_eq!(forked_from, Some(("parent".to_owned(), 41)));
+    }
+}

--- a/crates/zeph-session/src/fork.rs
+++ b/crates/zeph-session/src/fork.rs
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`ForkEngine`]: eager-copy session forking (spec §7).
+//!
+//! Copy-on-write forking is explicitly deferred (spec §7.2, §15 NEVER) — eager copy is simple and
+//! self-contained for MVP, and robust to either side independently condensing the shared prefix
+//! afterward (the child log is fully self-contained; `forked_at_seq` is historical metadata only).
+
+use std::path::Path;
+
+use crate::error::SessionError;
+use crate::event::SessionEvent;
+use crate::log::SessionEventLog;
+use crate::replay::ReplayEngine;
+use crate::store::SessionStore;
+
+/// The result of a successful fork.
+#[derive(Debug, Clone)]
+pub struct ForkResult {
+    /// The newly allocated child session id.
+    pub new_session_id: String,
+    /// Number of events copied from the parent's log (excludes the child's own `SessionStarted`
+    /// header, which is synthesized fresh).
+    pub events_copied: usize,
+}
+
+/// Forks a session at a given `seq`, producing a new, fully self-contained child session.
+pub struct ForkEngine;
+
+impl ForkEngine {
+    /// Fork `src_id` at `at_seq` into a caller-allocated `new_id` (`at_seq` is an exclusive upper
+    /// bound — matches [`ReplayEngine::replay`]'s `up_to` semantics: the child receives events
+    /// `[0, at_seq)` from the parent, plus a synthetic `SessionStarted` header recording
+    /// `forked_from`). `at_seq = None` forks at the current end of the log (copies everything) —
+    /// the default for callers with no explicit cut point (ACP's `fork_session`, which has no
+    /// `seq` parameter, and the CLI's optional `--at`).
+    ///
+    /// `new_id` is caller-supplied rather than minted internally: callers such as ACP's
+    /// `do_fork_session` need the id before the fork call completes (to construct the session's
+    /// `LoopbackChannel`/entry), and the CLI mints a fresh `SessionId::generate()` before calling
+    /// in.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::NotFound`] if `src_id` has no session-store row,
+    /// [`SessionError::InvalidForkPoint`] if `at_seq` exceeds the parent log's event count, or
+    /// [`SessionError::Io`]/[`SessionError::Db`] if the copy or store update fails.
+    #[tracing::instrument(name = "session.fork.run", skip_all, level = "info", fields(at_seq))]
+    pub async fn fork(
+        data_dir: &Path,
+        src_id: &str,
+        new_id: &str,
+        at_seq: Option<u64>,
+        store: &SessionStore,
+    ) -> Result<ForkResult, SessionError> {
+        if store.get(src_id).await?.is_none() {
+            return Err(SessionError::NotFound(src_id.to_owned()));
+        }
+
+        let src_dir = crate::session_dir(data_dir, src_id);
+        let src_log = SessionEventLog::open(&src_dir).await?;
+        let all_events = src_log.read_all().await?;
+
+        let total = u64::try_from(all_events.len()).unwrap_or(u64::MAX);
+        let at_seq = at_seq.unwrap_or(total);
+        if at_seq > total {
+            return Err(SessionError::InvalidForkPoint(format!(
+                "at_seq={at_seq} exceeds source session's event count={total}"
+            )));
+        }
+
+        // Validate the cut point is internally consistent (spec §7.2 step 2) — replay must not
+        // error. The reconstructed state itself is not needed further here.
+        ReplayEngine::replay(&src_dir, Some(at_seq)).await?;
+
+        let take_n = usize::try_from(at_seq).unwrap_or(usize::MAX);
+        let to_copy: Vec<_> = all_events.iter().take(take_n).cloned().collect();
+        let (cwd, provider_name, model) = to_copy
+            .iter()
+            .find_map(|e| match &e.kind {
+                SessionEvent::SessionStarted {
+                    cwd,
+                    provider_name,
+                    model,
+                    ..
+                } => Some((cwd.clone(), provider_name.clone(), model.clone())),
+                _ => None,
+            })
+            .unwrap_or_default();
+
+        let child_dir = crate::session_dir(data_dir, new_id);
+        let child_log = SessionEventLog::open(&child_dir).await?;
+
+        child_log
+            .append(
+                None,
+                None,
+                SessionEvent::SessionStarted {
+                    session_id: new_id.to_owned(),
+                    cwd,
+                    provider_name,
+                    model,
+                    forked_from: Some((src_id.to_owned(), at_seq)),
+                },
+            )
+            .await?;
+        for envelope in &to_copy {
+            child_log
+                .append(envelope.turn_id, envelope.parent_seq, envelope.kind.clone())
+                .await?;
+        }
+
+        store.record_fork(new_id, src_id, at_seq).await?;
+        store
+            .update_seq(
+                new_id,
+                child_log.last_seq().unwrap_or(0),
+                to_copy.len() as u64 + 1,
+            )
+            .await?;
+
+        // Non-destructive provenance record on the parent (spec §7.2 step 8).
+        src_log
+            .append(
+                None,
+                None,
+                SessionEvent::ForkPoint {
+                    new_session_id: new_id.to_owned(),
+                },
+            )
+            .await?;
+
+        Ok(ForkResult {
+            new_session_id: new_id.to_owned(),
+            events_copied: to_copy.len(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::SessionStore;
+
+    async fn make_pool() -> zeph_db::DbPool {
+        let config = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        };
+        let pool = config
+            .connect()
+            .await
+            .expect("connect in-memory sqlite pool");
+        zeph_db::run_migrations(&pool)
+            .await
+            .expect("run migrations");
+        pool
+    }
+
+    async fn seed_parent(data_dir: &Path, store: &SessionStore, id: &str) {
+        store.create(id).await.unwrap();
+        let dir = crate::session_dir(data_dir, id);
+        let log = SessionEventLog::open(&dir).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::SessionStarted {
+                session_id: id.to_owned(),
+                cwd: "/repo".to_owned(),
+                provider_name: "claude".to_owned(),
+                model: "opus".to_owned(),
+                forked_from: None,
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "hello".to_owned(),
+                image_refs: vec![],
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::AssistantMessage {
+                parts: vec![zeph_llm::provider::MessagePart::Text {
+                    text: "hi".to_owned(),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "second turn".to_owned(),
+                image_refs: vec![],
+            },
+        )
+        .await
+        .unwrap();
+        store
+            .update_seq(id, log.last_seq().unwrap(), 4)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_fork_copies_events() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        let result = ForkEngine::fork(data_dir.path(), "parent", "child", Some(3), &store)
+            .await
+            .unwrap();
+        assert_eq!(result.events_copied, 3);
+        assert_eq!(result.new_session_id, "child");
+
+        let child_dir = crate::session_dir(data_dir.path(), &result.new_session_id);
+        let child_log = SessionEventLog::open(&child_dir).await.unwrap();
+        let events = child_log.read_all().await.unwrap();
+        // 1 synthesized SessionStarted header + 3 copied events.
+        assert_eq!(events.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_fork_provenance_metadata() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        ForkEngine::fork(data_dir.path(), "parent", "child", Some(2), &store)
+            .await
+            .unwrap();
+
+        let meta = store.get("child").await.unwrap().unwrap();
+        assert_eq!(meta.forked_from.as_deref(), Some("parent"));
+        assert_eq!(meta.forked_at_seq, Some(2));
+    }
+
+    #[tokio::test]
+    async fn test_fork_appends_forkpoint_to_parent() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        ForkEngine::fork(data_dir.path(), "parent", "child", Some(2), &store)
+            .await
+            .unwrap();
+
+        let parent_dir = crate::session_dir(data_dir.path(), "parent");
+        let parent_log = SessionEventLog::open(&parent_dir).await.unwrap();
+        let events = parent_log.read_all().await.unwrap();
+        assert!(matches!(
+            events.last().unwrap().kind,
+            SessionEvent::ForkPoint { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_fork_rejects_seq_beyond_source() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        let err = ForkEngine::fork(data_dir.path(), "parent", "child", Some(100), &store)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SessionError::InvalidForkPoint(_)));
+    }
+
+    #[tokio::test]
+    async fn test_fork_rejects_unknown_source() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+
+        let err = ForkEngine::fork(data_dir.path(), "no-such", "child", Some(0), &store)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SessionError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_fork_none_copies_everything() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        let result = ForkEngine::fork(data_dir.path(), "parent", "child", None, &store)
+            .await
+            .unwrap();
+        // seed_parent appends 4 events total.
+        assert_eq!(result.events_copied, 4);
+    }
+}

--- a/crates/zeph-session/src/lib.rs
+++ b/crates/zeph-session/src/lib.rs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Conversation-session persistence, event-log replay, and fork engine for Zeph.
+//!
+//! `zeph-session` implements spec-068: an append-only JSONL event log (the source of truth for
+//! a conversation), a metadata index over the existing `acp_sessions` table, a deterministic
+//! [`replay::ReplayEngine`], and the [`condenser::Condenser`] contract for durable context
+//! condensation. It is consumed by `zeph-core` (agent-loop `SessionSink` wiring, `zeph serve`
+//! per-session actors) and `zeph-acp` (session load/list/fork/resume handlers thinned to
+//! delegate here).
+//!
+//! # Architectural placement
+//!
+//! `zeph-session` mirrors the append-only journal design of `zeph-durable`
+//! (sequential event ordering, a single-writer actor model) but is a **separate** crate: the two
+//! operate at different abstraction levels (task/step effect-idempotency vs. conversation
+//! semantics) and use different storage formats (`SQLite`-backed opaque payloads vs. JSONL
+//! domain-typed events). `zeph-session` MUST NOT depend on `zeph-durable`, and vice versa
+//! (spec-068 §3, §15 NEVER; INV-1 in spec-064).
+//!
+//! # Module map
+//!
+//! - [`error`] — the crate-wide [`error::SessionError`].
+//! - [`event`] — the [`event::SessionEvent`] tagged enum and its [`event::SessionEventEnvelope`]
+//!   on-disk wrapper. Reuses `zeph_llm::provider::MessagePart` and
+//!   `zeph_common::memory::AnchoredSummary` rather than redefining them.
+//! - [`log`] — [`log::SessionEventLog`]: the append-only JSONL writer/reader, including the
+//!   INV-SP-2 torn-append truncation logic.
+//! - [`store`] — [`store::SessionStore`]: CRUD over the `acp_sessions` metadata index (spec §5).
+//! - [`replay`] — [`replay::ReplayEngine`]: deterministic fold of an event log into agent-ready
+//!   messages. Never calls the LLM or a tool executor.
+//! - [`condenser`] — the [`condenser::Condenser`] trait contract and the INV-SP-4 non-overlap
+//!   guard.
+//! - [`llm_condenser`] — [`llm_condenser::LlmCondenser`]: the default `Condenser` implementation,
+//!   reusing `zeph_context::summarization::summarize_structured`.
+//! - [`fork`] — [`fork::ForkEngine`]: eager-copy session forking (spec §7).
+//!
+//! The `zeph-core` `SessionActor` integration (`zeph serve`, spec §9) lands in a later phase of
+//! the implementation plan (`specs/068-session-persistence/plan.md`).
+
+pub mod condenser;
+pub mod error;
+pub mod event;
+pub mod fork;
+pub mod llm_condenser;
+pub mod log;
+pub mod replay;
+pub mod store;
+
+pub use condenser::{CondensationResult, Condenser};
+pub use error::SessionError;
+pub use event::{CompactionTier, SessionEvent, SessionEventEnvelope};
+pub use fork::{ForkEngine, ForkResult};
+pub use llm_condenser::LlmCondenser;
+pub use log::SessionEventLog;
+pub use replay::{ReconstructedState, ReplayEngine};
+pub use store::{SessionFilter, SessionMetadata, SessionStatus, SessionStore};
+
+/// The on-disk directory for one session's event log and blobs, per spec §4.1:
+/// `<data_dir>/sessions/<session_id>/`.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+///
+/// let dir = zeph_session::session_dir(Path::new(".zeph/sessions"), "abc-123");
+/// assert_eq!(dir, Path::new(".zeph/sessions/sessions/abc-123"));
+/// ```
+#[must_use]
+pub fn session_dir(data_dir: &std::path::Path, session_id: &str) -> std::path::PathBuf {
+    data_dir.join("sessions").join(session_id)
+}

--- a/crates/zeph-session/src/llm_condenser.rs
+++ b/crates/zeph-session/src/llm_condenser.rs
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`LlmCondenser`]: the default [`Condenser`] implementation, reusing
+//! `zeph_context::summarization::summarize_structured` for durable, replayable condensation
+//! (spec §8).
+
+use zeph_context::summarization::{SummarizationDeps, summarize_structured};
+use zeph_llm::provider::{Message, MessagePart, Role};
+
+use crate::condenser::{CondensationResult, Condenser, validate_non_overlap};
+use crate::error::SessionError;
+use crate::event::{SessionEvent, SessionEventEnvelope};
+use crate::replay::{ReconstructedState, ReplayEngine};
+
+const CONDENSATION_GUIDELINES: &str = "Summarize the conversation so far, preserving the \
+    session's intent, files modified, decisions made, open questions, and next steps. This \
+    summary durably replaces the condensed portion of the event log — be precise, do not invent \
+    details.";
+
+/// Default [`Condenser`] implementation: summarizes a session's tail via an LLM, reusing
+/// `zeph_context::summarization::summarize_structured`. Distinct from live in-memory compaction
+/// (owned by `zeph-context`) — this operates on the durable event log and is recorded as a
+/// [`crate::event::SessionEvent::Condensation`] event so replay can fold the same summary
+/// deterministically (spec §8, AC-6).
+pub struct LlmCondenser {
+    deps: SummarizationDeps,
+    /// Trigger threshold: [`Condenser::should_condense`] returns `true` once
+    /// `budget_used_fraction` reaches this value (`0.0..=1.0`).
+    threshold: f64,
+    /// Number of trailing messages (`UserMessage`/`AssistantMessage`-initiated) to always keep
+    /// un-condensed.
+    keep_recent: usize,
+}
+
+impl LlmCondenser {
+    /// Construct a new condenser with the given LLM dependencies, trigger threshold (fraction of
+    /// context budget used, `0.0..=1.0`), and number of trailing messages to always keep.
+    #[must_use]
+    pub fn new(deps: SummarizationDeps, threshold: f64, keep_recent: usize) -> Self {
+        Self {
+            deps,
+            threshold,
+            keep_recent,
+        }
+    }
+}
+
+impl Condenser for LlmCondenser {
+    async fn should_condense(&self, state: &ReconstructedState, budget_used_fraction: f64) -> bool {
+        budget_used_fraction >= self.threshold && state.messages.len() > self.keep_recent
+    }
+
+    #[tracing::instrument(
+        name = "session.condenser.condense",
+        skip_all,
+        level = "info",
+        fields(event_count = events.len(), last_condensed_seq)
+    )]
+    async fn condense(
+        &self,
+        events: &[SessionEventEnvelope],
+        last_condensed_seq: u64,
+    ) -> Result<CondensationResult, SessionError> {
+        // N2 (impl-critic re-verify finding): restrict to events strictly after the INV-SP-4
+        // watermark before computing boundaries. Without this, a *second* condensation call
+        // re-includes the first's already-condensed range (callers pass the full log, not a
+        // pre-sliced tail), `to_condense` starts back near seq 0, and `validate_non_overlap`
+        // rejects every condensation after the first — durable condensation degrades to
+        // single-shot per session even though the caller keeps invoking it on every resume.
+        let uncondensed: Vec<SessionEventEnvelope> = events
+            .iter()
+            .filter(|e| e.seq > last_condensed_seq)
+            .cloned()
+            .collect();
+
+        // Indices of events that start a new agent-ready message; `ToolCall`/`ToolResult` attach
+        // to the preceding `AssistantMessage` boundary rather than starting their own.
+        let boundaries: Vec<usize> = uncondensed
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| {
+                matches!(
+                    e.kind,
+                    SessionEvent::UserMessage { .. } | SessionEvent::AssistantMessage { .. }
+                )
+            })
+            .map(|(i, _)| i)
+            .collect();
+
+        if boundaries.len() <= self.keep_recent {
+            return Err(SessionError::CondensationOverlap(format!(
+                "not enough events to condense: {} message(s) available, keep_recent={}",
+                boundaries.len(),
+                self.keep_recent
+            )));
+        }
+
+        let cutoff = boundaries[boundaries.len() - self.keep_recent];
+        let to_condense = &uncondensed[..cutoff];
+        let lo = to_condense
+            .first()
+            .map_or(last_condensed_seq + 1, |e| e.seq);
+        let hi = to_condense.last().map_or(last_condensed_seq, |e| e.seq);
+        validate_non_overlap(last_condensed_seq, (lo, hi))?;
+
+        let folded = ReplayEngine::fold(to_condense.to_vec(), None);
+        let tokens_before: usize = folded
+            .messages
+            .iter()
+            .map(|m| self.deps.token_counter.count_message_tokens(m))
+            .sum();
+
+        let summary = summarize_structured(&self.deps, &folded.messages, CONDENSATION_GUIDELINES)
+            .await
+            .map_err(SessionError::Llm)?;
+
+        let summary_message = Message::from_parts(
+            Role::System,
+            vec![MessagePart::Summary {
+                text: summary.to_markdown(),
+            }],
+        );
+        let tokens_after = self
+            .deps
+            .token_counter
+            .count_message_tokens(&summary_message);
+
+        Ok(CondensationResult {
+            replaced_range: (lo, hi),
+            summary,
+            tokens_before: u32::try_from(tokens_before).unwrap_or(u32::MAX),
+            tokens_after: u32::try_from(tokens_after).unwrap_or(u32::MAX),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+
+    use super::*;
+    use crate::event::SessionEventEnvelope;
+
+    struct WordCountTokenCounter;
+    impl zeph_context::summarization::MessageTokenCounter for WordCountTokenCounter {
+        fn count_message_tokens(&self, msg: &Message) -> usize {
+            msg.content.split_whitespace().count().max(1)
+        }
+    }
+
+    fn deps() -> SummarizationDeps {
+        let summary_json = serde_json::json!({
+            "session_intent": "implement feature X",
+            "files_modified": ["src/lib.rs"],
+            "decisions_made": ["used approach A"],
+            "open_questions": [],
+            "next_steps": ["write tests"],
+        })
+        .to_string();
+        SummarizationDeps {
+            provider: AnyProvider::Mock(MockProvider::with_responses(vec![summary_json])),
+            llm_timeout: Duration::from_secs(5),
+            token_counter: std::sync::Arc::new(WordCountTokenCounter),
+            structured_summaries: true,
+            on_anchored_summary: None,
+        }
+    }
+
+    fn envelope(seq: u64, kind: SessionEvent) -> SessionEventEnvelope {
+        SessionEventEnvelope::new(seq, None, None, kind)
+    }
+
+    fn user_msg(seq: u64, text: &str) -> SessionEventEnvelope {
+        envelope(
+            seq,
+            SessionEvent::UserMessage {
+                text: text.to_owned(),
+                image_refs: vec![],
+            },
+        )
+    }
+
+    fn assistant_msg(seq: u64, text: &str) -> SessionEventEnvelope {
+        envelope(
+            seq,
+            SessionEvent::AssistantMessage {
+                parts: vec![MessagePart::Text {
+                    text: text.to_owned(),
+                }],
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn should_condense_respects_threshold_and_keep_recent() {
+        let condenser = LlmCondenser::new(deps(), 0.8, 4);
+        let mut state = ReconstructedState::default();
+        assert!(
+            !condenser.should_condense(&state, 0.9).await,
+            "too few messages"
+        );
+
+        state.messages = vec![
+            Message::from_legacy(Role::User, "a"),
+            Message::from_legacy(Role::User, "b"),
+            Message::from_legacy(Role::User, "c"),
+            Message::from_legacy(Role::User, "d"),
+            Message::from_legacy(Role::User, "e"),
+        ];
+        assert!(
+            !condenser.should_condense(&state, 0.5).await,
+            "below threshold"
+        );
+        assert!(
+            condenser.should_condense(&state, 0.8).await,
+            "at threshold, enough messages"
+        );
+    }
+
+    #[tokio::test]
+    async fn condense_rejects_when_not_enough_events() {
+        let condenser = LlmCondenser::new(deps(), 0.8, 4);
+        let events = vec![user_msg(0, "a"), assistant_msg(1, "b")];
+        let err = condenser.condense(&events, 0).await.unwrap_err();
+        assert!(matches!(err, SessionError::CondensationOverlap(_)));
+    }
+
+    #[tokio::test]
+    async fn condense_computes_replaced_range_keeping_recent_tail() {
+        let condenser = LlmCondenser::new(deps(), 0.8, 1);
+        // seq 0 is conventionally `SessionStarted` (never condensable — `validate_non_overlap`
+        // treats `last_condensed_seq=0` as "nothing condensed yet", so a range cannot start at
+        // seq 0); real logs always have a non-message event there, so start message seqs at 1.
+        let events = vec![
+            user_msg(1, "first question"),
+            assistant_msg(2, "first answer"),
+            user_msg(3, "second question"),
+        ];
+        // keep_recent=1 keeps the last message-starting event (seq 3); condenses [1, 2].
+        let result = condenser.condense(&events, 0).await.unwrap();
+        assert_eq!(result.replaced_range, (1, 2));
+        assert!(result.tokens_before > 0);
+    }
+
+    /// N2 regression (impl-critic re-verify finding): a second condensation on a *growing* log
+    /// — the full event history so far, not a pre-sliced tail, matching how
+    /// `maybe_condense_on_resume` actually calls this in production — must succeed and cover a
+    /// range strictly after the first condensation's, not re-attempt the already-condensed
+    /// range and fail `validate_non_overlap`. Two fresh `LlmCondenser` instances (matching
+    /// production: a new condenser is built per resume) each carry one mock LLM response.
+    #[tokio::test]
+    async fn condense_twice_on_growing_log_advances_past_prior_range() {
+        let first_condenser = LlmCondenser::new(deps(), 0.8, 1);
+        let mut events = vec![
+            user_msg(1, "q1"),
+            assistant_msg(2, "a1"),
+            user_msg(3, "q2"),
+            assistant_msg(4, "a2"),
+            user_msg(5, "q3"),
+            assistant_msg(6, "a3"),
+            user_msg(7, "q4"),
+        ];
+        let first_result = first_condenser.condense(&events, 0).await.unwrap();
+        assert_eq!(first_result.replaced_range, (1, 6));
+
+        // The session keeps growing after the first condensation — a resume some turns later
+        // sees the FULL log (seq 1..10), not just the tail since last_condensed_seq.
+        events.push(assistant_msg(8, "a4"));
+        events.push(user_msg(9, "q5"));
+        events.push(assistant_msg(10, "a5"));
+
+        let second_condenser = LlmCondenser::new(deps(), 0.8, 1);
+        let second_result = second_condenser
+            .condense(&events, first_result.replaced_range.1)
+            .await
+            .expect("second condensation on a growing log must not re-attempt the first's range");
+        assert_eq!(
+            second_result.replaced_range,
+            (7, 9),
+            "second condensation must start strictly after the first's replaced_range.1"
+        );
+    }
+}

--- a/crates/zeph-session/src/log.rs
+++ b/crates/zeph-session/src/log.rs
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The append-only JSONL event log: [`SessionEventLog`].
+//!
+//! Mirrors the append + fsync pattern of `zeph-durable`'s `JournalWriter`
+//! (`crates/zeph-durable/src/writer.rs`) at the conversation-semantics level, but persists to a
+//! plain JSONL file rather than a `SQLite`-backed journal (spec-068 §3, §14).
+//!
+//! # Invariants
+//!
+//! - INV-SP-1 (log-first ordering): callers must append to this log before updating any
+//!   downstream projection (`SQLite` `messages`, `acp_sessions.last_seq`).
+//! - INV-SP-2 (torn-append truncation): [`SessionEventLog::open`] validates every line on open
+//!   and truncates a garbled/incomplete trailing line, which can only occur as the very last line
+//!   because appends are serialized through a single writer (INV-D2).
+//! - INV-D2 (single writer): only the session's owning actor/agent process may hold a
+//!   `SessionEventLog` for a given session directory at a time. This module does not itself
+//!   enforce cross-process exclusion; callers are responsible for the single-writer guarantee.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::fs::{self, File, OpenOptions};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+
+use crate::error::SessionError;
+use crate::event::{SessionEvent, SessionEventEnvelope};
+
+const EVENTS_FILE_NAME: &str = "events.jsonl";
+
+/// Append-only JSONL log for one conversation-session's `events.jsonl`.
+///
+/// # Examples
+///
+/// ```
+/// use tempfile::tempdir;
+/// use zeph_session::event::SessionEvent;
+/// use zeph_session::log::SessionEventLog;
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let dir = tempdir().unwrap();
+/// let log = SessionEventLog::open(dir.path()).await.unwrap();
+/// log.append(None, None, SessionEvent::SessionEnded { reason: "user_quit".to_owned() })
+///     .await
+///     .unwrap();
+/// assert_eq!(log.last_seq(), Some(0));
+/// # }
+/// ```
+pub struct SessionEventLog {
+    events_path: PathBuf,
+    writer: Mutex<File>,
+    next_seq: AtomicU64,
+}
+
+impl SessionEventLog {
+    /// Open (creating if absent) the `events.jsonl` log under `session_dir`.
+    ///
+    /// Validates the existing file per INV-SP-2, truncating a torn trailing write, then opens
+    /// the file in append mode for subsequent writes. Sets file/directory permissions to
+    /// `0o700`/`0o600` on Unix (spec §4.1); a no-op on other platforms.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Io`] if the directory or file cannot be created, or
+    /// [`SessionError::Serde`] surfaces only via [`Self::read_all`], never here (torn lines are
+    /// discarded, not treated as fatal).
+    pub async fn open(session_dir: &Path) -> Result<Self, SessionError> {
+        fs::create_dir_all(session_dir).await?;
+        set_permissions(session_dir, 0o700).await?;
+
+        let events_path = session_dir.join(EVENTS_FILE_NAME);
+        let (_, max_seq) = read_and_truncate(&events_path).await?;
+
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&events_path)
+            .await?;
+        set_permissions(&events_path, 0o600).await?;
+
+        let next_seq = max_seq.map_or(0, |seq| seq + 1);
+        Ok(Self {
+            events_path,
+            writer: Mutex::new(file),
+            next_seq: AtomicU64::new(next_seq),
+        })
+    }
+
+    /// The path to this session's `events.jsonl` file.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.events_path
+    }
+
+    /// The highest `seq` durably appended so far, or `None` if the log is empty.
+    #[must_use]
+    pub fn last_seq(&self) -> Option<u64> {
+        let next = self.next_seq.load(Ordering::SeqCst);
+        next.checked_sub(1)
+    }
+
+    /// Append one event, assigning it the next monotonic `seq`, and `fsync` before returning.
+    ///
+    /// The single `write_all` + `sync_all` pair is the atomicity boundary INV-SP-2 relies on: a
+    /// crash mid-write can only ever corrupt this one trailing line.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Serde`] if the event cannot be JSON-encoded, or
+    /// [`SessionError::Io`] if the write or fsync fails.
+    #[tracing::instrument(name = "session.log.append", skip_all, level = "debug")]
+    pub async fn append(
+        &self,
+        turn_id: Option<u64>,
+        parent_seq: Option<u64>,
+        kind: SessionEvent,
+    ) -> Result<SessionEventEnvelope, SessionError> {
+        let seq = self.next_seq.fetch_add(1, Ordering::SeqCst);
+        let envelope = SessionEventEnvelope::new(seq, turn_id, parent_seq, kind);
+
+        let mut line = serde_json::to_vec(&envelope)?;
+        line.push(b'\n');
+
+        let mut file = self.writer.lock().await;
+        file.write_all(&line).await?;
+        file.sync_all().await?;
+
+        Ok(envelope)
+    }
+
+    /// Read and validate every event currently in the log, applying INV-SP-2 truncation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Io`] if the file cannot be read.
+    #[tracing::instrument(name = "session.log.read_all", skip_all, level = "debug")]
+    pub async fn read_all(&self) -> Result<Vec<SessionEventEnvelope>, SessionError> {
+        let (events, _) = read_and_truncate(&self.events_path).await?;
+        Ok(events)
+    }
+}
+
+/// Read every valid line of `path`, truncating a garbled/incomplete trailing line (INV-SP-2).
+///
+/// Returns the validated events and the maximum `seq` seen (`None` for an empty/absent log).
+async fn read_and_truncate(
+    path: &Path,
+) -> Result<(Vec<SessionEventEnvelope>, Option<u64>), SessionError> {
+    let file = match File::open(path).await {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok((Vec::new(), None)),
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut reader = BufReader::new(file);
+    let mut events = Vec::new();
+    let mut max_seq = None;
+    let mut valid_len: u64 = 0;
+    let mut offset: u64 = 0;
+    let mut line = String::new();
+    let mut torn = false;
+
+    loop {
+        line.clear();
+        let bytes_read = reader.read_line(&mut line).await? as u64;
+        if bytes_read == 0 {
+            break;
+        }
+
+        let is_terminated = line.ends_with('\n');
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if trimmed.is_empty() {
+            offset += bytes_read;
+            if is_terminated {
+                valid_len = offset;
+            }
+            continue;
+        }
+
+        match serde_json::from_str::<SessionEventEnvelope>(trimmed) {
+            Ok(envelope) if is_terminated => {
+                max_seq = Some(envelope.seq);
+                events.push(envelope);
+                offset += bytes_read;
+                valid_len = offset;
+            }
+            _ => {
+                torn = true;
+                break;
+            }
+        }
+    }
+    drop(reader);
+
+    if torn {
+        tracing::warn!(
+            path = %path.display(),
+            valid_len,
+            "truncating torn tail in session event log (INV-SP-2)"
+        );
+    }
+
+    let actual_len = fs::metadata(path).await?.len();
+    if valid_len < actual_len {
+        let file = OpenOptions::new().write(true).open(path).await?;
+        file.set_len(valid_len).await?;
+    }
+
+    Ok((events, max_seq))
+}
+
+#[cfg(unix)]
+async fn set_permissions(path: &Path, mode: u32) -> Result<(), SessionError> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).await?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn set_permissions(_path: &Path, _mode: u32) -> Result<(), SessionError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_append_and_read_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+
+        for i in 0..5u64 {
+            log.append(
+                Some(i),
+                None,
+                SessionEvent::UserMessage {
+                    text: format!("msg-{i}"),
+                    image_refs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        assert_eq!(log.last_seq(), Some(4));
+        let events = log.read_all().await.unwrap();
+        assert_eq!(events.len(), 5);
+        for (i, envelope) in events.iter().enumerate() {
+            assert_eq!(envelope.seq, i as u64);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reopen_resumes_seq() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let log = SessionEventLog::open(dir.path()).await.unwrap();
+            log.append(
+                None,
+                None,
+                SessionEvent::SessionEnded { reason: "x".into() },
+            )
+            .await
+            .unwrap();
+        }
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        assert_eq!(log.last_seq(), Some(0));
+        let appended = log
+            .append(
+                None,
+                None,
+                SessionEvent::SessionEnded { reason: "y".into() },
+            )
+            .await
+            .unwrap();
+        assert_eq!(appended.seq, 1);
+    }
+
+    #[tokio::test]
+    async fn test_torn_write_truncation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path;
+        {
+            let log = SessionEventLog::open(dir.path()).await.unwrap();
+            for i in 0..3u64 {
+                log.append(
+                    None,
+                    None,
+                    SessionEvent::UserMessage {
+                        text: format!("msg-{i}"),
+                        image_refs: vec![],
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            path = log.path().to_path_buf();
+        }
+
+        // Simulate a torn write: truncate the file mid-way through the last line.
+        let full = tokio::fs::read(&path).await.unwrap();
+        let cut = full.len() - 5;
+        tokio::fs::write(&path, &full[..cut]).await.unwrap();
+
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        assert_eq!(
+            log.last_seq(),
+            Some(1),
+            "torn last line must be dropped cleanly"
+        );
+        let events = log.read_all().await.unwrap();
+        assert_eq!(events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_torn_write_truncation_various_offsets() {
+        for cut_from_end in [1usize, 3, 10, 20] {
+            let dir = tempfile::tempdir().unwrap();
+            let path;
+            {
+                let log = SessionEventLog::open(dir.path()).await.unwrap();
+                for i in 0..4u64 {
+                    log.append(
+                        None,
+                        None,
+                        SessionEvent::UserMessage {
+                            text: format!("event-number-{i}"),
+                            image_refs: vec![],
+                        },
+                    )
+                    .await
+                    .unwrap();
+                }
+                path = log.path().to_path_buf();
+            }
+            let full = tokio::fs::read(&path).await.unwrap();
+            let cut = full.len().saturating_sub(cut_from_end);
+            tokio::fs::write(&path, &full[..cut]).await.unwrap();
+
+            // Must not panic and must never see more than the 4 originally-committed events.
+            let log = SessionEventLog::open(dir.path()).await.unwrap();
+            let events = log.read_all().await.unwrap();
+            assert!(events.len() <= 4);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_empty_log_read_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        assert_eq!(log.last_seq(), None);
+        assert!(log.read_all().await.unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_file_permissions_are_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        let meta = tokio::fs::metadata(log.path()).await.unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+    }
+}

--- a/crates/zeph-session/src/replay.rs
+++ b/crates/zeph-session/src/replay.rs
@@ -1,0 +1,422 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`ReplayEngine`]: deterministic fold of a session's event log into agent-ready messages.
+//!
+//! Replay never calls the LLM or a tool executor (spec §6.2, §15 NEVER) — it only folds
+//! previously recorded events. This is the correctness guarantee behind AC-2 (byte-identical
+//! replay) and the foundation `ForkEngine` (spec §7) builds on.
+
+use std::path::Path;
+
+use zeph_llm::provider::{Message, MessagePart, Role};
+
+use crate::error::SessionError;
+use crate::event::{SessionEvent, SessionEventEnvelope};
+use crate::log::SessionEventLog;
+
+/// The result of folding a session's event log up to some point.
+#[derive(Debug, Clone, Default)]
+pub struct ReconstructedState {
+    /// Agent-ready message history, ready for hydration into `MessageState`.
+    pub messages: Vec<Message>,
+    /// The highest `seq` folded, or `None` if the log was empty.
+    pub last_seq: Option<u64>,
+    pub provider_name: String,
+    pub model: String,
+    pub cwd: String,
+}
+
+/// Folds a session's `events.jsonl` into a [`ReconstructedState`].
+pub struct ReplayEngine;
+
+impl ReplayEngine {
+    /// Replay the session log at `session_dir`.
+    ///
+    /// `up_to`, if set, is an *exclusive* upper bound on `seq` (used by `ForkEngine` to replay
+    /// only the prefix being copied). `None` replays the full log (resume).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Io`] if the log cannot be opened/read.
+    #[tracing::instrument(name = "session.replay.run", skip_all, level = "debug")]
+    pub async fn replay(
+        session_dir: &Path,
+        up_to: Option<u64>,
+    ) -> Result<ReconstructedState, SessionError> {
+        let log = SessionEventLog::open(session_dir).await?;
+        let events = log.read_all().await?;
+        Ok(Self::fold(events, up_to))
+    }
+
+    /// Fold a sequence of envelopes already read from disk. Exposed separately from
+    /// [`Self::replay`] so callers that already hold the events (e.g. a live `SessionActor`
+    /// applying its own just-appended event) can fold incrementally without re-reading the file.
+    #[must_use]
+    #[tracing::instrument(
+        name = "session.replay.fold",
+        skip_all,
+        level = "debug",
+        fields(event_count = events.len())
+    )]
+    pub fn fold(events: Vec<SessionEventEnvelope>, up_to: Option<u64>) -> ReconstructedState {
+        let mut messages: Vec<Message> = Vec::new();
+        // Parallel to `messages`: the seq of the event that produced each message, so a later
+        // `Condensation`/`Compaction` event can replace exactly the messages in its range.
+        let mut origin_seqs: Vec<u64> = Vec::new();
+        let mut state = ReconstructedState::default();
+
+        for envelope in events {
+            if let Some(bound) = up_to
+                && envelope.seq >= bound
+            {
+                break;
+            }
+            let seq = envelope.seq;
+            state.last_seq = Some(seq);
+
+            match envelope.kind {
+                SessionEvent::SessionStarted {
+                    cwd,
+                    provider_name,
+                    model,
+                    ..
+                } => {
+                    state.cwd = cwd;
+                    state.provider_name = provider_name;
+                    state.model = model;
+                }
+                SessionEvent::UserMessage { text, .. } => {
+                    messages.push(Message::from_legacy(Role::User, text));
+                    origin_seqs.push(seq);
+                }
+                SessionEvent::AssistantMessage { parts } => {
+                    messages.push(Message::from_parts(Role::Assistant, parts));
+                    origin_seqs.push(seq);
+                }
+                SessionEvent::ToolCall { id, name, input } => {
+                    push_part_to_last_assistant(
+                        &mut messages,
+                        &mut origin_seqs,
+                        seq,
+                        MessagePart::ToolUse { id, name, input },
+                    );
+                }
+                SessionEvent::ToolResult {
+                    id,
+                    output,
+                    is_error,
+                    ..
+                } => {
+                    push_part_to_last_assistant(
+                        &mut messages,
+                        &mut origin_seqs,
+                        seq,
+                        MessagePart::ToolResult {
+                            tool_use_id: id,
+                            content: output,
+                            is_error,
+                        },
+                    );
+                }
+                SessionEvent::Condensation {
+                    replaced_seq_range: (lo, hi),
+                    summary,
+                    ..
+                } => {
+                    replace_range(
+                        &mut messages,
+                        &mut origin_seqs,
+                        lo,
+                        hi,
+                        summary.to_markdown(),
+                    );
+                }
+                SessionEvent::Compaction { summary, .. } => {
+                    // Compaction's schema (spec §4.3) does not carry an explicit
+                    // `replaced_seq_range` the way `Condensation` does — it is emitted from the
+                    // live in-memory compactor, which prunes by message count, not by logged
+                    // seq. Until P2 wires real emission (zeph-agent-persistence) and settles the
+                    // exact seq-range accounting, fold conservatively: a recorded summary
+                    // replaces everything folded so far. No-op when `summary` is absent (a
+                    // soft-tier prune that dropped raw tool output but produced no summary).
+                    if let Some(summary) = summary {
+                        let hi = origin_seqs.last().copied().unwrap_or(seq);
+                        replace_range(
+                            &mut messages,
+                            &mut origin_seqs,
+                            0,
+                            hi,
+                            summary.to_markdown(),
+                        );
+                    }
+                }
+                SessionEvent::ModelChanged {
+                    provider_name,
+                    model,
+                } => {
+                    state.provider_name = provider_name;
+                    state.model = model;
+                }
+                SessionEvent::ForkPoint { .. } | SessionEvent::SessionEnded { .. } => {}
+            }
+        }
+
+        state.messages = messages;
+        state
+    }
+}
+
+/// Append `part` to the last message if it is a pending `Assistant` message; otherwise start a
+/// new one. Tool calls/results always follow the `AssistantMessage` that requested them within
+/// the same turn, but the fold does not assume `AssistantMessage` was itself logged first (a
+/// tool-only turn is valid).
+fn push_part_to_last_assistant(
+    messages: &mut Vec<Message>,
+    origin_seqs: &mut Vec<u64>,
+    seq: u64,
+    part: MessagePart,
+) {
+    if let Some(last) = messages.last_mut()
+        && last.role == Role::Assistant
+    {
+        last.parts.push(part);
+        return;
+    }
+    messages.push(Message::from_parts(Role::Assistant, vec![part]));
+    origin_seqs.push(seq);
+}
+
+/// Replace every message whose origin `seq` falls within `[lo, hi]` (inclusive) with a single
+/// system summary message, preserving the position of the first replaced message.
+fn replace_range(
+    messages: &mut Vec<Message>,
+    origin_seqs: &mut Vec<u64>,
+    lo: u64,
+    hi: u64,
+    summary_text: String,
+) {
+    let mut new_messages = Vec::with_capacity(messages.len());
+    let mut new_seqs = Vec::with_capacity(origin_seqs.len());
+    let mut inserted = false;
+
+    for (message, seq) in messages.drain(..).zip(origin_seqs.drain(..)) {
+        if seq >= lo && seq <= hi {
+            if !inserted {
+                new_messages.push(Message::from_parts(
+                    Role::System,
+                    vec![MessagePart::Summary {
+                        text: summary_text.clone(),
+                    }],
+                ));
+                new_seqs.push(lo);
+                inserted = true;
+            }
+            continue;
+        }
+        new_messages.push(message);
+        new_seqs.push(seq);
+    }
+
+    if !inserted {
+        new_messages.push(Message::from_parts(
+            Role::System,
+            vec![MessagePart::Summary { text: summary_text }],
+        ));
+        new_seqs.push(lo);
+    }
+
+    *messages = new_messages;
+    *origin_seqs = new_seqs;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_common::memory::AnchoredSummary;
+
+    fn envelope(seq: u64, kind: SessionEvent) -> SessionEventEnvelope {
+        SessionEventEnvelope::new(seq, None, None, kind)
+    }
+
+    #[tokio::test]
+    async fn test_replay_empty_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = ReplayEngine::replay(dir.path(), None).await.unwrap();
+        assert!(state.messages.is_empty());
+        assert!(state.last_seq.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_replay_basic_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::SessionStarted {
+                session_id: "s1".to_owned(),
+                cwd: "/repo".to_owned(),
+                provider_name: "claude".to_owned(),
+                model: "opus".to_owned(),
+                forked_from: None,
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            Some(1),
+            None,
+            SessionEvent::UserMessage {
+                text: "hi".to_owned(),
+                image_refs: vec![],
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            Some(1),
+            None,
+            SessionEvent::AssistantMessage {
+                parts: vec![MessagePart::Text {
+                    text: "hello".to_owned(),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let state = ReplayEngine::replay(dir.path(), None).await.unwrap();
+        assert_eq!(state.messages.len(), 2);
+        assert_eq!(state.messages[0].role, Role::User);
+        assert_eq!(state.messages[1].role, Role::Assistant);
+        assert_eq!(state.provider_name, "claude");
+        assert_eq!(state.cwd, "/repo");
+        assert_eq!(state.last_seq, Some(2));
+    }
+
+    #[test]
+    fn test_replay_tool_roundtrip() {
+        let events = vec![
+            envelope(
+                0,
+                SessionEvent::UserMessage {
+                    text: "run ls".to_owned(),
+                    image_refs: vec![],
+                },
+            ),
+            envelope(
+                1,
+                SessionEvent::ToolCall {
+                    id: "tc1".to_owned(),
+                    name: "shell".to_owned(),
+                    input: serde_json::json!({"cmd": "ls"}),
+                },
+            ),
+            envelope(
+                2,
+                SessionEvent::ToolResult {
+                    id: "tc1".to_owned(),
+                    name: "shell".to_owned(),
+                    output: "file.txt".to_owned(),
+                    is_error: false,
+                    duration_ms: 5,
+                },
+            ),
+        ];
+        let state = ReplayEngine::fold(events, None);
+        assert_eq!(
+            state.messages.len(),
+            2,
+            "user message + one assistant message holding both parts"
+        );
+        let assistant = &state.messages[1];
+        assert_eq!(assistant.role, Role::Assistant);
+        assert_eq!(assistant.parts.len(), 2);
+        assert!(matches!(assistant.parts[0], MessagePart::ToolUse { .. }));
+        assert!(matches!(assistant.parts[1], MessagePart::ToolResult { .. }));
+    }
+
+    #[test]
+    fn test_replay_condensation_folds() {
+        let summary = AnchoredSummary {
+            session_intent: "test".to_owned(),
+            files_modified: vec![],
+            decisions_made: vec![],
+            open_questions: vec![],
+            next_steps: vec!["continue".to_owned()],
+        };
+        let events = vec![
+            envelope(
+                0,
+                SessionEvent::UserMessage {
+                    text: "a".to_owned(),
+                    image_refs: vec![],
+                },
+            ),
+            envelope(
+                1,
+                SessionEvent::AssistantMessage {
+                    parts: vec![MessagePart::Text {
+                        text: "b".to_owned(),
+                    }],
+                },
+            ),
+            envelope(
+                2,
+                SessionEvent::Condensation {
+                    replaced_seq_range: (0, 1),
+                    summary,
+                    tokens_before: 100,
+                    tokens_after: 10,
+                },
+            ),
+            envelope(
+                3,
+                SessionEvent::UserMessage {
+                    text: "c".to_owned(),
+                    image_refs: vec![],
+                },
+            ),
+        ];
+        let state = ReplayEngine::fold(events, None);
+        // The two condensed messages collapse into one summary message, followed by the new one.
+        assert_eq!(state.messages.len(), 2);
+        assert_eq!(state.messages[0].role, Role::System);
+        assert!(matches!(
+            state.messages[0].parts[0],
+            MessagePart::Summary { .. }
+        ));
+        assert_eq!(state.messages[1].role, Role::User);
+    }
+
+    #[test]
+    fn test_replay_stop_at_seq() {
+        let events = vec![
+            envelope(
+                0,
+                SessionEvent::UserMessage {
+                    text: "a".to_owned(),
+                    image_refs: vec![],
+                },
+            ),
+            envelope(
+                1,
+                SessionEvent::UserMessage {
+                    text: "b".to_owned(),
+                    image_refs: vec![],
+                },
+            ),
+            envelope(
+                2,
+                SessionEvent::UserMessage {
+                    text: "c".to_owned(),
+                    image_refs: vec![],
+                },
+            ),
+        ];
+        let state = ReplayEngine::fold(events, Some(2));
+        assert_eq!(state.messages.len(), 2);
+        assert_eq!(state.last_seq, Some(1));
+    }
+}

--- a/crates/zeph-session/src/store.rs
+++ b/crates/zeph-session/src/store.rs
@@ -1,0 +1,515 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`SessionStore`]: the `acp_sessions` metadata index.
+//!
+//! Promotes the existing `acp_sessions` table (migration 013, `crates/zeph-memory`) to a
+//! channel-agnostic conversation-session index (spec-068 §2 Decision D1 — no new `sessions`
+//! table is introduced). `zeph-session` talks to the table directly via [`zeph_db::DbPool`]
+//! rather than depending on `zeph-memory`, keeping the crate boundary intact.
+//!
+//! The event log ([`crate::log::SessionEventLog`]) is the source of truth for conversation
+//! content; this store only tracks lightweight, queryable metadata (`last_seq`, `status`,
+//! fork provenance) used to reconcile the projection on open (INV-SP-3) and to answer
+//! `sessions list` without replaying every log.
+
+use zeph_db::{ActiveDialect, DbPool, dialect::Dialect, sql};
+
+use crate::error::SessionError;
+
+/// Lifecycle status of a conversation-session, mirroring the `acp_sessions.status` CHECK
+/// constraint added in migration 106.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    /// Actively attached to a live agent/actor.
+    Active,
+    /// Persisted but not currently attached.
+    Idle,
+    /// Explicitly archived; excluded from default `list` results.
+    Archived,
+}
+
+impl SessionStatus {
+    /// The `TEXT` representation stored in the `status` column.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Idle => "idle",
+            Self::Archived => "archived",
+        }
+    }
+}
+
+impl std::str::FromStr for SessionStatus {
+    type Err = SessionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(Self::Active),
+            "idle" => Ok(Self::Idle),
+            "archived" => Ok(Self::Archived),
+            other => Err(SessionError::NotFound(format!(
+                "unknown session status: {other}"
+            ))),
+        }
+    }
+}
+
+/// A conversation-session's metadata row, as tracked in `acp_sessions`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionMetadata {
+    pub session_id: String,
+    pub title: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub conversation_id: Option<i64>,
+    pub last_seq: u64,
+    pub event_count: u64,
+    pub forked_from: Option<String>,
+    pub forked_at_seq: Option<u64>,
+    pub status: SessionStatus,
+    pub last_condensed_seq: u64,
+}
+
+/// Filter parameters for [`SessionStore::list`].
+#[derive(Debug, Clone, Default)]
+pub struct SessionFilter {
+    /// Restrict to a single status; `None` returns all statuses.
+    pub status: Option<SessionStatus>,
+    /// Maximum rows returned; `0` means unlimited.
+    pub limit: usize,
+}
+
+/// CRUD access to the `acp_sessions` metadata index.
+pub struct SessionStore {
+    pool: DbPool,
+}
+
+impl SessionStore {
+    /// Wrap an existing [`DbPool`]. `zeph-session` does not own a dedicated database file —
+    /// it shares the pool that already owns `acp_sessions` (migration 013).
+    #[must_use]
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+
+    /// Insert a new session row with `status = 'active'`, ignoring the call if the row already
+    /// exists (idempotent, mirrors the existing `create_acp_session` pattern).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if the write fails.
+    #[tracing::instrument(name = "session.store.create", skip_all, level = "debug")]
+    pub async fn create(&self, session_id: &str) -> Result<(), SessionError> {
+        let stmt = zeph_db::rewrite_placeholders(&format!(
+            "{} INTO acp_sessions (id, status) VALUES (?, 'active'){}",
+            <ActiveDialect as Dialect>::INSERT_IGNORE,
+            <ActiveDialect as Dialect>::CONFLICT_NOTHING,
+        ));
+        zeph_db::query(sqlx::AssertSqlSafe(stmt))
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Update `last_seq`, `event_count`, and `updated_at` after a turn's events are flushed to
+    /// the log (INV-SP-1: called only after the log append is durable).
+    ///
+    /// Explicitly bumps `updated_at` here because the pre-cutover `AFTER INSERT ON
+    /// acp_session_events` trigger (migration 017) that used to drive it never fires for
+    /// post-cutover sessions (spec-068 §12.3 / D-2: `acp_session_events` is a write target only
+    /// for legacy pre-cutover sessions) — without this, `list_acp_sessions`' "ordered by last
+    /// activity descending" would silently degrade to "ordered by creation time" for every
+    /// session created after the cutover.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if the write fails.
+    #[allow(clippy::cast_possible_wrap)]
+    #[tracing::instrument(name = "session.store.update_seq", skip_all, level = "debug")]
+    pub async fn update_seq(
+        &self,
+        session_id: &str,
+        last_seq: u64,
+        event_count: u64,
+    ) -> Result<(), SessionError> {
+        let stmt = zeph_db::rewrite_placeholders(&format!(
+            "UPDATE acp_sessions SET last_seq = ?, event_count = ?, updated_at = {} WHERE id = ?",
+            <ActiveDialect as Dialect>::NOW,
+        ));
+        zeph_db::query(sqlx::AssertSqlSafe(stmt))
+            .bind(last_seq as i64)
+            .bind(event_count as i64)
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Update the session's lifecycle status.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if the write fails.
+    #[tracing::instrument(name = "session.store.set_status", skip_all, level = "debug")]
+    pub async fn set_status(
+        &self,
+        session_id: &str,
+        status: SessionStatus,
+    ) -> Result<(), SessionError> {
+        zeph_db::query(sql!("UPDATE acp_sessions SET status = ? WHERE id = ?"))
+            .bind(status.as_str())
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Update the high-water condensation mark (INV-SP-4 non-overlap tracking).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if the write fails.
+    #[allow(clippy::cast_possible_wrap)]
+    #[tracing::instrument(name = "session.store.set_condensed_seq", skip_all, level = "debug")]
+    pub async fn set_condensed_seq(
+        &self,
+        session_id: &str,
+        last_condensed_seq: u64,
+    ) -> Result<(), SessionError> {
+        zeph_db::query(sql!(
+            "UPDATE acp_sessions SET last_condensed_seq = ? WHERE id = ?"
+        ))
+        .bind(last_condensed_seq as i64)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Fetch a single session's metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if the query fails.
+    #[tracing::instrument(name = "session.store.get", skip_all, level = "debug")]
+    pub async fn get(&self, session_id: &str) -> Result<Option<SessionMetadata>, SessionError> {
+        let row = zeph_db::query_as::<_, SessionRow>(sql!(
+            "SELECT id, title, created_at, updated_at, conversation_id, last_seq, event_count, \
+             forked_from, forked_at_seq, status, last_condensed_seq \
+             FROM acp_sessions WHERE id = ?"
+        ))
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(TryInto::try_into).transpose()
+    }
+
+    /// List sessions, most recently updated first.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if the query fails.
+    #[tracing::instrument(name = "session.store.list", skip_all, level = "debug")]
+    pub async fn list(&self, filter: &SessionFilter) -> Result<Vec<SessionMetadata>, SessionError> {
+        #[allow(clippy::cast_possible_wrap)]
+        let sql_limit: i64 = if filter.limit == 0 {
+            -1
+        } else {
+            filter.limit as i64
+        };
+        let status_filter = filter.status.map(SessionStatus::as_str);
+
+        let rows = zeph_db::query_as::<_, SessionRow>(sql!(
+            "SELECT id, title, created_at, updated_at, conversation_id, last_seq, event_count, \
+             forked_from, forked_at_seq, status, last_condensed_seq \
+             FROM acp_sessions \
+             WHERE (? IS NULL OR status = ?) \
+             ORDER BY updated_at DESC LIMIT ?"
+        ))
+        .bind(status_filter)
+        .bind(status_filter)
+        .bind(sql_limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    /// Link this session to a `ConversationId` (raw `i64` — `zeph-session` does not depend on
+    /// `zeph-memory`'s newtype), enforcing the `SessionId`<->`ConversationId` bijection (spec
+    /// §5.2) via the unique partial index added in migration 106.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if the write fails (including a unique-constraint violation
+    /// when `conversation_id` is already linked to a different session).
+    #[tracing::instrument(name = "session.store.link_conversation", skip_all, level = "debug")]
+    pub async fn link_conversation(
+        &self,
+        session_id: &str,
+        conversation_id: i64,
+    ) -> Result<(), SessionError> {
+        zeph_db::query(sql!(
+            "UPDATE acp_sessions SET conversation_id = ? WHERE id = ?"
+        ))
+        .bind(conversation_id)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Look up the session already linked to a `ConversationId`, if any.
+    ///
+    /// Used at non-ACP channel startup (CLI/TUI/Telegram) to resume the same conversation's
+    /// existing session (and its event log) across process restarts, rather than minting a new
+    /// `SessionId` every launch (spec §12.2).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if the query fails.
+    #[tracing::instrument(
+        name = "session.store.get_by_conversation_id",
+        skip_all,
+        level = "debug"
+    )]
+    pub async fn get_by_conversation_id(
+        &self,
+        conversation_id: i64,
+    ) -> Result<Option<SessionMetadata>, SessionError> {
+        let row = zeph_db::query_as::<_, SessionRow>(sql!(
+            "SELECT id, title, created_at, updated_at, conversation_id, last_seq, event_count, \
+             forked_from, forked_at_seq, status, last_condensed_seq \
+             FROM acp_sessions WHERE conversation_id = ?"
+        ))
+        .bind(conversation_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(TryInto::try_into).transpose()
+    }
+
+    /// Record a fork: sets `forked_from`/`forked_at_seq` on the child row.
+    ///
+    /// Does not touch the parent's log (the `ForkPoint` provenance event is appended by
+    /// [`crate::replay`]'s `ForkEngine`, which owns the parent's [`crate::log::SessionEventLog`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if either write fails.
+    #[allow(clippy::cast_possible_wrap)]
+    #[tracing::instrument(name = "session.store.record_fork", skip_all, level = "debug")]
+    pub async fn record_fork(
+        &self,
+        new_session_id: &str,
+        src_session_id: &str,
+        forked_at_seq: u64,
+    ) -> Result<(), SessionError> {
+        let stmt = zeph_db::rewrite_placeholders(&format!(
+            "{} INTO acp_sessions (id, status, forked_from, forked_at_seq) VALUES (?, 'active', ?, ?){}",
+            <ActiveDialect as Dialect>::INSERT_IGNORE,
+            <ActiveDialect as Dialect>::CONFLICT_NOTHING,
+        ));
+        zeph_db::query(sqlx::AssertSqlSafe(stmt))
+            .bind(new_session_id)
+            .bind(src_session_id)
+            .bind(forked_at_seq as i64)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Delete a session's metadata row. Returns `true` if a row was deleted.
+    ///
+    /// Does not remove the on-disk event log directory or blobs — callers with access to
+    /// `[session] data_dir` are responsible for that (mirrors the separation of concerns between
+    /// [`SessionStore`] and [`crate::log::SessionEventLog`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::Db`] if the write fails.
+    #[tracing::instrument(name = "session.store.delete", skip_all, level = "debug")]
+    pub async fn delete(&self, session_id: &str) -> Result<bool, SessionError> {
+        let result = zeph_db::query(sql!("DELETE FROM acp_sessions WHERE id = ?"))
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct SessionRow {
+    id: String,
+    title: Option<String>,
+    created_at: String,
+    updated_at: String,
+    conversation_id: Option<i64>,
+    last_seq: i64,
+    event_count: i64,
+    forked_from: Option<String>,
+    forked_at_seq: Option<i64>,
+    status: String,
+    last_condensed_seq: i64,
+}
+
+impl TryFrom<SessionRow> for SessionMetadata {
+    type Error = SessionError;
+
+    fn try_from(row: SessionRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            session_id: row.id,
+            title: row.title,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            conversation_id: row.conversation_id,
+            last_seq: u64::try_from(row.last_seq).unwrap_or(0),
+            event_count: u64::try_from(row.event_count).unwrap_or(0),
+            forked_from: row.forked_from,
+            forked_at_seq: row.forked_at_seq.map(|v| u64::try_from(v).unwrap_or(0)),
+            status: row.status.parse()?,
+            last_condensed_seq: u64::try_from(row.last_condensed_seq).unwrap_or(0),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_pool() -> DbPool {
+        let config = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        };
+        let pool = config
+            .connect()
+            .await
+            .expect("connect in-memory sqlite pool");
+        zeph_db::run_migrations(&pool)
+            .await
+            .expect("run migrations");
+        pool
+    }
+
+    #[tokio::test]
+    async fn test_migration_106_idempotent() {
+        let pool = make_pool().await;
+        zeph_db::run_migrations(&pool)
+            .await
+            .expect("second run is a no-op");
+    }
+
+    #[tokio::test]
+    async fn create_and_get_defaults() {
+        let store = SessionStore::new(make_pool().await);
+        store.create("s1").await.unwrap();
+        let meta = store.get("s1").await.unwrap().expect("row exists");
+        assert_eq!(meta.session_id, "s1");
+        assert_eq!(meta.last_seq, 0);
+        assert_eq!(meta.event_count, 0);
+        assert_eq!(meta.status, SessionStatus::Active);
+        assert!(meta.forked_from.is_none());
+    }
+
+    #[tokio::test]
+    async fn update_seq_persists() {
+        let store = SessionStore::new(make_pool().await);
+        store.create("s1").await.unwrap();
+        store.update_seq("s1", 41, 20).await.unwrap();
+        let meta = store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.last_seq, 41);
+        assert_eq!(meta.event_count, 20);
+    }
+
+    #[tokio::test]
+    async fn set_status_persists() {
+        let store = SessionStore::new(make_pool().await);
+        store.create("s1").await.unwrap();
+        store.set_status("s1", SessionStatus::Idle).await.unwrap();
+        let meta = store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.status, SessionStatus::Idle);
+    }
+
+    #[tokio::test]
+    async fn record_fork_sets_provenance() {
+        let store = SessionStore::new(make_pool().await);
+        store.create("parent").await.unwrap();
+        store.record_fork("child", "parent", 12).await.unwrap();
+        let meta = store.get("child").await.unwrap().unwrap();
+        assert_eq!(meta.forked_from.as_deref(), Some("parent"));
+        assert_eq!(meta.forked_at_seq, Some(12));
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_status() {
+        let store = SessionStore::new(make_pool().await);
+        store.create("s1").await.unwrap();
+        store.create("s2").await.unwrap();
+        store
+            .set_status("s2", SessionStatus::Archived)
+            .await
+            .unwrap();
+
+        let active = store
+            .list(&SessionFilter {
+                status: Some(SessionStatus::Active),
+                limit: 0,
+            })
+            .await
+            .unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].session_id, "s1");
+
+        let all = store.list(&SessionFilter::default()).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_row() {
+        let store = SessionStore::new(make_pool().await);
+        store.create("s1").await.unwrap();
+        assert!(store.delete("s1").await.unwrap());
+        assert!(store.get("s1").await.unwrap().is_none());
+        assert!(!store.delete("s1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn get_missing_returns_none() {
+        let store = SessionStore::new(make_pool().await);
+        assert!(store.get("no-such").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn link_conversation_and_lookup_round_trips() {
+        let pool = make_pool().await;
+        let store = SessionStore::new(pool.clone());
+        store.create("s1").await.unwrap();
+
+        // `conversation_id` carries an FK to `conversations(id)` (migration 001); insert a row
+        // directly since creating conversations is zeph-memory's domain, out of scope here.
+        let (cid,): (i64,) =
+            zeph_db::query_as("INSERT INTO conversations DEFAULT VALUES RETURNING id")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        store.link_conversation("s1", cid).await.unwrap();
+
+        let meta = store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.conversation_id, Some(cid));
+
+        let found = store.get_by_conversation_id(cid).await.unwrap().unwrap();
+        assert_eq!(found.session_id, "s1");
+    }
+
+    #[tokio::test]
+    async fn get_by_conversation_id_returns_none_when_unlinked() {
+        let store = SessionStore::new(make_pool().await);
+        store.create("s1").await.unwrap();
+        assert!(store.get_by_conversation_id(99).await.unwrap().is_none());
+    }
+}

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -146,6 +146,17 @@ struct SharedAgentDeps {
 
     // Config snapshot — single source of truth for all config-derived agent settings
     session_config: zeph_core::AgentSessionConfig,
+    /// `[session]` persistence settings (spec-068, #5343) — durable JSONL event log dual-write.
+    /// Distinct from `session_config` (`AgentSessionConfig`, recap/loop settings).
+    session_persistence_config: zeph_config::SessionConfig,
+    /// D-13 (spec-068 §8.1, N3): resume-time durable condensation, pre-built once here (where
+    /// the full `Config` — needed for `[[llm.providers]]` name resolution and secrets — is
+    /// still in scope) rather than per-session in `spawn_acp_agent`, which only receives
+    /// pre-decomposed sub-configs, not the raw `Config`. Mirrors the existing
+    /// `session_persistence_config` pattern: extract once at deps-build time, read by
+    /// reference per session.
+    resume_condenser: zeph_session::LlmCondenser,
+    resume_token_counter: std::sync::Arc<zeph_agent_context::memory_backend::TokenCounterAdapter>,
     focus_config: zeph_core::config::FocusConfig,
     sidequest_config: zeph_core::config::SidequestConfig,
     trajectory_config: zeph_core::config::TrajectoryConfig,
@@ -577,6 +588,10 @@ async fn build_acp_deps(
     };
 
     let session_config = zeph_core::AgentSessionConfig::from_config(config, budget_tokens);
+    // D-13 (spec-068 §8.1, N3): built once here, where the full `Config` is still in scope —
+    // see the `resume_condenser` field's doc comment on `SharedAgentDeps`.
+    let (resume_condenser_built, resume_token_counter_built) =
+        zeph_core::provider_factory::build_resume_condenser(config, &provider);
     let feedback_classifier = app.build_feedback_classifier(&provider);
 
     let deps = SharedAgentDeps {
@@ -637,6 +652,9 @@ async fn build_acp_deps(
         audit_logger: acp_audit_logger,
         hooks_config: config.hooks.clone(),
         session_config,
+        session_persistence_config: config.session.clone(),
+        resume_condenser: resume_condenser_built,
+        resume_token_counter: resume_token_counter_built,
         focus_config: config.agent.focus.clone(),
         sidequest_config: config.memory.sidequest.clone(),
         trajectory_config: config.memory.trajectory.clone(),
@@ -750,6 +768,7 @@ async fn spawn_acp_agent(
     let quarantine_provider = d.quarantine_provider.clone();
     let guardrail_provider = d.guardrail_provider.clone();
     let session_config = d.session_config.clone();
+    let session_persistence_config = d.session_persistence_config.clone();
     let managed_skills_dir = crate::bootstrap::managed_skills_dir();
     let skill_reload_tx = d.skill_reload_tx.clone();
     let config_reload_tx = d.config_reload_tx.clone();
@@ -933,6 +952,76 @@ async fn spawn_acp_agent(
             recall_limit,
             summarization_threshold,
         );
+    }
+
+    // Session persistence (spec-068, #5343): reuse the ACP session_id directly as the
+    // zeph_common::SessionId — ACP already owns this session's identity/lifecycle, so no
+    // separate minting/reuse logic is needed here (unlike the CLI/TUI path in runner.rs, which
+    // has no pre-existing session identity to anchor to). `SessionStore::create` is idempotent
+    // (INSERT_IGNORE) and does not touch `conversation_id`, which ACP's own
+    // `create_acp_session_with_conversation` already manages — this call only ensures the row
+    // exists so `SessionStore::update_seq` has something to update.
+    if session_persistence_config.enabled {
+        let sid = zeph_common::SessionId::new(session_ctx.session_id.to_string());
+        let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+        if let Err(e) = store.create(sid.as_str()).await {
+            tracing::warn!(error = %e, session_id = %sid, "failed to create session-store row for ACP session");
+        }
+        let data_dir = std::path::PathBuf::from(&session_persistence_config.data_dir);
+        let session_path = zeph_session::session_dir(&data_dir, sid.as_str());
+
+        // D-10 (spec-068 §12.3/§13): route through the shared hydration pipeline (legacy
+        // bootstrap + ReplayEngine fold + INV-SP-3 reconcile) — the one pipeline every
+        // session-open path (ACP, CLI `sessions resume`, `/conv resume`) now shares, so they
+        // cannot silently diverge again (impl-critic finding C1). Bootstrap/reconcile need a
+        // linked `ConversationId`; when absent (store was unavailable at session creation —
+        // `with_memory` above was skipped too), fall back to a bare log open with no
+        // SQLite-touching steps, matching this edge case's pre-D-10 behavior.
+        // D-13 (spec-068 §8.1, N3): `hydrate_and_condense` additionally folds in resume-time
+        // durable condensation via the pre-built `d.resume_condenser`/`d.resume_token_counter`
+        // (see `SharedAgentDeps`'s doc comment for why they're built once at deps-construction
+        // time, not here).
+        let log = if let Some(cid) = session_ctx.conversation_id {
+            match zeph_agent_persistence::hydrate_and_condense(
+                &session_path,
+                &store,
+                sid.as_str(),
+                cid,
+                &memory,
+                None,
+                &d.resume_condenser,
+                d.resume_token_counter.as_ref(),
+                d.session_config.budget_tokens,
+            )
+            .await
+            {
+                Ok(hydrated) => {
+                    if !hydrated.messages.is_empty() {
+                        agent = agent.with_preloaded_messages(hydrated.messages);
+                    }
+                    Some(hydrated.log)
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "session hydration failed; session persistence disabled for this session");
+                    None
+                }
+            }
+        } else {
+            match zeph_session::SessionEventLog::open(&session_path).await {
+                Ok(log) => Some(Arc::new(log)),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to open session event log for ACP session; session persistence disabled for this session");
+                    None
+                }
+            }
+        };
+
+        if let Some(log) = log {
+            let sink = Arc::new(zeph_agent_persistence::SessionSink::new(log, store, sid));
+            agent = agent
+                .with_session_sink(Some(sink))
+                .with_session_persistence_config(Some(session_persistence_config.clone()));
+        }
     }
 
     if let Some(signal) = cancel_signal {
@@ -1437,6 +1526,10 @@ pub(crate) async fn run_acp_server(
         title_max_chars: deps.acp_title_max_chars,
         max_history: deps.acp_max_history,
         sqlite_path: Some(deps.sqlite_path.clone()),
+        session_data_dir: deps
+            .session_persistence_config
+            .enabled
+            .then(|| std::path::PathBuf::from(&deps.session_persistence_config.data_dir)),
         ready_notification: Some(zeph_acp::transport::ReadyNotification {
             version: deps.acp_agent_version.clone(),
             pid: std::process::id(),
@@ -1511,6 +1604,11 @@ pub(crate) async fn run_acp_http_server(
         title_max_chars: app.config().memory.sessions.title_max_chars,
         max_history: app.config().memory.sessions.max_history,
         sqlite_path: Some(crate::db_url::resolve_db_url(app.config()).to_owned()),
+        session_data_dir: app
+            .config()
+            .session
+            .enabled
+            .then(|| std::path::PathBuf::from(&app.config().session.data_dir)),
         ready_notification: None,
         additional_directories: app.config().acp.additional_directories.clone(),
         auth_methods: app.config().acp.auth_methods.clone(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -279,6 +279,14 @@ pub(crate) struct Cli {
     #[command(subcommand)]
     pub(crate) command: Option<Command>,
 
+    /// Session id to resume interactively (spec-068 D-6, #5343).
+    ///
+    /// Not a CLI flag — populated programmatically when dispatching `sessions resume <id>`
+    /// (without `--print`) to the interactive `runner::run` path instead of the one-shot
+    /// hydration-summary dump.
+    #[arg(skip)]
+    pub(crate) resume_session_id: Option<String>,
+
     /// Initial prompt pre-queued from a deep-link URI (set by `handle_url_open` before bootstrap).
     ///
     /// Not a CLI flag — populated programmatically by the `url-open` dispatch arm.
@@ -350,11 +358,29 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: ScheduleCommand,
     },
-    /// Manage ACP session history
-    #[cfg(feature = "acp")]
+    /// Manage conversation-session history (spec-068, #5343)
+    #[cfg(any(feature = "acp", feature = "session"))]
     Sessions {
         #[command(subcommand)]
         command: SessionsCommand,
+    },
+    /// Run as a persistent agent service exposing sessions over HTTP/SSE (spec-068 §9, #5343).
+    ///
+    /// Named `serve-sessions` rather than the spec's literal `serve` — `Command::Serve` is
+    /// already the scheduler's foreground-daemon command (`#[cfg(all(unix, feature =
+    /// "scheduler"))]`, `src/cli.rs` above); both features can be enabled simultaneously, so a
+    /// second command claiming the same top-level name is not viable.
+    #[cfg(feature = "session")]
+    ServeSessions {
+        /// HTTP/SSE API bind address (overrides `[serve] http_addr`).
+        #[arg(long, value_name = "ADDR")]
+        http_addr: Option<String>,
+        /// Also run the ACP protocol transport alongside the HTTP/SSE API.
+        #[arg(long)]
+        acp: bool,
+        /// Maximum concurrent live sessions (overrides `[serve] max_sessions`).
+        #[arg(long, value_name = "N")]
+        max_sessions: Option<usize>,
     },
     /// Inspect or reset Thompson Sampling router state
     Router {
@@ -896,20 +922,60 @@ pub(crate) enum ScheduleCommand {
     },
 }
 
-#[cfg(feature = "acp")]
+#[cfg(any(feature = "acp", feature = "session"))]
 #[derive(Subcommand)]
 pub(crate) enum SessionsCommand {
-    /// List recent ACP sessions
+    /// List recent conversation-sessions
     List,
-    /// Resume a past session by ID (print events to stdout)
+    /// Resume a session as a live interactive agent, replaying its event log to reconstruct
+    /// history (spec-068 D-6, #5343)
     Resume {
         /// Session ID
         id: String,
+        /// Dump the session's raw JSONL events to stdout instead of resuming interactively
+        /// (the pre-#5343 one-shot dump behavior)
+        #[arg(long)]
+        print: bool,
     },
-    /// Delete an ACP session and its events
+    /// Show metadata (and optionally events) for a single session
+    Show {
+        /// Session ID
+        id: String,
+        /// Only include events with `seq >= FROM`
+        #[arg(long, value_name = "SEQ")]
+        from: Option<u64>,
+        /// Only include events with `seq < TO`
+        #[arg(long, value_name = "SEQ")]
+        to: Option<u64>,
+        /// Also print the session's events (JSONL, one per line)
+        #[arg(long)]
+        events: bool,
+    },
+    /// Delete a session and its event log
     Delete {
         /// Session ID
         id: String,
+    },
+    /// Fork a session into a new, independent child session
+    Fork {
+        /// Session ID to fork from
+        id: String,
+        /// Fork at this event `seq` (exclusive upper bound); omit to fork at the current end of
+        /// the log (copies everything)
+        #[arg(long, value_name = "SEQ")]
+        at: Option<u64>,
+    },
+    /// Export a session's event log to a JSONL file
+    Export {
+        /// Session ID to export
+        id: String,
+        /// Destination path for the exported JSONL file
+        path: std::path::PathBuf,
+    },
+    /// Import a session event log from a JSONL file as a new session
+    Import {
+        /// Source JSONL file (as produced by `sessions export`)
+        path: std::path::PathBuf,
     },
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -25,7 +25,7 @@ pub(crate) mod router;
 pub(crate) mod schedule;
 #[cfg(all(unix, feature = "scheduler"))]
 pub(crate) mod scheduler_daemon;
-#[cfg(feature = "acp")]
+#[cfg(any(feature = "acp", feature = "session"))]
 pub(crate) mod sessions;
 pub(crate) mod skill;
 pub(crate) mod vault;

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -1,16 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#[cfg(feature = "acp")]
+#[cfg(any(feature = "acp", feature = "session"))]
 use crate::cli::SessionsCommand;
 
-#[cfg(feature = "acp")]
+#[cfg(any(feature = "acp", feature = "session"))]
 pub(crate) async fn handle_sessions_command(
     cmd: SessionsCommand,
     config_path: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     use crate::bootstrap::{load_config_or_default, resolve_config_path};
-    use zeph_core::text::truncate_to_chars;
     use zeph_memory::store::SqliteStore;
 
     let config_file = resolve_config_path(config_path);
@@ -18,75 +17,425 @@ pub(crate) async fn handle_sessions_command(
     let store = SqliteStore::new(crate::db_url::resolve_db_url(&config))
         .await
         .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
+    let session_store = zeph_session::SessionStore::new(store.pool().clone());
+    let data_dir = std::path::PathBuf::from(&config.session.data_dir);
 
     match cmd {
         SessionsCommand::List => {
-            let limit = config.memory.sessions.max_history;
-            let sessions = store
-                .list_acp_sessions(limit)
-                .await
-                .map_err(|e| anyhow::anyhow!("failed to list sessions: {e}"))?;
-
-            if sessions.is_empty() {
-                println!("No sessions found.");
-                return Ok(());
-            }
-
-            println!(
-                "{:<38} {:<62} {:<24} {:>5}",
-                "ID", "TITLE", "UPDATED", "MSGS"
-            );
-            println!("{}", "-".repeat(135));
-            for s in &sessions {
-                let title = s.title.as_deref().unwrap_or("(untitled)");
-                let title_display = truncate_to_chars(title, 60);
-                println!(
-                    "{:<38} {:<62} {:<24} {:>5}",
-                    s.id, title_display, s.updated_at, s.message_count
-                );
-            }
+            list_sessions(&session_store, config.memory.sessions.max_history).await
         }
-
-        SessionsCommand::Resume { id } => {
-            let exists = store
-                .acp_session_exists(&id)
-                .await
-                .map_err(|e| anyhow::anyhow!("failed to check session: {e}"))?;
-
-            if !exists {
-                anyhow::bail!("session not found: {id}");
-            }
-
-            let events = store
-                .load_acp_events(&id)
-                .await
-                .map_err(|e| anyhow::anyhow!("failed to load events: {e}"))?;
-
-            println!("Session: {id}");
-            println!("{} event(s):", events.len());
-            for event in &events {
-                println!("[{}] {}", event.event_type, event.payload);
-            }
+        // `print: false` is intercepted earlier, in `runner::run`, and dispatched to a live
+        // interactive agent instead (spec-068 D-6, #5343) — this handler only ever sees
+        // `print: true` in practice, but the field stays on the CLI schema either way.
+        SessionsCommand::Resume { id, print: _ } => {
+            print_session_events(&data_dir, &id, None, None).await
         }
-
-        SessionsCommand::Delete { id } => {
-            let exists = store
-                .acp_session_exists(&id)
-                .await
-                .map_err(|e| anyhow::anyhow!("failed to check session: {e}"))?;
-
-            if !exists {
-                anyhow::bail!("session not found: {id}");
-            }
-
-            store
-                .delete_acp_session_checked(&id)
-                .await
-                .map_err(|e| anyhow::anyhow!("failed to delete session: {e}"))?;
-
-            println!("Deleted session {id}.");
+        SessionsCommand::Show {
+            id,
+            from,
+            to,
+            events,
+        } => show_session(&session_store, &data_dir, &id, from, to, events).await,
+        SessionsCommand::Delete { id } => delete_session(&store, &session_store, &id).await,
+        SessionsCommand::Fork { id, at } => {
+            fork_session_cli(&session_store, &data_dir, &id, at).await
         }
+        SessionsCommand::Export { id, path } => export_session(&data_dir, &id, &path).await,
+        SessionsCommand::Import { path } => import_session(&session_store, &data_dir, &path).await,
+    }
+}
+
+#[cfg(any(feature = "acp", feature = "session"))]
+async fn list_sessions(
+    session_store: &zeph_session::SessionStore,
+    limit: usize,
+) -> anyhow::Result<()> {
+    use zeph_core::text::truncate_to_chars;
+
+    let sessions = session_store
+        .list(&zeph_session::SessionFilter {
+            status: None,
+            limit,
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list sessions: {e}"))?;
+
+    if sessions.is_empty() {
+        println!("No sessions found.");
+        return Ok(());
+    }
+
+    println!(
+        "{:<38} {:<40} {:<9} {:>6} {:<38} {:<24}",
+        "ID", "TITLE", "STATUS", "EVENTS", "FORKED_FROM", "UPDATED"
+    );
+    println!("{}", "-".repeat(160));
+    for s in &sessions {
+        let title = s.title.as_deref().unwrap_or("(untitled)");
+        let title_display = truncate_to_chars(title, 38);
+        let forked_from = s.forked_from.as_deref().unwrap_or("-");
+        println!(
+            "{:<38} {:<40} {:<9} {:>6} {:<38} {:<24}",
+            s.session_id,
+            title_display,
+            s.status.as_str(),
+            s.event_count,
+            forked_from,
+            s.updated_at
+        );
+    }
+    Ok(())
+}
+
+#[cfg(any(feature = "acp", feature = "session"))]
+async fn show_session(
+    session_store: &zeph_session::SessionStore,
+    data_dir: &std::path::Path,
+    id: &str,
+    from: Option<u64>,
+    to: Option<u64>,
+    events: bool,
+) -> anyhow::Result<()> {
+    let meta = session_store
+        .get(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to look up session: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("session not found: {id}"))?;
+
+    println!("Session:            {}", meta.session_id);
+    println!(
+        "Title:              {}",
+        meta.title.as_deref().unwrap_or("(untitled)")
+    );
+    println!("Status:             {}", meta.status.as_str());
+    println!("Created:            {}", meta.created_at);
+    println!("Updated:            {}", meta.updated_at);
+    println!(
+        "Conversation ID:    {}",
+        meta.conversation_id
+            .map_or_else(|| "-".to_owned(), |c| c.to_string())
+    );
+    println!("Last seq:           {}", meta.last_seq);
+    println!("Event count:        {}", meta.event_count);
+    println!("Last condensed seq: {}", meta.last_condensed_seq);
+    println!(
+        "Forked from:        {}",
+        meta.forked_from.as_deref().unwrap_or("-")
+    );
+    if let Some(at_seq) = meta.forked_at_seq {
+        println!("Forked at seq:      {at_seq}");
+    }
+
+    if events {
+        println!();
+        print_session_events(data_dir, id, from, to).await?;
     }
 
     Ok(())
+}
+
+#[cfg(any(feature = "acp", feature = "session"))]
+async fn print_session_events(
+    data_dir: &std::path::Path,
+    id: &str,
+    from: Option<u64>,
+    to: Option<u64>,
+) -> anyhow::Result<()> {
+    let session_path = zeph_session::session_dir(data_dir, id);
+    let log = zeph_session::SessionEventLog::open(&session_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to open session event log: {e}"))?;
+    let events = log
+        .read_all()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to read session event log: {e}"))?;
+
+    let filtered: Vec<_> = events
+        .into_iter()
+        .filter(|e| from.is_none_or(|f| e.seq >= f) && to.is_none_or(|t| e.seq < t))
+        .collect();
+
+    println!("{} event(s):", filtered.len());
+    for envelope in &filtered {
+        let payload = serde_json::to_string(&envelope.kind).unwrap_or_default();
+        println!("[{}] {payload}", envelope.seq);
+    }
+    Ok(())
+}
+
+#[cfg(any(feature = "acp", feature = "session"))]
+async fn delete_session(
+    store: &zeph_memory::store::SqliteStore,
+    session_store: &zeph_session::SessionStore,
+    id: &str,
+) -> anyhow::Result<()> {
+    let exists = session_store
+        .get(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to look up session: {e}"))?
+        .is_some()
+        || store
+            .acp_session_exists(id)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to check session: {e}"))?;
+
+    if !exists {
+        anyhow::bail!("session not found: {id}");
+    }
+
+    store
+        .delete_acp_session_checked(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete session: {e}"))?;
+
+    println!("Deleted session {id}.");
+    println!(
+        "Note: the on-disk event log directory is not removed yet (blob/event-log GC lands in a follow-up)."
+    );
+    Ok(())
+}
+
+/// `sessions fork <id> [--at <seq>]` — spec-068 P2, #5343.
+#[cfg(any(feature = "acp", feature = "session"))]
+async fn fork_session_cli(
+    session_store: &zeph_session::SessionStore,
+    data_dir: &std::path::Path,
+    id: &str,
+    at: Option<u64>,
+) -> anyhow::Result<()> {
+    let new_id = zeph_common::SessionId::generate();
+    let result = zeph_session::ForkEngine::fork(data_dir, id, new_id.as_str(), at, session_store)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to fork session: {e}"))?;
+
+    println!(
+        "Forked session {id} -> {} ({} event(s) copied).",
+        result.new_session_id, result.events_copied
+    );
+    Ok(())
+}
+
+/// `sessions export <id> <path.jsonl>` — spec-068 P2, #5343.
+///
+/// Copies the session's validated (INV-SP-2 torn-tail-truncated) `events.jsonl` file to `path`.
+#[cfg(any(feature = "acp", feature = "session"))]
+async fn export_session(
+    data_dir: &std::path::Path,
+    id: &str,
+    path: &std::path::Path,
+) -> anyhow::Result<()> {
+    let session_path = zeph_session::session_dir(data_dir, id);
+    let log = zeph_session::SessionEventLog::open(&session_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to open session event log: {e}"))?;
+
+    tokio::fs::copy(log.path(), path)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to write export file: {e}"))?;
+
+    println!("Exported session {id} to {}.", path.display());
+    Ok(())
+}
+
+/// `sessions import <path.jsonl>` — spec-068 P2, #5343.
+///
+/// Imports a previously-exported JSONL file as a brand-new session (fresh id, no `forked_from`
+/// provenance — an import is a restore, not a fork).
+#[cfg(any(feature = "acp", feature = "session"))]
+async fn import_session(
+    session_store: &zeph_session::SessionStore,
+    data_dir: &std::path::Path,
+    path: &std::path::Path,
+) -> anyhow::Result<()> {
+    let new_id = zeph_common::SessionId::generate();
+    let child_dir = zeph_session::session_dir(data_dir, new_id.as_str());
+
+    let empty_log = zeph_session::SessionEventLog::open(&child_dir)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create session directory: {e}"))?;
+    tokio::fs::copy(path, empty_log.path())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to read import file: {e}"))?;
+    drop(empty_log);
+
+    // Reopen to validate (INV-SP-2 torn-tail truncation) and read the imported content back.
+    let log = zeph_session::SessionEventLog::open(&child_dir)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to validate imported event log: {e}"))?;
+    let events = log
+        .read_all()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to read imported event log: {e}"))?;
+
+    session_store
+        .create(new_id.as_str())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create imported session: {e}"))?;
+    #[allow(clippy::cast_possible_truncation)]
+    let event_count = events.len() as u64;
+    session_store
+        .update_seq(new_id.as_str(), log.last_seq().unwrap_or(0), event_count)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to record imported session metadata: {e}"))?;
+
+    println!(
+        "Imported {} as new session {} ({event_count} event(s)).",
+        path.display(),
+        new_id.as_str()
+    );
+    Ok(())
+}
+
+#[cfg(all(test, any(feature = "acp", feature = "session")))]
+mod tests {
+    use crate::cli::{Cli, Command, SessionsCommand};
+    use clap::Parser;
+
+    #[test]
+    fn sessions_list_parses() {
+        let cli = Cli::try_parse_from(["zeph", "sessions", "list"]).expect("parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Sessions {
+                command: SessionsCommand::List
+            })
+        ));
+    }
+
+    #[test]
+    fn sessions_resume_parses_without_print() {
+        let cli = Cli::try_parse_from(["zeph", "sessions", "resume", "abc"]).expect("parse");
+        let Some(Command::Sessions {
+            command: SessionsCommand::Resume { id, print },
+        }) = cli.command
+        else {
+            panic!("expected Sessions(Resume)");
+        };
+        assert_eq!(id, "abc");
+        assert!(!print);
+    }
+
+    #[test]
+    fn sessions_resume_parses_with_print_flag() {
+        let cli =
+            Cli::try_parse_from(["zeph", "sessions", "resume", "abc", "--print"]).expect("parse");
+        let Some(Command::Sessions {
+            command: SessionsCommand::Resume { id, print },
+        }) = cli.command
+        else {
+            panic!("expected Sessions(Resume)");
+        };
+        assert_eq!(id, "abc");
+        assert!(print);
+    }
+
+    #[test]
+    fn sessions_show_parses_with_all_flags() {
+        let cli = Cli::try_parse_from([
+            "zeph", "sessions", "show", "abc", "--from", "1", "--to", "10", "--events",
+        ])
+        .expect("parse");
+        let Some(Command::Sessions {
+            command:
+                SessionsCommand::Show {
+                    id,
+                    from,
+                    to,
+                    events,
+                },
+        }) = cli.command
+        else {
+            panic!("expected Sessions(Show)");
+        };
+        assert_eq!(id, "abc");
+        assert_eq!(from, Some(1));
+        assert_eq!(to, Some(10));
+        assert!(events);
+    }
+
+    #[test]
+    fn sessions_show_parses_with_no_optional_flags() {
+        let cli = Cli::try_parse_from(["zeph", "sessions", "show", "abc"]).expect("parse");
+        let Some(Command::Sessions {
+            command:
+                SessionsCommand::Show {
+                    id,
+                    from,
+                    to,
+                    events,
+                },
+        }) = cli.command
+        else {
+            panic!("expected Sessions(Show)");
+        };
+        assert_eq!(id, "abc");
+        assert_eq!(from, None);
+        assert_eq!(to, None);
+        assert!(!events);
+    }
+
+    #[test]
+    fn sessions_delete_parses() {
+        let cli = Cli::try_parse_from(["zeph", "sessions", "delete", "abc"]).expect("parse");
+        let Some(Command::Sessions {
+            command: SessionsCommand::Delete { id },
+        }) = cli.command
+        else {
+            panic!("expected Sessions(Delete)");
+        };
+        assert_eq!(id, "abc");
+    }
+
+    #[test]
+    fn sessions_fork_parses_without_at() {
+        let cli = Cli::try_parse_from(["zeph", "sessions", "fork", "abc"]).expect("parse");
+        let Some(Command::Sessions {
+            command: SessionsCommand::Fork { id, at },
+        }) = cli.command
+        else {
+            panic!("expected Sessions(Fork)");
+        };
+        assert_eq!(id, "abc");
+        assert_eq!(at, None);
+    }
+
+    #[test]
+    fn sessions_fork_parses_with_at() {
+        let cli =
+            Cli::try_parse_from(["zeph", "sessions", "fork", "abc", "--at", "5"]).expect("parse");
+        let Some(Command::Sessions {
+            command: SessionsCommand::Fork { id, at },
+        }) = cli.command
+        else {
+            panic!("expected Sessions(Fork)");
+        };
+        assert_eq!(id, "abc");
+        assert_eq!(at, Some(5));
+    }
+
+    #[test]
+    fn sessions_export_parses() {
+        let cli =
+            Cli::try_parse_from(["zeph", "sessions", "export", "abc", "out.jsonl"]).expect("parse");
+        let Some(Command::Sessions {
+            command: SessionsCommand::Export { id, path },
+        }) = cli.command
+        else {
+            panic!("expected Sessions(Export)");
+        };
+        assert_eq!(id, "abc");
+        assert_eq!(path, std::path::PathBuf::from("out.jsonl"));
+    }
+
+    #[test]
+    fn sessions_import_parses() {
+        let cli = Cli::try_parse_from(["zeph", "sessions", "import", "in.jsonl"]).expect("parse");
+        let Some(Command::Sessions {
+            command: SessionsCommand::Import { path },
+        }) = cli.command
+        else {
+            panic!("expected Sessions(Import)");
+        };
+        assert_eq!(path, std::path::PathBuf::from("in.jsonl"));
+    }
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -22,6 +22,7 @@ pub(super) mod llm;
 pub(super) mod mcp;
 pub(super) mod memory;
 pub(super) mod security;
+pub(super) mod session;
 pub(super) mod worktree;
 
 use agents::{step_agents, step_learning, step_orchestration, step_router};
@@ -30,6 +31,7 @@ use llm::step_llm;
 use mcp::{step_mcp_discovery, step_mcp_remote, step_mcpls, write_mcpls_config};
 use memory::{step_context_compression, step_memory};
 use security::{step_policy, step_sandbox, step_security, step_trajectory};
+use session::{step_serve, step_session};
 use worktree::step_worktree;
 
 #[cfg_attr(test, derive(Clone))]
@@ -299,6 +301,17 @@ pub(crate) struct WizardState {
     pub(crate) tui_delights_enabled: bool,
     /// Whether opt-in mouse capture is enabled at startup.
     pub(crate) tui_mouse_enabled: bool,
+    // Durable session persistence (spec-068, #5343, P4)
+    /// Whether to maintain a durable, replayable JSONL event log per conversation-session.
+    pub(crate) session_persistence_enabled: bool,
+    /// Directory under which per-session event logs are stored.
+    pub(crate) session_data_dir: String,
+    // `zeph serve-sessions` HTTP/SSE API (spec-068 §9, #5343, P4)
+    pub(crate) serve_http_addr: String,
+    pub(crate) serve_require_auth: bool,
+    pub(crate) serve_auth_token_vault_key: String,
+    pub(crate) serve_max_sessions: usize,
+    pub(crate) serve_session_idle_ttl_secs: u64,
 }
 
 impl Default for WizardState {
@@ -495,6 +508,13 @@ impl Default for WizardState {
             tui_color_mode: zeph_config::ColorMode::Auto,
             tui_delights_enabled: true,
             tui_mouse_enabled: false,
+            session_persistence_enabled: zeph_config::SessionConfig::default().enabled,
+            session_data_dir: zeph_config::SessionConfig::default().data_dir,
+            serve_http_addr: zeph_config::ServeConfig::default().http_addr,
+            serve_require_auth: zeph_config::ServeConfig::default().require_auth,
+            serve_auth_token_vault_key: zeph_config::ServeConfig::default().auth_token_vault_key,
+            serve_max_sessions: zeph_config::ServeConfig::default().max_sessions,
+            serve_session_idle_ttl_secs: zeph_config::ServeConfig::default().session_idle_ttl_secs,
         }
     }
 }
@@ -564,6 +584,8 @@ pub fn run(output: Option<PathBuf>) -> anyhow::Result<()> {
     step_trajectory(&mut state)?;
     step_telemetry(&mut state)?;
     step_prometheus(&mut state)?;
+    step_session(&mut state)?;
+    step_serve(&mut state)?;
     step_session_recap(&mut state)?;
     step_caveman(&mut state)?;
     step_knowledge(&mut state)?;
@@ -858,6 +880,16 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     config.memory.digest.enabled = state.digest_enabled;
     config.session.recap.on_resume = state.recap_on_resume;
     config.session.persist_provider_overrides = state.persist_provider_overrides;
+    config.session.enabled = state.session_persistence_enabled;
+    config.session.data_dir.clone_from(&state.session_data_dir);
+    config.serve.http_addr.clone_from(&state.serve_http_addr);
+    config.serve.require_auth = state.serve_require_auth;
+    config
+        .serve
+        .auth_token_vault_key
+        .clone_from(&state.serve_auth_token_vault_key);
+    config.serve.max_sessions = state.serve_max_sessions;
+    config.serve.session_idle_ttl_secs = state.serve_session_idle_ttl_secs;
     config.caveman.default_on = state.caveman_default_on;
     config
         .knowledge
@@ -3293,5 +3325,59 @@ mod tests {
         };
         let config = build_config(&state);
         assert_eq!(config.tools.utility.utility_window, 5);
+    }
+
+    #[test]
+    fn build_config_defaults_match_session_and_serve_config_defaults() {
+        // A wizard run with no interactive customization of the new #5343 steps should produce
+        // a config identical to [session]/[serve]'s own Default impls.
+        let state = WizardState {
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert_eq!(
+            config.session.enabled,
+            zeph_config::SessionConfig::default().enabled
+        );
+        assert_eq!(
+            config.session.data_dir,
+            zeph_config::SessionConfig::default().data_dir
+        );
+        assert_eq!(
+            config.serve.http_addr,
+            zeph_config::ServeConfig::default().http_addr
+        );
+        assert_eq!(
+            config.serve.require_auth,
+            zeph_config::ServeConfig::default().require_auth
+        );
+        assert_eq!(
+            config.serve.max_sessions,
+            zeph_config::ServeConfig::default().max_sessions
+        );
+    }
+
+    #[test]
+    fn build_config_applies_customized_session_and_serve_settings() {
+        let state = WizardState {
+            vault_backend: "env".into(),
+            session_persistence_enabled: false,
+            session_data_dir: "/custom/sessions".into(),
+            serve_http_addr: "0.0.0.0:9000".into(),
+            serve_require_auth: false,
+            serve_auth_token_vault_key: "MY_TOKEN".into(),
+            serve_max_sessions: 10,
+            serve_session_idle_ttl_secs: 60,
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert!(!config.session.enabled);
+        assert_eq!(config.session.data_dir, "/custom/sessions");
+        assert_eq!(config.serve.http_addr, "0.0.0.0:9000");
+        assert!(!config.serve.require_auth);
+        assert_eq!(config.serve.auth_token_vault_key, "MY_TOKEN");
+        assert_eq!(config.serve.max_sessions, 10);
+        assert_eq!(config.serve.session_idle_ttl_secs, 60);
     }
 }

--- a/src/init/session.rs
+++ b/src/init/session.rs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Wizard steps for durable session persistence and `zeph serve-sessions` (spec-068, #5343, P4).
+//!
+//! Two independent steps: [`step_session`] configures `[session]` (the durable JSONL event log
+//! every channel dual-writes to), [`step_serve`] configures `[serve]` (`zeph serve-sessions`'s
+//! HTTP/SSE API defaults) — the latter's settings apply whether or not the user ever actually
+//! runs `zeph serve-sessions`, so it is gated behind its own "customize now?" confirmation rather
+//! than an "enable" toggle (there is no `[serve]` `enabled` field; the command is opt-in by
+//! virtue of being a separate CLI subcommand).
+
+use dialoguer::{Confirm, Input};
+
+use super::WizardState;
+
+/// Collect `[session]` durable persistence settings (spec-068 §4).
+///
+/// # Errors
+///
+/// Returns an error if a prompt cannot be read.
+pub(super) fn step_session(state: &mut WizardState) -> anyhow::Result<()> {
+    println!("== Session Persistence ==\n");
+    println!("Maintains a durable, replayable JSONL event log per conversation-session, enabling");
+    println!("crash-safe resume and `/conv resume`/`/conv fork` (spec-068).\n");
+
+    state.session_persistence_enabled = Confirm::new()
+        .with_prompt("Enable durable session persistence?")
+        .default(true)
+        .interact()?;
+
+    if state.session_persistence_enabled {
+        state.session_data_dir = Input::new()
+            .with_prompt("Event log directory")
+            .default(state.session_data_dir.clone())
+            .interact_text()?;
+    }
+
+    println!();
+    Ok(())
+}
+
+/// Collect `[serve]` settings for `zeph serve-sessions` (spec-068 §9).
+///
+/// # Errors
+///
+/// Returns an error if a prompt cannot be read.
+pub(super) fn step_serve(state: &mut WizardState) -> anyhow::Result<()> {
+    println!("== zeph serve-sessions (HTTP/SSE Session API) ==\n");
+    println!("Exposes durable sessions over HTTP/SSE. These settings apply whenever you run");
+    println!("`zeph serve-sessions`, independent of whether you use it now.\n");
+
+    let customize = Confirm::new()
+        .with_prompt("Customize `zeph serve-sessions` settings now? (sensible defaults otherwise)")
+        .default(false)
+        .interact()?;
+    if !customize {
+        println!();
+        return Ok(());
+    }
+
+    state.serve_http_addr = Input::new()
+        .with_prompt("Bind address")
+        .default(state.serve_http_addr.clone())
+        .interact_text()?;
+
+    state.serve_require_auth = Confirm::new()
+        .with_prompt("Require a bearer token on /sessions* endpoints? (/health is always open)")
+        .default(state.serve_require_auth)
+        .interact()?;
+
+    if state.serve_require_auth {
+        state.serve_auth_token_vault_key = Input::new()
+            .with_prompt("Vault key name to resolve the bearer token from")
+            .default(state.serve_auth_token_vault_key.clone())
+            .interact_text()?;
+        println!(
+            "  (set the actual token with: zeph vault set {} <token>)",
+            state.serve_auth_token_vault_key
+        );
+    }
+
+    state.serve_max_sessions = Input::new()
+        .with_prompt("Maximum concurrent live sessions")
+        .default(state.serve_max_sessions)
+        .interact_text()?;
+
+    state.serve_session_idle_ttl_secs = Input::new()
+        .with_prompt("Idle session eviction TTL (seconds)")
+        .default(state.serve_session_idle_ttl_secs)
+        .interact_text()?;
+
+    println!();
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,8 @@ mod runner;
 mod scheduler;
 #[cfg(feature = "scheduler")]
 mod scheduler_executor;
+#[cfg(feature = "session")]
+mod serve;
 mod startup_checks;
 mod tracing_init;
 mod tui_bridge;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -33,8 +33,8 @@ use parking_lot::RwLock;
 use zeph_channels::AnyChannel;
 #[cfg(feature = "deep-link")]
 use zeph_common::deep_link::parse_deep_link;
-use zeph_common::{RestartPolicy, TaskDescriptor, TaskSupervisor};
-use zeph_config::{ThinkingConfig, ThinkingEffort};
+use zeph_common::{RestartPolicy, SessionId, TaskDescriptor, TaskSupervisor};
+use zeph_config::{SessionConfig, ThinkingConfig, ThinkingEffort};
 use zeph_core::agent::Agent;
 #[cfg(feature = "acp")]
 use zeph_core::config::AcpTransport;
@@ -43,6 +43,8 @@ use zeph_core::config::AcpTransport;
 use crate::acp::run_acp_http_server;
 #[cfg(feature = "acp")]
 use crate::acp::{print_acp_manifest, run_acp_server};
+#[cfg(any(feature = "acp", feature = "session"))]
+use crate::cli::SessionsCommand;
 use crate::cli::{Command, DbCommand};
 #[cfg(feature = "acp")]
 use crate::commands::acp::handle_acp_command;
@@ -52,7 +54,7 @@ use crate::commands::memory::handle_memory_command;
 use crate::commands::router::handle_router_command;
 #[cfg(feature = "scheduler")]
 use crate::commands::schedule::handle_schedule_command;
-#[cfg(feature = "acp")]
+#[cfg(any(feature = "acp", feature = "session"))]
 use crate::commands::sessions::handle_sessions_command;
 use crate::commands::skill::handle_skill_command;
 use crate::commands::vault::handle_vault_command;
@@ -439,6 +441,64 @@ impl Drop for EarlyTuiGuard {
     }
 }
 
+/// Mint or resume this conversation's durable session event log (spec-068, #5343).
+///
+/// Reuses the session already linked to `conversation_id` across restarts rather than minting a
+/// new one every launch, so a CLI/TUI conversation's event log stays continuous. Returns `None`
+/// (and logs a warning) on any I/O/DB failure — session persistence is best-effort: the agent
+/// must still run with only the existing `SQLite` `messages` projection if it fails.
+async fn init_session_sink(
+    memory: &std::sync::Arc<zeph_memory::semantic::SemanticMemory>,
+    conversation_id: zeph_memory::ConversationId,
+    session_config: &SessionConfig,
+) -> Option<std::sync::Arc<zeph_agent_persistence::SessionSink>> {
+    if !session_config.enabled {
+        return None;
+    }
+
+    let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+    let existing = store
+        .get_by_conversation_id(conversation_id.0)
+        .await
+        .unwrap_or_default();
+
+    let session_id = if let Some(meta) = existing {
+        SessionId::new(meta.session_id)
+    } else {
+        let id = SessionId::generate();
+        if let Err(e) = store.create(id.as_str()).await {
+            tracing::warn!(error = %e, "failed to create session-store row; session persistence disabled for this run");
+            return None;
+        }
+        if let Err(e) = store
+            .link_conversation(id.as_str(), conversation_id.0)
+            .await
+        {
+            tracing::warn!(error = %e, "failed to link session to conversation");
+        }
+        id
+    };
+
+    let data_dir = std::path::PathBuf::from(&session_config.data_dir);
+    let session_path = zeph_session::session_dir(&data_dir, session_id.as_str());
+    match zeph_session::SessionEventLog::open(&session_path).await {
+        Ok(log) => {
+            tracing::info!(session_id = %session_id, "session event log opened");
+            Some(std::sync::Arc::new(
+                zeph_agent_persistence::SessionSink::new(
+                    std::sync::Arc::new(log),
+                    store,
+                    session_id,
+                ),
+            ))
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to open session event log; session persistence disabled for this run");
+            None
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines, clippy::large_futures)]
 #[cfg_attr(not(feature = "deep-link"), allow(unused_mut))]
 pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
@@ -541,9 +601,45 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         Some(Command::Acp { command: acp_cmd }) => {
             return handle_acp_command(acp_cmd, cli.config.as_deref()).await;
         }
-        #[cfg(feature = "acp")]
+        // D-6 (spec-068, #5343): `sessions resume <id>` (no `--print`) launches a live
+        // interactive agent bound to the chosen past session, not a one-shot dump. Falls
+        // through to the normal interactive bootstrap below (matching the `UrlOpen` precedent
+        // above) rather than `return`ing, so replay/hydration and the continuation loop reuse
+        // the existing interactive machinery — only `conversation_id` resolution differs (see
+        // `resume_session_id` handling further down).
+        #[cfg(any(feature = "acp", feature = "session"))]
+        Some(Command::Sessions {
+            command:
+                SessionsCommand::Resume {
+                    ref id,
+                    print: false,
+                },
+        }) => {
+            cli.resume_session_id = Some(id.clone());
+            cli.command = None;
+        }
+        #[cfg(any(feature = "acp", feature = "session"))]
         Some(Command::Sessions { command: sess_cmd }) => {
             return handle_sessions_command(sess_cmd, cli.config.as_deref()).await;
+        }
+        #[cfg(feature = "session")]
+        Some(Command::ServeSessions {
+            http_addr,
+            acp,
+            max_sessions,
+        }) => {
+            return crate::serve::handle_serve_sessions_command(
+                crate::serve::ServeSessionsArgs {
+                    http_addr,
+                    acp,
+                    max_sessions,
+                    vault_backend: cli.vault.clone(),
+                    vault_key: cli.vault_key.clone(),
+                    vault_path: cli.vault_path.clone(),
+                },
+                cli.config.as_deref(),
+            )
+            .await;
         }
         Some(Command::Agents {
             command: agents_cmd,
@@ -1544,11 +1640,93 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         _ => app.config().cli.allowed_tools.clone(),
     };
 
-    let conversation_id = match memory.sqlite().latest_conversation_id().await? {
-        Some(id) => id,
-        None => memory.sqlite().create_conversation().await?,
+    // D-6 (spec-068, #5343): `sessions resume <id>` seeds this run with a specific past
+    // session's conversation instead of the latest one.
+    let mut resumed_messages: Vec<zeph_llm::provider::Message> = Vec::new();
+    let mut resumed_session_sink: Option<std::sync::Arc<zeph_agent_persistence::SessionSink>> =
+        None;
+    let conversation_id = if let Some(resume_id) = cli.resume_session_id.clone() {
+        let session_store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+        let meta = session_store
+            .get(&resume_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("session not found: {resume_id}"))?;
+        let cid = meta
+            .conversation_id
+            .map(zeph_memory::ConversationId)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "session {resume_id} has no linked conversation (legacy session with no \
+                     recorded history); use `zeph sessions resume {resume_id} --print` to \
+                     inspect its raw event log instead"
+                )
+            })?;
+
+        // D-10 (spec-068 §12.3/§13): route through the shared hydration pipeline (legacy
+        // bootstrap + ReplayEngine fold + INV-SP-3 reconcile) instead of falling through to the
+        // SQLite-only `agent.load_history()` below — impl-critic finding C1: CLI resume
+        // previously never replayed the durable event log at all, silently diverging from the
+        // ACP resume pipeline for the exact path AC-1/AC-5 name. `hydrated.log` becomes this
+        // run's SessionSink directly (INV-D2: only one open `SessionEventLog` handle per
+        // session at a time — reusing it here instead of also calling `init_session_sink` avoids
+        // a second, conflicting open of the same file below).
+        // D-13 (spec-068 §8.1, N3): `hydrate_and_condense` folds in resume-time durable
+        // condensation — `condenser`/`token_counter`/`context_window` are all resolvable here,
+        // before agent construction, via the same `provider`/`budget_tokens` this run already
+        // computed for its own `AgentSessionConfig` (no live `Agent` needed, architect ruling).
+        if app.config().session.enabled {
+            let data_dir = std::path::PathBuf::from(&app.config().session.data_dir);
+            let session_path = zeph_session::session_dir(&data_dir, &resume_id);
+            let (condenser, token_counter_adapter) =
+                zeph_core::provider_factory::build_resume_condenser(app.config(), &provider);
+            match zeph_agent_persistence::hydrate_and_condense(
+                &session_path,
+                &session_store,
+                &resume_id,
+                cid,
+                &memory,
+                None,
+                &condenser,
+                token_counter_adapter.as_ref(),
+                budget_tokens,
+            )
+            .await
+            {
+                Ok(hydrated) => {
+                    resumed_messages = hydrated.messages;
+                    resumed_session_sink = Some(std::sync::Arc::new(
+                        zeph_agent_persistence::SessionSink::new(
+                            hydrated.log,
+                            session_store,
+                            SessionId::new(resume_id.clone()),
+                        ),
+                    ));
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "session hydration failed for resume; continuing with SQLite-only history");
+                }
+            }
+        }
+
+        cid
+    } else {
+        match memory.sqlite().latest_conversation_id().await? {
+            Some(id) => id,
+            None => memory.sqlite().create_conversation().await?,
+        }
     };
     tracing::info!("conversation id: {conversation_id}");
+
+    // Session persistence (spec-068, #5343): mint or resume this conversation's durable JSONL
+    // event log. Config-gated, not Cargo-feature-gated — `[session] enabled` (default: true)
+    // is the sole switch; the `session` Cargo feature is reserved for the CLI persistence verbs
+    // and `zeph serve` (P2/P3), not for this core dual-write path. When resuming, the sink was
+    // already constructed above from the hydration helper's opened log.
+    let session_sink = if let Some(sink) = resumed_session_sink {
+        Some(sink)
+    } else {
+        init_session_sink(&memory, conversation_id, &app.config().session).await
+    };
 
     let (shutdown_tx, shutdown_rx) = AppBuilder::build_shutdown();
     let config = app.config();
@@ -2433,6 +2611,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         config.memory.semantic.recall_limit,
         config.memory.summarization_threshold,
     )
+    .with_session_sink(session_sink.clone())
+    .with_session_persistence_config(Some(config.session.clone()))
     .with_compression(config.memory.compression.clone())
     .with_typed_pages_state(typed_pages_state)
     .with_routing(config.memory.store_routing.clone())
@@ -2487,6 +2667,15 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     .with_embedding_provider(embedding_provider.clone())
     .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), embedding_provider)
     .await;
+
+    // D-10 (spec-068 §12.3): seed replayed history from `sessions resume`'s hydration above —
+    // mirrors ACP's own `with_preloaded_messages` usage. Sets `history_preloaded`, so the
+    // `agent.load_history()` SQLite fallback further down becomes a no-op for this run.
+    let agent = if resumed_messages.is_empty() {
+        agent
+    } else {
+        agent.with_preloaded_messages(resumed_messages)
+    };
 
     // Hold ephemeral plugin TempDir handles in the agent for the session lifetime.
     let agent = if ephemeral_plugin_dirs.is_empty() {

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -1,0 +1,306 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Builds the per-session `build_agent` closure handed to `SessionActor::spawn` (spec-068 §9.4,
+//! #5343).
+//!
+//! Mirrors `src/acp.rs`'s `SessionSink` wiring in `spawn_acp_agent`: a durable
+//! [`zeph_session::SessionEventLog`] is opened at `[serve] data_dir` (via
+//! [`ServeAgentDeps::session_persistence_config`]) named after the session's own
+//! [`zeph_common::SessionId`], then wrapped in a [`zeph_agent_persistence::SessionSink`] and
+//! attached via `Agent::with_session_sink`. When `[session] enabled = false`, the agent still
+//! works — it just persists only the `SQLite` `messages` projection, matching every other
+//! channel's fallback behavior.
+//!
+//! Routes through the shared [`zeph_agent_persistence::hydrate_and_condense`] pipeline (D-10,
+//! D-13) unconditionally — a brand-new session's log is empty, so hydration is a harmless no-op
+//! there, and a *reactivated* session (D-12: `POST /sessions/:id/prompt` on an id whose actor was
+//! evicted or the process restarted) gets its prior turns correctly replayed into
+//! `with_preloaded_messages`, and durably condensed if over threshold, before the agent starts —
+//! exactly like ACP/CLI/`/conv` resume (D-13: all four session-open paths share this one
+//! pipeline). One `build_agent_factory` covers both "create" and "reactivate" without a separate
+//! code path.
+//!
+//! **Why the async work happens here, not inside the closure**: `SessionActor::spawn` (D-8)
+//! calls `build_agent(channel)` synchronously on a bare `std::thread` — *before* that thread's
+//! `current_thread` Tokio runtime is entered — specifically so the `!Send` `Agent` never has to
+//! cross a runtime boundary. Calling `.await` (or `Handle::current().block_on`) inside that
+//! closure would panic ("no reactor running"). So [`build_agent_factory`] is itself `async`: it
+//! does the `hydrate_and_condense`/`SessionStore::create` I/O once, up front, on the caller's
+//! (HTTP handler's) runtime, then returns a plain synchronous closure that only captures the
+//! already-built `Option<Arc<SessionSink>>` and replayed `Vec<Message>`.
+
+use std::sync::Arc;
+
+use zeph_core::agent::Agent;
+use zeph_core::channel::LoopbackChannel;
+
+use super::deps::ServeAgentDeps;
+
+/// Build a `build_agent` closure for [`zeph_core::serve::SessionActor::spawn`].
+///
+/// Opens (and, for a reactivated session, replays) the session's durable event log — if
+/// `[session] enabled = true` — before returning, so the returned closure is a plain synchronous
+/// `FnOnce` — safe to call from `SessionActor::spawn`'s dedicated thread before its Tokio
+/// runtime is entered. Captures only `Send`-safe values (`deps` is `Clone`,
+/// `session_id`/`conversation_id` are owned, `SessionSink` is `Send + Sync`, replayed messages
+/// are plain data) — the `LoopbackChannel` and the resulting `!Send` `Agent` never leave that
+/// thread.
+#[tracing::instrument(
+    name = "serve.agent_factory.build",
+    skip_all,
+    level = "info",
+    fields(session_id = session_id.as_str())
+)]
+pub(crate) async fn build_agent_factory(
+    deps: ServeAgentDeps,
+    session_id: zeph_common::SessionId,
+    conversation_id: zeph_memory::ConversationId,
+) -> impl FnOnce(LoopbackChannel) -> Agent<LoopbackChannel> + Send + 'static {
+    let (session_sink, preloaded_messages) = if deps.session_persistence_config.enabled {
+        hydrate_session_sink(
+            &deps.session_persistence_config,
+            &deps.memory,
+            session_id,
+            conversation_id,
+            &deps.resume_condenser,
+            deps.resume_token_counter.as_ref(),
+            deps.session_config.budget_tokens,
+        )
+        .await
+    } else {
+        (None, Vec::new())
+    };
+
+    move |channel| {
+        let mut agent = Agent::new_with_registry_arc(
+            deps.provider,
+            deps.embedding_provider,
+            channel,
+            deps.registry,
+            deps.matcher,
+            deps.max_active_skills,
+            zeph_tools::DynExecutor(deps.tool_executor),
+        )
+        .apply_session_config(deps.session_config)
+        .with_memory(
+            Arc::clone(&deps.memory),
+            conversation_id,
+            deps.history_limit,
+            deps.recall_limit,
+            deps.summarization_threshold,
+        )
+        .with_session_sink(session_sink)
+        .with_session_persistence_config(Some(deps.session_persistence_config));
+        if !preloaded_messages.is_empty() {
+            agent = agent.with_preloaded_messages(preloaded_messages);
+        }
+        agent
+    }
+}
+
+/// Opens (and replays, per D-10) the durable event log for `session_id`, wraps it in a
+/// `SessionSink`, and returns any history it recovered.
+///
+/// Returns `(None, Vec::new())` (logging a warning) if the log cannot be opened/read — matching
+/// `spawn_acp_agent`'s fallback: the session still works, just without durable persistence.
+async fn hydrate_session_sink(
+    session_persistence_config: &zeph_config::SessionConfig,
+    memory: &Arc<zeph_memory::semantic::SemanticMemory>,
+    session_id: zeph_common::SessionId,
+    conversation_id: zeph_memory::ConversationId,
+    resume_condenser: &zeph_session::LlmCondenser,
+    resume_token_counter: &zeph_agent_context::memory_backend::TokenCounterAdapter,
+    context_window: usize,
+) -> (
+    Option<Arc<zeph_agent_persistence::SessionSink>>,
+    Vec<zeph_llm::provider::Message>,
+) {
+    let data_dir = std::path::PathBuf::from(&session_persistence_config.data_dir);
+    let session_path = zeph_session::session_dir(&data_dir, session_id.as_str());
+    let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+
+    if let Err(e) = store.create(session_id.as_str()).await {
+        tracing::warn!(error = %e, "serve-sessions: failed to seed session metadata row");
+    }
+    // D-12: without this, `acp_sessions.conversation_id` stays NULL for every `/sessions`-created
+    // session, and reactivation (`reactivate_session`, `src/serve/handlers.rs`) — which resolves
+    // the conversation to replay via this exact column — can never find one. Idempotent: setting
+    // the same value again on a reactivation of an already-linked session is a no-op update.
+    if let Err(e) = store
+        .link_conversation(session_id.as_str(), conversation_id.0)
+        .await
+    {
+        tracing::warn!(error = %e, "serve-sessions: failed to link session to conversation");
+    }
+    // D-13 (spec-068 §8.1, N3): `hydrate_and_condense` folds in resume-time durable condensation
+    // via the deps-level pre-built `resume_condenser`/`resume_token_counter` (see
+    // `ServeAgentDeps::resume_condenser`'s doc comment for why they're built once at deps-
+    // construction time, not here).
+    match zeph_agent_persistence::hydrate_and_condense(
+        &session_path,
+        &store,
+        session_id.as_str(),
+        conversation_id,
+        memory,
+        None,
+        resume_condenser,
+        resume_token_counter,
+        context_window,
+    )
+    .await
+    {
+        Ok(hydrated) => {
+            let sink = Arc::new(zeph_agent_persistence::SessionSink::new(
+                hydrated.log,
+                store,
+                session_id,
+            ));
+            (Some(sink), hydrated.messages)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "serve-sessions: session persistence disabled for this session");
+            (None, Vec::new())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_agent_context::memory_backend::TokenCounterAdapter;
+    use zeph_llm::any::AnyProvider;
+    use zeph_memory::semantic::SemanticMemory;
+
+    async fn make_memory() -> Arc<SemanticMemory> {
+        Arc::new(
+            SemanticMemory::new(
+                ":memory:",
+                "http://127.0.0.1:1",
+                None,
+                AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+                "test-model",
+            )
+            .await
+            .unwrap(),
+        )
+    }
+
+    /// D-13 fixture: a condenser whose threshold is never crossed in these hydration/linking
+    /// tests — they pass `context_window: 0` too (belt-and-suspenders, since
+    /// `resume_budget_fraction` returns `0.0` for a zero window), so `should_condense` never
+    /// fires and cannot perturb the assertions these tests actually care about.
+    fn make_test_condenser() -> (zeph_session::LlmCondenser, TokenCounterAdapter) {
+        let deps = zeph_context::summarization::SummarizationDeps {
+            provider: AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            llm_timeout: std::time::Duration::from_secs(5),
+            token_counter: std::sync::Arc::new(TokenCounterAdapter::new(std::sync::Arc::new(
+                zeph_memory::TokenCounter::new(),
+            ))),
+            structured_summaries: true,
+            on_anchored_summary: None,
+        };
+        let condenser = zeph_session::LlmCondenser::new(deps, 1.0, 1);
+        let token_counter_adapter =
+            TokenCounterAdapter::new(std::sync::Arc::new(zeph_memory::TokenCounter::new()));
+        (condenser, token_counter_adapter)
+    }
+
+    /// D-12 regression: `hydrate_session_sink` must link `session_id` to `conversation_id` in
+    /// `SessionStore` — without this, `reactivate_session` (`src/serve/handlers.rs`) can never
+    /// resolve a conversation to replay for *any* serve-created session (the fourth bug found
+    /// during the D-10/D-11/D-12 correction pass; previously proven only via a live Ollama
+    /// session, not by any automated test — closing that gap here).
+    #[tokio::test]
+    async fn hydrate_session_sink_links_conversation_id() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let config = zeph_config::SessionConfig {
+            enabled: true,
+            data_dir: dir.path().to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        let session_id = zeph_common::SessionId::new("s1");
+        let (condenser, token_counter) = make_test_condenser();
+
+        let (sink, messages) = hydrate_session_sink(
+            &config,
+            &memory,
+            session_id.clone(),
+            cid,
+            &condenser,
+            &token_counter,
+            0,
+        )
+        .await;
+        assert!(
+            sink.is_some(),
+            "session persistence enabled must produce a SessionSink"
+        );
+        assert!(
+            messages.is_empty(),
+            "a brand-new session has no history to replay"
+        );
+
+        let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+        let meta = store.get(session_id.as_str()).await.unwrap().unwrap();
+        assert_eq!(
+            meta.conversation_id,
+            Some(cid.0),
+            "hydrate_session_sink must link the session to its conversation_id, or reactivation \
+             can never find one to replay"
+        );
+    }
+
+    /// Reactivation reuses this same function (`build_agent_factory` always calls it), and must
+    /// pick up a *linked* session's prior history — this is what makes the D-12 reactivation
+    /// path actually replay context instead of silently starting fresh.
+    #[tokio::test]
+    async fn hydrate_session_sink_replays_prior_history_on_reactivation() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let config = zeph_config::SessionConfig {
+            enabled: true,
+            data_dir: dir.path().to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        let session_id = zeph_common::SessionId::new("s1");
+        let (condenser, token_counter) = make_test_condenser();
+
+        // First call simulates the original `POST /sessions` creation.
+        let (sink, _) = hydrate_session_sink(
+            &config,
+            &memory,
+            session_id.clone(),
+            cid,
+            &condenser,
+            &token_counter,
+            0,
+        )
+        .await;
+        let sink = sink.expect("session persistence enabled must produce a SessionSink");
+        sink.record_message(zeph_llm::provider::Role::User, "hello", &[])
+            .await
+            .unwrap();
+        drop(sink);
+
+        // Second call simulates D-12 reactivation after the actor ended.
+        let (_, messages) = hydrate_session_sink(
+            &config,
+            &memory,
+            session_id,
+            cid,
+            &condenser,
+            &token_counter,
+            0,
+        )
+        .await;
+        assert_eq!(
+            messages.len(),
+            1,
+            "reactivation must replay the session's prior turn, not start fresh"
+        );
+    }
+}

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Agent-dependency assembly for `/sessions*` (spec-068 §9.4, #5343).
+//!
+//! Deliberately smaller than `src/acp.rs`'s `SharedAgentDeps`/`build_acp_deps`: that struct
+//! carries roughly fifteen ACP-transport-specific fields (permission files, the ACP
+//! model-switching provider factory, auth bearer tokens, project-rules metadata) that do not
+//! apply to a plain HTTP/SSE session, so it is not reused wholesale here. [`ServeAgentDeps`]
+//! covers the minimum needed for a working conversational session — provider, skills, memory,
+//! and a core tool set (shell/file/web/cwd, with sandbox and audit wired the same way
+//! `build_acp_deps` does for ACP sessions).
+//!
+//! **Known gap**: MCP tools, the scheduler executor, and skill/config hot-reload broadcast
+//! forwarding are not wired here — a session created via `/sessions` does not see MCP-provided
+//! tools or live-reload skill/config changes yet. Follow-up once the core create/prompt/events
+//! path is proven out.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use zeph_llm::any::AnyProvider;
+use zeph_memory::semantic::SemanticMemory;
+use zeph_skills::matcher::SkillMatcherBackend;
+use zeph_skills::registry::SkillRegistry;
+use zeph_tools::ErasedToolExecutor;
+
+/// Send-safe, cloneable agent dependencies shared across all `/sessions*`-created agents.
+///
+/// Built once in [`build_serve_deps`] at `zeph serve-sessions` startup; each session's
+/// `build_agent` factory (see `SessionActor::spawn`) clones the fields it needs — every field
+/// here is cheap to clone (`Arc`, `Clone` provider handles, or a `usize`/config snapshot).
+#[derive(Clone)]
+pub(crate) struct ServeAgentDeps {
+    pub(crate) provider: AnyProvider,
+    pub(crate) embedding_provider: AnyProvider,
+    pub(crate) registry: Arc<RwLock<SkillRegistry>>,
+    pub(crate) matcher: Option<SkillMatcherBackend>,
+    pub(crate) max_active_skills: usize,
+    pub(crate) tool_executor: Arc<dyn ErasedToolExecutor>,
+    pub(crate) memory: Arc<SemanticMemory>,
+    pub(crate) history_limit: u32,
+    pub(crate) recall_limit: usize,
+    pub(crate) summarization_threshold: usize,
+    pub(crate) session_config: zeph_core::AgentSessionConfig,
+    pub(crate) session_persistence_config: zeph_config::SessionConfig,
+    /// D-13 (spec-068 §8.1, N3): resume-time durable condensation, pre-built once here (where
+    /// the full `Config` is still in scope) rather than per-session in
+    /// `agent_factory::hydrate_session_sink`, which only receives this already-cloned
+    /// deps bundle — mirrors `src/acp.rs`'s `SharedAgentDeps::resume_condenser` field. `Arc`-
+    /// wrapped so `ServeAgentDeps` stays cheaply `Clone` without requiring `LlmCondenser: Clone`.
+    pub(crate) resume_condenser: Arc<zeph_session::LlmCondenser>,
+    pub(crate) resume_token_counter: Arc<zeph_agent_context::memory_backend::TokenCounterAdapter>,
+}
+
+/// Assemble [`ServeAgentDeps`] once at `zeph serve-sessions` startup, plus the resolved bearer
+/// auth token (spec §9.4's `require_auth`/`auth_token_vault_key`) as a separate value — it is
+/// server-level config, not an agent-construction dependency, so it does not belong on
+/// [`ServeAgentDeps`] itself.
+///
+/// Mirrors the early portion of `src/acp.rs`'s `build_acp_deps` (provider, embedding provider,
+/// skill registry/matcher, memory, and a core shell/file/web/cwd tool set with sandbox + audit)
+/// but stops before MCP, the scheduler, and every ACP-transport-only field.
+///
+/// # Errors
+///
+/// Returns an error if config loading/validation, vault resolution, provider construction, or
+/// memory (`SQLite`/Qdrant) initialization fails.
+pub(crate) async fn build_serve_deps(
+    config_path: Option<&std::path::Path>,
+    vault_backend: Option<&str>,
+    vault_key: Option<&std::path::Path>,
+    vault_path: Option<&std::path::Path>,
+) -> anyhow::Result<(ServeAgentDeps, Option<String>)> {
+    use crate::bootstrap::AppBuilder;
+
+    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path).await?;
+    let auth_token = resolve_auth_token(&app).await;
+
+    let (provider, _status_tx, _status_rx) = app.build_provider().await?;
+    let embedding_provider = crate::bootstrap::create_embedding_provider(app.config(), &provider);
+    let budget_tokens = app.auto_budget_tokens(&provider);
+    let registry = Arc::new(RwLock::new(app.build_registry()));
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = zeph_common::task_supervisor::TaskSupervisor::new(cancel);
+    let memory = Arc::new(app.build_memory(&provider, &supervisor).await?);
+
+    let all_meta_owned: Vec<zeph_skills::loader::SkillMeta> =
+        registry.read().all_meta().into_iter().cloned().collect();
+    let all_meta_refs: Vec<&zeph_skills::loader::SkillMeta> = all_meta_owned.iter().collect();
+    let matcher = app
+        .build_skill_matcher(&embedding_provider, &all_meta_refs, &memory)
+        .await;
+
+    let config = app.config();
+    let tool_executor = build_tool_executor(config, &supervisor).await?;
+
+    let session_config = zeph_core::AgentSessionConfig::from_config(config, budget_tokens);
+    let max_active_skills = config.skills.max_active_skills.get();
+    let history_limit = config.memory.history_limit;
+    let recall_limit = config.memory.semantic.recall_limit;
+    let summarization_threshold = config.memory.summarization_threshold;
+    let session_persistence_config = config.session.clone();
+    // D-13 (spec-068 §8.1, N3): built once here, where the full `Config` is still in scope —
+    // see `ServeAgentDeps::resume_condenser`'s doc comment.
+    let (resume_condenser, resume_token_counter) =
+        zeph_core::provider_factory::build_resume_condenser(config, &provider);
+
+    Ok((
+        ServeAgentDeps {
+            provider,
+            embedding_provider,
+            registry,
+            matcher,
+            max_active_skills,
+            tool_executor,
+            memory,
+            history_limit,
+            recall_limit,
+            summarization_threshold,
+            session_config,
+            session_persistence_config,
+            resume_condenser: Arc::new(resume_condenser),
+            resume_token_counter,
+        },
+        auth_token,
+    ))
+}
+
+/// Resolves `[serve] auth_token_vault_key` from the vault. `None` when the key is empty
+/// (`require_auth`'s default off-switch) or the vault lookup fails/misses — the caller
+/// (`handle_serve_sessions_command`) decides how to react (refuse to bind non-loopback, or
+/// proceed with `auth_middleware` rejecting every request when `require_auth = true`).
+async fn resolve_auth_token(app: &crate::bootstrap::AppBuilder) -> Option<String> {
+    let key = &app.config().serve.auth_token_vault_key;
+    if key.is_empty() {
+        return None;
+    }
+    app.vault().get_secret(key).await.unwrap_or_else(|e| {
+        tracing::warn!(
+            error = %e,
+            key = %key,
+            "serve-sessions: failed to resolve auth token from vault"
+        );
+        None
+    })
+}
+
+/// Builds the core shell/file/web/cwd tool set (sandbox + audit wired the same way
+/// `build_acp_deps` does for ACP sessions) — extracted from [`build_serve_deps`] to stay under
+/// clippy's `too_many_lines`.
+async fn build_tool_executor(
+    config: &zeph_core::config::Config,
+    supervisor: &zeph_common::task_supervisor::TaskSupervisor,
+) -> anyhow::Result<Arc<dyn ErasedToolExecutor>> {
+    let filter_registry = if config.tools.filters.enabled {
+        zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
+    } else {
+        zeph_tools::OutputFilterRegistry::new(false)
+    };
+    let mut shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
+        .with_permissions(zeph_tools::build_permission_policy(
+            &config.tools,
+            config.security.autonomy_level,
+        ))
+        .with_output_filters(filter_registry)
+        .with_task_supervisor(supervisor.clone());
+    if config.tools.sandbox.enabled {
+        let denied_present = !config.tools.sandbox.denied_domains.is_empty();
+        match zeph_tools::sandbox::build_sandbox_with_policy(
+            config.tools.sandbox.strict,
+            config.tools.sandbox.fail_if_unavailable,
+            denied_present,
+        ) {
+            Ok(backend) => {
+                let name = backend.name();
+                let policy = crate::agent_setup::sandbox_policy_from_config(&config.tools.sandbox);
+                shell_executor = shell_executor.with_sandbox(Arc::from(backend), policy);
+                tracing::info!(backend = name, "OS sandbox enabled (serve-sessions)");
+            }
+            Err(e) if config.tools.sandbox.strict || config.tools.sandbox.fail_if_unavailable => {
+                anyhow::bail!("sandbox initialization failed: {e}");
+            }
+            Err(e) => {
+                tracing::warn!("OS sandbox unavailable, running without isolation: {e}");
+            }
+        }
+    }
+    let mut scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape)
+        .with_egress_config(config.tools.egress.clone());
+    if config.tools.audit.enabled
+        && let Ok(logger) = zeph_tools::AuditLogger::from_config(&config.tools.audit, false).await
+    {
+        let logger = Arc::new(logger);
+        shell_executor = shell_executor.with_audit(Arc::clone(&logger));
+        scrape_executor = scrape_executor.with_audit(logger);
+    }
+    let file_executor = zeph_tools::FileExecutor::new(
+        config
+            .tools
+            .shell
+            .allowed_paths
+            .iter()
+            .map(PathBuf::from)
+            .collect(),
+    );
+    let cwd_executor = zeph_tools::SetCwdExecutor;
+    Ok(Arc::new(zeph_tools::CompositeExecutor::new(
+        file_executor,
+        zeph_tools::CompositeExecutor::new(
+            shell_executor,
+            zeph_tools::CompositeExecutor::new(scrape_executor, cwd_executor),
+        ),
+    )))
+}

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -1,0 +1,415 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::convert::Infallible;
+use std::path::PathBuf;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use futures::Stream;
+use serde::{Deserialize, Serialize};
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
+use zeph_common::SessionId;
+use zeph_core::serve::{SessionActor, SessionActorHandle, SessionCommand};
+
+use super::AppState;
+use super::agent_factory::build_agent_factory;
+
+/// Attempt to reactivate a session that has no live actor (D-12, spec §9.3: "connect to absent
+/// session: replay → spawn `SessionActor` → register → attach").
+///
+/// Before D-12, `POST /sessions/:id/prompt` and `GET /sessions/:id/events` returned `404` for
+/// any session whose actor had ended (idle eviction, explicit delete via a *different* endpoint
+/// racing this one, or a process restart) even though its durable log made it perfectly
+/// resumable — contradicting `GET /sessions/:id`'s own documented claim ("the durable log allows
+/// it to be resumed") and turning `[serve] session_idle_ttl_secs` eviction into a one-way trip.
+/// This closes that gap: looks up the session's durable `acp_sessions` row, and if it exists,
+/// replays its event log via [`build_agent_factory`] (which now always routes through
+/// [`zeph_agent_persistence::hydrate_and_condense`], D-10/D-13) and spawns + registers a fresh
+/// `SessionActor` exactly as `POST /sessions` does for a brand-new one.
+///
+/// Returns `None` — leaving the caller's `404`/`410` unchanged — when the session has no durable
+/// record at all (a genuinely unknown id), has no linked `conversation_id` (a legacy session
+/// session-persistence can't safely reconstruct), or the registry is already at
+/// `[serve] max_sessions` capacity (mirrors `POST /sessions`' own `503` guard, just folded into
+/// this `404` path since a capacity-rejected reactivation is still "not currently promptable").
+#[tracing::instrument(
+    name = "serve.handlers.reactivate_session",
+    skip_all,
+    level = "info",
+    fields(session_id = session_id.as_str())
+)]
+async fn reactivate_session(
+    state: &AppState,
+    session_id: &SessionId,
+) -> Option<SessionActorHandle> {
+    if state.registry.len() >= state.max_sessions {
+        tracing::warn!(
+            session_id = %session_id.as_str(),
+            max_sessions = state.max_sessions,
+            "serve-sessions: reactivation rejected, at capacity"
+        );
+        return None;
+    }
+
+    let store = zeph_session::SessionStore::new(state.deps.memory.sqlite().pool().clone());
+    let meta = store.get(session_id.as_str()).await.ok().flatten()?;
+    let conversation_id = meta.conversation_id.map(zeph_memory::ConversationId)?;
+
+    let build_agent =
+        build_agent_factory(state.deps.clone(), session_id.clone(), conversation_id).await;
+    let (handle, _blocking_handle) = SessionActor::spawn(
+        &state.supervisor,
+        &state.registry,
+        session_id,
+        build_agent,
+        state.mailbox_capacity,
+    );
+    state.registry.insert(session_id.clone(), handle.clone());
+
+    tracing::info!(session_id = %session_id.as_str(), "serve-sessions: session reactivated");
+    Some(handle)
+}
+
+/// Response body for `GET /health`.
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    uptime_secs: u64,
+    live_sessions: usize,
+}
+
+/// Handler for the unauthenticated `GET /health` liveness check (spec §9.4).
+pub(super) async fn health_handler(State(state): State<AppState>) -> impl IntoResponse {
+    Json(HealthResponse {
+        status: "ok",
+        uptime_secs: state.started_at.elapsed().as_secs(),
+        live_sessions: state.registry.len(),
+    })
+}
+
+/// Response body for `POST /sessions`.
+#[derive(Serialize)]
+struct CreateSessionResponse {
+    session_id: String,
+    conversation_id: i64,
+}
+
+/// Handler for `POST /sessions` (spec §9.4): mints a new session, spawns its `SessionActor`, and
+/// registers it in the [`zeph_core::serve::LiveSessionRegistry`].
+///
+/// Returns `503` when `[serve] max_sessions` is already reached.
+#[tracing::instrument(name = "serve.handlers.create_session", skip_all, level = "info")]
+pub(super) async fn create_session_handler(
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, StatusCode> {
+    if state.registry.len() >= state.max_sessions {
+        tracing::warn!(
+            max_sessions = state.max_sessions,
+            "serve-sessions: POST /sessions rejected, at capacity"
+        );
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    let session_id = SessionId::generate();
+    let conversation_id = state
+        .deps
+        .memory
+        .sqlite()
+        .create_conversation()
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "serve-sessions: failed to mint conversation id");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let build_agent =
+        build_agent_factory(state.deps.clone(), session_id.clone(), conversation_id).await;
+    let (handle, _blocking_handle) = SessionActor::spawn(
+        &state.supervisor,
+        &state.registry,
+        &session_id,
+        build_agent,
+        state.mailbox_capacity,
+    );
+    state.registry.insert(session_id.clone(), handle);
+
+    tracing::info!(session_id = %session_id.as_str(), "serve-sessions: session created");
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateSessionResponse {
+            session_id: session_id.as_str().to_owned(),
+            conversation_id: conversation_id.0,
+        }),
+    ))
+}
+
+/// Response body for `GET /sessions`.
+#[derive(Serialize)]
+struct ListSessionsResponse {
+    sessions: Vec<String>,
+}
+
+/// Handler for `GET /sessions` (spec §9.4): lists ids of all live (in-memory) sessions.
+///
+/// Does not include sessions that exist durably (`[session] data_dir`) but have no live actor —
+/// only `LiveSessionRegistry` entries. Listing sessions restored purely from the durable log is
+/// covered by the existing `sessions list` CLI verb, not this endpoint.
+#[tracing::instrument(name = "serve.handlers.list_sessions", skip_all, level = "debug")]
+pub(super) async fn list_sessions_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let sessions = state
+        .registry
+        .ids()
+        .into_iter()
+        .map(|id| id.as_str().to_owned())
+        .collect();
+    Json(ListSessionsResponse { sessions })
+}
+
+/// Response body for `GET /sessions/:id`.
+#[derive(Serialize)]
+struct SessionMetadataResponse {
+    #[serde(flatten)]
+    metadata: zeph_session::SessionMetadata,
+    /// Whether this session currently has a live `SessionActor` in this process's
+    /// [`zeph_core::serve::LiveSessionRegistry`] — distinct from `metadata.status`, which is the
+    /// durably persisted lifecycle state and does not change when a process restarts.
+    live: bool,
+}
+
+/// Handler for `GET /sessions/:id` (spec §9.4): returns durable session metadata (from
+/// `acp_sessions`, via `SessionStore`) plus whether the session currently has a live actor.
+///
+/// Returns `404` only when the session is neither live nor known to `SessionStore` — a session
+/// that was created, then its actor ended (idle eviction, explicit delete, or process restart),
+/// still returns its metadata with `live: false`, since the durable log allows it to be resumed.
+#[tracing::instrument(name = "serve.handlers.get_session", skip_all, level = "debug", fields(session_id = %id))]
+pub(super) async fn get_session_handler(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let session_id = SessionId::new(id);
+    let live = state.registry.get(&session_id).is_some();
+
+    let store = zeph_session::SessionStore::new(state.deps.memory.sqlite().pool().clone());
+    let metadata = store.get(session_id.as_str()).await.map_err(|e| {
+        tracing::error!(error = %e, "serve-sessions: failed to read session metadata");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    match metadata {
+        Some(metadata) => Ok(Json(SessionMetadataResponse { metadata, live })),
+        None if live => {
+            // Registered in the live registry but not yet in `SessionStore` — a narrow race
+            // between `SessionActor::spawn` returning and `build_agent_factory`'s
+            // `SessionStore::create` completing inside the dedicated thread. Retrying shortly
+            // resolves it; report `404` for this snapshot rather than fabricating metadata.
+            Err(StatusCode::NOT_FOUND)
+        }
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+/// Handler for `DELETE /sessions/:id` (spec §9.4): ends one live session gracefully by cancelling
+/// its own [`zeph_core::serve::SessionActorHandle::cancel`] token — the same mechanism
+/// `serve.evict` uses for idle eviction, just caller-initiated instead of TTL-triggered.
+///
+/// Returns `404` if the session is not currently live (already ended, or never existed).
+#[tracing::instrument(name = "serve.handlers.delete_session", skip_all, level = "info", fields(session_id = %id))]
+pub(super) async fn delete_session_handler(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> StatusCode {
+    let session_id = SessionId::new(id);
+    match state.registry.remove(&session_id) {
+        Some(handle) => {
+            handle.cancel.cancel();
+            tracing::info!(session_id = %session_id.as_str(), "serve-sessions: session deleted");
+            StatusCode::NO_CONTENT
+        }
+        None => StatusCode::NOT_FOUND,
+    }
+}
+
+/// Request body for `POST /sessions/:id/prompt`.
+#[derive(Deserialize)]
+pub(super) struct PromptRequest {
+    text: String,
+}
+
+/// Handler for `POST /sessions/:id/prompt` (spec §9.4): submits a prompt to a live session's
+/// mailbox. Fire-and-forget — the response streams separately via `GET /sessions/:id/events`.
+///
+/// Returns `202 Accepted` once queued, `404` if the session is neither live nor durably known
+/// (or reactivation failed — see [`reactivate_session`], D-12), or `410 Gone` if the session's
+/// mailbox has already closed (actor exiting/exited between the registry lookup and the send).
+#[tracing::instrument(name = "serve.handlers.prompt_session", skip_all, level = "info", fields(session_id = %id))]
+pub(super) async fn prompt_session_handler(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<PromptRequest>,
+) -> StatusCode {
+    let session_id = SessionId::new(id);
+    let Some(handle) = state
+        .registry
+        .get_or_reactivate(&session_id, || reactivate_session(&state, &session_id))
+        .await
+    else {
+        return StatusCode::NOT_FOUND;
+    };
+    if handle
+        .tx
+        .send(SessionCommand::Prompt { text: body.text })
+        .await
+        .is_ok()
+    {
+        StatusCode::ACCEPTED
+    } else {
+        tracing::warn!(
+            session_id = %session_id.as_str(),
+            "serve-sessions: prompt mailbox closed"
+        );
+        StatusCode::GONE
+    }
+}
+
+/// Handler for `GET /sessions/:id/events` (spec §9.4): subscribes to a live session's
+/// [`zeph_core::serve::SessionOutput`] broadcast and streams it as Server-Sent Events.
+///
+/// Multiple concurrent subscribers are supported (`broadcast::Sender` fans out to every
+/// receiver) — e.g. an SSE client and a TUI `/conv` attach on the same session simultaneously.
+/// A subscriber that falls behind (`BroadcastStreamRecvError::Lagged`) has those missed events
+/// dropped rather than the connection closed — the durable event log (when `[session] enabled =
+/// true`) is the source of truth for anything a lagged subscriber missed.
+///
+/// Returns `404` if the session is neither live nor durably known (or reactivation failed — see
+/// [`reactivate_session`], D-12).
+#[tracing::instrument(name = "serve.handlers.events_session", skip_all, level = "info", fields(session_id = %id))]
+pub(super) async fn events_session_handler(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, StatusCode> {
+    let session_id = SessionId::new(id);
+    let Some(handle) = state
+        .registry
+        .get_or_reactivate(&session_id, || reactivate_session(&state, &session_id))
+        .await
+    else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    let stream = BroadcastStream::new(handle.tx_out.subscribe()).filter_map(|item| match item {
+        Ok(output) => match Event::default().json_data(&output) {
+            Ok(event) => Some(Ok(event)),
+            Err(e) => {
+                tracing::error!(error = %e, "serve-sessions: failed to serialize SessionOutput");
+                None
+            }
+        },
+        Err(_lagged) => None,
+    });
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+/// Request body for `POST /sessions/:id/fork`.
+#[derive(Deserialize, Default)]
+pub(super) struct ForkRequest {
+    /// Exclusive upper bound on copied events; `None` forks at the current end of the log
+    /// (copies everything) — see [`zeph_session::ForkEngine::fork`].
+    at_seq: Option<u64>,
+}
+
+/// Response body for `POST /sessions/:id/fork`.
+#[derive(Serialize)]
+struct ForkSessionResponse {
+    session_id: String,
+    conversation_id: i64,
+    events_copied: usize,
+}
+
+/// Handler for `POST /sessions/:id/fork` (spec §9.4, §7.2): eager-copies the source session's
+/// durable event log up to `at_seq` into a fresh child session via
+/// [`zeph_session::ForkEngine::fork`], then immediately spawns a live `SessionActor` for the
+/// child — the fork is usable via `/prompt`+`/events` right away, not just durably persisted.
+///
+/// Returns `404` if the source session has no durable log (`ForkEngine::fork`'s
+/// `SessionError::NotFound`), `400` if `at_seq` exceeds the source log's event count
+/// (`SessionError::InvalidForkPoint`), or `503` when `[serve] max_sessions` is already reached
+/// (the child is a new live session, counted the same as any other).
+#[tracing::instrument(name = "serve.handlers.fork_session", skip_all, level = "info", fields(session_id = %id))]
+pub(super) async fn fork_session_handler(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<ForkRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    if state.registry.len() >= state.max_sessions {
+        tracing::warn!(
+            max_sessions = state.max_sessions,
+            "serve-sessions: POST /sessions/:id/fork rejected, at capacity"
+        );
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    let src_id = SessionId::new(id);
+    let new_id = SessionId::generate();
+    let data_dir = PathBuf::from(&state.deps.session_persistence_config.data_dir);
+    let store = zeph_session::SessionStore::new(state.deps.memory.sqlite().pool().clone());
+
+    let fork_result = zeph_session::ForkEngine::fork(
+        &data_dir,
+        src_id.as_str(),
+        new_id.as_str(),
+        body.at_seq,
+        &store,
+    )
+    .await
+    .map_err(|e| match e {
+        zeph_session::SessionError::NotFound(_) => StatusCode::NOT_FOUND,
+        zeph_session::SessionError::InvalidForkPoint(_) => StatusCode::BAD_REQUEST,
+        e => {
+            tracing::error!(error = %e, "serve-sessions: fork failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    })?;
+
+    let conversation_id = state
+        .deps
+        .memory
+        .sqlite()
+        .create_conversation()
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "serve-sessions: failed to mint conversation id for fork");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let build_agent =
+        build_agent_factory(state.deps.clone(), new_id.clone(), conversation_id).await;
+    let (handle, _blocking_handle) = SessionActor::spawn(
+        &state.supervisor,
+        &state.registry,
+        &new_id,
+        build_agent,
+        state.mailbox_capacity,
+    );
+    state.registry.insert(new_id.clone(), handle);
+
+    tracing::info!(
+        src_session_id = %src_id.as_str(),
+        session_id = %new_id.as_str(),
+        events_copied = fork_result.events_copied,
+        "serve-sessions: session forked"
+    );
+    Ok((
+        StatusCode::CREATED,
+        Json(ForkSessionResponse {
+            session_id: new_id.as_str().to_owned(),
+            conversation_id: conversation_id.0,
+            events_copied: fork_result.events_copied,
+        }),
+    ))
+}

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `zeph serve-sessions` — persistent agent service exposing sessions over HTTP/SSE
+//! (spec-068 §9, #5343).
+//!
+//! Named `serve-sessions` rather than the spec's literal `zeph serve`: `Command::Serve` already
+//! names the scheduler's foreground daemon (`#[cfg(all(unix, feature = "scheduler"))]`,
+//! `src/cli.rs`), and both features can be enabled simultaneously, so a second command claiming
+//! the same top-level name is not viable.
+//!
+//! **Status**: process lifecycle (bind, listen, graceful shutdown on SIGTERM/Ctrl-C via
+//! `TaskSupervisor::shutdown_all`), the unauthenticated `/health` endpoint, the `serve.evict`
+//! idle-eviction task (spec §9.3), and the full `/sessions*` surface (spec §9.4 —
+//! create/list/get/delete/prompt/events/fork) are implemented. `[serve] require_auth` /
+//! `auth_token_vault_key` are wired: every `/sessions*` route (not `/health`) is behind
+//! `zeph_common::http_middleware::auth_middleware`, keyed off a bearer token resolved from the
+//! vault at startup. If `require_auth = true` (the default) but no token could be resolved,
+//! [`handle_serve_sessions_command`] refuses to bind a non-loopback address — otherwise the API
+//! would be reachable over the network while rejecting every single request, or worse, an
+//! operator could assume auth is protecting it when it silently isn't.
+//!
+//! **`--acp` is intentionally not implemented as in-process combination**: `src/acp.rs`'s
+//! `run_acp_server`/`run_acp_http_server` each build a complete, independent `SharedAgentDeps`
+//! (own `SemanticMemory`/`SQLite` pool, provider, `McpManager`, skill registry,
+//! `TaskSupervisor`) with no path to share those with [`deps::ServeAgentDeps`]. Running both in
+//! one process would mean two independent `SQLite` connection pools writing the same database
+//! file concurrently — a real contention/correctness risk, not just wasted resources — plus
+//! duplicate MCP subprocess spawning if MCP servers are configured. `--acp` therefore returns an
+//! error naming the correct alternative (run `zeph --acp` or `zeph --acp-http` as a *separate*
+//! process alongside `zeph serve-sessions`) rather than silently building something unsafe.
+//! Proper in-process support would need `build_acp_deps` refactored to accept prebuilt
+//! shared resources (it already does this for MCP via `prebuilt_mcp_manager`) — real design work
+//! deserving its own attention, not something to squeeze into this change.
+
+mod agent_factory;
+mod deps;
+mod handlers;
+mod router;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};
+use zeph_core::serve::LiveSessionRegistry;
+
+use self::deps::ServeAgentDeps;
+
+/// How often `serve.evict` scans [`LiveSessionRegistry::idle_candidates`].
+const EVICT_SCAN_INTERVAL: Duration = Duration::from_mins(1);
+
+/// CLI-supplied overrides for `zeph serve-sessions` (spec-068 §9, #5343).
+pub(crate) struct ServeSessionsArgs {
+    /// Overrides `[serve] http_addr` when set.
+    pub(crate) http_addr: Option<String>,
+    /// Also run the ACP protocol transport alongside the HTTP/SSE API.
+    ///
+    /// Not implemented as in-process combination — see the module doc. Passing this flag is a
+    /// hard error naming the correct alternative (a separate `zeph --acp`/`zeph --acp-http`
+    /// process) rather than a silent no-op, since a user passing `--acp` clearly expects it to
+    /// take effect.
+    pub(crate) acp: bool,
+    /// Overrides `[serve] max_sessions` when set.
+    pub(crate) max_sessions: Option<usize>,
+    /// `--vault` — secrets backend override (`"env"` or `"age"`).
+    pub(crate) vault_backend: Option<String>,
+    /// `--vault-key` — path to the age identity file.
+    pub(crate) vault_key: Option<std::path::PathBuf>,
+    /// `--vault-path` — path to the age-encrypted secrets file.
+    pub(crate) vault_path: Option<std::path::PathBuf>,
+}
+
+/// Shared HTTP handler state.
+#[derive(Clone)]
+pub(crate) struct AppState {
+    pub(crate) registry: Arc<LiveSessionRegistry>,
+    pub(crate) started_at: std::time::Instant,
+    pub(crate) supervisor: TaskSupervisor,
+    pub(crate) deps: ServeAgentDeps,
+    pub(crate) mailbox_capacity: usize,
+    pub(crate) max_sessions: usize,
+}
+
+/// Run `zeph serve-sessions` until a shutdown signal (SIGTERM/Ctrl-C) is received.
+///
+/// # Errors
+///
+/// Returns an error if the configured bind address is invalid, the port cannot be bound, or the
+/// HTTP server encounters a fatal I/O error after binding.
+pub(crate) async fn handle_serve_sessions_command(
+    args: ServeSessionsArgs,
+    config_path: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    use crate::bootstrap::{load_config_or_default, resolve_config_path};
+
+    if args.acp {
+        anyhow::bail!(
+            "zeph serve-sessions --acp does not run the ACP transport in-process: doing so \
+             would mean two independent SQLite connection pools writing the same database file \
+             concurrently (build_acp_deps builds its own complete SharedAgentDeps with no path \
+             to share resources with serve-sessions' own agent dependencies), plus duplicate \
+             MCP subprocess spawning if MCP servers are configured. Run `zeph --acp` or \
+             `zeph --acp-http` as a separate process alongside `zeph serve-sessions` instead."
+        );
+    }
+
+    let config_file = resolve_config_path(config_path);
+    let config = load_config_or_default(&config_file);
+    let serve_config = &config.serve;
+
+    let http_addr: SocketAddr = args
+        .http_addr
+        .as_deref()
+        .unwrap_or(&serve_config.http_addr)
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid [serve] http_addr: {e}"))?;
+    let max_sessions = args.max_sessions.unwrap_or(serve_config.max_sessions);
+
+    let (deps, auth_token) = Box::pin(deps::build_serve_deps(
+        config_path,
+        args.vault_backend.as_deref(),
+        args.vault_key.as_deref(),
+        args.vault_path.as_deref(),
+    ))
+    .await?;
+
+    // `/sessions*` endpoints can execute shell/file/web tools on behalf of any caller that
+    // reaches this port. If `require_auth` is set but no token could be resolved from the vault,
+    // `auth_middleware` would reject every single request (`AuthConfig::new(None, true)`) — bind
+    // anyway on loopback (still useful for local-only access without a token requirement in
+    // practice), but refuse a non-loopback bind rather than silently serving an API nobody can
+    // ever successfully call, or worse, one where the operator assumes auth is protecting it.
+    if serve_config.require_auth && auth_token.is_none() && !http_addr.ip().is_loopback() {
+        anyhow::bail!(
+            "refusing to bind {http_addr}: [serve] require_auth is true but no auth token was \
+             resolved from the vault key \"{}\" — every request would be rejected. Set that \
+             vault key, bind to a loopback address (127.0.0.1 or ::1), or set \
+             [serve] require_auth = false to disable authentication explicitly.",
+            serve_config.auth_token_vault_key
+        );
+    }
+    if !serve_config.require_auth {
+        tracing::warn!(
+            "[serve] require_auth is false — /sessions* endpoints are unauthenticated; only \
+             bind to loopback or a trusted network"
+        );
+    }
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = TaskSupervisor::new(cancel.clone());
+    let registry = Arc::new(LiveSessionRegistry::new());
+    let state = AppState {
+        registry: Arc::clone(&registry),
+        started_at: std::time::Instant::now(),
+        supervisor: supervisor.clone(),
+        deps,
+        mailbox_capacity: serve_config.max_queued_prompts,
+        max_sessions,
+    };
+
+    let idle_ttl = Duration::from_secs(serve_config.session_idle_ttl_secs);
+    let evict_registry = Arc::clone(&registry);
+    let evict_cancel = supervisor.cancellation_token();
+    supervisor.spawn(TaskDescriptor {
+        name: "serve.evict",
+        restart: RestartPolicy::Restart {
+            max: 5,
+            base_delay: Duration::from_secs(1),
+        },
+        factory: move || evict_loop(Arc::clone(&evict_registry), idle_ttl, evict_cancel.clone()),
+    });
+
+    let listener = tokio::net::TcpListener::bind(http_addr)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to bind {http_addr}: {e}"))?;
+    tracing::info!(addr = %http_addr, max_sessions, "zeph serve-sessions listening");
+
+    let router = router::build_router(state, auth_token.as_deref(), serve_config.require_auth);
+    let shutdown_cancel = cancel.clone();
+    axum::serve(
+        listener,
+        router.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(async move {
+        wait_for_shutdown_signal().await;
+        tracing::info!("zeph serve-sessions: shutdown signal received");
+        shutdown_cancel.cancel();
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("http server error: {e}"))?;
+
+    supervisor.shutdown_all(Duration::from_secs(30)).await;
+    tracing::info!("zeph serve-sessions: shutdown complete");
+    Ok(())
+}
+
+/// `serve.evict` (spec §9.3): periodically scans `registry` for idle candidates (no attached
+/// broadcast subscribers, `last_active` older than `ttl`) and cancels each one's own
+/// [`zeph_core::serve::SessionActorHandle::cancel`] token — the same mechanism a caller would use
+/// to end one specific session gracefully, distinct from process-wide shutdown.
+///
+/// Uses `registry.remove` (not `registry.get`, which refreshes `last_active`) so an eviction scan
+/// itself never resets the idle timer it is reading. There is a small window between
+/// `idle_candidates` returning a snapshot and this loop iterating it where a session could
+/// legitimately regain an active subscriber — evicting it anyway in that rare case is a
+/// false-positive disconnect, not a correctness issue: the client's next connection replays the
+/// durable JSONL log from where it left off (spec §9.3's own resume-by-replay design already
+/// covers this).
+async fn evict_loop(
+    registry: Arc<LiveSessionRegistry>,
+    ttl: Duration,
+    cancel: tokio_util::sync::CancellationToken,
+) {
+    let mut ticker = tokio::time::interval(EVICT_SCAN_INTERVAL);
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::debug!("serve.evict: shutting down");
+                return;
+            }
+            _ = ticker.tick() => {
+                for id in registry.idle_candidates(ttl) {
+                    if let Some(handle) = registry.remove(&id) {
+                        tracing::info!(session_id = %id.as_str(), "serve.evict: evicting idle session");
+                        handle.cancel.cancel();
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Waits for SIGTERM (Unix) or Ctrl-C, whichever arrives first.
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        let Ok(mut term) =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        else {
+            tracing::warn!("failed to install SIGTERM handler; only Ctrl-C will trigger shutdown");
+            let _ = tokio::signal::ctrl_c().await;
+            return;
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}

--- a/src/serve/router.rs
+++ b/src/serve/router.rs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use axum::Router;
+use axum::middleware;
+use axum::routing::{get, post};
+use zeph_common::http_middleware::{AuthConfig, auth_middleware};
+
+use super::AppState;
+use super::handlers::{
+    create_session_handler, delete_session_handler, events_session_handler, fork_session_handler,
+    get_session_handler, health_handler, list_sessions_handler, prompt_session_handler,
+};
+
+/// Build the `zeph serve-sessions` axum [`Router`] (spec §9.4).
+///
+/// Routes:
+/// - `GET /health` — unauthenticated liveness check ([`health_handler`])
+/// - `POST /sessions` — create a session ([`create_session_handler`])
+/// - `GET /sessions` — list live session ids ([`list_sessions_handler`])
+/// - `GET /sessions/:id` — durable metadata + live status ([`get_session_handler`])
+/// - `DELETE /sessions/:id` — end a live session ([`delete_session_handler`])
+/// - `POST /sessions/:id/prompt` — submit a prompt ([`prompt_session_handler`])
+/// - `GET /sessions/:id/events` — SSE stream of [`zeph_core::serve::SessionOutput`]
+///   ([`events_session_handler`])
+/// - `POST /sessions/:id/fork` — eager-copy fork into a fresh live session
+///   ([`fork_session_handler`])
+///
+/// This completes spec §9.4's `/sessions*` surface. Every `/sessions*` route (not `/health`) is
+/// layered with [`auth_middleware`] the same way `zeph-gateway`'s router does
+/// (`crates/zeph-gateway/src/router.rs`) — constant-time bearer-token check via [`AuthConfig`],
+/// keyed off `[serve] require_auth` / `auth_token_vault_key`. No rate limiting is applied here
+/// (unlike the gateway): `[serve] max_sessions` and `max_queued_prompts` already bound resource
+/// usage per session, which is the more meaningful limit for this API.
+pub(super) fn build_router(
+    state: AppState,
+    auth_token: Option<&str>,
+    require_auth: bool,
+) -> Router {
+    let auth_cfg = AuthConfig::new(auth_token, require_auth);
+
+    let protected = Router::new()
+        .route(
+            "/sessions",
+            post(create_session_handler).get(list_sessions_handler),
+        )
+        .route(
+            "/sessions/{id}",
+            get(get_session_handler).delete(delete_session_handler),
+        )
+        .route("/sessions/{id}/prompt", post(prompt_session_handler))
+        .route("/sessions/{id}/events", get(events_session_handler))
+        .route("/sessions/{id}/fork", post(fork_session_handler))
+        .layer(middleware::from_fn_with_state(auth_cfg, auth_middleware));
+
+    Router::new()
+        .route("/health", get(health_handler))
+        .merge(protected)
+        .with_state(state)
+}


### PR DESCRIPTION
## Summary

Implements native session persistence for Zeph per spec-068 (`specs/068-session-persistence/`): an append-only JSONL event log (new `zeph-session` crate) as the durable source of truth for a conversation, with SQLite as a reconciled projection rather than the primary store.

- **P0** — `zeph-session` crate foundation: `SessionEventLog`, `SessionEvent` schema (reuses `MessagePart`/`AnchoredSummary`), `SessionStore`, `ReplayEngine`, `Condenser` trait, migration 106 (SQLite + PostgreSQL).
- **P1** — `SessionSink` dual-write wired into the agent turn loop ahead of the SQLite projection (INV-SP-1); replay-based resume/load/fork hydration; INV-SP-3 projection reconciliation; `zeph sessions` CLI enrichment. Retires the two legacy `acp_session_events` write sites so `SessionSink` is the sole live writer.
- **P2** — `ForkEngine` (eager-copy session forking), `LlmCondenser`, live `Compaction` event hook.
- **P3** — `zeph serve-sessions`: `SessionActor` per-session actor model (dedicated thread + `Send` coordinator via `TaskSupervisor::spawn_oneshot`), `LiveSessionRegistry`, full `/sessions*` REST+SSE API, bearer auth, idle eviction + reactivation. `/conv` slash commands (list/show/resume/fork). CLI `sessions resume <id>` now launches a live interactive agent by default.
- **P4** — legacy session lazy-bootstrap, `--init` wizard prompts, mdBook docs.

All four resume paths (ACP, CLI, `/conv`, `zeph serve`) are unified behind one shared `hydrate_from_event_log`/`hydrate_and_condense` pipeline so they cannot silently diverge — this was the single biggest source of correctness bugs found during review (see Test plan).

## Breaking change

`zeph sessions resume <id>` now launches a live interactive agent by default (previously a one-shot dump of session data). `--print` preserves the old dump behavior.

## Related issues

- Closes #5343
- Fixes #5419 (`SessionSink` recorded empty assistant-message content on the real production write path — found live-testing this PR, root-caused and fixed in this branch)
- Follow-ups filed and intentionally left open (out of scope for this PR): #5420 (`--acp` in-process combination with `serve-sessions`), #5435 (`src/serve/` integration test fixtures), #5445 (fsync p99 latency, idle-actor memory, bounded replay buffer)

## Test plan

This branch went through two full validation rounds (tester/perf/security/impl-critic) plus two code-review rounds before merge-readiness. Full detail in `.local/testing/playbooks/session-persistence.md` and `.local/testing/coverage-status.md` (main repo).

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,session,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler,session" --lib --bins` — 11663/11663 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler,session"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler,session"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler,session --locked`
- [x] Live-tested against a real local Ollama model: session create/list/show/resume/fork over REST+SSE, `/conv resume`/`fork` with genuine memory recall across a resume, CLI `sessions resume <id>` interactive resume, `zeph serve-sessions` process lifecycle (bind/health/SIGTERM), concurrent-reactivation race (2 real concurrent requests against an evicted session — confirmed exactly one live session, no log corruption), condensation firing end-to-end.
- [x] `cargo tree -p zeph-session` confirmed to have no path to `zeph-durable` (AC-9, INV-1).