### PR TITLE
fix(db): cache postgres sql! macro rewrite per call site instead of leaking on every call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   per turn (cleared at turn boundaries); when present, the `Retrieve` branch degrades
   gracefully and lets the requested tool proceed instead of mandating another retrieval
   attempt. Closes #5584.
+- `fix(db)`: `zeph_db::sql!`'s `postgres`-feature expansion no longer leaks a fresh heap
+  allocation on every invocation. Previously each call rewrote `?`/`?N` placeholders to
+  `$N` and `Box::leak`ed the result unconditionally, so a query executed repeatedly (e.g.
+  inside a loop, or simply called many times over a long-running process) leaked one
+  allocation per execution rather than per call site as the doc comment claimed. Replaced
+  with a call-site-local `static LazyLock<String>`: macro expansion is textual, so each
+  `sql!(...)` call site gets its own `LazyLock` that computes the rewrite once and caches
+  it for the process lifetime. Verified no call site in the workspace passes a
+  runtime-varying `$query` (a `LazyLock` closure only runs once, so a non-constant
+  `$query` would silently freeze at its first-seen value) — all ~620 `sql!(` invocations
+  pass a string literal. Delivers the per-call-site caching acceptance criterion
+  originally stated but never implemented for #2387. Closes #5431.
 
 ### Added
 

--- a/crates/zeph-db/src/lib.rs
+++ b/crates/zeph-db/src/lib.rs
@@ -80,12 +80,15 @@ pub type ActiveDialect = <ActiveDriver as DatabaseDriver>::Dialect;
 ///
 /// `PostgreSQL`: rewrites `?` to `$1`, `$2`, ... and `?N` (`SQLite`'s numbered
 /// placeholder, e.g. `?1`) to `$N` using [`rewrite_placeholders`]. Repeated
-/// references to the same `?N` collapse to the same `$N`. The rewritten
-/// string is leaked via `Box::leak` to obtain `&'static str` —
-/// no caching: each call site leaks one allocation per unique SQL string.
-/// The set of unique SQL strings is bounded (call sites are fixed at compile
-/// time), so total leaked memory is bounded and acceptable for a long-running
-/// process. Do NOT wrap `PostgreSQL` JSONB queries using `?`/`?|`/`?&`
+/// references to the same `?N` collapse to the same `$N`. The rewrite runs at
+/// most once per call site: the result is memoized in a call-site-local
+/// `LazyLock<String>`, so a query executed in a loop or on a hot path incurs
+/// the rewrite cost once per process lifetime rather than once per execution.
+/// This requires `$query` to be a compile-time-constant expression (in
+/// practice, always a string literal at every call site in this workspace) —
+/// the closure passed to `LazyLock::new` captures `$query` and runs exactly
+/// once, so a runtime-varying `$query` would silently freeze at its
+/// first-seen value. Do NOT wrap `PostgreSQL` JSONB queries using `?`/`?|`/`?&`
 /// operators through this macro; use `$N` placeholders directly for those.
 ///
 /// # Example
