### PR TITLE
test(memory): pin the SkillVersionTuple Postgres INTEGER decode fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -639,6 +639,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and `get_eviction_candidates`'s version/timestamp decode — both functions were already fixed by
   #5560 and lacked dedicated Postgres coverage for that fix; these tests close that gap as a
   bonus alongside this PR's own fixes. Closes #5567.
+- `test(memory)`: verified `store/skills.rs`'s `SkillVersionTuple` `INTEGER`-as-`i64` decode
+  (same defect class as #5538/#5544/#5567) was already fixed on `main` by #5560's broader sweep —
+  no source change needed. Closed the remaining test-coverage gap: strengthened
+  `skills_load_versions_decodes_timestamptz_column` (`postgres_integration.rs`) with explicit
+  `version`/`success_count`/`failure_count` assertions and added
+  `skills_predecessor_version_decodes_integer_columns` to cover `predecessor_version`, the third
+  call site sharing the tuple, previously untested. Closes #5573.
 - `fix(db,memory)`: `store/messages/mod.rs::replace_conversation`/`apply_tool_pair_summaries`
   bound a Rust-formatted epoch-seconds string directly into `messages.compacted_at`
   (`TIMESTAMPTZ` on Postgres), which Postgres's `timestamptz` parser rejects even under

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -2222,11 +2222,40 @@ mod pg {
 
         let versions = store.load_skill_versions("git").await.unwrap();
         assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, 1);
+        assert_eq!(versions[0].success_count, 0);
+        assert_eq!(versions[0].failure_count, 0);
         assert!(versions[0].is_active);
         assert!(!versions[0].created_at.is_empty());
 
         let active = store.active_skill_version("git").await.unwrap().unwrap();
         assert_eq!(active.id, v1);
+        assert_eq!(active.version, 1);
         assert!(!active.created_at.is_empty());
+    }
+
+    // Exercises `predecessor_version`, the third call site sharing `SkillVersionTuple` (#5573) —
+    // `skills_load_versions_decodes_timestamptz_column` above already covers the other two.
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn skills_predecessor_version_decodes_integer_columns() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool);
+
+        let v1 = store
+            .save_skill_version("git", 1, "body v1", "Git helper", "manual", None, None)
+            .await
+            .unwrap();
+        let v2 = store
+            .save_skill_version("git", 2, "body v2", "Git helper v2", "auto", None, Some(v1))
+            .await
+            .unwrap();
+        store.activate_skill_version("git", v2).await.unwrap();
+
+        let predecessor = store.predecessor_version(v2).await.unwrap().unwrap();
+        assert_eq!(predecessor.id, v1);
+        assert_eq!(predecessor.version, 1);
+        assert_eq!(predecessor.success_count, 0);
+        assert_eq!(predecessor.failure_count, 0);
     }
 }


### PR DESCRIPTION
## Summary

Closes #5573 (zeph-memory: `SkillVersionTuple` decoded Postgres `INTEGER` columns as `i64`, breaking `ColumnDecode`) — but with a twist: independent investigation (developer, tester, and adversarial critic all traced this separately) confirmed the source-level defect was already fixed by an unrelated commit, PR #5560 (`29275ff1`), which merged 20 minutes *before* #5573 was even filed. `SkillVersionTuple`'s `version`/`success_count`/`failure_count` fields already decode as `i32` and widen via `i64::from(...)`; `is_active` already decodes as native `bool`. No source change is needed or made.

What this PR actually does: closes a real test-coverage gap the investigation surfaced. The existing Postgres integration test for `load_skill_versions` exercised the decode path but never asserted the actual `version`/`success_count`/`failure_count` values, and the third call site sharing the same tuple (`predecessor_version`) had zero Postgres-integration coverage at all.

- Strengthens `skills_load_versions_decodes_timestamptz_column` with explicit value assertions.
- Adds `skills_predecessor_version_decodes_integer_columns`, covering the previously-uncovered third call site.

Per the adversarial critic's analysis: the #5573 bug class is a `sqlx` `ColumnDecode` type mismatch that panics/errors at runtime, so these tests do pin the fix — reverting #5560's `skills.rs` hunk in isolation would make them fail loudly, even though the currently-asserted values happen to be DB defaults.

A follow-up P3 test-coverage issue (#5591) was filed for an adjacent, out-of-scope gap the tester found: `load_skill_usage`'s `invocation_count` has the identical already-fixed defect class but no Postgres-integration coverage of its own.

## Review process

developer (investigated + found already-fixed, closed test gap instead) → parallel (tester + adversarial critic, both independently re-verified the "already fixed" claim rather than trusting it) → code reviewer (approved, re-verified the premise a third time directly against current `skills.rs`).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11900 passed, 0 failed
- [x] `cargo check -p zeph-memory --features postgres --tests` — compile-clean; the new/strengthened tests are `#[ignore = "requires Docker"]` and could not be executed against a live Postgres in this sandbox (no Docker daemon available) — compile-level verification only, consistent with this project's existing pattern for Postgres-integration tests
- [x] Live-testing playbook and coverage-status updated in `.local/testing/` (main repo) per project convention