### PR TITLE
fix(core): stop cancelled tool_calls from corrupting message history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1348,6 +1348,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `.bind()` call since its `?2` placeholder was reused twice in the SQL text for one bound value.
   Added 5 new Postgres regression tests (`tests/postgres_integration.rs`, `test-utils` feature)
   covering previously-untested fixed call sites. Closes #5488, closes #5491.
+- `fix(core)`: cancelled or queued `tool_calls` could persist out of order, corrupting message
+  history and permanently breaking every subsequent turn with a 400 from strict-ordering providers
+  (`"An assistant message with 'tool_calls' must be followed by tool messages..."`) (#5513). Three
+  distinct control-flow bugs in `crates/zeph-core/src/agent/tool_execution/tier_loop.rs`'s
+  post-dispatch cancellation handling: (1) `handle_confirmation_phase`/`handle_retry_phase`/
+  `handle_reformat_phase` signalled cancellation via a plain `Ok(())`, indistinguishable from
+  "completed," so `run_post_dispatch_phases`'s `?`-chaining never short-circuited — each phase
+  independently re-detected the still-cancelled token and wrote a duplicate `[Cancelled]` tombstone
+  for the full tool-call batch (up to 3x per cancellation event); (2) `handle_native_tool_calls`
+  unconditionally called `process_tool_result_batch` after `run_post_dispatch_phases` returned,
+  appending a further duplicate result regardless of cancellation state; (3) the retry-phase's
+  backoff-sleep cancellation branch was the one checkpoint in the file that never wrote a tombstone
+  at all, leaving a genuinely orphaned `ToolUse` sent to the LLM on the very next turn of the same
+  live session. All three phases now return `Result<bool, AgentError>` (mirroring the
+  `TierLoopOutput`/`Option<TierLoopData>` pattern already used correctly elsewhere in the file) so
+  cancellation short-circuits the phase chain and skips the batch persist exactly once. Added an
+  idempotency guard to `persist_cancelled_tool_results`
+  (`crates/zeph-core/src/agent/tool_execution/focus.rs`) and extended
+  `strip_mid_history_orphans` (`crates/zeph-agent-persistence/src/sanitize.rs`) to also strip a
+  duplicate `ToolResult` for an already-resolved `tool_use_id`, both scoped to the current
+  turn/call window (not whole history) so providers like Ollama that legitimately reuse
+  batch-indexed tool-call ids (`call_0`, `call_1`, ...) across turns are unaffected. Closes #5513.
 
 - `fix(db)`: `zeph_db::sql!()`'s Postgres `rewrite_placeholders` did a naive per-character `?`→`$N`
   walk with no awareness of `SQLite`'s `?N` numbered-placeholder syntax, so wrapping `?1` in

--- a/crates/zeph-agent-persistence/src/sanitize.rs
+++ b/crates/zeph-agent-persistence/src/sanitize.rs
@@ -239,10 +239,130 @@ fn orphaned_tool_result_ids(msg: &Message, prev_msg: Option<&Message>) -> HashSe
         .collect()
 }
 
