### PR TITLE
perf(memory): batch entity-name resolution in graph_recall_beam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   is not the code path this command uses; #5533/#5568 fixed the message-count logic of that
   dormant path only, not the live `/compact` command, which this change addresses separately.
   Closes #5572.
+- `perf(memory)`: `graph_recall_beam` resolved neighbour entity names via a sequential
+  per-id `find_entity_by_id` query on every hop of the beam search, an N+1 pattern on
+  the hot graph-recall path. Added `GraphStore::resolve_entity_names`, a single batched
+  `WHERE id IN (...)` query (chunked for the `SQLite` bind limit), and call it once per
+  hop instead. Traversal/pruning semantics of the beam are unchanged. Closes #5545.
 - `fix(tools)`: `TrustGateExecutor`'s `Supervised`-mode confirmation check no longer
   blanket-skips every tool without an explicit policy rule. The prior condition treated
   "no rule configured" as license to bypass confirmation, which silently let

--- a/crates/zeph-memory/src/graph/retrieval_beam.rs
+++ b/crates/zeph-memory/src/graph/retrieval_beam.rs
@@ -91,7 +91,7 @@ pub async fn graph_recall_beam(
             break;
         }
 
-        // Collect entity IDs from edges to resolve names.
+        // Collect entity IDs from edges and resolve their names in a single batched query.
         let new_entity_ids: Vec<i64> = edges
             .iter()
             .flat_map(|e| [e.source_entity_id, e.target_entity_id])
