### PR TITLE
refactor(memory): deduplicate router classification and SemanticMemory constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,6 +470,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   pass a string literal. Delivers the per-call-site caching acceptance criterion
   originally stated but never implemented for #2387. Closes #5431.
 
+### Changed
+
+- `refactor(memory)`: `HeuristicRouter::route()` and `route_with_confidence()`
+  (`crates/zeph-memory/src/router.rs`) independently recomputed the same six
+  classification signals (temporal cue, relationship pattern, structural code pattern,
+  question-word detection, word-count thresholds, `snake_case` detection), and
+  `route_with_confidence()` additionally called `self.route(query)` to get its result,
+  recomputing everything a second time. Extracted a `RouteSignals` struct and a
+  `compute_signals()` function to compute each signal exactly once, plus
+  `HeuristicRouter::decide_route()`/`decide_confidence()` helpers holding the existing
+  priority-chain and popcount-confidence logic unchanged. `route()` and
+  `route_with_confidence()` now both call `compute_signals()` once and derive their
+  result from the shared `RouteSignals`. Pure extraction — no behavior change. Closes
+  #5510.
+- `refactor(memory)`: `SemanticMemory`'s four public constructors
+  (`with_weights_and_pool_size`, `with_qdrant_ops`, `from_parts`,
+  `with_sqlite_backend_and_pool_size` in `crates/zeph-memory/src/semantic/mod.rs`) each
+  built the full ~35-field `SemanticMemory` struct via an inline literal, differing only
+  in how `qdrant` and `token_counter` were constructed. Extracted a private
+  `SemanticMemory::base()` helper that builds the struct once from the handful of
+  parameters that vary; all four constructors now delegate to it. Pure extraction — no
+  behavior change. Closes #5504.
+
 ### Added
 
 - `feat(memory)`: add `memory.qdrant_timeout_secs` config field, wired into

--- a/crates/zeph-memory/src/router.rs
+++ b/crates/zeph-memory/src/router.rs
@@ -356,6 +356,32 @@ fn starts_with_question(words: &[&str]) -> bool {
         .is_some_and(|w| QUESTION_WORDS.iter().any(|qw| w.eq_ignore_ascii_case(qw)))
 }
 
