### PR TITLE
fix(memory): close three async/DB hygiene gaps in zeph-memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(memory)`: three async/DB hygiene issues in `zeph-memory`.
+  - `EntityResolver::llm_disambiguate` (`crates/zeph-memory/src/graph/resolver/mod.rs`) called
+    `provider.chat()` with no timeout, violating this project's Await Discipline convention.
+    Since `resolve()` holds a per-normalized-name lock for its whole body, a hung LLM call
+    serialized every other resolution attempt for the same entity name behind that lock, and
+    could occupy one of `resolve_batch`'s 4 concurrent slots indefinitely. Wrapped the call in
+    `tokio::time::timeout(...)`, falling through to `None` (create new entity) on timeout.
+    An earlier version of this fix reused the resolver's existing 5s `embed_timeout` for this
+    chat call, which would have caused normal-latency LLM completions (routinely >5s) to time
+    out under default config and silently create duplicate entities instead of merging —
+    exactly the failure disambiguation exists to prevent. Added a dedicated `with_llm_timeout`
+    builder, wired to `GraphExtractionConfig::llm_timeout_secs` (default 30s, already used by
+    the sibling `GraphExtractor` chat call) instead. The disambiguation fallback counter is now
+    also bumped directly inside `llm_disambiguate` on every failure path (chat error, timeout,
+    and response-parse failure), matching `embed_entity_text`'s self-contained counter pattern.
+    (#5511)
+  - `embed_candidates` (`crates/zeph-memory/src/consolidation.rs`) fired up to
+    `sweep_batch_size` (default 500) concurrent `embed()` calls per sweep tick via
+    `futures::future::join_all`, with no concurrency bound. Replaced with a
+    `stream::iter(...).buffer_unordered(4)` pipeline (matching the
+    `EntityResolver::resolve_batch` convention), preserving per-item timeout/fail-open
+    behavior and input ordering. (#5512)
+  - Several `zeph-memory` store methods (`soft_delete_messages`, `mark_qdrant_cleaned`,
+    `mark_messages_consolidated`, `manual_promote`, and the per-source loops inside
+    `apply_tool_pair_summaries`, `apply_consolidation_merge`, `apply_consolidation_update`)
+    issued one query per ID instead of a single batched `WHERE id IN (...)` query, unlike
+    the file's own established batched helpers (`fetch_importance_scores`,
+    `message_access_counts`, `fetch_tiers`, etc.). Converted all seven sites to chunked
+    `IN (...)` queries (`crates/zeph-memory/src/store/messages/mod.rs`, new module-level
+    `MAX_BATCH = 490` constant, replacing a duplicate function-local constant), removing a
+    stale comment claiming `SQLite` doesn't support array binding. (#5498)
 - `test(tui)`: `detect_unicode_capable()` (`crates/zeph-tui/src/theme/color_mode.rs`) had no
   dedicated unit tests — only a doc-example, flagged as a coverage gap across 4+ consecutive
   CI cycles. Added 6 tests to the existing `mod tests` block covering `TERM=dumb` precedence

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -51,6 +51,15 @@ pub struct MockProvider {
     in_flight: Arc<std::sync::atomic::AtomicUsize>,
     /// High-watermark of concurrent `chat()` calls observed so far.
     peak_concurrent: Arc<std::sync::atomic::AtomicUsize>,
+    /// Counts currently-in-flight `embed()` calls. Updated atomically before and after the call body.
+    /// Shared with the test via [`MockProvider::with_embed_concurrency_tracking`].
+    embed_in_flight: Arc<std::sync::atomic::AtomicUsize>,
+    /// High-watermark of concurrent `embed()` calls observed so far.
+    peak_concurrent_embed: Arc<std::sync::atomic::AtomicUsize>,
+    /// Set by [`MockProvider::with_embed_concurrency_tracking`]. Gates the extra
+    /// `yield_now()` in `embed()` so tests using `embed_delay_ms` without opting into
+    /// tracking see unperturbed scheduling.
+    embed_tracking_enabled: bool,
     /// Per-call delay sequence. Each `chat()` call pops from the front; when empty, falls back to `delay_ms`.
     per_call_delays: Arc<Mutex<VecDeque<u64>>>,
     /// Captures the most recent [`GenerationOverrides`] applied via
@@ -82,6 +91,9 @@ impl Default for MockProvider {
             fixed_entropy: None,
             in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             peak_concurrent: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            embed_in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            peak_concurrent_embed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            embed_tracking_enabled: false,
             per_call_delays: Arc::new(Mutex::new(VecDeque::new())),
             captured_overrides: Arc::new(Mutex::new(None)),
         }
@@ -285,6 +297,34 @@ impl MockProvider {
         (self, peak)
     }
 
+    /// Enable in-flight concurrency tracking for `embed()`.
+    ///
+    /// Returns the provider and a shared atomic that holds the peak number of concurrent
+    /// `embed()` calls observed across the provider's lifetime. Mirrors
+    /// [`MockProvider::with_concurrency_tracking`] but for `embed()` instead of `chat()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::mock::MockProvider;
+    /// use std::sync::atomic::Ordering;
+    ///
+    /// let (provider, peak) = MockProvider::default()
+    ///     .with_embedding(vec![0.0; 4])
+    ///     .with_embed_concurrency_tracking();
+    /// // After running concurrent calls, peak.load(Ordering::SeqCst) <= expected_limit.
+    /// ```
+    #[must_use]
+    pub fn with_embed_concurrency_tracking(
+        mut self,
+    ) -> (Self, Arc<std::sync::atomic::AtomicUsize>) {
+        let peak = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        self.embed_in_flight = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        self.peak_concurrent_embed = Arc::clone(&peak);
+        self.embed_tracking_enabled = true;
+        (self, peak)
+    }
+
     /// Enable native `tool_use` support with a pre-configured sequence of `ChatResponse`
     /// values returned from `chat_with_tools()`.
     ///
