### PR TITLE
test(tui): add dedicated unit tests for detect_unicode_capable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `test(tui)`: `detect_unicode_capable()` (`crates/zeph-tui/src/theme/color_mode.rs`) had no
+  dedicated unit tests — only a doc-example, flagged as a coverage gap across 4+ consecutive
+  CI cycles. Added 6 tests to the existing `mod tests` block covering `TERM=dumb` precedence
+  over a UTF-8 `LANG`, the `LANG` and `LC_ALL` UTF-8-detection branches, case-insensitive
+  `utf-8` matching, and the default-to-Unicode-capable fallback for both fully-unset and
+  non-UTF-8 environments. Follows the sibling `auto_with_no_color_env_resolves_to_never`
+  test's established `#[serial_test::serial]` + `unsafe { std::env::set_var/remove_var }`
+  isolation pattern, via a shared `clear_unicode_env()` helper that clears all three relevant
+  vars before each test sets only what it needs — results no longer depend on the host
+  shell's actual `TERM`/`LANG`/`LC_ALL`. Closes #5480.
 - `fix(memory)`: `knowledge ingest`'s hub-degree kill-criterion (spec-067 §7) reported a
   24.3%-of-edges hub on the first live subagent-transcript extraction — the generic
   language name `Python` collapsed 26 near-duplicate "hello-world" transcripts onto a

--- a/crates/zeph-tui/src/theme/color_mode.rs
+++ b/crates/zeph-tui/src/theme/color_mode.rs
@@ -437,4 +437,113 @@ mod tests {
         unsafe { std::env::remove_var("NO_COLOR") };
         assert_eq!(result, EffectiveColorMode::Never);
     }
