### PR TITLE
fix(memory): anchor tech-doc extraction on specific artifacts to reduce hub-degree skew (#5467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(memory)`: `knowledge ingest`'s hub-degree kill-criterion (spec-067 §7) reported a
+  24.3%-of-edges hub on the first live subagent-transcript extraction — the generic
+  language name `Python` collapsed 26 near-duplicate "hello-world" transcripts onto a
+  single hub node, well above the 15% threshold. `TECH_DOC_SYSTEM_PROMPT`
+  (`crates/zeph-memory/src/graph/ingest/prompt.rs`) had no rule anchoring extraction on the
+  specific artifact (e.g. `hello.py`) over the generic, incidentally-used language/tool name
+  when the document's primary subject was something else. Added a rule instructing the
+  extractor to prefer the specific file/script/command entity and mention the
+  language/tool inline in that entity's summary rather than creating a shared node and edge
+  for it, reserving a standalone language/tool entity for documents actually about that
+  language or tool. This eliminates the specific `Python` hub (24.3% → ~10% on re-measurement).
+  Also extracted the previously duplicated `15.0` literal in `src/commands/knowledge.rs`'s
+  `print_graph_ingest_report` into a single `HUB_DEGREE_THRESHOLD_PCT` constant. Note: the
+  gate still WARNs (15.9%-20.8% across live re-runs) on the only corpus measured so far, as
+  hub degree partially relocates onto anchor artifacts (e.g. `hello.py`) on highly
+  repetitive corpora; broader/diverse-corpus re-measurement is tracked separately
+  (see follow-up issue #5625 for broader corpus re-measurement). (#5467)
+
 - `fix(tools,acp)`: ACP (`zeph --acp`) and the daemon (`zeph serve`) gated only the base
   tool chain (file/shell/scrape/cwd/diagnostics) behind `TrustGateExecutor`; `memory_save`,
   MCP-sourced tools, `load_skill`/`invoke_skill`, and `search_code` were composed outside

--- a/crates/zeph-memory/src/graph/ingest/prompt.rs
+++ b/crates/zeph-memory/src/graph/ingest/prompt.rs
@@ -32,28 +32,42 @@ people, languages, organizations, concepts, files, specifications, and modules.
    \"language\" covers programming and natural languages. \
    \"concept\" covers abstract ideas, methodologies, and patterns. \
    \"file\" covers named source files, specs, configuration files, and scripts.
-3. Do NOT extract structural metadata: TOML/JSON/YAML keys, config field names, \
+3. Do not extract a bare programming/scripting language or CLI tool/interpreter name \
+(e.g. \"Python\", \"python3\", \"py\", \"bash\", \"Rust\", \"git\", \"cargo\") as its own \
+entity, and do not create an edge targeting one, when the document merely uses it \
+incidentally to accomplish some other task. Versioned or aliased forms of the same \
+language/tool (e.g. \"python3\", \"py\" vs \"Python\") are covered by this rule identically \
+to the base name — they are not a loophole and must not be extracted as separate \
+anchor-worthy \"command\" entities. Anchor on the specific artifact instead (the file, \
+script, or command entity, e.g. \"hello.py\") and mention the language or tool inline in \
+that entity's summary text (e.g. \"a Python script that prints hello world\") rather than \
+as a graph node. This applies even when the same language or tool recurs across many \
+documents in the corpus — repeated incidental mentions must not accumulate into a shared \
+hub entity. Only extract a language or tool as its own entity, with edges, when the \
+document's primary subject is that language or tool itself (e.g. a language feature, spec, \
+or design discussion) rather than an incidental means of completing an unrelated task.
+4. Do NOT extract structural metadata: TOML/JSON/YAML keys, config field names, \
 SQL column names, or single-letter identifiers.
-4. Entity names must be at least 3 characters long. Reject bare paths without a meaningful name.
-5. Relations should be short verb phrases: \"uses\", \"depends_on\", \"implements\", \
+5. Entity names must be at least 3 characters long. Reject bare paths without a meaningful name.
+6. Relations should be short verb phrases: \"uses\", \"depends_on\", \"implements\", \
 \"defines\", \"extends\", \"replaces\", \"contains\", \"references\".
-6. The \"fact\" field is a human-readable sentence summarizing the relationship.
-7. If a document records a change (e.g., \"migrated from X to Y\"), include a \
+7. The \"fact\" field is a human-readable sentence summarizing the relationship.
+8. If a document records a change (e.g., \"migrated from X to Y\"), include a \
 temporal_hint like \"replaced X\" or \"as of 2026-Q2\".
-8. Each edge must include an \"edge_type\" field classifying the relationship:
+9. Each edge must include an \"edge_type\" field classifying the relationship:
   - \"semantic\": conceptual relationships (uses, prefers, depends_on, implements, defines)
   - \"temporal\": time-ordered events (preceded_by, followed_by, started_before)
   - \"causal\": cause-effect chains (caused, triggered, resulted_in, led_to)
   - \"entity\": identity/structural relationships (is_a, part_of, instance_of, alias_of, replaces)
   Default to \"semantic\" if the relationship type is uncertain.
-9. Each edge must include a \"confidence\" field: a float in [0.0, 1.0] reflecting how \
+10. Each edge must include a \"confidence\" field: a float in [0.0, 1.0] reflecting how \
 certain you are that this relationship is present in the document. \
 Use 1.0 for direct, verbatim statements. Use 0.5–0.8 for clear implications. \
 Use 0.3–0.5 for weak inferences. Omit or use null if uncertain.
-10. Do not extract personal identifiable information: email addresses, phone numbers, \
+11. Do not extract personal identifiable information: email addresses, phone numbers, \
 physical addresses, SSNs, or API keys. Use generic references instead.
-11. Always output entity names and relation verbs in English. Translate if needed.
-12. Return empty arrays if no entities or relationships are found.
+12. Always output entity names and relation verbs in English. Translate if needed.
+13. Return empty arrays if no entities or relationships are found.
 
 Output JSON schema:
 {

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -2295,6 +2295,126 @@ mod tests {
         assert_eq!(count, 0, "dry-run must not increment extraction_count");
     }
 
+    /// Regression for #5467: `global_degrees` in `ingest_documents` must sum an entity's
+    /// per-document degree across *every* document in the batch, not just the last one —
+    /// this is exactly the accumulation that let an incidentally-mentioned language/tool
+    /// name balloon into a hub entity when it recurred across many documents in the corpus.
+    #[tokio::test]
+    async fn ingest_documents_hub_degree_accumulates_across_documents() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        use super::{GraphExtractionConfig, IngestBatchConfig};
+        use crate::graph::ingest::ImportBatchId;
+
+        let json1 = r#"{"entities":[{"name":"Widget","type":"tool","summary":null},{"name":"Foo","type":"concept","summary":null}],"edges":[{"source":"Widget","target":"Foo","relation":"depends_on","fact":"Widget depends on Foo","edge_type":"semantic"}]}"#;
+        let json2 = r#"{"entities":[{"name":"Widget","type":"tool","summary":null},{"name":"Bar","type":"concept","summary":null}],"edges":[{"source":"Widget","target":"Bar","relation":"depends_on","fact":"Widget depends on Bar","edge_type":"semantic"}]}"#;
+
+        let provider = AnyProvider::Mock(MockProvider::with_responses(vec![
+            json1.to_owned(),
+            json2.to_owned(),
+        ]));
+        let memory = super::SemanticMemory::with_weights_and_pool_size(
+            ":memory:", "", None, provider, "", 0.7, 0.3, 1,
+        )
+        .await
+        .expect("SemanticMemory init");
+
+        let batch_id = ImportBatchId::new();
+        let doc1 = make_doc("Widget depends on Foo.", "task-hub-1", &batch_id);
+        let doc2 = make_doc("Widget depends on Bar.", "task-hub-2", &batch_id);
+        let config = IngestBatchConfig {
+            dry_run: true,
+            extraction: GraphExtractionConfig {
+                max_entities: 10,
+                max_edges: 10,
+                extraction_timeout_secs: 10,
+                ..GraphExtractionConfig::default()
+            },
+            ..IngestBatchConfig::default()
+        };
+
+        // concurrency=1: documents are processed in order, so MockProvider's queued
+        // responses (json1, json2) line up deterministically with (doc1, doc2).
+        let report = memory
+            .ingest_documents(vec![doc1, doc2], config, batch_id, 1, None, None)
+            .await
+            .expect("dry-run ingest should succeed");
+
+        assert!(report.dry_run);
+        assert_eq!(report.succeeded, 2, "both documents should be processed");
+
+        let widget = report
+            .hub_degree
+            .iter()
+            .find(|h| h.entity == "Widget")
+            .expect("Widget must be present in hub_degree");
+        assert_eq!(
+            widget.degree, 2,
+            "Widget's degree must accumulate across both documents (1 edge per doc)"
+        );
+        assert_eq!(
+            report.hub_degree[0].entity, "Widget",
+            "top-N must be sorted descending by accumulated degree"
+        );
+    }
+
+    /// Regression for #5467: `dry_run_hub_top_n` must truncate the projected hub-degree
+    /// list to the configured size, keeping only the highest-degree entities.
+    #[tokio::test]
+    async fn ingest_documents_hub_degree_respects_top_n_truncation() {
+        use super::{GraphExtractionConfig, IngestBatchConfig};
+        use crate::graph::ingest::ImportBatchId;
+
+        // Single document, 4 entities: A=3 (edges to B, C, D), B=2, C=2, D=1.
+        let extraction_json = r#"{"entities":[
+            {"name":"A","type":"concept","summary":null},
+            {"name":"B","type":"concept","summary":null},
+            {"name":"C","type":"concept","summary":null},
+            {"name":"D","type":"concept","summary":null}
+        ],"edges":[
+            {"source":"A","target":"B","relation":"depends_on","fact":"A depends on B","edge_type":"semantic"},
+            {"source":"A","target":"C","relation":"depends_on","fact":"A depends on C","edge_type":"semantic"},
+            {"source":"A","target":"D","relation":"depends_on","fact":"A depends on D","edge_type":"semantic"},
+            {"source":"B","target":"C","relation":"depends_on","fact":"B depends on C","edge_type":"semantic"}
+        ]}"#;
+        let memory = make_semantic_memory(Some(extraction_json)).await;
+
+        let batch_id = ImportBatchId::new();
+        let doc = make_doc("A depends on B, C, and D.", "task-hub-topn", &batch_id);
+        let config = IngestBatchConfig {
+            dry_run: true,
+            dry_run_hub_top_n: Some(2),
+            extraction: GraphExtractionConfig {
+                max_entities: 10,
+                max_edges: 10,
+                extraction_timeout_secs: 10,
+                ..GraphExtractionConfig::default()
+            },
+            ..IngestBatchConfig::default()
+        };
+
+        let report = memory
+            .ingest_documents(vec![doc], config, batch_id, 1, None, None)
+            .await
+            .expect("dry-run ingest should succeed");
+
+        assert_eq!(
+            report.hub_degree.len(),
+            2,
+            "hub_degree must be truncated to dry_run_hub_top_n"
+        );
+        assert_eq!(
+            report.hub_degree[0].entity, "A",
+            "the highest-degree entity must rank first"
+        );
+        assert_eq!(report.hub_degree[0].degree, 3);
+        assert_eq!(
+            report.hub_degree[1].degree, 2,
+            "second place is whichever of B/C ties at degree 2"
+        );
+    }
+
     #[tokio::test]
     async fn ingest_documents_collect_errors_and_continue() {
         use super::IngestBatchConfig;

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -1168,6 +1168,10 @@ async fn run_graph_ingest(
     Ok(())
 }
 
+/// Hub-degree kill-criterion threshold from spec-067 §7: the top entity by edge-degree
+/// must not exceed this percentage of total edges before the graph sink can ship.
+const HUB_DEGREE_THRESHOLD_PCT: f64 = 15.0;
+
 /// Print the summary of a graph-sink ingest run.
 fn print_graph_ingest_report(report: &zeph_memory::graph::ingest::IngestReport) {
     println!();
@@ -1194,7 +1198,7 @@ fn print_graph_ingest_report(report: &zeph_memory::graph::ingest::IngestReport) 
         let total_edges: usize = report.hub_degree.iter().map(|h| h.degree).sum();
         println!();
         println!(
-            "  Hub-degree (top-{}) — spec-067 §7 threshold ≤ 15% of total edges:",
+            "  Hub-degree (top-{}) — spec-067 §7 threshold ≤ {HUB_DEGREE_THRESHOLD_PCT}% of total edges:",
             report.hub_degree.len()
         );
         println!("  {:<50} {:>7}  {:>7}", "Entity", "Degree", "% edges");
@@ -1206,7 +1210,11 @@ fn print_graph_ingest_report(report: &zeph_memory::graph::ingest::IngestReport) 
             } else {
                 0.0
             };
-            let flag = if pct > 15.0 { " ⚠ HUB" } else { "" };
+            let flag = if pct > HUB_DEGREE_THRESHOLD_PCT {
+                " ⚠ HUB"
+            } else {
+                ""
+            };
             println!(
                 "  {:<50} {:>7}  {:>6.1}%{}",
                 truncate_uri(&h.entity, 50),
@@ -1218,10 +1226,10 @@ fn print_graph_ingest_report(report: &zeph_memory::graph::ingest::IngestReport) 
         if total_edges > 0 {
             #[allow(clippy::cast_precision_loss)]
             let top_pct = (report.hub_degree[0].degree as f64 / total_edges as f64) * 100.0;
-            let health = if top_pct <= 15.0 {
+            let health = if top_pct <= HUB_DEGREE_THRESHOLD_PCT {
                 "PASS"
             } else {
-                "WARN — top entity exceeds 15% hub-degree threshold"
+                "WARN — top entity exceeds hub-degree threshold"
             };
             println!("  {}", "-".repeat(68));
             println!("  Top entity: {top_pct:.1}% of edges — {health}");
@@ -2834,5 +2842,69 @@ collection = "zeph_test_reasoning_guard_unused_documents"
             result.is_ok(),
             "reasoning disabled (or non-Qdrant backend) must always no-op: {result:?}"
         );
+    }
+
+    // ── hub-degree kill-criterion (spec-067 §7, #5467) ────────────────────────
+
+    #[test]
+    fn hub_degree_threshold_pct_is_15_percent() {
+        // Regression pin: the constant was extracted from two duplicated `15.0` literals
+        // (per-row HUB flag and the overall PASS/WARN verdict). Both call sites must keep
+        // reading the same value, so pin it here rather than let a future edit silently
+        // change only one of the two use sites again.
+        assert!((HUB_DEGREE_THRESHOLD_PCT - 15.0).abs() < f64::EPSILON);
+    }
+
+    fn hub_report(
+        entries: &[(&str, usize)],
+        dry_run: bool,
+    ) -> zeph_memory::graph::ingest::IngestReport {
+        zeph_memory::graph::ingest::IngestReport {
+            dry_run,
+            hub_degree: entries
+                .iter()
+                .map(|&(entity, degree)| zeph_memory::graph::ingest::HubDegree {
+                    entity: entity.to_owned(),
+                    degree,
+                })
+                .collect(),
+            ..zeph_memory::graph::ingest::IngestReport::default()
+        }
+    }
+
+    // These are smoke tests: `print_graph_ingest_report` only prints to stdout (no
+    // return value to assert on), so they exist to exercise the threshold arithmetic
+    // and branching (division guard, cast, PASS/WARN comparison) without panicking
+    // across the boundary conditions the fix touched. They do not assert on the
+    // printed text.
+
+    #[test]
+    fn print_graph_ingest_report_empty_hub_degree_does_not_panic() {
+        print_graph_ingest_report(&hub_report(&[], true));
+    }
+
+    #[test]
+    fn print_graph_ingest_report_zero_total_edges_does_not_panic() {
+        // A hub_degree entry with degree 0 makes total_edges (the sum) 0, exercising the
+        // division-by-zero guard (`if total_edges > 0 { .. } else { 0.0 }`).
+        print_graph_ingest_report(&hub_report(&[("Solo", 0)], true));
+    }
+
+    #[test]
+    fn print_graph_ingest_report_exactly_at_threshold_does_not_panic() {
+        // 15 of 100 edges == exactly HUB_DEGREE_THRESHOLD_PCT: boundary is `<=`/`>`, must be PASS.
+        print_graph_ingest_report(&hub_report(&[("AtThreshold", 15), ("Rest", 85)], true));
+    }
+
+    #[test]
+    fn print_graph_ingest_report_above_threshold_does_not_panic() {
+        print_graph_ingest_report(&hub_report(&[("OverThreshold", 30), ("Rest", 70)], true));
+    }
+
+    #[test]
+    fn print_graph_ingest_report_non_dry_run_skips_hub_section() {
+        // Outside dry-run, the hub-degree block must not execute even if hub_degree is
+        // (unexpectedly) non-empty.
+        print_graph_ingest_report(&hub_report(&[("Ignored", 999)], false));
     }
 }


### PR DESCRIPTION
## Summary

- `TECH_DOC_SYSTEM_PROMPT` (`crates/zeph-memory/src/graph/ingest/prompt.rs`) had no rule anchoring extraction on a specific artifact (a file/script/command) over a generic, incidentally-used language or CLI tool name (e.g. "Python", "bash"). On the first live subagent-transcript extraction this let "Python" collapse 26 near-duplicate "hello-world" transcripts onto one hub node at 24.3% of edges, above spec-067 section 7's 15% hub-degree kill-criterion.
- Added a rule instructing the extractor to anchor on the specific artifact and mention the language/tool inline in that entity's summary instead of creating a shared node/edge for it. Versioned/aliased forms (`python3`, `py`) are covered identically to the base name to close a route-around ambiguity.
- Extracted the previously duplicated `15.0` hub-degree threshold literal in `print_graph_ingest_report` (`src/commands/knowledge.rs`) into a single `HUB_DEGREE_THRESHOLD_PCT` constant.
- Added regression coverage (8 new tests) for degree accumulation, top-N truncation, and the threshold/WARN-PASS math in `print_graph_ingest_report` — none of this had any prior test coverage.

## Measured outcome (honest framing — not a full closure)

Live re-runs against the real 14-transcript/61-doc `.zeph/subagents/*.jsonl` corpus show:

- The specific "Python" hub is fixed: its own share drops from 24.3% to roughly 10%.
- The overall gate still occasionally WARNs on this corpus: across 4 re-runs with the final prompt, the top entity (alternating between `bash` and `Python`) measured 15.9%, 16.9%, 17.1%, and 20.8%. Root mechanism: the anchoring rule relocates degree onto the anchor artifact (e.g. `hello.py`) rather than eliminating hub formation outright — on a corpus where nearly every transcript shares the same near-identical anchor, degree migrates there instead.

This is consistent with issue #5467's own analysis, which recommended (a) re-measuring against a larger/more diverse corpus before a final go/no-go call, and (b) tuning the prompt only if the skew persisted at scale. This PR does (b). Recommendation (a), plus a related `concept`-typed entity route-around risk flagged during review, is tracked separately in #5625 and intentionally out of scope here.

The issue stays open pending the broader re-measurement in #5625.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory` (1548 passed, includes 2 new async hub-degree tests)
- [x] `cargo nextest run --config-file .github/nextest.toml --features "desktop,ide,server,chat,pdf,scheduler" -p zeph --bins` (591 passed, includes 6 new sync tests)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-memory`
- [x] Live sanity re-run: `knowledge ingest --source subagents --dry-run` against the real subagent corpus (see measured outcome above)

Refs #5467, #5625