### PR TITLE
feat(memory): wire Qdrant gRPC timeout through to configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -383,6 +383,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `feat(memory)`: add `memory.qdrant_timeout_secs` config field, wired into
+  `QdrantOps::with_timeout` at all 5 production `QdrantOps::new` construction sites:
+  `AppBuilder::new` (`src/bootstrap/mod.rs`, via the extracted `build_qdrant_ops` helper),
+  `src/commands/doctor.rs`, `src/commands/ingest.rs`, `src/commands/knowledge.rs`, and
+  `src/commands/project.rs` (`PurgeEngine`, 2 call sites). Previously `QdrantOps::with_timeout`
+  had no production caller — every Qdrant gRPC call used the hardcoded 10-second default with
+  no way for an operator to tune it. Defaults to `10` (seconds), matching prior behavior
+  exactly. A `migrate-config` step adds a commented `qdrant_timeout_secs = 10` advisory under
+  `[memory]` for existing configs. (#5493)
+
 - `feat(session)`: add the `zeph-session` crate foundation (spec-068 P0, #5343) — an append-only
   JSONL event log (`SessionEventLog`) as the durable source of truth for a conversation, the
   `SessionEvent` schema (reusing `zeph_llm::provider::MessagePart` and

--- a/config/default.toml
+++ b/config/default.toml
@@ -315,6 +315,9 @@ injection_patterns = true
 history_limit = 50
 # Qdrant vector database URL for semantic memory
 qdrant_url = "http://localhost:6334"
+# Per-call timeout applied to every Qdrant gRPC operation, in seconds. Bounds each call
+# against a hung server or a stalled network path instead of blocking indefinitely.
+qdrant_timeout_secs = 10
 # Number of messages before triggering summarization (0 = disabled)
 summarization_threshold = 50
 # Total token budget for context window (0 = auto-detect from model)

--- a/crates/zeph-config/src/memory/root.rs
+++ b/crates/zeph-config/src/memory/root.rs
@@ -46,6 +46,10 @@ fn default_qdrant_url() -> String {
     "http://localhost:6334".into()
 }
 
+fn default_qdrant_timeout_secs() -> u64 {
+    10
+}
+
 fn default_summarization_threshold() -> usize {
     50
 }
@@ -167,6 +171,12 @@ pub struct MemoryConfig {
     /// `skip_serializing` prevents the key from being written back to TOML on config save.
     #[serde(default, skip_serializing)]
     pub qdrant_api_key: Option<Secret>,
+    /// Per-call timeout applied to every Qdrant gRPC operation, in seconds.
+    ///
+    /// Bounds each call against a hung server or a stalled network path instead of blocking
+    /// the calling async task indefinitely. Default: `10`.
+    #[serde(default = "default_qdrant_timeout_secs")]
+    pub qdrant_timeout_secs: u64,
     #[serde(default)]
     pub semantic: SemanticConfig,
     #[serde(default = "default_summarization_threshold")]

--- a/crates/zeph-config/src/memory/tests.rs
+++ b/crates/zeph-config/src/memory/tests.rs
@@ -408,6 +408,28 @@ mod apex_mem_quality_gate_config_tests {
     }
 
     #[test]
+    fn memory_config_qdrant_timeout_secs_default_is_ten() {
+        let cfg: MemoryConfig = toml::from_str("history_limit = 50").expect("must deserialize");
+        assert_eq!(
+            cfg.qdrant_timeout_secs, 10,
+            "qdrant_timeout_secs must default to 10, matching the previous hardcoded QdrantOps timeout"
+        );
+    }
+
+    #[test]
+    fn memory_config_qdrant_timeout_secs_toml_roundtrip() {
+        let toml = r"
+            history_limit = 50
+            qdrant_timeout_secs = 3
+        ";
+        let cfg: MemoryConfig = toml::from_str(toml).expect("must deserialize");
+        assert_eq!(
+            cfg.qdrant_timeout_secs, 3,
+            "qdrant_timeout_secs must deserialize from TOML"
+        );
+    }
+
+    #[test]
     fn five_signal_config_default_is_disabled() {
         let cfg: MemoryConfig = toml::from_str("history_limit = 50").expect("must deserialize");
         assert!(!cfg.five_signal.enabled);

--- a/crates/zeph-config/src/migrate/memory.rs
+++ b/crates/zeph-config/src/migrate/memory.rs
@@ -680,6 +680,43 @@ pub fn migrate_qdrant_api_key(toml_src: &str) -> Result<MigrationResult, Migrate
     })
 }
 
+/// No-op migration for the optional `qdrant_timeout_secs` field.
+///
+/// The field has `#[serde(default = "default_qdrant_timeout_secs")]` (10 seconds, matching the
+/// previously hardcoded `QdrantOps` default) so existing configs parse unchanged. This step adds
+/// a commented-out hint under `[memory]` if not already present.
+///
+/// # Errors
+///
+/// Returns `MigrateError` if the TOML cannot be parsed or `[memory]` is malformed.
+pub fn migrate_qdrant_timeout_secs(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("qdrant_timeout_secs") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let mut doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+
+    if !doc.contains_key("memory") {
+        doc.insert("memory", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+
+    let comment = "\n# Per-call timeout applied to every Qdrant gRPC operation, in seconds.\n\
+         # Bounds each call against a hung server or a stalled network path.\n\
+         # qdrant_timeout_secs = 10\n";
+    let raw = doc.to_string();
+    let output = format!("{raw}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["memory.qdrant_timeout_secs".to_owned()],
+    })
+}
+
 /// Add commented-out `embed_timeout_secs` and `compress_timeout_secs` to `[memory.fidelity]`
 /// when it is present in the config but does not yet have these keys (#4645, #4651).
 ///

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -612,17 +612,17 @@ use steps::{
     MigrateNliConfig, MigrateOrchestrationAssetSensitivity, MigrateOrchestrationPersistence,
     MigrateOrchestratorProvider, MigrateOtelFilter, MigratePiiFilterNames,
     MigratePlannerModelToProvider, MigratePolicyProviderAndUtilityWindow,
-    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig,
-    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSecretMaskingConfig,
-    MigrateServeConfig, MigrateSessionPersistProviderOverrides, MigrateSessionPersistenceConfig,
-    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellCheckpointsConfig,
-    MigrateShellTransactional, MigrateSttToProvider, MigrateSupervisorConfig,
-    MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateTraceMetadata,
-    MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig, MigrateTuiThemeDefaults,
-    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
+    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQdrantTimeoutSecs,
+    MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
+    MigrateSecretMaskingConfig, MigrateServeConfig, MigrateSessionPersistProviderOverrides,
+    MigrateSessionPersistenceConfig, MigrateSessionProviderPersistence, MigrateSessionRecapConfig,
+    MigrateShellCheckpointsConfig, MigrateShellTransactional, MigrateSttToProvider,
+    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
+    MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig,
+    MigrateTuiThemeDefaults, MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–74).
+/// Ordered registry of all sequential migration steps (steps 1–75).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -754,6 +754,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             // Step 74 — add a commented `filter_names = false` advisory to an existing
             // [security.pii_filter] table (#5530)
             Box::new(MigratePiiFilterNames),
+            // Step 75 — add qdrant_timeout_secs advisory under [memory]
+            Box::new(MigrateQdrantTimeoutSecs),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -34,7 +34,8 @@
 //! step 72 adds a `[security.content_isolation.nli]` advisory block (#5438);
 //! step 73 adds a `[security.content_isolation.secret_masking]` advisory block (#5437);
 //! step 74 adds a commented `filter_names = false` advisory to an existing
-//! `[security.pii_filter]` table (#5530).
+//! `[security.pii_filter]` table (#5530);
+//! step 75 adds a commented `qdrant_timeout_secs = 10` advisory under `[memory]`.
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -60,9 +61,9 @@ use super::{
     migrate_orchestration_asset_sensitivity, migrate_orchestration_orchestrator_provider,
     migrate_orchestration_persistence, migrate_otel_filter, migrate_pii_filter_names,
     migrate_planner_model_to_provider, migrate_policy_provider_and_utility_window,
-    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_quality_config,
-    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
-    migrate_secret_masking_config, migrate_serve_config,
+    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_qdrant_timeout_secs,
+    migrate_quality_config, migrate_sandbox_config, migrate_sandbox_egress_filter,
+    migrate_scheduler_daemon_config, migrate_secret_masking_config, migrate_serve_config,
     migrate_session_persist_provider_overrides, migrate_session_persistence_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_shell_checkpoints_config, migrate_shell_transactional, migrate_stt_to_provider,
@@ -897,5 +898,17 @@ impl Migration for MigratePiiFilterNames {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_pii_filter_names(toml_src)
+    }
+}
+
+/// Step 75 — adds a commented `qdrant_timeout_secs = 10` advisory under `[memory]`.
+pub(super) struct MigrateQdrantTimeoutSecs;
+impl Migration for MigrateQdrantTimeoutSecs {
+    fn name(&self) -> &'static str {
+        "migrate_qdrant_timeout_secs"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_qdrant_timeout_secs(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        74,
-        "MIGRATIONS registry must contain all 74 sequential steps"
+        75,
+        "MIGRATIONS registry must contain all 75 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1645,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 74);
+    assert_eq!(MIGRATIONS.len(), 75);
 }
 
 #[test]
@@ -1760,6 +1760,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_nli_config",
         "migrate_secret_masking_config",
         "migrate_pii_filter_names",
+        "migrate_qdrant_timeout_secs",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -1838,6 +1839,48 @@ fn migrate_qdrant_api_key_idempotent_on_commented_output() {
     let first = migrate_qdrant_api_key(base).unwrap();
     assert_eq!(first.changed_count, 1);
     let second = migrate_qdrant_api_key(&first.output).unwrap();
+    assert_eq!(second.changed_count, 0, "second run must not double-append");
+    assert_eq!(second.output, first.output);
+}
+
+// ── migrate_qdrant_timeout_secs tests ─────────────────────────────────────
+
+#[test]
+fn migrate_qdrant_timeout_secs_adds_comment_when_absent() {
+    let src = "[memory]\nqdrant_url = \"http://localhost:6334\"\n";
+    let result = migrate_qdrant_timeout_secs(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result
+            .sections_changed
+            .contains(&"memory.qdrant_timeout_secs".to_owned())
+    );
+    assert!(result.output.contains("# qdrant_timeout_secs = 10"));
+}
+
+#[test]
+fn migrate_qdrant_timeout_secs_is_noop_when_present() {
+    let src = "[memory]\nqdrant_url = \"http://localhost:6334\"\nqdrant_timeout_secs = 5\n";
+    let result = migrate_qdrant_timeout_secs(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert!(result.sections_changed.is_empty());
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn migrate_qdrant_timeout_secs_creates_memory_section_when_absent() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let result = migrate_qdrant_timeout_secs(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("# qdrant_timeout_secs = 10"));
+}
+
+#[test]
+fn migrate_qdrant_timeout_secs_idempotent_on_commented_output() {
+    let base = "[memory]\nqdrant_url = \"http://localhost:6334\"\n";
+    let first = migrate_qdrant_timeout_secs(base).unwrap();
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_qdrant_timeout_secs(&first.output).unwrap();
     assert_eq!(second.changed_count, 0, "second run must not double-append");
     assert_eq!(second.output, first.output);
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -260,6 +260,7 @@ impl Default for Config {
                 history_limit: 50,
                 qdrant_url: "http://localhost:6334".into(),
                 qdrant_api_key: None,
+                qdrant_timeout_secs: 10,
                 semantic: SemanticConfig::default(),
                 summarization_threshold: 50,
                 summarization_llm_timeout_secs: 60,

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -73,11 +73,8 @@ impl QdrantOps {
     /// Override the per-call timeout applied to every Qdrant gRPC operation.
     ///
     /// Defaults to 10 seconds. A slow or hung Qdrant server would otherwise block the
-    /// calling async task indefinitely (#5484).
-    ///
-    /// TODO(#5493): no production call site invokes this yet — the timeout is currently
-    /// hardcoded to the default rather than config-driven. Wire a config field through
-    /// `zeph-config`/bootstrap and call this from there.
+    /// calling async task indefinitely (#5484). The production bootstrap path drives this
+    /// from `MemoryConfig::qdrant_timeout_secs`.
     ///
     /// # Examples
     ///

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -26,6 +26,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use std::sync::RwLock;
+use std::time::Duration;
 
 use tokio::sync::watch;
 use zeph_llm::any::AnyProvider;
@@ -73,6 +74,43 @@ fn is_qdrant_localhost(url: &str) -> bool {
         host.as_deref(),
         Some("127.0.0.1" | "localhost" | "[::1]" | "0.0.0.0" | "host.docker.internal")
     )
+}
+
+/// Build the shared production [`QdrantOps`] client from resolved config, or `None` when
+/// `vector_backend` is not `Qdrant`.
+///
+/// Applies `memory.qdrant_timeout_secs` via [`QdrantOps::with_timeout`] — this is the single
+/// site the `AppBuilder::new` bootstrap path uses, so every subsystem constructed through
+/// `SemanticMemory::with_qdrant_ops` shares the operator-configured per-call timeout.
+///
+/// # Errors
+///
+/// Returns [`BootstrapError::Provider`] if `qdrant_url` fails to parse.
+fn build_qdrant_ops(config: &Config) -> Result<Option<QdrantOps>, BootstrapError> {
+    match config.memory.vector_backend {
+        zeph_core::config::VectorBackend::Qdrant => {
+            let api_key_str = config.memory.qdrant_api_key.as_ref().map(Secret::expose);
+            if api_key_str.unwrap_or("").trim().is_empty()
+                && !is_qdrant_localhost(&config.memory.qdrant_url)
+            {
+                tracing::warn!(
+                    url = %config.memory.qdrant_url,
+                    "qdrant_api_key is not set for non-localhost Qdrant — \
+                     set ZEPH_QDRANT_API_KEY in the vault to authenticate"
+                );
+            }
+            let ops = QdrantOps::new(&config.memory.qdrant_url, api_key_str)
+                .map_err(|e| {
+                    BootstrapError::Provider(format!(
+                        "invalid qdrant_url '{}': {e}",
+                        config.memory.qdrant_url
+                    ))
+                })?
+                .with_timeout(Duration::from_secs(config.memory.qdrant_timeout_secs));
+            Ok(Some(ops))
+        }
+        _ => Ok(None),
+    }
 }
 
 /// Top-level builder that owns all runtime dependencies resolved at startup.
@@ -216,28 +254,7 @@ impl AppBuilder {
             zeph_plugins::apply_plugin_config_overlays(&mut config, &plugins_dir())
                 .map_err(|e| BootstrapError::Provider(format!("plugin overlay merge: {e}")))?;
 
-        let qdrant_ops = match config.memory.vector_backend {
-            zeph_core::config::VectorBackend::Qdrant => {
-                let api_key_str = config.memory.qdrant_api_key.as_ref().map(Secret::expose);
-                if api_key_str.unwrap_or("").trim().is_empty()
-                    && !is_qdrant_localhost(&config.memory.qdrant_url)
-                {
-                    tracing::warn!(
-                        url = %config.memory.qdrant_url,
-                        "qdrant_api_key is not set for non-localhost Qdrant — \
-                         set ZEPH_QDRANT_API_KEY in the vault to authenticate"
-                    );
-                }
-                let ops = QdrantOps::new(&config.memory.qdrant_url, api_key_str).map_err(|e| {
-                    BootstrapError::Provider(format!(
-                        "invalid qdrant_url '{}': {e}",
-                        config.memory.qdrant_url
-                    ))
-                })?;
-                Some(ops)
-            }
-            _ => None,
-        };
+        let qdrant_ops = build_qdrant_ops(&config)?;
 
         Ok(Self {
             config,

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -556,6 +556,38 @@ fn appbuilder_qdrant_ops_valid_url_succeeds() {
     assert!(result.is_ok(), "QdrantOps::new with valid URL must succeed");
 }
 
+#[test]
+fn appbuilder_qdrant_ops_applies_configured_timeout() {
+    let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+    config.memory.vector_backend = zeph_core::config::VectorBackend::Qdrant;
+    config.memory.qdrant_timeout_secs = 3;
+
+    // `build_qdrant_ops` is the exact function `AppBuilder::new` calls to construct the
+    // shared production `QdrantOps` client — not a re-implementation. Deleting the
+    // `.with_timeout(...)` call from that function (or from `AppBuilder::new`, which would
+    // require breaking this call) fails this test. `timeout` is private on `QdrantOps`, so
+    // the configured value is observed via `Debug`.
+    let ops = build_qdrant_ops(&config)
+        .expect("valid default qdrant_url must build")
+        .expect("vector_backend explicitly set to Qdrant");
+    assert!(
+        format!("{ops:?}").contains("3s"),
+        "QdrantOps must be built with the configured qdrant_timeout_secs, not the default"
+    );
+}
+
+#[test]
+fn build_qdrant_ops_returns_none_for_sqlite_backend() {
+    let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+    config.memory.vector_backend = zeph_core::config::VectorBackend::Sqlite;
+
+    let ops = build_qdrant_ops(&config).unwrap();
+    assert!(
+        ops.is_none(),
+        "build_qdrant_ops must return None when vector_backend is not Qdrant"
+    );
+}
+
 // ── build_feedback_classifier ─────────────────────────────────────────────────
 //
 // Full integration tests require a live provider (Ollama/OpenAI). These tests only verify

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -606,10 +606,12 @@ async fn check_qdrant(config: &zeph_core::config::Config, timeout_secs: u64) -> 
         .qdrant_api_key
         .as_ref()
         .map(|s| s.expose().to_owned());
+    let qdrant_timeout_secs = config.memory.qdrant_timeout_secs;
     let result = tokio::time::timeout(Duration::from_secs(timeout_secs), async move {
         use zeph_memory::vector_store::VectorStore as _;
-        let ops =
-            zeph_memory::QdrantOps::new(&url, api_key.as_deref()).map_err(|e| e.to_string())?;
+        let ops = zeph_memory::QdrantOps::new(&url, api_key.as_deref())
+            .map_err(|e| e.to_string())?
+            .with_timeout(Duration::from_secs(qdrant_timeout_secs));
         ops.health_check()
             .await
             .map(|_| ())

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -23,7 +23,10 @@ pub(crate) async fn handle_ingest(
         &config.memory.qdrant_url,
         config.memory.qdrant_api_key.as_ref().map(Secret::expose),
     )
-    .map_err(|e| anyhow::anyhow!("failed to connect to Qdrant: {e}"))?;
+    .map_err(|e| anyhow::anyhow!("failed to connect to Qdrant: {e}"))?
+    .with_timeout(std::time::Duration::from_secs(
+        config.memory.qdrant_timeout_secs,
+    ));
 
     let (provider, _status_tx, _status_rx) = app.build_provider().await?;
     let provider = std::sync::Arc::new(provider);

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -674,7 +674,10 @@ async fn build_ingest_resources(
         &config.memory.qdrant_url,
         config.memory.qdrant_api_key.as_ref().map(Secret::expose),
     )
-    .map_err(|e| anyhow::anyhow!("failed to connect to Qdrant: {e}"))?;
+    .map_err(|e| anyhow::anyhow!("failed to connect to Qdrant: {e}"))?
+    .with_timeout(std::time::Duration::from_secs(
+        config.memory.qdrant_timeout_secs,
+    ));
     let collection = config.memory.documents.collection.clone();
     let provider = resolve_notes_embed_provider(provider_override, config, &app).await?;
     let embed_fn = {

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -513,7 +513,9 @@ impl PurgeEngine<'_> {
                 .as_ref()
                 .map(|s| s.expose().to_owned());
             let ops = match QdrantOps::new(&config.memory.qdrant_url, api_key.as_deref()) {
-                Ok(o) => o,
+                Ok(o) => o.with_timeout(std::time::Duration::from_secs(
+                    config.memory.qdrant_timeout_secs,
+                )),
                 Err(e) => {
                     println!("    (cannot connect to Qdrant: {e})");
                     return;
@@ -547,7 +549,9 @@ impl PurgeEngine<'_> {
             .as_ref()
             .map(|s| s.expose().to_owned());
         let ops = match QdrantOps::new(&config.memory.qdrant_url, api_key.as_deref()) {
-            Ok(o) => o,
+            Ok(o) => o.with_timeout(std::time::Duration::from_secs(
+                config.memory.qdrant_timeout_secs,
+            )),
             Err(e) => {
                 eprintln!("  Warning: cannot connect to Qdrant: {e}");
                 return 0;


### PR DESCRIPTION
## Summary

Closes #5493. `QdrantOps` exposes a `with_timeout` builder as the intended way to tune the per-call gRPC timeout added to guard against a hung Qdrant server (#5484), but nothing in config or bootstrap ever called it. Every production code path silently used the hardcoded 10-second default with no way for an operator to adjust it.

Adds `MemoryConfig::qdrant_timeout_secs` (default 10, matching the prior hardcoded value exactly, so existing deployments are unaffected), documents it in `config/default.toml` next to `qdrant_url`, and wires it into every production `QdrantOps` construction site: the shared bootstrap path, plus the four CLI commands (`doctor`, `ingest`, `knowledge`, `project`) that build their own client independently of bootstrap. Also adds a config-migration step for existing `config.toml` files, mirroring the established pattern already used for the sibling `qdrant_api_key` field.

## Review process

developer (read the existing `MemoryConfig`/migration conventions before adding anything) → parallel (tester independently confirmed the default is byte-for-byte consistent with the old hardcoded value, traced a second `QdrantOps` constructor family not mentioned in the original handoff and confirmed it has zero live production callers, verified the migration step and backward-compat deserialization; adversarial critic returned **significant** — found that 4 CLI commands, including `doctor` which ironically diagnoses hung Qdrant instances, still ignored the new config, and that one new test was tautological) → developer fixed all 3 findings (wired the remaining 4 call sites, made the test exercise the real bootstrap-shared helper instead of duplicating construction inline, rebased) → a transient agent crash (server-side API overload, not a task failure) was recovered by re-verifying rather than redoing the work from scratch, which also caught one more gap: `config/default.toml` was missing the new field entirely → code reviewer independently re-verified every one of the 6 call sites individually and re-ran the full CI-matching suite, approved.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11991 passed, 0 failed
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] New unit tests confirm the config default matches the prior hardcoded value, and that the configured (not default) timeout reaches the constructed client via the real bootstrap-shared helper function
- [x] Config-migration test suite (240 tests) confirms the new migration step doesn't disturb the existing 74-step chain
- [x] `--init` wizard: no change needed (no sibling low-level timeout knob is prompted there; this remains an advanced/expert setting with a sensible default)
- [x] CLI/TUI: no dedicated surface added, matching every sibling `*_timeout_ms`/`*_timeout_secs` knob in this codebase, none of which have CLI flags or TUI entries
- [x] Live-testing playbook and coverage-status.md updated in `.local/testing/` to cover all 5 wired call sites