### PR TITLE
fix(config): sum migrate-config summary counts across all migration passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   previously a stale/typo'd name would fall back to primary and could replace a clear "invalid
   parameters" error with a plausible-but-wrong corrected result from the wrong model. Closes
   #5478.
+- `fix(config)`: `zeph migrate-config` (`--diff` and `--in-place`) no longer under-reports its
+  summary line. The final "Migration would add N entries (M sections)" / "Config migrated
+  in-place: ... (N entries added, sections: ...)" text previously counted only the last
+  catch-all `ConfigMigrator` pass, ignoring every change made by the numbered `MIGRATIONS`
+  steps that run first — a config fully migrated by named steps alone printed "0 entries
+  added" even though the per-step lines above it listed real changes. The summary now sums
+  `changed_count` and de-duplicates `sections_changed` across every named step plus the
+  final pass. Closes #5429.
 
 - `fix(tools,core)`: live agent turns no longer stall indefinitely when Qdrant is
   unreachable (up to 240s observed, never dispatching the originally-requested tool). Two

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -1,10 +1,24 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use similar::{ChangeTag, TextDiff};
 use zeph_core::config::migrate::{ConfigMigrator, MIGRATIONS, MigrationResult};
+
+/// Aggregated totals from a `migrate-config` run, returned by [`handle_migrate_config`]
+/// so callers (and tests) can observe the counts behind the printed summary line
+/// without capturing stdout/stderr.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MigrateSummary {
+    /// Total entries added or renamed, summed across every named [`MIGRATIONS`] step
+    /// plus the final `ConfigMigrator` catch-all pass.
+    pub(crate) total_changed_count: usize,
+    /// Number of distinct sections touched across every named step plus the catch-all
+    /// pass (a section touched by both is counted once).
+    pub(crate) total_sections_changed: usize,
+}
 
 /// Handle the `zeph migrate-config` command.
 ///