@@ -108,11 +111,13 @@ macro_rules! sql {
 #[macro_export]
 macro_rules! sql {
     ($query:expr) => {{
-        // Leak the rewritten query string to obtain `&'static str`.
-        // The set of unique SQL strings in the application is finite, so total
-        // leaked memory is bounded and acceptable for a long-running process.
-        let s: String = $crate::rewrite_placeholders($query);
-        Box::leak(s.into_boxed_str()) as &'static str
+        // A `static` item inside a macro expansion is instantiated once per
+        // call site (macros expand textually), giving each call site its own
+        // `LazyLock`. The rewrite runs on first execution of this call site
+        // and is cached for the process lifetime — no per-execution leak.
+        static CACHE: ::std::sync::LazyLock<::std::string::String> =
+            ::std::sync::LazyLock::new(|| $crate::rewrite_placeholders($query));
+        CACHE.as_str()
     }};
 }
 

--- a/crates/zeph-db/tests/sql_macro.rs
+++ b/crates/zeph-db/tests/sql_macro.rs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression coverage for #5431: the `postgres` `sql!` macro must cache its
+//! rewritten query in a per-call-site `static LazyLock<String>` instead of
+//! leaking a fresh heap allocation on every invocation (the original defect).
+//!
+//! Only meaningful under the `postgres` feature — under `sqlite`, `sql!` is an
+//! identity macro over a `&'static str` literal, and the compiler is free to
+//! deduplicate identical string literals, which would make a pointer-identity
+//! test meaningless (and possibly flaky) for that branch.
+#![cfg(feature = "postgres")]
+
+/// Distinct call site from [`call_site_b`] despite the identical literal —
+/// macro hygiene must give each expansion its own `static`.
+fn call_site_a() -> &'static str {
+    zeph_db::sql!("SELECT id FROM messages WHERE conversation_id = ?")
+}
+
+/// Distinct call site from [`call_site_a`] despite the identical literal.
+fn call_site_b() -> &'static str {
+    zeph_db::sql!("SELECT id FROM messages WHERE conversation_id = ?")
+}
+
+#[test]
+fn sql_macro_caches_per_call_site_not_globally() {
+    let a1 = call_site_a();
+    let a2 = call_site_a();
+    let b1 = call_site_b();
+
+    assert_eq!(a1, "SELECT id FROM messages WHERE conversation_id = $1");
+    assert_eq!(a1, b1, "rewritten content must match at both call sites");
+
+    // Same call site, repeated invocation: the `static LazyLock` must return
+    // the exact same allocation both times — proves caching actually happens,
+    // not just that the rewrite is correct.
+    assert!(
+        std::ptr::eq(a1.as_ptr(), a2.as_ptr()),
+        "same call site must reuse the cached allocation across repeated calls"
+    );
+
+    // Two distinct call sites sharing the identical literal: macro hygiene
+    // must give each expansion its own `static`, so the allocations must NOT
+    // collide (a single shared/global cache would alias them).
+    assert!(
+        !std::ptr::eq(a1.as_ptr(), b1.as_ptr()),
+        "distinct call sites must not share the same cached allocation"
+    );
+}

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -409,8 +409,9 @@ impl LocalBackend {
         for entry in entries {
             rows.push(self.prepare_row(entry)?);
         }
-        // Evaluate the dialect-rewritten statement once (the postgres `sql!` leaks on each call),
-        // then reuse it for every row in the batch.
+        // `sql!()` caches its postgres rewrite per call site (see #5431), so hoisting
+        // this out of the loop below is no longer required to avoid a leak — kept
+        // anyway since it reads the intent clearly and costs nothing.
         let insert = sql!(
             "INSERT INTO durable_journal
                 (execution_id, step_id, entry_kind, idem_key, effect_class, payload, payload_version, hmac, created_at)


### PR DESCRIPTION
## Summary

Closes #5431. The `postgres`-feature `zeph_db::sql!` macro leaked a fresh heap allocation on *every runtime invocation* via `Box::leak`, not once per call site as its own doc comment and a previously-closed-but-never-implemented issue (#2387) both claimed. In a long-running process (daemon/gateway/scheduler) with the `postgres` backend configured, this leaked memory continuously and unboundedly with query volume.

Replaces the per-invocation leak with a call-site-local `static LazyLock<String>`: macro expansion is textual, so each `sql!(...)` call site gets its own `static` that computes the rewrite once and reuses it for the process lifetime. This delivers #2387's originally-stated but never-actually-implemented per-call-site-caching design and acceptance criterion.

**Critical design verification** (the risk that made this fix non-trivial): a `static LazyLock` cached per call site is only safe if `$query`'s value never varies at runtime between calls to that specific call site — a runtime-computed query (e.g. via `format!`) would silently freeze at its first-seen value under a naive cache, a correctness bug worse than the leak it fixes. Before applying the design, all ~620 `sql!(` call sites across the workspace were audited (grep + manual inspection) and confirmed to pass plain string literals exclusively — no exceptions found. The adversarial critic and tester independently re-verified this (critic extended postgres-feature compile coverage to 543/623 sites across zeph-db/zeph-memory/zeph-durable/zeph-scheduler; tester closed the remaining gap with a workspace-level `cargo check --features postgres`, plus 51/51 real-Postgres integration tests via testcontainers).

New test `crates/zeph-db/tests/sql_macro.rs::sql_macro_caches_per_call_site_not_globally` proves via `std::ptr::eq` that (a) the same call site returns an identical pointer on repeated calls (caching works — deterministically distinguishes this from the old `Box::leak`-per-call behavior, since two separate leaks can never share an address) and (b) two textually-identical-but-distinct call sites get independent allocations (macro hygiene, not a global content-keyed cache) — the "add a test" acceptance criterion from #2387 that was never delivered.

Also updates a stale comment in `crates/zeph-durable/src/backend/local.rs::append_batch` that manually hoisted `sql!()` out of a per-row loop to work around the leak — the workaround is no longer needed but harmless, so it was kept with an updated explanation.

## Out-of-scope findings (filed separately, not blocking)

Two pre-existing, unrelated issues surfaced while validating this fix against the workspace under `--features postgres`:
- #5595 — `zeph-scheduler`'s `test_pool()` hardcodes `SqlitePool`, fails to compile under `--features postgres` (predates this branch by months, confirmed via `git blame`).
- #5596 — `zeph-orchestration`'s `postgres` feature doesn't forward to `zeph-memory/postgres`, an inconsistent feature-flag state.

## Review process

developer → parallel (tester + adversarial critic, both independently re-audited the call-site safety claim rather than trusting it, and extended postgres-feature compile coverage) → code reviewer (approved).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11907 passed, 0 failed
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-db --features postgres -E 'test(sql_macro)'` — new regression test passes
- [x] rustdoc gate (workspace + `zeph-db --all-features`)
- [x] Workspace-level `cargo check --features postgres` (library code) — clean; `--all-targets` surfaces the pre-existing unrelated #5595, not caused by this fix
- [x] 51/51 real-Postgres integration tests (`zeph-db`, `zeph-memory`, `zeph-index`, via testcontainers) — no regression against the fixed macro arm
- [x] Live-testing playbook and coverage-status updated in `.local/testing/` (main repo) per project convention