### PR TITLE
fix(db): parse SQLite ?N placeholders correctly in sql!() for Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1230,6 +1230,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Added 5 new Postgres regression tests (`tests/postgres_integration.rs`, `test-utils` feature)
   covering previously-untested fixed call sites. Closes #5488, closes #5491.
 
+- `fix(db)`: `zeph_db::sql!()`'s Postgres `rewrite_placeholders` did a naive per-character `?`→`$N`
+  walk with no awareness of `SQLite`'s `?N` numbered-placeholder syntax, so wrapping `?1` in
+  `sql!()` produced `$11` (the `$1` rewrite immediately followed by the literal digit `1`) instead
+  of `$1`, and a repeated `?N` reference (valid `SQLite` syntax for binding the same value twice
+  with one `.bind()` call) was assigned two different Postgres placeholder numbers, silently
+  changing the required bind-parameter count (#5506). `rewrite_placeholders` now parses `?[0-9]+`
+  groups and rewrites them directly to `$N` — preserving the index rather than renumbering by
+  position, so repeated `?N` references collapse to the same `$N` and still need only one
+  `.bind()` call, matching both `SQLite`'s and `sqlx`'s Postgres binding semantics (bind values are
+  supplied once per distinct slot, in ascending order, regardless of how many times that slot's
+  placeholder appears in the SQL text). A bare `?` continues to be assigned the next index after
+  the highest index used so far, matching `SQLite`'s own numbering rule for anonymous
+  placeholders. This was a live, uncaught defect: 77 existing `sql!()` call sites across
+  `zeph-memory`'s test suite already used `?1`/`?2` syntax and would have silently emitted
+  corrupted SQL (or a bind-count mismatch) at runtime under the `postgres` feature. Added unit
+  tests covering numbered placeholders, repeated numbered placeholders, and mixed bare/numbered
+  placeholders in `crates/zeph-db/src/lib.rs`.
+
+- `fix(memory)`: `five_signal::consolidation::ConsolidationHandler::run_once` decoded
+  `messages.created_at` as `i64`, but the column is `TIMESTAMPTZ` on Postgres (`TEXT` on `SQLite`),
+  causing a `ColumnDecode` panic on every row once both the `scheduler` and `postgres` features
+  were enabled (#5507). The query now casts `created_at` through
+  `Dialect::epoch_from_col`, the existing dialect-neutral epoch-normalization pattern already used
+  by `semantic::recall`'s `created_at_map` fetch, aliasing the result back to `created_at` so it
+  decodes as `i64` on both backends. Added a Postgres regression test in
+  `crates/zeph-memory/tests/postgres_integration.rs` driving `ConsolidationHandler` through its
+  public `TaskHandler::execute` entry point (`run_once`/`apply_promotions`/`apply_demotions` are
+  private) and asserting a fresh, high-novelty fact is correctly promoted.
+
 ### Changed
 
 - `build(db)`: upgrade `sqlx` 0.8.6 → 0.9.0. The `runtime-tokio-rustls` feature was split into

--- a/crates/zeph-db/src/lib.rs
+++ b/crates/zeph-db/src/lib.rs
@@ -78,8 +78,10 @@ pub type ActiveDialect = <ActiveDriver as DatabaseDriver>::Dialect;
 ///
 /// `SQLite`: returns the input `&str` directly — zero allocation, zero runtime cost.
 ///
-/// `PostgreSQL`: rewrites `?` to `$1`, `$2`, ... using [`rewrite_placeholders`].
-/// The rewritten string is leaked via `Box::leak` to obtain `&'static str` —
+/// `PostgreSQL`: rewrites `?` to `$1`, `$2`, ... and `?N` (`SQLite`'s numbered
+/// placeholder, e.g. `?1`) to `$N` using [`rewrite_placeholders`]. Repeated
+/// references to the same `?N` collapse to the same `$N`. The rewritten
+/// string is leaked via `Box::leak` to obtain `&'static str` —
 /// no caching: each call site leaks one allocation per unique SQL string.
 /// The set of unique SQL strings is bounded (call sites are fixed at compile
 /// time), so total leaked memory is bounded and acceptable for a long-running
@@ -127,22 +129,43 @@ pub fn is_postgres_url(url: &str) -> bool {
 
 /// Rewrite `?` bind markers to `$1, $2, ...` for `PostgreSQL`.
 ///
+/// Handles both bare `?` (`SQLite`'s "next unused index" placeholder) and
+/// numbered `?N` (`SQLite`'s explicit-index placeholder, e.g. `?1`, `?2`).
+/// A numbered `?N` is rewritten directly to `$N` — preserving the index
+/// rather than renumbering by position — so that repeated references to the
+/// same `?N` collapse to the same `$N` and require only one `.bind()` call,
+/// matching both `SQLite`'s and `sqlx`'s `PostgreSQL` binding semantics (bind
+/// values are supplied once per distinct slot, in ascending slot order,
+/// regardless of how many times the slot's placeholder appears in the SQL
+/// text). A bare `?` is assigned the next index after the highest index used
+/// so far (explicit or bare), matching `SQLite`'s own numbering rule.
+///
 /// Skips `?` inside single-quoted string literals. Does NOT handle dollar-quoted
 /// strings (`$$...$$`) or `?` inside comments — document this limitation at call
 /// sites where those patterns appear.
 #[must_use]
 pub fn rewrite_placeholders(query: &str) -> String {
     let mut out = String::with_capacity(query.len() + 16);
-    let mut n = 0u32;
+    let mut chars = query.chars().peekable();
+    let mut max_n = 0u32;
     let mut in_string = false;
-    for ch in query.chars() {
+    while let Some(ch) = chars.next() {
         match ch {
             '\'' => {
                 in_string = !in_string;
                 out.push(ch);
             }
             '?' if !in_string => {
-                n += 1;
+                let digits: String =
+                    std::iter::from_fn(|| chars.next_if(char::is_ascii_digit)).collect();
+                let n = if digits.is_empty() {
+                    max_n += 1;
+                    max_n
+                } else {
+                    let explicit = digits.parse().unwrap_or(u32::MAX);
+                    max_n = max_n.max(explicit);
+                    explicit
+                };
                 out.push('$');
                 out.push_str(&n.to_string());
             }
@@ -203,6 +226,30 @@ mod tests {
     fn rewrite_placeholders_no_params() {
         let out = rewrite_placeholders("SELECT 1");
         assert_eq!(out, "SELECT 1");
+    }
+
+    #[test]
+    fn rewrite_placeholders_numbered() {
+        let out = rewrite_placeholders("INSERT INTO t (a, b) VALUES (?1, ?2) RETURNING id");
+        assert_eq!(out, "INSERT INTO t (a, b) VALUES ($1, $2) RETURNING id");
+    }
+
+    #[test]
+    fn rewrite_placeholders_collapses_repeated_numbered() {
+        // `?1` appears twice — SQLite binds it once, so PostgreSQL must too.
+        let out = rewrite_placeholders("INSERT INTO edges (source_id, target_id) VALUES (?1, ?1)");
+        assert_eq!(
+            out,
+            "INSERT INTO edges (source_id, target_id) VALUES ($1, $1)"
+        );
+    }
+
+    #[test]
+    fn rewrite_placeholders_mixed_bare_and_numbered() {
+        // A bare `?` after `?2` continues numbering from the highest index seen (3),
+        // matching SQLite's "next unused index" rule for anonymous placeholders.
+        let out = rewrite_placeholders("SELECT * FROM t WHERE a = ?2 AND b = ? AND c = ?1");
+        assert_eq!(out, "SELECT * FROM t WHERE a = $2 AND b = $3 AND c = $1");
     }
 
     #[test]

--- a/crates/zeph-memory/src/five_signal/consolidation.rs
+++ b/crates/zeph-memory/src/five_signal/consolidation.rs
@@ -94,18 +94,25 @@ impl ConsolidationHandler {
         rt.metrics.inc_consolidation_run();
 
         // NOTE: ORDER BY id DESC retrieves newest facts — known MVP trade-off per NFR-004.
-        let rows = zeph_db::query(sql!(
-            "SELECT id, created_at, qdrant_promoted, memory_tier \
+        // `messages.created_at` is `TIMESTAMPTZ` on PostgreSQL but text/epoch on SQLite;
+        // `epoch_from_col` normalizes it to an i64 epoch on both backends (same pattern
+        // used by `semantic::recall`'s `created_at_map` fetch).
+        let created_at_epoch =
+            <zeph_db::ActiveDialect as zeph_db::Dialect>::epoch_from_col("created_at");
+        let limit_placeholder = zeph_db::numbered_placeholder(1);
+        let query_sql = format!(
+            "SELECT id, {created_at_epoch} AS created_at, qdrant_promoted, memory_tier \
              FROM messages \
              WHERE deleted_at IS NULL \
                AND (memory_tier IS NULL OR memory_tier NOT IN ('episodic_only')) \
              ORDER BY id DESC \
-             LIMIT ?"
-        ))
-        .bind(i64::try_from(self.config.top_k_per_run).unwrap_or(i64::MAX))
-        .fetch_all(&rt.pool)
-        .await
-        .map_err(|e| MemoryError::Db(e.into()))?;
+             LIMIT {limit_placeholder}"
+        );
+        let rows = zeph_db::query(zeph_db::sqlx::AssertSqlSafe(query_sql))
+            .bind(i64::try_from(self.config.top_k_per_run).unwrap_or(i64::MAX))
+            .fetch_all(&rt.pool)
+            .await
+            .map_err(|e| MemoryError::Db(e.into()))?;
 
         let batch: Vec<_> = rows.iter().take(self.config.batch_size).collect();
         let processed = batch.len();
@@ -128,7 +135,7 @@ impl ConsolidationHandler {
 
         for row in &batch {
             let fact_id: i64 = row.get("id");
-            let novelty = rt.novelty_computer.compute(row.get("created_at"));
+            let novelty = rt.novelty_computer.compute(row.get::<i64, _>("created_at"));
             let frequency = freq_scores.get(&MessageId(fact_id)).copied().unwrap_or(0.0);
             let w = &rt.weights;
             let score = w.w_recency * novelty

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -1235,19 +1235,80 @@ mod pg {
         assert_eq!(row.3, "pending");
     }
 
-    // NOTE: a Postgres regression test for `ConsolidationHandler::execute` (which exercises
-    // `run_once` / `apply_promotions` / `apply_demotions`) was attempted here but is omitted.
-    // It immediately surfaced a pre-existing, UNRELATED production bug: `messages.created_at`
-    // is `TIMESTAMPTZ` in the Postgres schema (`zeph-db/migrations/postgres/001_init.sql`) but
-    // `five_signal/consolidation.rs::run_once` does `row.get::<i64, _>("created_at")`, which
-    // panics with `ColumnDecode { ... mismatched types ... INT8 ... TIMESTAMPTZ }` for any row
-    // when `scheduler` + `postgres` are both enabled. This is a distinct defect class from the
-    // `sql!()`/placeholder bug this PR fixes (`apply_promotions`/`apply_demotions` themselves
-    // only touch `id`, not `created_at`, and are already correctly fixed). `apply_promotions`
-    // and `apply_demotions` are private methods not reachable from this external test file, so
-    // they cannot be covered without either fixing the `created_at` decode bug or changing
-    // their visibility — both out of scope here. See the PR discussion / follow-up issue for
-    // the `created_at` type-mismatch bug before attempting this coverage again.
+    // ── five_signal::consolidation: run_once created_at TIMESTAMPTZ decode (#5507) ─────
+    //
+    // Regression coverage for #5507: `messages.created_at` is `TIMESTAMPTZ` in the Postgres
+    // schema but `run_once` used to decode it via `row.get::<i64, _>("created_at")`, which
+    // panicked with `ColumnDecode { ... mismatched types ... INT8 ... TIMESTAMPTZ }` for any
+    // row once `scheduler` + `postgres` were both enabled. The fix casts the column through
+    // `Dialect::epoch_from_col` (same pattern as `semantic::recall`'s `created_at_map` fetch)
+    // before decoding. `run_once`/`apply_promotions`/`apply_demotions` are private, so this
+    // drives them through the only public entry point, `ConsolidationHandler`'s `TaskHandler`
+    // impl (`execute`).
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    #[cfg(feature = "scheduler")]
+    async fn five_signal_consolidation_promotes_fresh_fact() {
+        use zeph_config::memory::{FiveSignalConfig, FiveSignalConsolidationConfig};
+        use zeph_memory::five_signal::FiveSignalRuntime;
+        use zeph_memory::five_signal::consolidation::ConsolidationHandler;
+        use zeph_scheduler::TaskHandler as _;
+
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool.clone());
+        let graph_store = std::sync::Arc::new(GraphStore::new(pool.clone()));
+
+        let cid = store.create_conversation().await.unwrap();
+        let msg_id = store.save_message(cid, "user", "fresh fact").await.unwrap();
+
+        // session_start ~= now, so the freshly-inserted message's TIMESTAMPTZ `created_at`
+        // (defaulted to `NOW()` by the schema) yields novelty ~= 1.0 once correctly decoded.
+        let session_start = chrono::Utc::now().timestamp() - 5;
+        let signal_config = FiveSignalConfig {
+            w_recency: 0.0,
+            w_relevance: 0.0,
+            w_frequency: 0.0,
+            w_causal: 0.0,
+            w_novelty: 1.0,
+            consolidation_daemon: FiveSignalConsolidationConfig {
+                enabled: true,
+                promotion_score_threshold: 0.5,
+                ..FiveSignalConsolidationConfig::default()
+            },
+            ..FiveSignalConfig::default()
+        };
+        let daemon_config = signal_config.consolidation_daemon.clone();
+
+        let runtime = std::sync::Arc::new(FiveSignalRuntime::new(
+            signal_config,
+            pool.clone(),
+            graph_store,
+            None,
+            session_start,
+            "sess-consolidation-pg",
+        ));
+
+        let handler = ConsolidationHandler::new(runtime, daemon_config);
+        handler
+            .execute(&serde_json::json!({}))
+            .await
+            .expect("consolidation run must not fail decoding created_at as TIMESTAMPTZ");
+
+        let (qdrant_promoted, memory_tier): (i64, Option<String>) = sqlx::query_as(zeph_db::sql!(
+            "SELECT qdrant_promoted, memory_tier FROM messages WHERE id = ?"
+        ))
+        .bind(msg_id.0)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            qdrant_promoted, 1,
+            "fresh, high-novelty fact must be promoted"
+        );
+        assert_eq!(memory_tier.as_deref(), Some("semantic"));
+    }
 
     // NOTE: Postgres regression tests for `episodic_consolidation.rs::fetch_candidates` and
     // `compute_cognitive_weight` (both fixed for the `?N`-inside-`sql!()` defect in this PR)


### PR DESCRIPTION
## Summary

Fixes two documented follow-up defects from PR #5505's review cycle:

- **#5506** — `zeph_db::sql!()`'s Postgres `rewrite_placeholders` did a naive per-character `?`→`$N` walk with no awareness of SQLite's `?N` numbered-placeholder syntax. Wrapping `?1` in `sql!()` produced `$11` instead of `$1`, and a repeated `?N` reference (valid SQLite syntax for binding the same value twice with one `.bind()` call) was assigned two different Postgres placeholder numbers, silently changing the required bind-parameter count. `rewrite_placeholders` now parses `?[0-9]+` groups and rewrites them directly to `$N`, preserving the index so repeated references collapse to a single bind; bare `?` still gets the next unused index. This was a live, previously-uncaught defect affecting 77 existing `sql!()` call sites in `zeph-memory`'s test suite. Added unit tests covering numbered, repeated-numbered, and mixed bare/numbered placeholders.

- **#5507** — `five_signal::consolidation::ConsolidationHandler::run_once` decoded `messages.created_at` as `i64`, but the column is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite), causing a guaranteed `ColumnDecode` panic on the first row processed under `scheduler`+`postgres`. The query now casts `created_at` through `Dialect::epoch_from_col` — the existing dialect-neutral epoch-normalization pattern already used by `semantic::recall` — so it decodes as `i64` on both backends. Added a Postgres regression test driving `ConsolidationHandler` through its public `TaskHandler::execute` entry point.

Both fixes were independently reviewed by an adversarial critic (traced the `?N`→`$N` rewrite against out-of-order, repeated, and mixed bare/numbered inputs; confirmed the bind-order correctness that both sqlx-sqlite and sqlx-postgres share) and validated live against a Postgres testcontainer.

Closes #5506, closes #5507

## Test plan

- [x] 3 new unit tests for `rewrite_placeholders` (bare, numbered, repeated-numbered, mixed) — pass under both `sqlite` and `postgres` features
- [x] New Postgres regression test in `crates/zeph-memory/tests/postgres_integration.rs` driving `ConsolidationHandler::execute`, run live against a Docker testcontainer — confirms the old `TIMESTAMPTZ`-as-`i64` panic no longer reproduces
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11744 passed, 0 failed
- [x] `migration_parity.rs` guard unaffected, still passing
- [x] Full-workspace rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)