### PR TITLE
fix(acp): wire provider_names into build_agent_state so providers/list is no longer empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -586,6 +586,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   following the switch. Re-checks `apply_provider_override()` at the start of
   `process_user_message()`, the single call site every turn-dispatch branch funnels through, so a
   switch written mid-wait is picked up for the very next turn it affects. Closes #5548.
+- `fix(acp)`: ACP `providers/list` (the `unstable-llm-providers` ext surface) no longer always
+  returns an empty array regardless of configured `[[llm.providers]]` entries (#5448). Root cause:
+  `AcpServerConfig` had no `provider_names` field, so `build_agent_state` (the shared constructor
+  for both the stdio and HTTP ACP transports) had nothing to plumb into
+  `ZephAcpAgentState::with_provider_names(...)`. Added the field (gated
+  `#[cfg(feature = "unstable-llm-providers")]`, matching the existing gate on
+  `ZephAcpAgentState::provider_names`) and a new `acp_provider_names()` helper in `src/acp.rs`
+  that derives `(name, protocol)` pairs from `config.llm.providers` — the same source of truth
+  already used by `build_acp_provider_factory` and `discover_models_from_config`, so the
+  advertised provider identity always matches what model switching already exposes. The root
+  `acp` Cargo feature now also forwards `zeph-acp/unstable-llm-providers` explicitly, instead of
+  relying on it happening to sit in `zeph-acp`'s default feature set.
+
+  Note: a related issue, #5556 (`ElicitationBridge::elicit()` has zero call sites, making ACP
+  elicitation structurally unreachable), was investigated in the same pass and found to be an
+  architectural gap rather than a wiring fix — a shared, take-once MCP elicitation receiver would
+  cross-wire concurrent ACP sessions' elicitation prompts if wired naively. Descoped from this fix
+  pending a dedicated design pass; findings recorded on the issue.
+
 - `fix(memory)`: clarify that `[memory.admission] admission_strategy = "rl"` is not silently a
   no-op (#5543) — `src/bootstrap/mod.rs::build_admission_control` already emits a startup
   `tracing::warn!` when this variant is selected (added by #2485 for #2416, predating this issue),

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,7 +223,7 @@ bench      = ["dep:zeph-bench"]
 # === Individual feature flags ===
 deep-link = ["zeph-common/deep-link", "zeph-config/deep-link"]
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server", "zeph-a2a?/ibct"]
-acp = ["dep:zeph-acp", "zeph-acp/unstable-session-delete", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-logout", "zeph-acp/unstable-auth-methods", "zeph-acp/unstable-message-id", "zeph-acp/unstable-session-add-dirs"]
+acp = ["dep:zeph-acp", "zeph-acp/unstable-session-delete", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-llm-providers", "zeph-acp/unstable-logout", "zeph-acp/unstable-auth-methods", "zeph-acp/unstable-message-id", "zeph-acp/unstable-session-add-dirs"]
 acp-http = ["acp", "dep:axum", "zeph-acp/acp-http"]
 candle = ["zeph-llm/candle", "zeph-core/candle"]
 classifiers = ["candle", "zeph-llm/classifiers", "zeph-sanitizer/classifiers", "zeph-core/classifiers"]

--- a/crates/zeph-acp/src/lib.rs
+++ b/crates/zeph-acp/src/lib.rs
@@ -98,3 +98,7 @@ pub use transport::{AcpServerConfig, serve_connection, serve_stdio};
 pub use agent::SendAgentSpawner;
 #[cfg(feature = "acp-http")]
 pub use transport::{AcpHttpState, acp_router};
+
+/// Wire protocol type for an LLM provider, used to populate [`AcpServerConfig::provider_names`].
+#[cfg(feature = "unstable-llm-providers")]
+pub use agent_client_protocol_schema::v1::LlmProtocol;

--- a/crates/zeph-acp/src/transport/mod.rs
+++ b/crates/zeph-acp/src/transport/mod.rs
@@ -95,6 +95,11 @@ pub struct AcpServerConfig {
     pub provider_factory: Option<crate::agent::ProviderFactory>,
     /// Available model identifiers to advertise in `new_session` `config_options`.
     pub available_models: SharedAvailableModels,
+    /// Provider name + protocol pairs from `[[llm.providers]]`, advertised via `providers/list`.
+    ///
+    /// Vault-resolved API keys are never passed here — only the public routing identity.
+    #[cfg(feature = "unstable-llm-providers")]
+    pub provider_names: Vec<(String, agent_client_protocol_schema::v1::LlmProtocol)>,
     /// Optional shared MCP manager for `ext_method` add/remove/list.
     pub mcp_manager: Option<std::sync::Arc<zeph_mcp::McpManager>>,
     /// Bearer token for HTTP and WebSocket transport authentication.
@@ -148,6 +153,8 @@ impl Clone for AcpServerConfig {
             permission_file: self.permission_file.clone(),
             provider_factory: self.provider_factory.clone(),
             available_models: self.available_models.clone(),
+            #[cfg(feature = "unstable-llm-providers")]
+            provider_names: self.provider_names.clone(),
             mcp_manager: self.mcp_manager.clone(),
             auth_bearer_token: self.auth_bearer_token.clone(),
             discovery_enabled: self.discovery_enabled,
@@ -177,6 +184,8 @@ impl Default for AcpServerConfig {
             permission_file: None,
             provider_factory: None,
             available_models: std::sync::Arc::new(parking_lot::RwLock::new(Vec::new())),
+            #[cfg(feature = "unstable-llm-providers")]
+            provider_names: Vec::new(),
             mcp_manager: None,
             auth_bearer_token: None,
             discovery_enabled: true,

--- a/crates/zeph-acp/src/transport/stdio.rs
+++ b/crates/zeph-acp/src/transport/stdio.rs
@@ -97,6 +97,10 @@ pub(crate) async fn build_agent_state(
     if let Some(factory) = server_config.provider_factory {
         agent = agent.with_provider_factory(factory, server_config.available_models);
     }
+    #[cfg(feature = "unstable-llm-providers")]
+    {
+        agent = agent.with_provider_names(server_config.provider_names);
+    }
     if let Some(manager) = server_config.mcp_manager {
         agent = agent.with_mcp_manager(manager);
     }

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -98,6 +98,24 @@ fn test_config_with_models(name: &str, models: Vec<&str>) -> AcpServerConfig {
     }
 }
 
+/// Server config with provider identities for `providers/list` coverage (#5448).
+#[cfg(feature = "unstable-llm-providers")]
+fn test_config_with_provider_names(
+    name: &str,
+    providers: Vec<(&str, zeph_acp::LlmProtocol)>,
+) -> AcpServerConfig {
+    AcpServerConfig {
+        agent_name: name.to_owned(),
+        agent_version: "0.0.1".to_owned(),
+        max_sessions: 8,
+        provider_names: providers
+            .into_iter()
+            .map(|(n, p)| (n.to_owned(), p))
+            .collect(),
+        ..AcpServerConfig::default()
+    }
+}
+
 /// Creates an in-process duplex transport pair.
 /// Returns `(server_writer, server_reader, client_writer, client_reader)`.
 fn duplex_pair() -> (
@@ -269,6 +287,53 @@ async fn unknown_ext_method_returns_null() {
                 res = server_fut => panic!("server exited before client: {res:?}"),
                 result = client_fut => {
                     assert!(result.is_ok(), "ext_method failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// #5448 regression: `providers/list` must reflect `AcpServerConfig::provider_names` as wired
+/// through `build_agent_state`, not always return an empty array.
+#[cfg(feature = "unstable-llm-providers")]
+#[tokio::test(flavor = "current_thread")]
+async fn providers_list_reflects_configured_provider_names() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (sw, sr, cw, cr) = duplex_pair();
+            let config = test_config_with_provider_names(
+                "test-agent",
+                vec![("openai", zeph_acp::LlmProtocol::OpenAi)],
+            );
+            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let raw_params =
+                    Arc::from(serde_json::value::RawValue::from_string("{}".to_owned()).unwrap());
+                let resp = cx
+                    .send_request(acp::schema::v1::ClientRequest::ExtMethodRequest(
+                        acp::schema::v1::ExtRequest::new("providers/list", raw_params),
+                    ))
+                    .block_task()
+                    .await?;
+
+                let body = resp.to_string();
+                assert!(
+                    body.contains("openai"),
+                    "providers/list must include the configured provider name, got: {body}"
+                );
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "providers/list ext_method failed: {result:?}");
                 }
             }
         })

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -190,6 +190,8 @@ struct SharedAgentDeps {
     /// Pre-built provider factory for ACP model switching.
     #[cfg(feature = "acp")]
     acp_provider_factory: Option<zeph_acp::ProviderFactory>,
+    /// Provider name + protocol pairs advertised via `providers/list` (#5448).
+    acp_provider_names: Vec<(String, zeph_acp::LlmProtocol)>,
     /// Project rule file paths to advertise in session `_meta`.
     acp_project_rules: Vec<PathBuf>,
     /// Allowlist of directories ACP clients may reference in session requests.
@@ -715,6 +717,7 @@ async fn build_acp_deps(
         },
         sqlite_path: crate::db_url::resolve_db_url(config).to_owned(),
         acp_provider_factory: Some(build_acp_provider_factory(config, app.secret_registry())),
+        acp_provider_names: acp_provider_names(config),
         acp_project_rules,
         acp_additional_directories: config.acp.additional_directories.clone(),
         acp_auth_methods: config.acp.auth_methods.clone(),
@@ -1531,6 +1534,29 @@ fn build_acp_provider_factory(
     })
 }
 
+/// Build the `(name, protocol)` list advertised via ACP `providers/list` (#5448).
+///
+/// Reuses the same `config.llm.providers` source of truth as [`build_acp_provider_factory`]
+/// and `discover_models_from_config`, so the advertised identity always matches the providers
+/// actually wired for model switching. Vault-resolved API keys are never included.
+#[cfg(feature = "acp")]
+fn acp_provider_names(config: &zeph_core::config::Config) -> Vec<(String, zeph_acp::LlmProtocol)> {
+    config
+        .llm
+        .providers
+        .iter()
+        .map(|entry| {
+            let protocol = match entry.provider_type {
+                zeph_core::config::ProviderKind::Claude => zeph_acp::LlmProtocol::Anthropic,
+                zeph_core::config::ProviderKind::OpenAi
+                | zeph_core::config::ProviderKind::Compatible => zeph_acp::LlmProtocol::OpenAi,
+                other => zeph_acp::LlmProtocol::Other(other.as_str().to_owned()),
+            };
+            (entry.effective_name(), protocol)
+        })
+        .collect()
+}
+
 /// Collect project rule file paths from `.claude/rules/*.md` and skill files.
 ///
 /// Rule files are resolved relative to the current working directory.
@@ -1637,6 +1663,7 @@ pub(crate) async fn run_acp_server(
         permission_file: deps.acp_permission_file.clone(),
         provider_factory: deps.acp_provider_factory.take(),
         available_models: std::sync::Arc::clone(&deps.acp_available_models),
+        provider_names: deps.acp_provider_names.clone(),
         mcp_manager: Some(mcp_manager_for_acp),
         auth_bearer_token: deps.acp_auth_bearer_token.clone(),
         discovery_enabled: deps.acp_discovery_enabled,
@@ -1718,6 +1745,7 @@ pub(crate) async fn run_acp_http_server(
                 app.config().acp.available_models.clone()
             },
         )),
+        provider_names: acp_provider_names(app.config()),
         mcp_manager: Some(Arc::clone(&mcp_manager_for_acp)),
         auth_bearer_token,
         discovery_enabled: app.config().acp.discovery_enabled,
@@ -1927,6 +1955,56 @@ mod tests {
             !matches!(provider, zeph_llm::any::AnyProvider::Masked(_)),
             "no registry supplied — factory output must be a plain passthrough"
         );
+    }
+
+    /// #5448 review follow-up: `acp_provider_names()` had zero direct test coverage — the
+    /// integration test only exercises a manually-constructed `LlmProtocol`, never these match arms.
+    #[test]
+    fn acp_provider_names_maps_known_protocols() {
+        let mut config = zeph_core::config::Config::default();
+        config.llm.providers = vec![
+            zeph_core::config::ProviderEntry {
+                provider_type: zeph_core::config::ProviderKind::Claude,
+                name: Some("claude".into()),
+                ..zeph_core::config::ProviderEntry::default()
+            },
+            zeph_core::config::ProviderEntry {
+                provider_type: zeph_core::config::ProviderKind::OpenAi,
+                name: Some("openai".into()),
+                ..zeph_core::config::ProviderEntry::default()
+            },
+            zeph_core::config::ProviderEntry {
+                provider_type: zeph_core::config::ProviderKind::Compatible,
+                name: Some("compat".into()),
+                ..zeph_core::config::ProviderEntry::default()
+            },
+            zeph_core::config::ProviderEntry {
+                provider_type: zeph_core::config::ProviderKind::Ollama,
+                name: Some("ollama".into()),
+                ..zeph_core::config::ProviderEntry::default()
+            },
+        ];
+
+        let names = acp_provider_names(&config);
+
+        assert_eq!(
+            names,
+            vec![
+                ("claude".to_owned(), zeph_acp::LlmProtocol::Anthropic),
+                ("openai".to_owned(), zeph_acp::LlmProtocol::OpenAi),
+                ("compat".to_owned(), zeph_acp::LlmProtocol::OpenAi),
+                (
+                    "ollama".to_owned(),
+                    zeph_acp::LlmProtocol::Other("ollama".to_owned())
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn acp_provider_names_empty_providers_returns_empty_vec() {
+        let config = zeph_core::config::Config::default();
+        assert!(acp_provider_names(&config).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #5448: ACP `providers/list` always returned `{"providers": []}` regardless of configured `[[llm.providers]]` entries. `AcpServerConfig` had no `provider_names` field, so `build_agent_state` (the shared constructor for both stdio and HTTP ACP transports) never called `ZephAcpAgentState::with_provider_names(...)`.
- Adds `acp_provider_names()` in `src/acp.rs`, deriving `(name, protocol)` pairs from `config.llm.providers` — the same source of truth already used by `build_acp_provider_factory`, so the advertised provider identity always matches what model switching already exposes.
- Forwards `zeph-acp/unstable-llm-providers` explicitly from the root `acp` Cargo feature instead of relying on it sitting in `zeph-acp`'s default feature set (review-requested robustness fix).
- Adds a real regression test (`providers_list_reflects_configured_provider_names`) that drives the actual JSON-RPC stack, plus unit tests for the `ProviderKind`→`LlmProtocol` mapping.

## #5556 (descoped)

A second issue, #5556 (`ElicitationBridge::elicit()` has zero call sites), was investigated in the same pass. It turned out to be an architectural gap rather than a mechanical wiring fix — a shared, take-once MCP elicitation receiver would cross-wire concurrent ACP sessions' elicitation prompts if wired naively, among other gaps. No code changed here for #5556; findings were posted as a comment on that issue and it was tagged `arch` for a dedicated design pass. Not closed by this PR.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11843 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-acp`
- [x] New regression test verified to exercise the previously-broken path (both stdio and HTTP transports covered via the shared `build_agent_state` constructor)
- [x] Security-reviewed: `acp_provider_names()` reads only `effective_name()` + `provider_type`, never vault-resolved key material