### PR TITLE
fix(core): wire provider_pool into ACP/serve/daemon agent construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   honest, differentiated guidance pointing to `--connect <URL>` and quitting the TUI,
   since live in-session daemon attach/detach requires a runtime-swappable transport that
   does not exist yet (the transport is fixed at TUI construction time). Closes #5509.
-
 - `fix(scheduler)`: `zeph-scheduler`'s test-only `test_pool()` helper hardcoded a
   `SqlitePool` constructor while its return type `DbPool` resolves to `Pool<Postgres>`
   when the `postgres` feature is enabled, causing an `E0308` compile failure under
   `--features postgres`. Now constructs the pool via `DbConfig::connect()`, mirroring
   the pattern already used by this crate's `store.rs` test_pool(). Closes #5595.
+- `fix(core)`: `Agent::resolve_background_provider` (used by ~20 background-provider lookups,
+  e.g. `memory.graph.extract_provider`, `memory.memcot.distill_provider`) silently fell back to
+  the primary provider — even for a name correctly declared in `[[llm.providers]]` — for every
+  `Agent` built via `zeph --acp`, `zeph serve-sessions`, or the A2A/gateway daemon, because
+  `AgentBuilder::with_provider_pool` was only ever called on the CLI single-session path
+  (`src/runner.rs`). The other three Agent-construction sites now build and wire the same
+  provider pool + config snapshot. Closes #5450.
+
+- `fix(core)`: `reformat_tool_call` (parameter-reformat retry, #5453) now leaves the original
+  tool error unchanged instead of silently retrying through the primary provider when
+  `tools.retry.parameter_reformat_provider` names a provider absent from `[[llm.providers]]` —
+  previously a stale/typo'd name would fall back to primary and could replace a clear "invalid
+  parameters" error with a plausible-but-wrong corrected result from the wrong model. Closes
+  #5478.
 
 - `fix(tools,core)`: live agent turns no longer stall indefinitely when Qdrant is
   unreachable (up to 240s observed, never dispatching the originally-requested tool). Two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10292,6 +10292,7 @@ dependencies = [
  "zeph-agent-persistence",
  "zeph-bench",
  "zeph-channels",
+ "zeph-commands",
  "zeph-common",
  "zeph-config",
  "zeph-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,6 +368,7 @@ qdrant-client = { workspace = true, features = ["serde"] }
 serial_test.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true
+zeph-commands.workspace = true
 zeph-core.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }
 zeph-memory.workspace = true

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -553,6 +553,10 @@ pub(crate) struct LifecycleState {
 ///
 /// Secrets are stored as plain strings because [`Secret`] intentionally does not implement
 /// `Clone`. They are re-wrapped in `Secret` when passed to `build_provider_for_switch`.
+///
+/// `Clone` so ACP/serve deps structs (built once per process) can hand each session its own
+/// owned copy via [`Agent::with_provider_pool`](crate::agent::Agent::with_provider_pool).
+#[derive(Clone, Default)]
 pub struct ProviderConfigSnapshot {
     pub claude_api_key: Option<String>,
     pub openai_api_key: Option<String>,

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -333,13 +333,24 @@ impl<C: Channel> Agent<C> {
     /// `InvalidParameters`/`TypeMismatch` error (issue #5453).
     ///
     /// Resolves `tools.retry.parameter_reformat_provider` from `[[llm.providers]]` via
-    /// [`Agent::resolve_background_provider`] (falling back to the primary provider when the
-    /// name is empty or unknown), asks it for corrected arguments given the tool's JSON schema,
-    /// the originally-submitted arguments, and the error message, then re-dispatches the tool
-    /// call once with the corrected arguments.
+    /// [`Agent::resolve_background_provider`], asks it for corrected arguments given the tool's
+    /// JSON schema, the originally-submitted arguments, and the error message, then re-dispatches
+    /// the tool call once with the corrected arguments.
     ///
-    /// Returns `None` when the provider call fails, times out, or returns arguments that do not
-    /// parse as a JSON object — the caller keeps the original error result unchanged.
+    /// This method is only ever called with a non-empty `parameter_reformat_provider`
+    /// (`handle_reformat_phase` returns early on the empty-name case before calling it). Unlike
+    /// `resolve_background_provider`'s other callers, a configured-but-unresolvable name (absent
+    /// from `[[llm.providers]]`) is not silently retried against the primary provider here
+    /// (#5478): a guard checks pool membership before resolution is attempted and returns `None`
+    /// on a miss, since a masked misconfiguration could otherwise replace a clear "invalid
+    /// parameters" error with a plausible-but-wrong result from the wrong model. This guard only
+    /// covers the name-absent-from-pool case — `resolve_background_provider` itself can still
+    /// fall back to primary for a name that IS in the pool if `provider_config_snapshot` is
+    /// unset or provider construction fails (tracked separately as #5600).
+    ///
+    /// Returns `None` when the provider name is unresolvable, the provider call fails, times
+    /// out, or returns arguments that do not parse as a JSON object — the caller keeps the
+    /// original error result unchanged.
     async fn reformat_tool_call(
         &mut self,
         call: &ToolCall,
@@ -365,6 +376,26 @@ impl<C: Channel> Agent<C> {
         };
 
         let provider_name = self.tool_orchestrator.parameter_reformat_provider.clone();
+        // #5478: unlike `resolve_background_provider`'s other ~19 call sites, an unresolvable
+        // name here must be a true no-op (keep the original tool error unchanged), not a
+        // silent fallback to primary — reformatting replaces `tool_results[idx]` with whatever
+        // the resolved provider proposes and re-dispatches it, so falling back to primary on a
+        // misconfigured name would mask the operator's config error behind plausible-but-wrong
+        // corrected arguments instead of surfacing the original, clear validation error.
+        if !self
+            .runtime
+            .providers
+            .provider_pool
+            .iter()
+            .any(|e| e.effective_name().eq_ignore_ascii_case(&provider_name))
+        {
+            tracing::warn!(
+                tool = %tc.name,
+                provider = %provider_name,
+                "parameter reformat: configured provider not found in [[llm.providers]], skipping reformat"
+            );
+            return None;
+        }
         let provider = self.resolve_background_provider(&provider_name);
 
         let original_args = serde_json::Value::Object(call.params.clone());
@@ -3576,6 +3607,18 @@ mod tests {
             }
         }
 
+        /// Registers `name` in `provider_pool` so the #5478 pool-membership guard in
+        /// `reformat_tool_call` lets these tests reach the actual reformat logic. No
+        /// `provider_config_snapshot` is set, so `resolve_background_provider` still falls back
+        /// to the primary (mock) provider once the guard passes — preserving these tests' original
+        /// intent of exercising the primary provider's canned responses.
+        fn register_pool_entry(agent: &mut Agent<MockChannel>, name: &str) {
+            agent.runtime.providers.provider_pool = vec![crate::config::ProviderEntry {
+                name: Some(name.to_owned()),
+                ..Default::default()
+            }];
+        }
+
         #[tokio::test]
         async fn retries_with_corrected_arguments_on_success() {
             let provider = mock_provider(vec![r#"{"arguments":{"path":"/corrected"}}"#.into()]);
@@ -3596,6 +3639,7 @@ mod tests {
             .with_definitions(vec![test_tool_def()]);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+            register_pool_entry(&mut agent, "fast");
 
             let tool_calls = vec![tool_use_request()];
             let calls = vec![bad_tool_call()];
@@ -3625,6 +3669,7 @@ mod tests {
                 MockToolExecutor::new(vec![Ok(None)]).with_definitions(vec![test_tool_def()]);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+            register_pool_entry(&mut agent, "fast");
 
             let tool_calls = vec![tool_use_request()];
             let calls = vec![bad_tool_call()];
@@ -3656,6 +3701,7 @@ mod tests {
             let executor = MockToolExecutor::new(vec![Ok(None)]);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+            register_pool_entry(&mut agent, "fast");
 
             let tool_calls = vec![tool_use_request()];
             let calls = vec![bad_tool_call()];
@@ -3709,6 +3755,59 @@ mod tests {
             );
         }
 
+        /// #5478 regression: a non-empty `parameter_reformat_provider` name that is not
+        /// registered in `provider_pool` must be a true no-op (original error preserved), not a
+        /// silent fallback to the primary provider. The primary provider here is set up to
+        /// return a *successful* corrected-arguments response — if the pool-membership guard in
+        /// `reformat_tool_call` were missing (pre-#5478 behavior), `resolve_background_provider`
+        /// would fall back to this primary provider, the tool would be retried successfully, and
+        /// `tool_results[0]` would be replaced — masking the original validation error behind a
+        /// plausible-but-wrong "fix" driven by a misconfigured provider name.
+        #[tokio::test]
+        async fn is_a_noop_when_provider_name_is_unresolvable() {
+            let provider = mock_provider(vec![r#"{"arguments":{"path":"/corrected"}}"#.into()]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::new(vec![Ok(Some(zeph_tools::ToolOutput {
+                tool_name: "test_tool".to_owned().into(),
+                summary: "done".to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))])
+            .with_definitions(vec![test_tool_def()]);
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            // Non-empty but never registered — provider_pool stays empty (default).
+            agent.tool_orchestrator.parameter_reformat_provider =
+                "unregistered-provider".to_owned();
+
+            let tool_calls = vec![tool_use_request()];
+            let calls = vec![bad_tool_call()];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(invalid_params_error())];
+            let cancel = tokio_util::sync::CancellationToken::new();
+
+            agent
+                .handle_reformat_phase(&tool_calls, &calls, &mut tool_results, &cancel)
+                .await
+                .unwrap();
+
+            assert!(
+                matches!(
+                    tool_results[0],
+                    Err(zeph_tools::ToolError::InvalidParams { .. })
+                ),
+                "an unresolvable parameter_reformat_provider name must not fall back to primary; \
+                 the original error must be preserved"
+            );
+        }
+
         #[tokio::test]
         async fn replaces_original_error_when_retry_still_fails() {
             // FR-004: the retried outcome MUST replace tool_results[idx] even when the retry
@@ -3723,6 +3822,7 @@ mod tests {
             .with_definitions(vec![test_tool_def()]);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+            register_pool_entry(&mut agent, "fast");
 
             let tool_calls = vec![tool_use_request()];
             let calls = vec![bad_tool_call()];
@@ -3781,6 +3881,7 @@ mod tests {
             .with_delay(1_100);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
+            register_pool_entry(&mut agent, "fast");
             agent.tool_orchestrator.max_retry_duration_secs = 1;
 
             let tool_calls = vec![tool_use_request(), tool_use_request()];

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -166,6 +166,11 @@ struct SharedAgentDeps {
     /// reference per session.
     resume_condenser: zeph_session::LlmCondenser,
     resume_token_counter: std::sync::Arc<zeph_agent_context::memory_backend::TokenCounterAdapter>,
+    /// Snapshot of `[[llm.providers]]` entries, wired into each session's `Agent` via
+    /// `with_provider_pool` so `resolve_background_provider` (background-provider lookups such
+    /// as `memory.graph.extract_provider`) can find named providers (#5450).
+    provider_pool: Vec<zeph_core::config::ProviderEntry>,
+    provider_config_snapshot: zeph_core::ProviderConfigSnapshot,
     focus_config: zeph_core::config::FocusConfig,
     sidequest_config: zeph_core::config::SidequestConfig,
     trajectory_config: zeph_core::config::TrajectoryConfig,
@@ -608,6 +613,49 @@ async fn build_acp_deps(
     let (resume_condenser_built, resume_token_counter_built) =
         zeph_core::provider_factory::build_resume_condenser(config, &provider);
     let feedback_classifier = app.build_feedback_classifier(&provider);
+    // #5450: built once here, where the full `Config` is still in scope — mirrors
+    // `src/runner.rs`'s CLI-path snapshot construction, so ACP sessions get a populated
+    // `provider_pool` too (previously left empty, breaking `resolve_background_provider`).
+    let provider_config_snapshot = zeph_core::ProviderConfigSnapshot {
+        claude_api_key: config
+            .secrets
+            .claude_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        openai_api_key: config
+            .secrets
+            .openai_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        gemini_api_key: config
+            .secrets
+            .gemini_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        compatible_api_keys: config
+            .secrets
+            .compatible_api_keys
+            .iter()
+            .map(|(k, v)| (k.clone(), v.expose().to_owned()))
+            .collect(),
+        llm_request_timeout_secs: config.timeouts.llm_request_timeout_secs,
+        embedding_model: config.llm.embedding_model.clone(),
+        gonka_private_key: config
+            .secrets
+            .gonka_private_key
+            .as_ref()
+            .map(|s| zeroize::Zeroizing::new(s.expose().to_owned())),
+        gonka_address: config
+            .secrets
+            .gonka_address
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        cocoon_access_hash: config
+            .secrets
+            .cocoon_access_hash
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+    };
 
     let deps = SharedAgentDeps {
         provider,
@@ -694,6 +742,8 @@ async fn build_acp_deps(
         session_persistence_config: config.session.clone(),
         resume_condenser: resume_condenser_built,
         resume_token_counter: resume_token_counter_built,
+        provider_pool: config.llm.providers.clone(),
+        provider_config_snapshot,
         focus_config: config.agent.focus.clone(),
         sidequest_config: config.memory.sidequest.clone(),
         trajectory_config: config.memory.trajectory.clone(),
@@ -814,6 +864,8 @@ async fn spawn_acp_agent(
     let guardrail_provider = d.guardrail_provider.clone();
     let session_config = d.session_config.clone();
     let session_persistence_config = d.session_persistence_config.clone();
+    let provider_pool = d.provider_pool.clone();
+    let provider_config_snapshot = d.provider_config_snapshot.clone();
     let managed_skills_dir = crate::bootstrap::managed_skills_dir();
     let skill_reload_tx = d.skill_reload_tx.clone();
     let config_reload_tx = d.config_reload_tx.clone();
@@ -1079,6 +1131,7 @@ async fn spawn_acp_agent(
         .with_mcp_shared_tools(mcp_shared_tools)
         .with_focus_and_sidequest_config(d.focus_config.clone(), d.sidequest_config.clone())
         .with_trajectory_and_category_config(d.trajectory_config.clone(), d.category_config.clone())
+        .with_provider_pool(provider_pool, provider_config_snapshot)
         .with_embedding_provider(d.embedding_provider.clone())
         .maybe_init_tool_schema_filter(tool_filter_config, provider.clone()),
     )

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -593,6 +593,49 @@ pub(crate) async fn run_daemon(
     let plugin_dirs_supplier = app.plugin_dirs_supplier();
     let config_path_owned = app.config_path().to_owned();
     let session_config = zeph_core::AgentSessionConfig::from_config(config, budget_tokens);
+    // #5450: built here, where the full `Config` is still in scope — mirrors
+    // `src/runner.rs`'s CLI-path snapshot construction, so the daemon's agent gets a populated
+    // `provider_pool` too (previously left empty, breaking `resolve_background_provider`).
+    let provider_config_snapshot = zeph_core::ProviderConfigSnapshot {
+        claude_api_key: config
+            .secrets
+            .claude_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        openai_api_key: config
+            .secrets
+            .openai_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        gemini_api_key: config
+            .secrets
+            .gemini_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        compatible_api_keys: config
+            .secrets
+            .compatible_api_keys
+            .iter()
+            .map(|(k, v)| (k.clone(), v.expose().to_owned()))
+            .collect(),
+        llm_request_timeout_secs: config.timeouts.llm_request_timeout_secs,
+        embedding_model: config.llm.embedding_model.clone(),
+        gonka_private_key: config
+            .secrets
+            .gonka_private_key
+            .as_ref()
+            .map(|s| zeroize::Zeroizing::new(s.expose().to_owned())),
+        gonka_address: config
+            .secrets
+            .gonka_address
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        cocoon_access_hash: config
+            .secrets
+            .cocoon_access_hash
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+    };
 
     let (loopback_channel, loopback_handle) = zeph_core::LoopbackChannel::pair(64);
 
@@ -669,6 +712,7 @@ pub(crate) async fn run_daemon(
             config.memory.category.clone(),
         )
         .with_embedding_provider(embedding_provider.clone())
+        .with_provider_pool(config.llm.providers.clone(), provider_config_snapshot)
         .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), embedding_provider),
     )
     .await;

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -107,7 +107,8 @@ pub(crate) async fn build_agent_factory(
             deps.summarization_threshold,
         )
         .with_session_sink(session_sink)
-        .with_session_persistence_config(Some(deps.session_persistence_config));
+        .with_session_persistence_config(Some(deps.session_persistence_config))
+        .with_provider_pool(deps.provider_pool, deps.provider_config_snapshot);
         if !preloaded_messages.is_empty() {
             agent = agent.with_preloaded_messages(preloaded_messages);
         }
@@ -480,6 +481,8 @@ mod tests {
             session_persistence_config: zeph_config::SessionConfig::default(),
             resume_condenser: Arc::new(condenser),
             resume_token_counter: Arc::new(token_counter),
+            provider_pool: Vec::new(),
+            provider_config_snapshot: zeph_core::ProviderConfigSnapshot::default(),
         };
 
         let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
@@ -498,6 +501,63 @@ mod tests {
         assert!(
             has_timestamped_child,
             "DebugDumper::new must create a timestamped subdirectory under the session dir"
+        );
+    }
+
+    /// #5450 regression: `build_agent_factory` must call `Agent::with_provider_pool` so
+    /// `resolve_background_provider` (used by e.g. `memory.graph.extract_provider`) can resolve
+    /// named providers for `/sessions`-created agents — previously `ServeAgentDeps` carried the
+    /// pool but `build_agent_factory`'s builder chain never consumed it, so the pool was always
+    /// empty at runtime. `Agent` exposes no `pub` accessor for `provider_pool` directly, so this
+    /// drives the same observable surface the real `/provider` command uses
+    /// ([`zeph_commands::AgentAccess::handle_provider`] with an empty argument lists configured
+    /// providers) rather than reaching into private fields from outside `zeph-core`.
+    #[tokio::test]
+    async fn build_agent_factory_wires_provider_pool_for_background_resolution() {
+        use zeph_commands::traits::agent::AgentAccess as _;
+
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let session_id = zeph_common::SessionId::new("provider-pool-test-session");
+
+        let config = zeph_core::config::Config::default();
+        let session_config = zeph_core::AgentSessionConfig::from_config(&config, 4096);
+        let (condenser, token_counter) = make_test_condenser();
+
+        let deps = ServeAgentDeps {
+            provider: AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            embedding_provider: AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            registry: Arc::new(parking_lot::RwLock::new(
+                zeph_skills::registry::SkillRegistry::empty(),
+            )),
+            matcher: None,
+            max_active_skills: 5,
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            memory: Arc::clone(&memory),
+            history_limit: 10,
+            recall_limit: 5,
+            summarization_threshold: 1000,
+            session_config,
+            session_persistence_config: zeph_config::SessionConfig::default(),
+            resume_condenser: Arc::new(condenser),
+            resume_token_counter: Arc::new(token_counter),
+            provider_pool: vec![zeph_core::config::ProviderEntry {
+                name: Some("named-test".into()),
+                model: Some("llama3.2".into()),
+                ..zeph_core::config::ProviderEntry::default()
+            }],
+            provider_config_snapshot: zeph_core::ProviderConfigSnapshot::default(),
+        };
+
+        let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
+        let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
+        let mut agent = build_agent(channel);
+
+        let output = agent.handle_provider("").await;
+        assert!(
+            output.contains("named-test"),
+            "the pool entry configured on ServeAgentDeps must be visible through the built \
+             Agent's provider_pool; got: {output}"
         );
     }
 }

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -52,6 +52,11 @@ pub(crate) struct ServeAgentDeps {
     /// wrapped so `ServeAgentDeps` stays cheaply `Clone` without requiring `LlmCondenser: Clone`.
     pub(crate) resume_condenser: Arc<zeph_session::LlmCondenser>,
     pub(crate) resume_token_counter: Arc<zeph_agent_context::memory_backend::TokenCounterAdapter>,
+    /// Snapshot of `[[llm.providers]]` entries, wired into each session's `Agent` via
+    /// `with_provider_pool` so `resolve_background_provider` (background-provider lookups such
+    /// as `memory.graph.extract_provider`) can find named providers (#5450).
+    pub(crate) provider_pool: Vec<zeph_core::config::ProviderEntry>,
+    pub(crate) provider_config_snapshot: zeph_core::ProviderConfigSnapshot,
 }
 
 /// Assemble [`ServeAgentDeps`] once at `zeph serve-sessions` startup, plus the resolved bearer
@@ -107,6 +112,49 @@ pub(crate) async fn build_serve_deps(
     // see `ServeAgentDeps::resume_condenser`'s doc comment.
     let (resume_condenser, resume_token_counter) =
         zeph_core::provider_factory::build_resume_condenser(config, &provider);
+    // #5450: built once here, where the full `Config` is still in scope — mirrors
+    // `src/runner.rs`'s CLI-path snapshot construction, so `/sessions`-created agents get a
+    // populated `provider_pool` too (previously left empty, breaking `resolve_background_provider`).
+    let provider_config_snapshot = zeph_core::ProviderConfigSnapshot {
+        claude_api_key: config
+            .secrets
+            .claude_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        openai_api_key: config
+            .secrets
+            .openai_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        gemini_api_key: config
+            .secrets
+            .gemini_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        compatible_api_keys: config
+            .secrets
+            .compatible_api_keys
+            .iter()
+            .map(|(k, v)| (k.clone(), v.expose().to_owned()))
+            .collect(),
+        llm_request_timeout_secs: config.timeouts.llm_request_timeout_secs,
+        embedding_model: config.llm.embedding_model.clone(),
+        gonka_private_key: config
+            .secrets
+            .gonka_private_key
+            .as_ref()
+            .map(|s| zeroize::Zeroizing::new(s.expose().to_owned())),
+        gonka_address: config
+            .secrets
+            .gonka_address
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        cocoon_access_hash: config
+            .secrets
+            .cocoon_access_hash
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+    };
 
     Ok((
         ServeAgentDeps {
@@ -124,6 +172,8 @@ pub(crate) async fn build_serve_deps(
             session_persistence_config,
             resume_condenser: Arc::new(resume_condenser),
             resume_token_counter,
+            provider_pool: config.llm.providers.clone(),
+            provider_config_snapshot,
         },
         auth_token,
     ))

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -503,6 +503,8 @@ mod tests {
             session_persistence_config: zeph_config::SessionConfig::default(),
             resume_condenser: Arc::new(resume_condenser),
             resume_token_counter: Arc::new(resume_token_counter),
+            provider_pool: Vec::new(),
+            provider_config_snapshot: zeph_core::ProviderConfigSnapshot::default(),
         };
         AppState {
             registry: Arc::new(LiveSessionRegistry::new()),


### PR DESCRIPTION
## Summary

- `AgentBuilder::with_provider_pool` was only ever called on the CLI single-session path (`src/runner.rs`). Every `Agent` built via `zeph --acp`, `zeph serve-sessions`, or the daemon left `provider_pool` empty, so all ~20 call sites of `Agent::resolve_background_provider` (e.g. `memory.graph.extract_provider`, `memory.memcot.distill_provider`) silently fell back to the primary provider and warned `provider not found in [[llm.providers]]` even when the name was correctly declared. Fixed by building and wiring the same provider pool + config snapshot at the three remaining Agent-construction sites (`src/acp.rs`, `src/serve/agent_factory.rs`, `src/daemon.rs`).
- `reformat_tool_call` (`tier_loop.rs`) now leaves the original tool error untouched instead of silently retrying through the primary provider when `tools.retry.parameter_reformat_provider` names a provider absent from `[[llm.providers]]` — a misconfigured name previously could replace a clear "invalid parameters" error with a plausible-but-wrong corrected result from the wrong model.

Closes #5450, closes #5478.

## Follow-up

Filed #5600 (P3) for a narrower residual gap: `resolve_background_provider` can still fall back to primary if a name IS present in `provider_pool` but provider construction fails or the config snapshot is missing — out of scope for this PR, tracked separately.

Construction-path test coverage for `spawn_acp_agent`/`run_daemon` is intentionally deferred (both require live Qdrant+Ollama per this codebase's existing test conventions); `build_agent_factory` is covered by a new unit test exercising the real builder chain. See `.local/testing/playbooks/provider-resolution.md` and the corresponding `coverage-status.md` rows (marked Untested pending a live session).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11907 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression tests: `is_a_noop_when_provider_name_is_unresolvable` (tier_loop.rs), `build_agent_factory_wires_provider_pool_for_background_resolution` (serve/agent_factory.rs)
- [ ] Live ACP/serve/daemon session re-verification (deferred to next CI live-testing cycle, see playbook)