### PR TITLE
fix(core): wire durable agent_turns/subagent and parameter_reformat_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -667,6 +667,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   build_graph_extraction_config(&config.memory.graph, None, embed_timeout_secs)` — the same
   field-mapping helper already used by the conversational memory graph-backfill path — instead of
   the bare zero-sentinel default.
+- `fix(durable)`: `[durable] agent_turns` and `[durable] subagent` were dead-code toggles (#5452) —
+  `services.session.durable_ctx`/`durable_subagent` were never populated anywhere in the
+  workspace, so `call_llm_durable()` and the subagent spawn sites' `maybe_make_durable_seat()`
+  always took the non-durable path regardless of config. New `Agent::ensure_session_durable_ctx`
+  (`crates/zeph-core/src/agent/durable_bootstrap.rs`) lazily constructs a `DurableContext` the
+  first time a durable-gated call site runs — deferred past `AgentBuilder::with_task_supervisor`
+  so the journal-writer actor spawns onto the real, shutdown-linked `TaskSupervisor` rather than
+  the builder's throwaway default — keyed on the session's `ConversationId` so every turn in a
+  session journals as a step within the same execution. New
+  `AgentBuilder::with_durable_agent_turns`/`with_durable_subagent` builder methods wire
+  `config.durable.agent_turns`/`subagent` in `src/runner.rs`, alongside the existing
+  `with_durable_orchestration` (P2) call. Extracted the P2 adapter's backend-open sequence
+  (`plan.rs::ensure_durable_backend`) into a shared `durable_bootstrap::open_durable_backend`
+  helper so both the P1 (agent-turn) and P2 (orchestration) adapters construct their
+  `LocalBackend`/`JournalWriter` consistently. Shutdown now flushes and aborts the P1 writer
+  alongside the existing P2 writer. **Critic-flagged correction:** a conversation switch
+  (`/new`, `/conv resume`, `/conv fork`) reassigns `conversation_id` but was leaving the P1
+  `durable_ctx` bound to the *old* conversation's `ExecutionId` — every turn after a switch kept
+  journaling under the stale execution, defeating per-conversation crash-resume. New
+  `Agent::reset_durable_ctx_for_conversation_switch` flushes/aborts the old writer and clears
+  `durable_ctx`/`durable_ctx_init_attempted` so the next durable-gated call re-derives a fresh
+  execution for the new `conversation_id`; wired into both `reset_conversation` and
+  `load_and_resume_conversation`.
+- `fix(tools)`: `tools.retry.parameter_reformat_provider` never called an LLM (#5453) — despite
+  being fully wired through config, the `--init` wizard, and the provider registry,
+  `handle_reformat_phase()` (`crates/zeph-core/src/agent/tool_execution/tier_loop.rs`) only logged
+  a warning on `InvalidParameters`/`TypeMismatch` tool errors. It now resolves the named provider
+  via `Agent::resolve_background_provider` (the same `[[llm.providers]]` lookup pattern as
+  `compress_provider`), asks it for corrected arguments (tool schema + original arguments + error
+  message) via `chat_typed_erased::<ReformattedArguments>`, and retries the tool call once with the
+  corrected arguments. Also fixed the reformat-phase budget guard, which previously created its
+  `Instant` immediately before the elapsed check (always ~0 elapsed, a no-op) — the guard now
+  spans the whole reformat phase, matching the retry phase's `retry_start` accounting.
+  **Critic-flagged correction:** the per-LLM-call timeout reused
+  `max_retry_duration_secs.max(1)`, so setting the budget to `0` ("unlimited") collapsed the
+  per-call timeout to 1 second — an always-timing-out call that silently disabled the feature.
+  The per-call timeout now falls back to a fixed 30s default when the budget is `0`, decoupled
+  from the phase-budget knob's zero-as-unlimited semantics.
 - `fix(session)`: resume-time durable condensation (D-11) only fired on `/conv resume`, not on
   the other three session-open paths — CLI `sessions resume`, ACP `spawn_acp_agent`, or `zeph
   serve` reactivation (impl-critic re-verify finding N3, architect ruling D-13). The original

--- a/crates/zeph-config/src/durable.rs
+++ b/crates/zeph-config/src/durable.rs
@@ -58,12 +58,24 @@ pub struct DurableConfig {
     /// startup warning) and is forbidden for non-local backends (INV-8).
     pub encrypt_payload: bool,
     /// P1 adapter: wrap agent-loop steps in durable steps.
+    ///
+    /// When `true` (with `enabled = true`), every ordinary agent turn's LLM call is journaled
+    /// via a `DurableContext` opened lazily on the session's first turn (see
+    /// `zeph_core::agent::Agent::ensure_session_durable_ctx`, #5452). The execution is keyed on
+    /// the session's `ConversationId`, so this adapter requires semantic memory (`[memory]`) to
+    /// be enabled — without it, `conversation_id` is never set and the agent degrades to
+    /// non-durable with a one-time `tracing::warn!` at bootstrap, even though `agent_turns = true`
+    /// looks fully enabled in the config.
     pub agent_turns: bool,
     /// P2 adapter: journal the orchestration `/plan resume` replan budget.
     pub orchestration: bool,
     /// P3 adapter: exactly-once scheduler job fire.
     pub scheduler: bool,
     /// P4 adapter: durable promise for subagent spawn/await.
+    ///
+    /// Requires `agent_turns = true` as well: the durable seat is only attached when the
+    /// session's `DurableContext` (populated by the `agent_turns` adapter) is already `Some`
+    /// (#5452).
     pub subagent: bool,
     /// Group-commit interval for buffered appends, in milliseconds.
     pub journal_flush_interval_ms: u64,

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2014,6 +2014,40 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Stash the P1 (agent-turn) durable adapter's config/db-url/cipher cheaply — no I/O runs
+    /// here (#5452). Call only when `config.durable.enabled && config.durable.agent_turns`;
+    /// the actual `DurableContext` is opened lazily by
+    /// [`Agent::ensure_session_durable_ctx`](crate::agent::Agent::ensure_session_durable_ctx) on
+    /// the first durable-gated call, once the real `TaskSupervisor` is attached
+    /// (see [`Self::with_task_supervisor`]).
+    ///
+    /// `db_url` is the same `durable.db` connection string as [`Self::with_durable_orchestration`]
+    /// — both P1 and P2 adapters share the same journal file when both are enabled.
+    #[must_use]
+    pub fn with_durable_agent_turns(
+        mut self,
+        config: zeph_config::DurableConfig,
+        db_url: String,
+        cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
+    ) -> Self {
+        self.services.session.durable_agent_turns_config = Some(config);
+        self.services.session.durable_agent_turns_db_url = Some(db_url);
+        self.services.session.durable_agent_turns_cipher = cipher;
+        self
+    }
+
+    /// Mirror `config.durable.subagent` onto `services.session.durable_subagent` (#5452 FR-003).
+    ///
+    /// A direct, unconditional config copy — no I/O, no dependency on `agent_turns`. The P4
+    /// gate at the subagent-spawn call sites (`maybe_make_durable_seat`) separately requires
+    /// `durable_ctx` to be `Some`, so setting this to `true` while `agent_turns = false` is a
+    /// harmless no-op there (FR-008).
+    #[must_use]
+    pub fn with_durable_subagent(mut self, enabled: bool) -> Self {
+        self.services.session.durable_subagent = enabled;
+        self
+    }
+
     /// Wire `graph_persistence` from the attached `SemanticMemory` `SQLite` pool.
     ///
     /// Idempotent: returns immediately if `graph_persistence` is already `Some`.

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -381,6 +381,10 @@ impl<C: Channel> Agent<C> {
         self.services.tool_state.cached_filtered_tool_ids = None;
         self.runtime.providers.cached_prompt_tokens = 0;
 
+        // --- Step 9b: detach the P1 durable execution (#5452 critic finding S1) — it is keyed
+        // on the OLD conversation_id and must not keep journaling turns for the new one. ---
+        self.reset_durable_ctx_for_conversation_switch().await;
+
         // --- Step 10: update conversation ID and memory state ---
         self.services.memory.persistence.conversation_id = new_conversation_id;
         self.services.memory.persistence.unsummarized_count = 0;
@@ -491,6 +495,10 @@ impl<C: Channel> Agent<C> {
         let old_conversation_id = self.services.memory.persistence.conversation_id;
         self.spawn_outgoing_digest(old_conversation_id);
         self.reset_swap_state();
+        // Detach the P1 durable execution (#5452 critic finding S1) — same reasoning as
+        // `reset_conversation`: it is keyed on the OLD conversation_id and must not keep
+        // journaling turns for the resumed/forked one.
+        self.reset_durable_ctx_for_conversation_switch().await;
 
         // --- Apply the replayed history (same shape as `with_preloaded_messages`, D-6) ---
         let mut messages = hydrated.messages;

--- a/crates/zeph-core/src/agent/durable_bootstrap.rs
+++ b/crates/zeph-core/src/agent/durable_bootstrap.rs
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared durable-backend construction, used by both the P1 (agent-turn) and P2
+//! (orchestration) durable adapters so backend/writer setup stays consistent across every
+//! adapter that reads the shared `[durable]` config section (#5452).
+//!
+//! This module owns only the mechanical "open backend, init schema, attach cipher, spawn
+//! writer" sequence. Each adapter keeps its own cache slot (`services.orchestration.durable_*`
+//! for P2, `services.session.durable_*` for P1) and its own [`zeph_durable::ExecutionId`]
+//! derivation — those decisions are adapter-specific and stay in `plan.rs` / `durable_bootstrap.rs`
+//! respectively.
+
+use std::sync::Arc;
+
+use zeph_durable::{DurableBackendEnum, JournalWriterHandle, LocalBackend, PayloadCipher};
+
+use crate::agent::Agent;
+use crate::channel::Channel;
+
+/// Open a [`LocalBackend`] at `db_url`, initialise its schema, attach `cipher` if present, and
+/// spawn its [`JournalWriter`](zeph_durable::JournalWriter) actor via `task_supervisor`.
+///
+/// Returns `None` (after logging a `tracing::warn!`) on any I/O failure so callers degrade to
+/// non-durable mode rather than fail session bootstrap (#5452 FR-004).
+pub(crate) async fn open_durable_backend(
+    task_supervisor: &zeph_common::TaskSupervisor,
+    writer_task_name: &'static str,
+    cfg: &zeph_config::DurableConfig,
+    db_url: &str,
+    cipher: Option<Arc<dyn PayloadCipher>>,
+) -> Option<(
+    Arc<DurableBackendEnum>,
+    JournalWriterHandle,
+    zeph_common::task_supervisor::BlockingHandle<()>,
+)> {
+    let local = match LocalBackend::open(db_url, cfg.max_payload_bytes).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(error = %e, db_url, "durable: failed to open backend; skipping");
+            return None;
+        }
+    };
+    if let Err(e) = local.init().await {
+        tracing::warn!(error = %e, "durable: failed to init schema; skipping");
+        return None;
+    }
+    let local = if let Some(c) = cipher {
+        local.with_cipher(c)
+    } else {
+        local
+    };
+    let local = Arc::new(local);
+    let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
+    let (writer_actor, handle) = zeph_durable::JournalWriter::new(local, cfg);
+    let task_handle =
+        task_supervisor.spawn_oneshot(Arc::from(writer_task_name), move || async move {
+            writer_actor.run().await;
+        });
+    Some((backend, handle, task_handle))
+}
+
+impl<C: Channel> Agent<C> {
+    /// Lazily construct the session's [`DurableContext`](zeph_durable::DurableContext) for the
+    /// P1 agent-turn adapter (#5452), the first time a durable-gated call site needs it.
+    ///
+    /// Deferred to first use (rather than built eagerly in the `AgentBuilder` chain) because the
+    /// real, shutdown-linked `TaskSupervisor` is only attached via `with_task_supervisor` late in
+    /// bootstrap — constructing here (well after `.build()`) guarantees the journal-writer actor
+    /// spawns onto the correct supervisor. A no-op after the first attempt (success or failure):
+    /// `durable_ctx_init_attempted` suppresses retrying I/O on every subsequent turn.
+    ///
+    /// The execution is keyed on the session's `ConversationId` (not per-turn), so every turn in
+    /// the session journals as a step within the *same* execution and a crash mid-session can
+    /// resume from any prior turn's journal state.
+    pub(crate) async fn ensure_session_durable_ctx(&mut self) {
+        if self.services.session.durable_ctx.is_some()
+            || self.services.session.durable_ctx_init_attempted
+        {
+            return;
+        }
+        self.services.session.durable_ctx_init_attempted = true;
+
+        let Some(cfg) = self.services.session.durable_agent_turns_config.clone() else {
+            return;
+        };
+        let Some(db_url) = self.services.session.durable_agent_turns_db_url.clone() else {
+            return;
+        };
+        let Some(conversation_id) = self.services.memory.persistence.conversation_id else {
+            tracing::warn!(
+                "durable agent_turns: no conversation_id at bootstrap; degrading to non-durable"
+            );
+            return;
+        };
+        let cipher = self.services.session.durable_agent_turns_cipher.clone();
+
+        tracing::debug!("durable agent_turns: opening backend start");
+        let backend_result = open_durable_backend(
+            &self.runtime.lifecycle.task_supervisor,
+            "agent.durable.turn_journal_writer",
+            &cfg,
+            &db_url,
+            cipher,
+        )
+        .await;
+        tracing::debug!("durable agent_turns: opening backend done");
+        let Some((backend, writer, task_handle)) = backend_result else {
+            tracing::warn!(
+                "durable agent_turns: backend construction failed; degrading to non-durable"
+            );
+            return;
+        };
+
+        let zeph_durable::DurableBackendEnum::Local(local_backend) = &*backend else {
+            tracing::warn!(
+                "durable agent_turns: only LocalBackend is supported; degrading to non-durable"
+            );
+            return;
+        };
+
+        let exec_id = zeph_durable::ExecutionId::derive(
+            b"zeph.agent_turn.v1",
+            &conversation_id.0.to_le_bytes(),
+        );
+        tracing::debug!("durable agent_turns: open_execution start");
+        let open_execution_result = local_backend
+            .open_execution(exec_id, zeph_durable::ExecutionKind::AgentTurn)
+            .await;
+        tracing::debug!("durable agent_turns: open_execution done");
+        let is_resume = match open_execution_result {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "durable agent_turns: open_execution failed; degrading to non-durable"
+                );
+                return;
+            }
+        };
+
+        let ctx = zeph_durable::DurableContext::new(
+            exec_id,
+            zeph_durable::ExecutionKind::AgentTurn,
+            is_resume,
+            backend,
+            writer.clone(),
+            &cfg,
+        );
+
+        tracing::info!(
+            execution_id = %exec_id.as_uuid(),
+            is_resume,
+            "durable agent_turns: DurableContext attached to session"
+        );
+        self.services.session.durable_ctx = Some(Arc::new(ctx));
+        self.services.session.durable_writer = Some(writer);
+        self.services.session.durable_writer_task = Some(task_handle);
+    }
+
+    /// Detach the P1 durable execution before a conversation switch (`/new`, `/conv resume`,
+    /// `/conv fork` — #5452 critic finding S1).
+    ///
+    /// `ensure_session_durable_ctx` keys its `ExecutionId` on `ConversationId` and then latches
+    /// `durable_ctx_init_attempted` so it never re-derives the execution again. Without this
+    /// reset, every turn after a conversation switch would keep journaling under the *old*
+    /// conversation's execution — silently mixing two conversations' turn state and defeating the
+    /// per-conversation crash-resume the keying is meant to provide. Flushes and aborts the old
+    /// writer (best-effort, same 2s deadline as `flush_durable_writer` on shutdown) before
+    /// clearing the session's durable fields so the next durable-gated call re-derives a fresh
+    /// execution for the new `conversation_id`.
+    pub(in crate::agent) async fn reset_durable_ctx_for_conversation_switch(&mut self) {
+        if let Some(ref writer) = self.services.session.durable_writer {
+            let flush_deadline = std::time::Duration::from_secs(2);
+            match tokio::time::timeout(flush_deadline, writer.flush()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        error = %e,
+                        "durable agent_turns writer: flush on conversation switch failed"
+                    );
+                }
+                Err(_) => tracing::warn!(
+                    "durable agent_turns writer: flush timed out on conversation switch"
+                ),
+            }
+        }
+        if let Some(h) = self.services.session.durable_writer_task.take() {
+            h.abort();
+        }
+        self.services.session.durable_ctx = None;
+        self.services.session.durable_writer = None;
+        self.services.session.durable_ctx_init_attempted = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::agent::agent_tests::*;
+
+    fn agent_with_conversation() -> crate::agent::Agent<MockChannel> {
+        let provider = mock_provider(vec!["ok".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.memory.persistence.conversation_id = Some(zeph_memory::ConversationId(1));
+        agent
+    }
+
+    #[tokio::test]
+    async fn populates_durable_ctx_when_agent_turns_enabled() {
+        let mut agent = agent_with_conversation();
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(":memory:".to_owned());
+
+        agent.ensure_session_durable_ctx().await;
+
+        assert!(agent.services.session.durable_ctx.is_some());
+        assert!(agent.services.session.durable_writer.is_some());
+        assert!(agent.services.session.durable_ctx_init_attempted);
+    }
+
+    #[tokio::test]
+    async fn stays_none_when_agent_turns_not_configured() {
+        // FR-002: no `with_durable_agent_turns` call at all (the builder-level gate), so the
+        // session's stash fields are `None` — mirrors a plain `[durable] enabled=false` deployment.
+        let mut agent = agent_with_conversation();
+
+        agent.ensure_session_durable_ctx().await;
+
+        assert!(agent.services.session.durable_ctx.is_none());
+        assert!(agent.services.session.durable_ctx_init_attempted);
+    }
+
+    #[tokio::test]
+    async fn degrades_when_conversation_id_missing() {
+        // FR-004: construction must not panic or hard-fail bootstrap when the conversation_id
+        // gate can't be satisfied — it degrades to non-durable instead.
+        let provider = mock_provider(vec!["ok".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(":memory:".to_owned());
+
+        agent.ensure_session_durable_ctx().await;
+
+        assert!(agent.services.session.durable_ctx.is_none());
+    }
+
+    #[tokio::test]
+    async fn is_a_noop_after_first_attempt() {
+        let mut agent = agent_with_conversation();
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(":memory:".to_owned());
+
+        agent.ensure_session_durable_ctx().await;
+        let first = agent
+            .services
+            .session
+            .durable_ctx
+            .clone()
+            .expect("durable_ctx should be populated");
+
+        // Second call must not reconstruct — same Arc instance, no panic on double-init.
+        agent.ensure_session_durable_ctx().await;
+        let second = agent
+            .services
+            .session
+            .durable_ctx
+            .clone()
+            .expect("durable_ctx should still be populated");
+        assert!(std::sync::Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn conversation_switch_rebinds_execution_id() {
+        // Regression test for critic finding S1: a conversation switch must not leave the P1
+        // execution bound to the stale (old) ConversationId.
+        let mut agent = agent_with_conversation();
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(":memory:".to_owned());
+
+        agent.ensure_session_durable_ctx().await;
+        let first_exec_id = agent
+            .services
+            .session
+            .durable_ctx
+            .as_ref()
+            .expect("durable_ctx should be populated")
+            .execution_id();
+
+        // Simulate `reset_conversation`'s durable-detach step, then the new conversation_id.
+        agent.reset_durable_ctx_for_conversation_switch().await;
+        assert!(
+            agent.services.session.durable_ctx.is_none(),
+            "durable_ctx must be cleared by the switch"
+        );
+        assert!(
+            !agent.services.session.durable_ctx_init_attempted,
+            "latch must be reset so the next call re-derives the execution"
+        );
+        agent.services.memory.persistence.conversation_id = Some(zeph_memory::ConversationId(2));
+
+        agent.ensure_session_durable_ctx().await;
+        let second_exec_id = agent
+            .services
+            .session
+            .durable_ctx
+            .as_ref()
+            .expect("durable_ctx should be repopulated for the new conversation")
+            .execution_id();
+
+        assert_ne!(
+            first_exec_id, second_exec_id,
+            "a conversation switch must rebind the P1 execution to the new conversation_id"
+        );
+    }
+}

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -17,6 +17,7 @@ mod context;
 mod context_impls;
 pub(crate) mod context_manager;
 mod corrections;
+mod durable_bootstrap;
 pub mod error;
 mod experiment_cmd;
 pub(crate) mod focus;

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -285,32 +285,16 @@ impl<C: crate::channel::Channel> Agent<C> {
                 return None;
             }
             let db_url = self.services.orchestration.durable_db_url.clone()?;
-            let local = match zeph_durable::LocalBackend::open(&db_url, cfg.max_payload_bytes).await
-            {
-                Ok(b) => b,
-                Err(e) => {
-                    tracing::warn!(error = %e, "P2 durable: failed to open backend; skipping");
-                    return None;
-                }
-            };
-            if let Err(e) = local.init().await {
-                tracing::warn!(error = %e, "P2 durable: failed to init schema; skipping");
-                return None;
-            }
-            // Attach cipher to the backend before wrapping — callers never need to re-inject it.
-            let local = if let Some(c) = self.services.orchestration.durable_cipher.clone() {
-                local.with_cipher(c)
-            } else {
-                local
-            };
-            let local = std::sync::Arc::new(local);
-            let backend =
-                std::sync::Arc::new(zeph_durable::DurableBackendEnum::Local(local.clone()));
-            let (writer_actor, handle) = zeph_durable::JournalWriter::new(local, &cfg);
-            let task_handle = self.runtime.lifecycle.task_supervisor.spawn_oneshot(
-                std::sync::Arc::from("agent.durable.journal_writer"),
-                move || async move { writer_actor.run().await },
-            );
+            let cipher = self.services.orchestration.durable_cipher.clone();
+            let (backend, handle, task_handle) =
+                crate::agent::durable_bootstrap::open_durable_backend(
+                    &self.runtime.lifecycle.task_supervisor,
+                    "agent.durable.journal_writer",
+                    &cfg,
+                    &db_url,
+                    cipher,
+                )
+                .await?;
             self.services.orchestration.durable_backend = Some(backend);
             self.services.orchestration.durable_writer = Some(handle);
             self.services.orchestration.durable_writer_task = Some(task_handle);

--- a/crates/zeph-core/src/agent/shutdown.rs
+++ b/crates/zeph-core/src/agent/shutdown.rs
@@ -427,13 +427,14 @@ impl<C: Channel> Agent<C> {
         tracing::info!("agent shutdown complete");
     }
 
-    /// Flush buffered durable journal entries then abort the writer task.
+    /// Flush buffered durable journal entries then abort the writer task, for both the P2
+    /// (orchestration) and P1 (agent-turn, #5452) durable adapters.
     ///
     /// `flush()` has a built-in ack timeout; the outer 2 s cap ensures shutdown never
     /// hangs beyond that. Errors are logged as warnings — shutdown must not fail.
     async fn flush_durable_writer(&mut self) {
+        let flush_deadline = std::time::Duration::from_secs(2);
         if let Some(ref writer) = self.services.orchestration.durable_writer {
-            let flush_deadline = std::time::Duration::from_secs(2);
             match tokio::time::timeout(flush_deadline, writer.flush()).await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
@@ -443,6 +444,18 @@ impl<C: Channel> Agent<C> {
             }
         }
         if let Some(h) = self.services.orchestration.durable_writer_task.take() {
+            h.abort();
+        }
+        if let Some(ref writer) = self.services.session.durable_writer {
+            match tokio::time::timeout(flush_deadline, writer.flush()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, "durable agent_turns writer: flush on shutdown failed");
+                }
+                Err(_) => tracing::warn!("durable agent_turns writer: flush timed out on shutdown"),
+            }
+        }
+        if let Some(h) = self.services.session.durable_writer_task.take() {
             h.abort();
         }
     }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -813,13 +813,18 @@ pub(crate) struct SessionState {
     /// When `true`, the agent prompt includes a brief guest-context annotation, and the response
     /// is delivered via `answerGuestQuery` instead of `sendMessage`.
     pub(crate) is_guest_context: bool,
-    /// Active durable execution context for the P1 agent-loop adapter (spec-064 §P1).
+    /// Active durable execution context for the P1 agent-loop adapter (spec-064 §P1, #5452).
     ///
     /// `Some` when `[durable] enabled = true` and `agent_turns = true`. The context is opened
-    /// once per session (or resumed from a prior crash) and shared across all turns via `Arc`.
-    /// `None` when durable execution is disabled — in which case the loop runs unmodified.
+    /// lazily by [`Agent::ensure_session_durable_ctx`](crate::agent::Agent::ensure_session_durable_ctx)
+    /// the first time a durable-gated call site runs (not eagerly in the builder chain, since the
+    /// real `TaskSupervisor` is only attached later via `with_task_supervisor`), keyed on the
+    /// session's `ConversationId` so every turn replays under the same execution. `None` when
+    /// durable execution is disabled (or construction failed and degraded) — in which case the
+    /// loop runs unmodified.
     pub(crate) durable_ctx: Option<std::sync::Arc<zeph_durable::DurableContext>>,
-    /// Mirror of `[durable] subagent` config flag (spec-064 §P4).
+    /// Mirror of `[durable] subagent` config flag (spec-064 §P4, #5452), set unconditionally at
+    /// bootstrap via `AgentBuilder::with_durable_subagent` from `config.durable.subagent`.
     ///
     /// When `true` and `durable_ctx` is `Some`, sub-agent spawns are wrapped in a durable
     /// promise so a resumed parent can replay the child result without re-running the child.
@@ -830,6 +835,30 @@ pub(crate) struct SessionState {
     /// output (spec-064 §INV-001 §15 `RuntimeLayer` double-print suppression). Cleared at the
     /// start of each turn.
     pub(crate) durable_turn_replayed: bool,
+    /// `DurableConfig`/db url/cipher stashed cheaply (no I/O) by
+    /// `AgentBuilder::with_durable_agent_turns` when `[durable] enabled = true` and
+    /// `agent_turns = true`. Consumed by `ensure_session_durable_ctx` to lazily open the backend
+    /// and construct `durable_ctx` on the first durable-gated call. `None` when the P1 adapter is
+    /// not configured, in which case `durable_ctx` stays `None` forever (#5452 FR-002).
+    pub(crate) durable_agent_turns_config: Option<zeph_config::DurableConfig>,
+    /// Sibling companion to [`Self::durable_agent_turns_config`]: the `durable.db` connection
+    /// string resolved at bootstrap.
+    pub(crate) durable_agent_turns_db_url: Option<String>,
+    /// Sibling companion to [`Self::durable_agent_turns_config`]: the AEAD cipher to attach to
+    /// the backend, `None` when `encrypt_payload = false` (development mode only).
+    pub(crate) durable_agent_turns_cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
+    /// Set to `true` the first time `ensure_session_durable_ctx` runs (success or failure) so a
+    /// failed backend construction (missing vault key, disk error) is not retried on every turn.
+    /// Reset to `false` by `reset_durable_ctx_for_conversation_switch` (`/new`, `/conv resume`,
+    /// `/conv fork` — #5452 critic finding S1) so a conversation switch re-derives a fresh
+    /// execution keyed on the new `ConversationId` instead of leaving this latched forever.
+    pub(crate) durable_ctx_init_attempted: bool,
+    /// Writer handle for the P1 adapter's durable backend, flushed on shutdown by
+    /// `flush_durable_writer` (mirrors `services.orchestration.durable_writer` for the P2 adapter).
+    pub(crate) durable_writer: Option<zeph_durable::JournalWriterHandle>,
+    /// [`BlockingHandle`] for the P1 adapter's background `JournalWriter` actor task, aborted on
+    /// shutdown by `flush_durable_writer` (mirrors `services.orchestration.durable_writer_task`).
+    pub(crate) durable_writer_task: Option<zeph_common::task_supervisor::BlockingHandle<()>>,
     /// When `true`, the system prompt volatile block includes the `CAVEMAN_DIRECTIVE` on every
     /// turn, instructing the LLM to use ultra-compressed telegraphic output.
     ///
@@ -1223,6 +1252,12 @@ impl SessionState {
             durable_ctx: None,
             durable_subagent: false,
             durable_turn_replayed: false,
+            durable_agent_turns_config: None,
+            durable_agent_turns_db_url: None,
+            durable_agent_turns_cipher: None,
+            durable_ctx_init_attempted: false,
+            durable_writer: None,
+            durable_writer_task: None,
             caveman_active: false,
             session_sink: None,
             session_persistence_config: None,

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -75,6 +75,12 @@ fn make_session_state() -> SessionState {
         durable_ctx: None,
         durable_subagent: false,
         durable_turn_replayed: false,
+        durable_agent_turns_config: None,
+        durable_agent_turns_db_url: None,
+        durable_agent_turns_cipher: None,
+        durable_ctx_init_attempted: false,
+        durable_writer: None,
+        durable_writer_task: None,
         session_sink: None,
         session_persistence_config: None,
     }

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -405,6 +405,7 @@ impl<C: Channel> Agent<C> {
         let mut spawn_ctx = self.build_spawn_context(&cfg);
         // Background durable: seat wired so child can resolve; promise dropped (background
         // results are collected via poll_subagents, not await_durable_subagent).
+        self.ensure_session_durable_ctx().await;
         if let Some(seat) = maybe_make_durable_seat(
             self.services.session.durable_subagent,
             self.services.session.durable_ctx.as_deref(),
@@ -442,6 +443,7 @@ impl<C: Channel> Agent<C> {
         // Wire the durable resolver seat so the child can resolve its promise on exit.
         // The promise (await side) is dropped here; foreground result is collected via
         // poll_subagent_until_done which reads the join-handle output directly.
+        self.ensure_session_durable_ctx().await;
         if let Some(seat) = maybe_make_durable_seat(
             self.services.session.durable_subagent,
             self.services.session.durable_ctx.as_deref(),
@@ -937,4 +939,71 @@ fn sanitize_parent_messages(
         }
     }
     msgs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::agent_tests::*;
+
+    /// Agent with `durable_ctx` populated via the real `ensure_session_durable_ctx` bootstrap
+    /// path (mirrors `durable_bootstrap::tests::agent_with_conversation`), with
+    /// `durable_subagent` set per `subagent_enabled` — used to test the FR-003/US-002 seat
+    /// wiring gate at `maybe_make_durable_seat`, not just the config-to-builder plumbing.
+    async fn agent_with_durable_ctx_ready(subagent_enabled: bool) -> Agent<MockChannel> {
+        let provider = mock_provider(vec!["ok".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.memory.persistence.conversation_id = Some(zeph_memory::ConversationId(42));
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(":memory:".to_owned());
+        agent.services.session.durable_subagent = subagent_enabled;
+
+        agent.ensure_session_durable_ctx().await;
+        assert!(
+            agent.services.session.durable_ctx.is_some(),
+            "test setup: durable_ctx must be populated before exercising the seat gate"
+        );
+        agent
+    }
+
+    #[tokio::test]
+    async fn seat_wired_when_subagent_enabled_and_durable_ctx_populated() {
+        let agent = Box::pin(agent_with_durable_ctx_ready(true)).await;
+
+        let seat = maybe_make_durable_seat(
+            agent.services.session.durable_subagent,
+            agent.services.session.durable_ctx.as_deref(),
+        )
+        .await;
+
+        assert!(
+            seat.is_some(),
+            "US-002: [durable] subagent=true with a populated durable_ctx must yield a seat, \
+             not just wire the config-to-builder plumbing"
+        );
+    }
+
+    #[tokio::test]
+    async fn seat_absent_when_subagent_disabled() {
+        let agent = Box::pin(agent_with_durable_ctx_ready(false)).await;
+
+        let seat = maybe_make_durable_seat(
+            agent.services.session.durable_subagent,
+            agent.services.session.durable_ctx.as_deref(),
+        )
+        .await;
+
+        assert!(
+            seat.is_none(),
+            "FR-008: durable_subagent=false must keep the seat gate closed even when \
+             durable_ctx is populated"
+        );
+    }
 }

--- a/crates/zeph-core/src/agent/tests/agent_tests/common.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/common.rs
@@ -210,6 +210,8 @@ impl Channel for MockChannel {
 pub(crate) struct MockToolExecutor {
     outputs: Arc<Mutex<Vec<ToolOutputResult>>>,
     pub(crate) captured_env: Arc<Mutex<Vec<EnvSnapshot>>>,
+    definitions: Vec<zeph_tools::registry::ToolDef>,
+    delay_ms: u64,
 }
 
 impl MockToolExecutor {
@@ -217,11 +219,31 @@ impl MockToolExecutor {
         Self {
             outputs: Arc::new(Mutex::new(outputs)),
             captured_env: Arc::new(Mutex::new(Vec::new())),
+            definitions: Vec::new(),
+            delay_ms: 0,
         }
     }
 
     pub(crate) fn no_tools() -> Self {
         Self::new(vec![Ok(None)])
+    }
+
+    /// Attach tool definitions returned by `tool_definitions()`/`tool_definitions_erased()`, for
+    /// tests that need a schema lookup (e.g. the parameter-reformat phase, #5453).
+    pub(crate) fn with_definitions(
+        mut self,
+        definitions: Vec<zeph_tools::registry::ToolDef>,
+    ) -> Self {
+        self.definitions = definitions;
+        self
+    }
+
+    /// Sleep for `ms` milliseconds before returning a dispatch result, so timing-sensitive
+    /// tests (e.g. the reformat-phase whole-phase budget guard, #5453) can advance real
+    /// wall-clock time deterministically without a background sleep of their own.
+    pub(crate) fn with_delay(mut self, ms: u64) -> Self {
+        self.delay_ms = ms;
+        self
     }
 }
 
@@ -239,6 +261,9 @@ impl ToolExecutor for MockToolExecutor {
         &self,
         _call: &zeph_tools::executor::ToolCall,
     ) -> Result<Option<ToolOutput>, ToolError> {
+        if self.delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(self.delay_ms)).await;
+        }
         let mut outputs = self.outputs.lock().unwrap();
         if outputs.is_empty() {
             Ok(None)
@@ -249,6 +274,10 @@ impl ToolExecutor for MockToolExecutor {
 
     fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
         self.captured_env.lock().unwrap().push(env);
+    }
+
+    fn tool_definitions(&self) -> Vec<zeph_tools::registry::ToolDef> {
+        self.definitions.clone()
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -17,6 +17,12 @@ use super::{
 use crate::agent::Agent;
 use crate::channel::{Channel, StopHint, ToolStartEvent};
 
+/// Per-call timeout for the parameter-reformat LLM call (#5453) when
+/// `tools.retry.max_retry_duration_secs` is `0` ("no phase budget limit") — that value must not
+/// be reused directly as a per-call timeout (critic finding M1: `max(1)` on `0` collapsed to a
+/// 1-second timeout that always failed, silently disabling the whole feature).
+const REFORMAT_DEFAULT_TIMEOUT_SECS: u64 = 30;
+
 fn make_tool_hook_env(
     tool_name: &str,
     tool_input: &serde_json::Value,
@@ -49,7 +55,7 @@ impl<C: Channel> Agent<C> {
             .await?;
         self.handle_retry_phase(tool_calls, calls, tool_results, max_retries, cancel)
             .await?;
-        self.handle_reformat_phase(tool_calls, tool_results, cancel)
+        self.handle_reformat_phase(tool_calls, calls, tool_results, cancel)
             .await?;
         Ok(())
     }
@@ -230,6 +236,7 @@ impl<C: Channel> Agent<C> {
     async fn handle_reformat_phase(
         &mut self,
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        calls: &[ToolCall],
         tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
         cancel: &tokio_util::sync::CancellationToken,
     ) -> Result<(), crate::agent::error::AgentError> {
@@ -240,7 +247,10 @@ impl<C: Channel> Agent<C> {
         {
             return Ok(());
         }
+        // Budget covers the whole reformat phase (all tool calls needing reformat this round),
+        // matching the retry phase's `retry_start`/`max_retry_duration_secs` accounting.
         let budget_secs = self.tool_orchestrator.max_retry_duration_secs;
+        let reformat_start = std::time::Instant::now();
         for idx in 0..tool_results.len() {
             if cancel.is_cancelled() {
                 self.tool_executor.set_skill_env(None);
@@ -258,29 +268,140 @@ impl<C: Channel> Agent<C> {
                 continue;
             }
             let tc = &tool_calls[idx];
-            tracing::warn!(
-                tool = %tc.name,
-                "parameter error detected; parameter reformat path is reserved for future \
-                 LLM-based reformat implementation"
-            );
-            // Budget check: a newly created instant always has ~0 elapsed, so this guard
-            // is effectively a no-op today. Kept for structural parity with the planned
-            // LLM-based reformat implementation that will run actual work here.
-            let reformat_start = std::time::Instant::now();
             if budget_secs > 0 && reformat_start.elapsed().as_secs() >= budget_secs {
                 tracing::warn!(tool = %tc.name, "parameter reformat budget exhausted, skipping");
                 continue;
             }
+            let error_message = tool_results[idx]
+                .as_ref()
+                .err()
+                .map(std::string::ToString::to_string)
+                .unwrap_or_default();
+
             let _ = self
                 .channel
-                .send_status(&format!(
-                    "Reformat for {} pending provider integration…",
-                    tc.name
-                ))
+                .send_status(&format!("Reformatting parameters for {}...", tc.name))
+                .await;
+            let new_result = self
+                .reformat_tool_call(&calls[idx], tc, &error_message, cancel)
                 .await;
             let _ = self.channel.send_status("").await;
+
+            if cancel.is_cancelled() {
+                self.tool_executor.set_skill_env(None);
+                tracing::info!("parameter reformat phase cancelled by user");
+                self.update_metrics(|m| m.cancellations += 1);
+                self.channel.send("[Cancelled]").await?;
+                self.persist_cancelled_tool_results(tool_calls).await;
+                return Ok(());
+            }
+
+            if let Some(result) = new_result {
+                if let Err(ref e) = result
+                    && let Some(ref d) = self.runtime.debug.debug_dumper
+                {
+                    d.dump_tool_error(tc.name.as_str(), e);
+                }
+                tool_results[idx] = result;
+            }
         }
         Ok(())
+    }
+
+    /// LLM-based single-shot reformat-and-retry for a tool call that failed with an
+    /// `InvalidParameters`/`TypeMismatch` error (issue #5453).
+    ///
+    /// Resolves `tools.retry.parameter_reformat_provider` from `[[llm.providers]]` via
+    /// [`Agent::resolve_background_provider`] (falling back to the primary provider when the
+    /// name is empty or unknown), asks it for corrected arguments given the tool's JSON schema,
+    /// the originally-submitted arguments, and the error message, then re-dispatches the tool
+    /// call once with the corrected arguments.
+    ///
+    /// Returns `None` when the provider call fails, times out, or returns arguments that do not
+    /// parse as a JSON object — the caller keeps the original error result unchanged.
+    async fn reformat_tool_call(
+        &mut self,
+        call: &ToolCall,
+        tc: &zeph_llm::provider::ToolUseRequest,
+        error_message: &str,
+        cancel: &tokio_util::sync::CancellationToken,
+    ) -> Option<Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>> {
+        #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+        struct ReformattedArguments {
+            /// Corrected JSON arguments object for the failed tool call.
+            arguments: serde_json::Value,
+        }
+
+        let Some(schema) = self
+            .tool_executor
+            .tool_definitions_erased()
+            .into_iter()
+            .find(|d| d.id.as_ref() == tc.name.as_str())
+            .map(|d| d.schema)
+        else {
+            tracing::warn!(tool = %tc.name, "parameter reformat: tool schema not found, skipping");
+            return None;
+        };
+
+        let provider_name = self.tool_orchestrator.parameter_reformat_provider.clone();
+        let provider = self.resolve_background_provider(&provider_name);
+
+        let original_args = serde_json::Value::Object(call.params.clone());
+        let prompt = format!(
+            "A tool call failed parameter validation. Propose corrected arguments as a JSON \
+             object under the `arguments` key.\n\n\
+             Tool: {}\nJSON schema:\n{}\n\nOriginal arguments:\n{}\n\nError: {error_message}",
+            tc.name,
+            serde_json::to_string_pretty(&schema).unwrap_or_default(),
+            serde_json::to_string_pretty(&original_args).unwrap_or_default(),
+        );
+        let messages = [Message::from_legacy(Role::User, prompt)];
+
+        // `max_retry_duration_secs == 0` means "no phase budget limit" (see the `budget_secs > 0`
+        // check in `handle_reformat_phase`), but a per-LLM-call timeout must never be 0 or
+        // collapse to 1s for that same value — that previously made `max_retry_duration_secs = 0`
+        // ("unlimited") silently disable the whole feature via an always-timing-out 1s call
+        // (critic finding M1). Use the configured budget as the per-call timeout only when it is a
+        // real bound; fall back to a fixed sane default otherwise.
+        let timeout_secs = match self.tool_orchestrator.max_retry_duration_secs {
+            0 => REFORMAT_DEFAULT_TIMEOUT_SECS,
+            secs => secs,
+        };
+        let reformat = tokio::select! {
+            r = tokio::time::timeout(
+                std::time::Duration::from_secs(timeout_secs),
+                provider.chat_typed_erased::<ReformattedArguments>(&messages),
+            ) => match r {
+                Ok(Ok(reformat)) => reformat,
+                Ok(Err(e)) => {
+                    tracing::warn!(tool = %tc.name, error = %e, "parameter reformat: provider call failed");
+                    return None;
+                }
+                Err(_) => {
+                    tracing::warn!(tool = %tc.name, timeout_secs, "parameter reformat: provider call timed out");
+                    return None;
+                }
+            },
+            () = cancel.cancelled() => return None,
+        };
+
+        let serde_json::Value::Object(corrected_params) = reformat.arguments else {
+            tracing::warn!(
+                tool = %tc.name,
+                "parameter reformat: corrected arguments were not a JSON object, skipping retry"
+            );
+            return None;
+        };
+
+        let mut retry_call = call.clone();
+        retry_call.params = corrected_params;
+
+        tokio::select! {
+            r = self.tool_executor.execute_tool_call_erased(&retry_call).instrument(
+                tracing::info_span!("tool_exec_reformat", tool_name = %tc.name)
+            ) => Some(r),
+            () = cancel.cancelled() => None,
+        }
     }
 
     fn run_pre_execution_verifiers(&mut self, calls: &[ToolCall]) -> Vec<bool> {
@@ -2536,6 +2657,7 @@ impl<C: Channel> Agent<C> {
         tool_defs: &[ToolDefinition],
         iteration: usize,
     ) -> Result<Option<zeph_llm::provider::ChatResponse>, crate::agent::error::AgentError> {
+        self.ensure_session_durable_ctx().await;
         let Some(ctx) = self.services.session.durable_ctx.clone() else {
             return self.call_chat_with_tools_retry(tool_defs, 2).await;
         };
@@ -3161,6 +3283,280 @@ mod tests {
             );
         } else {
             panic!("expected ToolResult part");
+        }
+    }
+
+    mod reformat_phase_tests {
+        use zeph_tools::registry::{InvocationHint, ToolDef};
+
+        use super::*;
+        use crate::agent::agent_tests::*;
+
+        fn test_tool_def() -> ToolDef {
+            ToolDef {
+                id: "test_tool".into(),
+                description: "a test tool".into(),
+                schema: schemars::Schema::default(),
+                invocation: InvocationHint::ToolCall,
+                output_schema: None,
+            }
+        }
+
+        fn invalid_params_error() -> zeph_tools::ToolError {
+            zeph_tools::ToolError::InvalidParams {
+                message: "path must be a string".to_owned(),
+            }
+        }
+
+        fn bad_tool_call() -> ToolCall {
+            let mut params = serde_json::Map::new();
+            params.insert("path".to_owned(), serde_json::json!(123));
+            ToolCall {
+                tool_id: zeph_common::ToolName::new("test_tool"),
+                params,
+                ..Default::default()
+            }
+        }
+
+        fn tool_use_request() -> zeph_llm::provider::ToolUseRequest {
+            zeph_llm::provider::ToolUseRequest {
+                id: "call-1".to_owned(),
+                name: "test_tool".to_owned().into(),
+                input: serde_json::json!({"path": 123}),
+            }
+        }
+
+        #[tokio::test]
+        async fn retries_with_corrected_arguments_on_success() {
+            let provider = mock_provider(vec![r#"{"arguments":{"path":"/corrected"}}"#.into()]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::new(vec![Ok(Some(zeph_tools::ToolOutput {
+                tool_name: "test_tool".to_owned().into(),
+                summary: "done".to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))])
+            .with_definitions(vec![test_tool_def()]);
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+
+            let tool_calls = vec![tool_use_request()];
+            let calls = vec![bad_tool_call()];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(invalid_params_error())];
+            let cancel = tokio_util::sync::CancellationToken::new();
+
+            agent
+                .handle_reformat_phase(&tool_calls, &calls, &mut tool_results, &cancel)
+                .await
+                .unwrap();
+
+            let output = tool_results
+                .remove(0)
+                .expect("reformat retry should succeed")
+                .expect("tool output should be present");
+            assert_eq!(output.summary, "done");
+        }
+
+        #[tokio::test]
+        async fn keeps_original_error_when_provider_returns_malformed_json() {
+            let provider = mock_provider(vec!["not json at all".into()]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor =
+                MockToolExecutor::new(vec![Ok(None)]).with_definitions(vec![test_tool_def()]);
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+
+            let tool_calls = vec![tool_use_request()];
+            let calls = vec![bad_tool_call()];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(invalid_params_error())];
+            let cancel = tokio_util::sync::CancellationToken::new();
+
+            agent
+                .handle_reformat_phase(&tool_calls, &calls, &mut tool_results, &cancel)
+                .await
+                .unwrap();
+
+            assert!(
+                matches!(
+                    tool_results[0],
+                    Err(zeph_tools::ToolError::InvalidParams { .. })
+                ),
+                "original error must be preserved on parse failure"
+            );
+        }
+
+        #[tokio::test]
+        async fn keeps_original_error_when_tool_schema_unknown() {
+            let provider = mock_provider(vec![r#"{"arguments":{"path":"/corrected"}}"#.into()]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            // No `with_definitions` — schema lookup for "test_tool" fails.
+            let executor = MockToolExecutor::new(vec![Ok(None)]);
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+
+            let tool_calls = vec![tool_use_request()];
+            let calls = vec![bad_tool_call()];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(invalid_params_error())];
+            let cancel = tokio_util::sync::CancellationToken::new();
+
+            agent
+                .handle_reformat_phase(&tool_calls, &calls, &mut tool_results, &cancel)
+                .await
+                .unwrap();
+
+            assert!(
+                matches!(
+                    tool_results[0],
+                    Err(zeph_tools::ToolError::InvalidParams { .. })
+                ),
+                "original error must be preserved when schema is unknown"
+            );
+        }
+
+        #[tokio::test]
+        async fn is_a_noop_when_provider_not_configured() {
+            let provider = mock_provider(vec![r#"{"arguments":{"path":"/corrected"}}"#.into()]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor =
+                MockToolExecutor::new(vec![Ok(None)]).with_definitions(vec![test_tool_def()]);
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            // parameter_reformat_provider left empty (default) — FR: disabled means no LLM call.
+
+            let tool_calls = vec![tool_use_request()];
+            let calls = vec![bad_tool_call()];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(invalid_params_error())];
+            let cancel = tokio_util::sync::CancellationToken::new();
+
+            agent
+                .handle_reformat_phase(&tool_calls, &calls, &mut tool_results, &cancel)
+                .await
+                .unwrap();
+
+            assert!(
+                matches!(
+                    tool_results[0],
+                    Err(zeph_tools::ToolError::InvalidParams { .. })
+                ),
+                "reformat must not run when parameter_reformat_provider is empty"
+            );
+        }
+
+        #[tokio::test]
+        async fn replaces_original_error_when_retry_still_fails() {
+            // FR-004: the retried outcome MUST replace tool_results[idx] even when the retry
+            // itself fails — the reformat phase gives up cleanly after a single attempt rather
+            // than looping, and never leaves the pre-reformat error in place.
+            let provider = mock_provider(vec![r#"{"arguments":{"path":"/still-bad"}}"#.into()]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::new(vec![Err(zeph_tools::ToolError::InvalidParams {
+                message: "still not a valid path".to_owned(),
+            })])
+            .with_definitions(vec![test_tool_def()]);
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+
+            let tool_calls = vec![tool_use_request()];
+            let calls = vec![bad_tool_call()];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(invalid_params_error())];
+            let cancel = tokio_util::sync::CancellationToken::new();
+
+            agent
+                .handle_reformat_phase(&tool_calls, &calls, &mut tool_results, &cancel)
+                .await
+                .unwrap();
+
+            match &tool_results[0] {
+                Err(zeph_tools::ToolError::InvalidParams { message }) => {
+                    assert_eq!(
+                        message, "still not a valid path",
+                        "the retried failure must replace the original error, not leave the \
+                         pre-reformat error in place"
+                    );
+                }
+                other => {
+                    panic!("expected the retried failure to replace the original, got {other:?}")
+                }
+            }
+        }
+
+        #[tokio::test]
+        async fn budget_exhausted_skips_remaining_calls_in_same_phase() {
+            // Regression test for the timing bug: `reformat_start` used to be recreated
+            // immediately before each per-call elapsed check, making the budget guard an
+            // effective no-op. It is now created once before the loop, so real time consumed
+            // by an earlier reformat call in the same phase counts against later calls' budget.
+            let provider = mock_provider(vec![
+                r#"{"arguments":{"path":"/corrected"}}"#.into(),
+                r#"{"arguments":{"path":"/corrected"}}"#.into(),
+            ]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::new(vec![Ok(Some(zeph_tools::ToolOutput {
+                tool_name: "test_tool".to_owned().into(),
+                summary: "done".to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))])
+            .with_definitions(vec![test_tool_def()])
+            // Consumes >1s of wall time on the first (only) dispatched retry, so the second
+            // tool call's budget check — using the same `reformat_start` — sees the whole-phase
+            // budget already exhausted.
+            .with_delay(1_100);
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+            agent.tool_orchestrator.max_retry_duration_secs = 1;
+
+            let tool_calls = vec![tool_use_request(), tool_use_request()];
+            let calls = vec![bad_tool_call(), bad_tool_call()];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(invalid_params_error()), Err(invalid_params_error())];
+            let cancel = tokio_util::sync::CancellationToken::new();
+
+            agent
+                .handle_reformat_phase(&tool_calls, &calls, &mut tool_results, &cancel)
+                .await
+                .unwrap();
+
+            assert!(
+                tool_results[0].is_ok(),
+                "first call is within budget and should be reformatted successfully"
+            );
+            assert!(
+                matches!(
+                    tool_results[1],
+                    Err(zeph_tools::ToolError::InvalidParams { .. })
+                ),
+                "second call must be skipped once the whole-phase budget is exhausted by the \
+                 first call's real elapsed time"
+            );
         }
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3290,13 +3290,23 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         }
 
         let agent = agent.with_orchestration(config.orchestration.clone(), agents_config, mgr);
-        if config.durable.enabled && config.durable.orchestration {
+        let agent = if config.durable.enabled && config.durable.orchestration {
             let durable_url = crate::commands::durable::resolve_durable_db_url(config);
             let cipher = crate::commands::durable::load_write_cipher(config)?;
             agent.with_durable_orchestration(config.durable.clone(), durable_url, cipher)
         } else {
             agent
-        }
+        };
+        // P1 agent-turn adapter (#5452): cheap stash only, no I/O — DurableContext is opened
+        // lazily by `ensure_session_durable_ctx` on the first turn.
+        let agent = if config.durable.enabled && config.durable.agent_turns {
+            let durable_url = crate::commands::durable::resolve_durable_db_url(config);
+            let cipher = crate::commands::durable::load_write_cipher(config)?;
+            agent.with_durable_agent_turns(config.durable.clone(), durable_url, cipher)
+        } else {
+            agent
+        };
+        agent.with_durable_subagent(config.durable.enabled && config.durable.subagent)
     };
     let agent = {
         let baseline = zeph_experiments::ConfigSnapshot::from_config(config);


### PR DESCRIPTION
## Summary

Two config toggles were fully plumbed through config/wizard/builder but never actually did anything at their consuming call site — the same "dead-code wiring" defect class as #5432/#5448/#5451.

- **#5452** — `[durable] agent_turns`/`subagent` never populated `services.session.durable_ctx`/`durable_subagent`, so every agent turn and subagent spawn silently skipped the durable journal regardless of config.
- **#5453** — `tools.retry.parameter_reformat_provider` resolved correctly through config, the `--init` wizard, `SessionConfig`, and the builder, but `handle_reformat_phase` never called an LLM — it only logged a warning. The budget-check guard was also a no-op (`Instant::now()` recreated immediately before each elapsed check).

## Changes

- New `crates/zeph-core/src/agent/durable_bootstrap.rs`: lazy, session-scoped `DurableContext` construction (`Agent::ensure_session_durable_ctx`), extracted `open_durable_backend` helper shared with the existing P2 orchestration adapter (`plan.rs`), and `reset_durable_ctx_for_conversation_switch` so `/new` and `/conv resume`/`/conv fork` correctly rebind the durable execution to the new conversation rather than leaking the old one's `ExecutionId`.
- `AgentBuilder::with_durable_agent_turns`/`with_durable_subagent` wired in `src/runner.rs` alongside the existing `with_durable_orchestration`.
- `shutdown.rs` flushes/aborts the new P1 writer alongside the existing P2 one.
- Rewrote `handle_reformat_phase` + new `reformat_tool_call` in `tier_loop.rs`: resolves `parameter_reformat_provider` via the existing `resolve_background_provider` registry lookup, requests corrected arguments for the failed tool call, retries once. Decoupled the per-call timeout from the phase-budget's zero-means-unlimited sentinel (was collapsing to a useless 1-second timeout when `max_retry_duration_secs = 0`).
- 13 new unit tests across `durable_bootstrap.rs`, `tier_loop.rs`, and `subagent_commands.rs` (previously untested).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci -p zeph-core -p zeph-config -p zeph-subagent --all-targets -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11708 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Adversarial critique pass (found and fixed a significant conversation-switch staleness bug; verified two independent SQLite connections to the shared `durable.db` are safe under WAL mode)
- [x] Independent code review pass (approved; re-ran full verification suite, confirmed line-level correctness of both fixes)
- [ ] Live-session verification (Scenario 4/5 in `.local/testing/playbooks/durable.md`) — deferred to a separate live-tester/CI session per this project's dev/CI separation convention

A follow-up issue will be filed for a non-blocking edge case found in final review: an unresolvable `parameter_reformat_provider` name currently falls back to the primary provider (matching the existing `compress_provider` convention) rather than no-op'ing, which contradicts one written acceptance criterion in spec-040 — the spec has an internal contradiction between its reference-pattern instruction and its stated criterion that needs an explicit decision, not a silent fix.