### PR TITLE
fix(sanitizer): harden PII detection across entry points and free-text names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1635,6 +1635,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   new `agent_sessions_upsert_and_list_postgres` regression test (insert, conflict-update, and
   both filtered/unfiltered list branches). Closes #5524, closes #5508.
 
+- `fix(sanitizer)`: harden PII detection (#5530, #5463). The NER union-merge PII classifier
+  (`apply_pii_ner_classifier`) was only ever wired in the CLI runner — `zeph --daemon` and
+  `zeph --acp` silently ran a strictly weaker single-layer PII stack for the same config. Added
+  `apply_pii_ner_classifier_with_cfg` (mirroring the existing `apply_pii_classifier`/`_with_cfg`
+  split) and wired it into `daemon.rs` and `acp.rs` (new `pii_filter_enabled` field on
+  `SharedAgentDeps`), so all three entry points now produce identical PII detection behavior.
+  Separately, the piiranha NER checkpoint is confirmed weak at recognizing free-text personal
+  names in casual sentences, while structured PII (email/phone/SSN/credit card) already has a
+  regex compensating control via `PiiFilter` — names had none. Added a capitalized-word-sequence
+  heuristic (new `filter_names` field on `PiiFilterConfig`, **opt-in, default `false`**): flags
+  runs of 2+ consecutive ASCII Titlecase tokens excluding a stoplist of common capitalized
+  non-name words, unioned into `PiiFilter::detect_spans`/`scrub`/`has_pii` the same way the
+  existing EMAIL/PHONE/SSN/CREDIT_CARD regex spans are — no NER dependency, works standalone.
+  Defaults off because it also flags common two-word technical/product terms (e.g. "Docker
+  Compose", "Pull Request") as candidate names; `--migrate-config` step 74
+  (`migrate_pii_filter_names`) surfaces it as a commented advisory on existing active
+  `[security.pii_filter]` tables rather than force-enabling it. Two further defects found in
+  review before merge: a sentence-initial real name (e.g. "John Smith is the CEO.") was silently
+  left completely unredacted (the leading token of any sentence-initial run was unconditionally
+  dropped instead of relying on the stoplist alone); and apostrophe/hyphen-joined surnames (e.g.
+  "Mary O'Brien", "Smith-Jones") were partially redacted, leaking the surname fragment after the
+  apostrophe/hyphen in the clear — both fixed by simplifying the run-detection to rely solely on
+  `NAME_STOPLIST` membership (no position-based dropping) and extending `CAPITALIZED_WORD_RE` to
+  keep an apostrophe/hyphen-joined compound name inside a single token. Closes #5530, closes
+  #5463.
+
 ### Changed
 
 - `build(db)`: upgrade `sqlx` 0.8.6 → 0.9.0. The `runtime-tokio-rustls` feature was split into

--- a/book/src/reference/security.md
+++ b/book/src/reference/security.md
@@ -519,7 +519,13 @@ Shell commands executed by the agent run in a scrubbed environment. Variables ma
 
 ### PII Protection
 
-A configurable NER-based PII detection system can identify and redact personally identifiable information in tool outputs before they enter the LLM context. A circuit breaker protects against runaway cost from paginated reads that trigger repeated PII scans.
+PII detection unions three independent layers before redacting tool outputs, so a gap in one layer is covered by the others:
+
+- **Regex filter** (`[security.pii_filter]`): email, phone, SSN, and credit card patterns, plus an opt-in (`filter_names`, default `false`) capitalized-word-sequence heuristic that flags runs of 2+ consecutive ASCII Titlecase tokens as candidate personal names — a compensating control for cases the NER model misses in free-text prose. This heuristic is high-recall but lower-precision: it also flags common two-word technical/product terms (e.g. "Docker Compose", "Pull Request"), so it defaults off and is not force-enabled on existing installs by `--migrate-config`.
+- **NER classifier** (`[classifiers]`, `pii_enabled`): a configurable `Candle`/DeBERTa-backed model (default `iiiorg/piiranha-v1-detect-personal-information`) that identifies structured and unstructured PII entities. A circuit breaker protects against runaway cost from paginated reads that trigger repeated PII scans.
+- **NER union-merge classifier** (`[classifiers]`, gated on `classifiers.enabled` and `security.pii_filter.enabled`): a second NER pass whose spans are merged with the regex filter's spans before redaction.
+
+All three layers are wired identically across every entry point — CLI, daemon (`zeph --daemon`), and ACP/IDE sessions — so PII coverage does not silently degrade depending on how the agent is launched.
 
 ## Code Security
 

--- a/config/testing.toml
+++ b/config/testing.toml
@@ -246,6 +246,7 @@ filter_email = true
 filter_phone = true
 filter_ssn = true
 filter_credit_card = true
+filter_names = true
 
 [security.exfiltration_guard]
 block_markdown_images = true

--- a/crates/zeph-config/src/migrate/infra.rs
+++ b/crates/zeph-config/src/migrate/infra.rs
@@ -697,3 +697,65 @@ pub fn migrate_secret_masking_config(toml_src: &str) -> Result<MigrationResult, 
         sections_changed: vec!["security.content_isolation.secret_masking".to_owned()],
     })
 }
