### PR TITLE
fix(tools): require confirmation for unconfigured tools in Supervised mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tools)`: `TrustGateExecutor`'s `Supervised`-mode confirmation check no longer
+  blanket-skips every tool without an explicit policy rule. The prior condition treated
+  "no rule configured" as license to bypass confirmation, which silently let
+  code-executing tools like `diagnostics` (runs `cargo check`/`cargo clippy`, executing
+  arbitrary `build.rs`/proc-macro code) proceed without a prompt. The skip is now scoped
+  to two existing, already-audited categories: tools registered as MCP-sourced
+  (`is_mcp_tool`, also covers LSP tools exposed via `mcpls`) or native read-only tools
+  (`permissions::is_readonly_tool`, reusing the existing `READONLY_TOOLS` allowlist).
+  Everything else (`bash`, `diagnostics`, `write`, `edit`, ...) now correctly falls
+  through to the `Ask` default. Also wires `TrustGateExecutor` into the ACP (`zeph
+  --acp`) and daemon (`zeph serve`) entry points, which previously built their tool
+  chain with no trust gate at all — `ConfirmationRequired` there reached
+  `LoopbackChannel::confirm()`, which unconditionally auto-approves, so the fix would
+  otherwise have been CLI-only. Closes #5575.
+- `fix(tools)`: `search_code`'s structural and grep-fallback directory walks each
+  hand-duplicated the same symlink-cycle-detection logic. Extracted into one shared
+  `enters_symlink_cycle` helper so the two walk modes cannot silently diverge. No
+  behavior change. Closes #5588.
+- `test`: the `diagnostics` tool reachability tests added for #5433 only asserted the
+  tool appears in `tool_definitions()`, never that a dispatched `ToolCall` actually
+  reaches `DiagnosticsExecutor` through the full composite chain. Added dispatch-level
+  tests (asserting `SandboxViolation`, a signal only `DiagnosticsExecutor` produces) for
+  the CLI, ACP, and daemon entry points, all calling a new shared
+  `agent_setup::build_base_executor_chain` helper so the test chain cannot drift from
+  the production wiring it is meant to guard. Closes #5578.
 - `fix(db)`: fix 25 `E0308` compile errors across `zeph-core`, `zeph-tools`, and the `zeph`
   binary under `cargo check --workspace --all-targets --features postgres`. Test helpers
   hardcoded `SqlitePool`/`SqlitePoolOptions` construction where the surrounding code expects

--- a/crates/zeph-tools/src/permissions.rs
+++ b/crates/zeph-tools/src/permissions.rs
@@ -10,6 +10,11 @@ pub(crate) use zeph_config::tools::{
 };
 
 /// Read-only tool allowlist (available in `ReadOnly` autonomy mode).
+///
+/// Also used, via [`is_readonly_tool`], to bypass the `Supervised`-mode confirmation
+/// default for unconfigured tools — see #5575. A tool added here is trusted to run
+/// without confirmation in *both* modes; do not add anything that mutates state or
+/// executes code.
 const READONLY_TOOLS: &[&str] = &[
     "read",
     "find_path",
@@ -20,6 +25,16 @@ const READONLY_TOOLS: &[&str] = &[
     "load_skill",
     "invoke_skill",
 ];
+
+/// Returns `true` if `tool_id` is a native read-only tool.
+///
+/// Reuses the same [`READONLY_TOOLS`] allowlist that gates `ReadOnly` autonomy mode, so
+/// `Supervised` mode's unconfigured-tool bypass (`TrustGateExecutor::check_trust`) cannot
+/// silently diverge from it — see #5575.
+#[must_use]
+pub(crate) fn is_readonly_tool(tool_id: &str) -> bool {
+    READONLY_TOOLS.contains(&tool_id)
+}
 
 /// Tool permission policy: maps `tool_id` → ordered list of rules.
 /// First matching rule wins; default is `Ask`.
@@ -298,6 +313,16 @@ mod tests {
     #[test]
     fn autonomy_level_default_is_supervised() {
         assert_eq!(AutonomyLevel::default(), AutonomyLevel::Supervised);
+    }
+
+    #[test]
+    fn is_readonly_tool_matches_allowlist() {
+        for tool in READONLY_TOOLS {
+            assert!(is_readonly_tool(tool), "{tool} should be a readonly tool");
+        }
+        assert!(!is_readonly_tool("bash"));
+        assert!(!is_readonly_tool("diagnostics"));
+        assert!(!is_readonly_tool("write"));
     }
 
     #[test]

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -257,6 +257,30 @@ struct WalkState<'a> {
     ancestors: &'a mut Vec<PathBuf>,
 }
 
+/// Canonicalizes `current` and checks it against the active recursion stack in
+/// `ancestors` — the canonical paths of directories on the *active* recursion path
+/// (not every directory ever visited). A symlinked directory is only a cycle when
+/// following it would revisit one of those ancestors; legitimate symlinks that point
+/// elsewhere (a vendored dependency, a symlinked source file) are not cycles.
+///
+/// Returns `true` when `current` would revisit an ancestor — the caller must stop
+/// without recursing further. Otherwise pushes `current`'s canonical path onto
+/// `ancestors` and returns `false`; the caller **must** pop it (`ancestors.pop()`)
+/// once the recursive body for `current` returns.
+///
+/// Shared by [`collect_structural_hits`] and [`collect_grep_hits`] so the two walk
+/// modes cannot silently diverge (#5588).
+fn enters_symlink_cycle(ancestors: &mut Vec<PathBuf>, current: &Path) -> bool {
+    let canonical = current
+        .canonicalize()
+        .unwrap_or_else(|_| current.to_path_buf());
+    if ancestors.contains(&canonical) {
+        return true;
+    }
+    ancestors.push(canonical);
+    false
+}
+
 pub struct SearchCodeExecutor {
     allowed_paths: Vec<PathBuf>,
     semantic_backend: Option<std::sync::Arc<dyn SemanticSearchBackend>>,
@@ -619,12 +643,8 @@ fn format_hits(hits: &[SearchCodeHit], root: &Path) -> String {
         .join("\n\n")
 }
 
-/// Walks `current`, guarding against symlink cycles via `state.ancestors`: the
-/// canonical paths of directories on the *active* recursion path (not every
-/// directory ever visited). A symlinked directory is only skipped when following it
-/// would revisit one of those ancestors — an actual cycle. Legitimate symlinks that
-/// point elsewhere (a vendored dependency, a symlinked source file) are walked
-/// normally, still bounded by [`WalkBudget`] via `state.budget`.
+/// Walks `current`, guarding against symlink cycles via [`enters_symlink_cycle`], still
+/// bounded by [`WalkBudget`] via `state.budget`.
 fn collect_structural_hits(
     root: &Path,
     current: &Path,
@@ -637,16 +657,9 @@ fn collect_structural_hits(
         return Ok(());
     }
 
-    // A plain directory tree has no cycles on its own — only a symlink pointing back
-    // at an ancestor can create one — so canonicalizing once per directory entered
-    // (not per entry) and comparing against the active stack is enough to catch it.
-    let canonical = current
-        .canonicalize()
-        .unwrap_or_else(|_| current.to_path_buf());
-    if state.ancestors.contains(&canonical) {
+    if enters_symlink_cycle(state.ancestors, current) {
         return Ok(());
     }
-    state.ancestors.push(canonical);
     let result = collect_structural_hits_inner(root, current, matcher, symbol_lower, hits, state);
     state.ancestors.pop();
     result
@@ -745,7 +758,7 @@ fn collect_structural_hits_inner(
     Ok(())
 }
 
-/// Symlink cycle guard mirrors [`collect_structural_hits`]; see its docs.
+/// Symlink cycle guard mirrors [`collect_structural_hits`] via [`enters_symlink_cycle`].
 fn collect_grep_hits(
     root: &Path,
     current: &Path,
@@ -759,13 +772,9 @@ fn collect_grep_hits(
         return Ok(());
     }
 
-    let canonical = current
-        .canonicalize()
-        .unwrap_or_else(|_| current.to_path_buf());
-    if state.ancestors.contains(&canonical) {
+    if enters_symlink_cycle(state.ancestors, current) {
         return Ok(());
     }
-    state.ancestors.push(canonical);
     let result = collect_grep_hits_inner(root, current, matcher, regex, hits, max_results, state);
     state.ancestors.pop();
     result
@@ -1027,6 +1036,35 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(out.summary.contains("retry_backoff_ms"));
+    }
+
+    /// Unit-level regression test for #5588: `enters_symlink_cycle` is the single
+    /// shared implementation of the cycle-detection logic previously duplicated
+    /// between `collect_structural_hits` and `collect_grep_hits`.
+    #[test]
+    fn enters_symlink_cycle_detects_repeated_ancestor() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ancestors = Vec::new();
+
+        assert!(!enters_symlink_cycle(&mut ancestors, dir.path()));
+        assert_eq!(ancestors.len(), 1);
+
+        // Re-entering the same (canonicalized) path is a cycle.
+        assert!(enters_symlink_cycle(&mut ancestors, dir.path()));
+        // A cycle must not push a duplicate entry.
+        assert_eq!(ancestors.len(), 1);
+    }
+
+    #[test]
+    fn enters_symlink_cycle_allows_distinct_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let child = dir.path().join("child");
+        std::fs::create_dir_all(&child).unwrap();
+        let mut ancestors = Vec::new();
+
+        assert!(!enters_symlink_cycle(&mut ancestors, dir.path()));
+        assert!(!enters_symlink_cycle(&mut ancestors, &child));
+        assert_eq!(ancestors.len(), 2);
     }
 
     /// Regression test for #5577 (critic finding M1 / tester coverage gap 1): a

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -122,11 +122,18 @@ impl<T: ToolExecutor> TrustGateExecutor<T> {
         }
 
         // PermissionPolicy was designed for the bash tool. In Supervised mode, tools
-        // without explicit rules default to Ask, which incorrectly blocks MCP/LSP tools.
-        // Skip the policy check for such tools — trust-level enforcement above is sufficient.
+        // without explicit rules default to Ask, which incorrectly blocks MCP/LSP tools
+        // and native read-only tools (both are already categorized elsewhere: MCP/LSP
+        // tools via `mcp_tool_ids`, read-only native tools via `permissions::READONLY_TOOLS`).
+        // Skip the policy check only for tools that fall into one of those two known-safe
+        // categories — trust-level enforcement above is sufficient for them. Any other
+        // unconfigured tool (e.g. `diagnostics`, which runs cargo check/clippy and can
+        // execute arbitrary code via build.rs/proc-macros) falls through to the Ask
+        // default below; see #5575.
         // ReadOnly mode is excluded: its allowlist is enforced inside policy.check().
         if self.policy.autonomy_level() == AutonomyLevel::Supervised
             && self.policy.rules().get(tool_id).is_none()
+            && (self.is_mcp_tool(tool_id) || crate::permissions::is_readonly_tool(tool_id))
         {
             return Ok(());
         }
@@ -317,13 +324,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trusted_allows_all() {
+    async fn supervised_readonly_native_tool_without_rule_allowed() {
+        // "read" is a native read-only tool (permissions::READONLY_TOOLS) — it must
+        // still bypass the Ask default in Supervised mode even without an explicit rule.
+        let gate = TrustGateExecutor::new(MockExecutor, PermissionPolicy::default());
+        gate.set_effective_trust(SkillTrustLevel::Trusted);
+
+        let result = gate.execute_tool_call(&make_call("read")).await;
+        assert!(result.is_ok());
+    }
+
+    /// Regression test for #5575: `bash` has no explicit policy rule and is neither an
+    /// MCP tool nor a native read-only tool, so it must NOT bypass confirmation in
+    /// Supervised mode — the prior blanket skip incorrectly allowed this.
+    #[tokio::test]
+    async fn supervised_unconfigured_non_mcp_non_readonly_tool_requires_confirmation() {
         let gate = TrustGateExecutor::new(MockExecutor, PermissionPolicy::default());
         gate.set_effective_trust(SkillTrustLevel::Trusted);
 
         let result = gate.execute_tool_call(&make_call("bash")).await;
-        // Default policy has no rules for bash => skip policy check => Ok
-        assert!(result.is_ok());
+        assert_matches!(result, Err(ToolError::ConfirmationRequired { .. }));
+    }
+
+    /// Regression test for #5575: `diagnostics` runs `cargo check`/`cargo clippy`, which
+    /// executes arbitrary code via `build.rs` scripts and proc-macros — it must require
+    /// confirmation in Supervised mode when no explicit rule is configured, not bypass it
+    /// via the (now-removed) blanket "no rule => Ok" skip.
+    #[tokio::test]
+    async fn supervised_unconfigured_diagnostics_requires_confirmation() {
+        let gate = TrustGateExecutor::new(MockExecutor, PermissionPolicy::default());
+        gate.set_effective_trust(SkillTrustLevel::Trusted);
+
+        let result = gate.execute_tool_call(&make_call("diagnostics")).await;
+        assert_matches!(result, Err(ToolError::ConfirmationRequired { .. }));
     }
 
     #[tokio::test]
@@ -407,12 +440,24 @@ mod tests {
 
     #[tokio::test]
     async fn quarantined_allows_file_read() {
-        let policy = crate::permissions::PermissionPolicy::from_legacy(&[], &[]);
+        // "file_read" is not in the quarantine-denied list, but (unlike "read") it is also
+        // not in `permissions::READONLY_TOOLS`, so an explicit Allow rule is required here
+        // to isolate this test from the Supervised-mode Ask default (see #5575) and keep it
+        // focused on quarantine-denial behavior only.
+        let mut rules = std::collections::HashMap::new();
+        rules.insert(
+            "file_read".to_owned(),
+            vec![crate::permissions::PermissionRule {
+                pattern: "*".to_owned(),
+                action: PermissionAction::Allow,
+            }],
+        );
+        let policy = crate::permissions::PermissionPolicy::new(rules);
         let gate = TrustGateExecutor::new(MockExecutor, policy);
         gate.set_effective_trust(SkillTrustLevel::Quarantined);
 
         let result = gate.execute_tool_call(&make_call("file_read")).await;
-        // file_read is not in quarantine denied list, and policy has no rules for file_read => Ok
+        // file_read is not in quarantine denied list, and the explicit rule allows it => Ok
         assert!(result.is_ok());
     }
 
@@ -547,10 +592,15 @@ mod tests {
 
     #[tokio::test]
     async fn mcp_tool_supervised_no_rules_allows() {
-        // MCP tool with Supervised mode + from_legacy policy (no rules for MCP tool) => Ok
+        // MCP tool with Supervised mode + from_legacy policy (no rules for MCP tool) => Ok.
+        // Registered via `mcp_tool_ids_handle` so `is_mcp_tool` recognizes it as genuinely
+        // MCP-sourced — see #5575 (the skip is no longer a blanket "no rule => Ok").
         let policy = crate::permissions::PermissionPolicy::from_legacy(&[], &[]);
         let gate = TrustGateExecutor::new(MockExecutor, policy);
         gate.set_effective_trust(SkillTrustLevel::Trusted);
+        gate.mcp_tool_ids_handle()
+            .write()
+            .insert("mcp_filesystem__read_file".to_owned());
 
         let mut params = serde_json::Map::new();
         params.insert(
@@ -710,7 +760,21 @@ mod tests {
 
     #[tokio::test]
     async fn quarantined_allows_mcp_read_file() {
-        let policy = crate::permissions::PermissionPolicy::from_legacy(&[], &[]);
+        // Deliberately NOT registered in `mcp_tool_ids`: a tool registered there is
+        // denied outright under Quarantine regardless of read/write (see
+        // `mcp_tool_ids` field docs), so this test isolates a different case — a
+        // tool that merely looks MCP-like by name but isn't quarantine-denied by
+        // `is_quarantine_denied`. An explicit Allow rule keeps it decoupled from the
+        // Supervised-mode Ask default for unconfigured tools (see #5575).
+        let mut rules = std::collections::HashMap::new();
+        rules.insert(
+            "filesystem_read_file".to_owned(),
+            vec![crate::permissions::PermissionRule {
+                pattern: "*".to_owned(),
+                action: PermissionAction::Allow,
+            }],
+        );
+        let policy = crate::permissions::PermissionPolicy::new(rules);
         let gate = TrustGateExecutor::new(MockExecutor, policy);
         gate.set_effective_trust(SkillTrustLevel::Quarantined);
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -337,11 +337,10 @@ async fn build_acp_deps(
     } else {
         zeph_tools::OutputFilterRegistry::new(false)
     };
+    let permission_policy =
+        zeph_tools::build_permission_policy(&config.tools, config.security.autonomy_level);
     let mut shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
-        .with_permissions(zeph_tools::build_permission_policy(
-            &config.tools,
-            config.security.autonomy_level,
-        ))
+        .with_permissions(permission_policy.clone())
         .with_output_filters(filter_registry)
         .with_task_supervisor((*acp_mem_supervisor).clone());
     if config.tools.sandbox.enabled {
@@ -422,18 +421,29 @@ async fn build_acp_deps(
     let mcp_executor =
         zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
     let shell_policy_handle = shell_executor.policy_handle();
-    let cwd_executor = zeph_tools::SetCwdExecutor;
     let diagnostics_executor = crate::agent_setup::build_diagnostics_executor(config);
-    let base_executor = zeph_tools::CompositeExecutor::new(
+    let base_executor = crate::agent_setup::build_base_executor_chain(
         file_executor,
-        zeph_tools::CompositeExecutor::new(
-            shell_executor,
-            zeph_tools::CompositeExecutor::new(
-                scrape_executor,
-                zeph_tools::CompositeExecutor::new(cwd_executor, diagnostics_executor),
-            ),
-        ),
+        shell_executor,
+        scrape_executor,
+        diagnostics_executor,
     );
+    // #5575: gate the base chain (file/shell/scrape/cwd/diagnostics) behind the same
+    // TrustGateExecutor the CLI path uses (src/runner.rs), so Supervised-mode
+    // confirmation for unconfigured, non-MCP/non-readonly tools (e.g. `diagnostics`)
+    // is enforced here too — previously this chain had no trust gate at all.
+    let base_executor =
+        zeph_tools::TrustGateExecutor::new(base_executor, permission_policy.clone());
+    // Register MCP tool IDs so TrustGateExecutor can recognize genuinely MCP-sourced
+    // tools for the Supervised-mode skip (see is_mcp_tool in trust_gate.rs) and block
+    // ALL MCP tools for Quarantined skills, mirroring runner.rs.
+    {
+        let ids: std::collections::HashSet<String> = mcp_tools
+            .iter()
+            .map(zeph_mcp::McpTool::sanitized_id)
+            .collect();
+        *base_executor.mcp_tool_ids_handle().write() = ids;
+    }
     let index_provider = crate::bootstrap::resolve_index_embed_provider(config, provider.clone());
     let tool_executor: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = {
         let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = std::sync::Arc::new(
@@ -1925,6 +1935,7 @@ mod tests {
     use serial_test::serial;
     use std::fs;
     use tempfile::TempDir;
+    use zeph_tools::executor::ToolExecutor;
 
     fn make_rules_dir(dir: &std::path::Path, files: &[&str]) {
         let rules = dir.join(".claude").join("rules");
@@ -1983,6 +1994,100 @@ mod tests {
         std::env::set_current_dir(orig).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], skill_file);
+    }
+
+    /// Regression test for #5578 (dispatch-level companion to #5433's reachability
+    /// test): calls the same `agent_setup::build_base_executor_chain` helper used by
+    /// `spawn_acp_agent` above, wrapped in the same `TrustGateExecutor` (see #5575),
+    /// and asserts a `diagnostics` `ToolCall` actually reaches `DiagnosticsExecutor` —
+    /// not just that it appears in `tool_definitions()`. `Full` autonomy bypasses the
+    /// trust gate's confirmation prompt so the call proceeds to the inner executor,
+    /// exercising the trust gate's pass-through path rather than #5575's Ask path.
+    #[tokio::test]
+    async fn diagnostics_tool_call_dispatches_through_acp_composite_chain() {
+        let config = zeph_core::config::Config::default();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = crate::agent_setup::build_diagnostics_executor(&config);
+        let base_executor = crate::agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+        );
+        let policy =
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
+        let base_executor = zeph_tools::TrustGateExecutor::new(base_executor, policy);
+
+        // Must exist on disk (DiagnosticsExecutor canonicalizes before the sandbox
+        // check) while staying outside `allowed_paths` (defaults to cwd). Assumes
+        // `TMPDIR`/temp_dir() is not itself under the repo/cwd, true in normal
+        // environments.
+        let outside = std::env::temp_dir();
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "path".into(),
+            serde_json::Value::String(outside.display().to_string()),
+        );
+        let call = zeph_tools::ToolCall {
+            tool_id: "diagnostics".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = base_executor.execute_tool_call(&call).await;
+        assert!(
+            matches!(result, Err(zeph_tools::ToolError::SandboxViolation { .. })),
+            "expected SandboxViolation from DiagnosticsExecutor, got {result:?}"
+        );
+    }
+
+    /// Regression test for #5575's ACP gap found in review: `spawn_acp_agent` built
+    /// the base chain with NO `TrustGateExecutor` at all, so `diagnostics` (and any
+    /// other unconfigured, non-MCP/non-readonly tool) reached `LoopbackChannel::confirm`
+    /// — which unconditionally returns `Ok(true)` — instead of ever producing
+    /// `ConfirmationRequired`. Now that `spawn_acp_agent` wraps the chain in
+    /// `TrustGateExecutor` (mirroring `runner.rs`), the default `Supervised` autonomy
+    /// must require confirmation for `diagnostics` here too.
+    #[tokio::test]
+    async fn diagnostics_requires_confirmation_in_acp_composite_chain() {
+        let config = zeph_core::config::Config::default();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = crate::agent_setup::build_diagnostics_executor(&config);
+        let base_executor = crate::agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+        );
+        // Default PermissionPolicy: Supervised autonomy, no explicit rules configured —
+        // the exact real-world "user never set tools.permissions" scenario #5575 covers.
+        let base_executor = zeph_tools::TrustGateExecutor::new(
+            base_executor,
+            zeph_tools::PermissionPolicy::default(),
+        );
+
+        let call = zeph_tools::ToolCall {
+            tool_id: "diagnostics".into(),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = base_executor.execute_tool_call(&call).await;
+        assert!(
+            matches!(
+                result,
+                Err(zeph_tools::ToolError::ConfirmationRequired { .. })
+            ),
+            "expected ConfirmationRequired for diagnostics under Supervised autonomy, got {result:?}"
+        );
     }
 
     /// #5437 (S1, third recurrence): `build_acp_provider_factory` constructs raw `AnyProvider`

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -556,17 +556,12 @@ pub(crate) async fn build_tool_setup(
     let shell_policy_handle = shell_executor.policy_handle();
     let shell_executor = Arc::new(shell_executor);
     let shell_executor_handle = Some(Arc::clone(&shell_executor));
-    let cwd_executor = zeph_tools::SetCwdExecutor;
     let diagnostics_executor = build_diagnostics_executor(config);
-    let base_executor = zeph_tools::CompositeExecutor::new(
+    let base_executor = build_base_executor_chain(
         file_executor,
-        zeph_tools::CompositeExecutor::new(
-            shell_executor,
-            zeph_tools::CompositeExecutor::new(
-                scrape_executor,
-                zeph_tools::CompositeExecutor::new(cwd_executor, diagnostics_executor),
-            ),
-        ),
+        shell_executor,
+        scrape_executor,
+        diagnostics_executor,
     );
     let composite = zeph_tools::CompositeExecutor::new(base_executor, mcp_executor);
     let (executor, taco_compressor) =
@@ -1506,6 +1501,61 @@ pub(crate) fn build_diagnostics_executor(config: &Config) -> zeph_tools::Diagnos
         .with_timeout(std::time::Duration::from_secs(config.tools.shell.timeout))
 }
 
+/// Assembles the `file -> shell -> scrape -> cwd -> diagnostics` composite tool chain
+/// shared by all three live entry points (CLI's [`build_tool_setup`], `acp.rs`'s
+/// `spawn_acp_agent`, `daemon.rs`'s `run_daemon`) and the #5578 dispatch-reachability
+/// tests. Pinning the nesting order in one function means a future reorder or drop of
+/// one of these executors in production is caught by every caller — including the
+/// tests — instead of a hand-copied test chain silently going stale.
+///
+/// Generic over the shell/scrape/file executor types so each entry point can pass in
+/// its own already-customized executors (audit logging, OS sandbox, task supervisor,
+/// egress config, etc. attached via their builder methods beforehand) without this
+/// function needing to know about any of that; the tests pass in bare/default ones.
+#[expect(
+    clippy::type_complexity,
+    reason = "concrete nested CompositeExecutor chain type mirrors the production wiring \
+              exactly; the whole point of this helper is pinning down that exact static \
+              chain shape, so hiding it behind a boxed/dyn return would defeat it"
+)]
+pub(crate) fn build_base_executor_chain<F, S, W>(
+    file_executor: F,
+    shell_executor: S,
+    scrape_executor: W,
+    diagnostics_executor: zeph_tools::DiagnosticsExecutor,
+) -> zeph_tools::CompositeExecutor<
+    F,
+    zeph_tools::CompositeExecutor<
+        S,
+        zeph_tools::CompositeExecutor<
+            W,
+            zeph_tools::CompositeExecutor<
+                zeph_tools::SetCwdExecutor,
+                zeph_tools::DiagnosticsExecutor,
+            >,
+        >,
+    >,
+>
+where
+    F: zeph_tools::ToolExecutor,
+    S: zeph_tools::ToolExecutor,
+    W: zeph_tools::ToolExecutor,
+{
+    zeph_tools::CompositeExecutor::new(
+        file_executor,
+        zeph_tools::CompositeExecutor::new(
+            shell_executor,
+            zeph_tools::CompositeExecutor::new(
+                scrape_executor,
+                zeph_tools::CompositeExecutor::new(
+                    zeph_tools::SetCwdExecutor,
+                    diagnostics_executor,
+                ),
+            ),
+        ),
+    )
+}
+
 fn resolve_search_lsp_server_id(config: &Config) -> Option<String> {
     config
         .mcp
@@ -1953,6 +2003,54 @@ mod tests {
         );
         let defs = base_executor.tool_definitions();
         assert!(defs.iter().any(|d| d.id == "diagnostics"));
+    }
+
+    /// Regression test for #5578: prior reachability tests for #5433 only asserted
+    /// `diagnostics` appears in `tool_definitions()`, never that a `ToolCall` for it
+    /// actually reaches `DiagnosticsExecutor` through the full composite chain — an
+    /// earlier executor silently swallowing the call would have gone unnoticed. Uses
+    /// the same `build_base_executor_chain` helper the CLI/ACP/daemon entry points
+    /// call, so a future reorder or drop of `diagnostics` in production wiring is
+    /// caught here too — a hand-copied chain could not. Dispatches a call with a path
+    /// outside `allowed_paths` and asserts `SandboxViolation`, a signal that can only
+    /// originate from `DiagnosticsExecutor`.
+    #[tokio::test]
+    async fn diagnostics_tool_call_dispatches_through_composite_chain() {
+        let config = Config::load(Path::new("/nonexistent")).unwrap();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = build_diagnostics_executor(&config);
+        let base_executor = build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+        );
+
+        // Must exist on disk (DiagnosticsExecutor canonicalizes before the sandbox
+        // check) while staying outside `allowed_paths` (defaults to cwd). Assumes
+        // `TMPDIR`/temp_dir() is not itself under the repo/cwd, true in normal
+        // environments.
+        let outside = std::env::temp_dir();
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "path".into(),
+            serde_json::Value::String(outside.display().to_string()),
+        );
+        let call = zeph_tools::ToolCall {
+            tool_id: "diagnostics".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = base_executor.execute_tool_call(&call).await;
+        assert!(
+            matches!(result, Err(zeph_tools::ToolError::SandboxViolation { .. })),
+            "expected SandboxViolation from DiagnosticsExecutor, got {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -401,11 +401,10 @@ pub(crate) async fn run_daemon(
     } else {
         zeph_tools::OutputFilterRegistry::new(false)
     };
+    let permission_policy =
+        zeph_tools::build_permission_policy(&config.tools, config.security.autonomy_level);
     let mut shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
-        .with_permissions(zeph_tools::build_permission_policy(
-            &config.tools,
-            config.security.autonomy_level,
-        ))
+        .with_permissions(permission_policy.clone())
         .with_output_filters(filter_registry)
         .with_task_supervisor(task_supervisor.clone());
     if config.tools.sandbox.enabled {
@@ -491,18 +490,29 @@ pub(crate) async fn run_daemon(
     let mcp_executor =
         zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
     let shell_policy_handle = shell_executor.policy_handle();
-    let cwd_executor = zeph_tools::SetCwdExecutor;
     let diagnostics_executor = agent_setup::build_diagnostics_executor(config);
-    let base_executor = zeph_tools::CompositeExecutor::new(
+    let base_executor = agent_setup::build_base_executor_chain(
         file_executor,
-        zeph_tools::CompositeExecutor::new(
-            shell_executor,
-            zeph_tools::CompositeExecutor::new(
-                scrape_executor,
-                zeph_tools::CompositeExecutor::new(cwd_executor, diagnostics_executor),
-            ),
-        ),
+        shell_executor,
+        scrape_executor,
+        diagnostics_executor,
     );
+    // #5575: gate the base chain (file/shell/scrape/cwd/diagnostics) behind the same
+    // TrustGateExecutor the CLI path uses (src/runner.rs), so Supervised-mode
+    // confirmation for unconfigured, non-MCP/non-readonly tools (e.g. `diagnostics`)
+    // is enforced here too — previously this chain had no trust gate at all.
+    let base_executor =
+        zeph_tools::TrustGateExecutor::new(base_executor, permission_policy.clone());
+    // Register MCP tool IDs so TrustGateExecutor can recognize genuinely MCP-sourced
+    // tools for the Supervised-mode skip (see is_mcp_tool in trust_gate.rs) and block
+    // ALL MCP tools for Quarantined skills, mirroring runner.rs.
+    {
+        let ids: std::collections::HashSet<String> = mcp_tools
+            .iter()
+            .map(zeph_mcp::McpTool::sanitized_id)
+            .collect();
+        *base_executor.mcp_tool_ids_handle().write() = ids;
+    }
     let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::with_validator(
         std::sync::Arc::clone(&memory),
         conversation_id,
@@ -997,6 +1007,104 @@ mod tests {
             language: "en".into(),
         });
         cfg
+    }
+
+    /// Regression test for #5578 (dispatch-level companion to #5433's reachability
+    /// test): calls the same `agent_setup::build_base_executor_chain` helper used by
+    /// `run_daemon` above, wrapped in the same `TrustGateExecutor` (see #5575), and
+    /// asserts a `diagnostics` `ToolCall` actually reaches `DiagnosticsExecutor` — not
+    /// just that it appears in `tool_definitions()`. `Full` autonomy bypasses the
+    /// trust gate's confirmation prompt so the call proceeds to the inner executor,
+    /// exercising the trust gate's pass-through path rather than #5575's Ask path.
+    #[tokio::test]
+    async fn diagnostics_tool_call_dispatches_through_daemon_composite_chain() {
+        use zeph_tools::executor::ToolExecutor;
+
+        let config = Config::default();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = agent_setup::build_diagnostics_executor(&config);
+        let base_executor = agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+        );
+        let policy =
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
+        let base_executor = zeph_tools::TrustGateExecutor::new(base_executor, policy);
+
+        // Must exist on disk (DiagnosticsExecutor canonicalizes before the sandbox
+        // check) while staying outside `allowed_paths` (defaults to cwd). Assumes
+        // `TMPDIR`/temp_dir() is not itself under the repo/cwd, true in normal
+        // environments.
+        let outside = std::env::temp_dir();
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "path".into(),
+            serde_json::Value::String(outside.display().to_string()),
+        );
+        let call = zeph_tools::ToolCall {
+            tool_id: "diagnostics".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = base_executor.execute_tool_call(&call).await;
+        assert!(
+            matches!(result, Err(zeph_tools::ToolError::SandboxViolation { .. })),
+            "expected SandboxViolation from DiagnosticsExecutor, got {result:?}"
+        );
+    }
+
+    /// Regression test for #5575's daemon gap found in review: `run_daemon` built the
+    /// base chain with NO `TrustGateExecutor` at all, so `diagnostics` (and any other
+    /// unconfigured, non-MCP/non-readonly tool) reached `LoopbackChannel::confirm` —
+    /// which unconditionally returns `Ok(true)` — instead of ever producing
+    /// `ConfirmationRequired`. Now that `run_daemon` wraps the chain in
+    /// `TrustGateExecutor` (mirroring `runner.rs`), the default `Supervised` autonomy
+    /// must require confirmation for `diagnostics` here too.
+    #[tokio::test]
+    async fn diagnostics_requires_confirmation_in_daemon_composite_chain() {
+        use zeph_tools::executor::ToolExecutor;
+
+        let config = Config::default();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = agent_setup::build_diagnostics_executor(&config);
+        let base_executor = agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+        );
+        // Default PermissionPolicy: Supervised autonomy, no explicit rules configured —
+        // the exact real-world "user never set tools.permissions" scenario #5575 covers.
+        let base_executor = zeph_tools::TrustGateExecutor::new(
+            base_executor,
+            zeph_tools::PermissionPolicy::default(),
+        );
+
+        let call = zeph_tools::ToolCall {
+            tool_id: "diagnostics".into(),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = base_executor.execute_tool_call(&call).await;
+        assert!(
+            matches!(
+                result,
+                Err(zeph_tools::ToolError::ConfirmationRequired { .. })
+            ),
+            "expected ConfirmationRequired for diagnostics under Supervised autonomy, got {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `TrustGateExecutor::check_trust` (`crates/zeph-tools/src/trust_gate.rs`) blanket-skipped the `PermissionPolicy` confirmation check for any tool with no explicit rule in `Supervised` mode. This let code-executing tools like `diagnostics` (runs `cargo check`/`cargo clippy`, executing `build.rs`/proc-macros) proceed without a prompt. The skip is now scoped to two existing, already-audited categories only: MCP-sourced tools (`is_mcp_tool`, also covers LSP tools via `mcpls`) and native read-only tools (`permissions::is_readonly_tool`, reusing the existing `READONLY_TOOLS` allowlist).
- `TrustGateExecutor` is now also wired into the ACP (`zeph --acp`) and daemon (`zeph serve`) entry points. These previously built their tool chain with no trust gate at all, so a `ConfirmationRequired` there would hit `LoopbackChannel::confirm()`, which unconditionally auto-approves — the fix would otherwise have been CLI-only.
- `search_code`'s structural and grep-fallback walks each hand-duplicated the same symlink-cycle-detection logic; extracted into one shared `enters_symlink_cycle` helper.
- Added dispatch-level reachability tests for the `diagnostics` tool (CLI/ACP/daemon), asserting a `SandboxViolation` signal that only `DiagnosticsExecutor` can produce, instead of only checking `tool_definitions()` listing. Production wiring and its tests now both route through a shared `agent_setup::build_base_executor_chain` helper so they cannot silently diverge.

Closes #5575, #5588, #5578

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (11932 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression tests dispatch through the real production composite chain (not a hand-copied mock) for CLI, ACP, and daemon entry points, verifying `diagnostics` now requires confirmation under default `Supervised` policy in all three.