### PR TITLE
fix(testing): mitigate orphaned postgres testcontainers with no ryuk reaper

### DIFF
--- a/.github/nextest.toml
+++ b/.github/nextest.toml
@@ -22,6 +22,22 @@ test-threads = 8
 filter = "binary(~integration)"
 retries = { backoff = "exponential", count = 2, delay = "10s", jitter = true }
 
+[test-groups.postgres-containers]
+# postgres_integration binaries (zeph-db, zeph-index, zeph-memory) each spin up
+# their own Postgres testcontainer per test with no shared coordination. At the
+# default test-threads = 8, dozens of containers can start concurrently, which
+# overloads Docker Desktop and trips testcontainers-rs 0.27.3's startup-timeout
+# leak (see #5546/#5547 — that crate version has no Ryuk reaper, so a timed-out
+# container is never cleaned up). Capping concurrency here is cheaper than
+# annotating ~40 individual tests with #[serial]. `test-threads` is not a valid
+# per-override key (nextest silently ignores it there) — a test-group with
+# max-threads is the correct mechanism.
+max-threads = 2
+
+[[profile.ci.overrides]]
+filter = "binary(postgres_integration)"
+test-group = "postgres-containers"
+
 [profile.ci.junit]
 # Store JUnit XML report for CI
 path = "target/nextest/ci/junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,12 @@ jobs:
         run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive-zeph-index-postgres.tar.zst --workspace-remap . --profile ci --run-ignored ignored-only -E 'binary(postgres_integration)'
       - name: Run Qdrant integration tests (testcontainers)
         run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive.tar.zst --workspace-remap . --profile ci --run-ignored ignored-only -E 'binary(qdrant_integration)'
+      - name: Reap orphaned testcontainers
+        # Defense-in-depth, not a fix: testcontainers-rs 0.27.3 (pinned) has no Ryuk
+        # reaper and can leak containers on SIGKILL or a StartupTimeout cancel under
+        # concurrent load (#5546, #5547). Runs even if a prior step failed/timed out.
+        if: always()
+        run: docker ps -aq --filter "label=org.testcontainers.managed-by=testcontainers" | xargs -r docker rm -f
 
   coverage:
     name: Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -590,6 +590,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `config.memory.sqlite_path` alongside `ConversationId`, so even two databases that ever ended up
   sharing one journal `db_url` (e.g. via a future config override) still could not collide.
 
+- `fix(testing)`: mitigate orphaned `postgres:11-alpine` testcontainers persisting across CI/local
+  test runs (#5546, #5547). Root cause: `testcontainers` 0.27.3 (the pinned version) has **no
+  Ryuk-based reaper at all**, unlike testcontainers-java/go/node — cleanup relies solely on (a)
+  `Drop`, which is bypassed by `SIGKILL`/abrupt process termination, and (b) a leak-by-design gap
+  where a container that hits `WaitContainerError::StartupTimeout` during `start()` is cancelled
+  and dropped *before* it is ever wrapped in a `Drop`-guarded `ContainerAsync`, so nothing ever
+  calls `rm` on it. Mitigated with three complementary changes (none of which close the gap
+  entirely — it is a crate-level defect, not a workspace misconfiguration): enabled the crate's
+  opt-in `watchdog` feature (`zeph-db`, `zeph-index`, `zeph-memory` `Cargo.toml`) to reap on
+  `SIGTERM`/`SIGINT`/`SIGQUIT` (does not cover `SIGKILL` or the `StartupTimeout` leak); raised
+  `Postgres::default()`'s startup timeout from the 60s default to 120s in the three
+  `postgres_integration.rs` test helpers (`zeph-db`, `zeph-index`, `zeph-memory`) to reduce how
+  often the timeout is hit under concurrent Docker load; capped `postgres_integration` binaries to
+  2 concurrent threads via a new `.github/nextest.toml` `[test-groups.postgres-containers]`
+  (`max-threads = 2`, referenced from a `[profile.ci]` override) to reduce concurrent container
+  starts (~40 tests across the three crates previously ran up to 8-wide). Added an `if: always()`
+  `docker rm -f` cleanup step to the `integration` job in `.github/workflows/ci.yml` so containers
+  that leak past the mitigations above are still reaped in CI. **This is a mitigation, not a full
+  fix**: neither leak path is eliminated (the `watchdog` feature only covers
+  `SIGTERM`/`SIGINT`/`SIGQUIT`, not `SIGKILL` or the `StartupTimeout` leak itself; the timeout and
+  concurrency changes only lower how often the `StartupTimeout` leak triggers). **Re-check on any
+  future `testcontainers` crate version bump** — this `StartupTimeout` leak-on-cancel path is a
+  known upstream limitation, not something fixable from this workspace alone.
 - `fix(memory)`: three more Postgres-dialect defects in `zeph-memory`, same class as #5508/#5524
   (SQLite-only SQL surfacing incorrectly under Postgres, live-verified via Docker testcontainers).
   `datetime('now')` (SQLite-only, no Postgres equivalent) was embedded as a literal in production

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "conquer-once"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d008a441c0f269f36ca13712528069a86a3e60dffee1d98b976eb3b0b2160b4"
+dependencies = [
+ "conquer-util",
+]
+
+[[package]]
+name = "conquer-util"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,7 +1657,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 1.1.4",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -7288,6 +7303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7295,7 +7320,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -8121,7 +8146,7 @@ dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
  "rustix 1.1.4",
- "signal-hook",
+ "signal-hook 0.3.18",
  "windows-sys 0.61.2",
 ]
 
