### PR TITLE
fix(db): restore sqlite/postgres compile-time mutual exclusivity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,15 +224,15 @@ jobs:
           path: nextest-archive-zeph-db-postgres.tar.zst
           retention-days: 1
       - name: Build and archive zeph-memory postgres integration tests
-        # zeph-memory's sqlite/postgres features are additive (unlike zeph-db's
-        # mutually-exclusive default), so default features stay on here — building
-        # with --no-default-features would disable the "sqlite" feature and turn
-        # unrelated sqlite-only test helpers into dead-code errors under -D warnings.
+        # sqlite and postgres are mutually exclusive (zeph-db's compile_error!
+        # fires if both are active), so default features (which include "sqlite")
+        # must be disabled here; "jsonschema" is re-added explicitly since it was
+        # previously pulled in via zeph-memory's default feature set.
         # --lib --bins (not just --tests) is required so cfg!(feature = "postgres")
         # branches inside src/ (e.g. dialect-selected SQL literals) get archived too —
         # see the "Run zeph-memory postgres unit tests" step below (#5540).
         if: matrix.os == 'ubuntu-latest'
-        run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci -p zeph-memory --features test-utils --lib --bins --tests --archive-file nextest-archive-zeph-memory-postgres.tar.zst
+        run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci -p zeph-memory --no-default-features --features test-utils,jsonschema --lib --bins --tests --archive-file nextest-archive-zeph-memory-postgres.tar.zst
       - name: Upload zeph-memory postgres test archive
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -241,8 +241,10 @@ jobs:
           path: nextest-archive-zeph-memory-postgres.tar.zst
           retention-days: 1
       - name: Build and archive zeph-index postgres integration tests
+        # sqlite and postgres are mutually exclusive; default features (which
+        # include "sqlite") must be disabled so only postgres is active.
         if: matrix.os == 'ubuntu-latest'
-        run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci -p zeph-index --features test-utils --tests --archive-file nextest-archive-zeph-index-postgres.tar.zst
+        run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci -p zeph-index --no-default-features --features test-utils --tests --archive-file nextest-archive-zeph-index-postgres.tar.zst
       - name: Upload zeph-index postgres test archive
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -342,24 +344,25 @@ jobs:
       - name: Run zeph-memory postgres integration tests (testcontainers)
         # Scoped to the postgres_integration binary: zeph-memory's archive also
         # contains hela_spreading_activation.rs (SQLite `:memory:` ignored tests,
