### PR TITLE
fix(tools): wire diagnostics tool and bound search_code recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -589,6 +589,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `*_matches_active_dialect` (this codebase's established naming convention for pure
   dialect-literal pinning tests) to avoid routing the crate's ~1500 `SqliteStore::new(":memory:")`
   unit tests through `connect_postgres` under this build's postgres cfg-priority. Closes #5540.
+- `fix(tools)`: wire `DiagnosticsExecutor` (the `diagnostics` tool — runs `cargo check`/`cargo
+  clippy` and returns structured diagnostics) into every live agent entry point. It shipped with
+  full unit coverage in `zeph-tools` but was never constructed by `agent_setup::build_tool_setup`
+  (CLI/TUI), `src/daemon.rs`, or `src/acp.rs`, so it never appeared in the LLM's tool list in any
+  configuration. Adds `agent_setup::build_diagnostics_executor`, reusing the existing
+  `tools.shell.allowed_paths` sandbox (same as `FileExecutor`/`SearchCodeExecutor`, no new config
+  surface), and nests it into the base `CompositeExecutor` chain alongside `SetCwdExecutor` at all
+  three sites. Since making the tool reachable also makes it reachable to Quarantined skills,
+  this also adds `"diagnostics"` to `zeph_common::quarantine::QUARANTINE_DENIED` (running `cargo
+  check`/`clippy` executes arbitrary code via `build.rs`/proc-macros, equivalent to `bash`) and
+  bounds the `cargo` subprocess with a `tokio::time::timeout` (default 30s, reuses
+  `tools.shell.timeout`, `kill_on_drop(true)` to avoid leaking a hung child on timeout) — both
+  required so the newly-reachable tool doesn't reintroduce the unbounded-subprocess class of bug
+  #5434 just fixed for `search_code`. Closes #5433.
+- `fix(tools)`: bound the `search_code` tool's recursive directory walk. `collect_structural_hits`
+  and the `collect_grep_hits` fallback (`crates/zeph-tools/src/search_code.rs`) recursed every
+  `allowed_paths` root with no entry-count or wall-clock budget beyond skipping
+  `.git`/`target`/`node_modules`/`.zeph`, and followed symlinks with no loop protection —
+  discovered as a 90s+ hang when `allowed_paths = ["~"]` post-#5424's tilde expansion. Adds a
+  shared `WalkBudget` (`MAX_WALK_ENTRIES` = 5,000 entries, `MAX_WALK_DURATION` = 2s wall-clock,
+  whichever trips first) and stops following symlinked directories entirely (`symlink_metadata`
+  check, no loop possible). A truncated walk now returns partial results with a
+  `[search truncated: ...]` note in the summary and `"truncated": true` in `raw_response` instead
+  of silently returning partial or hanging indefinitely. No new config surface. Closes #5434.
 - `fix(serve)`: sanitize `POST /sessions/:id/prompt` HTTP request bodies as `ExternalUntrusted`
   (`ContentSourceKind::ChannelMessage`) via `ContentSanitizer` before they reach the agent loopback
   queue — closes the same content-trust bypass already fixed for the gateway (#5459) and channel

--- a/crates/zeph-common/src/quarantine.rs
+++ b/crates/zeph-common/src/quarantine.rs
@@ -28,6 +28,10 @@ pub const QUARANTINE_DENIED: &[&str] = &[
     // Web access
     "web_scrape",
     "fetch",
+    // Runs `cargo check`/`cargo clippy`, which executes arbitrary code via build.rs
+    // scripts and proc-macros in the target workspace — equivalent to `bash` for
+    // security purposes.
+    "diagnostics",
     // Memory persistence
     "memory_save",
     // Skill body retrieval — denied for Quarantined active skills to prevent

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -11,6 +12,11 @@ use zeph_common::ToolName;
 use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params};
 use crate::file::expand_tilde;
 use crate::registry::{InvocationHint, ToolDef};
+
+/// Default bound on the `cargo check`/`cargo clippy` subprocess, mirroring
+/// `ShellConfig`'s default `timeout` (`zeph_config::tools::default_timeout`). A hostile
+/// or looping `build.rs`/proc-macro must not be able to hang the tool call indefinitely.
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
 /// Cargo diagnostics level.
 #[derive(Debug, Default, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -39,6 +45,8 @@ pub struct DiagnosticsExecutor {
     allowed_paths: Vec<PathBuf>,
     /// Maximum number of diagnostics to return (default: 50)
     max_diagnostics: usize,
+    /// Bound on the `cargo check`/`cargo clippy` subprocess (default: 30s).
+    timeout: Duration,
 }
 
 impl DiagnosticsExecutor {
@@ -55,12 +63,24 @@ impl DiagnosticsExecutor {
                 .map(|p| p.canonicalize().unwrap_or(p))
                 .collect(),
             max_diagnostics: 50,
+            timeout: Duration::from_secs(DEFAULT_TIMEOUT_SECS),
         }
     }
 
     #[must_use]
     pub fn with_max_diagnostics(mut self, max: usize) -> Self {
         self.max_diagnostics = max;
+        self
+    }
+
+    /// Overrides the default 30s bound on the `cargo check`/`cargo clippy` subprocess.
+    /// Callers wiring this into the live agent should pass the same value as
+    /// `tools.shell.timeout`, since it governs the same class of decision (how long a
+    /// subprocess is allowed to run) and cargo operations can legitimately exceed the
+    /// 30s default on larger workspaces.
+    #[must_use]
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
         self
     }
 
