### PR TITLE
fix(db): resolve postgres feature E0308 errors and widen CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,7 +515,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.run-full-ci == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
@@ -526,6 +526,8 @@ jobs:
           shared-key: "ci"
       - name: Check postgres build (zeph-db)
         run: cargo check -p zeph-db --no-default-features --features postgres
+      - name: Check postgres build (workspace)
+        run: cargo check --workspace --all-targets --features postgres
 
   rustdoc:
     name: Rustdoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(db)`: fix 25 `E0308` compile errors across `zeph-core`, `zeph-tools`, and the `zeph`
+  binary under `cargo check --workspace --all-targets --features postgres`. Test helpers
+  hardcoded `SqlitePool`/`SqlitePoolOptions` construction where the surrounding code expects
+  the feature-resolved `zeph_db::DbPool` alias, which resolves to `Pool<Postgres>` once the
+  `postgres` feature is compiled in. Replaced every hardcoded constructor with
+  `zeph_db::DbConfig::connect()`, which resolves to the correct backend for the active
+  feature set (and runs migrations, letting several tests drop hand-rolled `CREATE TABLE`
+  DDL that had drifted out of sync with the real schema). Closes #5602.
+- `ci`: widen the `build-postgres` job to also run
+  `cargo check --workspace --all-targets --features postgres`, exercising the exact command
+  that surfaced #5602 so this defect class is caught in CI going forward. Closes #5601.
 - `fix(tui)`: the TUI command palette's `daemon:connect`, `daemon:disconnect`, and
   `daemon:status` entries no longer collapse into one indistinguishable "not yet
   implemented" toast. `daemon:status` now reports genuine connection state (connected to

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -3483,10 +3483,13 @@ mod tests {
             }
         }
 
-        let pool = sqlx::sqlite::SqlitePoolOptions::new()
-            .connect("sqlite::memory:")
-            .await
-            .expect("in-memory SQLite");
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .expect("connect + migrate in-memory sqlite pool");
         let store = ShadowEventStore::new(pool);
         let config = zeph_config::ShadowSentinelConfig::default();
         let sentinel = std::sync::Arc::new(ShadowSentinel::new(

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -1072,10 +1072,7 @@ mod tests {
                 Box::pin(async { ProbeVerdict::Allow })
             }
         }
-        let pool = sqlx::sqlite::SqlitePoolOptions::new()
-            .connect("sqlite::memory:")
-            .await
-            .expect("in-memory SQLite pool");
+        let pool = test_pool().await;
         let store = ShadowEventStore::new(pool);
         ShadowSentinel::new(store, Box::new(NoopProbe), config, "test-session")
     }

--- a/crates/zeph-tools/src/compression/rule_based.rs
+++ b/crates/zeph-tools/src/compression/rule_based.rs
@@ -270,15 +270,11 @@ mod tests {
     use crate::compression::{CompressionRuleStore, OutputCompressor, store::CompressionRule};
 
     async fn make_store_with_rules(rules: &[(&str, &str)]) -> Arc<CompressionRuleStore> {
-        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::query(
-            "CREATE TABLE compression_rules (\
-             id TEXT PRIMARY KEY, tool_glob TEXT, pattern TEXT NOT NULL, \
-             replacement_template TEXT NOT NULL, hit_count INTEGER NOT NULL DEFAULT 0, \
-             source TEXT NOT NULL DEFAULT 'operator', created_at TEXT NOT NULL, \
-             UNIQUE(tool_glob, pattern))",
-        )
-        .execute(&pool)
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
         .await
         .unwrap();
 

--- a/crates/zeph-tools/src/compression/store.rs
+++ b/crates/zeph-tools/src/compression/store.rs
@@ -153,20 +153,19 @@ mod tests {
     use std::sync::Arc;
 
     use super::{CompressionRule, CompressionRuleStore};
+    use zeph_db::DbPool;
 
-    async fn make_store() -> (CompressionRuleStore, sqlx::SqlitePool) {
-        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::query(
-            "CREATE TABLE compression_rules (\
-             id TEXT PRIMARY KEY, tool_glob TEXT, pattern TEXT NOT NULL, \
-             replacement_template TEXT NOT NULL, hit_count INTEGER NOT NULL DEFAULT 0, \
-             source TEXT NOT NULL DEFAULT 'operator', created_at TEXT NOT NULL, \
-             UNIQUE(tool_glob, pattern))",
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
-        let store = CompressionRuleStore::new(Arc::new(pool.clone()));
+    async fn make_store() -> (CompressionRuleStore, Arc<DbPool>) {
+        let pool = Arc::new(
+            zeph_db::DbConfig {
+                url: ":memory:".to_owned(),
+                ..Default::default()
+            }
+            .connect()
+            .await
+            .unwrap(),
+        );
+        let store = CompressionRuleStore::new(Arc::clone(&pool));
         (store, pool)
     }
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1848,6 +1848,26 @@ mod tests {
         ))
     }
 
+    async fn memory_pool() -> zeph_db::DbPool {
+        zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap()
+    }
+
+    async fn file_pool(path: &Path) -> zeph_db::DbPool {
+        zeph_db::DbConfig {
+            url: path.display().to_string(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap()
+    }
+
     fn make_agent() -> Agent<CliChannel> {
         let config = Config::load(Path::new("/nonexistent")).unwrap();
         let registry = SkillRegistry::load(&[] as &[std::path::PathBuf]);
@@ -1937,9 +1957,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_search_code_executor_exposes_search_code_tool() {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = memory_pool().await;
         let config = Config::load(Path::new("/nonexistent")).unwrap();
         assert!(config.index.search_enabled, "expected default to be on");
         let executor =
@@ -1956,9 +1974,7 @@ mod tests {
     /// tool definition survives the merge.
     #[tokio::test]
     async fn search_code_executor_reachable_through_daemon_composite_chain() {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = memory_pool().await;
         let config = Config::load(Path::new("/nonexistent")).unwrap();
         let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> =
             std::sync::Arc::new(NoopExec);
@@ -1988,8 +2004,7 @@ mod tests {
     #[tokio::test]
     async fn apply_response_cache_disabled_returns_agent_unchanged() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        let db_url = format!("sqlite:{}", tmp.path().display());
-        let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
+        let pool = file_pool(tmp.path()).await;
         let agent = make_agent();
         let cancel = tokio_util::sync::CancellationToken::new();
         let (result, handle) =
@@ -2004,8 +2019,7 @@ mod tests {
     #[tokio::test]
     async fn apply_response_cache_enabled_attaches_cache() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        let db_url = format!("sqlite:{}", tmp.path().display());
-        let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
+        let pool = file_pool(tmp.path()).await;
         let agent = make_agent();
         let cancel = tokio_util::sync::CancellationToken::new();
         let (result, handle) =
@@ -2018,8 +2032,7 @@ mod tests {
     #[tokio::test]
     async fn apply_response_cache_cleanup_spawns_without_panic() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        let db_url = format!("sqlite:{}", tmp.path().display());
-        let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
+        let pool = file_pool(tmp.path()).await;
         let agent = make_agent();
         let cancel = tokio_util::sync::CancellationToken::new();
         let child = cancel.child_token();
@@ -2046,8 +2059,7 @@ mod tests {
             ..Config::default()
         };
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        let db_url = format!("sqlite:{}", tmp.path().display());
-        let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
+        let pool = file_pool(tmp.path()).await;
 
         let (watcher, progress_rx) = apply_code_indexer(
             &full_config,
@@ -2074,8 +2086,7 @@ mod tests {
             ..Config::default()
         };
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        let db_url = format!("sqlite:{}", tmp.path().display());
-        let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
+        let pool = file_pool(tmp.path()).await;
         let qdrant = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
 
         let (watcher, _progress_rx) = apply_code_indexer(
@@ -2102,8 +2113,7 @@ mod tests {
             ..Config::default()
         };
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        let db_url = format!("sqlite:{}", tmp.path().display());
-        let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
+        let pool = file_pool(tmp.path()).await;
 
         let (watcher, _) = apply_code_indexer(
             &full_config,
@@ -2131,8 +2141,7 @@ mod tests {
             ..Config::default()
         };
         let tmp_db = tempfile::NamedTempFile::new().unwrap();
-        let db_url = format!("sqlite:{}", tmp_db.path().display());
-        let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
+        let pool = file_pool(tmp_db.path()).await;
         let qdrant = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
 
         let (watcher, _) = apply_code_indexer(
@@ -2161,9 +2170,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_code_rag_retriever_disabled_is_noop() {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = memory_pool().await;
         let agent = make_agent();
         let config = IndexConfig {
             enabled: false,
@@ -2178,9 +2185,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_code_rag_retriever_no_qdrant_is_noop() {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = memory_pool().await;
         let agent = make_agent();
         let config = IndexConfig {
             enabled: true,
@@ -2196,9 +2201,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_code_rag_retriever_mcp_enabled_is_noop() {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = memory_pool().await;
         let agent = make_agent();
         let config = IndexConfig {
             enabled: true,

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -1981,23 +1981,13 @@ mod tests {
     // ── ingest_one skip gate (FR-012) ─────────────────────────────────────────
 
     async fn in_memory_ledger() -> IngestLedger {
-        let pool = sqlx::SqlitePool::connect(":memory:")
-            .await
-            .expect("in-memory sqlite");
-        sqlx::query(
-            "CREATE TABLE knowledge_ingest_ledger (\
-             source_uri TEXT NOT NULL, \
-             content_hash TEXT NOT NULL, \
-             import_batch_id TEXT NOT NULL, \
-             ingested_at TEXT NOT NULL DEFAULT (datetime('now')), \
-             entities INTEGER NOT NULL DEFAULT 0, \
-             edges INTEGER NOT NULL DEFAULT 0, \
-             PRIMARY KEY (source_uri, content_hash)\
-             )",
-        )
-        .execute(&pool)
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
         .await
-        .expect("create table");
+        .expect("connect + migrate in-memory sqlite pool");
         IngestLedger::new(pool)
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5091,10 +5091,13 @@ mod tests {
             }
         }
 
-        let pool = sqlx::sqlite::SqlitePoolOptions::new()
-            .connect("sqlite::memory:")
-            .await
-            .expect("in-memory SQLite");
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .expect("connect + migrate in-memory sqlite pool");
         let store = ShadowEventStore::new(pool);
         let config = zeph_config::ShadowSentinelConfig {
             enabled: true,
@@ -5159,10 +5162,13 @@ mod tests {
             }
         }
 
-        let pool = sqlx::sqlite::SqlitePoolOptions::new()
-            .connect("sqlite::memory:")
-            .await
-            .expect("in-memory SQLite");
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .expect("connect + migrate in-memory sqlite pool");
         let store = ShadowEventStore::new(pool);
         let config = zeph_config::ShadowSentinelConfig {
             enabled: false,
@@ -5479,10 +5485,13 @@ mod tests {
     }
 
     async fn make_runner_test_session_store() -> zeph_session::SessionStore {
-        let pool = sqlx::sqlite::SqlitePoolOptions::new()
-            .connect("sqlite::memory:")
-            .await
-            .expect("in-memory SQLite");
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .expect("connect + migrate in-memory sqlite pool");
         zeph_session::SessionStore::new(pool)
     }
 

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -540,10 +540,18 @@ mod tests {
 
     use super::*;
 
+    async fn test_pool() -> zeph_db::DbPool {
+        zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap()
+    }
+
     async fn make_executor() -> (SchedulerExecutor, mpsc::Receiver<SchedulerMessage>) {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = test_pool().await;
         let store = JobStore::new(pool);
         store.init().await.unwrap();
         let store = Arc::new(store);
@@ -652,9 +660,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_existing_task() {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = test_pool().await;
         let store = JobStore::new(pool);
         store.init().await.unwrap();
         store
@@ -693,9 +699,7 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_name_returns_updated_message() {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = test_pool().await;
         let store = JobStore::new(pool);
         store.init().await.unwrap();
         store
@@ -730,9 +734,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_tasks_with_jobs() {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = test_pool().await;
         let store = JobStore::new(pool);
         store.init().await.unwrap();
         store
@@ -1024,9 +1026,7 @@ mod tests {
 
     #[tokio::test]
     async fn execute_fenced_cancel_task_dispatches() {
-        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
-            .await
-            .unwrap();
+        let pool = test_pool().await;
         let store = JobStore::new(pool);
         store.init().await.unwrap();
         store


### PR DESCRIPTION
## Summary
- Fixed 25 pre-existing `E0308` compile errors across `zeph-core`, `zeph-tools`, and the `zeph` binary under `cargo check --workspace --all-targets --features postgres`. Test helpers hardcoded `SqlitePool`/`SqlitePoolOptions` construction where the surrounding code expects the feature-resolved `zeph_db::DbPool` alias (which resolves to `Pool<Postgres>` once the `postgres` feature is compiled in). Replaced every hardcoded constructor with `zeph_db::DbConfig::connect()`, which resolves to the correct backend for the active feature set and runs migrations — letting a few tests drop hand-rolled `CREATE TABLE` DDL that had drifted out of sync with the real schema (verified column-by-column parity before removal).
- Widened CI's `build-postgres` job to also run `cargo check --workspace --all-targets --features postgres` — the exact command that surfaced this defect class — so a regression is caught automatically going forward instead of only via manual local checks.
- Extracted small DRY test-pool helpers only where a file had 3+ duplicate inline construction blocks (`src/agent_setup.rs`: `memory_pool()`/`file_pool()`; `src/scheduler_executor.rs`: `test_pool()`); single-occurrence sites were fixed inline.

Closes #5602
Closes #5601

## Test plan
- [x] `cargo check --workspace --all-targets --features postgres --keep-going` — 0 errors (independently reproduced by developer, tester, impl-critic, and reviewer)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — 0 warnings
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11914 passed, 0 failed, 34 skipped
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-scheduler -p zeph-core -p zeph-tools --lib --bins` — 3003 passed, 0 failed, 1 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — exit 0
- [x] `fy validate .github/workflows/ci.yml` — valid YAML
- [x] Schema parity verified column-by-column for both dropped `CREATE TABLE` DDL blocks against the real migrations (`compression_rules`, `knowledge_ingest_ledger`)
- [x] Test isolation verified for the new pool helpers (fresh connection/tempfile per call site, no shared state)