+/// Classification signals computed once per query and shared by `route()` and
+/// `route_with_confidence()`, so neither has to recompute the same six checks.
+#[allow(clippy::struct_excessive_bools)] // independent classification flags, not state — each is checked separately in the priority chain
+struct RouteSignals {
+    temporal: bool,
+    relationship: bool,
+    structural_code: bool,
+    question: bool,
+    word_count: usize,
+    snake_case: bool,
+}
+
+/// Compute every routing signal for `query` exactly once.
+fn compute_signals(query: &str) -> RouteSignals {
+    let lower = query.to_ascii_lowercase();
+    let words: Vec<&str> = query.split_whitespace().collect();
+    RouteSignals {
+        temporal: has_temporal_cue(&lower),
+        relationship: RELATIONSHIP_PATTERNS.iter().any(|p| lower.contains(p)),
+        structural_code: query.contains('/') || query.contains("::"),
+        question: starts_with_question(&words),
+        word_count: words.len(),
+        snake_case: words.iter().any(|w| is_pure_snake_case(w)),
+    }
+}
+
 /// Returns true if `word` is a pure `snake_case` identifier (all ASCII, lowercase letters,
 /// digits and underscores, contains at least one underscore, not purely numeric).
 fn is_pure_snake_case(word: &str) -> bool {
@@ -371,101 +397,87 @@ fn is_pure_snake_case(word: &str) -> bool {
         && !word.chars().all(|c| c.is_ascii_digit() || c == '_')
 }
 
-impl MemoryRouter for HeuristicRouter {
+impl HeuristicRouter {
+    /// Decide the route from precomputed signals.
+    ///
+    /// Priority order:
+    /// 1. Temporal patterns → `Episodic` (checked first so e.g. "history of changes
+    ///    last week" routes to `Episodic`, not `Graph`).
+    /// 2. Relationship patterns → `Graph`.
+    /// 3. Code-like patterns (paths, `::`) without a question word → `Keyword`.
+    /// 4. Long NL query or question word → `Semantic`.
+    /// 5. Short non-question query → `Keyword`.
+    /// 6. Pure `snake_case` identifiers → `Keyword`.
+    /// 7. Default → `Hybrid`.
+    fn decide_route(signals: &RouteSignals) -> MemoryRoute {
+        if signals.temporal {
+            return MemoryRoute::Episodic;
+        }
+        if signals.relationship {
+            return MemoryRoute::Graph;
+        }
+        if signals.structural_code && !signals.question {
+            return MemoryRoute::Keyword;
+        }
+        if signals.question || signals.word_count >= 6 {
+            return MemoryRoute::Semantic;
+        }
+        if signals.word_count <= 3 && !signals.question {
+            return MemoryRoute::Keyword;
+        }
+        if signals.snake_case {
+            return MemoryRoute::Keyword;
+        }
+        MemoryRoute::Hybrid
+    }
+
     /// Returns a confidence signal based on pattern match count (W2.1 fix: gradual scale).
     ///
     /// - Exactly one route pattern matches → confidence `1.0` (clear signal)
     /// - Zero patterns match → confidence `0.0` (pure default fallback)
     /// - More than one pattern matches → confidence `1.0 / matched_count` (ambiguous, decreasing)
-    fn route_with_confidence(&self, query: &str) -> RoutingDecision {
-        let lower = query.to_ascii_lowercase();
+    #[allow(clippy::cast_precision_loss)]
+    fn decide_confidence(signals: &RouteSignals) -> f32 {
         let mut matched: u32 = 0;
-        if has_temporal_cue(&lower) {
+        if signals.temporal {
             matched += 1;
         }
-        if RELATIONSHIP_PATTERNS.iter().any(|p| lower.contains(p)) {
+        if signals.relationship {
             matched += 1;
         }
-        let words: Vec<&str> = query.split_whitespace().collect();
-        let word_count = words.len();
-        let has_structural = query.contains('/') || query.contains("::");
-        let question = starts_with_question(&words);
-        let has_snake = words.iter().any(|w| is_pure_snake_case(w));
-        if has_structural && !question {
+        if signals.structural_code && !signals.question {
             matched += 1;
         }
-        if question || word_count >= 6 {
+        if signals.question || signals.word_count >= 6 {
             matched += 1;
         }
-        if word_count <= 3 && !question {
+        if signals.word_count <= 3 && !signals.question {
             matched += 1;
         }
-        if has_snake {
+        if signals.snake_case {
             matched += 1;
         }
 
-        #[allow(clippy::cast_precision_loss)]
-        let confidence = match matched {
+        match matched {
             0 => 0.0,
             1 => 1.0,
             n => 1.0 / n as f32,
-        };
+        }
+    }
+}
 
+impl MemoryRouter for HeuristicRouter {
+    fn route_with_confidence(&self, query: &str) -> RoutingDecision {
+        let signals = compute_signals(query);
         RoutingDecision {
-            route: self.route(query),
-            confidence,
+            route: Self::decide_route(&signals),
+            confidence: Self::decide_confidence(&signals),
             reasoning: None,
         }
     }
 
     fn route(&self, query: &str) -> MemoryRoute {
-        let lower = query.to_ascii_lowercase();
-
-        // 1. Temporal queries take highest priority — must run before relationship check
-        //    to prevent "history of changes last week" from routing to Graph instead of Episodic.
-        if has_temporal_cue(&lower) {
-            return MemoryRoute::Episodic;
-        }
-
-        // 2. Relationship queries go to graph retrieval (feature-gated at call site)
-        let has_relationship = RELATIONSHIP_PATTERNS.iter().any(|p| lower.contains(p));
-        if has_relationship {
-            return MemoryRoute::Graph;
-        }
-
-        let words: Vec<&str> = query.split_whitespace().collect();
-        let word_count = words.len();
-
-        // Code-like patterns that unambiguously indicate keyword search:
-        // file paths (contain '/'), Rust paths (contain '::')
-        let has_structural_code_pattern = query.contains('/') || query.contains("::");
-
-        // Pure snake_case identifiers (e.g. "memory_limit", "error_handling")
-        // but only if the query does NOT start with a question word
-        let has_snake_case = words.iter().any(|w| is_pure_snake_case(w));
-        let question = starts_with_question(&words);
-
-        if has_structural_code_pattern && !question {
-            return MemoryRoute::Keyword;
-        }
-
-        // Long NL queries → semantic, regardless of snake_case tokens
-        if question || word_count >= 6 {
-            return MemoryRoute::Semantic;
-        }
-
-        // Short queries without question words → keyword
-        if word_count <= 3 && !question {
-            return MemoryRoute::Keyword;
-        }
-
-        // Short code-like patterns → keyword
-        if has_snake_case {
-            return MemoryRoute::Keyword;
-        }
-
-        // Default
-        MemoryRoute::Hybrid
+        Self::decide_route(&compute_signals(query))
     }
 }
 

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -402,6 +402,68 @@ pub struct SemanticMemory {
 }
 
 impl SemanticMemory {
+    /// Build a `SemanticMemory` with every field set to its default value, varying only
+    /// the handful of parameters that differ across the public constructors.
+    ///
+    /// Shared by [`SemanticMemory::with_weights_and_pool_size`], [`SemanticMemory::with_qdrant_ops`],
+    /// [`SemanticMemory::from_parts`] and [`SemanticMemory::with_sqlite_backend_and_pool_size`]
+    /// to avoid duplicating the full field literal in each.
+    fn base(
+        sqlite: SqliteStore,
+        qdrant: Option<Arc<EmbeddingStore>>,
+        provider: AnyProvider,
+        embedding_model: String,
+        vector_weight: f64,
+        keyword_weight: f64,
+        token_counter: Arc<TokenCounter>,
+    ) -> Self {
+        Self {
+            sqlite,
+            qdrant,
+            provider,
+            embed_provider: None,
+            embedding_model,
+            vector_weight,
+            keyword_weight,
+            temporal_decay: TemporalDecay::Disabled,
+            temporal_decay_half_life_days: 30,
+            mmr_reranking: MmrReranking::Disabled,
+            mmr_lambda: 0.7,
+            importance_scoring: ImportanceScoring::Disabled,
+            importance_weight: 0.15,
+            tier_boost_semantic: 1.3,
+            token_counter,
+            graph_store: None,
+            experience: None,
+            reasoning: None,
+            community_detection_failures: Arc::new(AtomicU64::new(0)),
+            graph_extraction_count: Arc::new(AtomicU64::new(0)),
+            graph_extraction_failures: Arc::new(AtomicU64::new(0)),
+            last_qdrant_warn: Arc::new(AtomicU64::new(0)),
+            admission_control: None,
+            quality_gate: None,
+            key_facts_dedup_threshold: 0.95,
+            embed_tasks: std::sync::Mutex::new(tokio::task::JoinSet::new()),
+            retrieval_depth: 0,
+            search_prompt_template: String::new(),
+            depth_below_limit_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            missing_placeholder_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            query_bias_correction: QueryBiasCorrection::Enabled,
+            query_bias_profile_weight: 0.25,
+            profile_centroid: RwLock::new(None),
+            profile_centroid_ttl_secs: 300,
+            hebbian_reinforcement: HebbianReinforcement::Disabled,
+            hebbian_lr: 0.1,
+            hebbian_spread: HelaSpreadRuntime::default(),
+            retrieval_failure_logger: None,
+            summarization_llm_timeout_secs: 60,
+            query_sensitive_cost: false,
+            five_signal: None,
+            embed_timeout: std::time::Duration::from_secs(5),
+            graph_cancel: Mutex::new(Vec::new()),
+        }
+    }
+
     /// Create a new `SemanticMemory` instance with default hybrid search weights (0.7/0.3).
     ///
     /// Qdrant connection is best-effort: if unavailable, semantic search is disabled.
@@ -491,51 +553,15 @@ impl SemanticMemory {
             }
         };
 
-        Ok(Self {
+        Ok(Self::base(
             sqlite,
             qdrant,
             provider,
-            embed_provider: None,
-            embedding_model: embedding_model.into(),
+            embedding_model.into(),
             vector_weight,
             keyword_weight,
-            temporal_decay: TemporalDecay::Disabled,
-            temporal_decay_half_life_days: 30,
-            mmr_reranking: MmrReranking::Disabled,
-            mmr_lambda: 0.7,
-            importance_scoring: ImportanceScoring::Disabled,
-            importance_weight: 0.15,
-            tier_boost_semantic: 1.3,
-            token_counter: Arc::new(TokenCounter::new()),
-            graph_store: None,
-            experience: None,
-            reasoning: None,
-            community_detection_failures: Arc::new(AtomicU64::new(0)),
-            graph_extraction_count: Arc::new(AtomicU64::new(0)),
-            graph_extraction_failures: Arc::new(AtomicU64::new(0)),
-            last_qdrant_warn: Arc::new(AtomicU64::new(0)),
-            admission_control: None,
-            quality_gate: None,
-            key_facts_dedup_threshold: 0.95,
-            embed_tasks: std::sync::Mutex::new(tokio::task::JoinSet::new()),
-            retrieval_depth: 0,
-            search_prompt_template: String::new(),
-            depth_below_limit_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            missing_placeholder_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            query_bias_correction: QueryBiasCorrection::Enabled,
-            query_bias_profile_weight: 0.25,
-            profile_centroid: RwLock::new(None),
-            profile_centroid_ttl_secs: 300,
-            hebbian_reinforcement: HebbianReinforcement::Disabled,
-            hebbian_lr: 0.1,
-            hebbian_spread: HelaSpreadRuntime::default(),
-            retrieval_failure_logger: None,
-            summarization_llm_timeout_secs: 60,
-            query_sensitive_cost: false,
-            five_signal: None,
-            embed_timeout: std::time::Duration::from_secs(5),
-            graph_cancel: Mutex::new(Vec::new()),
-        })
+            Arc::new(TokenCounter::new()),
+        ))
     }
 
     /// Create a `SemanticMemory` from a pre-built `QdrantOps` instance.
@@ -559,51 +585,15 @@ impl SemanticMemory {
         let pool = sqlite.pool().clone();
         let store = EmbeddingStore::with_store(Box::new(ops), pool);
 
-        Ok(Self {
+        Ok(Self::base(
             sqlite,
-            qdrant: Some(Arc::new(store)),
+            Some(Arc::new(store)),
             provider,
-            embed_provider: None,
-            embedding_model: embedding_model.into(),
+            embedding_model.into(),
             vector_weight,
             keyword_weight,
-            temporal_decay: TemporalDecay::Disabled,
-            temporal_decay_half_life_days: 30,
-            mmr_reranking: MmrReranking::Disabled,
-            mmr_lambda: 0.7,
-            importance_scoring: ImportanceScoring::Disabled,
-            importance_weight: 0.15,
-            tier_boost_semantic: 1.3,
-            token_counter: Arc::new(TokenCounter::new()),
-            graph_store: None,
-            experience: None,
-            reasoning: None,
-            community_detection_failures: Arc::new(AtomicU64::new(0)),
-            graph_extraction_count: Arc::new(AtomicU64::new(0)),
-            graph_extraction_failures: Arc::new(AtomicU64::new(0)),
-            last_qdrant_warn: Arc::new(AtomicU64::new(0)),
-            admission_control: None,
-            quality_gate: None,
-            key_facts_dedup_threshold: 0.95,
-            embed_tasks: std::sync::Mutex::new(tokio::task::JoinSet::new()),
-            retrieval_depth: 0,
-            search_prompt_template: String::new(),
-            depth_below_limit_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            missing_placeholder_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            query_bias_correction: QueryBiasCorrection::Enabled,
-            query_bias_profile_weight: 0.25,
-            profile_centroid: RwLock::new(None),
-            profile_centroid_ttl_secs: 300,
-            hebbian_reinforcement: HebbianReinforcement::Disabled,
-            hebbian_lr: 0.1,
-            hebbian_spread: HelaSpreadRuntime::default(),
-            retrieval_failure_logger: None,
-            summarization_llm_timeout_secs: 60,
-            query_sensitive_cost: false,
-            five_signal: None,
-            embed_timeout: std::time::Duration::from_secs(5),
-            graph_cancel: Mutex::new(Vec::new()),
-        })
+            Arc::new(TokenCounter::new()),
+        ))
     }
 
     /// Attach a `GraphStore` for graph-aware retrieval.
@@ -1118,51 +1108,15 @@ impl SemanticMemory {
         keyword_weight: f64,
         token_counter: Arc<TokenCounter>,
     ) -> Self {
-        Self {
+        Self::base(
             sqlite,
             qdrant,
             provider,
-            embed_provider: None,
-            embedding_model: embedding_model.into(),
+            embedding_model.into(),
             vector_weight,
             keyword_weight,
-            temporal_decay: TemporalDecay::Disabled,
-            temporal_decay_half_life_days: 30,
-            mmr_reranking: MmrReranking::Disabled,
-            mmr_lambda: 0.7,
-            importance_scoring: ImportanceScoring::Disabled,
-            importance_weight: 0.15,
-            tier_boost_semantic: 1.3,
             token_counter,
-            graph_store: None,
-            experience: None,
-            reasoning: None,
-            community_detection_failures: Arc::new(AtomicU64::new(0)),
-            graph_extraction_count: Arc::new(AtomicU64::new(0)),
-            graph_extraction_failures: Arc::new(AtomicU64::new(0)),
-            last_qdrant_warn: Arc::new(AtomicU64::new(0)),
-            admission_control: None,
-            quality_gate: None,
-            key_facts_dedup_threshold: 0.95,
-            embed_tasks: std::sync::Mutex::new(tokio::task::JoinSet::new()),
-            retrieval_depth: 0,
-            search_prompt_template: String::new(),
-            depth_below_limit_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            missing_placeholder_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            query_bias_correction: QueryBiasCorrection::Enabled,
-            query_bias_profile_weight: 0.25,
-            profile_centroid: RwLock::new(None),
-            profile_centroid_ttl_secs: 300,
-            hebbian_reinforcement: HebbianReinforcement::Disabled,
-            hebbian_lr: 0.1,
-            hebbian_spread: HelaSpreadRuntime::default(),
-            retrieval_failure_logger: None,
-            summarization_llm_timeout_secs: 60,
-            query_sensitive_cost: false,
-            five_signal: None,
-            embed_timeout: std::time::Duration::from_secs(5),
-            graph_cancel: Mutex::new(Vec::new()),
-        }
+        )
     }
 
     /// Create a `SemanticMemory` using the `SQLite`-embedded vector backend.
@@ -1205,51 +1159,15 @@ impl SemanticMemory {
         let pool = sqlite.pool().clone();
         let store = EmbeddingStore::new_sqlite(pool);
 
-        Ok(Self {
+        Ok(Self::base(
             sqlite,
-            qdrant: Some(Arc::new(store)),
+            Some(Arc::new(store)),
             provider,
-            embed_provider: None,
-            embedding_model: embedding_model.into(),
+            embedding_model.into(),
             vector_weight,
             keyword_weight,
-            temporal_decay: TemporalDecay::Disabled,
-            temporal_decay_half_life_days: 30,
-            mmr_reranking: MmrReranking::Disabled,
-            mmr_lambda: 0.7,
-            importance_scoring: ImportanceScoring::Disabled,
-            importance_weight: 0.15,
-            tier_boost_semantic: 1.3,
-            token_counter: Arc::new(TokenCounter::new()),
-            graph_store: None,
-            experience: None,
-            reasoning: None,
-            community_detection_failures: Arc::new(AtomicU64::new(0)),
-            graph_extraction_count: Arc::new(AtomicU64::new(0)),
-            graph_extraction_failures: Arc::new(AtomicU64::new(0)),
-            last_qdrant_warn: Arc::new(AtomicU64::new(0)),
-            admission_control: None,
-            quality_gate: None,
-            key_facts_dedup_threshold: 0.95,
-            embed_tasks: std::sync::Mutex::new(tokio::task::JoinSet::new()),
-            retrieval_depth: 0,
-            search_prompt_template: String::new(),
-            depth_below_limit_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            missing_placeholder_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            query_bias_correction: QueryBiasCorrection::Enabled,
-            query_bias_profile_weight: 0.25,
-            profile_centroid: RwLock::new(None),
-            profile_centroid_ttl_secs: 300,
-            hebbian_reinforcement: HebbianReinforcement::Disabled,
-            hebbian_lr: 0.1,
-            hebbian_spread: HelaSpreadRuntime::default(),
-            retrieval_failure_logger: None,
-            summarization_llm_timeout_secs: 60,
-            query_sensitive_cost: false,
-            five_signal: None,
-            embed_timeout: std::time::Duration::from_secs(5),
-            graph_cancel: Mutex::new(Vec::new()),
-        })
+            Arc::new(TokenCounter::new()),
+        ))
     }
 
     /// Access the underlying `SqliteStore` for operations that don't involve semantics.


### PR DESCRIPTION
## Summary

- `HeuristicRouter::route()` and `route_with_confidence()` (`crates/zeph-memory/src/router.rs`) independently recomputed the same six classification signals, with `route_with_confidence()` also calling `route()` again to derive its result, tripling the work. Extracted a `RouteSignals` struct and `compute_signals()` to compute each signal exactly once, plus `decide_route()`/`decide_confidence()` helpers holding the existing priority-chain and popcount logic unchanged.
- `SemanticMemory`'s four public constructors (`crates/zeph-memory/src/semantic/mod.rs`) each built the full ~35-field struct via an inline literal, differing only in how `qdrant` and `token_counter` were constructed. Extracted a private `base()` helper that all four now delegate to.

Both are pure extractions — no behavior change. Verified via independent diff review (adversarial critique) and full test-suite re-runs.

Closes #5510, #5504

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 11991 passed, 0 failed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`) — clean, no new warnings
- [x] Adversarially verified byte-for-byte behavioral equivalence for both refactors (all shared struct fields, exact priority order, exact confidence scoring)