### PR TITLE
fix(memory): route all raw and mis-numbered SQL through sql!() for Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1181,6 +1181,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   brand-new conversation with no linked session yet still falls back to a bare log open since there
   is nothing to hydrate. `src/runner.rs`.
 
+- `fix(memory)`: `zeph-memory` sent malformed SQL to Postgres from 22 production call sites across
+  `graph/store/mod.rs`, `graph/implicit_conflict.rs`, `five_signal/consolidation.rs`,
+  `five_signal/access_frequency.rs`, `optical_forgetting.rs`, `episodic_consolidation.rs`, and
+  `graph/experience.rs`. `zeph_db::sql!()` is the only place that rewrites SQLite's `?` placeholder
+  syntax to Postgres's `$1, $2, ...` — under `--features postgres`, `DbPool`/`DbTransaction` are
+  compile-time aliases for the Postgres driver, so any call bypassing the macro fails at runtime.
+  Two defect shapes were found and fixed: (1) 11 sites called `sqlx::query`/`query_as`/
+  `query_scalar` directly instead of through `sql!()`, sending raw `?` tokens straight to Postgres;
+  (2) 11 more sites already used `sql!()` but contained SQLite's numbered `?1`/`?2` placeholder
+  syntax, which the macro's `rewrite_placeholders` cannot parse (it does a naive per-character
+  `?`→`$N` replace with no `?N` awareness, e.g. turning `?1` into `$11`) — renumbered to bare `?`,
+  with one site (`episodic_consolidation.rs::compute_cognitive_weight`) requiring a duplicated
+  `.bind()` call since its `?2` placeholder was reused twice in the SQL text for one bound value.
+  Added 5 new Postgres regression tests (`tests/postgres_integration.rs`, `test-utils` feature)
+  covering previously-untested fixed call sites. Closes #5488, closes #5491.
+
 ### Changed
 
 - `build(db)`: upgrade `sqlx` 0.8.6 → 0.9.0. The `runtime-tokio-rustls` feature was split into

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -367,10 +367,10 @@ async fn fetch_candidates(
          FROM episodic_events e
          JOIN messages m ON m.id = e.message_id
          WHERE e.consolidated_at IS NULL
-           AND e.created_at < unixepoch() - ?1
+           AND e.created_at < unixepoch() - ?
            AND m.content_fidelity != 'SummaryOnly'
          ORDER BY e.created_at ASC
-         LIMIT ?2"
+         LIMIT ?"
     ))
     .bind(min_age)
     .bind(batch)
@@ -398,10 +398,11 @@ async fn compute_cognitive_weight(
              ELSE 0.0
          END), 0.0)
          FROM experience_nodes
-         WHERE session_id = ?1
-           AND created_at BETWEEN ?2 - 30 AND ?2 + 30"
+         WHERE session_id = ?
+           AND created_at BETWEEN ? - 30 AND ? + 30"
     ))
     .bind(session_id)
+    .bind(created_at)
     .bind(created_at)
     .fetch_one(pool)
     .await
