### PR TITLE
fix(tools,acp): enforce quarantine trust gate across full ACP/daemon executor tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tools,acp)`: ACP (`zeph --acp`) and the daemon (`zeph serve`) gated only the base
+  tool chain (file/shell/scrape/cwd/diagnostics) behind `TrustGateExecutor`; `memory_save`,
+  MCP-sourced tools, `load_skill`/`invoke_skill`, and `search_code` were composed outside
+  that gate and never passed through trust enforcement at all. A `Quarantined` skill could
+  therefore still persist attacker-controlled content via `memory_save` or invoke any
+  MCP-sourced tool, even though the CLI (`src/runner.rs`) already blocked both. Fixed by
+  wrapping the FULLY composed executor tree — base chain, MCP, search, skill loader,
+  memory, overflow — in a single outermost `TrustGateExecutor`, matching the CLI. Extracted
+  the wrap into a shared `agent_setup::apply_common_tool_gating` helper (plus
+  `register_mcp_tool_ids`) so the CLI, ACP, and daemon entry points all gate through one
+  code path instead of three independent, divergence-prone inline constructions (partial
+  slice of #5610 — the shared helper covers trust-gate/permission-policy wiring only;
+  provider-pool wiring stays triplicated and is left for a future focused pass under the
+  same issue). **User-visible behavior change**: `memory_save`, `overflow`, and
+  `search_code` in ACP/daemon now also fall under the `Supervised`-mode `Ask` confirmation
+  default for tools with no explicit policy rule — previously they bypassed confirmation
+  entirely because no gate stood in front of them at all. This is intentional and brings
+  ACP/daemon in line with the CLI's existing, already-shipped behavior. Closes #5611.
+  Refs #5610.
 - `fix(ci)`: nextest flagged `zeph-index`'s `index_file_spawn_blocking_dedup_path` and
   `index_file_with_blocking_spawner` tests as `LEAK`. Both tests join their
   `tokio::task::spawn_blocking` handle before returning, but the `#[tokio::test]`

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -102,7 +102,13 @@ struct SharedAgentDeps {
     /// involves copying in-memory embedding vectors only for the `InMemory` variant.
     matcher: Option<zeph_skills::matcher::SkillMatcherBackend>,
     max_active_skills: usize,
+    /// Ungated base+MCP+search executor tree. Per-session state (skill loader, memory,
+    /// overflow) is composed on top in `spawn_acp_agent`, which wraps the FULL result in one
+    /// outermost `TrustGateExecutor` via `agent_setup::apply_common_tool_gating` (#5611) —
+    /// so this field must never be dispatched to directly without that wrap.
     tool_executor: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor>,
+    /// Shared permission policy, threaded into `spawn_acp_agent`'s trust gate (#5611).
+    permission_policy: zeph_tools::PermissionPolicy,
     skill_paths: Vec<PathBuf>,
     memory: std::sync::Arc<zeph_memory::semantic::SemanticMemory>,
     history_limit: u32,
@@ -422,28 +428,17 @@ async fn build_acp_deps(
         zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
     let shell_policy_handle = shell_executor.policy_handle();
     let diagnostics_executor = crate::agent_setup::build_diagnostics_executor(config);
+    // #5611: base chain stays ungated here — it is composed with mcp/search below, then the
+    // per-session skill_loader/memory/overflow layers are added on top in `spawn_acp_agent`,
+    // which wraps the FULLY composed tree in one outermost `TrustGateExecutor` (see
+    // `apply_common_tool_gating`). Gating only this sub-tree (as before #5611) let tools
+    // composed outside it (memory, MCP, skill loader) bypass Quarantine/Blocked entirely.
     let base_executor = crate::agent_setup::build_base_executor_chain(
         file_executor,
         shell_executor,
         scrape_executor,
         diagnostics_executor,
     );
-    // #5575: gate the base chain (file/shell/scrape/cwd/diagnostics) behind the same
-    // TrustGateExecutor the CLI path uses (src/runner.rs), so Supervised-mode
-    // confirmation for unconfigured, non-MCP/non-readonly tools (e.g. `diagnostics`)
-    // is enforced here too — previously this chain had no trust gate at all.
-    let base_executor =
-        zeph_tools::TrustGateExecutor::new(base_executor, permission_policy.clone());
-    // Register MCP tool IDs so TrustGateExecutor can recognize genuinely MCP-sourced
-    // tools for the Supervised-mode skip (see is_mcp_tool in trust_gate.rs) and block
-    // ALL MCP tools for Quarantined skills, mirroring runner.rs.
-    {
-        let ids: std::collections::HashSet<String> = mcp_tools
-            .iter()
-            .map(zeph_mcp::McpTool::sanitized_id)
-            .collect();
-        *base_executor.mcp_tool_ids_handle().write() = ids;
-    }
     let index_provider = crate::bootstrap::resolve_index_embed_provider(config, provider.clone());
     let tool_executor: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = {
         let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = std::sync::Arc::new(
@@ -674,6 +669,7 @@ async fn build_acp_deps(
         matcher,
         max_active_skills: config.skills.max_active_skills.get(),
         tool_executor,
+        permission_policy,
         skill_paths,
         skill_reload_tx,
         config_reload_tx,
@@ -839,6 +835,7 @@ async fn spawn_acp_agent(
     let matcher = d.matcher.clone();
     let max_active_skills = d.max_active_skills;
     let tool_executor = Arc::clone(&d.tool_executor);
+    let permission_policy = d.permission_policy.clone();
     let skill_paths = d.skill_paths.clone();
     let plugin_dirs_supplier = Arc::clone(&d.plugin_dirs_supplier);
     let memory = Arc::clone(&d.memory);
@@ -969,8 +966,18 @@ async fn spawn_acp_agent(
                     ),
                 ),
             ));
-            (
+            // #5611: gate the FULLY composed tree (skill loader + memory + overflow +
+            // base/mcp/search, plus any ACP-provided fs/shell overrides) behind one
+            // outermost TrustGateExecutor, matching runner.rs. Previously only the base
+            // chain carried a gate, so memory/MCP/skill-loader tools composed outside it
+            // bypassed Quarantine/Blocked entirely.
+            let (gated, mcp_ids_handle) = crate::agent_setup::apply_common_tool_gating(
                 zeph_tools::DynExecutor(base),
+                &permission_policy,
+            );
+            crate::agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &mcp_tools);
+            (
+                gated,
                 Some(cancel_signal),
                 Some(provider_override),
                 parent_tool_use_id,
@@ -989,7 +996,13 @@ async fn spawn_acp_agent(
                     ),
                 ),
             ));
-            (zeph_tools::DynExecutor(base), None, None, None)
+            // #5611: same outermost gate as the `Some(ctx)` branch above.
+            let (gated, mcp_ids_handle) = crate::agent_setup::apply_common_tool_gating(
+                zeph_tools::DynExecutor(base),
+                &permission_policy,
+            );
+            crate::agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &mcp_tools);
+            (gated, None, None, None)
         };
 
     // Session persistence (spec-068, #5343): reuse the ACP session_id directly as the
