### PR TITLE
fix(memory): route datetime('now') and NUMERIC/TIMESTAMPTZ sites through dialect-aware SQL for Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(memory)`: three more Postgres-dialect defects in `zeph-memory`, same class as #5508/#5524
+  (SQLite-only SQL surfacing incorrectly under Postgres, live-verified via Docker testcontainers).
+  `datetime('now')` (SQLite-only, no Postgres equivalent) was embedded as a literal in production
+  SQL across `graph/entity_lock.rs`, `store/trajectory.rs`, `store/persona.rs`,
+  `store/memory_tree.rs`, and `store/overflow.rs` (#5526) — replaced with
+  `<ActiveDialect as Dialect>::NOW` interpolated via `format!()`, matching the established
+  `EPOCH_NOW` idiom; the two `datetime('now', <offset>)` call sites (`entity_lock.rs`'s advisory
+  lock TTL, `overflow.rs`'s age-based cleanup) needed a small dialect-selected
+  `NOW() +/- INTERVAL '...'` expression alongside it, mirroring the existing
+  `NOW() - INTERVAL '1 day' * ?` idiom in `store/skills.rs`. `store/acp_sessions.rs`'s
+  `list_acp_sessions`/`get_acp_session_info` decoded `created_at`/`updated_at` (`TIMESTAMPTZ` on
+  Postgres) directly into `String` with no cast and no `sql!()` placeholder rewrite (#5527) — fixed
+  with `Dialect::select_as_text`, mirroring the `agent_sessions.rs::list_agent_sessions` fix for
+  #5524. `episodic_consolidation.rs::compute_cognitive_weight`'s `SELECT COALESCE(SUM(...), 0.0)`
+  decoded a Postgres `NUMERIC` aggregate into `f64` with no cast (#5525) — fixed with
+  `CAST(... AS DOUBLE PRECISION)`, the same idiom used at the 14 other `EdgeRow`-projecting call
+  sites from #5364; this was the last blocker on `run_episodic_consolidation_sweep` getting a real
+  Postgres round-trip test (`postgres_integration.rs::episodic_consolidation_sweep_promotes_fact_postgres`,
+  replacing a `NOTE` block left pending this fix).
 - `fix(orchestration)`: `TaskGraph::created_at`/`finished_at` timestamps could be corrupted with an
   invalid `month=00` ISO-8601 component. The hand-rolled `epoch_secs_to_datetime` Gregorian
   decomposition in `graph.rs` mis-computed the month for dates immediately preceding a leap year

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -394,12 +394,17 @@ async fn compute_cognitive_weight(
     session_id: &str,
     created_at: i64,
 ) -> Result<f64, MemoryError> {
+    // `SUM()` over decimal literals aggregates to `NUMERIC` on Postgres, which sqlx cannot
+    // decode into `f64` without an explicit cast — `CAST(... AS DOUBLE PRECISION)` matches
+    // the idiom already used at the other `EdgeRow`-projecting call sites (see the
+    // `postgres_integration.rs` module docstring for issue #5364). `DOUBLE PRECISION`
+    // resolves to `SQLite`'s REAL affinity too, so this cast is dialect-neutral.
     let weight: f64 = zeph_db::query_scalar(sql!(
-        "SELECT COALESCE(SUM(CASE
+        "SELECT CAST(COALESCE(SUM(CASE
              WHEN outcome = 'success' THEN 1.0
              WHEN outcome = 'error'   THEN -0.5
              ELSE 0.0
-         END), 0.0)
+         END), 0.0) AS DOUBLE PRECISION)
          FROM experience_nodes
          WHERE session_id = ?
            AND created_at BETWEEN ? - 30 AND ? + 30"

--- a/crates/zeph-memory/src/graph/entity_lock.rs
+++ b/crates/zeph-memory/src/graph/entity_lock.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use tokio::time::sleep;
 use zeph_common::SessionId;
-use zeph_db::{DbPool, query, query_scalar, sql};
+use zeph_db::{ActiveDialect, DbPool, query, query_scalar, sql};
 
 use crate::error::MemoryError;
 
@@ -81,28 +81,38 @@ impl EntityLockManager {
         // condition requires a WHERE clause that INSERT OR IGNORE cannot express.
         // We use a two-statement approach in a transaction for atomicity.
 
-        let acquired: bool = query_scalar(sql!(
+        let now = <ActiveDialect as zeph_db::dialect::Dialect>::NOW;
+        // `LOCK_TTL_SECS` is a compile-time constant, so the "now + TTL" expiry expression is
+        // interpolated as a literal rather than bound — `datetime('now', 'N seconds')`
+        // (`SQLite`) has no equivalent syntax to `NOW() + INTERVAL 'N seconds'` (`PostgreSQL`).
+        let expires_at_expr = if cfg!(feature = "postgres") {
+            format!("NOW() + INTERVAL '{LOCK_TTL_SECS} seconds'")
+        } else {
+            format!("datetime('now', '{LOCK_TTL_SECS} seconds')")
+        };
+        let raw = format!(
             "INSERT INTO entity_advisory_locks (entity_name, session_id, acquired_at, expires_at)
-             VALUES (?, ?, datetime('now'), datetime('now', ? || ' seconds'))
+             VALUES (?, ?, {now}, {expires_at_expr})
              ON CONFLICT(entity_name) DO UPDATE SET
                  session_id  = excluded.session_id,
                  acquired_at = excluded.acquired_at,
                  expires_at  = excluded.expires_at
              WHERE
                  -- reclaim if expired
-                 entity_advisory_locks.expires_at < datetime('now')
+                 entity_advisory_locks.expires_at < {now}
                  OR
                  -- refresh if same session
                  entity_advisory_locks.session_id = excluded.session_id
              RETURNING (session_id = ?) AS acquired"
-        ))
-        .bind(entity_name)
-        .bind(self.session_id.as_str())
-        .bind(LOCK_TTL_SECS.to_string())
-        .bind(self.session_id.as_str())
-        .fetch_optional(self.pool())
-        .await?
-        .unwrap_or(false);
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let acquired: bool = query_scalar(sqlx::AssertSqlSafe(query_sql))
+            .bind(entity_name)
+            .bind(self.session_id.as_str())
+            .bind(self.session_id.as_str())
+            .fetch_optional(self.pool())
+            .await?
+            .unwrap_or(false);
 
         Ok(acquired)
     }

--- a/crates/zeph-memory/src/store/acp_sessions.rs
+++ b/crates/zeph-memory/src/store/acp_sessions.rs
@@ -134,11 +134,23 @@ impl SqliteStore {
         // `SessionStore::update_seq` on every turn flush per INV-SP-1) replaces the subquery
         // against `acp_session_events`, which the P1 write cutover leaves permanently empty for
         // post-cutover sessions.
-        let rows = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
-            "SELECT s.id, s.title, s.created_at, s.updated_at, s.event_count AS message_count \
+        // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project
+        // both through `Dialect::select_as_text` so they decode into the `String` fields below,
+        // mirroring `agent_sessions.rs::list_agent_sessions`'s fix for the same mismatch.
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let updated_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let raw = format!(
+            "SELECT s.id, s.title, s.{created_at_sel}, s.{updated_at_sel}, \
+             s.event_count AS message_count \
              FROM acp_sessions s \
              ORDER BY s.updated_at DESC \
-             LIMIT ?",
+             LIMIT ?"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
+            sqlx::AssertSqlSafe(query_sql),
         )
         .bind(sql_limit)
         .fetch_all(&self.pool)
@@ -171,10 +183,20 @@ impl SqliteStore {
     ) -> Result<Option<AcpSessionInfo>, MemoryError> {
         // spec-068 §12.3 / D-2: see `list_acp_sessions` — `event_count` replaces the emptied
         // `acp_session_events` subquery.
-        let row = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
-            "SELECT s.id, s.title, s.created_at, s.updated_at, s.event_count AS message_count \
+        // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres — see `list_acp_sessions`.
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let updated_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let raw = format!(
+            "SELECT s.id, s.title, s.{created_at_sel}, s.{updated_at_sel}, \
+             s.event_count AS message_count \
              FROM acp_sessions s \
-             WHERE s.id = ?",
+             WHERE s.id = ?"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
+            sqlx::AssertSqlSafe(query_sql),
         )
         .bind(session_id)
         .fetch_optional(&self.pool)

--- a/crates/zeph-memory/src/store/memory_tree.rs
+++ b/crates/zeph-memory/src/store/memory_tree.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use zeph_db::{query, query_as, query_scalar, sql};
+use zeph_db::{ActiveDialect, query, query_as, query_scalar, sql};
 
 use super::DbStore;
 use crate::error::MemoryError;
@@ -60,19 +60,22 @@ impl DbStore {
         source_ids: &str,
         token_count: i64,
     ) -> Result<i64, MemoryError> {
-        let (id,): (i64,) = query_as(sql!(
+        let now = <ActiveDialect as zeph_db::dialect::Dialect>::NOW;
+        let raw = format!(
             "INSERT INTO memory_tree
                 (level, parent_id, content, source_ids, token_count, consolidated_at)
-             VALUES (?, ?, ?, ?, ?, datetime('now'))
+             VALUES (?, ?, ?, ?, ?, {now})
              RETURNING id"
-        ))
-        .bind(level)
-        .bind(parent_id)
-        .bind(content)
-        .bind(source_ids)
-        .bind(token_count)
-        .fetch_one(self.pool())
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let (id,): (i64,) = query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(level)
+            .bind(parent_id)
+            .bind(content)
+            .bind(source_ids)
+            .bind(token_count)
+            .fetch_one(self.pool())
+            .await?;
 
         Ok(id)
     }
@@ -190,16 +193,19 @@ impl DbStore {
 
         let mut tx = self.pool().begin().await?;
 
+        let now = <ActiveDialect as zeph_db::dialect::Dialect>::NOW;
+        let raw = format!(
+            "UPDATE memory_tree
+             SET parent_id = ?, consolidated_at = {now}
+             WHERE id = ? AND parent_id IS NULL"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
         for &child_id in child_ids {
-            query(sql!(
-                "UPDATE memory_tree
-                 SET parent_id = ?, consolidated_at = datetime('now')
-                 WHERE id = ? AND parent_id IS NULL"
-            ))
-            .bind(parent_id)
-            .bind(child_id)
-            .execute(&mut *tx)
-            .await?;
+            query(sqlx::AssertSqlSafe(query_sql.as_str()))
+                .bind(parent_id)
+                .bind(child_id)
+                .execute(&mut *tx)
+                .await?;
         }
 
         tx.commit().await?;
@@ -234,29 +240,34 @@ impl DbStore {
 
         let mut tx = self.pool().begin().await?;
 
-        let (parent_id,): (i64,) = zeph_db::query_as(zeph_db::sql!(
+        let now = <ActiveDialect as zeph_db::dialect::Dialect>::NOW;
+        let insert_raw = format!(
             "INSERT INTO memory_tree
                 (level, content, source_ids, token_count, consolidated_at)
-             VALUES (?, ?, ?, ?, datetime('now'))
+             VALUES (?, ?, ?, ?, {now})
              RETURNING id"
-        ))
-        .bind(level)
-        .bind(summary)
-        .bind(source_ids_json)
-        .bind(token_count)
-        .fetch_one(&mut *tx)
-        .await?;
-
-        for &child_id in child_ids {
-            zeph_db::query(zeph_db::sql!(
-                "UPDATE memory_tree
-                 SET parent_id = ?, consolidated_at = datetime('now')
-                 WHERE id = ? AND parent_id IS NULL"
-            ))
-            .bind(parent_id)
-            .bind(child_id)
-            .execute(&mut *tx)
+        );
+        let insert_sql = zeph_db::rewrite_placeholders(&insert_raw);
+        let (parent_id,): (i64,) = zeph_db::query_as(sqlx::AssertSqlSafe(insert_sql))
+            .bind(level)
+            .bind(summary)
+            .bind(source_ids_json)
+            .bind(token_count)
+            .fetch_one(&mut *tx)
             .await?;
+
+        let update_raw = format!(
+            "UPDATE memory_tree
+             SET parent_id = ?, consolidated_at = {now}
+             WHERE id = ? AND parent_id IS NULL"
+        );
+        let update_sql = zeph_db::rewrite_placeholders(&update_raw);
+        for &child_id in child_ids {
+            zeph_db::query(sqlx::AssertSqlSafe(update_sql.as_str()))
+                .bind(parent_id)
+                .bind(child_id)
+                .execute(&mut *tx)
+                .await?;
         }
 
         tx.commit().await?;
@@ -269,15 +280,18 @@ impl DbStore {
     ///
     /// Returns an error if the query fails.
     pub async fn increment_tree_consolidation_count(&self) -> Result<(), MemoryError> {
-        query(sql!(
+        let now = <ActiveDialect as zeph_db::dialect::Dialect>::NOW;
+        let raw = format!(
             "UPDATE memory_tree_meta
              SET total_consolidations = total_consolidations + 1,
-                 last_consolidation_at = datetime('now'),
-                 updated_at = datetime('now')
+                 last_consolidation_at = {now},
+                 updated_at = {now}
              WHERE id = 1"
-        ))
-        .execute(self.pool())
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        query(sqlx::AssertSqlSafe(query_sql))
+            .execute(self.pool())
+            .await?;
 
         Ok(())
     }

--- a/crates/zeph-memory/src/store/overflow.rs
+++ b/crates/zeph-memory/src/store/overflow.rs
@@ -8,6 +8,19 @@ use zeph_db::sql;
 use crate::error::MemoryError;
 use crate::store::SqliteStore;
 
+/// `now() - N seconds` expression, dialect-selected at compile time.
+///
+/// `SQLite`'s `datetime('now', printf('-%d seconds', ?))` has no `PostgreSQL` equivalent —
+/// `NOW() - INTERVAL '1 second' * ?` is the established substitution (mirrors the
+/// `NOW() - INTERVAL '1 day' * ?` idiom already used in `store/skills.rs`).
+fn now_minus_seconds_expr() -> &'static str {
+    if cfg!(feature = "postgres") {
+        "NOW() - INTERVAL '1 second' * ?"
+    } else {
+        "datetime('now', printf('-%d seconds', ?))"
+    }
+}
+
 impl SqliteStore {
     /// Save overflow content associated with a conversation, returning the generated UUID.
     ///
@@ -93,14 +106,17 @@ impl SqliteStore {
     ///
     /// Returns an error if the database delete fails.
     pub async fn cleanup_overflow(&self, max_age_secs: u64) -> Result<u64, MemoryError> {
-        let result = zeph_db::query(sql!(
+        let now_minus = now_minus_seconds_expr();
+        let raw = format!(
             "DELETE FROM tool_overflow \
              WHERE archive_type = 'overflow' \
-             AND created_at < datetime('now', printf('-%d seconds', ?))"
-        ))
-        .bind(max_age_secs.cast_signed())
-        .execute(&self.pool)
-        .await?;
+             AND created_at < {now_minus}"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let result = zeph_db::query(sqlx::AssertSqlSafe(query_sql))
+            .bind(max_age_secs.cast_signed())
+            .execute(&self.pool)
+            .await?;
         Ok(result.rows_affected())
     }
 
@@ -123,6 +139,31 @@ impl SqliteStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pins the exact SQL fragment emitted by `now_minus_seconds_expr` for the dialect this
+    /// test binary was compiled with. The `sqlite` and `postgres` features are additive on this
+    /// crate (see `Cargo.toml`), so running with `--features postgres` exercises the branch that
+    /// `cargo nextest run -p zeph-memory --lib` alone never reaches — a typo in the Postgres
+    /// literal would otherwise only surface via a live-DB integration test or manual `psql` check.
+    #[test]
+    fn now_minus_seconds_expr_matches_active_dialect() {
+        let expr = now_minus_seconds_expr();
+        if cfg!(feature = "postgres") {
+            assert_eq!(expr, "NOW() - INTERVAL '1 second' * ?");
+        } else {
+            assert_eq!(expr, "datetime('now', printf('-%d seconds', ?))");
+        }
+    }
+
+    /// `now() - N days` literal, dialect-selected at compile time (see
+    /// `now_minus_seconds_expr` above for the same idiom with a bound parameter).
+    fn now_minus_days_literal(days: u32) -> String {
+        if cfg!(feature = "postgres") {
+            format!("NOW() - INTERVAL '{days} days'")
+        } else {
+            format!("datetime('now', '-{days} days')")
+        }
+    }
 
     async fn make_store() -> (SqliteStore, i64) {
         let store = SqliteStore::new(":memory:")
@@ -213,17 +254,20 @@ mod tests {
         let (store, cid) = make_store().await;
         // Insert a row with an old timestamp.
         let id = Uuid::new_v4().to_string();
-        zeph_db::query(sql!(
+        let raw = format!(
             "INSERT INTO tool_overflow (id, conversation_id, content, byte_size, created_at) \
-             VALUES (?, ?, ?, ?, datetime('now', '-2 days'))"
-        ))
-        .bind(&id)
-        .bind(cid)
-        .bind(b"old data".as_slice())
-        .bind(8i64)
-        .execute(store.pool())
-        .await
-        .expect("insert old row");
+             VALUES (?, ?, ?, ?, {})",
+            now_minus_days_literal(2)
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        zeph_db::query(sqlx::AssertSqlSafe(query_sql))
+            .bind(&id)
+            .bind(cid)
+            .bind(b"old data".as_slice())
+            .bind(8i64)
+            .execute(store.pool())
+            .await
+            .expect("insert old row");
 
         // Insert a fresh row.
         let fresh_id = store.save_overflow(cid, b"fresh").await.expect("fresh");
@@ -275,33 +319,39 @@ mod tests {
         let (store, cid) = make_store().await;
         // Insert a very old archive-type row directly.
         let archive_id = Uuid::new_v4().to_string();
-        zeph_db::query(sql!(
+        let archive_raw = format!(
             "INSERT INTO tool_overflow \
              (id, conversation_id, content, byte_size, archive_type, created_at) \
-             VALUES (?, ?, ?, ?, 'archive', datetime('now', '-30 days'))"
-        ))
-        .bind(&archive_id)
-        .bind(cid)
-        .bind(b"old archive".as_slice())
-        .bind(11i64)
-        .execute(store.pool())
-        .await
-        .expect("insert old archive");
+             VALUES (?, ?, ?, ?, 'archive', {})",
+            now_minus_days_literal(30)
+        );
+        let archive_sql = zeph_db::rewrite_placeholders(&archive_raw);
+        zeph_db::query(sqlx::AssertSqlSafe(archive_sql))
+            .bind(&archive_id)
+            .bind(cid)
+            .bind(b"old archive".as_slice())
+            .bind(11i64)
+            .execute(store.pool())
+            .await
+            .expect("insert old archive");
 
         // Insert an old overflow-type row — this should be cleaned up.
         let overflow_id = Uuid::new_v4().to_string();
-        zeph_db::query(sql!(
+        let overflow_raw = format!(
             "INSERT INTO tool_overflow \
              (id, conversation_id, content, byte_size, archive_type, created_at) \
-             VALUES (?, ?, ?, ?, 'overflow', datetime('now', '-30 days'))"
-        ))
-        .bind(&overflow_id)
-        .bind(cid)
-        .bind(b"old overflow".as_slice())
-        .bind(12i64)
-        .execute(store.pool())
-        .await
-        .expect("insert old overflow");
+             VALUES (?, ?, ?, ?, 'overflow', {})",
+            now_minus_days_literal(30)
+        );
+        let overflow_sql = zeph_db::rewrite_placeholders(&overflow_raw);
+        zeph_db::query(sqlx::AssertSqlSafe(overflow_sql))
+            .bind(&overflow_id)
+            .bind(cid)
+            .bind(b"old overflow".as_slice())
+            .bind(12i64)
+            .execute(store.pool())
+            .await
+            .expect("insert old overflow");
 
         let deleted = store.cleanup_overflow(86400).await.expect("cleanup");
         assert_eq!(deleted, 1, "only the overflow-type row should be deleted");

--- a/crates/zeph-memory/src/store/persona.rs
+++ b/crates/zeph-memory/src/store/persona.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use zeph_db::{query, query_as, query_scalar, sql};
+use zeph_db::{ActiveDialect, query, query_as, query_scalar, sql};
 
 use super::DbStore;
 use crate::error::MemoryError;
@@ -55,26 +55,29 @@ impl DbStore {
             }
         };
 
-        let (id,): (i64,) = query_as(sql!(
+        let now = <ActiveDialect as zeph_db::dialect::Dialect>::NOW;
+        let raw = format!(
             "INSERT INTO persona_memory
                 (category, content, confidence, evidence_count, source_conversation_id,
                  supersedes_id, updated_at)
              VALUES
-                (?, ?, ?, 1, ?, ?, datetime('now'))
+                (?, ?, ?, 1, ?, ?, {now})
              ON CONFLICT(category, content) DO UPDATE SET
                 evidence_count = evidence_count + 1,
                 confidence     = excluded.confidence,
                 supersedes_id  = COALESCE(excluded.supersedes_id, persona_memory.supersedes_id),
-                updated_at     = datetime('now')
+                updated_at     = {now}
              RETURNING id"
-        ))
-        .bind(category)
-        .bind(content)
-        .bind(confidence)
-        .bind(safe_source_id)
-        .bind(supersedes_id)
-        .fetch_one(self.pool())
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let (id,): (i64,) = query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(category)
+            .bind(content)
+            .bind(confidence)
+            .bind(safe_source_id)
+            .bind(supersedes_id)
+            .fetch_one(self.pool())
+            .await?;
 
         Ok(id)
     }
@@ -164,14 +167,17 @@ impl DbStore {
         &self,
         message_id: i64,
     ) -> Result<(), MemoryError> {
-        query(sql!(
+        let now = <ActiveDialect as zeph_db::dialect::Dialect>::NOW;
+        let raw = format!(
             "UPDATE persona_meta
-             SET last_extracted_message_id = ?, updated_at = datetime('now')
+             SET last_extracted_message_id = ?, updated_at = {now}
              WHERE id = 1"
-        ))
-        .bind(message_id)
-        .execute(self.pool())
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        query(sqlx::AssertSqlSafe(query_sql))
+            .bind(message_id)
+            .execute(self.pool())
+            .await?;
 
         Ok(())
     }

--- a/crates/zeph-memory/src/store/trajectory.rs
+++ b/crates/zeph-memory/src/store/trajectory.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use zeph_db::{query, query_as, query_scalar, sql};
+use zeph_db::{ActiveDialect, query, query_as, query_scalar, sql};
 
 use super::DbStore;
 use crate::error::MemoryError;
@@ -159,17 +159,20 @@ impl DbStore {
         conversation_id: i64,
         message_id: i64,
     ) -> Result<(), MemoryError> {
-        query(sql!(
+        let now = <ActiveDialect as zeph_db::dialect::Dialect>::NOW;
+        let raw = format!(
             "INSERT INTO trajectory_meta (conversation_id, last_extracted_message_id, updated_at)
-             VALUES (?, ?, datetime('now'))
+             VALUES (?, ?, {now})
              ON CONFLICT(conversation_id) DO UPDATE SET
                  last_extracted_message_id = excluded.last_extracted_message_id,
-                 updated_at = datetime('now')"
-        ))
-        .bind(conversation_id)
-        .bind(message_id)
-        .execute(self.pool())
-        .await?;
+                 updated_at = {now}"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        query(sqlx::AssertSqlSafe(query_sql))
+            .bind(conversation_id)
+            .bind(message_id)
+            .execute(self.pool())
+            .await?;
 
         Ok(())
     }

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -47,13 +47,25 @@
 //! `mark_consolidated`, `graph/belief.rs::mark_promoted`/`apply_evidence_update`), which
 //! has no Postgres equivalent and fails at runtime. Fixed by interpolating
 //! `<ActiveDialect as Dialect>::EPOCH_NOW` via `format!()` before `rewrite_placeholders`.
+//!
+//! Regression coverage for issue #5525: `episodic_consolidation.rs::compute_cognitive_weight`'s
+//! `SELECT COALESCE(SUM(CASE ... THEN 1.0 ... END), 0.0)` decoded directly into `f64`, but
+//! Postgres types a `SUM()` over decimal literals as `NUMERIC`, which sqlx cannot decode into
+//! `f64` without an explicit cast. Fixed with `CAST(... AS DOUBLE PRECISION)`, the same idiom
+//! already used at the 14 `EdgeRow`-projecting call sites referenced above (#5364). This was
+//! the last blocker on the full `run_episodic_consolidation_sweep` pipeline (`fetch_candidates`
+//! → `compute_cognitive_weight` → ... → `mark_consolidated`) getting real Postgres round-trip
+//! coverage — see `episodic_consolidation_sweep_promotes_fact_postgres` below.
 
 #[cfg(feature = "test-utils")]
 mod pg {
     use testcontainers::runners::AsyncRunner as _;
     use testcontainers_modules::postgres::Postgres;
     use zeph_common::SessionId;
+    use zeph_common::types::ProviderName;
     use zeph_db::DbConfig;
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
     use zeph_memory::db_vector_store::DbVectorStore;
     use zeph_memory::graph::activation::ActivatedFact;
     use zeph_memory::graph::belief::{BeliefMemConfig, BeliefStore};
@@ -65,7 +77,7 @@ mod pg {
         SqliteStore,
     };
     use zeph_memory::types::MessageId;
-    use zeph_memory::{VectorStore, episodic_graph, snapshot};
+    use zeph_memory::{VectorStore, episodic_consolidation, episodic_graph, snapshot};
 
     async fn start_pg() -> (zeph_db::DbPool, impl Drop) {
         let image = Postgres::default();
@@ -811,6 +823,43 @@ mod pg {
         assert_eq!(linked_cid.0, Some(cid.0));
     }
 
+    // ── acp_sessions: list_acp_sessions / get_acp_session_info (#5527) ──────────
+    //
+    // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite);
+    // `AcpSessionInfo` binds plain `String`s. Regression coverage for issue #5527:
+    // both queries now project through `Dialect::select_as_text`, mirroring the
+    // `agent_sessions.rs::list_agent_sessions` fix for #5524.
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn acp_sessions_list_and_get_include_timestamps_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        store.create_acp_session("sess-ts-1").await.unwrap();
+
+        let list = store.list_acp_sessions(10).await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "sess-ts-1");
+        assert!(
+            !list[0].created_at.is_empty(),
+            "created_at must decode as non-empty text"
+        );
+        assert!(
+            !list[0].updated_at.is_empty(),
+            "updated_at must decode as non-empty text"
+        );
+
+        let info = store
+            .get_acp_session_info("sess-ts-1")
+            .await
+            .unwrap()
+            .expect("session must exist");
+        assert_eq!(info.id, "sess-ts-1");
+        assert!(!info.created_at.is_empty());
+        assert!(!info.updated_at.is_empty());
+    }
+
     // ── acp_sessions: session_config snapshot (#5373/#5384) ─────────────────────
     //
     // `thinking_enabled` is `INTEGER` on SQLite vs `BOOLEAN` on Postgres (migration
@@ -1390,24 +1439,96 @@ mod pg {
         assert!(none_active.is_empty());
     }
 
-    // NOTE (found live, unrelated to issues #5524/#5508): a Postgres regression test for the
-    // full `episodic_consolidation.rs` sweep (`run_episodic_consolidation_sweep`, which chains
-    // `fetch_candidates` → `compute_cognitive_weight` → ... → `mark_consolidated`) was attempted
-    // here and is omitted. `fetch_candidates`'s `unixepoch()` fix (issue #5508) is confirmed
-    // structurally sound — the SELECT executes and returns the mature candidate row without
-    // error — but the very next step, `compute_cognitive_weight`'s
-    // `SELECT COALESCE(SUM(CASE ... THEN 1.0 ... END), 0.0)`, fails to decode: Postgres types an
-    // aggregate `SUM()` over decimal literals as `NUMERIC`, and sqlx cannot decode `NUMERIC` into
-    // the declared `f64` without an explicit cast — `ColumnDecode { source: "mismatched types;
-    // Rust type \`f64\` (as SQL type \`FLOAT8\`) is not compatible with SQL type \`NUMERIC\`" }`.
-    // This is the exact same REAL/NUMERIC-decode defect class already fixed at 14 other
-    // `EdgeRow`-projecting queries elsewhere in this file (see the module docstring), just missed
-    // at this call site — `compute_cognitive_weight` does not call `unixepoch()` itself and was
-    // not touched by this PR's #5508 fix. Because it always runs before `mark_consolidated` is
-    // ever reached, `mark_consolidated`'s `EPOCH_NOW`-based UPDATE (also part of #5508) cannot get
-    // real Postgres round-trip coverage until `compute_cognitive_weight` gets an explicit
-    // `CAST(... AS DOUBLE PRECISION)`, matching the established idiom. File a follow-up issue for
-    // the `compute_cognitive_weight` decode bug before attempting this coverage again.
+    // ── episodic_consolidation: full sweep (fetch_candidates → compute_cognitive_weight →
+    // extract_facts_via_llm → mark_consolidated), Postgres ─────────────────────────────────
+    //
+    // Regression coverage for issue #5525 (see module docstring). Exercises the full
+    // `run_episodic_consolidation_sweep` pipeline end-to-end against real Postgres, closing the
+    // coverage gap left by #5508's `fetch_candidates`/`mark_consolidated` fix.
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn episodic_consolidation_sweep_promotes_fact_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool.clone());
+        let session_id = SessionId::new("sess-consolidation-1");
+
+        let cid = store.create_conversation().await.unwrap();
+        let message_id = store
+            .save_message(cid, "user", "Alice uses Rust for systems programming")
+            .await
+            .unwrap();
+
+        // Inserted directly (rather than via `episodic_graph::store_events`, which always
+        // stamps `created_at` at insert time) so `created_at` is safely in the past —
+        // `fetch_candidates` requires `created_at < NOW() - min_age_secs`, and a
+        // server-timestamped row risks landing in the same second as the sweep's query.
+        let created_at = chrono::Utc::now().timestamp() - 600;
+        let event_id: i64 = sqlx::query_scalar(zeph_db::sql!(
+            "INSERT INTO episodic_events (session_id, message_id, event_type, summary, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             RETURNING id"
+        ))
+        .bind(session_id.as_str())
+        .bind(message_id)
+        .bind("tool_call")
+        .bind("Alice prefers Rust")
+        .bind(created_at)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let llm_response = format!(
+            r#"[{{"fact":"Alice uses Rust for systems programming","source_event_ids":[{event_id}]}}]"#
+        );
+        let mut mock = MockProvider::default();
+        mock.default_response = llm_response;
+        let provider = AnyProvider::Mock(mock);
+
+        let config = episodic_consolidation::EpisodicConsolidationConfig {
+            enabled: true,
+            consolidation_provider: ProviderName::default(),
+            interval_secs: 1800,
+            batch_size: 30,
+            min_age_secs: 0,
+            dedup_jaccard_threshold: 0.6,
+        };
+
+        let result = episodic_consolidation::run_episodic_consolidation_sweep(
+            pool.clone(),
+            &provider,
+            &config,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.events_processed, 1);
+        assert_eq!(
+            result.facts_promoted, 1,
+            "compute_cognitive_weight's NUMERIC->f64 decode must succeed for the sweep to reach \
+             fact promotion (#5525)"
+        );
+
+        let count: i64 =
+            sqlx::query_scalar(zeph_db::sql!("SELECT COUNT(*) FROM consolidated_facts"))
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 1, "one fact must be persisted to consolidated_facts");
+
+        let consolidated_at: Option<i64> = sqlx::query_scalar(zeph_db::sql!(
+            "SELECT consolidated_at FROM episodic_events WHERE id = ?1"
+        ))
+        .bind(event_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            consolidated_at.is_some(),
+            "event must be marked consolidated after sweep"
+        );
+    }
 
     // ── belief: record_evidence (apply_evidence_update) + mark_promoted (Postgres) ──
     // Regression coverage for issue #5508. `mark_promoted` and `apply_evidence_update` had


