### PR TITLE
perf(build): reduce local disk footprint of parallel worktree builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[build]
+build-dir = "{cargo-cache-home}/build/{workspace-path-hash}"
+rustc-wrapper = "sccache"
+incremental = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `perf(build)`: parallel agent teams building the workspace across multiple git
+  worktrees each got a full independent `target/`, and with 21 crates the combined
+  footprint reached 100+ GB, dominated by dependency debuginfo and per-worktree
+  duplication of intermediate artifacts. Set `[profile.dev] debug = "line-tables-only"`
+  in the root `Cargo.toml` (dependencies already built with `debug = false` via
+  `[profile.dev.package."*"]`) since agent-driven builds only consume compiler
+  diagnostics and test output, not full debuginfo. Also set `opt-level = 1` for
+  `[profile.dev.package."*"]` so dependency code runs faster during test execution,
+  at negligible extra compile cost over `opt-level = 0`. Added `.cargo/config.toml` with
+  `[build] build-dir = "{cargo-cache-home}/build/{workspace-path-hash}"` (Cargo's
+  build-dir/target-dir split, stable since 1.91) so intermediate compilation artifacts
+  from all worktrees live under one shared cache root instead of being duplicated
+  per-worktree, while `rustc-wrapper = "sccache"` lets identical dependency builds
+  across worktrees hit the same object cache. Also set `incremental = false` for local
+  builds, matching the CI profile, since incremental caches are dead weight for
+  one-shot agent builds. Fixes a doc/reality mismatch where
+  `book/src/development/sccache.md` already documented a `.cargo/config.toml` with
+  sccache pre-configured that did not actually exist in the repo. (#5627)
+
 ### Fixed
 
 - `fix(memory)`: `knowledge ingest`'s hub-degree kill-criterion (spec-067 §7) reported a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,10 +381,12 @@ zeph-skills.workspace = true
 workspace = true
 
 [profile.dev]
+debug = "line-tables-only"
 split-debuginfo = "unpacked"
 
 [profile.dev.package."*"]
 debug = false
+opt-level = 1
 
 [profile.release]
 opt-level = "z"

--- a/book/src/development/sccache.md
+++ b/book/src/development/sccache.md
@@ -20,10 +20,28 @@ The workspace ships `.cargo/config.toml` with sccache pre-configured:
 
 ```toml
 [build]
+build-dir = "{cargo-cache-home}/build/{workspace-path-hash}"
 rustc-wrapper = "sccache"
+incremental = false
 ```
 
+`build-dir` separates intermediate compilation artifacts from the final `target-dir` layout
+(Cargo's build-dir/target-dir split, stable since 1.91). Combined with `rustc-wrapper`, this
+means parallel builds across multiple git worktrees of this repo (e.g. agent teams working in
+separate worktrees) do not duplicate dependency compilation: each worktree keeps its own
+lock-free build-dir keyed by `{workspace-path-hash}`, but identical dependency builds still hit
+the same sccache object cache instead of being recompiled per worktree. `incremental = false`
+disables incremental compilation locally to match the CI profile — incremental caches are dead
+weight for one-shot builds and would otherwise grow unboundedly per worktree.
+
 If sccache is not installed, Cargo prints a warning and falls back to direct `rustc` invocation. CI jobs that don't need compilation override the wrapper with `RUSTC_WRAPPER=""` (env var takes priority over config file).
+
+`SCCACHE_CACHE_SIZE` and `SCCACHE_DIR` are machine-level settings, not committed to this
+project's config — set them in your own `~/.cargo/config.toml` `[env]` table (as
+`{ value = "...", force = true }` entries) or shell profile. Do not add a plain-string
+`SCCACHE_CACHE_SIZE` to the project's `.cargo/config.toml`: Cargo merges `[env]` tables
+key-by-key across config files, and a plain string here conflicts with a table-form entry
+in a user's global config, breaking every `cargo` invocation with a config-merge error.
 
 ## Verify
 


### PR DESCRIPTION
## Summary

- Set `[profile.dev] debug = "line-tables-only"` in the root `Cargo.toml` (dependencies already build with `debug = false`); agent-driven builds only consume compiler diagnostics and test output, not full debuginfo
- Bumped `[profile.dev.package."*"] opt-level = 1` so dependency code runs faster during test execution, at negligible extra compile cost over `opt-level = 0`
- Added `.cargo/config.toml`: `[build] build-dir = "{cargo-cache-home}/build/{workspace-path-hash}"` splits intermediate compilation artifacts from `target-dir`, so parallel worktrees do not share a build lock but do share a cache root; `rustc-wrapper = "sccache"` and `incremental = false` for local dev builds, matching CI's approach
- Fixed a doc/reality mismatch: `book/src/development/sccache.md` already documented a `.cargo/config.toml` with sccache pre-configured that did not actually exist in the repo; updated the page to describe the real config and warn against committing a plain-string `SCCACHE_CACHE_SIZE` (conflicts with a table-form `{ value = ..., force = true }` entry in a user's global config, breaking every `cargo` invocation with a config-merge error)

Closes #5627

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11973 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo build --profile ci --features "desktop,ide,server,chat,pdf,scheduler,testing"` — confirmed final binary still lands at `target/ci/zeph` with `build-dir` active, matching CI's expected artifact path