### PR TITLE
fix(skills): bound SkillGenerator LLM calls with a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -582,6 +582,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(skills)`: `SkillGenerator::generate` awaited both of its `provider.chat()` calls (initial
+  generation and the single retry on parse failure) with no timeout, unlike every other external
+  LLM call in the crate (e.g. `SkillMiner::embed_candidate`). The background skill-promotion path
+  (`compression_spectrum.promotion_scan` -> `PromotionEngine::promote` ->
+  `GeneratorSkillWriter::write_skill` -> `generate`) had no caller-side timeout wrap either, so an
+  unresponsive LLM provider could hang that named background task forever and, since candidates in
+  a promotion sweep are processed sequentially, block every other candidate behind it. `generate`
+  now wraps both calls in `tokio::time::timeout` against a new `generation_timeout_ms` field
+  (default 60s, matching `SkillsConfig::generation_timeout_ms`), returning the existing
+  `SkillError::Timeout` on expiry; a new `SkillGenerator::with_generation_timeout_ms` builder
+  overrides it, and `GeneratorSkillWriter` now threads `config.skills.generation_timeout_ms`
+  through to the generator it constructs. The `/skill create` command
+  (`skill_commands.rs`) and the proactive-exploration generator (`agent_setup.rs`) now thread
+  their own governing config values (`skills.generation_timeout_ms` and
+  `skills.proactive_exploration.timeout_ms` respectively) into the same builder, so the new
+  60s internal default no longer silently truncates a user-configured timeout greater than 60s
+  on either of those two pre-existing call paths. Closes #5534.
 - `fix(memory)`: `SemanticMemory::spawn_graph_extraction` stored the in-flight background
   graph-extraction task's `CancellationToken` in a single-slot `Mutex<Option<CancellationToken>>`,
   so calling it again before the previous extraction finished silently overwrote the earlier

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -338,8 +338,11 @@ pub struct SkillsConfig {
     /// Provider name for `/skill create` NL generation. Empty = primary provider.
     #[serde(default)]
     pub generation_provider: ProviderName,
-    /// Timeout in milliseconds for `/skill create` LLM generation (covers all internal retries).
-    /// Default: `60000` (60 s).
+    /// Timeout in milliseconds for `/skill create` LLM generation. For `/skill create` this is
+    /// enforced as a single end-to-end budget covering the initial call and its retry. The
+    /// background promotion path (`GeneratorSkillWriter`) reuses the same value as a per-call
+    /// budget instead (via `SkillGenerator::with_generation_timeout_ms`), so a generate-with-retry
+    /// there may take up to 2x this value. Default: `60000` (60 s).
     #[serde(default = "default_generation_timeout_ms")]
     pub generation_timeout_ms: u64,
     /// Directory where generated skills are written. Defaults to first entry in `paths`.

--- a/crates/zeph-core/src/agent/learning/skill_commands.rs
+++ b/crates/zeph-core/src/agent/learning/skill_commands.rs
@@ -87,7 +87,8 @@ impl<C: Channel> Agent<C> {
 
         let generation_provider =
             self.resolve_background_provider(&self.services.skill.generation_provider_name.clone());
-        let generator = zeph_skills::SkillGenerator::new(generation_provider, output_dir.clone());
+        let generator = zeph_skills::SkillGenerator::new(generation_provider, output_dir.clone())
+            .with_generation_timeout_ms(self.services.skill.generation_timeout_ms);
         let generator = if let Some(ref eval) = self.services.skill.skill_evaluator {
             generator.with_evaluator(
                 std::sync::Arc::clone(eval),

--- a/crates/zeph-skills/src/generator.rs
+++ b/crates/zeph-skills/src/generator.rs
@@ -8,6 +8,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
@@ -130,10 +131,15 @@ pub struct SkillGenerator {
     eval_weights: EvaluationWeights,
     /// Minimum composite score required to accept a generated skill.
     eval_threshold: f32,
+    /// Timeout in milliseconds applied to each LLM call made by [`Self::generate`].
+    generation_timeout_ms: u64,
 }
 
 impl SkillGenerator {
     /// Create a new generator that writes approved skills to `output_dir`.
+    ///
+    /// Each LLM call made by [`Self::generate`] defaults to a 60s timeout;
+    /// override with [`Self::with_generation_timeout_ms`].
     #[must_use]
     pub fn new(provider: AnyProvider, output_dir: PathBuf) -> Self {
         Self {
@@ -142,6 +148,7 @@ impl SkillGenerator {
             evaluator: None,
             eval_weights: EvaluationWeights::default(),
             eval_threshold: 0.60,
+            generation_timeout_ms: 60_000,
         }
     }
 
@@ -163,6 +170,13 @@ impl SkillGenerator {
         self
     }
 
+    /// Override the per-call LLM timeout used by [`Self::generate`] (default 60s).
+    #[must_use]
+    pub fn with_generation_timeout_ms(mut self, ms: u64) -> Self {
+        self.generation_timeout_ms = ms;
+        self
+    }
+
     /// Generate a SKILL.md candidate from a natural language description.
     ///
     /// Does NOT write to disk. Call `approve_and_save` after user confirmation.
@@ -171,6 +185,7 @@ impl SkillGenerator {
     ///
     /// Returns `SkillError::Invalid` if the LLM output cannot be parsed or fails validation.
     /// Returns `SkillError::Other` on LLM communication failures.
+    /// Returns `SkillError::Timeout` if either LLM call exceeds `generation_timeout_ms`.
     #[cfg_attr(
         feature = "profiling",
         tracing::instrument(name = "skill.generate", skip_all, fields(input_len = %request.description.len()))
@@ -185,11 +200,13 @@ impl SkillGenerator {
             Message::from_legacy(Role::User, &user_prompt),
         ];
 
-        let raw = self
-            .provider
-            .chat(&messages)
-            .await
-            .map_err(|e| SkillError::Other(format!("LLM generation failed: {e}")))?;
+        let raw = tokio::time::timeout(
+            Duration::from_millis(self.generation_timeout_ms),
+            self.provider.chat(&messages),
+        )
+        .await
+        .map_err(|_| SkillError::Timeout(self.generation_timeout_ms))?
+        .map_err(|e| SkillError::Other(format!("LLM generation failed: {e}")))?;
 
         let content = extract_skill_md(&raw);
 
@@ -209,11 +226,13 @@ impl SkillGenerator {
                     Message::from_legacy(Role::System, SYSTEM_PROMPT),
                     Message::from_legacy(Role::User, &correction),
                 ];
-                let raw2 = self
-                    .provider
-                    .chat(&retry_messages)
-                    .await
-                    .map_err(|e| SkillError::Other(format!("LLM retry failed: {e}")))?;
+                let raw2 = tokio::time::timeout(
+                    Duration::from_millis(self.generation_timeout_ms),
+                    self.provider.chat(&retry_messages),
+                )
+                .await
+                .map_err(|_| SkillError::Timeout(self.generation_timeout_ms))?
+                .map_err(|e| SkillError::Other(format!("LLM retry failed: {e}")))?;
                 let content2 = extract_skill_md(&raw2);
                 parse_and_validate(&content2)
             }
@@ -668,5 +687,65 @@ mod tests {
     fn validate_generated_name_rejects_too_long() {
         let name = "a".repeat(65);
         assert!(validate_generated_name(&name).is_err());
+    }
+
+    fn timeout_test_request() -> SkillGenerationRequest {
+        SkillGenerationRequest {
+            description: "fetch weather data".into(),
+            category: None,
+            allowed_tools: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn generate_returns_timeout_when_initial_chat_hangs() {
+        let dir = tempfile::tempdir().unwrap();
+        let slow_provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default().with_delay(500),
+        );
+        let generator = SkillGenerator::new(slow_provider, dir.path().to_path_buf())
+            .with_generation_timeout_ms(20);
+
+        // Safety net: if the internal timeout regresses to an unbounded await, fail fast
+        // instead of hanging the whole test suite.
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            generator.generate(timeout_test_request()),
+        )
+        .await
+        .expect("generate() must return within the outer safety-net timeout");
+
+        match result {
+            Err(err) => assert_matches!(err, SkillError::Timeout(20)),
+            Ok(_) => panic!("expected SkillError::Timeout, got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn generate_returns_timeout_when_retry_chat_hangs() {
+        let dir = tempfile::tempdir().unwrap();
+        // First call returns fast but fails validation (missing `name`), forcing the
+        // retry-after-parse-failure branch; the retry call then hangs past the timeout.
+        let invalid_first_response =
+            "---\ndescription: A skill without a name.\n---\n\n## Usage\n\nDo stuff.\n".to_string();
+        let provider = zeph_llm::mock::MockProvider::with_responses(vec![invalid_first_response])
+            .with_per_call_delays(vec![0, 500]);
+        let generator = SkillGenerator::new(
+            zeph_llm::any::AnyProvider::Mock(provider),
+            dir.path().to_path_buf(),
+        )
+        .with_generation_timeout_ms(20);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            generator.generate(timeout_test_request()),
+        )
+        .await
+        .expect("generate() must return within the outer safety-net timeout");
+
+        match result {
+            Err(err) => assert_matches!(err, SkillError::Timeout(20)),
+            Ok(_) => panic!("expected SkillError::Timeout, got Ok"),
+        }
     }
 }

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1733,7 +1733,8 @@ pub(crate) fn apply_proactive_explorer<C: zeph_core::channel::Channel>(
         }
     };
 
-    let generator = zeph_skills::SkillGenerator::new(provider, output_dir.clone());
+    let generator = zeph_skills::SkillGenerator::new(provider, output_dir.clone())
+        .with_generation_timeout_ms(exp_cfg.timeout_ms);
     let explorer = zeph_skills::proactive::ProactiveExplorer::new(
         generator,
         evaluator,

--- a/src/bootstrap/skills.rs
+++ b/src/bootstrap/skills.rs
@@ -178,6 +178,8 @@ struct GeneratorSkillWriter {
     eval_weights: zeph_skills::evaluator::EvaluationWeights,
     /// Evaluation threshold forwarded to `with_evaluator`.
     eval_threshold: f32,
+    /// Per-call LLM timeout forwarded to `with_generation_timeout_ms`.
+    generation_timeout_ms: u64,
 }
 
 impl zeph_memory::compression::promotion::SkillWriter for GeneratorSkillWriter {
@@ -188,7 +190,8 @@ impl zeph_memory::compression::promotion::SkillWriter for GeneratorSkillWriter {
     ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>> {
         Box::pin(async move {
             let generator =
-                zeph_skills::SkillGenerator::new(self.provider.clone(), self.output_dir.clone());
+                zeph_skills::SkillGenerator::new(self.provider.clone(), self.output_dir.clone())
+                    .with_generation_timeout_ms(self.generation_timeout_ms);
             let generator = if let Some(ref eval) = self.evaluator {
                 generator.with_evaluator(Arc::clone(eval), self.eval_weights, self.eval_threshold)
             } else {
@@ -267,5 +270,6 @@ pub fn build_skill_writer(
         evaluator,
         eval_weights,
         eval_threshold,
+        generation_timeout_ms: config.skills.generation_timeout_ms,
     }))
 }


### PR DESCRIPTION
## Summary

- `SkillGenerator::generate` awaited both `provider.chat()` calls (initial generation and the parse-failure retry) with no timeout, violating this project's Await Discipline rule. The background skill-promotion path (`compression_spectrum.promotion_scan` -> `PromotionEngine::promote` -> `GeneratorSkillWriter::write_skill` -> `generate`) had no caller-side timeout wrap at all, so an unresponsive LLM provider could hang that named background task forever and block every other candidate in the same sequential promotion sweep.
- `generate()` now wraps both calls in `tokio::time::timeout` against a new `generation_timeout_ms` field (default 60s), returning the existing `SkillError::Timeout` on expiry. A new `with_generation_timeout_ms` builder allows overriding it; `GeneratorSkillWriter` threads `config.skills.generation_timeout_ms` through to close the previously unbounded promotion path.
- The `/skill create` command and the proactive-exploration generator now thread their own governing config values into the same builder, closing a config-shadowing regression (found during adversarial review) where the new internal 60s default would have silently truncated a caller's already-configured timeout above 60s.

Closes #5534

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11907 passed, 34 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression tests: `generate_returns_timeout_when_initial_chat_hangs`, `generate_returns_timeout_when_retry_chat_hangs` (both call sites covered)