### PR TITLE
fix: postgres in-memory backend runtime failures and provider fallback masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `changed_count` and de-duplicates `sections_changed` across every named step plus the
   final pass. Closes #5429.
 
+- `fix(scheduler,durable)`: `zeph-scheduler`'s `durable.rs` test module opened a
+  `LocalBackend` over the `:memory:` sentinel without gating on the postgres-priority
+  dual-backend cfg model, so `--features postgres` routed `:memory:` into
+  `connect_postgres` and failed at runtime with `Configuration(RelativeUrlWithoutBase)`
+  (a `cargo check` could not catch it — only running the tests could). The two
+  backend-dependent tests now live in a `with_backend` submodule gated by
+  `#[cfg(all(feature = "sqlite", not(feature = "postgres")))]`, mirroring the pattern
+  already used by `zeph-durable`'s `writer.rs`/`replay.rs`/`backend/local.rs`/`handle.rs`
+  test modules (which were already correctly gated). `zeph-durable`'s `tests/nfr_gates.rs`
+  integration test shared the same unguarded `:memory:` pattern and is now gated the same
+  way at the file level. Closes #5603.
+
 - `fix(tools,core)`: live agent turns no longer stall indefinitely when Qdrant is
   unreachable (up to 240s observed, never dispatching the originally-requested tool). Two
   compounding defects: (1) `handle_tool_failure_outcomes` misclassified every structured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   integration test shared the same unguarded `:memory:` pattern and is now gated the same
   way at the file level. Closes #5603.
 
