### PR TITLE
fix(tools): wire search_code into daemon and fix symlink walk safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -648,6 +648,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   check, no loop possible). A truncated walk now returns partial results with a
   `[search truncated: ...]` note in the summary and `"truncated": true` in `raw_response` instead
   of silently returning partial or hanging indefinitely. No new config surface. Closes #5434.
+- `fix(tools)`: three adversarial-review follow-ups to the `search_code` walk-budget/symlink fix
+  above. `src/daemon.rs` never wired `SearchCodeExecutor` into its composite tool chain, unlike
+  `src/agent_setup.rs` (CLI/TUI) and `src/acp.rs` (ACP) — a silent cross-mode tool-availability
+  gap, now wired identically to the other two entry points. The blanket "stop following symlinked
+  directories entirely" fix from #5434 also silently dropped legitimate non-looping symlinks
+  (vendored directories, monorepo packages, symlinked source files); replaced with active-
+  recursion-stack cycle detection (`crates/zeph-tools/src/search_code.rs`) that canonicalizes the
+  current directory and checks/pushes/pops it against the directories on the active walk path, so
+  a symlink is only treated as a loop if it points back into an already-visited ancestor —
+  including indirect cycles through a plain (non-symlinked) intermediate ancestor several levels
+  deep, and mutual A↔B symlink cycles. `MAX_WALK_ENTRIES` raised from 5,000 to 50,000, since the
+  2s wall-clock `MAX_WALK_DURATION` budget already backstops the original pathological-scope hang
+  independently of entry count, avoiding silent result truncation on large but legitimate
+  monorepos. No new config surface. Closes #5579, #5577, #5576. Filed #5588 to track the
+  now-test-covered but still hand-duplicated cycle-detection logic between the structural and
+  grep-fallback search paths as a fast-follow.
 - `fix(serve)`: sanitize `POST /sessions/:id/prompt` HTTP request bodies as `ExternalUntrusted`
   (`ContentSourceKind::ChannelMessage`) via `ContentSanitizer` before they reach the agent loopback
   queue — closes the same content-trust bypass already fixed for the gateway (#5459) and channel

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -200,7 +200,13 @@ const fn default_max_results() -> usize {
 
 /// Maximum directory entries a single structural/grep walk may visit before it
 /// is truncated. Bounds `allowed_paths` resolving to a huge tree (e.g. `~`).
-const MAX_WALK_ENTRIES: usize = 5_000;
+///
+/// Large monorepos can exceed a few thousand entries in normal operation, so this is
+/// generous; `MAX_WALK_DURATION` is the real backstop against the original
+/// pathological-scope hang (e.g. `allowed_paths` resolving to `~`), since wall-clock
+/// time bounds the walk regardless of how many entries a given filesystem can visit
+/// per second.
+const MAX_WALK_ENTRIES: usize = 50_000;
 
 /// Maximum wall-clock time a single structural/grep walk may run before it is
 /// truncated, independent of entry count (guards against slow filesystems).
@@ -240,6 +246,15 @@ impl WalkBudget {
         }
         self.truncated
     }
+}
+
+/// Bundles the two pieces of walk-wide mutable state threaded through the
+/// structural/grep directory recursion: the [`WalkBudget`] and the symlink-cycle
+/// guard (canonical paths of directories on the *active* recursion path). Grouped
+/// into one struct so the walk functions stay under clippy's argument-count limit.
+struct WalkState<'a> {
+    budget: &'a mut WalkBudget,
+    ancestors: &'a mut Vec<PathBuf>,
 }
 
 pub struct SearchCodeExecutor {
@@ -399,6 +414,11 @@ impl SearchCodeExecutor {
         let mut hits = Vec::new();
         let mut budget = WalkBudget::new();
         for root in &self.allowed_paths {
+            let mut ancestors = Vec::new();
+            let mut state = WalkState {
+                budget: &mut budget,
+                ancestors: &mut ancestors,
+            };
             collect_grep_hits(
                 root,
                 root,
@@ -406,7 +426,7 @@ impl SearchCodeExecutor {
                 &regex,
                 &mut hits,
                 max_results,
-                &mut budget,
+                &mut state,
             )?;
             if hits.len() >= max_results || budget.truncated {
                 break;
@@ -467,13 +487,18 @@ fn collect_all_structural_hits(
     let symbol_lower = symbol.to_lowercase();
     let mut budget = WalkBudget::new();
     for root in allowed_paths {
+        let mut ancestors = Vec::new();
+        let mut state = WalkState {
+            budget: &mut budget,
+            ancestors: &mut ancestors,
+        };
         collect_structural_hits(
             root,
             root,
             matcher.as_ref(),
             &symbol_lower,
             &mut hits,
-            &mut budget,
+            &mut state,
         )?;
         if hits.len() >= max_results || budget.truncated {
             break;
@@ -594,35 +619,67 @@ fn format_hits(hits: &[SearchCodeHit], root: &Path) -> String {
         .join("\n\n")
 }
 
+/// Walks `current`, guarding against symlink cycles via `state.ancestors`: the
+/// canonical paths of directories on the *active* recursion path (not every
+/// directory ever visited). A symlinked directory is only skipped when following it
+/// would revisit one of those ancestors — an actual cycle. Legitimate symlinks that
+/// point elsewhere (a vendored dependency, a symlinked source file) are walked
+/// normally, still bounded by [`WalkBudget`] via `state.budget`.
 fn collect_structural_hits(
     root: &Path,
     current: &Path,
     matcher: Option<&glob::Pattern>,
     symbol_lower: &str,
     hits: &mut Vec<SearchCodeHit>,
-    budget: &mut WalkBudget,
+    state: &mut WalkState<'_>,
 ) -> Result<(), ToolError> {
-    if should_skip_path(current) || budget.truncated {
+    if should_skip_path(current) || state.budget.truncated {
         return Ok(());
     }
 
+    // A plain directory tree has no cycles on its own — only a symlink pointing back
+    // at an ancestor can create one — so canonicalizing once per directory entered
+    // (not per entry) and comparing against the active stack is enough to catch it.
+    let canonical = current
+        .canonicalize()
+        .unwrap_or_else(|_| current.to_path_buf());
+    if state.ancestors.contains(&canonical) {
+        return Ok(());
+    }
+    state.ancestors.push(canonical);
+    let result = collect_structural_hits_inner(root, current, matcher, symbol_lower, hits, state);
+    state.ancestors.pop();
+    result
+}
+
+fn collect_structural_hits_inner(
+    root: &Path,
+    current: &Path,
+    matcher: Option<&glob::Pattern>,
+    symbol_lower: &str,
+    hits: &mut Vec<SearchCodeHit>,
+    state: &mut WalkState<'_>,
+) -> Result<(), ToolError> {
     let entries = std::fs::read_dir(current).map_err(ToolError::Execution)?;
     for entry in entries {
-        if budget.tick() {
+        if state.budget.tick() {
             return Ok(());
         }
         let entry = entry.map_err(ToolError::Execution)?;
         let path = entry.path();
-        // Never follow symlinks: avoids symlink-loop hangs and matches the
-        // `symlink_metadata` convention used elsewhere in zeph-tools (file.rs).
         let Ok(meta) = std::fs::symlink_metadata(&path) else {
             continue;
         };
-        if meta.file_type().is_symlink() {
-            continue;
-        }
-        if meta.is_dir() {
-            collect_structural_hits(root, &path, matcher, symbol_lower, hits, budget)?;
+        let is_dir = if meta.file_type().is_symlink() {
+            match std::fs::metadata(&path) {
+                Ok(target_meta) => target_meta.is_dir(),
+                Err(_) => continue, // broken symlink target
+            }
+        } else {
+            meta.is_dir()
+        };
+        if is_dir {
+            collect_structural_hits(root, &path, matcher, symbol_lower, hits, state)?;
             continue;
         }
         if !matches_pattern(root, &path, matcher) {
@@ -688,6 +745,7 @@ fn collect_structural_hits(
     Ok(())
 }
 
+/// Symlink cycle guard mirrors [`collect_structural_hits`]; see its docs.
 fn collect_grep_hits(
     root: &Path,
     current: &Path,
@@ -695,15 +753,36 @@ fn collect_grep_hits(
     regex: &regex::Regex,
     hits: &mut Vec<SearchCodeHit>,
     max_results: usize,
-    budget: &mut WalkBudget,
+    state: &mut WalkState<'_>,
 ) -> Result<(), ToolError> {
-    if hits.len() >= max_results || should_skip_path(current) || budget.truncated {
+    if hits.len() >= max_results || should_skip_path(current) || state.budget.truncated {
         return Ok(());
     }
 
+    let canonical = current
+        .canonicalize()
+        .unwrap_or_else(|_| current.to_path_buf());
+    if state.ancestors.contains(&canonical) {
+        return Ok(());
+    }
+    state.ancestors.push(canonical);
+    let result = collect_grep_hits_inner(root, current, matcher, regex, hits, max_results, state);
+    state.ancestors.pop();
+    result
+}
+
+fn collect_grep_hits_inner(
+    root: &Path,
+    current: &Path,
+    matcher: Option<&glob::Pattern>,
+    regex: &regex::Regex,
+    hits: &mut Vec<SearchCodeHit>,
+    max_results: usize,
+    state: &mut WalkState<'_>,
+) -> Result<(), ToolError> {
     let entries = std::fs::read_dir(current).map_err(ToolError::Execution)?;
     for entry in entries {
-        if budget.tick() {
+        if state.budget.tick() {
             return Ok(());
         }
         let entry = entry.map_err(ToolError::Execution)?;
@@ -711,11 +790,16 @@ fn collect_grep_hits(
         let Ok(meta) = std::fs::symlink_metadata(&path) else {
             continue;
         };
-        if meta.file_type().is_symlink() {
-            continue;
-        }
-        if meta.is_dir() {
-            collect_grep_hits(root, &path, matcher, regex, hits, max_results, budget)?;
+        let is_dir = if meta.file_type().is_symlink() {
+            match std::fs::metadata(&path) {
+                Ok(target_meta) => target_meta.is_dir(),
+                Err(_) => continue, // broken symlink target
+            }
+        } else {
+            meta.is_dir()
+        };
+        if is_dir {
+            collect_grep_hits(root, &path, matcher, regex, hits, max_results, state)?;
             continue;
         }
         if !matches_pattern(root, &path, matcher) {
@@ -913,8 +997,8 @@ mod tests {
     }
 
     /// A directory cycle created via a symlink pointing back to an ancestor
-    /// must not send the walk into an infinite loop — symlinked directories
-    /// are never followed.
+    /// must not send the walk into an infinite loop, even though symlinks are
+    /// now followed in general (#5577).
     #[cfg(unix)]
     #[tokio::test]
     async fn search_code_does_not_follow_symlink_loop() {
@@ -943,6 +1027,159 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(out.summary.contains("retry_backoff_ms"));
+    }
+
+    /// Regression test for #5577 (critic finding M1 / tester coverage gap 1): a
+    /// symlink several directories deep pointing back at a non-root ancestor — not
+    /// a direct self-loop — must still be caught. This only works because *every*
+    /// directory entered (not just symlinked ones) is pushed onto the active
+    /// recursion stack; a design that only tracked symlinked directories would miss
+    /// this cycle, since `a` here is a plain directory, not a symlink.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn search_code_does_not_follow_indirect_symlink_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        let c = a.join("b").join("c");
+        std::fs::create_dir_all(&c).unwrap();
+        std::fs::write(a.join("lib.rs"), "pub fn retry_backoff_ms() -> u64 { 0 }\n").unwrap();
+        let back_to_a = c.join("back_to_a");
+        std::os::unix::fs::symlink(&a, &back_to_a).unwrap();
+
+        let exec = SearchCodeExecutor::new(vec![dir.path().to_path_buf()]);
+        let call = ToolCall {
+            tool_id: "search_code".into(),
+            params: serde_json::json!({ "symbol": "retry_backoff_ms" })
+                .as_object()
+                .unwrap()
+                .clone(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let out = tokio::time::timeout(Duration::from_secs(10), exec.execute_tool_call(&call))
+            .await
+            .expect("search_code must not hang on an indirect symlink cycle several levels deep")
+            .unwrap()
+            .unwrap();
+        assert!(out.summary.contains("retry_backoff_ms"));
+    }
+
+    /// Regression test for #5577 (tester coverage gap 2): `collect_grep_hits`'s
+    /// cycle-detection logic is a hand-duplicated copy of
+    /// `collect_structural_hits`'s (see [`WalkState`] docs) and had zero direct
+    /// test coverage of its own loop-protection path — only the structural walk's
+    /// was exercised by `search_code_does_not_follow_symlink_loop`. Uses `query`
+    /// (no `symbol`, no semantic backend attached) so the search falls through to
+    /// `grep_fallback`, exactly like `search_code_uses_grep_fallback`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn search_code_grep_fallback_does_not_follow_symlink_loop() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("mod.rs");
+        std::fs::write(&file, "let retry_backoff_ms = 5;\n").unwrap();
+        let loop_link = dir.path().join("self_loop");
+        std::os::unix::fs::symlink(dir.path(), &loop_link).unwrap();
+
+        let exec = SearchCodeExecutor::new(vec![dir.path().to_path_buf()]);
+        let call = ToolCall {
+            tool_id: "search_code".into(),
+            params: serde_json::json!({ "query": "retry_backoff_ms" })
+                .as_object()
+                .unwrap()
+                .clone(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let out = tokio::time::timeout(Duration::from_secs(10), exec.execute_tool_call(&call))
+            .await
+            .expect("grep fallback must not hang on a symlink loop")
+            .unwrap()
+            .unwrap();
+        assert!(out.summary.contains("grep fallback"));
+    }
+
+    /// Regression test for #5577: a symlinked directory that does *not* create a
+    /// cycle (e.g. a vendored dependency symlinked into the tree) must still be
+    /// walked and searched, not blanket-skipped just because it is a symlink.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn search_code_follows_non_looping_symlinked_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let vendor = tempfile::tempdir().unwrap();
+        std::fs::write(
+            vendor.path().join("vendored.rs"),
+            "pub fn vendored_symbol_xyz() -> u64 { 0 }\n",
+        )
+        .unwrap();
+        let link = dir.path().join("vendor_link");
+        std::os::unix::fs::symlink(vendor.path(), &link).unwrap();
+
+        let exec = SearchCodeExecutor::new(vec![dir.path().to_path_buf()]);
+        let call = ToolCall {
+            tool_id: "search_code".into(),
+            params: serde_json::json!({ "symbol": "vendored_symbol_xyz" })
+                .as_object()
+                .unwrap()
+                .clone(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let out = tokio::time::timeout(Duration::from_secs(10), exec.execute_tool_call(&call))
+            .await
+            .expect("search_code must not hang")
+            .unwrap()
+            .unwrap();
+        assert!(
+            out.summary.contains("vendored_symbol_xyz"),
+            "expected symlinked directory to be walked, got: {}",
+            out.summary
+        );
+    }
+
+    /// Regression test for #5577: a symlinked source file (not a directory) must
+    /// still be searched, not skipped just because it is a symlink.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn search_code_follows_symlinked_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_file = tempfile::tempdir().unwrap();
+        let target = real_file.path().join("real.rs");
+        std::fs::write(&target, "pub fn symlinked_file_symbol_xyz() -> u64 { 0 }\n").unwrap();
+        let link = dir.path().join("linked.rs");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let exec = SearchCodeExecutor::new(vec![dir.path().to_path_buf()]);
+        let call = ToolCall {
+            tool_id: "search_code".into(),
+            params: serde_json::json!({ "symbol": "symlinked_file_symbol_xyz" })
+                .as_object()
+                .unwrap()
+                .clone(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let out = tokio::time::timeout(Duration::from_secs(10), exec.execute_tool_call(&call))
+            .await
+            .expect("search_code must not hang")
+            .unwrap()
+            .unwrap();
+        assert!(
+            out.summary.contains("symlinked_file_symbol_xyz"),
+            "expected symlinked file to be searched, got: {}",
+            out.summary
+        );
     }
 
     #[test]

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1935,6 +1935,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn build_search_code_executor_exposes_search_code_tool() {
+        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let config = Config::load(Path::new("/nonexistent")).unwrap();
+        assert!(config.index.search_enabled, "expected default to be on");
+        let executor =
+            build_search_code_executor(&config, None, offline_provider(), pool, None).unwrap();
+        let defs = executor.tool_definitions();
+        assert!(defs.iter().any(|d| d.id == "search_code"));
+    }
+
+    /// Regression test for #5579: `search_code` was wired into `agent_setup.rs`'s
+    /// CLI/TUI tool chain and `acp.rs`, but never into `daemon.rs`'s composite chain,
+    /// so the `search_code` tool silently never appeared for the `zeph serve --a2a`
+    /// entry point. Mirrors the exact nesting shape used in `daemon.rs::run_daemon`
+    /// (`CompositeExecutor::new(DynExecutor(base), search_executor)`) and asserts the
+    /// tool definition survives the merge.
+    #[tokio::test]
+    async fn search_code_executor_reachable_through_daemon_composite_chain() {
+        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let config = Config::load(Path::new("/nonexistent")).unwrap();
+        let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> =
+            std::sync::Arc::new(NoopExec);
+        let search_executor =
+            build_search_code_executor(&config, None, offline_provider(), pool, None).unwrap();
+        let composite =
+            zeph_tools::CompositeExecutor::new(zeph_tools::DynExecutor(base), search_executor);
+        let defs = composite.tool_definitions();
+        assert!(defs.iter().any(|d| d.id == "search_code"));
+    }
+
+    #[tokio::test]
     async fn apply_summary_provider_none_returns_agent_unchanged() {
         let agent = make_agent();
         let result = apply_summary_provider(agent, None);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -516,9 +516,27 @@ pub(crate) async fn run_daemon(
     .with_conversation(conversation_id.0);
     let skill_loader_executor =
         zeph_core::SkillLoaderExecutor::new(std::sync::Arc::clone(&registry));
-    let base_tool: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = std::sync::Arc::new(
-        zeph_tools::CompositeExecutor::new(base_executor, mcp_executor),
-    );
+    let base_tool: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = {
+        let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = std::sync::Arc::new(
+            zeph_tools::CompositeExecutor::new(base_executor, mcp_executor),
+        );
+        let index_provider =
+            crate::bootstrap::resolve_index_embed_provider(config, provider.clone());
+        if let Some(search_executor) = agent_setup::build_search_code_executor(
+            config,
+            app.qdrant_ops().cloned(),
+            index_provider,
+            memory.sqlite().pool().clone(),
+            Some(std::sync::Arc::clone(&mcp_manager)),
+        ) {
+            std::sync::Arc::new(zeph_tools::CompositeExecutor::new(
+                zeph_tools::DynExecutor(base),
+                search_executor,
+            ))
+        } else {
+            base
+        }
+    };
     let tool_executor =
         zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::CompositeExecutor::new(
             skill_loader_executor,


### PR DESCRIPTION
## Summary

Three adversarial-review follow-ups from the just-merged PR #5574 (which added `DiagnosticsExecutor` wiring and a `WalkBudget`-bounded recursion guard with symlink-loop protection to `search_code`):

- Wire `SearchCodeExecutor` into `src/daemon.rs`'s composite executor chain, matching CLI/TUI (`src/agent_setup.rs`) and ACP (`src/acp.rs`), which already exposed it — closes the daemon/CLI/TUI/ACP cross-mode tool-availability gap.
- Replace the blanket "skip every symlink" walk logic in `crates/zeph-tools/src/search_code.rs` with active-recursion-stack cycle detection: the current directory is canonicalized and checked/pushed/popped against the directories on the active recursion path, so a symlink is only treated as a loop if it points back into an already-visited ancestor. Legitimate non-looping symlinks (vendored directories, monorepo packages, symlinked source files) are now searched instead of silently dropped.
- Raise `MAX_WALK_ENTRIES` from 5,000 to 50,000, since the existing 2s wall-clock `MAX_WALK_DURATION` budget already backstops the original pathological-scope hang independently of entry count — avoids silent result truncation on large but legitimate monorepos.

Closes #5579, #5577, #5576

## Review process

Implemented and validated through a multi-agent chain: developer → parallel (tester + adversarial critic) → developer (closed 2 flagged test-coverage gaps) → code reviewer (approved). The critic traced cycle-detection correctness in depth, including indirect/mutual symlink cycles (a symlink pointing at a plain intermediate ancestor several levels up, and A↔B mutual-symlink "diamond" cases) and confirmed the implementation handles both correctly. The tester independently found the same gap plus a second one (the grep-fallback search path had its own independently-duplicated cycle-detection copy with zero test coverage); both gaps were closed with regression tests before final review.

The intentional duplication between the two cycle-detection copies (structural-search path vs grep-fallback path) was evaluated for extraction during review and judged disproportionate for this PR's scope; filed as a fast-follow tech-debt issue: #5588.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11895 passed, 0 failed
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] New/changed regression tests: daemon search_code reachability (2 tests in `agent_setup.rs`), non-looping symlinked directory/file walk, indirect multi-level symlink cycle, grep-fallback symlink-loop coverage, existing direct-loop test re-verified — all in `crates/zeph-tools/src/search_code.rs`
- [x] Live-testing playbook and coverage-status updated in `.local/testing/` (main repo) per project convention