-        # unrelated to postgres). Both sqlite and postgres are enabled in this
-        # archive (see the archive step's comment in build-tests), so DbConfig::connect
-        # gives postgres cfg-priority for the whole crate; running crate-wide would
-        # route those unrelated :memory: tests through connect_postgres and fail them.
+        # unrelated to postgres). This archive is built postgres-only (sqlite is
+        # disabled, see the archive step's comment in build-tests) — the vast
+        # majority of zeph-memory's tests use a `SqliteStore::new(":memory:")`
+        # fixture unconditionally (not gated on `#[cfg(feature = "sqlite")]`), so
+        # they'd try to parse ":memory:" as a Postgres URL and fail; running
+        # crate-wide would hit those unrelated failures.
         run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive-zeph-memory-postgres.tar.zst --workspace-remap . --profile ci --run-ignored ignored-only -E 'binary(postgres_integration)'
       - name: Run zeph-memory postgres unit tests (#5540)
-        # Runs the --lib/--bins portion of the same archive (built with --features
-        # postgres via test-utils, see the archive step in build-tests), so
+        # Runs the --lib/--bins portion of the same archive (built postgres-only
+        # via test-utils, see the archive step in build-tests), so
         # cfg!(feature = "postgres") branches inside src/ get unit-test coverage in
         # CI, not just integration-test coverage that depends on happening to exercise
         # the right code path. Scoped by name (not `kind(lib) + kind(bin)`) because the
         # vast majority of zeph-memory's ~1500 lib unit tests open a `SqliteStore::new(
-        # ":memory:")` — under this postgres-featured build, DbConfig::connect has
-        # postgres cfg-priority for the whole crate (see the comment on the step above),
-        # so those unrelated tests would try to parse ":memory:" as a Postgres URL and
-        # fail. `_matches_active_dialect` is this codebase's established naming
-        # convention (see store/overflow.rs) for pure dialect-literal pinning tests that
-        # take no DB connection and are safe to run under either feature build.
+        # ":memory:")` fixture unconditionally — under this postgres-only build, those
+        # unrelated tests would try to parse ":memory:" as a Postgres URL and fail.
+        # `_matches_active_dialect` is this codebase's established naming convention
+        # (see store/overflow.rs) for pure dialect-literal pinning tests that take no
+        # DB connection and are safe to run under either feature build.
         run: cargo nextest run --config-file .github/nextest.toml --archive-file nextest-archive-zeph-memory-postgres.tar.zst --workspace-remap . --profile ci -E 'kind(lib) and test(matches_active_dialect)'
       - name: Download zeph-index postgres test archive
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -524,10 +527,37 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "ci"
-      - name: Check postgres build (zeph-db)
-        run: cargo check -p zeph-db --no-default-features --features postgres
+      - name: Verify sqlite+postgres compile_error guard
+        # Intentionally attempts the forbidden both-enabled combination and asserts it
+        # fails with the expected compile_error! message. Guards against a future
+        # accidental deletion of the mutual-exclusivity guard in zeph-db/src/lib.rs —
+        # this exact regression (guard silently dropped for #5377) is how #5571 happened.
+        # `cargo check` here is EXPECTED to fail (exit 101, the compile_error firing).
+        # GitHub Actions runs `run:` blocks under `bash -eo pipefail`, so piping that
+        # exit code directly into `grep` would poison the pipeline status regardless of
+        # whether grep matches — `|| true` swallows the expected failure so only the
+        # grep result (checked separately against the redirected log) determines pass/fail.
+        run: |
+          cargo check -p zeph-db --features postgres > /tmp/guard.log 2>&1 || true
+          if grep -q "mutually exclusive for \`zeph-db\`" /tmp/guard.log; then
+            echo "guard fired as expected"
+          else
+            echo "::error::compile_error! guard did not fire — sqlite+postgres both-enabled regression"
+            cat /tmp/guard.log
+            exit 1
+          fi
       - name: Check postgres build (workspace)
-        run: cargo check --workspace --all-targets --features postgres
+        # `full` is backend-agnostic (does not include sqlite or postgres); the default
+        # sqlite feature must be disabled explicitly since Cargo features are
+        # additive-only and cannot "override" an already-active default. Every
+        # "sqlite"/"postgres"-gated crate's workspace-dependency entry in the root
+        # Cargo.toml has `default-features = false` (with explicit forwarding through
+        # each crate's own `sqlite`/`postgres` feature) precisely so this cascades
+        # cleanly instead of silently pulling in a conflicting default via a
+        # `foo.workspace = true` edge somewhere in the graph.
+        run: cargo check --workspace --all-targets --no-default-features --features full,postgres
+      - name: Check sqlite build (workspace, no-default-features parity)
+        run: cargo check --workspace --all-targets --no-default-features --features full,sqlite
 
   rustdoc:
     name: Rustdoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,57 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   repetitive corpora; broader/diverse-corpus re-measurement is tracked separately
   (see follow-up issue #5625 for broader corpus re-measurement). (#5467)
 
+- `fix(db)`: restore the `sqlite`/`postgres` mutual-exclusivity `compile_error!` in
+  `zeph-db` (spec-031 §4.2). A prior change for #5377 left only the "neither enabled"
+  guard in place, so a build with both features active silently fell through to a
+  cfg-based "postgres wins" resolution instead of failing to compile. Since `zeph-memory`'s
+  and `zeph-index`'s `postgres`/`test-utils` features are additive on top of their own
+  `default = ["sqlite", ...]`, every CI/local invocation that added `--features
+  test-utils` (or `postgres`) without also passing `--no-default-features` silently
+  compiled both backends in and routed every `SqliteStore::new(":memory:")` fixture
+  through `connect_postgres`, breaking ~55% of `zeph-memory`'s unit test suite
+  (676/827 failing) under `cargo test --features postgres -p zeph-memory --lib`.
+  Restored the hard `compile_error!` for both-enabled and removed the now-dead
+  `not(feature = "postgres")` exclusions in `zeph-db`'s per-item `#[cfg]` guards (they
+  were only needed to avoid duplicate-definition errors under the old silent-priority
+  behavior). Updated the `build-tests` CI job to build `zeph-db`, `zeph-memory`, and
+  `zeph-index` with `--no-default-features --features test-utils[,jsonschema]` so only
+  `postgres` is active.
+
+  Restoring the hard `compile_error!` also broke the documented PostgreSQL production
+  build path (`--features full,postgres`), which previously "worked" only because the
+  old silent-priority behavior tolerated both features being nominally active at once.
+  `full` itself is now backend-agnostic (no longer hardcodes `sqlite`), and every
+  workspace crate that transitively depends on `zeph-db`/`zeph-memory` now has
+  `default-features = false` set on its workspace-dependency entry plus explicit
+  `sqlite`/`postgres` forwarding through its own `[features]` (~20 crates total,
+  matching the pre-existing `zeph-db`/`zeph-durable`/`zeph-memory`/`zeph-session`
+  pattern), so `cargo check --workspace --no-default-features --features full,postgres`
+  now compiles cleanly end-to-end, alongside the unaffected default/`--features full`
+  sqlite path. The `build-postgres` CI job's workspace-level check is restored (no
+  longer scoped down to 3 crates) and gains a dedicated regression-guard step that
+  intentionally triggers the forbidden both-enabled combination and asserts the
+  `compile_error!` fires — the exact silent regression class that turned #5377 into
+  #5571. Root `Cargo.toml`'s feature-selection comment, `crates/zeph-db/README.md`, and
+  `specs/031-database-abstraction/spec.md` §4.2 are updated to state the actual working
+  invocation (`--no-default-features` is required for a PostgreSQL build; it cannot be
+  omitted, since Cargo features are additive-only and cannot override the default
+  `sqlite`).
+
+  **Breaking**: compiling `zeph-db` (or anything depending on it, including the full
+  workspace) with both `sqlite` and `postgres` features enabled simultaneously is no
+  longer supported and is now a compile error. A PostgreSQL build requires
+  `--no-default-features --features full,postgres` (or `postgres`/`test-utils` for a
+  single crate) — plain `--features full,postgres` without `--no-default-features` still
+  fails intentionally, since the default `sqlite` feature stays active otherwise.
+
+  **Scope note**: this fix restores compile-time build correctness (the mutual
+  exclusivity invariant and the documented production build path) but does not address
+  #5571's originally-stated runtime-routing goal — `DbConfig::connect()` still resolves
+  the backend purely from compiled features, not from the connection string, so the
+  `*_matches_active_dialect` CI name-filter scoping in `zeph-memory`'s postgres test job
+  remains necessary and is not widened. That remains open follow-up work. Refs #5571.
+
 - `fix(tools,acp)`: ACP (`zeph --acp`) and the daemon (`zeph serve`) gated only the base
   tool chain (file/shell/scrape/cwd/diagnostics) behind `TrustGateExecutor`; `memory_save`,
   MCP-sourced tools, `load_skill`/`invoke_skill`, and `search_code` were composed outside

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,35 +152,35 @@ uuid = "1.23.4"
 walkdir = "2.5"
 wiremock = "0.6.5"
 zeph-a2a = { path = "crates/zeph-a2a", version = "0.21.4" }
-zeph-acp = { path = "crates/zeph-acp", version = "0.21.4" }
-zeph-agent-context = { path = "crates/zeph-agent-context", version = "0.21.4" }
+zeph-acp = { path = "crates/zeph-acp", default-features = false, version = "0.21.4" }
+zeph-agent-context = { path = "crates/zeph-agent-context", default-features = false, version = "0.21.4" }
 zeph-agent-feedback = { path = "crates/zeph-agent-feedback", version = "0.21.4" }