@@ -116,18 +136,34 @@ impl ToolExecutor for DiagnosticsExecutor {
 
         let cargo = which_cargo()?;
 
-        let output = tokio::process::Command::new(&cargo)
-            .arg(subcmd)
-            .arg("--message-format=json")
-            .current_dir(&work_dir)
-            .output()
-            .await
-            .map_err(|e| {
-                ToolError::Execution(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("failed to run cargo: {e}"),
-                ))
-            })?;
+        // kill_on_drop ensures a hostile/looping build.rs or proc-macro is killed rather
+        // than leaked when the timeout below fires and drops this future.
+        let output = tokio::time::timeout(
+            self.timeout,
+            tokio::process::Command::new(&cargo)
+                .arg(subcmd)
+                .arg("--message-format=json")
+                .current_dir(&work_dir)
+                .kill_on_drop(true)
+                .output(),
+        )
+        .await
+        .map_err(|_| {
+            tracing::warn!(
+                cmd = subcmd,
+                timeout_secs = self.timeout.as_secs(),
+                "cargo diagnostics subprocess timed out, killing child"
+            );
+            ToolError::Timeout {
+                timeout_secs: self.timeout.as_secs(),
+            }
+        })?
+        .map_err(|e| {
+            ToolError::Execution(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("failed to run cargo: {e}"),
+            ))
+        })?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let diagnostics = parse_cargo_json(&stdout, self.max_diagnostics);
@@ -257,6 +293,8 @@ pub(crate) fn parse_cargo_json(output: &str, max: usize) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     fn make_params(
@@ -339,6 +377,32 @@ mod tests {
         let input = "not json\n{\"reason\":\"build-script-executed\"}";
         let result = parse_cargo_json(input, 50);
         assert!(result.is_empty());
+    }
+
+    // --- timeout tests ---
+
+    /// Regression test for #5433 critic finding S1: the cargo subprocess had no
+    /// timeout, violating the project's mandatory Await Discipline rule (every external
+    /// `.await` must be bounded) and letting a hostile/looping `build.rs` or proc-macro
+    /// hang the tool call indefinitely. An unrealistically small timeout (1ns) makes the
+    /// timeout branch deterministic regardless of how fast the real `cargo` spawn is.
+    #[tokio::test]
+    async fn diagnostics_timeout_returns_timeout_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let exec = DiagnosticsExecutor::new(vec![dir.path().to_path_buf()])
+            .with_timeout(std::time::Duration::from_nanos(1));
+
+        let call = ToolCall {
+            tool_id: ToolName::new("diagnostics"),
+            params: make_params(&[("path", serde_json::json!(dir.path().to_str().unwrap()))]),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = exec.execute_tool_call(&call).await;
+        assert_matches!(result, Err(ToolError::Timeout { .. }));
     }
 
     // --- sandbox tests ---

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -197,6 +198,50 @@ const fn default_max_results() -> usize {
     10
 }
 
+/// Maximum directory entries a single structural/grep walk may visit before it
+/// is truncated. Bounds `allowed_paths` resolving to a huge tree (e.g. `~`).
+const MAX_WALK_ENTRIES: usize = 5_000;
+
+/// Maximum wall-clock time a single structural/grep walk may run before it is
+/// truncated, independent of entry count (guards against slow filesystems).
+const MAX_WALK_DURATION: Duration = Duration::from_secs(2);
+
+/// Safety net shared by the structural and grep-fallback directory walks.
+///
+/// `allowed_paths` is user/config controlled and may resolve to an
+/// unexpectedly broad root (e.g. `~`). Without a bound, a recursive walk over
+/// such a root can run indefinitely. `tick` caps both the number of entries
+/// visited and elapsed wall-clock time; once either limit is hit, the walk
+/// stops and reports partial results as truncated instead of hanging.
+struct WalkBudget {
+    started: Instant,
+    visited: usize,
+    truncated: bool,
+}
+
+impl WalkBudget {
+    fn new() -> Self {
+        Self {
+            started: Instant::now(),
+            visited: 0,
+            truncated: false,
+        }
+    }
+
+    /// Records one visited directory entry; returns `true` once the walk
+    /// should stop because the budget is exhausted.
+    fn tick(&mut self) -> bool {
+        if self.truncated {
+            return true;
+        }
+        self.visited += 1;
+        if self.visited > MAX_WALK_ENTRIES || self.started.elapsed() > MAX_WALK_DURATION {
+            self.truncated = true;
+        }
+        self.truncated
+    }
+}
+
 pub struct SearchCodeExecutor {
     allowed_paths: Vec<PathBuf>,
     semantic_backend: Option<std::sync::Arc<dyn SemanticSearchBackend>>,
@@ -269,6 +314,7 @@ impl SearchCodeExecutor {
 
         let max_results = params.max_results.clamp(1, 50);
         let mut hits = Vec::new();
+        let mut walk_truncated = false;
 
         if let Some(query) = query
             && let Some(backend) = &self.semantic_backend
@@ -284,12 +330,13 @@ impl SearchCodeExecutor {
             let paths = self.allowed_paths.clone();
             let sym = symbol.to_owned();
             let pat = params.file_pattern.clone();
-            let structural_hits = tokio::task::spawn_blocking(move || {
+            let (structural_hits, structural_truncated) = tokio::task::spawn_blocking(move || {
                 collect_all_structural_hits(&paths, &sym, pat.as_deref(), max_results)
             })
             .await
             .map_err(|e| ToolError::Execution(e.into()))??;
             hits.extend(structural_hits);
+            walk_truncated |= structural_truncated;
 
             if let Some(backend) = &self.lsp_backend {
                 if let Ok(lsp_hits) = backend
@@ -310,11 +357,10 @@ impl SearchCodeExecutor {
 
         if hits.is_empty() {
             let fallback_term = symbol.or(query).unwrap_or_default();
-            hits.extend(self.grep_fallback(
-                fallback_term,
-                params.file_pattern.as_deref(),
-                max_results,
-            )?);
+            let (grep_hits, grep_truncated) =
+                self.grep_fallback(fallback_term, params.file_pattern.as_deref(), max_results)?;
+            hits.extend(grep_hits);
+            walk_truncated |= grep_truncated;
         }
 
         let merged = dedupe_hits(hits, max_results);
@@ -322,45 +368,21 @@ impl SearchCodeExecutor {
             .allowed_paths
             .first()
             .map_or(Path::new("."), PathBuf::as_path);
-        let summary = format_hits(&merged, root);
-        let locations = merged
-            .iter()
-            .map(|hit| hit.file_path.clone())
-            .collect::<Vec<_>>();
-        let raw_response = serde_json::json!({
-            "results": merged.iter().map(|hit| {
-                serde_json::json!({
-                    "file_path": hit.file_path,
-                    "line_start": hit.line_start,
-                    "line_end": hit.line_end,
-                    "snippet": hit.snippet,
-                    "source": hit.source.label(),
-                    "score": hit.score,
-                    "symbol_name": hit.symbol_name,
-                })
-            }).collect::<Vec<_>>()
-        });
-
-        Ok(Some(ToolOutput {
-            tool_name: ToolName::new("search_code"),
-            summary,
-            blocks_executed: 1,
-            filter_stats: None,
-            diff: None,
-            streamed: false,
-            terminal_id: None,
-            locations: Some(locations),
-            raw_response: Some(raw_response),
-            claim_source: Some(ClaimSource::CodeSearch),
-        }))
+        Ok(Some(build_search_code_output(
+            &merged,
+            root,
+            walk_truncated,
+        )))
     }
 
+    /// Returns the collected hits alongside whether the walk was cut short by
+    /// [`WalkBudget`].
     fn grep_fallback(
         &self,
         pattern: &str,
         file_pattern: Option<&str>,
         max_results: usize,
-    ) -> Result<Vec<SearchCodeHit>, ToolError> {
+    ) -> Result<(Vec<SearchCodeHit>, bool), ToolError> {
         let matcher = file_pattern
             .map(glob::Pattern::new)
             .transpose()
@@ -375,13 +397,22 @@ impl SearchCodeExecutor {
                 message: e.to_string(),
             })?;
         let mut hits = Vec::new();
+        let mut budget = WalkBudget::new();
         for root in &self.allowed_paths {
-            collect_grep_hits(root, root, matcher.as_ref(), &regex, &mut hits, max_results)?;
-            if hits.len() >= max_results {
+            collect_grep_hits(
+                root,
+                root,
+                matcher.as_ref(),
+                &regex,
+                &mut hits,
+                max_results,
+                &mut budget,
+            )?;
+            if hits.len() >= max_results || budget.truncated {
                 break;
             }
         }
-        Ok(hits)
+        Ok((hits, budget.truncated))
     }
 }
 
@@ -417,12 +448,15 @@ impl ToolExecutor for SearchCodeExecutor {
 ///
 /// Extracted as a free function so callers can run it inside
 /// `tokio::task::spawn_blocking` without borrowing `self`.
+///
+/// Returns the collected hits alongside whether the walk was cut short by
+/// [`WalkBudget`] (see its docs for why the bound exists).
 fn collect_all_structural_hits(
     allowed_paths: &[PathBuf],
     symbol: &str,
     file_pattern: Option<&str>,
     max_results: usize,
-) -> Result<Vec<SearchCodeHit>, ToolError> {
+) -> Result<(Vec<SearchCodeHit>, bool), ToolError> {
     let matcher = file_pattern
         .map(glob::Pattern::new)
         .transpose()
@@ -431,13 +465,21 @@ fn collect_all_structural_hits(
         })?;
     let mut hits = Vec::new();
     let symbol_lower = symbol.to_lowercase();
+    let mut budget = WalkBudget::new();
     for root in allowed_paths {
-        collect_structural_hits(root, root, matcher.as_ref(), &symbol_lower, &mut hits)?;
-        if hits.len() >= max_results {
+        collect_structural_hits(
+            root,
+            root,
+            matcher.as_ref(),
+            &symbol_lower,
+            &mut hits,
+            &mut budget,
+        )?;
+        if hits.len() >= max_results || budget.truncated {
             break;
         }
     }
-    Ok(hits)
+    Ok((hits, budget.truncated))
 }
 
 fn dedupe_hits(mut hits: Vec<SearchCodeHit>, max_results: usize) -> Vec<SearchCodeHit> {
@@ -475,6 +517,57 @@ fn dedupe_hits(mut hits: Vec<SearchCodeHit>, max_results: usize) -> Vec<SearchCo
     merged
 }
 
+/// Assembles the final `search_code` [`ToolOutput`] from merged hits.
+///
+/// `walk_truncated` reports whether any directory walk (structural or grep
+/// fallback) was cut short by [`WalkBudget`] — surfaced both as a note in the
+/// summary text and as a `truncated` field in `raw_response` so callers can
+/// detect incomplete results programmatically.
+fn build_search_code_output(
+    hits: &[SearchCodeHit],
+    root: &Path,
+    walk_truncated: bool,
+) -> ToolOutput {
+    let mut summary = format_hits(hits, root);
+    if walk_truncated {
+        summary.push_str(
+            "\n\n[search truncated: directory walk exceeded the safety budget; \
+             results may be incomplete — narrow `allowed_paths` or `file_pattern`]",
+        );
+    }
+    let locations = hits
+        .iter()
+        .map(|hit| hit.file_path.clone())
+        .collect::<Vec<_>>();
+    let raw_response = serde_json::json!({
+        "results": hits.iter().map(|hit| {
+            serde_json::json!({
+                "file_path": hit.file_path,
+                "line_start": hit.line_start,
+                "line_end": hit.line_end,
+                "snippet": hit.snippet,
+                "source": hit.source.label(),
+                "score": hit.score,
+                "symbol_name": hit.symbol_name,
+            })
+        }).collect::<Vec<_>>(),
+        "truncated": walk_truncated,
+    });
+
+    ToolOutput {
+        tool_name: ToolName::new("search_code"),
+        summary,
+        blocks_executed: 1,
+        filter_stats: None,
+        diff: None,
+        streamed: false,
+        terminal_id: None,
+        locations: Some(locations),
+        raw_response: Some(raw_response),
+        claim_source: Some(ClaimSource::CodeSearch),
+    }
+}
+
 fn format_hits(hits: &[SearchCodeHit], root: &Path) -> String {
     if hits.is_empty() {
         return "No code matches found.".into();
@@ -507,17 +600,29 @@ fn collect_structural_hits(
     matcher: Option<&glob::Pattern>,
     symbol_lower: &str,
     hits: &mut Vec<SearchCodeHit>,
+    budget: &mut WalkBudget,
 ) -> Result<(), ToolError> {
-    if should_skip_path(current) {
+    if should_skip_path(current) || budget.truncated {
         return Ok(());
     }
 
     let entries = std::fs::read_dir(current).map_err(ToolError::Execution)?;
     for entry in entries {
+        if budget.tick() {
+            return Ok(());
+        }
         let entry = entry.map_err(ToolError::Execution)?;
         let path = entry.path();
-        if path.is_dir() {
-            collect_structural_hits(root, &path, matcher, symbol_lower, hits)?;
+        // Never follow symlinks: avoids symlink-loop hangs and matches the
+        // `symlink_metadata` convention used elsewhere in zeph-tools (file.rs).
+        let Ok(meta) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            collect_structural_hits(root, &path, matcher, symbol_lower, hits, budget)?;
             continue;
         }
         if !matches_pattern(root, &path, matcher) {
@@ -590,17 +695,27 @@ fn collect_grep_hits(
     regex: &regex::Regex,
     hits: &mut Vec<SearchCodeHit>,
     max_results: usize,
+    budget: &mut WalkBudget,
 ) -> Result<(), ToolError> {
-    if hits.len() >= max_results || should_skip_path(current) {
+    if hits.len() >= max_results || should_skip_path(current) || budget.truncated {
         return Ok(());
     }
 
     let entries = std::fs::read_dir(current).map_err(ToolError::Execution)?;
     for entry in entries {
+        if budget.tick() {
+            return Ok(());
+        }
         let entry = entry.map_err(ToolError::Execution)?;
         let path = entry.path();
-        if path.is_dir() {
-            collect_grep_hits(root, &path, matcher, regex, hits, max_results)?;
+        let Ok(meta) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            collect_grep_hits(root, &path, matcher, regex, hits, max_results, budget)?;
             continue;
         }
         if !matches_pattern(root, &path, matcher) {
@@ -742,6 +857,92 @@ mod tests {
         };
         let out = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(out.summary.contains("grep fallback"));
+    }
+
+    #[test]
+    fn walk_budget_truncates_after_entry_limit() {
+        let mut budget = WalkBudget::new();
+        for _ in 0..MAX_WALK_ENTRIES {
+            assert!(!budget.tick(), "budget must not trip before the limit");
+        }
+        assert!(
+            budget.tick(),
+            "budget must trip once entries exceed MAX_WALK_ENTRIES"
+        );
+        assert!(budget.truncated);
+    }
+
+    /// Regression test for the hang reported against a broad `allowed_paths`
+    /// scope (e.g. `~`): a directory containing far more entries than
+    /// `MAX_WALK_ENTRIES` must not be walked exhaustively — the search
+    /// returns promptly with a truncation indicator instead of hanging.
+    #[tokio::test]
+    async fn search_code_bounds_wide_directory_walk() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..(MAX_WALK_ENTRIES + 200) {
+            std::fs::write(dir.path().join(format!("f{i}.txt")), "").unwrap();
+        }
+        let exec = SearchCodeExecutor::new(vec![dir.path().to_path_buf()]);
+        let call = ToolCall {
+            tool_id: "search_code".into(),
+            params: serde_json::json!({ "symbol": "nonexistent_symbol_xyz" })
+                .as_object()
+                .unwrap()
+                .clone(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let out = tokio::time::timeout(
+            Duration::from_secs(MAX_WALK_DURATION.as_secs() + 10),
+            exec.execute_tool_call(&call),
+        )
+        .await
+        .expect("search_code must return within the walk budget, not hang")
+        .unwrap()
+        .unwrap();
+        assert!(
+            out.summary.contains("truncated"),
+            "expected truncation note in summary, got: {}",
+            out.summary
+        );
+        let raw = out.raw_response.unwrap();
+        assert_eq!(raw["truncated"], serde_json::json!(true));
+    }
+
+    /// A directory cycle created via a symlink pointing back to an ancestor
+    /// must not send the walk into an infinite loop — symlinked directories
+    /// are never followed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn search_code_does_not_follow_symlink_loop() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("lib.rs");
+        std::fs::write(&file, "pub fn retry_backoff_ms() -> u64 { 0 }\n").unwrap();
+        let loop_link = dir.path().join("self_loop");
+        std::os::unix::fs::symlink(dir.path(), &loop_link).unwrap();
+
+        let exec = SearchCodeExecutor::new(vec![dir.path().to_path_buf()]);
+        let call = ToolCall {
+            tool_id: "search_code".into(),
+            params: serde_json::json!({ "symbol": "retry_backoff_ms" })
+                .as_object()
+                .unwrap()
+                .clone(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let out = tokio::time::timeout(Duration::from_secs(10), exec.execute_tool_call(&call))
+            .await
+            .expect("search_code must not hang on a symlink loop")
+            .unwrap()
+            .unwrap();
+        assert!(out.summary.contains("retry_backoff_ms"));
     }
 
     #[test]

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -380,6 +380,20 @@ mod tests {
         assert_matches!(result, Err(ToolError::Blocked { .. }));
     }
 
+    /// Regression test for #5433: `diagnostics` runs `cargo check`/`cargo clippy`, which
+    /// executes arbitrary code via `build.rs` scripts and proc-macros in the target
+    /// workspace — equivalent to `bash` for security purposes. Now that #5433 wires
+    /// `DiagnosticsExecutor` into the live, `TrustGateExecutor`-gated composite chain, it
+    /// must be quarantine-denied like `bash`.
+    #[tokio::test]
+    async fn quarantined_denies_diagnostics() {
+        let gate = TrustGateExecutor::new(MockExecutor, PermissionPolicy::default());
+        gate.set_effective_trust(SkillTrustLevel::Quarantined);
+
+        let result = gate.execute_tool_call(&make_call("diagnostics")).await;
+        assert_matches!(result, Err(ToolError::Blocked { .. }));
+    }
+
     #[tokio::test]
     async fn quarantined_allows_read() {
         let policy = crate::permissions::PermissionPolicy::from_legacy(&[], &[]);
@@ -633,6 +647,7 @@ mod tests {
         assert!(is_quarantine_denied("memory_save"));
         assert!(is_quarantine_denied("delete_path"));
         assert!(is_quarantine_denied("create_directory"));
+        assert!(is_quarantine_denied("diagnostics"));
     }
 
     #[test]

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -414,11 +414,15 @@ async fn build_acp_deps(
         zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
     let shell_policy_handle = shell_executor.policy_handle();
     let cwd_executor = zeph_tools::SetCwdExecutor;
+    let diagnostics_executor = crate::agent_setup::build_diagnostics_executor(config);
     let base_executor = zeph_tools::CompositeExecutor::new(
         file_executor,
         zeph_tools::CompositeExecutor::new(
             shell_executor,
-            zeph_tools::CompositeExecutor::new(scrape_executor, cwd_executor),
+            zeph_tools::CompositeExecutor::new(
+                scrape_executor,
+                zeph_tools::CompositeExecutor::new(cwd_executor, diagnostics_executor),
+            ),
         ),
     );
     let index_provider = crate::bootstrap::resolve_index_embed_provider(config, provider.clone());

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -557,11 +557,15 @@ pub(crate) async fn build_tool_setup(
     let shell_executor = Arc::new(shell_executor);
     let shell_executor_handle = Some(Arc::clone(&shell_executor));
     let cwd_executor = zeph_tools::SetCwdExecutor;
+    let diagnostics_executor = build_diagnostics_executor(config);
     let base_executor = zeph_tools::CompositeExecutor::new(
         file_executor,
         zeph_tools::CompositeExecutor::new(
             shell_executor,
-            zeph_tools::CompositeExecutor::new(scrape_executor, cwd_executor),
+            zeph_tools::CompositeExecutor::new(
+                scrape_executor,
+                zeph_tools::CompositeExecutor::new(cwd_executor, diagnostics_executor),
+            ),
         ),
     );
     let composite = zeph_tools::CompositeExecutor::new(base_executor, mcp_executor);
@@ -1467,6 +1471,23 @@ pub(crate) fn build_search_code_executor(
     Some(executor)
 }
 
+/// Builds the `DiagnosticsExecutor` for the `diagnostics` tool, sandboxed to the same
+/// `tools.shell.allowed_paths` as `FileExecutor` and `SearchCodeExecutor`. Reuses
+/// `tools.shell.timeout` to bound the `cargo check`/`cargo clippy` subprocess — the same
+/// existing knob users already tune for long-running shell commands, rather than
+/// introducing a separate `tools.diagnostics.*` config surface for one field.
+pub(crate) fn build_diagnostics_executor(config: &Config) -> zeph_tools::DiagnosticsExecutor {
+    let allowed_paths = config
+        .tools
+        .shell
+        .allowed_paths
+        .iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+    zeph_tools::DiagnosticsExecutor::new(allowed_paths)
+        .with_timeout(std::time::Duration::from_secs(config.tools.shell.timeout))
+}
+
 fn resolve_search_lsp_server_id(config: &Config) -> Option<String> {
     config
         .mcp
@@ -1788,7 +1809,7 @@ mod tests {
     use zeph_llm::any::AnyProvider;
     use zeph_llm::ollama::OllamaProvider;
     use zeph_skills::registry::SkillRegistry;
-    use zeph_tools::executor::{ToolError, ToolOutput};
+    use zeph_tools::executor::{ToolError, ToolExecutor, ToolOutput};
 
     use super::*;
 
@@ -1858,6 +1879,41 @@ mod tests {
         config.llm.providers = vec![entry];
         let result = apply_cost_tracker(agent, &config);
         drop(result);
+    }
+
+    #[test]
+    fn build_diagnostics_executor_exposes_diagnostics_tool() {
+        let config = Config::load(Path::new("/nonexistent")).unwrap();
+        let executor = build_diagnostics_executor(&config);
+        let defs = executor.tool_definitions();
+        assert!(defs.iter().any(|d| d.id == "diagnostics"));
+    }
+
+    /// Regression test for #5433: `DiagnosticsExecutor` was fully unit-tested in
+    /// `zeph-tools` but never constructed by any live entry point, so the `diagnostics`
+    /// tool never appeared in the LLM's tool list. This mirrors the exact composite
+    /// nesting shape used in `build_tool_setup`/`acp.rs`/`daemon.rs` and asserts the tool
+    /// definition survives the merge.
+    #[test]
+    fn diagnostics_executor_reachable_through_composite_chain() {
+        let config = Config::load(Path::new("/nonexistent")).unwrap();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let cwd_executor = zeph_tools::SetCwdExecutor;
+        let diagnostics_executor = build_diagnostics_executor(&config);
+        let base_executor = zeph_tools::CompositeExecutor::new(
+            file_executor,
+            zeph_tools::CompositeExecutor::new(
+                shell_executor,
+                zeph_tools::CompositeExecutor::new(
+                    scrape_executor,
+                    zeph_tools::CompositeExecutor::new(cwd_executor, diagnostics_executor),
+                ),
+            ),
+        );
+        let defs = base_executor.tool_definitions();
+        assert!(defs.iter().any(|d| d.id == "diagnostics"));
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -492,11 +492,15 @@ pub(crate) async fn run_daemon(
         zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
     let shell_policy_handle = shell_executor.policy_handle();
     let cwd_executor = zeph_tools::SetCwdExecutor;
+    let diagnostics_executor = agent_setup::build_diagnostics_executor(config);
     let base_executor = zeph_tools::CompositeExecutor::new(
         file_executor,
         zeph_tools::CompositeExecutor::new(
             shell_executor,
-            zeph_tools::CompositeExecutor::new(scrape_executor, cwd_executor),
+            zeph_tools::CompositeExecutor::new(
+                scrape_executor,
+                zeph_tools::CompositeExecutor::new(cwd_executor, diagnostics_executor),
+            ),
         ),
     );
     let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::with_validator(


### PR DESCRIPTION
## Summary

- Wires `DiagnosticsExecutor` (the `diagnostics` tool — runs `cargo check`/`cargo clippy` and returns structured diagnostics) into the live agent's composite executor chain at all three entry points (`src/agent_setup.rs` for CLI/TUI, `src/daemon.rs`, `src/acp.rs`) via a shared `build_diagnostics_executor` helper. The tool was fully implemented and unit-tested but never constructed by any production entry point, so it was unreachable from a live agent.
- Since wiring it live also makes it reachable to Quarantined skills, adds `"diagnostics"` to `QUARANTINE_DENIED` (`cargo check`/`clippy` executes arbitrary code via `build.rs`/proc-macros, equivalent to `bash` for security purposes) and bounds the `cargo` subprocess with a `tokio::time::timeout` (reuses `tools.shell.timeout`, `kill_on_drop(true)` to avoid leaking a hung child on timeout).
- Bounds `search_code`'s recursive directory walk with a shared `WalkBudget` (entry-count + wall-clock, whichever trips first) across both the structural-hits and grep-hits fallback paths, and stops following symlinked directories to prevent loops. A budget-exceeded walk now returns partial results with a truncation note instead of hanging indefinitely — reproduced as a 90s+ hang when `allowed_paths = ["~"]` post-#5424's tilde-expansion fix.

No new config surface in either fix — both reuse existing `tools.shell.*` config.

Closes #5433, closes #5434

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11868 passed, 0 failed
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`) — clean
- [x] New regression test `quarantined_denies_diagnostics` (trust_gate.rs) confirms a Quarantined skill cannot invoke `diagnostics`
- [x] New tests for `WalkBudget` truncation and symlink-loop protection in `search_code.rs`
- [x] `.local/testing/playbooks/tools-diagnostics.md` and `.local/testing/playbooks/filesystem-access.md` (Scenario 5b) updated with live-test scenarios; `coverage-status.md` rows added (status: Untested, pending a live-tester CI cycle)