### PR TITLE
fix(tui): differentiate daemon palette command messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tui)`: the TUI command palette's `daemon:connect`, `daemon:disconnect`, and
+  `daemon:status` entries no longer collapse into one indistinguishable "not yet
+  implemented" toast. `daemon:status` now reports genuine connection state (connected to
+  the remote daemon URL passed via `--connect <URL>`, or local mode) via a new
+  `App.remote_daemon_url` field set at startup; `daemon:connect`/`daemon:disconnect` give
+  honest, differentiated guidance pointing to `--connect <URL>` and quitting the TUI,
+  since live in-session daemon attach/detach requires a runtime-swappable transport that
+  does not exist yet (the transport is fixed at TUI construction time). Closes #5509.
 - `fix(tools,core)`: live agent turns no longer stall indefinitely when Qdrant is
   unreachable (up to 240s observed, never dispatching the originally-requested tool). Two
   compounding defects: (1) `handle_tool_failure_outcomes` misclassified every structured

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -514,6 +514,12 @@ pub struct App {
     /// Drained by `tui_loop` in the shared post-select block (C2 — never
     /// inside an event arm to avoid ordering hazards).
     pub(crate) pending_mouse_capture: Option<bool>,
+
+    /// URL of the remote daemon this session was attached to via `--connect <URL>`, if any.
+    ///
+    /// Set once at startup by [`with_remote_daemon_url`](Self::with_remote_daemon_url) —
+    /// there is no runtime mechanism to attach/detach mid-session (#5509).
+    remote_daemon_url: Option<String>,
 }
 
 pub(crate) mod action;

--- a/crates/zeph-tui/src/app/reducer.rs
+++ b/crates/zeph-tui/src/app/reducer.rs
@@ -730,11 +730,29 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
                     );
                     return vec![];
                 }
-                TuiCommand::DaemonConnect
-                | TuiCommand::DaemonDisconnect
-                | TuiCommand::DaemonStatus => {
+                TuiCommand::DaemonStatus => {
+                    let msg = match app.remote_daemon_url() {
+                        Some(url) => format!("Connected to remote daemon at {url}"),
+                        None => "Running in local mode (not connected to a remote daemon).\n\
+                                 Use `zeph --tui --connect <URL>` to attach to a remote daemon."
+                            .to_owned(),
+                    };
+                    app.push_system_message_pub(msg);
+                    return vec![];
+                }
+                TuiCommand::DaemonConnect => {
                     app.push_system_message_pub(
-                        "Daemon commands are not yet implemented in this mode.".to_owned(),
+                        "Live in-session daemon attach is not supported yet.\n\
+                         To connect to a remote daemon, restart with:\n  zeph --tui --connect <URL>"
+                            .to_owned(),
+                    );
+                    return vec![];
+                }
+                TuiCommand::DaemonDisconnect => {
+                    app.push_system_message_pub(
+                        "There is no live daemon connection to tear down in this mode.\n\
+                         If you started with `--connect <URL>`, quit the TUI (q / Ctrl+C) to disconnect."
+                            .to_owned(),
                     );
                     return vec![];
                 }
@@ -1273,6 +1291,55 @@ mod tests {
         let effects = reduce(&mut app, Action::Dispatch(TuiCommand::SecurityEvents));
         assert!(effects.is_empty());
         assert_eq!(app.sessions.current().messages.len(), 1);
+    }
+
+    #[test]
+    fn dispatch_daemon_status_reports_local_mode_when_disconnected() {
+        let (mut app, _rx) = make_app();
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::DaemonStatus));
+        assert!(effects.is_empty());
+        let msg = &app.sessions.current().messages.last().unwrap().content;
+        assert!(msg.contains("local mode"));
+        assert!(msg.contains("--connect"));
+    }
+
+    #[test]
+    fn dispatch_daemon_status_reports_connected_when_remote_url_set() {
+        let (mut app, _rx) = make_app();
+        app = app.with_remote_daemon_url("http://example.com:9000");
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::DaemonStatus));
+        assert!(effects.is_empty());
+        let msg = &app.sessions.current().messages.last().unwrap().content;
+        assert!(msg.contains("Connected"));
+        assert!(msg.contains("http://example.com:9000"));
+    }
+
+    #[test]
+    fn dispatch_daemon_connect_and_disconnect_give_distinct_messages() {
+        let (mut app, _rx) = make_app();
+        reduce(&mut app, Action::Dispatch(TuiCommand::DaemonConnect));
+        let connect_msg = app
+            .sessions
+            .current()
+            .messages
+            .last()
+            .unwrap()
+            .content
+            .clone();
+
+        reduce(&mut app, Action::Dispatch(TuiCommand::DaemonDisconnect));
+        let disconnect_msg = app
+            .sessions
+            .current()
+            .messages
+            .last()
+            .unwrap()
+            .content
+            .clone();
+
+        assert_ne!(connect_msg, disconnect_msg);
+        assert!(connect_msg.contains("--connect"));
+        assert!(disconnect_msg.contains("quit"));
     }
 
     // ── Group C tests ───────────────────────────────────────────────────────────

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -113,6 +113,7 @@ impl App {
             mouse_enabled: false,
             last_layout: None,
             pending_mouse_capture: None,
+            remote_daemon_url: None,
         }
     }
 
@@ -584,6 +585,35 @@ impl App {
     pub fn with_tool_density(mut self, density: ToolDensity) -> Self {
         self.tool_density = density;
         self
+    }
+
+    /// Record the remote daemon URL this session was attached to via `--connect <URL>`.
+    ///
+    /// Set once at startup in `run_tui_remote`; there is no runtime mechanism to attach
+    /// to or detach from a daemon mid-session (#5509). Used by `daemon:status` to report
+    /// real connection state instead of a stub message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tokio::sync::mpsc;
+    /// use zeph_tui::App;
+    ///
+    /// let (user_tx, _) = mpsc::channel(64);
+    /// let (_, agent_rx) = mpsc::channel(64);
+    /// let app = App::new(user_tx, agent_rx).with_remote_daemon_url("http://localhost:8765");
+    /// ```
+    #[must_use]
+    pub fn with_remote_daemon_url(mut self, url: impl Into<String>) -> Self {
+        self.remote_daemon_url = Some(url.into());
+        self
+    }
+
+    /// Return the remote daemon URL this session was attached to at startup, if any.
+    ///
+    /// `None` means this is a local session (no `--connect <URL>` flag was used).
+    pub(crate) fn remote_daemon_url(&self) -> Option<&str> {
+        self.remote_daemon_url.as_deref()
     }
 
     /// Wire a [`TaskSupervisor`] into the `App` for the task registry panel.
