### PR TITLE
fix(memory): route agent_sessions.rs and unixepoch() sites through dialect-aware SQL for Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1259,6 +1259,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   public `TaskHandler::execute` entry point (`run_once`/`apply_promotions`/`apply_demotions` are
   private) and asserting a fresh, high-novelty fact is correctly promoted.
 
+- `fix(memory)`: two more Postgres SQL-compatibility gaps in the same defect class as #5488/#5491.
+  `agent_sessions.rs`'s `upsert_agent_session` and both branches of `list_agent_sessions` passed
+  raw `?`-placeholder string literals straight to `zeph_db::query`/`query_as`, bypassing
+  `sql!()`'s SQLite-to-Postgres placeholder rewrite (#5524). Separately, four call sites embedded
+  the SQLite-only `unixepoch()` function literally in SQL text with no Postgres equivalent —
+  `episodic_consolidation.rs`'s `fetch_candidates` and `mark_consolidated`, and `graph/belief.rs`'s
+  `mark_promoted` and `apply_evidence_update` (#5508); each now builds its query via
+  `format!("... {epoch_now} ...")` with `<ActiveDialect as Dialect>::EPOCH_NOW` interpolated
+  before `zeph_db::rewrite_placeholders` runs, then dispatches through `sqlx::AssertSqlSafe`,
+  mirroring the existing `episodic_graph.rs`/`store/messages/mod.rs` idiom for dynamic SQL text.
+  The remaining `unixepoch()` occurrences in `reasoning.rs` (SQLite-only test fixture, already
+  `#[cfg(not(feature = "postgres"))]`-gated) and in `mem_scenes.rs`/`store/messages/mod.rs`
+  (comments/doc text, not SQL) were confirmed as false positives and left unchanged.
+
+  A live Postgres run against the `sql!()`-only #5524 fix then surfaced a second, deeper defect
+  blocking closure: `agent_sessions.created_at`/`last_active_at` are `TIMESTAMPTZ` columns
+  (`zeph-db/migrations/postgres/090_agent_sessions.sql`) but `AgentSessionRow` binds/decodes them
+  as plain `String` — Postgres has no implicit `text`↔`timestamptz` cast, so the INSERT failed
+  with `PgDatabaseError` 42804 and, once that was fixed, the SELECT failed to decode with a
+  `ColumnDecode` mismatch. Added a new `Dialect::TIMESTAMPTZ_CAST` associated constant
+  (`::timestamptz` on Postgres, empty on `SQLite`) appended after the two INSERT placeholders,
+  and reused the existing `Dialect::select_as_text` helper (already used elsewhere for the same
+  native-column-vs-`String`-decode mismatch) to project `created_at`/`last_active_at` as text in
+  both `list_agent_sessions` SELECT branches. Verified against a real Postgres container with a
+  new `agent_sessions_upsert_and_list_postgres` regression test (insert, conflict-update, and
+  both filtered/unfiltered list branches). Closes #5524, closes #5508.
+
 ### Changed
 
 - `build(db)`: upgrade `sqlx` 0.8.6 → 0.9.0. The `runtime-tokio-rustls` feature was split into

--- a/crates/zeph-db/src/dialect.rs
+++ b/crates/zeph-db/src/dialect.rs
@@ -72,6 +72,20 @@ pub trait Dialect: Send + Sync + 'static {
     /// `PostgreSQL`: `::jsonb`
     const JSON_CAST: &'static str;
 
+    /// Cast suffix for a bind parameter carrying a pre-formatted timestamp string, destined
+    /// for a timestamp-typed column.
+    ///
+    /// `sqlx` sends string bind parameters as `TEXT`/`VARCHAR`. `SQLite` stores timestamp
+    /// columns as `TEXT` so no cast is needed. `PostgreSQL` stores them as `TIMESTAMPTZ`, which
+    /// has no implicit cast from `TEXT` — binding a plain string fails with
+    /// `PgDatabaseError` 42804 ("column is of type timestamptz but expression is of type
+    /// text"). Append this suffix directly after the `?` placeholder for that bind position,
+    /// e.g. `format!("VALUES (?{timestamptz_cast})", timestamptz_cast = ...)`.
+    ///
+    /// `SQLite`: empty string
+    /// `PostgreSQL`: `::timestamptz`
+    const TIMESTAMPTZ_CAST: &'static str;
+
     /// Project a non-`TEXT` column so it decodes into a plain `String`.
     ///
     /// `SQLite` is dynamically typed and stores JSON/timestamp columns as `TEXT`, so
@@ -121,6 +135,7 @@ impl Dialect for Sqlite {
     const EPOCH_NOW: &'static str = "unixepoch('now')";
     const NOW: &'static str = "datetime('now')";
     const JSON_CAST: &'static str = "";
+    const TIMESTAMPTZ_CAST: &'static str = "";
     const GREATEST_FN: &'static str = "MAX";
     const LEAST_FN: &'static str = "MIN";
 
@@ -148,6 +163,7 @@ impl Dialect for Postgres {
     const EPOCH_NOW: &'static str = "EXTRACT(EPOCH FROM NOW())::BIGINT";
     const NOW: &'static str = "NOW()";
     const JSON_CAST: &'static str = "::jsonb";
+    const TIMESTAMPTZ_CAST: &'static str = "::timestamptz";
     const GREATEST_FN: &'static str = "GREATEST";
     const LEAST_FN: &'static str = "LEAST";
 
@@ -217,6 +233,11 @@ mod tests {
         }
 
         #[test]
+        fn timestamptz_cast() {
+            assert_eq!(Sqlite::TIMESTAMPTZ_CAST, "");
+        }
+
+        #[test]
         fn greatest_fn() {
             assert_eq!(Sqlite::GREATEST_FN, "MAX");
         }
@@ -273,6 +294,11 @@ mod tests {
         #[test]
         fn json_cast() {
             assert_eq!(Postgres::JSON_CAST, "::jsonb");
+        }
+
+        #[test]
+        fn timestamptz_cast() {
+            assert_eq!(Postgres::TIMESTAMPTZ_CAST, "::timestamptz");
         }
 
         #[test]

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument as _;
 use zeph_common::types::ProviderName;
-use zeph_db::{DbPool, sql};
+use zeph_db::{ActiveDialect, DbPool, sql};
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
 
@@ -360,23 +360,26 @@ async fn fetch_candidates(
     let min_age = i64::try_from(config.min_age_secs).unwrap_or(i64::MAX);
     let batch = i64::try_from(config.batch_size).unwrap_or(i64::MAX);
 
-    let rows: Vec<CandidateRow> = zeph_db::query_as(sql!(
+    let epoch_now = <ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
+    let raw = format!(
         "SELECT e.id, e.session_id, e.event_type, e.summary,
                 COALESCE(m.compressed_content, m.content) AS message_content,
                 e.created_at
          FROM episodic_events e
          JOIN messages m ON m.id = e.message_id
          WHERE e.consolidated_at IS NULL
-           AND e.created_at < unixepoch() - ?
+           AND e.created_at < {epoch_now} - ?
            AND m.content_fidelity != 'SummaryOnly'
          ORDER BY e.created_at ASC
          LIMIT ?"
-    ))
-    .bind(min_age)
-    .bind(batch)
-    .fetch_all(pool)
-    .await
-    .map_err(MemoryError::from)?;
+    );
+    let query_sql = zeph_db::rewrite_placeholders(&raw);
+    let rows: Vec<CandidateRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+        .bind(min_age)
+        .bind(batch)
+        .fetch_all(pool)
+        .await
+        .map_err(MemoryError::from)?;
 
     Ok(rows)
 }
@@ -632,13 +635,14 @@ async fn promote_fact(
 /// Mark an episodic event as consolidated.
 #[tracing::instrument(skip(pool), name = "memory.episodic.mark_consolidated")]
 async fn mark_consolidated(pool: &DbPool, event_id: i64) -> Result<(), MemoryError> {
-    zeph_db::query(sql!(
-        "UPDATE episodic_events SET consolidated_at = unixepoch() WHERE id = ?"
-    ))
-    .bind(event_id)
-    .execute(pool)
-    .await
-    .map_err(MemoryError::from)?;
+    let epoch_now = <ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
+    let raw = format!("UPDATE episodic_events SET consolidated_at = {epoch_now} WHERE id = ?");
+    let query_sql = zeph_db::rewrite_placeholders(&raw);
+    zeph_db::query(sqlx::AssertSqlSafe(query_sql))
+        .bind(event_id)
+        .execute(pool)
+        .await
+        .map_err(MemoryError::from)?;
     Ok(())
 }
 

--- a/crates/zeph-memory/src/graph/belief.rs
+++ b/crates/zeph-memory/src/graph/belief.rs
@@ -24,7 +24,7 @@
 //! - Noisy-OR guarantees `prob ∈ (0, 1)` given inputs in `(0, 1)`.
 
 use tracing::instrument;
-use zeph_db::{DbPool, sql};
+use zeph_db::{ActiveDialect, DbPool, sql};
 
 use crate::error::MemoryError;
 use crate::graph::types::EdgeType;
@@ -362,15 +362,18 @@ impl BeliefStore {
         belief_id: i64,
         committed_edge_id: i64,
     ) -> Result<(), MemoryError> {
-        zeph_db::query(sql!(
+        let epoch_now = <ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
+        let raw = format!(
             "UPDATE pending_beliefs
-             SET promoted_at = unixepoch(), promoted_edge_id = ?
+             SET promoted_at = {epoch_now}, promoted_edge_id = ?
              WHERE id = ?"
-        ))
-        .bind(committed_edge_id)
-        .bind(belief_id)
-        .execute(&self.pool)
-        .await?;
+        );
+        let sql = zeph_db::rewrite_placeholders(&raw);
+        zeph_db::query(sqlx::AssertSqlSafe(sql))
+            .bind(committed_edge_id)
+            .bind(belief_id)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 
@@ -472,16 +475,19 @@ impl BeliefStore {
 
         let posterior = noisy_or(prior_prob, evidence_prob);
 
-        zeph_db::query(sql!(
+        let epoch_now = <ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
+        let raw = format!(
             "UPDATE pending_beliefs
-             SET prob = ?, updated_at = unixepoch(), episode_id = ?
+             SET prob = ?, updated_at = {epoch_now}, episode_id = ?
              WHERE id = ?"
-        ))
-        .bind(posterior)
-        .bind(episode_id)
-        .bind(row.id)
-        .execute(&self.pool)
-        .await?;
+        );
+        let sql = zeph_db::rewrite_placeholders(&raw);
+        zeph_db::query(sqlx::AssertSqlSafe(sql))
+            .bind(posterior)
+            .bind(episode_id)
+            .bind(row.id)
+            .execute(&self.pool)
+            .await?;
 
         zeph_db::query(sql!(
             "INSERT INTO belief_evidence

--- a/crates/zeph-memory/src/store/agent_sessions.rs
+++ b/crates/zeph-memory/src/store/agent_sessions.rs
@@ -4,6 +4,7 @@
 //! CRUD for the `agent_sessions` table used by the fleet dashboard (#3884).
 
 use serde::{Deserialize, Serialize};
+use zeph_db::ActiveDialect;
 #[allow(unused_imports)]
 use zeph_db::sql;
 
@@ -194,11 +195,17 @@ impl SqliteStore {
     /// Returns an error if the database write fails.
     #[tracing::instrument(name = "memory.fleet.upsert_session", skip_all, level = "debug", err)]
     pub async fn upsert_agent_session(&self, s: &AgentSessionRow) -> Result<(), MemoryError> {
-        zeph_db::query(
+        // `created_at`/`last_active_at` are Rust-formatted timestamp strings bound into a
+        // `TIMESTAMPTZ` column on Postgres (`TEXT` on SQLite). Postgres has no implicit
+        // text->timestamptz cast, so an explicit `::timestamptz` suffix is required on those
+        // two placeholders (PgDatabaseError 42804 otherwise); `excluded.last_active_at` in the
+        // conflict clause already carries the column's native type, no cast needed there.
+        let ts_cast = <ActiveDialect as zeph_db::dialect::Dialect>::TIMESTAMPTZ_CAST;
+        let raw = format!(
             "INSERT INTO agent_sessions \
              (id, kind, status, channel, model, created_at, last_active_at, \
               turns, prompt_tokens, completion_tokens, reasoning_tokens, cost_cents, goal_text) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+             VALUES (?, ?, ?, ?, ?, ?{ts_cast}, ?{ts_cast}, ?, ?, ?, ?, ?, ?) \
              ON CONFLICT(id) DO UPDATE SET \
                kind = excluded.kind, \
                status = excluded.status, \
@@ -210,27 +217,29 @@ impl SqliteStore {
                completion_tokens = excluded.completion_tokens, \
                reasoning_tokens = excluded.reasoning_tokens, \
                cost_cents = excluded.cost_cents, \
-               goal_text = excluded.goal_text",
-        )
-        .bind(&s.id)
-        .bind(s.kind.as_str())
-        .bind(s.status.as_str())
-        .bind(s.channel.as_str())
-        .bind(&s.model)
-        .bind(&s.created_at)
-        .bind(&s.last_active_at)
-        // `turns` maps to an `INTEGER` column in both dialects; bind it as `i32` so the query
-        // stays backend-agnostic. A bare `u32` only implements `Type<Sqlite>` (Postgres has no
-        // unsigned integer types), which pins the query to the SQLite driver and breaks the
-        // Postgres backend (#4964).
-        .bind(s.turns.cast_signed())
-        .bind(s.prompt_tokens.cast_signed())
-        .bind(s.completion_tokens.cast_signed())
-        .bind(s.reasoning_tokens.cast_signed())
-        .bind(s.cost_cents)
-        .bind(&s.goal_text)
-        .execute(&self.pool)
-        .await?;
+               goal_text = excluded.goal_text"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        zeph_db::query(sqlx::AssertSqlSafe(query_sql))
+            .bind(&s.id)
+            .bind(s.kind.as_str())
+            .bind(s.status.as_str())
+            .bind(s.channel.as_str())
+            .bind(&s.model)
+            .bind(&s.created_at)
+            .bind(&s.last_active_at)
+            // `turns` maps to an `INTEGER` column in both dialects; bind it as `i32` so the query
+            // stays backend-agnostic. A bare `u32` only implements `Type<Sqlite>` (Postgres has no
+            // unsigned integer types), which pins the query to the SQLite driver and breaks the
+            // Postgres backend (#4964).
+            .bind(s.turns.cast_signed())
+            .bind(s.prompt_tokens.cast_signed())
+            .bind(s.completion_tokens.cast_signed())
+            .bind(s.reasoning_tokens.cast_signed())
+            .bind(s.cost_cents)
+            .bind(&s.goal_text)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 
@@ -322,27 +331,39 @@ impl SqliteStore {
             f64,
             Option<String>,
         );
+        // `created_at`/`last_active_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite);
+        // decoding straight into `String` fails on Postgres without an explicit `::text`
+        // projection, mirroring `Dialect::select_as_text`'s use elsewhere for the same
+        // native-column-type-vs-`String`-decode mismatch.
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let last_active_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("last_active_at");
         let rows: Vec<SessionRow> = if let Some(sf) = status_filter {
-            zeph_db::query_as(
-                "SELECT id, kind, status, channel, model, created_at, last_active_at, \
+            let raw = format!(
+                "SELECT id, kind, status, channel, model, {created_at_sel}, {last_active_at_sel}, \
                  turns, prompt_tokens, completion_tokens, reasoning_tokens, cost_cents, goal_text \
                  FROM agent_sessions WHERE status = ? \
-                 ORDER BY last_active_at DESC LIMIT ?",
-            )
-            .bind(sf.as_str())
-            .bind(sql_limit)
-            .fetch_all(&self.pool)
-            .await?
+                 ORDER BY last_active_at DESC LIMIT ?"
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+                .bind(sf.as_str())
+                .bind(sql_limit)
+                .fetch_all(&self.pool)
+                .await?
         } else {
-            zeph_db::query_as(
-                "SELECT id, kind, status, channel, model, created_at, last_active_at, \
+            let raw = format!(
+                "SELECT id, kind, status, channel, model, {created_at_sel}, {last_active_at_sel}, \
                  turns, prompt_tokens, completion_tokens, reasoning_tokens, cost_cents, goal_text \
                  FROM agent_sessions \
-                 ORDER BY last_active_at DESC LIMIT ?",
-            )
-            .bind(sql_limit)
-            .fetch_all(&self.pool)
-            .await?
+                 ORDER BY last_active_at DESC LIMIT ?"
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+                .bind(sql_limit)
+                .fetch_all(&self.pool)
+                .await?
         };
 
         Ok(rows

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -31,6 +31,22 @@
 //! of `$1` under Postgres. The tests below close the Postgres coverage gap for those
 //! fixes; see the `NOTE` comment near the end of this module for one call-site family
 //! that could not get coverage here due to an unrelated bug.
+//!
+//! Regression coverage for issue #5524: `agent_sessions.rs`'s `upsert_agent_session`
+//! (INSERT ... ON CONFLICT) and both branches of `list_agent_sessions`'s SELECT used raw
+//! `?`-placeholder string literals passed directly to `zeph_db::query`/`query_as` instead
+//! of through `sql!()`, so the `?` tokens were never rewritten to Postgres's `$1, $2, ...`.
+//! A live Postgres run against the `sql!()`-only fix then surfaced a second defect blocking
+//! closure: `created_at`/`last_active_at` are `TIMESTAMPTZ` columns but `AgentSessionRow`
+//! binds plain `String`s, which Postgres rejects (no implicit text->timestamptz cast).
+//! `upsert_agent_session` now appends the new `Dialect::TIMESTAMPTZ_CAST` constant
+//! (`::timestamptz` on Postgres, empty on `SQLite`) after those two placeholders.
+//!
+//! Regression coverage for issue #5508: `unixepoch()` (SQLite-only) was embedded as a
+//! literal in SQL text at four call sites (`episodic_consolidation.rs::fetch_candidates`/
+//! `mark_consolidated`, `graph/belief.rs::mark_promoted`/`apply_evidence_update`), which
+//! has no Postgres equivalent and fails at runtime. Fixed by interpolating
+//! `<ActiveDialect as Dialect>::EPOCH_NOW` via `format!()` before `rewrite_placeholders`.
 
 #[cfg(feature = "test-utils")]
 mod pg {
@@ -40,10 +56,14 @@ mod pg {
     use zeph_db::DbConfig;
     use zeph_memory::db_vector_store::DbVectorStore;
     use zeph_memory::graph::activation::ActivatedFact;
+    use zeph_memory::graph::belief::{BeliefMemConfig, BeliefStore};
     use zeph_memory::graph::implicit_conflict;
     use zeph_memory::graph::store::GraphStore;
-    use zeph_memory::graph::types::EntityType;
-    use zeph_memory::store::{AcpSessionConfigSnapshot, SqliteStore};
+    use zeph_memory::graph::types::{EdgeType, EntityType};
+    use zeph_memory::store::{
+        AcpSessionConfigSnapshot, AgentSessionRow, SessionChannel, SessionKind, SessionStatus,
+        SqliteStore,
+    };
     use zeph_memory::types::MessageId;
     use zeph_memory::{VectorStore, episodic_graph, snapshot};
 
@@ -1310,20 +1330,176 @@ mod pg {
         assert_eq!(memory_tier.as_deref(), Some("semantic"));
     }
 
-    // NOTE: Postgres regression tests for `episodic_consolidation.rs::fetch_candidates` and
-    // `compute_cognitive_weight` (both fixed for the `?N`-inside-`sql!()` defect in this PR)
-    // are omitted for the same reason as above: both are private, reachable only via the
-    // public `run_episodic_consolidation_sweep` entry point, and `fetch_candidates`'s WHERE
-    // clause calls SQLite's `unixepoch()` function directly — undefined under Postgres (no
-    // compat function/extension is installed; confirmed via `crates/zeph-db/migrations/postgres/`
-    // and `crates/zeph-db/src/dialect.rs`'s `EPOCH_NOW` abstraction, which exists for exactly
-    // this purpose but isn't used at this call site). Since `fetch_candidates` runs first in
-    // the sweep pipeline, this fails before `compute_cognitive_weight` is ever reached, so
-    // neither function can get real Postgres coverage without fixing the `unixepoch()` dialect
-    // bug first — a distinct defect class from the placeholder bug, out of scope here. The
-    // `?N` renumbering itself is still correct and necessary (verify by inspection: bind
-    // count/order match the SQL text exactly for both functions) — it just cannot be exercised
-    // end-to-end against a real Postgres instance until the dialect bug is fixed separately.
+    // ── agent_sessions: upsert_agent_session + list_agent_sessions (Postgres) ──
+    // Regression coverage for issue #5524, completing the fix after a live Postgres run
+    // surfaced a second, previously-theorized-only defect: `agent_sessions.created_at`/
+    // `last_active_at` are `TIMESTAMPTZ` in the Postgres schema
+    // (`zeph-db/migrations/postgres/090_agent_sessions.sql`) but `AgentSessionRow.created_at`/
+    // `last_active_at` are plain `String`, bound as text — Postgres has no implicit
+    // text->timestamptz cast, so the INSERT failed with `PgDatabaseError` 42804 even after the
+    // `sql!()` placeholder rewrite was fixed. `upsert_agent_session` now appends
+    // `<ActiveDialect as Dialect>::TIMESTAMPTZ_CAST` (`::timestamptz` on Postgres, empty on
+    // SQLite) directly after the `created_at`/`last_active_at` placeholders, mirroring the
+    // existing `JSON_CAST` idiom used for `messages.parts`.
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn agent_sessions_upsert_and_list_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        let row = AgentSessionRow {
+            id: "sess-pg-1".to_owned(),
+            kind: SessionKind::Interactive,
+            status: SessionStatus::Active,
+            channel: SessionChannel::Cli,
+            model: "claude-sonnet-5".to_owned(),
+            created_at: "2026-07-03T00:00:00".to_owned(),
+            last_active_at: "2026-07-03T00:00:00".to_owned(),
+            turns: 3,
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            reasoning_tokens: 0,
+            cost_cents: 1.5,
+            goal_text: None,
+        };
+        store.upsert_agent_session(&row).await.unwrap();
+
+        // Second upsert exercises the ON CONFLICT DO UPDATE branch.
+        let mut updated = row.clone();
+        updated.turns = 7;
+        updated.status = SessionStatus::Completed;
+        updated.last_active_at = "2026-07-03T00:05:00".to_owned();
+        store.upsert_agent_session(&updated).await.unwrap();
+
+        let all = store.list_agent_sessions(10, None).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, "sess-pg-1");
+        assert_eq!(all[0].turns, 7);
+        assert_eq!(all[0].status, SessionStatus::Completed);
+
+        let filtered = store
+            .list_agent_sessions(10, Some(SessionStatus::Completed))
+            .await
+            .unwrap();
+        assert_eq!(filtered.len(), 1);
+        let none_active = store
+            .list_agent_sessions(10, Some(SessionStatus::Active))
+            .await
+            .unwrap();
+        assert!(none_active.is_empty());
+    }
+
+    // NOTE (found live, unrelated to issues #5524/#5508): a Postgres regression test for the
+    // full `episodic_consolidation.rs` sweep (`run_episodic_consolidation_sweep`, which chains
+    // `fetch_candidates` → `compute_cognitive_weight` → ... → `mark_consolidated`) was attempted
+    // here and is omitted. `fetch_candidates`'s `unixepoch()` fix (issue #5508) is confirmed
+    // structurally sound — the SELECT executes and returns the mature candidate row without
+    // error — but the very next step, `compute_cognitive_weight`'s
+    // `SELECT COALESCE(SUM(CASE ... THEN 1.0 ... END), 0.0)`, fails to decode: Postgres types an
+    // aggregate `SUM()` over decimal literals as `NUMERIC`, and sqlx cannot decode `NUMERIC` into
+    // the declared `f64` without an explicit cast — `ColumnDecode { source: "mismatched types;
+    // Rust type \`f64\` (as SQL type \`FLOAT8\`) is not compatible with SQL type \`NUMERIC\`" }`.
+    // This is the exact same REAL/NUMERIC-decode defect class already fixed at 14 other
+    // `EdgeRow`-projecting queries elsewhere in this file (see the module docstring), just missed
+    // at this call site — `compute_cognitive_weight` does not call `unixepoch()` itself and was
+    // not touched by this PR's #5508 fix. Because it always runs before `mark_consolidated` is
+    // ever reached, `mark_consolidated`'s `EPOCH_NOW`-based UPDATE (also part of #5508) cannot get
+    // real Postgres round-trip coverage until `compute_cognitive_weight` gets an explicit
+    // `CAST(... AS DOUBLE PRECISION)`, matching the established idiom. File a follow-up issue for
+    // the `compute_cognitive_weight` decode bug before attempting this coverage again.
+
+    // ── belief: record_evidence (apply_evidence_update) + mark_promoted (Postgres) ──
+    // Regression coverage for issue #5508. `mark_promoted` and `apply_evidence_update` had
+    // zero test coverage under either backend before this PR.
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn belief_store_record_evidence_and_promote_postgres() {
+        let (pool, _container) = start_pg().await;
+        let graph = GraphStore::new(pool.clone());
+
+        let source = graph
+            .upsert_entity("Rust", "rust", EntityType::Tool, None, None)
+            .await
+            .unwrap();
+        let target = graph
+            .upsert_entity(
+                "Memory Safety",
+                "memory-safety",
+                EntityType::Concept,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let belief_store = BeliefStore::new(
+            pool.clone(),
+            BeliefMemConfig {
+                enabled: true,
+                min_entry_prob: 0.3,
+                promote_threshold: 0.85,
+                max_candidates_per_group: 10,
+                retrieval_top_k: 3,
+                belief_decay_rate: 0.0,
+            },
+        );
+
+        // First call hits insert_new_belief; the remaining five hit apply_evidence_update —
+        // the exact call site that embedded the SQLite-only unixepoch() before this fix.
+        let mut promoted = None;
+        for _ in 0..6 {
+            promoted = belief_store
+                .record_evidence(
+                    source.0,
+                    target.0,
+                    "provides",
+                    "provides",
+                    "Rust provides memory safety",
+                    EdgeType::Semantic,
+                    0.3,
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+        let belief = promoted.expect("six evidence updates at 0.3 must cross the 0.85 threshold");
+        assert!(belief.prob >= 0.85);
+
+        // Commit a real edge and mark the belief promoted — the other call site that
+        // embedded the SQLite-only unixepoch() before this fix.
+        let committed_edge_id = graph
+            .insert_edge(
+                source.0,
+                target.0,
+                "provides",
+                "Rust provides memory safety",
+                belief.prob,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        belief_store
+            .mark_promoted(belief.id, committed_edge_id)
+            .await
+            .unwrap();
+
+        let (promoted_at, promoted_edge_id): (Option<i64>, Option<i64>) = sqlx::query_as(
+            zeph_db::sql!("SELECT promoted_at, promoted_edge_id FROM pending_beliefs WHERE id = ?"),
+        )
+        .bind(belief.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            promoted_at.is_some(),
+            "mark_promoted must set promoted_at via the EPOCH_NOW-based UPDATE"
+        );
+        assert_eq!(promoted_edge_id, Some(committed_edge_id));
+    }
 
     #[tokio::test]
     #[ignore = "requires Docker"]


### PR DESCRIPTION
## Summary

- `agent_sessions.rs`'s `upsert_agent_session` and both branches of `list_agent_sessions` passed raw `?`-placeholder SQL literals directly to `zeph_db::query`/`query_as`, bypassing `sql!()`'s SQLite-to-Postgres placeholder rewrite. Same defect class as #5488/#5491/#5505/#5516, missed by that earlier sweep.
- Four call sites (`episodic_consolidation.rs::fetch_candidates`/`mark_consolidated`, `graph/belief.rs::mark_promoted`/`apply_evidence_update`) embedded SQLite-only `unixepoch()` literally in SQL text with no Postgres equivalent. Converted to the existing `EPOCH_NOW`/`format!()`/`AssertSqlSafe` dynamic-SQL idiom already used in `episodic_graph.rs`/`store/messages/mod.rs`.
- A live Postgres run against the `sql!()`-only fix surfaced a second, deeper defect blocking #5524's actual closure: `agent_sessions.created_at`/`last_active_at` are `TIMESTAMPTZ` columns but `AgentSessionRow` binds/decodes them as plain `String`. Added `Dialect::TIMESTAMPTZ_CAST` (mirrors the existing `JSON_CAST` idiom) for the INSERT side and reused `Dialect::select_as_text` for the SELECT side.

## Test plan

- [x] `cargo check -p zeph-memory -p zeph-db` clean on both `--features postgres` and default (sqlite)
- [x] `cargo clippy --profile ci --all-targets --features "postgres,test-utils"` and default feature set both clean
- [x] `cargo +nightly fmt --check` clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --features postgres` clean (3 pre-existing `private_intra_doc_links` warnings confirmed unrelated to this diff)
- [x] sqlite full crate suite: 1527/1527 passed
- [x] Live Postgres testcontainer suite (`postgres_integration.rs`): 30/30 passed, including two new regression tests (`agent_sessions_upsert_and_list_postgres`, `belief_store_record_evidence_and_promote_postgres`) exercising previously-uncovered call sites end-to-end against a real Postgres container
- [x] `.local/testing/coverage-status.md` and the `zeph-db-dual-backend.md` playbook updated in the main repo to reflect the new coverage

## Follow-ups filed (out of scope for this PR)

- #5525 — `episodic_consolidation.rs::compute_cognitive_weight` NUMERIC→f64 decode bug (unrelated function, blocks full-sweep Postgres coverage of `mark_consolidated`)
- #5526 — sibling `datetime('now')` SQLite-only literal used in production SQL across 5 files
- #5527 — `acp_sessions.rs` has the same `TIMESTAMPTZ`-decoded-as-`String` bug just fixed here, in two SELECT sites