### PR TITLE
fix(core): satisfy non-exhaustive AcpTransport match without acp-http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   existing explicit arms under every feature combination — that warns and falls back to
   stdio, matching the convention already used for the TUI transport-selection match earlier
   in the same file. Closes #5623.
+- `test(subagent)`: `supervised_subagent_task_is_visible_in_supervisor`
+  (`crates/zeph-subagent/src/manager/tests.rs`) relied on a single `tokio::task::yield_now()`
+  to observe a spawned subagent task in the `TaskSupervisor` snapshot before it completed and
+  was reaped — `RunOnce` entries are removed from supervisor state in the same lock update
+  that marks them `Completed`, so under CI scheduling pressure the near-instant mock provider
+  response could finish and get reaped before the single yield resumed the test, leaving the
+  snapshot empty. Switched to a `MockProvider` with an explicit 50ms response delay so the
+  task is deterministically still `Running` when the snapshot is taken, and dropped the racy
+  yield.
 - `fix(tools,acp)`: ACP (`zeph --acp`) and the daemon (`zeph serve`) gated only the base
   tool chain (file/shell/scrape/cwd/diagnostics) behind `TrustGateExecutor`; `memory_save`,
   MCP-sourced tools, `load_skill`/`invoke_skill`, and `search_code` were composed outside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `*_matches_active_dialect` CI name-filter scoping in `zeph-memory`'s postgres test job
   remains necessary and is not widened. That remains open follow-up work. Refs #5571.
 
+- `fix(core)`: `run_configured_acp_autostart` (`src/runner.rs`) failed to compile with the
+  `acp` feature enabled and `acp-http` disabled (`E0004`, non-exhaustive match). `AcpTransport`
+  (`zeph-config`) is `#[non_exhaustive]`, so matching it from outside its defining crate
+  requires an unconditional wildcard arm regardless of local variant coverage; the only
+  wildcard arm present was itself gated `#[cfg(feature = "acp-http")]`, leaving no catch-all
+  when that feature was off. Replaced it with a single unconditional `_` arm — covering only
+  genuinely-unknown future variants, since `Stdio`/`Http`/`Both` remain fully handled by the
+  existing explicit arms under every feature combination — that warns and falls back to
+  stdio, matching the convention already used for the TUI transport-selection match earlier
+  in the same file. Closes #5623.
 - `fix(tools,acp)`: ACP (`zeph --acp`) and the daemon (`zeph serve`) gated only the base
   tool chain (file/shell/scrape/cwd/diagnostics) behind `TrustGateExecutor`; `memory_save`,
   MCP-sourced tools, `load_skill`/`invoke_skill`, and `search_code` were composed outside

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -3574,10 +3574,23 @@ async fn supervised_subagent_task_is_visible_in_supervisor() {
     mgr.set_task_supervisor(supervisor.clone());
     mgr.definitions.push(sample_def());
 
-    let task_id = do_spawn(&mut mgr, "bot", "supervised work").await.unwrap();
-
-    // Yield so the spawn_oneshot future has a chance to register in supervisor state.
-    tokio::task::yield_now().await;
+    // A delayed response keeps the background task in the Running state long enough to
+    // observe: spawn_oneshot registers synchronously, but with an instant mock response
+    // the task can complete and get reaped before this test ever inspects the snapshot.
+    let provider =
+        AnyProvider::Mock(MockProvider::with_responses(vec!["done".into()]).with_delay(50));
+    let task_id = mgr
+        .spawn(
+            "bot",
+            "supervised work",
+            provider,
+            noop_executor(),
+            None,
+            &SubAgentConfig::default(),
+            SpawnContext::default(),
+        )
+        .await
+        .unwrap();
 
     let snaps = supervisor.snapshot();
     let found = snaps.iter().any(|s| {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -350,8 +350,13 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
             ))
             .await
         }
-        #[cfg(feature = "acp-http")]
+        // AcpTransport is #[non_exhaustive]; this arm only reaches variants unknown to
+        // this build (Stdio/Http/Both are all handled above under every feature combination).
         _ => {
+            tracing::warn!(
+                transport = ?transport,
+                "ACP autostart requested with an unrecognized transport variant; falling back to stdio"
+            );
             Box::pin(run_acp_server(
                 config_path.as_deref(),
                 vault_backend.as_deref(),


### PR DESCRIPTION
## Summary

Closes #5623. `run_configured_acp_autostart` (`src/runner.rs`) matches on `AcpTransport`, which is marked non-exhaustive and defined outside this crate (`zeph-config`) — so rustc requires an unconditional wildcard arm regardless of local variant coverage. The only wildcard arm present was itself feature-gated to `acp-http`, leaving no catch-all when that feature was disabled. Building with `acp` enabled and `acp-http` disabled therefore failed to compile with `E0004`, a combination invisible to CI since the `ide` bundle always pairs the two features together.

Replaces the feature-gated wildcard with a single unconditional arm that warns and falls back to `stdio`. `Stdio`, `Http`, and `Both` remain fully handled by existing explicit arms under every feature combination — the new arm only ever reaches a variant unknown to this build. Adversarial review confirmed this fallback is effectively unreachable today: an unrecognized transport value in config fails at serde deserialization before ever reaching this match, so warn+fallback is a safe, zero-cost safety net rather than a behavior that could mask a real misconfiguration in practice.

## Review process

developer (read the full match block and `AcpTransport`'s definition before restructuring) → parallel (tester independently reproduced the original `E0004` via a real revert-and-recheck rather than trusting the report, confirmed no unreachable-pattern overlap between the two wildcard-adjacent arms; adversarial critic verified the new arm is genuinely unreachable under every currently-compilable feature combination, confirmed no other latent instance of this pattern elsewhere in the codebase) → code reviewer (independently re-verified both feature combinations compile, full CI suite, approved).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11973 passed, 0 failed
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] `cargo check --features "acp,session,scheduler"` (the broken combination from the issue) — now compiles clean, independently reproduced as broken beforehand via a real revert
- [x] `cargo check --features "ide,session,scheduler"` (acp+acp-http) — still compiles clean, no regression
- [x] No dedicated unit test added: a `#[non_exhaustive]` missing-wildcard-arm bug is a compile-time-only defect not constructible/triggerable at runtime from outside the defining crate — the two `cargo check` invocations above are the real and sufficient regression guard, matching agreement from both the tester and reviewer
- [x] Live-testing playbook and coverage-status updated in `.local/testing/` (main repo) per project convention