-zeph-agent-persistence = { path = "crates/zeph-agent-persistence", version = "0.21.4" }
-zeph-agent-tools = { path = "crates/zeph-agent-tools", version = "0.21.4" }
-zeph-bench = { path = "crates/zeph-bench", version = "0.21.4" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.21.4" }
+zeph-agent-persistence = { path = "crates/zeph-agent-persistence", default-features = false, version = "0.21.4" }
+zeph-agent-tools = { path = "crates/zeph-agent-tools", default-features = false, version = "0.21.4" }
+zeph-bench = { path = "crates/zeph-bench", default-features = false, version = "0.21.4" }
+zeph-channels = { path = "crates/zeph-channels", default-features = false, version = "0.21.4" }
 zeph-commands = { path = "crates/zeph-commands", version = "0.21.4" }
 zeph-common = { path = "crates/zeph-common", version = "0.21.4" }
 zeph-config = { path = "crates/zeph-config", version = "0.21.4" }
 zeph-context = { path = "crates/zeph-context", version = "0.21.4" }
-zeph-core = { path = "crates/zeph-core", version = "0.21.4" }
+zeph-core = { path = "crates/zeph-core", default-features = false, version = "0.21.4" }
 zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.21.4" }
 zeph-durable = { path = "crates/zeph-durable", default-features = false, version = "0.21.4" }
-zeph-experiments = { path = "crates/zeph-experiments", version = "0.21.4" }
+zeph-experiments = { path = "crates/zeph-experiments", default-features = false, version = "0.21.4" }
 zeph-gateway = { path = "crates/zeph-gateway", version = "0.21.4" }
-zeph-index = { path = "crates/zeph-index", version = "0.21.4" }
+zeph-index = { path = "crates/zeph-index", default-features = false, version = "0.21.4" }
 zeph-llm = { path = "crates/zeph-llm", version = "0.21.4" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.21.4" }
+zeph-mcp = { path = "crates/zeph-mcp", default-features = false, version = "0.21.4" }
 zeph-memory = { path = "crates/zeph-memory", default-features = false, version = "0.21.4" }
-zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.21.4" }
-zeph-plugins = { path = "crates/zeph-plugins", version = "0.21.4" }
-zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.21.4" }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.21.4" }
+zeph-orchestration = { path = "crates/zeph-orchestration", default-features = false, version = "0.21.4" }
+zeph-plugins = { path = "crates/zeph-plugins", default-features = false, version = "0.21.4" }
+zeph-sanitizer = { path = "crates/zeph-sanitizer", default-features = false, version = "0.21.4" }
+zeph-scheduler = { path = "crates/zeph-scheduler", default-features = false, version = "0.21.4" }
 zeph-session = { path = "crates/zeph-session", default-features = false, version = "0.21.4" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.21.4" }
-zeph-subagent = { path = "crates/zeph-subagent", version = "0.21.4" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.21.4" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.21.4" }
+zeph-skills = { path = "crates/zeph-skills", default-features = false, version = "0.21.4" }
+zeph-subagent = { path = "crates/zeph-subagent", default-features = false, version = "0.21.4" }
+zeph-tools = { path = "crates/zeph-tools", default-features = false, version = "0.21.4" }
+zeph-tui = { path = "crates/zeph-tui", default-features = false, version = "0.21.4" }
 zeph-worktree = { path = "crates/zeph-worktree", version = "0.21.4" }
 zeph-vault = { path = "crates/zeph-vault", version = "0.21.4" }
 zeroize = { version = "1.9.0", default-features = false }
@@ -215,7 +215,7 @@ ide     = ["acp", "acp-http"]
 server  = ["gateway", "a2a", "otel", "prometheus", "session"]
 chat    = ["discord", "slack"]
 ml      = ["candle", "pdf"]
-full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "sandbox", "gonka", "cocoon", "sqlite", "testing"]
+full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "sandbox", "gonka", "cocoon", "testing"]
 testing = ["zeph-llm/testing"]
 sandbox    = ["zeph-tools/sandbox"]
 bench      = ["dep:zeph-bench"]
@@ -257,9 +257,18 @@ profiling = [
 ]
 profiling-alloc = ["profiling", "zeph-core/profiling-alloc"]
 profiling-pyroscope = ["profiling", "otel", "dep:pprof"]
-# Database backend selection — mutually exclusive. Default includes sqlite.
+# Database backend selection — mutually exclusive. Default includes sqlite, so plain
+# `cargo build`/`cargo build --features full` (no --no-default-features) always get a
+# working sqlite build. `full` itself does NOT include a backend — it is
+# backend-agnostic so it can be combined with either.
 # NOTE: --all-features activates both, triggering compile_error! in zeph-db.
-# Use --features full or --features full,postgres instead.
+# For a PostgreSQL build, default features must be disabled (the plain default
+# always includes sqlite, and Cargo features are additive-only — sqlite cannot be
+# "overridden" by requesting postgres on top of it):
+#   cargo build --no-default-features --features full,postgres
+# For the equivalent explicit sqlite build:
+#   cargo build --no-default-features --features full,sqlite
+# Or simply `cargo build --features full` to rely on the default sqlite backend.
 gonka = ["zeph-llm/gonka", "zeph-core/gonka"]
 cocoon = ["zeph-llm/cocoon", "zeph-core/cocoon", "zeph-tui?/cocoon"]
 index = ["zeph-core/index"]