+
+    /// Clear the three env vars `detect_unicode_capable` reads, so each test starts from a
+    /// known-empty baseline instead of depending on whatever the host shell happens to export.
+    ///
+    /// SAFETY: caller runs under `#[serial_test::serial]`, so no other test observes env state
+    /// concurrently.
+    #[allow(unsafe_code)]
+    unsafe fn clear_unicode_env() {
+        unsafe {
+            std::env::remove_var("TERM");
+            std::env::remove_var("LANG");
+            std::env::remove_var("LC_ALL");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[allow(unsafe_code)]
+    fn unicode_capable_term_dumb_returns_false_even_with_utf8_lang() {
+        // TERM=dumb short-circuits before LANG/LC_ALL are consulted (detection order #1).
+        // SAFETY: single-threaded via #[serial].
+        unsafe {
+            clear_unicode_env();
+            std::env::set_var("TERM", "dumb");
+            std::env::set_var("LANG", "en_US.UTF-8");
+        }
+        let result = detect_unicode_capable();
+        unsafe { clear_unicode_env() };
+        assert!(!result, "TERM=dumb must return false regardless of LANG");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[allow(unsafe_code)]
+    fn unicode_capable_lang_utf8_returns_true() {
+        // SAFETY: single-threaded via #[serial].
+        unsafe {
+            clear_unicode_env();
+            std::env::set_var("TERM", "xterm-256color");
+            std::env::set_var("LANG", "en_US.UTF-8");
+        }
+        let result = detect_unicode_capable();
+        unsafe { clear_unicode_env() };
+        assert!(result, "LANG containing UTF-8 must return true");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[allow(unsafe_code)]
+    fn unicode_capable_lc_all_utf8_returns_true() {
+        // Exercises the LC_ALL branch specifically (checked before LANG in the detection loop).
+        // SAFETY: single-threaded via #[serial].
+        unsafe {
+            clear_unicode_env();
+            std::env::set_var("TERM", "xterm-256color");
+            std::env::set_var("LC_ALL", "C.UTF-8");
+        }
+        let result = detect_unicode_capable();
+        unsafe { clear_unicode_env() };
+        assert!(result, "LC_ALL containing UTF-8 must return true");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[allow(unsafe_code)]
+    fn unicode_capable_lowercase_utf8_is_still_detected() {
+        // Detection uppercases before matching, so lowercase "utf-8" must also count.
+        // SAFETY: single-threaded via #[serial].
+        unsafe {
+            clear_unicode_env();
+            std::env::set_var("TERM", "xterm-256color");
+            std::env::set_var("LANG", "en_US.utf-8");
+        }
+        let result = detect_unicode_capable();
+        unsafe { clear_unicode_env() };
+        assert!(result, "lowercase utf-8 in LANG must still be detected");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[allow(unsafe_code)]
+    fn unicode_capable_unset_env_defaults_to_true() {
+        // No TERM/LANG/LC_ALL at all — default is Unicode-capable (opt-in to ASCII, not opt-out).
+        // SAFETY: single-threaded via #[serial].
+        unsafe { clear_unicode_env() };
+        let result = detect_unicode_capable();
+        unsafe { clear_unicode_env() };
+        assert!(result, "unset environment must default to Unicode-capable");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[allow(unsafe_code)]
+    fn unicode_capable_non_utf8_lang_without_dumb_defaults_to_true() {
+        // Ambiguous case: TERM set but not "dumb", LANG/LC_ALL present but not UTF-8 — falls
+        // through to the same opt-in-to-ASCII default as the fully-unset case.
+        // SAFETY: single-threaded via #[serial].
+        unsafe {
+            clear_unicode_env();
+            std::env::set_var("TERM", "xterm");
+            std::env::set_var("LANG", "C");
+        }
+        let result = detect_unicode_capable();
+        unsafe { clear_unicode_env() };
+        assert!(
+            result,
+            "non-UTF-8 LANG without TERM=dumb must default to true"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #5480. `detect_unicode_capable()` (`crates/zeph-tui/src/theme/color_mode.rs`) decides ASCII-vs-Unicode rendering fallback for the whole TUI (splash, spinners, borders), but had no dedicated unit test — only a doc-example. Its env-var branching logic was unverified by the test suite, a coverage gap re-confirmed across 4+ consecutive CI cycles.

Adds a `clear_unicode_env()` helper plus six tests covering: `TERM=dumb` overriding a UTF-8 `LANG` (precedence), the `LANG` and `LC_ALL` UTF-8-detection branches, case-insensitive `utf-8` matching, and the default-to-Unicode-capable fallback for both fully-unset and non-UTF-8 environments. Follows the isolation pattern already established by the sibling `NO_COLOR` test in the same file: `#[serial_test::serial]` plus explicit `unsafe { std::env::set_var/remove_var }`, so results never depend on the host shell's ambient `TERM`/`LANG`/`LC_ALL`.

## Review process

developer (read the actual implementation and existing test-isolation convention before writing anything) → parallel (tester independently verified every precedence/default claim against the real source rather than trusting test names, ran the full crate suite 5x with zero flakiness; adversarial critic independently grepped the whole crate to confirm `#[serial]` isolation is actually sound — no unmarked reader/writer of the same env vars exists anywhere else) → code reviewer (independently re-ran every CI-matching check, confirmed diff scope, approved).

Both the tester and adversarial critic independently converged on the same minor, non-blocking coverage gap: none of the 6 tests exercise the no-hyphen `"UTF8"` substring variant of the detection condition (all real-world locale strings use the hyphenated form). Left as an optional follow-up rather than blocking this PR.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11983 passed, 0 failed
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] `cargo test --doc -p zeph-tui --all-features` — 105 passed, including `detect_unicode_capable`'s own doc-example
- [x] New tests run in isolation (6/6 pass) and the full `zeph-tui` crate suite re-run 5x with zero flakiness
- [x] Live-testing playbook updates (`tui-theme.md` IP-8, `tui-visual-polish.md` Scenario 4) and coverage-status.md row (Untested → Tested) updated in `.local/testing/`