@@ -8172,7 +8197,7 @@ dependencies = [
  "pest_derive",
  "phf 0.11.3",
  "sha2 0.10.9",
- "signal-hook",
+ "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
  "termios",
@@ -8198,6 +8223,7 @@ dependencies = [
  "async-trait",
  "bollard",
  "bytes",
+ "conquer-once",
  "docker_credential",
  "either",
  "etcetera",
@@ -8212,6 +8238,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "signal-hook 0.4.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/crates/zeph-db/Cargo.toml
+++ b/crates/zeph-db/Cargo.toml
@@ -26,7 +26,7 @@ test-utils = ["dep:testcontainers", "dep:testcontainers-modules", "postgres"]
 regex = { workspace = true }
 # "macros" required for sqlx::migrate! in driver implementations.
 sqlx = { workspace = true, features = ["macros", "migrate", "runtime-tokio", "tls-rustls"] }
-testcontainers = { workspace = true, optional = true }
+testcontainers = { workspace = true, features = ["watchdog"], optional = true }
 testcontainers-modules = { workspace = true, features = ["postgres"], optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt"] }

--- a/crates/zeph-db/tests/postgres_integration.rs
+++ b/crates/zeph-db/tests/postgres_integration.rs
@@ -11,12 +11,18 @@
 
 #[cfg(feature = "test-utils")]
 mod pg {
+    use std::time::Duration;
+
+    use testcontainers::ImageExt as _;
     use testcontainers::runners::AsyncRunner as _;
     use testcontainers_modules::postgres::Postgres;
     use zeph_db::DbConfig;
 
+    // Generous startup timeout: under concurrent CI load (see #5546/#5547), the
+    // default 60s can elapse before Postgres is ready, and testcontainers-rs 0.27.3
+    // leaks the container on a startup-timeout cancel (no Drop guard is ever created).
     async fn start_pg() -> (zeph_db::DbPool, impl Drop) {
-        let image = Postgres::default();
+        let image = Postgres::default().with_startup_timeout(Duration::from_mins(2));
         let container = image.start().await.expect("docker must be available");
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();

--- a/crates/zeph-index/Cargo.toml
+++ b/crates/zeph-index/Cargo.toml
@@ -20,7 +20,7 @@ notify-debouncer-mini.workspace = true
 schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-testcontainers = { workspace = true, optional = true }
+testcontainers = { workspace = true, features = ["watchdog"], optional = true }
 testcontainers-modules = { workspace = true, features = ["postgres"], optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "rt"] }

--- a/crates/zeph-index/tests/postgres_integration.rs
+++ b/crates/zeph-index/tests/postgres_integration.rs
@@ -11,14 +11,20 @@
 
 #[cfg(feature = "test-utils")]
 mod pg {
+    use std::time::Duration;
+
+    use testcontainers::ImageExt as _;
     use testcontainers::runners::AsyncRunner as _;
     use testcontainers_modules::postgres::Postgres;
     use zeph_db::DbConfig;
     use zeph_index::store::CodeStore;
     use zeph_memory::QdrantOps;
 
+    // Generous startup timeout: under concurrent CI load (see #5546/#5547), the
+    // default 60s can elapse before Postgres is ready, and testcontainers-rs 0.27.3
+    // leaks the container on a startup-timeout cancel (no Drop guard is ever created).
     async fn start_pg() -> (zeph_db::DbPool, impl Drop) {
-        let image = Postgres::default();
+        let image = Postgres::default().with_startup_timeout(Duration::from_mins(2));
         let container = image.start().await.expect("docker must be available");
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -66,7 +66,7 @@ criterion.workspace = true
 insta.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
-testcontainers.workspace = true
+testcontainers = { workspace = true, features = ["watchdog"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 toml.workspace = true
 tracing-test.workspace = true

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -59,6 +59,9 @@
 
 #[cfg(feature = "test-utils")]
 mod pg {
+    use std::time::Duration;
+
+    use testcontainers::ImageExt as _;
     use testcontainers::runners::AsyncRunner as _;
     use testcontainers_modules::postgres::Postgres;
     use zeph_common::SessionId;
@@ -79,8 +82,11 @@ mod pg {
     use zeph_memory::types::MessageId;
     use zeph_memory::{VectorStore, episodic_consolidation, episodic_graph, snapshot};
 
+    // Generous startup timeout: under concurrent CI load (see #5546/#5547), the
+    // default 60s can elapse before Postgres is ready, and testcontainers-rs 0.27.3
+    // leaks the container on a startup-timeout cancel (no Drop guard is ever created).
     async fn start_pg() -> (zeph_db::DbPool, impl Drop) {
-        let image = Postgres::default();
+        let image = Postgres::default().with_startup_timeout(Duration::from_mins(2));
         let container = image.start().await.expect("docker must be available");
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();


### PR DESCRIPTION
## Summary

- `testcontainers-rs` 0.27.3, the version pinned in this workspace, implements **no Ryuk-based reaper at all** (unlike testcontainers-java/go/node). Confirmed via direct crate source inspection. Cleanup relies solely on `Drop`, which is bypassed by `SIGKILL`/abrupt process termination, and on a leak-by-design gap where a container that hits `WaitContainerError::StartupTimeout` during `start()` is dropped before it is ever wrapped in a `Drop`-guarded `ContainerAsync` — nothing ever removes it.
- Mitigated with three complementary changes: enabled the crate's opt-in `watchdog` feature (`zeph-db`, `zeph-index`, `zeph-memory`) for graceful-interrupt cleanup (`SIGTERM`/`SIGINT`/`SIGQUIT`, not `SIGKILL`); raised the Postgres image startup timeout to 120s in all three `postgres_integration.rs` test helpers to reduce how often the timeout path triggers under concurrent Docker load; capped `postgres_integration` binaries to 2 concurrent threads via a new nextest `test-group` to lower that load in the first place.
- Added a `docker rm -f`, `if: always()` cleanup step to the `integration` CI job as defense-in-depth for whatever leaks through despite the above.

## This is a mitigation, not a full fix

Neither underlying leak path is eliminated — this is a known upstream `testcontainers-rs` 0.27.3 limitation, not a workspace misconfiguration:
- The `watchdog` feature only covers `SIGTERM`/`SIGINT`/`SIGQUIT`, not `SIGKILL`.
- The `StartupTimeout` leak-on-cancel path itself is not closed; the timeout/concurrency changes only lower how often it triggers.

Documented in `CHANGELOG.md` with a note to re-check this on any future `testcontainers` crate version bump.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11835/11835 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing unrelated warnings only)
- [x] Live-ran all 38 postgres integration tests across zeph-db/zeph-index/zeph-memory (4+2+32): all passed, zero orphaned containers before or after (`docker ps -a --filter label=org.testcontainers.managed-by=testcontainers` empty in both cases)
- [x] Verified the nextest `test-group` config is actually wired (no "ignoring unknown configuration keys" warning) and matches all three crates' `postgres_integration` binaries

Closes #5546, Closes #5547