+
+/// Adds a commented `# filter_names = false` advisory line to an existing active
+/// `[security.pii_filter]` table that lacks the field: a capitalized-word-sequence heuristic
+/// that compensates for weak NER-model recall on free-text personal names (#5530).
+///
+/// Opt-in by design (defaults to `false`) — unlike the other `pii_filter` flags, this heuristic
+/// also flags common two-word technical/product terms (e.g. `"Docker Compose"`, `"Pull
+/// Request"`) as candidate names, so it is surfaced as a commented advisory rather than
+/// force-enabled on existing installs (#5530 review S1). No-op when `[security.pii_filter]` is
+/// absent, or `filter_names` (active or commented) is already present.
+///
+/// # Errors
+///
+/// Returns [`MigrateError`] if the source is not valid TOML.
+pub fn migrate_pii_filter_names(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Anchored multiline pattern: matches `[security.pii_filter]` with optional inline comment,
+    // followed by LF or CRLF. Does NOT match subtables so the replacement target stays aligned.
+    static PII_FILTER_HEADER_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+        Regex::new(r"(?m)^[ \t]*\[security\.pii_filter\][ \t]*(?:#[^\r\n]*)?\r?\n")
+            .expect("static pattern")
+    });
+
+    if !section_header_present(toml_src, "security.pii_filter") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let already_present = toml_src.lines().any(|l| {
+        let t = l.trim().trim_start_matches('#').trim();
+        t.starts_with("filter_names")
+    });
+    if already_present || !PII_FILTER_HEADER_RE.is_match(toml_src) {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "# filter_names = false  # capitalized-word-sequence name heuristic \
+        (opt-in; also flags technical/product terms like \"Docker Compose\", #5530)\n";
+    let output = PII_FILTER_HEADER_RE
+        .replacen(toml_src, 1, |caps: &regex::Captures| {
+            format!("{}{comment}", &caps[0])
+        })
+        .into_owned();
+
+    let changed = output != toml_src;
+    let changed_count = usize::from(changed);
+    Ok(MigrationResult {
+        output,
+        changed_count,
+        sections_changed: if changed {
+            vec!["security.pii_filter".to_owned()]
+        } else {
+            Vec::new()
+        },
+    })
+}

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -610,18 +610,19 @@ use steps::{
     MigrateMemoryPersonaConfig, MigrateMemoryReasoning, MigrateMemoryReasoningJudge,
     MigrateMemoryRetrieval, MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig,
     MigrateNliConfig, MigrateOrchestrationAssetSensitivity, MigrateOrchestrationPersistence,
-    MigrateOrchestratorProvider, MigrateOtelFilter, MigratePlannerModelToProvider,
-    MigratePolicyProviderAndUtilityWindow, MigrateProviderMaxConcurrent, MigrateQdrantApiKey,
-    MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
-    MigrateSecretMaskingConfig, MigrateServeConfig, MigrateSessionPersistProviderOverrides,
-    MigrateSessionPersistenceConfig, MigrateSessionProviderPersistence, MigrateSessionRecapConfig,
-    MigrateShellCheckpointsConfig, MigrateShellTransactional, MigrateSttToProvider,
-    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
-    MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig,
-    MigrateTuiThemeDefaults, MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
+    MigrateOrchestratorProvider, MigrateOtelFilter, MigratePiiFilterNames,
+    MigratePlannerModelToProvider, MigratePolicyProviderAndUtilityWindow,
+    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig,
+    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSecretMaskingConfig,
+    MigrateServeConfig, MigrateSessionPersistProviderOverrides, MigrateSessionPersistenceConfig,
+    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellCheckpointsConfig,
+    MigrateShellTransactional, MigrateSttToProvider, MigrateSupervisorConfig,
+    MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateTraceMetadata,
+    MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig, MigrateTuiThemeDefaults,
+    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–73).
+/// Ordered registry of all sequential migration steps (steps 1–74).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -750,6 +751,9 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateNliConfig),
             // Step 73 — add [security.content_isolation.secret_masking] advisory block (#5437)
             Box::new(MigrateSecretMaskingConfig),
+            // Step 74 — add a commented `filter_names = false` advisory to an existing
+            // [security.pii_filter] table (#5530)
+            Box::new(MigratePiiFilterNames),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -32,7 +32,9 @@
 //! step 70 adds session-persistence keys and a `[session.condense]` advisory block (spec-068, #5343);
 //! step 71 adds a `[serve]` advisory block for `zeph serve` (spec-068 §9, #5343);
 //! step 72 adds a `[security.content_isolation.nli]` advisory block (#5438);
-//! step 73 adds a `[security.content_isolation.secret_masking]` advisory block (#5437).
+//! step 73 adds a `[security.content_isolation.secret_masking]` advisory block (#5437);
+//! step 74 adds a commented `filter_names = false` advisory to an existing
+//! `[security.pii_filter]` table (#5530).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -56,17 +58,18 @@ use super::{
     migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
     migrate_memory_retrieval_query_bias, migrate_microcompact_config, migrate_nli_config,
     migrate_orchestration_asset_sensitivity, migrate_orchestration_orchestrator_provider,
-    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
-    migrate_policy_provider_and_utility_window, migrate_provider_max_concurrent,
-    migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
-    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config, migrate_secret_masking_config,
-    migrate_serve_config, migrate_session_persist_provider_overrides,
-    migrate_session_persistence_config, migrate_session_provider_persistence,
-    migrate_session_recap_config, migrate_shell_checkpoints_config, migrate_shell_transactional,
-    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
-    migrate_tools_compression_config, migrate_trace_metadata, migrate_tui_delights,
-    migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults, migrate_vigil_config,
-    migrate_worktree_config, migrate_worktree_git_timeout,
+    migrate_orchestration_persistence, migrate_otel_filter, migrate_pii_filter_names,
+    migrate_planner_model_to_provider, migrate_policy_provider_and_utility_window,
+    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_quality_config,
+    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
+    migrate_secret_masking_config, migrate_serve_config,
+    migrate_session_persist_provider_overrides, migrate_session_persistence_config,
+    migrate_session_provider_persistence, migrate_session_recap_config,
+    migrate_shell_checkpoints_config, migrate_shell_transactional, migrate_stt_to_provider,
+    migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
+    migrate_trace_metadata, migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config,
+    migrate_tui_theme_defaults, migrate_vigil_config, migrate_worktree_config,
+    migrate_worktree_git_timeout,
 };
 
 // ── Wrapper structs for all 73 sequential migration steps ───────────────────────────────────────