@@ -275,6 +284,14 @@ sqlite = [
     "zeph-durable/sqlite",
     "zeph-session/sqlite",
     "zeph-agent-persistence/sqlite",
+    "zeph-agent-context/sqlite",
+    "zeph-sanitizer/sqlite",
+    "zeph-skills/sqlite",
+    "zeph-subagent/sqlite",
+    "zeph-acp?/sqlite",
+    "zeph-bench?/sqlite",
+    "zeph-tui?/sqlite",
+    "zeph-experiments/sqlite",
 ]
 postgres = [
     "zeph-db/postgres",
@@ -288,6 +305,14 @@ postgres = [
     "zeph-durable/postgres",
     "zeph-session/postgres",
     "zeph-agent-persistence/postgres",
+    "zeph-agent-context/postgres",
+    "zeph-sanitizer/postgres",
+    "zeph-skills/postgres",
+    "zeph-subagent/postgres",
+    "zeph-acp?/postgres",
+    "zeph-bench?/postgres",
+    "zeph-tui?/postgres",
+    "zeph-experiments/postgres",
 ]
 
 [dependencies]

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -24,8 +24,8 @@ default = [
 ]
 # `zeph-memory`/`zeph-db` require a backend to compile; default to `sqlite` so this crate
 # builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
-sqlite = ["zeph-memory/sqlite", "zeph-session/sqlite"]
-postgres = ["zeph-memory/postgres", "zeph-session/postgres"]
+sqlite = ["zeph-memory/sqlite", "zeph-session/sqlite", "zeph-core/sqlite", "zeph-mcp/sqlite", "zeph-tools/sqlite"]
+postgres = ["zeph-memory/postgres", "zeph-session/postgres", "zeph-core/postgres", "zeph-mcp/postgres", "zeph-tools/postgres"]
 acp-http = ["dep:axum", "dep:blake3", "dep:dashmap", "dep:async-stream", "dep:tower-http", "dep:subtle", "dep:tower", "zeph-common/deep-link"]
 # session/close and session/delete stabilized in acp 0.14.0; no upstream feature gate needed
 unstable-session-delete = []

--- a/crates/zeph-agent-context/Cargo.toml
+++ b/crates/zeph-agent-context/Cargo.toml
@@ -34,8 +34,8 @@ zeph-skills.workspace = true
 tokio-util.workspace = true
 
 [features]
-sqlite = ["zeph-memory/sqlite"]
-postgres = ["zeph-memory/postgres"]
+sqlite = ["zeph-memory/sqlite", "zeph-sanitizer/sqlite", "zeph-skills/sqlite"]
+postgres = ["zeph-memory/postgres", "zeph-sanitizer/postgres", "zeph-skills/postgres"]
 default = ["sqlite"]
 # Enables `zeph-index` integration via `IndexAccess` in context assembly views.
 index = ["dep:zeph-index"]

--- a/crates/zeph-agent-persistence/Cargo.toml
+++ b/crates/zeph-agent-persistence/Cargo.toml
@@ -27,7 +27,7 @@ zeph-session = { workspace = true, default-features = false }
 
 [dev-dependencies]
 tempfile.workspace = true
-zeph-db = { workspace = true, default-features = false, features = ["sqlite"] }
+zeph-db.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }
 
 [features]

--- a/crates/zeph-agent-tools/Cargo.toml
+++ b/crates/zeph-agent-tools/Cargo.toml
@@ -30,5 +30,14 @@ zeph-sanitizer.workspace = true
 zeph-skills.workspace = true
 zeph-tools.workspace = true
 
+[features]
+# `zeph-mcp`/`zeph-orchestration`/`zeph-sanitizer`/`zeph-skills`/`zeph-tools`/
+# `zeph-agent-persistence` (and transitively `zeph-db`) require a backend to compile;
+# default to `sqlite` so this crate builds in isolation, and expose `postgres` for
+# PostgreSQL deployments (#4956).
+default = ["sqlite"]
+sqlite = ["zeph-mcp/sqlite", "zeph-orchestration/sqlite", "zeph-sanitizer/sqlite", "zeph-skills/sqlite", "zeph-tools/sqlite", "zeph-agent-persistence/sqlite"]
+postgres = ["zeph-mcp/postgres", "zeph-orchestration/postgres", "zeph-sanitizer/postgres", "zeph-skills/postgres", "zeph-tools/postgres", "zeph-agent-persistence/postgres"]
+
 [lints]
 workspace = true

--- a/crates/zeph-bench/Cargo.toml
+++ b/crates/zeph-bench/Cargo.toml
@@ -15,8 +15,8 @@ publish = true
 # `zeph-memory`/`zeph-db` require a backend to compile; default to `sqlite` so this crate
 # builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
 default = ["sqlite"]
