### PR TITLE
fix(memory): document RL admission strategy fallback warning (#5543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(memory)`: clarify that `[memory.admission] admission_strategy = "rl"` is not silently a
+  no-op (#5543) — `src/bootstrap/mod.rs::build_admission_control` already emits a startup
+  `tracing::warn!` when this variant is selected (added by #2485 for #2416, predating this issue),
+  so the fallback to heuristic scoring was already operator-visible; no new runtime warning was
+  needed. Tightened that existing warning to also flag that the RL training write path
+  (`record_admission_training`/`save_rl_weights`/`load_rl_weights`/`cleanup_old_training_data` in
+  `zeph_memory::store::admission_training`) has no production caller, so even once a learned-model
+  scorer is wired, there is currently no training data collected to train it on. Expanded the
+  `AdmissionStrategy::Rl` variant's doc comment in `zeph-config` to state this plainly. The `Rl`
+  enum variant, `rl_min_samples` / `rl_retrain_interval_secs` config fields, and the
+  `admission_training_data` / `admission_rl_weights` storage tables are unchanged and remain
+  scaffolding for a future RL wiring effort.
 - `fix(memory)`: three more Postgres-dialect defects in `zeph-memory`, same class as #5508/#5524
   (SQLite-only SQL surfacing incorrectly under Postgres, live-verified via Docker testcontainers).
   `datetime('now')` (SQLite-only, no Postgres equivalent) was embedded as a literal in production

--- a/crates/zeph-config/src/memory/retrieval.rs
+++ b/crates/zeph-config/src/memory/retrieval.rs
@@ -531,7 +531,19 @@ pub enum AdmissionStrategy {
     #[default]
     Heuristic,
     /// Learned model: logistic regression trained on recall feedback.
-    /// Falls back to `Heuristic` when training data is below `rl_min_samples`.
+    ///
+    /// **Not yet wired to a runtime scorer** (#2416/#5543): no admission code path scores
+    /// with a learned model today, so selecting this variant falls back to
+    /// [`AdmissionStrategy::Heuristic`] scoring. `src/bootstrap/mod.rs`'s
+    /// `build_admission_control` emits a `tracing::warn!` at startup when this variant is
+    /// selected, so the fallback is operator-visible rather than silent.
+    ///
+    /// The training write path this strategy would need — `record_admission_training`,
+    /// `save_rl_weights`, `load_rl_weights`, and `cleanup_old_training_data` in
+    /// `zeph_memory::store::admission_training` — has no production caller, so even once a
+    /// scorer is wired, there is no training data to train it on yet. The `rl_min_samples` /
+    /// `rl_retrain_interval_secs` fields and the `admission_training_data` /
+    /// `admission_rl_weights` storage tables remain as scaffolding for that future work.
     Rl,
 }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -912,7 +912,9 @@ impl AppBuilder {
         if self.config.memory.admission.admission_strategy == zeph_config::AdmissionStrategy::Rl {
             tracing::warn!(
                 "admission_strategy = \"rl\" is configured but the RL model is not yet wired \
-                 into the admission path — falling back to heuristic. See #2416."
+                 into the admission path — falling back to heuristic. The training write path \
+                 (record_admission_training/save_rl_weights) also has no production caller yet, \
+                 so no training data is being collected. See #2416/#5543."
             );
         }
 


### PR DESCRIPTION
## Summary
- #5543 claimed `admission_strategy = "rl"` is silently accepted with zero warning and zero
  effect. Investigation found this is only half true: `src/bootstrap/mod.rs::build_admission_control`
  already emits a startup `tracing::warn!` for this exact condition (added by #2485 for #2416,
  predating this issue), so the heuristic fallback is already operator-visible. No new runtime
  warning was needed.
- Expanded the `AdmissionStrategy::Rl` doc comment in `zeph-config` to state plainly that the
  variant is not wired to a runtime scorer, that the existing warning covers the fallback, and
  that the RL training write path (`record_admission_training`/`save_rl_weights`/`load_rl_weights`/
  `cleanup_old_training_data`) has no production caller — so there is no training data collected
  even once a scorer is wired.
- Tightened the existing `src/bootstrap/mod.rs` warning message with one added sentence covering
  the training write path, and updated its issue reference from `#2416` to `#2416/#5543`.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11835 passed, 34 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-config` (confirms the new intra-doc link resolves)

Closes #5543