### PR TITLE
fix(memory): three independent P2 gaps in zeph-memory (timeouts + metadata restoration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -582,6 +582,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   sites from #5364; this was the last blocker on `run_episodic_consolidation_sweep` getting a real
   Postgres round-trip test (`postgres_integration.rs::episodic_consolidation_sweep_promotes_fact_postgres`,
   replacing a `NOTE` block left pending this fix).
+- `fix(memory)`: three independent zeph-memory gaps from the ongoing architecture rotation (#5497,
+  #5500, #5502). `generate_community_summary`'s `provider.chat` call (`graph/community.rs`) had no
+  call-site timeout, violating the mandatory Await Discipline rule — a hung LLM call could stall a
+  `detect_communities` `JoinSet` task indefinitely; now wraps the call in a 15s `tokio::time::timeout`
+  matching sibling call sites, warn-logging and yielding an empty summary on expiry. Closes #5502.
+  `GraphStore::qdrant_point_ids_for_entities` (`graph/store/mod.rs`) issued its per-chunk `fetch_all`
+  with no query-level timeout, silently defeating the documented per-step circuit breaker in
+  `hela_spreading_recall`; now wraps each chunk's query in the same 500ms `tokio::time::timeout`
+  pattern already used by its sibling `query_batch_edges`, converting a stalled query into a typed
+  `MemoryError::Timeout`. Closes #5500. `SqliteStore::message_by_id` (`store/messages/mod.rs`)
+  hardcoded `db_id` and `fidelity_tag` to `None` on every returned message instead of populating them
+  from the input parameter and the SQL row respectively, inconsistent with its own batch sibling
+  `messages_by_ids` and with `load_history`/`load_history_filtered`; both fields are now restored
+  using the existing conventions. Closes #5497.
 - `fix(orchestration)`: `TaskGraph::created_at`/`finished_at` timestamps could be corrupted with an
   invalid `month=00` ISO-8601 component. The hand-rolled `epoch_secs_to_datetime` Gregorian
   decomposition in `graph.rs` mis-computed the month for dates immediately preceding a leap year

--- a/crates/zeph-memory/src/graph/community.rs
+++ b/crates/zeph-memory/src/graph/community.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 #[allow(unused_imports)]
 use zeph_db::sql;
 
@@ -614,7 +615,13 @@ async fn generate_community_summary(
     }
 
     let messages = [Message::from_legacy(Role::User, prompt)];
-    let response: String = provider.chat(&messages).await.map_err(MemoryError::Llm)?;
+    let response: String = tokio::time::timeout(Duration::from_secs(15), provider.chat(&messages))
+        .await
+        .map_err(|_| {
+            tracing::warn!("community summary generation: LLM call timed out after 15s");
+            MemoryError::Timeout("community summary: LLM call timed out after 15s".into())
+        })?
+        .map_err(MemoryError::Llm)?;
     Ok(response)
 }
 
@@ -991,6 +998,34 @@ mod tests {
         // floor_char_boundary(10) for 4-byte chars lands at 8 (2 full emojis = 8 bytes)
         assert_eq!(result.len(), 8 + 3, "2 emojis (8 bytes) + '...' (3 bytes)");
         assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    // ── timeout regression test (#5502) ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_generate_community_summary_times_out() {
+        tokio::time::pause();
+        let mock = zeph_llm::mock::MockProvider::default().with_delay(20_000);
+        let provider = AnyProvider::Mock(mock);
+        let fut = async move {
+            generate_community_summary(
+                &provider,
+                &["A".to_owned(), "B".to_owned()],
+                &["A relates B".to_owned()],
+                usize::MAX,
+            )
+            .await
+        };
+        let handle = tokio::spawn(fut); // EXEMPT: test-only tokio::time::pause harness
+        tokio::time::advance(Duration::from_secs(16)).await;
+        let result = handle.await.expect("task panicked");
+        match result {
+            Err(MemoryError::Timeout(msg)) => assert!(
+                msg.contains("community summary"),
+                "unexpected timeout message: {msg}"
+            ),
+            other => panic!("expected MemoryError::Timeout, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -729,9 +729,9 @@ impl GraphStore {
             query = query.bind(et.as_str());
         }
 
-        // Wrap pool.acquire() + query execution in a short timeout to prevent the outer
-        // tokio::time::timeout (in SemanticMemory recall) from cancelling a mid-acquire
-        // future, which causes sqlx 0.8 semaphore count drift and permanent pool starvation.
+        // Bound worst-case per-chunk blocking on pool.acquire() + query execution: a
+        // stuck pool turns into a typed MemoryError::Timeout instead of an indefinite
+        // hang, so the caller (SemanticMemory recall) can fail fast and proceed.
         let rows: Vec<EdgeRow> = tokio::time::timeout(
             std::time::Duration::from_millis(500),
             query.fetch_all(&self.pool),
@@ -1517,7 +1517,16 @@ impl GraphStore {
             for id in chunk {
                 q = q.bind(*id);
             }
-            let rows = q.fetch_all(&self.pool).await?;
+            // Bound worst-case per-chunk blocking on pool.acquire() + query execution: a
+            // stuck pool turns into a typed MemoryError::Timeout instead of an indefinite
+            // hang, so callers (e.g. hela_spreading_recall's per-step circuit breaker) can
+            // fail fast and proceed.
+            let rows: Vec<(i64, String)> = tokio::time::timeout(
+                std::time::Duration::from_millis(500),
+                q.fetch_all(&self.pool),
+            )
+            .await
+            .map_err(|_| MemoryError::Timeout("qdrant_point_ids_for_entities".into()))??;
             for (entity_id, point_id) in rows {
                 result.insert(entity_id, point_id);
             }

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -3723,6 +3723,43 @@ async fn pool_isolation_independent_pools_do_not_starve() {
     assert!(result.unwrap().is_ok(), "pool B query must succeed");
 }
 
+// ── Regression: #5500 qdrant_point_ids_for_entities timeout ─────────────────
+
+/// Regression test for #5500: `qdrant_point_ids_for_entities` must return
+/// `MemoryError::Timeout` instead of hanging when its pool has no idle connection
+/// available past the method's internal 500ms deadline.
+///
+/// Uses a single-connection pool (same construction as
+/// `migration_024_backfill_preserves_entities_and_edges` above) and holds the sole
+/// connection for 800ms via a spawned task, matching the `#2591` pool-starvation
+/// test's real-time hold/timeout ratio. The connection is acquired synchronously
+/// before spawning so there is no race for who gets it first.
+#[tokio::test]
+async fn qdrant_point_ids_for_entities_times_out_on_pool_starvation() {
+    let store = SqliteStore::with_pool_size(":memory:", 1).await.unwrap();
+    let gs = GraphStore::new(store.pool().clone());
+
+    // Grab the pool's sole connection synchronously, then release it after 800ms —
+    // longer than the method's internal 500ms timeout — so `fetch_all`'s implicit
+    // pool.acquire() never completes in time.
+    let conn = store.pool().acquire().await.expect("sole connection");
+    let holder = tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+        drop(conn);
+    });
+
+    let result = gs.qdrant_point_ids_for_entities(&[1]).await;
+    holder.await.expect("holder task");
+
+    assert!(
+        matches!(
+            result,
+            Err(crate::error::MemoryError::Timeout(ref msg)) if msg == "qdrant_point_ids_for_entities"
+        ),
+        "expected Timeout(\"qdrant_point_ids_for_entities\"), got: {result:?}"
+    );
+}
+
 // ── GAAMA episode tests ────────────────────────────────────────────────────────
 
 /// Insert a conversation row and return its id (satisfies `FK` in `graph_episodes`).

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -602,6 +602,10 @@ impl SqliteStore {
 
     /// Fetch a single message by its ID.
     ///
+    /// Restores persisted `fidelity_tag` into [`MessageMetadata::fidelity_tag`].
+    /// A stored value of `0` maps to `None` (never scored / Full by default) so
+    /// messages written before CAM was enabled do not acquire a spurious floor.
+    ///
     /// # Errors
     ///
     /// Returns an error if the query fails.
@@ -611,33 +615,42 @@ impl SqliteStore {
     ) -> Result<Option<Message>, MemoryError> {
         let parts_select = <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("parts");
         let sql = zeph_db::rewrite_placeholders(&format!(
-            "SELECT role, content, {parts_select} AS parts, visibility FROM messages \
+            "SELECT role, content, {parts_select} AS parts, visibility, \
+                    CAST(fidelity_tag AS INTEGER) AS fidelity_tag FROM messages \
              WHERE id = ? AND deleted_at IS NULL"
         ));
-        let row: Option<(String, String, String, String)> =
+        let row: Option<(String, String, String, String, i32)> =
             zeph_db::query_as(sqlx::AssertSqlSafe(sql))
                 .bind(message_id)
                 .fetch_optional(&self.pool)
                 .await?;
 
-        Ok(row.map(|(role_str, content, parts_json, visibility_str)| {
-            let parts = parse_parts_json(&role_str, &parts_json);
-            Message {
-                role: parse_role(&role_str),
-                content,
-                parts,
-                metadata: MessageMetadata {
-                    visibility: MessageVisibility::from_db_str(&visibility_str),
-                    compacted_at: None,
-                    deferred_summary: None,
-                    focus_pinned: false,
-                    focus_marker_id: None,
-                    db_id: None,
-                    fidelity_tag: None,
-                    embedding: None,
-                },
-            }
-        }))
+        Ok(row.map(
+            |(role_str, content, parts_json, visibility_str, fidelity_raw)| {
+                let parts = parse_parts_json(&role_str, &parts_json);
+                Message {
+                    role: parse_role(&role_str),
+                    content,
+                    parts,
+                    metadata: MessageMetadata {
+                        visibility: MessageVisibility::from_db_str(&visibility_str),
+                        compacted_at: None,
+                        deferred_summary: None,
+                        focus_pinned: false,
+                        focus_marker_id: None,
+                        db_id: Some(message_id.0),
+                        fidelity_tag: if fidelity_raw == 0 {
+                            None
+                        } else {
+                            u8::try_from(fidelity_raw)
+                                .ok()
+                                .map(ContextFidelity::from_u8)
+                        },
+                        embedding: None,
+                    },
+                }
+            },
+        ))
     }
 
     /// Fetch messages by a list of IDs in a single query.

--- a/crates/zeph-memory/src/store/messages/tests.rs
+++ b/crates/zeph-memory/src/store/messages/tests.rs
@@ -203,6 +203,15 @@ async fn message_by_id_fetches_existing() {
     let msg = msg.unwrap();
     assert_eq!(msg.role, Role::User);
     assert_eq!(msg.content, "hello");
+    assert_eq!(
+        msg.metadata.db_id,
+        Some(msg_id.0),
+        "db_id must be populated from the input message_id"
+    );
+    assert_eq!(
+        msg.metadata.fidelity_tag, None,
+        "default DB value 0 must load as None (never-scored marker)"
+    );
 }
 
 #[tokio::test]
@@ -210,6 +219,26 @@ async fn message_by_id_returns_none_for_nonexistent() {
     let store = test_store().await;
     let msg = store.message_by_id(MessageId(999)).await.unwrap();
     assert!(msg.is_none());
+}
+
+#[tokio::test]
+async fn message_by_id_restores_fidelity_tag() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let msg_id = store.save_message(cid, "user", "hello").await.unwrap();
+
+    store
+        .update_fidelity_tags(&[(msg_id, zeph_common::ContextFidelity::Compressed as u8)])
+        .await
+        .unwrap();
+
+    let msg = store.message_by_id(msg_id).await.unwrap().unwrap();
+    assert_eq!(msg.metadata.db_id, Some(msg_id.0));
+    assert_eq!(
+        msg.metadata.fidelity_tag,
+        Some(zeph_common::ContextFidelity::Compressed),
+        "persisted Compressed must round-trip through message_by_id"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Three independent, non-overlapping P2 bug fixes in `zeph-memory`, part of the ongoing architecture rotation. Bundled into one PR since each is small and touches a different file.

- `generate_community_summary`'s LLM call (`graph/community.rs`) had no call-site timeout, violating the crate's Await Discipline convention — now wrapped in a 15s `tokio::time::timeout`, matching sibling call sites. Closes #5502.
- `qdrant_point_ids_for_entities`'s query (`graph/store/mod.rs`) had no query-level timeout, silently defeating the documented HL-F5 circuit breaker in `hela_spreading_recall` — now wrapped in the same 500ms `tokio::time::timeout` pattern used by its sibling `query_batch_edges`. Also corrects a stale/incorrect comment (wrong sqlx version reference, inconsistent justification) on both call sites. Closes #5500.
- `message_by_id` (`store/messages/mod.rs`) hardcoded `db_id`/`fidelity_tag` to `None` on every returned message, diverging from its own batch sibling `messages_by_ids` and from `load_history`/`load_history_filtered` — both fields are now restored using the existing conventions. Closes #5497.

## Test plan

- [x] New regression test `test_generate_community_summary_times_out` (mock provider delay + `tokio::time::pause`/`advance`)
- [x] New regression test `qdrant_point_ids_for_entities_times_out_on_pool_starvation` (single-connection pool contention)
- [x] Extended `message_by_id_fetches_existing` + new `message_by_id_restores_fidelity_tag` (both directions of the `0 -> None` mapping)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11774/11774 passed
- [x] Rustdoc gate (`RUSTFLAGS=-D warnings`, `--deny rustdoc::broken_intra_doc_links`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `.local/testing/coverage-status.md` + `playbooks/memory-graph.md` + `playbooks/context-adaptive-memory.md` updated with new scenarios