-sqlite = ["zeph-memory/sqlite"]
-postgres = ["zeph-memory/postgres"]
+sqlite = ["zeph-memory/sqlite", "zeph-core/sqlite", "zeph-skills/sqlite", "zeph-tools/sqlite"]
+postgres = ["zeph-memory/postgres", "zeph-core/postgres", "zeph-skills/postgres", "zeph-tools/postgres"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -16,6 +16,12 @@ readme = "README.md"
 profiling = []
 discord = ["dep:tokio-tungstenite", "dep:futures"]
 slack = ["dep:hmac", "dep:sha2", "dep:subtle"]
+# `zeph-core`/`zeph-tools` (and transitively `zeph-db`) require a backend to compile;
+# default to `sqlite` so this crate builds in isolation, and expose `postgres` for
+# PostgreSQL deployments (#4956).
+default = ["sqlite"]
+sqlite = ["zeph-core/sqlite", "zeph-tools/sqlite"]
+postgres = ["zeph-core/postgres", "zeph-tools/postgres"]
 
 [dependencies]
 axum = { workspace = true }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -22,11 +22,11 @@ cocoon = ["zeph-llm/cocoon", "zeph-commands/cocoon"]
 index = ["zeph-agent-context/index"]
 metal = ["zeph-llm/metal"]
 mock = ["zeph-vault/mock"]
-postgres = ["zeph-db/postgres", "zeph-agent-context/postgres", "zeph-agent-persistence/postgres", "zeph-durable/postgres", "zeph-session/postgres"]
+postgres = ["zeph-db/postgres", "zeph-agent-context/postgres", "zeph-agent-persistence/postgres", "zeph-durable/postgres", "zeph-session/postgres", "zeph-index/postgres", "zeph-mcp/postgres", "zeph-memory/postgres", "zeph-orchestration/postgres", "zeph-sanitizer/postgres", "zeph-skills/postgres", "zeph-subagent/postgres", "zeph-tools/postgres", "zeph-experiments/postgres"]
 profiling = ["dep:tracing-subscriber", "zeph-commands/profiling"]
 profiling-alloc = ["profiling"]
 scheduler  = []
-sqlite = ["zeph-db/sqlite", "zeph-agent-context/sqlite", "zeph-agent-persistence/sqlite", "zeph-durable/sqlite", "zeph-session/sqlite"]
+sqlite = ["zeph-db/sqlite", "zeph-agent-context/sqlite", "zeph-agent-persistence/sqlite", "zeph-durable/sqlite", "zeph-session/sqlite", "zeph-index/sqlite", "zeph-mcp/sqlite", "zeph-memory/sqlite", "zeph-orchestration/sqlite", "zeph-sanitizer/sqlite", "zeph-skills/sqlite", "zeph-subagent/sqlite", "zeph-tools/sqlite", "zeph-experiments/sqlite"]
 sysinfo = ["dep:sysinfo"]
 
 [dependencies]
@@ -78,7 +78,7 @@ zeph-index.workspace = true
 zeph-llm.workspace = true
 zeph-mcp.workspace = true
 zeph-memory.workspace = true
-zeph-orchestration.workspace = true
+zeph-orchestration = { workspace = true, features = ["llm-planning"] }
 zeph-plugins.workspace = true
 zeph-sanitizer.workspace = true
 zeph-session = { workspace = true, default-features = false }

--- a/crates/zeph-db/Cargo.toml
+++ b/crates/zeph-db/Cargo.toml
@@ -13,7 +13,7 @@ description = "Database abstraction layer for Zeph (SQLite and PostgreSQL backen
 readme = "README.md"
 
 [features]
-# sqlite and postgres are mutually exclusive; when both are enabled, postgres takes priority.
+# sqlite and postgres are mutually exclusive; enabling both is a compile_error! (see src/lib.rs).
 # default = ["sqlite"] ensures standalone `cargo check -p zeph-db` and rust-analyzer work.
 # The root workspace Cargo.toml also enables sqlite via its own default feature set.
 default = ["sqlite"]

--- a/crates/zeph-db/README.md
+++ b/crates/zeph-db/README.md
@@ -3,7 +3,7 @@
 Database abstraction layer for [Zeph](https://github.com/bug-ops/zeph) — unified SQLite and PostgreSQL backends with compile-time backend selection, automatic migrations, dialect-aware SQL helpers, and FTS support.
 
 **Important:**
-> Exactly one of the `sqlite` or `postgres` features must be enabled. The default is `sqlite`. Enabling both simultaneously triggers a `compile_error!`. Using `--all-features` is intentionally unsupported — use `--features full` or `--features full,postgres` instead.
+> Exactly one of the `sqlite` or `postgres` features must be enabled. The default is `sqlite`, so plain `cargo build`/`cargo build --features full` (no `--no-default-features`) always produce a working sqlite build. Enabling both simultaneously triggers a `compile_error!`. Using `--all-features` is intentionally unsupported. For a PostgreSQL build, disable default features explicitly — `cargo build --no-default-features --features full,postgres` — since the default sqlite backend cannot be "overridden" by additively requesting postgres on top of it.
 
 ## Features
 

--- a/crates/zeph-db/src/fts.rs
+++ b/crates/zeph-db/src/fts.rs
@@ -10,7 +10,7 @@
 /// `PostgreSQL`: `plainto_tsquery` handles most sanitization; strip obvious
 /// injection attempts (single quotes).
 #[must_use]
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub fn sanitize_fts_query(query: &str) -> String {
     query
         .split(|c: char| !c.is_alphanumeric())
@@ -42,7 +42,7 @@ pub fn sanitize_fts_query(query: &str) -> String {
 /// `SQLite`: `messages_fts MATCH ?`
 /// `PostgreSQL`: `m.tsv @@ plainto_tsquery('english', $1)`
 #[must_use]
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub fn messages_fts_where() -> &'static str {
     "messages_fts MATCH ?"
 }
@@ -58,7 +58,7 @@ pub fn messages_fts_where() -> &'static str {
 /// `SQLite`: `JOIN messages_fts f ON f.rowid = m.id`
 /// `PostgreSQL`: empty string (tsv column is on messages directly)
 #[must_use]
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub fn messages_fts_join() -> &'static str {
     "JOIN messages_fts f ON f.rowid = m.id"
 }
@@ -74,7 +74,7 @@ pub fn messages_fts_join() -> &'static str {
 /// `SQLite`: `-rank AS score` (FTS5 `rank` is negative; negate for positive-is-better)
 /// `PostgreSQL`: `ts_rank(m.tsv, plainto_tsquery('english', $1)) AS score`
 #[must_use]
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub fn messages_fts_rank_select() -> &'static str {
     "-rank AS score"
 }
@@ -90,7 +90,7 @@ pub fn messages_fts_rank_select() -> &'static str {
 /// `SQLite`: `rank` (ascending — FTS5 rank is negative so ASC = best first)
 /// `PostgreSQL`: `score DESC` (`ts_rank` is positive so DESC = best first)
 #[must_use]
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub fn messages_fts_order_by() -> &'static str {
     "rank"
 }
@@ -108,7 +108,7 @@ pub fn messages_fts_order_by() -> &'static str {
 /// `SQLite`: `graph_entities_fts MATCH ?`
 /// `PostgreSQL`: `e.tsv @@ plainto_tsquery('english', $1)`
 #[must_use]
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub fn graph_entities_fts_where() -> &'static str {
     "graph_entities_fts MATCH ?"
 }
@@ -124,7 +124,7 @@ pub fn graph_entities_fts_where() -> &'static str {
 /// `SQLite`: `JOIN graph_entities_fts fts ON fts.rowid = e.id`
 /// `PostgreSQL`: empty string (tsv column lives on `graph_entities`)
 #[must_use]
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub fn graph_entities_fts_join() -> &'static str {
     "JOIN graph_entities_fts fts ON fts.rowid = e.id"
 }
@@ -142,7 +142,7 @@ pub fn graph_entities_fts_join() -> &'static str {
 /// `PostgreSQL`: `ts_rank(ARRAY[0,0,1,10], e.tsv, plainto_tsquery('english', $1)) AS fts_rank`
 ///   (weight array: [D, C, B, A]; A=name weight 10, B=summary weight 1)
 #[must_use]
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub fn graph_entities_fts_rank_select() -> &'static str {
     "-bm25(graph_entities_fts, 10.0, 1.0) AS fts_rank"
 }
