### PR TITLE
fix(scheduler,orchestration,subagent): gate remaining :memory: test-pool sites behind sqlite-only cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the CLI, ACP, and daemon entry points, all calling a new shared
   `agent_setup::build_base_executor_chain` helper so the test chain cannot drift from
   the production wiring it is meant to guard. Closes #5578.
+- `fix(scheduler,orchestration,subagent)`: four remaining test-only `:memory:` pool sites
+  that `#5603`/PR `#5607` didn't cover still opened a real connection pool without gating
+  on the postgres-priority dual-backend cfg model, so `--features postgres` routed
+  `:memory:` into `connect_postgres` and failed at runtime with
+  `Configuration(RelativeUrlWithoutBase)` (a `cargo check` could not catch it — only running
+  the tests could). `zeph-scheduler`'s `store.rs` and `scheduler.rs` test modules (100% of
+  their tests depend on the shared pool) are now gated at the module level via
+  `#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]`. `zeph-orchestration`'s
+  `durable.rs` moved its three backend-dependent tests into a `with_backend` submodule gated
+  by `#[cfg(all(feature = "sqlite", not(feature = "postgres")))]`, keeping its two
+  backend-independent tests ungated. `zeph-subagent`'s single backend-dependent test gained
+  the same `#[cfg(...)]` directly on the function; since `zeph-subagent` had no `sqlite`/
+  `postgres` features of its own, the gate would otherwise never trigger, so this crate now
+  declares both features, forwarding to every dependency (`zeph-durable`, `zeph-sanitizer`,
+  `zeph-skills`, `zeph-tools`) that needs coordinated backend selection. Closes #5608.
 - `fix(db)`: fix 25 `E0308` compile errors across `zeph-core`, `zeph-tools`, and the `zeph`
   binary under `cargo check --workspace --all-targets --features postgres`. Test helpers
   hardcoded `SqlitePool`/`SqlitePoolOptions` construction where the surrounding code expects

