### PR TITLE
fix(session): serialize SessionEventLog writes and stop silent seq collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,6 +617,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   restoring the pre-#5454 guarantee. Both paths gained direct unit-test coverage via real
   failure-injection (dropped `acp_sessions` column/index for the store-query error; a
   file-blocking-a-directory path for the bare-open failure).
+- `fix(session)`: `SessionEventLog` could reuse an already-committed `seq` after two sequential
+  (non-overlapping) `zeph` runs against the same session, corrupting replay with duplicate `seq`
+  entries (#5487). Two compounding bugs: `append()` assigned `seq` via `fetch_add` *before*
+  acquiring the writer mutex, so two concurrent callers could be assigned adjacent seqs but land
+  their physical writes in the opposite order on disk; `read_and_truncate` then computed "next
+  seq" from the *last physical line's* value instead of the true running maximum across all
+  valid lines, so a since-reordered file's last line under-counted `next_seq` and a new append
+  collided with a seq already present earlier in the file. `append()` now assigns `seq` while
+  holding the writer lock (physical write order matches seq order again); `read_and_truncate`
+  (renamed `read_events`) now tracks `max_seq` as a running maximum, correct regardless of
+  on-disk physical order.
+
+  Also closes the issue's original concurrent-*process* scenario: added
+  `SessionEventLog::open_exclusive`, a non-blocking `flock(2)`-backed advisory lock (mirroring
+  `zeph-scheduler`'s `PidFile`) returning the new `SessionError::AlreadyLocked` if another process
+  already holds a session's lock, now wired into every writer-owning session-open path via the
+  shared D-10 hydration choke point (`hydrate_from_event_log`) plus the CLI/ACP bare-open
+  fallbacks — covering CLI default continuation, explicit `sessions resume`, `/conv resume`/
+  `fork`, ACP resume, and `zeph serve` reactivation in one edit. `AlreadyLocked` aborts CLI
+  startup and `/conv resume`/`fork` with a clear message instead of silently racing the other
+  process (`/conv resume` into the session already active in the current agent is now a fast
+  no-op instead of a self-deadlock); `zeph serve` reactivation retries a bounded number of times
+  first, since idle-eviction can race its own not-yet-drained prior actor. The plain `open()`
+  stays non-locking so read-only tooling (`sessions show`/`export`, the ACP HTTP inspection
+  endpoint, ACP `session/load` replay) can keep reading a session concurrently with a live
+  writer — and, closing a second defect that false premise exposed, `open()`/`read_all()` no
+  longer physically truncate a torn trailing line they find (only `open_exclusive`'s holder does):
+  a lockless reader can't prove a "torn" line isn't a live writer's in-flight, not-yet-fsynced
+  append, so mutating the file on every read-only `open()` could have destroyed that writer's
+  tail out from under it. ACP sessions now also surface an `AlreadyLocked` degrade to the client
+  (delivered as an agent-thought status update on the session's next prompt, via the same
+  `LoopbackChannel` used for every other agent output) instead of leaving it visible only in
+  server logs.
 - `fix(channels,sanitizer)`: the Telegram, Discord, and Slack channel adapters built
   `ChannelMessage` directly from raw bot-adapter input with zero `ContentSanitizer` involvement —
   the same unsanitized-input gap flagged as a follow-up when `zeph-gateway` webhooks were fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10992,6 +10992,7 @@ dependencies = [
 name = "zeph-session"
 version = "0.21.4"
 dependencies = [
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/zeph-agent-persistence/src/hydrate.rs
+++ b/crates/zeph-agent-persistence/src/hydrate.rs
@@ -92,7 +92,13 @@ pub async fn hydrate_from_event_log(
     memory: &SemanticMemory,
     up_to: Option<u64>,
 ) -> Result<Hydrated, PersistenceError> {
-    let log = SessionEventLog::open(session_path).await?;
+    // #5487 fix 3: this is the single shared choke point every writer-owning session-open
+    // path (ACP resume, CLI `sessions resume`/default continuation, `/conv resume`, `zeph
+    // serve` reactivation) routes through (D-10) — taking the exclusive advisory lock here
+    // activates INV-D2 enforcement for all of them at once. Read-only tooling (`sessions
+    // show`/`export`, the ACP HTTP inspection endpoint) does not call this function; it opens
+    // the log directly via the still-lockless `SessionEventLog::open`.
+    let log = SessionEventLog::open_exclusive(session_path).await?;
 
     // Legacy session lazy-bootstrap (spec §18): no-op unless this session predates durable
     // event-log persistence (has SQLite history but an empty log). Soft-fail like

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1756,6 +1756,16 @@ impl<C: Channel> Agent<C> {
         if id.is_empty() {
             return Ok("Usage: /conv resume <id>".to_owned());
         }
+        // #5487 fix 3: `load_and_resume_conversation` now opens the target session's event log
+        // exclusively (INV-D2). Resuming into the session already live in this agent would try
+        // to acquire a second exclusive lock on the same directory this agent's own
+        // `SessionSink` already holds open, deadlocking on `AlreadyLocked` — short-circuit with a
+        // clear message instead of attempting a self-conflicting reopen.
+        if let Some(sink) = &self.services.session.session_sink
+            && sink.session_id().as_str() == id
+        {
+            return Ok(format!("Already in session '{id}'."));
+        }
         let Some(memory) = self.services.memory.persistence.memory.clone() else {
             return Ok(
                 "Conversation-session persistence requires memory to be enabled ([memory] enabled = true)."
@@ -2584,6 +2594,106 @@ path = "skill-second"
         assert!(
             msg.contains("semantic_scan_provider"),
             "error message must mention semantic_scan_provider, got: {msg}"
+        );
+    }
+
+    // #5487 fix 3: `handle_conv_resume` had zero prior test coverage. Resuming into the
+    // session already live in this agent must short-circuit before attempting to re-acquire
+    // the exclusive lock this agent's own SessionSink already holds (a guaranteed
+    // `AlreadyLocked` self-deadlock, since flock conflicts are per open-file-description, not
+    // per-process).
+    #[tokio::test]
+    async fn handle_conv_resume_same_session_short_circuits() {
+        let memory = memory_without_qdrant().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_path_buf();
+        let session_id = zeph_common::SessionId::new("s1");
+        let session_path = zeph_session::session_dir(&data_dir, session_id.as_str());
+        let log = zeph_session::SessionEventLog::open_exclusive(&session_path)
+            .await
+            .unwrap();
+        let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+        let sink = zeph_agent_persistence::SessionSink::new(
+            std::sync::Arc::new(log),
+            store,
+            session_id.clone(),
+        );
+        let session_config = zeph_config::SessionConfig {
+            enabled: true,
+            data_dir: data_dir.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+
+        let mut agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![]),
+            create_test_registry(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        )
+        .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
+        .with_session_sink(Some(std::sync::Arc::new(sink)))
+        .with_session_persistence_config(Some(session_config));
+
+        let result = agent.handle_conv("resume s1").await.unwrap();
+        assert_eq!(
+            result, "Already in session 's1'.",
+            "resuming into the currently-active session must short-circuit, not attempt \
+             hydration/lock acquisition"
+        );
+    }
+
+    // Regression check for the guard above: resuming into a genuinely different session (not
+    // the one already live in this agent) must still hydrate normally.
+    #[tokio::test]
+    async fn handle_conv_resume_different_session_still_hydrates() {
+        let memory = memory_without_qdrant().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_path_buf();
+
+        // Agent is currently "in" session s1, whose own lock is held by its SessionSink.
+        let active_session_id = zeph_common::SessionId::new("s1");
+        let active_session_path = zeph_session::session_dir(&data_dir, active_session_id.as_str());
+        let active_log = zeph_session::SessionEventLog::open_exclusive(&active_session_path)
+            .await
+            .unwrap();
+        let active_store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+        let active_sink = zeph_agent_persistence::SessionSink::new(
+            std::sync::Arc::new(active_log),
+            active_store,
+            active_session_id,
+        );
+
+        // Target session s2 exists in the store (unlocked directory) — this is what should be
+        // resumed into.
+        let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+        store.create("s2").await.unwrap();
+
+        let session_config = zeph_config::SessionConfig {
+            enabled: true,
+            data_dir: data_dir.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+
+        let mut agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![]),
+            create_test_registry(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        )
+        .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
+        .with_session_sink(Some(std::sync::Arc::new(active_sink)))
+        .with_session_persistence_config(Some(session_config));
+
+        let result = agent.handle_conv("resume s2").await.unwrap();
+        assert!(
+            result.starts_with("Resumed session s2"),
+            "resuming into a different, unlocked session must still hydrate normally, got: {result}"
         );
     }
 }

--- a/crates/zeph-session/Cargo.toml
+++ b/crates/zeph-session/Cargo.toml
@@ -18,6 +18,7 @@ sqlite = ["zeph-db/sqlite"]
 postgres = ["zeph-db/postgres"]
 
 [dependencies]
+rustix = { workspace = true, features = ["fs", "std"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sqlx = { workspace = true, features = ["macros"] }

--- a/crates/zeph-session/src/error.rs
+++ b/crates/zeph-session/src/error.rs
@@ -35,4 +35,9 @@ pub enum SessionError {
     /// Condensation summarization failed (LLM call error or timeout).
     #[error("condensation summarization failed: {0}")]
     Llm(#[from] zeph_llm::LlmError),
+
+    /// [`crate::log::SessionEventLog::open_exclusive`] found another process already
+    /// holding the session's advisory write lock.
+    #[error("session event log at {0} is already locked by another process")]
+    AlreadyLocked(String),
 }

--- a/crates/zeph-session/src/log.rs
+++ b/crates/zeph-session/src/log.rs
@@ -11,12 +11,21 @@
 //!
 //! - INV-SP-1 (log-first ordering): callers must append to this log before updating any
 //!   downstream projection (`SQLite` `messages`, `acp_sessions.last_seq`).
-//! - INV-SP-2 (torn-append truncation): [`SessionEventLog::open`] validates every line on open
-//!   and truncates a garbled/incomplete trailing line, which can only occur as the very last line
-//!   because appends are serialized through a single writer (INV-D2).
+//! - INV-SP-2 (torn-append truncation): every read validates each line and drops a garbled/
+//!   incomplete trailing line from the in-memory result, which can only occur as the very last
+//!   line because appends are serialized through a single writer (INV-D2). Only
+//!   [`SessionEventLog::open_exclusive`] additionally repairs the torn tail physically on disk —
+//!   a lockless [`SessionEventLog::open`]/[`SessionEventLog::read_all`] cannot prove a "torn"
+//!   line isn't a live writer's in-flight, not-yet-fsynced append, so it must never mutate the
+//!   file (#5487 Finding B).
 //! - INV-D2 (single writer): only the session's owning actor/agent process may hold a
-//!   `SessionEventLog` for a given session directory at a time. This module does not itself
-//!   enforce cross-process exclusion; callers are responsible for the single-writer guarantee.
+//!   `SessionEventLog` for a given session directory at a time. [`SessionEventLog::open`]
+//!   does not itself enforce cross-process exclusion — it is also used by read-only
+//!   tooling (session export/inspection) that may legitimately run alongside a live
+//!   writer. The session's owning actor/agent process should instead use
+//!   [`SessionEventLog::open_exclusive`], which takes a non-blocking `flock(2)` advisory
+//!   lock (Unix only) and fails with [`SessionError::AlreadyLocked`] if another writer
+//!   already holds the session directory.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -29,6 +38,7 @@ use crate::error::SessionError;
 use crate::event::{SessionEvent, SessionEventEnvelope};
 
 const EVENTS_FILE_NAME: &str = "events.jsonl";
+const LOCK_FILE_NAME: &str = "events.jsonl.lock";
 
 /// Append-only JSONL log for one conversation-session's `events.jsonl`.
 ///
@@ -53,14 +63,23 @@ pub struct SessionEventLog {
     events_path: PathBuf,
     writer: Mutex<File>,
     next_seq: AtomicU64,
+    #[allow(dead_code)] // held only for its Drop (releases the flock, if taken)
+    lock: Option<AdvisoryLock>,
 }
 
 impl SessionEventLog {
     /// Open (creating if absent) the `events.jsonl` log under `session_dir`.
     ///
-    /// Validates the existing file per INV-SP-2, truncating a torn trailing write, then opens
-    /// the file in append mode for subsequent writes. Sets file/directory permissions to
-    /// `0o700`/`0o600` on Unix (spec §4.1); a no-op on other platforms.
+    /// Validates the existing file per INV-SP-2, dropping a torn trailing line from the
+    /// in-memory result, then opens the file in append mode for subsequent writes. Sets
+    /// file/directory permissions to `0o700`/`0o600` on Unix (spec §4.1); a no-op on other
+    /// platforms.
+    ///
+    /// Does not take the cross-process advisory lock, and never physically truncates the file
+    /// (even if a torn tail is found) — safe for read-only tooling that may run alongside a live
+    /// writer whose in-flight, not-yet-fsynced line could otherwise be mistaken for "torn" and
+    /// destroyed (#5487 Finding B). The session's owning actor/agent process should use
+    /// [`Self::open_exclusive`] instead, which does perform the physical repair.
     ///
     /// # Errors
     ///
@@ -68,11 +87,39 @@ impl SessionEventLog {
     /// [`SessionError::Serde`] surfaces only via [`Self::read_all`], never here (torn lines are
     /// discarded, not treated as fatal).
     pub async fn open(session_dir: &Path) -> Result<Self, SessionError> {
+        Self::open_with_lock(session_dir, None).await
+    }
+
+    /// Open the `events.jsonl` log under `session_dir` like [`Self::open`], but additionally
+    /// take a non-blocking, exclusive advisory lock (`flock(2)` on Unix, mirroring
+    /// `zeph-scheduler`'s `PidFile`) enforcing INV-D2's single-writer invariant.
+    ///
+    /// Intended for the session's owning actor/agent process. On non-Unix targets the lock
+    /// is a no-op (the workspace has no vetted cross-platform advisory-locking primitive), so
+    /// this degrades to [`Self::open`]'s behavior there.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::AlreadyLocked`] if another process already holds the session's
+    /// write lock, or any error [`Self::open`] can return.
+    pub async fn open_exclusive(session_dir: &Path) -> Result<Self, SessionError> {
+        fs::create_dir_all(session_dir).await?;
+        let lock = AdvisoryLock::acquire(session_dir)?;
+        Self::open_with_lock(session_dir, Some(lock)).await
+    }
+
+    async fn open_with_lock(
+        session_dir: &Path,
+        lock: Option<AdvisoryLock>,
+    ) -> Result<Self, SessionError> {
         fs::create_dir_all(session_dir).await?;
         set_permissions(session_dir, 0o700).await?;
 
         let events_path = session_dir.join(EVENTS_FILE_NAME);
-        let (_, max_seq) = read_and_truncate(&events_path).await?;
+        // Only the exclusive-lock holder may physically repair a torn tail (see
+        // `read_events`'s doc comment) — a lockless `open()` cannot prove the "torn" line
+        // isn't a live writer's in-flight, not-yet-fsynced append.
+        let (_, max_seq) = read_events(&events_path, lock.is_some()).await?;
 
         let file = OpenOptions::new()
             .create(true)
@@ -86,6 +133,7 @@ impl SessionEventLog {
             events_path,
             writer: Mutex::new(file),
             next_seq: AtomicU64::new(next_seq),
+            lock,
         })
     }
 
@@ -118,36 +166,56 @@ impl SessionEventLog {
         parent_seq: Option<u64>,
         kind: SessionEvent,
     ) -> Result<SessionEventEnvelope, SessionError> {
+        let mut file = self.writer.lock().await;
+
+        // seq assignment MUST happen while holding the writer lock: two concurrent
+        // callers assigned seq N and N+1 before the lock could still race for the
+        // lock and land their physical writes in the opposite order, breaking
+        // INV-SP-2's ascending-seq-order assumption (#5487).
         let seq = self.next_seq.fetch_add(1, Ordering::SeqCst);
         let envelope = SessionEventEnvelope::new(seq, turn_id, parent_seq, kind);
 
         let mut line = serde_json::to_vec(&envelope)?;
         line.push(b'\n');
 
-        let mut file = self.writer.lock().await;
         file.write_all(&line).await?;
         file.sync_all().await?;
 
         Ok(envelope)
     }
 
-    /// Read and validate every event currently in the log, applying INV-SP-2 truncation.
+    /// Read and validate every event currently in the log, dropping a torn trailing line from
+    /// the result (INV-SP-2). Only physically repairs the file if this handle was opened via
+    /// [`Self::open_exclusive`] — see that method's doc comment.
     ///
     /// # Errors
     ///
     /// Returns [`SessionError::Io`] if the file cannot be read.
     #[tracing::instrument(name = "session.log.read_all", skip_all, level = "debug")]
     pub async fn read_all(&self) -> Result<Vec<SessionEventEnvelope>, SessionError> {
-        let (events, _) = read_and_truncate(&self.events_path).await?;
+        // Same repair gating as `open_with_lock`: only repair the physical file when this
+        // handle holds the exclusive lock (i.e. is the session's owning writer). A read-only
+        // handle (`open()`) calling `read_all()` — e.g. `sessions show --events`, the ACP HTTP
+        // inspection endpoint — must never truncate a live writer's in-flight tail out from
+        // under it (#5487 Finding B).
+        let (events, _) = read_events(&self.events_path, self.lock.is_some()).await?;
         Ok(events)
     }
 }
 
-/// Read every valid line of `path`, truncating a garbled/incomplete trailing line (INV-SP-2).
+/// Read every valid line of `path`, dropping a garbled/incomplete trailing line from the
+/// in-memory result (INV-SP-2).
+///
+/// When `repair` is `true`, additionally truncates that torn tail physically on disk. Only the
+/// session's exclusive-lock holder (see [`SessionEventLog::open_exclusive`]) may pass `true`: it
+/// is the only caller that can prove a "torn" trailing line isn't actually a live writer's
+/// in-flight, not-yet-fsynced append (#5487 Finding B) — a lockless reader physically truncating
+/// the file could destroy a concurrent writer's tail out from under it.
 ///
 /// Returns the validated events and the maximum `seq` seen (`None` for an empty/absent log).
-async fn read_and_truncate(
+async fn read_events(
     path: &Path,
+    repair: bool,
 ) -> Result<(Vec<SessionEventEnvelope>, Option<u64>), SessionError> {
     let file = match File::open(path).await {
         Ok(file) => file,
@@ -182,7 +250,10 @@ async fn read_and_truncate(
 
         match serde_json::from_str::<SessionEventEnvelope>(trimmed) {
             Ok(envelope) if is_terminated => {
-                max_seq = Some(envelope.seq);
+                // Track the true running maximum, not just the last line's value: a
+                // file whose physical order doesn't match seq order (e.g. from a
+                // pre-fix #5487 race) must still yield the correct next seq.
+                max_seq = Some(max_seq.map_or(envelope.seq, |m: u64| m.max(envelope.seq)));
                 events.push(envelope);
                 offset += bytes_read;
                 valid_len = offset;
@@ -199,14 +270,17 @@ async fn read_and_truncate(
         tracing::warn!(
             path = %path.display(),
             valid_len,
-            "truncating torn tail in session event log (INV-SP-2)"
+            repair,
+            "dropped torn tail in session event log (INV-SP-2)"
         );
     }
 
-    let actual_len = fs::metadata(path).await?.len();
-    if valid_len < actual_len {
-        let file = OpenOptions::new().write(true).open(path).await?;
-        file.set_len(valid_len).await?;
+    if repair {
+        let actual_len = fs::metadata(path).await?.len();
+        if valid_len < actual_len {
+            let file = OpenOptions::new().write(true).open(path).await?;
+            file.set_len(valid_len).await?;
+        }
     }
 
     Ok((events, max_seq))
@@ -217,6 +291,55 @@ async fn set_permissions(path: &Path, mode: u32) -> Result<(), SessionError> {
     use std::os::unix::fs::PermissionsExt;
     fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).await?;
     Ok(())
+}
+
+/// Cross-process advisory lock enforcing INV-D2's single-writer invariant, held for the
+/// lifetime of a [`SessionEventLog`] opened via [`SessionEventLog::open_exclusive`].
+///
+/// Backed by `flock(2)` on a sibling lock file (`events.jsonl.lock`) rather than
+/// `events.jsonl` itself, so the lock is independent of the append-mode file handle already
+/// held for writing. Mirrors `zeph-scheduler`'s `PidFile`, but — unlike a pid file — the lock
+/// file is never unlinked on drop: it is a permanent sentinel, not ephemeral process identity,
+/// and unlinking it would reopen an unlink/re-create race between the releasing and the next
+/// acquiring process.
+#[cfg(unix)]
+struct AdvisoryLock(#[allow(dead_code)] rustix::fd::OwnedFd);
+
+#[cfg(unix)]
+impl AdvisoryLock {
+    fn acquire(session_dir: &Path) -> Result<Self, SessionError> {
+        use rustix::fs::{FlockOperation, Mode, OFlags};
+
+        let lock_path = session_dir.join(LOCK_FILE_NAME);
+        let fd = rustix::fs::open(
+            &lock_path,
+            OFlags::RDWR | OFlags::CREATE | OFlags::CLOEXEC,
+            Mode::from_raw_mode(0o600),
+        )
+        .map_err(std::io::Error::from)?;
+
+        rustix::fs::flock(&fd, FlockOperation::NonBlockingLockExclusive).map_err(|e| {
+            if e == rustix::io::Errno::WOULDBLOCK {
+                SessionError::AlreadyLocked(lock_path.display().to_string())
+            } else {
+                SessionError::Io(e.into())
+            }
+        })?;
+
+        Ok(Self(fd))
+    }
+}
+
+/// No vetted cross-platform advisory-locking primitive exists in this workspace, so
+/// [`SessionEventLog::open_exclusive`] does not enforce INV-D2 on non-Unix targets.
+#[cfg(not(unix))]
+struct AdvisoryLock;
+
+#[cfg(not(unix))]
+impl AdvisoryLock {
+    fn acquire(_session_dir: &Path) -> Result<Self, SessionError> {
+        Ok(Self)
+    }
 }
 
 #[cfg(not(unix))]
@@ -316,6 +439,60 @@ mod tests {
         assert_eq!(events.len(), 2);
     }
 
+    /// Regression test for #5487 Finding B: a lockless `open()`/`read_all()` must never
+    /// physically truncate a torn tail — it cannot distinguish a genuinely torn line from a
+    /// live writer's in-flight, not-yet-fsynced append, so mutating the file could destroy that
+    /// writer's data out from under it. Only `open_exclusive()` may repair.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_open_does_not_physically_truncate_torn_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let path;
+        {
+            let log = SessionEventLog::open(dir.path()).await.unwrap();
+            for i in 0..3u64 {
+                log.append(
+                    None,
+                    None,
+                    SessionEvent::UserMessage {
+                        text: format!("msg-{i}"),
+                        image_refs: vec![],
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            path = log.path().to_path_buf();
+        }
+
+        let full = tokio::fs::read(&path).await.unwrap();
+        let cut = full.len() - 5;
+        tokio::fs::write(&path, &full[..cut]).await.unwrap();
+        let torn_len = tokio::fs::metadata(&path).await.unwrap().len();
+
+        // Lockless open()/read_all(): in-memory result drops the torn line, but the file on
+        // disk must be untouched.
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        assert_eq!(log.last_seq(), Some(1));
+        let events = log.read_all().await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            tokio::fs::metadata(&path).await.unwrap().len(),
+            torn_len,
+            "open()/read_all() must never physically truncate the file"
+        );
+        drop(log);
+
+        // open_exclusive(): now physically repairs the file.
+        let log = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
+        assert_eq!(log.last_seq(), Some(1));
+        let repaired_len = tokio::fs::metadata(&path).await.unwrap().len();
+        assert!(
+            repaired_len < torn_len,
+            "open_exclusive() must physically truncate the torn tail"
+        );
+    }
+
     #[tokio::test]
     async fn test_torn_write_truncation_various_offsets() {
         for cut_from_end in [1usize, 3, 10, 20] {
@@ -364,5 +541,134 @@ mod tests {
         let log = SessionEventLog::open(dir.path()).await.unwrap();
         let meta = tokio::fs::metadata(log.path()).await.unwrap();
         assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+    }
+
+    /// Regression test for #5487 bug B: `read_events` must compute the true running
+    /// maximum `seq`, not just take the last physical line's value. Simulates the on-disk
+    /// shape a pre-fix concurrent-append race could produce: seq 7 written physically before
+    /// seq 6.
+    #[tokio::test]
+    async fn test_max_seq_survives_out_of_order_physical_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(EVENTS_FILE_NAME);
+
+        let make_line = |seq: u64| {
+            let envelope = SessionEventEnvelope::new(
+                seq,
+                None,
+                None,
+                SessionEvent::SessionEnded { reason: "x".into() },
+            );
+            let mut line = serde_json::to_vec(&envelope).unwrap();
+            line.push(b'\n');
+            line
+        };
+
+        // Physical order is seq=7 then seq=6 — out of seq order, as a pre-fix race could
+        // produce, but every line individually well-formed and fsynced.
+        let mut contents = make_line(7);
+        contents.extend(make_line(6));
+        tokio::fs::write(&path, &contents).await.unwrap();
+
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        assert_eq!(
+            log.last_seq(),
+            Some(7),
+            "next_seq must be derived from the true max seq, not the last physical line"
+        );
+        let appended = log
+            .append(
+                None,
+                None,
+                SessionEvent::SessionEnded { reason: "z".into() },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            appended.seq, 8,
+            "must not reuse a seq already present earlier in the file"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_open_exclusive_rejects_second_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let _first = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
+        match SessionEventLog::open_exclusive(dir.path()).await {
+            Err(SessionError::AlreadyLocked(_)) => {}
+            Err(e) => panic!("expected AlreadyLocked, got different error: {e}"),
+            Ok(_) => panic!("expected AlreadyLocked, but second open_exclusive succeeded"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_open_exclusive_allows_reacquire_after_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _first = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
+        }
+        // Lock released when the first handle dropped — must not still be held.
+        let _second = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_open_is_not_blocked_by_open_exclusive() {
+        let dir = tempfile::tempdir().unwrap();
+        let _writer = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
+        // Read-only `open()` must still succeed while a writer holds the exclusive lock.
+        let _reader = SessionEventLog::open(dir.path()).await.unwrap();
+    }
+
+    /// Regression test for #5487 bug A: drives genuine concurrent `append()` calls (on real
+    /// OS threads, not just cooperative interleaving) against one shared `SessionEventLog` and
+    /// asserts seq assignment and physical write order never diverge. Before the fix, `seq`
+    /// was assigned via `fetch_add` before acquiring the writer lock, so a task could win a
+    /// low seq but lose the race for the lock, landing its line after a higher-seq task's line.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn test_concurrent_append_preserves_seq_order() {
+        const N: u64 = 100;
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = std::sync::Arc::new(SessionEventLog::open(dir.path()).await.unwrap());
+
+        let mut tasks = tokio::task::JoinSet::new();
+        for i in 0..N {
+            let log = log.clone();
+            tasks.spawn(async move {
+                log.append(
+                    None,
+                    None,
+                    SessionEvent::UserMessage {
+                        text: format!("msg-{i}"),
+                        image_refs: vec![],
+                    },
+                )
+                .await
+                .unwrap()
+                .seq
+            });
+        }
+
+        let mut assigned_seqs: Vec<u64> = tasks.join_all().await;
+        assigned_seqs.sort_unstable();
+        assert_eq!(
+            assigned_seqs,
+            (0..N).collect::<Vec<_>>(),
+            "every seq in 0..{N} must be assigned exactly once, with no gaps or duplicates"
+        );
+
+        // Physical order on disk must match seq order: seq assignment and the write it
+        // guards must never diverge under contention (#5487 fix 2).
+        let events = log.read_all().await.unwrap();
+        assert_eq!(events.len(), usize::try_from(N).unwrap());
+        for (i, envelope) in events.iter().enumerate() {
+            assert_eq!(
+                envelope.seq, i as u64,
+                "physical line {i} must carry seq {i}; seq and write order diverged"
+            );
+        }
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -13,6 +13,7 @@ use crate::agent_setup;
 use crate::bootstrap::{AppBuilder, create_mcp_registry};
 #[cfg(feature = "acp")]
 use zeph_core::agent::Agent;
+use zeph_core::channel::Channel;
 #[cfg(feature = "acp")]
 use zeph_tools::ErasedToolExecutor;
 
@@ -728,7 +729,7 @@ async fn build_acp_deps(
 #[allow(clippy::too_many_lines)]
 async fn spawn_acp_agent(
     d: std::sync::Arc<SharedAgentDeps>,
-    channel: zeph_core::channel::LoopbackChannel,
+    mut channel: zeph_core::channel::LoopbackChannel,
     acp_ctx: Option<zeph_acp::AcpContext>,
     session_ctx: zeph_acp::SessionContext,
 ) {
@@ -885,6 +886,124 @@ async fn spawn_acp_agent(
             (zeph_tools::DynExecutor(base), None, None, None)
         };
 
+    // Session persistence (spec-068, #5343): reuse the ACP session_id directly as the
+    // zeph_common::SessionId — ACP already owns this session's identity/lifecycle, so no
+    // separate minting/reuse logic is needed here (unlike the CLI/TUI path in runner.rs, which
+    // has no pre-existing session identity to anchor to). `SessionStore::create` is idempotent
+    // (INSERT_IGNORE) and does not touch `conversation_id`, which ACP's own
+    // `create_acp_session_with_conversation` already manages — this call only ensures the row
+    // exists so `SessionStore::update_seq` has something to update.
+    //
+    // Computed here, before `channel` is consumed by `Agent::new_with_registry_arc` below, so an
+    // `AlreadyLocked` failure can be surfaced to the client via `channel.send_status` (delivered
+    // to the IDE as an `AgentThoughtChunk` on this session's next prompt-response drain, per
+    // `loopback_event_to_updates`) instead of only being visible in logs (#5487 fix 3).
+    let mut acp_session_sink = None;
+    let mut preloaded_messages: Vec<zeph_llm::provider::Message> = Vec::new();
+    if session_persistence_config.enabled {
+        let sid = zeph_common::SessionId::new(session_ctx.session_id.to_string());
+        let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
+        if let Err(e) = store.create(sid.as_str()).await {
+            tracing::warn!(error = %e, session_id = %sid, "failed to create session-store row for ACP session");
+        }
+        let data_dir = std::path::PathBuf::from(&session_persistence_config.data_dir);
+        let session_path = zeph_session::session_dir(&data_dir, sid.as_str());
+
+        // D-10 (spec-068 §12.3/§13): route through the shared hydration pipeline (legacy
+        // bootstrap + ReplayEngine fold + INV-SP-3 reconcile) — the one pipeline every
+        // session-open path (ACP, CLI `sessions resume`, `/conv resume`) now shares, so they
+        // cannot silently diverge again (impl-critic finding C1). Bootstrap/reconcile need a
+        // linked `ConversationId`; when absent (store was unavailable at session creation —
+        // `with_memory` above was skipped too), fall back to a bare log open with no
+        // SQLite-touching steps, matching this edge case's pre-D-10 behavior.
+        // D-13 (spec-068 §8.1, N3): `hydrate_and_condense` additionally folds in resume-time
+        // durable condensation via the pre-built `d.resume_condenser`/`d.resume_token_counter`
+        // (see `SharedAgentDeps`'s doc comment for why they're built once at deps-construction
+        // time, not here).
+        let log = if let Some(cid) = session_ctx.conversation_id {
+            match zeph_agent_persistence::hydrate_and_condense(
+                &session_path,
+                &store,
+                sid.as_str(),
+                cid,
+                &memory,
+                None,
+                &d.resume_condenser,
+                d.resume_token_counter.as_ref(),
+                d.session_config.budget_tokens,
+            )
+            .await
+            {
+                Ok(hydrated) => {
+                    preloaded_messages = hydrated.messages;
+                    Some(hydrated.log)
+                }
+                // #5487 fix 3: another process already holds this session's exclusive write
+                // lock. Unlike the generic degrade-to-no-persistence branch below, this is
+                // elevated to `error` plus a client-visible status notification — silently
+                // continuing here would let this ACP session race the other process's writes
+                // exactly like the reported bug.
+                Err(zeph_agent_persistence::PersistenceError::Session(
+                    zeph_session::SessionError::AlreadyLocked(lock_path),
+                )) => {
+                    tracing::error!(
+                        lock_path,
+                        "session hydration failed: another process already holds this session's \
+                         write lock; session persistence disabled for this session"
+                    );
+                    // Do not interpolate `lock_path` into the client-facing message: it is an
+                    // absolute filesystem path (leaks the server's home-directory prefix/OS
+                    // username) and this session may be reached over an unauthenticated,
+                    // non-loopback ACP HTTP transport (security review finding).
+                    let _ = channel
+                        .send_status(
+                            "Session persistence unavailable: another process already holds \
+                             this session's write lock.",
+                        )
+                        .await;
+                    None
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "session hydration failed; session persistence disabled for this session");
+                    None
+                }
+            }
+        } else {
+            match zeph_session::SessionEventLog::open_exclusive(&session_path).await {
+                Ok(log) => Some(Arc::new(log)),
+                Err(zeph_session::SessionError::AlreadyLocked(lock_path)) => {
+                    tracing::error!(
+                        lock_path,
+                        "failed to open session event log for ACP session: another process \
+                         already holds this session's write lock; session persistence disabled \
+                         for this session"
+                    );
+                    // Do not interpolate `lock_path` into the client-facing message: it is an
+                    // absolute filesystem path (leaks the server's home-directory prefix/OS
+                    // username) and this session may be reached over an unauthenticated,
+                    // non-loopback ACP HTTP transport (security review finding).
+                    let _ = channel
+                        .send_status(
+                            "Session persistence unavailable: another process already holds \
+                             this session's write lock.",
+                        )
+                        .await;
+                    None
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to open session event log for ACP session; session persistence disabled for this session");
+                    None
+                }
+            }
+        };
+
+        if let Some(log) = log {
+            acp_session_sink = Some(Arc::new(zeph_agent_persistence::SessionSink::new(
+                log, store, sid,
+            )));
+        }
+    }
+
     let mut agent = Box::pin(
         Agent::new_with_registry_arc(
             provider.clone(),
@@ -954,74 +1073,15 @@ async fn spawn_acp_agent(
         );
     }
 
-    // Session persistence (spec-068, #5343): reuse the ACP session_id directly as the
-    // zeph_common::SessionId — ACP already owns this session's identity/lifecycle, so no
-    // separate minting/reuse logic is needed here (unlike the CLI/TUI path in runner.rs, which
-    // has no pre-existing session identity to anchor to). `SessionStore::create` is idempotent
-    // (INSERT_IGNORE) and does not touch `conversation_id`, which ACP's own
-    // `create_acp_session_with_conversation` already manages — this call only ensures the row
-    // exists so `SessionStore::update_seq` has something to update.
-    if session_persistence_config.enabled {
-        let sid = zeph_common::SessionId::new(session_ctx.session_id.to_string());
-        let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
-        if let Err(e) = store.create(sid.as_str()).await {
-            tracing::warn!(error = %e, session_id = %sid, "failed to create session-store row for ACP session");
-        }
-        let data_dir = std::path::PathBuf::from(&session_persistence_config.data_dir);
-        let session_path = zeph_session::session_dir(&data_dir, sid.as_str());
-
-        // D-10 (spec-068 §12.3/§13): route through the shared hydration pipeline (legacy
-        // bootstrap + ReplayEngine fold + INV-SP-3 reconcile) — the one pipeline every
-        // session-open path (ACP, CLI `sessions resume`, `/conv resume`) now shares, so they
-        // cannot silently diverge again (impl-critic finding C1). Bootstrap/reconcile need a
-        // linked `ConversationId`; when absent (store was unavailable at session creation —
-        // `with_memory` above was skipped too), fall back to a bare log open with no
-        // SQLite-touching steps, matching this edge case's pre-D-10 behavior.
-        // D-13 (spec-068 §8.1, N3): `hydrate_and_condense` additionally folds in resume-time
-        // durable condensation via the pre-built `d.resume_condenser`/`d.resume_token_counter`
-        // (see `SharedAgentDeps`'s doc comment for why they're built once at deps-construction
-        // time, not here).
-        let log = if let Some(cid) = session_ctx.conversation_id {
-            match zeph_agent_persistence::hydrate_and_condense(
-                &session_path,
-                &store,
-                sid.as_str(),
-                cid,
-                &memory,
-                None,
-                &d.resume_condenser,
-                d.resume_token_counter.as_ref(),
-                d.session_config.budget_tokens,
-            )
-            .await
-            {
-                Ok(hydrated) => {
-                    if !hydrated.messages.is_empty() {
-                        agent = agent.with_preloaded_messages(hydrated.messages);
-                    }
-                    Some(hydrated.log)
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "session hydration failed; session persistence disabled for this session");
-                    None
-                }
-            }
-        } else {
-            match zeph_session::SessionEventLog::open(&session_path).await {
-                Ok(log) => Some(Arc::new(log)),
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to open session event log for ACP session; session persistence disabled for this session");
-                    None
-                }
-            }
-        };
-
-        if let Some(log) = log {
-            let sink = Arc::new(zeph_agent_persistence::SessionSink::new(log, store, sid));
-            agent = agent
-                .with_session_sink(Some(sink))
-                .with_session_persistence_config(Some(session_persistence_config.clone()));
-        }
+    // Attach the session log/history computed above, before `channel` was moved into
+    // `Agent::new_with_registry_arc`.
+    if !preloaded_messages.is_empty() {
+        agent = agent.with_preloaded_messages(preloaded_messages);
+    }
+    if let Some(sink) = acp_session_sink {
+        agent = agent
+            .with_session_sink(Some(sink))
+            .with_session_persistence_config(Some(session_persistence_config.clone()));
     }
 
     if let Some(signal) = cancel_signal {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -13,6 +13,7 @@ use crate::agent_setup;
 use crate::bootstrap::{AppBuilder, create_mcp_registry};
 #[cfg(feature = "acp")]
 use zeph_core::agent::Agent;
+#[cfg(feature = "acp")]
 use zeph_core::channel::Channel;
 #[cfg(feature = "acp")]
 use zeph_tools::ErasedToolExecutor;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -468,22 +468,29 @@ impl Drop for EarlyTuiGuard {
 /// falls back to a bare [`zeph_session::SessionEventLog::open`] after creating and linking the
 /// session row.
 ///
-/// Returns `(None, Vec::new())` (and logs a warning) on any I/O/DB failure — session persistence
-/// is best-effort: the agent must still run with only the existing `SQLite` `messages` projection
-/// if it fails.
+/// Returns `Ok((None, Vec::new()))` (and logs a warning) on any ordinary I/O/DB failure —
+/// session persistence is best-effort: the agent must still run with only the existing
+/// `SQLite` `messages` projection if it fails. The one exception is
+/// [`zeph_session::SessionError::AlreadyLocked`] (#5487 fix 3): silently degrading there would
+/// let a second `zeph` process race the same session's `SQLite` projection and durable log, so
+/// that case returns `Err` instead, aborting startup with a clear message.
+///
+/// # Errors
+///
+/// Returns `Err` only when another process already holds this session's exclusive write lock.
 async fn init_session_sink(
     memory: &std::sync::Arc<zeph_memory::semantic::SemanticMemory>,
     conversation_id: zeph_memory::ConversationId,
     config: &Config,
     provider: &LlmAnyProvider,
     budget_tokens: usize,
-) -> (
+) -> anyhow::Result<(
     Option<std::sync::Arc<zeph_agent_persistence::SessionSink>>,
     Vec<zeph_llm::provider::Message>,
-) {
+)> {
     let session_config = &config.session;
     if !session_config.enabled {
-        return (None, Vec::new());
+        return Ok((None, Vec::new()));
     }
 
     let store = zeph_session::SessionStore::new(memory.sqlite().pool().clone());
@@ -495,7 +502,7 @@ async fn init_session_sink(
             // link_conversation write against the real link, and open a bare orphan log instead
             // of hydrating the actual session. Defer session linkage entirely instead.
             tracing::warn!(error = %e, "failed to query session store for conversation link; session persistence disabled for this run");
-            return (None, Vec::new());
+            return Ok((None, Vec::new()));
         }
     };
 
@@ -503,7 +510,7 @@ async fn init_session_sink(
         let id = SessionId::generate();
         if let Err(e) = store.create(id.as_str()).await {
             tracing::warn!(error = %e, "failed to create session-store row; session persistence disabled for this run");
-            return (None, Vec::new());
+            return Ok((None, Vec::new()));
         }
         if let Err(e) = store
             .link_conversation(id.as_str(), conversation_id.0)
@@ -514,10 +521,10 @@ async fn init_session_sink(
 
         let data_dir = std::path::PathBuf::from(&session_config.data_dir);
         let session_path = zeph_session::session_dir(&data_dir, id.as_str());
-        return match zeph_session::SessionEventLog::open(&session_path).await {
+        return match zeph_session::SessionEventLog::open_exclusive(&session_path).await {
             Ok(log) => {
                 tracing::info!(session_id = %id, "session event log opened");
-                (
+                Ok((
                     Some(std::sync::Arc::new(
                         zeph_agent_persistence::SessionSink::new(
                             std::sync::Arc::new(log),
@@ -526,11 +533,14 @@ async fn init_session_sink(
                         ),
                     )),
                     Vec::new(),
-                )
+                ))
             }
+            Err(zeph_session::SessionError::AlreadyLocked(lock_path)) => Err(anyhow::anyhow!(
+                "another zeph session is already active for this conversation; lock: {lock_path}"
+            )),
             Err(e) => {
                 tracing::warn!(error = %e, "failed to open session event log; session persistence disabled for this run");
-                (None, Vec::new())
+                Ok((None, Vec::new()))
             }
         };
     };
@@ -564,11 +574,16 @@ async fn init_session_sink(
                 store,
                 SessionId::new(session_id),
             ));
-            (Some(sink), hydrated.messages)
+            Ok((Some(sink), hydrated.messages))
         }
+        Err(zeph_agent_persistence::PersistenceError::Session(
+            zeph_session::SessionError::AlreadyLocked(lock_path),
+        )) => Err(anyhow::anyhow!(
+            "another zeph session is already active for this conversation; lock: {lock_path}"
+        )),
         Err(e) => {
             tracing::warn!(error = %e, "session hydration failed for default continuation; session persistence disabled for this run");
-            (None, Vec::new())
+            Ok((None, Vec::new()))
         }
     }
 }
@@ -579,27 +594,36 @@ async fn init_session_sink(
 /// Mirrors the bare-open branch [`init_session_sink`] already takes when minting a brand-new
 /// session, so a resume with a failing initial hydration still gets a working sink whenever the
 /// event log directory is otherwise accessible, instead of silently narrowing to no sink at all.
-/// Returns `None` (and logs a warning) if the bare open also fails — session persistence stays
-/// best-effort/non-fatal here too.
+/// Returns `Ok(None)` (and logs a warning) if the bare open also fails for an ordinary reason —
+/// session persistence stays best-effort/non-fatal here too. Like [`init_session_sink`],
+/// [`zeph_session::SessionError::AlreadyLocked`] is the one exception: it returns `Err` instead
+/// of silently disabling persistence (#5487 fix 3).
+///
+/// # Errors
+///
+/// Returns `Err` only when another process already holds this session's exclusive write lock.
 async fn resume_session_sink_fallback(
     session_path: &std::path::Path,
     session_store: zeph_session::SessionStore,
     resume_id: &str,
-) -> Option<std::sync::Arc<zeph_agent_persistence::SessionSink>> {
-    match zeph_session::SessionEventLog::open(session_path).await {
+) -> anyhow::Result<Option<std::sync::Arc<zeph_agent_persistence::SessionSink>>> {
+    match zeph_session::SessionEventLog::open_exclusive(session_path).await {
         Ok(log) => {
             tracing::info!(session_id = %resume_id, "session event log opened via bare fallback after failed hydration");
-            Some(std::sync::Arc::new(
+            Ok(Some(std::sync::Arc::new(
                 zeph_agent_persistence::SessionSink::new(
                     std::sync::Arc::new(log),
                     session_store,
                     SessionId::new(resume_id.to_string()),
                 ),
-            ))
+            )))
         }
+        Err(zeph_session::SessionError::AlreadyLocked(lock_path)) => Err(anyhow::anyhow!(
+            "another zeph session is already active for session '{resume_id}'; lock: {lock_path}"
+        )),
         Err(open_err) => {
             tracing::warn!(error = %open_err, "bare session event log fallback also failed; continuing with SQLite-only history");
-            None
+            Ok(None)
         }
     }
 }
@@ -1807,6 +1831,17 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                         ),
                     ));
                 }
+                // #5487 fix 3: another process already holds this session's exclusive write
+                // lock — abort startup with a clear message instead of attempting the bare-open
+                // fallback below, which would just hit the same lock and fail identically, or
+                // (with a lockless open) silently race the other process's writes.
+                Err(zeph_agent_persistence::PersistenceError::Session(
+                    zeph_session::SessionError::AlreadyLocked(lock_path),
+                )) => {
+                    anyhow::bail!(
+                        "another zeph session is already active for session '{resume_id}'; lock: {lock_path}"
+                    );
+                }
                 Err(e) => {
                     // #5456: pre-#5451 behavior always guaranteed a bare SessionEventLog::open
                     // fallback for the resumed session. Falling through to init_session_sink
@@ -1816,7 +1851,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                     tracing::warn!(error = %e, "session hydration failed for resume; attempting bare event log fallback");
                     resumed_session_sink =
                         resume_session_sink_fallback(&session_path, session_store, &resume_id)
-                            .await;
+                            .await?;
                 }
             }
         }
@@ -1842,7 +1877,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         Some(sink)
     } else {
         let (sink, hydrated_messages) =
-            init_session_sink(&memory, conversation_id, config, &provider, budget_tokens).await;
+            init_session_sink(&memory, conversation_id, config, &provider, budget_tokens).await?;
         if !hydrated_messages.is_empty() {
             resumed_messages = hydrated_messages;
         }
@@ -5295,7 +5330,9 @@ mod tests {
         let config = runner_test_session_config(dir.path());
         let provider = LlmAnyProvider::Mock(zeph_llm::mock::MockProvider::default());
 
-        let (sink, messages) = init_session_sink(&memory, cid, &config, &provider, 0).await;
+        let (sink, messages) = init_session_sink(&memory, cid, &config, &provider, 0)
+            .await
+            .unwrap();
         assert!(
             sink.is_some(),
             "session persistence enabled must produce a SessionSink"
@@ -5326,7 +5363,9 @@ mod tests {
         let provider = LlmAnyProvider::Mock(zeph_llm::mock::MockProvider::default());
 
         // First launch: mints the session, nothing to replay yet.
-        let (sink, initial_messages) = init_session_sink(&memory, cid, &config, &provider, 0).await;
+        let (sink, initial_messages) = init_session_sink(&memory, cid, &config, &provider, 0)
+            .await
+            .unwrap();
         let sink = sink.expect("session persistence enabled must produce a SessionSink");
         assert!(initial_messages.is_empty());
         sink.record_message(zeph_llm::provider::Role::User, "hello", &[])
@@ -5336,7 +5375,9 @@ mod tests {
 
         // Second launch (plain `zeph`, no --resume): must hydrate the message recorded above
         // from the durable event log, not silently return an empty history.
-        let (sink, messages) = init_session_sink(&memory, cid, &config, &provider, 0).await;
+        let (sink, messages) = init_session_sink(&memory, cid, &config, &provider, 0)
+            .await
+            .unwrap();
         assert!(sink.is_some());
         assert_eq!(
             messages.len(),
@@ -5373,7 +5414,9 @@ mod tests {
             .await
             .expect("sqlite must support DROP COLUMN to set up this test's failure mode");
 
-        let (sink, messages) = init_session_sink(&memory, cid, &config, &provider, 0).await;
+        let (sink, messages) = init_session_sink(&memory, cid, &config, &provider, 0)
+            .await
+            .unwrap();
         assert!(
             sink.is_none(),
             "a store query error must not produce a SessionSink"
@@ -5408,7 +5451,9 @@ mod tests {
         let session_path = dir.path().join("session-abc");
         let session_store = make_runner_test_session_store().await;
 
-        let sink = resume_session_sink_fallback(&session_path, session_store, "resume-id-1").await;
+        let sink = resume_session_sink_fallback(&session_path, session_store, "resume-id-1")
+            .await
+            .unwrap();
         let sink =
             sink.expect("SessionEventLog::open must succeed against a fresh, writable directory");
         assert_eq!(sink.session_id().as_str(), "resume-id-1");
@@ -5426,10 +5471,76 @@ mod tests {
         let session_path = blocker.join("session-subdir");
         let session_store = make_runner_test_session_store().await;
 
-        let sink = resume_session_sink_fallback(&session_path, session_store, "resume-id-2").await;
+        let sink = resume_session_sink_fallback(&session_path, session_store, "resume-id-2")
+            .await
+            .unwrap();
         assert!(
             sink.is_none(),
             "a session_path colliding with a non-directory file must not produce a sink"
+        );
+    }
+
+    /// #5487 fix 3: when a second process already holds this session's exclusive write lock,
+    /// `init_session_sink` must fail fast with `Err` instead of silently degrading to
+    /// `(None, Vec::new())` — a real concurrent `SessionEventLog::open_exclusive` held on the
+    /// same directory (not a mocked error), exercising the actual `hydrate_and_condense` ->
+    /// `hydrate_from_event_log` -> `open_exclusive` call chain.
+    #[tokio::test]
+    async fn init_session_sink_bails_when_hydration_hits_already_locked() {
+        let memory = make_runner_test_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let config = runner_test_session_config(dir.path());
+        let provider = LlmAnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+
+        // First call mints and links the session, then releases its lock.
+        let (sink, _) = init_session_sink(&memory, cid, &config, &provider, 0)
+            .await
+            .unwrap();
+        let sink = sink.expect("session persistence enabled must produce a SessionSink");
+        let session_id = sink.session_id().clone();
+        drop(sink);
+
+        // A second process holds the session's exclusive write lock.
+        let session_path = zeph_session::session_dir(
+            std::path::Path::new(&config.session.data_dir),
+            session_id.as_str(),
+        );
+        let _blocker = zeph_session::SessionEventLog::open_exclusive(&session_path)
+            .await
+            .unwrap();
+
+        let result = init_session_sink(&memory, cid, &config, &provider, 0).await;
+        let Err(err) = result else {
+            panic!("AlreadyLocked must fail fast, not silently degrade to no persistence")
+        };
+        assert!(
+            err.to_string().contains("already active"),
+            "error must clearly state another session is active, got: {err}"
+        );
+    }
+
+    /// #5487 fix 3 counterpart for the bare-open fallback: a real concurrent
+    /// `SessionEventLog::open_exclusive` on the same directory must make
+    /// `resume_session_sink_fallback` fail fast with `Err`, not silently return `None`.
+    #[tokio::test]
+    async fn resume_session_sink_fallback_bails_when_already_locked() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_path = dir.path().join("session-abc");
+        let session_store = make_runner_test_session_store().await;
+
+        let _blocker = zeph_session::SessionEventLog::open_exclusive(&session_path)
+            .await
+            .unwrap();
+
+        let result =
+            resume_session_sink_fallback(&session_path, session_store, "resume-id-3").await;
+        let Err(err) = result else {
+            panic!("AlreadyLocked must fail fast, not silently degrade to no persistence")
+        };
+        assert!(
+            err.to_string().contains("already active"),
+            "error must clearly state another session is active, got: {err}"
         );
     }
 }

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -37,6 +37,19 @@ use zeph_core::channel::LoopbackChannel;
 
 use super::deps::ServeAgentDeps;
 
+/// Bounds the retry-on-`AlreadyLocked` loop in [`hydrate_session_sink`] (#5487 fix 3).
+///
+/// `evict_loop` (`src/serve/mod.rs`) removes an idle session from `LiveSessionRegistry` and
+/// cancels its actor *before* that actor's dedicated thread has necessarily finished dropping
+/// its `SessionEventLog` (and releasing the actor's flock) — a fast reactivation request for the
+/// same `session_id` can race the still-draining old actor and see a transient `AlreadyLocked`
+/// that is not a genuine second writer, just a slow release. Retrying a few times with a short
+/// backoff resolves this without restructuring `LiveSessionRegistry`/`evict_loop` to award the
+/// reactivation path direct visibility into the old actor's drain-completion signal.
+const REACTIVATION_LOCK_RETRY_ATTEMPTS: u32 = 5;
+/// Delay between retry attempts — see [`REACTIVATION_LOCK_RETRY_ATTEMPTS`].
+const REACTIVATION_LOCK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(20);
+
 /// Build a `build_agent` closure for [`zeph_core::serve::SessionActor::spawn`].
 ///
 /// Opens (and, for a reactivated session, replays) the session's durable event log — if
@@ -137,32 +150,54 @@ async fn hydrate_session_sink(
     // via the deps-level pre-built `resume_condenser`/`resume_token_counter` (see
     // `ServeAgentDeps::resume_condenser`'s doc comment for why they're built once at deps-
     // construction time, not here).
-    match zeph_agent_persistence::hydrate_and_condense(
-        &session_path,
-        &store,
-        session_id.as_str(),
-        conversation_id,
-        memory,
-        None,
-        resume_condenser,
-        resume_token_counter,
-        context_window,
-    )
-    .await
-    {
-        Ok(hydrated) => {
-            let sink = Arc::new(zeph_agent_persistence::SessionSink::new(
-                hydrated.log,
-                store,
-                session_id,
-            ));
-            (Some(sink), hydrated.messages)
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "serve-sessions: session persistence disabled for this session");
-            (None, Vec::new())
+    //
+    // #5487 fix 3: `hydrate_and_condense` now opens the log exclusively (INV-D2). Retry a
+    // bounded number of times on `AlreadyLocked` — see `REACTIVATION_LOCK_RETRY_ATTEMPTS`'s doc
+    // comment for the eviction/reactivation race this closes. A non-transient `AlreadyLocked`
+    // (a genuinely still-live second writer) degrades to no persistence after the retry budget
+    // is exhausted, same as any other hydration failure — this function's contract is
+    // best-effort, not fail-fast, since the daemon has no synchronous caller to fail back to.
+    for attempt in 1..=REACTIVATION_LOCK_RETRY_ATTEMPTS {
+        match zeph_agent_persistence::hydrate_and_condense(
+            &session_path,
+            &store,
+            session_id.as_str(),
+            conversation_id,
+            memory,
+            None,
+            resume_condenser,
+            resume_token_counter,
+            context_window,
+        )
+        .await
+        {
+            Ok(hydrated) => {
+                let sink = Arc::new(zeph_agent_persistence::SessionSink::new(
+                    hydrated.log,
+                    store,
+                    session_id,
+                ));
+                return (Some(sink), hydrated.messages);
+            }
+            Err(zeph_agent_persistence::PersistenceError::Session(
+                zeph_session::SessionError::AlreadyLocked(lock_path),
+            )) if attempt < REACTIVATION_LOCK_RETRY_ATTEMPTS => {
+                tracing::debug!(
+                    lock_path,
+                    attempt,
+                    "serve-sessions: event log still locked by a draining prior actor; retrying reactivation"
+                );
+                tokio::time::sleep(REACTIVATION_LOCK_RETRY_DELAY).await;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "serve-sessions: session persistence disabled for this session");
+                return (None, Vec::new());
+            }
         }
     }
+    unreachable!(
+        "the loop always returns: the last attempt's AlreadyLocked falls into the generic Err(e) arm"
+    )
 }
 
 #[cfg(test)]
@@ -302,5 +337,94 @@ mod tests {
             1,
             "reactivation must replay the session's prior turn, not start fresh"
         );
+    }
+
+    /// #5487 fix 3: `evict_loop` frees a session's registry slot before its actor's dedicated
+    /// thread has necessarily finished dropping the old `SessionEventLog` (and releasing its
+    /// flock) — a fast reactivation can see a transient `AlreadyLocked` that isn't a genuine
+    /// second writer. Simulates that race: a background task holds the exclusive lock for
+    /// longer than a couple of retry intervals, then releases it. `hydrate_session_sink` must
+    /// retry past the transient failures and still succeed.
+    #[tokio::test]
+    async fn hydrate_session_sink_retries_transient_already_locked_and_succeeds() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let config = zeph_config::SessionConfig {
+            enabled: true,
+            data_dir: dir.path().to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        let session_id = zeph_common::SessionId::new("s1");
+        let session_path = zeph_session::session_dir(dir.path(), session_id.as_str());
+        let (condenser, token_counter) = make_test_condenser();
+
+        // Held past attempts 1-3 (t=0, 20, 40ms), released before attempt 4 (t=60ms).
+        let blocker = zeph_session::SessionEventLog::open_exclusive(&session_path)
+            .await
+            .unwrap();
+        let release_handle = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            drop(blocker);
+        });
+
+        let (sink, _) = hydrate_session_sink(
+            &config,
+            &memory,
+            session_id,
+            cid,
+            &condenser,
+            &token_counter,
+            0,
+        )
+        .await;
+
+        release_handle.await.unwrap();
+        assert!(
+            sink.is_some(),
+            "hydrate_session_sink must retry past a transient AlreadyLocked and eventually \
+             succeed once the draining actor releases its flock"
+        );
+    }
+
+    /// Counterpart to the retry-success test above: a genuinely still-live second writer (lock
+    /// held for the whole call, not just a drain race) must exhaust the retry budget and
+    /// gracefully degrade to no persistence, not panic or hang.
+    #[tokio::test]
+    async fn hydrate_session_sink_gives_up_after_retry_budget_exhausted() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let config = zeph_config::SessionConfig {
+            enabled: true,
+            data_dir: dir.path().to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        let session_id = zeph_common::SessionId::new("s1");
+        let session_path = zeph_session::session_dir(dir.path(), session_id.as_str());
+        let (condenser, token_counter) = make_test_condenser();
+
+        // Held for the entire call — never released, unlike the transient-race test above.
+        let _blocker = zeph_session::SessionEventLog::open_exclusive(&session_path)
+            .await
+            .unwrap();
+
+        let (sink, messages) = hydrate_session_sink(
+            &config,
+            &memory,
+            session_id,
+            cid,
+            &condenser,
+            &token_counter,
+            0,
+        )
+        .await;
+
+        assert!(
+            sink.is_none(),
+            "retry budget exhaustion against a genuinely still-locked session must degrade to \
+             no persistence, not panic or hang"
+        );
+        assert!(messages.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

`SessionEventLog` produced duplicate/colliding `seq` numbers and phantom/interleaved events in two related scenarios: a sequential re-attach to the same conversation (session-open hydration only tracked the last physical line's `seq`, not the true running maximum) and genuinely concurrent writers (`append` assigned `seq` before acquiring the writer lock, letting concurrent callers land physical writes in the wrong order). Both are fixed at the root, and the fix additionally closes the original two-concurrent-process scenario the issue was filed against, not just the narrower sequential-reopen variant.

- `read_events` (renamed from `read_and_truncate`) now computes a true running `max_seq` across all valid lines, regardless of on-disk physical order.
- `append` now assigns `seq` while holding the writer lock, so seq assignment and physical write order can no longer diverge under concurrent callers.
- New `SessionEventLog::open_exclusive` takes a non-blocking `flock`-based advisory lock (mirrors `zeph-scheduler`'s `PidFile`), wired into all four writer-owning session-open paths (CLI default/explicit resume, in-agent `/conv resume`, ACP resume, `zeph serve` reactivation) via the existing `hydrate_from_event_log` choke point plus three bare-open fallbacks.
- `open()`/`read_all()` no longer physically truncate a torn tail unless the caller holds the exclusive lock — a lockless read-only caller (`sessions export`, ACP inspection) can no longer corrupt a live writer's in-flight tail.
- `AlreadyLocked` is handled explicitly per mode instead of silently degrading to no-persistence: CLI hard-aborts startup with a clear message, `/conv resume` gets a self-resume guard to avoid a self-deadlock when resuming into the already-active session, `zeph serve` reactivation retries briefly to absorb an idle-eviction/still-draining-actor race, and ACP surfaces a client-visible status message in addition to server-side logging.
- Security review caught and fixed one Medium information-disclosure: the ACP client-facing message initially included the raw filesystem lock path, which could reach an unauthenticated, non-loopback HTTP client — dropped from the client message, kept in server-side logs only.

## Test plan

- [x] `test_concurrent_append_preserves_seq_order` — genuine multi-thread concurrent-append regression test; fails against the pre-fix code (`fetch_add` before the lock), passes after
- [x] `test_max_seq_survives_out_of_order_physical_lines` — regression test for the seq-hydration bug
- [x] `test_open_exclusive_rejects_second_writer` / `test_open_exclusive_allows_reacquire_after_drop` / `test_open_is_not_blocked_by_open_exclusive` — flock semantics
- [x] `test_open_does_not_physically_truncate_torn_tail` — confirms lockless `open()`/`read_all()` never mutate the file, only `open_exclusive()`'s holder repairs
- [x] `handle_conv_resume_same_session_short_circuits` / `handle_conv_resume_different_session_still_hydrates` — self-resume guard
- [x] `hydrate_session_sink_retries_transient_already_locked_and_succeeds` / `hydrate_session_sink_gives_up_after_retry_budget_exhausted` — daemon reactivation retry, real locks not mocks
- [x] `init_session_sink_bails_when_hydration_hits_already_locked` / `resume_session_sink_fallback_bails_when_already_locked` — CLI fail-fast against a real concurrent lock
- [x] Full CI-matching suite green: `fmt`, `clippy --profile ci` (full feature set), 11753 workspace tests passed (1 pre-existing unrelated flaky `llm_condenser` leak, not introduced by this PR), rustdoc gate, doc-tests
- [ ] Live-tested — this fix went through debugger/developer/tester/critic/security/architect/review passes but no `rust-live-tester` session; flagged as a follow-up in the testing playbook

## Known follow-ups (not blocking, to be filed as separate issues)

- Daemon silent-degrade under sustained load (retry budget exhaustion) is only `warn!`-logged, no metric/counter
- ACP client notification is not proactive — it only surfaces on the client's next `session/prompt` call, not immediately at session creation, since `spawn_acp_agent` has no other handle back to the ACP protocol layer

Closes #5487