### PR TITLE
refactor(cargo): split default feature arrays and simplify postgres cfg guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   behavior change; existing test coverage extended to target the new shared functions
   directly (moved clustering tests into `sweep_helpers.rs`, added per-`remember*`-variant
   admission/quality-gate coverage in `semantic/tests/recall.rs`).
+- `refactor(cargo)`: split 4 crates' (`zeph-orchestration`, `zeph-memory`, `zeph-tui`,
+  `zeph-acp`) `default` feature arrays that bundled the `sqlite`/`postgres`
+  backend-selection axis with an unrelated functional feature (`llm-planning`,
+  `jsonschema`, `clipboard`, and 6 `unstable-*` ACP features respectively) — a future
+  backend-only change could otherwise silently drop an unrelated feature for any
+  consumer relying on the bundled default instead of an explicit dependency
+  declaration. Every split-out feature was verified to already be declared explicitly
+  by its real consumer (`zeph-core`'s `llm-planning`, `zeph-context`'s `jsonschema`)
+  (#5631). Simplified 45 now-redundant `all(feature = "sqlite", not(feature =
+  "postgres"))` / bare `not(feature = "postgres")` cfg guards to plain `feature =
+  "sqlite"` across 7 crates (`zeph-scheduler`, `zeph-durable`, `zeph-memory`,
+  `zeph-index`, `zeph-core`, `zeph-subagent`, `zeph-orchestration`), mirroring the
+  pattern already applied to `zeph-db` for #5571 — safe because `zeph-db`'s
+  `compile_error!` guarantees both-enabled and neither-enabled are unreachable states,
+  so `not(postgres) ⟺ sqlite` for every state in which the crate compiles (#5632).
+  Also restored `zeph-acp/unstable-session-usage` forwarding in root `Cargo.toml`'s
+  `acp` feature list, recovering 4 unit tests that the `zeph-acp` default-array split
+  had silently dropped from the CI-matching test run. Pure Cargo-hygiene change, no
+  runtime behavior change.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,7 +223,7 @@ bench      = ["dep:zeph-bench"]
 # === Individual feature flags ===
 deep-link = ["zeph-common/deep-link", "zeph-config/deep-link"]
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server", "zeph-a2a?/ibct"]
-acp = ["dep:zeph-acp", "zeph-acp/unstable-session-delete", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-llm-providers", "zeph-acp/unstable-logout", "zeph-acp/unstable-auth-methods", "zeph-acp/unstable-message-id", "zeph-acp/unstable-session-add-dirs"]
+acp = ["dep:zeph-acp", "zeph-acp/unstable-session-delete", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-session-usage", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-llm-providers", "zeph-acp/unstable-logout", "zeph-acp/unstable-auth-methods", "zeph-acp/unstable-message-id", "zeph-acp/unstable-session-add-dirs"]
 acp-http = ["acp", "dep:axum", "zeph-acp/acp-http"]
 candle = ["zeph-llm/candle", "zeph-core/candle"]
 classifiers = ["candle", "zeph-llm/classifiers", "zeph-sanitizer/classifiers", "zeph-core/classifiers"]

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -13,15 +13,7 @@ description = "ACP (Agent Client Protocol) server for IDE embedding"
 readme = "README.md"
 
 [features]
-default = [
-    "sqlite",
-    "unstable-session-delete",
-    "unstable-session-fork",
-    "unstable-session-usage",
-    "unstable-logout",
-    "unstable-elicitation",
-    "unstable-llm-providers",
-]
+default = ["sqlite"]
 # `zeph-memory`/`zeph-db` require a backend to compile; default to `sqlite` so this crate
 # builds in isolation, and expose `postgres` for PostgreSQL deployments (#4956).
 sqlite = ["zeph-memory/sqlite", "zeph-session/sqlite", "zeph-core/sqlite", "zeph-mcp/sqlite", "zeph-tools/sqlite"]

--- a/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
@@ -1523,7 +1523,7 @@ use crate::agent::context::chunk_messages;
 
 // ── G3: active_goal appears after <!-- cache:volatile --> ──────────────────────
 
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 async fn goal_test_store() -> crate::goal::GoalStore {
     let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
     sqlx::query(
@@ -1547,7 +1547,7 @@ async fn goal_test_store() -> crate::goal::GoalStore {
     crate::goal::GoalStore::new(std::sync::Arc::new(pool))
 }
 
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 #[tokio::test]
 async fn g3_active_goal_appears_after_volatile_marker() {
     use crate::goal::GoalAccounting;

--- a/crates/zeph-core/src/goal/accounting.rs
+++ b/crates/zeph-core/src/goal/accounting.rs
@@ -177,7 +177,7 @@ impl GoalAccounting {
     }
 }
 
-#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/zeph-core/src/goal/store.rs
+++ b/crates/zeph-core/src/goal/store.rs
@@ -313,7 +313,7 @@ impl GoalRow {
     }
 }
 
-#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use std::assert_matches;
 

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -1510,7 +1510,7 @@ fn static_entry_tag(tag: &str) -> &'static str {
 // whose `:memory:` pool is SQLite-specific). The dialect-agnostic `sql!()` SQL and `i64`/`Vec<u8>`
 // column types are verified to compile under the Postgres feature; live Postgres parity is exercised
 // by the `#[ignore]`d integration test below.
