### PR TITLE
fix(memory): guard Qdrant gRPC calls with timeout, dedupe EmbeddingStore payload logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,6 +580,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   turn. Also extracted a shared `append_budgeted_lines` helper for the byte-identical
   greedy-budget-accumulation loop duplicated across `fetch_persona_facts`,
   `fetch_trajectory_hints`, and `fetch_tree_memory` (#5482).
+- `fix(memory)`: no Qdrant gRPC operation in `zeph-memory` (`ensure_collection`,
+  `collection_exists`, `delete_collection`, `upsert`, `search`, `delete_by_ids`, `scroll_all`,
+  `scroll_all_with_point_ids`, `ensure_collection_with_quantization`, `health_check`,
+  `create_keyword_indexes`, `get_points`) had a timeout guard, so a slow or hung Qdrant server
+  could block the calling async task indefinitely, violating the mandatory Await Discipline rule
+  (#5484). `QdrantOps` now wraps every underlying gRPC call through a shared `timed` helper with a
+  10-second default (`QdrantOps::with_timeout` overrides it), converting an elapsed timeout into
+  `QdrantError::Io` so existing `Result<T, Box<QdrantError>>` call sites need no signature change.
+  Also replaced a duplicate inline `collection_info` dimension-extraction in
+  `EmbeddingRegistry::ensure_collection` with a call to the already-timeout-guarded
+  `QdrantOps::get_collection_vector_size`.
+- `fix(memory)`: `EmbeddingStore::store`, `store_with_tool_context`, and `store_with_category` each
+  duplicated the point-id/dimensions/base-payload construction and the `embeddings_metadata`
+  upsert SQL, having drifted independently three times (#5486). Factored the shared logic into a
+  private `store_impl` helper parameterized by a `StoreExtra` enum carrying each variant's
+  differing payload fields (tool metadata, category, or none); the three public methods'
+  signatures are unchanged.
 - `fix(session)`: two `init_session_sink`/resume hydration bugs found during code review of
   PR #5454 (default CLI continuation hydration fix). `init_session_sink` (`src/runner.rs`)
   resolved whether a session was already linked to the conversation via

--- a/crates/zeph-memory/src/embedding_registry.rs
+++ b/crates/zeph-memory/src/embedding_registry.rs
@@ -435,23 +435,11 @@ impl EmbeddingRegistry {
 
         let existing_size = self
             .ops
-            .client()
-            .collection_info(&self.collection)
+            .get_collection_vector_size(&self.collection)
             .await
             .map_err(|e| {
                 EmbeddingRegistryError::VectorStore(VectorStoreError::Collection(e.to_string()))
-            })?
-            .result
-            .and_then(|info| info.config)
-            .and_then(|cfg| cfg.params)
-            .and_then(|params| params.vectors_config)
-            .and_then(|vc| vc.config)
-            .and_then(|cfg| match cfg {
-                qdrant_client::qdrant::vectors_config::Config::Params(vp) => Some(vp.size),
-                // Named-vector collections (ParamsMap) are not supported by this registry;
-                // treat size as unknown and recreate to ensure a compatible single-vector layout.
-                qdrant_client::qdrant::vectors_config::Config::ParamsMap(_) => None,
-            });
+            })?;
 
         let vector_size = probe_dimension(embed_fn).await?;
 

--- a/crates/zeph-memory/src/embedding_store.rs
+++ b/crates/zeph-memory/src/embedding_store.rs
@@ -100,6 +100,24 @@ pub struct SearchResult {
     pub score: f32,
 }
 
+/// Extra Qdrant payload fields specific to one of the `store*` variants (#5486).
+///
+/// Passed to [`EmbeddingStore::store_impl`], which owns the point-id/dimensions/base-payload
+/// construction and `embeddings_metadata` upsert shared by [`EmbeddingStore::store`],
+/// [`EmbeddingStore::store_with_tool_context`], and [`EmbeddingStore::store_with_category`].
+enum StoreExtra<'a> {
+    /// No extra payload fields (plain [`EmbeddingStore::store`]).
+    None,
+    /// `category` field for category-aware memory (#2428).
+    Category(Option<&'a str>),
+    /// Tool execution metadata fields.
+    ToolContext {
+        tool_name: &'a str,
+        exit_code: Option<i32>,
+        timestamp: Option<&'a str>,
+    },
+}
+
 impl EmbeddingStore {
     /// Create a new `EmbeddingStore` connected to the given Qdrant URL with optional API key.
     ///
@@ -231,54 +249,21 @@ impl EmbeddingStore {
         exit_code: Option<i32>,
         timestamp: Option<&str>,
     ) -> Result<String, MemoryError> {
-        let point_id = uuid::Uuid::new_v4().to_string();
-        let dimensions = i64::try_from(vector.len())?;
-
-        let mut payload = std::collections::HashMap::from([
-            ("message_id".to_owned(), serde_json::json!(message_id.0)),
-            (
-                "conversation_id".to_owned(),
-                serde_json::json!(conversation_id.0),
-            ),
-            ("role".to_owned(), serde_json::json!(role)),
-            (
-                "is_summary".to_owned(),
-                serde_json::json!(kind.is_summary()),
-            ),
-            ("tool_name".to_owned(), serde_json::json!(tool_name)),
-        ]);
-        if let Some(code) = exit_code {
-            payload.insert("exit_code".to_owned(), serde_json::json!(code));
-        }
-        if let Some(ts) = timestamp {
-            payload.insert("timestamp".to_owned(), serde_json::json!(ts));
-        }
-
-        let point = VectorPoint {
-            id: point_id.clone(),
+        self.store_impl(
+            message_id,
+            conversation_id,
+            role,
             vector,
-            payload,
-        };
-
-        self.ops.upsert(&self.collection, vec![point]).await?;
-
-        let chunk_index_i64 = i64::from(chunk_index);
-        zeph_db::query(sql!(
-            "INSERT INTO embeddings_metadata \
-             (message_id, chunk_index, qdrant_point_id, dimensions, model) \
-             VALUES (?, ?, ?, ?, ?) \
-             ON CONFLICT(message_id, chunk_index, model) DO UPDATE SET \
-             qdrant_point_id = excluded.qdrant_point_id, dimensions = excluded.dimensions"
-        ))
-        .bind(message_id)
-        .bind(chunk_index_i64)
-        .bind(&point_id)
-        .bind(dimensions)
-        .bind(model)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(point_id)
+            kind,
+            model,
+            chunk_index,
+            StoreExtra::ToolContext {
+                tool_name,
+                exit_code,
+                timestamp,
+            },
+        )
+        .await
     }
 
     /// Store a vector in Qdrant and persist metadata to `SQLite`.
@@ -303,47 +288,17 @@ impl EmbeddingStore {
         model: &str,
         chunk_index: u32,
     ) -> Result<String, MemoryError> {
-        let point_id = uuid::Uuid::new_v4().to_string();
-        let dimensions = i64::try_from(vector.len())?;
-
-        let payload = std::collections::HashMap::from([
-            ("message_id".to_owned(), serde_json::json!(message_id.0)),
-            (
-                "conversation_id".to_owned(),
-                serde_json::json!(conversation_id.0),
-            ),
-            ("role".to_owned(), serde_json::json!(role)),
-            (
-                "is_summary".to_owned(),
-                serde_json::json!(kind.is_summary()),
-            ),
-        ]);
-
-        let point = VectorPoint {
-            id: point_id.clone(),
+        self.store_impl(
+            message_id,
+            conversation_id,
+            role,
             vector,
-            payload,
-        };
-
-        self.ops.upsert(&self.collection, vec![point]).await?;
-
-        let chunk_index_i64 = i64::from(chunk_index);
-        zeph_db::query(sql!(
-            "INSERT INTO embeddings_metadata \
-             (message_id, chunk_index, qdrant_point_id, dimensions, model) \
-             VALUES (?, ?, ?, ?, ?) \
-             ON CONFLICT(message_id, chunk_index, model) DO UPDATE SET \
-             qdrant_point_id = excluded.qdrant_point_id, dimensions = excluded.dimensions"
-        ))
-        .bind(message_id)
-        .bind(chunk_index_i64)
-        .bind(&point_id)
-        .bind(dimensions)
-        .bind(model)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(point_id)
+            kind,
+            model,
+            chunk_index,
+            StoreExtra::None,
+        )
+        .await
     }
 
     /// Store a vector with an optional category tag in the Qdrant payload.
@@ -372,6 +327,34 @@ impl EmbeddingStore {
         chunk_index: u32,
         category: Option<&str>,
     ) -> Result<String, MemoryError> {
+        self.store_impl(
+            message_id,
+            conversation_id,
+            role,
+            vector,
+            kind,
+            model,
+            chunk_index,
+            StoreExtra::Category(category),
+        )
+        .await
+    }
+
+    /// Shared point-id/dimensions/base-payload construction and `embeddings_metadata` upsert
+    /// for [`Self::store`], [`Self::store_with_tool_context`], and [`Self::store_with_category`]
+    /// (#5486). `extra` supplies the payload fields that differ between the three callers.
+    #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
+    async fn store_impl(
+        &self,
+        message_id: MessageId,
+        conversation_id: ConversationId,
+        role: &str,
+        vector: Vec<f32>,
+        kind: MessageKind,
+        model: &str,
+        chunk_index: u32,
+        extra: StoreExtra<'_>,
+    ) -> Result<String, MemoryError> {
         let point_id = uuid::Uuid::new_v4().to_string();
         let dimensions = i64::try_from(vector.len())?;
 
@@ -387,8 +370,26 @@ impl EmbeddingStore {
                 serde_json::json!(kind.is_summary()),
             ),
         ]);
-        if let Some(cat) = category {
-            payload.insert("category".to_owned(), serde_json::json!(cat));
+        match extra {
+            StoreExtra::None => {}
+            StoreExtra::Category(category) => {
+                if let Some(cat) = category {
+                    payload.insert("category".to_owned(), serde_json::json!(cat));
+                }
+            }
+            StoreExtra::ToolContext {
+                tool_name,
+                exit_code,
+                timestamp,
+            } => {
+                payload.insert("tool_name".to_owned(), serde_json::json!(tool_name));
+                if let Some(code) = exit_code {
+                    payload.insert("exit_code".to_owned(), serde_json::json!(code));
+                }
+                if let Some(ts) = timestamp {
+                    payload.insert("timestamp".to_owned(), serde_json::json!(ts));
+                }
+            }
         }
 
         let point = VectorPoint {
@@ -995,6 +996,116 @@ mod tests {
         assert_eq!(results[0].message_id, msg_id);
         assert_eq!(results[0].conversation_id, cid);
         assert!((results[0].score - 1.0).abs() < 0.001);
+    }
+
+    /// `store_with_category` must write a `category` payload field when given `Some` (#5486
+    /// shared `store_impl` helper must preserve this variant's distinguishing behavior).
+    #[tokio::test]
+    async fn embedding_store_store_with_category_sets_payload_field() {
+        let (store, sqlite) = setup_with_store().await;
+        let cid = sqlite.create_conversation().await.unwrap();
+        let msg_id = sqlite.save_message(cid, "user", "cat test").await.unwrap();
+
+        store
+            .store_with_category(
+                msg_id,
+                cid,
+                "user",
+                vec![1.0, 0.0, 0.0, 0.0],
+                MessageKind::Regular,
+                "test-model",
+                0,
+                Some("preference"),
+            )
+            .await
+            .unwrap();
+
+        let results = store
+            .search_collection(COLLECTION_NAME, &[1.0, 0.0, 0.0, 0.0], 1, None)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].payload.get("category").and_then(|v| v.as_str()),
+            Some("preference")
+        );
+    }
+
+    /// `store_with_category(None)` must omit the `category` field entirely (no false positives
+    /// on category filters for pre-existing memories).
+    #[tokio::test]
+    async fn embedding_store_store_with_category_none_omits_payload_field() {
+        let (store, sqlite) = setup_with_store().await;
+        let cid = sqlite.create_conversation().await.unwrap();
+        let msg_id = sqlite.save_message(cid, "user", "no cat").await.unwrap();
+
+        store
+            .store_with_category(
+                msg_id,
+                cid,
+                "user",
+                vec![0.0, 1.0, 0.0, 0.0],
+                MessageKind::Regular,
+                "m",
+                0,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let results = store
+            .search_collection(COLLECTION_NAME, &[0.0, 1.0, 0.0, 0.0], 1, None)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].payload.contains_key("category"));
+    }
+
+    /// `store_with_tool_context` must write `tool_name`, `exit_code`, and `timestamp` payload
+    /// fields (#5486 shared `store_impl` helper must preserve this variant's fields).
+    #[tokio::test]
+    async fn embedding_store_store_with_tool_context_sets_payload_fields() {
+        let (store, sqlite) = setup_with_store().await;
+        let cid = sqlite.create_conversation().await.unwrap();
+        let msg_id = sqlite
+            .save_message(cid, "assistant", "ran a tool")
+            .await
+            .unwrap();
+
+        store
+            .store_with_tool_context(
+                msg_id,
+                cid,
+                "assistant",
+                vec![0.0, 0.0, 1.0, 0.0],
+                MessageKind::Regular,
+                "m",
+                0,
+                "shell",
+                Some(0),
+                Some("2026-07-02T00:00:00Z"),
+            )
+            .await
+            .unwrap();
+
+        let results = store
+            .search_collection(COLLECTION_NAME, &[0.0, 0.0, 1.0, 0.0], 1, None)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        let payload = &results[0].payload;
+        assert_eq!(
+            payload.get("tool_name").and_then(|v| v.as_str()),
+            Some("shell")
+        );
+        assert_eq!(
+            payload.get("exit_code").and_then(serde_json::Value::as_i64),
+            Some(0)
+        );
+        assert_eq!(
+            payload.get("timestamp").and_then(|v| v.as_str()),
+            Some("2026-07-02T00:00:00Z")
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -75,6 +75,10 @@ impl QdrantOps {
     /// Defaults to 10 seconds. A slow or hung Qdrant server would otherwise block the
     /// calling async task indefinitely (#5484).
     ///
+    /// TODO(#5493): no production call site invokes this yet — the timeout is currently
+    /// hardcoded to the default rather than config-driven. Wire a config field through
+    /// `zeph-config`/bootstrap and call this from there.
+    ///
     /// # Examples
     ///
     /// ```
@@ -92,6 +96,13 @@ impl QdrantOps {
     }
 
     /// Access the underlying Qdrant client for advanced operations.
+    ///
+    /// # Warning
+    ///
+    /// Calls made directly through the returned client bypass the [`Self::with_timeout`]
+    /// guard (#5484) — they are not wrapped by [`Self::timed`]. Prefer the inherent
+    /// `QdrantOps` methods, which are all timeout-guarded, unless the client exposes an
+    /// operation this type does not wrap.
     #[must_use]
     pub fn client(&self) -> &Qdrant {
         &self.client

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -8,6 +8,9 @@
 //! [`crate::embedding_registry::EmbeddingRegistry`]) route through this type.
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
 
 use crate::vector_store::BoxFuture;
 use qdrant_client::Qdrant;
@@ -20,15 +23,25 @@ use qdrant_client::qdrant::{
 
 type QdrantResult<T> = Result<T, Box<qdrant_client::QdrantError>>;
 
+/// Default per-call timeout applied to every Qdrant gRPC operation (#5484).
+///
+/// Qdrant calls normally complete in well under a second; 10s bounds the await against a
+/// hung server or a stalled network path without misfiring on ordinary load spikes.
+/// Override via [`QdrantOps::with_timeout`].
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Thin wrapper over [`Qdrant`] client encapsulating common collection operations.
 #[derive(Clone)]
 pub struct QdrantOps {
     client: Qdrant,
+    timeout: Duration,
 }
 
 impl std::fmt::Debug for QdrantOps {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("QdrantOps").finish_non_exhaustive()
+        f.debug_struct("QdrantOps")
+            .field("timeout", &self.timeout)
+            .finish_non_exhaustive()
     }
 }
 
@@ -51,13 +64,61 @@ impl QdrantOps {
             builder = builder.api_key(key.trim());
         }
         let client = builder.build().map_err(Box::new)?;
-        Ok(Self { client })
+        Ok(Self {
+            client,
+            timeout: DEFAULT_TIMEOUT,
+        })
+    }
+
+    /// Override the per-call timeout applied to every Qdrant gRPC operation.
+    ///
+    /// Defaults to 10 seconds. A slow or hung Qdrant server would otherwise block the
+    /// calling async task indefinitely (#5484).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use zeph_memory::QdrantOps;
+    ///
+    /// let ops = QdrantOps::new("http://localhost:6334", None)
+    ///     .unwrap()
+    ///     .with_timeout(Duration::from_secs(3));
+    /// ```
+    #[must_use]
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
     }
 
     /// Access the underlying Qdrant client for advanced operations.
     #[must_use]
     pub fn client(&self) -> &Qdrant {
         &self.client
+    }
+
+    /// Run a Qdrant gRPC future under the configured [`Self::with_timeout`] bound.
+    ///
+    /// Converts an elapsed timeout into `QdrantError::Io` so every existing call site
+    /// (which already returns `Result<T, Box<QdrantError>>`) needs no signature change.
+    ///
+    /// Takes a boxed future (rather than `impl Future`) so the timeout wrapper does not
+    /// inline the callee's gRPC future type into every caller's generated state machine —
+    /// with a generic parameter, that inlining compounds at each layer of async call
+    /// nesting and trips `clippy::large_futures` across the whole call chain.
+    async fn timed<T>(
+        &self,
+        fut: Pin<Box<dyn Future<Output = Result<T, qdrant_client::QdrantError>> + Send + '_>>,
+    ) -> QdrantResult<T> {
+        match tokio::time::timeout(self.timeout, fut).await {
+            Ok(result) => result.map_err(Box::new),
+            Err(_) => Err(Box::new(qdrant_client::QdrantError::Io(
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("Qdrant gRPC call exceeded {:?}", self.timeout),
+                ),
+            ))),
+        }
     }
 
     /// Ensure a collection exists with cosine distance vectors.
@@ -75,10 +136,8 @@ impl QdrantOps {
     #[tracing::instrument(name = "memory.qdrant.ensure_collection", skip_all, err)]
     pub async fn ensure_collection(&self, collection: &str, vector_size: u64) -> QdrantResult<()> {
         if self
-            .client
-            .collection_exists(collection)
-            .await
-            .map_err(Box::new)?
+            .timed(Box::pin(self.client.collection_exists(collection)))
+            .await?
         {
             let existing_size = self.get_collection_vector_size(collection).await?;
             if existing_size == Some(vector_size) {
@@ -90,18 +149,16 @@ impl QdrantOps {
                 required = vector_size,
                 "vector dimension mismatch — recreating collection (existing data will be lost)"
             );
-            self.client
-                .delete_collection(collection)
-                .await
-                .map_err(Box::new)?;
+            self.timed(Box::pin(self.client.delete_collection(collection)))
+                .await?;
         }
-        self.client
-            .create_collection(
+        self.timed(Box::pin(
+            self.client.create_collection(
                 CreateCollectionBuilder::new(collection)
                     .vectors_config(VectorParamsBuilder::new(vector_size, Distance::Cosine)),
-            )
-            .await
-            .map_err(Box::new)?;
+            ),
+        ))
+        .await?;
         Ok(())
     }
 
@@ -136,10 +193,8 @@ impl QdrantOps {
     )]
     pub async fn get_collection_vector_size(&self, collection: &str) -> QdrantResult<Option<u64>> {
         let info = self
-            .client
-            .collection_info(collection)
-            .await
-            .map_err(Box::new)?;
+            .timed(Box::pin(self.client.collection_info(collection)))
+            .await?;
         let size = info
             .result
             .and_then(|r| r.config)
@@ -161,10 +216,8 @@ impl QdrantOps {
     /// Returns an error if Qdrant cannot be reached.
     #[tracing::instrument(name = "memory.qdrant.collection_exists", skip_all, err)]
     pub async fn collection_exists(&self, collection: &str) -> QdrantResult<bool> {
-        self.client
-            .collection_exists(collection)
+        self.timed(Box::pin(self.client.collection_exists(collection)))
             .await
-            .map_err(Box::new)
     }
 
     /// Delete a collection.
@@ -174,10 +227,8 @@ impl QdrantOps {
     /// Returns an error if the collection cannot be deleted.
     #[tracing::instrument(name = "memory.qdrant.delete_collection", skip_all, err)]
     pub async fn delete_collection(&self, collection: &str) -> QdrantResult<()> {
-        self.client
-            .delete_collection(collection)
-            .await
-            .map_err(Box::new)?;
+        self.timed(Box::pin(self.client.delete_collection(collection)))
+            .await?;
         Ok(())
     }
 
@@ -188,10 +239,10 @@ impl QdrantOps {
     /// Returns an error if the upsert fails.
     #[tracing::instrument(name = "memory.qdrant.upsert", skip_all, err)]
     pub async fn upsert(&self, collection: &str, points: Vec<PointStruct>) -> QdrantResult<()> {
-        self.client
-            .upsert_points(UpsertPointsBuilder::new(collection, points).wait(true))
-            .await
-            .map_err(Box::new)?;
+        self.timed(Box::pin(self.client.upsert_points(
+            UpsertPointsBuilder::new(collection, points).wait(true),
+        )))
+        .await?;
         Ok(())
     }
 
@@ -218,7 +269,7 @@ impl QdrantOps {
         if let Some(f) = filter {
             builder = builder.filter(f);
         }
-        let results = self.client.query(builder).await.map_err(Box::new)?;
+        let results = self.timed(Box::pin(self.client.query(builder))).await?;
         Ok(results.result)
     }
 
@@ -232,14 +283,14 @@ impl QdrantOps {
         if ids.is_empty() {
             return Ok(());
         }
-        self.client
-            .delete_points(
+        self.timed(Box::pin(
+            self.client.delete_points(
                 DeletePointsBuilder::new(collection)
                     .points(PointsIdsList { ids })
                     .wait(true),
-            )
-            .await
-            .map_err(Box::new)?;
+            ),
+        ))
+        .await?;
         Ok(())
     }
 
@@ -269,7 +320,7 @@ impl QdrantOps {
                 builder = builder.offset(off.clone());
             }
 
-            let response = self.client.scroll(builder).await.map_err(Box::new)?;
+            let response = self.timed(Box::pin(self.client.scroll(builder))).await?;
 
             for point in &response.result {
                 let Some(key_val) = point.payload.get(key_field) else {
@@ -324,7 +375,7 @@ impl QdrantOps {
                 builder = builder.offset(off.clone());
             }
 
-            let response = self.client.scroll(builder).await.map_err(Box::new)?;
+            let response = self.timed(Box::pin(self.client.scroll(builder))).await?;
 
             for point in &response.result {
                 let Some(key_val) = point.payload.get(key_field) else {
@@ -379,8 +430,7 @@ impl QdrantOps {
             CreateFieldIndexCollectionBuilder, FieldType, ScalarQuantizationBuilder,
         };
         if self
-            .client
-            .collection_exists(collection)
+            .timed(Box::pin(self.client.collection_exists(collection)))
             .await
             .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?
         {
@@ -397,29 +447,26 @@ impl QdrantOps {
                 required = vector_size,
                 "vector dimension mismatch — recreating collection (existing data will be lost)"
             );
-            self.client
-                .delete_collection(collection)
+            self.timed(Box::pin(self.client.delete_collection(collection)))
                 .await
                 .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?;
         }
-        self.client
-            .create_collection(
+        self.timed(Box::pin(
+            self.client.create_collection(
                 CreateCollectionBuilder::new(collection)
                     .vectors_config(VectorParamsBuilder::new(vector_size, Distance::Cosine))
                     .quantization_config(ScalarQuantizationBuilder::default()),
-            )
-            .await
-            .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?;
+            ),
+        ))
+        .await
+        .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?;
 
         for field in keyword_fields {
-            self.client
-                .create_field_index(CreateFieldIndexCollectionBuilder::new(
-                    collection,
-                    *field,
-                    FieldType::Keyword,
-                ))
-                .await
-                .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?;
+            self.timed(Box::pin(self.client.create_field_index(
+                CreateFieldIndexCollectionBuilder::new(collection, *field, FieldType::Keyword),
+            )))
+            .await
+            .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?;
         }
         Ok(())
     }
@@ -564,7 +611,7 @@ impl crate::vector_store::VectorStore for QdrantOps {
         use tracing::Instrument as _;
         Box::pin(
             async move {
-                match self.client.health_check().await {
+                match self.timed(Box::pin(self.client.health_check())).await {
                     Ok(_) => Ok(true),
                     Err(e) => {
                         tracing::warn!(err = %e, "health_check failed");
@@ -588,14 +635,15 @@ impl crate::vector_store::VectorStore for QdrantOps {
         Box::pin(
             async move {
                 for field in &fields {
-                    self.client
-                        .create_field_index(CreateFieldIndexCollectionBuilder::new(
+                    self.timed(Box::pin(self.client.create_field_index(
+                        CreateFieldIndexCollectionBuilder::new(
                             &collection,
                             field.as_str(),
                             FieldType::Keyword,
-                        ))
-                        .await
-                        .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?;
+                        ),
+                    )))
+                    .await
+                    .map_err(|e| crate::VectorStoreError::Collection(e.to_string()))?;
                 }
                 Ok(())
             }
@@ -617,12 +665,13 @@ impl crate::vector_store::VectorStore for QdrantOps {
                 }
                 let point_ids: Vec<PointId> = ids.into_iter().map(PointId::from).collect();
                 let response = self
-                    .client
-                    .get_points(
-                        GetPointsBuilder::new(&collection, point_ids)
-                            .with_vectors(true)
-                            .with_payload(true),
-                    )
+                    .timed(Box::pin(
+                        self.client.get_points(
+                            GetPointsBuilder::new(&collection, point_ids)
+                                .with_vectors(true)
+                                .with_payload(true),
+                        ),
+                    ))
                     .await
                     .map_err(|e| {
                         tracing::error!(err = %e, "get_points failed");
@@ -767,6 +816,36 @@ mod tests {
     fn new_with_api_key_constructs_successfully() {
         let result = QdrantOps::new("http://127.0.0.1:9999", Some("valid-key"));
         assert!(result.is_ok(), "valid key must not cause a build error");
+    }
+
+    /// `new` must apply [`DEFAULT_TIMEOUT`] and [`QdrantOps::with_timeout`] must override it
+    /// (#5484). The override is observable via the `Debug` impl since `timeout` is private.
+    #[test]
+    fn with_timeout_overrides_default() {
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
+        assert!(format!("{ops:?}").contains("10s"), "default must be 10s");
+
+        let ops = ops.with_timeout(Duration::from_secs(2));
+        assert!(
+            format!("{ops:?}").contains("2s"),
+            "with_timeout must override the default"
+        );
+    }
+
+    /// `timed` must return an error instead of hanging forever when the wrapped future never
+    /// resolves — the core guarantee of #5484.
+    #[tokio::test]
+    async fn timed_returns_error_instead_of_hanging() {
+        let ops = QdrantOps::new("http://localhost:6334", None)
+            .unwrap()
+            .with_timeout(Duration::from_millis(10));
+
+        let never_resolves: Pin<
+            Box<dyn Future<Output = Result<(), qdrant_client::QdrantError>> + Send>,
+        > = Box::pin(std::future::pending());
+
+        let result = ops.timed(never_resolves).await;
+        assert!(result.is_err(), "must time out instead of hanging forever");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wraps every Qdrant gRPC call in `QdrantOps` (ensure_collection, collection_exists, delete_collection, upsert, search, delete_by_ids, both scroll_all variants, ensure_collection_with_quantization, health_check, create_keyword_indexes, get_points) in a bounded `tokio::time::timeout` (10s default, `with_timeout()` override), converting an elapsed timeout into `QdrantError::Io` instead of letting a slow/hung Qdrant server block the calling async task indefinitely. Closes #5484.
- Factors the triple-duplicated point-id/dimensions/base-payload construction and `embeddings_metadata` upsert SQL out of `EmbeddingStore::store`, `store_with_tool_context`, and `store_with_category` into a shared private `store_impl` helper parameterized by a `StoreExtra` enum. Public signatures unchanged. Closes #5486.
- Replaces a duplicate inline `collection_info` dimension-extraction in `EmbeddingRegistry::ensure_collection` with a call to the now-guarded `QdrantOps::get_collection_vector_size`.

## Notes

- The timeout duration is intentionally not wired through `config.toml`/bootstrap in this PR (scoped to `crates/zeph-memory` only); `with_timeout()` is the extension point. Follow-up tracked in #5493.
- Testing playbook (`playbooks/qdrant-backend.md`, Scenarios 6-7) and `coverage-status.md` rows added in the main repo per project convention.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11735 passed, 1 leaky matching baseline)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-memory`
- [x] Adversarial critique verified `StoreExtra`/`store_impl` refactor is byte-for-byte equivalent to the original three methods
- [x] New unit tests cover the timeout path (`timed_returns_error_instead_of_hanging`) and all three `store*` variants through `store_impl`

Closes #5486, closes #5484.