@@ -371,29 +411,42 @@ impl LlmProvider for MockProvider {
     }
 
     async fn embed(&self, _text: &str) -> Result<Vec<f32>, crate::LlmError> {
+        use std::sync::atomic::Ordering as AOrdering;
+        let current = self.embed_in_flight.fetch_add(1, AOrdering::SeqCst) + 1;
+        self.peak_concurrent_embed
+            .fetch_max(current, AOrdering::SeqCst);
+
         self.embed_call_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         if self.embed_delay_ms > 0 {
+            if self.embed_tracking_enabled {
+                // Yield before sleeping so concurrent tasks can register in-flight before
+                // any of them finish, enabling accurate peak measurement. Gated on the
+                // tracking opt-in so other `embed_delay_ms`-using tests see unperturbed
+                // scheduling.
+                tokio::task::yield_now().await;
+            }
             tokio::time::sleep(std::time::Duration::from_millis(self.embed_delay_ms)).await;
         }
-        if let Ok(mut errors) = self.errors.lock()
+        let result = if let Ok(mut errors) = self.errors.lock()
             && !errors.is_empty()
         {
-            return Err(errors.pop_front().expect("non-empty"));
-        }
-        if self.embed_invalid_input {
-            return Err(crate::LlmError::InvalidInput {
+            Err(errors.pop_front().expect("non-empty"))
+        } else if self.embed_invalid_input {
+            Err(crate::LlmError::InvalidInput {
                 provider: self.name().to_owned(),
                 message: "input exceeds maximum sequence length".into(),
-            });
-        }
-        if self.supports_embeddings {
+            })
+        } else if self.supports_embeddings {
             Ok(self.embedding.clone())
         } else {
             Err(crate::LlmError::EmbedUnsupported {
                 provider: "mock".into(),
             })
-        }
+        };
+
+        self.embed_in_flight.fetch_sub(1, AOrdering::SeqCst);
+        result
     }
 
     fn supports_embeddings(&self) -> bool {

--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -209,19 +209,33 @@ async fn process_conversation(
     Ok(())
 }
 
+/// Maximum number of `embed()` calls run concurrently per sweep tick.
+///
+/// `candidates` can be as large as `ConsolidationConfig::sweep_batch_size` (default 500);
+/// matches the bound used by `EntityResolver::resolve_batch` (`graph/resolver/mod.rs`).
+const CONSOLIDATION_EMBED_CONCURRENCY: usize = 4;
+
 /// Embed all consolidation candidates for a single conversation.
 ///
-/// Runs all embeds concurrently via `join_all`.  Candidates that fail to embed are logged
-/// and dropped; they will be retried in a future sweep cycle.
+/// Runs embeds with bounded concurrency (see [`CONSOLIDATION_EMBED_CONCURRENCY`]).
+/// Candidates that fail to embed are logged and dropped; they will be retried in a
+/// future sweep cycle.
 #[tracing::instrument(name = "memory.consolidation.embed_batch", skip_all, fields(count = candidates.len()))]
 async fn embed_candidates(
     provider: &AnyProvider,
     candidates: &[(crate::types::MessageId, String)],
     embed_timeout: Duration,
 ) -> Vec<(i64, String, Vec<f32>)> {
+    use futures::stream::{self, StreamExt as _};
+
+    // Eagerly collected into an owned `Vec` (rather than streamed lazily over
+    // `candidates.iter()`) so the resulting futures don't borrow `candidates` — otherwise
+    // rustc's Send/HRTB inference for the opaque `async fn` type fails at distant call
+    // sites that require a `'static + Send` future (e.g. `TaskSupervisor` factories).
     let futures: Vec<_> = candidates
         .iter()
-        .map(|(id, content)| {
+        .enumerate()
+        .map(|(idx, (id, content))| {
             let id = id.0;
             let content = content.clone();
             async move {
@@ -236,16 +250,21 @@ async fn embed_candidates(
                     );
                     Err(zeph_llm::LlmError::Timeout)
                 };
-                (id, content.clone(), embed_result)
+                (idx, id, content, embed_result)
             }
         })
         .collect();
-    let results = futures::future::join_all(futures).await;
 
-    let mut embedded: Vec<(i64, String, Vec<f32>)> = Vec::with_capacity(results.len());
-    for (id, content, embed_result) in results {
+    // Indexed so results can be restored to input order after `buffer_unordered`,
+    // matching `join_all`'s ordering guarantee (order affects cluster representative
+    // selection in `cluster_by_similarity`).
+    let mut results: Vec<Option<(i64, String, Vec<f32>)>> = vec![None; candidates.len()];
+
+    let mut stream = stream::iter(futures).buffer_unordered(CONSOLIDATION_EMBED_CONCURRENCY);
+
+    while let Some((idx, id, content, embed_result)) = stream.next().await {
         match embed_result {
-            Ok(vec) => embedded.push((id, content, vec)),
+            Ok(vec) => results[idx] = Some((id, content, vec)),
             Err(e) => {
                 tracing::warn!(
                     message_id = id,
@@ -255,7 +274,8 @@ async fn embed_candidates(
             }
         }
     }
-    embedded
+
+    results.into_iter().flatten().collect()
 }
 
 /// Propose and apply a topology op for a single cluster of similar messages.
@@ -1082,6 +1102,61 @@ mod tests {
             result.is_empty(),
             "all candidates must be dropped on embed timeout, got {} entries",
             result.len()
+        );
+    }
+
+    /// #5512: happy path (all embeds succeed) must return one entry per candidate,
+    /// in input order, with matching id/content/vector — identical to the pre-fix
+    /// `join_all` behavior.
+    #[tokio::test]
+    async fn embed_candidates_happy_path_preserves_order_and_results() {
+        let provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default().with_embedding(vec![1.0, 0.0, 0.0]),
+        );
+
+        let candidates = vec![
+            (crate::types::MessageId(1), "Alice uses Rust".to_owned()),
+            (crate::types::MessageId(2), "Alice loves Rust".to_owned()),
+            (crate::types::MessageId(3), "Bob uses Python".to_owned()),
+        ];
+
+        let result = embed_candidates(&provider, &candidates, Duration::from_secs(5)).await;
+
+        assert_eq!(result.len(), 3);
+        for ((expected_id, expected_content), (id, content, vec)) in
+            candidates.iter().zip(result.iter())
+        {
+            assert_eq!(*id, expected_id.0);
+            assert_eq!(content, expected_content);
+            assert_eq!(vec, &vec![1.0, 0.0, 0.0]);
+        }
+    }
+
+    /// #5512: a batch larger than `CONSOLIDATION_EMBED_CONCURRENCY` must never drive more
+    /// than that many concurrent `embed()` calls.
+    #[tokio::test]
+    async fn embed_candidates_bounds_concurrency() {
+        let (mock, peak) = zeph_llm::mock::MockProvider::default()
+            .with_embedding(vec![1.0, 0.0, 0.0])
+            .with_embed_delay(20)
+            .with_embed_concurrency_tracking();
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+
+        let candidates: Vec<_> = (0..i64::try_from(CONSOLIDATION_EMBED_CONCURRENCY * 3).unwrap())
+            .map(|i| (crate::types::MessageId(i), format!("content {i}")))
+            .collect();
+
+        let result = embed_candidates(&provider, &candidates, Duration::from_secs(5)).await;
+
+        assert_eq!(result.len(), candidates.len());
+        // Exact equality (not just `<=`) proves concurrency actually happened: with a batch
+        // size that's an exact multiple of the bound and a uniform delay, the bound is always
+        // reached. `<=` alone would still pass if `buffer_unordered` were ever reverted to
+        // fully sequential execution (peak == 1).
+        assert_eq!(
+            peak.load(std::sync::atomic::Ordering::SeqCst),
+            CONSOLIDATION_EMBED_CONCURRENCY,
+            "peak concurrent embed() calls must reach the {CONSOLIDATION_EMBED_CONCURRENCY} bound exactly"
         );
     }
 }

--- a/crates/zeph-memory/src/graph/resolver/mod.rs
+++ b/crates/zeph-memory/src/graph/resolver/mod.rs
@@ -81,6 +81,12 @@ pub struct EntityResolver<'a> {
     collection_ensured: Arc<tokio::sync::OnceCell<()>>,
     /// Per-call timeout for every `embed()` invocation. Default: 5 s.
     embed_timeout: std::time::Duration,
+    /// Per-call timeout for the LLM disambiguation `chat()` invocation. Default: 30 s.
+    ///
+    /// Kept separate from `embed_timeout` because chat completions are substantially
+    /// slower than embeds — see `GraphExtractionConfig::llm_timeout_secs`, which this
+    /// should be set from at construction time.
+    llm_timeout: std::time::Duration,
 }
 
 impl<'a> EntityResolver<'a> {
@@ -102,6 +108,7 @@ impl<'a> EntityResolver<'a> {
             fallback_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             collection_ensured: Arc::new(tokio::sync::OnceCell::new()),
             embed_timeout: std::time::Duration::from_secs(5),
+            llm_timeout: std::time::Duration::from_secs(30),
         }
     }
 
@@ -111,6 +118,16 @@ impl<'a> EntityResolver<'a> {
     #[must_use]
     pub fn with_embed_timeout(mut self, timeout_secs: u64) -> Self {
         self.embed_timeout = std::time::Duration::from_secs(timeout_secs);
+        self
+    }
+
+    /// Set the per-call timeout for the LLM disambiguation `chat()` invocation.
+    ///
+    /// Default: 30 s. Callers should set this from `GraphExtractionConfig::llm_timeout_secs`
+    /// rather than reusing the (much shorter) embed timeout — chat completions are slower.
+    #[must_use]
+    pub fn with_llm_timeout(mut self, timeout_secs: u64) -> Self {
+        self.llm_timeout = std::time::Duration::from_secs(timeout_secs);
         self
     }
 
@@ -376,8 +393,8 @@ impl<'a> EntityResolver<'a> {
             }
             Some(false) => Ok(None),
             None => {
-                self.fallback_count
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                // `fallback_count` was already bumped inside `llm_disambiguate` itself
+                // (mirrors `embed_entity_text`'s self-contained counter increment).
                 tracing::warn!(entity_name = %normalized,
                     "LLM disambiguation failed; falling back to create new entity");
                 Ok(None)
@@ -824,10 +841,22 @@ impl<'a> EntityResolver<'a> {
             Message::from_legacy(Role::User, prompt),
         ];
 
-        let response = match provider.chat(&messages).await {
-            Ok(r) => r,
-            Err(err) => {
+        let response = match tokio::time::timeout(self.llm_timeout, provider.chat(&messages)).await
+        {
+            Ok(Ok(r)) => r,
+            Ok(Err(err)) => {
+                self.fallback_count
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 tracing::warn!(error = %err, "LLM disambiguation chat failed");
+                return None;
+            }
+            Err(_timeout) => {
+                self.fallback_count
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                tracing::warn!(
+                    timeout = ?self.llm_timeout,
+                    "LLM disambiguation chat timed out"
+                );
                 return None;
             }
         };
@@ -837,6 +866,8 @@ impl<'a> EntityResolver<'a> {
         match serde_json::from_str::<DisambiguationResponse>(json_str) {
             Ok(parsed) => Some(parsed.same_entity),
             Err(err) => {
+                self.fallback_count
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 tracing::warn!(error = %err, response = %response, "failed to parse LLM disambiguation response");
                 None
             }

--- a/crates/zeph-memory/src/graph/resolver/tests.rs
+++ b/crates/zeph-memory/src/graph/resolver/tests.rs
@@ -1085,6 +1085,92 @@ async fn resolve_ambiguous_score_llm_failure_increments_fallback() {
     );
 }
 
+// ── #5511: LLM disambiguation must be bounded by a timeout ────────────────
+
+// `llm_disambiguate` is exercised directly (rather than through the full `resolve()`
+// pipeline) so the paused-clock zone never overlaps real SQLite I/O — combining
+// `tokio::time::pause()` with pool-backed database calls is flaky under parallel test
+// load, since the runtime can fast-forward the virtual clock past the connection pool's
+// real `acquire_timeout` while a connection is still genuinely pending in wall-clock time.
+#[tokio::test]
+async fn llm_disambiguate_timeout_returns_none() {
+    let gs = setup().await;
+
+    // chat() sleeps far longer than the configured llm_timeout — llm_disambiguate
+    // must time out and return None instead of hanging indefinitely.
+    let mut provider = make_mock_with_embedding_and_chat(
+        vec![1.0, 0.0, 0.0, 0.0],
+        vec![r#"{"same_entity": true}"#.to_owned()],
+    );
+    provider.delay_ms = 60_000;
+    let any_provider = zeph_llm::any::AnyProvider::Mock(provider);
+
+    let resolver = EntityResolver::new(&gs).with_llm_timeout(1);
+    let fallback_count = resolver.fallback_count();
+
+    tokio::time::pause();
+    let fut = resolver.llm_disambiguate(
+        &any_provider,
+        "semaphore lock",
+        "concept",
+        "synchronization primitive",
+        "semaphore",
+        "concept",
+        "counting synchronization primitive",
+        0.6,
+    );
+    let (result, ()) = tokio::join!(fut, async {
+        tokio::time::advance(std::time::Duration::from_secs(2)).await;
+    });
+
+    assert_eq!(
+        result, None,
+        "llm_disambiguate must return None when the chat() call exceeds llm_timeout"
+    );
+    assert_eq!(
+        fallback_count.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "fallback counter must be incremented directly inside llm_disambiguate on timeout"
+    );
+}
+
+// F8(b): the distinct `Err` (chat failure, not timeout) branch inside `llm_disambiguate`
+// must also bump `fallback_count` directly, symmetric with the timeout branch above.
+#[tokio::test]
+async fn llm_disambiguate_chat_error_returns_none_and_increments_fallback() {
+    let gs = setup().await;
+
+    let mut provider = make_mock_with_embedding_and_chat(vec![1.0, 0.0, 0.0, 0.0], vec![]);
+    provider.fail_chat = true;
+    let any_provider = zeph_llm::any::AnyProvider::Mock(provider);
+
+    let resolver = EntityResolver::new(&gs);
+    let fallback_count = resolver.fallback_count();
+
+    let result = resolver
+        .llm_disambiguate(
+            &any_provider,
+            "semaphore lock",
+            "concept",
+            "synchronization primitive",
+            "semaphore",
+            "concept",
+            "counting synchronization primitive",
+            0.6,
+        )
+        .await;
+
+    assert_eq!(
+        result, None,
+        "llm_disambiguate must return None when chat() returns an error"
+    );
+    assert_eq!(
+        fallback_count.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "fallback counter must be incremented directly inside llm_disambiguate on chat error"
+    );
+}
+
 // ── Canonicalization / alias tests ────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -465,8 +465,11 @@ pub async fn extract_and_store(
             .with_embedding_store(emb)
             .with_provider(&provider)
             .with_embed_timeout(config.embed_timeout_secs)
+            .with_llm_timeout(config.llm_timeout_secs)
     } else {
-        EntityResolver::new(&store).with_embed_timeout(config.embed_timeout_secs)
+        EntityResolver::new(&store)
+            .with_embed_timeout(config.embed_timeout_secs)
+            .with_llm_timeout(config.llm_timeout_secs)
     };
 
     let (entity_name_to_id, entities_upserted) =

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -15,6 +15,12 @@ use super::SqliteStore;
 use crate::error::MemoryError;
 use crate::types::{ConversationId, MessageId};
 
+/// Maximum number of `id IN (...)` placeholders (rows) per batched query chunk.
+///
+/// Stays under `SQLite`'s `SQLITE_MAX_VARIABLE_NUMBER = 999` bind-parameter limit even
+/// for the two-bind-per-row queries in this module (`490 * 2 = 980 < 999`).
+const MAX_BATCH: usize = 490;
+
 /// SQL fragment binding a `?` placeholder into `compacted_at` (`TEXT` on `SQLite`,
 /// `TIMESTAMPTZ` on `PostgreSQL`), dialect-selected.
 ///
@@ -546,16 +552,17 @@ impl SqliteStore {
         let mut tx = self.pool.begin().await?;
 
         let compacted_at_expr = compacted_at_bind_expr();
-        let update_sql = zeph_db::rewrite_placeholders(&format!(
-            "UPDATE messages SET visibility = 'user_only', compacted_at = {compacted_at_expr} \
-             WHERE id = ?"
-        ));
-        for &id in hide_ids {
-            zeph_db::query(sqlx::AssertSqlSafe(update_sql.clone()))
-                .bind(&now)
-                .bind(id)
-                .execute(&mut *tx)
-                .await?;
+        for chunk in hide_ids.chunks(MAX_BATCH) {
+            let in_list: String = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let update_sql = zeph_db::rewrite_placeholders(&format!(
+                "UPDATE messages SET visibility = 'user_only', compacted_at = {compacted_at_expr} \
+                 WHERE id IN ({in_list})"
+            ));
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(update_sql)).bind(&now);
+            for &id in chunk {
+                q = q.bind(id);
+            }
+            q.execute(&mut *tx).await?;
         }
 
         for summary in summaries {
@@ -1060,14 +1067,17 @@ impl SqliteStore {
         if ids.is_empty() {
             return Ok(());
         }
-        // SQLite does not support array binding natively. Batch via individual updates.
-        for &id in ids {
-            zeph_db::query(
-                sql!("UPDATE messages SET deleted_at = CURRENT_TIMESTAMP WHERE id = ? AND deleted_at IS NULL"),
-            )
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+        for chunk in ids.chunks(MAX_BATCH) {
+            let placeholders = placeholder_list(1, chunk.len());
+            let sql = format!(
+                "UPDATE messages SET deleted_at = CURRENT_TIMESTAMP \
+                 WHERE id IN ({placeholders}) AND deleted_at IS NULL"
+            );
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(sql));
+            for &id in chunk {
+                q = q.bind(id);
+            }
+            q.execute(&self.pool).await?;
         }
         Ok(())
     }
@@ -1106,7 +1116,6 @@ impl SqliteStore {
         &self,
         candidate_ids: &[MessageId],
     ) -> Result<Vec<MessageId>, crate::error::MemoryError> {
-        const MAX_BATCH: usize = 490;
         if candidate_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -1145,13 +1154,18 @@ impl SqliteStore {
         &self,
         ids: &[MessageId],
     ) -> Result<(), crate::error::MemoryError> {
-        for &id in ids {
-            zeph_db::query(sql!(
-                "UPDATE messages SET qdrant_cleaned = TRUE WHERE id = ?"
-            ))
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+        if ids.is_empty() {
+            return Ok(());
+        }
+        for chunk in ids.chunks(MAX_BATCH) {
+            let placeholders = placeholder_list(1, chunk.len());
+            let sql =
+                format!("UPDATE messages SET qdrant_cleaned = TRUE WHERE id IN ({placeholders})");
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(sql));
+            for &id in chunk {
+                q = q.bind(id);
+            }
+            q.execute(&self.pool).await?;
         }
         Ok(())
     }
@@ -1400,18 +1414,19 @@ impl SqliteStore {
             return Ok(0);
         }
         let epoch_now = <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
-        let manual_promote_raw = format!(
-            "UPDATE messages \
-             SET tier = 'semantic', promotion_timestamp = {epoch_now} \
-             WHERE id = ? AND deleted_at IS NULL AND tier = 'episodic'"
-        );
-        let manual_promote_sql = zeph_db::rewrite_placeholders(&manual_promote_raw);
         let mut count = 0usize;
-        for &id in ids {
-            let result = zeph_db::query(sqlx::AssertSqlSafe(manual_promote_sql.as_str()))
-                .bind(id)
-                .execute(&self.pool)
-                .await?;
+        for chunk in ids.chunks(MAX_BATCH) {
+            let placeholders = placeholder_list(1, chunk.len());
+            let manual_promote_sql = format!(
+                "UPDATE messages \
+                 SET tier = 'semantic', promotion_timestamp = {epoch_now} \
+                 WHERE id IN ({placeholders}) AND deleted_at IS NULL AND tier = 'episodic'"
+            );
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(manual_promote_sql));
+            for &id in chunk {
+                q = q.bind(id);
+            }
+            let result = q.execute(&self.pool).await?;
             count += usize::try_from(result.rows_affected()).unwrap_or(0);
         }
         Ok(count)
@@ -1585,23 +1600,33 @@ impl SqliteStore {
         .await?;
         let consolidated_id = row.0;
 
-        let consol_sql = zeph_db::rewrite_placeholders(&format!(
-            "{} INTO memory_consolidation_sources (consolidated_id, source_id) VALUES (?, ?){}",
-            <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
-            <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
-        ));
-        for &source_id in source_ids {
-            zeph_db::query(sqlx::AssertSqlSafe(consol_sql.as_str()))
-                .bind(consolidated_id)
-                .bind(source_id)
-                .execute(&mut *tx)
-                .await?;
+        for chunk in source_ids.chunks(MAX_BATCH) {
+            let values_list: String = chunk
+                .iter()
+                .map(|_| "(?, ?)")
+                .collect::<Vec<_>>()
+                .join(", ");
+            let consol_sql = zeph_db::rewrite_placeholders(&format!(
+                "{} INTO memory_consolidation_sources (consolidated_id, source_id) VALUES {values_list}{}",
+                <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
+                <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
+            ));
+            let mut insert_q = zeph_db::query(sqlx::AssertSqlSafe(consol_sql));
+            for &source_id in chunk {
+                insert_q = insert_q.bind(consolidated_id).bind(source_id);
+            }
+            insert_q.execute(&mut *tx).await?;
 
-            // Mark original as consolidated so future sweeps skip it.
-            zeph_db::query(sql!("UPDATE messages SET consolidated = TRUE WHERE id = ?"))
-                .bind(source_id)
-                .execute(&mut *tx)
-                .await?;
+            // Mark originals as consolidated so future sweeps skip them.
+            let in_list: String = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let update_sql = zeph_db::rewrite_placeholders(&format!(
+                "UPDATE messages SET consolidated = TRUE WHERE id IN ({in_list})"
+            ));
+            let mut update_q = zeph_db::query(sqlx::AssertSqlSafe(update_sql));
+            for &source_id in chunk {
+                update_q = update_q.bind(source_id);
+            }
+            update_q.execute(&mut *tx).await?;
         }
 
         tx.commit().await?;
@@ -1643,22 +1668,32 @@ impl SqliteStore {
         .execute(&mut *tx)
         .await?;
 
-        let consol_sql = zeph_db::rewrite_placeholders(&format!(
-            "{} INTO memory_consolidation_sources (consolidated_id, source_id) VALUES (?, ?){}",
-            <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
-            <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
-        ));
-        for &source_id in additional_source_ids {
-            zeph_db::query(sqlx::AssertSqlSafe(consol_sql.as_str()))
-                .bind(target_id)
-                .bind(source_id)
-                .execute(&mut *tx)
-                .await?;
+        for chunk in additional_source_ids.chunks(MAX_BATCH) {
+            let values_list: String = chunk
+                .iter()
+                .map(|_| "(?, ?)")
+                .collect::<Vec<_>>()
+                .join(", ");
+            let consol_sql = zeph_db::rewrite_placeholders(&format!(
+                "{} INTO memory_consolidation_sources (consolidated_id, source_id) VALUES {values_list}{}",
+                <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
+                <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
+            ));
+            let mut insert_q = zeph_db::query(sqlx::AssertSqlSafe(consol_sql));
+            for &source_id in chunk {
+                insert_q = insert_q.bind(target_id).bind(source_id);
+            }
+            insert_q.execute(&mut *tx).await?;
 
-            zeph_db::query(sql!("UPDATE messages SET consolidated = TRUE WHERE id = ?"))
-                .bind(source_id)
-                .execute(&mut *tx)
-                .await?;
+            let in_list: String = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let update_sql = zeph_db::rewrite_placeholders(&format!(
+                "UPDATE messages SET consolidated = TRUE WHERE id IN ({in_list})"
+            ));
+            let mut update_q = zeph_db::query(sqlx::AssertSqlSafe(update_sql));
+            for &source_id in chunk {
+                update_q = update_q.bind(source_id);
+            }
+            update_q.execute(&mut *tx).await?;
         }
 
         tx.commit().await?;
@@ -1721,11 +1756,18 @@ impl SqliteStore {
     ///
     /// Returns an error if the update fails.
     pub async fn mark_messages_consolidated(&self, ids: &[i64]) -> Result<(), MemoryError> {
-        for &id in ids {
-            zeph_db::query(sql!("UPDATE messages SET consolidated = TRUE WHERE id = ?"))
-                .bind(id)
-                .execute(&self.pool)
-                .await?;
+        if ids.is_empty() {
+            return Ok(());
+        }
+        for chunk in ids.chunks(MAX_BATCH) {
+            let placeholders = placeholder_list(1, chunk.len());
+            let sql =
+                format!("UPDATE messages SET consolidated = TRUE WHERE id IN ({placeholders})");
+            let mut q = zeph_db::query(sqlx::AssertSqlSafe(sql));
+            for &id in chunk {
+                q = q.bind(id);
+            }
+            q.execute(&self.pool).await?;
         }
         Ok(())
     }

--- a/crates/zeph-memory/src/store/messages/tests.rs
+++ b/crates/zeph-memory/src/store/messages/tests.rs
@@ -10,6 +10,21 @@ async fn test_store() -> SqliteStore {
     SqliteStore::new(":memory:").await.unwrap()
 }
 
+/// Insert `n` plain user messages into `cid` and return their IDs, for tests that need
+/// a batch larger than `MAX_BATCH` to exercise chunked `IN (...)` queries.
+async fn save_n_messages(store: &SqliteStore, cid: ConversationId, n: usize) -> Vec<MessageId> {
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n {
+        ids.push(
+            store
+                .save_message(cid, "user", &format!("msg {i}"))
+                .await
+                .unwrap(),
+        );
+    }
+    ids
+}
+
 #[tokio::test]
 async fn create_conversation_returns_id() {
     let store = test_store().await;
@@ -1275,6 +1290,93 @@ async fn manual_promote_skips_nonexistent_ids() {
     assert_eq!(count, 0);
 }
 
+/// #5498: `manual_promote` must correctly promote a batch larger than the chunked
+/// `IN (...)` batch size, spanning multiple query chunks.
+#[tokio::test]
+async fn manual_promote_chunks_beyond_max_batch() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let n = MAX_BATCH + 10;
+    let ids = save_n_messages(&store, cid, n).await;
+
+    let count = store.manual_promote(&ids).await.unwrap();
+    assert_eq!(count, n, "all messages across chunks must be promoted");
+
+    let (episodic, semantic) = store.count_messages_by_tier().await.unwrap();
+    assert_eq!(episodic, 0);
+    assert_eq!(semantic, i64::try_from(n).unwrap());
+}
+
+/// #5498: `soft_delete_messages` must soft-delete a batch larger than the chunked
+/// `IN (...)` batch size.
+#[tokio::test]
+async fn soft_delete_messages_chunks_beyond_max_batch() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let n = MAX_BATCH + 10;
+    let ids = save_n_messages(&store, cid, n).await;
+
+    store.soft_delete_messages(&ids).await.unwrap();
+
+    let (episodic, _) = store.count_messages_by_tier().await.unwrap();
+    assert_eq!(
+        episodic, 0,
+        "all messages across chunks must be soft-deleted"
+    );
+}
+
+/// #5498: `mark_qdrant_cleaned` must update a batch larger than the chunked
+/// `IN (...)` batch size.
+#[tokio::test]
+async fn mark_qdrant_cleaned_chunks_beyond_max_batch() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let n = MAX_BATCH + 10;
+    let ids = save_n_messages(&store, cid, n).await;
+
+    store.mark_qdrant_cleaned(&ids).await.unwrap();
+
+    let row: (i64,) = sqlx::query_as(sql!(
+        "SELECT COUNT(*) FROM messages WHERE qdrant_cleaned = TRUE"
+    ))
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        row.0,
+        i64::try_from(n).unwrap(),
+        "all messages across chunks must be marked qdrant_cleaned"
+    );
+}
+
+/// #5498: `mark_messages_consolidated` must update a batch larger than the chunked
+/// `IN (...)` batch size.
+#[tokio::test]
+async fn mark_messages_consolidated_chunks_beyond_max_batch() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let n = MAX_BATCH + 10;
+    let ids: Vec<i64> = save_n_messages(&store, cid, n)
+        .await
+        .into_iter()
+        .map(|id| id.0)
+        .collect();
+
+    store.mark_messages_consolidated(&ids).await.unwrap();
+
+    let row: (i64,) = sqlx::query_as(sql!(
+        "SELECT COUNT(*) FROM messages WHERE consolidated = TRUE"
+    ))
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        row.0,
+        i64::try_from(n).unwrap(),
+        "all messages across chunks must be marked consolidated"
+    );
+}
+
 #[tokio::test]
 async fn migration_042_default_tier_for_preexisting_rows() {
     // Directly INSERT without the tier column to verify the schema DEFAULT applies.
@@ -1432,6 +1534,41 @@ async fn apply_tool_pair_summaries_hides_pairs_and_inserts_summary() {
     let all = store.load_history(cid, 50).await.unwrap();
     // load_history returns all messages regardless of visibility; 3 total: 2 hidden + 1 summary.
     assert_eq!(all.len(), 3, "hidden messages must remain in DB");
+}
+
+/// #5498: `apply_tool_pair_summaries` must hide a `hide_ids` batch larger than the
+/// chunked `IN (...)` batch size.
+#[tokio::test]
+async fn apply_tool_pair_summaries_chunks_beyond_max_batch() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let n = MAX_BATCH + 10;
+    let ids: Vec<i64> = save_n_messages(&store, cid, n)
+        .await
+        .into_iter()
+        .map(|id| id.0)
+        .collect();
+
+    store
+        .apply_tool_pair_summaries(cid, &ids, &["batched summary".to_string()])
+        .await
+        .unwrap();
+
+    let after_visible = store
+        .load_history_filtered(cid, u32::try_from(n + 1).unwrap(), Some(true), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        after_visible.len(),
+        1,
+        "only the inserted summary should remain agent-visible after hiding all originals"
+    );
+
+    let all = store
+        .load_history(cid, u32::try_from(n + 1).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(all.len(), n + 1, "hidden messages must remain in DB");
 }
 
 // Regression test for #2257: `apply_tool_pair_summaries` must write parts using the
@@ -1640,6 +1777,138 @@ async fn apply_consolidation_update_skips_below_threshold() {
     assert_eq!(
         row.0, "fact",
         "content must not change when update is skipped"
+    );
+}
+
+/// #5498: `apply_consolidation_update` must link and mark a batch of
+/// `additional_source_ids` larger than the chunked `IN (...)` batch size.
+#[tokio::test]
+async fn apply_consolidation_update_chunks_beyond_max_batch() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+
+    let target = store
+        .save_message(cid, "user", "target fact")
+        .await
+        .unwrap();
+    let n = MAX_BATCH + 10;
+    let sources = save_n_messages(&store, cid, n).await;
+
+    let accepted = store
+        .apply_consolidation_update(target, "merged content", &sources, 0.9, 0.7)
+        .await
+        .unwrap();
+    assert!(accepted);
+
+    let consolidated_count: (i64,) = sqlx::query_as(sql!(
+        "SELECT COUNT(*) FROM messages WHERE consolidated = TRUE"
+    ))
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        consolidated_count.0,
+        i64::try_from(n).unwrap() + 1,
+        "all additional sources across chunks, plus the target row itself, must be marked consolidated"
+    );
+
+    let join_count: (i64,) = sqlx::query_as(sql!(
+        "SELECT COUNT(*) FROM memory_consolidation_sources WHERE consolidated_id = ?"
+    ))
+    .bind(target)
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        join_count.0,
+        i64::try_from(n).unwrap(),
+        "join table must link target to all sources across chunks"
+    );
+}
+
+/// #5498: `apply_consolidation_merge` must link and mark a `source_ids` batch larger
+/// than the chunked `IN (...)` batch size.
+#[tokio::test]
+async fn apply_consolidation_merge_chunks_beyond_max_batch() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let n = MAX_BATCH + 10;
+    let sources = save_n_messages(&store, cid, n).await;
+
+    let accepted = store
+        .apply_consolidation_merge(cid, "assistant", "merged content", &sources, 0.9, 0.7)
+        .await
+        .unwrap();
+    assert!(accepted);
+
+    let consolidated_count: (i64,) = sqlx::query_as(sql!(
+        "SELECT COUNT(*) FROM messages WHERE consolidated = TRUE"
+    ))
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        consolidated_count.0,
+        i64::try_from(n).unwrap() + 1,
+        "all sources across chunks, plus the new consolidated row itself, must be marked consolidated"
+    );
+
+    let new_row: (MessageId,) = sqlx::query_as(sql!(
+        "SELECT id FROM messages WHERE content = 'merged content'"
+    ))
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+
+    let join_count: (i64,) = sqlx::query_as(sql!(
+        "SELECT COUNT(*) FROM memory_consolidation_sources WHERE consolidated_id = ?"
+    ))
+    .bind(new_row.0)
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        join_count.0,
+        i64::try_from(n).unwrap(),
+        "join table must link the new consolidated row to all sources across chunks"
+    );
+}
+
+/// #5498: a single chunk of exactly `MAX_BATCH` rows, on the 2-binds-per-row
+/// `memory_consolidation_sources` insert, must stay within `SQLite`'s
+/// `SQLITE_MAX_VARIABLE_NUMBER = 999` bind-parameter limit (`MAX_BATCH * 2 = 980 < 999`).
+/// This proves the boundary sizing itself, not just multi-chunk iteration — a single
+/// legal chunk larger than `MAX_BATCH` here would exceed 999 binds and fail the query.
+#[tokio::test]
+async fn apply_consolidation_merge_at_exactly_max_batch_stays_within_bind_limit() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let sources = save_n_messages(&store, cid, MAX_BATCH).await;
+
+    let accepted = store
+        .apply_consolidation_merge(cid, "assistant", "merged content", &sources, 0.9, 0.7)
+        .await
+        .unwrap();
+    assert!(accepted);
+
+    let new_row: (MessageId,) = sqlx::query_as(sql!(
+        "SELECT id FROM messages WHERE content = 'merged content'"
+    ))
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+
+    let join_count: (i64,) = sqlx::query_as(sql!(
+        "SELECT COUNT(*) FROM memory_consolidation_sources WHERE consolidated_id = ?"
+    ))
+    .bind(new_row.0)
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        join_count.0,
+        i64::try_from(MAX_BATCH).unwrap(),
+        "a single MAX_BATCH-sized chunk must link all sources in one INSERT within the bind limit"
     );
 }
 


### PR DESCRIPTION
## Summary

Bundles three independent, non-overlapping zeph-memory fixes into one PR (same crate, different files, no cross-dependencies):

- **#5511** — `EntityResolver::llm_disambiguate`'s `provider.chat()` call had no timeout, violating this project's Await Discipline convention. Since `resolve()` holds a per-normalized-name lock for its entire body, a hung LLM call serialized every other resolution attempt for the same entity name behind that lock, and could permanently occupy one of `resolve_batch`'s 4 concurrent slots. Wrapped the call in `tokio::time::timeout`, falling through to `None` (create new entity) on timeout. An earlier draft of this fix reused the 5s `embed_timeout` for the chat call, which an adversarial review round caught as wrong — a real LLM chat completion routinely exceeds 5s, so it would have caused normal-latency completions to spuriously time out and create duplicate entities under default config, defeating the purpose of disambiguation. Fixed by wiring a dedicated `with_llm_timeout` builder to the existing `GraphExtractionConfig::llm_timeout_secs` (30s default, already used by the sibling `GraphExtractor` chat call) instead.
- **#5512** — `consolidation.rs`'s `embed_candidates` fired up to `sweep_batch_size` (default 500) concurrent embed calls via unbounded `futures::future::join_all`. Replaced with `stream::iter(...).buffer_unordered(4)`, matching the existing `EntityResolver::resolve_batch` convention; preserves per-item timeout/fail-open behavior and input ordering.
- **#5498** — 7 sites in `store/messages/mod.rs` (`soft_delete_messages`, `mark_qdrant_cleaned`, `mark_messages_consolidated`, `manual_promote`, and the per-source loops in `apply_tool_pair_summaries`, `apply_consolidation_merge`, `apply_consolidation_update`) issued one query per ID instead of the file's own established chunked `WHERE id IN (...)` batching pattern. Converted all 7 to batched, dual-backend (sqlite/postgres) compatible chunked queries at `MAX_BATCH=490`; removed a stale comment claiming SQLite doesn't support array binding.

Closes #5511, Closes #5512, Closes #5498

## Review process

Went through a full team-develop cycle (developer -> perf verify + tester + adversarial impl-critic in parallel -> code review). The impl-critic pass caught the #5511 timeout-value bug described above before merge; tester independently flagged and the developer strengthened a concurrency-bound test that only asserted an upper bound instead of exact equality. Reviewer independently reran the full CI-matching check suite (fmt, clippy --profile ci, nextest, rustdoc gate) plus a dual-backend postgres build check and approved with no blocking issues.

Not touched: `.local/testing/` playbook and `coverage-status.md`. These are internal correctness/perf fixes to existing, already-unit-tested code paths (verified extensively by the review's tester/perf passes) with no new user-facing config, CLI, or TUI surface — judged out of scope for the live-testing playbook requirement, which targets new functionality. Flagging here for visibility per reviewer's suggestion.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12003 passed)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory -p zeph-llm` (2475 passed, re-run for flakes)
- [x] `cargo check -p zeph-memory --features postgres --no-default-features` (dual-backend compat for #5498)
- [x] RUSTDOCFLAGS rustdoc gate + `cargo test --doc --workspace`
- [x] New unit tests: #5511 deterministic timeout-to-None via `tokio::time::pause`; #5512 exact concurrency-bound assertion + order-preservation; #5498 chunk-boundary tests at `MAX_BATCH+10` for all 7 sites plus an exact-`MAX_BATCH` bind-limit test