### PR TITLE
fix(core,channels): correct misleading /image path-rejection message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `ci`: widen the `build-postgres` job to also run
   `cargo check --workspace --all-targets --features postgres`, exercising the exact command
   that surfaced #5602 so this defect class is caught in CI going forward. Closes #5601.
+- `fix(core,channels)`: `/image <path>` now reports an accurate error instead of the
+  misleading `"path traversal not allowed"` for every absolute path, even a safe one
+  like `/tmp/screenshot.png` with no `..` component. The rejection check was duplicated
+  across three call sites — `handle_image_as_string`
+  (`crates/zeph-core/src/agent/slash_commands.rs`), the `AgentAccess::load_image` impl
+  (`crates/zeph-core/src/agent/agent_access_impl.rs`), and the CLI channel's own
+  `/image` handling (`crates/zeph-channels/src/cli.rs`) — all three now return a
+  distinct message for the absolute-path case (`"absolute paths are not supported, use
+  a path relative to the working directory"`) versus genuine `..` traversal
+  (`"path traversal ('..') is not allowed"`). All three now share a single
+  `zeph_common::path_guard::classify_relative_path` classifier instead of three
+  independently-maintained checks, which also fixes a latent Windows-only gap in the
+  CLI channel's check (it was missing the leading-`/` guard the other two already had).
+  The underlying restriction — relative paths only — is unchanged. Closes #5472.
 - `fix(tui)`: the TUI command palette's `daemon:connect`, `daemon:disconnect`, and
   `daemon:status` entries no longer collapse into one indistinguishable "not yet
   implemented" toast. `daemon:status` now reports genuine connection state (connected to

--- a/crates/zeph-channels/src/cli.rs
+++ b/crates/zeph-channels/src/cli.rs
@@ -19,6 +19,7 @@ use std::collections::VecDeque;
 use std::io::{BufReader, IsTerminal};
 
 use tokio::sync::mpsc;
+use zeph_common::path_guard::{PathRejection, classify_relative_path};
 use zeph_core::channel::{
     Attachment, AttachmentKind, Channel, ChannelError, ChannelMessage, ElicitationField,
     ElicitationFieldType, ElicitationRequest, ElicitationResponse,
@@ -72,6 +73,24 @@ impl std::fmt::Debug for InputHistory {
     }
 }
 
+/// Format the `/image` rejection message for a [`PathRejection`], or `None` when the
+/// path is allowed.
+///
+/// Extracted as a pure function (rather than inlined `println!` calls) so the exact
+/// message text is directly unit-testable without capturing stdout.
+fn image_path_rejection_message(rejection: PathRejection) -> Option<&'static str> {
+    match rejection {
+        PathRejection::Allowed => None,
+        PathRejection::Absolute => Some(
+            "Zeph: Invalid image path: absolute paths are not supported, use a path \
+            relative to the working directory",
+        ),
+        PathRejection::Traversal => {
+            Some("Zeph: Invalid image path: path traversal ('..') is not allowed")
+        }
+    }
+}
+
 /// Process a raw line from stdin: handle exit commands, empty-line logic,
 /// `/image` commands. Returns `None` to continue the loop, `Some(msg)` to
 /// send a message, or `Err(())` to break out of the loop.
@@ -105,9 +124,8 @@ async fn process_line(
             return Ok(None);
         }
         let path_owned = path.to_owned();
