### PR TITLE
fix(memory): sweep TIMESTAMPTZ->String decode defect across zeph-memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -710,6 +710,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   concurrency changes only lower how often the `StartupTimeout` leak triggers). **Re-check on any
   future `testcontainers` crate version bump** — this `StartupTimeout` leak-on-cancel path is a
   known upstream limitation, not something fixable from this workspace alone.
+- `fix(memory)`: full-crate sweep for the `TIMESTAMPTZ`->`String` decode defect (#5538), same
+  class as #5524/#5527/#5525 — extends `Dialect::select_as_text` (and, where a Rust-formatted
+  timestamp is bound against a `TIMESTAMPTZ` column, `Dialect::TIMESTAMPTZ_CAST`) to ~50
+  previously-unfixed call sites across `store/{corrections,trust,preferences,persona,trajectory,
+  session_digest,compression_guidelines,experiments,admission_training,memory_tree,skills,
+  retrieval_failures}.rs`, `store/messages/mod.rs::get_eviction_candidates`, and the bulk of
+  `graph/store/mod.rs`'s entity/edge/community/alias/episode queries (three new shared
+  `*_select_cols()` helpers replace ~20 duplicated inline column lists there). `experiments.rs`'s
+  3 result-listing functions and `admission_training.rs::get_training_batch` also needed
+  co-located `CAST(... AS BIGINT)`/`CAST(... AS DOUBLE PRECISION)` casts for `latency_ms`/
+  `tokens_used`/`composite_score` (`INT4`/`FLOAT4` on Postgres vs. `i64`/`f64` in the Rust tuple) —
+  without these the `TIMESTAMPTZ` fix in those 4 functions would have shipped as untested dead code
+  on Postgres, still failing on the next column over. New/extended Postgres integration tests were
+  added for all of the above but not yet run against a real Postgres instance this session (Docker
+  environment blocker); pending live verification before merge. Also
+  fixes `store/mem_scenes.rs::find_unscened_semantic_messages` (#5544), which bypassed the `sql!()`
+  macro, so its `LIMIT ?` was never rewritten to Postgres's `$N` syntax.
 - `fix(memory)`: three more Postgres-dialect defects in `zeph-memory`, same class as #5508/#5524
   (SQLite-only SQL surfacing incorrectly under Postgres, live-verified via Docker testcontainers).
   `datetime('now')` (SQLite-only, no Postgres equivalent) was embedded as a literal in production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -717,15 +717,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   session_digest,compression_guidelines,experiments,admission_training,memory_tree,skills,
   retrieval_failures}.rs`, `store/messages/mod.rs::get_eviction_candidates`, and the bulk of
   `graph/store/mod.rs`'s entity/edge/community/alias/episode queries (three new shared
-  `*_select_cols()` helpers replace ~20 duplicated inline column lists there). `experiments.rs`'s
-  3 result-listing functions and `admission_training.rs::get_training_batch` also needed
-  co-located `CAST(... AS BIGINT)`/`CAST(... AS DOUBLE PRECISION)` casts for `latency_ms`/
-  `tokens_used`/`composite_score` (`INT4`/`FLOAT4` on Postgres vs. `i64`/`f64` in the Rust tuple) —
-  without these the `TIMESTAMPTZ` fix in those 4 functions would have shipped as untested dead code
-  on Postgres, still failing on the next column over. New/extended Postgres integration tests were
-  added for all of the above but not yet run against a real Postgres instance this session (Docker
-  environment blocker); pending live verification before merge. Also
-  fixes `store/mem_scenes.rs::find_unscened_semantic_messages` (#5544), which bypassed the `sql!()`
+  `*_select_cols()` helpers replace ~20 duplicated inline column lists there). Several of the
+  same functions also had a *co-located, independent* `INTEGER`/`INT4`-vs-`i64` decode mismatch
+  in the very same tuple (`experiments.rs`'s `latency_ms`/`tokens_used`, `admission_training.rs`'s
+  `composite_score`/`was_admitted`/`was_recalled`, `persona.rs`'s `evidence_count`,
+  `preferences.rs`'s `evidence_count`, `session_digest.rs`'s `token_count`,
+  `compression_guidelines.rs`'s `version`, `skills.rs`'s `invocation_count`/`version`/
+  `success_count`/`failure_count` plus an `is_active` `BOOLEAN`-vs-`i64` mismatch in the same
+  tuple, `messages/mod.rs::get_eviction_candidates`'s `access_count`, `trust.rs`'s
+  `requires_trust_check`, and `graph/store/mod.rs`'s `EdgeRow.superseded_by`/`turn_index`) —
+  without these companion fixes the `TIMESTAMPTZ` fix in those functions would have shipped as
+  dead code on Postgres, still failing one column later. The `admission_training.rs` instance
+  was caught live by CI's Postgres integration job on this PR (`ColumnDecode` failure on
+  `was_admitted`); the rest were found by a follow-up audit of every `INTEGER`-typed column
+  against every touched decode site and fixed in the same pass. Also fixes
+  `store/mem_scenes.rs::find_unscened_semantic_messages` (#5544), which bypassed the `sql!()`
   macro, so its `LIMIT ?` was never rewritten to Postgres's `$N` syntax.
 - `fix(memory)`: three more Postgres-dialect defects in `zeph-memory`, same class as #5508/#5524
   (SQLite-only SQL surfacing incorrectly under Postgres, live-verified via Docker testcontainers).

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -2558,7 +2558,8 @@ struct EdgeRow {
     edge_type: String,
     retrieval_count: i32,
     last_retrieved_at: Option<i64>,
-    superseded_by: Option<i64>,
+    // `INTEGER` (`INT4`) on Postgres, so it decodes as `Option<i32>`, not `Option<i64>`.
+    superseded_by: Option<i32>,
     canonical_relation: Option<String>,
     supersedes: Option<i64>,
     // Hebbian reinforcement weight (HL-F1, #3344). SQLite REAL maps to f64 via sqlx.
@@ -2566,7 +2567,8 @@ struct EdgeRow {
     // SYNAPSE multi-timescale variables (#3709).
     confidence_fast: f64,
     confidence_slow: f64,
-    turn_index: Option<i64>,
+    // `INTEGER` (`INT4`) on Postgres, so it decodes as `Option<i32>`, not `Option<i64>`.
+    turn_index: Option<i32>,
 }
 
 /// `graph_edges` projection for [`EdgeRow`], dialect-cast for `TIMESTAMPTZ` columns.
@@ -2618,7 +2620,7 @@ fn edge_from_row(row: EdgeRow) -> Edge {
         edge_type,
         retrieval_count: row.retrieval_count,
         last_retrieved_at: row.last_retrieved_at,
-        superseded_by: row.superseded_by,
+        superseded_by: row.superseded_by.map(i64::from),
         supersedes: row.supersedes,
         #[allow(clippy::cast_possible_truncation)]
         weight: row.weight as f32,

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -140,15 +140,16 @@ impl GraphStore {
         entity_type: EntityType,
     ) -> Result<Option<Entity>, MemoryError> {
         let type_str = entity_type.as_str();
-        let row: Option<EntityRow> = zeph_db::query_as(
-            sql!("SELECT id, name, canonical_name, entity_type, summary, first_seen_at, last_seen_at, qdrant_point_id
-             FROM graph_entities
-             WHERE canonical_name = ? AND entity_type = ?"),
-        )
-        .bind(canonical_name)
-        .bind(type_str)
-        .fetch_optional(&self.pool)
-        .await?;
+        let raw = format!(
+            "SELECT {} FROM graph_entities WHERE canonical_name = ? AND entity_type = ?",
+            entity_select_cols()
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row: Option<EntityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(canonical_name)
+            .bind(type_str)
+            .fetch_optional(&self.pool)
+            .await?;
         row.map(entity_from_row).transpose()
     }
 
@@ -159,14 +160,15 @@ impl GraphStore {
     /// Returns an error if the database query fails.
     #[tracing::instrument(name = "memory.graph.store.find_entity_by_id", skip_all)]
     pub async fn find_entity_by_id(&self, entity_id: i64) -> Result<Option<Entity>, MemoryError> {
-        let row: Option<EntityRow> = zeph_db::query_as(
-            sql!("SELECT id, name, canonical_name, entity_type, summary, first_seen_at, last_seen_at, qdrant_point_id
-             FROM graph_entities
-             WHERE id = ?"),
-        )
-        .bind(entity_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        let raw = format!(
+            "SELECT {} FROM graph_entities WHERE id = ?",
+            entity_select_cols()
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row: Option<EntityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(entity_id)
+            .fetch_optional(&self.pool)
+            .await?;
         row.map(entity_from_row).transpose()
     }
 
@@ -307,14 +309,15 @@ impl GraphStore {
     /// Stream all entities from the database incrementally (true cursor, no full-table load).
     pub fn all_entities_stream(&self) -> impl Stream<Item = Result<Entity, MemoryError>> + '_ {
         use futures::StreamExt as _;
-        zeph_db::query_as::<_, EntityRow>(
-            sql!("SELECT id, name, canonical_name, entity_type, summary, first_seen_at, last_seen_at, qdrant_point_id
-             FROM graph_entities ORDER BY id ASC"),
-        )
-        .fetch(&self.pool)
-        .map(|r: Result<EntityRow, zeph_db::SqlxError>| {
-            r.map_err(MemoryError::from).and_then(entity_from_row)
-        })
+        let raw = format!(
+            "SELECT {} FROM graph_entities ORDER BY id ASC",
+            entity_select_cols()
+        );
+        zeph_db::query_as::<_, EntityRow>(sqlx::AssertSqlSafe(raw))
+            .fetch(&self.pool)
+            .map(|r: Result<EntityRow, zeph_db::SqlxError>| {
+                r.map_err(MemoryError::from).and_then(entity_from_row)
+            })
     }
 
     // ── Alias methods ─────────────────────────────────────────────────────────
@@ -387,13 +390,9 @@ impl GraphStore {
         &self,
         entity_id: i64,
     ) -> Result<Vec<EntityAlias>, MemoryError> {
-        let created_at_sel =
-            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let sql = zeph_db::rewrite_placeholders(&format!(
-            "SELECT id, entity_id, alias_name, {created_at_sel} AS created_at
-             FROM graph_entity_aliases
-             WHERE entity_id = ?
-             ORDER BY id ASC"
+            "SELECT {} FROM graph_entity_aliases WHERE entity_id = ? ORDER BY id ASC",
+            alias_select_cols()
         ));
         let rows: Vec<AliasRow> = zeph_db::query_as(sqlx::AssertSqlSafe(sql))
             .bind(entity_id)
@@ -690,14 +689,13 @@ impl GraphStore {
             " AND origin = 'conversation'".to_owned()
         };
 
+        let edge_cols = edge_select_cols();
         let sql = if n_types == 0 {
             // placeholders used twice (source IN and target IN)
             let placeholders = placeholder_list(1, n_ids);
             let placeholders2 = placeholder_list(n_ids + 1, n_ids);
             format!(
-                "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                        valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                        edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
+                "SELECT {edge_cols}
                  FROM graph_edges
                  WHERE valid_to IS NULL{origin_filter}
                    AND (source_entity_id IN ({placeholders}) OR target_entity_id IN ({placeholders2}))"
@@ -707,9 +705,7 @@ impl GraphStore {
             let placeholders2 = placeholder_list(n_ids + 1, n_ids);
             let type_placeholders = placeholder_list(n_ids * 2 + 1, n_types);
             format!(
-                "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                        valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                        edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
+                "SELECT {edge_cols}
                  FROM graph_edges
                  WHERE valid_to IS NULL{origin_filter}
                    AND (source_entity_id IN ({placeholders}) OR target_entity_id IN ({placeholders2}))
@@ -756,14 +752,14 @@ impl GraphStore {
             " AND origin = 'conversation'"
         };
         let sql = format!(
-            "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                    valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                    edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
-             FROM graph_edges
-             WHERE valid_to IS NULL{origin_filter}
-               AND (source_entity_id = ? OR target_entity_id = ?)"
+            "SELECT {} \
+             FROM graph_edges \
+             WHERE valid_to IS NULL{origin_filter} \
+               AND (source_entity_id = ? OR target_entity_id = ?)",
+            edge_select_cols()
         );
-        let rows: Vec<EdgeRow> = zeph_db::query_as::<_, EdgeRow>(sqlx::AssertSqlSafe(sql))
+        let query_sql = zeph_db::rewrite_placeholders(&sql);
+        let rows: Vec<EdgeRow> = zeph_db::query_as::<_, EdgeRow>(sqlx::AssertSqlSafe(query_sql))
             .bind(entity_id)
             .bind(entity_id)
             .fetch_all(&self.pool)
@@ -785,20 +781,21 @@ impl GraphStore {
         limit: usize,
     ) -> Result<Vec<Edge>, MemoryError> {
         let limit = i64::try_from(limit)?;
-        let rows: Vec<EdgeRow> = zeph_db::query_as(sql!(
-            "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                    valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                    edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
-             FROM graph_edges
-             WHERE source_entity_id = ? OR target_entity_id = ?
-             ORDER BY valid_from DESC
-             LIMIT ?"
-        ))
-        .bind(entity_id)
-        .bind(entity_id)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
+        let raw = format!(
+            "SELECT {} \
+             FROM graph_edges \
+             WHERE source_entity_id = ? OR target_entity_id = ? \
+             ORDER BY graph_edges.valid_from DESC \
+             LIMIT ?",
+            edge_select_cols()
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<EdgeRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(entity_id)
+            .bind(entity_id)
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(edge_from_row).collect())
     }
 
@@ -814,21 +811,22 @@ impl GraphStore {
         entity_a: i64,
         entity_b: i64,
     ) -> Result<Vec<Edge>, MemoryError> {
-        let rows: Vec<EdgeRow> = zeph_db::query_as(sql!(
-            "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                    valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                    edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
-             FROM graph_edges
-             WHERE valid_to IS NULL
-               AND ((source_entity_id = ? AND target_entity_id = ?)
-                 OR (source_entity_id = ? AND target_entity_id = ?))"
-        ))
-        .bind(entity_a)
-        .bind(entity_b)
-        .bind(entity_b)
-        .bind(entity_a)
-        .fetch_all(&self.pool)
-        .await?;
+        let raw = format!(
+            "SELECT {} \
+             FROM graph_edges \
+             WHERE valid_to IS NULL \
+               AND ((source_entity_id = ? AND target_entity_id = ?) \
+                 OR (source_entity_id = ? AND target_entity_id = ?))",
+            edge_select_cols()
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<EdgeRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(entity_a)
+            .bind(entity_b)
+            .bind(entity_b)
+            .bind(entity_a)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(edge_from_row).collect())
     }
 
@@ -844,19 +842,20 @@ impl GraphStore {
         source_entity_id: i64,
         target_entity_id: i64,
     ) -> Result<Vec<Edge>, MemoryError> {
-        let rows: Vec<EdgeRow> = zeph_db::query_as(sql!(
-            "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                    valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                    edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
-             FROM graph_edges
-             WHERE valid_to IS NULL
-               AND source_entity_id = ?
-               AND target_entity_id = ?"
-        ))
-        .bind(source_entity_id)
-        .bind(target_entity_id)
-        .fetch_all(&self.pool)
-        .await?;
+        let raw = format!(
+            "SELECT {} \
+             FROM graph_edges \
+             WHERE valid_to IS NULL \
+               AND source_entity_id = ? \
+               AND target_entity_id = ?",
+            edge_select_cols()
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<EdgeRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(source_entity_id)
+            .bind(target_entity_id)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(edge_from_row).collect())
     }
 
@@ -991,15 +990,21 @@ impl GraphStore {
         &self,
         entity_id: i64,
     ) -> Result<Option<Community>, MemoryError> {
-        let row: Option<CommunityRow> = zeph_db::query_as(
-            sql!("SELECT c.id, c.name, c.summary, c.entity_ids, c.fingerprint, c.created_at, c.updated_at
-             FROM graph_communities c, json_each(c.entity_ids) j
-             WHERE CAST(j.value AS INTEGER) = ?
-             LIMIT 1"),
-        )
-        .bind(entity_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        // NOTE: `json_each()` is `SQLite`-only syntax; this query is not yet dialect-gated for
+        // Postgres (see `community_ids_sql` for the established sqlite/postgres split pattern
+        // used elsewhere) — pre-existing gap, out of scope for the `TIMESTAMPTZ` decode fix here.
+        let raw = format!(
+            "SELECT {} \
+             FROM graph_communities c, json_each(c.entity_ids) j \
+             WHERE CAST(j.value AS INTEGER) = ? \
+             LIMIT 1",
+            community_select_cols("c.")
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row: Option<CommunityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(entity_id)
+            .fetch_optional(&self.pool)
+            .await?;
         match row {
             Some(row) => {
                 let raw_ids: Vec<i64> = serde_json::from_str(&row.entity_ids)?;
@@ -1025,13 +1030,13 @@ impl GraphStore {
     /// Returns an error if the database query fails or JSON parsing fails.
     #[tracing::instrument(name = "memory.graph.store.all_communities", skip_all)]
     pub async fn all_communities(&self) -> Result<Vec<Community>, MemoryError> {
-        let rows: Vec<CommunityRow> = zeph_db::query_as(sql!(
-            "SELECT id, name, summary, entity_ids, fingerprint, created_at, updated_at
-             FROM graph_communities
-             ORDER BY id ASC"
-        ))
-        .fetch_all(&self.pool)
-        .await?;
+        let raw = format!(
+            "SELECT {} FROM graph_communities ORDER BY id ASC",
+            community_select_cols("")
+        );
+        let rows: Vec<CommunityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(raw))
+            .fetch_all(&self.pool)
+            .await?;
 
         rows.into_iter()
             .map(|row| {
@@ -1114,16 +1119,13 @@ impl GraphStore {
     /// Stream all active (non-invalidated) edges.
     pub fn all_active_edges_stream(&self) -> impl Stream<Item = Result<Edge, MemoryError>> + '_ {
         use futures::StreamExt as _;
-        zeph_db::query_as::<_, EdgeRow>(sql!(
-            "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                    valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                    edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
-             FROM graph_edges
-             WHERE valid_to IS NULL
-             ORDER BY id ASC"
-        ))
-        .fetch(&self.pool)
-        .map(|r| r.map_err(MemoryError::from).map(edge_from_row))
+        let raw = format!(
+            "SELECT {} FROM graph_edges WHERE valid_to IS NULL ORDER BY id ASC",
+            edge_select_cols()
+        );
+        zeph_db::query_as::<_, EdgeRow>(sqlx::AssertSqlSafe(raw))
+            .fetch(&self.pool)
+            .map(|r| r.map_err(MemoryError::from).map(edge_from_row))
     }
 
     /// Fetch a chunk of active edges using keyset pagination.
@@ -1148,19 +1150,20 @@ impl GraphStore {
         after_id: i64,
         limit: i64,
     ) -> Result<Vec<Edge>, MemoryError> {
-        let rows: Vec<EdgeRow> = zeph_db::query_as(sql!(
-            "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                    valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                    edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
-             FROM graph_edges
-             WHERE valid_to IS NULL AND id > ?
-             ORDER BY id ASC
-             LIMIT ?"
-        ))
-        .bind(after_id)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
+        let raw = format!(
+            "SELECT {} \
+             FROM graph_edges \
+             WHERE valid_to IS NULL AND id > ? \
+             ORDER BY id ASC \
+             LIMIT ?",
+            edge_select_cols()
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<EdgeRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(after_id)
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(edge_from_row).collect())
     }
 
@@ -1171,14 +1174,15 @@ impl GraphStore {
     /// Returns an error if the database query fails or JSON parsing fails.
     #[tracing::instrument(name = "memory.graph.store.find_community_by_id", skip_all)]
     pub async fn find_community_by_id(&self, id: i64) -> Result<Option<Community>, MemoryError> {
-        let row: Option<CommunityRow> = zeph_db::query_as(sql!(
-            "SELECT id, name, summary, entity_ids, fingerprint, created_at, updated_at
-             FROM graph_communities
-             WHERE id = ?"
-        ))
-        .bind(id)
-        .fetch_optional(&self.pool)
-        .await?;
+        let raw = format!(
+            "SELECT {} FROM graph_communities WHERE id = ?",
+            community_select_cols("")
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row: Option<CommunityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
         match row {
             Some(row) => {
                 let raw_ids: Vec<i64> = serde_json::from_str(&row.entity_ids)?;
@@ -1757,33 +1761,38 @@ impl GraphStore {
         // Split into two UNIONed branches to leverage the partial indexes from migration 030:
         //   Branch 1 (active edges):     idx_graph_edges_valid + idx_graph_edges_source/target
         //   Branch 2 (historical edges): idx_graph_edges_src_temporal / idx_graph_edges_tgt_temporal
-        let rows: Vec<EdgeRow> = zeph_db::query_as(sql!(
-            "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                    valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                    edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
+        //
+        // `timestamp` is a Rust-formatted string bound against `valid_from`/`valid_to`
+        // (`TIMESTAMPTZ` on Postgres); Postgres has no implicit text->timestamptz cast for a
+        // bound parameter, so an explicit `TIMESTAMPTZ_CAST` is required on each placeholder —
+        // mirrors `agent_sessions.rs`'s fix for the same class of mismatch.
+        let ts_cast = <ActiveDialect as zeph_db::dialect::Dialect>::TIMESTAMPTZ_CAST;
+        let edge_cols = edge_select_cols();
+        let raw = format!(
+            "SELECT {edge_cols}
              FROM graph_edges
              WHERE valid_to IS NULL
-               AND valid_from <= ?
+               AND valid_from <= ?{ts_cast}
                AND (source_entity_id = ? OR target_entity_id = ?)
              UNION ALL
-             SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                    valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                    edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
+             SELECT {edge_cols}
              FROM graph_edges
              WHERE valid_to IS NOT NULL
-               AND valid_from <= ?
-               AND valid_to > ?
+               AND valid_from <= ?{ts_cast}
+               AND valid_to > ?{ts_cast}
                AND (source_entity_id = ? OR target_entity_id = ?)"
-        ))
-        .bind(timestamp)
-        .bind(entity_id)
-        .bind(entity_id)
-        .bind(timestamp)
-        .bind(timestamp)
-        .bind(entity_id)
-        .bind(entity_id)
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<EdgeRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(timestamp)
+            .bind(entity_id)
+            .bind(entity_id)
+            .bind(timestamp)
+            .bind(timestamp)
+            .bind(entity_id)
+            .bind(entity_id)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(edge_from_row).collect())
     }
 
@@ -1810,40 +1819,41 @@ impl GraphStore {
             .replace('_', "\\_");
         let like_pattern = format!("%{escaped}%");
         let limit = i64::try_from(limit)?;
+        let edge_cols = edge_select_cols();
         let rows: Vec<EdgeRow> = if let Some(rel) = relation {
-            zeph_db::query_as(sql!(
-                "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                        valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                        edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
+            let raw = format!(
+                "SELECT {edge_cols}
                  FROM graph_edges
                  WHERE source_entity_id = ?
                    AND fact LIKE ? ESCAPE '\\'
                    AND relation = ?
-                 ORDER BY valid_from DESC
+                 ORDER BY graph_edges.valid_from DESC
                  LIMIT ?"
-            ))
-            .bind(source_entity_id)
-            .bind(&like_pattern)
-            .bind(rel)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+                .bind(source_entity_id)
+                .bind(&like_pattern)
+                .bind(rel)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?
         } else {
-            zeph_db::query_as(sql!(
-                "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
-                        valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id,
-                        edge_type, retrieval_count, last_retrieved_at, superseded_by, canonical_relation, supersedes, CAST(weight AS DOUBLE PRECISION) AS weight, CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index
+            let raw = format!(
+                "SELECT {edge_cols}
                  FROM graph_edges
                  WHERE source_entity_id = ?
                    AND fact LIKE ? ESCAPE '\\'
-                 ORDER BY valid_from DESC
+                 ORDER BY graph_edges.valid_from DESC
                  LIMIT ?"
-            ))
-            .bind(source_entity_id)
-            .bind(&like_pattern)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+                .bind(source_entity_id)
+                .bind(&like_pattern)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?
         };
         Ok(rows.into_iter().map(edge_from_row).collect())
     }
@@ -2342,13 +2352,15 @@ impl GraphStore {
     #[tracing::instrument(name = "memory.graph.store.find_entity_by_name", skip_all)]
     pub async fn find_entity_by_name(&self, name: &str) -> Result<Vec<Entity>, MemoryError> {
         let find_by_name_sql = format!(
-            "SELECT id, name, canonical_name, entity_type, summary, first_seen_at, last_seen_at, qdrant_point_id \
+            "SELECT {} \
              FROM graph_entities \
              WHERE name = ? {cn} OR canonical_name = ? {cn} \
              LIMIT 5",
+            entity_select_cols(),
             cn = <ActiveDialect as zeph_db::dialect::Dialect>::COLLATE_NOCASE,
         );
-        let rows: Vec<EntityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(find_by_name_sql))
+        let query_sql = zeph_db::rewrite_placeholders(&find_by_name_sql);
+        let rows: Vec<EntityRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
             .bind(name)
             .bind(name)
             .fetch_all(&self.pool)
@@ -2470,6 +2482,22 @@ struct EntityRow {
     qdrant_point_id: Option<String>,
 }
 
+/// `graph_entities` projection for [`EntityRow`], dialect-cast for `TIMESTAMPTZ` columns.
+///
+/// `first_seen_at`/`last_seen_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on `SQLite`); both are
+/// projected through `Dialect::select_as_text` and aliased back to their original names so
+/// `#[derive(FromRow)]` still binds them into `EntityRow`'s `String` fields.
+fn entity_select_cols() -> String {
+    let first_seen_sel =
+        <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("first_seen_at");
+    let last_seen_sel =
+        <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("last_seen_at");
+    format!(
+        "id, name, canonical_name, entity_type, summary, \
+         {first_seen_sel} AS first_seen_at, {last_seen_sel} AS last_seen_at, qdrant_point_id"
+    )
+}
+
 fn entity_from_row(row: EntityRow) -> Result<Entity, MemoryError> {
     let entity_type = row
         .entity_type
@@ -2493,6 +2521,14 @@ struct AliasRow {
     entity_id: i64,
     alias_name: String,
     created_at: String,
+}
+
+/// `graph_entity_aliases` projection for [`AliasRow`], dialect-cast for `TIMESTAMPTZ` columns.
+///
+/// `created_at` is `TIMESTAMPTZ` on Postgres — see [`entity_select_cols`].
+fn alias_select_cols() -> String {
+    let created_at_sel = <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+    format!("id, entity_id, alias_name, {created_at_sel} AS created_at")
 }
 
 fn alias_from_row(row: AliasRow) -> EntityAlias {
@@ -2531,6 +2567,29 @@ struct EdgeRow {
     confidence_fast: f64,
     confidence_slow: f64,
     turn_index: Option<i64>,
+}
+
+/// `graph_edges` projection for [`EdgeRow`], dialect-cast for `TIMESTAMPTZ` columns.
+///
+/// `valid_from`/`valid_to`/`created_at`/`expired_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on
+/// `SQLite`); each is projected through `Dialect::select_as_text` and aliased back to its
+/// original name so `#[derive(FromRow)]` still binds them into `EdgeRow`'s `String`/
+/// `Option<String>` fields.
+fn edge_select_cols() -> String {
+    let valid_from_sel = <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("valid_from");
+    let valid_to_sel = <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("valid_to");
+    let created_at_sel = <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+    let expired_at_sel = <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("expired_at");
+    format!(
+        "id, source_entity_id, target_entity_id, relation, fact, confidence, \
+         {valid_from_sel} AS valid_from, {valid_to_sel} AS valid_to, \
+         {created_at_sel} AS created_at, {expired_at_sel} AS expired_at, \
+         episode_id, qdrant_point_id, edge_type, retrieval_count, last_retrieved_at, \
+         superseded_by, canonical_relation, supersedes, \
+         CAST(weight AS DOUBLE PRECISION) AS weight, \
+         CAST(confidence_fast AS DOUBLE PRECISION) AS confidence_fast, \
+         CAST(confidence_slow AS DOUBLE PRECISION) AS confidence_slow, turn_index"
+    )
 }
 
 fn edge_from_row(row: EdgeRow) -> Edge {
@@ -2581,6 +2640,24 @@ struct CommunityRow {
     fingerprint: Option<String>,
     created_at: String,
     updated_at: String,
+}
+
+/// `graph_communities` projection for [`CommunityRow`], dialect-cast for `TIMESTAMPTZ` columns.
+///
+/// `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres — see [`entity_select_cols`].
+/// `table_prefix` (e.g. `"c."` or `""`) is prepended to each source column reference so this
+/// helper works both in plain `FROM graph_communities` queries and in joins with an alias.
+fn community_select_cols(table_prefix: &str) -> String {
+    let created_at_sel = <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text(&format!(
+        "{table_prefix}created_at"
+    ));
+    let updated_at_sel = <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text(&format!(
+        "{table_prefix}updated_at"
+    ));
+    format!(
+        "{table_prefix}id, {table_prefix}name, {table_prefix}summary, {table_prefix}entity_ids, \
+         {table_prefix}fingerprint, {created_at_sel} AS created_at, {updated_at_sel} AS updated_at"
+    )
 }
 
 // ── GAAMA Episode methods ──────────────────────────────────────────────────────
@@ -2660,15 +2737,26 @@ impl GraphStore {
             created_at: String,
             closed_at: Option<String>,
         }
-        let rows: Vec<EpisodeRow> = zeph_db::query_as(sql!(
-            "SELECT e.id, e.conversation_id, e.created_at, e.closed_at
+        // `created_at`/`closed_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project
+        // both through `Dialect::select_as_text`, aliased back to their original names so
+        // `#[derive(FromRow)]` still binds them into `EpisodeRow`'s `String`/`Option<String>`
+        // fields.
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("e.created_at");
+        let closed_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("e.closed_at");
+        let raw = format!(
+            "SELECT e.id, e.conversation_id, {created_at_sel} AS created_at, \
+                    {closed_at_sel} AS closed_at
              FROM graph_episodes e
              JOIN graph_episode_entities ee ON ee.episode_id = e.id
              WHERE ee.entity_id = ?"
-        ))
-        .bind(entity_id)
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<EpisodeRow> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(entity_id)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows
             .into_iter()
             .map(|r| super::types::Episode {

--- a/crates/zeph-memory/src/store/admission_training.rs
+++ b/crates/zeph-memory/src/store/admission_training.rs
@@ -154,6 +154,8 @@ impl SqliteStore {
         // `composite_score` is `REAL` (`FLOAT4`) on Postgres but the tuple decodes it as `f64`;
         // `CAST(... AS DOUBLE PRECISION)` widens it (same un-gated idiom already used for
         // `weight`/`confidence_fast`/`confidence_slow` in `graph/store/mod.rs`).
+        // `was_admitted`/`was_recalled` are `INTEGER` (`INT4`) on Postgres, so they decode as
+        // `i32`, not `i64` (INT8) — same rule as any other INTEGER/INT4 column in this crate.
         let created_at_sel =
             <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let raw = format!(
@@ -174,8 +176,8 @@ impl SqliteStore {
                 String,
                 String,
                 f64,
-                i64,
-                i64,
+                i32,
+                i32,
                 String,
                 String,
             ),

--- a/crates/zeph-memory/src/store/admission_training.rs
+++ b/crates/zeph-memory/src/store/admission_training.rs
@@ -148,6 +148,23 @@ impl SqliteStore {
         limit: usize,
     ) -> Result<Vec<AdmissionTrainingRecord>, MemoryError> {
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` tuple field below.
+        // `ORDER BY` is table-qualified so it sorts on the native timestamp, not the cast text.
+        // `composite_score` is `REAL` (`FLOAT4`) on Postgres but the tuple decodes it as `f64`;
+        // `CAST(... AS DOUBLE PRECISION)` widens it (same un-gated idiom already used for
+        // `weight`/`confidence_fast`/`confidence_slow` in `graph/store/mod.rs`).
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
+            "SELECT id, message_id, conversation_id, content_hash, role, \
+                    CAST(composite_score AS DOUBLE PRECISION) AS composite_score, \
+                    was_admitted, was_recalled, features_json, {created_at_sel} \
+             FROM admission_training_data \
+             ORDER BY admission_training_data.created_at ASC \
+             LIMIT ?"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
         let rows = zeph_db::query_as::<
             _,
             (
@@ -162,13 +179,7 @@ impl SqliteStore {
                 String,
                 String,
             ),
-        >(sql!(
-            "SELECT id, message_id, conversation_id, content_hash, role, \
-                    composite_score, was_admitted, was_recalled, features_json, created_at \
-             FROM admission_training_data \
-             ORDER BY created_at ASC \
-             LIMIT ?"
-        ))
+        >(sqlx::AssertSqlSafe(query_sql))
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;

--- a/crates/zeph-memory/src/store/compression_guidelines.rs
+++ b/crates/zeph-memory/src/store/compression_guidelines.rs
@@ -131,6 +131,8 @@ impl SqliteStore {
     ) -> Result<(i64, String), MemoryError> {
         // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
         // `Dialect::select_as_text` so it decodes into the `String` tuple field below.
+        // `version` is `INTEGER` (`INT4`) on Postgres, so it decodes as `i32`, not `i64`;
+        // widened back to `i64` below to keep this function's public return type unchanged.
         let created_at_sel =
             <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let raw = format!(
@@ -141,12 +143,14 @@ impl SqliteStore {
              LIMIT 1"
         );
         let query_sql = zeph_db::rewrite_placeholders(&raw);
-        let row = zeph_db::query_as::<_, (i64, String)>(sqlx::AssertSqlSafe(query_sql))
+        let row = zeph_db::query_as::<_, (i32, String)>(sqlx::AssertSqlSafe(query_sql))
             .bind(conversation_id.map(|c| c.0)) // lgtm[rust/cleartext-logging]
             .fetch_optional(&self.pool)
             .await?;
 
-        Ok(row.unwrap_or((0, String::new())))
+        Ok(row.map_or((0, String::new()), |(version, created_at)| {
+            (i64::from(version), created_at)
+        }))
     }
 
     /// Save a new version of the compression guidelines.

--- a/crates/zeph-memory/src/store/compression_guidelines.rs
+++ b/crates/zeph-memory/src/store/compression_guidelines.rs
@@ -129,16 +129,22 @@ impl SqliteStore {
         &self,
         conversation_id: Option<ConversationId>,
     ) -> Result<(i64, String), MemoryError> {
-        let row = zeph_db::query_as::<_, (i64, String)>(sql!(
-            "SELECT version, created_at FROM compression_guidelines \
+        // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` tuple field below.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
+            "SELECT version, {created_at_sel} FROM compression_guidelines \
              WHERE conversation_id = ? OR conversation_id IS NULL \
              ORDER BY CASE WHEN conversation_id IS NOT NULL THEN 0 ELSE 1 END, \
                       version DESC \
              LIMIT 1"
-        ))
-        .bind(conversation_id.map(|c| c.0)) // lgtm[rust/cleartext-logging]
-        .fetch_optional(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row = zeph_db::query_as::<_, (i64, String)>(sqlx::AssertSqlSafe(query_sql))
+            .bind(conversation_id.map(|c| c.0)) // lgtm[rust/cleartext-logging]
+            .fetch_optional(&self.pool)
+            .await?;
 
         Ok(row.unwrap_or((0, String::new())))
     }
@@ -226,13 +232,22 @@ impl SqliteStore {
         limit: usize,
     ) -> Result<Vec<CompressionFailurePair>, MemoryError> {
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
-        let rows = zeph_db::query_as::<_, (i64, i64, String, String, String, String)>(sql!(
-            "SELECT id, conversation_id, compressed_context, failure_reason, category, created_at \
+        // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` tuple field below.
+        // `ORDER BY` is table-qualified so it sorts on the native timestamp, not the cast text.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
+            "SELECT id, conversation_id, compressed_context, failure_reason, category, {created_at_sel} \
              FROM compression_failure_pairs \
              WHERE used_in_update = FALSE \
-             ORDER BY created_at ASC \
+             ORDER BY compression_failure_pairs.created_at ASC \
              LIMIT ?"
-        ))
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows = zeph_db::query_as::<_, (i64, i64, String, String, String, String)>(
+            sqlx::AssertSqlSafe(query_sql),
+        )
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
@@ -265,13 +280,20 @@ impl SqliteStore {
         limit: usize,
     ) -> Result<Vec<CompressionFailurePair>, MemoryError> {
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
-        let rows = zeph_db::query_as::<_, (i64, i64, String, String, String, String)>(sql!(
-            "SELECT id, conversation_id, compressed_context, failure_reason, category, created_at \
+        // `created_at` is `TIMESTAMPTZ` on Postgres — see `get_unused_failure_pairs`.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
+            "SELECT id, conversation_id, compressed_context, failure_reason, category, {created_at_sel} \
              FROM compression_failure_pairs \
              WHERE used_in_update = FALSE AND category = ? \
-             ORDER BY created_at ASC \
+             ORDER BY compression_failure_pairs.created_at ASC \
              LIMIT ?"
-        ))
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows = zeph_db::query_as::<_, (i64, i64, String, String, String, String)>(
+            sqlx::AssertSqlSafe(query_sql),
+        )
         .bind(category)
         .bind(limit)
         .fetch_all(&self.pool)

--- a/crates/zeph-memory/src/store/corrections.rs
+++ b/crates/zeph-memory/src/store/corrections.rs
@@ -78,16 +78,22 @@ impl SqliteStore {
         skill_name: &str,
         limit: u32,
     ) -> Result<Vec<UserCorrectionRow>, MemoryError> {
-        let rows: Vec<CorrectionTuple> = zeph_db::query_as(sql!(
+        // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` field below.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
             "SELECT id, session_id, original_output, correction_text, \
-             skill_name, correction_kind, created_at \
+             skill_name, correction_kind, {created_at_sel} \
              FROM user_corrections WHERE skill_name = ? \
              ORDER BY id DESC LIMIT ?"
-        ))
-        .bind(skill_name)
-        .bind(i64::from(limit))
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<CorrectionTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(skill_name)
+            .bind(i64::from(limit))
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(row_from_tuple).collect())
     }
 
@@ -100,14 +106,19 @@ impl SqliteStore {
         &self,
         limit: u32,
     ) -> Result<Vec<UserCorrectionRow>, MemoryError> {
-        let rows: Vec<CorrectionTuple> = zeph_db::query_as(sql!(
+        // `created_at` is `TIMESTAMPTZ` on Postgres — see `load_corrections_for_skill`.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
             "SELECT id, session_id, original_output, correction_text, \
-             skill_name, correction_kind, created_at \
+             skill_name, correction_kind, {created_at_sel} \
              FROM user_corrections ORDER BY id DESC LIMIT ?"
-        ))
-        .bind(i64::from(limit))
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<CorrectionTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(i64::from(limit))
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(row_from_tuple).collect())
     }
 
@@ -120,14 +131,19 @@ impl SqliteStore {
         &self,
         id: i64,
     ) -> Result<Vec<UserCorrectionRow>, MemoryError> {
-        let rows: Vec<CorrectionTuple> = zeph_db::query_as(sql!(
+        // `created_at` is `TIMESTAMPTZ` on Postgres — see `load_corrections_for_skill`.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
             "SELECT id, session_id, original_output, correction_text, \
-             skill_name, correction_kind, created_at \
+             skill_name, correction_kind, {created_at_sel} \
              FROM user_corrections WHERE id = ?"
-        ))
-        .bind(id)
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<CorrectionTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(id)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(row_from_tuple).collect())
     }
 }

--- a/crates/zeph-memory/src/store/experiments.rs
+++ b/crates/zeph-memory/src/store/experiments.rs
@@ -162,25 +162,38 @@ impl SqliteStore {
         session_id: Option<&str>,
         limit: u32,
     ) -> Result<Vec<ExperimentResultRow>, MemoryError> {
+        // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` tuple field below.
+        // `latency_ms`/`tokens_used` are `INTEGER` (`INT4`) on Postgres but the tuple decodes
+        // them as `i64`; `CAST(... AS BIGINT)` widens them (same un-gated idiom already used
+        // for `weight`/`confidence_fast`/`confidence_slow` in `graph/store/mod.rs`).
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let rows: Vec<ResultTuple> = if let Some(sid) = session_id {
-            zeph_db::query_as(sql!(
+            let raw = format!(
                 "SELECT id, session_id, parameter, value_json, baseline_score, candidate_score, \
-                 delta, latency_ms, tokens_used, accepted, source, created_at \
+                 delta, CAST(latency_ms AS BIGINT) AS latency_ms, \
+                 CAST(tokens_used AS BIGINT) AS tokens_used, accepted, source, {created_at_sel} \
                  FROM experiment_results WHERE session_id = ? ORDER BY id DESC LIMIT ?"
-            ))
-            .bind(sid)
-            .bind(i64::from(limit))
-            .fetch_all(&self.pool)
-            .await?
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+                .bind(sid)
+                .bind(i64::from(limit))
+                .fetch_all(&self.pool)
+                .await?
         } else {
-            zeph_db::query_as(sql!(
+            let raw = format!(
                 "SELECT id, session_id, parameter, value_json, baseline_score, candidate_score, \
-                 delta, latency_ms, tokens_used, accepted, source, created_at \
+                 delta, CAST(latency_ms AS BIGINT) AS latency_ms, \
+                 CAST(tokens_used AS BIGINT) AS tokens_used, accepted, source, {created_at_sel} \
                  FROM experiment_results ORDER BY id DESC LIMIT ?"
-            ))
-            .bind(i64::from(limit))
-            .fetch_all(&self.pool)
-            .await?
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+                .bind(i64::from(limit))
+                .fetch_all(&self.pool)
+                .await?
         };
         Ok(rows.into_iter().map(row_from_tuple).collect())
     }
@@ -194,25 +207,36 @@ impl SqliteStore {
         &self,
         parameter: Option<&str>,
     ) -> Result<Option<ExperimentResultRow>, MemoryError> {
+        // `created_at` is `TIMESTAMPTZ` on Postgres — see `list_experiment_results`.
+        // `latency_ms`/`tokens_used` need the same `CAST(... AS BIGINT)` widening — see
+        // `list_experiment_results`.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let row: Option<ResultTuple> = if let Some(param) = parameter {
-            zeph_db::query_as(sql!(
+            let raw = format!(
                 "SELECT id, session_id, parameter, value_json, baseline_score, candidate_score, \
-                 delta, latency_ms, tokens_used, accepted, source, created_at \
+                 delta, CAST(latency_ms AS BIGINT) AS latency_ms, \
+                 CAST(tokens_used AS BIGINT) AS tokens_used, accepted, source, {created_at_sel} \
                  FROM experiment_results \
                  WHERE accepted = TRUE AND parameter = ? ORDER BY delta DESC LIMIT 1"
-            ))
-            .bind(param)
-            .fetch_optional(&self.pool)
-            .await?
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+                .bind(param)
+                .fetch_optional(&self.pool)
+                .await?
         } else {
-            zeph_db::query_as(sql!(
+            let raw = format!(
                 "SELECT id, session_id, parameter, value_json, baseline_score, candidate_score, \
-                 delta, latency_ms, tokens_used, accepted, source, created_at \
+                 delta, CAST(latency_ms AS BIGINT) AS latency_ms, \
+                 CAST(tokens_used AS BIGINT) AS tokens_used, accepted, source, {created_at_sel} \
                  FROM experiment_results \
                  WHERE accepted = TRUE ORDER BY delta DESC LIMIT 1"
-            ))
-            .fetch_optional(&self.pool)
-            .await?
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+                .fetch_optional(&self.pool)
+                .await?
         };
         Ok(row.map(row_from_tuple))
     }
@@ -228,14 +252,27 @@ impl SqliteStore {
         since: &str,
     ) -> Result<Vec<ExperimentResultRow>, MemoryError> {
         validate_timestamp(since)?;
-        let rows: Vec<ResultTuple> = zeph_db::query_as(sql!(
+        // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite): the output projects
+        // through `Dialect::select_as_text` to decode into the `String` tuple field below, and
+        // the `since` bind parameter needs an explicit `TIMESTAMPTZ_CAST` — Postgres has no
+        // implicit text->timestamptz cast for a bound (non-literal) parameter — mirroring
+        // `agent_sessions.rs::upsert_agent_session`'s fix for the same class of mismatch.
+        // `latency_ms`/`tokens_used` need the same `CAST(... AS BIGINT)` widening — see
+        // `list_experiment_results`.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let ts_cast = <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::TIMESTAMPTZ_CAST;
+        let raw = format!(
             "SELECT id, session_id, parameter, value_json, baseline_score, candidate_score, \
-             delta, latency_ms, tokens_used, accepted, source, created_at \
-             FROM experiment_results WHERE created_at >= ? ORDER BY id DESC LIMIT 10000"
-        ))
-        .bind(since)
-        .fetch_all(&self.pool)
-        .await?;
+             delta, CAST(latency_ms AS BIGINT) AS latency_ms, \
+             CAST(tokens_used AS BIGINT) AS tokens_used, accepted, source, {created_at_sel} \
+             FROM experiment_results WHERE created_at >= ?{ts_cast} ORDER BY id DESC LIMIT 10000"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<ResultTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(since)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(row_from_tuple).collect())
     }
 

--- a/crates/zeph-memory/src/store/mem_scenes.rs
+++ b/crates/zeph-memory/src/store/mem_scenes.rs
@@ -27,17 +27,15 @@ impl SqliteStore {
         limit: usize,
     ) -> Result<Vec<(MessageId, String)>, MemoryError> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
-        let rows: Vec<(i64, String)> = zeph_db::query_as(
-            r"
-            SELECT m.id, m.content
-            FROM messages m
-            WHERE m.tier = 'semantic'
-              AND m.deleted_at IS NULL
-              AND m.id NOT IN (SELECT message_id FROM mem_scene_members)
-            ORDER BY m.id ASC
-            LIMIT ?
-            ",
-        )
+        let rows: Vec<(i64, String)> = zeph_db::query_as(sql!(
+            "SELECT m.id, m.content
+             FROM messages m
+             WHERE m.tier = 'semantic'
+               AND m.deleted_at IS NULL
+               AND m.id NOT IN (SELECT message_id FROM mem_scene_members)
+             ORDER BY m.id ASC
+             LIMIT ?"
+        ))
         .bind(limit_i64)
         .fetch_all(&self.pool)
         .await?;

--- a/crates/zeph-memory/src/store/memory_tree.rs
+++ b/crates/zeph-memory/src/store/memory_tree.rs
@@ -89,17 +89,27 @@ impl DbStore {
         &self,
         limit: usize,
     ) -> Result<Vec<MemoryTreeRow>, MemoryError> {
-        let rows: Vec<MemoryTreeRow> = query_as(sql!(
+        // `consolidated_at`/`created_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite);
+        // project both through `Dialect::select_as_text`, aliased back to their original
+        // names so `#[derive(sqlx::FromRow)]` still binds them into the `String`/`Option<String>`
+        // fields below. `ORDER BY` is table-qualified so it sorts on the native timestamp.
+        let consolidated_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("consolidated_at");
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
             "SELECT id, level, parent_id, content, source_ids, token_count,
-                    consolidated_at, created_at
+                    {consolidated_at_sel} AS consolidated_at, {created_at_sel} AS created_at
              FROM memory_tree
              WHERE level = 0 AND parent_id IS NULL
-             ORDER BY created_at ASC
+             ORDER BY memory_tree.created_at ASC
              LIMIT ?"
-        ))
-        .bind(i64::try_from(limit).unwrap_or(i64::MAX))
-        .fetch_all(self.pool())
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<MemoryTreeRow> = query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+            .fetch_all(self.pool())
+            .await?;
 
         Ok(rows)
     }
@@ -114,18 +124,26 @@ impl DbStore {
         level: i64,
         limit: usize,
     ) -> Result<Vec<MemoryTreeRow>, MemoryError> {
-        let rows: Vec<MemoryTreeRow> = query_as(sql!(
+        // `consolidated_at`/`created_at` are `TIMESTAMPTZ` on Postgres — see
+        // `load_tree_leaves_unconsolidated`.
+        let consolidated_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("consolidated_at");
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
             "SELECT id, level, parent_id, content, source_ids, token_count,
-                    consolidated_at, created_at
+                    {consolidated_at_sel} AS consolidated_at, {created_at_sel} AS created_at
              FROM memory_tree
              WHERE level = ? AND parent_id IS NULL
-             ORDER BY created_at ASC
+             ORDER BY memory_tree.created_at ASC
              LIMIT ?"
-        ))
-        .bind(level)
-        .bind(i64::try_from(limit).unwrap_or(i64::MAX))
-        .fetch_all(self.pool())
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<MemoryTreeRow> = query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(level)
+            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+            .fetch_all(self.pool())
+            .await?;
 
         Ok(rows)
     }
@@ -146,16 +164,25 @@ impl DbStore {
         let mut result = Vec::new();
         let mut current_id = leaf_id;
 
+        // `consolidated_at`/`created_at` are `TIMESTAMPTZ` on Postgres — see
+        // `load_tree_leaves_unconsolidated`.
+        let consolidated_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("consolidated_at");
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
+            "SELECT id, level, parent_id, content, source_ids, token_count,
+                    {consolidated_at_sel} AS consolidated_at, {created_at_sel} AS created_at
+             FROM memory_tree
+             WHERE id = ?"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+
         for _ in 0..=max_level {
-            let row: Option<MemoryTreeRow> = query_as(sql!(
-                "SELECT id, level, parent_id, content, source_ids, token_count,
-                        consolidated_at, created_at
-                 FROM memory_tree
-                 WHERE id = ?"
-            ))
-            .bind(current_id)
-            .fetch_optional(self.pool())
-            .await?;
+            let row: Option<MemoryTreeRow> = query_as(sqlx::AssertSqlSafe(query_sql.clone()))
+                .bind(current_id)
+                .fetch_optional(self.pool())
+                .await?;
 
             match row {
                 None => break,

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -1017,7 +1017,8 @@ impl SqliteStore {
     ) -> Result<Vec<crate::eviction::EvictionEntry>, crate::error::MemoryError> {
         // `created_at`/`last_accessed` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project
         // both through `Dialect::select_as_text` so they decode into the `String`/`Option<String>`
-        // fields below.
+        // fields below. `access_count` is `INTEGER` (`INT4`) on Postgres, so it decodes as `i32`,
+        // not `i64`.
         let created_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let last_accessed_sel =
@@ -1027,7 +1028,7 @@ impl SqliteStore {
              FROM messages WHERE deleted_at IS NULL"
         );
         let query_sql = zeph_db::rewrite_placeholders(&raw);
-        let rows: Vec<(MessageId, String, Option<String>, i64)> =
+        let rows: Vec<(MessageId, String, Option<String>, i32)> =
             zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
                 .fetch_all(&self.pool)
                 .await?;

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -1015,12 +1015,22 @@ impl SqliteStore {
     pub async fn get_eviction_candidates(
         &self,
     ) -> Result<Vec<crate::eviction::EvictionEntry>, crate::error::MemoryError> {
-        let rows: Vec<(MessageId, String, Option<String>, i64)> = zeph_db::query_as(sql!(
-            "SELECT id, created_at, last_accessed, access_count \
+        // `created_at`/`last_accessed` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project
+        // both through `Dialect::select_as_text` so they decode into the `String`/`Option<String>`
+        // fields below.
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let last_accessed_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("last_accessed");
+        let raw = format!(
+            "SELECT id, {created_at_sel}, {last_accessed_sel}, access_count \
              FROM messages WHERE deleted_at IS NULL"
-        ))
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<(MessageId, String, Option<String>, i64)> =
+            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+                .fetch_all(&self.pool)
+                .await?;
 
         Ok(rows
             .into_iter()

--- a/crates/zeph-memory/src/store/persona.rs
+++ b/crates/zeph-memory/src/store/persona.rs
@@ -98,13 +98,15 @@ impl DbStore {
         // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project
         // both through `Dialect::select_as_text`, aliased back to their original names so
         // `#[derive(sqlx::FromRow)]` still binds them into the `String` fields below.
+        // `confidence` is `REAL` (`FLOAT4`) on Postgres but decodes into an `f64` field;
+        // `CAST(... AS DOUBLE PRECISION)` widens it (same idiom used elsewhere in this crate).
         let created_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let updated_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
         let raw = format!(
-            "SELECT id, category, content, confidence, evidence_count,
-                    source_conversation_id, supersedes_id,
+            "SELECT id, category, content, CAST(confidence AS DOUBLE PRECISION) AS confidence,
+                    evidence_count, source_conversation_id, supersedes_id,
                     {created_at_sel} AS created_at, {updated_at_sel} AS updated_at
              FROM persona_memory
              WHERE confidence >= ?

--- a/crates/zeph-memory/src/store/persona.rs
+++ b/crates/zeph-memory/src/store/persona.rs
@@ -95,9 +95,17 @@ impl DbStore {
     ) -> Result<Vec<PersonaFactRow>, MemoryError> {
         // Facts that appear in any other row's supersedes_id column are excluded:
         // they have been replaced by a newer, contradicting fact.
-        let rows: Vec<PersonaFactRow> = query_as(sql!(
+        // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project
+        // both through `Dialect::select_as_text`, aliased back to their original names so
+        // `#[derive(sqlx::FromRow)]` still binds them into the `String` fields below.
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let updated_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let raw = format!(
             "SELECT id, category, content, confidence, evidence_count,
-                    source_conversation_id, supersedes_id, created_at, updated_at
+                    source_conversation_id, supersedes_id,
+                    {created_at_sel} AS created_at, {updated_at_sel} AS updated_at
              FROM persona_memory
              WHERE confidence >= ?
                AND id NOT IN (
@@ -105,10 +113,12 @@ impl DbStore {
                    WHERE supersedes_id IS NOT NULL
                )
              ORDER BY confidence DESC"
-        ))
-        .bind(min_confidence)
-        .fetch_all(self.pool())
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<PersonaFactRow> = query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(min_confidence)
+            .fetch_all(self.pool())
+            .await?;
 
         Ok(rows)
     }

--- a/crates/zeph-memory/src/store/persona.rs
+++ b/crates/zeph-memory/src/store/persona.rs
@@ -63,7 +63,7 @@ impl DbStore {
              VALUES
                 (?, ?, ?, 1, ?, ?, {now})
              ON CONFLICT(category, content) DO UPDATE SET
-                evidence_count = evidence_count + 1,
+                evidence_count = persona_memory.evidence_count + 1,
                 confidence     = excluded.confidence,
                 supersedes_id  = COALESCE(excluded.supersedes_id, persona_memory.supersedes_id),
                 updated_at     = {now}

--- a/crates/zeph-memory/src/store/persona.rs
+++ b/crates/zeph-memory/src/store/persona.rs
@@ -13,7 +13,7 @@ pub struct PersonaFactRow {
     pub category: String,
     pub content: String,
     pub confidence: f64,
-    pub evidence_count: i64,
+    pub evidence_count: i32,
     pub source_conversation_id: Option<i64>,
     pub supersedes_id: Option<i64>,
     pub created_at: String,

--- a/crates/zeph-memory/src/store/preferences.rs
+++ b/crates/zeph-memory/src/store/preferences.rs
@@ -18,7 +18,8 @@ pub struct LearnedPreferenceRow {
     pub updated_at: String,
 }
 
-type PreferenceTuple = (i64, String, String, f64, i64, String);
+// `evidence_count` is `INTEGER` (`INT4`) on Postgres, so it decodes as `i32`, not `i64` (INT8).
+type PreferenceTuple = (i64, String, String, f64, i32, String);
 
 fn row_from_tuple(t: PreferenceTuple) -> LearnedPreferenceRow {
     LearnedPreferenceRow {
@@ -26,7 +27,7 @@ fn row_from_tuple(t: PreferenceTuple) -> LearnedPreferenceRow {
         preference_key: t.1,
         preference_value: t.2,
         confidence: t.3,
-        evidence_count: t.4,
+        evidence_count: i64::from(t.4),
         updated_at: t.5,
     }
 }

--- a/crates/zeph-memory/src/store/preferences.rs
+++ b/crates/zeph-memory/src/store/preferences.rs
@@ -92,13 +92,19 @@ impl SqliteStore {
     ///
     /// Returns an error if the query fails.
     pub async fn load_learned_preferences(&self) -> Result<Vec<LearnedPreferenceRow>, MemoryError> {
-        let rows: Vec<PreferenceTuple> = zeph_db::query_as(sql!(
-            "SELECT id, preference_key, preference_value, confidence, evidence_count, updated_at \
+        // `updated_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` field below.
+        let updated_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let raw = format!(
+            "SELECT id, preference_key, preference_value, confidence, evidence_count, {updated_at_sel} \
              FROM learned_preferences \
              ORDER BY confidence DESC"
-        ))
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<PreferenceTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(row_from_tuple).collect())
     }
 
@@ -127,17 +133,23 @@ impl SqliteStore {
             String,
         );
 
-        let rows: Vec<Tuple> = zeph_db::query_as(sql!(
+        // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` field below.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
             "SELECT id, session_id, original_output, correction_text, \
-             skill_name, correction_kind, created_at \
+             skill_name, correction_kind, {created_at_sel} \
              FROM user_corrections \
              WHERE id > ? \
              ORDER BY id ASC LIMIT ?"
-        ))
-        .bind(after_id)
-        .bind(i64::from(limit))
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<Tuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(after_id)
+            .bind(i64::from(limit))
+            .fetch_all(&self.pool)
+            .await?;
 
         Ok(rows
             .into_iter()

--- a/crates/zeph-memory/src/store/retrieval_failures.rs
+++ b/crates/zeph-memory/src/store/retrieval_failures.rs
@@ -153,12 +153,17 @@ impl SqliteStore {
             (chrono::Utc::now() - chrono::Duration::days(i64::from(retention_days)))
                 .format("%Y-%m-%d %H:%M:%S")
         );
-        let rows = zeph_db::query(sql!(
-            "DELETE FROM memory_retrieval_failures WHERE created_at < ?"
-        ))
-        .bind(cutoff)
-        .execute(self.pool())
-        .await?;
+        // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); Postgres has no
+        // implicit text->timestamptz cast for a bound (non-literal) parameter, so an explicit
+        // `TIMESTAMPTZ_CAST` is required — mirrors `agent_sessions.rs`'s fix for the same
+        // class of mismatch.
+        let ts_cast = <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::TIMESTAMPTZ_CAST;
+        let raw = format!("DELETE FROM memory_retrieval_failures WHERE created_at < ?{ts_cast}");
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows = zeph_db::query(sqlx::AssertSqlSafe(query_sql))
+            .bind(cutoff)
+            .execute(self.pool())
+            .await?;
         Ok(rows.rows_affected())
     }
 }

--- a/crates/zeph-memory/src/store/session_digest.rs
+++ b/crates/zeph-memory/src/store/session_digest.rs
@@ -63,6 +63,7 @@ impl SqliteStore {
     ) -> Result<Option<SessionDigest>, MemoryError> {
         // `updated_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
         // `Dialect::select_as_text` so it decodes into the `String` field below.
+        // `token_count` is `INTEGER` (`INT4`) on Postgres, so it decodes as `i32`, not `i64`.
         let updated_at_sel =
             <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
         let raw = format!(
@@ -71,7 +72,7 @@ impl SqliteStore {
         );
         let query_sql = zeph_db::rewrite_placeholders(&raw);
         let row =
-            zeph_db::query_as::<_, (i64, i64, String, i64, String)>(sqlx::AssertSqlSafe(query_sql))
+            zeph_db::query_as::<_, (i64, i64, String, i32, String)>(sqlx::AssertSqlSafe(query_sql))
                 .bind(conversation_id.0)
                 .fetch_optional(&self.pool)
                 .await?;
@@ -81,7 +82,7 @@ impl SqliteStore {
                 id,
                 conversation_id: ConversationId(conv_id),
                 digest,
-                token_count,
+                token_count: i64::from(token_count),
                 updated_at,
             },
         ))

--- a/crates/zeph-memory/src/store/session_digest.rs
+++ b/crates/zeph-memory/src/store/session_digest.rs
@@ -61,13 +61,20 @@ impl SqliteStore {
         &self,
         conversation_id: ConversationId,
     ) -> Result<Option<SessionDigest>, MemoryError> {
-        let row = zeph_db::query_as::<_, (i64, i64, String, i64, String)>(sql!(
-            "SELECT id, conversation_id, digest, token_count, updated_at \
+        // `updated_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` field below.
+        let updated_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let raw = format!(
+            "SELECT id, conversation_id, digest, token_count, {updated_at_sel} \
              FROM session_digest WHERE conversation_id = ?"
-        ))
-        .bind(conversation_id.0)
-        .fetch_optional(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row =
+            zeph_db::query_as::<_, (i64, i64, String, i64, String)>(sqlx::AssertSqlSafe(query_sql))
+                .bind(conversation_id.0)
+                .fetch_optional(&self.pool)
+                .await?;
 
         Ok(row.map(
             |(id, conv_id, digest, token_count, updated_at)| SessionDigest {

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -57,16 +57,19 @@ pub struct SkillVersionRow {
     pub created_at: String,
 }
 
+// `version`/`success_count`/`failure_count` are `INTEGER` (`INT4`) on Postgres, so they decode
+// as `i32`, not `i64`; `is_active` is `BOOLEAN` on Postgres, so it decodes as `bool` directly,
+// not `i64`. Widened/converted back to `SkillVersionRow`'s field types in the function below.
 type SkillVersionTuple = (
     i64,
     String,
-    i64,
+    i32,
     String,
     String,
     String,
-    i64,
-    i64,
-    i64,
+    bool,
+    i32,
+    i32,
     String,
 );
 
@@ -74,13 +77,13 @@ fn skill_version_from_tuple(t: SkillVersionTuple) -> SkillVersionRow {
     SkillVersionRow {
         id: t.0,
         skill_name: t.1,
-        version: t.2,
+        version: i64::from(t.2),
         body: t.3,
         description: t.4,
         source: t.5,
-        is_active: t.6 != 0,
-        success_count: t.7,
-        failure_count: t.8,
+        is_active: t.6,
+        success_count: i64::from(t.7),
+        failure_count: i64::from(t.8),
         created_at: t.9,
     }
 }
@@ -122,6 +125,8 @@ impl SqliteStore {
     pub async fn load_skill_usage(&self) -> Result<Vec<SkillUsageRow>, MemoryError> {
         // `last_used_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
         // `Dialect::select_as_text` so it decodes into the `String` tuple field below.
+        // `invocation_count` is `INTEGER` (`INT4`) on Postgres, so it decodes as `i32`, not
+        // `i64`; widened back to `i64` below to keep `SkillUsageRow`'s field type unchanged.
         let last_used_at_sel =
             <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("last_used_at");
         let raw = format!(
@@ -129,7 +134,7 @@ impl SqliteStore {
              FROM skill_usage ORDER BY invocation_count DESC"
         );
         let query_sql = zeph_db::rewrite_placeholders(&raw);
-        let rows: Vec<(String, i64, String)> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+        let rows: Vec<(String, i32, String)> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
             .fetch_all(&self.pool)
             .await?;
 
@@ -138,7 +143,7 @@ impl SqliteStore {
             .map(
                 |(skill_name, invocation_count, last_used_at)| SkillUsageRow {
                     skill_name,
-                    invocation_count,
+                    invocation_count: i64::from(invocation_count),
                     last_used_at,
                 },
             )

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -120,12 +120,18 @@ impl SqliteStore {
     /// Returns an error if the query fails.
     #[tracing::instrument(skip_all, name = "memory.skills.load_skill_usage")]
     pub async fn load_skill_usage(&self) -> Result<Vec<SkillUsageRow>, MemoryError> {
-        let rows: Vec<(String, i64, String)> = zeph_db::query_as(sql!(
-            "SELECT skill_name, invocation_count, last_used_at \
+        // `last_used_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` tuple field below.
+        let last_used_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("last_used_at");
+        let raw = format!(
+            "SELECT skill_name, invocation_count, {last_used_at_sel} \
              FROM skill_usage ORDER BY invocation_count DESC"
-        ))
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<(String, i64, String)> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .fetch_all(&self.pool)
+            .await?;
 
         Ok(rows
             .into_iter()
@@ -411,14 +417,20 @@ impl SqliteStore {
         &self,
         skill_name: &str,
     ) -> Result<Option<SkillVersionRow>, MemoryError> {
-        let row: Option<SkillVersionTuple> = zeph_db::query_as(sql!(
+        // `created_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` tuple field below.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
             "SELECT id, skill_name, version, body, description, source, \
-                 is_active, success_count, failure_count, created_at \
+                 is_active, success_count, failure_count, {created_at_sel} \
                  FROM skill_versions WHERE skill_name = ? AND is_active = TRUE LIMIT 1"
-        ))
-        .bind(skill_name)
-        .fetch_optional(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row: Option<SkillVersionTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(skill_name)
+            .fetch_optional(&self.pool)
+            .await?;
 
         Ok(row.map(skill_version_from_tuple))
     }
@@ -480,14 +492,19 @@ impl SqliteStore {
         &self,
         skill_name: &str,
     ) -> Result<Option<String>, MemoryError> {
-        let row: Option<(String,)> = zeph_db::query_as(sql!(
-            "SELECT created_at FROM skill_versions \
+        // `created_at` is `TIMESTAMPTZ` on Postgres — see `active_skill_version`.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
+            "SELECT {created_at_sel} FROM skill_versions \
              WHERE skill_name = ? AND source = 'auto' \
              ORDER BY id DESC LIMIT 1"
-        ))
-        .bind(skill_name)
-        .fetch_optional(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row: Option<(String,)> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(skill_name)
+            .fetch_optional(&self.pool)
+            .await?;
         Ok(row.map(|r| r.0))
     }
 
@@ -558,14 +575,19 @@ impl SqliteStore {
         &self,
         skill_name: &str,
     ) -> Result<Vec<SkillVersionRow>, MemoryError> {
-        let rows: Vec<SkillVersionTuple> = zeph_db::query_as(sql!(
+        // `created_at` is `TIMESTAMPTZ` on Postgres — see `active_skill_version`.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
             "SELECT id, skill_name, version, body, description, source, \
-                 is_active, success_count, failure_count, created_at \
+                 is_active, success_count, failure_count, {created_at_sel} \
                  FROM skill_versions WHERE skill_name = ? ORDER BY version ASC"
-        ))
-        .bind(skill_name)
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<SkillVersionTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(skill_name)
+            .fetch_all(&self.pool)
+            .await?;
 
         Ok(rows.into_iter().map(skill_version_from_tuple).collect())
     }
@@ -664,14 +686,19 @@ impl SqliteStore {
             return Ok(None);
         };
 
-        let row: Option<SkillVersionTuple> = zeph_db::query_as(sql!(
+        // `created_at` is `TIMESTAMPTZ` on Postgres — see `active_skill_version`.
+        let created_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let raw = format!(
             "SELECT id, skill_name, version, body, description, source, \
-                 is_active, success_count, failure_count, created_at \
+                 is_active, success_count, failure_count, {created_at_sel} \
                  FROM skill_versions WHERE id = ?"
-        ))
-        .bind(pid)
-        .fetch_optional(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row: Option<SkillVersionTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(pid)
+            .fetch_optional(&self.pool)
+            .await?;
 
         Ok(row.map(skill_version_from_tuple))
     }

--- a/crates/zeph-memory/src/store/trajectory.rs
+++ b/crates/zeph-memory/src/store/trajectory.rs
@@ -81,33 +81,43 @@ impl DbStore {
         kind: Option<&str>,
         limit: usize,
     ) -> Result<Vec<TrajectoryEntryRow>, MemoryError> {
-        let rows: Vec<TrajectoryEntryRow> = match kind {
-            Some(k) => {
-                query_as(sql!(
-                    "SELECT id, conversation_id, turn_index, kind, intent, outcome,
-                        tools_used, confidence, created_at, updated_at
-                 FROM trajectory_memory
-                 WHERE kind = ?
-                 ORDER BY confidence DESC, created_at DESC
-                 LIMIT ?"
-                ))
+        // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project
+        // both through `Dialect::select_as_text`, aliased back to their original names so
+        // `#[derive(sqlx::FromRow)]` still binds them into the `String` fields below.
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let updated_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let rows: Vec<TrajectoryEntryRow> = if let Some(k) = kind {
+            let raw = format!(
+                "SELECT id, conversation_id, turn_index, kind, intent, outcome,
+                    tools_used, confidence, {created_at_sel} AS created_at,
+                    {updated_at_sel} AS updated_at
+             FROM trajectory_memory
+             WHERE kind = ?
+             ORDER BY confidence DESC, trajectory_memory.created_at DESC
+             LIMIT ?"
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            query_as(sqlx::AssertSqlSafe(query_sql))
                 .bind(k)
                 .bind(i64::try_from(limit).unwrap_or(i64::MAX))
                 .fetch_all(self.pool())
                 .await?
-            }
-            None => {
-                query_as(sql!(
-                    "SELECT id, conversation_id, turn_index, kind, intent, outcome,
-                        tools_used, confidence, created_at, updated_at
-                 FROM trajectory_memory
-                 ORDER BY confidence DESC, created_at DESC
-                 LIMIT ?"
-                ))
+        } else {
+            let raw = format!(
+                "SELECT id, conversation_id, turn_index, kind, intent, outcome,
+                    tools_used, confidence, {created_at_sel} AS created_at,
+                    {updated_at_sel} AS updated_at
+             FROM trajectory_memory
+             ORDER BY confidence DESC, trajectory_memory.created_at DESC
+             LIMIT ?"
+            );
+            let query_sql = zeph_db::rewrite_placeholders(&raw);
+            query_as(sqlx::AssertSqlSafe(query_sql))
                 .bind(i64::try_from(limit).unwrap_or(i64::MAX))
                 .fetch_all(self.pool())
                 .await?
-            }
         };
 
         Ok(rows)

--- a/crates/zeph-memory/src/store/trajectory.rs
+++ b/crates/zeph-memory/src/store/trajectory.rs
@@ -84,6 +84,8 @@ impl DbStore {
         // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project
         // both through `Dialect::select_as_text`, aliased back to their original names so
         // `#[derive(sqlx::FromRow)]` still binds them into the `String` fields below.
+        // `confidence` is `REAL` (`FLOAT4`) on Postgres but decodes into an `f64` field;
+        // `CAST(... AS DOUBLE PRECISION)` widens it (same idiom used elsewhere in this crate).
         let created_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let updated_at_sel =
@@ -91,8 +93,8 @@ impl DbStore {
         let rows: Vec<TrajectoryEntryRow> = if let Some(k) = kind {
             let raw = format!(
                 "SELECT id, conversation_id, turn_index, kind, intent, outcome,
-                    tools_used, confidence, {created_at_sel} AS created_at,
-                    {updated_at_sel} AS updated_at
+                    tools_used, CAST(confidence AS DOUBLE PRECISION) AS confidence,
+                    {created_at_sel} AS created_at, {updated_at_sel} AS updated_at
              FROM trajectory_memory
              WHERE kind = ?
              ORDER BY confidence DESC, trajectory_memory.created_at DESC
@@ -107,8 +109,8 @@ impl DbStore {
         } else {
             let raw = format!(
                 "SELECT id, conversation_id, turn_index, kind, intent, outcome,
-                    tools_used, confidence, {created_at_sel} AS created_at,
-                    {updated_at_sel} AS updated_at
+                    tools_used, CAST(confidence AS DOUBLE PRECISION) AS confidence,
+                    {created_at_sel} AS created_at, {updated_at_sel} AS updated_at
              FROM trajectory_memory
              ORDER BY confidence DESC, trajectory_memory.created_at DESC
              LIMIT ?"

--- a/crates/zeph-memory/src/store/trust.rs
+++ b/crates/zeph-memory/src/store/trust.rs
@@ -69,6 +69,7 @@ pub struct SkillTrustRow {
     pub requires_trust_check: bool,
 }
 
+// `requires_trust_check` is `INTEGER` (`INT4`) on Postgres, so it decodes as `i32`, not `i64`.
 type TrustTuple = (
     String,
     String,
@@ -78,7 +79,7 @@ type TrustTuple = (
     String,
     String,
     Option<String>,
-    i64,
+    i32,
 );
 
 fn row_from_tuple(t: TrustTuple) -> SkillTrustRow {

--- a/crates/zeph-memory/src/store/trust.rs
+++ b/crates/zeph-memory/src/store/trust.rs
@@ -182,14 +182,20 @@ impl SqliteStore {
         &self,
         skill_name: &str,
     ) -> Result<Option<SkillTrustRow>, MemoryError> {
-        let row: Option<TrustTuple> = zeph_db::query_as(sql!(
+        // `updated_at` is `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project through
+        // `Dialect::select_as_text` so it decodes into the `String` field below.
+        let updated_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let raw = format!(
             "SELECT skill_name, trust_level, source_kind, source_url, source_path, \
-             blake3_hash, updated_at, git_hash, requires_trust_check \
+             blake3_hash, {updated_at_sel}, git_hash, requires_trust_check \
              FROM skill_trust WHERE skill_name = ?"
-        ))
-        .bind(skill_name)
-        .fetch_optional(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row: Option<TrustTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .bind(skill_name)
+            .fetch_optional(&self.pool)
+            .await?;
         Ok(row.map(row_from_tuple))
     }
 
@@ -200,13 +206,18 @@ impl SqliteStore {
     /// Returns an error if the query fails.
     #[tracing::instrument(name = "memory.trust.load_all", skip_all)]
     pub async fn load_all_skill_trust(&self) -> Result<Vec<SkillTrustRow>, MemoryError> {
-        let rows: Vec<TrustTuple> = zeph_db::query_as(sql!(
+        // `updated_at` is `TIMESTAMPTZ` on Postgres — see `load_skill_trust`.
+        let updated_at_sel =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let raw = format!(
             "SELECT skill_name, trust_level, source_kind, source_url, source_path, \
-             blake3_hash, updated_at, git_hash, requires_trust_check \
+             blake3_hash, {updated_at_sel}, git_hash, requires_trust_check \
              FROM skill_trust ORDER BY skill_name"
-        ))
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows: Vec<TrustTuple> = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows.into_iter().map(row_from_tuple).collect())
     }
 

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -86,12 +86,16 @@ mod pg {
     use zeph_memory::graph::implicit_conflict;
     use zeph_memory::graph::store::GraphStore;
     use zeph_memory::graph::types::{EdgeType, EntityType};
+    use zeph_memory::store::admission_training::AdmissionTrainingInput;
     use zeph_memory::store::{
         AcpSessionConfigSnapshot, AgentSessionRow, SessionChannel, SessionKind, SessionStatus,
         SqliteStore,
     };
     use zeph_memory::types::MessageId;
-    use zeph_memory::{VectorStore, episodic_consolidation, episodic_graph, snapshot};
+    use zeph_memory::{
+        NewExperimentResult, RetrievalFailureRecord, RetrievalFailureType, VectorStore,
+        episodic_consolidation, episodic_graph, snapshot,
+    };
 
     // Generous startup timeout: under concurrent CI load (see #5546/#5547), the
     // default 60s can elapse before Postgres is ready, and testcontainers-rs 0.27.3
@@ -890,6 +894,29 @@ mod pg {
         let cid = store.create_conversation().await.unwrap();
         let m1 = store.save_message(cid, "user", "a").await.unwrap();
         let m2 = store.save_message(cid, "user", "b").await.unwrap();
+        let m3 = store.save_message(cid, "user", "c").await.unwrap();
+
+        // Promote all three to the semantic tier so `find_unscened_semantic_messages`
+        // (#5544's fix target) can see them.
+        for id in [m1, m2, m3] {
+            sqlx::query(zeph_db::sql!(
+                "UPDATE messages SET tier = 'semantic' WHERE id = ?"
+            ))
+            .bind(id.0)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Bound `LIMIT ?` exercises the exact placeholder-rewrite path #5544 fixes: the
+        // function previously passed a raw string straight to `query_as`, bypassing
+        // `sql!()`'s rewrite of `?` to Postgres's `$1`.
+        let unscened = store.find_unscened_semantic_messages(2).await.unwrap();
+        assert_eq!(
+            unscened.len(),
+            2,
+            "LIMIT bind must be honored under Postgres"
+        );
 
         let scene_id = store
             .insert_mem_scene("label", "profile", &[m1, m2])
@@ -904,6 +931,11 @@ mod pg {
         .await
         .unwrap();
         assert_eq!(member_count, 2, "both members must be linked to the scene");
+
+        // After assigning m1/m2 to a scene, only m3 remains unscened.
+        let remaining = store.find_unscened_semantic_messages(100).await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].0, m3);
     }
 
     // ── acp_sessions: create (Pattern B) ─────────────────────────────────────────
@@ -1865,5 +1897,252 @@ mod pg {
             expires_epoch > now_epoch,
             "newly acquired lock must expire in the future (TTL applied via NOW() + INTERVAL)"
         );
+    }
+
+    // ── Regression coverage for #5538: TIMESTAMPTZ->String decode defect + the paired
+    // TIMESTAMPTZ_CAST-on-bind defect, found during a full-crate dialect sweep. Each test
+    // below exercises a call site that decodes a `TIMESTAMPTZ` column into a `String` field
+    // and/or binds a Rust-formatted timestamp string against one, neither of which had
+    // Postgres coverage before. ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn graph_store_edges_at_timestamp_filters_and_decodes() {
+        let (pool, _container) = start_pg().await;
+        let graph = GraphStore::new(pool.clone());
+
+        let a = graph
+            .upsert_entity("Alice", "alice", EntityType::Person, None, None)
+            .await
+            .unwrap();
+        let b = graph
+            .upsert_entity("Bob", "bob", EntityType::Person, None, None)
+            .await
+            .unwrap();
+        graph
+            .insert_edge(a.0, b.0, "knows", "Alice knows Bob", 0.5, None, None)
+            .await
+            .unwrap();
+
+        // A future timestamp must still find the still-active edge (valid_to IS NULL),
+        // exercising both the `TIMESTAMPTZ_CAST` bind and the `EdgeRow` decode together.
+        let edges = graph
+            .edges_at_timestamp(a.0, "2099-01-01 00:00:00")
+            .await
+            .unwrap();
+        assert_eq!(
+            edges.len(),
+            1,
+            "active edge must be found at a future timestamp"
+        );
+        assert_eq!(edges[0].fact, "Alice knows Bob");
+        assert!(
+            !edges[0].valid_from.is_empty(),
+            "valid_from must decode to a non-empty string"
+        );
+
+        // A timestamp before the edge existed must find nothing.
+        let edges_before = graph
+            .edges_at_timestamp(a.0, "2000-01-01 00:00:00")
+            .await
+            .unwrap();
+        assert!(
+            edges_before.is_empty(),
+            "edge must not be valid before its valid_from"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn graph_store_communities_decode_timestamps() {
+        let (pool, _container) = start_pg().await;
+        let graph = GraphStore::new(pool.clone());
+
+        let a = graph
+            .upsert_entity("Alice", "alice", EntityType::Person, None, None)
+            .await
+            .unwrap();
+        let community_id = graph
+            .upsert_community("team-a", "Alice's team", &[a.0], None)
+            .await
+            .unwrap();
+
+        let all = graph.all_communities().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert!(
+            !all[0].created_at.is_empty() && !all[0].updated_at.is_empty(),
+            "created_at/updated_at must decode to non-empty strings"
+        );
+
+        let found = graph
+            .find_community_by_id(community_id)
+            .await
+            .unwrap()
+            .expect("community must be found by id");
+        assert_eq!(found.name, "team-a");
+        assert!(!found.created_at.is_empty() && !found.updated_at.is_empty());
+    }
+
+    // `experiments::experiment_results_since`/`list_experiment_results`/`best_experiment_result`
+    // and `admission_training::get_training_batch` were also fixed for the `TIMESTAMPTZ`->
+    // `String` decode defect, but a co-located, pre-existing column type mismatch
+    // (`experiment_results.latency_ms`/`tokens_used` are `INTEGER`/`INT4` vs. the tuple's `i64`;
+    // `admission_training_data.composite_score` is `REAL`/`FLOAT4` vs. the tuple's `f64`) made
+    // that fix unreachable on Postgres until the co-located `CAST(... AS BIGINT)`/
+    // `CAST(... AS DOUBLE PRECISION)` casts below were folded in. These tests exercise both the
+    // `TIMESTAMPTZ` decode/bind-cast and the widening casts together.
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn experiments_list_best_and_since_decode_on_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        store
+            .insert_experiment_result(&NewExperimentResult {
+                session_id: "sess-1",
+                parameter: "temperature",
+                value_json: r#"{"type":"Float","value":0.7}"#,
+                baseline_score: 7.0,
+                candidate_score: 8.0,
+                delta: 1.0,
+                latency_ms: 500,
+                tokens_used: 100,
+                accepted: true,
+                source: "manual",
+            })
+            .await
+            .unwrap();
+
+        let listed = store
+            .list_experiment_results(Some("sess-1"), 10)
+            .await
+            .unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].latency_ms, 500);
+        assert_eq!(listed[0].tokens_used, 100);
+        assert!(!listed[0].created_at.is_empty());
+
+        let best = store.best_experiment_result(None).await.unwrap().unwrap();
+        assert_eq!(best.latency_ms, 500);
+        assert_eq!(best.tokens_used, 100);
+
+        let since = store
+            .experiment_results_since("2000-01-01 00:00:00")
+            .await
+            .unwrap();
+        assert_eq!(since.len(), 1);
+        assert_eq!(since[0].tokens_used, 100);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn admission_training_get_training_batch_decodes_on_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+        let cid = store.create_conversation().await.unwrap();
+
+        store
+            .record_admission_training(AdmissionTrainingInput {
+                message_id: None,
+                conversation_id: cid,
+                content: "content",
+                role: "user",
+                composite_score: 0.5,
+                was_admitted: false,
+                features_json: "[]",
+            })
+            .await
+            .unwrap();
+
+        let batch = store.get_training_batch(10).await.unwrap();
+        assert_eq!(batch.len(), 1);
+        assert!((batch[0].composite_score - 0.5).abs() < 1e-6);
+        assert!(!batch[0].created_at.is_empty());
+    }
+
+    // ── retrieval_failures: bind-cast DELETE (#5538) ────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn retrieval_failures_purge_old_deletes_by_timestamptz_cutoff() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool.clone());
+
+        store
+            .record_retrieval_failure(&RetrievalFailureRecord {
+                conversation_id: None,
+                turn_index: 0,
+                failure_type: RetrievalFailureType::NoHit,
+                retrieval_strategy: "semantic".to_owned(),
+                query_text: "query".to_owned(),
+                query_len: 5,
+                top_score: None,
+                confidence_threshold: None,
+                result_count: 0,
+                latency_ms: 10,
+                edge_types: None,
+                error_context: None,
+            })
+            .await
+            .unwrap();
+
+        // Backdate `created_at` well past any retention window so the bind-cast DELETE
+        // (`WHERE created_at < ?::timestamptz`) actually matches the row.
+        sqlx::query(zeph_db::sql!(
+            "UPDATE memory_retrieval_failures SET created_at = NOW() - INTERVAL '30 days'"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let deleted = store.purge_old_retrieval_failures(7).await.unwrap();
+        assert_eq!(
+            deleted, 1,
+            "row older than the retention cutoff must be purged"
+        );
+    }
+
+    // ── persona: `AS`-alias `#[derive(FromRow)]` projection (#5538) ─────────────
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn persona_load_facts_decodes_timestamptz_columns() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        store
+            .upsert_persona_fact("preference", "prefers dark mode", 0.9, None, None)
+            .await
+            .unwrap();
+
+        let facts = store.load_persona_facts(0.0).await.unwrap();
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].content, "prefers dark mode");
+        assert!(!facts[0].created_at.is_empty());
+        assert!(!facts[0].updated_at.is_empty());
+    }
+
+    // ── skills: tuple-decode cluster (#5538) ─────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn skills_load_versions_decodes_timestamptz_column() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        let v1 = store
+            .save_skill_version("git", 1, "body v1", "Git helper", "manual", None, None)
+            .await
+            .unwrap();
+        store.activate_skill_version("git", v1).await.unwrap();
+
+        let versions = store.load_skill_versions("git").await.unwrap();
+        assert_eq!(versions.len(), 1);
+        assert!(versions[0].is_active);
+        assert!(!versions[0].created_at.is_empty());
+
+        let active = store.active_skill_version("git").await.unwrap().unwrap();
+        assert_eq!(active.id, v1);
+        assert!(!active.created_at.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Full-crate sweep for the `TIMESTAMPTZ`->`String` decode defect (#5538), same class as #5524/#5527/#5525. The issue estimated ~15 sites; the real count is ~50 across 15 files. Extends `Dialect::select_as_text` (and, where a Rust-formatted timestamp is bound against a `TIMESTAMPTZ` column, `Dialect::TIMESTAMPTZ_CAST`) to every previously-unfixed site in `store/{corrections,trust,preferences,persona,trajectory,session_digest,compression_guidelines,experiments,admission_training,memory_tree,skills,retrieval_failures}.rs`, `store/messages/mod.rs::get_eviction_candidates`, and the bulk of `graph/store/mod.rs`'s entity/edge/community/alias/episode queries. Three new shared `*_select_cols()` helpers in `graph/store/mod.rs` replace ~20 duplicated inline column-list strings (this DRY violation was itself likely why several sites were missed in earlier partial sweeps).
- `experiments.rs`'s 3 result-listing functions and `admission_training.rs::get_training_batch` also needed co-located `CAST(... AS BIGINT)`/`CAST(... AS DOUBLE PRECISION)` casts for `latency_ms`/`tokens_used`/`composite_score` (`INT4`/`FLOAT4` on Postgres vs. `i64`/`f64` in the Rust tuple) — an adversarial critique pass caught that without these casts, the `TIMESTAMPTZ` fix in those 4 functions would have shipped as untested dead code on Postgres (query still fails, just on the next column).
- Fixes `store/mem_scenes.rs::find_unscened_semantic_messages` (#5544), which passed a raw string literal to `zeph_db::query_as` instead of `sql!()`, so its bound `LIMIT` was never rewritten from `?` to Postgres's `$N` placeholder syntax.
- Two incidental fixes of the same class (dynamic queries built via `format!()` that never called `rewrite_placeholders`) surfaced and fixed while touching `graph/store/mod.rs::edges_for_entity`/`find_entity_by_name` for the timestamp fix.

## Out of scope (flagged, not fixed here)

- `graph/store/mod.rs::community_for_entity`/`find_entities_fuzzy` use `json_each()` (SQLite-only; needs `jsonb_array_elements_text` on Postgres) — pre-existing, unrelated gap.
- `store/messages/mod.rs::replace_conversation`/`apply_tool_pair_summaries` bind a raw epoch-seconds string into `messages.compacted_at` (`TIMESTAMPTZ`) — a write-path defect distinct from the read-path decode issue this PR fixes; Postgres's timestamptz parser rejects a bare epoch-seconds string even with a cast, so this needs a new `zeph-db` dialect primitive that doesn't exist yet. Will file as a follow-up issue.
- Two pre-existing, unrelated Postgres column-type mismatches were found while testing (`admission_training_data.composite_score` is `FLOAT4` vs. Rust `f64`; `experiment_results.latency_ms`/`tokens_used` are `INT4` vs. Rust `i64` — same defect family as this PR, different type pair) — the co-located ones in this PR's touched functions were fixed directly (see above); will file a follow-up issue if any related sites remain outside this PR's scope.

## Known verification gap — please re-run before merge

**Docker/testcontainers was unreachable for this entire PR's development** (a sandbox disk-full incident crashed Docker Desktop; a restart was attempted but did not recover within the session). As a result, **none of the 39 tests in `crates/zeph-memory/tests/postgres_integration.rs`** (32 pre-existing + 7 new/modified by this PR) were executed against a real Postgres instance. All new/modified tests compile cleanly (`cargo check --tests --features test-utils --test postgres_integration` passes) and were reviewed for correctness by an adversarial critique pass and a full code review, but they are **functionally unverified**.

Please run this before merging:
```
cargo nextest run -p zeph-memory --features test-utils --test postgres_integration --run-ignored ignored-only
```
Expected: 39 passed (32 baseline + 7 new/modified: `mem_scenes_insert_links_all_members` extended for #5544, `retrieval_failures_purge_old_deletes_by_timestamptz_cutoff`, `persona_load_facts_decodes_timestamptz_columns`, `skills_load_versions_decodes_timestamptz_column`, `experiments_list_best_and_since_decode_on_postgres`, `admission_training_get_training_batch_decodes_on_postgres`, and the fix to `mem_scenes.rs` itself).

## Test plan

- [x] `cargo +nightly fmt --check -p zeph-memory`
- [x] `cargo clippy --profile ci -p zeph-memory --all-targets --features postgres -- -D warnings`
- [x] `cargo clippy --profile ci -p zeph-memory --all-targets -- -D warnings` (sqlite/default)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory` (1531 passed, 27 skipped, no regressions)
- [x] `cargo test --doc -p zeph-memory` (51 passed)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-memory`
- [ ] `cargo nextest run -p zeph-memory --features test-utils --test postgres_integration --run-ignored ignored-only` — **blocked by environment (Docker unreachable), please run before merge**