### PR TITLE
fix(db,memory): route compacted_at Postgres writes through to_timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,8 +228,11 @@ jobs:
         # mutually-exclusive default), so default features stay on here — building
         # with --no-default-features would disable the "sqlite" feature and turn
         # unrelated sqlite-only test helpers into dead-code errors under -D warnings.
+        # --lib --bins (not just --tests) is required so cfg!(feature = "postgres")
+        # branches inside src/ (e.g. dialect-selected SQL literals) get archived too —
+        # see the "Run zeph-memory postgres unit tests" step below (#5540).
         if: matrix.os == 'ubuntu-latest'
-        run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci -p zeph-memory --features test-utils --tests --archive-file nextest-archive-zeph-memory-postgres.tar.zst
+        run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci -p zeph-memory --features test-utils --lib --bins --tests --archive-file nextest-archive-zeph-memory-postgres.tar.zst
       - name: Upload zeph-memory postgres test archive
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -344,6 +347,20 @@ jobs:
         # gives postgres cfg-priority for the whole crate; running crate-wide would
         # route those unrelated :memory: tests through connect_postgres and fail them.
         run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive-zeph-memory-postgres.tar.zst --workspace-remap . --profile ci --run-ignored ignored-only -E 'binary(postgres_integration)'
+      - name: Run zeph-memory postgres unit tests (#5540)
+        # Runs the --lib/--bins portion of the same archive (built with --features
+        # postgres via test-utils, see the archive step in build-tests), so
+        # cfg!(feature = "postgres") branches inside src/ get unit-test coverage in
+        # CI, not just integration-test coverage that depends on happening to exercise
+        # the right code path. Scoped by name (not `kind(lib) + kind(bin)`) because the
+        # vast majority of zeph-memory's ~1500 lib unit tests open a `SqliteStore::new(
+        # ":memory:")` — under this postgres-featured build, DbConfig::connect has
+        # postgres cfg-priority for the whole crate (see the comment on the step above),
+        # so those unrelated tests would try to parse ":memory:" as a Postgres URL and
+        # fail. `_matches_active_dialect` is this codebase's established naming
+        # convention (see store/overflow.rs) for pure dialect-literal pinning tests that
+        # take no DB connection and are safe to run under either feature build.
+        run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive-zeph-memory-postgres.tar.zst --workspace-remap . --profile ci -E 'kind(lib) and test(matches_active_dialect)'
       - name: Download zeph-index postgres test archive
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(db,memory)`: `store/messages/mod.rs::replace_conversation`/`apply_tool_pair_summaries`
+  bound a Rust-formatted epoch-seconds string directly into `messages.compacted_at`
+  (`TIMESTAMPTZ` on Postgres), which Postgres's `timestamptz` parser rejects even under
+  `Dialect::TIMESTAMPTZ_CAST` (no ISO-8601 syntax) — a write-path defect distinct from the
+  read-path `TIMESTAMPTZ`->`String` decode class. Adds `Dialect::timestamptz_from_epoch`, a new
+  `zeph-db` dialect primitive that wraps the bind placeholder in `to_timestamp({placeholder}::double
+  precision)` on Postgres (bare passthrough on SQLite, preserving existing behavior);
+  `compacted_at_bind_expr()` shares it between both write sites. The explicit `::double precision`
+  cast is required, not cosmetic: `sqlx` sends a bound `String`/`&str` with the `TEXT` type OID, and
+  `to_timestamp()` has no `text`-argument overload (only `to_timestamp(double precision)` and
+  `to_timestamp(text, text)`), so an uncast bind fails Postgres function resolution with
+  `ERROR 42883: function to_timestamp(text) does not exist` — caught by adversarial review, then
+  reproduced and fixed against a real local Postgres instance (not just testcontainers-gated CI).
+  Adds `replace_conversation_writes_compacted_at_on_postgres` and
+  `apply_tool_pair_summaries_writes_compacted_at_on_postgres` to
+  `tests/postgres_integration.rs`, which execute the UPDATE against a live Postgres and decode
+  `compacted_at` back via `EXTRACT(EPOCH FROM ...)` — a string-equality unit test on the dialect
+  fragment alone cannot catch a function-resolution error, only real execution can. Closes #5561.
+- `ci`: the `zeph-memory` postgres archive step (`.github/workflows/ci.yml`) only archived/ran
+  the `tests/` integration binaries (`--tests`), never `--lib --bins`, so no
+  `cfg!(feature = "postgres")` branch inside `crates/zeph-memory/src/` (e.g. dialect-selected SQL
+  literals) got unit-test coverage in CI. Adds `--lib --bins` to the archive step and a new
+  "Run zeph-memory postgres unit tests" step in the `integration` job, scoped to tests named
+  `*_matches_active_dialect` (this codebase's established naming convention for pure
+  dialect-literal pinning tests) to avoid routing the crate's ~1500 `SqliteStore::new(":memory:")`
+  unit tests through `connect_postgres` under this build's postgres cfg-priority. Closes #5540.
 - `fix(serve)`: sanitize `POST /sessions/:id/prompt` HTTP request bodies as `ExternalUntrusted`
   (`ContentSourceKind::ChannelMessage`) via `ContentSanitizer` before they reach the agent loopback
   queue — closes the same content-trust bypass already fixed for the gateway (#5459) and channel

--- a/crates/zeph-db/src/dialect.rs
+++ b/crates/zeph-db/src/dialect.rs
@@ -122,6 +122,35 @@ pub trait Dialect: Send + Sync + 'static {
     /// `SQLite`: `MIN`
     /// `PostgreSQL`: `LEAST`
     const LEAST_FN: &'static str;
+
+    /// Timestamp expression for binding a Unix epoch-seconds value into a
+    /// `TEXT`/`TIMESTAMPTZ` `compacted_at`-style column.
+    ///
+    /// Wraps the given bind-parameter placeholder (e.g. `?`, later rewritten to `$N`
+    /// by [`crate::rewrite_placeholders`]) in the backend-specific conversion from
+    /// Unix epoch seconds to the column's native timestamp representation.
+    ///
+    /// `SQLite` stores such columns as bare epoch-seconds `TEXT`, so the placeholder
+    /// passes through unchanged. `PostgreSQL` stores them as `TIMESTAMPTZ`; unlike an
+    /// ISO-8601 string, a bare epoch-seconds string has no valid `timestamptz` input
+    /// syntax — `'1735999999'::timestamptz` fails to parse even with
+    /// [`Self::TIMESTAMPTZ_CAST`] appended. The bound value must instead be routed
+    /// through `to_timestamp()`, which both performs the epoch conversion and yields a
+    /// `TIMESTAMPTZ` directly, so no additional cast is needed on the result.
+    ///
+    /// The placeholder itself still needs an explicit `::double precision` cast:
+    /// callers typically bind a Rust `String`/`&str` (the value is formatted with
+    /// `format!("{secs}")` before binding), which `sqlx` sends with the `TEXT` type OID.
+    /// `to_timestamp()` has only `to_timestamp(double precision)` and
+    /// `to_timestamp(text, text)` overloads — there is no implicit `text` ->
+    /// `double precision` cast, so an unqualified `to_timestamp({placeholder})` fails
+    /// function-argument resolution with `ERROR 42883: function to_timestamp(text) does
+    /// not exist`. The `::double precision` cast on the placeholder is what makes the
+    /// bound text resolve to the numeric overload.
+    ///
+    /// `SQLite`: `{placeholder}`
+    /// `PostgreSQL`: `to_timestamp({placeholder}::double precision)`
+    fn timestamptz_from_epoch(placeholder: &str) -> String;
 }
 
 /// `SQLite` dialect marker type.