-        let p = std::path::Path::new(&path_owned);
-        if p.is_absolute() || p.components().any(|c| c == std::path::Component::ParentDir) {
-            println!("Zeph: Invalid image path: path traversal not allowed");
+        if let Some(msg) = image_path_rejection_message(classify_relative_path(&path_owned)) {
+            println!("{msg}");
             return Ok(None);
         }
         match tokio::fs::read(&path_owned).await {
@@ -828,5 +846,26 @@ mod tests {
         .await;
         assert_matches!(result, Ok(None));
         assert!(pending.is_empty());
+    }
+
+    // `process_line`'s rejection messages go to stdout via `println!` rather than a
+    // return value, so `image_path_rejection_message` (the classifier->message wiring)
+    // is the directly-testable seam.
+
+    #[test]
+    fn image_path_rejection_message_absolute() {
+        let msg = image_path_rejection_message(PathRejection::Absolute).unwrap();
+        assert!(msg.contains("absolute paths are not supported"));
+    }
+
+    #[test]
+    fn image_path_rejection_message_traversal() {
+        let msg = image_path_rejection_message(PathRejection::Traversal).unwrap();
+        assert!(msg.contains("path traversal") && msg.contains("not allowed"));
+    }
+
+    #[test]
+    fn image_path_rejection_message_allowed_is_none() {
+        assert!(image_path_rejection_message(PathRejection::Allowed).is_none());
     }
 }

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -22,6 +22,7 @@ pub mod http_middleware;
 pub mod math;
 pub mod memory;
 pub mod net;
+pub mod path_guard;
 pub mod patterns;
 pub mod policy;
 pub mod quarantine;

--- a/crates/zeph-common/src/path_guard.rs
+++ b/crates/zeph-common/src/path_guard.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Classifier for the "relative paths only, no `..`" policy used by every
+//! attachment-loading entry point that has no sandbox/`allowed_paths` configuration
+//! available to it (currently `/image`).
+//!
+//! This is deliberately **not** a sandbox: it has no notion of allowed roots and does
+//! not canonicalize or touch the filesystem. It only classifies a path string as
+//! absolute, `..`-traversing, or acceptable, so every caller enforcing "relative paths
+//! only" applies the exact same rule and reports the exact same classification —
+//! closing the drift risk of three independent, textually-similar-but-not-identical
+//! checks (one such check previously missed the Windows leading-`/` guard the other
+//! two had).
+
+use std::path::{Component, Path};
+
+/// Outcome of classifying a path against the "relative, no `..`" policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathRejection {
+    /// Path is relative and contains no `..` component — acceptable.
+    Allowed,
+    /// Path is absolute, or looks absolute via a leading `/`.
+    ///
+    /// `Path::is_absolute` is `false` on Windows for Unix-style paths like `/etc/passwd`
+    /// (no drive letter), so the leading-`/` string check is required in addition to it.
+    Absolute,
+    /// Path contains a `..` (`Component::ParentDir`) component.
+    Traversal,
+}
+
+/// Classify `path` against the "relative paths only, no `..`" policy.
+///
+/// Checks the absolute case before the traversal case, so a path that is both absolute
+/// and contains `..` is reported as [`PathRejection::Absolute`].
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::path_guard::{PathRejection, classify_relative_path};
+///
+/// assert_eq!(classify_relative_path("photo.jpg"), PathRejection::Allowed);
+/// assert_eq!(classify_relative_path("/etc/passwd"), PathRejection::Absolute);
+/// assert_eq!(classify_relative_path("../../etc/passwd"), PathRejection::Traversal);
+/// ```
+#[must_use]
+pub fn classify_relative_path(path: &str) -> PathRejection {
+    let p = Path::new(path);
+    if p.is_absolute() || path.starts_with('/') {
+        return PathRejection::Absolute;
+    }
+    if p.components().any(|c| c == Component::ParentDir) {
+        return PathRejection::Traversal;
+    }
+    PathRejection::Allowed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_plain_relative_path() {
+        assert_eq!(classify_relative_path("photo.jpg"), PathRejection::Allowed);
+    }
+
+    #[test]
+    fn allows_nested_relative_path() {
+        assert_eq!(
+            classify_relative_path("sub/dir/photo.jpg"),
+            PathRejection::Allowed
+        );
+    }
+
+    #[test]
+    fn rejects_absolute_unix_path() {
+        assert_eq!(
+            classify_relative_path("/etc/passwd"),
+            PathRejection::Absolute
+        );
+    }
+
+    #[test]
+    fn rejects_leading_slash_even_when_is_absolute_would_miss_it() {
+        // A leading '/' must be caught even on platforms where `Path::is_absolute()`
+        // alone would not flag it (Windows).
+        assert_eq!(
+            classify_relative_path("/tmp/screenshot.png"),
+            PathRejection::Absolute
+        );
+    }
+
+    #[test]
+    fn rejects_parent_dir_traversal() {
+        assert_eq!(
+            classify_relative_path("../../etc/passwd"),
+            PathRejection::Traversal
+        );
+    }
+
+    #[test]
+    fn rejects_nested_parent_dir_traversal() {
+        assert_eq!(
+            classify_relative_path("sub/../../etc/passwd"),
+            PathRejection::Traversal
+        );
+    }
+
+    #[test]
+    fn absolute_takes_priority_over_traversal() {
+        assert_eq!(
+            classify_relative_path("/etc/../etc/passwd"),
+            PathRejection::Absolute
+        );
+    }
+
+    #[test]
+    fn allows_single_dot_component() {
+        assert_eq!(
+            classify_relative_path("./photo.jpg"),
+            PathRejection::Allowed
+        );
+    }
+}

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1031,17 +1031,25 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
         &'a mut self,
         path: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