### PR DESCRIPTION
## Summary

Fixes three related Postgres SQL dialect defects in `zeph-memory` — same defect class as #5508/#5524 (SQLite-only SQL surfacing incorrectly under Postgres), found during the #5524/#5508 branch work.

- **#5526**: `datetime('now')` (SQLite-only, no Postgres equivalent) was embedded as a literal in production SQL across `graph/entity_lock.rs`, `store/trajectory.rs`, `store/persona.rs`, `store/memory_tree.rs`, and `store/overflow.rs`. Replaced with the dialect-neutral `Dialect::NOW` constant, matching the established `EPOCH_NOW` idiom. The two `datetime('now', <offset>)` sites (`entity_lock.rs`'s advisory lock TTL, `overflow.rs`'s age-based cleanup) needed a dialect-selected `NOW() +/- INTERVAL` expression, mirroring the existing `NOW() - INTERVAL '1 day' * ?` idiom in `store/skills.rs`.
- **#5527**: `store/acp_sessions.rs`'s `list_acp_sessions`/`get_acp_session_info` decoded `created_at`/`updated_at` (`TIMESTAMPTZ` on Postgres) into `String` with no cast, and had no `sql!()` wrapper at all — a latent bug that would fail on the raw `?` placeholder before ever reaching the decode error. Fixed with `Dialect::select_as_text`, mirroring the `agent_sessions.rs::list_agent_sessions` fix for #5524.
- **#5525**: `episodic_consolidation.rs::compute_cognitive_weight`'s `SELECT COALESCE(SUM(...), 0.0)` decoded a Postgres `NUMERIC` aggregate into `f64` with no cast. Fixed with `CAST(... AS DOUBLE PRECISION)`, the idiom already used at 14 other `EdgeRow`-projecting call sites. Replaces a pending `NOTE` block in `postgres_integration.rs` with a real end-to-end Postgres sweep test.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci -p zeph-memory --all-targets --features postgres,test-utils -- -D warnings` — clean
- [x] `cargo clippy --profile ci -p zeph-memory --all-targets -- -D warnings` (default/sqlite) — clean
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory --lib --bins` — 1528 passed, 8 skipped, 0 failed
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-memory` — clean
- [x] Live-verified against real Postgres via Docker testcontainers: full `postgres_integration.rs` suite (32 tests, including 2 new ones added by this PR) — 32 passed, 0 failed, 0 skipped
- [x] Two `#5526` sites with no automated integration coverage (`entity_lock.rs`'s `INSERT...ON CONFLICT...RETURNING`, `overflow.rs`'s `NOW()-INTERVAL*bind`) manually verified against a throwaway `postgres:16-alpine` container via `psql`
- [x] Adversarial critique (independent second grep sweep for the defect class, bind-count/dialect-branch verification) — no blockers found
- [x] Code review — approved

## Follow-ups (out of scope for this PR, to be filed separately)

- Systemic `TIMESTAMPTZ`->`String` decode defect (same class as #5527) found in additional stores beyond this PR's scope: `corrections.rs`, `trust.rs`, `preferences.rs`, and the `persona_memory`/`trajectory_memory` `_meta` tables — roughly 15 `*_at: String` decode sites crate-wide warrant a dedicated audit issue.
- `entity_lock.rs::extend_lock`'s `datetime(expires_at, ...)` is the same defect class as #5526 but offsets a stored column value rather than `'now'`, so it's outside this issue's literal-grep scope. Currently latent (`EntityLockManager` has no production callers).
- zeph-memory's CI Postgres archive step (`ci.yml:232`) runs `--tests` only, never `--lib --bins` — meaning no `cfg!(feature = "postgres")` branch inside `src/` is ever exercised by CI unit tests. Pre-existing gap, made concretely costly by this PR's two new dialect-branching helpers.