### PR TITLE
fix(core): wire ShadowSentinel Postgres SQL and cross-session detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2211,6 +2211,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs(config)`: `CandleConfig` in `zeph-config` now has a `///` doc comment describing its
   purpose (`[llm.candle]` TOML section) and its relationship to `CandleInlineConfig`. (#4869)
 
+### Fixed
+- `fix(core)`: `ShadowEventStore`'s three query methods (`record`, `get_trajectory`,
+  `get_tool_history`) used raw `sqlx::query`/`sqlx::query_as` with literal `?` placeholders instead
+  of `zeph_db::query*(sql!(...))`, so under a `postgres`-feature build the placeholders were never
+  rewritten to `$1, $2, ...` and every call to the `ShadowSentinel` safety-audit-trail persistence
+  layer would fail at runtime (#5494).
+- `fix(core,security)`: `ShadowSentinel`'s cross-session pattern detection was schema/comment-only —
+  `ShadowEventStore::get_tool_history` had zero callers, so probe context was built exclusively from
+  the current session's own trajectory (#5449). `check_tool_call` now merges cross-session tool
+  history (same `tool_id`, other sessions) into the probe context, reserving half of
+  `max_context_events` for each source so neither can fully starve the other. Closing this out
+  required wiring the previously-dead-code writer as well: `record_tool_event` had no production
+  caller either, so even after wiring the reader, no `tool_call` events existed to read back. Added
+  `ProbeGate::record(...)` (`zeph-tools`), called from `ShadowProbeExecutor` on `Allow`/`Deny`
+  outcomes (never `Skip`, to avoid recording low-risk/disabled calls) and skipped when the result is
+  `Err(ToolError::ConfirmationRequired { .. })` (avoids double-recording confirmation-gated calls,
+  which would otherwise record once as a spurious failure and again after user confirmation).
+  `get_tool_history` also gained a SQL-level `exclude_session_id` filter so the current session's
+  own rows cannot crowd out cross-session rows within the query's `LIMIT`.
+
 
 ## [0.21.4] - 2026-06-05
 

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -38,7 +38,7 @@ use tokio::task::JoinSet;
 
 use serde_json::Value as JsonValue;
 use tracing::{Instrument as _, info_span};
-use zeph_db::DbPool;
+use zeph_db::{DbPool, sql};
 use zeph_llm::LlmProvider;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{Message, Role};
@@ -320,12 +320,12 @@ impl ShadowEventStore {
     /// Returns `AgentError` on database failure.
     #[tracing::instrument(name = "security.shadow.record", skip_all, fields(event_type = %event.event_type))]
     pub async fn record(&self, event: &SentinelEvent) -> Result<(), AgentError> {
-        sqlx::query(
+        zeph_db::query(sql!(
             "INSERT INTO safety_shadow_events \
              (session_id, turn_number, event_type, tool_id, risk_signal, risk_level, \
               probe_verdict, context_summary, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        ))
         .bind(event.session_id.as_str())
         .bind(i64::try_from(event.turn_number).unwrap_or(i64::MAX))
         .bind(&event.event_type)
@@ -355,14 +355,14 @@ impl ShadowEventStore {
         session_id: &str,
         limit: usize,
     ) -> Result<Vec<SentinelEvent>, AgentError> {
-        let rows = sqlx::query_as::<_, ShadowEventRow>(
+        let rows = zeph_db::query_as::<_, ShadowEventRow>(sql!(
             "SELECT id, session_id, turn_number, event_type, tool_id, risk_signal, \
              risk_level, probe_verdict, context_summary, created_at \
              FROM safety_shadow_events \
              WHERE session_id = ? \
              ORDER BY created_at DESC \
-             LIMIT ?",
-        )
+             LIMIT ?"
+        ))
         .bind(session_id)
         .bind(i64::try_from(limit).unwrap_or(i64::MAX))
         .fetch_all(&self.pool)
@@ -375,9 +375,13 @@ impl ShadowEventStore {
         Ok(events)
     }
 
-    /// Retrieve the last `limit` events for a specific tool across all sessions.
+    /// Retrieve the last `limit` events for a specific tool from sessions OTHER than
+    /// `exclude_session_id`.
     ///
-    /// Used for cross-session pattern detection.
+    /// Used for cross-session pattern detection. The exclusion is applied in SQL (not just
+    /// filtered client-side afterward) so that a session with heavy recent activity for
+    /// `tool_id` cannot crowd its own rows into the `LIMIT` clip and starve genuinely
+    /// cross-session rows out of the result.
     ///
     /// # Errors
     ///
@@ -386,17 +390,19 @@ impl ShadowEventStore {
     pub async fn get_tool_history(
         &self,
         tool_id: &str,
+        exclude_session_id: &str,
         limit: usize,
     ) -> Result<Vec<SentinelEvent>, AgentError> {
-        let rows = sqlx::query_as::<_, ShadowEventRow>(
+        let rows = zeph_db::query_as::<_, ShadowEventRow>(sql!(
             "SELECT id, session_id, turn_number, event_type, tool_id, risk_signal, \
              risk_level, probe_verdict, context_summary, created_at \
              FROM safety_shadow_events \
-             WHERE tool_id = ? \
+             WHERE tool_id = ? AND session_id != ? \
              ORDER BY created_at DESC \
-             LIMIT ?",
-        )
+             LIMIT ?"
+        ))
         .bind(tool_id)
+        .bind(exclude_session_id)
         .bind(i64::try_from(limit).unwrap_or(i64::MAX))
         .fetch_all(&self.pool)
         .await
@@ -597,7 +603,7 @@ impl ShadowSentinel {
         // Load recent trajectory for probe context.
         // Filter out probe_result events — exposing probe verdicts to the LLM would allow
         // prompt injection attacks that craft tool outputs to manipulate perceived safety.
-        let trajectory = match self
+        let mut trajectory: Vec<SentinelEvent> = match self
             .store
             .get_trajectory(&self.session_id, self.config.max_context_events)
             .await
@@ -611,6 +617,51 @@ impl ShadowSentinel {
                 vec![]
             }
         };
+
+        // Reserve half the total budget for cross-session history so recurring risk patterns
+        // from other sessions always have visibility — even in the busiest sessions, where the
+        // session's own trajectory alone would otherwise fill (and, pre-fix, silently evict
+        // the entire cross-session block from) the whole budget. Enforce the session-side cap
+        // here (trajectory is oldest-first/ASC, so excess is trimmed from the front, keeping
+        // the most recent events).
+        let cross_session_budget = self.config.max_context_events / 2;
+        let session_budget = self.config.max_context_events - cross_session_budget;
+        if trajectory.len() > session_budget {
+            let excess = trajectory.len() - session_budget;
+            trajectory.drain(0..excess);
+        }
+
+        // Load cross-session history for this tool so recurring risk patterns from
+        // other sessions inform the probe, not just the current session (#5449). The
+        // current session is excluded in SQL (not just filtered client-side) so its own
+        // activity can never crowd genuinely cross-session rows out of the LIMIT clip.
+        match self
+            .store
+            .get_tool_history(
+                qualified_tool_id,
+                self.session_id.as_str(),
+                self.config.max_context_events,
+            )
+            .await
+        {
+            Ok(history) => {
+                // get_tool_history is DESC (newest first); reverse to ASC to match
+                // trajectory ordering, then prepend so trajectory stays oldest-first.
+                let mut cross_session: Vec<SentinelEvent> = history
+                    .into_iter()
+                    .filter(|e| e.event_type != "probe_result")
+                    .rev()
+                    .collect();
+                if cross_session.len() > cross_session_budget {
+                    let excess = cross_session.len() - cross_session_budget;
+                    cross_session.drain(0..excess);
+                }
+                trajectory.splice(0..0, cross_session);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "ShadowSentinel: failed to load cross-session tool history, proceeding without it");
+            }
+        }
 
         let verdict = self
             .probe
@@ -1027,5 +1078,456 @@ mod tests {
             .expect("in-memory SQLite pool");
         let store = ShadowEventStore::new(pool);
         ShadowSentinel::new(store, Box::new(NoopProbe), config, "test-session")
+    }
+
+    // Opens a migrated in-memory SQLite pool (unlike `make_test_sentinel`'s pool, this one
+    // has the `safety_shadow_events` table from migration 085 and can serve real store queries.
+    async fn test_pool() -> DbPool {
+        zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .expect("connect + migrate in-memory sqlite pool")
+    }
+
+    fn make_event(
+        session_id: &str,
+        turn_number: u64,
+        tool_id: &str,
+        summary: &str,
+    ) -> SentinelEvent {
+        SentinelEvent {
+            id: 0,
+            session_id: SessionId::new(session_id),
+            turn_number,
+            event_type: "tool_call".to_owned(),
+            tool_id: Some(tool_id.to_owned()),
+            risk_signal: None,
+            risk_level: "elevated".to_owned(),
+            probe_verdict: None,
+            context_summary: Some(summary.to_owned()),
+            created_at: unix_now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_tool_history_returns_events_across_sessions() {
+        let store = ShadowEventStore::new(test_pool().await);
+
+        store
+            .record(&make_event(
+                "session-a",
+                1,
+                "builtin:shell",
+                "session-a ran a command",
+            ))
+            .await
+            .expect("record session-a event");
+        store
+            .record(&make_event(
+                "session-b",
+                1,
+                "builtin:shell",
+                "session-b ran a command",
+            ))
+            .await
+            .expect("record session-b event");
+        store
+            .record(&make_event(
+                "session-a",
+                2,
+                "builtin:write",
+                "unrelated tool",
+            ))
+            .await
+            .expect("record unrelated-tool event");
+
+        let history = store
+            .get_tool_history("builtin:shell", "unrelated-session", 10)
+            .await
+            .expect("get_tool_history");
+
+        assert_eq!(
+            history.len(),
+            2,
+            "must return events from both non-excluded sessions for the queried tool_id, \
+             excluding other tools"
+        );
+        assert!(history.iter().any(|e| e.session_id.as_str() == "session-a"));
+        assert!(history.iter().any(|e| e.session_id.as_str() == "session-b"));
+
+        let history_excluding_a = store
+            .get_tool_history("builtin:shell", "session-a", 10)
+            .await
+            .expect("get_tool_history");
+        assert_eq!(
+            history_excluding_a.len(),
+            1,
+            "exclude_session_id must be applied in SQL, not just usable for client-side \
+             filtering afterward"
+        );
+        assert!(
+            history_excluding_a
+                .iter()
+                .all(|e| e.session_id.as_str() != "session-a")
+        );
+    }
+
+    /// #5449 regression: `check_tool_call` must fold cross-session `get_tool_history` results
+    /// into the trajectory passed to the probe, not just the current session's own events.
+    #[tokio::test]
+    async fn check_tool_call_incorporates_cross_session_tool_history() {
+        struct CapturingProbe {
+            captured: Arc<Mutex<Vec<SentinelEvent>>>,
+        }
+        impl SafetyProbe for CapturingProbe {
+            fn evaluate<'a>(
+                &'a self,
+                _tool_id: &'a str,
+                _tool_args: &'a JsonValue,
+                trajectory: &'a [SentinelEvent],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>
+            {
+                let captured = Arc::clone(&self.captured);
+                let trajectory = trajectory.to_vec();
+                Box::pin(async move {
+                    *captured.lock().await = trajectory;
+                    ProbeVerdict::Allow
+                })
+            }
+        }
+
+        let store = ShadowEventStore::new(test_pool().await);
+        let other_session = "other-session";
+        store
+            .record(&make_event(
+                other_session,
+                1,
+                "builtin:shell",
+                "other session ran rm -rf",
+            ))
+            .await
+            .expect("record cross-session event");
+
+        let captured: Arc<Mutex<Vec<SentinelEvent>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let config = zeph_config::ShadowSentinelConfig {
+            enabled: true,
+            ..zeph_config::ShadowSentinelConfig::default()
+        };
+        let sentinel = ShadowSentinel::new(
+            store,
+            Box::new(CapturingProbe {
+                captured: Arc::clone(&captured),
+            }),
+            config,
+            "current-session",
+        );
+
+        let args = serde_json::Value::Object(serde_json::Map::new());
+        sentinel
+            .check_tool_call("builtin:shell", &args, 1, "calm")
+            .await;
+
+        let seen = captured.lock().await;
+        assert!(
+            seen.iter().any(|e| e.session_id.as_str() == other_session
+                && e.context_summary.as_deref() == Some("other session ran rm -rf")),
+            "probe context must include the cross-session tool history event, got: {seen:?}"
+        );
+    }
+
+    /// Drives `check_tool_call` for `tool_id` under `session_id` and returns the exact
+    /// trajectory the probe received, so cap tests can assert WHICH events survive, not
+    /// just how many — a count-only assertion can pass while the cap silently drops all
+    /// cross-session data (the bug found in code review of the initial #5449 fix).
+    async fn capture_check_tool_call_trajectory(
+        store: ShadowEventStore,
+        config: zeph_config::ShadowSentinelConfig,
+        session_id: &str,
+        tool_id: &str,
+    ) -> Vec<SentinelEvent> {
+        struct CapturingProbe {
+            captured: Arc<Mutex<Vec<SentinelEvent>>>,
+        }
+        impl SafetyProbe for CapturingProbe {
+            fn evaluate<'a>(
+                &'a self,
+                _tool_id: &'a str,
+                _tool_args: &'a JsonValue,
+                trajectory: &'a [SentinelEvent],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>
+            {
+                let captured = Arc::clone(&self.captured);
+                let trajectory = trajectory.to_vec();
+                Box::pin(async move {
+                    *captured.lock().await = trajectory;
+                    ProbeVerdict::Allow
+                })
+            }
+        }
+
+        let captured: Arc<Mutex<Vec<SentinelEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sentinel = ShadowSentinel::new(
+            store,
+            Box::new(CapturingProbe {
+                captured: Arc::clone(&captured),
+            }),
+            config,
+            session_id,
+        );
+        let args = serde_json::Value::Object(serde_json::Map::new());
+        sentinel.check_tool_call(tool_id, &args, 1, "calm").await;
+        captured.lock().await.clone()
+    }
+
+    /// Seeds `count` events for `session_id`/`tool_id`, with ascending `created_at`
+    /// timestamps starting at `base`, so cap tests can control which events are "most
+    /// recent". Summaries are `"{summary_prefix}-{i}"` for index-based assertions.
+    async fn seed_events(
+        store: &ShadowEventStore,
+        session_id: &str,
+        tool_id: &str,
+        summary_prefix: &str,
+        base: i64,
+        count: u32,
+    ) {
+        for i in 0..count {
+            let mut event = make_event(
+                session_id,
+                u64::from(i),
+                tool_id,
+                &format!("{summary_prefix}-{i}"),
+            );
+            event.created_at = base + i64::from(i);
+            store.record(&event).await.expect("record seeded event");
+        }
+    }
+
+    /// Session trajectory and cross-session history are each independently capped at
+    /// `max_context_events`, so a naive merge can total up to 2x the configured budget.
+    /// `check_tool_call` must enforce the combined cap AND reserve budget for cross-session
+    /// data — the original fix trimmed unconditionally from the front, which silently wiped
+    /// ALL cross-session events whenever the session's own trajectory alone filled the
+    /// budget (precisely the busiest-session scenario #5449 cares about most).
+    #[tokio::test]
+    async fn check_tool_call_cap_reserves_cross_session_budget_when_session_heavy() {
+        let store = ShadowEventStore::new(test_pool().await);
+        let base = unix_now();
+        seed_events(
+            &store,
+            "current-session",
+            "builtin:shell",
+            "session",
+            base,
+            4,
+        )
+        .await;
+        seed_events(&store, "other-session", "builtin:shell", "cross", base, 3).await;
+
+        let config = zeph_config::ShadowSentinelConfig {
+            enabled: true,
+            max_context_events: 4,
+            ..zeph_config::ShadowSentinelConfig::default()
+        };
+        let trajectory =
+            capture_check_tool_call_trajectory(store, config, "current-session", "builtin:shell")
+                .await;
+
+        assert_eq!(
+            trajectory.len(),
+            4,
+            "total must be capped at max_context_events"
+        );
+        let cross_session_count = trajectory
+            .iter()
+            .filter(|e| e.session_id.as_str() == "other-session")
+            .count();
+        assert_eq!(
+            cross_session_count, 2,
+            "cross-session budget is max_context_events/2 = 2, and must survive even \
+             though the session's own trajectory alone fills the whole budget; \
+             got trajectory: {trajectory:?}"
+        );
+    }
+
+    /// Mirror case: cross-session history is the one over budget, session's own trajectory
+    /// is light. The session-side cap must not trim events that don't need trimming.
+    #[tokio::test]
+    async fn check_tool_call_cap_cross_session_heavy_case() {
+        let store = ShadowEventStore::new(test_pool().await);
+        let base = unix_now();
+        seed_events(
+            &store,
+            "current-session",
+            "builtin:shell",
+            "session",
+            base,
+            1,
+        )
+        .await;
+        seed_events(&store, "other-session", "builtin:shell", "cross", base, 4).await;
+
+        let config = zeph_config::ShadowSentinelConfig {
+            enabled: true,
+            max_context_events: 4,
+            ..zeph_config::ShadowSentinelConfig::default()
+        };
+        let trajectory =
+            capture_check_tool_call_trajectory(store, config, "current-session", "builtin:shell")
+                .await;
+
+        let session_count = trajectory
+            .iter()
+            .filter(|e| e.session_id.as_str() == "current-session")
+            .count();
+        let cross_session_count = trajectory.len() - session_count;
+        assert_eq!(
+            session_count, 1,
+            "session's own (light) trajectory must not be trimmed"
+        );
+        assert_eq!(
+            cross_session_count, 2,
+            "cross-session budget is max_context_events/2 = 2"
+        );
+    }
+
+    /// Boundary: session + cross-session totals exactly `max_context_events` — nothing
+    /// should be dropped from either side.
+    #[tokio::test]
+    async fn check_tool_call_cap_boundary_at_exact_limit() {
+        let store = ShadowEventStore::new(test_pool().await);
+        let base = unix_now();
+        seed_events(
+            &store,
+            "current-session",
+            "builtin:shell",
+            "session",
+            base,
+            2,
+        )
+        .await;
+        seed_events(&store, "other-session", "builtin:shell", "cross", base, 2).await;
+
+        let config = zeph_config::ShadowSentinelConfig {
+            enabled: true,
+            max_context_events: 4,
+            ..zeph_config::ShadowSentinelConfig::default()
+        };
+        let trajectory =
+            capture_check_tool_call_trajectory(store, config, "current-session", "builtin:shell")
+                .await;
+
+        assert_eq!(
+            trajectory.len(),
+            4,
+            "exactly at the limit: nothing should be dropped"
+        );
+    }
+
+    /// Boundary: one more cross-session event than the reserved budget — exactly one event
+    /// must be dropped, and it must be the OLDEST cross-session event (trajectory stays
+    /// oldest-first/ASC, so the most recent events are kept).
+    #[tokio::test]
+    async fn check_tool_call_cap_boundary_at_limit_plus_one() {
+        let store = ShadowEventStore::new(test_pool().await);
+        let base = unix_now();
+        seed_events(
+            &store,
+            "current-session",
+            "builtin:shell",
+            "session",
+            base,
+            2,
+        )
+        .await;
+        seed_events(&store, "other-session", "builtin:shell", "cross", base, 3).await;
+
+        let config = zeph_config::ShadowSentinelConfig {
+            enabled: true,
+            max_context_events: 4,
+            ..zeph_config::ShadowSentinelConfig::default()
+        };
+        let trajectory =
+            capture_check_tool_call_trajectory(store, config, "current-session", "builtin:shell")
+                .await;
+
+        assert_eq!(
+            trajectory.len(),
+            4,
+            "limit+1 overall: exactly one event must be dropped"
+        );
+        let cross_summaries: Vec<&str> = trajectory
+            .iter()
+            .filter(|e| e.session_id.as_str() == "other-session")
+            .filter_map(|e| e.context_summary.as_deref())
+            .collect();
+        assert_eq!(
+            cross_summaries,
+            vec!["cross-1", "cross-2"],
+            "the oldest cross-session event (cross-0) must be the one dropped, \
+             got: {cross_summaries:?}"
+        );
+    }
+
+    /// The current session's own events must not be double-counted into the cross-session
+    /// block — `get_tool_history` excludes `exclude_session_id` directly in its SQL
+    /// (`AND session_id != ?`), and this test confirms that exclusion end-to-end through
+    /// `check_tool_call`.
+    #[tokio::test]
+    async fn check_tool_call_excludes_current_session_from_cross_session_merge() {
+        let store = ShadowEventStore::new(test_pool().await);
+        let base = unix_now();
+        seed_events(&store, "current-session", "builtin:shell", "own", base, 2).await;
+
+        let config = zeph_config::ShadowSentinelConfig {
+            enabled: true,
+            max_context_events: 10,
+            ..zeph_config::ShadowSentinelConfig::default()
+        };
+        let trajectory =
+            capture_check_tool_call_trajectory(store, config, "current-session", "builtin:shell")
+                .await;
+
+        assert_eq!(
+            trajectory.len(),
+            2,
+            "current session's own events must appear exactly once, not duplicated via \
+             the cross-session merge; got: {trajectory:?}"
+        );
+    }
+
+    /// `probe_result` events from OTHER sessions must never leak into the cross-session
+    /// merge — `get_tool_history`'s SQL does not filter by `event_type`, so this relies
+    /// entirely on the Rust-side filter (the same LLM-isolation invariant already tested
+    /// for the same-session trajectory, exercised here on the cross-session path).
+    #[tokio::test]
+    async fn check_tool_call_excludes_probe_result_events_from_cross_session_merge() {
+        let store = ShadowEventStore::new(test_pool().await);
+        let base = unix_now();
+        let mut event = make_event("other-session", 1, "builtin:shell", "probe verdict leaked");
+        event.event_type = "probe_result".to_owned();
+        event.created_at = base;
+        store
+            .record(&event)
+            .await
+            .expect("record probe_result event");
+
+        let config = zeph_config::ShadowSentinelConfig {
+            enabled: true,
+            max_context_events: 10,
+            ..zeph_config::ShadowSentinelConfig::default()
+        };
+        let trajectory =
+            capture_check_tool_call_trajectory(store, config, "current-session", "builtin:shell")
+                .await;
+
+        assert!(
+            trajectory.is_empty(),
+            "probe_result events from other sessions must never appear in the \
+             cross-session merge (LLM isolation invariant), got: {trajectory:?}"
+        );
     }
 }

--- a/crates/zeph-tools/src/shadow_probe.rs
+++ b/crates/zeph-tools/src/shadow_probe.rs
@@ -41,6 +41,26 @@ pub trait ProbeGate: Send + Sync {
         turn_number: u64,
         risk_level: &'a str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeOutcome> + Send + 'a>>;
+
+    /// Record a completed tool call in the persistent safety event stream.
+    ///
+    /// Called by [`ShadowProbeExecutor`] after a probe outcome of `Allow` or `Deny` (never
+    /// `Skip` — recording every low-risk/disabled-feature call would flood the store with
+    /// noise and defeat the purpose of cross-session pattern detection). Best-effort: no
+    /// error is surfaced to the tool-dispatch path.
+    ///
+    /// Default implementation is a no-op, so gates that don't back a persistent store
+    /// (e.g. test doubles) don't need to implement it.
+    fn record<'a>(
+        &'a self,
+        qualified_tool_id: &'a str,
+        turn_number: u64,
+        risk_level: &'a str,
+        context_summary: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        let _ = (qualified_tool_id, turn_number, risk_level, context_summary);
+        Box::pin(async {})
+    }
 }
 
 /// Result of a probe gate evaluation.
@@ -116,6 +136,15 @@ impl<T: ToolExecutor> ShadowProbeExecutor<T> {
     fn current_risk_level(&self) -> String {
         self.risk_level.read().clone()
     }
+
+    /// Summarise a tool execution result for the shadow event stream's `context_summary`.
+    fn context_summary_for_result(result: &Result<Option<ToolOutput>, ToolError>) -> String {
+        match result {
+            Ok(Some(output)) => output.summary.clone(),
+            Ok(None) => "tool call completed with no output".to_owned(),
+            Err(e) => format!("tool call failed: {e}"),
+        }
+    }
 }
 
 impl<T: ToolExecutor> ToolExecutor for ShadowProbeExecutor<T> {
@@ -154,13 +183,35 @@ impl<T: ToolExecutor> ToolExecutor for ShadowProbeExecutor<T> {
             .await;
 
         match outcome {
-            ProbeOutcome::Allow | ProbeOutcome::Skip => self.inner.execute_tool_call(call).await,
+            ProbeOutcome::Allow => {
+                let result = self.inner.execute_tool_call(call).await;
+                // `ConfirmationRequired` is not a terminal outcome — the same call will run
+                // again via `execute_tool_call_confirmed` once the user approves, which records
+                // its own (correct) event. Recording here too would double-record every
+                // confirmation-gated call with a spurious "tool call failed" entry.
+                if !matches!(result, Err(ToolError::ConfirmationRequired { .. })) {
+                    let summary = Self::context_summary_for_result(&result);
+                    self.probe
+                        .record(call.tool_id.as_str(), turn, &risk, &summary)
+                        .await;
+                }
+                result
+            }
+            ProbeOutcome::Skip => self.inner.execute_tool_call(call).await,
             ProbeOutcome::Deny { reason } => {
                 tracing::warn!(
                     tool_id = %call.tool_id,
                     reason = %reason,
                     "ShadowProbeExecutor: safety probe denied tool call"
                 );
+                self.probe
+                    .record(
+                        call.tool_id.as_str(),
+                        turn,
+                        &risk,
+                        &format!("probe denied: {reason}"),
+                    )
+                    .await;
                 Err(ToolError::SafetyDenied { reason })
             }
         }
@@ -189,15 +240,34 @@ impl<T: ToolExecutor> ToolExecutor for ShadowProbeExecutor<T> {
             .await;
 
         match outcome {
-            ProbeOutcome::Allow | ProbeOutcome::Skip => {
-                self.inner.execute_tool_call_confirmed(call).await
+            ProbeOutcome::Allow => {
+                let result = self.inner.execute_tool_call_confirmed(call).await;
+                // Defense-in-depth/symmetry with `execute_tool_call`: `TrustGateExecutor`
+                // itself never reissues `ConfirmationRequired` on the confirmed path, but a
+                // future inner layer could, and the same double-recording rationale applies.
+                if !matches!(result, Err(ToolError::ConfirmationRequired { .. })) {
+                    let summary = Self::context_summary_for_result(&result);
+                    self.probe
+                        .record(call.tool_id.as_str(), turn, &risk, &summary)
+                        .await;
+                }
+                result
             }
+            ProbeOutcome::Skip => self.inner.execute_tool_call_confirmed(call).await,
             ProbeOutcome::Deny { reason } => {
                 tracing::warn!(
                     tool_id = %call.tool_id,
                     reason = %reason,
                     "ShadowProbeExecutor: safety probe denied confirmed tool call"
                 );
+                self.probe
+                    .record(
+                        call.tool_id.as_str(),
+                        turn,
+                        &risk,
+                        &format!("probe denied: {reason}"),
+                    )
+                    .await;
                 Err(ToolError::SafetyDenied { reason })
             }
         }
@@ -280,6 +350,53 @@ mod tests {
         }
     }
 
+    /// Test double that returns a fixed `probe()` outcome and captures every `record()` call,
+    /// so tests can assert whether recording happened without a real `ShadowSentinel`.
+    struct RecordingProbe {
+        outcome: ProbeOutcome,
+        recorded: std::sync::Mutex<Vec<(String, u64, String, String)>>,
+    }
+
+    impl RecordingProbe {
+        fn new(outcome: ProbeOutcome) -> Self {
+            Self {
+                outcome,
+                recorded: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ProbeGate for RecordingProbe {
+        fn probe<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a serde_json::Value,
+            _: u64,
+            _: &'a str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeOutcome> + Send + 'a>>
+        {
+            let outcome = self.outcome.clone();
+            Box::pin(async move { outcome })
+        }
+
+        fn record<'a>(
+            &'a self,
+            qualified_tool_id: &'a str,
+            turn_number: u64,
+            risk_level: &'a str,
+            context_summary: &'a str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+            Box::pin(async move {
+                self.recorded.lock().unwrap().push((
+                    qualified_tool_id.to_owned(),
+                    turn_number,
+                    risk_level.to_owned(),
+                    context_summary.to_owned(),
+                ));
+            })
+        }
+    }
+
     struct OkInner;
     impl ToolExecutor for OkInner {
         async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
@@ -302,6 +419,24 @@ mod tests {
                 raw_response: None,
                 claim_source: None,
             }))
+        }
+    }
+
+    /// Inner executor that always returns `ConfirmationRequired`, simulating
+    /// `TrustGateExecutor::execute_tool_call` for a `PermissionAction::Ask`-gated tool.
+    struct ConfirmationRequiredInner;
+    impl ToolExecutor for ConfirmationRequiredInner {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+
+        async fn execute_tool_call(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            Err(ToolError::ConfirmationRequired {
+                command: call.tool_id.to_string(),
+            })
         }
     }
 
@@ -379,5 +514,124 @@ mod tests {
         let exec = make_executor(AllowProbe);
         assert!(!exec.is_tool_speculatable("builtin:read"));
         assert!(!exec.is_tool_speculatable("builtin:shell"));
+    }
+
+    // ── record() wiring (#5449 follow-up) ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn allow_outcome_records_after_execution() {
+        let probe = Arc::new(RecordingProbe::new(ProbeOutcome::Allow));
+        let gate: Arc<dyn ProbeGate> = probe.clone();
+        let exec = ShadowProbeExecutor::new(
+            OkInner,
+            gate,
+            Arc::new(std::sync::atomic::AtomicU64::new(3)),
+            Arc::new(parking_lot::RwLock::new("elevated".to_owned())),
+        );
+
+        let result = exec.execute_tool_call(&make_call("builtin:shell")).await;
+        assert!(result.unwrap().is_some());
+
+        let recorded = probe.recorded.lock().unwrap();
+        assert_eq!(
+            recorded.len(),
+            1,
+            "Allow outcome must record exactly one event"
+        );
+        let (tool_id, turn, risk, summary) = &recorded[0];
+        assert_eq!(tool_id, "builtin:shell");
+        assert_eq!(*turn, 3);
+        assert_eq!(risk, "elevated");
+        assert_eq!(summary, "ok");
+    }
+
+    /// Regression: `ConfirmationRequired` is not terminal — the confirmed re-run records the
+    /// real outcome, so recording here too would double-record every confirmation-gated call
+    /// with a spurious "tool call failed" entry (found in code review of the initial fix).
+    #[tokio::test]
+    async fn allow_outcome_does_not_record_on_confirmation_required() {
+        let probe = Arc::new(RecordingProbe::new(ProbeOutcome::Allow));
+        let gate: Arc<dyn ProbeGate> = probe.clone();
+        let exec = ShadowProbeExecutor::new(
+            ConfirmationRequiredInner,
+            gate,
+            Arc::new(std::sync::atomic::AtomicU64::new(1)),
+            Arc::new(parking_lot::RwLock::new("calm".to_owned())),
+        );
+
+        let result = exec.execute_tool_call(&make_call("builtin:shell")).await;
+        assert!(matches!(
+            result,
+            Err(ToolError::ConfirmationRequired { .. })
+        ));
+        assert!(
+            probe.recorded.lock().unwrap().is_empty(),
+            "ConfirmationRequired must not be recorded — the confirmed re-run records instead"
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_outcome_records_denial_reason() {
+        let probe = Arc::new(RecordingProbe::new(ProbeOutcome::Deny {
+            reason: "risky pattern".to_owned(),
+        }));
+        let gate: Arc<dyn ProbeGate> = probe.clone();
+        let exec = ShadowProbeExecutor::new(
+            OkInner,
+            gate,
+            Arc::new(std::sync::atomic::AtomicU64::new(1)),
+            Arc::new(parking_lot::RwLock::new("calm".to_owned())),
+        );
+
+        let result = exec.execute_tool_call(&make_call("builtin:shell")).await;
+        assert!(result.is_err(), "Deny outcome must still return an error");
+
+        let recorded = probe.recorded.lock().unwrap();
+        assert_eq!(
+            recorded.len(),
+            1,
+            "Deny outcome must be recorded even though the tool never executed"
+        );
+        assert!(recorded[0].3.contains("risky pattern"));
+    }
+
+    #[tokio::test]
+    async fn skip_outcome_does_not_record() {
+        let probe = Arc::new(RecordingProbe::new(ProbeOutcome::Skip));
+        let gate: Arc<dyn ProbeGate> = probe.clone();
+        let exec = ShadowProbeExecutor::new(
+            OkInner,
+            gate,
+            Arc::new(std::sync::atomic::AtomicU64::new(1)),
+            Arc::new(parking_lot::RwLock::new("calm".to_owned())),
+        );
+
+        let _ = exec.execute_tool_call(&make_call("builtin:read")).await;
+        assert!(
+            probe.recorded.lock().unwrap().is_empty(),
+            "Skip outcome must never record — it covers both disabled-feature and \
+             low-risk-tool cases and would flood the store with noise"
+        );
+    }
+
+    #[tokio::test]
+    async fn allow_outcome_records_on_confirmed_path_too() {
+        let probe = Arc::new(RecordingProbe::new(ProbeOutcome::Allow));
+        let gate: Arc<dyn ProbeGate> = probe.clone();
+        let exec = ShadowProbeExecutor::new(
+            OkInner,
+            gate,
+            Arc::new(std::sync::atomic::AtomicU64::new(1)),
+            Arc::new(parking_lot::RwLock::new("calm".to_owned())),
+        );
+
+        let _ = exec
+            .execute_tool_call_confirmed(&make_call("builtin:shell"))
+            .await;
+        assert_eq!(
+            probe.recorded.lock().unwrap().len(),
+            1,
+            "confirmed path must also record on Allow"
+        );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -132,6 +132,20 @@ impl zeph_tools::ProbeGate for ShadowSentinelProbeGateAdapter {
             }
         })
     }
+
+    fn record<'a>(
+        &'a self,
+        qualified_tool_id: &'a str,
+        turn_number: u64,
+        risk_level: &'a str,
+        context_summary: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            self.sentinel
+                .record_tool_event(qualified_tool_id, turn_number, risk_level, context_summary)
+                .await;
+        })
+    }
 }
 
 /// Warn at startup if legacy artifact paths exist but new `.zeph/`-based paths do not.
@@ -5085,6 +5099,163 @@ mod tests {
         let args = serde_json::Value::Object(serde_json::Map::new());
         let outcome = adapter.probe("builtin:shell", &args, 1, "calm").await;
         assert_eq!(outcome, ProbeOutcome::Skip);
+    }
+
+    /// Drives a single `builtin:shell` call through the real production chain —
+    /// `ShadowProbeExecutor` -> `ShadowSentinelProbeGateAdapter::record` ->
+    /// `ShadowSentinel::record_tool_event` -> `ShadowEventStore::record` — for `session_id`,
+    /// using `pool` as the backing store. Blocks until the fire-and-forget persist completes.
+    ///
+    /// Extracted from `shadow_probe_executor_writes_reach_a_different_sessions_probe_context`
+    /// to keep that test under the line-count lint.
+    async fn drive_tool_call_through_shadow_probe_executor(
+        pool: zeph_db::DbPool,
+        session_id: &'static str,
+    ) {
+        use zeph_core::agent::shadow_sentinel::{
+            ProbeVerdict, SafetyProbe, SentinelEvent, ShadowEventStore, ShadowSentinel,
+        };
+        use zeph_tools::{ProbeGate, ToolCall, ToolExecutor, ToolOutput};
+
+        struct AllowProbe;
+        impl SafetyProbe for AllowProbe {
+            fn evaluate<'a>(
+                &'a self,
+                _: &'a str,
+                _: &'a serde_json::Value,
+                _: &'a [SentinelEvent],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>
+            {
+                Box::pin(async { ProbeVerdict::Allow })
+            }
+        }
+
+        struct OkExec;
+        impl ToolExecutor for OkExec {
+            async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, zeph_tools::ToolError> {
+                Ok(None)
+            }
+
+            async fn execute_tool_call(
+                &self,
+                call: &ToolCall,
+            ) -> Result<Option<ToolOutput>, zeph_tools::ToolError> {
+                Ok(Some(ToolOutput {
+                    tool_name: call.tool_id.clone(),
+                    summary: "command completed".to_owned(),
+                    blocks_executed: 1,
+                    filter_stats: None,
+                    diff: None,
+                    streamed: false,
+                    terminal_id: None,
+                    locations: None,
+                    raw_response: None,
+                    claim_source: None,
+                }))
+            }
+        }
+
+        let sentinel = std::sync::Arc::new(ShadowSentinel::new(
+            ShadowEventStore::new(pool),
+            Box::new(AllowProbe),
+            zeph_config::ShadowSentinelConfig {
+                enabled: true,
+                ..Default::default()
+            },
+            session_id,
+        ));
+        let probe_gate: std::sync::Arc<dyn ProbeGate> =
+            std::sync::Arc::new(ShadowSentinelProbeGateAdapter {
+                sentinel: std::sync::Arc::clone(&sentinel),
+            });
+        let executor = zeph_tools::ShadowProbeExecutor::new(
+            OkExec,
+            probe_gate,
+            std::sync::Arc::new(std::sync::atomic::AtomicU64::new(7)),
+            std::sync::Arc::new(parking_lot::RwLock::new("elevated".to_owned())),
+        );
+        let call = ToolCall {
+            tool_id: zeph_common::ToolName::new("builtin:shell"),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = executor.execute_tool_call(&call).await;
+        assert!(result.unwrap().is_some(), "tool call must succeed");
+        // record_tool_event is fire-and-forget; drain before the store is queried.
+        sentinel.drain_pending().await;
+    }
+
+    /// #5449 regression: prove the production write path actually persists a `tool_call`
+    /// event that a DIFFERENT session's probe later sees via `get_tool_history`. Prior test
+    /// coverage only seeded `tool_call` events directly into the store, which never happens
+    /// in production since nothing called `record_tool_event`.
+    #[tokio::test]
+    async fn shadow_probe_executor_writes_reach_a_different_sessions_probe_context() {
+        use zeph_core::agent::shadow_sentinel::{
+            ProbeVerdict, SafetyProbe, SentinelEvent, ShadowEventStore, ShadowSentinel,
+        };
+
+        struct CapturingProbe {
+            captured: std::sync::Arc<tokio::sync::Mutex<Vec<SentinelEvent>>>,
+        }
+        impl SafetyProbe for CapturingProbe {
+            fn evaluate<'a>(
+                &'a self,
+                _: &'a str,
+                _: &'a serde_json::Value,
+                trajectory: &'a [SentinelEvent],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>
+            {
+                let captured = std::sync::Arc::clone(&self.captured);
+                let trajectory = trajectory.to_vec();
+                Box::pin(async move {
+                    *captured.lock().await = trajectory;
+                    ProbeVerdict::Allow
+                })
+            }
+        }
+
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .expect("connect + migrate in-memory sqlite pool");
+
+        // Session A: drives a real tool call through the production executor chain.
+        drive_tool_call_through_shadow_probe_executor(pool.clone(), "session-a").await;
+
+        // Session B: a completely different ShadowSentinel/session, probing the same tool.
+        let captured: std::sync::Arc<tokio::sync::Mutex<Vec<SentinelEvent>>> =
+            std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let sentinel_b = ShadowSentinel::new(
+            ShadowEventStore::new(pool),
+            Box::new(CapturingProbe {
+                captured: std::sync::Arc::clone(&captured),
+            }),
+            zeph_config::ShadowSentinelConfig {
+                enabled: true,
+                ..Default::default()
+            },
+            "session-b",
+        );
+        let args = serde_json::Value::Object(serde_json::Map::new());
+        sentinel_b
+            .check_tool_call("builtin:shell", &args, 1, "calm")
+            .await;
+
+        let seen = captured.lock().await;
+        assert!(
+            seen.iter().any(|e| e.session_id.as_str() == "session-a"
+                && e.event_type == "tool_call"
+                && e.context_summary.as_deref() == Some("command completed")),
+            "session-b's probe context must include session-a's real tool_call event \
+             persisted via ShadowProbeExecutor, got: {seen:?}"
+        );
     }
 
     // --- init_session_sink (#5451: default CLI continuation hydration) ---


### PR DESCRIPTION
## Summary

- `ShadowEventStore`'s three query methods (`record`, `get_trajectory`, `get_tool_history`) used raw `sqlx::query`/`sqlx::query_as` with literal `?` placeholders instead of `zeph_db::query*(sql!(...))`, so under a `postgres`-feature build every call to the safety shadow-sentinel audit trail would fail at runtime (#5494).
- `ShadowSentinel`'s cross-session pattern detection was schema/comment-only: `get_tool_history` (the reader) had zero callers, and `record_tool_event` (the writer of `tool_call` events) also had zero callers, so no cross-session data ever existed to read back even once the reader was wired (#5449). Added `ProbeGate::record(...)` so `ShadowProbeExecutor` persists a `tool_call` event on `Allow`/`Deny` outcomes (never `Skip`), and `check_tool_call` now merges cross-session history for the current tool via `get_tool_history`, reserving half of `max_context_events` for each source so a busy session cannot fully starve cross-session signal.
- Two further correctness bugs found and fixed during code review: confirmation-gated tool calls (`ConfirmationRequired`) were being double-recorded (once spuriously before confirmation, once correctly after); the original merge/cap logic drained cross-session data first whenever the session was already busy, defeating the feature exactly when it mattered most.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11755 passed, 34 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] New unit/integration tests: end-to-end cross-session visibility through the real production chain (`ShadowProbeExecutor` -> adapter -> `ShadowSentinel` -> `ShadowEventStore`), confirmation-gating skip, session-heavy/cross-session-heavy/boundary cap splits, current-session exclusion, `probe_result` exclusion on the cross-session path
- [ ] Live end-to-end session verification (real `zeph --acp`/CLI run driving two sessions against a live LLM) — tracked as a fast-follow in `.local/testing/coverage-status.md` (ShadowSentinel cross-session trajectory persistence row) and `.local/testing/playbooks/beliefmem-shadow-sentinel.md` (TC-SS-05, TC-SS-09)

Closes #5494
Closes #5449