-#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use std::assert_matches;
 

--- a/crates/zeph-durable/src/handle.rs
+++ b/crates/zeph-durable/src/handle.rs
@@ -832,7 +832,7 @@ fn idem_key_hex8(key: IdempotencyKey) -> String {
     out
 }
 
-#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use std::assert_matches;
 

--- a/crates/zeph-durable/src/replay.rs
+++ b/crates/zeph-durable/src/replay.rs
@@ -271,7 +271,7 @@ fn insert_entry(state: &mut CursorState, entry: JournalEntry) {
     }
 }
 
-#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use std::assert_matches;
 

--- a/crates/zeph-durable/src/writer.rs
+++ b/crates/zeph-durable/src/writer.rs
@@ -358,7 +358,7 @@ mod tests {
         assert_eq!(received, 2, "the over-capacity buffered entry is dropped");
     }
 
-    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    #[cfg(feature = "sqlite")]
     mod with_backend {
         use super::*;
         use crate::DurableConfig;

--- a/crates/zeph-durable/tests/nfr_gates.rs
+++ b/crates/zeph-durable/tests/nfr_gates.rs
@@ -12,7 +12,7 @@
 //! the `src/`-side `with_backend` test modules): under `--features postgres`, `DbConfig::connect()`
 //! takes cfg-priority and routes `:memory:` into `connect_postgres`, which fails to parse it as a
 //! Postgres URL. See #5603.
-#![cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#![cfg(feature = "sqlite")]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/crates/zeph-index/src/watcher.rs
+++ b/crates/zeph-index/src/watcher.rs
@@ -231,23 +231,23 @@ impl IndexWatcher {
 mod tests {
     use super::*;
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     use zeph_llm::any::AnyProvider;
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     use zeph_llm::ollama::OllamaProvider;
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     use zeph_memory::QdrantOps;
 
     // Hardcodes `sqlx::SqlitePool` and is not portable to PostgreSQL; skipped entirely
     // when `postgres` is the active backend (see issue #5364).
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     async fn create_test_pool() -> zeph_db::DbPool {
         zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
             .await
             .unwrap()
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     async fn create_test_indexer() -> Arc<CodeIndexer> {
         let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let store = crate::store::CodeStore::with_ops(ops, create_test_pool().await);
@@ -263,7 +263,7 @@ mod tests {
         ))
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn start_with_valid_directory() {
         let dir = tempfile::tempdir().unwrap();
@@ -271,7 +271,7 @@ mod tests {
         assert!(watcher.is_ok());
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn start_with_nonexistent_directory_fails() {
         let result = IndexWatcher::start(

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -47,7 +47,7 @@ zeph-scheduler = { workspace = true, optional = true }
 
 [features]
 profiling = []
-default = ["sqlite", "jsonschema"]
+default = ["sqlite"]
 jsonschema = ["zeph-common/jsonschema"]
 pdf = ["dep:pdf-extract"]
 scheduler = ["dep:zeph-scheduler"]

--- a/crates/zeph-memory/src/five_signal/causal_distance.rs
+++ b/crates/zeph-memory/src/five_signal/causal_distance.rs
@@ -178,7 +178,7 @@ mod tests {
     // Regression test for #4405: goal_entity_id=None returns empty map without touching the DB.
     // Hardcodes `sqlx::SqlitePool` and is not portable to PostgreSQL; skipped entirely
     // when `postgres` is the active backend (see issue #5364).
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn compute_none_goal_returns_empty_map() {
         use std::sync::Arc;

--- a/crates/zeph-memory/src/graph/ingest/ledger.rs
+++ b/crates/zeph-memory/src/graph/ingest/ledger.rs
@@ -312,7 +312,7 @@ impl IngestLedger {
 
 // Hardcodes `sqlx::SqlitePool` and is not portable to PostgreSQL; skipped entirely
 // when `postgres` is the active backend (see issue #5364).
-#[cfg(all(test, not(feature = "postgres")))]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use super::*;
 

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -327,7 +327,7 @@ impl GraphStore {
     /// # Errors
     ///
     /// Returns an error if the PRAGMA execution fails.
-    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    #[cfg(feature = "sqlite")]
     #[tracing::instrument(name = "memory.graph.store.checkpoint_wal", skip_all)]
     pub async fn checkpoint_wal(&self) -> Result<(), MemoryError> {
         zeph_db::query("PRAGMA wal_checkpoint(PASSIVE)")
@@ -2271,7 +2271,7 @@ impl GraphStore {
 
 // ── Dialect helpers ───────────────────────────────────────────────────────────
 
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[cfg(feature = "sqlite")]
 fn community_ids_sql(placeholders: &str) -> String {
     format!(
         "SELECT CAST(j.value AS INTEGER) AS entity_id, c.id AS community_id

--- a/crates/zeph-memory/src/reasoning.rs
+++ b/crates/zeph-memory/src/reasoning.rs
@@ -961,7 +961,7 @@ mod tests {
     // These tests hardcode `sqlx::SqlitePool` and are not portable to PostgreSQL;
     // skipped entirely when `postgres` is the active backend (see issue #5364).
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     async fn make_test_pool() -> DbPool {
         let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
         sqlx::query(
@@ -982,7 +982,7 @@ mod tests {
         pool
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     fn make_strategy(id: &str) -> ReasoningStrategy {
         ReasoningStrategy {
             id: id.to_owned(),
@@ -996,7 +996,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn insert_and_fetch_by_ids() {
         let pool = make_test_pool().await;
@@ -1011,7 +1011,7 @@ mod tests {
         assert_eq!(rows[0].outcome, Outcome::Success);
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn mark_used_increments_count() {
         let pool = make_test_pool().await;
@@ -1026,7 +1026,7 @@ mod tests {
         assert_eq!(rows[0].use_count, 2);
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn mark_used_empty_is_noop() {
         let pool = make_test_pool().await;
@@ -1035,7 +1035,7 @@ mod tests {
         mem.mark_used(&[]).await.unwrap();
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn count_returns_correct_total() {
         let pool = make_test_pool().await;
@@ -1050,7 +1050,7 @@ mod tests {
         assert_eq!(mem.count().await.unwrap(), 5);
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn evict_lru_cold_rows() {
         let pool = make_test_pool().await;
@@ -1069,7 +1069,7 @@ mod tests {
         assert_eq!(mem.count().await.unwrap(), 3);
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn evict_lru_respects_hot_rows_under_ceiling() {
         let pool = make_test_pool().await;
@@ -1092,7 +1092,7 @@ mod tests {
         assert_eq!(mem.count().await.unwrap(), 5);
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn evict_lru_hard_ceiling_forces_deletion() {
         let pool = make_test_pool().await;
@@ -1114,7 +1114,7 @@ mod tests {
         assert_eq!(remaining, 3, "should be trimmed to store_limit");
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn evict_lru_no_op_when_under_limit() {
         let pool = make_test_pool().await;
@@ -1133,7 +1133,7 @@ mod tests {
 
     // ── mark_used chunked path ────────────────────────────────────────────────
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn mark_used_chunked_over_490_ids() {
         let pool = make_test_pool().await;
@@ -1203,7 +1203,7 @@ mod tests {
 
     // ── process_turn smoke test ───────────────────────────────────────────────
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn process_turn_with_empty_messages_is_noop() {
         use zeph_llm::any::AnyProvider;

--- a/crates/zeph-memory/src/store/graph_store.rs
+++ b/crates/zeph-memory/src/store/graph_store.rs
@@ -61,7 +61,7 @@ impl RawGraphStore for TaskGraphStore {
         Ok(())
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tracing::instrument(skip_all, name = "memory.graph.load_graph")]
     async fn load_graph(&self, id: &str) -> Result<Option<String>, DbError> {
         let row: Option<(String,)> =
@@ -73,7 +73,7 @@ impl RawGraphStore for TaskGraphStore {
         Ok(row.map(|(json,)| json))
     }
 
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     async fn list_graphs(&self, limit: u32) -> Result<Vec<GraphSummary>, DbError> {
         let rows: Vec<(String, String, String, String, Option<String>)> = zeph_db::query_as(sql!(
             "SELECT id, goal, status, created_at, finished_at \

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -583,7 +583,7 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns an error if the delete fails.
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tracing::instrument(skip_all, name = "memory.skills.prune_skill_versions")]
     pub async fn prune_skill_versions(
         &self,
@@ -728,7 +728,7 @@ impl SqliteStore {
     ///
     /// # Errors
     /// Returns [`MemoryError`] on query failure.
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tracing::instrument(skip_all, name = "memory.skills.find_recurring_patterns")]
     pub async fn find_recurring_patterns(
         &self,
@@ -809,7 +809,7 @@ impl SqliteStore {
     ///
     /// # Errors
     /// Returns [`MemoryError`] on delete failure.
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tracing::instrument(skip_all, name = "memory.skills.prune_tool_usage_log")]
     pub async fn prune_tool_usage_log(&self, retention_days: u32) -> Result<u64, MemoryError> {
         let result = zeph_db::query(sql!(
@@ -869,7 +869,7 @@ impl SqliteStore {
     ///
     /// # Errors
     /// Returns [`MemoryError`] on update failure.
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tracing::instrument(skip_all, name = "memory.skills.increment_heuristic_use_count")]
     pub async fn increment_heuristic_use_count(&self, id: i64) -> Result<(), MemoryError> {
         zeph_db::query(sql!(
@@ -963,7 +963,7 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns [`MemoryError`] on query failure.
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tracing::instrument(skip_all, name = "memory.skills.find_step_corrections")]
     pub async fn find_step_corrections(
         &self,
@@ -1118,7 +1118,7 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns [`MemoryError`] on query failure.
-    #[cfg(not(feature = "postgres"))]
+    #[cfg(feature = "sqlite")]
     #[tracing::instrument(skip_all, name = "memory.skills.save_routing_head_weights")]
     pub async fn save_routing_head_weights(
         &self,

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -45,7 +45,7 @@ zeph-memory.workspace = true
 sqlite = ["zeph-db/sqlite", "zeph-durable/sqlite", "zeph-subagent/sqlite"]
 postgres = ["zeph-db/postgres", "zeph-durable/postgres", "zeph-subagent/postgres"]
 llm-planning = ["dep:zeph-llm"]
-default = ["sqlite", "llm-planning"]
+default = ["sqlite"]
 
 [lints]
 workspace = true

--- a/crates/zeph-orchestration/src/durable.rs
+++ b/crates/zeph-orchestration/src/durable.rs
@@ -364,7 +364,7 @@ mod tests {
     // (mirroring `zeph-durable`'s `writer.rs`/`local.rs` test modules): under `--features postgres`
     // `DbConfig::connect()` takes cfg-priority and routes `:memory:` into `connect_postgres`, which
     // fails to parse it as a Postgres URL. See #5608.
-    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    #[cfg(feature = "sqlite")]
     mod with_backend {
         use zeph_durable::{DurableBackendEnum, DurableConfig, JournalWriter, LocalBackend};
 

--- a/crates/zeph-scheduler/src/durable.rs
+++ b/crates/zeph-scheduler/src/durable.rs
@@ -243,7 +243,7 @@ mod tests {
     // (mirroring `zeph-durable`'s `writer.rs`/`local.rs` test modules): under `--features postgres`
     // `DbConfig::connect()` takes cfg-priority and routes `:memory:` into `connect_postgres`, which
     // fails to parse it as a Postgres URL. See #5603.
-    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    #[cfg(feature = "sqlite")]
     mod with_backend {
         use std::sync::atomic::{AtomicU32, Ordering};
 

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -967,7 +967,7 @@ impl Scheduler {
 // Every test in this module opens a real connection pool via the `:memory:` sentinel, which is
 // SQLite-specific: under `--features postgres`, `DbConfig::connect()` takes cfg-priority and routes
 // `:memory:` into `connect_postgres`, which fails to parse it as a Postgres URL. See #5608.
-#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use std::pin::Pin;
     use std::sync::Arc;

--- a/crates/zeph-scheduler/src/store.rs
+++ b/crates/zeph-scheduler/src/store.rs
@@ -471,7 +471,7 @@ impl JobStore {
 // Every test in this module opens a real connection pool via the `:memory:` sentinel, which is
 // SQLite-specific: under `--features postgres`, `DbConfig::connect()` takes cfg-priority and routes
 // `:memory:` into `connect_postgres`, which fails to parse it as a Postgres URL. See #5608.
-#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use super::*;
 

--- a/crates/zeph-subagent/src/durable.rs
+++ b/crates/zeph-subagent/src/durable.rs
@@ -265,7 +265,7 @@ mod tests {
     // `postgres` features enable `zeph-db/postgres` directly), `DbConfig::connect()` takes
     // cfg-priority and routes `:memory:` into `connect_postgres`, which fails to parse it as a
     // Postgres URL. See #5608.
-    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn durable_promise_resolve_and_await_roundtrip() {
         use std::sync::Arc;

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -62,7 +62,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util.workspace = true
 
 [features]
-default = ["clipboard", "sqlite"]
+default = ["sqlite"]
 clipboard = ["dep:arboard"]
 cocoon = []
 profiling = []


### PR DESCRIPTION
## Summary

- Splits 4 crates' `default` feature arrays that bundled the `sqlite`/`postgres` backend-selection axis with an unrelated functional feature — `zeph-orchestration` (`llm-planning`), `zeph-memory` (`jsonschema`), `zeph-tui` (`clipboard`), `zeph-acp` (6 `unstable-*` ACP features). Every split-out feature is already declared explicitly by its real consumer (`zeph-core`'s `llm-planning`, `zeph-context`'s `jsonschema`), so no build silently loses a capability. Closes #5631.
- Simplifies 45 now-redundant `all(feature = "sqlite", not(feature = "postgres"))` / bare `not(feature = "postgres")` cfg guards to plain `feature = "sqlite"` across `zeph-scheduler`, `zeph-durable`, `zeph-memory`, `zeph-index`, `zeph-core`, `zeph-subagent`, `zeph-orchestration`, mirroring the pattern already applied to `zeph-db` for #5571. Safe because `zeph-db`'s `compile_error!` makes both-enabled and neither-enabled unreachable states, so `not(postgres) ⟺ sqlite` for every state in which each crate compiles. Closes #5632.
- Also restores `zeph-acp/unstable-session-usage` forwarding in root `Cargo.toml`'s `acp` feature list, recovering 4 unit tests that the `zeph-acp` default-array split had silently dropped from the CI-matching test run (found during validation).

No behavior change intended — pure Cargo-hygiene/mechanical change.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12031 passed, 34 skipped, 0 failed
- [x] `cargo check --workspace --no-default-features --features "postgres,desktop,ide,server,chat,pdf,scheduler,testing"` (postgres backend)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Standalone `cargo check -p` for each of the 4 crates with split default arrays, confirming their real consumers still build with the split-out feature declared explicitly