### PR TITLE
fix(llm): add gonkagate live smoke test for unreachable gonka URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -601,6 +601,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `MemoryError::Timeout` on expiry; `graph_recall_astar`'s existing fire-and-forget `if let Err`
   handling at the call site already logs and continues, so recall itself remains fail-open.
   Closes #5522.
+- `fix(llm)`: `gonka_live_chat_round_trip` (`crates/zeph-llm/tests/gonka_live.rs`) hard-failed
+  with an opaque `ApiError { status: 405 }` when its default node URL
+  (`http://node1.gonka.ai:8000`) or the repo-documented example (`https://node1.gonka.ai`)
+  were unreachable — indistinguishable from a real `GonkaProvider` regression (#5549). Neither
+  URL is a guaranteed-reachable testnet endpoint; investigation confirmed the `gonkagate`
+  OpenAI-compatible gateway (`https://api.gonkagate.com/v1`, the `--init` wizard's "gonkagate"
+  preset) reaches the same Gonka network and is currently live. Adds a second live-gated test,
+  `gonkagate_compatible_chat_round_trip`, exercising that path via `CompatibleProvider` and
+  gated on `ZEPH_COMPATIBLE_GONKAGATE_API_KEY` — a tolerated `LlmError::RateLimited` (HTTP
+  429/503, both mapped to the same variant by `send_with_retry`) is logged as a transient
+  condition rather than failing the test, without claiming it confirms reachability or auth
+  (only a real `Ok` response does). The native-path test's known-dead default node URL was
+  removed entirely rather than kept as a fallback: `ZEPH_GONKA_NODE_URL` is now required and
+  the test skips (mirroring the existing `ZEPH_GONKA_PRIVATE_KEY` skip convention) rather than
+  silently hitting a host already proven to serve an unrelated Cosmos explorer app. On a
+  genuine chat failure it now fails with a message clarifying that an unreachable node is an
+  infra/URL problem, not necessarily a provider-code regression, and points at the
+  compatible-path test as a network-reachability cross-check; both tests restore/keep a
+  `!response.is_empty()` assertion on success. The documented `https://node1.gonka.ai` URL
+  format itself was left unchanged — it is structurally correct (plain HTTPS base URL); only
+  the specific host's current reachability is in question, which this project does not
+  control.
 - `fix(memory)`: five `INTEGER`-as-`i64` decode mismatches (same defect class as #5538/#5544,
   fixed in #5560) surfaced outside that PR's touched functions: `compression_guidelines.rs`'s
   `load_compression_guidelines`/`load_compression_guidelines_by_category` decoded the `INTEGER`

--- a/crates/zeph-llm/tests/gonka_live.rs
+++ b/crates/zeph-llm/tests/gonka_live.rs
@@ -1,12 +1,24 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Live testnet integration test for the Gonka provider.
+//! Live integration tests for the Gonka network, exercised via two independent transports.
 //!
-//! Skipped by default — requires a running Gonka testnet node and a funded wallet.
-//! Run with:
+//! `gonka_live_chat_round_trip` drives the native, request-signing `GonkaProvider` against a
+//! raw testnet node. Skipped by default — requires a funded wallet and a *reachable* node URL:
+//! there is no fixed, globally-reachable testnet endpoint, so `ZEPH_GONKA_NODE_URL` must be set
+//! explicitly to a node that is actually up from the current network vantage point (there is no
+//! built-in default — both known candidate hosts have been proven unreachable, see #5549). Run
+//! with:
 //! ```shell
-//! ZEPH_GONKA_PRIVATE_KEY=<hex> cargo nextest run -p zeph-llm -- --ignored gonka_live
+//! ZEPH_GONKA_PRIVATE_KEY=<hex> ZEPH_GONKA_NODE_URL=<url> \
+//!     cargo nextest run -p zeph-llm --features gonka -- --ignored gonka_live
+//! ```
+//!
+//! `gonkagate_compatible_chat_round_trip` drives the same Gonka network via the OpenAI-compatible
+//! `gonkagate` gateway (`https://api.gonkagate.com/v1`), the same route used by the `--init`
+//! wizard's "gonkagate" preset. Run with:
+//! ```shell
+//! ZEPH_COMPATIBLE_GONKAGATE_API_KEY=<key> cargo nextest run -p zeph-llm -- --ignored gonkagate_compatible
 //! ```
 
 #[cfg(feature = "gonka")]
@@ -29,8 +41,18 @@ mod live {
             }
         };
 
-        let node_url = std::env::var("ZEPH_GONKA_NODE_URL")
-            .unwrap_or_else(|_| "http://node1.gonka.ai:8000".into());
+        let node_url = match std::env::var("ZEPH_GONKA_NODE_URL") {
+            Ok(u) if !u.is_empty() => u,
+            _ => {
+                eprintln!(
+                    "ZEPH_GONKA_NODE_URL not set to a reachable node, skipping — neither the \
+                     old built-in default (`http://node1.gonka.ai:8000`) nor the repo-documented \
+                     example (`https://node1.gonka.ai`) are known-reachable (#5549), so this test \
+                     no longer guesses a node URL"
+                );
+                return;
+            }
+        };
 
         let signer = Arc::new(
             RequestSigner::from_hex(&priv_key, "gonka").expect("valid secp256k1 private key"),
@@ -58,11 +80,71 @@ mod live {
             "Say hello in one word.".to_owned(),
         )];
 
-        let response = provider
-            .chat(&messages)
-            .await
-            .expect("chat should succeed against live testnet");
+        match provider.chat(&messages).await {
+            Ok(response) => assert!(!response.is_empty(), "response must not be empty"),
+            Err(err) => panic!(
+                "chat request against Gonka testnet node `{node_url}` failed: {err}\n\
+                 ZEPH_GONKA_NODE_URL is not guaranteed to point at a live node — confirm it is \
+                 actually up (e.g. `curl {node_url}`) before treating this as a regression. To \
+                 check whether the Gonka network itself is reachable independent of node URL, \
+                 run `gonkagate_compatible_chat_round_trip` in this file, which reaches the \
+                 same network through the OpenAI-compatible gonkagate gateway."
+            ),
+        }
+    }
+}
 