@@ -880,5 +883,19 @@ impl Migration for MigrateSecretMaskingConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_secret_masking_config(toml_src)
+    }
+}
+
+/// Step 74 — add a commented `filter_names = false` advisory to an existing active
+/// `[security.pii_filter]` table (compensating name-detection heuristic for weak NER-model
+/// recall, opt-in by design, #5530).
+pub(super) struct MigratePiiFilterNames;
+impl Migration for MigratePiiFilterNames {
+    fn name(&self) -> &'static str {
+        "migrate_pii_filter_names"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_pii_filter_names(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        73,
-        "MIGRATIONS registry must contain all 73 sequential steps"
+        74,
+        "MIGRATIONS registry must contain all 74 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1645,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 73);
+    assert_eq!(MIGRATIONS.len(), 74);
 }
 
 #[test]
@@ -1684,7 +1684,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–73).
+    // Names must follow the documented step order (steps 1–74).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1759,6 +1759,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_serve_config",
         "migrate_nli_config",
         "migrate_secret_masking_config",
+        "migrate_pii_filter_names",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -3205,6 +3206,61 @@ fn step_73_idempotent_on_own_output() {
     let first = migrate_secret_masking_config(src).expect("first migrate");
     assert_eq!(first.changed_count, 1);
     let second = migrate_secret_masking_config(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
+    );
+}
+
+// ── migrate_pii_filter_names tests (step 74, #5530) ──────────────────────
+
+#[test]
+fn step_74_adds_commented_advisory_when_pii_filter_active_and_missing_field() {
+    let src = "[security.pii_filter]\nenabled = true\nfilter_email = true\n";
+    let result = migrate_pii_filter_names(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    // Advisory only — must NOT force-activate the noisy heuristic for existing installs (S1).
+    assert!(result.output.contains("# filter_names = false"));
+    assert!(!result.output.contains("\nfilter_names ="));
+    assert!(result.output.contains("enabled = true"));
+    assert!(result.output.contains("filter_email = true"));
+    assert_eq!(
+        result.sections_changed,
+        vec!["security.pii_filter".to_owned()]
+    );
+}
+
+#[test]
+fn step_74_noop_when_filter_names_already_present() {
+    let src = "[security.pii_filter]\nenabled = true\nfilter_names = false\n";
+    let result = migrate_pii_filter_names(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_74_noop_when_filter_names_comment_already_present() {
+    let src = "[security.pii_filter]\nenabled = true\n# filter_names = false\n";
+    let result = migrate_pii_filter_names(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_74_noop_when_pii_filter_section_absent() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_pii_filter_names(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_74_idempotent_on_own_output() {
+    let src = "[security.pii_filter]\nenabled = true\n";
+    let first = migrate_pii_filter_names(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_pii_filter_names(&first.output).expect("second migrate");
     assert_eq!(second.changed_count, 0, "second run must be a no-op");
     assert_eq!(
         second.output, first.output,

--- a/crates/zeph-config/src/sanitizer.rs
+++ b/crates/zeph-config/src/sanitizer.rs
@@ -421,6 +421,16 @@ pub struct PiiFilterConfig {
     /// Scrub credit card numbers (16-digit patterns).
     #[serde(default = "default_true")]
     pub filter_credit_card: bool,
+    /// Scrub personal names via a capitalized-word-sequence heuristic: 2+ consecutive
+    /// ASCII Titlecase tokens excluding a stoplist of common capitalized non-name words.
+    /// Compensating control for weak NER-model recall on free-text names (#5530).
+    ///
+    /// Defaults to `false` (opt-in), unlike the other `filter_*` flags: this is a high-recall,
+    /// lower-precision heuristic that also flags common two-word technical/product terms (e.g.
+    /// `"Docker Compose"`, `"Pull Request"`, `"New York"`) as candidate names, so it is not
+    /// force-enabled for existing `pii_filter.enabled = true` deployments.
+    #[serde(default)]
+    pub filter_names: bool,
     /// Custom regex patterns to add on top of the built-ins.
     #[serde(default)]
     pub custom_patterns: Vec<CustomPiiPattern>,
@@ -434,6 +444,7 @@ impl Default for PiiFilterConfig {
             filter_phone: true,
             filter_ssn: true,
             filter_credit_card: true,
+            filter_names: false,
             custom_patterns: Vec::new(),
         }
     }

--- a/crates/zeph-sanitizer/src/pii.rs
+++ b/crates/zeph-sanitizer/src/pii.rs
@@ -82,15 +82,19 @@ static CREDIT_CARD_RE: LazyLock<Regex> =
 ///   segments (e.g. `Smith-Jones`) so a hyphenated surname is captured as a single token instead
 ///   of splitting into two separate matches that would otherwise leave the second half
 ///   unredacted (#5530 review S3).
-/// - `[A-Z]'[A-Z][a-z]+` — a single leading capital immediately followed by an apostrophe and a
-///   second capitalized segment (e.g. `O'Brien`, `D'Angelo`), for surnames with no lowercase
-///   letters before the apostrophe.
+/// - `[A-Z]'[A-Z][a-z]+(?:['-][A-Z][a-z]*)*` — a single leading capital immediately followed by
+///   an apostrophe and a second capitalized segment (e.g. `O'Brien`, `D'Angelo`), for surnames
+///   with no lowercase letters before the apostrophe. This branch carries the same
+///   apostrophe/hyphen compound-continuation group as the primary branch, so a surname that is
+///   both apostrophe-prefixed and hyphenated (e.g. `O'Brien-Doyle`) is captured as a single
+///   token instead of splitting at the hyphen and leaking the second half in the clear (#5530
+///   review S3, compound case).
 ///
 /// Anchored on word boundaries so it never matches inside a larger mixed-case token (e.g.
 /// `iPhone`, `McDonald`) and never matches ALL-CAPS acronyms (e.g. `API`, `URL`) or bare single
 /// letters, since both branches require at least one lowercase letter in the token.
 static CAPITALIZED_WORD_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"\b[A-Z](?:[a-z]+(?:['-][A-Z][a-z]*)*|'[A-Z][a-z]+)\b")
+    Regex::new(r"\b[A-Z](?:[a-z]+(?:['-][A-Z][a-z]*)*|'[A-Z][a-z]+(?:['-][A-Z][a-z]*)*)\b")
         .expect("valid CAPITALIZED_WORD_RE")
 });
 
@@ -1140,6 +1144,37 @@ mod tests {
         assert!(!result.contains("Smith-Jones"), "raw name must not remain");
         assert!(
             !result.contains("Jones"),
+            "surname fragment must not leak: {result}"
+        );
+    }
+
+    #[test]
+    fn scrubs_compound_apostrophe_hyphen_surname_without_leaking_fragment() {
+        // Regression test for #5530 review S3 (round 2): the apostrophe-initial branch of
+        // CAPITALIZED_WORD_RE lacked the compound-continuation group that the plain branch had,
+        // so a surname that is both apostrophe-prefixed and hyphenated ("O'Brien-Doyle") matched
+        // only as far as "O'Brien", leaking "-Doyle" unredacted right next to the marker.
+        let f = filter_all();
+        let text = "Mary O'Brien-Doyle is the CEO.";
+        let result = f.scrub(text);
+        assert!(
+            result.contains("[PII:name]"),
+            "compound apostrophe/hyphen surname must be scrubbed: {result}"
+        );
+        assert!(
+            !result.contains("O'Brien-Doyle"),
+            "raw name must not remain"
+        );
+        assert!(
+            !result.contains("Brien"),
+            "surname fragment must not leak: {result}"
+        );
+        assert!(
+            !result.contains("Doyle"),
+            "surname fragment must not leak: {result}"
+        );
+        assert!(
+            !result.contains("-Doyle"),
             "surname fragment must not leak: {result}"
         );
     }

--- a/crates/zeph-sanitizer/src/pii.rs
+++ b/crates/zeph-sanitizer/src/pii.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! PII filter: regex-based scrubber for email, phone, SSN, and credit card numbers.
+//! PII filter: regex-based scrubber for email, phone, SSN, credit card numbers, and (opt-in)
+//! a capitalized-word-sequence personal-name heuristic.
 //!
 //! Applied to tool outputs before they enter LLM context and before debug dumps are written.
 //! Configured under `[security.pii_filter]` in the agent config file.
@@ -27,6 +28,7 @@
 //! ```
 
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::sync::LazyLock;
 
 use regex::{Regex, RegexBuilder};
@@ -65,6 +67,145 @@ pub(crate) static SSN_RE: LazyLock<Regex> =
 /// Credit card number: 16 digits in groups of 4 (space or dash separated, or bare).
 static CREDIT_CARD_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\b(?:\d{4}[-\s]?){3}\d{4}\b").expect("valid CREDIT_CARD_RE"));
+
+// ---------------------------------------------------------------------------
+// Name heuristic (#5530): compensating control for weak NER-model recall on
+// free-text personal names.
+// ---------------------------------------------------------------------------
+
+/// Titlecase word, ASCII-only (English-language scope; accented and non-Latin names such as
+/// `José` or Cyrillic/CJK names are not matched — a known, accepted limitation of this
+/// heuristic, not a bug). Two shapes are matched:
+///
+/// - `[A-Z][a-z]+(?:['-][A-Z][a-z]*)*` — a leading capital followed by one or more lowercase
+///   letters (e.g. `John`, `Smith`), optionally extended by apostrophe/hyphen-joined compound
+///   segments (e.g. `Smith-Jones`) so a hyphenated surname is captured as a single token instead
+///   of splitting into two separate matches that would otherwise leave the second half
+///   unredacted (#5530 review S3).
+/// - `[A-Z]'[A-Z][a-z]+` — a single leading capital immediately followed by an apostrophe and a
+///   second capitalized segment (e.g. `O'Brien`, `D'Angelo`), for surnames with no lowercase
+///   letters before the apostrophe.
+///
+/// Anchored on word boundaries so it never matches inside a larger mixed-case token (e.g.
+/// `iPhone`, `McDonald`) and never matches ALL-CAPS acronyms (e.g. `API`, `URL`) or bare single
+/// letters, since both branches require at least one lowercase letter in the token.
+static CAPITALIZED_WORD_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b[A-Z](?:[a-z]+(?:['-][A-Z][a-z]*)*|'[A-Z][a-z]+)\b")
+        .expect("valid CAPITALIZED_WORD_RE")
+});
+
+/// Common capitalized words that are not personal names: sentence-initial function
+/// words, calendar terms, and common acronyms/abbreviations that happen to be
+/// Titlecase. Matched case-sensitively against the exact token text.
+static NAME_STOPLIST: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        "The",
+        "This",
+        "That",
+        "These",
+        "Those",
+        "There",
+        "Here",
+        "It",
+        "A",
+        "An",
+        "If",
+        "When",
+        "While",
+        "After",
+        "Before",
+        "Since",
+        "Because",
+        "Although",
+        "However",
+        "Therefore",
+        "Moreover",
+        "Furthermore",
+        "Meanwhile",
+        "Otherwise",
+        "Please",
+        "Note",
+        "Warning",
+        "Error",
+        "Example",
+        "Yes",
+        "No",
+        "Ok",
+        "Okay",
+        "Thanks",
+        "Hello",
+        "Hi",
+        "Dear",
+        "Sincerely",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ]
+    .into_iter()
+    .collect()
+});
+
+/// Detect personal-name-shaped spans: runs of 2+ consecutive Titlecase tokens (separated by
+/// exactly one space, nothing else) that are not stoplisted.
+///
+/// Sentence-initial non-name capitalization (e.g. `"The quick brown fox"`) is excluded purely
+/// via [`NAME_STOPLIST`] membership of the leading word, not by position — an earlier revision
+/// unconditionally dropped the leading token of any sentence-initial run, which silently
+/// defeated the heuristic for the extremely common `"<FirstName> <LastName> is/does ..."`
+/// sentence shape (e.g. `"John Smith is the CEO."` redacted nothing, since "John" is not
+/// stoplisted; #5530 review S2). Relying solely on the stoplist preserves the false-positive
+/// avoidance for real non-name sentence starters without that false-negative.
+///
+/// Single first names alone (e.g. `"Reach out to Marcus"`) are never flagged — this heuristic
+/// only fires on 2+-token runs, by design (mitigates, does not eliminate, the underlying
+/// NER-recall gap on free-text names).
+///
+/// This is an additive, non-ML compensating control for the confirmed weak spot in the
+/// NER PII model's free-text name recall (#5530) — it runs independently of any NER
+/// backend and unions its spans in the same way `EMAIL`/`PHONE`/`SSN`/`CREDIT_CARD` spans do.
+fn detect_name_spans(text: &str) -> Vec<PiiSpan> {
+    let matches: Vec<regex::Match<'_>> = CAPITALIZED_WORD_RE
+        .find_iter(text)
+        .filter(|m| !NAME_STOPLIST.contains(m.as_str()))
+        .collect();
+
+    let mut spans = Vec::new();
+    let mut i = 0usize;
+    while i < matches.len() {
+        let mut j = i;
+        while j + 1 < matches.len()
+            && text.get(matches[j].end()..matches[j + 1].start()) == Some(" ")
+        {
+            j += 1;
+        }
+        // Run is matches[i..=j].
+        if j > i {
+            spans.push(PiiSpan {
+                label: "name".to_owned(),
+                start: matches[i].start(),
+                end: matches[j].end(),
+            });
+        }
+        i = j + 1;
+    }
+    spans
+}
 
 // ---------------------------------------------------------------------------
 // Internal pattern record
@@ -179,6 +320,8 @@ pub struct PiiFilter {
     builtin: Vec<PiiPattern>,
     /// User-defined patterns from `custom_patterns`.
     custom: Vec<CustomPiiPatternCompiled>,
+    /// Whether the capitalized-word-sequence name heuristic (#5530) is active.
+    filter_names: bool,
 }
 
 impl PiiFilter {
@@ -245,7 +388,14 @@ impl PiiFilter {
             enabled: config.enabled,
             builtin,
             custom,
+            filter_names: config.filter_names,
         }
+    }
+
+    /// Returns `true` when no active detector (builtin, custom, or name heuristic) is
+    /// configured — the shared early-return condition for `detect_spans`/`scrub`/`has_pii`.
+    fn has_no_active_detectors(&self) -> bool {
+        self.builtin.is_empty() && self.custom.is_empty() && !self.filter_names
     }
 
     /// Detect PII spans in `text` and return their byte offsets without replacing.
@@ -254,10 +404,13 @@ impl PiiFilter {
     /// Offsets are byte offsets (same unit as `regex::Match::start()`/`end()`).
     #[must_use]
     pub fn detect_spans(&self, text: &str) -> Vec<PiiSpan> {
-        if !self.enabled || (self.builtin.is_empty() && self.custom.is_empty()) {
+        if !self.enabled || self.has_no_active_detectors() {
             return vec![];
         }
         let mut spans = Vec::new();
+        if self.filter_names {
+            spans.extend(detect_name_spans(text));
+        }
         for p in &self.builtin {
             let label = p
                 .replacement
@@ -299,11 +452,18 @@ impl PiiFilter {
     /// When the filter is disabled, always returns `Cow::Borrowed(text)`.
     #[must_use]
     pub fn scrub<'a>(&self, text: &'a str) -> Cow<'a, str> {
-        if !self.enabled || (self.builtin.is_empty() && self.custom.is_empty()) {
+        if !self.enabled || self.has_no_active_detectors() {
             return Cow::Borrowed(text);
         }
 
         let mut result: Option<String> = None;
+
+        if self.filter_names {
+            let name_spans = detect_name_spans(text);
+            if !name_spans.is_empty() {
+                result = Some(redact_spans(text, &merge_spans(name_spans)));
+            }
+        }
 
         for p in &self.builtin {
             let current: &str = result.as_deref().unwrap_or(text);
@@ -337,12 +497,13 @@ impl PiiFilter {
         }
         self.builtin.iter().any(|p| p.regex.is_match(text))
             || self.custom.iter().any(|p| p.regex.is_match(text))
+            || (self.filter_names && !detect_name_spans(text).is_empty())
     }
 
     /// Returns `true` if the filter is enabled and has at least one active pattern.
     #[must_use]
     pub fn is_enabled(&self) -> bool {
-        self.enabled && (!self.builtin.is_empty() || !self.custom.is_empty())
+        self.enabled && !self.has_no_active_detectors()
     }
 }
 
@@ -356,8 +517,11 @@ mod tests {
     use std::assert_matches;
 
     fn filter_all() -> PiiFilter {
+        // filter_names defaults to false (opt-in, #5530 review S1) — explicitly enable it here
+        // so "all" actually means all detector categories for the tests that use this helper.
         PiiFilter::new(PiiFilterConfig {
             enabled: true,
+            filter_names: true,
             ..PiiFilterConfig::default()
         })
     }
@@ -511,6 +675,7 @@ mod tests {
             filter_phone: false,
             filter_ssn: false,
             filter_credit_card: false,
+            filter_names: false,
             custom_patterns: vec![CustomPiiPattern {
                 name: "employee_id".to_owned(),
                 pattern: r"EMP-\d{6}".to_owned(),
@@ -605,6 +770,7 @@ mod tests {
             filter_phone: false,
             filter_ssn: false,
             filter_credit_card: false,
+            filter_names: false,
             custom_patterns: vec![],
         });
         assert!(!f.is_enabled());
@@ -620,6 +786,7 @@ mod tests {
             filter_phone: false,
             filter_ssn: false,
             filter_credit_card: false,
+            filter_names: false,
             custom_patterns: vec![],
         });
         let result = f.scrub("user@example.com and 555-867-5309");
@@ -640,6 +807,7 @@ mod tests {
             filter_phone: false,
             filter_ssn: false,
             filter_credit_card: false,
+            filter_names: false,
             custom_patterns: vec![CustomPiiPattern {
                 name: "token".to_owned(),
                 pattern: r"TOKEN-\d+".to_owned(),
@@ -859,6 +1027,7 @@ mod tests {
             filter_email: false,
             filter_phone: false,
             filter_credit_card: false,
+            filter_names: false,
             custom_patterns: vec![],
         });
         // A date like 12-01-2024 has the form DDD-DD-DDDD but \b\d{3}-\d{2}-\d{4}\b
@@ -866,5 +1035,209 @@ mod tests {
         let text = "date 12-01-2024 passed";
         let result = f.scrub(text);
         assert_eq!(result, text, "date DD-MM-YYYY must not be detected as SSN");
+    }
+
+    // --- name heuristic (#5530): compensating control for weak NER free-text name recall ---
+
+    #[test]
+    fn scrubs_name_not_at_sentence_start() {
+        // Regression test for #5530: the NER model alone yields no confident span for
+        // "John Smith" here (see `free_text_names_yield_no_confident_span` in candle_pii.rs).
+        // This heuristic is a separate, additive layer that does not depend on any NER backend.
+        let f = filter_all();
+        let text = "Contact John Smith at john@example.com for details.";
+        let result = f.scrub(text);
+        assert!(
+            result.contains("[PII:name]"),
+            "name must be scrubbed: {result}"
+        );
+        assert!(
+            !result.contains("John Smith"),
+            "raw name must not remain: {result}"
+        );
+        assert!(
+            result.contains("[PII:email]"),
+            "email must also be scrubbed: {result}"
+        );
+    }
+
+    #[test]
+    fn detect_name_spans_standalone_without_other_detectors() {
+        // Exercises the heuristic directly, with every other detector (including any NER
+        // backend, which PiiFilter never depends on) disabled — proves it works standalone.
+        // "Reach"/"out"/"to" break the run before "John" (lowercase words in between), so the
+        // detected span is exactly "John Smith", not the whole sentence-initial phrase.
+        let f = PiiFilter::new(PiiFilterConfig {
+            enabled: true,
+            filter_email: false,
+            filter_phone: false,
+            filter_ssn: false,
+            filter_credit_card: false,
+            filter_names: true,
+            custom_patterns: vec![],
+        });
+        let text = "Reach out to John Smith at john@example.com for details.";
+        let spans = f.detect_spans(text);
+        let name_span = spans
+            .iter()
+            .find(|s| s.label == "name")
+            .expect("name span must be detected");
+        assert_eq!(&text[name_span.start..name_span.end], "John Smith");
+    }
+
+    #[test]
+    fn scrubs_sentence_initial_full_name() {
+        // Regression test for #5530 review S2: an earlier revision unconditionally dropped the
+        // leading token of any sentence-initial run, which silently left a name entirely
+        // unredacted when the name itself opened the sentence — one of the most common name
+        // mention shapes in chat/tool output. "John" is not stoplisted, so it must stay in the
+        // run and the full name must be redacted.
+        let f = filter_all();
+        let text = "John Smith is the CEO.";
+        let result = f.scrub(text);
+        assert!(
+            result.contains("[PII:name]"),
+            "sentence-initial full name must be scrubbed: {result}"
+        );
+        assert!(!result.contains("John Smith"), "raw name must not remain");
+        assert!(
+            !result.contains("John "),
+            "first name fragment must not remain"
+        );
+    }
+
+    #[test]
+    fn scrubs_apostrophe_surname_without_leaking_fragment() {
+        // Regression test for #5530 review S3: the old regex ended a token at an internal
+        // apostrophe when the next character was uppercase (`O'` then a separate `Brien` token
+        // with no space between them), so the run broke and "Brien" leaked in the clear right
+        // next to the redaction marker. The whole surname must now stay inside one token.
+        let f = filter_all();
+        let text = "Please contact Mary O'Brien now.";
+        let result = f.scrub(text);
+        assert!(
+            result.contains("[PII:name]"),
+            "apostrophe surname must be scrubbed: {result}"
+        );
+        assert!(!result.contains("O'Brien"), "raw name must not remain");
+        assert!(
+            !result.contains("Brien"),
+            "surname fragment must not leak: {result}"
+        );
+    }
+
+    #[test]
+    fn scrubs_hyphenated_surname_without_leaking_fragment() {
+        // Regression test for #5530 review S3, hyphen variant: the old regex broke the run at
+        // the hyphen ("Smith-" then a separate "Jones" token), leaking "Jones".
+        let f = filter_all();
+        let text = "Loop in John Smith-Jones on this thread.";
+        let result = f.scrub(text);
+        assert!(
+            result.contains("[PII:name]"),
+            "hyphenated surname must be scrubbed: {result}"
+        );
+        assert!(!result.contains("Smith-Jones"), "raw name must not remain");
+        assert!(
+            !result.contains("Jones"),
+            "surname fragment must not leak: {result}"
+        );
+    }
+
+    #[test]
+    fn filter_names_defaults_to_false() {
+        // #5530 review S1: the heuristic also flags common two-word technical/product terms
+        // (e.g. "Docker Compose", "Pull Request") as candidate names, so it must be opt-in
+        // rather than default-on for every existing `pii_filter.enabled = true` deployment.
+        assert!(!PiiFilterConfig::default().filter_names);
+    }
+
+    #[test]
+    fn flags_two_consecutive_capitalized_words_mid_sentence() {
+        let f = filter_all();
+        let text = "Please loop in Sarah Connor on this thread.";
+        let result = f.scrub(text);
+        assert!(
+            result.contains("[PII:name]"),
+            "mid-sentence name run must be scrubbed: {result}"
+        );
+        assert!(!result.contains("Sarah Connor"));
+    }
+
+    #[test]
+    fn does_not_flag_sentence_initial_capitalization() {
+        let f = filter_all();
+        let text = "The quick brown fox jumps.";
+        let result = f.scrub(text);
+        assert_eq!(
+            result, text,
+            "ordinary sentence-initial capitalization must not be flagged"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_single_capitalized_word() {
+        let f = filter_all();
+        let text = "We use Docker for deployment.";
+        let result = f.scrub(text);
+        assert_eq!(
+            result, text,
+            "a lone capitalized word must not trigger the heuristic"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_all_caps_acronym_run() {
+        let f = filter_all();
+        let text = "Send the request via HTTP API now.";
+        let result = f.scrub(text);
+        assert_eq!(
+            result, text,
+            "ALL-CAPS acronyms must not be flagged as names"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_stoplisted_calendar_words() {
+        let f = filter_all();
+        let text = "Please review this on Monday in January.";
+        let result = f.scrub(text);
+        assert_eq!(
+            result, text,
+            "stoplisted capitalized words must not be flagged"
+        );
+    }
+
+    #[test]
+    fn name_heuristic_disabled_by_config() {
+        let f = PiiFilter::new(PiiFilterConfig {
+            enabled: true,
+            filter_email: false,
+            filter_phone: false,
+            filter_ssn: false,
+            filter_credit_card: false,
+            filter_names: false,
+            custom_patterns: vec![],
+        });
+        let text = "Please loop in Sarah Connor on this thread.";
+        let result = f.scrub(text);
+        assert_eq!(
+            result, text,
+            "filter_names = false must leave names untouched"
+        );
+    }
+
+    #[test]
+    fn is_enabled_true_when_only_names_active() {
+        let f = PiiFilter::new(PiiFilterConfig {
+            enabled: true,
+            filter_email: false,
+            filter_phone: false,
+            filter_ssn: false,
+            filter_credit_card: false,
+            filter_names: true,
+            custom_patterns: vec![],
+        });
+        assert!(f.is_enabled());
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -129,6 +129,10 @@ struct SharedAgentDeps {
     feedback_classifier: Option<zeph_llm::classifier::llm::LlmClassifier>,
     #[cfg(feature = "classifiers")]
     classifiers_config: zeph_core::config::ClassifiersConfig,
+    /// `security.pii_filter.enabled` — gates the NER union-merge PII layer (#5463),
+    /// mirroring the check in `agent_setup::apply_pii_ner_classifier`.
+    #[cfg(feature = "classifiers")]
+    pii_filter_enabled: bool,
     causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig,
     causal_provider: Option<zeph_llm::any::AnyProvider>,
     nli_config: zeph_sanitizer::nli::NliConfig,
@@ -631,6 +635,8 @@ async fn build_acp_deps(
         feedback_classifier,
         #[cfg(feature = "classifiers")]
         classifiers_config: config.classifiers.clone(),
+        #[cfg(feature = "classifiers")]
+        pii_filter_enabled: config.security.pii_filter.enabled,
         causal_ipi_config: config.security.causal_ipi.clone(),
         causal_provider: config
             .security
@@ -791,6 +797,8 @@ async fn spawn_acp_agent(
     let feedback_classifier = d.feedback_classifier.clone();
     #[cfg(feature = "classifiers")]
     let classifiers_config = d.classifiers_config.clone();
+    #[cfg(feature = "classifiers")]
+    let pii_filter_enabled = d.pii_filter_enabled;
     let causal_ipi_config = d.causal_ipi_config.clone();
     let causal_provider = d.causal_provider.clone();
     let nli_config = d.nli_config.clone();
@@ -1175,6 +1183,11 @@ async fn spawn_acp_agent(
         }
         agent = agent_setup::apply_three_class_classifier_with_cfg(agent, &classifiers_config);
         agent = agent_setup::apply_pii_classifier_with_cfg(agent, &classifiers_config);
+        agent = agent_setup::apply_pii_ner_classifier_with_cfg(
+            agent,
+            &classifiers_config,
+            pii_filter_enabled,
+        );
     }
     agent = agent_setup::apply_causal_analyzer_with_cfg(
         agent,

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -906,24 +906,42 @@ pub(crate) fn apply_pii_ner_classifier<C: Channel>(
     agent: zeph_core::agent::Agent<C>,
     config: &Config,
 ) -> zeph_core::agent::Agent<C> {
-    if !config.classifiers.enabled || !config.security.pii_filter.enabled {
+    apply_pii_ner_classifier_with_cfg(
+        agent,
+        &config.classifiers,
+        config.security.pii_filter.enabled,
+    )
+}
+
+/// Wire the `CandleNerClassifier` into the PII union merge pipeline (takes `ClassifiersConfig`
+/// and the `security.pii_filter.enabled` flag directly).
+///
+/// Only active when `classifiers.enabled = true` AND `pii_filter_enabled = true`.
+/// Uses `classifiers.ner_model` as the NER model repo ID.
+#[cfg(feature = "classifiers")]
+pub(crate) fn apply_pii_ner_classifier_with_cfg<C: Channel>(
+    agent: zeph_core::agent::Agent<C>,
+    classifiers: &zeph_core::config::ClassifiersConfig,
+    pii_filter_enabled: bool,
+) -> zeph_core::agent::Agent<C> {
+    if !classifiers.enabled || !pii_filter_enabled {
         return agent;
     }
     let mut ner_classifier =
-        zeph_llm::classifier::ner::CandleNerClassifier::new(config.classifiers.pii_model.as_str());
-    if let Some(token) = &config.classifiers.hf_token {
+        zeph_llm::classifier::ner::CandleNerClassifier::new(classifiers.pii_model.as_str());
+    if let Some(token) = &classifiers.hf_token {
         ner_classifier = ner_classifier.with_hf_token(token.as_str());
     }
     let backend = std::sync::Arc::new(ner_classifier);
     tracing::info!(
-        repo_id = %config.classifiers.pii_model,
+        repo_id = %classifiers.pii_model,
         "NER PII classifier attached for union merge pipeline (model loads lazily on first use)"
     );
     agent.with_pii_ner_classifier(
         backend,
-        config.classifiers.timeout_ms,
-        config.classifiers.pii_ner_max_chars,
-        config.classifiers.pii_ner_circuit_breaker,
+        classifiers.timeout_ms,
+        classifiers.pii_ner_max_chars,
+        classifiers.pii_ner_circuit_breaker,
     )
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -734,6 +734,8 @@ pub(crate) async fn run_daemon(
     let agent = agent_setup::apply_three_class_classifier(agent, config);
     #[cfg(feature = "classifiers")]
     let agent = agent_setup::apply_pii_classifier(agent, config);
+    #[cfg(feature = "classifiers")]
+    let agent = agent_setup::apply_pii_ner_classifier(agent, config);
     let agent = agent_setup::apply_causal_analyzer(
         agent,
         provider.clone(),


### PR DESCRIPTION
## Summary

- Wired `apply_pii_ner_classifier` (NER union-merge PII layer) into `daemon.rs` and `acp.rs`, matching the existing CLI runner call site — CLI, daemon, and ACP now produce identical PII detection behavior for the same config. Closes #5463.
- Added a capitalized-word-sequence heuristic to `zeph-sanitizer`'s `PiiFilter` as a compensating control for free-text personal names, which the piiranha NER checkpoint is confirmed weak at detecting. Gated by a new `filter_names` config flag (default `false`, opt-in). Closes #5530.
- Added migration step 74 (`migrate_pii_filter_names`) that inserts a commented `# filter_names = false` advisory into existing active `[security.pii_filter]` tables.
- Updated `book/src/reference/security.md`, `config/testing.toml`, `.local/testing/playbooks/security-sanitization.md`, and `.local/testing/coverage-status.md` (main repo).

## Review history

Went through the full bug-fix team pipeline (developer → tester + impl-critic in parallel → reviewer). First review round found three real defects in the name-detection heuristic, all fixed and independently re-verified in a second review round:

- False-positive flood on common technical multi-word phrases ("Rust Analyzer", "Pull Request", "Docker Compose") — fixed by defaulting `filter_names` to `false` and making the migration advisory-only rather than force-enabling.
- Sentence-initial full names not redacted at all (e.g. "John Smith is the CEO.") — fixed by gating leading-token exclusion on stoplist membership instead of sentence position.
- Apostrophe/hyphenated surnames partially leaking (e.g. "Mary O'Brien" redacting only "Brien") — fixed by extending the token regex to keep compound surnames in a single match.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo clippy --profile ci --workspace --all-targets --features full -- -D warnings` (validates classifiers-gated code in daemon.rs/acp.rs/agent_setup.rs)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11881 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo nextest run -p zeph-sanitizer -E 'test(pii)'` — 54/54, including regression tests for the sentence-initial and apostrophe/hyphen leak fixes
- [x] `cargo nextest run -p zeph-config -E 'test(migrat)'` — includes 4 new step-74 tests
- [ ] Live cross-mode session verification (CLI/daemon/ACP parity) — flagged for the next CI live-testing cycle, unit/integration coverage only in this PR