### PR TITLE
fix(serve,acp): surface session-lock degradation via metric and notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(serve)`: `zeph serve`'s session reactivation retry-exhaustion fallback
+  (`hydrate_session_sink`, `src/serve/agent_factory.rs`) now increments
+  `metrics::counter!("serve.session.reactivation_lock_exhausted_total")` when the bounded
+  `AlreadyLocked` retry budget is exhausted and reactivation degrades to no-persistence for that
+  session — previously observable only via a `tracing::warn!` log line, with no countable signal
+  for operators at scale. Mirrors the existing `durable.journal.writer.degraded_appends_total`
+  degradation-counter pattern (`crates/zeph-durable`); no new metrics framework introduced. The
+  counter is currently write-only — no global `metrics` recorder is installed anywhere in the
+  process, so this delivers instrumentation parity, not yet end-to-end dashboard/alerting
+  observability. Follow-up to #5487/PR #5517. Closes #5518.
+- `fix(acp)`: ACP clients now learn about a degraded (no-persistence) session proactively at
+  session-creation time instead of only on their next prompt. New `SessionStatusNotifier`
+  (`crates/zeph-acp`) pushes the existing `AlreadyLocked` degradation status message through the
+  session's own notify-drainer channel as soon as hydration fails, wired into all 4
+  session-construction paths (`do_new_session`/`do_load_session`/`do_fork_session`/
+  `do_resume_session`); `spawn_acp_agent` (`src/acp.rs`) falls back to the previous
+  prompt-drain-time delivery only when no ACP context is present. Follow-up to #5487/PR #5517.
+  Closes #5519.
 - `fix(ci)`: nextest flagged `zeph-index`'s `index_file_spawn_blocking_dedup_path` and
   `index_file_with_blocking_spawner` tests as `LEAK`. Both tests join their
   `tokio::task::spawn_blocking` handle before returning, but the `#[tokio::test]`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10243,6 +10243,7 @@ dependencies = [
 name = "zeph"
 version = "0.21.4"
 dependencies = [
+ "agent-client-protocol",
  "anyhow",
  "async-trait",
  "axum 0.8.9",
@@ -10256,6 +10257,7 @@ dependencies = [
  "futures",
  "glob",
  "insta",
+ "metrics",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,6 +302,7 @@ dialoguer.workspace = true
 dirs.workspace = true
 futures.workspace = true
 glob.workspace = true
+metrics.workspace = true
 opentelemetry = { workspace = true, optional = true }
 # NOTE: grpc-tonic pulls tonic ^0.14 which coexists with qdrant-client's tonic 0.12.
 # Binary bloat is acceptable until qdrant-client upgrades (tracked in #2347).
@@ -362,6 +363,7 @@ zeph-worktree.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
+agent-client-protocol.workspace = true
 bytes.workspace = true
 insta.workspace = true
 qdrant-client = { workspace = true, features = ["serde"] }

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -299,6 +299,10 @@ pub struct AcpContext {
     /// Shared diagnostics cache — written by the LSP notification handler in `ZephAcpAgent`
     /// and read by the agent loop context builder to inject diagnostics into the system prompt.
     pub diagnostics_cache: Arc<RwLock<DiagnosticsCache>>,
+    /// Handle for proactively notifying the client outside of the prompt-drain path.
+    ///
+    /// See [`SessionStatusNotifier`] for why this exists alongside `LoopbackChannel::send_status`.
+    pub status_notifier: SessionStatusNotifier,
     /// Elicitation bridge for sending form requests to the IDE.
     ///
     /// `None` when the IDE did not advertise elicitation capability during `initialize()`,
@@ -353,12 +357,89 @@ pub type AgentSpawner = Arc<
 pub type SendAgentSpawner = AgentSpawner;
 
 /// Sender half for delivering session notifications to the per-session drainer.
-pub(crate) type NotifySender =
-    mpsc::Sender<(acp::schema::v1::SessionNotification, oneshot::Sender<()>)>;
+///
+/// `pub` (not `pub(crate)`) solely so [`SessionStatusNotifier::new`] can appear in the public
+/// API: it lets integration tests outside this crate construct a real notifier bound to a
+/// plain `mpsc::channel`, without a full `AcpContext`/ACP connection.
+pub type NotifySender = mpsc::Sender<(acp::schema::v1::SessionNotification, oneshot::Sender<()>)>;
 
 /// Receiver half paired with [`NotifySender`].
 pub(crate) type NotifyReceiver =
     mpsc::Receiver<(acp::schema::v1::SessionNotification, oneshot::Sender<()>)>;
+
+/// Fire-and-forget handle for pushing a client-visible status update outside of the normal
+/// prompt-drain path.
+///
+/// Most agent output reaches the client through [`LoopbackChannel`] and is only flushed to
+/// the IDE as part of a `session/prompt` response (see `helpers::loopback_event_to_updates`
+/// and `drain_agent_events`). Some failures are discovered before any prompt is ever sent —
+/// e.g. session hydration in `spawn_acp_agent` (`zeph` binary crate) hitting
+/// `SessionError::AlreadyLocked` — so a client that never prompts, or whose first prompt is
+/// cancelled before the drain, would otherwise never learn persistence degraded (#5519).
+/// `SessionStatusNotifier` reuses the same per-session notification channel that
+/// `ZephAcpAgentState::send_notification_nowait` already drives for other proactive updates
+/// (e.g. `available_commands_update`), so it delivers immediately via the session's notify
+/// drainer instead of waiting on the next prompt.
+#[derive(Clone)]
+pub struct SessionStatusNotifier {
+    notify_tx: NotifySender,
+    session_id: acp::schema::v1::SessionId,
+}
+
+impl SessionStatusNotifier {
+    /// Builds a notifier bound to a session's notification channel.
+    ///
+    /// `notify_tx` is normally a `SessionEntry`'s own notify sender (see `build_acp_context`),
+    /// so pushes from this notifier are drained by the same task that delivers this session's
+    /// `session/update` notifications to the client. `pub` (not `pub(crate)`) so integration
+    /// tests outside this crate can bind a notifier to a plain `mpsc::channel` and assert on
+    /// the receiving end directly, without constructing a full `AcpContext`/ACP connection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use agent_client_protocol::schema::v1::SessionId;
+    /// use tokio::sync::mpsc;
+    /// use zeph_acp::SessionStatusNotifier;
+    ///
+    /// let (tx, mut rx) = mpsc::channel(4);
+    /// let notifier = SessionStatusNotifier::new(tx, SessionId::new("session-1".to_owned()));
+    /// notifier.notify_status_nowait("degraded");
+    /// assert!(rx.try_recv().is_ok());
+    /// ```
+    #[must_use]
+    pub fn new(notify_tx: NotifySender, session_id: acp::schema::v1::SessionId) -> Self {
+        Self {
+            notify_tx,
+            session_id,
+        }
+    }
+
+    /// Push a status message to the client immediately, without waiting for an ack.
+    ///
+    /// Mirrors the `AgentThoughtChunk` shape `loopback_event_to_updates` already produces for
+    /// `LoopbackEvent::Status`, so proactive and prompt-drained status messages render
+    /// identically on the client. Errors (channel full or closed) are logged and swallowed —
+    /// same tolerance as `ZephAcpAgentState::send_notification_nowait`.
+    pub fn notify_status_nowait(&self, text: impl Into<String>) {
+        let text = text.into();
+        if text.is_empty() {
+            return;
+        }
+        let update = acp::schema::v1::SessionUpdate::AgentThoughtChunk(
+            acp::schema::v1::ContentChunk::new(text.into()),
+        );
+        let notification =
+            acp::schema::v1::SessionNotification::new(self.session_id.clone(), update);
+        let (ack_tx, _) = oneshot::channel();
+        if let Err(e) = self.notify_tx.try_send((notification, ack_tx)) {
+            tracing::warn!(
+                error = %e,
+                "proactive session status notification dropped: channel full or closed"
+            );
+        }
+    }
+}
 
 /// Return value of [`ZephAcpAgentState::drain_agent_events`].
 ///
@@ -784,6 +865,7 @@ impl ZephAcpAgentState {
         self.reaper_cancel.cancel();
     }
 
+    #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
     pub(crate) async fn build_acp_context(
         &self,
         session_id: &acp::schema::v1::SessionId,
@@ -791,6 +873,7 @@ impl ZephAcpAgentState {
         cancel_signal: Arc<tokio::sync::Notify>,
         provider_override: Arc<RwLock<Option<AnyProvider>>>,
         cwd: PathBuf,
+        notify_tx: NotifySender,
         #[cfg(feature = "unstable-elicitation")] elicitation_tx: Option<
             elicitation::ElicitationSender,
         >,
@@ -859,6 +942,7 @@ impl ZephAcpAgentState {
             parent_tool_use_id: None,
             lsp_provider,
             diagnostics_cache: Arc::clone(&self.diagnostics_cache),
+            status_notifier: SessionStatusNotifier::new(notify_tx, session_id.clone()),
             #[cfg(feature = "unstable-elicitation")]
             elicitation_bridge: elicitation_tx.map(|tx| elicitation::ElicitationBridge {
                 tx,
@@ -1341,6 +1425,11 @@ impl ZephAcpAgentState {
         let cancel_signal = Arc::clone(&handle.cancel_signal);
         let provider_override: Arc<RwLock<Option<AnyProvider>>> = Arc::new(RwLock::new(None));
         let provider_override_for_ctx = Arc::clone(&provider_override);
+        // Bounded: prevents a misbehaving IDE from buffering notifications without limit.
+        // 256 slots cover any realistic burst between drainer loop iterations. Created here
+        // (not inside `make_session_entry`) so `notify_tx` can also seed `build_acp_context`'s
+        // `SessionStatusNotifier`.
+        let (notify_tx, notify_rx) = mpsc::channel(256);
 
         let session_cwd = args.cwd.clone();
 
@@ -1368,6 +1457,7 @@ impl ZephAcpAgentState {
                 cancel_signal,
                 provider_override_for_ctx,
                 session_cwd.clone(),
+                notify_tx.clone(),
                 #[cfg(feature = "unstable-elicitation")]
                 elicitation_tx,
             )
@@ -1391,6 +1481,8 @@ impl ZephAcpAgentState {
                 auto_approve_level: "suggest".to_owned(),
                 temperature_preset: self.model_config.default_temperature_preset,
             },
+            notify_tx,
+            notify_rx,
         );
         #[cfg(feature = "unstable-elicitation")]
         {
@@ -1672,6 +1764,7 @@ impl ZephAcpAgentState {
         let cancel_signal = Arc::clone(&handle.cancel_signal);
         let provider_override: Arc<RwLock<Option<AnyProvider>>> = Arc::new(RwLock::new(None));
         let provider_override_for_ctx = Arc::clone(&provider_override);
+        let (notify_tx, notify_rx) = mpsc::channel(256);
         let acp_ctx = self
             .build_acp_context(
                 &args.session_id,
@@ -1679,6 +1772,7 @@ impl ZephAcpAgentState {
                 cancel_signal,
                 provider_override_for_ctx,
                 session_cwd.clone(),
+                notify_tx.clone(),
                 #[cfg(feature = "unstable-elicitation")]
                 None,
             )
@@ -1701,6 +1795,8 @@ impl ZephAcpAgentState {
                 auto_approve_level: "suggest".to_owned(),
                 temperature_preset: self.model_config.default_temperature_preset,
             },
+            notify_tx,
+            notify_rx,
         );
 
         Self::spawn_notify_drainer(&entry, cx)?;
@@ -1925,6 +2021,7 @@ impl ZephAcpAgentState {
         let cancel_signal = Arc::clone(&handle.cancel_signal);
         let provider_override: Arc<RwLock<Option<AnyProvider>>> = Arc::new(RwLock::new(None));
         let provider_override_for_ctx = Arc::clone(&provider_override);
+        let (notify_tx, notify_rx) = mpsc::channel(256);
         let acp_ctx = self
             .build_acp_context(
                 &new_id,
@@ -1932,6 +2029,7 @@ impl ZephAcpAgentState {
                 cancel_signal,
                 provider_override_for_ctx,
                 args.cwd.clone(),
+                notify_tx.clone(),
                 #[cfg(feature = "unstable-elicitation")]
                 None,
             )
@@ -1950,6 +2048,8 @@ impl ZephAcpAgentState {
                 auto_approve_level: inherited_auto_approve.clone(),
                 temperature_preset: inherited_preset,
             },
+            notify_tx,
+            notify_rx,
         );
 
         Self::spawn_notify_drainer(&entry, cx)?;
@@ -2051,6 +2151,7 @@ impl ZephAcpAgentState {
         let cancel_signal = Arc::clone(&handle.cancel_signal);
         let provider_override: Arc<RwLock<Option<AnyProvider>>> = Arc::new(RwLock::new(None));
         let provider_override_for_ctx = Arc::clone(&provider_override);
+        let (notify_tx, notify_rx) = mpsc::channel(256);
         let acp_ctx = self
             .build_acp_context(
                 &args.session_id,
@@ -2058,6 +2159,7 @@ impl ZephAcpAgentState {
                 cancel_signal,
                 provider_override_for_ctx,
                 args.cwd.clone(),
+                notify_tx.clone(),
                 #[cfg(feature = "unstable-elicitation")]
                 None,
             )
@@ -2076,6 +2178,8 @@ impl ZephAcpAgentState {
                 auto_approve_level: inherited_auto_approve,
                 temperature_preset: inherited_preset,
             },
+            notify_tx,
+            notify_rx,
         );
 
         Self::spawn_notify_drainer(&entry, cx)?;
@@ -2979,6 +3083,11 @@ impl ZephAcpAgentState {
     }
 
     /// Build a fresh `SessionEntry` from a `LoopbackHandle`, seeded with `config` (#5373).
+    ///
+    /// `notify_tx`/`notify_rx` are created by the caller (not internally) so `notify_tx` can
+    /// also be handed to `build_acp_context` for [`SessionStatusNotifier`] before the entry
+    /// exists — both must share the same channel.
+    #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
     fn make_session_entry(
         handle: LoopbackHandle,
         initial_model: String,
@@ -2986,10 +3095,9 @@ impl ZephAcpAgentState {
         shell_executor: Option<AcpShellExecutor>,
         provider_override: Arc<RwLock<Option<AnyProvider>>>,
         config: SessionConfigSeed,
+        notify_tx: NotifySender,
+        notify_rx: NotifyReceiver,
     ) -> SessionEntry {
-        // Bounded: prevents a misbehaving IDE from buffering notifications without limit.
-        // 256 slots cover any realistic burst between drainer loop iterations.
-        let (notify_tx, notify_rx) = mpsc::channel(256);
         let now_ms = u64::try_from(
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -3505,6 +3613,7 @@ mod notify_timeout_tests {
 
         let (_, handle) = LoopbackChannel::pair(4);
         let provider_override = Arc::new(RwLock::new(None::<AnyProvider>));
+        let (notify_tx, notify_rx) = mpsc::channel(256);
         let entry = ZephAcpAgent::make_session_entry(
             handle,
             "test-model".to_owned(),
@@ -3516,6 +3625,8 @@ mod notify_timeout_tests {
                 auto_approve_level: "suggest".to_owned(),
                 temperature_preset: zeph_config::AcpTemperaturePreset::default(),
             },
+            notify_tx,
+            notify_rx,
         );
         // Insert without starting the drainer — no ack will ever be sent.
         agent.sessions.lock().insert(session_id.clone(), entry);
@@ -3529,6 +3640,47 @@ mod notify_timeout_tests {
             result.is_err(),
             "send_notification must fail when ack does not arrive within the timeout"
         );
+    }
+}
+
+/// Regression tests for #5519: `SessionStatusNotifier` pushes status updates immediately,
+/// without waiting for a prompt-drain.
+#[cfg(test)]
+mod session_status_notifier_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn notify_status_nowait_delivers_agent_thought_chunk_immediately() {
+        let (notify_tx, mut notify_rx) = mpsc::channel(4);
+        let session_id = acp::schema::v1::SessionId::new("notifier-test".to_owned());
+        let notifier = SessionStatusNotifier::new(notify_tx, session_id.clone());
+
+        notifier.notify_status_nowait("degraded");
+
+        let (notification, _ack) = notify_rx.try_recv().expect(
+            "notify_status_nowait must push onto the channel synchronously, without a drainer",
+        );
+        assert_eq!(notification.session_id, session_id);
+        match notification.update {
+            acp::schema::v1::SessionUpdate::AgentThoughtChunk(chunk) => match chunk.content {
+                acp::schema::v1::ContentBlock::Text(t) => assert_eq!(t.text, "degraded"),
+                other => panic!("expected ContentBlock::Text, got {other:?}"),
+            },
+            other => panic!("expected AgentThoughtChunk, got {other:?}"),
+        }
+    }
+
+    /// Matches `loopback_event_to_updates`'s handling of `LoopbackEvent::Status("")`: empty
+    /// text is a no-op, not an empty chunk.
+    #[tokio::test]
+    async fn notify_status_nowait_skips_empty_text() {
+        let (notify_tx, mut notify_rx) = mpsc::channel(4);
+        let session_id = acp::schema::v1::SessionId::new("notifier-empty-test".to_owned());
+        let notifier = SessionStatusNotifier::new(notify_tx, session_id);
+
+        notifier.notify_status_nowait("");
+
+        assert!(notify_rx.try_recv().is_err(), "empty text must not be sent");
     }
 }
 
@@ -3559,6 +3711,7 @@ mod inherited_session_config_tests {
         let session_id = acp::schema::v1::SessionId::new("source-session".to_owned());
         let (_, handle) = LoopbackChannel::pair(4);
         let provider_override = Arc::new(RwLock::new(None::<AnyProvider>));
+        let (notify_tx, notify_rx) = mpsc::channel(256);
         let entry = ZephAcpAgent::make_session_entry(
             handle,
             "claude:opus".to_owned(),
@@ -3570,6 +3723,8 @@ mod inherited_session_config_tests {
                 auto_approve_level: "auto-edit".to_owned(),
                 temperature_preset: zeph_config::AcpTemperaturePreset::Creative,
             },
+            notify_tx,
+            notify_rx,
         );
         agent.sessions.lock().insert(session_id.clone(), entry);
 

--- a/crates/zeph-acp/src/lib.rs
+++ b/crates/zeph-acp/src/lib.rs
@@ -82,7 +82,9 @@ pub mod permission;
 pub mod terminal;
 pub mod transport;
 
-pub use agent::{AcpContext, AgentSpawner, ProviderFactory, SessionContext, run_agent};
+pub use agent::{
+    AcpContext, AgentSpawner, ProviderFactory, SessionContext, SessionStatusNotifier, run_agent,
+};
 pub use client::{
     AcpClientError, RunOutcome, SubagentConfig, SubagentHandle, run_session, spawn_subagent,
 };

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -948,6 +948,7 @@ async fn build_acp_deps(
 /// Deliberately omits the lock path: it is an absolute filesystem path (leaks the server's
 /// home-directory prefix/OS username) and this session may be reached over an unauthenticated,
 /// non-loopback ACP HTTP transport (security review finding, #5487).
+#[cfg(feature = "acp")]
 const SESSION_LOCK_DEGRADED_MESSAGE: &str =
     "Session persistence unavailable: another process already holds this session's write lock.";
 
@@ -960,6 +961,7 @@ const SESSION_LOCK_DEGRADED_MESSAGE: &str =
 /// (#5519). Falls back to `channel.send_status` when no notifier is available (e.g.
 /// `acp_ctx` is `None`, as for non-ACP callers of `spawn_acp_agent`) — that path is still
 /// only flushed to the client on the session's next prompt-response drain.
+#[cfg(feature = "acp")]
 async fn notify_lock_degraded(
     status_notifier: Option<&zeph_acp::SessionStatusNotifier>,
     channel: &mut zeph_core::channel::LoopbackChannel,
@@ -978,6 +980,7 @@ async fn notify_lock_degraded(
 /// `AlreadyLocked` trigger that doesn't require a full `SharedAgentDeps`/`Agent` to reach — so
 /// `notify_lock_degraded`'s real trigger path (genuine file-lock contention, not a mocked
 /// error) is covered by a lightweight integration test (#5519 review S2).
+#[cfg(feature = "acp")]
 async fn open_session_log_or_notify_locked(
     session_path: &std::path::Path,
     status_notifier: Option<&zeph_acp::SessionStatusNotifier>,

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -815,6 +815,65 @@ async fn build_acp_deps(
     Ok((deps, keepalive))
 }
 
+/// Text shown to the client when session persistence is disabled due to a held write lock.
+///
+/// Deliberately omits the lock path: it is an absolute filesystem path (leaks the server's
+/// home-directory prefix/OS username) and this session may be reached over an unauthenticated,
+/// non-loopback ACP HTTP transport (security review finding, #5487).
+const SESSION_LOCK_DEGRADED_MESSAGE: &str =
+    "Session persistence unavailable: another process already holds this session's write lock.";
+
+/// Notify the client that session persistence degraded to no-persistence because another
+/// process already holds this session's write lock (`SessionError::AlreadyLocked`).
+///
+/// Prefers `status_notifier` (present for real ACP sessions): it pushes the message
+/// immediately through the session's notification drainer, so the client learns about the
+/// degradation at session-creation time rather than only as a side effect of its next prompt
+/// (#5519). Falls back to `channel.send_status` when no notifier is available (e.g.
+/// `acp_ctx` is `None`, as for non-ACP callers of `spawn_acp_agent`) — that path is still
+/// only flushed to the client on the session's next prompt-response drain.
+async fn notify_lock_degraded(
+    status_notifier: Option<&zeph_acp::SessionStatusNotifier>,
+    channel: &mut zeph_core::channel::LoopbackChannel,
+) {
+    if let Some(notifier) = status_notifier {
+        notifier.notify_status_nowait(SESSION_LOCK_DEGRADED_MESSAGE);
+    } else {
+        let _ = channel.send_status(SESSION_LOCK_DEGRADED_MESSAGE).await;
+    }
+}
+
+/// Open a session's durable JSONL event log, degrading (and notifying the client) instead of
+/// failing the session when another process already holds the session's write lock.
+///
+/// Extracted from `spawn_acp_agent`'s no-`conversation_id` hydration branch — the only
+/// `AlreadyLocked` trigger that doesn't require a full `SharedAgentDeps`/`Agent` to reach — so
+/// `notify_lock_degraded`'s real trigger path (genuine file-lock contention, not a mocked
+/// error) is covered by a lightweight integration test (#5519 review S2).
+async fn open_session_log_or_notify_locked(
+    session_path: &std::path::Path,
+    status_notifier: Option<&zeph_acp::SessionStatusNotifier>,
+    channel: &mut zeph_core::channel::LoopbackChannel,
+) -> Option<std::sync::Arc<zeph_session::SessionEventLog>> {
+    match zeph_session::SessionEventLog::open_exclusive(session_path).await {
+        Ok(log) => Some(std::sync::Arc::new(log)),
+        Err(zeph_session::SessionError::AlreadyLocked(lock_path)) => {
+            tracing::error!(
+                lock_path,
+                "failed to open session event log for ACP session: another process \
+                 already holds this session's write lock; session persistence disabled \
+                 for this session"
+            );
+            notify_lock_degraded(status_notifier, channel).await;
+            None
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to open session event log for ACP session; session persistence disabled for this session");
+            None
+        }
+    }
+}
+
 /// Spawn an `Agent` from shared deps and per-session context, then run its loop.
 ///
 /// Called once per ACP session. Each invocation creates independent per-session state:
@@ -888,6 +947,13 @@ async fn spawn_acp_agent(
 
     let hooks_config = d.hooks_config.clone();
     let tool_filter_config = d.tool_filter_config.clone();
+
+    // Cloned before `acp_ctx` is destructured into individual per-session executors below
+    // (the tool-executor setup consumes `ctx` by value), so it survives to the session
+    // hydration block further down and can proactively push a client-visible notification if
+    // hydration hits `AlreadyLocked` — reaching the client without waiting for this session's
+    // next `session/prompt` drain (#5519).
+    let status_notifier = acp_ctx.as_ref().map(|ctx| ctx.status_notifier.clone());
 
     // Per-session receivers: each session gets its own mpsc::Receiver forwarded from the
     // shared broadcast senders. The CancellationToken is derived from the AcpContext cancel
@@ -1001,9 +1067,9 @@ async fn spawn_acp_agent(
     // exists so `SessionStore::update_seq` has something to update.
     //
     // Computed here, before `channel` is consumed by `Agent::new_with_registry_arc` below, so an
-    // `AlreadyLocked` failure can be surfaced to the client via `channel.send_status` (delivered
-    // to the IDE as an `AgentThoughtChunk` on this session's next prompt-response drain, per
-    // `loopback_event_to_updates`) instead of only being visible in logs (#5487 fix 3).
+    // `AlreadyLocked` failure can be surfaced to the client (`notify_lock_degraded` above, via
+    // `status_notifier` — pushed immediately, see #5519) instead of only being visible in logs
+    // (#5487 fix 3).
     let mut acp_session_sink = None;
     let mut preloaded_messages: Vec<zeph_llm::provider::Message> = Vec::new();
     if session_persistence_config.enabled {
@@ -1057,16 +1123,7 @@ async fn spawn_acp_agent(
                         "session hydration failed: another process already holds this session's \
                          write lock; session persistence disabled for this session"
                     );
-                    // Do not interpolate `lock_path` into the client-facing message: it is an
-                    // absolute filesystem path (leaks the server's home-directory prefix/OS
-                    // username) and this session may be reached over an unauthenticated,
-                    // non-loopback ACP HTTP transport (security review finding).
-                    let _ = channel
-                        .send_status(
-                            "Session persistence unavailable: another process already holds \
-                             this session's write lock.",
-                        )
-                        .await;
+                    notify_lock_degraded(status_notifier.as_ref(), &mut channel).await;
                     None
                 }
                 Err(e) => {
@@ -1075,32 +1132,8 @@ async fn spawn_acp_agent(
                 }
             }
         } else {
-            match zeph_session::SessionEventLog::open_exclusive(&session_path).await {
-                Ok(log) => Some(Arc::new(log)),
-                Err(zeph_session::SessionError::AlreadyLocked(lock_path)) => {
-                    tracing::error!(
-                        lock_path,
-                        "failed to open session event log for ACP session: another process \
-                         already holds this session's write lock; session persistence disabled \
-                         for this session"
-                    );
-                    // Do not interpolate `lock_path` into the client-facing message: it is an
-                    // absolute filesystem path (leaks the server's home-directory prefix/OS
-                    // username) and this session may be reached over an unauthenticated,
-                    // non-loopback ACP HTTP transport (security review finding).
-                    let _ = channel
-                        .send_status(
-                            "Session persistence unavailable: another process already holds \
-                             this session's write lock.",
-                        )
-                        .await;
-                    None
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to open session event log for ACP session; session persistence disabled for this session");
-                    None
-                }
-            }
+            open_session_log_or_notify_locked(&session_path, status_notifier.as_ref(), &mut channel)
+                .await
         };
 
         if let Some(log) = log {
@@ -2316,6 +2349,80 @@ mod tests {
             if next.is_none() {
                 break;
             }
+        }
+    }
+
+    /// Regression test for #5519 review S2: `notify_lock_degraded`'s fallback branch (no
+    /// `SessionStatusNotifier` — e.g. `spawn_acp_agent` invoked without an `AcpContext`) must
+    /// still reach the caller, via `channel.send_status`.
+    #[tokio::test]
+    async fn notify_lock_degraded_falls_back_to_channel_send_status_without_notifier() {
+        let (mut channel, mut handle) = zeph_core::channel::LoopbackChannel::pair(8);
+
+        notify_lock_degraded(None, &mut channel).await;
+
+        let event = handle
+            .output_rx
+            .recv()
+            .await
+            .expect("channel must receive a status event");
+        match event {
+            zeph_core::LoopbackEvent::Status(text) => {
+                assert_eq!(text, SESSION_LOCK_DEGRADED_MESSAGE);
+            }
+            other => panic!("expected LoopbackEvent::Status, got {other:?}"),
+        }
+    }
+
+    /// Regression test for #5519 review S2: drives the real trigger path — genuine file-lock
+    /// contention (not a mocked error) through `open_session_log_or_notify_locked`, the same
+    /// helper `spawn_acp_agent`'s no-`conversation_id` hydration branch calls — and asserts the
+    /// client is notified via `SessionStatusNotifier` synchronously, i.e. without any
+    /// `session/prompt` drain (`try_recv`, not `recv().await` behind a drain loop).
+    #[tokio::test]
+    async fn already_locked_session_log_notifies_client_proactively_without_prompt() {
+        let tmp = TempDir::new().unwrap();
+        let session_path = tmp.path().join("already-locked-session");
+        // Hold the write lock ourselves first — the exact contention a second concurrent
+        // `spawn_acp_agent` invocation for the same session would hit.
+        let _held_lock = zeph_session::SessionEventLog::open_exclusive(&session_path)
+            .await
+            .expect("first open_exclusive must succeed and hold the lock");
+
+        let (mut channel, _handle) = zeph_core::channel::LoopbackChannel::pair(8);
+        let (notify_tx, mut notify_rx) = tokio::sync::mpsc::channel(8);
+        let session_id =
+            agent_client_protocol::schema::v1::SessionId::new("already-locked-test".to_owned());
+        let status_notifier = Some(zeph_acp::SessionStatusNotifier::new(
+            notify_tx,
+            session_id.clone(),
+        ));
+
+        let log = open_session_log_or_notify_locked(
+            &session_path,
+            status_notifier.as_ref(),
+            &mut channel,
+        )
+        .await;
+        assert!(
+            log.is_none(),
+            "AlreadyLocked must degrade to no persistence, not fail session creation"
+        );
+
+        let (notification, _ack) = notify_rx.try_recv().expect(
+            "client must be notified proactively — synchronously, with no prompt drain needed",
+        );
+        assert_eq!(notification.session_id, session_id);
+        match notification.update {
+            agent_client_protocol::schema::v1::SessionUpdate::AgentThoughtChunk(chunk) => {
+                match chunk.content {
+                    agent_client_protocol::schema::v1::ContentBlock::Text(t) => {
+                        assert_eq!(t.text, SESSION_LOCK_DEGRADED_MESSAGE);
+                    }
+                    other => panic!("expected ContentBlock::Text, got {other:?}"),
+                }
+            }
+            other => panic!("expected AgentThoughtChunk, got {other:?}"),
         }
     }
 }

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -206,6 +206,19 @@ async fn hydrate_session_sink(
                 tokio::time::sleep(REACTIVATION_LOCK_RETRY_DELAY).await;
             }
             Err(e) => {
+                // #5518: distinguish "retry budget exhausted against a still-live lock" from any
+                // other hydration failure — only the former is the silent degrade this counter
+                // exists to surface (an operator has no other way to notice it happening at
+                // scale short of grepping the warn log below).
+                if matches!(
+                    e,
+                    zeph_agent_persistence::PersistenceError::Session(
+                        zeph_session::SessionError::AlreadyLocked(_)
+                    )
+                ) {
+                    metrics::counter!("serve.session.reactivation_lock_exhausted_total")
+                        .increment(1);
+                }
                 tracing::warn!(error = %e, "serve-sessions: session persistence disabled for this session");
                 return (None, Vec::new());
             }


### PR DESCRIPTION
## Summary

Follow-up to #5487/PR #5517. Two independent, small fixes for how session-lock
degradation (`SessionError::AlreadyLocked`) is surfaced to operators and clients:

- **#5518** — `zeph serve`'s `hydrate_session_sink` (`src/serve/agent_factory.rs`)
  silently degraded to no-persistence when its `AlreadyLocked` retry budget exhausted,
  with only a `tracing::warn!` log line — no countable signal for operators at scale.
  Adds `metrics::counter!("serve.session.reactivation_lock_exhausted_total")`,
  gated to only fire on genuine retry-budget exhaustion (not other hydration
  failure modes). Mirrors the existing `durable.journal.writer.degraded_appends_total`
  pattern; no new metrics framework introduced.

  **Caveat**: this is currently write-only — no global `metrics` recorder is
  installed anywhere in the process, so this delivers instrumentation parity,
  not yet end-to-end dashboard/alerting observability. A recorder install is
  tracked as separate follow-up work.

- **#5519** — an ACP client that creates a session against an already-locked
  target, and never sends a prompt (or whose first prompt is cancelled before
  the drain), never learned persistence had degraded — the existing
  `channel.send_status` notification only reached the client as a side effect
  of the next `session/prompt` drain. Adds `SessionStatusNotifier`
  (`crates/zeph-acp`), which pushes the degradation message through the
  session's own notify-drainer channel proactively at session-creation time.
  Wired into all four session-construction paths (`do_new_session`,
  `do_load_session`, `do_fork_session`, `do_resume_session`).
  `spawn_acp_agent` (`src/acp.rs`) falls back to the previous prompt-drain-time
  delivery only when no ACP context is present.

  Design choice: preferred reusing the existing per-session notify-drainer
  channel over patching the pinned `agent-client-protocol-schema = "1.1.0"`
  crate with a new notification kind (its `SessionUpdate` enum has no
  extensible degradation variant).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean, verified from a genuine `cargo clean` (ruled out stale-cache false-greens)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11950/11950 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing warnings in unrelated crates only)
- [x] New end-to-end test drives genuine `SessionEventLog::open_exclusive` lock contention and asserts the client receives the proactive notification without a prompt
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `.local/testing/coverage-status.md` and the session-persistence playbook updated per project convention

Closes #5518, #5519