### PR TITLE
fix(scheduler): construct test_pool via DbConfig::connect for postgres compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   honest, differentiated guidance pointing to `--connect <URL>` and quitting the TUI,
   since live in-session daemon attach/detach requires a runtime-swappable transport that
   does not exist yet (the transport is fixed at TUI construction time). Closes #5509.
+
+- `fix(scheduler)`: `zeph-scheduler`'s test-only `test_pool()` helper hardcoded a
+  `SqlitePool` constructor while its return type `DbPool` resolves to `Pool<Postgres>`
+  when the `postgres` feature is enabled, causing an `E0308` compile failure under
+  `--features postgres`. Now constructs the pool via `DbConfig::connect()`, mirroring
+  the pattern already used by this crate's `store.rs` test_pool(). Closes #5595.
+
 - `fix(tools,core)`: live agent turns no longer stall indefinitely when Qdrant is
   unreachable (up to 240s observed, never dispatching the originally-requested tool). Two
   compounding defects: (1) `handle_tool_failure_outcomes` misclassified every structured

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -997,9 +997,14 @@ mod tests {
     }
 
     async fn test_pool() -> DbPool {
-        zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap()
+        zeph_db::DbConfig {
+            url: ":memory:".to_string(),
+            max_connections: 5,
+            pool_size: 5,
+        }
+        .connect()
+        .await
+        .unwrap()
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- `test_pool()` in `crates/zeph-scheduler/src/scheduler.rs` hardcoded a `SqlitePool` constructor while its return type `DbPool` resolves to `Pool<Postgres>` when the `postgres` feature is enabled, causing an `E0308` compile failure under `--features postgres`.
- Fixed by mirroring the `DbConfig::connect()` pattern already used by this crate's own `store.rs` test_pool() — no new pattern introduced.

## Validation
- `cargo check -p zeph-scheduler --all-targets --features postgres` — clean (previously E0308)
- `cargo check -p zeph-scheduler --all-targets` (default/sqlite) — clean
- `cargo clippy --profile ci -p zeph-scheduler --all-targets -- -D warnings` — clean (default and `--features postgres`)
- `cargo nextest run -p zeph-scheduler` — 105 passed, 0 skipped
- `cargo +nightly fmt --check -p zeph-scheduler` — clean
- Adversarial critique (rust-critic): APPROVED (minor) — confirmed the fix compiles correctly under both feature configurations; a latent runtime caveat (`:memory:` misrouted to `connect_postgres` if ever exercised under real postgres) is unreachable in practice since zeph-scheduler is not in any postgres CI matrix today, and is the same accepted deviation already tracked by #5571.

## Follow-ups filed separately (out of scope for this PR)
Found during validation, will be filed as their own issues rather than expanding this fix:
- CI's `build-postgres` job only covers `-p zeph-db`, never exercises `--features postgres` for zeph-scheduler or most of the workspace.
- ~25 pre-existing (unrelated) `E0308` errors surface across zeph-core, zeph-tools, and the main zeph binary's test suite once this blocker is removed (visible only with `cargo check --keep-going`).
- 8 call sites of `LocalBackend::open(":memory:", ...)` across zeph-durable/zeph-scheduler runtime-fail under `--features postgres` — same anti-pattern family, different (runtime, not compile) failure mode.

## Test plan
- [x] `cargo check --features postgres` compiles cleanly
- [x] Default (sqlite) test suite passes
- [x] Clippy clean under both feature sets

Closes #5595