### PR TITLE
refactor(memory): dedupe sweep clustering, admission gate, and bg-embed logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   free function replacing 3 duplicated `CommunityRow` → `Community` conversion blocks. Pure
   refactor, no behavior change — all 4 public BFS entry points keep their original
   signatures. (#5501, #5490)
+- `refactor(memory)`: extracted three DRY helpers out of `zeph-memory`'s duplicated sweep,
+  admission-gate, and background-embed logic. New `crates/zeph-memory/src/sweep_helpers.rs`
+  (`pub(crate)`) holds `cluster_by_cosine_similarity` (generalizes `scenes.rs`'s
+  `cluster_messages` and `tiers.rs`'s `cluster_by_similarity` over a generic candidate type),
+  `embed_batch_with_validation` (shared batch-embed + length-validation), and
+  `llm_call_with_timeout` (shared 15s-timeout LLM call), used by both `scenes.rs` and
+  `tiers.rs` (#5581). `semantic/recall.rs` gained `run_admission_gate` /
+  `run_quality_gate` / `record_admission_sample_opt` private helpers shared by all four
+  `remember*` variants — `remember_tool_output` and `remember_categorized` continue to
+  skip the quality gate, which is unchanged, load-bearing behavior (#5569). The three
+  near-identical `embed_and_store_*_bg` background tasks collapsed into one generic
+  `embed_chunk_and_store_bg` taking a boxed-future per-chunk store closure, with the
+  rate-limited Qdrant-ensure-collection warning extracted into a pure
+  `should_emit_qdrant_warn` predicate plus `warn_qdrant_ensure_failure` (#5565). No
+  behavior change; existing test coverage extended to target the new shared functions
+  directly (moved clustering tests into `sweep_helpers.rs`, added per-`remember*`-variant
+  admission/quality-gate coverage in `semantic/tests/recall.rs`).
 
 ### Fixed
 

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -83,6 +83,7 @@ pub mod reasoning;
 pub mod recall_view;
 pub mod retrieval_failure_logger;
 pub mod scenes;
+mod sweep_helpers;
 pub mod tiered_retrieval;
 pub mod tiers;
 

--- a/crates/zeph-memory/src/scenes.rs
+++ b/crates/zeph-memory/src/scenes.rs
@@ -16,8 +16,10 @@ use zeph_llm::provider::LlmProvider as _;
 
 use crate::error::MemoryError;
 use crate::store::SqliteStore;
+use crate::sweep_helpers::{
+    EmbedBatchOutcome, cluster_by_cosine_similarity, embed_batch_with_validation,
+};
 use crate::types::{MemSceneId, MessageId};
-use zeph_common::math::cosine_similarity;
 
 /// A `MemScene` groups semantically related semantic-tier messages with a stable entity profile.
 ///
@@ -143,27 +145,12 @@ pub async fn consolidate_scenes(
     // Embed all candidates in a single batch call.
     let texts: Vec<&str> = candidates.iter().map(|(_, c)| c.as_str()).collect();
     let span = tracing::info_span!("memory.scenes.embed_batch", count = texts.len());
-    let vecs = provider.embed_batch(&texts).instrument(span).await;
-    let embedded: Vec<(MessageId, String, Vec<f32>)> = match vecs {
-        Ok(vecs) => {
-            if vecs.len() != texts.len() {
-                tracing::warn!(
-                    expected = texts.len(),
-                    got = vecs.len(),
-                    "scene consolidation: embed_batch length mismatch, skipping sweep"
-                );
-                return Ok(stats);
-            }
-            candidates
-                .into_iter()
-                .zip(vecs)
-                .map(|((msg_id, content), vec)| (msg_id, content, vec))
-                .collect()
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "scene consolidation: batch embed failed, skipping sweep");
-            return Ok(stats);
-        }
+    let vecs = embed_batch_with_validation(provider, &texts, "scene consolidation")
+        .instrument(span)
+        .await;
+    let embedded: Vec<((MessageId, String), Vec<f32>)> = match vecs {
+        EmbedBatchOutcome::Ok(vecs) => candidates.into_iter().zip(vecs).collect(),
+        EmbedBatchOutcome::Skip => return Ok(stats),
     };
 
     if embedded.len() < 2 {
@@ -171,15 +158,15 @@ pub async fn consolidate_scenes(
     }
 
     // Cluster by cosine similarity.
-    let clusters = cluster_messages(embedded, config.similarity_threshold);
+    let clusters = cluster_by_cosine_similarity(embedded, config.similarity_threshold);
 
     for cluster in clusters {
         if cluster.len() < 2 {
             continue;
         }
 
-        let contents: Vec<&str> = cluster.iter().map(|(_, c, _)| c.as_str()).collect();
-        let msg_ids: Vec<MessageId> = cluster.iter().map(|(id, _, _)| *id).collect();
+        let contents: Vec<&str> = cluster.iter().map(|((_, c), _)| c.as_str()).collect();
+        let msg_ids: Vec<MessageId> = cluster.iter().map(|((id, _), _)| *id).collect();
 
         match generate_scene_label_and_profile(provider, &contents).await {
             Ok((label, profile)) => {
@@ -210,26 +197,6 @@ pub async fn consolidate_scenes(
     }
 
     Ok(stats)
-}
-
-fn cluster_messages(
-    candidates: Vec<(MessageId, String, Vec<f32>)>,
-    threshold: f32,
-) -> Vec<Vec<(MessageId, String, Vec<f32>)>> {
-    let mut clusters: Vec<Vec<(MessageId, String, Vec<f32>)>> = Vec::new();
-
-    'outer: for candidate in candidates {
-        for cluster in &mut clusters {
-            let rep = &cluster[0].2;
-            if cosine_similarity(&candidate.2, rep) >= threshold {
-                cluster.push(candidate);
-                continue 'outer;
-            }
-        }
-        clusters.push(vec![candidate]);
-    }
-
-    clusters
 }
 
 async fn generate_scene_label_and_profile(
@@ -269,10 +236,8 @@ async fn generate_scene_label_and_profile(
         },
     ];
 
-    let result = tokio::time::timeout(Duration::from_secs(15), provider.chat(&messages))
-        .await
-        .map_err(|_| MemoryError::Timeout("scene LLM call timed out after 15s".into()))?
-        .map_err(MemoryError::Llm)?;
+    let result =
+        crate::sweep_helpers::llm_call_with_timeout(provider, &messages, "scene LLM call").await?;
 
     parse_label_profile(&result)
 }
@@ -326,24 +291,6 @@ pub async fn list_scenes(store: &SqliteStore) -> Result<Vec<MemScene>, MemoryErr
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn cluster_messages_groups_similar() {
-        let v1 = vec![1.0f32, 0.0, 0.0];
-        let v2 = vec![1.0f32, 0.0, 0.0];
-        let v3 = vec![0.0f32, 1.0, 0.0];
-
-        let candidates = vec![
-            (MessageId(1), "a".to_owned(), v1),
-            (MessageId(2), "b".to_owned(), v2),
-            (MessageId(3), "c".to_owned(), v3),
-        ];
-
-        let clusters = cluster_messages(candidates, 0.80);
-        assert_eq!(clusters.len(), 2);
-        assert_eq!(clusters[0].len(), 2);
-        assert_eq!(clusters[1].len(), 1);
-    }
 
     #[test]
     fn parse_label_profile_valid_json() {

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -91,29 +93,58 @@ pub struct RecalledMessage {
 /// Maximum number of concurrent background embed tasks per `SemanticMemory` instance.
 const MAX_EMBED_BG_TASKS: usize = 64;
 
+/// Rate-limit window (seconds) for the "failed to ensure Qdrant collection" warning.
+const QDRANT_WARN_WINDOW_SECS: u64 = 10;
+
+/// Whether enough time has passed since the last suppressed warning to emit a new one.
+fn should_emit_qdrant_warn(last: u64, now: u64, window_secs: u64) -> bool {
+    now.saturating_sub(last) >= window_secs
+}
+
+/// Log a Qdrant `ensure_collection` failure, rate-limited to one WARN per
+/// [`QDRANT_WARN_WINDOW_SECS`] across all background embed call sites sharing `last_warn`.
+fn warn_qdrant_ensure_failure(last_warn: &AtomicU64, log_tag: &str, err: &MemoryError) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let last = last_warn.load(Ordering::Relaxed);
+    if should_emit_qdrant_warn(last, now, QDRANT_WARN_WINDOW_SECS) {
+        last_warn.store(now, Ordering::Relaxed);
+        tracing::warn!("{log_tag}: failed to ensure Qdrant collection: {err:#}");
+    } else {
+        tracing::debug!("{log_tag}: failed to ensure Qdrant collection (suppressed): {err:#}");
+    }
+}
+
 /// Shared arguments for background embed tasks.
+///
+/// Deliberately slim: only what [`embed_chunk_and_store_bg`] itself needs. Per-chunk store
+/// arguments (`embedding_model`, `conversation_id`, `role`, category/tool metadata) are
+/// captured by the caller-supplied `store_chunk` closure instead, since they vary by variant.
 struct EmbedBgArgs {
     qdrant: Arc<crate::embedding_store::EmbeddingStore>,
     embed_provider: zeph_llm::any::AnyProvider,
-    embedding_model: String,
     message_id: MessageId,
-    conversation_id: ConversationId,
-    role: String,
     content: String,
     last_qdrant_warn: Arc<AtomicU64>,
 }
 
-/// Background task: embed chunks and store as regular message vectors.
+/// Background task: embed content chunks and store each via `store_chunk`.
 ///
-/// All errors are logged as warnings; the function never panics.
-async fn embed_and_store_regular_bg(args: EmbedBgArgs) {
+/// All errors are logged as warnings; the function never panics. Shared by
+/// `embed_and_store_regular`, `embed_chunks_with_tool_context`, and
+/// `embed_and_store_with_category` — the only difference between them is how each chunk
+/// is stored, expressed here as a boxed-future closure to sidestep borrow-checker fights
+/// over an in-loop `.await` on a stored future type.
+async fn embed_chunk_and_store_bg<F>(args: EmbedBgArgs, log_tag: &'static str, store_chunk: F)
+where
+    F: Fn(u32, Vec<f32>) -> Pin<Box<dyn Future<Output = Result<(), MemoryError>> + Send>> + Send,
+{
     let EmbedBgArgs {
         qdrant,
         embed_provider,
-        embedding_model,
         message_id,
-        conversation_id,
-        role,
         content,
         last_qdrant_warn,
     } = args;
@@ -123,7 +154,7 @@ async fn embed_and_store_regular_bg(args: EmbedBgArgs) {
     let vectors = match embed_provider.embed_batch(&chunks).await {
         Ok(v) => v,
         Err(e) => {
-            tracing::warn!("bg embed_regular: failed to embed chunks for msg {message_id}: {e:#}");
+            tracing::warn!("{log_tag}: failed to embed chunks for msg {message_id}: {e:#}");
             return;
         }
     };
@@ -132,199 +163,29 @@ async fn embed_and_store_regular_bg(args: EmbedBgArgs) {
         return;
     };
     if let Err(e) = qdrant.ensure_collection_for_vector(first).await {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let last = last_qdrant_warn.load(Ordering::Relaxed);
-        if now.saturating_sub(last) >= 10 {
-            last_qdrant_warn.store(now, Ordering::Relaxed);
-            tracing::warn!("bg embed_regular: failed to ensure Qdrant collection: {e:#}");
-        } else {
-            tracing::debug!(
-                "bg embed_regular: failed to ensure Qdrant collection (suppressed): {e:#}"
-            );
-        }
+        warn_qdrant_ensure_failure(&last_qdrant_warn, log_tag, &e);
         return;
     }
 
     for (chunk_index, vector) in vectors.into_iter().enumerate() {
         let chunk_index_u32 = u32::try_from(chunk_index).unwrap_or(u32::MAX);
-        if let Err(e) = qdrant
-            .store(
-                message_id,
-                conversation_id,
-                &role,
-                vector,
-                MessageKind::Regular,
-                &embedding_model,
-                chunk_index_u32,
-            )
-            .await
-        {
+        if let Err(e) = store_chunk(chunk_index_u32, vector).await {
             tracing::warn!(
-                "bg embed_regular: failed to store chunk {chunk_index}/{chunk_count} \
+                "{log_tag}: failed to store chunk {chunk_index}/{chunk_count} \
                  for msg {message_id}: {e:#}"
             );
         }
     }
 }
 
-/// Background task: embed chunks with tool context metadata and store in Qdrant.
-///
-/// All errors are logged as warnings; the function never panics.
-async fn embed_chunks_with_tool_context_bg(args: EmbedBgArgs, embed_ctx: EmbedContext) {
-    let EmbedBgArgs {
-        qdrant,
-        embed_provider,
-        embedding_model,
-        message_id,
-        conversation_id,
-        role,
-        content,
-        last_qdrant_warn,
-    } = args;
-    let chunks = chunk_text(&content);
-    let chunk_count = chunks.len();
-
-    let vectors = match embed_provider.embed_batch(&chunks).await {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(
-                "bg embed_tool: failed to embed tool-output chunks for msg {message_id}: {e:#}"
-            );
-            return;
-        }
-    };
-
-    if let Some(first) = vectors.first()
-        && let Err(e) = qdrant.ensure_collection_for_vector(first).await
-    {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let last = last_qdrant_warn.load(Ordering::Relaxed);
-        if now.saturating_sub(last) >= 10 {
-            last_qdrant_warn.store(now, Ordering::Relaxed);
-            tracing::warn!("bg embed_tool: failed to ensure Qdrant collection: {e:#}");
-        } else {
-            tracing::debug!(
-                "bg embed_tool: failed to ensure Qdrant collection (suppressed): {e:#}"
-            );
-        }
-        return;
-    }
-
-    for (chunk_index, vector) in vectors.into_iter().enumerate() {
-        let chunk_index_u32 = u32::try_from(chunk_index).unwrap_or(u32::MAX);
-        let result = if let Some(ref tool_name) = embed_ctx.tool_name {
-            qdrant
-                .store_with_tool_context(
-                    message_id,
-                    conversation_id,
-                    &role,
-                    vector,
-                    MessageKind::Regular,
-                    &embedding_model,
-                    chunk_index_u32,
-                    tool_name,
-                    embed_ctx.exit_code,
-                    embed_ctx.timestamp.as_deref(),
-                )
-                .await
-                .map(|_| ())
-        } else {
-            qdrant
-                .store(
-                    message_id,
-                    conversation_id,
-                    &role,
-                    vector,
-                    MessageKind::Regular,
-                    &embedding_model,
-                    chunk_index_u32,
-                )
-                .await
-                .map(|_| ())
-        };
-        if let Err(e) = result {
-            tracing::warn!(
-                "bg embed_tool: failed to store chunk {chunk_index}/{chunk_count} \
-                 for msg {message_id}: {e:#}"
-            );
-        }
-    }
-}
-
-/// Background task: embed chunks with optional category and store in Qdrant.
-///
-/// All errors are logged as warnings; the function never panics.
-async fn embed_and_store_with_category_bg(args: EmbedBgArgs, category: Option<String>) {
-    let EmbedBgArgs {
-        qdrant,
-        embed_provider,
-        embedding_model,
-        message_id,
-        conversation_id,
-        role,
-        content,
-        last_qdrant_warn,
-    } = args;
-    let chunks = chunk_text(&content);
-    let chunk_count = chunks.len();
-
-    let vectors = match embed_provider.embed_batch(&chunks).await {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(
-                "bg embed_category: failed to embed categorized chunks for msg {message_id}: {e:#}"
-            );
-            return;
-        }
-    };
-
-    let Some(first) = vectors.first() else {
-        return;
-    };
-    if let Err(e) = qdrant.ensure_collection_for_vector(first).await {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let last = last_qdrant_warn.load(Ordering::Relaxed);
-        if now.saturating_sub(last) >= 10 {
-            last_qdrant_warn.store(now, Ordering::Relaxed);
-            tracing::warn!("bg embed_category: failed to ensure Qdrant collection: {e:#}");
-        } else {
-            tracing::debug!(
-                "bg embed_category: failed to ensure Qdrant collection (suppressed): {e:#}"
-            );
-        }
-        return;
-    }
-
-    for (chunk_index, vector) in vectors.into_iter().enumerate() {
-        let chunk_index_u32 = u32::try_from(chunk_index).unwrap_or(u32::MAX);
-        if let Err(e) = qdrant
-            .store_with_category(
-                message_id,
-                conversation_id,
-                &role,
-                vector,
-                MessageKind::Regular,
-                &embedding_model,
-                chunk_index_u32,
-                category.as_deref(),
-            )
-            .await
-        {
-            tracing::warn!(
-                "bg embed_category: failed to store chunk {chunk_index}/{chunk_count} \
-                 for msg {message_id}: {e:#}"
-            );
-        }
-    }
+/// Outcome of [`SemanticMemory::run_admission_gate`].
+enum AdmissionOutcome {
+    /// A-MAC rejected the message; the training sample was already recorded.
+    Reject,
+    /// A-MAC admitted the message (or no `AdmissionControl` is configured), carrying the
+    /// decision onward so the caller can record the training sample once the outcome of
+    /// any downstream quality gate and the `SQLite` write are known.
+    Proceed(Option<AdmissionDecision>),
 }
 
 impl SemanticMemory {
@@ -348,38 +209,18 @@ impl SemanticMemory {
         content: &str,
         goal_text: Option<&str>,
     ) -> Result<Option<MessageId>, MemoryError> {
-        // A-MAC admission gate.
-        let mut admission_decision = None;
-        if let Some(ref admission) = self.admission_control {
-            let decision = admission
-                .evaluate(
-                    content,
-                    role,
-                    self.effective_embed_provider(),
-                    self.qdrant.as_ref(),
-                    goal_text,
-                )
-                .await;
-            let preview: String = content.chars().take(100).collect();
-            log_admission_decision(&decision, &preview, role, admission.threshold());
-            if !decision.admitted {
-                self.record_admission_sample(conversation_id, role, content, &decision, None)
-                    .await;
-                return Ok(None);
-            }
-            admission_decision = Some(decision);
-        }
-
-        if let Some(gate) = &self.quality_gate
-            && gate
-                .evaluate(content, self.effective_embed_provider(), &[])
-                .await
-                .is_some()
+        let admission_decision = match self
+            .run_admission_gate(conversation_id, role, content, goal_text)
+            .await
         {
-            if let Some(decision) = &admission_decision {
-                self.record_admission_sample(conversation_id, role, content, decision, None)
-                    .await;
-            }
+            AdmissionOutcome::Reject => return Ok(None),
+            AdmissionOutcome::Proceed(decision) => decision,
+        };
+
+        if self
+            .run_quality_gate(conversation_id, role, content, admission_decision.as_ref())
+            .await
+        {
             return Ok(None);
         }
 
@@ -388,16 +229,14 @@ impl SemanticMemory {
             .save_message(conversation_id, role, content)
             .await?;
 
-        if let Some(decision) = &admission_decision {
-            self.record_admission_sample(
-                conversation_id,
-                role,
-                content,
-                decision,
-                Some(message_id),
-            )
-            .await;
-        }
+        self.record_admission_sample_opt(
+            conversation_id,
+            role,
+            content,
+            admission_decision.as_ref(),
+            Some(message_id),
+        )
+        .await;
 
         self.embed_and_store_regular(message_id, conversation_id, role, content);
 
@@ -424,38 +263,18 @@ impl SemanticMemory {
         parts_json: &str,
         goal_text: Option<&str>,
     ) -> Result<(Option<MessageId>, bool), MemoryError> {
-        // A-MAC admission gate.
-        let mut admission_decision = None;
-        if let Some(ref admission) = self.admission_control {
-            let decision = admission
-                .evaluate(
-                    content,
-                    role,
-                    self.effective_embed_provider(),
-                    self.qdrant.as_ref(),
-                    goal_text,
-                )
-                .await;
-            let preview: String = content.chars().take(100).collect();
-            log_admission_decision(&decision, &preview, role, admission.threshold());
-            if !decision.admitted {
-                self.record_admission_sample(conversation_id, role, content, &decision, None)
-                    .await;
-                return Ok((None, false));
-            }
-            admission_decision = Some(decision);
-        }
-
-        if let Some(gate) = &self.quality_gate
-            && gate
-                .evaluate(content, self.effective_embed_provider(), &[])
-                .await
-                .is_some()
+        let admission_decision = match self
+            .run_admission_gate(conversation_id, role, content, goal_text)
+            .await
         {
-            if let Some(decision) = &admission_decision {
-                self.record_admission_sample(conversation_id, role, content, decision, None)
-                    .await;
-            }
+            AdmissionOutcome::Reject => return Ok((None, false)),
+            AdmissionOutcome::Proceed(decision) => decision,
+        };
+
+        if self
+            .run_quality_gate(conversation_id, role, content, admission_decision.as_ref())
+            .await
+        {
             return Ok((None, false));
         }
 
@@ -464,16 +283,14 @@ impl SemanticMemory {
             .save_message_with_parts(conversation_id, role, content, parts_json)
             .await?;
 
-        if let Some(decision) = &admission_decision {
-            self.record_admission_sample(
-                conversation_id,
-                role,
-                content,
-                decision,
-                Some(message_id),
-            )
-            .await;
-        }
+        self.record_admission_sample_opt(
+            conversation_id,
+            role,
+            content,
+            admission_decision.as_ref(),
+            Some(message_id),
+        )
+        .await;
 
         let embedding_stored =
             self.embed_and_store_regular(message_id, conversation_id, role, content);
@@ -504,42 +321,29 @@ impl SemanticMemory {
         parts_json: &str,
         embed_ctx: EmbedContext,
     ) -> Result<(Option<MessageId>, bool), MemoryError> {
-        let mut admission_decision = None;
-        if let Some(ref admission) = self.admission_control {
-            let decision = admission
-                .evaluate(
-                    content,
-                    role,
-                    self.effective_embed_provider(),
-                    self.qdrant.as_ref(),
-                    None,
-                )
-                .await;
-            let preview: String = content.chars().take(100).collect();
-            log_admission_decision(&decision, &preview, role, admission.threshold());
-            if !decision.admitted {
-                self.record_admission_sample(conversation_id, role, content, &decision, None)
-                    .await;
-                return Ok((None, false));
-            }
-            admission_decision = Some(decision);
-        }
+        // No quality gate here: tool output is not subject to the reference-completeness /
+        // information-value checks applied to conversational messages.
+        let admission_decision = match self
+            .run_admission_gate(conversation_id, role, content, None)
+            .await
+        {
+            AdmissionOutcome::Reject => return Ok((None, false)),
+            AdmissionOutcome::Proceed(decision) => decision,
+        };
 
         let message_id = self
             .sqlite
             .save_message_with_parts(conversation_id, role, content, parts_json)
             .await?;
 
-        if let Some(decision) = &admission_decision {
-            self.record_admission_sample(
-                conversation_id,
-                role,
-                content,
-                decision,
-                Some(message_id),
-            )
-            .await;
-        }
+        self.record_admission_sample_opt(
+            conversation_id,
+            role,
+            content,
+            admission_decision.as_ref(),
+            Some(message_id),
+        )
+        .await;
 
         let embedding_stored = self.embed_chunks_with_tool_context(
             message_id,
@@ -574,46 +378,113 @@ impl SemanticMemory {
         category: Option<&str>,
         goal_text: Option<&str>,
     ) -> Result<Option<MessageId>, MemoryError> {
-        let mut admission_decision = None;
-        if let Some(ref admission) = self.admission_control {
-            let decision = admission
-                .evaluate(
-                    content,
-                    role,
-                    self.effective_embed_provider(),
-                    self.qdrant.as_ref(),
-                    goal_text,
-                )
-                .await;
-            let preview: String = content.chars().take(100).collect();
-            log_admission_decision(&decision, &preview, role, admission.threshold());
-            if !decision.admitted {
-                self.record_admission_sample(conversation_id, role, content, &decision, None)
-                    .await;
-                return Ok(None);
-            }
-            admission_decision = Some(decision);
-        }
+        // No quality gate here: categorized writes (e.g. persona facts, structured summaries)
+        // bypass the reference-completeness / information-value checks applied to `remember`.
+        let admission_decision = match self
+            .run_admission_gate(conversation_id, role, content, goal_text)
+            .await
+        {
+            AdmissionOutcome::Reject => return Ok(None),
+            AdmissionOutcome::Proceed(decision) => decision,
+        };
 
         let message_id = self
             .sqlite
             .save_message_with_category(conversation_id, role, content, category)
             .await?;
 
-        if let Some(decision) = &admission_decision {
-            self.record_admission_sample(
-                conversation_id,
-                role,
-                content,
-                decision,
-                Some(message_id),
-            )
-            .await;
-        }
+        self.record_admission_sample_opt(
+            conversation_id,
+            role,
+            content,
+            admission_decision.as_ref(),
+            Some(message_id),
+        )
+        .await;
 
         self.embed_and_store_with_category(message_id, conversation_id, role, content, category);
 
         Ok(Some(message_id))
+    }
+
+    /// Evaluate the A-MAC admission gate shared by all `remember*` variants.
+    ///
+    /// On rejection, records the training sample (with no `message_id`, since the message
+    /// is never persisted) and returns [`AdmissionOutcome::Reject`]. When no
+    /// [`crate::admission::AdmissionControl`] is configured, always proceeds with `None`.
+    async fn run_admission_gate(
+        &self,
+        conversation_id: ConversationId,
+        role: &str,
+        content: &str,
+        goal_text: Option<&str>,
+    ) -> AdmissionOutcome {
+        let Some(admission) = &self.admission_control else {
+            return AdmissionOutcome::Proceed(None);
+        };
+        let decision = admission
+            .evaluate(
+                content,
+                role,
+                self.effective_embed_provider(),
+                self.qdrant.as_ref(),
+                goal_text,
+            )
+            .await;
+        let preview: String = content.chars().take(100).collect();
+        log_admission_decision(&decision, &preview, role, admission.threshold());
+        if !decision.admitted {
+            self.record_admission_sample(conversation_id, role, content, &decision, None)
+                .await;
+            return AdmissionOutcome::Reject;
+        }
+        AdmissionOutcome::Proceed(Some(decision))
+    }
+
+    /// Evaluate the optional quality gate. Only called by [`Self::remember`] and
+    /// [`Self::remember_with_parts`] — `remember_tool_output` and `remember_categorized`
+    /// deliberately skip it (see their doc comments).
+    ///
+    /// Returns `true` when the gate rejects the content, having already recorded the
+    /// training sample (with no `message_id`, since the message is never persisted).
+    async fn run_quality_gate(
+        &self,
+        conversation_id: ConversationId,
+        role: &str,
+        content: &str,
+        admission_decision: Option<&AdmissionDecision>,
+    ) -> bool {
+        let Some(gate) = &self.quality_gate else {
+            return false;
+        };
+        if gate
+            .evaluate(content, self.effective_embed_provider(), &[])
+            .await
+            .is_none()
+        {
+            return false;
+        }
+        if let Some(decision) = admission_decision {
+            self.record_admission_sample(conversation_id, role, content, decision, None)
+                .await;
+        }
+        true
+    }
+
+    /// Record the admission training sample for a message that passed every gate, when an
+    /// A-MAC decision was made (no-op when `admission_control` is unconfigured).
+    async fn record_admission_sample_opt(
+        &self,
+        conversation_id: ConversationId,
+        role: &str,
+        content: &str,
+        decision: Option<&AdmissionDecision>,
+        message_id: Option<MessageId>,
+    ) {
+        if let Some(decision) = decision {
+            self.record_admission_sample(conversation_id, role, content, decision, message_id)
+                .await;
+        }
     }
 
     /// Record an A-MAC admission decision as an RL training sample.
@@ -723,18 +594,44 @@ impl SemanticMemory {
         if !embed_provider.supports_embeddings() {
             return false;
         }
-        self.spawn_embed_bg(embed_and_store_with_category_bg(
+        let store_qdrant = Arc::clone(&qdrant);
+        let embedding_model = self.embedding_model.clone();
+        let role = role.to_owned();
+        let category = category.map(str::to_owned);
+        let store_chunk =
+            move |chunk_index: u32,
+                  vector: Vec<f32>|
+                  -> Pin<Box<dyn Future<Output = Result<(), MemoryError>> + Send>> {
+                let qdrant = Arc::clone(&store_qdrant);
+                let embedding_model = embedding_model.clone();
+                let role = role.clone();
+                let category = category.clone();
+                Box::pin(async move {
+                    qdrant
+                        .store_with_category(
+                            message_id,
+                            conversation_id,
+                            &role,
+                            vector,
+                            MessageKind::Regular,
+                            &embedding_model,
+                            chunk_index,
+                            category.as_deref(),
+                        )
+                        .await
+                        .map(|_| ())
+                })
+            };
+        self.spawn_embed_bg(embed_chunk_and_store_bg(
             EmbedBgArgs {
                 qdrant,
                 embed_provider,
-                embedding_model: self.embedding_model.clone(),
                 message_id,
-                conversation_id,
-                role: role.to_owned(),
                 content: content.to_owned(),
                 last_qdrant_warn: Arc::clone(&self.last_qdrant_warn),
             },
-            category.map(str::to_owned),
+            "bg embed_category",
+            store_chunk,
         ))
     }
 
@@ -755,16 +652,42 @@ impl SemanticMemory {
         if !embed_provider.supports_embeddings() {
             return false;
         }
-        self.spawn_embed_bg(embed_and_store_regular_bg(EmbedBgArgs {
-            qdrant,
-            embed_provider,
-            embedding_model: self.embedding_model.clone(),
-            message_id,
-            conversation_id,
-            role: role.to_owned(),
-            content: content.to_owned(),
-            last_qdrant_warn: Arc::clone(&self.last_qdrant_warn),
-        }))
+        let store_qdrant = Arc::clone(&qdrant);
+        let embedding_model = self.embedding_model.clone();
+        let role = role.to_owned();
+        let store_chunk =
+            move |chunk_index: u32,
+                  vector: Vec<f32>|
+                  -> Pin<Box<dyn Future<Output = Result<(), MemoryError>> + Send>> {
+                let qdrant = Arc::clone(&store_qdrant);
+                let embedding_model = embedding_model.clone();
+                let role = role.clone();
+                Box::pin(async move {
+                    qdrant
+                        .store(
+                            message_id,
+                            conversation_id,
+                            &role,
+                            vector,
+                            MessageKind::Regular,
+                            &embedding_model,
+                            chunk_index,
+                        )
+                        .await
+                        .map(|_| ())
+                })
+            };
+        self.spawn_embed_bg(embed_chunk_and_store_bg(
+            EmbedBgArgs {
+                qdrant,
+                embed_provider,
+                message_id,
+                content: content.to_owned(),
+                last_qdrant_warn: Arc::clone(&self.last_qdrant_warn),
+            },
+            "bg embed_regular",
+            store_chunk,
+        ))
     }
 
     /// Embed content chunks, enriching Qdrant payload with tool metadata when present.
@@ -785,18 +708,60 @@ impl SemanticMemory {
         if !embed_provider.supports_embeddings() {
             return false;
         }
-        self.spawn_embed_bg(embed_chunks_with_tool_context_bg(
+        let store_qdrant = Arc::clone(&qdrant);
+        let embedding_model = self.embedding_model.clone();
+        let role = role.to_owned();
+        let store_chunk =
+            move |chunk_index: u32,
+                  vector: Vec<f32>|
+                  -> Pin<Box<dyn Future<Output = Result<(), MemoryError>> + Send>> {
+                let qdrant = Arc::clone(&store_qdrant);
+                let embedding_model = embedding_model.clone();
+                let role = role.clone();
+                let embed_ctx = embed_ctx.clone();
+                Box::pin(async move {
+                    if let Some(tool_name) = embed_ctx.tool_name {
+                        qdrant
+                            .store_with_tool_context(
+                                message_id,
+                                conversation_id,
+                                &role,
+                                vector,
+                                MessageKind::Regular,
+                                &embedding_model,
+                                chunk_index,
+                                &tool_name,
+                                embed_ctx.exit_code,
+                                embed_ctx.timestamp.as_deref(),
+                            )
+                            .await
+                            .map(|_| ())
+                    } else {
+                        qdrant
+                            .store(
+                                message_id,
+                                conversation_id,
+                                &role,
+                                vector,
+                                MessageKind::Regular,
+                                &embedding_model,
+                                chunk_index,
+                            )
+                            .await
+                            .map(|_| ())
+                    }
+                })
+            };
+        self.spawn_embed_bg(embed_chunk_and_store_bg(
             EmbedBgArgs {
                 qdrant,
                 embed_provider,
-                embedding_model: self.embedding_model.clone(),
                 message_id,
-                conversation_id,
-                role: role.to_owned(),
                 content: content.to_owned(),
                 last_qdrant_warn: Arc::clone(&self.last_qdrant_warn),
             },
-            embed_ctx,
+            "bg embed_tool",
+            store_chunk,
         ))
     }
 
@@ -2286,33 +2251,21 @@ mod tests {
 
     #[test]
     fn qdrant_warn_rate_limit_suppresses_within_window() {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicU64, Ordering};
-
-        let last_warn = Arc::new(AtomicU64::new(0));
-        let window_secs = 10u64;
-
-        // Simulate first call: last=0, now=100 → should emit (diff >= 10)
-        let now1 = 100u64;
-        let last1 = last_warn.load(Ordering::Relaxed);
-        let should_warn1 = now1.saturating_sub(last1) >= window_secs;
-        assert!(should_warn1, "first call must not be suppressed");
-        if should_warn1 {
-            last_warn.store(now1, Ordering::Relaxed);
-        }
-
-        // Simulate second call 5s later: now=105 → should be suppressed (diff < 10)
-        let now2 = 105u64;
-        let last2 = last_warn.load(Ordering::Relaxed);
-        let should_warn2 = now2.saturating_sub(last2) >= window_secs;
-        assert!(!should_warn2, "call within 10s window must be suppressed");
-
-        // Simulate third call 10s after first: now=110 → should emit again
-        let now3 = 110u64;
-        let last3 = last_warn.load(Ordering::Relaxed);
-        let should_warn3 = now3.saturating_sub(last3) >= window_secs;
+        // First call: last=0, now=100 → should emit (diff >= 10)
         assert!(
-            should_warn3,
+            should_emit_qdrant_warn(0, 100, 10),
+            "first call must not be suppressed"
+        );
+
+        // Second call 5s later: now=105, last=100 → should be suppressed (diff < 10)
+        assert!(
+            !should_emit_qdrant_warn(100, 105, 10),
+            "call within 10s window must be suppressed"
+        );
+
+        // Third call 10s after first: now=110, last=100 → should emit again
+        assert!(
+            should_emit_qdrant_warn(100, 110, 10),
             "call after window expiry must not be suppressed"
         );
     }
@@ -2420,29 +2373,46 @@ mod tests {
 
     #[test]
     fn qdrant_warn_rate_limit_shared_across_concurrent_sites() {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicU64, Ordering};
-
-        // All 3 WARN sites share one Arc<AtomicU64>. Simulate site A warning at t=100,
-        // then site B attempting at t=105 — must be suppressed.
+        // All 3 WARN sites (bg embed_regular/embed_tool/embed_category) share one
+        // Arc<AtomicU64> via `SemanticMemory::last_qdrant_warn`. Simulate site A warning
+        // at t=100, then site B attempting at t=105 — must be suppressed, mirroring the
+        // exact check `warn_qdrant_ensure_failure` performs against the shared atomic.
         let shared = Arc::new(AtomicU64::new(0));
-        let window_secs = 10u64;
 
         let site_a = Arc::clone(&shared);
         let site_b = Arc::clone(&shared);
 
         let now_a = 100u64;
         let last_a = site_a.load(Ordering::Relaxed);
-        if now_a.saturating_sub(last_a) >= window_secs {
+        if should_emit_qdrant_warn(last_a, now_a, QDRANT_WARN_WINDOW_SECS) {
             site_a.store(now_a, Ordering::Relaxed);
         }
 
         let now_b = 105u64;
         let last_b = site_b.load(Ordering::Relaxed);
-        let warn_b = now_b.saturating_sub(last_b) >= window_secs;
+        let warn_b = should_emit_qdrant_warn(last_b, now_b, QDRANT_WARN_WINDOW_SECS);
         assert!(
             !warn_b,
             "site B must be suppressed because site A already warned within the window"
+        );
+    }
+
+    #[test]
+    fn warn_qdrant_ensure_failure_updates_shared_atomic_once() {
+        let shared = Arc::new(AtomicU64::new(0));
+        let err = MemoryError::InvalidInput("boom".into());
+
+        warn_qdrant_ensure_failure(&shared, "site A", &err);
+        let after_first = shared.load(Ordering::Relaxed);
+        assert!(after_first > 0, "first call must record a warn timestamp");
+
+        // Immediately calling again (same instant, well within the window) must not
+        // move the stored timestamp forward, since the second call is suppressed.
+        warn_qdrant_ensure_failure(&shared, "site B", &err);
+        assert_eq!(
+            shared.load(Ordering::Relaxed),
+            after_first,
+            "suppressed call must not overwrite the shared warn timestamp"
         );
     }
 }

--- a/crates/zeph-memory/src/semantic/tests/recall.rs
+++ b/crates/zeph-memory/src/semantic/tests/recall.rs
@@ -762,6 +762,143 @@ async fn admitted_then_quality_gate_rejected_records_training_sample_with_no_mes
     );
 }
 
+// ── #5569 DRY refactor coverage: run_admission_gate / run_quality_gate /
+//    record_admission_sample_opt shared by all 4 `remember*` variants ───────────
+
+#[tokio::test]
+async fn remember_tool_output_returns_none_when_admission_rejects() {
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_reject_admission());
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let (opt_id, stored) = memory
+        .remember_tool_output(
+            cid,
+            "assistant",
+            "rejected tool output",
+            "[]",
+            EmbedContext::default(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        opt_id.is_none(),
+        "remember_tool_output must return None when A-MAC rejects"
+    );
+    assert!(!stored, "embedding_stored must be false when rejected");
+    assert_eq!(
+        memory.sqlite.count_training_records().await.unwrap(),
+        1,
+        "rejection must still record exactly one training sample"
+    );
+}
+
+#[tokio::test]
+async fn remember_categorized_returns_none_when_admission_rejects() {
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_reject_admission());
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let result = memory
+        .remember_categorized(cid, "user", "rejected categorized content", None, None)
+        .await
+        .unwrap();
+    assert!(
+        result.is_none(),
+        "remember_categorized must return None when A-MAC rejects"
+    );
+    assert_eq!(
+        memory.sqlite.count_training_records().await.unwrap(),
+        1,
+        "rejection must still record exactly one training sample"
+    );
+}
+
+#[tokio::test]
+async fn remember_tool_output_skips_quality_gate() {
+    // Same gate config as `admitted_then_quality_gate_rejected_records_training_sample_with_no_message_id`,
+    // which reliably rejects this exact pronoun-heavy content for `remember()`. Tool output
+    // must NOT go through the quality gate, so it must be persisted here instead.
+    let gate_config = crate::quality_gate::QualityGateConfig {
+        enabled: true,
+        threshold: 0.75,
+        reference_completeness_weight: 0.9,
+        information_value_weight: 0.05,
+        contradiction_weight: 0.05,
+        ..crate::quality_gate::QualityGateConfig::default()
+    };
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_admit_admission())
+        .with_quality_gate(Arc::new(crate::quality_gate::QualityGate::new(gate_config)));
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let (opt_id, _stored) = memory
+        .remember_tool_output(
+            cid,
+            "assistant",
+            "yeah he confirmed it they said so",
+            "[]",
+            EmbedContext::default(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        opt_id.is_some(),
+        "remember_tool_output must skip the quality gate and persist admitted content"
+    );
+}
+
+#[tokio::test]
+async fn remember_categorized_skips_quality_gate() {
+    let gate_config = crate::quality_gate::QualityGateConfig {
+        enabled: true,
+        threshold: 0.75,
+        reference_completeness_weight: 0.9,
+        information_value_weight: 0.05,
+        contradiction_weight: 0.05,
+        ..crate::quality_gate::QualityGateConfig::default()
+    };
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_admit_admission())
+        .with_quality_gate(Arc::new(crate::quality_gate::QualityGate::new(gate_config)));
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let result = memory
+        .remember_categorized(cid, "user", "yeah he confirmed it they said so", None, None)
+        .await
+        .unwrap();
+    assert!(
+        result.is_some(),
+        "remember_categorized must skip the quality gate and persist admitted content"
+    );
+}
+
+#[tokio::test]
+async fn no_admission_control_configured_proceeds_without_recording_sample() {
+    // test_semantic_memory() leaves admission_control = None, so run_admission_gate must
+    // return Proceed(None) unconditionally and no training sample should ever be recorded.
+    let memory = test_semantic_memory(false).await;
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let result = memory
+        .remember(cid, "user", "no admission control configured", None)
+        .await
+        .unwrap();
+    assert!(
+        result.is_some(),
+        "message must be persisted when no admission control is configured"
+    );
+    assert_eq!(
+        memory.sqlite.count_training_records().await.unwrap(),
+        0,
+        "no training sample should be recorded without an AdmissionDecision"
+    );
+}
+
 // ── effective_depth tests (MM-F1, #3340) ──────────────────────────────────────
 
 #[tokio::test]

--- a/crates/zeph-memory/src/sweep_helpers.rs
+++ b/crates/zeph-memory/src/sweep_helpers.rs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared helpers for the background sweep loops in [`crate::scenes`] and [`crate::tiers`].
+//!
+//! Both sweeps cluster candidates by cosine similarity, batch-embed with the same
+//! validation rules, and call the LLM under the same fixed timeout. Extracted here to
+//! avoid duplicating that logic across the two modules (#5581).
+
+use std::time::Duration;
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::{LlmProvider as _, Message};
+
+use crate::error::MemoryError;
+use zeph_common::math::cosine_similarity;
+
+/// Fixed timeout applied to every LLM call issued from a sweep loop.
+const LLM_SWEEP_TIMEOUT_SECS: u64 = 15;
+
+/// Cluster `items` by cosine similarity using greedy nearest-neighbor.
+///
+/// Each item is compared to the representative (first member) of existing clusters; if
+/// similarity to that representative is `>= threshold`, it joins that cluster, otherwise
+/// it starts a new one. Items with an empty embedding vector always start their own
+/// singleton cluster (their similarity to anything is defined as `0.0`, so this is
+/// equivalent to falling through every existing cluster, made explicit here for clarity
+/// and to skip the unnecessary inner-loop comparisons).
+///
+/// This is O(n * k) where k is the number of clusters formed, not O(n^2).
+pub(crate) fn cluster_by_cosine_similarity<T>(
+    items: Vec<(T, Vec<f32>)>,
+    threshold: f32,
+) -> Vec<Vec<(T, Vec<f32>)>> {
+    let mut clusters: Vec<Vec<(T, Vec<f32>)>> = Vec::new();
+
+    'outer: for item in items {
+        if item.1.is_empty() {
+            clusters.push(vec![item]);
+            continue;
+        }
+
+        for cluster in &mut clusters {
+            let rep = &cluster[0].1;
+            if rep.is_empty() {
+                continue;
+            }
+            if cosine_similarity(&item.1, rep) >= threshold {
+                cluster.push(item);
+                continue 'outer;
+            }
+        }
+
+        clusters.push(vec![item]);
+    }
+
+    clusters
+}
+
+/// Outcome of a validated batch-embed call.
+pub(crate) enum EmbedBatchOutcome {
+    /// Embeddings were returned and match `texts` in length, one-to-one.
+    Ok(Vec<Vec<f32>>),
+    /// The call failed or returned a mismatched number of vectors; already logged.
+    Skip,
+}
+
+/// Batch-embed `texts`, validating the result length before handing it back to the caller.
+///
+/// Assumes the caller has already confirmed `provider.supports_embeddings()` — that gate,
+/// and any no-embedding-support fallback, stays at the call site because the two current
+/// callers (`scenes`, `tiers`) diverge on that path.
+///
+/// The tracing span around the `embed_batch` call is deliberately built by the caller
+/// (via `.instrument()`), not here: `tracing::info_span!` requires its name to be a
+/// literal known at compile time, so it cannot be threaded through as a runtime
+/// parameter. Each caller keeps its own literal span name (`memory.scenes.embed_batch` /
+/// `memory.tiers.embed_batch`).
+pub(crate) async fn embed_batch_with_validation(
+    provider: &AnyProvider,
+    texts: &[&str],
+    log_tag: &'static str,
+) -> EmbedBatchOutcome {
+    let vecs = provider.embed_batch(texts).await;
+    match vecs {
+        Ok(vecs) => {
+            if vecs.len() != texts.len() {
+                tracing::warn!(
+                    expected = texts.len(),
+                    got = vecs.len(),
+                    "{log_tag}: embed_batch length mismatch, skipping sweep"
+                );
+                return EmbedBatchOutcome::Skip;
+            }
+            EmbedBatchOutcome::Ok(vecs)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "{log_tag}: batch embed failed, skipping sweep");
+            EmbedBatchOutcome::Skip
+        }
+    }
+}
+
+/// Call the LLM with a fixed sweep timeout, mapping timeout and provider errors uniformly.
+///
+/// Callers build their own prompt `messages` and parse the returned text themselves.
+pub(crate) async fn llm_call_with_timeout(
+    provider: &AnyProvider,
+    messages: &[Message],
+    timeout_label: &str,
+) -> Result<String, MemoryError> {
+    tokio::time::timeout(
+        Duration::from_secs(LLM_SWEEP_TIMEOUT_SECS),
+        provider.chat(messages),
+    )
+    .await
+    .map_err(|_| MemoryError::Timeout(format!("{timeout_label} timed out after 15s")))?
+    .map_err(MemoryError::Llm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::MessageId;
+
+    #[test]
+    fn cluster_by_cosine_similarity_groups_similar() {
+        let v1 = vec![1.0f32, 0.0, 0.0];
+        let v2 = vec![1.0f32, 0.0, 0.0];
+        let v3 = vec![0.0f32, 1.0, 0.0];
+
+        let items = vec![(MessageId(1), v1), (MessageId(2), v2), (MessageId(3), v3)];
+
+        let clusters = cluster_by_cosine_similarity(items, 0.80);
+        assert_eq!(clusters.len(), 2);
+        assert_eq!(clusters[0].len(), 2);
+        assert_eq!(clusters[1].len(), 1);
+    }
+
+    #[test]
+    fn cluster_by_cosine_similarity_groups_identical() {
+        let v1 = vec![1.0f32, 0.0, 0.0];
+        let v2 = vec![1.0f32, 0.0, 0.0];
+        let v3 = vec![0.0f32, 1.0, 0.0]; // orthogonal
+
+        let items = vec![(MessageId(1), v1), (MessageId(2), v2), (MessageId(3), v3)];
+
+        let clusters = cluster_by_cosine_similarity(items, 0.92f32);
+        assert_eq!(clusters.len(), 2, "should produce 2 clusters");
+        assert_eq!(clusters[0].len(), 2, "first cluster should have 2 members");
+        assert_eq!(clusters[1].len(), 1, "second cluster is the orthogonal one");
+    }
+
+    #[test]
+    fn cluster_by_cosine_similarity_empty_embeddings_become_singletons() {
+        let items = vec![(MessageId(1), vec![]), (MessageId(2), vec![])];
+        let clusters = cluster_by_cosine_similarity(items, 0.92);
+        assert_eq!(clusters.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn embed_batch_with_validation_success_returns_ok() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let provider =
+            AnyProvider::Mock(MockProvider::default().with_embedding(vec![1.0, 0.0, 0.0]));
+        let texts = ["a", "b"];
+
+        match embed_batch_with_validation(&provider, &texts, "test").await {
+            EmbedBatchOutcome::Ok(vecs) => assert_eq!(vecs.len(), 2),
+            EmbedBatchOutcome::Skip => panic!("expected Ok, got Skip"),
+        }
+    }
+
+    #[tokio::test]
+    async fn embed_batch_with_validation_provider_error_returns_skip() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let provider = AnyProvider::Mock(
+            MockProvider::default()
+                .with_embedding(vec![1.0, 0.0, 0.0])
+                .with_embed_invalid_input(),
+        );
+        let texts = ["a", "b"];
+
+        match embed_batch_with_validation(&provider, &texts, "test").await {
+            EmbedBatchOutcome::Ok(_) => panic!("expected Skip, got Ok"),
+            EmbedBatchOutcome::Skip => {}
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn llm_call_with_timeout_times_out() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_llm::provider::{MessageMetadata, Role};
+
+        let provider = AnyProvider::Mock(
+            MockProvider::with_responses(vec!["late reply".into()])
+                .with_delay(LLM_SWEEP_TIMEOUT_SECS * 1_000 + 1_000),
+        );
+        let messages = vec![Message {
+            role: Role::User,
+            content: "hello".to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+
+        let result = llm_call_with_timeout(&provider, &messages, "test call").await;
+        assert!(
+            matches!(result, Err(MemoryError::Timeout(_))),
+            "expected Timeout error, got {result:?}"
+        );
+    }
+}

--- a/crates/zeph-memory/src/tiers.rs
+++ b/crates/zeph-memory/src/tiers.rs
@@ -25,6 +25,9 @@ use zeph_llm::provider::LlmProvider as _;
 use crate::error::MemoryError;
 use crate::store::SqliteStore;
 use crate::store::messages::PromotionCandidate;
+use crate::sweep_helpers::{
+    EmbedBatchOutcome, cluster_by_cosine_similarity, embed_batch_with_validation,
+};
 use crate::types::ConversationId;
 use zeph_common::math::cosine_similarity;
 
@@ -147,23 +150,12 @@ async fn run_promotion_sweep(
     let embedded: Vec<(PromotionCandidate, Vec<f32>)> = if provider.supports_embeddings() {
         let texts: Vec<&str> = candidates.iter().map(|c| c.content.as_str()).collect();
         let span = tracing::info_span!("memory.tiers.embed_batch", count = texts.len());
-        let vecs = provider.embed_batch(&texts).instrument(span).await;
+        let vecs = embed_batch_with_validation(provider, &texts, "tier promotion")
+            .instrument(span)
+            .await;
         match vecs {
-            Ok(vecs) => {
-                if vecs.len() != texts.len() {
-                    tracing::warn!(
-                        expected = texts.len(),
-                        got = vecs.len(),
-                        "tier promotion: embed_batch length mismatch, skipping sweep"
-                    );
-                    return Ok(stats);
-                }
-                candidates.into_iter().zip(vecs).collect()
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "tier promotion: batch embed failed, skipping sweep");
-                return Ok(stats);
-            }
+            EmbedBatchOutcome::Ok(vecs) => candidates.into_iter().zip(vecs).collect(),
+            EmbedBatchOutcome::Skip => return Ok(stats),
         }
     } else {
         // No embedding support — push all with empty vecs (will become singletons).
@@ -178,7 +170,7 @@ async fn run_promotion_sweep(
     // Each candidate is assigned to the first existing cluster whose centroid
     // representative has similarity >= threshold with it, or starts a new cluster.
     let threshold = config.similarity_threshold;
-    let clusters = cluster_by_similarity(embedded, threshold);
+    let clusters = cluster_by_cosine_similarity(embedded, threshold);
 
     for cluster in clusters {
         if cluster.len() < 2 {
@@ -216,42 +208,6 @@ async fn run_promotion_sweep(
     }
 
     Ok(stats)
-}
-
-/// Cluster candidates by cosine similarity using greedy nearest-neighbor.
-///
-/// Each candidate is compared to the representative (first member) of existing clusters.
-/// If similarity >= threshold, it joins that cluster; otherwise it starts a new one.
-/// This is O(n * k) where k is the number of clusters formed, not O(n^2).
-fn cluster_by_similarity(
-    candidates: Vec<(PromotionCandidate, Vec<f32>)>,
-    threshold: f32,
-) -> Vec<Vec<(PromotionCandidate, Vec<f32>)>> {
-    let mut clusters: Vec<Vec<(PromotionCandidate, Vec<f32>)>> = Vec::new();
-
-    'outer: for candidate in candidates {
-        if candidate.1.is_empty() {
-            // No embedding — own cluster (will be skipped as singleton).
-            clusters.push(vec![candidate]);
-            continue;
-        }
-
-        for cluster in &mut clusters {
-            let rep = &cluster[0].1;
-            if rep.is_empty() {
-                continue;
-            }
-            let sim = cosine_similarity(&candidate.1, rep);
-            if sim >= threshold {
-                cluster.push(candidate);
-                continue 'outer;
-            }
-        }
-
-        clusters.push(vec![candidate]);
-    }
-
-    clusters
 }
 
 /// Call the LLM to merge a cluster and promote the result to semantic tier.
@@ -390,45 +346,12 @@ async fn call_merge_llm(provider: &AnyProvider, contents: &[&str]) -> Result<Str
         },
     ];
 
-    let timeout = Duration::from_secs(15);
-
-    let result = tokio::time::timeout(timeout, provider.chat(&messages))
-        .await
-        .map_err(|_| MemoryError::Timeout("LLM merge timed out after 15s".into()))?
-        .map_err(MemoryError::Llm)?;
-
-    Ok(result)
+    crate::sweep_helpers::llm_call_with_timeout(provider, &messages, "LLM merge").await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn cluster_by_similarity_groups_identical() {
-        // Two identical unit vectors should cluster together at any threshold <= 1.0.
-        let v1 = vec![1.0f32, 0.0, 0.0];
-        let v2 = vec![1.0f32, 0.0, 0.0];
-        let v3 = vec![0.0f32, 1.0, 0.0]; // orthogonal
-
-        let candidates = vec![
-            (make_candidate(1), v1),
-            (make_candidate(2), v2),
-            (make_candidate(3), v3),
-        ];
-
-        let clusters = cluster_by_similarity(candidates, 0.92f32);
-        assert_eq!(clusters.len(), 2, "should produce 2 clusters");
-        assert_eq!(clusters[0].len(), 2, "first cluster should have 2 members");
-        assert_eq!(clusters[1].len(), 1, "second cluster is the orthogonal one");
-    }
-
-    #[test]
-    fn cluster_by_similarity_empty_embeddings_become_singletons() {
-        let candidates = vec![(make_candidate(1), vec![]), (make_candidate(2), vec![])];
-        let clusters = cluster_by_similarity(candidates, 0.92);
-        assert_eq!(clusters.len(), 2);
-    }
 
     fn make_candidate(id: i64) -> PromotionCandidate {
         PromotionCandidate {


### PR DESCRIPTION
## Summary

Bundled DRY cleanup in `zeph-memory` covering three related duplication findings:

- Extract `cluster_by_cosine_similarity`, `embed_batch_with_validation`, and `llm_call_with_timeout` into a new `sweep_helpers` module shared by `scenes.rs` and `tiers.rs`, removing the duplicated greedy clustering, batch-embed-validation, and 15s LLM-timeout logic from both background sweep loops.
- Consolidate the A-MAC admission-gate + `record_admission_sample` block duplicated across `remember`, `remember_with_parts`, `remember_tool_output`, and `remember_categorized` into `run_admission_gate` / `run_quality_gate` / `record_admission_sample_opt` helpers in `semantic/recall.rs`.
- Collapse the three near-identical background embed functions (`embed_and_store_regular_bg`, `embed_chunks_with_tool_context_bg`, `embed_and_store_with_category_bg`) into one generic `embed_chunk_and_store_bg` helper, keeping the rate-limited Qdrant-ensure-collection warn state as a single shared `Arc<AtomicU64>` across all call sites.

No behavior change intended, with one documented exception: `scenes.rs`'s clustering now explicitly special-cases empty embeddings as singleton clusters (matching `tiers.rs`'s existing behavior). In practice this is a no-op — `cosine_similarity` already returns `0.0` for empty/mismatched vectors, so `scenes.rs` already produced singletons for empty-embedding candidates before this change; the new shared helper just makes that explicit instead of relying on the implicit fallback.

Closes #5581, closes #5569, closes #5565

## Test plan

- [x] `cargo +nightly fmt --check` (workspace)
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12000 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Added/retargeted unit tests covering the new shared helpers, including the shared rate-limit atomic and the admission-gate reject/continue branches for all four `remember*` variants