@@ -157,7 +157,7 @@ pub fn graph_entities_fts_rank_select() -> &'static str {
 mod tests {
     use super::*;
 
-    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    #[cfg(feature = "sqlite")]
     mod sqlite {
         use super::*;
 

--- a/crates/zeph-db/src/lib.rs
+++ b/crates/zeph-db/src/lib.rs
@@ -12,9 +12,13 @@
 //!
 //! # Feature Flags
 //!
-//! Exactly one of `sqlite` or `postgres` must be enabled. The root workspace
-//! default includes `zeph-db/sqlite`. When both are enabled simultaneously,
-//! `postgres` takes priority. Use `--features full` for the standard `SQLite` build.
+//! `sqlite` and `postgres` are mutually exclusive: exactly one must be enabled.
+//! The root workspace default includes `zeph-db/sqlite`. Enabling both, or
+//! neither, is a compile error. Use `--no-default-features --features postgres`
+//! for a `PostgreSQL` build.
+
+#[cfg(all(feature = "sqlite", feature = "postgres"))]
+compile_error!("features `sqlite` and `postgres` are mutually exclusive for `zeph-db`");
 
 #[cfg(not(any(feature = "sqlite", feature = "postgres")))]
 compile_error!("exactly one of `sqlite` or `postgres` must be enabled for `zeph-db`");
@@ -47,7 +51,7 @@ pub use sqlx;
 // --- Active driver type alias ---
 
 /// The active database driver, selected at compile time.
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub type ActiveDriver = driver::SqliteDriver;
 #[cfg(feature = "postgres")]
 pub type ActiveDriver = driver::PostgresDriver;
@@ -99,7 +103,7 @@ pub type ActiveDialect = <ActiveDriver as DatabaseDriver>::Dialect;
 ///     .fetch_all(&pool)
 ///     .await?;
 /// ```
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 #[macro_export]
 macro_rules! sql {
     ($query:expr) => {
@@ -184,7 +188,7 @@ pub fn rewrite_placeholders(query: &str) -> String {
 ///
 /// `SQLite`: `?N`, `PostgreSQL`: `$N`
 #[must_use]
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 pub fn numbered_placeholder(n: usize) -> String {
     format!("?{n}")
 }
@@ -261,7 +265,7 @@ mod tests {
     fn numbered_placeholder_one_based() {
         let p1 = numbered_placeholder(1);
         let p3 = numbered_placeholder(3);
-        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+        #[cfg(feature = "sqlite")]
         {
             assert_eq!(p1, "?1");
             assert_eq!(p3, "?3");
@@ -276,7 +280,7 @@ mod tests {
     #[test]
     fn placeholder_list_range() {
         let list = placeholder_list(2, 3);
-        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+        #[cfg(feature = "sqlite")]
         assert_eq!(list, "?2, ?3, ?4");
         #[cfg(feature = "postgres")]
         assert_eq!(list, "$2, $3, $4");

--- a/crates/zeph-db/src/migrate.rs
+++ b/crates/zeph-db/src/migrate.rs
@@ -15,7 +15,7 @@ use crate::{DbPool, error::DbError};
 /// # Errors
 ///
 /// Returns [`DbError::Migration`] if any migration fails.
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 #[tracing::instrument(name = "db.migrate.run", skip_all, err)]
 pub async fn run_migrations(pool: &DbPool) -> Result<(), DbError> {
     sqlx::migrate!("./migrations/sqlite")

--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -33,18 +33,9 @@ impl DbConfig {
     /// # Errors
     ///
     /// Returns [`DbError`] if connection or migration fails.
-    // `postgres` takes cfg-priority over `sqlite` when both are enabled on a crate
-    // (documented in this crate's Cargo.toml `[features]` comment). This is safe for
-    // `zeph-db` in isolation, but a downstream crate that enables both (e.g. via a
-    // `test-utils` feature that adds `postgres` on top of a default `sqlite`) will have
-    // every `SqliteStore::new(":memory:")` call silently routed through
-    // `connect_postgres`, which fails to parse the bare `:memory:` string as a Postgres
-    // URL. See #5377: this bit `zeph-memory`/`zeph-index`'s crate-wide
-    // `--features test-utils --ignored` test runs; the fix there was to scope test
-    // execution to the Postgres-only test binary rather than changing this priority.
     #[tracing::instrument(name = "db.pool.connect", skip_all, err)]
     pub async fn connect(&self) -> Result<DbPool, DbError> {
-        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+        #[cfg(feature = "sqlite")]
         {
             Self::connect_sqlite(&self.url, self.max_connections, self.pool_size).await
         }
@@ -54,7 +45,7 @@ impl DbConfig {
         }
     }
 
-    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    #[cfg(feature = "sqlite")]
     async fn connect_sqlite(
         path: &str,
         max_connections: u32,
@@ -219,7 +210,7 @@ mod tests {
         assert!(redact_url(url).is_none());
     }
 
-    #[cfg(all(unix, feature = "sqlite", not(feature = "postgres")))]
+    #[cfg(all(unix, feature = "sqlite"))]
     #[tokio::test]
     async fn sqlite_precreated_with_0600() {
         use std::os::unix::fs::PermissionsExt as _;

--- a/crates/zeph-db/src/transaction.rs
+++ b/crates/zeph-db/src/transaction.rs
@@ -25,7 +25,7 @@ pub async fn begin(pool: &DbPool) -> Result<crate::DbTransaction<'_>, sqlx::Erro
 /// # Errors
 ///
 /// Returns a sqlx error if the transaction cannot be started.
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 #[tracing::instrument(name = "db.tx.begin_write", skip_all, err)]
 pub async fn begin_write(pool: &DbPool) -> Result<crate::DbTransaction<'_>, sqlx::Error> {
     pool.begin_with("BEGIN IMMEDIATE").await

--- a/crates/zeph-experiments/Cargo.toml
+++ b/crates/zeph-experiments/Cargo.toml
@@ -27,7 +27,7 @@ tracing.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-llm.workspace = true
-zeph-memory = { workspace = true, features = ["sqlite"] }
+zeph-memory.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
@@ -38,5 +38,10 @@ zeph-llm.workspace = true
 zeph-memory = { workspace = true, features = ["testing"] }
 
 [features]
-default = []
+# `zeph-memory` (and transitively `zeph-db`) requires a backend to compile; default to
+# `sqlite` so this crate builds in isolation, and expose `postgres` for PostgreSQL
+# deployments (#4956).
+default = ["sqlite"]
+sqlite = ["zeph-memory/sqlite"]
+postgres = ["zeph-memory/postgres"]
 mock = []

--- a/crates/zeph-index/Cargo.toml
+++ b/crates/zeph-index/Cargo.toml
@@ -52,8 +52,8 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"
 zeph-llm = { workspace = true, features = ["testing"] }
 
 [features]
-sqlite = ["zeph-db/sqlite", "zeph-memory/sqlite"]
-postgres = ["zeph-db/postgres", "zeph-memory/postgres"]
+sqlite = ["zeph-db/sqlite", "zeph-memory/sqlite", "zeph-tools/sqlite"]
+postgres = ["zeph-db/postgres", "zeph-memory/postgres", "zeph-tools/postgres"]
 default = ["sqlite"]
 # Enables test utilities and testcontainers for PostgreSQL integration tests.
 test-utils = ["dep:testcontainers", "dep:testcontainers-modules", "postgres"]

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [features]
 profiling = []
-sqlite = ["zeph-db/sqlite", "zeph-memory/sqlite"]
-postgres = ["zeph-db/postgres", "zeph-memory/postgres"]
+sqlite = ["zeph-db/sqlite", "zeph-memory/sqlite", "zeph-tools/sqlite"]
+postgres = ["zeph-db/postgres", "zeph-memory/postgres", "zeph-tools/postgres"]
 default = ["sqlite"]
 mock = []
 

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -1088,6 +1088,7 @@ async fn migration_024_backfill_preserves_entities_and_edges() {
     assert_edges_survived(conn).await;
 }
 
+#[cfg(feature = "sqlite")]
 async fn create_pre_023_schema(pool: &sqlx::SqlitePool) {
     sqlx::query(sql!(
         "CREATE TABLE graph_entities (
@@ -1160,6 +1161,7 @@ async fn create_pre_023_schema(pool: &sqlx::SqlitePool) {
     .unwrap();
 }
 
+#[cfg(feature = "sqlite")]
 async fn seed_pre_023_fixtures(pool: &sqlx::SqlitePool) -> (i64, i64) {
     let alice_id: i64 = sqlx::query_scalar(sql!(
         "INSERT INTO graph_entities (name, entity_type) VALUES ('Alice', 'person') RETURNING id"
@@ -1192,6 +1194,7 @@ async fn seed_pre_023_fixtures(pool: &sqlx::SqlitePool) -> (i64, i64) {
 ///
 /// Must use a single connection so `PRAGMA foreign_keys = OFF` takes effect on the same
 /// connection that executes DROP TABLE (PRAGMA is per-connection, not per-transaction).
+#[cfg(feature = "sqlite")]
 #[allow(clippy::too_many_lines)]
 async fn apply_migration_024(conn: &mut sqlx::SqliteConnection) {
     sqlx::query(sql!("PRAGMA foreign_keys = OFF"))
@@ -1302,6 +1305,7 @@ async fn apply_migration_024(conn: &mut sqlx::SqliteConnection) {
         .unwrap();
 }
 
+#[cfg(feature = "sqlite")]
 async fn assert_canonical_names_backfilled(conn: &mut sqlx::SqliteConnection, ids: (i64, i64)) {
     let (alice_id, rust_id) = ids;
     let alice_canon: String = sqlx::query_scalar(sql!(
@@ -1329,6 +1333,7 @@ async fn assert_canonical_names_backfilled(conn: &mut sqlx::SqliteConnection, id
     );
 }
 
+#[cfg(feature = "sqlite")]
 async fn assert_aliases_seeded(conn: &mut sqlx::SqliteConnection, alice_id: i64) {
     let alice_aliases: Vec<String> = sqlx::query_scalar(sql!(
         "SELECT alias_name FROM graph_entity_aliases WHERE entity_id = ?1"
@@ -1343,6 +1348,7 @@ async fn assert_aliases_seeded(conn: &mut sqlx::SqliteConnection, alice_id: i64)
     );
 }
 
+#[cfg(feature = "sqlite")]
 async fn assert_edges_survived(conn: &mut sqlx::SqliteConnection) {
     let edge_count: i64 = sqlx::query_scalar(sql!("SELECT COUNT(*) FROM graph_edges"))
         .fetch_one(&mut *conn)

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -42,8 +42,8 @@ zeph-llm = { workspace = true, features = ["testing"] }
 zeph-memory.workspace = true
 
 [features]
-sqlite = ["zeph-db/sqlite"]
-postgres = ["zeph-db/postgres"]
+sqlite = ["zeph-db/sqlite", "zeph-durable/sqlite", "zeph-subagent/sqlite"]
+postgres = ["zeph-db/postgres", "zeph-durable/postgres", "zeph-subagent/postgres"]
 llm-planning = ["dep:zeph-llm"]
 default = ["sqlite", "llm-planning"]
 

--- a/crates/zeph-plugins/Cargo.toml
+++ b/crates/zeph-plugins/Cargo.toml
@@ -37,5 +37,13 @@ zeph-tools.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wiremock.workspace = true
 
+[features]
+# `zeph-skills`/`zeph-tools` (and transitively `zeph-db`) require a backend to compile;
+# default to `sqlite` so this crate builds in isolation, and expose `postgres` for
+# PostgreSQL deployments (#4956).
+default = ["sqlite"]
+sqlite = ["zeph-skills/sqlite", "zeph-tools/sqlite"]
+postgres = ["zeph-skills/postgres", "zeph-tools/postgres"]
+
 [lints]
 workspace = true

--- a/crates/zeph-scheduler/Cargo.toml
+++ b/crates/zeph-scheduler/Cargo.toml
@@ -18,8 +18,8 @@ readme = "README.md"
 ## Pulls in `rustix` (fs + process features) for advisory file locking.
 ## Only meaningful on Unix targets; daemon code is `#[cfg(unix)]`-gated.
 daemon = ["dep:rustix"]
-sqlite = ["zeph-db/sqlite"]
-postgres = ["zeph-db/postgres"]
+sqlite = ["zeph-db/sqlite", "zeph-durable/sqlite"]
+postgres = ["zeph-db/postgres", "zeph-durable/postgres"]
 default = ["sqlite"]
 
 [dependencies]

--- a/crates/zeph-subagent/Cargo.toml
+++ b/crates/zeph-subagent/Cargo.toml
@@ -47,7 +47,6 @@ schemars.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-zeph-durable = { workspace = true, features = ["sqlite"] }
 zeph-llm = { workspace = true, features = ["testing"] }
 
 [lints]

--- a/crates/zeph-tools/Cargo.toml
+++ b/crates/zeph-tools/Cargo.toml
@@ -61,8 +61,8 @@ wiremock.workspace = true
 
 [features]
 profiling = []
-sqlite = ["zeph-db/sqlite"]
-postgres = ["zeph-db/postgres"]
+sqlite = ["zeph-db/sqlite", "zeph-sanitizer/sqlite"]
+postgres = ["zeph-db/postgres", "zeph-sanitizer/postgres"]
 default = ["sqlite"]
 # Gates Linux-only landlock + seccompiler deps. macOS backend compiles unconditionally.
 sandbox = ["dep:landlock", "dep:seccompiler"]

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -68,8 +68,8 @@ cocoon = []
 profiling = []
 # `zeph-memory`/`zeph-db` require a backend to compile; default to `sqlite` so this crate
 # builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
-sqlite = ["zeph-memory/sqlite"]
-postgres = ["zeph-memory/postgres"]
+sqlite = ["zeph-memory/sqlite", "zeph-core/sqlite", "zeph-subagent/sqlite"]
+postgres = ["zeph-memory/postgres", "zeph-core/postgres", "zeph-subagent/postgres"]
 
 [lints]
 workspace = true

--- a/specs/031-database-abstraction/spec.md
+++ b/specs/031-database-abstraction/spec.md
@@ -191,8 +191,16 @@ zeph-db (Layer 0)
 The root `Cargo.toml` `default` feature explicitly includes `zeph-db/sqlite`. This
 avoids the problem where `cargo test --all-features` or `cargo clippy --all-features`
 would fail: with both features activated, the `compile_error!` fires intentionally.
-`--all-features` is not a supported build mode for this workspace; use `--features full`
-or `--features full,postgres` instead. This is documented in CI configuration.
+`--all-features` is not a supported build mode for this workspace. `full` itself is
+backend-agnostic (does not include `sqlite` or `postgres`); use plain `--features full`
+(relies on the default `sqlite`) for a SQLite build, or `--no-default-features --features
+full,postgres` for a PostgreSQL build — default features must be disabled explicitly for
+PostgreSQL because Cargo features are additive-only, so the default `sqlite` cannot be
+"overridden" by requesting `postgres` on top of it. This is documented in CI
+configuration (see also §4.2 amendment at line ~1129 on the `--no-default-features`
+requirement, and the full-workspace `default-features = false` audit required across
+every crate transitively depending on `zeph-db`/`zeph-memory` for this to compile
+cleanly).
 
 ```toml
 # zeph-db/Cargo.toml
@@ -207,9 +215,11 @@ postgres = ["sqlx/postgres"]
 # Root Cargo.toml
 [features]
 default = ["bundled-skills", "scheduler", "guardrail", "zeph-db/sqlite"]
+full = [...]  # backend-agnostic; does not include sqlite or postgres
 postgres = ["zeph-db/postgres"]
 # NOTE: --all-features activates both sqlite and postgres, triggering compile_error!.
-# This is intentional. CI and developers must use --features full or --features full,postgres.
+# This is intentional. Use --features full (sqlite, via default) or
+# --no-default-features --features full,postgres.
 ```
 
 **Mutual exclusivity**: `sqlite` and `postgres` are mutually exclusive at compile


### PR DESCRIPTION
## Summary

- `zeph-db`'s compile-time guard only covered "neither `sqlite` nor `postgres` enabled" — a #5377-era workaround left the "both enabled" case to silently fall through to a "postgres wins by priority" cfg resolution instead of failing to compile. This let any invocation that added `--features postgres`/`test-utils` without `--no-default-features` silently compile both backends in and route `:memory:` SQLite test fixtures through `connect_postgres`, breaking ~55% of `zeph-memory`'s unit tests (676/827 failing).
- Restores the spec-031-mandated hard `compile_error!` for both-enabled, and extends `default-features = false` + explicit `sqlite`/`postgres` forwarding to ~21 workspace crates so the documented production build path (`--no-default-features --features full,postgres`) actually compiles end-to-end again — this broke as a direct consequence of restoring the compile_error, since the old silent-priority behavior was the only thing that ever let that combination "work".
- Restores the `build-postgres` CI job to full workspace scope and adds a regression-guard step asserting the `compile_error!` fires, to catch a repeat of the #5377 → #5571 regression path.
- Fixes 3 stale docs (root `Cargo.toml` comment, `crates/zeph-db/README.md`, `specs/031-database-abstraction/spec.md` §4.2) that recommended the now-invalid bare `--features full,postgres` invocation.

**Scope note**: this does not achieve #5571's originally-stated runtime-routing goal (`DbConfig::connect()` still resolves the backend purely from compiled features, not the connection string) — the `*_matches_active_dialect` CI test filter remains necessary. Refs #5571 (left open).

Follow-ups filed (non-blocking, out of scope for this PR):
- #5631 (P3) — Cargo `default` arrays that mix backend selection with unrelated functional features (the `zeph-orchestration`/`llm-planning` case found while extending this fix).
- #5632 (P4) — cosmetic cleanup of now-redundant `not(feature = "postgres")` cfg guards in ~7 sibling crates, made possible (not required) by this fix.

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — pass
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11977 passed, 34 skipped, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — pass
- [x] `cargo check --workspace --all-targets --no-default-features --features full,postgres` — pass, zero errors (headline fix)
- [x] `cargo check --workspace --all-targets --no-default-features --features full,sqlite` — pass (parity)
- [x] `cargo check -p zeph-db --features postgres` — correctly fails with the expected `compile_error!` message
- [x] `cargo check --workspace --features full,postgres` (without `--no-default-features`) — correctly still fails (intentional; default `sqlite` stays active otherwise)
- [x] New CI regression-guard step independently reproduced under real `bash -eo pipefail` semantics, both branches (guard fires / guard fails to fire)
- [x] Branch rebased onto current `origin/main` (728aa40b); all checks above re-run post-rebase