@@ -150,6 +179,10 @@ impl Dialect for Sqlite {
     fn select_as_text(col: &str) -> String {
         col.to_string()
     }
+
+    fn timestamptz_from_epoch(placeholder: &str) -> String {
+        placeholder.to_string()
+    }
 }
 
 /// `PostgreSQL` dialect marker type.
@@ -177,6 +210,10 @@ impl Dialect for Postgres {
 
     fn select_as_text(col: &str) -> String {
         format!("{col}::text")
+    }
+
+    fn timestamptz_from_epoch(placeholder: &str) -> String {
+        format!("to_timestamp({placeholder}::double precision)")
     }
 }
 
@@ -246,6 +283,11 @@ mod tests {
         fn least_fn() {
             assert_eq!(Sqlite::LEAST_FN, "MIN");
         }
+
+        #[test]
+        fn timestamptz_from_epoch() {
+            assert_eq!(Sqlite::timestamptz_from_epoch("?"), "?");
+        }
     }
 
     #[cfg(feature = "postgres")]
@@ -309,6 +351,14 @@ mod tests {
         #[test]
         fn least_fn() {
             assert_eq!(Postgres::LEAST_FN, "LEAST");
+        }
+
+        #[test]
+        fn timestamptz_from_epoch() {
+            assert_eq!(
+                Postgres::timestamptz_from_epoch("?"),
+                "to_timestamp(?::double precision)"
+            );
         }
     }
 }

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -15,6 +15,17 @@ use super::SqliteStore;
 use crate::error::MemoryError;
 use crate::types::{ConversationId, MessageId};
 
