### PR TITLE
fix(durable): namespace durable.db journal per-database to stop ExecutionId collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -575,6 +575,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   enum variant, `rl_min_samples` / `rl_retrain_interval_secs` config fields, and the
   `admission_training_data` / `admission_rl_weights` storage tables are unchanged and remain
   scaffolding for a future RL wiring effort.
+
+- `fix(durable)`: distinct memory SQLite databases sharing a directory no longer collide on the
+  P1 agent-turn adapter's `ExecutionId`, which previously caused every fresh conversation's first
+  turn to spuriously diverge (#5553). `resolve_durable_db_url` (`src/commands/durable.rs`) now
+  namespaces the journal file by the main DB's full file name (e.g. `zeph.db.durable.db` for
+  `zeph.db`) instead of a bare `durable.db`, so two databases in the same directory — including
+  same-stem, different-extension pairs like `zeph.db` and `zeph.sqlite` — get distinct journal
+  files. A pre-existing bare `durable.db` is still preferred when present, so an upgrade does not
+  orphan that journal *file*; note this does not make pre-upgrade in-flight P1 agent-turn
+  executions inside it resumable, since the `ExecutionId` derivation changed too (see below) — a
+  one-time, low-impact effect at the upgrade boundary only. As defense in depth, the P1
+  `ExecutionId` derivation (`durable_bootstrap.rs::ensure_session_durable_ctx`) now also folds in
+  `config.memory.sqlite_path` alongside `ConversationId`, so even two databases that ever ended up
+  sharing one journal `db_url` (e.g. via a future config override) still could not collide.
+
 - `fix(memory)`: three more Postgres-dialect defects in `zeph-memory`, same class as #5508/#5524
   (SQLite-only SQL surfacing incorrectly under Postgres, live-verified via Docker testcontainers).
   `datetime('now')` (SQLite-only, no Postgres equivalent) was embedded as a literal in production

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2122,17 +2122,25 @@ impl<C: Channel> Agent<C> {
     /// the first durable-gated call, once the real `TaskSupervisor` is attached
     /// (see [`Self::with_task_supervisor`]).
     ///
-    /// `db_url` is the same `durable.db` connection string as [`Self::with_durable_orchestration`]
-    /// — both P1 and P2 adapters share the same journal file when both are enabled.
+    /// `db_url` is the same durable journal connection string as
+    /// [`Self::with_durable_orchestration`] — both P1 and P2 adapters share the same journal
+    /// file when both are enabled.
+    ///
+    /// `sqlite_path` is `config.memory.sqlite_path`, folded into the P1 [`ExecutionId`](zeph_durable::ExecutionId)
+    /// derivation alongside `ConversationId` (see `durable_bootstrap.rs`) so that even if a
+    /// future config override ever pointed two different memory databases at the same journal
+    /// `db_url`, their executions still would not collide (#5553).
     #[must_use]
     pub fn with_durable_agent_turns(
         mut self,
         config: zeph_config::DurableConfig,
         db_url: String,
+        sqlite_path: String,
         cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
     ) -> Self {
         self.services.session.durable_agent_turns_config = Some(config);
         self.services.session.durable_agent_turns_db_url = Some(db_url);
+        self.services.session.durable_agent_turns_sqlite_path = Some(sqlite_path);
         self.services.session.durable_agent_turns_cipher = cipher;
         self
     }

--- a/crates/zeph-core/src/agent/durable_bootstrap.rs
+++ b/crates/zeph-core/src/agent/durable_bootstrap.rs
@@ -87,6 +87,12 @@ impl<C: Channel> Agent<C> {
         let Some(db_url) = self.services.session.durable_agent_turns_db_url.clone() else {
             return;
         };
+        let sqlite_path = self
+            .services
+            .session
+            .durable_agent_turns_sqlite_path
+            .clone()
+            .unwrap_or_default();
         let Some(conversation_id) = self.services.memory.persistence.conversation_id else {
             tracing::warn!(
                 "durable agent_turns: no conversation_id at bootstrap; degrading to non-durable"
@@ -119,10 +125,15 @@ impl<C: Channel> Agent<C> {
             return;
         };
 
-        let exec_id = zeph_durable::ExecutionId::derive(
-            b"zeph.agent_turn.v1",
-            &conversation_id.0.to_le_bytes(),
-        );
+        // Fold `sqlite_path` in alongside the fixed-width `ConversationId` bytes so that even if
+        // two distinct memory databases were ever configured to share the same durable journal
+        // `db_url`, their first-ever conversation (always `ConversationId(1)`) still cannot
+        // derive the same `ExecutionId` (#5553). The journal-file-per-database fix in
+        // `resolve_durable_db_url` already prevents the collision in the common case; this is
+        // defense in depth for that derivation.
+        let mut exec_payload = conversation_id.0.to_le_bytes().to_vec();
+        exec_payload.extend_from_slice(sqlite_path.as_bytes());
+        let exec_id = zeph_durable::ExecutionId::derive(b"zeph.agent_turn.v1", &exec_payload);
         tracing::debug!("durable agent_turns: open_execution start");
         let open_execution_result = local_backend
             .open_execution(exec_id, zeph_durable::ExecutionKind::AgentTurn)
@@ -332,6 +343,113 @@ mod tests {
         assert_ne!(
             first_exec_id, second_exec_id,
             "a conversation switch must rebind the P1 execution to the new conversation_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn distinct_sqlite_paths_do_not_collide_on_first_conversation() {
+        // Regression test for #5553: two agents pointed at different memory databases (but
+        // sharing the same durable `db_url`, e.g. via directory collision) must not derive the
+        // same `ExecutionId` for their respective first-ever `ConversationId(1)`.
+        async fn exec_id_for(sqlite_path: &str) -> zeph_durable::ExecutionId {
+            let mut agent = agent_with_conversation();
+            agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+                enabled: true,
+                agent_turns: true,
+                ..zeph_config::DurableConfig::default()
+            });
+            agent.services.session.durable_agent_turns_db_url = Some(":memory:".to_owned());
+            agent.services.session.durable_agent_turns_sqlite_path = Some(sqlite_path.to_owned());
+
+            agent.ensure_session_durable_ctx().await;
+            agent
+                .services
+                .session
+                .durable_ctx
+                .as_ref()
+                .expect("durable_ctx should be populated")
+                .execution_id()
+        }
+
+        let a = Box::pin(exec_id_for("/data/alpha/zeph.db")).await;
+        let b = Box::pin(exec_id_for("/data/beta/zeph.db")).await;
+
+        assert_ne!(
+            a, b,
+            "two databases' first conversation must not derive the same ExecutionId"
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_shared_durable_db_upgrade_path_does_not_collide() {
+        // Regression for #5553's "upgrade" scenario: a directory already has a legacy bare
+        // `durable.db` (the pre-fix layout), so `resolve_durable_db_url` (src/commands/durable.rs)
+        // deliberately keeps every database in that directory pointed at the *same* legacy file
+        // rather than namespacing it — this is the one path where the file-separation half of the
+        // fix does NOT kick in. The `ExecutionId` fold over `sqlite_path` (the defense-in-depth
+        // half, exercised here through the real production code path) is the only thing that
+        // still prevents a second database's first-ever conversation from colliding with the
+        // first database's execution already journaled in that shared file.
+        async fn bootstrap(
+            legacy_db_url: &str,
+            sqlite_path: &str,
+        ) -> crate::agent::Agent<MockChannel> {
+            let mut agent = agent_with_conversation();
+            agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+                enabled: true,
+                agent_turns: true,
+                ..zeph_config::DurableConfig::default()
+            });
+            agent.services.session.durable_agent_turns_db_url = Some(legacy_db_url.to_owned());
+            agent.services.session.durable_agent_turns_sqlite_path = Some(sqlite_path.to_owned());
+            agent.ensure_session_durable_ctx().await;
+            agent
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let legacy_db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+        let sqlite_a = dir.path().join("alpha.db").to_string_lossy().into_owned();
+        let sqlite_b = dir.path().join("beta.db").to_string_lossy().into_owned();
+
+        // DB A runs first, journaling its first-conversation execution into the legacy file.
+        let agent_a = Box::pin(bootstrap(&legacy_db_url, &sqlite_a)).await;
+        let exec_a = agent_a
+            .services
+            .session
+            .durable_ctx
+            .as_ref()
+            .expect("DB A's durable_ctx should be populated")
+            .execution_id();
+
+        // DB B is a distinct database but, per the legacy-preferred branch of
+        // `resolve_durable_db_url`, resolves to the SAME shared journal file.
+        let agent_b = Box::pin(bootstrap(&legacy_db_url, &sqlite_b)).await;
+        let exec_b = agent_b
+            .services
+            .session
+            .durable_ctx
+            .as_ref()
+            .expect("DB B's durable_ctx should be populated")
+            .execution_id();
+
+        assert_ne!(
+            exec_a, exec_b,
+            "DB B's first conversation must not collide with DB A's execution in the shared legacy journal"
+        );
+
+        // Confirm both landed as two genuinely distinct rows in the shared file, not one
+        // execution spuriously "resumed" by the other.
+        let backend = zeph_durable::LocalBackend::open(&legacy_db_url, 1_000_000)
+            .await
+            .expect("legacy journal file must be openable after both bootstraps");
+        let executions = backend
+            .list_executions(None, None, 10)
+            .await
+            .expect("list_executions must succeed");
+        assert_eq!(
+            executions.len(),
+            2,
+            "the shared legacy journal must contain two distinct executions, not a collapsed one"
         );
     }
 }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -849,6 +849,11 @@ pub(crate) struct SessionState {
     /// Sibling companion to [`Self::durable_agent_turns_config`]: the `durable.db` connection
     /// string resolved at bootstrap.
     pub(crate) durable_agent_turns_db_url: Option<String>,
+    /// Sibling companion to [`Self::durable_agent_turns_config`]: `config.memory.sqlite_path`,
+    /// folded into the P1 `ExecutionId` derivation alongside `ConversationId` so distinct memory
+    /// databases never collide on execution identity even if they ever shared a journal
+    /// `db_url` (#5553).
+    pub(crate) durable_agent_turns_sqlite_path: Option<String>,
     /// Sibling companion to [`Self::durable_agent_turns_config`]: the AEAD cipher to attach to
     /// the backend, `None` when `encrypt_payload = false` (development mode only).
     pub(crate) durable_agent_turns_cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
@@ -1259,6 +1264,7 @@ impl SessionState {
             durable_turn_replayed: false,
             durable_agent_turns_config: None,
             durable_agent_turns_db_url: None,
+            durable_agent_turns_sqlite_path: None,
             durable_agent_turns_cipher: None,
             durable_ctx_init_attempted: false,
             durable_writer: None,

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -77,6 +77,7 @@ fn make_session_state() -> SessionState {
         durable_turn_replayed: false,
         durable_agent_turns_config: None,
         durable_agent_turns_db_url: None,
+        durable_agent_turns_sqlite_path: None,
         durable_agent_turns_cipher: None,
         durable_ctx_init_attempted: false,
         durable_writer: None,

--- a/specs/064-durable-execution/spec.md
+++ b/specs/064-durable-execution/spec.md
@@ -148,8 +148,12 @@ the divergence was detected.
 
 **INV-14 — `durable.db` is a dedicated SQLite file (SQLite mode only); migrations live in
 `zeph-db`.**
-`zeph-durable` owns its own `DbPool` instance on a separate database file (default:
-`{data_dir}/durable.db`). This eliminates cross-writer `BEGIN IMMEDIATE` contention with the main
+`zeph-durable` owns its own `DbPool` instance on a separate database file, namespaced by the main
+DB's full file name so two distinct memory databases sharing a directory never collide on one
+journal file (default: `{data_dir}/{main_db_file_name}.durable.db`, e.g. `zeph.db.durable.db` for
+`memory.sqlite_path = zeph.db`; a pre-existing bare `{data_dir}/durable.db` from before this
+namespacing was introduced is preferred when present, so upgrades do not orphan it — see #5553).
+This eliminates cross-writer `BEGIN IMMEDIATE` contention with the main
 DB's five hot writers (messages, graph blob, jobs, memory, audit). However, `zeph-durable` NEVER
 owns migrations: all durable schema (the four `durable_*` tables) is added as numbered `.sql`
 files in `zeph-db/migrations/sqlite/` and `zeph-db/migrations/postgres/` (matching file counts,

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -24,18 +24,45 @@ use crate::cli::DurableCommand;
 const REVEAL_WARNING: &str =
     "WARNING: --reveal decrypts and prints payload bytes in cleartext. Do not share this output.";
 
-/// Resolve the dedicated `durable.db` path: a sibling of the main database file.
+/// Resolve the dedicated durable journal path: a sibling of the main database file.
 ///
 /// The durable journal lives in its own file on its own pool (INV-14), next to `memory.sqlite_path`.
 /// Shared with the TUI durable poll task so both target the same file.
+///
+/// The journal file name is namespaced by the main DB's full file name (e.g. `zeph.db.durable.db`
+/// for `zeph.db`) rather than a bare `durable.db`, so two distinct memory databases living in the
+/// same directory never share a journal file — sharing one previously made a fresh conversation
+/// in one DB collide with an unrelated `ExecutionId` from the other DB's journal, since both
+/// databases' first-ever conversation gets the same small-integer `ConversationId` (#5553). The
+/// full file name (not just the stem) is used so that same-stem, different-extension DBs (e.g.
+/// `zeph.db` and `zeph.sqlite`) also resolve to distinct journal files.
+///
+/// A pre-existing bare `durable.db` in the directory is still preferred when present, so an
+/// upgrade does not orphan that *file*. Note this does not make old in-flight P1 agent-turn
+/// executions inside it resumable — the `ExecutionId` derivation also changed (folds in
+/// `sqlite_path`, see `durable_bootstrap.rs`), so a pre-upgrade execution simply is not found and
+/// a fresh one starts; this is a one-time, low-impact effect at the upgrade boundary only.
 pub(crate) fn resolve_durable_db_url(config: &Config) -> String {
     let main = config.memory.sqlite_path.as_str();
-    match Path::new(main).parent() {
-        Some(dir) if !dir.as_os_str().is_empty() => {
-            dir.join("durable.db").to_string_lossy().into_owned()
-        }
-        _ => "durable.db".to_owned(),
+    let Some(dir) = Path::new(main)
+        .parent()
+        .filter(|d| !d.as_os_str().is_empty())
+    else {
+        return "durable.db".to_owned();
+    };
+
+    let legacy = dir.join("durable.db");
+    if legacy.exists() {
+        return legacy.to_string_lossy().into_owned();
     }
+
+    let file_name = Path::new(main).file_name().map_or_else(
+        || "zeph.db".to_owned(),
+        |s| s.to_string_lossy().into_owned(),
+    );
+    dir.join(format!("{file_name}.durable.db"))
+        .to_string_lossy()
+        .into_owned()
 }
 
 /// Format a Unix-epoch-millisecond timestamp as a readable UTC string, falling back to the raw value.
@@ -344,10 +371,137 @@ mod tests {
     use serial_test::serial;
 
     #[test]
-    fn durable_db_is_sibling_of_sqlite_path() {
+    fn durable_db_is_filename_namespaced_sibling_of_sqlite_path() {
         let mut config = Config::default();
         config.memory.sqlite_path = "/data/zeph/zeph.db".to_owned();
-        assert_eq!(resolve_durable_db_url(&config), "/data/zeph/durable.db");
+        assert_eq!(
+            resolve_durable_db_url(&config),
+            "/data/zeph/zeph.db.durable.db"
+        );
+    }
+
+    /// Regression for #5553: distinct memory databases sharing a directory must resolve to
+    /// distinct journal files, or their fresh conversations collide on `ExecutionId`.
+    #[test]
+    fn distinct_sqlite_stems_resolve_to_distinct_durable_urls() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config_a = Config::default();
+        config_a.memory.sqlite_path = dir.path().join("alpha.db").to_string_lossy().into_owned();
+        let mut config_b = Config::default();
+        config_b.memory.sqlite_path = dir.path().join("beta.db").to_string_lossy().into_owned();
+
+        assert_ne!(
+            resolve_durable_db_url(&config_a),
+            resolve_durable_db_url(&config_b)
+        );
+    }
+
+    /// Regression for critic finding F1 on #5553: `file_stem()`-only namespacing would collapse
+    /// same-stem, different-extension DBs (e.g. `zeph.db` and `zeph.sqlite`) onto the same journal
+    /// file, reproducing the exact shared-journal condition the fix is meant to close.
+    #[test]
+    fn same_stem_different_extension_resolves_to_distinct_durable_urls() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config_a = Config::default();
+        config_a.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        let mut config_b = Config::default();
+        config_b.memory.sqlite_path = dir
+            .path()
+            .join("zeph.sqlite")
+            .to_string_lossy()
+            .into_owned();
+
+        assert_ne!(
+            resolve_durable_db_url(&config_a),
+            resolve_durable_db_url(&config_b)
+        );
+    }
+
+    /// Regression for #5553: an already-existing bare `durable.db` (the pre-fix layout) must
+    /// keep resolving to itself so upgrading deployments do not orphan their journal history.
+    #[test]
+    fn preexisting_legacy_durable_db_is_preferred() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("durable.db"), []).unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+
+        assert_eq!(
+            resolve_durable_db_url(&config),
+            dir.path().join("durable.db").to_string_lossy()
+        );
+    }
+
+    /// End-to-end regression for #5553: two distinct `memory.sqlite_path` databases in the same
+    /// directory, each opening its P1 durable backend for its first-ever conversation, must land
+    /// in genuinely distinct journal files on disk and must not collide on `ExecutionId` — the
+    /// full composition of `resolve_durable_db_url` (file separation) and the `ExecutionId`
+    /// derivation fold (defense in depth), exercised against real `LocalBackend` instances rather
+    /// than `:memory:` stand-ins.
+    #[tokio::test]
+    async fn distinct_databases_do_not_collide_on_shared_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let sqlite_a = dir.path().join("alpha.db").to_string_lossy().into_owned();
+        let sqlite_b = dir.path().join("beta.db").to_string_lossy().into_owned();
+
+        let mut config_a = Config::default();
+        config_a.memory.sqlite_path = sqlite_a.clone();
+        let mut config_b = Config::default();
+        config_b.memory.sqlite_path = sqlite_b.clone();
+
+        let url_a = resolve_durable_db_url(&config_a);
+        let url_b = resolve_durable_db_url(&config_b);
+        assert_ne!(
+            url_a, url_b,
+            "the two databases must resolve to distinct journal files"
+        );
+
+        let backend_a = LocalBackend::open(&url_a, 1_000_000).await.unwrap();
+        backend_a.init().await.unwrap();
+        let backend_b = LocalBackend::open(&url_b, 1_000_000).await.unwrap();
+        backend_b.init().await.unwrap();
+
+        assert!(
+            Path::new(&url_a).exists() && Path::new(&url_b).exists(),
+            "both journal files must actually exist on disk"
+        );
+        assert_ne!(
+            std::fs::canonicalize(&url_a).unwrap(),
+            std::fs::canonicalize(&url_b).unwrap(),
+            "the two journal files must be genuinely distinct files, not the same file via aliasing"
+        );
+
+        // Mirrors the P1 fold in `ensure_session_durable_ctx`: ConversationId(1)'s fixed-width
+        // bytes plus the owning database's `sqlite_path`.
+        let conv_one = 1u64.to_le_bytes();
+        let fold = |sqlite_path: &str| {
+            let mut payload = conv_one.to_vec();
+            payload.extend_from_slice(sqlite_path.as_bytes());
+            ExecutionId::derive(b"zeph.agent_turn.v1", &payload)
+        };
+        let exec_a = fold(&sqlite_a);
+        let exec_b = fold(&sqlite_b);
+        assert_ne!(exec_a, exec_b);
+
+        let resumed_a = backend_a
+            .open_execution(exec_a, zeph_durable::ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let resumed_b = backend_b
+            .open_execution(exec_b, zeph_durable::ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        assert!(
+            !resumed_a && !resumed_b,
+            "each database's first conversation must open a fresh execution, not resume the other's"
+        );
+
+        let executions_a = backend_a.list_executions(None, None, 10).await.unwrap();
+        let executions_b = backend_b.list_executions(None, None, 10).await.unwrap();
+        assert_eq!(executions_a.len(), 1);
+        assert_eq!(executions_b.len(), 1);
+        assert_eq!(executions_a[0].execution_id, exec_a);
+        assert_eq!(executions_b[0].execution_id, exec_b);
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3379,7 +3379,12 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         let agent = if config.durable.enabled && config.durable.agent_turns {
             let durable_url = crate::commands::durable::resolve_durable_db_url(config);
             let cipher = crate::commands::durable::load_write_cipher(config)?;
-            agent.with_durable_agent_turns(config.durable.clone(), durable_url, cipher)
+            agent.with_durable_agent_turns(
+                config.durable.clone(),
+                durable_url,
+                config.memory.sqlite_path.clone(),
+                cipher,
+            )
         } else {
             agent
         };


### PR DESCRIPTION
## Summary

- Two distinct memory SQLite databases sharing a directory collided on the P1 agent-turn adapter's `ExecutionId`, since `resolve_durable_db_url` derived the `durable.db` journal path from only the parent directory (ignoring the database filename), and every fresh database's first conversation always gets `ConversationId(1)`. This made a brand-new session's very first turn spuriously diverge against an unrelated database's journal entry, permanently degrading durable execution for the entire session.
- `resolve_durable_db_url` (`src/commands/durable.rs`) now namespaces the journal file by the main database's full file name (e.g. `zeph.db` -> `zeph.db.durable.db`), so distinct databases in one directory — including same-stem, different-extension pairs like `zeph.db`/`zeph.sqlite` — get distinct journal files. A pre-existing bare `durable.db` is still preferred when present, so upgrading deployments does not orphan that journal file.
- As defense in depth, the P1 `ExecutionId` derivation (`durable_bootstrap.rs::ensure_session_durable_ctx`) now also folds in `config.memory.sqlite_path` alongside `ConversationId`, so even two databases that ever ended up sharing one journal `db_url` still could not collide on execution identity.
- Updated `specs/064-durable-execution/spec.md` INV-14 wording to match the new default path scheme.

## Test plan

- [x] `cargo nextest run -p zeph -p zeph-core -E 'test(durable)'` — 32/32 pass, including new regression tests:
  - `distinct_sqlite_stems_resolve_to_distinct_durable_urls`
  - `same_stem_different_extension_resolves_to_distinct_durable_urls`
  - `preexisting_legacy_durable_db_is_preferred`
  - `distinct_sqlite_paths_do_not_collide_on_first_conversation`
  - `distinct_databases_do_not_collide_on_shared_directory` (real on-disk `LocalBackend`, two distinct sqlite paths in one directory)
  - `legacy_shared_durable_db_upgrade_path_does_not_collide` (real `ensure_session_durable_ctx`, two databases sharing one pre-existing legacy journal file)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11841 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] Adversarial critique (2 rounds) — approved
- [x] Testing playbook (`durable.md` Scenario 6) and coverage-status.md updated

Closes #5553