+- `fix(core)`: `reformat_tool_call` (`crates/zeph-core/src/agent/tool_execution/tier_loop.rs`)
+  still silently substituted the primary provider for `tools.retry.parameter_reformat_provider`
+  when the configured name matched an entry in `provider_pool` whose provider failed to build,
+  or when no `provider_config_snapshot` was available — masking the original tool error behind
+  a "corrected" call made with the wrong model. This extends #5604's fix for #5478 (which
+  guarded only the name-absent-from-pool case) with `Agent::resolve_pool_entry_provider`
+  (`crates/zeph-core/src/agent/learning/arise.rs`), which distinguishes: (1) the provider-pool
+  registry never having been wired for this `Agent` at all (empty `provider_pool`, no
+  snapshot — only possible for lightweight test/bootstrap agents, since
+  `zeph_config::providers::validate_pool` rejects an empty `[[llm.providers]]` list at
+  config-load time, so #5450 guarantees a non-empty pool for every real production agent) —
+  unchanged, still falls back to the primary provider, matching every other
+  `resolve_background_provider` call site such as `compress_provider`; from (2) a registry that
+  IS wired but the configured name doesn't resolve, whether absent from the pool or present but
+  unbuildable — a real misconfiguration, where `reformat_tool_call` now no-ops and preserves the
+  original tool error instead of silently swapping providers. The other ~19
+  `resolve_background_provider` call sites are unchanged. Closes #5600.
+
 - `fix(tools,core)`: live agent turns no longer stall indefinitely when Qdrant is
   unreachable (up to 240s observed, never dispatching the originally-requested tool). Two
   compounding defects: (1) `handle_tool_failure_outcomes` misclassified every structured

--- a/crates/zeph-core/src/agent/learning/arise.rs
+++ b/crates/zeph-core/src/agent/learning/arise.rs
@@ -5,6 +5,20 @@ use super::super::{Agent, Channel, Role};
 use super::background::AriseTaskArgs;
 use zeph_llm::provider::MessagePart;
 
+/// Outcome of [`Agent::resolve_pool_entry_provider`]. See that method's doc comment for the
+/// rationale behind each variant.
+pub(crate) enum PoolProviderResolution {
+    /// The provider-pool registry was never wired for this `Agent` (empty pool, no config
+    /// snapshot) or `provider_name` was empty — the caller may fall back to
+    /// [`Agent::resolve_background_provider`]'s existing convention.
+    RegistryNotWired,
+    /// The registry IS wired, but `provider_name` does not resolve to a usable provider
+    /// (absent from `provider_pool`, no config snapshot, or construction failed).
+    Unresolvable,
+    /// `provider_name` resolved to a distinct, usable provider.
+    Resolved(Box<zeph_llm::any::AnyProvider>),
+}
+
 impl<C: Channel> Agent<C> {
     /// Resolve a named provider from the pool, falling back to the primary provider.
     /// Returns a clone of the primary provider if the name is empty, unknown, or resolution fails.
@@ -41,6 +55,65 @@ impl<C: Channel> Agent<C> {
             Err(e) => {
                 tracing::warn!("failed to build provider '{provider_name}': {e:#}, using primary");
                 self.provider.clone()
+            }
+        }
+    }
+
+    /// Attempt to build the provider registered under `provider_name` in `provider_pool`,
+    /// without ever substituting the primary provider for a real misconfiguration.
+    ///
+    /// Distinguishes three outcomes a caller like `reformat_tool_call` (#5600, follow-up to
+    /// #5478) must not conflate:
+    ///
+    /// - [`PoolProviderResolution::RegistryNotWired`]: `provider_name` is empty, or
+    ///   `provider_pool`/`provider_config_snapshot` were never populated for this `Agent` at
+    ///   all. `zeph_config::providers::validate_pool` rejects an empty `[[llm.providers]]` list
+    ///   at config-validation time, so a genuinely empty pool never occurs for a fully
+    ///   constructed production `Agent` (#5450 populates it on every construction path) — this
+    ///   only happens for lightweight test/bootstrap agents that skip provider-pool wiring
+    ///   entirely. Falling back to [`Agent::resolve_background_provider`]'s existing convention
+    ///   is safe here since there is no registry to have misconfigured against.
+    /// - [`PoolProviderResolution::Unresolvable`]: the registry IS wired (non-empty pool) but
+    ///   `provider_name` does not match any entry, or the matched entry fails to build, or no
+    ///   `provider_config_snapshot` is available. This is a real misconfiguration: silently
+    ///   substituting the primary provider would mask the original error behind a "corrected"
+    ///   call made with the wrong model.
+    /// - [`PoolProviderResolution::Resolved`]: the name matched and the provider built
+    ///   successfully.
+    pub(crate) fn resolve_pool_entry_provider(
+        &self,
+        provider_name: &str,
+    ) -> PoolProviderResolution {
+        if provider_name.is_empty() {
+            return PoolProviderResolution::RegistryNotWired;
+        }
+        let registry_wired = !self.runtime.providers.provider_pool.is_empty()
+            || self.runtime.providers.provider_config_snapshot.is_some();
+        if !registry_wired {
+            return PoolProviderResolution::RegistryNotWired;
+        }
+        let Some(entry) = self
+            .runtime
+            .providers
+            .provider_pool
+            .iter()
+            .find(|e| e.effective_name().eq_ignore_ascii_case(provider_name))
+            .cloned()
+        else {
+            return PoolProviderResolution::Unresolvable;
+        };
+        let Some(ref snapshot) = self.runtime.providers.provider_config_snapshot else {
+            return PoolProviderResolution::Unresolvable;
+        };
+        match crate::provider_factory::build_provider_for_switch(
+            &entry,
+            snapshot,
+            self.services.security.secret_registry.as_ref(),
+        ) {
+            Ok(p) => PoolProviderResolution::Resolved(Box::new(p)),
+            Err(e) => {
+                tracing::warn!("failed to build provider '{provider_name}': {e:#}");
+                PoolProviderResolution::Unresolvable
             }
         }
     }

--- a/crates/zeph-core/src/agent/learning/mod.rs
+++ b/crates/zeph-core/src/agent/learning/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod arise;
+pub(crate) use arise::PoolProviderResolution;
 mod background;
 mod d2skill;
 mod erl;

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -333,24 +333,22 @@ impl<C: Channel> Agent<C> {
     /// `InvalidParameters`/`TypeMismatch` error (issue #5453).
     ///
     /// Resolves `tools.retry.parameter_reformat_provider` from `[[llm.providers]]` via
-    /// [`Agent::resolve_background_provider`], asks it for corrected arguments given the tool's
-    /// JSON schema, the originally-submitted arguments, and the error message, then re-dispatches
-    /// the tool call once with the corrected arguments.
+    /// [`Agent::resolve_pool_entry_provider`]. Unlike most other background-provider call sites
+    /// (which use [`Agent::resolve_background_provider`] and fall back to the primary provider
+    /// on any resolution failure), a *configured* name — one the provider-pool registry was
+    /// actually wired to recognize — must not silently substitute the primary provider when it
+    /// fails to resolve: that would mask the original tool error behind a "corrected" call made
+    /// with the wrong model (#5600, #5478). This method no-ops instead (keeps the original tool
+    /// error) whenever the registry is wired but the name is absent from `provider_pool`, the
+    /// matched entry fails to build, or no `provider_config_snapshot` is available. It only
+    /// falls back to [`Agent::resolve_background_provider`]'s legacy convention when the
+    /// provider-pool registry itself was never wired for this `Agent` at all — which
+    /// `zeph_config::providers::validate_pool` guarantees cannot happen for a real, fully
+    /// constructed production agent (see [`Agent::resolve_pool_entry_provider`]'s doc comment).
     ///
-    /// This method is only ever called with a non-empty `parameter_reformat_provider`
-    /// (`handle_reformat_phase` returns early on the empty-name case before calling it). Unlike
-    /// `resolve_background_provider`'s other callers, a configured-but-unresolvable name (absent
-    /// from `[[llm.providers]]`) is not silently retried against the primary provider here
-    /// (#5478): a guard checks pool membership before resolution is attempted and returns `None`
-    /// on a miss, since a masked misconfiguration could otherwise replace a clear "invalid
-    /// parameters" error with a plausible-but-wrong result from the wrong model. This guard only
-    /// covers the name-absent-from-pool case — `resolve_background_provider` itself can still
-    /// fall back to primary for a name that IS in the pool if `provider_config_snapshot` is
-    /// unset or provider construction fails (tracked separately as #5600).
-    ///
-    /// Returns `None` when the provider name is unresolvable, the provider call fails, times
-    /// out, or returns arguments that do not parse as a JSON object — the caller keeps the
-    /// original error result unchanged.
+    /// Returns `None` when the provider is unresolvable, the provider call fails, times out, or
+    /// returns arguments that do not parse as a JSON object — the caller keeps the original error
+    /// result unchanged.
     async fn reformat_tool_call(
         &mut self,
         call: &ToolCall,
@@ -376,27 +374,20 @@ impl<C: Channel> Agent<C> {
         };
 
         let provider_name = self.tool_orchestrator.parameter_reformat_provider.clone();
-        // #5478: unlike `resolve_background_provider`'s other ~19 call sites, an unresolvable
-        // name here must be a true no-op (keep the original tool error unchanged), not a
-        // silent fallback to primary — reformatting replaces `tool_results[idx]` with whatever
-        // the resolved provider proposes and re-dispatches it, so falling back to primary on a
-        // misconfigured name would mask the operator's config error behind plausible-but-wrong
-        // corrected arguments instead of surfacing the original, clear validation error.
-        if !self
-            .runtime
-            .providers
-            .provider_pool
-            .iter()
-            .any(|e| e.effective_name().eq_ignore_ascii_case(&provider_name))
-        {
-            tracing::warn!(
-                tool = %tc.name,
-                provider = %provider_name,
-                "parameter reformat: configured provider not found in [[llm.providers]], skipping reformat"
-            );
-            return None;
-        }
-        let provider = self.resolve_background_provider(&provider_name);
+        let provider = match self.resolve_pool_entry_provider(&provider_name) {
+            super::super::learning::PoolProviderResolution::Resolved(p) => *p,
+            super::super::learning::PoolProviderResolution::RegistryNotWired => {
+                self.resolve_background_provider(&provider_name)
+            }
+            super::super::learning::PoolProviderResolution::Unresolvable => {
+                tracing::warn!(
+                    tool = %tc.name,
+                    provider = %provider_name,
+                    "parameter reformat: configured provider unresolvable, keeping original error"
+                );
+                return None;
+            }
+        };
 
         let original_args = serde_json::Value::Object(call.params.clone());
         let prompt = format!(
@@ -3607,18 +3598,6 @@ mod tests {
             }
         }
 
-        /// Registers `name` in `provider_pool` so the #5478 pool-membership guard in
-        /// `reformat_tool_call` lets these tests reach the actual reformat logic. No
-        /// `provider_config_snapshot` is set, so `resolve_background_provider` still falls back
-        /// to the primary (mock) provider once the guard passes — preserving these tests' original
-        /// intent of exercising the primary provider's canned responses.
-        fn register_pool_entry(agent: &mut Agent<MockChannel>, name: &str) {
-            agent.runtime.providers.provider_pool = vec![crate::config::ProviderEntry {
-                name: Some(name.to_owned()),
-                ..Default::default()
-            }];
-        }
-
         #[tokio::test]
         async fn retries_with_corrected_arguments_on_success() {
             let provider = mock_provider(vec![r#"{"arguments":{"path":"/corrected"}}"#.into()]);
@@ -3639,7 +3618,6 @@ mod tests {
             .with_definitions(vec![test_tool_def()]);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
-            register_pool_entry(&mut agent, "fast");
 
             let tool_calls = vec![tool_use_request()];
             let calls = vec![bad_tool_call()];
@@ -3669,7 +3647,6 @@ mod tests {
                 MockToolExecutor::new(vec![Ok(None)]).with_definitions(vec![test_tool_def()]);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
-            register_pool_entry(&mut agent, "fast");
 
             let tool_calls = vec![tool_use_request()];
             let calls = vec![bad_tool_call()];
@@ -3701,7 +3678,6 @@ mod tests {
             let executor = MockToolExecutor::new(vec![Ok(None)]);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
-            register_pool_entry(&mut agent, "fast");
 
             let tool_calls = vec![tool_use_request()];
             let calls = vec![bad_tool_call()];
@@ -3755,16 +3731,16 @@ mod tests {
             );
         }
 
-        /// #5478 regression: a non-empty `parameter_reformat_provider` name that is not
-        /// registered in `provider_pool` must be a true no-op (original error preserved), not a
-        /// silent fallback to the primary provider. The primary provider here is set up to
-        /// return a *successful* corrected-arguments response — if the pool-membership guard in
-        /// `reformat_tool_call` were missing (pre-#5478 behavior), `resolve_background_provider`
-        /// would fall back to this primary provider, the tool would be retried successfully, and
-        /// `tool_results[0]` would be replaced — masking the original validation error behind a
-        /// plausible-but-wrong "fix" driven by a misconfigured provider name.
+        // Regression test: when the provider-pool registry was never wired for this `Agent`
+        // (empty `provider_pool`, no `provider_config_snapshot` — the state of a lightweight
+        // test/bootstrap agent that never called `with_provider_pool`, never a real production
+        // agent since `validate_pool` rejects an empty `[[llm.providers]]` list at config-load
+        // time), `reformat_tool_call` still falls back to the primary provider, matching every
+        // other `resolve_background_provider` call site (e.g. `compress_provider`). Only once
+        // the registry IS wired does an unresolvable name become a real misconfiguration (see
+        // `is_a_noop_when_registry_wired_but_name_absent_from_pool` below).
         #[tokio::test]
-        async fn is_a_noop_when_provider_name_is_unresolvable() {
+        async fn falls_back_to_primary_when_registry_never_wired() {
             let provider = mock_provider(vec![r#"{"arguments":{"path":"/corrected"}}"#.into()]);
             let channel = MockChannel::new(vec![]);
             let registry = create_test_registry();
@@ -3782,9 +3758,67 @@ mod tests {
             }))])
             .with_definitions(vec![test_tool_def()]);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-            // Non-empty but never registered — provider_pool stays empty (default).
-            agent.tool_orchestrator.parameter_reformat_provider =
-                "unregistered-provider".to_owned();
+            // Non-empty name, but provider_pool is empty — name cannot resolve.
+            agent.tool_orchestrator.parameter_reformat_provider = "unregistered".to_owned();
+
+            let tool_calls = vec![tool_use_request()];
+            let calls = vec![bad_tool_call()];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(invalid_params_error())];
+            let cancel = tokio_util::sync::CancellationToken::new();
+
+            agent
+                .handle_reformat_phase(&tool_calls, &calls, &mut tool_results, &cancel)
+                .await
+                .unwrap();
+
+            let output = tool_results
+                .remove(0)
+                .expect("reformat should run using the primary provider fallback")
+                .expect("tool output should be present");
+            assert_eq!(output.summary, "done");
+        }
+
+        /// Minimal `ProviderConfigSnapshot` fixture shared by the registry-wired regression
+        /// tests below — all `None`/empty since the fields under test don't need real secrets.
+        fn empty_snapshot() -> crate::agent::state::ProviderConfigSnapshot {
+            crate::agent::state::ProviderConfigSnapshot {
+                claude_api_key: None,
+                openai_api_key: None,
+                gemini_api_key: None,
+                compatible_api_keys: std::collections::HashMap::new(),
+                llm_request_timeout_secs: 30,
+                embedding_model: String::new(),
+                gonka_private_key: None,
+                gonka_address: None,
+                cocoon_access_hash: None,
+            }
+        }
+
+        // Regression test for #5478: once the provider-pool registry IS wired (non-empty
+        // `provider_pool`, the state every real production `Agent` is in per #5450), a
+        // configured `parameter_reformat_provider` name that does not match any entry is a real
+        // misconfiguration and must no-op (keep the original tool error) rather than silently
+        // reformatting with the primary provider.
+        #[tokio::test]
+        async fn is_a_noop_when_registry_wired_but_name_absent_from_pool() {
+            let provider = mock_provider(vec![r#"{"arguments":{"path":"/corrected"}}"#.into()]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor =
+                MockToolExecutor::new(vec![Ok(None)]).with_definitions(vec![test_tool_def()]);
+
+            // The pool is wired (non-empty), but registers a different name than the one
+            // configured below, so "unregistered" still cannot resolve.
+            let other_entry = crate::config::ProviderEntry {
+                provider_type: crate::config::ProviderKind::Ollama,
+                name: Some("other".into()),
+                ..Default::default()
+            };
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+                .with_provider_pool(vec![other_entry], empty_snapshot());
+            agent.tool_orchestrator.parameter_reformat_provider = "unregistered".to_owned();
 
             let tool_calls = vec![tool_use_request()];
             let calls = vec![bad_tool_call()];
@@ -3803,8 +3837,53 @@ mod tests {
                     tool_results[0],
                     Err(zeph_tools::ToolError::InvalidParams { .. })
                 ),
-                "an unresolvable parameter_reformat_provider name must not fall back to primary; \
-                 the original error must be preserved"
+                "reformat must no-op when the registry is wired but the configured name is \
+                 absent from the pool, not silently fall back to the primary provider"
+            );
+        }
+
+        // Regression test for #5600: a configured `parameter_reformat_provider` name that IS
+        // present in `provider_pool` but whose provider construction fails (e.g. a required
+        // secret is missing from the config snapshot) must no-op — unlike the registry-not-wired
+        // case above, this must not silently fall back to the primary provider.
+        #[tokio::test]
+        async fn is_a_noop_when_registry_wired_but_provider_build_fails() {
+            let provider = mock_provider(vec![r#"{"arguments":{"path":"/corrected"}}"#.into()]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor =
+                MockToolExecutor::new(vec![Ok(None)]).with_definitions(vec![test_tool_def()]);
+
+            // "broken" is present in provider_pool, but is a Claude entry with no API key in
+            // the snapshot, so `build_provider_for_switch` fails at resolve time.
+            let broken_entry = crate::config::ProviderEntry {
+                provider_type: crate::config::ProviderKind::Claude,
+                name: Some("broken".into()),
+                ..Default::default()
+            };
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+                .with_provider_pool(vec![broken_entry], empty_snapshot());
+            agent.tool_orchestrator.parameter_reformat_provider = "broken".to_owned();
+
+            let tool_calls = vec![tool_use_request()];
+            let calls = vec![bad_tool_call()];
+            let mut tool_results: Vec<
+                Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+            > = vec![Err(invalid_params_error())];
+            let cancel = tokio_util::sync::CancellationToken::new();
+
+            agent
+                .handle_reformat_phase(&tool_calls, &calls, &mut tool_results, &cancel)
+                .await
+                .unwrap();
+
+            assert!(
+                matches!(
+                    tool_results[0],
+                    Err(zeph_tools::ToolError::InvalidParams { .. })
+                ),
+                "reformat must no-op when the in-pool provider fails to build, not silently \
+                 fall back to the primary provider"
             );
         }
 
@@ -3822,7 +3901,6 @@ mod tests {
             .with_definitions(vec![test_tool_def()]);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
-            register_pool_entry(&mut agent, "fast");
 
             let tool_calls = vec![tool_use_request()];
             let calls = vec![bad_tool_call()];
@@ -3881,7 +3959,6 @@ mod tests {
             .with_delay(1_100);
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
             agent.tool_orchestrator.parameter_reformat_provider = "fast".to_owned();
-            register_pool_entry(&mut agent, "fast");
             agent.tool_orchestrator.max_retry_duration_secs = 1;
 
             let tool_calls = vec![tool_use_request(), tool_use_request()];

--- a/crates/zeph-durable/tests/nfr_gates.rs
+++ b/crates/zeph-durable/tests/nfr_gates.rs
@@ -7,6 +7,12 @@
 //! collects wall-clock samples, discards a warm-up prefix, computes a percentile, and asserts it
 //! against the spec bound. If a gate proves flaky on a noisy CI runner, mark it `#[ignore]` and
 //! document in the PR — do NOT loosen the spec bounds.
+//!
+//! Every gate opens a real `LocalBackend` pool via `:memory:`, which is SQLite-specific (mirroring
+//! the `src/`-side `with_backend` test modules): under `--features postgres`, `DbConfig::connect()`
+//! takes cfg-priority and routes `:memory:` into `connect_postgres`, which fails to parse it as a
+//! Postgres URL. See #5603.
+#![cfg(all(feature = "sqlite", not(feature = "postgres")))]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/crates/zeph-scheduler/src/durable.rs
+++ b/crates/zeph-scheduler/src/durable.rs
@@ -194,11 +194,6 @@ fn fingerprint(job_name: &str, slot_ms: i64) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU32, Ordering};
-
-    use zeph_durable::config::DurableConfig;
-    use zeph_durable::{DurableBackendEnum, JournalWriter, LocalBackend};
-
     use super::*;
 
     #[test]
@@ -236,90 +231,104 @@ mod tests {
         );
     }
 
-    fn fast_config() -> DurableConfig {
-        DurableConfig {
-            journal_flush_interval_ms: 5,
-            journal_ack_timeout_ms: 2000,
-            ..DurableConfig::default()
-        }
-    }
-
-    async fn make_adapter() -> (SchedulerDurableAdapter, tokio::task::JoinHandle<()>) {
-        let local = Arc::new(LocalBackend::open(":memory:", 1_048_576).await.unwrap());
-        local.init().await.unwrap();
-        let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
-        let cfg = Arc::new(fast_config());
-        let (writer, handle) = JournalWriter::new(local, &cfg);
-        let task = tokio::spawn(writer.run()); // EXEMPT: test-only helper
-        (SchedulerDurableAdapter::new(backend, handle, cfg), task)
-    }
-
-    /// First fire executes the closure and journals the result.
-    /// Second call (same job+slot, same execution) replays without invoking the closure.
-    #[tokio::test]
-    async fn fire_with_durable_replays_without_reinvocation() {
-        let (adapter, _task) = make_adapter().await;
-        let count = Arc::new(AtomicU32::new(0));
-
-        // First fire — closure must run.
-        let c = count.clone();
-        fire_with_durable(&adapter, "test-job", 1_000, move || async move {
-            c.fetch_add(1, Ordering::Relaxed);
-            Ok(())
-        })
-        .await
-        .unwrap();
-        assert_eq!(count.load(Ordering::Relaxed), 1, "first fire must execute");
-
-        // Second fire — same (job, slot) — closure must NOT run again.
-        let c = count.clone();
-        fire_with_durable(&adapter, "test-job", 1_000, move || async move {
-            c.fetch_add(1, Ordering::Relaxed);
-            Ok(())
-        })
-        .await
-        .unwrap();
-        assert_eq!(
-            count.load(Ordering::Relaxed),
-            1,
-            "replay must not re-invoke the closure"
-        );
-    }
-
-    /// A different slot derives a different execution — the closure runs again.
-    #[tokio::test]
-    async fn fire_with_durable_different_slot_runs_again() {
-        let (adapter, _task) = make_adapter().await;
-        let count = Arc::new(AtomicU32::new(0));
-
-        let c = count.clone();
-        fire_with_durable(&adapter, "test-job", 1_000, move || async move {
-            c.fetch_add(1, Ordering::Relaxed);
-            Ok(())
-        })
-        .await
-        .unwrap();
-
-        let c = count.clone();
-        fire_with_durable(&adapter, "test-job", 2_000, move || async move {
-            c.fetch_add(1, Ordering::Relaxed);
-            Ok(())
-        })
-        .await
-        .unwrap();
-
-        assert_eq!(
-            count.load(Ordering::Relaxed),
-            2,
-            "different slot_ms must produce a separate execution and run"
-        );
-    }
-
     /// When durable is not configured (no `with_durable`), the scheduler calls the handler directly.
     #[test]
     fn no_adapter_means_no_durable_overhead() {
         // The Scheduler struct's `durable` field defaults to None; this is a structural check only.
         // The property is validated indirectly by the scheduler_init_and_tick test in scheduler.rs.
         assert!(derive_execution_id("job", 0) != derive_execution_id("other", 0));
+    }
+
+    // These tests open a real `LocalBackend` pool via `:memory:`, which is SQLite-specific
+    // (mirroring `zeph-durable`'s `writer.rs`/`local.rs` test modules): under `--features postgres`
+    // `DbConfig::connect()` takes cfg-priority and routes `:memory:` into `connect_postgres`, which
+    // fails to parse it as a Postgres URL. See #5603.
+    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    mod with_backend {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        use zeph_durable::config::DurableConfig;
+        use zeph_durable::{DurableBackendEnum, JournalWriter, LocalBackend};
+
+        use super::*;
+
+        fn fast_config() -> DurableConfig {
+            DurableConfig {
+                journal_flush_interval_ms: 5,
+                journal_ack_timeout_ms: 2000,
+                ..DurableConfig::default()
+            }
+        }
+
+        async fn make_adapter() -> (SchedulerDurableAdapter, tokio::task::JoinHandle<()>) {
+            let local = Arc::new(LocalBackend::open(":memory:", 1_048_576).await.unwrap());
+            local.init().await.unwrap();
+            let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
+            let cfg = Arc::new(fast_config());
+            let (writer, handle) = JournalWriter::new(local, &cfg);
+            let task = tokio::spawn(writer.run()); // EXEMPT: test-only helper
+            (SchedulerDurableAdapter::new(backend, handle, cfg), task)
+        }
+
+        /// First fire executes the closure and journals the result.
+        /// Second call (same job+slot, same execution) replays without invoking the closure.
+        #[tokio::test]
+        async fn fire_with_durable_replays_without_reinvocation() {
+            let (adapter, _task) = make_adapter().await;
+            let count = Arc::new(AtomicU32::new(0));
+
+            // First fire — closure must run.
+            let c = count.clone();
+            fire_with_durable(&adapter, "test-job", 1_000, move || async move {
+                c.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            })
+            .await
+            .unwrap();
+            assert_eq!(count.load(Ordering::Relaxed), 1, "first fire must execute");
+
+            // Second fire — same (job, slot) — closure must NOT run again.
+            let c = count.clone();
+            fire_with_durable(&adapter, "test-job", 1_000, move || async move {
+                c.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            })
+            .await
+            .unwrap();
+            assert_eq!(
+                count.load(Ordering::Relaxed),
+                1,
+                "replay must not re-invoke the closure"
+            );
+        }
+
+        /// A different slot derives a different execution — the closure runs again.
+        #[tokio::test]
+        async fn fire_with_durable_different_slot_runs_again() {
+            let (adapter, _task) = make_adapter().await;
+            let count = Arc::new(AtomicU32::new(0));
+
+            let c = count.clone();
+            fire_with_durable(&adapter, "test-job", 1_000, move || async move {
+                c.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+            let c = count.clone();
+            fire_with_durable(&adapter, "test-job", 2_000, move || async move {
+                c.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(
+                count.load(Ordering::Relaxed),
+                2,
+                "different slot_ms must produce a separate execution and run"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two independent bug fixes bundled together (grouped by triage, no shared subsystem or dependency):

- **#5603**: `LocalBackend::open(":memory:", ...)` runtime-fails under `--features postgres`. Of the issue's 8 cited call sites, 7 in `zeph-durable` were already correctly cfg-gated; the real bug was in `zeph-scheduler/src/durable.rs` (ungated `mod tests`), plus 3 unlisted call sites in `zeph-durable/tests/nfr_gates.rs`. Both are now gated behind `#[cfg(all(feature = "sqlite", not(feature = "postgres")))]`, mirroring the existing pattern in `zeph-durable`'s other test modules.

- **#5600**: `reformat_tool_call` silently substituted the primary provider when a `provider_pool`-registered name failed to build or had no config snapshot, reintroducing the failure mode #5478 was meant to prevent (a misconfigured provider masking the original tool error behind a plausible-but-wrong "corrected" call). New `Agent::resolve_pool_entry_provider` distinguishes a never-wired registry (falls back to primary, unchanged for test/bootstrap agents) from a wired registry with an unresolvable name (now a true no-op, preserving the original error).

## Note on #5478

PR #5604 merged into `main` concurrently with this work and independently closed #5478 by adding a narrower "name-absent-from-pool" guard to the same function. This branch's #5600 fix is a strict superset of that guard (it also covers the in-pool-but-build-fails case) and has been rebased onto the post-#5604 `main`, with the redundant standalone guard removed in favor of the more complete `resolve_pool_entry_provider`-based dispatch. This PR does not re-close #5478.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11916 passed, 0 failed)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-durable --features postgres` (60 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` (clean)
- [x] Independent adversarial critique (verdict: approved, no blocking findings)
- [x] Independent code review, including a byte-diff of the 5 tests touched by a silent (non-conflicting) merge insertion during the rebase against origin/main, confirming they match the pre-#5604 baseline exactly

Closes #5603
Closes #5600