### PR TITLE
refactor(mcp): extract shared rmcp Tool -> McpTool conversion helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,6 +489,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(mcp)`: extract shared `rmcp_tool_to_mcp_tool` helper (`crates/zeph-mcp/src/client.rs`)
+  for converting an rmcp `tools/list` entry into `McpTool`, replacing two byte-for-byte identical
+  inline closures in `ToolListChangedHandler::on_tool_list_changed` (background refresh path) and
+  `McpClient::list_tools` (initial connect / manual list path). No behavior change. Closes #5479.
 - `feat(cli)!`: `zeph sessions resume <id>` no longer dumps events to stdout by default (spec-068,
   #5343) — it now launches a **live interactive agent** bound to that session's conversation,
   replaying its JSONL event log to reconstruct history before accepting the next prompt (spec §10,

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -56,6 +56,31 @@ impl CredentialStore for ArcCredentialStore {
 /// Maximum number of tools accepted from a single server on refresh.
 const MAX_TOOLS_PER_SERVER: usize = 100;
 
+/// Convert a raw rmcp `tools/list` entry into the crate's `McpTool` representation.
+///
+/// Shared by the background `tools/list_changed` refresh path and the manual/initial
+/// `McpClient::list_tools` call so both stay byte-for-byte identical.
+fn rmcp_tool_to_mcp_tool(server_id: &str, tool: rmcp::model::Tool) -> McpTool {
+    let output_schema = tool.output_schema.as_ref().map(|s| {
+        let val = serde_json::to_value(s.as_ref()).unwrap_or_default();
+        tracing::debug!(
+            server_id = %server_id,
+            tool = %tool.name,
+            event = "mcp.output_schema.captured",
+            "MCP tool advertises output schema"
+        );
+        val
+    });
+    McpTool {
+        server_id: server_id.to_owned(),
+        name: tool.name.to_string(),
+        description: tool.description.map_or_else(String::new, |d| d.to_string()),
+        input_schema: serde_json::to_value(&*tool.input_schema).unwrap_or_default(),
+        output_schema,
+        security_meta: crate::tool::ToolSecurityMeta::default(),
+    }
+}
+
 /// Event sent from `ToolListChangedHandler` to `McpManager`'s refresh task.
 pub struct ToolRefreshEvent {
     pub server_id: String,
@@ -276,26 +301,7 @@ impl rmcp::ClientHandler for ToolListChangedHandler {
         // Convert to McpTool.
         let tools: Vec<McpTool> = capped
             .into_iter()
-            .map(|t| {
-                let output_schema = t.output_schema.as_ref().map(|s| {
-                    let val = serde_json::to_value(s.as_ref()).unwrap_or_default();
-                    tracing::debug!(
-                        server_id = %self.server_id,
-                        tool = %t.name,
-                        event = "mcp.output_schema.captured",
-                        "MCP tool advertises output schema"
-                    );
-                    val
-                });
-                McpTool {
-                    server_id: self.server_id.clone(),
-                    name: t.name.to_string(),
-                    description: t.description.map_or_else(String::new, |d| d.to_string()),
-                    input_schema: serde_json::to_value(&*t.input_schema).unwrap_or_default(),
-                    output_schema,
-                    security_meta: crate::tool::ToolSecurityMeta::default(),
-                }
-            })
+            .map(|t| rmcp_tool_to_mcp_tool(&self.server_id, t))
             .collect();
 
         // Update rate-limit timestamp only after a successful refresh.
@@ -845,26 +851,7 @@ impl McpClient {
 
         Ok(tools
             .into_iter()
-            .map(|t| {
-                let output_schema = t.output_schema.as_ref().map(|s| {
-                    let val = serde_json::to_value(s.as_ref()).unwrap_or_default();
-                    tracing::debug!(
-                        server_id = %self.server_id,
-                        tool = %t.name,
-                        event = "mcp.output_schema.captured",
-                        "MCP tool advertises output schema"
-                    );
-                    val
-                });
-                McpTool {
-                    server_id: self.server_id.clone(),
-                    name: t.name.to_string(),
-                    description: t.description.map_or_else(String::new, |d| d.to_string()),
-                    input_schema: serde_json::to_value(&*t.input_schema).unwrap_or_default(),
-                    output_schema,
-                    security_meta: crate::tool::ToolSecurityMeta::default(),
-                }
-            })
+            .map(|t| rmcp_tool_to_mcp_tool(&self.server_id, t))
             .collect())
     }
 


### PR DESCRIPTION
## Summary
- `crates/zeph-mcp/src/client.rs` converted an rmcp `tools/list` `Tool` into `McpTool` with byte-for-byte identical logic in two places: `ToolListChangedHandler::on_tool_list_changed` (background refresh path) and `McpClient::list_tools` (initial connect / manual list path).
- Extracted the duplicated logic into a single `rmcp_tool_to_mcp_tool(server_id: &str, tool: rmcp::model::Tool) -> McpTool` helper, called from both sites. Pure mechanical refactor, no behavior change.
- This is the same duplication pattern already fixed elsewhere this cycle (#5470/#5471 in zeph-orchestration, #5475 in zeph-subagent) — a second inline copy that silently required remembering to update both sites on any future change.

Closes #5479

## Test plan
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci -p zeph-mcp --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-mcp` — 490/490 passed
- [x] Adversarial critique (rust-critic): verified byte-for-byte behavioral equivalence at both call sites (server_id sourcing, tracing fields, ownership, surrounding rate-limit/timeout logic untouched); confirmed no third duplicate copy exists in the codebase
- [x] Code review approved
- [ ] Note: a follow-up could add a focused unit test asserting all `McpTool` fields directly on `rmcp_tool_to_mcp_tool` (currently covered indirectly via `duplex_round_trip_covers_all_content_block_variants`, a real wire round-trip test with name-only assertions); reviewer assessed this as non-blocking since the gap pre-dates this refactor and is not introduced by it