@@ -100,10 +100,8 @@ pub async fn graph_recall_beam(
             .into_iter()
             .collect();
 
-        for id in new_entity_ids {
-            if let Ok(Some(entity)) = store.find_entity_by_id(id).await {
-                entity_name_map.insert(id, entity.canonical_name.clone());
-            }
+        if !new_entity_ids.is_empty() {
+            entity_name_map.extend(store.resolve_entity_names(&new_entity_ids).await?);
         }
 
         // Score each neighbour by edge confidence (proxy for traversal quality).
@@ -306,5 +304,74 @@ mod tests {
         .await
         .unwrap();
         assert!(!result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn beam_resolves_names_for_converging_edges_in_same_hop() {
+        // A -> B, A -> C at hop 1; B -> D and C -> D at hop 2, so D is referenced by two
+        // edges within the same hop. The batched name resolution must still produce a
+        // single correct name for D (no double-fetch, no wrong/missing data).
+        let store = setup_store().await;
+        let a = store
+            .upsert_entity("Alice", "alice", EntityType::Person, None, None)
+            .await
+            .unwrap()
+            .0;
+        let b = store
+            .upsert_entity("Bob", "bob", EntityType::Person, None, None)
+            .await
+            .unwrap()
+            .0;
+        let c = store
+            .upsert_entity("Carol", "carol", EntityType::Person, None, None)
+            .await
+            .unwrap()
+            .0;
+        let d = store
+            .upsert_entity("Dave", "dave", EntityType::Person, None, None)
+            .await
+            .unwrap()
+            .0;
+        store
+            .insert_edge(a, b, "knows", "Alice knows Bob", 0.9, None, None)
+            .await
+            .unwrap();
+        store
+            .insert_edge(a, c, "knows", "Alice knows Carol", 0.8, None, None)
+            .await
+            .unwrap();
+        store
+            .insert_edge(b, d, "knows", "Bob knows Dave", 0.9, None, None)
+            .await
+            .unwrap();
+        store
+            .insert_edge(c, d, "knows", "Carol knows Dave", 0.9, None, None)
+            .await
+            .unwrap();
+
+        let provider = mock_provider();
+        let result = graph_recall_beam(
+            &store,
+            None,
+            &provider,
+            "Alice",
+            10,
+            2,
+            2,
+            &[],
+            0.0,
+            false,
+            0.0,
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        let dave_facts: Vec<_> = result.iter().filter(|f| f.target_name == "dave").collect();
+        assert_eq!(dave_facts.len(), 2, "both edges into Dave must resolve");
+        for fact in &dave_facts {
+            assert!(!fact.entity_name.is_empty());
+            assert_eq!(fact.target_name, "dave");
+        }
     }
 }

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -172,6 +172,42 @@ impl GraphStore {
         row.map(entity_from_row).transpose()
     }
 
+    /// Resolve entity IDs to their canonical names in a single batched query.
+    ///
+    /// Ids with no matching row are silently omitted from the result map. Requests are
+    /// chunked at 490 ids to stay under the `SQLite` bind-parameter limit, mirroring the
+    /// chunking used by [`Self::entity_ids_in`] and [`Self::qdrant_point_ids_for_entities`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    #[tracing::instrument(name = "memory.graph.store.resolve_entity_names", skip_all, fields(count = ids.len()))]
+    pub async fn resolve_entity_names(
+        &self,
+        ids: &[i64],
+    ) -> Result<HashMap<i64, String>, MemoryError> {
+        const MAX_BATCH: usize = 490;
+        let mut result: HashMap<i64, String> = HashMap::with_capacity(ids.len());
+        if ids.is_empty() {
+            return Ok(result);
+        }
+        for chunk in ids.chunks(MAX_BATCH) {
+            let placeholders = placeholder_list(1, chunk.len());
+            let sql = format!(
+                "SELECT id, canonical_name FROM graph_entities WHERE id IN ({placeholders})"
+            );
+            let mut q = zeph_db::query_as::<_, (i64, String)>(sqlx::AssertSqlSafe(sql));
+            for id in chunk {
+                q = q.bind(*id);
+            }
+            let rows: Vec<(i64, String)> = q.fetch_all(&self.pool).await?;
+            for (id, name) in rows {
+                result.insert(id, name);
+            }
+        }
+        Ok(result)
+    }
+
     /// Update the `qdrant_point_id` for an entity.
     ///
     /// # Errors

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -790,6 +790,73 @@ async fn find_entity_by_id_not_found() {
 }
 
 #[tokio::test]
+async fn resolve_entity_names_matches_sequential_find_by_id() {
+    let gs = setup().await;
+    let a = gs
+        .upsert_entity("Alice", "alice", EntityType::Person, None, None)
+        .await
+        .unwrap()
+        .0;
+    let b = gs
+        .upsert_entity("Bob", "bob", EntityType::Person, None, None)
+        .await
+        .unwrap()
+        .0;
+    let c = gs
+        .upsert_entity("Carol", "carol", EntityType::Person, None, None)
+        .await
+        .unwrap()
+        .0;
+
+    let batched = gs.resolve_entity_names(&[a, b, c]).await.unwrap();
+
+    let mut expected = HashMap::new();
+    for id in [a, b, c] {
+        let entity = gs.find_entity_by_id(id).await.unwrap().unwrap();
+        expected.insert(id, entity.canonical_name);
+    }
+    assert_eq!(batched, expected);
+}
+
+#[tokio::test]
+async fn resolve_entity_names_dedupes_repeated_ids() {
+    let gs = setup().await;
+    let a = gs
+        .upsert_entity("Alice", "alice", EntityType::Person, None, None)
+        .await
+        .unwrap()
+        .0;
+
+    // Same id referenced multiple times (as source and target of different edges) must
+    // resolve to a single, correct entry rather than erroring or duplicating rows.
+    let result = gs.resolve_entity_names(&[a, a, a]).await.unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.get(&a).map(String::as_str), Some("alice"));
+}
+
+#[tokio::test]
+async fn resolve_entity_names_omits_unresolvable_ids() {
+    let gs = setup().await;
+    let a = gs
+        .upsert_entity("Alice", "alice", EntityType::Person, None, None)
+        .await
+        .unwrap()
+        .0;
+
+    let result = gs.resolve_entity_names(&[a, 999_999]).await.unwrap();
+    assert_eq!(result.len(), 1);
+    assert!(result.contains_key(&a));
+    assert!(!result.contains_key(&999_999));
+}
+
+#[tokio::test]
+async fn resolve_entity_names_empty_input_is_noop() {
+    let gs = setup().await;
+    let result = gs.resolve_entity_names(&[]).await.unwrap();
+    assert!(result.is_empty());
+}
+
+#[tokio::test]
 async fn set_entity_qdrant_point_id_updates() {
     let gs = setup().await;
     let id = gs


### PR DESCRIPTION
## Summary

Closes #5545. `graph_recall_beam` resolved neighbour entity names via a sequential per-id `find_entity_by_id` query on every hop of the beam search — an N+1 pattern on the hot graph-recall path (every memory query using the beam strategy). For a representative 3-hop beam search with ~10 distinct new entities per hop (default `beam_width=10`), this was ~30 sequential DB queries.

Adds `GraphStore::resolve_entity_names`, a single batched `WHERE id IN (...)` query (chunked at 490 ids for SQLite's bind-parameter limit, generalizing a pattern already inline-duplicated in `bfs_fetch_results` and a structural-neighbor lookup block), called once per hop instead of once per entity — reducing the same scenario to ~3 queries, a ~10x reduction.

**Investigated and declined** switching to the sibling `retrieval_watercircles.rs` strategy's `bfs_with_depth`/`bfs_typed` pattern: beam search traverses a pruned, dynamically-converging frontier across the current beam's members (which may trace back to different original seeds), not a fixed-depth BFS from a single seed. Adopting `bfs_with_depth` would have changed which edges are considered at each hop, not just how names resolve — a correctness risk, not just a stylistic difference. This fix touches only entity-name resolution; `edges_for_entities` and all pruning/scoring logic are byte-for-byte unchanged.

**Behavior note**: a database error during name resolution now propagates via `?` instead of being silently swallowed per-entity (the old code was `if let Ok(Some(entity)) = ... { }`, which just dropped that entity's name on any error). This aborts the whole call on a DB error rather than continuing with a silently incomplete name map. Verified this is a safe, intentional consistency fix, not a regression: `edges_for_entities` in the same function already propagates errors via `?` on every hop, so beam search already aborted on a DB hiccup before this change — this just makes name resolution consistent with that. It also brings beam in line with 3 of the other 4 graph-retrieval strategies (Bfs/AStar/WaterCircles already propagate); beam and Synapse were the only two that silently swallowed name-resolution errors.

## Review process

developer (investigated the traversal-semantics risk before choosing a fix approach) → parallel (performance engineer verified the real ~10x query-count reduction and zero traversal-behavior change; tester confirmed no regression and traced the error-handling change through every caller; adversarial critic independently re-verified the traversal judgment call and did the deepest trace of the error-handling change across all 6 graph-retrieval strategy branches) → code reviewer (one non-code finding: CHANGELOG commit type corrected from `fix(memory)` to `perf(memory)` to match this project's convention for pure query-count optimizations with no prior incorrect behavior, per 5 existing `perf(scope):` precedents).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11950 passed, 0 failed
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] 5 new tests: 4 store-level (`resolve_entity_names_matches_sequential_find_by_id`, `_dedupes_repeated_ids`, `_omits_unresolvable_ids`, `_empty_input_is_noop`) proving equivalence to the old N-sequential-lookup behavior, plus 1 beam-level integration test confirming correct name resolution when two edges converge on the same entity within a single hop
- [x] Query-count reduction independently verified with concrete before/after numbers for a representative scenario (~30 queries → ~3 queries for a 3-hop/10-entities-per-hop beam search)
- [x] Traversal/pruning semantics confirmed byte-for-byte unchanged (only the entity-name-resolution lines were touched)
- [x] Live-testing playbook and coverage-status updated in `.local/testing/` (main repo) per project convention