-/// Scan all messages and strip orphaned `ToolUse`/`ToolResult` parts from mid-history messages.
+/// Strips orphaned `ToolUse` parts from `messages[i]` (an assistant message) when unmatched by a
+/// `ToolResult` in the next non-system message. Returns `true` if the message was removed
+/// entirely (caller must not advance past `i`).
+fn strip_orphaned_tool_use_at(
+    messages: &mut Vec<Message>,
+    i: usize,
+    db_ids: &mut Vec<i64>,
+) -> bool {
+    let next_non_system = (i + 1..messages.len())
+        .find(|&j| messages[j].role != Role::System)
+        .and_then(|j| messages.get(j));
+    let orphaned_ids = orphaned_tool_use_ids(&messages[i], next_non_system);
+    if orphaned_ids.is_empty() {
+        return false;
+    }
+    tracing::warn!(
+        tool_ids = ?orphaned_ids,
+        index = i,
+        "stripping orphaned mid-history tool_use parts from assistant message"
+    );
+    messages[i]
+        .parts
+        .retain(|p| !matches!(p, MessagePart::ToolUse { id, .. } if orphaned_ids.contains(id)));
+    let is_empty = !has_meaningful_content(&messages[i].content) && messages[i].parts.is_empty();
+    if is_empty {
+        if let Some(db_id) = messages[i].metadata.db_id {
+            db_ids.push(db_id);
+        }
+        messages.remove(i);
+    }
+    is_empty
+}
+
+/// Strips orphaned and duplicate `ToolResult` parts from `messages[i]` (a user message).
+///
+/// A part is orphaned when unmatched by a `ToolUse` in the previous non-system message, or a
+/// **duplicate** (#5513) when its `tool_use_id` is already in `resolved_tool_use_ids` — i.e. a
+/// `tool_use_id` that already received a result (real or tombstone) earlier in history and shows
+/// up again later, e.g. from a cancellation-handling defect that wrote more than one tombstone for
+/// the same call. Either shape would trip the same "`tool_calls` must be followed by tool
+/// messages" provider error, so both are stripped.
+///
+/// Whatever `ToolResult` parts survive are added to `resolved_tool_use_ids`. Returns `true` if the
+/// message was removed entirely (caller must not advance past `i`).
+fn strip_tool_result_orphans_at(
+    messages: &mut Vec<Message>,
+    i: usize,
+    resolved_tool_use_ids: &mut HashSet<String>,
+    db_ids: &mut Vec<i64>,
+) -> bool {
+    let prev_non_system = (0..i)
+        .rev()
+        .find(|&j| messages[j].role != Role::System)
+        .and_then(|j| messages.get(j));
+    let orphaned_ids = orphaned_tool_result_ids(&messages[i], prev_non_system);
+    let duplicate_ids: HashSet<String> = messages[i]
+        .parts
+        .iter()
+        .filter_map(|p| {
+            if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                Some(tool_use_id.clone())
+            } else {
+                None
+            }
+        })
+        .filter(|id| resolved_tool_use_ids.contains(id))
+        .collect();
+    if !duplicate_ids.is_empty() {
+        tracing::warn!(
+            tool_use_ids = ?duplicate_ids,
+            index = i,
+            "stripping duplicate mid-history tool_result parts from user message"
+        );
+    }
+    if !orphaned_ids.is_empty() {
+        tracing::warn!(
+            tool_use_ids = ?orphaned_ids,
+            index = i,
+            "stripping orphaned mid-history tool_result parts from user message"
+        );
+    }
+    let strip_ids: HashSet<&str> = orphaned_ids
+        .iter()
+        .chain(duplicate_ids.iter())
+        .map(String::as_str)
+        .collect();
+    let mut removed = false;
+    if !strip_ids.is_empty() {
+        messages[i].parts.retain(|p| {
+            !matches!(p, MessagePart::ToolResult { tool_use_id, .. } if strip_ids.contains(tool_use_id.as_str()))
+        });
+        let is_empty =
+            !has_meaningful_content(&messages[i].content) && messages[i].parts.is_empty();
+        if is_empty {
+            if let Some(db_id) = messages[i].metadata.db_id {
+                db_ids.push(db_id);
+            }
+            messages.remove(i);
+            removed = true;
+        }
+    }
+    if !removed {
+        for p in &messages[i].parts {
+            if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                resolved_tool_use_ids.insert(tool_use_id.clone());
+            }
+        }
+    }
+    removed
+}
+
+/// Scan all messages and strip orphaned `ToolUse`/`ToolResult` parts from mid-history messages,
+/// as well as **duplicate** `ToolResult` parts (#5513) — see [`strip_tool_result_orphans_at`].
+///
+/// `resolved_tool_use_ids` is scoped to the current open call window: whenever a `ToolUse(id)`
+/// is encountered, `id` is removed from the set first, since it is being re-opened. Some
+/// providers (e.g. Ollama, which assigns `tool_call` ids as `format!("call_{i}")` by batch
+/// index) legitimately reuse the same `tool_use_id` across turns; without this, a later turn's
+/// real `ToolResult` would be misdetected as a duplicate of an earlier turn's and stripped,
+/// orphaning the later turn's `ToolUse`.
 fn strip_mid_history_orphans(messages: &mut Vec<Message>) -> (usize, Vec<i64>) {
     let mut removed = 0;
     let mut db_ids: Vec<i64> = Vec::new();
+    let mut resolved_tool_use_ids: HashSet<String> = HashSet::new();
     let mut i = 0;
     while i < messages.len() {
         if messages[i].role == Role::Assistant
@@ -251,29 +371,14 @@ fn strip_mid_history_orphans(messages: &mut Vec<Message>) -> (usize, Vec<i64>) {
                 .iter()
                 .any(|p| matches!(p, MessagePart::ToolUse { .. }))
         {
-            let next_non_system = (i + 1..messages.len())
-                .find(|&j| messages[j].role != Role::System)
-                .and_then(|j| messages.get(j));
-            let orphaned_ids = orphaned_tool_use_ids(&messages[i], next_non_system);
-            if !orphaned_ids.is_empty() {
-                tracing::warn!(
-                    tool_ids = ?orphaned_ids,
-                    index = i,
-                    "stripping orphaned mid-history tool_use parts from assistant message"
-                );
-                messages[i].parts.retain(
-                    |p| !matches!(p, MessagePart::ToolUse { id, .. } if orphaned_ids.contains(id)),
-                );
-                let is_empty =
-                    !has_meaningful_content(&messages[i].content) && messages[i].parts.is_empty();
-                if is_empty {
-                    if let Some(db_id) = messages[i].metadata.db_id {
-                        db_ids.push(db_id);
-                    }
-                    messages.remove(i);
-                    removed += 1;
-                    continue;
+            for p in &messages[i].parts {
+                if let MessagePart::ToolUse { id, .. } = p {
+                    resolved_tool_use_ids.remove(id);
                 }
+            }
+            if strip_orphaned_tool_use_at(messages, i, &mut db_ids) {
+                removed += 1;
+                continue;
             }
         }
 
@@ -282,33 +387,10 @@ fn strip_mid_history_orphans(messages: &mut Vec<Message>) -> (usize, Vec<i64>) {
                 .parts
                 .iter()
                 .any(|p| matches!(p, MessagePart::ToolResult { .. }))
+            && strip_tool_result_orphans_at(messages, i, &mut resolved_tool_use_ids, &mut db_ids)
         {
-            let prev_non_system = (0..i)
-                .rev()
-                .find(|&j| messages[j].role != Role::System)
-                .and_then(|j| messages.get(j));
-            let orphaned_ids = orphaned_tool_result_ids(&messages[i], prev_non_system);
-            if !orphaned_ids.is_empty() {
-                tracing::warn!(
-                    tool_use_ids = ?orphaned_ids,
-                    index = i,
-                    "stripping orphaned mid-history tool_result parts from user message"
-                );
-                messages[i].parts.retain(|p| {
-                    !matches!(p, MessagePart::ToolResult { tool_use_id, .. } if orphaned_ids.contains(tool_use_id.as_str()))
-                });
-
-                let is_empty =
-                    !has_meaningful_content(&messages[i].content) && messages[i].parts.is_empty();
-                if is_empty {
-                    if let Some(db_id) = messages[i].metadata.db_id {
-                        db_ids.push(db_id);
-                    }
-                    messages.remove(i);
-                    removed += 1;
-                    continue;
-                }
-            }
+            removed += 1;
+            continue;
         }
 
         i += 1;
@@ -444,5 +526,215 @@ mod tests {
     #[test]
     fn has_meaningful_content_empty() {
         assert!(!has_meaningful_content(""));
+    }
+
+    /// Regression test for #5513 item 6 (turn-scoped, see S1 correction below):
+    /// `strip_mid_history_orphans` must track resolved `tool_use_id`s cumulatively *within one
+    /// open call window*, so a duplicate `ToolResult` several messages downstream of its
+    /// matching `ToolUse` (no intervening re-open) is still caught — see
+    /// `duplicate_tool_result_several_messages_downstream_is_stripped` for that shape.
+    ///
+    /// This test instead documents the corrected boundary: when a *second* `ToolUse` reuses the
+    /// same id (re-opening the call), `resolved_tool_use_ids` forgets the earlier resolution, so
+    /// the following `ToolResult` is evaluated as a fresh pairing, not a duplicate. An earlier
+    /// version of this test asserted the opposite (id reuse via a new `ToolUse` always means
+    /// duplicate) — that assumption was wrong: it is indistinguishable from legitimate
+    /// index-based id reuse (e.g. Ollama's `format!("call_{i}")`, see
+    /// `legitimate_id_reuse_across_turns_ollama_style_must_not_be_stripped`), and stripping it
+    /// unconditionally re-creates the #5513 corruption for those providers.
+    #[test]
+    fn tool_result_after_id_reopened_by_new_tool_use_is_not_a_duplicate() {
+        let tool_use = |id: &str| MessagePart::ToolUse {
+            id: id.to_owned(),
+            name: "bash".to_owned(),
+            input: serde_json::json!({}),
+        };
+        let tool_result = |id: &str, content: &str| MessagePart::ToolResult {
+            tool_use_id: id.to_owned(),
+            content: content.to_owned(),
+            is_error: false,
+        };
+
+        let mut msgs = vec![
+            msg_with_parts(
+                Role::Assistant,
+                "[tool_use: bash(t1)]",
+                vec![tool_use("t1")],
+            ),
+            msg_with_parts(
+                Role::User,
+                "[tool_result: t1]\nfirst output",
+                vec![tool_result("t1", "first output")],
+            ),
+            // A second ToolUse legitimately re-opens the same id "t1".
+            msg_with_parts(
+                Role::Assistant,
+                "[tool_use: bash(t1)]",
+                vec![tool_use("t1")],
+            ),
+            msg_with_parts(
+                Role::User,
+                "[tool_result: t1]\nsecond output",
+                vec![tool_result("t1", "second output")],
+            ),
+        ];
+
+        let (removed, _) = sanitize_tool_pairs(&mut msgs);
+
+        assert_eq!(
+            removed, 0,
+            "the second ToolResult for t1 must survive: it pairs with the second ToolUse, \
+             not a duplicate of the first"
+        );
+        let remaining_results: Vec<&str> = msgs
+            .iter()
+            .flat_map(|m| m.parts.iter())
+            .filter_map(|p| {
+                if let MessagePart::ToolResult { content, .. } = p {
+                    Some(content.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(
+            remaining_results,
+            vec!["first output", "second output"],
+            "both results must survive intact"
+        );
+    }
+
+    /// Regression test for the Ollama id-reuse finding (impl-critic, verified against
+    /// `crates/zeph-llm/src/ollama.rs:462`): Ollama assigns `tool_call` ids as `format!("call_{i}")`
+    /// by batch index, so `call_0` legitimately recurs on *every* turn of a multi-turn tool
+    /// conversation — unlike OpenAI/Claude/Gemini, which use globally unique per-call ids.
+    ///
+    /// `resolved_tool_use_ids` is scoped to the current open call window (S1 fix): a `ToolUse(id)`
+    /// removes `id` from the set, so a later turn's legitimate `ToolUse(call_0) ->
+    /// ToolResult(call_0, real)` pair is evaluated fresh, not flagged as a duplicate of an
+    /// earlier turn's result.
+    #[test]
+    fn legitimate_id_reuse_across_turns_ollama_style_must_not_be_stripped() {
+        let tool_use = |id: &str| MessagePart::ToolUse {
+            id: id.to_owned(),
+            name: "bash".to_owned(),
+            input: serde_json::json!({}),
+        };
+        let tool_result = |id: &str, content: &str| MessagePart::ToolResult {
+            tool_use_id: id.to_owned(),
+            content: content.to_owned(),
+            is_error: false,
+        };
+
+        let mut msgs = vec![
+            // Turn 1: ToolUse(call_0) -> ToolResult(call_0, real turn-1 output).
+            msg_with_parts(
+                Role::Assistant,
+                "[tool_use: bash(call_0)]",
+                vec![tool_use("call_0")],
+            ),
+            msg_with_parts(
+                Role::User,
+                "[tool_result: call_0]\nturn-1 output",
+                vec![tool_result("call_0", "turn-1 output")],
+            ),
+            // Turn 2 (Ollama-style id reuse, unrelated to turn 1): ToolUse(call_0) ->
+            // ToolResult(call_0, real turn-2 output). Both parts are legitimate — this is not
+            // a cancellation-cascade duplicate.
+            msg_with_parts(
+                Role::Assistant,
+                "[tool_use: bash(call_0)]",
+                vec![tool_use("call_0")],
+            ),
+            msg_with_parts(
+                Role::User,
+                "[tool_result: call_0]\nturn-2 output",
+                vec![tool_result("call_0", "turn-2 output")],
+            ),
+        ];
+
+        let (removed, _) = sanitize_tool_pairs(&mut msgs);
+
+        assert_eq!(
+            removed, 0,
+            "turn 2's legitimate ToolResult(call_0) must not be stripped just because \
+             call_0 was already resolved in turn 1 (Ollama-style id reuse)"
+        );
+        let remaining_results: Vec<&str> = msgs
+            .iter()
+            .flat_map(|m| m.parts.iter())
+            .filter_map(|p| {
+                if let MessagePart::ToolResult { content, .. } = p {
+                    Some(content.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(
+            remaining_results,
+            vec!["turn-1 output", "turn-2 output"],
+            "both turns' results must survive intact"
+        );
+    }
+
+    /// Regression test for #5513: the exact malformed shape from the issue's evidence dump —
+    /// a real `ToolResult` followed several turns later by a contradicting `[Cancelled]`
+    /// tombstone for the same `tool_use_id`, with unrelated messages in between. Even though
+    /// this shape was already caught by the pre-existing single-lookback "orphan" check (its
+    /// immediate predecessor is a plain non-tool message), this test locks in that end-to-end
+    /// behavior so a future refactor of the lookback logic cannot silently regress it.
+    #[test]
+    fn duplicate_tool_result_several_messages_downstream_is_stripped() {
+        let tool_use = |id: &str| MessagePart::ToolUse {
+            id: id.to_owned(),
+            name: "bash".to_owned(),
+            input: serde_json::json!({}),
+        };
+        let tool_result = |id: &str, content: &str| MessagePart::ToolResult {
+            tool_use_id: id.to_owned(),
+            content: content.to_owned(),
+            is_error: false,
+        };
+
+        let mut msgs = vec![
+            msg_with_parts(
+                Role::Assistant,
+                "[tool_use: bash(t1)]",
+                vec![tool_use("t1")],
+            ),
+            msg_with_parts(
+                Role::User,
+                "[tool_result: t1]\nreal output",
+                vec![tool_result("t1", "real output")],
+            ),
+            msg(Role::User, "a follow-up question"),
+            msg(Role::Assistant, "a plain reply, no tool use"),
+            msg(Role::User, "another follow-up"),
+            msg_with_parts(
+                Role::User,
+                "[tool_result: t1]",
+                vec![tool_result("t1", "[Cancelled]")],
+            ),
+        ];
+
+        let (removed, _) = sanitize_tool_pairs(&mut msgs);
+
+        assert_eq!(
+            removed, 1,
+            "the downstream duplicate ToolResult must be stripped"
+        );
+        let remaining_results: Vec<&str> = msgs
+            .iter()
+            .flat_map(|m| m.parts.iter())
+            .filter_map(|p| {
+                if let MessagePart::ToolResult { content, .. } = p {
+                    Some(content.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(remaining_results, vec!["real output"]);
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/focus.rs
+++ b/crates/zeph-core/src/agent/tool_execution/focus.rs
@@ -346,11 +346,24 @@ impl<C: Channel> Agent<C> {
         self.rebuild_knowledge_block();
     }
 
-    /// Persist a tombstone `ToolResult` (`is_error=true`) for every tool call in `tool_calls`.
+    /// Persist a tombstone `ToolResult` (`is_error=true`) for every tool call in `tool_calls` that
+    /// does not already have one.
     ///
     /// Called on early-return cancellation paths where the assistant `ToolUse` message was already
     /// persisted but the matching user `ToolResult` message was not yet written. Without this, the
     /// DB contains an orphaned `ToolUse` that will trigger a Claude API 400 on the next session.
+    ///
+    /// Idempotency guard (#5513): skips any `tool_use_id` that already has a `ToolResult` (real or
+    /// tombstone) earlier in the *current turn*, so a caller that (mistakenly, or via a future
+    /// defect) invokes this more than once for the same batch cannot write duplicate/contradicting
+    /// results.
+    ///
+    /// The scan is scoped to messages from the current turn's assistant `ToolUse` message onward
+    /// (found as the most recent `Role::Assistant` message, mirroring
+    /// `shutdown::flush_orphaned_tool_use_on_shutdown`), not the whole history. Some providers
+    /// (e.g. Ollama, which assigns `tool_call` ids as `format!("call_{i}")` by batch index) reuse
+    /// the same `tool_use_id` across turns; scanning full history would treat an earlier turn's
+    /// legitimate result as covering this turn's call and wrongly skip its tombstone.
     #[tracing::instrument(
         name = "core.tool.persist_cancelled_tool_results",
         skip_all,
@@ -360,14 +373,36 @@ impl<C: Channel> Agent<C> {
         &mut self,
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
     ) {
+        let turn_start = self
+            .msg
+            .messages
+            .iter()
+            .rposition(|m| m.role == Role::Assistant)
+            .unwrap_or(0);
+        let already_resolved: std::collections::HashSet<&str> = self.msg.messages[turn_start..]
+            .iter()
+            .flat_map(|m| m.parts.iter())
+            .filter_map(|p| {
+                if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                    Some(tool_use_id.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         let result_parts: Vec<MessagePart> = tool_calls
             .iter()
+            .filter(|tc| !already_resolved.contains(tc.id.as_str()))
             .map(|tc| MessagePart::ToolResult {
                 tool_use_id: tc.id.clone(),
                 content: "[Cancelled]".to_owned(),
                 is_error: true,
             })
             .collect();
+        if result_parts.is_empty() {
+            return;
+        }
         let user_msg = Message::from_parts(Role::User, result_parts);
         self.persist_message(Role::User, &user_msg.content, &user_msg.parts, false)
             .await;

--- a/crates/zeph-core/src/agent/tool_execution/tests/focus_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/focus_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use zeph_llm::provider::{Message, Role};
+use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role, ToolUseRequest};
 
 use crate::agent::Agent;
 use crate::agent::tests::agent_tests::{
@@ -106,4 +106,157 @@ fn select_messages_for_compression_excludes_pinned() {
             m.content
         );
     }
+}
+
+fn tool_use_request(id: &str) -> ToolUseRequest {
+    ToolUseRequest {
+        id: id.to_owned(),
+        name: "bash".to_owned().into(),
+        input: serde_json::json!({}),
+    }
+}
+
+fn push_tool_result(agent: &mut Agent<MockChannel>, id: &str, content: &str, is_error: bool) {
+    let part = MessagePart::ToolResult {
+        tool_use_id: id.to_owned(),
+        content: content.to_owned(),
+        is_error,
+    };
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: format!("[tool_result: {id}]\n{content}"),
+        parts: vec![part],
+        metadata: MessageMetadata::default(),
+    });
+}
+
+fn tool_result_count(agent: &Agent<MockChannel>, id: &str) -> usize {
+    agent
+        .msg
+        .messages
+        .iter()
+        .flat_map(|m| m.parts.iter())
+        .filter(|p| matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == id))
+        .count()
+}
+
+/// Regression test for #5513 item 5: `persist_cancelled_tool_results` must be a complete
+/// no-op — no new message pushed at all — when every `tool_use_id` in the batch already has
+/// a `ToolResult` (real or tombstone) in history. Before the idempotency guard was added, a
+/// caller invoking this a second time for the same batch (as the pre-fix `tier_loop.rs`
+/// cascading-cancellation bug did) would append a duplicate/contradicting `ToolResult`.
+#[tokio::test]
+async fn persist_cancelled_tool_results_is_noop_when_all_ids_already_resolved() {
+    let mut agent = make_agent();
+    push_tool_result(&mut agent, "call-1", "real output", false);
+    let message_count_before = agent.msg.messages.len();
+
+    agent
+        .persist_cancelled_tool_results(&[tool_use_request("call-1")])
+        .await;
+
+    assert_eq!(
+        agent.msg.messages.len(),
+        message_count_before,
+        "no new message must be pushed when the id is already resolved"
+    );
+    assert_eq!(
+        tool_result_count(&agent, "call-1"),
+        1,
+        "the original real ToolResult must not be duplicated"
+    );
+}
+
+/// Regression test for #5513 item 5: when a batch mixes already-resolved and unresolved
+/// `tool_use_id`s, `persist_cancelled_tool_results` must tombstone only the unresolved ones.
+#[tokio::test]
+async fn persist_cancelled_tool_results_only_tombstones_unresolved_ids() {
+    let mut agent = make_agent();
+    push_tool_result(&mut agent, "call-1", "real output", false);
+
+    agent
+        .persist_cancelled_tool_results(&[tool_use_request("call-1"), tool_use_request("call-2")])
+        .await;
+
+    assert_eq!(
+        tool_result_count(&agent, "call-1"),
+        1,
+        "already-resolved call-1 must not receive a second ToolResult"
+    );
+    assert_eq!(
+        tool_result_count(&agent, "call-2"),
+        1,
+        "unresolved call-2 must receive exactly one tombstone ToolResult"
+    );
+    let call2_is_tombstone = agent.msg.messages.iter().any(|m| {
+        m.parts.iter().any(|p| {
+            matches!(
+                p,
+                MessagePart::ToolResult { tool_use_id, content, is_error }
+                    if tool_use_id == "call-2" && content == "[Cancelled]" && *is_error
+            )
+        })
+    });
+    assert!(
+        call2_is_tombstone,
+        "call-2's ToolResult must be the [Cancelled] tombstone"
+    );
+}
+
+/// Regression test for #5513 item 5: with no pre-existing results at all, every id in the
+/// batch must still receive a tombstone (the guard must not become a universal no-op).
+#[tokio::test]
+async fn persist_cancelled_tool_results_tombstones_all_ids_when_none_resolved() {
+    let mut agent = make_agent();
+
+    agent
+        .persist_cancelled_tool_results(&[tool_use_request("call-1"), tool_use_request("call-2")])
+        .await;
+
+    assert_eq!(tool_result_count(&agent, "call-1"), 1);
+    assert_eq!(tool_result_count(&agent, "call-2"), 1);
+}
+
+/// Regression test for the Ollama id-reuse finding (impl-critic, verified against
+/// `crates/zeph-llm/src/ollama.rs:462`): Ollama assigns `tool_call` ids as `format!("call_{i}")`
+/// by batch index, so `call_0` legitimately recurs on *every* turn of a multi-turn tool
+/// conversation — unlike OpenAI/Claude/Gemini, which use globally unique per-call ids.
+///
+/// The item-5 idempotency guard (S1 fix) scopes its "already resolved" scan to messages from
+/// the current turn's assistant `ToolUse` message onward (the most recent `Role::Assistant`
+/// message), not the whole history — mirroring production, where
+/// `push_assistant_tool_use_message` always pushes that message before any cancellation path
+/// can call `persist_cancelled_tool_results`. So turn 1's resolved `call_0` no longer shadows
+/// turn 2's unrelated dispatch of the same id.
+#[tokio::test]
+async fn persist_cancelled_tool_results_writes_tombstone_for_id_reused_in_a_new_turn() {
+    let mut agent = make_agent();
+    // Turn 1: call_0 already resolved with a real result (Ollama-style id, batch index 0).
+    push_tool_result(&mut agent, "call_0", "turn-1 output", false);
+
+    // Turn 2: push_assistant_tool_use_message's effect — the current turn's assistant ToolUse
+    // message reusing the same id "call_0" (Ollama assigns ids by batch index, not globally).
+    agent.msg.messages.push(Message {
+        role: Role::Assistant,
+        content: "[tool_use: bash(call_0)]".to_owned(),
+        parts: vec![MessagePart::ToolUse {
+            id: "call_0".to_owned(),
+            name: "bash".to_owned(),
+            input: serde_json::json!({}),
+        }],
+        metadata: MessageMetadata::default(),
+    });
+
+    // Turn 2's dispatch gets cancelled before completion.
+    agent
+        .persist_cancelled_tool_results(&[tool_use_request("call_0")])
+        .await;
+
+    assert_eq!(
+        tool_result_count(&agent, "call_0"),
+        2,
+        "turn 2's cancelled call_0 must still receive its own tombstone ToolResult, \
+         separate from turn 1's real result — the guard must not treat a new turn's \
+         id-reused call as already resolved"
+    );
 }

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -43,6 +43,11 @@ impl<C: Channel> Agent<C> {
         level = "debug",
         err
     )]
+    /// Runs the confirmation, retry, and parameter-reformat phases in sequence.
+    ///
+    /// Returns `Ok(true)` as soon as any phase reports that the user cancelled the turn, skipping
+    /// the remaining phases — each phase already persists its own `[Cancelled]` tombstone, so
+    /// running further phases after one reports cancellation would duplicate that write (#5513).
     async fn run_post_dispatch_phases(
         &mut self,
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
@@ -50,14 +55,26 @@ impl<C: Channel> Agent<C> {
         tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
         max_retries: usize,
         cancel: &tokio_util::sync::CancellationToken,
-    ) -> Result<(), crate::agent::error::AgentError> {
-        self.handle_confirmation_phase(tool_calls, calls, tool_results, cancel)
-            .await?;
-        self.handle_retry_phase(tool_calls, calls, tool_results, max_retries, cancel)
-            .await?;
-        self.handle_reformat_phase(tool_calls, calls, tool_results, cancel)
-            .await?;
-        Ok(())
+    ) -> Result<bool, crate::agent::error::AgentError> {
+        if self
+            .handle_confirmation_phase(tool_calls, calls, tool_results, cancel)
+            .await?
+        {
+            return Ok(true);
+        }
+        if self
+            .handle_retry_phase(tool_calls, calls, tool_results, max_retries, cancel)
+            .await?
+        {
+            return Ok(true);
+        }
+        if self
+            .handle_reformat_phase(tool_calls, calls, tool_results, cancel)
+            .await?
+        {
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     #[tracing::instrument(
@@ -66,13 +83,14 @@ impl<C: Channel> Agent<C> {
         level = "debug",
         err
     )]
+    /// Returns `Ok(true)` if the user cancelled the turn during this phase.
     async fn handle_confirmation_phase(
         &mut self,
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
         calls: &[ToolCall],
         tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
         cancel: &tokio_util::sync::CancellationToken,
-    ) -> Result<(), crate::agent::error::AgentError> {
+    ) -> Result<bool, crate::agent::error::AgentError> {
         for idx in 0..tool_results.len() {
             if cancel.is_cancelled() {
                 self.tool_executor.set_skill_env(None);
@@ -80,7 +98,7 @@ impl<C: Channel> Agent<C> {
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
                 self.persist_cancelled_tool_results(tool_calls).await;
-                return Ok(());
+                return Ok(true);
             }
             let new_result =
                 if let Err(zeph_tools::ToolError::ConfirmationRequired { ref command }) =
@@ -124,9 +142,10 @@ impl<C: Channel> Agent<C> {
                 tool_results[idx] = result;
             }
         }
-        Ok(())
+        Ok(false)
     }
 
+    /// Returns `Ok(true)` if the user cancelled the turn during this phase.
     #[tracing::instrument(name = "core.tool.handle_retry_phase", skip_all, level = "debug", err)]
     async fn handle_retry_phase(
         &mut self,
@@ -135,9 +154,9 @@ impl<C: Channel> Agent<C> {
         tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
         max_retries: usize,
         cancel: &tokio_util::sync::CancellationToken,
-    ) -> Result<(), crate::agent::error::AgentError> {
+    ) -> Result<bool, crate::agent::error::AgentError> {
         if max_retries == 0 {
-            return Ok(());
+            return Ok(false);
         }
         let max_retry_duration_secs = self.tool_orchestrator.max_retry_duration_secs;
         let retry_base_ms = self.tool_orchestrator.retry_base_ms;
@@ -149,7 +168,7 @@ impl<C: Channel> Agent<C> {
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
                 self.persist_cancelled_tool_results(tool_calls).await;
-                return Ok(());
+                return Ok(true);
             }
             let is_transient = matches!(
                 tool_results[idx],
@@ -179,7 +198,7 @@ impl<C: Channel> Agent<C> {
                         self.update_metrics(|m| m.cancellations += 1);
                         self.channel.send("[Cancelled]").await?;
                         self.persist_cancelled_tool_results(tool_calls).await;
-                        return Ok(());
+                        return Ok(true);
                     }
                 };
                 match exec_result {
@@ -213,7 +232,8 @@ impl<C: Channel> Agent<C> {
                                 tracing::info!("retry backoff interrupted by cancellation");
                                 self.update_metrics(|m| m.cancellations += 1);
                                 self.channel.send("[Cancelled]").await?;
-                                return Ok(());
+                                self.persist_cancelled_tool_results(tool_calls).await;
+                                return Ok(true);
                             }
                         }
                         let _ = self.channel.send_status("").await;
@@ -224,9 +244,10 @@ impl<C: Channel> Agent<C> {
             };
             tool_results[idx] = result;
         }
-        Ok(())
+        Ok(false)
     }
 
+    /// Returns `Ok(true)` if the user cancelled the turn during this phase.
     #[tracing::instrument(
         name = "core.tool.handle_reformat_phase",
         skip_all,
@@ -239,13 +260,13 @@ impl<C: Channel> Agent<C> {
         calls: &[ToolCall],
         tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
         cancel: &tokio_util::sync::CancellationToken,
-    ) -> Result<(), crate::agent::error::AgentError> {
+    ) -> Result<bool, crate::agent::error::AgentError> {
         if self
             .tool_orchestrator
             .parameter_reformat_provider
             .is_empty()
         {
-            return Ok(());
+            return Ok(false);
         }
         // Budget covers the whole reformat phase (all tool calls needing reformat this round),
         // matching the retry phase's `retry_start`/`max_retry_duration_secs` accounting.
@@ -258,7 +279,7 @@ impl<C: Channel> Agent<C> {
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
                 self.persist_cancelled_tool_results(tool_calls).await;
-                return Ok(());
+                return Ok(true);
             }
             let needs_reformat = matches!(
                 tool_results[idx],
@@ -293,7 +314,7 @@ impl<C: Channel> Agent<C> {
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
                 self.persist_cancelled_tool_results(tool_calls).await;
-                return Ok(());
+                return Ok(true);
             }
 
             if let Some(result) = new_result {
@@ -305,7 +326,7 @@ impl<C: Channel> Agent<C> {
                 tool_results[idx] = result;
             }
         }
-        Ok(())
+        Ok(false)
     }
 
     /// LLM-based single-shot reformat-and-retry for a tool call that failed with an
@@ -722,9 +743,14 @@ impl<C: Channel> Agent<C> {
         }
 
         // Phases 2a / 2 / 3: confirmation, transient retry, parameter reformat.
-        // Each phase may return early on cancellation (Ok(())) or propagate channel errors.
-        self.run_post_dispatch_phases(tool_calls, &calls, &mut tool_results, max_retries, &cancel)
+        // Each phase may signal cancellation (Ok(true)), which already persisted its own
+        // tombstone — skip process_tool_result_batch below to avoid a duplicate batch write (#5513).
+        let post_dispatch_cancelled = self
+            .run_post_dispatch_phases(tool_calls, &calls, &mut tool_results, max_retries, &cancel)
             .await?;
+        if post_dispatch_cancelled {
+            return Ok(false);
+        }
 
         // Process results, persist messages, run LSP hooks, fire deferred reflection.
         // Also clears skill env and syncs cache counters after execution.
@@ -3772,6 +3798,250 @@ mod tests {
             assert_eq!(misses, 0);
             assert!(value["code"].as_str().unwrap().contains(tricky_secret));
             assert_eq!(value["list"][0], serde_json::json!(tricky_secret));
+        }
+    }
+
+    /// Regression tests for #5513: cancellation during the post-dispatch phases
+    /// (confirmation / retry / reformat) must write exactly one `[Cancelled]` tombstone
+    /// `ToolResult` per `tool_use_id` and must never leave a `ToolUse` orphaned or let the
+    /// batch persist run again afterward.
+    mod cancellation_regression_tests {
+        use super::*;
+        use crate::agent::agent_tests::*;
+
+        /// Always fails with a `Transient` error and is marked retryable, so
+        /// `handle_retry_phase` enters its backoff-sleep branch on every attempt.
+        struct AlwaysTransientExecutor;
+
+        impl zeph_tools::executor::ToolExecutor for AlwaysTransientExecutor {
+            fn execute(
+                &self,
+                _response: &str,
+            ) -> impl std::future::Future<
+                Output = Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > + Send {
+                std::future::ready(Ok(None))
+            }
+
+            fn execute_tool_call(
+                &self,
+                _call: &ToolCall,
+            ) -> impl std::future::Future<
+                Output = Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > + Send {
+                std::future::ready(Err(zeph_tools::ToolError::Execution(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "always transient",
+                ))))
+            }
+
+            fn is_tool_retryable(&self, _tool_id: &str) -> bool {
+                true
+            }
+        }
+
+        fn tool_result_ids(agent: &Agent<MockChannel>, id: &str) -> Vec<&'static str> {
+            agent
+                .msg
+                .messages
+                .iter()
+                .flat_map(|m| m.parts.iter())
+                .filter(|p| {
+                    matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == id)
+                })
+                .map(|_| "match")
+                .collect()
+        }
+
+        /// Bug A: a token already cancelled before `handle_confirmation_phase` runs must
+        /// short-circuit `run_post_dispatch_phases` after the first phase reports
+        /// cancellation, instead of cascading into `handle_retry_phase` and
+        /// `handle_reformat_phase` as well. Before the fix, each of the three phases
+        /// independently detected the same cancellation and wrote its own tombstone batch,
+        /// producing up to 3 duplicate `[Cancelled]` `ToolResult`s per `tool_use_id`.
+        #[tokio::test]
+        async fn cancelled_before_confirmation_phase_writes_one_tombstone_and_skips_later_phases() {
+            let provider = mock_provider(vec![]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::no_tools();
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent.tool_orchestrator.max_tool_retries = 2;
+            agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+
+            let tool_calls = vec![
+                zeph_llm::provider::ToolUseRequest {
+                    id: "id-1".to_owned(),
+                    name: "bash".to_owned().into(),
+                    input: serde_json::json!({}),
+                },
+                zeph_llm::provider::ToolUseRequest {
+                    id: "id-2".to_owned(),
+                    name: "bash".to_owned().into(),
+                    input: serde_json::json!({}),
+                },
+            ];
+            let calls = vec![
+                ToolCall {
+                    tool_id: zeph_common::ToolName::new("bash"),
+                    ..Default::default()
+                },
+                ToolCall {
+                    tool_id: zeph_common::ToolName::new("bash"),
+                    ..Default::default()
+                },
+            ];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Ok(None), Ok(None)];
+
+            let cancel = tokio_util::sync::CancellationToken::new();
+            cancel.cancel();
+
+            let cancelled = agent
+                .run_post_dispatch_phases(&tool_calls, &calls, &mut tool_results, 2, &cancel)
+                .await
+                .unwrap();
+
+            assert!(
+                cancelled,
+                "run_post_dispatch_phases must report cancellation"
+            );
+
+            for id in ["id-1", "id-2"] {
+                let matches = tool_result_ids(&agent, id);
+                assert_eq!(
+                    matches.len(),
+                    1,
+                    "tool_use_id {id} must have exactly one [Cancelled] tombstone, got {}",
+                    matches.len()
+                );
+            }
+        }
+
+        /// Bug C: cancellation landing specifically inside the retry-phase backoff-sleep
+        /// `tokio::select!` must still persist a tombstone `ToolResult` for the pending
+        /// `ToolUse`. Before the fix this was the only cancellation checkpoint in the file
+        /// that returned without calling `persist_cancelled_tool_results`, leaving the
+        /// `ToolUse` message genuinely orphaned (zero `ToolResult`s) for the rest of the
+        /// live session.
+        #[tokio::test]
+        async fn handle_retry_phase_cancelled_during_backoff_sleep_persists_tombstone() {
+            let provider = mock_provider(vec![]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = AlwaysTransientExecutor;
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent.tool_orchestrator.max_tool_retries = 3;
+            // Large, deterministic-enough backoff window so the spawned cancellation below
+            // (fired after a short real-time delay) lands during the sleep rather than after
+            // it — full-jitter backoff makes an exact guarantee impossible, but at this
+            // magnitude the chance of picking a delay under 200ms is negligible.
+            agent.tool_orchestrator.retry_base_ms = 600_000;
+            agent.tool_orchestrator.retry_max_ms = 600_000;
+            agent.tool_orchestrator.max_retry_duration_secs = 0;
+
+            let tool_calls = vec![zeph_llm::provider::ToolUseRequest {
+                id: "id-retry".to_owned(),
+                name: "bash".to_owned().into(),
+                input: serde_json::json!({}),
+            }];
+            let calls = vec![ToolCall {
+                tool_id: zeph_common::ToolName::new("bash"),
+                ..Default::default()
+            }];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(zeph_tools::ToolError::Execution(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "initial transient failure",
+            )))];
+
+            let cancel = tokio_util::sync::CancellationToken::new();
+            let cancel_trigger = cancel.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                cancel_trigger.cancel();
+            });
+
+            let cancelled = agent
+                .handle_retry_phase(&tool_calls, &calls, &mut tool_results, 3, &cancel)
+                .await
+                .unwrap();
+
+            assert!(cancelled, "handle_retry_phase must report cancellation");
+
+            let matches = tool_result_ids(&agent, "id-retry");
+            assert_eq!(
+                matches.len(),
+                1,
+                "cancellation during backoff sleep must still write exactly one tombstone \
+                 ToolResult, got {}",
+                matches.len()
+            );
+        }
+
+        /// Bug B + Bug C, exercised through the full `handle_native_tool_calls` entry point:
+        /// once `run_post_dispatch_phases` reports cancellation (here triggered during the
+        /// retry-phase backoff sleep), `handle_native_tool_calls` must return immediately and
+        /// must NOT call `process_tool_result_batch` afterward. Before the fix, the batch
+        /// persist ran unconditionally, appending a second (contradicting, non-cancelled)
+        /// `ToolResult` message right after the phases' own tombstone write.
+        #[tokio::test]
+        async fn handle_native_tool_calls_cancelled_during_retry_backoff_skips_batch_persist() {
+            let provider = mock_provider(vec![]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = AlwaysTransientExecutor;
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent.tool_orchestrator.max_tool_retries = 3;
+            agent.tool_orchestrator.retry_base_ms = 600_000;
+            agent.tool_orchestrator.retry_max_ms = 600_000;
+            agent.tool_orchestrator.max_retry_duration_secs = 0;
+
+            let tool_calls = vec![zeph_llm::provider::ToolUseRequest {
+                id: "id-e2e".to_owned(),
+                name: "bash".to_owned().into(),
+                input: serde_json::json!({"command": "echo hi"}),
+            }];
+
+            let cancel_trigger = agent.runtime.lifecycle.cancel_token.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                cancel_trigger.cancel();
+            });
+
+            let window_exhausted = agent
+                .handle_native_tool_calls(None, &tool_calls)
+                .await
+                .unwrap();
+            assert!(
+                !window_exhausted,
+                "a cancelled turn must not report utility-window exhaustion"
+            );
+
+            let matches = tool_result_ids(&agent, "id-e2e");
+            assert_eq!(
+                matches.len(),
+                1,
+                "exactly one ToolResult must exist for id-e2e after cancellation, got {}",
+                matches.len()
+            );
+
+            // The tombstone must be the very last message — proving process_tool_result_batch
+            // did not run afterward and append a second, contradicting result.
+            let last = agent.msg.messages.last().expect("at least one message");
+            let has_tombstone = last.parts.iter().any(|p| {
+                matches!(
+                    p,
+                    MessagePart::ToolResult { tool_use_id, content, is_error }
+                        if tool_use_id == "id-e2e" && content == "[Cancelled]" && *is_error
+                )
+            });
+            assert!(
+                has_tombstone,
+                "last message must be the [Cancelled] tombstone for id-e2e, got: {last:?}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #5513: cancelled/queued `tool_calls` could persist out of order in message history, permanently breaking every subsequent turn with a 400 from strict-ordering LLM providers (`"An assistant message with 'tool_calls' must be followed by tool messages..."`).
- Root cause: three control-flow bugs in `tier_loop.rs`'s post-dispatch cancellation handling (confirmation/retry/reformat phases). Each phase signalled cancellation via a plain `Ok(())`, indistinguishable from "completed", so the phase chain never short-circuited — this produced up to 3 duplicate `[Cancelled]` tombstones per cancellation event, plus a 4th unconditional batch-result write, and separately left one cancellation checkpoint (retry backoff-sleep) writing no tombstone at all, orphaning the `ToolUse`.
- All three phases now return `Result<bool, AgentError>` so cancellation short-circuits correctly. Added an idempotency guard to `persist_cancelled_tool_results` and extended `strip_mid_history_orphans` to strip duplicate `ToolResult`s — both scoped to the current turn/call window (not whole history), since Ollama legitimately reuses batch-indexed tool-call ids (`call_0`, `call_1`, ...) across turns, unlike OpenAI/Claude/Gemini's unique ids. This scoping gap was caught by adversarial review before merge and fixed in a second round.

## Test plan

- [x] 9 new unit/regression tests across `zeph-core` (`tier_loop.rs`, `focus_tests.rs`) and `zeph-agent-persistence` (`sanitize.rs`), covering all 3 original bugs plus the Ollama id-reuse edge case — all passing.
- [x] Adversarial critique round (found and fixed the Ollama id-reuse scoping gap before this diff landed).
- [x] Code review: approved.
- [x] Full workspace pre-commit gate: `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11765 passed, 0 failed), rustdoc gate — all clean.
- [x] LLM Serialization Gate live session test (required per `.claude/rules/continuous-improvement.md` for changes touching tool-call/history persistence): reproduced the original scenario live against Ollama (`gemma4:26b`) — triggered a `bash` tool call, cancelled it mid-execution via the real TUI cancel keybinding, confirmed exactly one `[Cancelled]` tombstone immediately adjacent to its `tool_use`, zero 400/422 across 4 requests, and directly exercised the S1 Ollama id-reuse scenario (`call_0` reused 3 times across 3 different tool invocations in one session with no cross-contamination). A pure OpenAI/Claude-id live run was not separately completed in this session (blocked by unrelated tool-trust config gates in the full test config, not by this fix); the unit-level regression tests cover that path deterministically.
- [x] `.local/testing/playbooks/tool-call-cancellation-ordering.md` and `coverage-status.md` updated (main repo) with this fix's scenario and test coverage.