+/// SQL fragment binding a `?` placeholder into `compacted_at` (`TEXT` on `SQLite`,
+/// `TIMESTAMPTZ` on `PostgreSQL`), dialect-selected.
+///
+/// `compacted_at` is written as a Rust-formatted epoch-seconds string, which has no
+/// valid `timestamptz` input syntax on Postgres — see
+/// [`zeph_db::dialect::Dialect::timestamptz_from_epoch`] for why a bare bind (or one
+/// under `TIMESTAMPTZ_CAST`) is insufficient there.
+fn compacted_at_bind_expr() -> String {
+    <ActiveDialect as zeph_db::dialect::Dialect>::timestamptz_from_epoch("?")
+}
+
 fn parse_role(s: &str) -> Role {
     match s {
         "assistant" => Role::Assistant,
@@ -477,16 +488,18 @@ impl SqliteStore {
 
         let mut tx = self.pool.begin().await?;
 
-        zeph_db::query(sql!(
-            "UPDATE messages SET visibility = 'user_only', compacted_at = ? \
+        let compacted_at_expr = compacted_at_bind_expr();
+        let update_sql = zeph_db::rewrite_placeholders(&format!(
+            "UPDATE messages SET visibility = 'user_only', compacted_at = {compacted_at_expr} \
              WHERE conversation_id = ? AND id >= ? AND id <= ?"
-        ))
-        .bind(&now)
-        .bind(conversation_id)
-        .bind(start_id)
-        .bind(end_id)
-        .execute(&mut *tx)
-        .await?;
+        ));
+        zeph_db::query(sqlx::AssertSqlSafe(update_sql))
+            .bind(&now)
+            .bind(conversation_id)
+            .bind(start_id)
+            .bind(end_id)
+            .execute(&mut *tx)
+            .await?;
 
         // importance_score uses schema DEFAULT 0.5 (neutral); compaction summaries are not scored at write time.
         let row: (MessageId,) = zeph_db::query_as(sql!(
@@ -532,14 +545,17 @@ impl SqliteStore {
 
         let mut tx = self.pool.begin().await?;
 
+        let compacted_at_expr = compacted_at_bind_expr();
+        let update_sql = zeph_db::rewrite_placeholders(&format!(
+            "UPDATE messages SET visibility = 'user_only', compacted_at = {compacted_at_expr} \
+             WHERE id = ?"
+        ));
         for &id in hide_ids {
-            zeph_db::query(sql!(
-                "UPDATE messages SET visibility = 'user_only', compacted_at = ? WHERE id = ?"
-            ))
-            .bind(&now)
-            .bind(id)
-            .execute(&mut *tx)
-            .await?;
+            zeph_db::query(sqlx::AssertSqlSafe(update_sql.clone()))
+                .bind(&now)
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
         }
 
         for summary in summaries {

--- a/crates/zeph-memory/src/store/messages/tests.rs
+++ b/crates/zeph-memory/src/store/messages/tests.rs
@@ -1916,3 +1916,20 @@ async fn update_fidelity_tags_chunk_boundary() {
         "all {N} rows must be updated across chunk boundary"
     );
 }
+
+/// Pins the exact SQL fragment `replace_conversation`/`apply_tool_pair_summaries` bind
+/// into `compacted_at` for the dialect this test binary was compiled with. The `sqlite`
+/// and `postgres` features are additive on this crate (see `Cargo.toml`), so running with
+/// `--features postgres` exercises the branch that `cargo nextest run -p zeph-memory --lib`
+/// alone never reaches — a bare epoch-seconds bind here fails to parse against Postgres's
+/// `TIMESTAMPTZ` column at runtime (#5561), and only surfaces via a live-DB integration test
+/// or manual `psql` check without this pin.
+#[test]
+fn compacted_at_bind_expr_matches_active_dialect() {
+    let expr = compacted_at_bind_expr();
+    if cfg!(feature = "postgres") {
+        assert_eq!(expr, "to_timestamp(?::double precision)");
+    } else {
+        assert_eq!(expr, "?");
+    }
+}

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -434,6 +434,108 @@ mod pg {
         assert_eq!(tags[1].1, 2);
     }
 
+    // ── messages: compacted_at write path (#5561) ───────────────────────────────
+    //
+    // `replace_conversation`/`apply_tool_pair_summaries` bind a Rust-formatted
+    // epoch-seconds `String` into `compacted_at` via `Dialect::timestamptz_from_epoch`
+    // (`to_timestamp(?::double precision)` on Postgres). A string-equality unit test on
+    // the emitted SQL fragment cannot catch a Postgres function-resolution error (e.g.
+    // `to_timestamp(text)` does not exist — only `to_timestamp(double precision)`); only
+    // executing the UPDATE against a real Postgres backend can. These two tests do that,
+    // then decode `compacted_at` back via `EXTRACT(EPOCH FROM ...)` to confirm the value
+    // round-trips to a sane epoch, not just that the statement didn't error.
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn replace_conversation_writes_compacted_at_on_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        let cid = store.create_conversation().await.unwrap();
+        let m1 = store.save_message(cid, "user", "one").await.unwrap();
+        let m2 = store.save_message(cid, "user", "two").await.unwrap();
+
+        let before = i64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap();
+
+        store
+            .replace_conversation(cid, m1..=m2, "assistant", "compacted summary")
+            .await
+            .unwrap();
+
+        let (visibility, compacted_epoch): (String, i64) = sqlx::query_as(zeph_db::sql!(
+            "SELECT visibility, EXTRACT(EPOCH FROM compacted_at)::BIGINT FROM messages WHERE id = ?"
+        ))
+        .bind(m1)
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(visibility, "user_only");
+        assert!(
+            (before - 60..=before + 60).contains(&compacted_epoch),
+            "compacted_at must round-trip to a value near 'now' ({before}), got {compacted_epoch}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn apply_tool_pair_summaries_writes_compacted_at_on_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        let cid = store.create_conversation().await.unwrap();
+        let tool_use = store
+            .save_message(cid, "assistant", "tool_use")
+            .await
+            .unwrap();
+        let tool_result = store
+            .save_message(cid, "user", "tool_result")
+            .await
+            .unwrap();
+
+        let before = i64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap();
+
+        store
+            .apply_tool_pair_summaries(
+                cid,
+                &[tool_use.0, tool_result.0],
+                &["[tool summary] did the thing".to_string()],
+            )
+            .await
+            .unwrap();
+
+        let rows: Vec<(String, i64)> = sqlx::query_as(zeph_db::sql!(
+            "SELECT visibility, EXTRACT(EPOCH FROM compacted_at)::BIGINT FROM messages \
+             WHERE id IN (?, ?) ORDER BY id ASC"
+        ))
+        .bind(tool_use)
+        .bind(tool_result)
+        .fetch_all(store.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(rows.len(), 2);
+        for (visibility, compacted_epoch) in rows {
+            assert_eq!(visibility, "user_only");
+            assert!(
+                (before - 60..=before + 60).contains(&compacted_epoch),
+                "compacted_at must round-trip to a value near 'now' ({before}), got {compacted_epoch}"
+            );
+        }
+    }
+
     // ── messages: forgetting sweep (downscale / replay / prune) ────────────────
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- `store/messages/mod.rs::replace_conversation` and `apply_tool_pair_summaries` bound a raw epoch-seconds string directly into `messages.compacted_at` (`TIMESTAMPTZ` on Postgres), which Postgres's `timestamptz` parser rejects even under `Dialect::TIMESTAMPTZ_CAST`. Adds `Dialect::timestamptz_from_epoch`, a new `zeph-db` dialect primitive wrapping the bind placeholder in `to_timestamp({placeholder}::double precision)` on Postgres (bare passthrough on SQLite). The explicit `::double precision` cast is required because `sqlx` sends a bound `String` with the `TEXT` type OID and `to_timestamp()` has no `text`-argument overload — an uncast bind fails Postgres function resolution with `ERROR 42883`.
- Adds `replace_conversation_writes_compacted_at_on_postgres` / `apply_tool_pair_summaries_writes_compacted_at_on_postgres` integration tests that execute the real write path against a live Postgres testcontainer and decode `compacted_at` back, closing the gap a string-equality unit test alone would miss.
- Fixes the `zeph-memory` postgres CI archive step, which only ran `tests/` integration binaries (`--tests`) and never exercised `cfg!(feature = "postgres")` branches inside `src/` via unit tests. Adds `--lib --bins` to the archive step and a scoped run for `*_matches_active_dialect` tests to avoid routing the crate's ~1500 `SqliteStore::new(":memory:")` unit tests through `connect_postgres` under postgres cfg-priority.

Closes #5561, #5540

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci -p zeph-memory -p zeph-db --all-targets --features postgres -- -D warnings`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` (independently re-run by code reviewer)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory -p zeph-db --lib --bins` (1566/1566, no regressions)
- [x] `cargo nextest run -p zeph-memory -p zeph-db -E 'test(matches_active_dialect)' --features postgres` (2/2 pass)
- [x] `cargo test --features postgres -p zeph-db`
- [x] Rustdoc gate (`zeph-db`, `zeph-memory`, `--features postgres`)
- [x] `fy validate .github/workflows/ci.yml`
- [x] Reproduced the pre-fix `42883` failure and the post-fix success against a real local Postgres instance
- [x] Two new `#[ignore = "requires Docker"]` integration tests wired into the existing testcontainers pattern in `tests/postgres_integration.rs`; CI's `binary(postgres_integration)` step already runs `--run-ignored ignored-only`, so no additional CI wiring needed for them