-        use std::path::Component;
+        use zeph_common::path_guard::{PathRejection, classify_relative_path};
         use zeph_llm::provider::{ImageData, MessagePart};
 
-        let p = std::path::Path::new(path);
-        if p.is_absolute()
-            || path.starts_with('/')
-            || p.components().any(|c| c == Component::ParentDir)
-        {
-            return Box::pin(async move {
-                Ok("Invalid image path: path traversal not allowed".to_owned())
-            });
+        match classify_relative_path(path) {
+            PathRejection::Allowed => {}
+            PathRejection::Absolute => {
+                return Box::pin(async move {
+                    Ok(
+                        "Invalid image path: absolute paths are not supported, use a path \
+                        relative to the working directory"
+                            .to_owned(),
+                    )
+                });
+            }
+            PathRejection::Traversal => {
+                return Box::pin(async move {
+                    Ok("Invalid image path: path traversal ('..') is not allowed".to_owned())
+                });
+            }
         }
 
         let path_owned = path.to_owned();
@@ -2695,5 +2703,43 @@ path = "skill-second"
             result.starts_with("Resumed session s2"),
             "resuming into a different, unlocked session must still hydrate normally, got: {result}"
         );
+    }
+
+    // `AgentAccess::load_image` had zero direct coverage — only
+    // `Agent::handle_image_as_string` (slash_commands.rs) and `cli.rs`'s inline check
+    // were tested. These exercise the real `Agent<C>` impl via the trait.
+
+    #[tokio::test]
+    async fn load_image_rejects_absolute_path() {
+        let mut agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![]),
+            create_test_registry(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+
+        let result = AgentAccess::load_image(&mut agent, "/etc/passwd")
+            .await
+            .unwrap();
+        assert!(result.contains("absolute paths are not supported"));
+    }
+
+    #[tokio::test]
+    async fn load_image_rejects_parent_dir_traversal() {
+        let mut agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![]),
+            create_test_registry(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+
+        let result = AgentAccess::load_image(&mut agent, "../../etc/passwd")
+            .await
+            .unwrap();
+        assert!(result.contains("path traversal") && result.contains("not allowed"));
     }
 }

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -339,17 +339,19 @@ impl<C: crate::channel::Channel> Agent<C> {
     /// Load an image and return a status string for use via [`AgentAccess::load_image`].
     #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn handle_image_as_string(&mut self, path: &str) -> String {
-        use std::path::Component;
+        use zeph_common::path_guard::{PathRejection, classify_relative_path};
         use zeph_llm::provider::{ImageData, MessagePart};
 
-        let p = std::path::Path::new(path);
-        // `is_absolute()` is false on Windows for Unix-style paths like `/etc/passwd`
-        // (no drive letter), so also check for a leading slash explicitly.
-        if p.is_absolute()
-            || path.starts_with('/')
-            || p.components().any(|c| c == Component::ParentDir)
-        {
-            return "Invalid image path: path traversal not allowed".to_owned();
+        match classify_relative_path(path) {
+            PathRejection::Allowed => {}
+            PathRejection::Absolute => {
+                return "Invalid image path: absolute paths are not supported, use a path \
+                    relative to the working directory"
+                    .to_owned();
+            }
+            PathRejection::Traversal => {
+                return "Invalid image path: path traversal ('..') is not allowed".to_owned();
+            }
         }
 
         let data = match std::fs::read(path) {

--- a/crates/zeph-core/src/agent/tests/agent_tests/image_attachment_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/image_attachment_tests.rs
@@ -115,7 +115,7 @@ fn handle_image_command_absolute_path_is_rejected() {
 
     let result = agent.handle_image_as_string("/etc/passwd");
     assert!(agent.msg.pending_image_parts.is_empty());
-    assert!(result.contains("path traversal not allowed"));
+    assert!(result.contains("absolute paths are not supported"));
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn handle_image_command_parent_dir_traversal_is_rejected() {
 
     let result = agent.handle_image_as_string("../../etc/passwd");
     assert!(agent.msg.pending_image_parts.is_empty());
-    assert!(result.contains("path traversal not allowed"));
+    assert!(result.contains("path traversal") && result.contains("not allowed"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #5472. `/image <path>` rejected every absolute image path with `"Invalid image path: path traversal not allowed"`, even a safe path with no `..` component like `/tmp/screenshot.png` — the message conflated "absolute path" with "path-traversal attempt". This is not a security hole (the restriction itself is intentional and unchanged), just a misleading error.

Investigation found the rejection check was independently duplicated across three call sites: `handle_image_as_string` (`crates/zeph-core/src/agent/slash_commands.rs`), `AgentAccess::load_image` (`crates/zeph-core/src/agent/agent_access_impl.rs`), and a standalone implementation in `crates/zeph-channels/src/cli.rs::process_line`. The richer fix suggested by the issue — extending the `~`-expansion/sandboxed-absolute-path support #5413/#5424 added to other path-accepting commands — was evaluated and declined: it would require wiring sandbox config across the `zeph-core`/`zeph-channels` crate boundary through every `Agent`-construction site, disproportionate scope for a P3 message-accuracy bug.

Instead, adds `zeph_common::path_guard::classify_relative_path`, a small config-free classifier (`PathRejection::{Allowed, Absolute, Traversal}`) distinguishing an absolute path from a genuine `..`-traversal attempt. All three call sites now share this one classifier and format their own accurate message from the result — absolute path → "absolute paths are not supported, use a path relative to the working directory"; `..` traversal → "path traversal ('..') is not allowed". This also fixes a latent gap surfaced during review: `cli.rs`'s check was missing the Windows-only leading-`/` guard the other two sites already had, closed by construction now that there's a single implementation instead of three to keep in sync.

## Review process

developer (investigated the richer-fix option, declined it with reasoning, applied message-accuracy fix) → parallel (tester + adversarial critic, both independently confirmed no security regression by tracing the split-condition logic at all 3 sites) → developer (extracted the shared classifier per the critic's DRY judgment call, closing the Windows gap and two test-coverage gaps the tester found) → code reviewer (one round of `changes_requested` — 4 new comments embedded issue/review-label references, violating the project's no-task-reference-in-comments convention — fixed, then approved).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11935 passed, 0 failed
- [x] `cargo test --doc -p zeph-common` — all pass, including the new `classify_relative_path` doctest
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] New unit tests: 8 on the classifier itself (`path_guard.rs`, including one pinning the Windows leading-slash regression), plus direct call-site tests at all 3 sites confirming correct message wiring (`agent_access_impl.rs` previously had zero coverage of `load_image`; `cli.rs` previously never asserted the printed message text — both closed via a pure `image_path_rejection_message` extraction for testability)
- [x] Traversal protection confirmed not weakened at any of the 3 sites — same rejection set as before, message text only
- [x] Live-testing playbook and coverage-status updated in `.local/testing/` (main repo) per project convention