### PR TITLE
fix(session): pair tool-result events correctly in session replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -591,6 +591,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `false`, since `forward_webhooks`/`AgentTaskProcessor` already sanitize before injecting a
   `ChannelMessage`, avoiding a double-wrap. Telegram's internally-generated `/reset`/`/skills`
   literal `ChannelMessage`s remain unsanitized (fixed strings, not external input).
+- `fix(session)`: a resumed CLI/TUI session that had used a tool during its previous run corrupted
+  every subsequent turn with an OpenAI/Claude 400 error ("`tool_calls` must be followed by tool
+  messages") (#5464). Two compounding bugs in the durable event-log write/replay path:
+  `SessionSink::record_message` (`crates/zeph-agent-persistence/src/session_sink.rs`) collapsed a
+  `Role::User` tool-result turn (`MessagePart::ToolResult` parts, the shape
+  `process_tool_result_batch`/`persist_cancelled_tool_results` in
+  `crates/zeph-core/src/agent/tool_execution/` always produce) into a generic
+  `SessionEvent::UserMessage`, discarding the `tool_use_id` pairing — now emits one
+  `SessionEvent::ToolResult` per part instead. Separately, `ReplayEngine::fold`
+  (`crates/zeph-session/src/replay.rs`) folded `SessionEvent::ToolResult` back onto the *preceding*
+  `Role::Assistant` message (via `push_part_to_last_assistant`), producing a single assistant
+  message carrying both `MessagePart::ToolUse` and `MessagePart::ToolResult` — a shape neither
+  `zeph-llm`'s OpenAI nor Claude serializer accepts, since both require tool results in a separate
+  `Role::User` message. New `push_part_to_tool_result_batch` folds consecutive `ToolResult` events
+  from the same tool-call batch into one `Role::User` message instead, matching the live turn
+  loop's real shape (`Assistant{ToolUse}` → `User{ToolResult...}`). Both fixes apply identically to
+  the ACP path, which already emitted dedicated `SessionEvent::ToolCall`/`ToolResult` events and
+  hit the same fold bug.
 - `fix(gateway)`: `zeph-gateway`'s `/webhook` endpoint forwarded third-party payloads into the
   agent's primary input queue as a plain `ChannelMessage` with only control-character stripping
   applied — bypassing the `ContentTrustLevel::ExternalUntrusted` classification, spotlight

--- a/crates/zeph-agent-persistence/src/session_sink.rs
+++ b/crates/zeph-agent-persistence/src/session_sink.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 
 use zeph_common::SessionId;
 use zeph_llm::provider::{MessagePart, Role};
-use zeph_session::{CompactionTier, SessionError, SessionEvent, SessionEventLog, SessionStore};
+use zeph_session::{
+    CompactionTier, SessionError, SessionEvent, SessionEventEnvelope, SessionEventLog, SessionStore,
+};
 
 /// Dual-writes turn messages to the durable JSONL event log ahead of the `SQLite` projection.
 ///
@@ -56,7 +58,19 @@ impl SessionSink {
     /// populated in a handful of tests that construct it explicitly. When `parts` is empty and
     /// `content` is non-empty, `content` is wrapped into a single [`MessagePart::Text`] so the
     /// durable log captures the real response either way; an explicitly provided `parts` is used
-    /// as-is (never overwritten by `content`).
+    /// as-is (never overwritten by `content`) — this is what preserves `MessagePart::ToolUse`
+    /// entries for `SessionEvent::AssistantMessage`.
+    ///
+    /// For `Role::User`, `parts` containing one or more [`MessagePart::ToolResult`] (the shape
+    /// `process_tool_result_batch`/`persist_cancelled_tool_results` in
+    /// `crates/zeph-core/src/agent/tool_execution/` always use for a tool-result turn) is recorded
+    /// as one [`SessionEvent::ToolResult`] per part instead of being collapsed into a plain
+    /// [`SessionEvent::UserMessage`]. This preserves the `tool_use_id` pairing
+    /// [`crate::hydrate_from_event_log`]'s [`zeph_session::ReplayEngine::fold`] needs to
+    /// reconstruct a valid `MessagePart::ToolUse`/`MessagePart::ToolResult` pair — both
+    /// `zeph-llm`'s `OpenAI` and Claude serializers reject a `tool_calls` assistant message that
+    /// is not immediately followed by matching tool-result messages. A plain user turn (no
+    /// `ToolResult` parts) still becomes a single `SessionEvent::UserMessage`, as before.
     ///
     /// # Errors
     ///
@@ -75,11 +89,8 @@ impl SessionSink {
         content: &str,
         parts: &[MessagePart],
     ) -> Result<(), SessionError> {
-        let event = match role {
-            Role::User => SessionEvent::UserMessage {
-                text: content.to_owned(),
-                image_refs: Vec::new(),
-            },
+        match role {
+            Role::User => self.record_user_message(content, parts).await,
             Role::Assistant => {
                 let parts = if parts.is_empty() && !content.is_empty() {
                     vec![MessagePart::Text {
@@ -88,17 +99,83 @@ impl SessionSink {
                 } else {
                     parts.to_vec()
                 };
-                SessionEvent::AssistantMessage { parts }
+                self.append_and_advance(SessionEvent::AssistantMessage { parts })
+                    .await
             }
-            _ => return Ok(()),
-        };
+            _ => Ok(()),
+        }
+    }
 
+    /// Record a `Role::User` turn: one [`SessionEvent::ToolResult`] per `MessagePart::ToolResult`
+    /// in `parts` when present, otherwise a single [`SessionEvent::UserMessage`] carrying `content`.
+    /// See [`Self::record_message`] for why this split exists.
+    async fn record_user_message(
+        &self,
+        content: &str,
+        parts: &[MessagePart],
+    ) -> Result<(), SessionError> {
+        let mut last_envelope: Option<SessionEventEnvelope> = None;
+        for part in parts {
+            let MessagePart::ToolResult {
+                tool_use_id,
+                content: output,
+                is_error,
+            } = part
+            else {
+                continue;
+            };
+            let envelope = self
+                .log
+                .append(
+                    None,
+                    None,
+                    SessionEvent::ToolResult {
+                        id: tool_use_id.clone(),
+                        // Not available at this call site — only the flat `MessagePart` reaches
+                        // `record_message`, not the originating `ToolUseRequest`. Every consumer
+                        // of `SessionEvent::ToolResult` (replay, ACP session updates) keys off
+                        // `id`/`output`/`is_error`, never `name`.
+                        name: String::new(),
+                        output: output.clone(),
+                        is_error: *is_error,
+                        duration_ms: 0,
+                    },
+                )
+                .await?;
+            last_envelope = Some(envelope);
+        }
+
+        let envelope = match last_envelope {
+            Some(envelope) => envelope,
+            None => {
+                self.log
+                    .append(
+                        None,
+                        None,
+                        SessionEvent::UserMessage {
+                            text: content.to_owned(),
+                            image_refs: Vec::new(),
+                        },
+                    )
+                    .await?
+            }
+        };
+        self.advance_seq(&envelope).await
+    }
+
+    /// Append `event` and advance `acp_sessions.last_seq`/`event_count` to match.
+    async fn append_and_advance(&self, event: SessionEvent) -> Result<(), SessionError> {
         let envelope = self.log.append(None, None, event).await?;
+        self.advance_seq(&envelope).await
+    }
+
+    /// Update `acp_sessions.last_seq`/`event_count` to reflect `envelope` as the latest appended
+    /// event.
+    async fn advance_seq(&self, envelope: &SessionEventEnvelope) -> Result<(), SessionError> {
         let event_count = envelope.seq + 1;
         self.store
             .update_seq(self.session_id.as_str(), envelope.seq, event_count)
-            .await?;
-        Ok(())
+            .await
     }
 
     /// Record that live in-memory compaction fired (spec §8.1), making it replayable.
@@ -144,10 +221,7 @@ impl SessionSink {
             summary: None,
         };
         let envelope = self.log.append(None, None, event).await?;
-        let event_count = envelope.seq + 1;
-        self.store
-            .update_seq(self.session_id.as_str(), envelope.seq, event_count)
-            .await?;
+        self.advance_seq(&envelope).await?;
         self.store
             .set_condensed_seq(self.session_id.as_str(), envelope.seq)
             .await?;
@@ -188,6 +262,219 @@ mod tests {
         let events = sink.log.read_all().await.unwrap();
         assert_eq!(events.len(), 1);
         assert!(matches!(events[0].kind, SessionEvent::UserMessage { .. }));
+    }
+
+    #[tokio::test]
+    async fn record_user_message_with_tool_result_parts_emits_tool_result_events() {
+        // Regression test for #5464: a Role::User call carrying MessagePart::ToolResult parts
+        // (the shape process_tool_result_batch/persist_cancelled_tool_results always use) must
+        // not collapse into a generic SessionEvent::UserMessage — that drops the tool_use_id
+        // pairing ReplayEngine::fold needs and corrupts every subsequent turn on resume.
+        let (sink, _dir) = make_sink("s1").await;
+        let parts = vec![
+            MessagePart::ToolResult {
+                tool_use_id: "call_1".to_owned(),
+                content: "file1.rs".to_owned(),
+                is_error: false,
+            },
+            MessagePart::ToolResult {
+                tool_use_id: "call_2".to_owned(),
+                content: "boom".to_owned(),
+                is_error: true,
+            },
+        ];
+        sink.record_message(Role::User, "", &parts).await.unwrap();
+
+        let events = sink.log.read_all().await.unwrap();
+        assert_eq!(events.len(), 2);
+        for event in &events {
+            assert!(matches!(event.kind, SessionEvent::ToolResult { .. }));
+        }
+        let SessionEvent::ToolResult {
+            id,
+            output,
+            is_error,
+            ..
+        } = &events[0].kind
+        else {
+            panic!("expected ToolResult");
+        };
+        assert_eq!(id, "call_1");
+        assert_eq!(output, "file1.rs");
+        assert!(!is_error);
+
+        let meta = sink.store.get("s1").await.unwrap().unwrap();
+        assert_eq!(meta.last_seq, 1);
+        assert_eq!(meta.event_count, 2);
+    }
+
+    #[tokio::test]
+    async fn record_user_message_without_tool_parts_still_emits_user_message() {
+        let (sink, _dir) = make_sink("s1").await;
+        sink.record_message(Role::User, "plain text", &[])
+            .await
+            .unwrap();
+
+        let events = sink.log.read_all().await.unwrap();
+        assert_eq!(events.len(), 1);
+        let SessionEvent::UserMessage { text, .. } = &events[0].kind else {
+            panic!("expected UserMessage");
+        };
+        assert_eq!(text, "plain text");
+    }
+
+    /// Shared setup for the round-trip regression tests below (#5464): records a
+    /// User{prompt} -> Assistant{ToolUse} -> User{ToolResult} turn through
+    /// `SessionSink::record_message` and folds it back via `ReplayEngine::fold`.
+    async fn replayed_tool_call_messages() -> Vec<zeph_llm::provider::Message> {
+        let (sink, _dir) = make_sink("s1").await;
+
+        sink.record_message(Role::User, "run ls", &[])
+            .await
+            .unwrap();
+        sink.record_message(
+            Role::Assistant,
+            "",
+            &[MessagePart::ToolUse {
+                id: "call_1".to_owned(),
+                name: "shell".to_owned(),
+                input: serde_json::json!({"command": "ls"}),
+            }],
+        )
+        .await
+        .unwrap();
+        sink.record_message(
+            Role::User,
+            "",
+            &[MessagePart::ToolResult {
+                tool_use_id: "call_1".to_owned(),
+                content: "file.txt".to_owned(),
+                is_error: false,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let events = sink.log.read_all().await.unwrap();
+        zeph_session::ReplayEngine::fold(events, None).messages
+    }
+
+    fn shell_tool_definition() -> [zeph_common::ToolDefinition; 1] {
+        [zeph_common::ToolDefinition {
+            name: zeph_common::ToolName::new("shell"),
+            description: "Run a shell command".to_owned(),
+            parameters: serde_json::json!({"type": "object"}),
+            output_schema: None,
+        }]
+    }
+
+    /// Regression test for #5464: round-trips a tool-call turn through
+    /// `SessionSink::record_message` -> `ReplayEngine::fold` -> the `OpenAI` serializer, and
+    /// asserts the resulting `messages` array pairs the assistant `tool_calls` entry with an
+    /// immediately-following `tool`-role message carrying a matching `tool_call_id` — the shape
+    /// `OpenAI` rejects a request for when it is missing.
+    #[tokio::test]
+    async fn session_replay_tool_call_turn_produces_valid_openai_message_array() {
+        use zeph_llm::openai::{OpenAiConfig, OpenAiProvider};
+        use zeph_llm::provider::LlmProvider;
+
+        let messages = replayed_tool_call_messages().await;
+        let tools = shell_tool_definition();
+
+        let provider = OpenAiProvider::new(OpenAiConfig {
+            api_key: "sk-test".to_owned(),
+            base_url: "https://api.openai.com/v1".to_owned(),
+            model: "gpt-5.2".to_owned(),
+            max_tokens: 4096,
+            embedding_model: None,
+            reasoning_effort: None,
+            context_window: None,
+            completion_tokens_param: None,
+        });
+        let request = provider.debug_request_json(&messages, &tools, false);
+
+        let api_messages = request["messages"]
+            .as_array()
+            .expect("messages array present");
+        let assistant_idx = api_messages
+            .iter()
+            .position(|m| m["role"] == "assistant" && m["tool_calls"].is_array())
+            .expect("assistant tool_calls message present");
+        assert_eq!(
+            api_messages[assistant_idx]["tool_calls"][0]["id"], "call_1",
+            "assistant tool_calls entry must carry the original tool_use_id"
+        );
+
+        let tool_msg = &api_messages[assistant_idx + 1];
+        assert_eq!(
+            tool_msg["role"], "tool",
+            "assistant tool_calls message must be immediately followed by a tool-role message"
+        );
+        assert_eq!(
+            tool_msg["tool_call_id"], "call_1",
+            "tool-role message must carry the matching tool_call_id"
+        );
+        assert_eq!(tool_msg["content"], "file.txt");
+    }
+
+    /// Regression test for #5464: same round-trip as
+    /// `session_replay_tool_call_turn_produces_valid_openai_message_array`, but through the
+    /// Claude serializer. Also exercises `compute_matched_tool_ids`'s orphan guard
+    /// (`crates/zeph-llm/src/claude/request.rs`): if the fold still produced a mismatched/merged
+    /// shape, the guard would silently downgrade the `tool_use`/`tool_result` blocks to plain
+    /// text instead of letting the API 400 — so asserting the blocks keep their native
+    /// `tool_use`/`tool_result` type is what actually proves the fix here, not just that a
+    /// `messages` array of the right length exists.
+    #[tokio::test]
+    async fn session_replay_tool_call_turn_produces_valid_claude_message_array() {
+        use zeph_llm::claude::ClaudeProvider;
+        use zeph_llm::provider::LlmProvider;
+
+        let messages = replayed_tool_call_messages().await;
+        let tools = shell_tool_definition();
+
+        let provider = ClaudeProvider::new(
+            "sk-ant-test".to_owned(),
+            "claude-sonnet-4-6".to_owned(),
+            4096,
+        );
+        let request = provider.debug_request_json(&messages, &tools, false);
+
+        let api_messages = request["messages"]
+            .as_array()
+            .expect("messages array present");
+        let assistant_idx = api_messages
+            .iter()
+            .position(|m| {
+                m["role"] == "assistant"
+                    && m["content"]
+                        .as_array()
+                        .is_some_and(|blocks| blocks.iter().any(|b| b["type"] == "tool_use"))
+            })
+            .expect("assistant tool_use message present");
+        let assistant_blocks = api_messages[assistant_idx]["content"]
+            .as_array()
+            .expect("assistant content is a block array");
+        let tool_use_block = assistant_blocks
+            .iter()
+            .find(|b| b["type"] == "tool_use")
+            .expect("tool_use block present (not downgraded to text by the orphan guard)");
+        assert_eq!(tool_use_block["id"], "call_1");
+
+        let tool_msg = &api_messages[assistant_idx + 1];
+        assert_eq!(
+            tool_msg["role"], "user",
+            "assistant tool_use message must be immediately followed by a user message"
+        );
+        let tool_result_blocks = tool_msg["content"]
+            .as_array()
+            .expect("tool result content is a block array");
+        let tool_result_block = tool_result_blocks
+            .iter()
+            .find(|b| b["type"] == "tool_result")
+            .expect("tool_result block present (not downgraded to text by the orphan guard)");
+        assert_eq!(tool_result_block["tool_use_id"], "call_1");
+        assert_eq!(tool_result_block["content"], "file.txt");
     }
 
     #[tokio::test]

--- a/crates/zeph-session/src/llm_condenser.rs
+++ b/crates/zeph-session/src/llm_condenser.rs
@@ -74,8 +74,9 @@ impl Condenser for LlmCondenser {
             .cloned()
             .collect();
 
-        // Indices of events that start a new agent-ready message; `ToolCall`/`ToolResult` attach
-        // to the preceding `AssistantMessage` boundary rather than starting their own.
+        // Indices of events that start a new agent-ready message; `ToolCall` attaches to the
+        // preceding `AssistantMessage` boundary and `ToolResult` to its own open tool-result
+        // batch (see `ReplayEngine::fold`) rather than starting a counted boundary of its own.
         let boundaries: Vec<usize> = uncondensed
             .iter()
             .enumerate()

--- a/crates/zeph-session/src/replay.rs
+++ b/crates/zeph-session/src/replay.rs
@@ -108,7 +108,7 @@ impl ReplayEngine {
                     is_error,
                     ..
                 } => {
-                    push_part_to_last_assistant(
+                    push_part_to_tool_result_batch(
                         &mut messages,
                         &mut origin_seqs,
                         seq,
@@ -167,10 +167,10 @@ impl ReplayEngine {
     }
 }
 
-/// Append `part` to the last message if it is a pending `Assistant` message; otherwise start a
-/// new one. Tool calls/results always follow the `AssistantMessage` that requested them within
-/// the same turn, but the fold does not assume `AssistantMessage` was itself logged first (a
-/// tool-only turn is valid).
+/// Append `part` (a `MessagePart::ToolUse`) to the last message if it is a pending `Assistant`
+/// message; otherwise start a new one. `ToolCall` events always follow the `AssistantMessage`
+/// that requested them within the same turn, but the fold does not assume `AssistantMessage` was
+/// itself logged first (a tool-only turn is valid).
 fn push_part_to_last_assistant(
     messages: &mut Vec<Message>,
     origin_seqs: &mut Vec<u64>,
@@ -184,6 +184,40 @@ fn push_part_to_last_assistant(
         return;
     }
     messages.push(Message::from_parts(Role::Assistant, vec![part]));
+    origin_seqs.push(seq);
+}
+
+/// Append `part` (a `MessagePart::ToolResult`) to the last message if it is an already-open
+/// tool-result batch; otherwise start a new `Role::User` message.
+///
+/// `zeph-llm`'s `OpenAI` and Claude serializers require every tool result to arrive in a
+/// `Role::User` message, never merged into the preceding `Role::Assistant` message that carried
+/// the matching `MessagePart::ToolUse` (#5464) — this mirrors the real shape
+/// `process_tool_result_batch` in `crates/zeph-core/src/agent/tool_execution/tier_loop.rs`
+/// produces live: one `Role::User` message per tool-call batch, holding one `ToolResult` part per
+/// tool. "Already-open batch" is a `Role::User` message with non-empty `parts` that are all
+/// `ToolResult` — a genuine `SessionEvent::UserMessage` always folds to empty `parts`
+/// ([`Message::from_legacy`]), so this never merges into a real user turn.
+fn push_part_to_tool_result_batch(
+    messages: &mut Vec<Message>,
+    origin_seqs: &mut Vec<u64>,
+    seq: u64,
+    part: MessagePart,
+) {
+    let is_open_batch = messages.last().is_some_and(|m| {
+        m.role == Role::User
+            && !m.parts.is_empty()
+            && m.parts
+                .iter()
+                .all(|p| matches!(p, MessagePart::ToolResult { .. }))
+    });
+    if is_open_batch {
+        let last = messages.last_mut().expect("checked by is_open_batch above");
+        last.parts.push(part);
+        last.rebuild_content();
+        return;
+    }
+    messages.push(Message::from_parts(Role::User, vec![part]));
     origin_seqs.push(seq);
 }
 
@@ -327,14 +361,103 @@ mod tests {
         let state = ReplayEngine::fold(events, None);
         assert_eq!(
             state.messages.len(),
-            2,
-            "user message + one assistant message holding both parts"
+            3,
+            "user message + assistant ToolUse message + user ToolResult message (#5464: a \
+             ToolResult must never merge into the preceding Assistant message — OpenAI/Claude \
+             both require it in a separate Role::User message)"
         );
         let assistant = &state.messages[1];
         assert_eq!(assistant.role, Role::Assistant);
-        assert_eq!(assistant.parts.len(), 2);
+        assert_eq!(assistant.parts.len(), 1);
         assert!(matches!(assistant.parts[0], MessagePart::ToolUse { .. }));
-        assert!(matches!(assistant.parts[1], MessagePart::ToolResult { .. }));
+
+        let tool_result_msg = &state.messages[2];
+        assert_eq!(tool_result_msg.role, Role::User);
+        assert_eq!(tool_result_msg.parts.len(), 1);
+        assert!(matches!(
+            tool_result_msg.parts[0],
+            MessagePart::ToolResult { .. }
+        ));
+    }
+
+    #[test]
+    fn test_replay_tool_result_batch_merges_into_one_user_message() {
+        // Multiple ToolResult events from the same tool-call batch (tier_loop.rs's
+        // process_tool_result_batch persists one Role::User message per batch, holding one
+        // ToolResult part per tool) must fold back into a single Role::User message, not one
+        // per event.
+        let events = vec![
+            envelope(
+                0,
+                SessionEvent::AssistantMessage {
+                    parts: vec![
+                        MessagePart::ToolUse {
+                            id: "tc1".to_owned(),
+                            name: "shell".to_owned(),
+                            input: serde_json::json!({}),
+                        },
+                        MessagePart::ToolUse {
+                            id: "tc2".to_owned(),
+                            name: "shell".to_owned(),
+                            input: serde_json::json!({}),
+                        },
+                    ],
+                },
+            ),
+            envelope(
+                1,
+                SessionEvent::ToolResult {
+                    id: "tc1".to_owned(),
+                    name: "shell".to_owned(),
+                    output: "a".to_owned(),
+                    is_error: false,
+                    duration_ms: 1,
+                },
+            ),
+            envelope(
+                2,
+                SessionEvent::ToolResult {
+                    id: "tc2".to_owned(),
+                    name: "shell".to_owned(),
+                    output: "b".to_owned(),
+                    is_error: false,
+                    duration_ms: 1,
+                },
+            ),
+        ];
+        let state = ReplayEngine::fold(events, None);
+        assert_eq!(state.messages.len(), 2);
+        assert_eq!(state.messages[1].role, Role::User);
+        assert_eq!(state.messages[1].parts.len(), 2);
+    }
+
+    #[test]
+    fn test_replay_tool_result_never_merges_into_plain_user_message() {
+        // A genuine SessionEvent::UserMessage (folds to empty `parts`) must never be treated as
+        // an open tool-result batch, even if a ToolResult event immediately follows it.
+        let events = vec![
+            envelope(
+                0,
+                SessionEvent::UserMessage {
+                    text: "hello".to_owned(),
+                    image_refs: vec![],
+                },
+            ),
+            envelope(
+                1,
+                SessionEvent::ToolResult {
+                    id: "tc1".to_owned(),
+                    name: "shell".to_owned(),
+                    output: "a".to_owned(),
+                    is_error: false,
+                    duration_ms: 1,
+                },
+            ),
+        ];
+        let state = ReplayEngine::fold(events, None);
+        assert_eq!(state.messages.len(), 2);
+        assert!(state.messages[0].parts.is_empty());
+        assert_eq!(state.messages[1].parts.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #5464 — a resumed CLI/TUI session that had used a tool during its previous run corrupted every subsequent turn with an OpenAI/Claude 400 error (`tool_calls` must be followed by tool messages), effectively bricking the conversation until a new one was started.
- Two compounding bugs in the durable event-log write and replay path:
  - `SessionSink::record_message` (`crates/zeph-agent-persistence/src/session_sink.rs`) collapsed a `Role::User` tool-result turn into a generic `SessionEvent::UserMessage`, discarding the `tool_use_id` pairing. It now emits one `SessionEvent::ToolResult` per `MessagePart::ToolResult` part.
  - `ReplayEngine::fold` (`crates/zeph-session/src/replay.rs`) folded `SessionEvent::ToolResult` onto the *preceding* assistant message instead of creating a new `Role::User` message — a shape neither the OpenAI nor Claude serializer accepts. New `push_part_to_tool_result_batch` produces the correct `Assistant{ToolUse} -> User{ToolResult...}` shape, batching consecutive `ToolResult` events from the same tool-call turn into one message.
  - Both fixes apply identically to the ACP replay path, which was hitting the same fold bug.

## Known limitation

Sessions whose event log was already corrupted by this bug (written before this fix) remain bricked — this is a write+read fix, not a data migration. Only new sessions, and replay of the previously-mis-folded ACP `ToolResult` shape, are fixed going forward.

## Test plan

- [x] Added 5 regression tests, including a required round-trip test that drives `SessionSink::record_message` -> `ReplayEngine::fold` -> the real `zeph-llm` serializer and asserts the message array is valid — for **both** OpenAI and Claude/Anthropic serializers.
- [x] Targeted suite: `cargo nextest run --config-file .github/nextest.toml -p zeph-agent-persistence -p zeph-session -p zeph-llm` — 990/990 passed.
- [x] Full workspace suite: `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11706/11706 passed.
- [x] `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, rustdoc gate — all clean.
- [x] LLM Serialization Gate live-API test (required per `.claude/rules/branching.md` for changes touching session/context assembly and `zeph-llm` request serialization): built `--features full`, ran the exact reproduction from the issue against the real OpenAI API — sent a message that triggered a tool call, relaunched `zeph` in the same conversation, sent a follow-up message. Confirmed the event log now records a `tool_result` event (not a collapsed `user_message`), the resumed session correctly linked ("Welcome back"), and the follow-up turn succeeded with no 400/422 error.