### PR TITLE
fix(tools,core): stop live turn stall when Qdrant is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(tools,core)`: live agent turns no longer stall indefinitely when Qdrant is
+  unreachable (up to 240s observed, never dispatching the originally-requested tool). Two
+  compounding defects: (1) `handle_tool_failure_outcomes` misclassified every structured
+  `[tool_error]` tool failure as skill outcome `"success"` — a stale substring check
+  (`"[error]"` / `"[exit code"`) written before the error-taxonomy refactor never matched
+  the newer `[tool_error]\ncategory: ...` format, so a failed `memory_search` spuriously
+  triggered repeated `spawn_erl_reflection`/`spawn_arise_trace_improvement` reflection
+  sweeps instead of being recorded as a failure; `handle_tool_failure_outcomes` now uses
+  the authoritative `is_error` flag additively. (2) the utility gate's `Retrieve` branch
+  unconditionally re-injected a mandatory "call the tool again" hint even after
+  `memory_search` had already failed this turn with a retryable network-class error, so
+  the LLM kept retrying a hard-down Qdrant instead of dispatching the originally-requested
+  tool. `ToolOrchestrator` now tracks the most recent retryable failure of `memory_search`
+  per turn (cleared at turn boundaries); when present, the `Retrieve` branch degrades
+  gracefully and lets the requested tool proceed instead of mandating another retrieval
+  attempt. Closes #5584.
+
 ### Added
 
 - `feat(session)`: add the `zeph-session` crate foundation (spec-068 P0, #5343) — an append-only

--- a/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
@@ -420,6 +420,170 @@ async fn native_tool_executor_error_does_not_panic() {
     );
 }
 
+// R-NTP-4b: executor Err classified as a retryable NetworkError must record a "tool_failure"
+// skill outcome, not "success" — regression guard for #5584 (a stale substring check in
+// handle_tool_failure_outcomes never recognized the structured "[tool_error]" format, so every
+// classified Err was silently recorded as a skill success, spamming reflection).
+#[tokio::test]
+async fn native_tool_network_error_records_tool_failure_not_success() {
+    use crate::agent::agent_tests::{MockChannel, create_test_registry, mock_provider};
+    use zeph_memory::semantic::SemanticMemory;
+
+    struct NetworkErrorExecutor;
+    impl ToolExecutor for NetworkErrorExecutor {
+        fn execute(
+            &self,
+            _response: &str,
+        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+            std::future::ready(Ok(None))
+        }
+
+        fn execute_tool_call(
+            &self,
+            _call: &ToolCall,
+        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+            std::future::ready(Err(ToolError::Execution(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "connection refused",
+            ))))
+        }
+    }
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+        "test-model",
+    )
+    .await
+    .unwrap();
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+
+    let mut agent =
+        crate::agent::Agent::new(provider, channel, registry, None, 5, NetworkErrorExecutor)
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 50);
+    agent
+        .services
+        .skill
+        .active_skill_names
+        .push("test-skill".into());
+
+    let tool_calls = vec![make_tool_use_request("id-net-err", "memory_search")];
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    let last = agent.msg.messages.last().unwrap();
+    assert!(
+        last.content.contains("[tool_error]"),
+        "sanity check: result must use the structured tool_error format: {}",
+        last.content
+    );
+
+    let mem = agent.services.memory.persistence.memory.as_ref().unwrap();
+    let row: Option<(String,)> = zeph_db::query_as(
+        "SELECT outcome FROM skill_outcomes WHERE skill_name = 'test-skill' LIMIT 1",
+    )
+    .fetch_optional(mem.sqlite().pool())
+    .await
+    .unwrap();
+
+    assert!(row.is_some(), "skill outcome must be recorded in DB");
+    assert_eq!(
+        row.unwrap().0,
+        "tool_failure",
+        "a classified Err tool result must record tool_failure, not success"
+    );
+}
+
+// Regression guard for a critic-flagged follow-up to #5584: record_gate_feedback must not
+// reset UtilityScorer::consecutive_low, the counter note_action owns for the utility_window
+// cross-iteration hard-break. Gate-intercepted (Respond/Retrieve/Verify/Stop) results are
+// synthetic Ok(Some(out)) outputs that always classify is_error = false, and every one of
+// them is routed through process_one_tool_result -> record_gate_feedback just like a real
+// dispatched result. Before the fix, record_gate_feedback fed that same "success" signal
+// into consecutive_low, silently defeating the window for utility_window >= 2.
+#[tokio::test]
+async fn skipped_output_processing_does_not_reset_cross_iteration_utility_window() {
+    use crate::agent::agent_tests::{MockChannel, create_test_registry, mock_provider};
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = FixedOutputExecutor {
+        summary: String::new(),
+        is_err: false,
+    };
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+    agent.tool_orchestrator.utility_scorer =
+        zeph_tools::UtilityScorer::new(zeph_tools::UtilityScoringConfig {
+            enabled: true,
+            utility_window: 3,
+            ..zeph_tools::UtilityScoringConfig::default()
+        });
+
+    let tc = make_tool_use_request("id-skip", "bash");
+    let skipped = zeph_tools::ToolOutput {
+        tool_name: "bash".into(),
+        summary: "[skipped] Tool call to bash skipped — utility policy recommends \
+                  retrieving additional context first."
+            .into(),
+        blocks_executed: 0,
+        filter_stats: None,
+        diff: None,
+        streamed: false,
+        terminal_id: None,
+        locations: None,
+        raw_response: None,
+        claim_source: None,
+    };
+
+    // Two LLM iterations, each: note_action records a non-ToolCall (Retrieve)
+    // recommendation, then the gate-skipped result is processed exactly like a real
+    // dispatched result would be. Neither call should fire yet, and — this is the
+    // regression guard — the second `process_one_tool_result` call must not reset the
+    // counter that the two `note_action` calls are accumulating.
+    for _ in 0..2 {
+        assert!(
+            !agent
+                .tool_orchestrator
+                .utility_scorer
+                .note_action(&zeph_tools::UtilityAction::Retrieve)
+        );
+        agent
+            .process_one_tool_result(
+                &tc,
+                "id-skip",
+                &std::time::Instant::now(),
+                Ok(Some(skipped.clone())),
+                &mut Vec::new(),
+                &mut Vec::new(),
+                &mut false,
+                &mut None,
+                &mut Vec::new(),
+            )
+            .await
+            .unwrap();
+    }
+
+    // Third note_action call must trip the utility_window=3 hard-break — proving the two
+    // intervening process_one_tool_result calls above did not reset consecutive_low.
+    assert!(
+        agent
+            .tool_orchestrator
+            .utility_scorer
+            .note_action(&zeph_tools::UtilityAction::Retrieve),
+        "utility_window hard-break must still fire across iterations even when gate-\
+         skipped results are processed in between"
+    );
+}
+
 // R-NTP-6: injection pattern in tool output populates flagged_urls and emits security event.
 // Verifies that handle_native_tool_calls() routes output through sanitize_tool_output().
 #[tokio::test]

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -1425,6 +1425,57 @@ impl<C: Channel> Agent<C> {
         Ok(commits)
     }
 
+    /// Handles `UtilityAction::Retrieve` — either mandates a context-retrieval-then-retry
+    /// round, or, when a prior retrieval attempt this turn already failed with a
+    /// retryable/network-class error (e.g. Qdrant unreachable), lets the originally
+    /// requested tool proceed directly instead of demanding another doomed retry (#5584).
+    async fn handle_retrieve_action(
+        &mut self,
+        idx: usize,
+        tc: &zeph_llm::provider::ToolUseRequest,
+        pending_system_hints: &mut Vec<String>,
+    ) -> Result<Option<(usize, ToolExecFut)>, crate::agent::error::AgentError> {
+        if self.tool_orchestrator.has_retryable_failure_this_turn() {
+            let _ = self
+                .channel
+                .send_status(&format!(
+                    "Utility action: Retrieve skipped, context unavailable ({})",
+                    tc.name
+                ))
+                .await;
+            pending_system_hints.push(format!(
+                "[utility:retrieve] Context retrieval failed and appears unavailable. \
+                 Proceed with the '{}' tool call using the best information already \
+                 available rather than retrying the failed retrieval.",
+                tc.name
+            ));
+            return Ok(None);
+        }
+        let _ = self
+            .channel
+            .send_status(&format!("Utility action: Retrieve ({})", tc.name))
+            .await;
+        // Inject a system message directing the LLM to retrieve context first (#2620).
+        pending_system_hints.push(format!(
+            "[utility:retrieve] Before executing the '{}' tool, retrieve \
+             relevant context via memory_search or a related lookup to ensure \
+             the call is well-targeted. After retrieving context, you MUST call \
+             the '{}' tool again with the same arguments.",
+            tc.name, tc.name
+        ));
+        Ok(Some(ready_fut(
+            idx,
+            skipped_output(
+                tc.name.clone(),
+                format!(
+                    "[skipped] Tool call to {} skipped — utility policy recommends \
+                     retrieving additional context first.",
+                    tc.name
+                ),
+            ),
+        )))
+    }
+
     async fn handle_utility_gate(
         &mut self,
         idx: usize,
@@ -1451,29 +1502,8 @@ impl<C: Channel> Agent<C> {
                 )))
             }
             zeph_tools::UtilityAction::Retrieve => {
-                let _ = self
-                    .channel
-                    .send_status(&format!("Utility action: Retrieve ({})", tc.name))
-                    .await;
-                // Inject a system message directing the LLM to retrieve context first (#2620).
-                pending_system_hints.push(format!(
-                    "[utility:retrieve] Before executing the '{}' tool, retrieve \
-                     relevant context via memory_search or a related lookup to ensure \
-                     the call is well-targeted. After retrieving context, you MUST call \
-                     the '{}' tool again with the same arguments.",
-                    tc.name, tc.name
-                ));
-                Ok(Some(ready_fut(
-                    idx,
-                    skipped_output(
-                        tc.name.clone(),
-                        format!(
-                            "[skipped] Tool call to {} skipped — utility policy recommends \
-                             retrieving additional context first.",
-                            tc.name
-                        ),
-                    ),
-                )))
+                self.handle_retrieve_action(idx, tc, pending_system_hints)
+                    .await
             }
             zeph_tools::UtilityAction::Verify => {
                 let _ = self
@@ -3382,6 +3412,128 @@ mod tests {
         } else {
             panic!("expected ToolResult part");
         }
+    }
+
+    // Regression guard for #5584: when a retryable failure (e.g. Qdrant unreachable) was
+    // already recorded this turn, handle_retrieve_action must not mandate another doomed
+    // retry — it should let the originally-requested tool call proceed (Ok(None)) and inject
+    // a graceful-degradation hint instead of the "you MUST call again" hint.
+    #[tokio::test]
+    async fn handle_retrieve_action_skips_mandatory_retry_after_retryable_failure() {
+        use crate::testing::{MockChannel, MockToolExecutor, mock_provider};
+        use zeph_skills::registry::SkillRegistry;
+        use zeph_tools::error_taxonomy::ToolErrorCategory;
+
+        let mut agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![] as Vec<String>),
+            SkillRegistry::empty(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+        agent
+            .tool_orchestrator
+            .last_tool_error
+            .insert("memory_search".to_owned(), ToolErrorCategory::NetworkError);
+
+        let tc = make_tool_req("bash");
+        let mut hints = Vec::new();
+        let result = agent
+            .handle_retrieve_action(0, &tc, &mut hints)
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "must return None so the originally-requested tool proceeds to dispatch"
+        );
+        assert_eq!(hints.len(), 1);
+        assert!(
+            hints[0].contains("Proceed with the 'bash' tool call"),
+            "hint must direct graceful degradation, got: {}",
+            hints[0]
+        );
+        assert!(
+            !hints[0].contains("you MUST call"),
+            "must not mandate another retry, got: {}",
+            hints[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_retrieve_action_mandates_retry_without_prior_failure() {
+        use crate::testing::{MockChannel, MockToolExecutor, mock_provider};
+        use zeph_skills::registry::SkillRegistry;
+
+        let mut agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![] as Vec<String>),
+            SkillRegistry::empty(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+
+        let tc = make_tool_req("bash");
+        let mut hints = Vec::new();
+        let result = agent
+            .handle_retrieve_action(0, &tc, &mut hints)
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_some(),
+            "without a prior failure, the tool call is skipped pending retrieval"
+        );
+        assert_eq!(hints.len(), 1);
+        assert!(
+            hints[0].contains("you MUST call the 'bash' tool again"),
+            "hint must mandate a retry, got: {}",
+            hints[0]
+        );
+    }
+
+    // Regression guard for critic-flagged S3 (#5584 follow-up): a retryable failure of an
+    // UNRELATED tool (e.g. web_fetch) must not suppress the Retrieve mandatory-retry hint
+    // for the rest of the turn — only a failure of memory_search, the retrieval tool the
+    // Retrieve branch's hint actually recommends, should trigger graceful degradation.
+    #[tokio::test]
+    async fn handle_retrieve_action_mandates_retry_when_only_unrelated_tool_failed() {
+        use crate::testing::{MockChannel, MockToolExecutor, mock_provider};
+        use zeph_skills::registry::SkillRegistry;
+        use zeph_tools::error_taxonomy::ToolErrorCategory;
+
+        let mut agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![] as Vec<String>),
+            SkillRegistry::empty(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+        agent
+            .tool_orchestrator
+            .last_tool_error
+            .insert("web_fetch".to_owned(), ToolErrorCategory::NetworkError);
+
+        let tc = make_tool_req("bash");
+        let mut hints = Vec::new();
+        let result = agent
+            .handle_retrieve_action(0, &tc, &mut hints)
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_some(),
+            "an unrelated tool's stale retryable failure must not suppress Retrieve"
+        );
+        assert_eq!(hints.len(), 1);
+        assert!(
+            hints[0].contains("you MUST call the 'bash' tool again"),
+            "hint must still mandate a retry, got: {}",
+            hints[0]
+        );
     }
 
     mod reformat_phase_tests {

--- a/crates/zeph-core/src/agent/tool_execution/tool_result.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_result.rs
@@ -142,6 +142,33 @@ impl<C: Channel> Agent<C> {
         }
     }
 
+    /// Remembers the post-execution error category for the utility gate's `Retrieve`
+    /// branch, so a subsequent `Retrieve` decision can detect a just-failed retryable
+    /// dependency (e.g. `memory_search` hitting a down Qdrant) instead of mandating
+    /// another doomed retry (#5584).
+    ///
+    /// This is called for every processed result, including gate-intercepted
+    /// (`Respond`/`Retrieve`/`Verify`/`Stop`) synthetic outputs, which always classify as
+    /// `is_error = false`. It deliberately does NOT touch
+    /// `UtilityScorer`'s `consecutive_low` counter — that counter is owned exclusively by
+    /// `note_action`'s pre-dispatch cross-iteration accounting, and mixing a second
+    /// reset/increment source into it silently defeated the `utility_window` hard-break
+    /// (every gate-intercepted result reset the counter before it could accumulate).
+    ///
+    /// Skips exempt tools (`invoke_skill`, `load_skill`, ...) — the pre-dispatch scoring
+    /// pass never scores them either, so they must not affect gate state.
+    fn record_gate_feedback(
+        &mut self,
+        tool_name: &str,
+        tool_err_category: Option<zeph_tools::error_taxonomy::ToolErrorCategory>,
+    ) {
+        if self.tool_orchestrator.utility_scorer.is_exempt(tool_name) {
+            return;
+        }
+        self.tool_orchestrator
+            .record_tool_outcome_for_gate(tool_name, tool_err_category);
+    }
+
     fn record_tool_execution_telemetry(
         &mut self,
         tool_name: &str,
@@ -173,12 +200,13 @@ impl<C: Channel> Agent<C> {
     fn handle_tool_failure_outcomes(
         &mut self,
         output: &str,
+        is_error: bool,
         tool_err_category: &mut Option<zeph_tools::error_taxonomy::ToolErrorCategory>,
         is_quality_failure: bool,
         pending_outcomes: &mut Vec<crate::agent::learning::PendingSkillOutcome>,
         pending_reflection: &mut Option<String>,
     ) -> bool {
-        if output.contains("[error]") || output.contains("[exit code") {
+        if is_error || output.contains("[error]") || output.contains("[exit code") {
             let kind = tool_err_category
                 .take()
                 .map_or_else(|| FailureKind::from_error(output), FailureKind::from);
@@ -206,6 +234,32 @@ impl<C: Channel> Agent<C> {
             false
         } else {
             true
+        }
+    }
+
+    /// Pushes the terminal skill outcome (`SecurityBlocked` or `success`) once vigil and
+    /// tool-failure classification have both been resolved, and records the quality
+    /// signal for successful dispatches.
+    fn record_final_skill_outcome(
+        &mut self,
+        vigil_blocked: bool,
+        tool_succeeded: bool,
+        pending_outcomes: &mut Vec<crate::agent::learning::PendingSkillOutcome>,
+    ) {
+        if vigil_blocked {
+            pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
+                outcome: FailureKind::SecurityBlocked.as_str().into(),
+                error_context: Some("VIGIL blocked tool output".into()),
+                outcome_detail: None,
+            });
+        } else if tool_succeeded {
+            pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
+                outcome: "success".into(),
+                error_context: None,
+                outcome_detail: None,
+            });
+            self.provider
+                .record_quality_outcome(self.provider.name(), true);
         }
     }
 
@@ -336,9 +390,11 @@ impl<C: Channel> Agent<C> {
         } = self.classify_tool_result(tc, tool_result);
 
         self.record_tool_execution_telemetry(tc.name.as_str(), started_at, is_error, &output);
+        self.record_gate_feedback(tc.name.as_str(), tool_err_category);
 
         let tool_succeeded = self.handle_tool_failure_outcomes(
             &output,
+            is_error,
             &mut tool_err_category,
             is_quality_failure,
             pending_outcomes,
@@ -396,21 +452,7 @@ impl<C: Channel> Agent<C> {
             lsp_tool_calls.push((tc.name.to_string(), tc.input.clone(), llm_content.clone()));
         }
 
-        if vigil_blocked {
-            pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
-                outcome: FailureKind::SecurityBlocked.as_str().into(),
-                error_context: Some("VIGIL blocked tool output".into()),
-                outcome_detail: None,
-            });
-        } else if tool_succeeded {
-            pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
-                outcome: "success".into(),
-                error_context: None,
-                outcome_detail: None,
-            });
-            self.provider
-                .record_quality_outcome(self.provider.name(), true);
-        }
+        self.record_final_skill_outcome(vigil_blocked, tool_succeeded, pending_outcomes);
 
         self.record_tool_experience(
             tc.name.as_str(),

--- a/crates/zeph-core/src/agent/tool_orchestrator.rs
+++ b/crates/zeph-core/src/agent/tool_orchestrator.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::time::Duration;
 
 use zeph_tools::{
@@ -64,6 +64,11 @@ pub(crate) struct ToolOrchestrator {
     /// Maximum `PreToolUse` hook blocks per turn before the turn is ended with a warning.
     /// Matches `HooksConfig::hook_block_cap`. 0 = no cap.
     pub(super) hook_block_cap: usize,
+    /// Error category of the most recent failed execution per tool name, used by the
+    /// utility gate's `Retrieve` branch to detect a just-failed retryable call and avoid
+    /// re-issuing a mandatory retry hint against a dependency that is still down.
+    /// Cleared alongside `recent_tool_calls` at the start of each user turn.
+    pub(super) last_tool_error: HashMap<String, zeph_tools::error_taxonomy::ToolErrorCategory>,
 }
 
 /// Truncate a tool name to at most 256 bytes, respecting UTF-8 char boundaries.
@@ -107,6 +112,7 @@ impl ToolOrchestrator {
             max_tool_calls_per_session: None,
             hook_block_count: 0,
             hook_block_cap: 8,
+            last_tool_error: HashMap::new(),
         }
     }
 
@@ -216,6 +222,43 @@ impl ToolOrchestrator {
     /// Reset the repeat-detection sliding window between user turns.
     pub(super) fn clear_recent_tool_calls(&mut self) {
         self.recent_tool_calls.clear();
+        self.last_tool_error.clear();
+    }
+
+    /// Record the outcome of a dispatched tool call for `last_tool_error` tracking.
+    ///
+    /// On failure, remembers the error category so the utility gate's `Retrieve` branch
+    /// can detect a just-failed retryable call for the same tool. On success, clears any
+    /// previously recorded failure so a subsequent unrelated failure isn't masked by a
+    /// stale entry.
+    pub(super) fn record_tool_outcome_for_gate(
+        &mut self,
+        tool_name: &str,
+        error_category: Option<zeph_tools::error_taxonomy::ToolErrorCategory>,
+    ) {
+        match error_category {
+            Some(category) => {
+                self.last_tool_error.insert(tool_name.to_owned(), category);
+            }
+            None => {
+                self.last_tool_error.remove(tool_name);
+            }
+        }
+    }
+
+    /// Returns `true` when `memory_search` — the retrieval tool the `Retrieve` branch's
+    /// hint recommends — most recently failed this turn with a retryable/network-class
+    /// error (e.g. a down Qdrant).
+    ///
+    /// Scoped to `memory_search` specifically rather than "any tool this turn": an
+    /// unrelated tool's transient retryable failure (e.g. a `web_fetch` 503) must not
+    /// suppress the `Retrieve` optimization for the rest of the turn once the actual
+    /// retrieval dependency is healthy or was never involved.
+    #[must_use]
+    pub(super) fn has_retryable_failure_this_turn(&self) -> bool {
+        self.last_tool_error
+            .get("memory_search")
+            .is_some_and(|c| c.is_retryable())
     }
 
     /// Returns `true` if the last `DOOM_LOOP_WINDOW` hashes are identical.


### PR DESCRIPTION
## Summary

- `handle_tool_failure_outcomes` used a stale substring check (`[error]` / `[exit code`) that predates the error-taxonomy refactor, so structured `[tool_error]` failures (e.g. `memory_search` hitting a downed Qdrant) were recorded as skill outcome `"success"` instead of `"tool_failure"` — spuriously firing repeated reflection/pattern-learning sweeps right after a failed call. Now uses the authoritative `is_error` flag additively, preserving the legitimate `Ok(Some(out))` shell-textual-error path unchanged.
- The utility gate's `Retrieve` branch unconditionally mandated another `memory_search` retry even after that tool had already failed this turn with a retryable network-class error, so the LLM kept retrying a hard-down Qdrant instead of ever dispatching the originally-requested tool — burning the turn's entire iteration budget (observed up to 240s). `ToolOrchestrator` now tracks `memory_search`'s most recent retryable failure per turn (cleared at turn boundaries); when present, `Retrieve` degrades gracefully and lets the requested tool proceed.

Closes #5584

## Process notes

Built via the debugger → developer → tester/critic → developer (fix-round) → critic (re-verify) → reviewer chain. The adversarial critic caught a real regression in the first implementation pass (a "structural" safety-net addition was silently resetting the pre-existing `utility_window` cross-iteration hard-break counter, and was otherwise inert/dead code); the follow-up pass removed that dead/regressive half entirely and narrowed a related over-broad check to `memory_search` specifically, relying solely on the confirmed-working graceful-degradation path. A second critic pass and full code review both approved the final state.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11894 passed, 0 failed (full workspace, reviewer-verified)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] 3 new regression tests: skill-outcome misclassification (real SQLite-backed assertion), utility-gate graceful-degradation branch (2 tests: skip-after-failure, mandate-without-failure, mandate-when-only-unrelated-tool-failed), cross-iteration `utility_window` non-regression
- [x] CHANGELOG.md updated