### PR TITLE
fix(memory): reactivate three dormant write paths in zeph-memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,6 +604,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   architectural gap rather than a wiring fix — a shared, take-once MCP elicitation receiver would
   cross-wire concurrent ACP sessions' elicitation prompts if wired naively. Descoped from this fix
   pending a dedicated design pass; findings recorded on the issue.
+- `fix(memory)`: three dormant write paths in `zeph-memory` reactivated (#5555, #5539, #5533).
+
+  - **#5555** — `AdmissionControl::evaluate()`'s decisions were never persisted via
+    `SqliteStore::record_admission_training`, so the RL admission training table
+    (`admission_training_data`) stayed empty in production regardless of `admission_strategy`
+    — the prerequisite data collection for #2416/#5543's `Rl` scorer effort was scaffolding with
+    no caller. `SemanticMemory::remember`/`remember_with_parts`/`remember_tool_output`/
+    `remember_categorized` (`crates/zeph-memory/src/semantic/recall.rs`) now record every A-MAC
+    decision — admitted and rejected, including messages later dropped by the post-admission
+    quality gate — via a new best-effort `record_admission_sample` helper, avoiding survivorship
+    bias per the module's own design intent. Failures are logged at debug level and never
+    propagated, matching the existing `mark_training_recalled` fire-and-forget pattern already on
+    this path.
+  - **#5539** — `EntityLockManager::extend_lock` (`crates/zeph-memory/src/graph/entity_lock.rs`)
+    used `SQLite`-only `datetime(expires_at, ? || ' seconds')` to offset the stored `expires_at`
+    column, which has no `PostgreSQL` equivalent (`expires_at` is `TIMESTAMPTZ` there) — the
+    method would fail at runtime under the `postgres` feature. Split into a dialect-selected
+    expression (`expires_at + INTERVAL '1 second' * ?` on `PostgreSQL`), mirroring the pattern
+    already used by the sibling `try_acquire_once` method in the same file (PR #5537).
+  - **#5533** — `MemoryFacade::compact` for `SemanticMemory`
+    (`crates/zeph-memory/src/facade.rs`) reported `messages_compacted` as the *total* message
+    count fetched before summarization ran, not the number of messages `summarize()` actually
+    folded into the new summary — overcounting whenever the unsummarized range was smaller than
+    the conversation, and reporting a nonzero count even when `summarize()` was a no-op.
+    `SemanticMemory::summarize` (`crates/zeph-memory/src/semantic/summarization.rs`) now returns
+    a `SummarizeOutcome { summary_id, messages_folded }` instead of a bare summary id, and
+    `compact` derives `messages_compacted` from `messages_folded` (`0` when summarization is a
+    no-op). Updates the one other production caller
+    (`zeph_core::agent::persistence::store::enqueue_summarization_task`).
 
 - `fix(memory)`: clarify that `[memory.admission] admission_strategy = "rl"` is not silently a
   no-op (#5543) — `src/bootstrap/mod.rs::build_admission_control` already emits a startup

--- a/crates/zeph-core/src/agent/persistence/store.rs
+++ b/crates/zeph-core/src/agent/persistence/store.rs
@@ -197,32 +197,38 @@ impl<C: Channel> Agent<C> {
 
         let batch_size = self.services.memory.compaction.summarization_threshold / 2;
 
-        self.runtime.lifecycle.supervisor.spawn_summarization("summarization", async move {
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(30),
-                memory.summarize(cid, batch_size),
-            )
-            .await
-            {
-                Ok(Ok(Some(summary_id))) => {
-                    tracing::info!(
-                        "background summarization: created summary {summary_id} for conversation {cid}"
-                    );
-                    true
+        self.runtime
+            .lifecycle
+            .supervisor
+            .spawn_summarization("summarization", async move {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    memory.summarize(cid, batch_size),
+                )
+                .await
+                {
+                    Ok(Ok(Some(outcome))) => {
+                        tracing::info!(
+                            "background summarization: created summary {} for conversation {cid} \
+                         ({} messages folded)",
+                            outcome.summary_id,
+                            outcome.messages_folded
+                        );
+                        true
+                    }
+                    Ok(Ok(None)) => {
+                        tracing::debug!("background summarization: no summarization needed");
+                        false
+                    }
+                    Ok(Err(e)) => {
+                        tracing::error!("background summarization failed: {e:#}");
+                        false
+                    }
+                    Err(_) => {
+                        tracing::warn!("background summarization timed out after 30s");
+                        false
+                    }
                 }
-                Ok(Ok(None)) => {
-                    tracing::debug!("background summarization: no summarization needed");
-                    false
-                }
-                Ok(Err(e)) => {
-                    tracing::error!("background summarization failed: {e:#}");
-                    false
-                }
-                Err(_) => {
-                    tracing::warn!("background summarization timed out after 30s");
-                    false
-                }
-            }
-        });
+            });
     }
 }

--- a/crates/zeph-memory/src/facade.rs
+++ b/crates/zeph-memory/src/facade.rs
@@ -356,14 +356,13 @@ impl MemoryFacade for crate::semantic::SemanticMemory {
 
     #[tracing::instrument(name = "memory.facade.compact", skip_all)]
     async fn compact(&self, ctx: &CompactionContext) -> Result<CompactionResult, MemoryError> {
-        let before = self.message_count(ctx.conversation_id).await?;
-        let messages_compacted = usize::try_from(before).unwrap_or(0);
         // Trigger a summarization pass to reduce context below the token budget.
         // The message_count parameter drives how many messages to summarize at once.
         // Approximate: 4 chars per token; produce a target message count that
         // keeps the resulting context under the token budget.
         let target_msgs = ctx.token_budget.checked_div(4).unwrap_or(512);
-        let _ = self.summarize(ctx.conversation_id, target_msgs).await?;
+        let outcome = self.summarize(ctx.conversation_id, target_msgs).await?;
+        let messages_compacted = outcome.map_or(0, |o| o.messages_folded);
         let summary = self
             .load_summaries(ctx.conversation_id)
             .await?

--- a/crates/zeph-memory/src/graph/entity_lock.rs
+++ b/crates/zeph-memory/src/graph/entity_lock.rs
@@ -132,17 +132,28 @@ impl EntityLockManager {
         entity_name: &str,
         extra_secs: i64,
     ) -> Result<bool, MemoryError> {
-        let affected = query(sql!(
+        // Offsets the stored `expires_at` column value (not `'now'`), so this needs the same
+        // dialect split as `try_acquire_once`'s `expires_at_expr`: `SQLite`'s
+        // `datetime(expires_at, ? || ' seconds')` has no `PostgreSQL` equivalent — `expires_at`
+        // is `TIMESTAMPTZ` there and `datetime()` does not exist.
+        let expires_at_expr = if cfg!(feature = "postgres") {
+            "expires_at + INTERVAL '1 second' * ?"
+        } else {
+            "datetime(expires_at, ? || ' seconds')"
+        };
+        let raw = format!(
             "UPDATE entity_advisory_locks
-             SET expires_at = datetime(expires_at, ? || ' seconds')
+             SET expires_at = {expires_at_expr}
              WHERE entity_name = ? AND session_id = ?"
-        ))
-        .bind(extra_secs.to_string())
-        .bind(entity_name)
-        .bind(self.session_id.as_str())
-        .execute(self.pool())
-        .await?
-        .rows_affected();
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let affected = query(sqlx::AssertSqlSafe(query_sql))
+            .bind(extra_secs)
+            .bind(entity_name)
+            .bind(self.session_id.as_str())
+            .execute(self.pool())
+            .await?
+            .rows_affected();
 
         Ok(affected > 0)
     }

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -76,7 +76,7 @@ pub use persona::{
     PersonaExtractionConfig, contains_self_referential_language, extract_persona_facts,
 };
 pub use recall::{EmbedContext, RecalledMessage};
-pub use summarization::{StructuredSummary, Summary, build_summarization_prompt};
+pub use summarization::{StructuredSummary, SummarizeOutcome, Summary, build_summarization_prompt};
 pub use trajectory::{TrajectoryEntry, TrajectoryExtractionConfig, extract_trajectory_entries};
 pub use tree_consolidation::{
     TreeConsolidationConfig, TreeConsolidationResult, run_tree_consolidation_sweep,

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -63,9 +63,10 @@ fn chunk_text(text: &str) -> Vec<&str> {
     chunks
 }
 
-use crate::admission::log_admission_decision;
+use crate::admission::{AdmissionDecision, log_admission_decision};
 use crate::embedding_store::{MessageKind, SearchFilter};
 use crate::error::MemoryError;
+use crate::store::admission_training::AdmissionTrainingInput;
 use crate::types::{ConversationId, MessageId};
 
 use super::SemanticMemory;
@@ -348,6 +349,7 @@ impl SemanticMemory {
         goal_text: Option<&str>,
     ) -> Result<Option<MessageId>, MemoryError> {
         // A-MAC admission gate.
+        let mut admission_decision = None;
         if let Some(ref admission) = self.admission_control {
             let decision = admission
                 .evaluate(
@@ -361,8 +363,11 @@ impl SemanticMemory {
             let preview: String = content.chars().take(100).collect();
             log_admission_decision(&decision, &preview, role, admission.threshold());
             if !decision.admitted {
+                self.record_admission_sample(conversation_id, role, content, &decision, None)
+                    .await;
                 return Ok(None);
             }
+            admission_decision = Some(decision);
         }
 
         if let Some(gate) = &self.quality_gate
@@ -371,6 +376,10 @@ impl SemanticMemory {
                 .await
                 .is_some()
         {
+            if let Some(decision) = &admission_decision {
+                self.record_admission_sample(conversation_id, role, content, decision, None)
+                    .await;
+            }
             return Ok(None);
         }
 
@@ -378,6 +387,17 @@ impl SemanticMemory {
             .sqlite
             .save_message(conversation_id, role, content)
             .await?;
+
+        if let Some(decision) = &admission_decision {
+            self.record_admission_sample(
+                conversation_id,
+                role,
+                content,
+                decision,
+                Some(message_id),
+            )
+            .await;
+        }
 
         self.embed_and_store_regular(message_id, conversation_id, role, content);
 
@@ -405,6 +425,7 @@ impl SemanticMemory {
         goal_text: Option<&str>,
     ) -> Result<(Option<MessageId>, bool), MemoryError> {
         // A-MAC admission gate.
+        let mut admission_decision = None;
         if let Some(ref admission) = self.admission_control {
             let decision = admission
                 .evaluate(
@@ -418,8 +439,11 @@ impl SemanticMemory {
             let preview: String = content.chars().take(100).collect();
             log_admission_decision(&decision, &preview, role, admission.threshold());
             if !decision.admitted {
+                self.record_admission_sample(conversation_id, role, content, &decision, None)
+                    .await;
                 return Ok((None, false));
             }
+            admission_decision = Some(decision);
         }
 
         if let Some(gate) = &self.quality_gate
@@ -428,6 +452,10 @@ impl SemanticMemory {
                 .await
                 .is_some()
         {
+            if let Some(decision) = &admission_decision {
+                self.record_admission_sample(conversation_id, role, content, decision, None)
+                    .await;
+            }
             return Ok((None, false));
         }
 
@@ -435,6 +463,17 @@ impl SemanticMemory {
             .sqlite
             .save_message_with_parts(conversation_id, role, content, parts_json)
             .await?;
+
+        if let Some(decision) = &admission_decision {
+            self.record_admission_sample(
+                conversation_id,
+                role,
+                content,
+                decision,
+                Some(message_id),
+            )
+            .await;
+        }
 
         let embedding_stored =
             self.embed_and_store_regular(message_id, conversation_id, role, content);
@@ -465,6 +504,7 @@ impl SemanticMemory {
         parts_json: &str,
         embed_ctx: EmbedContext,
     ) -> Result<(Option<MessageId>, bool), MemoryError> {
+        let mut admission_decision = None;
         if let Some(ref admission) = self.admission_control {
             let decision = admission
                 .evaluate(
@@ -478,14 +518,28 @@ impl SemanticMemory {
             let preview: String = content.chars().take(100).collect();
             log_admission_decision(&decision, &preview, role, admission.threshold());
             if !decision.admitted {
+                self.record_admission_sample(conversation_id, role, content, &decision, None)
+                    .await;
                 return Ok((None, false));
             }
+            admission_decision = Some(decision);
         }
 
         let message_id = self
             .sqlite
             .save_message_with_parts(conversation_id, role, content, parts_json)
             .await?;
+
+        if let Some(decision) = &admission_decision {
+            self.record_admission_sample(
+                conversation_id,
+                role,
+                content,
+                decision,
+                Some(message_id),
+            )
+            .await;
+        }
 
         let embedding_stored = self.embed_chunks_with_tool_context(
             message_id,
@@ -520,6 +574,7 @@ impl SemanticMemory {
         category: Option<&str>,
         goal_text: Option<&str>,
     ) -> Result<Option<MessageId>, MemoryError> {
+        let mut admission_decision = None;
         if let Some(ref admission) = self.admission_control {
             let decision = admission
                 .evaluate(
@@ -533,8 +588,11 @@ impl SemanticMemory {
             let preview: String = content.chars().take(100).collect();
             log_admission_decision(&decision, &preview, role, admission.threshold());
             if !decision.admitted {
+                self.record_admission_sample(conversation_id, role, content, &decision, None)
+                    .await;
                 return Ok(None);
             }
+            admission_decision = Some(decision);
         }
 
         let message_id = self
@@ -542,9 +600,59 @@ impl SemanticMemory {
             .save_message_with_category(conversation_id, role, content, category)
             .await?;
 
+        if let Some(decision) = &admission_decision {
+            self.record_admission_sample(
+                conversation_id,
+                role,
+                content,
+                decision,
+                Some(message_id),
+            )
+            .await;
+        }
+
         self.embed_and_store_with_category(message_id, conversation_id, role, content, category);
 
         Ok(Some(message_id))
+    }
+
+    /// Record an A-MAC admission decision as an RL training sample.
+    ///
+    /// Best-effort: failures are logged at debug level and never propagated, since training
+    /// data collection must not affect the write path it observes. Records both admitted and
+    /// rejected decisions so the training set avoids survivorship bias (see
+    /// `crate::store::admission_training` module docs). `message_id` is `None` when the
+    /// message was rejected (by A-MAC or a downstream quality gate) and never persisted.
+    async fn record_admission_sample(
+        &self,
+        conversation_id: ConversationId,
+        role: &str,
+        content: &str,
+        decision: &AdmissionDecision,
+        message_id: Option<MessageId>,
+    ) {
+        let features_json = match serde_json::to_string(&decision.factors) {
+            Ok(json) => json,
+            Err(e) => {
+                tracing::debug!(error = %e, "admission training: failed to serialize factors");
+                return;
+            }
+        };
+        if let Err(e) = self
+            .sqlite
+            .record_admission_training(AdmissionTrainingInput {
+                message_id,
+                conversation_id,
+                content,
+                role,
+                composite_score: decision.composite_score,
+                was_admitted: decision.admitted,
+                features_json: &features_json,
+            })
+            .await
+        {
+            tracing::debug!(error = %e, "admission training: failed to record sample (non-fatal)");
+        }
     }
 
     /// Recall messages filtered by category.

--- a/crates/zeph-memory/src/semantic/summarization.rs
+++ b/crates/zeph-memory/src/semantic/summarization.rs
@@ -27,6 +27,16 @@ pub struct Summary {
     pub token_estimate: i64,
 }
 
+/// Outcome of a successful [`SemanticMemory::summarize`] call.
+#[derive(Debug, Clone, Copy)]
+pub struct SummarizeOutcome {
+    /// Row id of the newly created summary.
+    pub summary_id: i64,
+    /// Number of messages actually folded into this summary (the size of the
+    /// unsummarized range consumed, not the `message_count` argument requested).
+    pub messages_folded: usize,
+}
+
 #[must_use]
 pub fn build_summarization_prompt(messages: &[(MessageId, String, String)]) -> String {
     let mut prompt = String::from(
@@ -85,6 +95,9 @@ impl SemanticMemory {
     /// Generate a summary of the oldest unsummarized messages.
     ///
     /// Returns `Ok(None)` if there are not enough messages to summarize.
+    /// [`SummarizeOutcome::messages_folded`] reflects the actual number of messages folded
+    /// into the new summary, which may be less than `message_count` when fewer unsummarized
+    /// messages exist.
     ///
     /// # Errors
     ///
@@ -94,7 +107,7 @@ impl SemanticMemory {
         &self,
         conversation_id: ConversationId,
         message_count: usize,
-    ) -> Result<Option<i64>, MemoryError> {
+    ) -> Result<Option<SummarizeOutcome>, MemoryError> {
         let total = self.sqlite.count_messages(conversation_id).await?;
 
         if total <= i64::try_from(message_count)? {
@@ -116,6 +129,7 @@ impl SemanticMemory {
             return Ok(None);
         }
 
+        let messages_folded = messages.len();
         let prompt = build_summarization_prompt(&messages);
         let chat_messages = vec![Message {
             role: Role::User,
@@ -183,7 +197,10 @@ impl SemanticMemory {
                 .await;
         }
 
-        Ok(Some(summary_id))
+        Ok(Some(SummarizeOutcome {
+            summary_id,
+            messages_folded,
+        }))
     }
 
     /// Call the LLM to produce a [`StructuredSummary`], falling back to plain text on parse error.

--- a/crates/zeph-memory/src/semantic/tests/recall.rs
+++ b/crates/zeph-memory/src/semantic/tests/recall.rs
@@ -649,6 +649,119 @@ async fn admission_without_dedicated_provider_uses_embed_provider() {
     );
 }
 
+// ── A-MAC admission training data collection tests (#5555) ───────────────────
+//
+// Regression coverage for issue #5555: `record_admission_sample` (the private helper
+// wired into all 4 `remember*` methods) had no test asserting it actually writes to
+// `admission_training_data`, nor that `message_id`/`was_admitted` are correct for each
+// of the three possible outcomes. The existing A-MAC tests above only assert the
+// `remember()` return value and `messages` table state — they would not catch
+// `record_admission_sample` silently never being called, or being called with the
+// wrong `message_id`.
+
+#[tokio::test]
+async fn rejected_by_amac_records_training_sample_with_no_message_id() {
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_reject_admission());
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let result = memory
+        .remember(cid, "user", "this message will be rejected", None)
+        .await
+        .unwrap();
+    assert!(result.is_none());
+
+    assert_eq!(
+        memory.sqlite.count_training_records().await.unwrap(),
+        1,
+        "A-MAC rejection must still be recorded as a training sample"
+    );
+    let batch = memory.sqlite.get_training_batch(10).await.unwrap();
+    assert_eq!(batch.len(), 1);
+    assert_eq!(
+        batch[0].message_id, None,
+        "rejected message was never persisted, so message_id must be None"
+    );
+    assert!(
+        !batch[0].was_admitted,
+        "training record must reflect the rejection"
+    );
+}
+
+#[tokio::test]
+async fn admitted_and_persisted_records_training_sample_with_message_id() {
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_admit_admission());
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let message_id = memory
+        .remember(cid, "user", "important factual content", None)
+        .await
+        .unwrap()
+        .expect("admitted message must return Some(id)");
+
+    assert_eq!(memory.sqlite.count_training_records().await.unwrap(), 1);
+    let batch = memory.sqlite.get_training_batch(10).await.unwrap();
+    assert_eq!(batch.len(), 1);
+    assert_eq!(
+        batch[0].message_id,
+        Some(message_id.0),
+        "admitted-and-persisted training record must carry the real message_id"
+    );
+    assert!(
+        batch[0].was_admitted,
+        "training record must reflect the admission"
+    );
+}
+
+#[tokio::test]
+async fn admitted_then_quality_gate_rejected_records_training_sample_with_no_message_id() {
+    // Quality gate config matching `gate_rejects_pronoun_only_at_low_threshold` in
+    // quality_gate.rs, which reliably rejects pronoun-heavy content as IncompleteReference.
+    let gate_config = crate::quality_gate::QualityGateConfig {
+        enabled: true,
+        threshold: 0.75,
+        reference_completeness_weight: 0.9,
+        information_value_weight: 0.05,
+        contradiction_weight: 0.05,
+        ..crate::quality_gate::QualityGateConfig::default()
+    };
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_admit_admission())
+        .with_quality_gate(Arc::new(crate::quality_gate::QualityGate::new(gate_config)));
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let result = memory
+        .remember(cid, "user", "yeah he confirmed it they said so", None)
+        .await
+        .unwrap();
+    assert!(
+        result.is_none(),
+        "quality gate must reject this pronoun-heavy content after A-MAC admits it"
+    );
+
+    assert_eq!(
+        memory.sqlite.count_training_records().await.unwrap(),
+        1,
+        "A-MAC-admitted-but-quality-gate-rejected message must still be recorded, to \
+         avoid survivorship bias in the training set"
+    );
+    let batch = memory.sqlite.get_training_batch(10).await.unwrap();
+    assert_eq!(batch.len(), 1);
+    assert_eq!(
+        batch[0].message_id, None,
+        "message was never persisted (quality gate rejected it after admission), \
+         so message_id must be None"
+    );
+    assert!(
+        batch[0].was_admitted,
+        "was_admitted reflects the A-MAC decision, not the downstream quality-gate outcome"
+    );
+}
+
 // ── effective_depth tests (MM-F1, #3340) ──────────────────────────────────────
 
 #[tokio::test]

--- a/crates/zeph-memory/src/semantic/tests/summarization.rs
+++ b/crates/zeph-memory/src/semantic/tests/summarization.rs
@@ -191,12 +191,17 @@ async fn summarize_stores_summary() {
             .unwrap();
     }
 
-    let summary_id = memory.summarize(cid, 3).await.unwrap();
-    assert!(summary_id.is_some());
+    let outcome = memory.summarize(cid, 3).await.unwrap();
+    assert!(outcome.is_some());
+    let outcome = outcome.unwrap();
+    assert_eq!(
+        outcome.messages_folded, 3,
+        "must fold exactly message_count messages"
+    );
 
     let summaries = memory.load_summaries(cid).await.unwrap();
     assert_eq!(summaries.len(), 1);
-    assert_eq!(summaries[0].id, summary_id.unwrap());
+    assert_eq!(summaries[0].id, outcome.summary_id);
     assert!(!summaries[0].content.is_empty());
 }
 
@@ -393,12 +398,77 @@ async fn summarize_message_range_bounds() {
             .unwrap();
     }
 
-    let summary_id = memory.summarize(cid, 4).await.unwrap().unwrap();
+    let outcome = memory.summarize(cid, 4).await.unwrap().unwrap();
+    assert_eq!(
+        outcome.messages_folded, 4,
+        "must fold exactly message_count messages"
+    );
     let summaries = memory.load_summaries(cid).await.unwrap();
     assert_eq!(summaries.len(), 1);
-    assert_eq!(summaries[0].id, summary_id);
+    assert_eq!(summaries[0].id, outcome.summary_id);
     assert!(summaries[0].first_message_id >= Some(MessageId(1)));
     assert!(summaries[0].last_message_id >= summaries[0].first_message_id);
+}
+
+// ── MemoryFacade::compact messages_compacted accuracy (#5533) ──────────────────
+
+#[tokio::test]
+async fn compact_reports_actual_messages_folded_not_total_message_count() {
+    use crate::facade::{CompactionContext, MemoryFacade};
+
+    let memory = test_semantic_memory(false).await;
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+
+    for i in 0..20 {
+        memory
+            .remember(cid, "user", &format!("msg {i}"), None)
+            .await
+            .unwrap();
+    }
+
+    // token_budget=40 -> target_msgs = 40/4 = 10, so summarize() folds only 10 of the 20
+    // unsummarized messages (capped by the range LIMIT), not the full conversation.
+    let result = memory
+        .compact(&CompactionContext {
+            conversation_id: cid,
+            token_budget: 40,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.messages_compacted, 10,
+        "messages_compacted must reflect what summarize() actually folded, not the total \
+         message count fetched before summarization"
+    );
+}
+
+#[tokio::test]
+async fn compact_reports_zero_when_summarize_is_noop() {
+    use crate::facade::{CompactionContext, MemoryFacade};
+
+    let memory = test_semantic_memory(false).await;
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+
+    memory
+        .remember(cid, "user", "only one message", None)
+        .await
+        .unwrap();
+
+    // token_budget=4096 -> target_msgs=1024, far above the single message present, so
+    // summarize() is a no-op (total <= message_count) and returns None.
+    let result = memory
+        .compact(&CompactionContext {
+            conversation_id: cid,
+            token_budget: 4096,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.messages_compacted, 0,
+        "messages_compacted must be 0 when summarize() is a no-op"
+    );
 }
 
 #[tokio::test]

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -56,6 +56,16 @@
 //! the last blocker on the full `run_episodic_consolidation_sweep` pipeline (`fetch_candidates`
 //! → `compute_cognitive_weight` → ... → `mark_consolidated`) getting real Postgres round-trip
 //! coverage — see `episodic_consolidation_sweep_promotes_fact_postgres` below.
+//!
+//! Regression coverage for issue #5539: `graph/entity_lock.rs::extend_lock` built its
+//! `expires_at` offset expression with `SQLite`-only `datetime(expires_at, ? || ' seconds')`
+//! syntax, which is invalid against Postgres's `TIMESTAMPTZ` column (no `datetime()`
+//! function). The existing unit tests in `entity_lock.rs` only run against `SQLite` and
+//! assert the boolean return value, so they could not catch the syntax mismatch. The tests
+//! below exercise `extend_lock` (and the sibling `try_acquire_once`, fixed earlier in
+//! PR #5537 with the same dialect-split pattern but never covered here either) against a
+//! live Postgres instance and assert the actual `expires_at` column value moved, not just
+//! that the call succeeded.
 
 #[cfg(feature = "test-utils")]
 mod pg {
@@ -70,6 +80,7 @@ mod pg {
     use zeph_llm::any::AnyProvider;
     use zeph_llm::mock::MockProvider;
     use zeph_memory::db_vector_store::DbVectorStore;
+    use zeph_memory::graph::EntityLockManager;
     use zeph_memory::graph::activation::ActivatedFact;
     use zeph_memory::graph::belief::{BeliefMemConfig, BeliefStore};
     use zeph_memory::graph::implicit_conflict;
@@ -1686,5 +1697,71 @@ mod pg {
         .unwrap();
         assert_eq!(fidelity, "SummaryOnly");
         assert_eq!(content, "one-line summary");
+    }
+
+    // ── entity_lock: extend_lock + try_acquire dialect-split SQL (#5539) ───────
+
+    /// Fetch `entity_advisory_locks.expires_at` as a Unix epoch (seconds), via the same
+    /// `Dialect::epoch_from_col` cast used in production code (`semantic::recall`'s
+    /// `created_at_map` fetch, `five_signal_consolidation_promotes_fresh_fact` above) to
+    /// decode a `TIMESTAMPTZ` column without requiring sqlx's `chrono` feature.
+    async fn fetch_lock_expires_at_epoch(pool: &zeph_db::DbPool, entity_name: &str) -> i64 {
+        let epoch_expr =
+            <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::epoch_from_col("expires_at");
+        let raw = format!("SELECT {epoch_expr} FROM entity_advisory_locks WHERE entity_name = ?");
+        sqlx::query_scalar(sqlx::AssertSqlSafe(zeph_db::rewrite_placeholders(&raw)))
+            .bind(entity_name)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn entity_lock_extend_lock_advances_expiry_postgres() {
+        let (pool, _container) = start_pg().await;
+        let mgr = EntityLockManager::new(pool.clone(), "session-pg-ext");
+
+        assert!(
+            mgr.try_acquire("entity::PgExt").await.unwrap(),
+            "initial acquire must succeed"
+        );
+        let before = fetch_lock_expires_at_epoch(&pool, "entity::PgExt").await;
+
+        let extended = mgr.extend_lock("entity::PgExt", 3600).await.unwrap();
+        assert!(
+            extended,
+            "extend_lock must succeed against a live Postgres instance \
+             (regression check for #5539: SQLite-only datetime() syntax used to fail here)"
+        );
+
+        let after = fetch_lock_expires_at_epoch(&pool, "entity::PgExt").await;
+        assert_eq!(
+            after - before,
+            3600,
+            "expires_at must advance by exactly extra_secs via \
+             `expires_at + INTERVAL '1 second' * ?`"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn entity_lock_try_acquire_postgres() {
+        let (pool, _container) = start_pg().await;
+        let mgr = EntityLockManager::new(pool.clone(), "session-pg-acq");
+
+        // Exercises `try_acquire_once`'s `NOW() + INTERVAL 'N seconds'` Postgres branch
+        // (the sibling fix from PR #5537, previously uncovered by any Postgres test).
+        assert!(
+            mgr.try_acquire("entity::PgAcq").await.unwrap(),
+            "try_acquire must succeed against a live Postgres instance"
+        );
+
+        let now_epoch = chrono::Utc::now().timestamp();
+        let expires_epoch = fetch_lock_expires_at_epoch(&pool, "entity::PgAcq").await;
+        assert!(
+            expires_epoch > now_epoch,
+            "newly acquired lock must expire in the future (TTL applied via NOW() + INTERVAL)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes three related bugs in `zeph-memory`, all in the same "dormant/dead production write path" defect class, grouped and solved together per triage.

- **#5555** — `AdmissionControl::evaluate()`'s decisions were never persisted via `SqliteStore::record_admission_training`, so `admission_training_data` stayed empty in production regardless of `admission_strategy` — the prerequisite data collection for a future `Rl` scorer was scaffolding with no caller. `SemanticMemory::remember`/`remember_with_parts`/`remember_tool_output`/`remember_categorized` now record every A-MAC decision (admitted and rejected, including quality-gate drops) via a new best-effort `record_admission_sample` helper.
- **#5539** — `EntityLockManager::extend_lock` used SQLite-only `datetime(expires_at, ? || ' seconds')` syntax with no Postgres equivalent. Split into a dialect-selected expression mirroring the pattern PR #5537 used for the sibling `try_acquire_once` in the same file.
- **#5533** — `MemoryFacade::compact` reported `messages_compacted` as the conversation's total message count fetched before summarization ran, not the count `summarize()` actually folded. `SemanticMemory::summarize` now returns `SummarizeOutcome { summary_id, messages_folded }`; `compact` derives the count from `messages_folded`.

Closes #5555
Closes #5539
Closes #5533

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11846 passed, 0 failed, 34 skipped
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler" -p zeph-memory -p zeph-core` — clean
- [x] 3 new unit tests for #5555 admission-training write paths (one per outcome: A-MAC-rejected, admitted+persisted, admitted-then-quality-gate-rejected)
- [x] 2 new `#[ignore]`-gated Postgres integration tests for #5539 (`extend_lock` and sibling `try_acquire_once`, neither previously covered under Postgres) — compile-verified, not yet executed against live Postgres (no Docker available in the dev environment; flagged for the next Docker-capable CI/live-test run)
- [x] 2 new regression tests for #5533, traced against actual pre-fix behavior (would fail on old code)