### PR TITLE
fix(memory): surface folded-message count in live /compact command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(core)`: the `/compact` command's response now reports the actual number of messages
+  folded into the summary (e.g. "Context compacted: 6 message(s) folded into summary.")
+  instead of the generic "Context compacted successfully." string. `CompactionOutcome::
+  Compacted`/`CompactedWithPersistError` (`zeph-agent-context`) now carry a `compacted_count`
+  field sourced from the same counter already used for the `compacted_count` debug log line,
+  and `Agent::compact_context_command` surfaces it to the caller. Note: `MemoryFacade::
+  compact()` in `zeph-memory` (fixed by #5568/#5533) remains unwired scaffolding for a future
+  `Arc<dyn MemoryFacade>` migration (see `crates/zeph-memory/src/facade.rs` module docs) — it
+  is not the code path this command uses; #5533/#5568 fixed the message-count logic of that
+  dormant path only, not the live `/compact` command, which this change addresses separately.
+  Closes #5572.
 - `fix(tools)`: `TrustGateExecutor`'s `Supervised`-mode confirmation check no longer
   blanket-skips every tool without an explicit policy rule. The prior condition treated
   "no rule configured" as license to bypass confirmation, which silently let

--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -477,12 +477,16 @@ pub enum CompactionOutcome {
     Compacted {
         /// Optional Qdrant write future to dispatch via the supervisor.
         qdrant_future: Option<QdrantPersistFuture>,
+        /// Number of messages folded into the summary.
+        compacted_count: usize,
     },
     /// Messages were drained and replaced with a summary, but synchronous `SQLite` persistence
     /// reported failure. The in-memory state is correct; only persistence failed.
     CompactedWithPersistError {
         /// Optional Qdrant write future to dispatch via the supervisor.
         qdrant_future: Option<QdrantPersistFuture>,
+        /// Number of messages folded into the summary.
+        compacted_count: usize,
     },
     /// Probe rejected the summary — original messages are preserved.
     /// Caller must NOT check `freed_tokens` or transition to `Exhausted`.
@@ -510,13 +514,21 @@ impl PartialEq for CompactionOutcome {
 impl std::fmt::Debug for CompactionOutcome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Compacted { qdrant_future } => f
+            Self::Compacted {
+                qdrant_future,
+                compacted_count,
+            } => f
                 .debug_struct("Compacted")
                 .field("qdrant_future", &qdrant_future.as_ref().map(|_| "<future>"))
+                .field("compacted_count", compacted_count)
                 .finish(),
-            Self::CompactedWithPersistError { qdrant_future } => f
+            Self::CompactedWithPersistError {
+                qdrant_future,
+                compacted_count,
+            } => f
                 .debug_struct("CompactedWithPersistError")
                 .field("qdrant_future", &qdrant_future.as_ref().map(|_| "<future>"))
+                .field("compacted_count", compacted_count)
                 .finish(),
             Self::ProbeRejected => write!(f, "ProbeRejected"),
             Self::NoChange => write!(f, "NoChange"),
@@ -532,8 +544,8 @@ impl CompactionOutcome {
     /// future through `BackgroundSupervisor::spawn_summarization`.
     pub fn qdrant_future_take(&mut self) -> Option<QdrantPersistFuture> {
         match self {
-            Self::Compacted { qdrant_future }
-            | Self::CompactedWithPersistError { qdrant_future } => qdrant_future.take(),
+            Self::Compacted { qdrant_future, .. }
+            | Self::CompactedWithPersistError { qdrant_future, .. } => qdrant_future.take(),
             _ => None,
         }
     }
@@ -545,6 +557,21 @@ impl CompactionOutcome {
             self,
             Self::Compacted { .. } | Self::CompactedWithPersistError { .. }
         )
+    }
+
+    /// Returns the number of messages folded into the summary, or `None` when no
+    /// compaction occurred (`ProbeRejected` / `NoChange`).
+    #[must_use]
+    pub fn compacted_count(&self) -> Option<usize> {
+        match self {
+            Self::Compacted {
+                compacted_count, ..
+            }
+            | Self::CompactedWithPersistError {
+                compacted_count, ..
+            } => Some(*compacted_count),
+            _ => None,
+        }
     }
 }
 

--- a/crates/zeph-agent-context/src/summarization/compaction.rs
+++ b/crates/zeph-agent-context/src/summarization/compaction.rs
@@ -220,9 +220,15 @@ pub(crate) async fn compact_context(
     }
 
     if persist_failed {
-        Ok(CompactionOutcome::CompactedWithPersistError { qdrant_future })
+        Ok(CompactionOutcome::CompactedWithPersistError {
+            qdrant_future,
+            compacted_count,
+        })
     } else {
-        Ok(CompactionOutcome::Compacted { qdrant_future })
+        Ok(CompactionOutcome::Compacted {
+            qdrant_future,
+            compacted_count,
+        })
     }
 }
 

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -68,23 +68,29 @@ impl<C: Channel> Agent<C> {
         if self.msg.messages.len() <= self.context_manager.compaction_preserve_tail + 1 {
             return Ok("Nothing to compact.".to_owned());
         }
-        match self
+        let outcome = self
             .compact_context()
             .await
-            .map_err(|e| zeph_commands::CommandError::new(e.to_string()))?
-        {
-            CompactionOutcome::Compacted { .. } | CompactionOutcome::NoChange => {
-                Ok("Context compacted successfully.".to_owned())
-            }
-            CompactionOutcome::CompactedWithPersistError { .. } => {
-                Ok("Context compacted, but persistence to storage failed (see logs).".to_owned())
-            }
+            .map_err(|e| zeph_commands::CommandError::new(e.to_string()))?;
+        match outcome {
+            CompactionOutcome::Compacted {
+                compacted_count, ..
+            } => Ok(format!(
+                "Context compacted: {compacted_count} message(s) folded into summary."
+            )),
+            CompactionOutcome::CompactedWithPersistError {
+                compacted_count, ..
+            } => Ok(format!(
+                "Context compacted: {compacted_count} message(s) folded into summary, \
+                 but persistence to storage failed (see logs)."
+            )),
             CompactionOutcome::ProbeRejected => {
                 Ok("Compaction rejected: summary quality below threshold. \
                  Original context preserved."
                     .to_owned())
             }
-            _ => Ok("Context compacted successfully.".to_owned()),
+            // `NoChange` and any future non-exhaustive variant share the generic message.
+            CompactionOutcome::NoChange | _ => Ok("Context compacted successfully.".to_owned()),
         }
     }
 

--- a/crates/zeph-core/src/agent/tests/compaction_e2e.rs
+++ b/crates/zeph-core/src/agent/tests/compaction_e2e.rs
@@ -50,6 +50,58 @@ async fn agent_recovers_from_context_length_exceeded_and_produces_response() {
     );
 }
 
+/// Regression test for #5572: the `/compact` command's user-facing response must surface
+/// the actual number of messages folded into the summary rather than the generic
+/// "Context compacted successfully." string, so the fix landed for #5533/#5568 (which made
+/// `MemoryFacade::compact`'s `messages_compacted` count correct) is also observable through
+/// the live `/compact` command path, not just in dormant `zeph-memory` scaffolding.
+#[tokio::test]
+async fn compact_context_command_reports_folded_message_count() {
+    // 11 messages total (1 seeded system prompt + 10 pushed) minus preserve_tail (4) leaves
+    // a compact_end of 7; to_compact = messages[1..7] (system message at index 0 is never
+    // compacted) = 6 messages. Assert the exact count, not just "some digit" — a regression
+    // to the total message count (11 or 10) instead of the folded subset must fail this test,
+    // matching the rigor of zeph-memory's
+    // `compact_reports_actual_messages_folded_not_total_message_count`.
+    const TOTAL_SEEDED_MESSAGES: usize = 10;
+    const EXPECTED_FOLDED_COUNT: usize = 6;
+    // Compile-time sanity check: the folded count fixture must be a strict subset of seeded
+    // messages, otherwise this test cannot distinguish "folded subset" from "total message
+    // count".
+    const { assert!(EXPECTED_FOLDED_COUNT < TOTAL_SEEDED_MESSAGES) };
+
+    let provider = mock_provider(vec!["summary text".into()]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_context_budget(200_000, 0.20, 0.80, 4, 0);
+
+    // Seed enough messages to exceed compaction_preserve_tail (4) + 1.
+    for i in 0..TOTAL_SEEDED_MESSAGES {
+        let role = if i % 2 == 0 {
+            Role::User
+        } else {
+            Role::Assistant
+        };
+        agent.msg.messages.push(Message {
+            role,
+            content: format!("message {i}"),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        });
+    }
+
+    let result = agent.compact_context_command().await.unwrap();
+
+    assert_eq!(
+        result,
+        format!("Context compacted: {EXPECTED_FOLDED_COUNT} message(s) folded into summary."),
+        "response must report the exact number of messages folded into the summary; got: {result}"
+    );
+}
+
 /// E2E test: spawn sub-agent in background, verify it runs and produces output.
 ///
 /// Scope: spawn → text response → collect (`MockProvider` only supports text responses).


### PR DESCRIPTION
## Summary

- PR #5568 fixed `MemoryFacade::compact()`'s message-count logic (`crates/zeph-memory/src/facade.rs`), but that type has zero production callers — the real `/compact` command uses a completely separate path (`Agent::compact_context_command()` -> `compact_context()`) that carried no message count at all, only a generic "Context compacted successfully." string.
- Surfaces the existing `compacted_count` counter (previously only visible in a debug log line) through the public `CompactionOutcome` enum so the live `/compact` command, shared across CLI/TUI/Telegram, now reports the actual number of messages folded into the summary.
- `MemoryFacade::compact` remains intentionally dormant Phase-1 scaffolding per its module docs; no Phase-2 migration spec exists yet in `/specs/`, so this PR does not force-wire it into the live path. CHANGELOG.md documents this scoping explicitly.

Closes #5572

## Test plan

- [x] Regression test `compact_context_command_reports_folded_message_count` (`crates/zeph-core/src/agent/tests/compaction_e2e.rs`) asserts the exact folded-message count via `assert_eq!`, not just presence of a digit — verified the live `/compact` path is exercised end-to-end (not a dormant-path shortcut), traced through `CompactCommand::handle` -> `AgentAccess::compact_context` -> `Agent::compact_context_command()`.
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11946 passed, 34 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing warnings only in unrelated crates)