@@ -2087,6 +2100,125 @@ mod tests {
                 Err(zeph_tools::ToolError::ConfirmationRequired { .. })
             ),
             "expected ConfirmationRequired for diagnostics under Supervised autonomy, got {result:?}"
+        );
+    }
+
+    /// Mock executor that only handles calls matching its own `tool_id`, mirroring
+    /// `CompositeExecutor`'s first-match-wins dispatch (`Ok(None)` = "not mine, try next").
+    #[derive(Debug)]
+    struct AcpTaggedMock(&'static str);
+
+    impl zeph_tools::executor::ToolExecutor for AcpTaggedMock {
+        async fn execute(
+            &self,
+            _response: &str,
+        ) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> {
+            Ok(None)
+        }
+
+        async fn execute_tool_call(
+            &self,
+            call: &zeph_tools::ToolCall,
+        ) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> {
+            if call.tool_id != self.0 {
+                return Ok(None);
+            }
+            Ok(Some(zeph_tools::ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "ok".into(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+    }
+
+    fn acp_test_call(tool_id: &str) -> zeph_tools::ToolCall {
+        zeph_tools::ToolCall {
+            tool_id: tool_id.into(),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    /// Regression test for #5611: `spawn_acp_agent` composes `skill_loader -> memory ->
+    /// overflow -> (base_chain -> mcp)` into one tree and gates the WHOLE thing via
+    /// `agent_setup::apply_common_tool_gating`. Before the fix, only the base chain carried
+    /// a `TrustGateExecutor` (wired in `build_acp_deps`), so a Quarantined skill could still
+    /// reach `memory_save`, any MCP-sourced tool, or `load_skill` — all composed outside that
+    /// gate. Mirrors `spawn_acp_agent`'s exact nesting order with lightweight mocks standing
+    /// in for the real `MemoryToolExecutor`/`McpToolExecutor` (which need a live
+    /// `SemanticMemory`/`McpManager`).
+    #[tokio::test]
+    async fn quarantine_blocks_memory_and_mcp_in_acp_composite_chain() {
+        let mcp_tool = zeph_mcp::McpTool {
+            server_id: "mcp".to_owned(),
+            name: "write_file".to_owned(),
+            description: String::new(),
+            input_schema: serde_json::Value::Null,
+            output_schema: None,
+            security_meta: zeph_mcp::tool::ToolSecurityMeta::default(),
+        };
+        let mcp_tool_id = mcp_tool.sanitized_id();
+        assert_eq!(mcp_tool_id, "mcp_write_file");
+
+        // base tier: a readonly native tool ("read") alongside the mock MCP-sourced tool,
+        // mirroring `CompositeExecutor::new(base_executor, mcp_executor)` in `build_acp_deps`.
+        let base_tool = zeph_tools::CompositeExecutor::new(
+            AcpTaggedMock("read"),
+            AcpTaggedMock("mcp_write_file"),
+        );
+        let inner_executor =
+            zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::CompositeExecutor::new(
+                AcpTaggedMock("load_skill"),
+                zeph_tools::CompositeExecutor::new(
+                    AcpTaggedMock("memory_save"),
+                    zeph_tools::CompositeExecutor::new(AcpTaggedMock("overflow_flush"), base_tool),
+                ),
+            )));
+        let (gated, mcp_ids_handle) = crate::agent_setup::apply_common_tool_gating(
+            inner_executor,
+            &zeph_tools::PermissionPolicy::default(),
+        );
+        crate::agent_setup::register_mcp_tool_ids(&mcp_ids_handle, std::slice::from_ref(&mcp_tool));
+        zeph_tools::executor::ToolExecutor::set_effective_trust(
+            &gated,
+            zeph_common::SkillTrustLevel::Quarantined,
+        );
+
+        let memory_result = gated.execute_tool_call(&acp_test_call("memory_save")).await;
+        assert!(
+            matches!(memory_result, Err(zeph_tools::ToolError::Blocked { .. })),
+            "memory_save must be denied under Quarantine, got {memory_result:?}"
+        );
+
+        let mcp_result = gated.execute_tool_call(&acp_test_call(&mcp_tool_id)).await;
+        assert!(
+            matches!(mcp_result, Err(zeph_tools::ToolError::Blocked { .. })),
+            "MCP-sourced tool must be denied under Quarantine, got {mcp_result:?}"
+        );
+
+        let skill_load_result = gated.execute_tool_call(&acp_test_call("load_skill")).await;
+        assert!(
+            matches!(
+                skill_load_result,
+                Err(zeph_tools::ToolError::Blocked { .. })
+            ),
+            "load_skill must be denied under Quarantine, got {skill_load_result:?}"
+        );
+
+        let read_result = gated.execute_tool_call(&acp_test_call("read")).await;
+        assert!(
+            read_result.is_ok(),
+            "readonly native tool must remain reachable under Quarantine, got {read_result:?}"
         );
     }
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1556,6 +1556,41 @@ where
     )
 }
 
+/// MCP tool-id set consumed by [`zeph_tools::TrustGateExecutor`] to recognize genuinely
+/// MCP-sourced tools. Populated after MCP servers connect via [`register_mcp_tool_ids`].
+pub(crate) type McpToolIdsHandle = Arc<RwLock<std::collections::HashSet<String>>>;
+
+/// Wraps a fully-composed tool-executor tree in the single outermost `TrustGateExecutor`
+/// gate shared by every agent entry point (CLI, ACP, daemon).
+///
+/// `inner` must already contain the ENTIRE tool-executor composition for the run — base
+/// chain, MCP, search, skill loader/invoke, memory, overflow. Wrapping only a sub-tree (as
+/// ACP and daemon used to do before #5611) lets tools composed outside the wrap bypass
+/// Quarantine/Blocked enforcement entirely, since `TrustGateExecutor::check_trust` only runs
+/// for calls that dispatch through the gate itself.
+///
+/// Returns the gated executor plus the MCP tool-id handle the caller must populate (via
+/// [`register_mcp_tool_ids`]) once the MCP tool list is known.
+pub(crate) fn apply_common_tool_gating(
+    inner: zeph_tools::DynExecutor,
+    permission_policy: &zeph_tools::PermissionPolicy,
+) -> (zeph_tools::DynExecutor, McpToolIdsHandle) {
+    let gated = zeph_tools::TrustGateExecutor::new(inner, permission_policy.clone());
+    let handle = gated.mcp_tool_ids_handle();
+    (zeph_tools::DynExecutor(Arc::new(gated)), handle)
+}
+
+/// Populates a `TrustGateExecutor` MCP tool-id handle from the connected MCP tool list, so
+/// Quarantine denies ALL MCP-sourced tools — not just those matching `QUARANTINE_DENIED` by
+/// name.
+pub(crate) fn register_mcp_tool_ids(handle: &McpToolIdsHandle, mcp_tools: &[zeph_mcp::McpTool]) {
+    let ids: std::collections::HashSet<String> = mcp_tools
+        .iter()
+        .map(zeph_mcp::McpTool::sanitized_id)
+        .collect();
+    *handle.write() = ids;
+}
+
 fn resolve_search_lsp_server_id(config: &Config) -> Option<String> {
     config
         .mcp
@@ -2377,5 +2412,139 @@ mod tests {
             rx.borrow().secret_masking_enabled,
             "Some(registry) must attach secret masking and flip the metrics flag"
         );
+    }
+
+    // --- apply_common_tool_gating / register_mcp_tool_ids (#5611) ---
+
+    /// Mock executor that only handles calls matching its own `tool_id`, mirroring
+    /// `CompositeExecutor`'s first-match-wins dispatch (`Ok(None)` = "not mine, try next").
+    #[derive(Debug)]
+    struct TaggedMock(String);
+
+    impl ToolExecutor for TaggedMock {
+        async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+
+        async fn execute_tool_call(
+            &self,
+            call: &zeph_tools::ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            if call.tool_id != self.0 {
+                return Ok(None);
+            }
+            Ok(Some(ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "ok".into(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+    }
+
+    fn make_tool_call(tool_id: &str) -> zeph_tools::ToolCall {
+        zeph_tools::ToolCall {
+            tool_id: tool_id.into(),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    fn make_test_mcp_tool(server_id: &str, name: &str) -> zeph_mcp::McpTool {
+        zeph_mcp::McpTool {
+            server_id: server_id.to_owned(),
+            name: name.to_owned(),
+            description: String::new(),
+            input_schema: serde_json::Value::Null,
+            output_schema: None,
+            security_meta: zeph_mcp::tool::ToolSecurityMeta::default(),
+        }
+    }
+
+    /// Regression test for #5611: the gate must wrap the ENTIRE composed tree — including
+    /// tools that used to be composed outside it in ACP/daemon (memory, MCP) — not just the
+    /// base chain. Mirrors the production shape built by `spawn_acp_agent`/`run_daemon`:
+    /// a "memory_save"-like tool and an MCP-sourced tool sit alongside a readonly tool in one
+    /// `CompositeExecutor` tree, gated by a single outermost `apply_common_tool_gating` call.
+    #[tokio::test]
+    async fn quarantine_blocks_memory_and_mcp_tools_reached_through_composed_tree() {
+        let mcp_tool = make_test_mcp_tool("fs", "write_file");
+        let mcp_tool_id = mcp_tool.sanitized_id();
+
+        let inner: Arc<dyn zeph_tools::ErasedToolExecutor> =
+            Arc::new(zeph_tools::CompositeExecutor::new(
+                TaggedMock("memory_save".to_owned()),
+                zeph_tools::CompositeExecutor::new(
+                    TaggedMock(mcp_tool_id.clone()),
+                    TaggedMock("read".to_owned()),
+                ),
+            ));
+        let (gated, mcp_handle) = apply_common_tool_gating(
+            zeph_tools::DynExecutor(inner),
+            &zeph_tools::PermissionPolicy::default(),
+        );
+        register_mcp_tool_ids(&mcp_handle, std::slice::from_ref(&mcp_tool));
+        gated.set_effective_trust(zeph_common::SkillTrustLevel::Quarantined);
+
+        let memory_result = gated
+            .execute_tool_call(&make_tool_call("memory_save"))
+            .await;
+        assert!(
+            matches!(memory_result, Err(zeph_tools::ToolError::Blocked { .. })),
+            "memory_save must be denied under Quarantine even when composed outside the \
+             former gate boundary, got {memory_result:?}"
+        );
+
+        let mcp_result = gated.execute_tool_call(&make_tool_call(&mcp_tool_id)).await;
+        assert!(
+            matches!(mcp_result, Err(zeph_tools::ToolError::Blocked { .. })),
+            "MCP-sourced tool must be denied under Quarantine once its id is registered, \
+             got {mcp_result:?}"
+        );
+
+        let read_result = gated.execute_tool_call(&make_tool_call("read")).await;
+        assert!(
+            read_result.is_ok(),
+            "readonly native tool must remain reachable under Quarantine, got {read_result:?}"
+        );
+    }
+
+    /// Companion to the above: under `Trusted`, none of the gate's Quarantine-specific
+    /// denials apply, so all three tools in the same composed tree must dispatch normally.
+    #[tokio::test]
+    async fn trusted_allows_memory_and_mcp_tools_through_composed_tree() {
+        let mcp_tool = make_test_mcp_tool("fs", "write_file");
+        let mcp_tool_id = mcp_tool.sanitized_id();
+
+        let inner: Arc<dyn zeph_tools::ErasedToolExecutor> =
+            Arc::new(zeph_tools::CompositeExecutor::new(
+                TaggedMock("memory_save".to_owned()),
+                zeph_tools::CompositeExecutor::new(
+                    TaggedMock(mcp_tool_id.clone()),
+                    TaggedMock("read".to_owned()),
+                ),
+            ));
+        let policy =
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
+        let (gated, mcp_handle) = apply_common_tool_gating(zeph_tools::DynExecutor(inner), &policy);
+        register_mcp_tool_ids(&mcp_handle, std::slice::from_ref(&mcp_tool));
+        gated.set_effective_trust(zeph_common::SkillTrustLevel::Trusted);
+
+        for tool_id in ["memory_save", mcp_tool_id.as_str(), "read"] {
+            let result = gated.execute_tool_call(&make_tool_call(tool_id)).await;
+            assert!(
+                result.is_ok(),
+                "{tool_id} must dispatch normally under Trusted/Full autonomy, got {result:?}"
+            );
+        }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -491,28 +491,16 @@ pub(crate) async fn run_daemon(
         zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
     let shell_policy_handle = shell_executor.policy_handle();
     let diagnostics_executor = agent_setup::build_diagnostics_executor(config);
+    // #5611: base chain stays ungated here; it is composed with mcp/search/skill_loader/
+    // memory/overflow below, then the FULLY composed tree is wrapped in one outermost
+    // TrustGateExecutor via `apply_common_tool_gating`, matching runner.rs. Gating only this
+    // sub-tree (as before #5611) let tools composed outside it bypass Quarantine/Blocked.
     let base_executor = agent_setup::build_base_executor_chain(
         file_executor,
         shell_executor,
         scrape_executor,
         diagnostics_executor,
     );
-    // #5575: gate the base chain (file/shell/scrape/cwd/diagnostics) behind the same
-    // TrustGateExecutor the CLI path uses (src/runner.rs), so Supervised-mode
-    // confirmation for unconfigured, non-MCP/non-readonly tools (e.g. `diagnostics`)
-    // is enforced here too — previously this chain had no trust gate at all.
-    let base_executor =
-        zeph_tools::TrustGateExecutor::new(base_executor, permission_policy.clone());
-    // Register MCP tool IDs so TrustGateExecutor can recognize genuinely MCP-sourced
-    // tools for the Supervised-mode skip (see is_mcp_tool in trust_gate.rs) and block
-    // ALL MCP tools for Quarantined skills, mirroring runner.rs.
-    {
-        let ids: std::collections::HashSet<String> = mcp_tools
-            .iter()
-            .map(zeph_mcp::McpTool::sanitized_id)
-            .collect();
-        *base_executor.mcp_tool_ids_handle().write() = ids;
-    }
     let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::with_validator(
         std::sync::Arc::clone(&memory),
         conversation_id,
@@ -547,7 +535,7 @@ pub(crate) async fn run_daemon(
             base
         }
     };
-    let tool_executor =
+    let inner_executor =
         zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::CompositeExecutor::new(
             skill_loader_executor,
             zeph_tools::CompositeExecutor::new(
@@ -558,6 +546,13 @@ pub(crate) async fn run_daemon(
                 ),
             ),
         )));
+    // #5611: gate the FULLY composed tree (base chain + mcp + search + skill loader +
+    // memory + overflow) behind one outermost TrustGateExecutor, matching runner.rs and
+    // ACP (`src/acp.rs`). Previously only the base chain was gated here, so a Quarantined
+    // skill could still reach `memory_save` and any MCP-sourced tool.
+    let (tool_executor, mcp_ids_handle) =
+        agent_setup::apply_common_tool_gating(inner_executor, &permission_policy);
+    agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &mcp_tools);
 
     let mcp_embed_provider = {
         let discovery = &config.mcp.tool_discovery;
@@ -1104,6 +1099,132 @@ mod tests {
                 Err(zeph_tools::ToolError::ConfirmationRequired { .. })
             ),
             "expected ConfirmationRequired for diagnostics under Supervised autonomy, got {result:?}"
+        );
+    }
+
+    /// Mock executor that only handles calls matching its own `tool_id`, mirroring
+    /// `CompositeExecutor`'s first-match-wins dispatch (`Ok(None)` = "not mine, try next").
+    #[derive(Debug)]
+    struct DaemonTaggedMock(&'static str);
+
+    impl zeph_tools::executor::ToolExecutor for DaemonTaggedMock {
+        async fn execute(
+            &self,
+            _response: &str,
+        ) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> {
+            Ok(None)
+        }
+
+        async fn execute_tool_call(
+            &self,
+            call: &zeph_tools::ToolCall,
+        ) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> {
+            if call.tool_id != self.0 {
+                return Ok(None);
+            }
+            Ok(Some(zeph_tools::ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "ok".into(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+    }
+
+    fn daemon_test_call(tool_id: &str) -> zeph_tools::ToolCall {
+        zeph_tools::ToolCall {
+            tool_id: tool_id.into(),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    /// Regression test for #5611: `run_daemon` composes `skill_loader -> memory -> overflow
+    /// -> (base_chain -> mcp)` into one tree and gates the WHOLE thing via
+    /// `agent_setup::apply_common_tool_gating`. Before the fix, only the base chain carried
+    /// a `TrustGateExecutor`, so tools composed outside it (memory, mcp, skill loader) never
+    /// reached `check_trust` at all. This mirrors that exact nesting order with lightweight
+    /// mocks standing in for the real `MemoryToolExecutor`/`McpToolExecutor` (which need a
+    /// live `SemanticMemory`/`McpManager`) and asserts Quarantine now reaches all of them.
+    #[tokio::test]
+    async fn quarantine_blocks_memory_and_mcp_in_daemon_composite_chain() {
+        use zeph_tools::executor::ToolExecutor;
+
+        let mcp_tool = zeph_mcp::McpTool {
+            server_id: "mcp".to_owned(),
+            name: "write_file".to_owned(),
+            description: String::new(),
+            input_schema: serde_json::Value::Null,
+            output_schema: None,
+            security_meta: zeph_mcp::tool::ToolSecurityMeta::default(),
+        };
+        let mcp_tool_id = mcp_tool.sanitized_id();
+        assert_eq!(mcp_tool_id, "mcp_write_file");
+
+        // base tier: a readonly native tool ("read") alongside the mock MCP-sourced tool,
+        // mirroring `CompositeExecutor::new(base_executor, mcp_executor)` in `run_daemon`.
+        let base_tool = zeph_tools::CompositeExecutor::new(
+            DaemonTaggedMock("read"),
+            DaemonTaggedMock("mcp_write_file"),
+        );
+        let inner_executor =
+            zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::CompositeExecutor::new(
+                DaemonTaggedMock("load_skill"),
+                zeph_tools::CompositeExecutor::new(
+                    DaemonTaggedMock("memory_save"),
+                    zeph_tools::CompositeExecutor::new(
+                        DaemonTaggedMock("overflow_flush"),
+                        base_tool,
+                    ),
+                ),
+            )));
+        let (gated, mcp_ids_handle) = agent_setup::apply_common_tool_gating(
+            inner_executor,
+            &zeph_tools::PermissionPolicy::default(),
+        );
+        agent_setup::register_mcp_tool_ids(&mcp_ids_handle, std::slice::from_ref(&mcp_tool));
+        gated.set_effective_trust(zeph_common::SkillTrustLevel::Quarantined);
+
+        let memory_result = gated
+            .execute_tool_call(&daemon_test_call("memory_save"))
+            .await;
+        assert!(
+            matches!(memory_result, Err(zeph_tools::ToolError::Blocked { .. })),
+            "memory_save must be denied under Quarantine, got {memory_result:?}"
+        );
+
+        let mcp_result = gated
+            .execute_tool_call(&daemon_test_call(&mcp_tool_id))
+            .await;
+        assert!(
+            matches!(mcp_result, Err(zeph_tools::ToolError::Blocked { .. })),
+            "MCP-sourced tool must be denied under Quarantine, got {mcp_result:?}"
+        );
+
+        let skill_load_result = gated
+            .execute_tool_call(&daemon_test_call("load_skill"))
+            .await;
+        assert!(
+            matches!(
+                skill_load_result,
+                Err(zeph_tools::ToolError::Blocked { .. })
+            ),
+            "load_skill must be denied under Quarantine, got {skill_load_result:?}"
+        );
+
+        let read_result = gated.execute_tool_call(&daemon_test_call("read")).await;
+        assert!(
+            read_result.is_ok(),
+            "readonly native tool must remain reachable under Quarantine, got {read_result:?}"
         );
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2366,9 +2366,11 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
         std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
     let (tool_executor, mcp_ids_handle) = {
-        let trust_gated =
-            zeph_tools::TrustGateExecutor::new(inner_executor, permission_policy.clone());
-        let handle = trust_gated.mcp_tool_ids_handle();
+        // #5610: shared TrustGateExecutor wrap, also used by ACP (`src/acp.rs`) and the
+        // daemon (`src/daemon.rs`) so all three entry points gate the full executor tree
+        // through one code path.
+        let (trust_gated, handle) =
+            crate::agent_setup::apply_common_tool_gating(inner_executor, &permission_policy);
 
         // Layer 1 (innermost of the policy stack): adversarial policy gate (LLM-based).
         let adversarial_gated: zeph_tools::DynExecutor = if config.tools.adversarial_policy.enabled
@@ -2466,7 +2468,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             }
             zeph_tools::DynExecutor(std::sync::Arc::new(gate))
         } else {
-            zeph_tools::DynExecutor(std::sync::Arc::new(trust_gated))
+            trust_gated
         };
 
         // Layer 2 (outermost): declarative policy gate.
@@ -2635,13 +2637,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     let mcp_outcomes = tool_setup.mcp_outcomes;
     // Register MCP tool IDs so TrustGateExecutor can block ALL MCP tools for
     // Quarantined skills — not just those matching QUARANTINE_DENIED suffixes.
-    {
-        let ids: std::collections::HashSet<String> = mcp_tools
-            .iter()
-            .map(zeph_mcp::McpTool::sanitized_id)
-            .collect();
-        *mcp_ids_handle.write() = ids;
-    }
+    crate::agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &mcp_tools);
     let mcp_manager = tool_setup.mcp_manager;
     let mcp_shared_tools = tool_setup.mcp_shared_tools;
     let mcp_tool_rx = tool_setup.mcp_tool_rx;


### PR DESCRIPTION
## Summary

- ACP (`zeph --acp`) and the daemon (`zeph serve`) only wrapped the base tool chain (file/shell/scrape/cwd/diagnostics) in `TrustGateExecutor`. `mcp_executor`, `memory_executor`, `skill_loader_executor`, `overflow_executor`, and `search_executor` were composed outside that wrap, so a `Quarantined` skill could still invoke `memory_save` or any MCP-sourced tool in ACP/daemon, bypassing the `QUARANTINE_DENIED` enforcement the CLI already had.
- Fixed by wrapping the FULLY composed executor tree (base + mcp + search + skill_loader/invoke + memory + overflow, plus ACP's per-session `ctx.file_executor`/`ctx.shell_executor` overrides) in one outermost `TrustGateExecutor` in both ACP and daemon, matching `src/runner.rs`.
- Extracted the wrap into a shared `agent_setup::apply_common_tool_gating`/`register_mcp_tool_ids` helper, and switched the CLI runner to use it too, so CLI/ACP/daemon now share one gating code path instead of three independently (re-)implemented ones.

**User-visible behavior change**: `memory_save`, `overflow`, and `search_code` in ACP/daemon now also fall under the `Supervised`-mode `Ask` confirmation default for tools with no explicit policy rule, matching the CLI's existing behavior (previously they bypassed confirmation entirely because no gate stood in front of them).

**Scope note on #5610**: this PR closes the trust-gate/permission-policy wiring slice of #5610 only. Provider-pool wiring (also part of #5610's stated scope) remains triplicated across `runner.rs`/`acp.rs`/`daemon.rs` and is left open under #5610 for a future focused pass — see the comment on that issue.

A related but separate gap was found during the audit for this PR (`PolicyGateExecutor`/`AdversarialPolicyGateExecutor` also unwired in ACP/daemon) and filed as #5615 rather than folded into this PR's scope.

Closes #5611.
Refs #5610.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11950 passed, 0 failed, 34 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing unrelated doc warnings in zeph-core/zeph-tui/zeph-channels, not touched by this diff)
- [x] New regression tests in `src/acp.rs`/`src/daemon.rs` construct a Quarantined-trust scenario and assert `memory_save`/MCP-sourced tool calls return `Err(ToolError::Blocked)`
- [x] Verified Supervised-mode Ask-default side effect is safe in both ACP and daemon: `LoopbackChannel::confirm()` unconditionally auto-approves (same accepted pattern as #5575's diagnostics fix) — no hang risk
- [x] Added `.local/testing/coverage-status.md` row + `.local/testing/playbooks/trust-gate.md` for live-session verification of Quarantine denial in ACP/daemon
- [x] `CHANGELOG.md` updated