### PR TITLE
fix(serve,daemon): wire debug dumper into serve-sessions and daemon paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -636,6 +636,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the prompt content is safe. `LoopbackChannel::requires_input_sanitization()` stays `false`, since
   the queue is shared with the gateway/A2A producers which already sanitize upstream of it.
   Closes #5474.
+- `fix(serve,daemon)`: wire `[debug] enabled = true` into the two remaining agent-construction
+  paths that silently ignored it — `zeph serve-sessions` (`src/serve/agent_factory.rs`) and
+  gateway/`--daemon` mode (`src/daemon.rs`) — matching the CLI (`src/runner.rs`) and ACP
+  (`src/acp.rs`) paths, which already called `DebugDumper::new` + `Agent::with_debug_dumper`.
+  `build_agent_factory`'s returned closure now wires a session-id-scoped dump directory (same
+  rationale as `spawn_acp_agent`, so concurrent `/sessions`-created agents never collide on a
+  timestamped directory); `run_daemon` wires a single dump directory directly, matching the
+  CLI's non-flag fallback. `src/gateway_spawn.rs` itself builds no `Agent` (it only forwards
+  sanitized webhook payloads into an existing input queue), so the actual gateway-side gap was in
+  `daemon.rs`'s agent-construction chain. Closes #5566.
 - `fix(core)`: `--bare` mode no longer fires shutdown-path LLM calls. `Agent::maybe_autodream`,
   `maybe_extract_skills_from_trace`, `maybe_store_shutdown_summary`, and
   `maybe_store_session_digest` only checked their own subsystem config flags, not

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -783,6 +783,19 @@ pub(crate) async fn run_daemon(
         .with_document_config(config.memory.documents.clone())
         .with_hooks_config(&config.hooks);
 
+    // #5566: daemon mode (the process that actually serves `[gateway]` long-lived, since
+    // `spawn_gateway_server` only forwards webhooks into an already-built agent) never wired
+    // `[debug]`, unlike the CLI (src/runner.rs) and ACP (src/acp.rs) agent-construction paths.
+    if config.debug.enabled {
+        match zeph_core::debug_dump::DebugDumper::new(
+            config.debug.output_dir.as_path(),
+            config.debug.format,
+        ) {
+            Ok(dumper) => agent = agent.with_debug_dumper(dumper),
+            Err(e) => tracing::warn!(error = %e, "debug dump initialization failed"),
+        }
+    }
+
     agent.load_history().await?;
     agent
         .check_vector_store_health(config.memory.vector_backend.as_str())

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -74,7 +74,7 @@ pub(crate) async fn build_agent_factory(
         hydrate_session_sink(
             &deps.session_persistence_config,
             &deps.memory,
-            session_id,
+            session_id.clone(),
             conversation_id,
             &deps.resume_condenser,
             deps.resume_token_counter.as_ref(),
@@ -86,6 +86,9 @@ pub(crate) async fn build_agent_factory(
     };
 
     move |channel| {
+        // Capture before apply_session_config consumes deps.session_config (mirrors
+        // spawn_acp_agent's debug_config capture in src/acp.rs).
+        let debug_config = deps.session_config.debug_config.clone();
         let mut agent = Agent::new_with_registry_arc(
             deps.provider,
             deps.embedding_provider,
@@ -107,6 +110,18 @@ pub(crate) async fn build_agent_factory(
         .with_session_persistence_config(Some(deps.session_persistence_config));
         if !preloaded_messages.is_empty() {
             agent = agent.with_preloaded_messages(preloaded_messages);
+        }
+        if debug_config.enabled {
+            // Session-id subdirectory prefix (I2, matches spawn_acp_agent) so concurrent
+            // `/sessions` agents never share the same timestamped dump directory.
+            let session_dump_dir = debug_config.output_dir.join(session_id.as_str());
+            match zeph_core::debug_dump::DebugDumper::new(
+                session_dump_dir.as_path(),
+                debug_config.format,
+            ) {
+                Ok(dumper) => agent = agent.with_debug_dumper(dumper),
+                Err(e) => tracing::warn!(error = %e, "debug dump initialization failed"),
+            }
         }
         agent
     }
@@ -426,5 +441,63 @@ mod tests {
              no persistence, not panic or hang"
         );
         assert!(messages.is_empty());
+    }
+
+    /// #5566 regression: `build_agent_factory` must wire a `DebugDumper` when `[debug] enabled =
+    /// true`, the same way `spawn_acp_agent` (`src/acp.rs`) and the CLI path (`src/runner.rs`)
+    /// already do. `Agent` exposes no public accessor for its internal `debug_dumper` state, so
+    /// this asserts the documented, directly observable side effect instead:
+    /// `DebugDumper::new` creates its timestamped subdirectory synchronously on construction.
+    #[tokio::test]
+    async fn build_agent_factory_wires_debug_dumper_when_enabled() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let dump_dir = tempfile::tempdir().unwrap();
+        let session_id = zeph_common::SessionId::new("debug-test-session");
+
+        let mut config = zeph_core::config::Config::default();
+        config.debug.enabled = true;
+        config.debug.output_dir = dump_dir.path().to_path_buf();
+        config.debug.format = zeph_config::DumpFormat::Raw;
+
+        let session_config = zeph_core::AgentSessionConfig::from_config(&config, 4096);
+        let (condenser, token_counter) = make_test_condenser();
+
+        let deps = ServeAgentDeps {
+            provider: AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            embedding_provider: AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            registry: Arc::new(parking_lot::RwLock::new(
+                zeph_skills::registry::SkillRegistry::empty(),
+            )),
+            matcher: None,
+            max_active_skills: 5,
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            memory: Arc::clone(&memory),
+            history_limit: 10,
+            recall_limit: 5,
+            summarization_threshold: 1000,
+            session_config,
+            session_persistence_config: zeph_config::SessionConfig::default(),
+            resume_condenser: Arc::new(condenser),
+            resume_token_counter: Arc::new(token_counter),
+        };
+
+        let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
+        let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
+        let _agent = build_agent(channel);
+
+        let session_dump_dir = dump_dir.path().join(session_id.as_str());
+        assert!(
+            session_dump_dir.is_dir(),
+            "debug dump session subdirectory must be created when [debug] enabled = true"
+        );
+        let has_timestamped_child = std::fs::read_dir(&session_dump_dir)
+            .unwrap()
+            .next()
+            .is_some();
+        assert!(
+            has_timestamped_child,
+            "DebugDumper::new must create a timestamped subdirectory under the session dir"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `zeph serve-sessions` (`src/serve/agent_factory.rs`) and gateway/`--daemon` mode (`src/daemon.rs`) built agents without a `DebugDumper`, so `[debug] enabled = true` had no observable effect for those two entry points, unlike the CLI (`src/runner.rs`) and ACP (`src/acp.rs`) paths.
- `src/gateway_spawn.rs` itself builds no `Agent` (it only forwards sanitized webhook payloads into an already-built agent's input queue), so the actual gateway-side gap was in `daemon.rs`'s agent-construction chain, not `gateway_spawn.rs` as originally assumed in the issue.
- `build_agent_factory` now wires a session-id-scoped dump directory (mirrors `spawn_acp_agent`'s pattern, so concurrent `/sessions`-created agents never collide on a timestamped directory); `run_daemon` wires a single dump directory directly, matching the CLI's non-flag fallback.

Closes #5566.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11864 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression test `build_agent_factory_wires_debug_dumper_when_enabled`
- [x] Live-verified via `.local/testing/playbooks/debug-dumper.md`; `.local/testing/coverage-status.md` updated with two new rows