@@ -520,7 +521,7 @@ async fn extract_facts_via_llm(
 #[tracing::instrument(skip(pool), name = "memory.episodic.fetch_existing_facts")]
 async fn fetch_existing_facts(pool: &DbPool, limit: i64) -> Result<Vec<String>, MemoryError> {
     let rows: Vec<(String,)> = zeph_db::query_as(sql!(
-        "SELECT fact_text FROM consolidated_facts ORDER BY created_at DESC LIMIT ?1"
+        "SELECT fact_text FROM consolidated_facts ORDER BY created_at DESC LIMIT ?"
     ))
     .bind(limit)
     .fetch_all(pool)
@@ -573,7 +574,7 @@ async fn promote_fact(
 
         let fid: i64 = sqlx::query_scalar(sql!(
             "INSERT INTO consolidated_facts (fact_text, source, cognitive_weight)
-             VALUES (?1, 'episodic_consolidation', ?2)
+             VALUES (?, 'episodic_consolidation', ?)
              RETURNING id"
         ))
         .bind(fact_text)
@@ -585,7 +586,7 @@ async fn promote_fact(
         for &event_id in source_event_ids {
             sqlx::query(sql!(
                 "INSERT INTO consolidated_fact_sources (fact_id, event_id)
-                 VALUES (?1, ?2)
+                 VALUES (?, ?)
                  ON CONFLICT (fact_id, event_id) DO NOTHING"
             ))
             .bind(fid)
@@ -632,7 +633,7 @@ async fn promote_fact(
 #[tracing::instrument(skip(pool), name = "memory.episodic.mark_consolidated")]
 async fn mark_consolidated(pool: &DbPool, event_id: i64) -> Result<(), MemoryError> {
     zeph_db::query(sql!(
-        "UPDATE episodic_events SET consolidated_at = unixepoch() WHERE id = ?1"
+        "UPDATE episodic_events SET consolidated_at = unixepoch() WHERE id = ?"
     ))
     .bind(event_id)
     .execute(pool)

--- a/crates/zeph-memory/src/five_signal/access_frequency.rs
+++ b/crates/zeph-memory/src/five_signal/access_frequency.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use sqlx::Row as _;
-use zeph_db::DbPool;
+use zeph_db::{DbPool, sql};
 
 use crate::types::MessageId;
 
@@ -108,10 +108,10 @@ impl AccessFrequencyCache {
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
 
-        let res = sqlx::query(
+        let res = zeph_db::query(sql!(
             "INSERT INTO fact_access_log (fact_id, fact_type, session_id, accessed_at) \
-             VALUES (?1, ?2, ?3, ?4)",
-        )
+             VALUES (?, ?, ?, ?)"
+        ))
         .bind(fact_id.0)
         .bind(fact_type)
         .bind(session_id)

--- a/crates/zeph-memory/src/five_signal/consolidation.rs
+++ b/crates/zeph-memory/src/five_signal/consolidation.rs
@@ -16,6 +16,8 @@ use std::sync::Arc;
 use tokio::time::Duration;
 #[cfg(feature = "scheduler")]
 use zeph_config::memory::FiveSignalConsolidationConfig;
+#[cfg(feature = "scheduler")]
+use zeph_db::sql;
 
 #[cfg(feature = "scheduler")]
 use crate::error::MemoryError;
@@ -92,14 +94,14 @@ impl ConsolidationHandler {
         rt.metrics.inc_consolidation_run();
 
         // NOTE: ORDER BY id DESC retrieves newest facts — known MVP trade-off per NFR-004.
-        let rows = sqlx::query(
+        let rows = zeph_db::query(sql!(
             "SELECT id, created_at, qdrant_promoted, memory_tier \
              FROM messages \
              WHERE deleted_at IS NULL \
                AND (memory_tier IS NULL OR memory_tier NOT IN ('episodic_only')) \
              ORDER BY id DESC \
-             LIMIT ?1",
-        )
+             LIMIT ?"
+        ))
         .bind(i64::try_from(self.config.top_k_per_run).unwrap_or(i64::MAX))
         .fetch_all(&rt.pool)
         .await
@@ -168,9 +170,9 @@ impl ConsolidationHandler {
         let mut count: u64 = 0;
         for fact_id in promote_ids {
             tracing::debug!(fact_id, "five_signal: promoting fact");
-            let res = sqlx::query(
-                "UPDATE messages SET memory_tier = 'semantic', qdrant_promoted = 1 WHERE id = ?1",
-            )
+            let res = zeph_db::query(sql!(
+                "UPDATE messages SET memory_tier = 'semantic', qdrant_promoted = 1 WHERE id = ?"
+            ))
             .bind(fact_id)
             .execute(&rt.pool)
             .await;
@@ -193,10 +195,10 @@ impl ConsolidationHandler {
         let mut count: u64 = 0;
         for msg_id in demote_ids {
             tracing::debug!(fact_id = msg_id.0, "five_signal: demoting fact");
-            let res = sqlx::query(
+            let res = zeph_db::query(sql!(
                 "UPDATE messages SET memory_tier = 'episodic_only', qdrant_promoted = 0 \
-                 WHERE id = ?1",
-            )
+                 WHERE id = ?"
+            ))
             .bind(msg_id.0)
             .execute(&rt.pool)
             .await;

--- a/crates/zeph-memory/src/graph/experience.rs
+++ b/crates/zeph-memory/src/graph/experience.rs
@@ -79,7 +79,7 @@ impl ExperienceStore {
         let id: i64 = zeph_db::query_scalar(sql!(
             "INSERT INTO experience_nodes
              (session_id, turn, tool_name, outcome, detail, error_ctx, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             VALUES (?, ?, ?, ?, ?, ?, ?)
              RETURNING id"
         ))
         .bind(session_id)
@@ -111,7 +111,7 @@ impl ExperienceStore {
         for &entity_id in entity_ids {
             zeph_db::query(sql!(
                 "INSERT INTO experience_entity_links
-                 (experience_id, entity_id) VALUES (?1, ?2)
+                 (experience_id, entity_id) VALUES (?, ?)
                  ON CONFLICT (experience_id, entity_id) DO NOTHING"
             ))
             .bind(experience_id.0)
@@ -136,7 +136,7 @@ impl ExperienceStore {
         zeph_db::query(sql!(
             "INSERT INTO experience_edges
              (source_exp_id, target_exp_id, relation)
-             VALUES (?1, ?2, 'followed_by')"
+             VALUES (?, ?, 'followed_by')"
         ))
         .bind(prev.0)
         .bind(next.0)
@@ -173,7 +173,7 @@ impl ExperienceStore {
 
         let low_conf = zeph_db::query(sql!(
             "DELETE FROM graph_edges
-             WHERE confidence < ?1 AND retrieval_count = 0 AND valid_to IS NULL"
+             WHERE confidence < ? AND retrieval_count = 0 AND valid_to IS NULL"
         ))
         .bind(confidence_threshold)
         .execute(graph_store.pool())

--- a/crates/zeph-memory/src/graph/implicit_conflict.rs
+++ b/crates/zeph-memory/src/graph/implicit_conflict.rs
@@ -17,7 +17,7 @@ const MAX_IDS_PER_QUERY: usize = 499;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use zeph_config::ImplicitConflictConfig;
-use zeph_db::DbTransaction;
+use zeph_db::{DbTransaction, sql};
 
 use crate::error::MemoryError;
 use crate::graph::activation::ActivatedFact;
@@ -146,11 +146,11 @@ impl ImplicitConflictDetector {
         let expires_at = now + ttl_secs;
 
         for c in candidates {
-            sqlx::query(
+            zeph_db::query(sql!(
                 "INSERT INTO implicit_conflict_candidates
                  (edge_a_id, edge_b_id, similarity, method, status, created_at, expires_at)
-                 VALUES (?, ?, ?, ?, 'pending', ?, ?)",
-            )
+                 VALUES (?, ?, ?, ?, 'pending', ?, ?)"
+            ))
             .bind(c.edge_a_id)
             .bind(c.edge_b_id)
             .bind(c.similarity)

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -2921,12 +2921,12 @@ impl GraphStore {
                 onto.cardinality(canonical_relation) == crate::graph::ontology::Cardinality::Many;
 
             // Query existing active edges for the same source entity (excluding the new one).
-            let existing_raw = sqlx::query(
+            let existing_raw = zeph_db::query(sql!(
                 "SELECT id, canonical_relation FROM graph_edges
                      WHERE source_entity_id = ?
                        AND id != ?
-                       AND expired_at IS NULL",
-            )
+                       AND expired_at IS NULL"
+            ))
             .bind(source_entity_id)
             .bind(new_id)
             .fetch_all(&self.pool)
@@ -3088,7 +3088,7 @@ impl GraphStore {
         edge_id: i64,
     ) -> Result<Option<i64>, crate::error::MemoryError> {
         let row: Option<i64> = zeph_db::query_scalar(sql!(
-            "SELECT source_entity_id FROM graph_edges WHERE id = ?1 AND valid_to IS NULL LIMIT 1"
+            "SELECT source_entity_id FROM graph_edges WHERE id = ? AND valid_to IS NULL LIMIT 1"
         ))
         .bind(edge_id)
         .fetch_optional(&self.pool)
@@ -3340,7 +3340,7 @@ async fn find_prior_active_head(
 #[tracing::instrument(name = "memory.graph.store.check_supersede_depth_in_tx", skip_all)]
 async fn check_supersede_depth_in_tx(tx: &mut Tx<'_>, head_id: i64) -> Result<(), MemoryError> {
     let cap = i64::try_from(SUPERSEDE_DEPTH_CAP + 1).unwrap_or(i64::MAX);
-    let depth: Option<i64> = sqlx::query_scalar(
+    let depth: Option<i64> = zeph_db::query_scalar(sql!(
         "WITH RECURSIVE chain(id, depth) AS (
            SELECT supersedes, 1 FROM graph_edges WHERE id = ? AND supersedes IS NOT NULL
            UNION ALL
@@ -3348,8 +3348,8 @@ async fn check_supersede_depth_in_tx(tx: &mut Tx<'_>, head_id: i64) -> Result<()
            FROM graph_edges e JOIN chain c ON e.id = c.id
            WHERE e.supersedes IS NOT NULL AND c.depth < ?
          )
-         SELECT MAX(depth) FROM chain",
-    )
+         SELECT MAX(depth) FROM chain"
+    ))
     .bind(head_id)
     .bind(cap)
     .fetch_optional(&mut **tx)

--- a/crates/zeph-memory/src/optical_forgetting.rs
+++ b/crates/zeph-memory/src/optical_forgetting.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
+use zeph_db::sql;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
 
@@ -236,15 +237,15 @@ async fn fetch_full_candidates(
     // so pinned messages are not excluded here — the caller should avoid passing pinned
     // message IDs through optical forgetting, which is ensured by only sweeping full
     // sessions at the agent level.
-    let rows = sqlx::query_as::<_, (i64, String)>(
+    let rows = zeph_db::query_as::<_, (i64, String)>(sql!(
         "SELECT id, content FROM messages
          WHERE content_fidelity = 'Full'
            AND deleted_at IS NULL
            AND (importance_score IS NULL OR importance_score >= ?)
            AND id <= (SELECT COALESCE(MAX(id), 0) - ? FROM messages)
          ORDER BY id ASC
-         LIMIT ?",
-    )
+         LIMIT ?"
+    ))
     .bind(forgetting_floor)
     .bind(i64::from(config.compress_after_turns))
     .bind(i64::try_from(config.sweep_batch_size).unwrap_or(i64::MAX))
@@ -260,15 +261,15 @@ async fn fetch_compressed_candidates(
     config: &OpticalForgettingConfig,
     forgetting_floor: f32,
 ) -> Result<Vec<(i64, String)>, MemoryError> {
-    let rows = sqlx::query_as::<_, (i64, Option<String>)>(
+    let rows = zeph_db::query_as::<_, (i64, Option<String>)>(sql!(
         "SELECT id, compressed_content FROM messages
          WHERE content_fidelity = 'Compressed'
            AND deleted_at IS NULL
            AND (importance_score IS NULL OR importance_score >= ?)
            AND id <= (SELECT COALESCE(MAX(id), 0) - ? FROM messages)
          ORDER BY id ASC
-         LIMIT ?",
-    )
+         LIMIT ?"
+    ))
     .bind(forgetting_floor)
     .bind(i64::from(config.summarize_after_turns))
     .bind(i64::try_from(config.sweep_batch_size).unwrap_or(i64::MAX))
@@ -287,11 +288,11 @@ async fn store_compressed(
     msg_id: i64,
     compressed: &str,
 ) -> Result<(), MemoryError> {
-    sqlx::query(
+    zeph_db::query(sql!(
         "UPDATE messages
          SET content_fidelity = 'Compressed', compressed_content = ?
-         WHERE id = ?",
-    )
+         WHERE id = ?"
+    ))
     .bind(compressed)
     .bind(msg_id)
     .execute(store.pool())
@@ -305,11 +306,11 @@ async fn store_summary_only(
     msg_id: i64,
     summary: &str,
 ) -> Result<(), MemoryError> {
-    sqlx::query(
+    zeph_db::query(sql!(
         "UPDATE messages
          SET content_fidelity = 'SummaryOnly', content = ?, compressed_content = NULL
-         WHERE id = ?",
-    )
+         WHERE id = ?"
+    ))
     .bind(summary)
     .bind(msg_id)
     .execute(store.pool())

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -22,6 +22,15 @@
 //! exercises one of the fixed call sites against a real Postgres instance and
 //! asserts actual row-level results (not just absence of error), since a bind-count
 //! mismatch can in some cases silently return zero rows rather than erroring.
+//!
+//! Regression coverage for issues #5488/#5491: several call sites used raw
+//! `sqlx::query`/`query_as`/`query_scalar` with literal `?`/`?N` placeholders instead of
+//! going through the `sql!()` macro, and a handful of call sites already wrapped in
+//! `sql!()` still used `SQLite`'s `?1`/`?2` numbered-placeholder syntax — which
+//! `sql!()`'s `rewrite_placeholders` does not parse, producing malformed `$11` instead
+//! of `$1` under Postgres. The tests below close the Postgres coverage gap for those
+//! fixes; see the `NOTE` comment near the end of this module for one call-site family
+//! that could not get coverage here due to an unrelated bug.
 
 #[cfg(feature = "test-utils")]
 mod pg {
@@ -1021,5 +1030,297 @@ mod pg {
         .await
         .unwrap();
         assert_eq!(was_recalled, 1);
+    }
+
+    // ── Regression coverage for #5488/#5491: sql!() bypasses and the ?N-inside-sql!()
+    // Postgres rewrite defect (raw `?` characters silently become `$11` instead of `$1`
+    // when the literal SQL used SQLite's numbered-placeholder syntax). Each test below
+    // exercises a call site that was fixed as part of that pass and had zero Postgres
+    // coverage before. ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn access_frequency_log_access_writes_entry() {
+        use zeph_memory::five_signal::access_frequency::AccessFrequencyCache;
+
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool.clone());
+        let cache = AccessFrequencyCache::new(pool.clone());
+
+        let cid = store.create_conversation().await.unwrap();
+        let msg = store
+            .save_message(cid, "user", "logged fact")
+            .await
+            .unwrap();
+
+        cache.log_access(msg, "message", "sess-log").await;
+
+        let (fact_id, fact_type, session_id): (i64, String, String) =
+            sqlx::query_as(zeph_db::sql!(
+                "SELECT fact_id, fact_type, session_id FROM fact_access_log WHERE fact_id = ?"
+            ))
+            .bind(msg.0)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(fact_id, msg.0);
+        assert_eq!(fact_type, "message");
+        assert_eq!(session_id, "sess-log");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn graph_store_source_entity_id_for_edge_postgres() {
+        let (pool, _container) = start_pg().await;
+        let graph = GraphStore::new(pool.clone());
+
+        let a = graph
+            .upsert_entity("Ivy", "ivy", EntityType::Person, None, None)
+            .await
+            .unwrap();
+        let b = graph
+            .upsert_entity("Jack", "jack", EntityType::Person, None, None)
+            .await
+            .unwrap();
+        let edge_id = graph
+            .insert_edge(a.0, b.0, "knows", "Ivy knows Jack", 0.9, None, None)
+            .await
+            .unwrap();
+
+        let found = graph.source_entity_id_for_edge(edge_id).await.unwrap();
+        assert_eq!(found, Some(a.0));
+
+        let missing = graph.source_entity_id_for_edge(999_999_999).await.unwrap();
+        assert_eq!(missing, None);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn graph_store_insert_or_supersede_with_conflict_detection_and_depth_check() {
+        let (pool, _container) = start_pg().await;
+        let graph = GraphStore::new(pool.clone());
+
+        let a = graph
+            .upsert_entity("Eve", "eve", EntityType::Person, None, None)
+            .await
+            .unwrap();
+        let b = graph
+            .upsert_entity("Frank", "frank", EntityType::Person, None, None)
+            .await
+            .unwrap();
+
+        let detector_config = zeph_config::memory::ImplicitConflictConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let detector = implicit_conflict::ImplicitConflictDetector::new(detector_config);
+        let ontology = zeph_memory::graph::ontology::OntologyTable::from_default(64);
+
+        let first_id = graph
+            .insert_or_supersede_with_conflict_detection(
+                a.0,
+                b.0,
+                "manages",
+                "manages",
+                "Eve manages Frank",
+                0.6,
+                None,
+                zeph_memory::graph::types::EdgeType::Semantic,
+                true,
+                None,
+                Some(&detector),
+                Some(&ontology),
+            )
+            .await
+            .unwrap();
+
+        // Different fact text for the same (source, target, canonical_relation, edge_type) head
+        // must go through the supersede chain — exercising check_supersede_depth_in_tx — and,
+        // since the detector is enabled, the conflict-candidate raw query.
+        let second_id = graph
+            .insert_or_supersede_with_conflict_detection(
+                a.0,
+                b.0,
+                "manages",
+                "manages",
+                "Eve no longer manages Frank",
+                0.9,
+                None,
+                zeph_memory::graph::types::EdgeType::Semantic,
+                true,
+                None,
+                Some(&detector),
+                Some(&ontology),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(
+            first_id, second_id,
+            "differing fact text must create a new superseding row, not a reassertion"
+        );
+
+        let supersedes: Option<i64> = sqlx::query_scalar(zeph_db::sql!(
+            "SELECT supersedes FROM graph_edges WHERE id = ?"
+        ))
+        .bind(second_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            supersedes,
+            Some(first_id),
+            "second edge must record the first as superseded"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn implicit_conflict_stage_candidates_inserts_pending_row() {
+        let (pool, _container) = start_pg().await;
+        let graph = GraphStore::new(pool.clone());
+
+        let a = graph
+            .upsert_entity("G", "g", EntityType::Concept, None, None)
+            .await
+            .unwrap();
+        let b = graph
+            .upsert_entity("H", "h", EntityType::Concept, None, None)
+            .await
+            .unwrap();
+        let edge_a = graph
+            .insert_edge(a.0, b.0, "relates_to", "G relates to H", 0.8, None, None)
+            .await
+            .unwrap();
+        let edge_b = graph
+            .insert_edge(b.0, a.0, "relates_to", "H relates to G", 0.8, None, None)
+            .await
+            .unwrap();
+
+        let detector = implicit_conflict::ImplicitConflictDetector::new(
+            zeph_config::memory::ImplicitConflictConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        );
+
+        let candidates = vec![implicit_conflict::ConflictCandidate {
+            edge_a_id: edge_a,
+            edge_b_id: edge_b,
+            similarity: 0.9,
+            method: "levenshtein".to_owned(),
+        }];
+
+        let mut tx = pool.begin().await.unwrap();
+        detector
+            .stage_candidates(&candidates, &mut tx, 30)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let row: (i64, i64, String, String) = sqlx::query_as(zeph_db::sql!(
+            "SELECT edge_a_id, edge_b_id, method, status FROM implicit_conflict_candidates \
+             WHERE edge_a_id = ? AND edge_b_id = ?"
+        ))
+        .bind(edge_a)
+        .bind(edge_b)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(row.0, edge_a);
+        assert_eq!(row.1, edge_b);
+        assert_eq!(row.2, "levenshtein");
+        assert_eq!(row.3, "pending");
+    }
+
+    // NOTE: a Postgres regression test for `ConsolidationHandler::execute` (which exercises
+    // `run_once` / `apply_promotions` / `apply_demotions`) was attempted here but is omitted.
+    // It immediately surfaced a pre-existing, UNRELATED production bug: `messages.created_at`
+    // is `TIMESTAMPTZ` in the Postgres schema (`zeph-db/migrations/postgres/001_init.sql`) but
+    // `five_signal/consolidation.rs::run_once` does `row.get::<i64, _>("created_at")`, which
+    // panics with `ColumnDecode { ... mismatched types ... INT8 ... TIMESTAMPTZ }` for any row
+    // when `scheduler` + `postgres` are both enabled. This is a distinct defect class from the
+    // `sql!()`/placeholder bug this PR fixes (`apply_promotions`/`apply_demotions` themselves
+    // only touch `id`, not `created_at`, and are already correctly fixed). `apply_promotions`
+    // and `apply_demotions` are private methods not reachable from this external test file, so
+    // they cannot be covered without either fixing the `created_at` decode bug or changing
+    // their visibility — both out of scope here. See the PR discussion / follow-up issue for
+    // the `created_at` type-mismatch bug before attempting this coverage again.
+
+    // NOTE: Postgres regression tests for `episodic_consolidation.rs::fetch_candidates` and
+    // `compute_cognitive_weight` (both fixed for the `?N`-inside-`sql!()` defect in this PR)
+    // are omitted for the same reason as above: both are private, reachable only via the
+    // public `run_episodic_consolidation_sweep` entry point, and `fetch_candidates`'s WHERE
+    // clause calls SQLite's `unixepoch()` function directly — undefined under Postgres (no
+    // compat function/extension is installed; confirmed via `crates/zeph-db/migrations/postgres/`
+    // and `crates/zeph-db/src/dialect.rs`'s `EPOCH_NOW` abstraction, which exists for exactly
+    // this purpose but isn't used at this call site). Since `fetch_candidates` runs first in
+    // the sweep pipeline, this fails before `compute_cognitive_weight` is ever reached, so
+    // neither function can get real Postgres coverage without fixing the `unixepoch()` dialect
+    // bug first — a distinct defect class from the placeholder bug, out of scope here. The
+    // `?N` renumbering itself is still correct and necessary (verify by inspection: bind
+    // count/order match the SQL text exactly for both functions) — it just cannot be exercised
+    // end-to-end against a real Postgres instance until the dialect bug is fixed separately.
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn optical_forgetting_summarizes_compressed_message() {
+        use std::sync::Arc;
+
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_memory::optical_forgetting::run_optical_forgetting_sweep;
+
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool.clone());
+
+        let cid = store.create_conversation().await.unwrap();
+        let msg_id = store
+            .save_message(cid, "user", "original content")
+            .await
+            .unwrap();
+
+        // Force the message into `Compressed` fidelity with prior compressed_content so
+        // Phase 2 (fetch_compressed_candidates + store_summary_only) picks it up.
+        sqlx::query(zeph_db::sql!(
+            "UPDATE messages SET content_fidelity = 'Compressed', \
+             compressed_content = 'prior summary', importance_score = 1.0 WHERE id = ?"
+        ))
+        .bind(msg_id.0)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let provider = Arc::new(AnyProvider::Mock(MockProvider::with_responses(vec![
+            "one-line summary".to_owned(),
+        ])));
+
+        let config = zeph_config::memory::OpticalForgettingConfig {
+            enabled: true,
+            summarize_after_turns: 0,
+            sweep_batch_size: 50,
+            ..Default::default()
+        };
+
+        let result = run_optical_forgetting_sweep(&store, &provider, &config, 0.0)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.summarized, 1,
+            "the Compressed message must transition to SummaryOnly"
+        );
+
+        let (fidelity, content): (String, String) = sqlx::query_as(zeph_db::sql!(
+            "SELECT content_fidelity, content FROM messages WHERE id = ?"
+        ))
+        .bind(msg_id.0)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(fidelity, "SummaryOnly");
+        assert_eq!(content, "one-line summary");
     }
 }


### PR DESCRIPTION
## Summary

`zeph_db::sql!()` is the only place that rewrites SQLite's `?` placeholder syntax to Postgres's `$1, $2, ...` — under `--features postgres`, `DbPool`/`DbTransaction` are compile-time aliases for the Postgres driver, so any call that bypasses or defeats the macro fails at runtime.

Fixed two defect shapes across 22 production call sites in `graph/store/mod.rs`, `graph/implicit_conflict.rs`, `five_signal/consolidation.rs`, `five_signal/access_frequency.rs`, `optical_forgetting.rs`, `episodic_consolidation.rs`, and `graph/experience.rs`:

- **11 sites** called `sqlx::query`/`query_as`/`query_scalar` directly instead of through `sql!()`, sending raw `?` tokens straight to Postgres (the original scope of #5488 + #5491).
- **11 more sites** already used `sql!()` but contained SQLite's numbered `?1`/`?2` placeholder syntax, which `rewrite_placeholders` cannot parse (naive per-character `?`→`$N` replace with no `?N` awareness, e.g. `?1` becomes `$11`) — found across three independent completeness sweeps (developer, critic, reviewer) during this PR's review cycle. Renumbered to bare `?`; one site (`episodic_consolidation.rs::compute_cognitive_weight`) required a duplicated `.bind()` call since its `?2` placeholder was reused twice in the SQL text for one bound value.

Added 5 new Postgres regression tests (`tests/postgres_integration.rs`, `test-utils` feature) covering previously-untested fixed call sites.

Closes #5488, closes #5491

## Known follow-ups (out of scope for this PR, will be filed separately)

- `sql!()`/`rewrite_placeholders` has no awareness of `?N` numbered-placeholder syntax and will silently produce malformed SQL if such a query is ever wrapped in `sql!()` and run against Postgres — missed independently three times during this PR's review passes, worth a `debug_assert!`/lint at the macro level.
- `messages.created_at` is `TIMESTAMPTZ` under Postgres but `five_signal/consolidation.rs::run_once` decodes it as `i64` — a guaranteed crash for any `scheduler`+`postgres` deployment with the five-signal consolidation daemon enabled. Unrelated defect class (column type mismatch, not placeholder syntax), found while writing regression tests for this PR.
- SQLite's `unixepoch()` is called as a literal in several production queries (`episodic_consolidation.rs`, `reasoning.rs`, `graph/belief.rs`, `store/mem_scenes.rs`, `store/messages/mod.rs`) and is undefined under Postgres — the existing `zeph_db::dialect::EPOCH_NOW` abstraction exists for exactly this but isn't used at these call sites. This currently blocks adding Postgres regression test coverage for `episodic_consolidation.rs::fetch_candidates`/`compute_cognitive_weight` (documented as a `NOTE` in `postgres_integration.rs`).

## Test plan

- [x] `cargo build -p zeph-memory` (default/sqlite)
- [x] `cargo build -p zeph-memory --features postgres`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory --lib` — 1522/1522 passed
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory --features test-utils --test postgres_integration --run-ignored ignored-only` — 28/28 passed (real Postgres via testcontainers, up from 23 baseline)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11730/11730 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-memory` — 50/50 passed