### PR TITLE
fix(core): gate shutdown LLM calls behind --bare and fix ACP model-switch lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(core)`: `--bare` mode no longer fires shutdown-path LLM calls. `Agent::maybe_autodream`,
+  `maybe_extract_skills_from_trace`, `maybe_store_shutdown_summary`, and
+  `maybe_store_session_digest` only checked their own subsystem config flags, not
+  `exec_mode.bare`; bare mode still attaches an in-memory `SemanticMemory` and
+  `conversation_id`, so all four config gates passed and a `--bare` invocation fired extra LLM
+  round-trips at session end, defeating the documented "useful for scripting and CI pipelines"
+  purpose. Adds a `bare` flag to `RuntimeConfig`, set via `Agent::with_bare_mode()` from the CLI
+  `--bare` flag, and an early return in all four subsystems when set. Closes #5551.
+- `fix(core)`: ACP `session/set_config_option` model switches no longer lag one turn behind the
+  response's `currentValue`. `Agent::apply_provider_override()` ran once per run-loop iteration,
+  before the iteration blocked on `next_event()`; a switch written to the shared
+  `provider_override` slot while the iteration was already parked waiting for the next message
+  could not retrigger that check, so it only applied on the turn after the one immediately
+  following the switch. Re-checks `apply_provider_override()` at the start of
+  `process_user_message()`, the single call site every turn-dispatch branch funnels through, so a
+  switch written mid-wait is picked up for the very next turn it affects. Closes #5548.
 - `fix(memory)`: clarify that `[memory.admission] admission_strategy = "rl"` is not silently a
   no-op (#5543) — `src/bootstrap/mod.rs::build_admission_control` already emits a startup
   `tracing::warn!` when this variant is selected (added by #2485 for #2416, predating this issue),

--- a/crates/zeph-core/src/agent/autodream.rs
+++ b/crates/zeph-core/src/agent/autodream.rs
@@ -67,6 +67,9 @@ impl<C: Channel> super::Agent<C> {
     /// Respects `max_iterations` as a safety bound via timeout.
     #[tracing::instrument(name = "core.agent.maybe_autodream", skip_all, level = "debug")]
     pub(super) async fn maybe_autodream(&mut self) {
+        if self.runtime.config.bare {
+            return;
+        }
         let cfg = self.services.memory.subsystems.autodream_config.clone();
         if !cfg.enabled {
             return;

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -627,6 +627,22 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set whether the agent is running in `--bare` mode (#5551).
+    ///
+    /// Bare mode skips skill loading, memory init, MCP connections, scheduler startup, and
+    /// filesystem watchers at startup. This flag additionally gates all four shutdown-path
+    /// subsystems that can fire LLM calls after the run loop exits — autoDream consolidation
+    /// (`maybe_autodream`), skill trace-extraction (`maybe_extract_skills_from_trace`), the
+    /// shutdown summary (`maybe_store_shutdown_summary`), and the session digest
+    /// (`maybe_store_session_digest`) — so a bare-mode session never fires a shutdown LLM call.
+    /// Those subsystems are otherwise only gated on their own config flags, which bare mode's
+    /// still-attached in-memory `SemanticMemory` and `conversation_id` do not suppress.
+    #[must_use]
+    pub fn with_bare_mode(mut self, bare: bool) -> Self {
+        self.runtime.config.bare = bare;
+        self
+    }
+
     /// Configure channel identity for per-channel UX preference persistence (#3308, #4654).
     ///
     /// `channel_type` must match the active I/O channel name (`"cli"`, `"tui"`, `"telegram"`,

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1123,6 +1123,12 @@ impl<C: Channel> Agent<C> {
         text: String,
         image_parts: Vec<zeph_llm::provider::MessagePart>,
     ) -> Result<(), error::AgentError> {
+        // Re-check for a pending provider override (#5548): the loop-top check in `run()`
+        // happens before the potentially long block on `next_event()`, so an ACP
+        // `session/set_config_option` model switch written while this iteration was
+        // parked would otherwise miss this turn and only apply on the next one.
+        self.apply_provider_override();
+
         let input = turn::TurnInput::new(text, image_parts);
         let mut t = self.begin_turn(input);
 

--- a/crates/zeph-core/src/agent/session_digest.rs
+++ b/crates/zeph-core/src/agent/session_digest.rs
@@ -203,8 +203,14 @@ fn recap_is_duplicate_impl(
 impl<C: Channel> Agent<C> {
     /// Generate and persist a session digest at shutdown when digest is enabled.
     ///
+    /// Skips entirely when `self.runtime.config.bare` is `true` (#5551 — bare mode never fires
+    /// shutdown LLM calls).
+    ///
     /// All errors are logged as warnings and swallowed — shutdown must never fail.
     pub(super) async fn maybe_store_session_digest(&mut self) {
+        if self.runtime.config.bare {
+            return;
+        }
         if !self.services.memory.compaction.digest_config.enabled {
             return;
         }

--- a/crates/zeph-core/src/agent/shutdown.rs
+++ b/crates/zeph-core/src/agent/shutdown.rs
@@ -152,6 +152,7 @@ impl<C: Channel> Agent<C> {
     /// Generate and store a lightweight session summary at shutdown when no hard compaction fired.
     ///
     /// Guards:
+    /// - `self.runtime.config.bare` must be `false` (#5551 — bare mode never fires shutdown LLM calls)
     /// - `shutdown_summary` config must be enabled
     /// - `conversation_id` must be set (memory must be attached)
     /// - no existing session summary in the store (primary guard — resilient to failed Qdrant writes)
@@ -159,6 +160,9 @@ impl<C: Channel> Agent<C> {
     ///
     /// All errors are logged as warnings and swallowed — shutdown must never fail.
     pub(super) async fn maybe_store_shutdown_summary(&mut self) {
+        if self.runtime.config.bare {
+            return;
+        }
         if !self.services.memory.compaction.shutdown_summary {
             return;
         }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -314,6 +314,13 @@ pub(crate) struct RuntimeConfig {
     pub(crate) restoring_provider: bool,
     /// Goal lifecycle feature configuration.
     pub(crate) goals: GoalRuntimeConfig,
+    /// Set from the CLI `--bare` flag (#5551).
+    ///
+    /// Bare mode skips skill loading, memory init, MCP connections, scheduler startup, and
+    /// filesystem watchers at startup; this flag lets shutdown-path subsystems (autoDream
+    /// consolidation, skill trace-extraction, shutdown summary, session digest) apply the
+    /// same gating instead of firing unconditional LLM calls at session end.
+    pub(crate) bare: bool,
 }
 
 /// Groups feedback detection subsystems: correction detector, judge detector, and LLM classifier.
@@ -1242,6 +1249,7 @@ impl Default for RuntimeConfig {
             persist_provider_overrides_enabled: true,
             restoring_provider: false,
             goals: GoalRuntimeConfig::default(),
+            bare: false,
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -118,6 +118,7 @@ fn make_runtime_config() -> RuntimeConfig {
         persist_provider_overrides_enabled: true,
         restoring_provider: false,
         goals: crate::agent::state::GoalRuntimeConfig::default(),
+        bare: false,
     }
 }
 

--- a/crates/zeph-core/src/agent/tests/bare_mode_shutdown_tests.rs
+++ b/crates/zeph-core/src/agent/tests/bare_mode_shutdown_tests.rs
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression tests for #5551: `--bare` mode must not fire shutdown-path LLM calls.
+//!
+//! Covers all four shutdown-path subsystems gated on `self.runtime.config.bare`:
+//! `maybe_autodream`, `maybe_extract_skills_from_trace`, `maybe_store_shutdown_summary`, and
+//! `maybe_store_session_digest`. Each checks `bare` before its own subsystem-enabled checks.
+//! These tests prove the `bare` gate short-circuits even when the subsystem's own config flag
+//! is `true` — the exact reproduction scenario from the issue — and that a non-bare agent still
+//! reaches the gated work. The `shutdown_summary`/`session_digest` gap (two of the four
+//! subsystems originally left ungated) was found in adversarial review — see
+//! `.local/handoff/2026-07-03T10-55-16-critic.md`.
+
+use std::sync::Arc;
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::mock::MockProvider;
+use zeph_llm::provider::{Message, MessageMetadata, Role};
+use zeph_memory::semantic::SemanticMemory;
+
+use crate::agent::agent_tests::{
+    MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+};
+use crate::config::LearningConfig;
+
+fn base_agent() -> crate::agent::Agent<MockChannel> {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+}
+
+#[tokio::test]
+async fn maybe_autodream_skips_when_bare_even_if_enabled() {
+    let mut agent = base_agent().with_bare_mode(true);
+    agent.services.memory.subsystems.autodream_config.enabled = true;
+
+    agent.maybe_autodream().await;
+
+    assert_eq!(
+        agent
+            .services
+            .memory
+            .subsystems
+            .autodream
+            .sessions_since_consolidation,
+        0,
+        "bare mode must return before record_session() runs, even with autodream.enabled = true"
+    );
+}
+
+#[tokio::test]
+async fn maybe_autodream_runs_gate_check_when_not_bare() {
+    let mut agent = base_agent().with_bare_mode(false);
+    agent.services.memory.subsystems.autodream_config.enabled = true;
+
+    agent.maybe_autodream().await;
+
+    assert_eq!(
+        agent
+            .services
+            .memory
+            .subsystems
+            .autodream
+            .sessions_since_consolidation,
+        1,
+        "non-bare agent must reach record_session() when autodream is enabled"
+    );
+}
+
+#[tokio::test]
+async fn maybe_extract_skills_from_trace_skips_when_bare_even_if_enabled() {
+    let managed = tempfile::tempdir().unwrap();
+    let mut agent = base_agent()
+        .with_bare_mode(true)
+        .with_managed_skills_dir(managed.path().to_path_buf());
+    agent.services.learning_engine.config = Some(LearningConfig {
+        trace_extraction_enabled: true,
+        ..Default::default()
+    });
+    agent.services.memory.persistence.conversation_id = Some(zeph_memory::ConversationId(1));
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "hello".into(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    });
+
+    agent.maybe_extract_skills_from_trace().await;
+
+    assert!(
+        agent
+            .services
+            .learning_engine
+            .trace_extraction_handle
+            .is_none(),
+        "bare mode must return before spawning the trace-extraction task, even with \
+         trace_extraction_enabled = true"
+    );
+}
+
+#[tokio::test]
+async fn maybe_extract_skills_from_trace_spawns_when_not_bare() {
+    let managed = tempfile::tempdir().unwrap();
+    let mut agent = base_agent()
+        .with_bare_mode(false)
+        .with_managed_skills_dir(managed.path().to_path_buf());
+    agent.services.learning_engine.config = Some(LearningConfig {
+        trace_extraction_enabled: true,
+        ..Default::default()
+    });
+    agent.services.memory.persistence.conversation_id = Some(zeph_memory::ConversationId(1));
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "hello".into(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    });
+
+    agent.maybe_extract_skills_from_trace().await;
+
+    assert!(
+        agent
+            .services
+            .learning_engine
+            .trace_extraction_handle
+            .is_some(),
+        "non-bare agent must reach the spawn point when trace_extraction_enabled is true"
+    );
+}
+
+/// Build an in-memory `SemanticMemory` + conversation id for shutdown-summary/digest tests,
+/// which both require `persistence.memory`/`persistence.conversation_id` to be `Some` before
+/// their own config checks run.
+async fn memory_with_conversation() -> (Arc<SemanticMemory>, zeph_memory::ConversationId) {
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        AnyProvider::Mock(MockProvider::default()),
+        "test-model",
+    )
+    .await
+    .unwrap();
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+    (Arc::new(memory), cid)
+}
+
+#[tokio::test]
+async fn maybe_store_shutdown_summary_skips_when_bare_even_if_enabled() {
+    let (mock, recorded) = MockProvider::default().with_recording();
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (memory, cid) = memory_with_conversation().await;
+
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_bare_mode(true)
+        .with_memory(memory, cid, 100, 5, 1000)
+        .with_shutdown_summary_config(true, 4, 20, 10);
+
+    // >= min_messages (4) user turns so the non-bare path would otherwise proceed.
+    for i in 0..5 {
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: format!("user message {i}"),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        });
+    }
+
+    agent.maybe_store_shutdown_summary().await;
+
+    assert!(
+        recorded.lock().unwrap().is_empty(),
+        "bare mode must return before any LLM call, even with shutdown_summary enabled and \
+         the min_messages threshold met"
+    );
+}
+
+#[tokio::test]
+async fn maybe_store_shutdown_summary_runs_when_not_bare() {
+    let (mock, recorded) = MockProvider::default().with_recording();
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (memory, cid) = memory_with_conversation().await;
+
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_bare_mode(false)
+        .with_memory(memory, cid, 100, 5, 1000)
+        .with_shutdown_summary_config(true, 4, 20, 10);
+
+    for i in 0..5 {
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: format!("user message {i}"),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        });
+    }
+
+    agent.maybe_store_shutdown_summary().await;
+
+    assert!(
+        !recorded.lock().unwrap().is_empty(),
+        "non-bare agent must reach the LLM call when shutdown_summary is enabled and the \
+         min_messages threshold is met"
+    );
+}
+
+#[tokio::test]
+async fn maybe_store_session_digest_skips_when_bare_even_if_enabled() {
+    let (mock, recorded) = MockProvider::default().with_recording();
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (memory, cid) = memory_with_conversation().await;
+
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_bare_mode(true)
+        .with_memory(memory, cid, 100, 5, 1000);
+    agent.services.memory.compaction.digest_config.enabled = true;
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "hello".into(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    });
+
+    agent.maybe_store_session_digest().await;
+
+    assert!(
+        recorded.lock().unwrap().is_empty(),
+        "bare mode must return before any LLM call, even with digest_config.enabled = true"
+    );
+}
+
+#[tokio::test]
+async fn maybe_store_session_digest_runs_when_not_bare() {
+    let (mock, recorded) = MockProvider::default().with_recording();
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (memory, cid) = memory_with_conversation().await;
+
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_bare_mode(false)
+        .with_memory(memory, cid, 100, 5, 1000);
+    agent.services.memory.compaction.digest_config.enabled = true;
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "hello".into(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    });
+
+    agent.maybe_store_session_digest().await;
+
+    assert!(
+        !recorded.lock().unwrap().is_empty(),
+        "non-bare agent must reach the LLM call when digest_config.enabled = true"
+    );
+}

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -4,6 +4,8 @@
 pub mod agent_tests; // path-preserving — DO NOT rename (used by 24+ modules via crate::agent::agent_tests::*)
 
 #[cfg(test)]
+mod bare_mode_shutdown_tests;
+#[cfg(test)]
 mod compaction_e2e;
 #[cfg(test)]
 mod confirmation_propagation_tests;

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -18,6 +18,8 @@ mod pre_execution_audit_tests;
 #[cfg(test)]
 mod provider_override_masking_tests;
 #[cfg(test)]
+mod provider_override_timing_tests;
+#[cfg(test)]
 mod secret_reason_truncation;
 #[cfg(test)]
 mod shutdown_summary_tests;

--- a/crates/zeph-core/src/agent/tests/provider_override_timing_tests.rs
+++ b/crates/zeph-core/src/agent/tests/provider_override_timing_tests.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression test for #5548: ACP model-switch must apply within the same turn.
+//!
+//! `process_user_message` now calls `self.apply_provider_override()` as its first statement
+//! (`crates/zeph-core/src/agent/mod.rs`), so a `provider_override` written after the loop-top
+//! `apply_provider_override()` call but before the message reaches dispatch — e.g. an ACP
+//! `session/set_config_option` write landing while the loop iteration is parked in
+//! `next_event()` — is picked up before that same turn's LLM call, not one turn later.
+
+use std::sync::Arc;
+
+use zeph_llm::any::AnyProvider;
+
+use crate::agent::agent_tests::{
+    MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+};
+
+fn base_agent() -> crate::agent::Agent<MockChannel> {
+    let provider = mock_provider(vec!["initial response".into()]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+}
+
+#[tokio::test]
+async fn process_user_message_applies_override_written_just_before_it_is_called() {
+    let slot: Arc<parking_lot::RwLock<Option<AnyProvider>>> =
+        Arc::new(parking_lot::RwLock::new(None));
+    let mut agent = base_agent().with_provider_override(Arc::clone(&slot));
+
+    // Simulate a provider_override write that lands after the loop-top `apply_provider_override()`
+    // call but before this turn's `process_user_message` dispatch (the exact race in #5548).
+    *slot.write() = Some(mock_provider(vec!["override response".into()]));
+
+    agent
+        .process_user_message("hi".to_string(), vec![])
+        .await
+        .unwrap();
+
+    let sent = agent.channel.sent_messages();
+    assert!(
+        sent.iter().any(|m| m.contains("override response")),
+        "process_user_message must apply a provider_override written just before it runs, \
+         within that same call — not one turn later; got: {sent:?}"
+    );
+    assert!(
+        sent.iter().all(|m| !m.contains("initial response")),
+        "the stale pre-override provider must not be used once an override is pending; got: {sent:?}"
+    );
+}
+
+#[tokio::test]
+async fn process_user_message_is_noop_override_when_slot_empty() {
+    let slot: Arc<parking_lot::RwLock<Option<AnyProvider>>> =
+        Arc::new(parking_lot::RwLock::new(None));
+    let mut agent = base_agent().with_provider_override(Arc::clone(&slot));
+
+    agent
+        .process_user_message("hi".to_string(), vec![])
+        .await
+        .unwrap();
+
+    let sent = agent.channel.sent_messages();
+    assert!(
+        sent.iter().any(|m| m.contains("initial response")),
+        "with no pending override, the original provider must still be used; got: {sent:?}"
+    );
+}

--- a/crates/zeph-core/src/agent/trace_extraction.rs
+++ b/crates/zeph-core/src/agent/trace_extraction.rs
@@ -24,6 +24,9 @@ impl<C: Channel> super::Agent<C> {
     /// Reads `[skills.learning]` config via `learning_engine.config`. When
     /// `trace_extraction_enabled = false`, returns immediately without spawning a task.
     pub(super) async fn maybe_extract_skills_from_trace(&mut self) {
+        if self.runtime.config.bare {
+            return;
+        }
         let Some(ref learning_cfg) = self.services.learning_engine.config else {
             return;
         };

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2833,6 +2833,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         config.memory.category.clone(),
     )
     .with_embedding_provider(embedding_provider.clone())
+    .with_bare_mode(exec_mode.bare)
     .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), embedding_provider)
     .await;
 


### PR DESCRIPTION
## Summary

Two independent, unrelated bug fixes in the agent run loop, grouped into one PR because both are self-contained changes localized to `crates/zeph-core/src/agent/mod.rs` and its neighboring files.

### #5551 — `--bare` mode still ran shutdown-path LLM calls

`--bare` is documented as "useful for scripting and CI pipelines," and every other subsystem gate in `src/runner.rs` correctly checks `exec_mode.bare`. Four shutdown-path subsystems did not: `maybe_autodream`, `maybe_extract_skills_from_trace`, `maybe_store_shutdown_summary`, and `maybe_store_session_digest` (the latter two found by adversarial critique during this fix — the original issue only named the first two). Bare mode's still-attached in-memory `SemanticMemory`/`conversation_id` let all four subsystems' own config gates pass, so a `--bare` invocation could still fire several extra LLM round-trips at shutdown.

Adds `RuntimeConfig.bare`, set via `Agent::with_bare_mode()` from the CLI `--bare` flag, and an early return in all four subsystems when set.

Closes #5551.

### #5548 — ACP `session/set_config_option` model switch had a one-turn lag

`Agent::apply_provider_override()` ran once per run-loop iteration, before the iteration blocked on `next_event()`. A model switch written to the shared `provider_override` slot while the iteration was already parked waiting for the next message could not retrigger that check, so the switch applied one turn later than the ACP response's `currentValue` implied.

Re-checks `apply_provider_override()` at the start of `process_user_message()` — the single call site every turn-dispatch branch (including autonomous turns) funnels through — in addition to the existing loop-top call. `apply_provider_override()` is idempotent, so the extra call is a no-op when nothing is pending.

Closes #5548.

## Test plan

- [x] 10 new unit tests: `crates/zeph-core/src/agent/tests/bare_mode_shutdown_tests.rs` (8, all 4 gated subsystems × bare-true/false), `crates/zeph-core/src/agent/tests/provider_override_timing_tests.rs` (2)
- [x] Each new test independently verified to fail when its corresponding guard is reverted
- [x] Adversarial critique (2 rounds — first round found the 2 missed subsystems, second round re-verified the closed gap and did a full shutdown-path sweep for any remaining leak)
- [x] Independent code review (approved)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11845 passed, 0 failed, 34 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] CHANGELOG.md updated
- [x] Testing playbooks updated (`playbooks/bare-mode.md` scenarios 6-7, `playbooks/acp.md` scenario 10) and `coverage-status.md` rows updated in the main repo
- [ ] Live CI re-verification of the updated playbook scenarios (next CI cycle)

No new/changed config, no CLI/TUI/wizard/migration touchpoints needed — both fixes are internal wiring corrections with no user-facing config surface.