### PR TITLE
fix(memory): decode remaining Postgres INTEGER columns as i32 not i64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(memory)`: three `INTEGER`-as-`i64` decode mismatches (same defect class as #5538/#5544,
+  fixed in #5560) surfaced outside that PR's touched functions: `compression_guidelines.rs`'s
+  `load_compression_guidelines`/`load_compression_guidelines_by_category` decoded the `INTEGER`
+  `version` column directly into an `i64` tuple field, and `messages/mod.rs::find_promotion_candidates`
+  decoded the `INTEGER` `session_count` column the same way (mirrors the sibling
+  `message_access_counts`: `CAST(... AS BIGINT)` in the `SELECT`). All three throw `ColumnDecode`
+  ("Rust type i64 (as SQL type INT8) is not compatible with SQL type INT4") on Postgres, though
+  SQLite's dynamic typing masked it. Adds Postgres-gated regression tests
+  (`postgres_integration.rs`, requires Docker) for `load_compression_guidelines_meta`'s and
+  `get_eviction_candidates`'s version/timestamp decode — both functions were already fixed by
+  #5560 and lacked dedicated Postgres coverage for that fix; these tests close that gap as a
+  bonus alongside this PR's own three fixes. Closes #5567.
 - `fix(db,memory)`: `store/messages/mod.rs::replace_conversation`/`apply_tool_pair_summaries`
   bound a Rust-formatted epoch-seconds string directly into `messages.compacted_at`
   (`TIMESTAMPTZ` on Postgres), which Postgres's `timestamptz` parser rejects even under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,18 +563,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- `fix(memory)`: three `INTEGER`-as-`i64` decode mismatches (same defect class as #5538/#5544,
+- `fix(memory)`: five `INTEGER`-as-`i64` decode mismatches (same defect class as #5538/#5544,
   fixed in #5560) surfaced outside that PR's touched functions: `compression_guidelines.rs`'s
   `load_compression_guidelines`/`load_compression_guidelines_by_category` decoded the `INTEGER`
   `version` column directly into an `i64` tuple field, and `messages/mod.rs::find_promotion_candidates`
   decoded the `INTEGER` `session_count` column the same way (mirrors the sibling
-  `message_access_counts`: `CAST(... AS BIGINT)` in the `SELECT`). All three throw `ColumnDecode`
-  ("Rust type i64 (as SQL type INT8) is not compatible with SQL type INT4") on Postgres, though
-  SQLite's dynamic typing masked it. Adds Postgres-gated regression tests
-  (`postgres_integration.rs`, requires Docker) for `load_compression_guidelines_meta`'s and
-  `get_eviction_candidates`'s version/timestamp decode — both functions were already fixed by
+  `message_access_counts`: `CAST(... AS BIGINT)` in the `SELECT`). Two more instances, in the same
+  file, were caught only by CI's live-Postgres run of this PR's own new regression test (Docker was
+  unavailable in the development environment): `save_compression_guidelines`/
+  `save_compression_guidelines_with_category` both decoded their `INSERT ... RETURNING version`
+  scalar directly into `i64` via `query_scalar`; fixed the same way (decode as `i32`, widen with
+  `i64::from`). All five throw `ColumnDecode` ("Rust type i64 (as SQL type INT8) is not compatible
+  with SQL type INT4") on Postgres, though SQLite's dynamic typing masked it. Adds Postgres-gated
+  regression tests (`postgres_integration.rs`, requires Docker) for `load_compression_guidelines_meta`'s
+  and `get_eviction_candidates`'s version/timestamp decode — both functions were already fixed by
   #5560 and lacked dedicated Postgres coverage for that fix; these tests close that gap as a
-  bonus alongside this PR's own three fixes. Closes #5567.
+  bonus alongside this PR's own fixes. Closes #5567.
 - `fix(db,memory)`: `store/messages/mod.rs::replace_conversation`/`apply_tool_pair_summaries`
   bound a Rust-formatted epoch-seconds string directly into `messages.compacted_at`
   (`TIMESTAMPTZ` on Postgres), which Postgres's `timestamptz` parser rejects even under

--- a/crates/zeph-memory/src/store/compression_guidelines.rs
+++ b/crates/zeph-memory/src/store/compression_guidelines.rs
@@ -96,7 +96,9 @@ impl SqliteStore {
         &self,
         conversation_id: Option<ConversationId>,
     ) -> Result<(i64, String), MemoryError> {
-        let row = zeph_db::query_as::<_, (i64, String)>(sql!(
+        // `version` is `INTEGER` (`INT4`) on Postgres, so it decodes as `i32`, not `i64`;
+        // widened back to `i64` below to keep this function's public return type unchanged.
+        let row = zeph_db::query_as::<_, (i32, String)>(sql!(
             // When conversation_id is Some(cid): `conversation_id = cid` matches
             // conversation-specific rows; `conversation_id IS NULL` matches global rows.
             // The CASE ensures conversation-specific rows sort before global ones.
@@ -112,7 +114,9 @@ impl SqliteStore {
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(row.unwrap_or((0, String::new())))
+        Ok(row.map_or((0, String::new()), |(version, guidelines)| {
+            (i64::from(version), guidelines)
+        }))
     }
 
     /// Load only the version and creation timestamp of the latest active compression guidelines.
@@ -350,7 +354,9 @@ impl SqliteStore {
         category: &str,
         conversation_id: Option<ConversationId>,
     ) -> Result<(i64, String), MemoryError> {
-        let row = zeph_db::query_as::<_, (i64, String)>(sql!(
+        // `version` is `INTEGER` (`INT4`) on Postgres, so it decodes as `i32`, not `i64`;
+        // widened back to `i64` below to keep this function's public return type unchanged.
+        let row = zeph_db::query_as::<_, (i32, String)>(sql!(
             "SELECT version, guidelines FROM compression_guidelines \
              WHERE category = ? \
              AND (conversation_id = ? OR conversation_id IS NULL) \
@@ -363,7 +369,9 @@ impl SqliteStore {
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(row.unwrap_or((0, String::new())))
+        Ok(row.map_or((0, String::new()), |(version, guidelines)| {
+            (i64::from(version), guidelines)
+        }))
     }
 
     /// Save a new version of compression guidelines for a specific category.

--- a/crates/zeph-memory/src/store/compression_guidelines.rs
+++ b/crates/zeph-memory/src/store/compression_guidelines.rs
@@ -182,7 +182,10 @@ impl SqliteStore {
         // The INSERT...SELECT computes MAX(version)+1 across all rows (global + per-conversation)
         // and inserts it in a single statement. SQLite's single-writer WAL guarantee makes this
         // atomic — no concurrent writer can observe the same MAX and produce a duplicate version.
-        let new_version: i64 = zeph_db::query_scalar(
+        // `version` is `INTEGER` (`INT4`) on Postgres, so `RETURNING version` decodes as `i32`,
+        // not `i64`; widened back to `i64` below to keep this function's public return type
+        // unchanged.
+        let new_version: i32 = zeph_db::query_scalar(
             sql!("INSERT INTO compression_guidelines (version, guidelines, token_count, conversation_id) \
              SELECT COALESCE(MAX(version), 0) + 1, ?, ?, ? \
              FROM compression_guidelines \
@@ -193,7 +196,7 @@ impl SqliteStore {
         .bind(conversation_id.map(|c| c.0))
         .fetch_one(&self.pool)
         .await?;
-        Ok(new_version)
+        Ok(i64::from(new_version))
     }
 
     /// Log a compression failure pair.
@@ -386,7 +389,10 @@ impl SqliteStore {
         category: &str,
         conversation_id: Option<ConversationId>,
     ) -> Result<i64, MemoryError> {
-        let new_version: i64 = zeph_db::query_scalar(sql!(
+        // `version` is `INTEGER` (`INT4`) on Postgres, so `RETURNING version` decodes as `i32`,
+        // not `i64`; widened back to `i64` below to keep this function's public return type
+        // unchanged.
+        let new_version: i32 = zeph_db::query_scalar(sql!(
             "INSERT INTO compression_guidelines \
              (version, category, guidelines, token_count, conversation_id) \
              SELECT COALESCE(MAX(version), 0) + 1, ?, ?, ?, ? \
@@ -399,7 +405,7 @@ impl SqliteStore {
         .bind(conversation_id.map(|c| c.0))
         .fetch_one(&self.pool)
         .await?;
-        Ok(new_version)
+        Ok(i64::from(new_version))
     }
 
     /// Mark failure pairs as consumed by the updater.

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -1252,8 +1252,11 @@ impl SqliteStore {
     ) -> Result<Vec<PromotionCandidate>, MemoryError> {
         let limit = i64::try_from(batch_size).unwrap_or(i64::MAX);
         let min = i64::from(min_sessions);
+        // `session_count` is `INTEGER` (`INT4`) on Postgres, so it must be cast to `BIGINT`
+        // to decode into the `i64` tuple field below (mirrors `message_access_counts`).
         let rows: Vec<(MessageId, ConversationId, String, i64, f64)> = zeph_db::query_as(sql!(
-            "SELECT id, conversation_id, content, session_count, importance_score \
+            "SELECT id, conversation_id, content, \
+                    CAST(session_count AS BIGINT) AS session_count, importance_score \
              FROM messages \
              WHERE tier = 'episodic' AND session_count >= ? AND deleted_at IS NULL \
              ORDER BY session_count DESC, importance_score DESC \

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -597,6 +597,49 @@ mod pg {
         assert!(is_deleted, "pruned message must be soft-deleted");
     }
 
+    // ── messages: get_eviction_candidates INT4/TIMESTAMPTZ decode ──────────────
+    //
+    // Bonus regression coverage for a fix already merged in PR #5560: `get_eviction_candidates`
+    // used to decode `created_at` (`TIMESTAMPTZ` on Postgres, migrations/postgres/001_init.sql)
+    // and `last_accessed` (`TIMESTAMPTZ`, migrations/postgres/020_eviction_columns.sql) directly
+    // into `String`/`Option<String>`, which `sqlx-postgres` rejects outright (`ColumnDecode`) —
+    // the function could not run against Postgres at all. That defect (and the co-located
+    // `access_count` INT4-as-i64 mismatch) was already fixed by #5560, but shipped without
+    // dedicated Postgres coverage for this function; this test closes that gap. It accesses a
+    // message (populating `last_accessed`, which is `NULL` until first access) and asserts the
+    // full row decodes with non-empty `created_at`/`last_accessed` and the expected
+    // `access_count`.
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn messages_get_eviction_candidates_decodes_timestamps_and_access_count_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        let cid = store.create_conversation().await.unwrap();
+        let msg = store.save_message(cid, "user", "hello").await.unwrap();
+        store.increment_access_counts(&[msg]).await.unwrap();
+        store.increment_access_counts(&[msg]).await.unwrap();
+
+        let candidates = store.get_eviction_candidates().await.unwrap();
+        let entry = candidates
+            .iter()
+            .find(|e| e.id == msg)
+            .expect("saved message must appear among eviction candidates");
+
+        assert!(
+            !entry.created_at.is_empty(),
+            "created_at must decode as non-empty text, not error with ColumnDecode"
+        );
+        assert!(
+            entry.last_accessed.as_ref().is_some_and(|s| !s.is_empty()),
+            "last_accessed must decode as non-empty text after access, not error with ColumnDecode"
+        );
+        assert_eq!(
+            entry.access_count, 2,
+            "access_count must decode as the full INTEGER value, not truncate/zero"
+        );
+    }
+
     // ── messages: consolidation-source insert (Pattern B) ───────────────────────
 
     #[tokio::test]
@@ -881,6 +924,47 @@ mod pg {
 
         let after = store.count_unused_failure_pairs().await.unwrap();
         assert_eq!(after, 0, "both failure pairs must be marked used");
+    }
+
+    // ── compression_guidelines: load_compression_guidelines_meta INT4/TIMESTAMPTZ
+    //    decode ─────────────────────────────────────────────────────────────────
+    //
+    // Bonus regression coverage for a fix already merged in PR #5560:
+    // `load_compression_guidelines_meta` used to decode `version` (`INTEGER`/`INT4` on Postgres)
+    // directly into `i64` and `created_at` (`TIMESTAMPTZ` on Postgres) directly into `String`,
+    // both of which `sqlx-postgres` rejects with a `ColumnDecode` mismatch (`String`/`i64` are
+    // only compatible with `TEXT`/`INT8`-family OIDs). That defect was already fixed by #5560,
+    // but shipped without dedicated Postgres
+    // coverage for this function; this test closes that gap. A `SQLite`-only unit test cannot
+    // catch either mismatch: `SQLite` is dynamically typed, so the same decode succeeds there
+    // regardless of the fix. This test saves two versions and asserts the second (non-zero, so a
+    // truncated/zeroed `i32`-as-`i64` misread would be caught) round-trips correctly against a
+    // real Postgres instance, with a non-empty `created_at`.
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn compression_guidelines_meta_decodes_version_and_created_at_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        store
+            .save_compression_guidelines("first guideline", 4, None)
+            .await
+            .unwrap();
+        let v2 = store
+            .save_compression_guidelines("second guideline", 8, None)
+            .await
+            .unwrap();
+        assert_eq!(v2, 2, "second save must produce version 2");
+
+        let (version, created_at) = store.load_compression_guidelines_meta(None).await.unwrap();
+        assert_eq!(
+            version, 2,
+            "version must decode as the latest INTEGER value, not truncate/zero"
+        );
+        assert!(
+            !created_at.is_empty(),
+            "created_at must decode as non-empty text, not error with ColumnDecode"
+        );
     }
 
     // ── mem_scenes: member insert loop (Pattern B) ──────────────────────────────


### PR DESCRIPTION
## Summary

- Fixes 3 remaining instances of the `INTEGER`(INT4)-as-`i64` `ColumnDecode` defect (same class as #5538/#5544, fixed in #5560), found in functions that PR's sweep didn't touch:
  - `compression_guidelines.rs::load_compression_guidelines` — `version` decoded as i32, widened via `i64::from`
  - `compression_guidelines.rs::load_compression_guidelines_by_category` — same pattern
  - `messages/mod.rs::find_promotion_candidates` — `session_count` via `CAST(session_count AS BIGINT)`, mirroring the existing `message_access_counts` idiom
- Adds 2 Postgres-gated regression tests (`postgres_integration.rs`, `#[ignore = "requires Docker"]`) for `load_compression_guidelines_meta` and `get_eviction_candidates` — both already fixed by #5560, but previously without dedicated Postgres coverage for that fix; these close that gap.
- Closes #5567.

**Note on #5571**: originally grouped with this PR, but investigation found it's a genuine architectural conflict (`DbPool` is a compile-time monomorphic type alias; making `DbConfig::connect()` connection-string-driven while both `sqlite`/`postgres` features are compiled requires an enum-dispatch refactor across ~10 crates, and conflicts with `specs/031-database-abstraction/spec.md`'s mutual-exclusivity mandate). Findings posted to #5571, relabeled `P2`/`architecture`, descoped from this PR — needs a dedicated `/sdd` pass to choose a resolution path. Not touched here.

Also filed #5573 as a follow-up for the same defect class found in `skills.rs::SkillVersionTuple` (different file/subsystem, deliberately out of scope for this PR).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11863 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing unrelated `private_intra_doc_links` warnings in zeph-bench/zeph-channels/zeph-tui, not touched by this diff)
- [x] `cargo check -p zeph-memory --features "postgres,test-utils" --tests` — new Postgres-gated tests compile clean
- [ ] Live Postgres run of the 2 new `#[ignore = "requires Docker"]` tests — not possible in this environment (Docker daemon unavailable), flagged for CI's testcontainers-backed job to pick up