--- a/crates/zeph-orchestration/src/durable.rs
+++ b/crates/zeph-orchestration/src/durable.rs
@@ -291,30 +291,8 @@ fn find_budget_snapshot(entries: Vec<zeph_durable::JournalEntry>) -> Option<Repl
 
 #[cfg(test)]
 mod tests {
-    use zeph_durable::{DurableBackendEnum, DurableConfig, JournalWriter, LocalBackend};
-
     use super::*;
     use crate::graph::GraphId;
-
-    fn test_config() -> DurableConfig {
-        DurableConfig {
-            enabled: true,
-            encrypt_payload: false,
-            journal_flush_interval_ms: 1,
-            journal_ack_timeout_ms: 1000,
-            ..DurableConfig::default()
-        }
-    }
-
-    async fn make_backend() -> (Arc<DurableBackendEnum>, JournalWriterHandle) {
-        let local = LocalBackend::open(":memory:", 1_048_576).await.unwrap();
-        local.init().await.unwrap();
-        let local = Arc::new(local);
-        let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
-        let (writer, handle) = JournalWriter::new(local, &test_config());
-        tokio::spawn(async move { writer.run().await }); // EXEMPT: test-only helper
-        (backend, handle)
-    }
 
     #[test]
     fn snapshot_serde_round_trip() {
@@ -372,49 +350,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn journal_then_restore_returns_snapshot() {
-        let (backend, writer) = make_backend().await;
-        let config = test_config();
-        let graph_id = GraphId::new();
-        let generation: u32 = 0;
-
-        let snap = ReplanBudgetSnapshot {
-            global_replan_count: 7,
-            task_replan_counts: [(TaskId(0), 3)].into(),
-            ..Default::default()
-        };
-
-        journal_budget(
-            &graph_id,
-            generation,
-            backend.clone(),
-            writer.clone(),
-            &config,
-            snap.clone(),
-        )
-        .await
-        .unwrap();
-        // flush ensures the buffered step result is persisted before we read it back.
-        writer.flush().await.unwrap();
-
-        let restored = restore_budget(&graph_id, generation, backend)
-            .await
-            .unwrap();
-        let restored = restored.expect("snapshot should be present");
-        assert_eq!(restored.global_replan_count, 7);
-        assert_eq!(*restored.task_replan_counts.get(&TaskId(0)).unwrap(), 3);
-    }
-
-    #[tokio::test]
-    async fn restore_returns_none_when_no_snapshot() {
-        let (backend, _writer) = make_backend().await;
-        let graph_id = GraphId::new();
-
-        let result = restore_budget(&graph_id, 0, backend).await.unwrap();
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
     async fn generation_counter_produces_distinct_exec_ids() {
         let graph_id = GraphId::new();
         let id0 = budget_exec_id(&graph_id, 0);
@@ -425,54 +360,128 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn restore_picks_latest_generation() {
-        let (backend, writer) = make_backend().await;
-        let config = test_config();
-        let graph_id = GraphId::new();
+    // These tests open a real `LocalBackend` pool via `:memory:`, which is SQLite-specific
+    // (mirroring `zeph-durable`'s `writer.rs`/`local.rs` test modules): under `--features postgres`
+    // `DbConfig::connect()` takes cfg-priority and routes `:memory:` into `connect_postgres`, which
+    // fails to parse it as a Postgres URL. See #5608.
+    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    mod with_backend {
+        use zeph_durable::{DurableBackendEnum, DurableConfig, JournalWriter, LocalBackend};
 
-        // First pause: global_replan_count = 1
-        let snap0 = ReplanBudgetSnapshot {
-            global_replan_count: 1,
-            ..Default::default()
-        };
-        journal_budget(
-            &graph_id,
-            0,
-            backend.clone(),
-            writer.clone(),
-            &config,
-            snap0,
-        )
-        .await
-        .unwrap();
+        use super::*;
 
-        // Second pause (after resume): global_replan_count = 2
-        let snap1 = ReplanBudgetSnapshot {
-            global_replan_count: 2,
-            ..Default::default()
-        };
-        journal_budget(
-            &graph_id,
-            1,
-            backend.clone(),
-            writer.clone(),
-            &config,
-            snap1,
-        )
-        .await
-        .unwrap();
-        // flush ensures all buffered writes are persisted before reading back.
-        writer.flush().await.unwrap();
+        fn test_config() -> DurableConfig {
+            DurableConfig {
+                enabled: true,
+                encrypt_payload: false,
+                journal_flush_interval_ms: 1,
+                journal_ack_timeout_ms: 1000,
+                ..DurableConfig::default()
+            }
+        }
 
-        // restore_budget with generation=1 should return snap1
-        let restored = restore_budget(&graph_id, 1, backend)
+        async fn make_backend() -> (Arc<DurableBackendEnum>, JournalWriterHandle) {
+            let local = LocalBackend::open(":memory:", 1_048_576).await.unwrap();
+            local.init().await.unwrap();
+            let local = Arc::new(local);
+            let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
+            let (writer, handle) = JournalWriter::new(local, &test_config());
+            tokio::spawn(async move { writer.run().await }); // EXEMPT: test-only helper
+            (backend, handle)
+        }
+
+        #[tokio::test]
+        async fn journal_then_restore_returns_snapshot() {
+            let (backend, writer) = make_backend().await;
+            let config = test_config();
+            let graph_id = GraphId::new();
+            let generation: u32 = 0;
+
+            let snap = ReplanBudgetSnapshot {
+                global_replan_count: 7,
+                task_replan_counts: [(TaskId(0), 3)].into(),
+                ..Default::default()
+            };
+
+            journal_budget(
+                &graph_id,
+                generation,
+                backend.clone(),
+                writer.clone(),
+                &config,
+                snap.clone(),
+            )
             .await
-            .unwrap()
-            .expect("snapshot must be present");
-        assert_eq!(
-            restored.global_replan_count, 2,
-            "restore should pick the latest generation"
-        );
+            .unwrap();
+            // flush ensures the buffered step result is persisted before we read it back.
+            writer.flush().await.unwrap();
+
+            let restored = restore_budget(&graph_id, generation, backend)
+                .await
+                .unwrap();
+            let restored = restored.expect("snapshot should be present");
+            assert_eq!(restored.global_replan_count, 7);
+            assert_eq!(*restored.task_replan_counts.get(&TaskId(0)).unwrap(), 3);
+        }
+
+        #[tokio::test]
+        async fn restore_returns_none_when_no_snapshot() {
+            let (backend, _writer) = make_backend().await;
+            let graph_id = GraphId::new();
+
+            let result = restore_budget(&graph_id, 0, backend).await.unwrap();
+            assert!(result.is_none());
+        }
+
+        #[tokio::test]
+        async fn restore_picks_latest_generation() {
+            let (backend, writer) = make_backend().await;
+            let config = test_config();
+            let graph_id = GraphId::new();
+
+            // First pause: global_replan_count = 1
+            let snap0 = ReplanBudgetSnapshot {
+                global_replan_count: 1,
+                ..Default::default()
+            };
+            journal_budget(
+                &graph_id,
+                0,
+                backend.clone(),
+                writer.clone(),
+                &config,
+                snap0,
+            )
+            .await
+            .unwrap();
+
+            // Second pause (after resume): global_replan_count = 2
+            let snap1 = ReplanBudgetSnapshot {
+                global_replan_count: 2,
+                ..Default::default()
+            };
+            journal_budget(
+                &graph_id,
+                1,
+                backend.clone(),
+                writer.clone(),
+                &config,
+                snap1,
+            )
+            .await
+            .unwrap();
+            // flush ensures all buffered writes are persisted before reading back.
+            writer.flush().await.unwrap();
+
+            // restore_budget with generation=1 should return snap1
+            let restored = restore_budget(&graph_id, 1, backend)
+                .await
+                .unwrap()
+                .expect("snapshot must be present");
+            assert_eq!(
+                restored.global_replan_count, 2,
+                "restore should pick the latest generation"
+            );
+        }
     }
 }

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -964,7 +964,10 @@ impl Scheduler {
     }
 }
 
-#[cfg(test)]
+// Every test in this module opens a real connection pool via the `:memory:` sentinel, which is
+// SQLite-specific: under `--features postgres`, `DbConfig::connect()` takes cfg-priority and routes
+// `:memory:` into `connect_postgres`, which fails to parse it as a Postgres URL. See #5608.
+#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
 mod tests {
     use std::pin::Pin;
     use std::sync::Arc;

--- a/crates/zeph-scheduler/src/store.rs
+++ b/crates/zeph-scheduler/src/store.rs
@@ -468,7 +468,10 @@ impl JobStore {
     }
 }
 
-#[cfg(test)]
+// Every test in this module opens a real connection pool via the `:memory:` sentinel, which is
+// SQLite-specific: under `--features postgres`, `DbConfig::connect()` takes cfg-priority and routes
+// `:memory:` into `connect_postgres`, which fails to parse it as a Postgres URL. See #5608.
+#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
 mod tests {
     use super::*;
 

--- a/crates/zeph-subagent/Cargo.toml
+++ b/crates/zeph-subagent/Cargo.toml
@@ -12,6 +12,11 @@ publish.workspace = true
 description = "Subagent management: spawning, grants, transcripts, and lifecycle hooks for Zeph"
 readme = "README.md"
 
+[features]
+sqlite = ["zeph-durable/sqlite", "zeph-sanitizer/sqlite", "zeph-skills/sqlite", "zeph-tools/sqlite"]
+postgres = ["zeph-durable/postgres", "zeph-sanitizer/postgres", "zeph-skills/postgres", "zeph-tools/postgres"]
+default = ["sqlite"]
+
 [dependencies]
 dirs.workspace = true
 regex.workspace = true

--- a/crates/zeph-subagent/src/durable.rs
+++ b/crates/zeph-subagent/src/durable.rs
@@ -258,6 +258,14 @@ mod tests {
     /// 1. `make_durable_promise` returns a fresh promise + seat on first call.
     /// 2. `resolve_durable_promise` stores the payload via the seat's token.
     /// 3. `await_durable_subagent` on a resumed context returns the stored `SubagentResult`.
+    //
+    // Opens a real `LocalBackend` pool via `:memory:`, which is SQLite-specific: under
+    // `--features postgres` (reachable here through workspace-level feature unification, even
+    // though this crate has no `postgres` feature of its own — zeph-scheduler/zeph-orchestration's
+    // `postgres` features enable `zeph-db/postgres` directly), `DbConfig::connect()` takes
+    // cfg-priority and routes `:memory:` into `connect_postgres`, which fails to parse it as a
+    // Postgres URL. See #5608.
+    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
     #[tokio::test]
     async fn durable_promise_resolve_and_await_roundtrip() {
         use std::sync::Arc;


### PR DESCRIPTION
## Summary

- `DbConfig::connect()` gives Postgres cfg-priority, so the `:memory:` sentinel used by test-only pool/backend helpers gets routed into `connect_postgres` under `--features postgres` and fails at runtime with `Configuration(RelativeUrlWithoutBase)`.
- Follow-up to #5603/PR #5607, covering the 4 sites outside that fix's scope: `zeph-scheduler`'s own `test_pool()` helpers in `store.rs`/`scheduler.rs`, and the `LocalBackend::open(":memory:", ...)` sites in `zeph-orchestration/durable.rs` and `zeph-subagent/durable.rs`.
- `zeph-subagent` had no `sqlite`/`postgres` features of its own, which would have made its new cfg-gate a permanent no-op; added feature forwarding to `zeph-durable`, `zeph-sanitizer`, `zeph-skills`, and `zeph-tools` so the gate is meaningful.

Closes #5608

## Verification

- `cargo nextest run -p zeph-scheduler -p zeph-subagent --features postgres` — 471 passed, 0 failed (clean, no exclusion filters needed post-rebase onto merged #5607)
- `cargo nextest run -p zeph-scheduler -p zeph-orchestration -p zeph-subagent --lib --bins` (default sqlite) — 914 passed, 0 failed
- `cargo check --workspace --all-targets --features postgres` (actual CI gate) — passes
- `cargo +nightly fmt --check` — clean
- `cargo clippy --profile ci -p zeph-scheduler -p zeph-subagent --all-targets --features postgres -- -D warnings` — clean
- `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-scheduler -p zeph-orchestration -p zeph-subagent --all-features` — clean

## Known, out-of-scope items (not addressed here)

- `crates/zeph-orchestration/src/plan_cache.rs:618` has another ungated `SqliteStore::new(":memory:")` test-pool site (~10 tests, different construction path, never run under `--features postgres` in CI) — worth tracking separately, defensibly outside this issue's 4-site scope.
- `cargo check -p zeph-orchestration --features postgres --tests` hits a pre-existing, unrelated `E0271` compile error originating entirely in `crates/zeph-memory/src/store/skills.rs` (partial feature-forwarding gap, not touched by this diff) — belongs to #5571's territory, not fixable here without touching `DbConfig::connect()`/zeph-db routing.
- CI only `cargo check`s these 3 crates under `--features postgres`; it never runs their unit tests under that feature set, so this fix's runtime correctness isn't CI-guarded against future regression.

## Test plan

- [x] `cargo nextest run` for the 3 touched crates under both default (sqlite) and `--features postgres`
- [x] fmt/clippy/rustdoc gates on touched crates
- [x] Full workspace `cargo check --features postgres` (CI-matching)