@@ -1462,5 +1492,19 @@ mod tests {
         let (_, agent_rx) = mpsc::channel(1);
         let app = App::new(user_tx, agent_rx).with_theme_name("gruvbox-dark");
         assert_eq!(app.active_theme_name(), "gruvbox-dark");
+    }
+
+    #[test]
+    fn with_remote_daemon_url_builder_sets_url() {
+        let (user_tx, _) = mpsc::channel(1);
+        let (_, agent_rx) = mpsc::channel(1);
+        let app = App::new(user_tx, agent_rx).with_remote_daemon_url("http://localhost:8765");
+        assert_eq!(app.remote_daemon_url(), Some("http://localhost:8765"));
+    }
+
+    #[test]
+    fn remote_daemon_url_defaults_to_none() {
+        let app = make_app();
+        assert_eq!(app.remote_daemon_url(), None);
     }
 }

--- a/src/tui_remote.rs
+++ b/src/tui_remote.rs
@@ -26,6 +26,9 @@ pub(crate) async fn run_tui_remote(
         },
     );
 
+    // Cloned before `url` is moved into the `async move` SSE pump block below.
+    let remote_daemon_url = url.clone();
+
     // user_tx is passed to App; App sends user text through it.
     // We receive on user_rx and forward to the A2A SSE pump.
     let (user_tx, mut user_rx) = tokio::sync::mpsc::channel::<String>(32);
@@ -168,7 +171,8 @@ pub(crate) async fn run_tui_remote(
         .with_tool_density(config.tui.tool_density)
         .with_theme(tui_theme)
         .with_theme_name(tui_theme_name)
-        .with_effective_color_mode(tui_color_mode);
+        .with_effective_color_mode(tui_color_mode)
+        .with_remote_daemon_url(remote_daemon_url);
     tui_app.set_show_source_labels(config.tui.show_source_labels);
 
     zeph_tui::run_tui(tui_app, event_rx).await?;


### PR DESCRIPTION
## Summary
- `daemon:connect`, `daemon:disconnect`, and `daemon:status` in the TUI command palette previously all fell through to one shared "not yet implemented" toast, misleadingly advertising three distinct capabilities as a single dead end.
- `daemon:status` now reports genuine connection state via a new `App.remote_daemon_url` field set at startup from the `--connect <URL>` argument (`src/tui_remote.rs`).
- `daemon:connect` / `daemon:disconnect` give honest, differentiated guidance instead, since live in-session attach/detach would require a runtime-swappable transport backend that does not exist today — the local-agent vs. A2A-SSE transport is fixed at TUI construction time, with no seam to swap it once the reducer is running. Full analysis of that architectural constraint is preserved in this branch's `.local/handoff/2026-07-03T17-17-42-debug.md`.
- A follow-up issue for true live in-session daemon attach (runtime-swappable transport, `TaskSupervisor`-driven connect with timeout/spinner, URL-input UI) is recommended as future work, not filed yet.

Closes #5509.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-tui` — 815 passed, 3 skipped
- [x] `cargo test --doc -p zeph-tui` — 105 passed
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-tui`
- [x] `cargo build --workspace --features "tui,a2a"`
- [x] 6 new unit tests added covering the builder/accessor and the three differentiated dispatch messages (including a regression test asserting `daemon:connect` and `daemon:disconnect` produce distinct messages)
- [x] Adversarial critique (verdict: minor, non-blocking) and code review (approved) completed