### PR TITLE
refactor(memory): extract duplicated dedup helpers in skills/recall paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -694,6 +694,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(memory)`: `store/skills.rs`'s deactivate-old/activate-new skill-version-switch
+  SQL pair was copy-pasted across `save_and_activate_skill_version`, `activate_skill_version`,
+  and `ensure_skill_version_exists`. Extracted into a shared `switch_active_skill_version`
+  transaction helper. Closes #5496.
+- `refactor(memory)`: `semantic/recall.rs`'s `MemoryRoute` dispatch match was duplicated
+  between `recall_routed` and `recall_routed_async`, and had already drifted — the async
+  path was missing the Episodic arm's debug trace. Extracted into a shared `recall_by_route`
+  helper and unified the trace onto both paths. Closes #5495.
 - `refactor(orchestration)`: `dag::propagate_failure`'s trailing wildcard match arm on
   `FailureStrategy` no longer silently falls back to `Abort`-equivalent behavior with no signal.
   The wildcard arm is required for compilation because `FailureStrategy` is `#[non_exhaustive]`

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -1299,38 +1299,30 @@ impl SemanticMemory {
         );
     }
 
-    /// Recall messages using query-aware routing.
-    ///
-    /// Delegates to FTS5-only, vector-only, or hybrid search based on the router decision,
-    /// then runs the shared merge and ranking pipeline.
-    ///
-    /// * `goal_entity_id` — optional goal entity for causal distance scoring; when `None`, the
-    ///   causal distance signal contribution is zero (FR-006).
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any underlying search or database operation fails.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "memory.recall", skip_all, fields(query_len = %query.len(), result_count = tracing::field::Empty))
-    )]
-    pub async fn recall_routed(
+    /// Routed search stage: dispatch to keyword-only, vector-only, or hybrid retrieval
+    /// per `route`, returning the raw `(keyword, vector)` pair for the shared
+    /// merge-and-rank pipeline. Shared by [`Self::recall_routed`] and
+    /// [`Self::recall_routed_async`] — those differ only in how `route` is obtained
+    /// (sync `MemoryRouter::route` vs async `AsyncMemoryRouter::route_async`).
+    async fn recall_by_route(
         &self,
+        route: crate::router::MemoryRoute,
         query: &str,
         limit: usize,
-        filter: Option<SearchFilter>,
-        router: &dyn crate::router::MemoryRouter,
-        goal_entity_id: Option<i64>,
-    ) -> Result<Vec<RecalledMessage>, MemoryError> {
+        filter: Option<crate::embedding_store::SearchFilter>,
+    ) -> Result<
+        (
+            Vec<(crate::types::MessageId, f64)>,
+            Vec<crate::embedding_store::SearchResult>,
+        ),
+        MemoryError,
+    > {
         use crate::router::MemoryRoute;
-
-        let route = router.route(query);
-        tracing::debug!(?route, query_len = query.len(), "memory routing decision");
 
         let conversation_id = filter.as_ref().and_then(|f| f.conversation_id);
 
-        let (keyword_results, vector_results): (
-            Vec<(MessageId, f64)>,
+        let results: (
+            Vec<(crate::types::MessageId, f64)>,
             Vec<crate::embedding_store::SearchResult>,
         ) = match route {
             MemoryRoute::Keyword => {
@@ -1400,6 +1392,37 @@ impl SemanticMemory {
                 (Vec::new(), vr)
             }
         };
+        Ok(results)
+    }
+
+    /// Recall messages using query-aware routing.
+    ///
+    /// Delegates to FTS5-only, vector-only, or hybrid search based on the router decision,
+    /// then runs the shared merge and ranking pipeline.
+    ///
+    /// * `goal_entity_id` — optional goal entity for causal distance scoring; when `None`, the
+    ///   causal distance signal contribution is zero (FR-006).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any underlying search or database operation fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "memory.recall", skip_all, fields(query_len = %query.len(), result_count = tracing::field::Empty))
+    )]
+    pub async fn recall_routed(
+        &self,
+        query: &str,
+        limit: usize,
+        filter: Option<SearchFilter>,
+        router: &dyn crate::router::MemoryRouter,
+        goal_entity_id: Option<i64>,
+    ) -> Result<Vec<RecalledMessage>, MemoryError> {
+        let route = router.route(query);
+        tracing::debug!(?route, query_len = query.len(), "memory routing decision");
+
+        let (keyword_results, vector_results) =
+            self.recall_by_route(route, query, limit, filter).await?;
 
         tracing::debug!(
             keyword_count = keyword_results.len(),
@@ -1436,8 +1459,6 @@ impl SemanticMemory {
         router: &dyn crate::router::AsyncMemoryRouter,
         goal_entity_id: Option<i64>,
     ) -> Result<Vec<RecalledMessage>, MemoryError> {
-        use crate::router::MemoryRoute;
-
         let decision = router.route_async(query).await;
         let route = decision.route;
         tracing::debug!(
@@ -1447,63 +1468,8 @@ impl SemanticMemory {
             "memory routing decision (async)"
         );
 
-        let conversation_id = filter.as_ref().and_then(|f| f.conversation_id);
-
-        let (keyword_results, vector_results): (
-            Vec<(crate::types::MessageId, f64)>,
-            Vec<crate::embedding_store::SearchResult>,
-        ) = match route {
-            MemoryRoute::Keyword => {
-                let kw = self.recall_fts5_raw(query, limit, conversation_id).await?;
-                (kw, Vec::new())
-            }
-            MemoryRoute::Hybrid => {
-                let kw = match self.recall_fts5_raw(query, limit, conversation_id).await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::warn!("FTS5 keyword search failed: {e:#}");
-                        Vec::new()
-                    }
-                };
-                let vr = self.recall_vectors_raw(query, limit, filter).await?;
-                (kw, vr)
-            }
-            MemoryRoute::Episodic => {
-                let range = crate::router::resolve_temporal_range(query, chrono::Utc::now());
-                let cleaned = crate::router::strip_temporal_keywords(query);
-                let search_query = if cleaned.is_empty() { query } else { &cleaned };
-                let kw = if let Some(ref r) = range {
-                    self.sqlite
-                        .keyword_search_with_time_range(
-                            search_query,
-                            limit,
-                            conversation_id,
-                            r.after.as_deref(),
-                            r.before.as_deref(),
-                        )
-                        .await?
-                } else {
-                    self.recall_fts5_raw(search_query, limit, conversation_id)
-                        .await?
-                };
-                (kw, Vec::new())
-            }
-            MemoryRoute::Graph => {
-                let kw = match self.recall_fts5_raw(query, limit, conversation_id).await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::warn!("FTS5 keyword search failed (graph→hybrid fallback): {e:#}");
-                        Vec::new()
-                    }
-                };
-                let vr = self.recall_vectors_raw(query, limit, filter).await?;
-                (kw, vr)
-            }
-            _ => {
-                let vr = self.recall_vectors_raw(query, limit, filter).await?;
-                (Vec::new(), vr)
-            }
-        };
+        let (keyword_results, vector_results) =
+            self.recall_by_route(route, query, limit, filter).await?;
 
         tracing::debug!(
             keyword_count = keyword_results.len(),

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -374,19 +374,7 @@ impl SqliteStore {
         .await?;
         let id = row.0;
 
-        zeph_db::query(sql!(
-            "UPDATE skill_versions SET is_active = FALSE WHERE skill_name = ? AND is_active = TRUE"
-        ))
-        .bind(skill_name)
-        .execute(&mut *tx)
-        .await?;
-
-        zeph_db::query(sql!(
-            "UPDATE skill_versions SET is_active = TRUE WHERE id = ?"
-        ))
-        .bind(id)
-        .execute(&mut *tx)
-        .await?;
+        switch_active_skill_version(&mut tx, skill_name, id).await?;
 
         tx.commit().await?;
         Ok(id)
@@ -453,19 +441,7 @@ impl SqliteStore {
     ) -> Result<(), MemoryError> {
         let mut tx = begin_write(&self.pool).await?;
 
-        zeph_db::query(sql!(
-            "UPDATE skill_versions SET is_active = FALSE WHERE skill_name = ? AND is_active = TRUE"
-        ))
-        .bind(skill_name)
-        .execute(&mut *tx)
-        .await?;
-
-        zeph_db::query(sql!(
-            "UPDATE skill_versions SET is_active = TRUE WHERE id = ?"
-        ))
-        .bind(version_id)
-        .execute(&mut *tx)
-        .await?;
+        switch_active_skill_version(&mut tx, skill_name, version_id).await?;
 
         tx.commit().await?;
         Ok(())
@@ -551,19 +527,7 @@ impl SqliteStore {
             .await?;
             let id = row.0;
 
-            zeph_db::query(sql!(
-                "UPDATE skill_versions SET is_active = FALSE WHERE skill_name = ? AND is_active = TRUE"
-            ))
-            .bind(skill_name)
-            .execute(&mut *tx)
-            .await?;
-
-            zeph_db::query(sql!(
-                "UPDATE skill_versions SET is_active = TRUE WHERE id = ?"
-            ))
-            .bind(id)
-            .execute(&mut *tx)
-            .await?;
+            switch_active_skill_version(&mut tx, skill_name, id).await?;
         }
 
         tx.commit().await?;
@@ -1332,6 +1296,34 @@ impl SqliteStore {
         .await?;
         Ok(())
     }
+}
+
+/// Flip the active skill version within an open write transaction: clear the current
+/// active row for `skill_name`, then mark `version_id` active.
+///
+/// Both statements run on the caller's `tx` so the swap is atomic with the caller's
+/// surrounding work (insert / existence check). Shared by
+/// [`SqliteStore::save_and_activate_skill_version`], [`SqliteStore::activate_skill_version`],
+/// and [`SqliteStore::ensure_skill_version_exists`].
+async fn switch_active_skill_version(
+    tx: &mut zeph_db::DbTransaction<'_>,
+    skill_name: &str,
+    version_id: i64,
+) -> Result<(), MemoryError> {
+    zeph_db::query(sql!(
+        "UPDATE skill_versions SET is_active = FALSE WHERE skill_name = ? AND is_active = TRUE"
+    ))
+    .bind(skill_name)
+    .execute(&mut **tx)
+    .await?;
+
+    zeph_db::query(sql!(
+        "UPDATE skill_versions SET is_active = TRUE WHERE id = ?"
+    ))
+    .bind(version_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Extract `switch_active_skill_version` to replace the deactivate-old/activate-new SQL pair duplicated 3x in `crates/zeph-memory/src/store/skills.rs` (`save_and_activate_skill_version`, `activate_skill_version`, `ensure_skill_version_exists`).
- Extract `recall_by_route` to replace the `MemoryRoute` dispatch match duplicated between `recall_routed` and `recall_routed_async` in `crates/zeph-memory/src/semantic/recall.rs`, reconciling a pre-existing drift where the async path was missing the Episodic arm's debug trace (now emitted by both paths).
- Pure refactor: no public API, config, or behavior change beyond the sanctioned tracing unification. Diff confined to the two target files.

Closes #5496
Closes #5495

## Test plan

- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11945 passed, 34 skipped (two file_watcher/config_watcher failures on first run were confirmed flaky/load-sensitive on re-run in isolation and on a full `--no-fail-fast` re-run; unrelated to this diff)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`) clean
- [x] Adversarial critique confirmed both extractions are byte-for-byte behavior-preserving
- [x] Code review approved with no changes requested

## Notes

- A pre-existing test-coverage gap was identified during review: `MemoryRoute::Graph` and the entire `recall_routed_async` path have no test coverage anywhere in the workspace. This pre-dates this refactor (both original duplicated copies were equally untested) but is now more consequential since the logic is consolidated into one shared function. Filed as a separate follow-up issue per reviewer recommendation rather than bundled into this refactor PR.