-        assert!(!response.is_empty(), "response must not be empty");
+mod compatible_live {
+    use zeph_llm::compatible::{CompatibleConfig, CompatibleProvider};
+    use zeph_llm::provider::{LlmProvider, Message, Role};
+
+    /// Live smoke test for the `gonkagate` OpenAI-compatible gateway
+    /// (`https://api.gonkagate.com/v1`), the same preset offered by the `--init` wizard
+    /// (`src/init/llm.rs`, option 5). Unlike the native, request-signing `GonkaProvider`
+    /// path in `gonka_live_chat_round_trip`, this transport does not depend on locating a
+    /// currently-reachable raw testnet node.
+    #[tokio::test]
+    #[ignore = "requires ZEPH_COMPATIBLE_GONKAGATE_API_KEY env var and live gonkagate access"]
+    async fn gonkagate_compatible_chat_round_trip() {
+        let api_key = match std::env::var("ZEPH_COMPATIBLE_GONKAGATE_API_KEY") {
+            Ok(k) if !k.is_empty() => k,
+            _ => {
+                eprintln!("ZEPH_COMPATIBLE_GONKAGATE_API_KEY not set, skipping");
+                return;
+            }
+        };
+
+        let provider = CompatibleProvider::new(CompatibleConfig {
+            provider_name: "gonkagate".into(),
+            api_key,
+            base_url: "https://api.gonkagate.com/v1".into(),
+            // Catalog-dependent: confirmed present in gonkagate's `/v1/models` list as of
+            // #5549's investigation, but hosted-gateway model catalogs can change over time.
+            model: "moonshotai/kimi-k2.6".into(),
+            max_tokens: 16,
+            embedding_model: None,
+            completion_tokens_param: None,
+        });
+
+        let messages = vec![Message::from_legacy(
+            Role::User,
+            "Say hello in one word.".to_owned(),
+        )];
+
+        match provider.chat(&messages).await {
+            Ok(response) => assert!(!response.is_empty(), "response must not be empty"),
+            Err(zeph_llm::error::LlmError::RateLimited) => {
+                // `send_with_retry` maps both HTTP 429 (throttled) and 503 (gateway down)
+                // to this same variant after retries are exhausted, so this arm cannot tell
+                // "account is busy" apart from "gateway is down" — only a real `Ok` response
+                // confirms the endpoint, auth, and routing are actually functional.
+                eprintln!(
+                    "gonkagate gateway is throttled or temporarily unavailable \
+                     (HTTP 429/503) — treating as a transient condition rather than a test \
+                     failure, without asserting reachability or auth are confirmed."
+                );
+            }
+            Err(err) => panic!("chat request against gonkagate gateway failed: {err}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `gonka_live_chat_round_trip` (`crates/zeph-llm/tests/gonka_live.rs`) hard-failed with an opaque `ApiError { status: 405 }` because both its default node URL (`http://node1.gonka.ai:8000`) and the repo-documented example (`https://node1.gonka.ai`) are unreachable from this environment — one resolves to an unrelated Cosmos blockchain explorer, the other times out. The failure was indistinguishable from a real `GonkaProvider` regression.
- Added a second live-gated test, `gonkagate_compatible_chat_round_trip`, exercising the confirmed-reachable `gonkagate` OpenAI-compatible gateway (`https://api.gonkagate.com/v1`, the same route as the `--init` wizard's "gonkagate" preset) as an independent network-reachability cross-check that doesn't depend on locating a live raw testnet node.
- Dropped the known-dead default node URL from the native test — `ZEPH_GONKA_NODE_URL` is now required, with a clean skip message (mirroring the existing `ZEPH_GONKA_PRIVATE_KEY` skip pattern) instead of silently hitting a host proven to serve an unrelated app.
- Clarified the native test's failure message to separate "node URL unreachable / infra" from "provider code regression," pointing at the new gonkagate test as a cross-check.
- The `gonkagate` test's tolerated-error handling explicitly notes that `LlmError::RateLimited` conflates HTTP 429 and 503 (per `send_with_retry`), so it only logs a transient-condition message rather than claiming reachability/auth are confirmed — only a real `Ok` response is treated as a verified round-trip.
- Left the documented `https://node1.gonka.ai` URL format in `crates/zeph-config/src/providers/entry.rs` unchanged — the format itself is correct and consistent with the pervasive `node1/2/3.gonka.ai` convention used elsewhere in specs/docs/wizard; only this specific host's current reachability is in question, which is outside this project's control.

Closes #5549

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci -p zeph-llm --all-targets --features "gonka,testing" -- -D warnings` (and without `gonka`)
- [x] `cargo check -p zeph-llm --tests` with and without `--features gonka`
- [x] Both live tests correctly `#[ignore]`-gated — confirmed 0 tests run in a normal `nextest` pass; both skip cleanly under `--ignored` when their required env vars are unset
- [ ] Live network round-trip against the `gonkagate` gateway (requires `ZEPH_COMPATIBLE_GONKAGATE_API_KEY` from vault, not exercised in this session — no vault/network access)