@@ -19,7 +33,7 @@ pub(crate) fn handle_migrate_config(
     config_path: &Path,
     in_place: bool,
     diff: bool,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<MigrateSummary> {
     let input = if config_path.exists() {
         std::fs::read_to_string(config_path)?
     } else {
@@ -39,6 +53,11 @@ pub(crate) fn handle_migrate_config(
     let migrator = ConfigMigrator::new();
     let result = migrator.migrate(&current)?;
 
+    // Aggregate totals across every named step plus the final catch-all pass, so the
+    // summary line reflects all changes, not just the catch-all pass alone.
+    let (total_changed_count, total_sections_changed) = aggregate_totals(&step_results, &result);
+    let total_sections_len = total_sections_changed.len();
+
     if diff {
         print_diff(&input, &result.output);
         for (name, step_result) in &step_results {
@@ -56,27 +75,52 @@ pub(crate) fn handle_migrate_config(
             }
         }
         eprintln!(
-            "Migration would add {} entries ({} sections).",
-            result.changed_count,
-            result.sections_changed.len()
+            "Migration would add {total_changed_count} entries ({total_sections_len} sections)."
         );
     } else if in_place {
         atomic_write(config_path, &result.output)?;
         eprintln!(
             "Config migrated in-place: {} ({} entries added, sections: {})",
             config_path.display(),
-            result.changed_count,
-            if result.sections_changed.is_empty() {
+            total_changed_count,
+            if total_sections_changed.is_empty() {
                 "none".to_owned()
             } else {
-                result.sections_changed.join(", ")
+                total_sections_changed
+                    .into_iter()
+                    .collect::<Vec<_>>()
+                    .join(", ")
             }
         );
     } else {
         print!("{}", result.output);
     }
 
-    Ok(())
+    Ok(MigrateSummary {
+        total_changed_count,
+        total_sections_changed: total_sections_len,
+    })
+}
+
+/// Sum `changed_count` and union `sections_changed` across every named migration step
+/// and the final [`ConfigMigrator`] catch-all pass, so the printed summary reflects all
+/// changes rather than only the catch-all pass. Sections touched by both a named step
+/// and the catch-all pass are counted once.
+fn aggregate_totals<'a>(
+    step_results: &'a [(&str, MigrationResult)],
+    final_result: &'a MigrationResult,
+) -> (usize, BTreeSet<&'a str>) {
+    let total_changed_count = step_results
+        .iter()
+        .map(|(_, r)| r.changed_count)
+        .sum::<usize>()
+        + final_result.changed_count;
+    let total_sections_changed: BTreeSet<&str> = step_results
+        .iter()
+        .flat_map(|(_, r)| r.sections_changed.iter().map(String::as_str))
+        .chain(final_result.sections_changed.iter().map(String::as_str))
+        .collect();
+    (total_changed_count, total_sections_changed)
 }
 
 /// Print a unified-style diff between `old` and `new`.
@@ -115,4 +159,129 @@ fn atomic_write(path: &Path, content: &str) -> anyhow::Result<()> {
     tmp.persist(path)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    fn result(changed_count: usize, sections: &[&str]) -> MigrationResult {
+        MigrationResult {
+            output: String::new(),
+            changed_count,
+            sections_changed: sections.iter().map(|s| (*s).to_owned()).collect(),
+        }
+    }
+
+    #[test]
+    fn aggregate_totals_sums_named_step_changes_when_catchall_is_a_no_op() {
+        // Reproduces #5429: named migration steps make real changes but the final
+        // `ConfigMigrator` catch-all pass finds nothing left to add.
+        let step_results = vec![
+            ("rename_embed_provider", result(2, &["memory"])),
+            ("add_goals_section", result(1, &["goals"])),
+        ];
+        let final_result = result(0, &[]);
+
+        let (total_changed, total_sections) = aggregate_totals(&step_results, &final_result);
+
+        assert_eq!(total_changed, 3);
+        assert_eq!(total_sections.len(), 2);
+        assert!(total_sections.contains("memory"));
+        assert!(total_sections.contains("goals"));
+    }
+
+    #[test]
+    fn aggregate_totals_deduplicates_sections_touched_by_both_passes() {
+        let step_results = vec![("rename_embed_provider", result(2, &["memory"]))];
+        let final_result = result(1, &["memory", "goals"]);
+
+        let (total_changed, total_sections) = aggregate_totals(&step_results, &final_result);
+
+        // Entry count is a plain sum (each entry change is distinct)...
+        assert_eq!(total_changed, 3);
+        // ...but "memory" is counted once even though both passes touched it.
+        assert_eq!(total_sections.len(), 2);
+        assert!(total_sections.contains("memory"));
+        assert!(total_sections.contains("goals"));
+    }
+
+    #[test]
+    fn aggregate_totals_empty_when_nothing_changed() {
+        let final_result = result(0, &[]);
+        let (total_changed, total_sections) = aggregate_totals(&[], &final_result);
+
+        assert_eq!(total_changed, 0);
+        assert!(total_sections.is_empty());
+    }
+
+    #[test]
+    fn handle_migrate_config_in_place_writes_migrated_output() {
+        let mut file = NamedTempFile::new().expect("create temp config file");
+        file.write_all(b"").expect("write empty config");
+        let path = file.path().to_path_buf();
+
+        let summary = handle_migrate_config(&path, true, false).expect("migration succeeds");
+
+        assert!(summary.total_changed_count > 0);
+        assert!(summary.total_sections_changed > 0);
+        let migrated = std::fs::read_to_string(&path).expect("read migrated config");
+        assert!(
+            !migrated.is_empty(),
+            "migration should add content to an empty config"
+        );
+    }
+
+    #[test]
+    fn handle_migrate_config_diff_mode_does_not_modify_the_file() {
+        let mut file = NamedTempFile::new().expect("create temp config file");
+        file.write_all(b"").expect("write empty config");
+        let path = file.path().to_path_buf();
+
+        let summary = handle_migrate_config(&path, false, true).expect("migration succeeds");
+
+        assert!(summary.total_changed_count > 0);
+        let unchanged = std::fs::read_to_string(&path).expect("read config after diff");
+        assert!(unchanged.is_empty(), "diff mode must not write to disk");
+    }
+
+    #[test]
+    fn handle_migrate_config_summary_includes_named_step_contributions() {
+        // Pins #5429 at the `handle_migrate_config` API surface: a regression back to
+        // reading `changed_count` from only the final `ConfigMigrator` catch-all pass
+        // (discarding every named `MIGRATIONS` step's contribution) must fail this
+        // assertion, because `catchall_only` below is exactly that buggy value.
+        let raw = "[index]\nembed_provider = \"openai\"\n";
+        let mut file = NamedTempFile::new().expect("create temp config file");
+        file.write_all(raw.as_bytes()).expect("write config");
+        let path = file.path().to_path_buf();
+
+        // Replicate what the final catch-all pass alone would report once the named
+        // steps (e.g. the `embed_provider` -> `embedding_provider` rename) have run —
+        // this is the pre-fix value `handle_migrate_config` used to return.
+        let mut current = raw.to_owned();
+        for migration in MIGRATIONS.iter() {
+            current = migration
+                .apply(&current)
+                .expect("named step applies")
+                .output;
+        }
+        let catchall_only = ConfigMigrator::new()
+            .migrate(&current)
+            .expect("catch-all pass migrates");
+
+        let summary = handle_migrate_config(&path, true, false).expect("migration succeeds");
+
+        assert!(
+            summary.total_changed_count > catchall_only.changed_count,
+            "summary total ({}) must exceed the catch-all-only count ({}); named step \
+             contributions (e.g. the embed_provider rename) must be included",
+            summary.total_changed_count,
+            catchall_only.changed_count,
+        );
+    }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -782,7 +782,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         }) => {
             let resolved =
                 resolve_config_path(migrate_config_path.as_deref().or(cli.config.as_deref()));
-            return crate::commands::migrate::handle_migrate_config(&resolved, in_place, diff);
+            return crate::commands::migrate::handle_migrate_config(&resolved, in_place, diff)
+                .map(|_summary| ());
         }
         Some(Command::Classifiers { command: clf_cmd }) => {
             let config_path = resolve_config_path(cli.config.as_deref());


### PR DESCRIPTION
## Summary

Closes #5429. `zeph migrate-config` (both `--diff` and `--in-place` modes) printed a final summary line that reported only the count from the last catch-all `ConfigMigrator` pass, ignoring every change made by the numbered `MIGRATIONS` steps that run first. A config whose gaps were fully covered by named steps always reported "0 entries added" while the file diff — or the actual written file — showed real additions, silently under-reporting whenever the real changes came from named steps rather than the catch-all pass. This is dangerous for any automation/CI script that gates on the reported count rather than the actual diff/file content.

Adds `aggregate_totals`, which sums `changed_count` and unions `sections_changed` across the `MIGRATIONS` loop's step results plus the final catch-all pass; both the `--diff` and `--in-place` summary lines now use it. The sum-vs-union asymmetry is intentional and correct: `changed_count` sums (each named entry addition is counted once, even if multiple entries land in the same section), while `sections_changed` is deduplicated via a `BTreeSet` (a section touched by more than one pass is still one section in the summary).

`handle_migrate_config` now returns the aggregated `MigrateSummary` instead of `()`, so a test (or future caller) can assert directly on the printed totals — this closes a regression-pinning gap found during review: the initial pass's tests only checked file/diff state, not the printed summary text, so they would not have caught a full revert back to the original bug. The developer verified the new pinning test by temporarily reintroducing the literal bug and confirming the test failed before restoring the fix.

## Review process

developer → parallel (tester + adversarial critic, both independently confirmed the aggregation logic is semantically correct and both independently found the same test-coverage gap) → developer (closed the gap with a minimal API change, no new test infrastructure) → code reviewer (independently re-derived the regression test's logic rather than trusting the self-check, approved).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11920 passed, 0 failed
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] Manual before/after reproduction against a real copy of `.local/config/testing.toml`: before the fix, `Migration would add 11 entries (0 sections)` while per-step lines above showed 23 real changes across 23 sections; after the fix, `Migration would add 34 entries (23 sections)`, matching the real diff — reproduced independently by both the developer and the tester
- [x] New regression-pinning test confirmed to actually fail against a temporary reintroduction of the original bug
- [x] Live-testing playbook and coverage-status updated in `.local/testing/` (main repo) per project convention