### PR TITLE
fix(ci): widen nextest leak-timeout for zeph-index spawn_blocking tests

### DIFF
--- a/.github/nextest.toml
+++ b/.github/nextest.toml
@@ -7,6 +7,13 @@
 # Integration tests are in separate test binaries (tests/*_integration.rs)
 # and can be run explicitly with --test flag or using the ci profile
 
+[[profile.default.overrides]]
+# tokio::task::spawn_blocking worker-thread teardown can outlast the default
+# leak-timeout under load even though the handle is joined before the test
+# returns (false-positive LEAK, see #5425).
+filter = 'package(zeph-index) & (test(index_file_spawn_blocking_dedup_path) | test(index_file_with_blocking_spawner))'
+leak-timeout = "1s"
+
 [profile.ci]
 # CI profile that runs ALL tests including integration tests
 # Override with: cargo nextest run --profile ci
@@ -51,6 +58,13 @@ test-threads = 8
 # Warn (but don't fail) if any test exceeds 30s — surfaces slow tests early.
 filter = "all()"
 slow-timeout = { period = "30s" }
+
+[[profile.ci-partition.overrides]]
+# tokio::task::spawn_blocking worker-thread teardown can outlast the default
+# leak-timeout under load even though the handle is joined before the test
+# returns (false-positive LEAK, see #5425).
+filter = 'package(zeph-index) & (test(index_file_spawn_blocking_dedup_path) | test(index_file_with_blocking_spawner))'
+leak-timeout = "1s"
 
 [profile.ci-partition.junit]
 path = "target/nextest/ci/junit.xml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(ci)`: nextest flagged `zeph-index`'s `index_file_spawn_blocking_dedup_path` and
+  `index_file_with_blocking_spawner` tests as `LEAK`. Both tests join their
+  `tokio::task::spawn_blocking` handle before returning, but the `#[tokio::test]`
+  runtime's drop can wait on the blocking-pool worker thread's OS-level teardown
+  longer than nextest's default leak-timeout under load — a false positive, not an
+  orphaned resource. Added a `leak-timeout = "1s"` override for these two tests in
+  `.github/nextest.toml`, mirrored across the `default` and `ci-partition` profiles.
+  Closes #5425.
 - `fix(tools)`: `TrustGateExecutor`'s `Supervised`-mode confirmation check no longer
   blanket-skips every tool without an explicit policy rule. The prior condition treated
   "no rule configured" as license to bypass confirmation, which silently let


### PR DESCRIPTION
## Summary
- nextest flagged `zeph-index`'s `index_file_spawn_blocking_dedup_path` and `index_file_with_blocking_spawner` tests as `LEAK` during a CI regression pass. Root cause: both tests properly join their `tokio::task::spawn_blocking` handle before returning, but the `#[tokio::test]`-generated runtime's drop can wait on worker-thread teardown (either the spawn_blocking pool or the `:memory:` sqlx-sqlite `ConnectionWorker` thread — both are plausible, teardown-timing-sensitive candidates) longer than nextest's default ~100ms leak-timeout under load, producing a false positive rather than a real orphaned resource.
- Added a `leak-timeout = "1s"` override in `.github/nextest.toml`, scoped to exactly these two tests via `package(zeph-index) & (test(...) | test(...))`, mirrored under `[profile.default.overrides]` and `[profile.ci-partition.overrides]` (the profile CI's partitioned unit-test matrix actually uses).
- No Rust source changed — this is a test-infra tuning fix, not a code defect fix.

## Test plan
- [x] `cargo nextest list` confirms the override filter matches exactly the two intended tests, no over/under-match
- [x] Both tests pass with no `LEAK` on `default` and `ci-partition` profiles
- [x] Full workspace suite (`--features desktop,ide,server,chat,pdf,scheduler --lib --bins`) passes cleanly, matching the pre-change pass count
- [x] `cargo +nightly fmt --check`, `cargo clippy --profile ci` (CI feature set), rustdoc gate all clean
- [x] Independent re-review confirmed the fix scope and re-ran the targeted + full-workspace suites

## Follow-up
During validation, an unrelated plain synchronous test (`zeph-tui app::tests::q_quits_in_normal_mode`, no tokio involved) was also observed flagged `LEAK` in a full-workspace run, and reproduced again independently during review. This indicates nextest's leak-timeout false-positive is a broader, workspace-wide flakiness class under load, not limited to the `spawn_blocking` pattern fixed here. Will file a separate low-priority follow-up issue to track it.

Closes #5425