### PR TITLE
refactor(memory): deduplicate SQLite-datetime, ingest doc building, and LLM-judge/embed fail-open helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `acp` feature list, recovering 4 unit tests that the `zeph-acp` default-array split
   had silently dropped from the CI-matching test run. Pure Cargo-hygiene change, no
   runtime behavior change.
+- `refactor(memory)`: deduplicated three more independent hand-rolled patterns in
+  `zeph-memory`. A single SQLite-datetime-to-Unix-seconds parser now lives in new
+  `crates/zeph-memory/src/sqlite_time.rs`, replacing three separate implementations
+  (`graph/types.rs`, `graph/activation.rs`, `eviction.rs`) that had drifted apart
+  (different algorithms, different return types, different fractional-second/timezone
+  tolerance); `eviction.rs`'s `Option<u64>`-returning wrapper is now a thin
+  `u64::try_from(...)` conversion over the canonical `Option<i64>` parser — this
+  changes one previously-untested edge case (a malformed/pre-1970 timestamp string now
+  falls through to `None` instead of silently returning `Some(0)`/epoch), documented
+  and pinned with a regression test since it's unreachable in practice (`datetime('now')`
+  never produces pre-1970 strings) (#5523). A new `build_ingest_documents` free function
+  in `graph/ingest/adapter.rs` replaces the near-identical context-window
+  document-assembly loop duplicated across all three `IngestSourceAdapter` impls
+  (`SubagentJsonl`, `ClaudeCodeJsonl`, `CodexJsonl`) (#5515). New
+  `crates/zeph-memory/src/llm_judge.rs` holds `embed_with_timeout_fail_open` and
+  `llm_judge_score`, consolidating four embed-timeout-fail-open call sites and three
+  single-shot LLM-judge call sites previously duplicated across `admission.rs` and
+  `quality_gate.rs`, including the subtle clamped-vs-unclamped fail-open asymmetry in
+  `refine_goal_utility_llm` (now pinned by a dedicated regression test) (#5514). No
+  behavior change beyond the one documented eviction.rs edge case above; added direct
+  unit test coverage for all three new shared helpers.
 
 ### Fixed
 

--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -370,16 +370,17 @@ async fn compute_semantic_novelty(
     if !provider.supports_embeddings() {
         return 1.0;
     }
-    let vector = match tokio::time::timeout(embed_timeout, provider.embed(content)).await {
-        Ok(Ok(v)) => v,
-        Ok(Err(e)) => {
-            tracing::debug!(error = %e, "A-MAC: failed to embed for novelty, using 1.0");
-            return 1.0;
-        }
-        Err(_) => {
-            tracing::warn!("A-MAC: embed timed out in semantic_novelty, using 1.0");
-            return 1.0;
-        }
+    let vector = match crate::llm_judge::embed_with_timeout_fail_open(
+        provider,
+        content,
+        embed_timeout,
+        1.0,
+        "A-MAC: semantic_novelty",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(fail_open) => return fail_open,
     };
     if let Err(e) = store.ensure_collection_for_vector(&vector).await {
         tracing::debug!(error = %e, "A-MAC: collection not ready for novelty check");
@@ -401,8 +402,6 @@ async fn compute_semantic_novelty(
 /// On timeout or error, returns `0.5` (neutral — no bias toward admit or reject).
 #[tracing::instrument(name = "memory.admission.future_utility_llm", skip_all)]
 async fn compute_future_utility(content: &str, role: &str, provider: &AnyProvider) -> f32 {
-    use zeph_llm::provider::{Message, MessageMetadata, Role};
-
     let system = "You are a memory relevance judge. Rate how likely this message will be \
         referenced in future conversations on a scale of 0.0 to 1.0. \
         Respond with ONLY a decimal number between 0.0 and 1.0, nothing else.";
@@ -412,35 +411,16 @@ async fn compute_future_utility(content: &str, role: &str, provider: &AnyProvide
         content.chars().take(500).collect::<String>()
     );
 
-    let messages = vec![
-        Message {
-            role: Role::System,
-            content: system.to_owned(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::User,
-            content: user,
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-    ];
-
-    let result = match tokio::time::timeout(Duration::from_secs(8), provider.chat(&messages)).await
-    {
-        Ok(Ok(r)) => r,
-        Ok(Err(e)) => {
-            tracing::debug!(error = %e, "A-MAC: future_utility LLM call failed, using 0.5");
-            return 0.5;
-        }
-        Err(_) => {
-            tracing::debug!("A-MAC: future_utility LLM timed out, using 0.5");
-            return 0.5;
-        }
-    };
-
-    result.trim().parse::<f32>().unwrap_or(0.5).clamp(0.0, 1.0)
+    crate::llm_judge::llm_judge_score(
+        provider,
+        system,
+        user,
+        Duration::from_secs(8),
+        0.5,
+        "A-MAC: future_utility",
+        |s| s.trim().parse::<f32>().ok(),
+    )
+    .await
 }
 
 /// Compute goal-conditioned utility for a candidate memory.
@@ -467,27 +447,29 @@ async fn compute_goal_utility(
         return 0.0;
     }
 
-    let goal_emb = match tokio::time::timeout(embed_timeout, provider.embed(goal_text)).await {
-        Ok(Ok(v)) => v,
-        Ok(Err(e)) => {
-            tracing::debug!(error = %e, "goal_utility: failed to embed goal text, using 0.0");
-            return 0.0;
-        }
-        Err(_) => {
-            tracing::warn!("A-MAC: embed timed out in goal_utility (goal text), using 0.0");
-            return 0.0;
-        }
+    let goal_emb = match crate::llm_judge::embed_with_timeout_fail_open(
+        provider,
+        goal_text,
+        embed_timeout,
+        0.0,
+        "goal_utility: goal text",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(fail_open) => return fail_open,
     };
-    let content_emb = match tokio::time::timeout(embed_timeout, provider.embed(content)).await {
-        Ok(Ok(v)) => v,
-        Ok(Err(e)) => {
-            tracing::debug!(error = %e, "goal_utility: failed to embed content, using 0.0");
-            return 0.0;
-        }
-        Err(_) => {
-            tracing::warn!("A-MAC: embed timed out in goal_utility (content), using 0.0");
-            return 0.0;
-        }
+    let content_emb = match crate::llm_judge::embed_with_timeout_fail_open(
+        provider,
+        content,
+        embed_timeout,
+        0.0,
+        "goal_utility: content",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(fail_open) => return fail_open,
     };
 
     // Qdrant is used for novelty search, not for goal utility — we compute cosine directly.
@@ -528,8 +510,6 @@ async fn refine_goal_utility_llm(
     embedding_sim: f32,
     provider: &AnyProvider,
 ) -> f32 {
-    use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
-
     let system = "You are a memory relevance judge. Given a task goal and a candidate memory, \
         rate how relevant the memory is to the goal on a scale of 0.0 to 1.0. \
         Respond with ONLY a decimal number between 0.0 and 1.0, nothing else.";
@@ -540,39 +520,16 @@ async fn refine_goal_utility_llm(
         content.chars().take(300).collect::<String>(),
     );
 
-    let messages = vec![
-        Message {
-            role: Role::System,
-            content: system.to_owned(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::User,
-            content: user,
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-    ];
-
-    let result = match tokio::time::timeout(Duration::from_secs(6), provider.chat(&messages)).await
-    {
-        Ok(Ok(r)) => r,
-        Ok(Err(e)) => {
-            tracing::debug!(error = %e, "goal_utility LLM refinement failed, using embedding sim");
-            return embedding_sim;
-        }
-        Err(_) => {
-            tracing::debug!("goal_utility LLM refinement timed out, using embedding sim");
-            return embedding_sim;
-        }
-    };
-
-    result
-        .trim()
-        .parse::<f32>()
-        .unwrap_or(embedding_sim)
-        .clamp(0.0, 1.0)
+    crate::llm_judge::llm_judge_score(
+        provider,
+        system,
+        user,
+        Duration::from_secs(6),
+        embedding_sim,
+        "goal_utility LLM refinement",
+        |s| s.trim().parse::<f32>().ok(),
+    )
+    .await
 }
 
 /// Log an admission decision to the audit log via `tracing`.

--- a/crates/zeph-memory/src/eviction.rs
+++ b/crates/zeph-memory/src/eviction.rs
@@ -19,6 +19,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::embedding_store::EmbeddingStore;
 use crate::error::MemoryError;
+use crate::sqlite_time::parse_sqlite_datetime_to_unix;
 use crate::store::SqliteStore;
 use crate::types::MessageId;
 
@@ -113,48 +114,25 @@ fn unix_now_secs() -> u64 {
 
 /// Parse a `SQLite` TEXT timestamp ("YYYY-MM-DD HH:MM:SS") into Unix seconds.
 ///
-/// Does not use `chrono` to avoid adding a dependency to `zeph-memory`.
+/// Thin `u64` wrapper around [`parse_sqlite_datetime_to_unix`] — eviction timestamps are
+/// always post-epoch, so the conversion only fails on a (impossible in practice) negative
+/// parse result.
+///
+/// # Behavior note (pre-1970 / negative timestamps)
+///
+/// A pre-1970 (or otherwise negative-computing) input now returns `None` here, whereas the
+/// old hand-rolled `u64`-only parser this replaced silently returned `Some(0)` for such
+/// input (its `for y in 1970..year` day-accumulation loop is simply empty when `year <
+/// 1970`, contributing zero days with no error). That old behavior treated a corrupt
+/// timestamp as "epoch" — maximally old, strongly favoring eviction. This function instead
+/// treats it as unparseable, so [`EbbinghausPolicy::score`]'s `last_accessed → created_at →
+/// now_secs` fallback chain falls through to the next signal (or `now_secs`, i.e. "brand
+/// new" — the *opposite* eviction bias) instead. `last_accessed`/`created_at` are always
+/// application-generated `datetime('now')` strings, so a real pre-1970 value should never
+/// occur outside data corruption — this divergence is believed unreachable in practice, but
+/// is intentional and pinned by a test rather than accidental.
 fn parse_sqlite_timestamp_secs(s: &str) -> Option<u64> {
-    // Expected format: "YYYY-MM-DD HH:MM:SS"
-    let s = s.trim();
-    if s.len() < 19 {
-        return None;
-    }
-    let year: u64 = s[0..4].parse().ok()?;
-    let month: u64 = s[5..7].parse().ok()?;
-    let day: u64 = s[8..10].parse().ok()?;
-    let hour: u64 = s[11..13].parse().ok()?;
-    let min: u64 = s[14..16].parse().ok()?;
-    let sec: u64 = s[17..19].parse().ok()?;
-
-    // Days since Unix epoch (1970-01-01). Simple but accurate for years 1970-2099.
-    // Leap year calculation: divisible by 4 and not 100, or divisible by 400.
-    let is_leap = |y: u64| (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400);
-    let days_in_month = |y: u64, m: u64| -> u64 {
-        match m {
-            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
-            4 | 6 | 9 | 11 => 30,
-            2 => {
-                if is_leap(y) {
-                    29
-                } else {
-                    28
-                }
-            }
-            _ => 0,
-        }
-    };
-
-    let mut days: u64 = 0;
-    for y in 1970..year {
-        days += if is_leap(y) { 366 } else { 365 };
-    }
-    for m in 1..month {
-        days += days_in_month(year, m);
-    }
-    days += day.saturating_sub(1);
-
-    Some(days * 86400 + hour * 3600 + min * 60 + sec)
+    u64::try_from(parse_sqlite_datetime_to_unix(s)?).ok()
 }
 
 // ── Sweep loop ────────────────────────────────────────────────────────────────
@@ -496,6 +474,15 @@ mod tests {
             ts, 1_704_067_200,
             "2024-01-01 must parse to known timestamp"
         );
+    }
+
+    #[test]
+    fn parse_sqlite_timestamp_pre_1970_returns_none() {
+        // Pinned behavior (post-refactor): a pre-epoch date now returns `None` rather than
+        // the old hand-rolled parser's silent `Some(0)` fallback — see the doc comment on
+        // `parse_sqlite_timestamp_secs` for why this divergence is intentional.
+        assert_eq!(parse_sqlite_timestamp_secs("1969-12-31 23:59:59"), None);
+        assert_eq!(parse_sqlite_timestamp_secs("1900-01-01 00:00:00"), None);
     }
 
     // ── Phase-2 Qdrant cleanup tests ─────────────────────────────────────────

--- a/crates/zeph-memory/src/graph/activation.rs
+++ b/crates/zeph-memory/src/graph/activation.rs
@@ -23,6 +23,7 @@ use crate::embedding_store::EmbeddingStore;
 use crate::error::MemoryError;
 use crate::graph::store::GraphStore;
 use crate::graph::types::{Edge, EdgeType, edge_type_weight, evolved_weight};
+use crate::sqlite_time::parse_sqlite_datetime_to_unix;
 
 /// A graph node that was activated during spreading activation.
 #[derive(Debug, Clone)]
@@ -729,38 +730,6 @@ impl SpreadingActivation {
         let w = weight as f32;
         w
     }
-}
-
-/// Parse a `SQLite` `datetime('now')` string to Unix seconds.
-///
-/// Accepts `"YYYY-MM-DD HH:MM:SS"` (and variants with fractional seconds or timezone suffix).
-/// Returns `None` if the string cannot be parsed.
-#[must_use]
-fn parse_sqlite_datetime_to_unix(s: &str) -> Option<i64> {
-    if s.len() < 19 {
-        return None;
-    }
-    let year: i64 = s[0..4].parse().ok()?;
-    let month: i64 = s[5..7].parse().ok()?;
-    let day: i64 = s[8..10].parse().ok()?;
-    let hour: i64 = s[11..13].parse().ok()?;
-    let min: i64 = s[14..16].parse().ok()?;
-    let sec: i64 = s[17..19].parse().ok()?;
-
-    // Days since Unix epoch via civil calendar algorithm.
-    // Reference: https://howardhinnant.github.io/date_algorithms.html#days_from_civil
-    let (y, m) = if month <= 2 {
-        (year - 1, month + 9)
-    } else {
-        (year, month - 3)
-    };
-    let era = y.div_euclid(400);
-    let yoe = y - era * 400;
-    let doy = (153 * m + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    let days = era * 146_097 + doe - 719_468;
-
-    Some(days * 86_400 + hour * 3_600 + min * 60 + sec)
 }
 
 #[cfg(test)]

--- a/crates/zeph-memory/src/graph/ingest/adapter.rs
+++ b/crates/zeph-memory/src/graph/ingest/adapter.rs
@@ -17,13 +17,43 @@ use zeph_llm::provider::Message;
 
 use crate::MemoryError;
 use crate::graph::ingest::document::IngestSourceKind;
-use crate::graph::types::GraphProvenance;
+use crate::graph::types::{GraphOrigin, GraphProvenance};
 
 use super::document::IngestDocument;
 use super::report::ImportBatchId;
 
 mod sealed {
     pub trait Sealed {}
+}
+
+/// Build one [`IngestDocument`] per non-empty `texts[i]`, pairing it with `ids[i]` and the
+/// `context_window` preceding texts.
+///
+/// Shared by every [`IngestSourceAdapter`] impl in this module — they differ only in how
+/// `source_uri` is formatted and which [`GraphOrigin`] tags the provenance.
+fn build_ingest_documents(
+    texts: &[String],
+    ids: &[String],
+    context_window: usize,
+    batch_id: &ImportBatchId,
+    origin: GraphOrigin,
+    source_uri: impl Fn(&str) -> String,
+) -> Vec<IngestDocument> {
+    let mut docs = Vec::with_capacity(texts.len());
+    for (i, (content, id)) in texts.iter().zip(ids.iter()).enumerate() {
+        if content.trim().is_empty() {
+            continue;
+        }
+        let start = i.saturating_sub(context_window);
+        let ctx: Vec<String> = texts[start..i].to_vec();
+        let provenance = GraphProvenance {
+            origin,
+            import_batch_id: batch_id.as_str().to_owned(),
+            source_uri: Some(source_uri(id)),
+        };
+        docs.push(IngestDocument::new(content.clone(), ctx, provenance));
+    }
+    docs
 }
 
 /// Adapter that converts raw source material into [`IngestDocument`] values.
@@ -153,26 +183,16 @@ impl IngestSourceAdapter for SubagentJsonl {
             .iter()
             .map(|e| e.message.to_llm_content().to_owned())
             .collect();
+        let ids: Vec<String> = entries.iter().map(|e| e.seq.to_string()).collect();
 
-        let mut docs = Vec::with_capacity(entries.len());
-        for (i, entry) in entries.iter().enumerate() {
-            let content = texts[i].clone();
-            if content.trim().is_empty() {
-                continue;
-            }
-            let start = i.saturating_sub(self.context_window);
-            let ctx: Vec<String> = texts[start..i].to_vec();
-
-            let source_uri = format!("subagent:{}#{}", self.task_id, entry.seq);
-            let provenance = GraphProvenance {
-                origin: IngestSourceKind::SubagentTranscript.graph_origin(),
-                import_batch_id: batch_id.as_str().to_owned(),
-                source_uri: Some(source_uri),
-            };
-            docs.push(IngestDocument::new(content, ctx, provenance));
-        }
-
-        Ok(docs)
+        Ok(build_ingest_documents(
+            &texts,
+            &ids,
+            self.context_window,
+            batch_id,
+            IngestSourceKind::SubagentTranscript.graph_origin(),
+            |id| format!("subagent:{}#{id}", self.task_id),
+        ))
     }
 }
 
@@ -346,23 +366,14 @@ impl IngestSourceAdapter for ClaudeCodeJsonl {
             uuids.push(record.uuid.unwrap_or_else(|| format!("line{lineno}")));
         }
 
-        let mut docs = Vec::with_capacity(texts.len());
-        for (i, (content, uuid)) in texts.iter().zip(uuids.iter()).enumerate() {
-            if content.trim().is_empty() {
-                continue;
-            }
-            let start = i.saturating_sub(self.context_window);
-            let ctx: Vec<String> = texts[start..i].to_vec();
-            let source_uri = format!("claude-code:{}#{}", self.session_id, uuid);
-            let provenance = GraphProvenance {
-                origin: IngestSourceKind::ExternalAgent.graph_origin(),
-                import_batch_id: batch_id.as_str().to_owned(),
-                source_uri: Some(source_uri),
-            };
-            docs.push(IngestDocument::new(content.clone(), ctx, provenance));
-        }
-
-        Ok(docs)
+        Ok(build_ingest_documents(
+            &texts,
+            &uuids,
+            self.context_window,
+            batch_id,
+            IngestSourceKind::ExternalAgent.graph_origin(),
+            |uuid| format!("claude-code:{}#{uuid}", self.session_id),
+        ))
     }
 }
 
@@ -522,23 +533,14 @@ impl IngestSourceAdapter for CodexJsonl {
             item_ids.push(item_id);
         }
 
-        let mut docs = Vec::with_capacity(texts.len());
-        for (i, (content, item_id)) in texts.iter().zip(item_ids.iter()).enumerate() {
-            if content.trim().is_empty() {
-                continue;
-            }
-            let start = i.saturating_sub(self.context_window);
-            let ctx: Vec<String> = texts[start..i].to_vec();
-            let source_uri = format!("codex:{}#{}", self.session_id, item_id);
-            let provenance = GraphProvenance {
-                origin: IngestSourceKind::ExternalAgent.graph_origin(),
-                import_batch_id: batch_id.as_str().to_owned(),
-                source_uri: Some(source_uri),
-            };
-            docs.push(IngestDocument::new(content.clone(), ctx, provenance));
-        }
-
-        Ok(docs)
+        Ok(build_ingest_documents(
+            &texts,
+            &item_ids,
+            self.context_window,
+            batch_id,
+            IngestSourceKind::ExternalAgent.graph_origin(),
+            |item_id| format!("codex:{}#{item_id}", self.session_id),
+        ))
     }
 }
 

--- a/crates/zeph-memory/src/graph/types.rs
+++ b/crates/zeph-memory/src/graph/types.rs
@@ -6,6 +6,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use crate::sqlite_time::parse_sqlite_datetime_to_unix;
 use crate::types::{EntityId, MessageId};
 
 /// MAGMA edge type: the semantic category of a relationship between two entities.
@@ -470,44 +471,6 @@ impl GraphFact {
         // Additive blend: base * (1 + boost_fraction), capped at 2x base.
         base * (1.0 + boost_f32).min(2.0)
     }
-}
-
-/// Parse a `SQLite` `datetime('now')` string to Unix seconds.
-///
-/// Accepts:
-/// - `"YYYY-MM-DD HH:MM:SS"` (19 chars, standard `SQLite` format)
-/// - `"YYYY-MM-DD HH:MM:SS.fff"` (fractional seconds — truncated, not rounded)
-/// - `"YYYY-MM-DD HH:MM:SSZ"` or `"YYYY-MM-DD HH:MM:SS+HH:MM"` (timezone suffix — treated as UTC)
-///
-/// Returns `None` if the string cannot be parsed.
-#[must_use]
-fn parse_sqlite_datetime_to_unix(s: &str) -> Option<i64> {
-    // Minimum: "YYYY-MM-DD HH:MM:SS" (19 chars)
-    if s.len() < 19 {
-        return None;
-    }
-    let year: i64 = s[0..4].parse().ok()?;
-    let month: i64 = s[5..7].parse().ok()?;
-    let day: i64 = s[8..10].parse().ok()?;
-    let hour: i64 = s[11..13].parse().ok()?;
-    let min: i64 = s[14..16].parse().ok()?;
-    // Only parse the base seconds; ignore fractional seconds and timezone suffix.
-    let sec: i64 = s[17..19].parse().ok()?;
-
-    // Days since Unix epoch (1970-01-01) via civil calendar algorithm.
-    // Reference: https://howardhinnant.github.io/date_algorithms.html#days_from_civil
-    let (y, m) = if month <= 2 {
-        (year - 1, month + 9)
-    } else {
-        (year, month - 3)
-    };
-    let era = y.div_euclid(400);
-    let yoe = y - era * 400;
-    let doy = (153 * m + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    let days = era * 146_097 + doe - 719_468;
-
-    Some(days * 86_400 + hour * 3_600 + min * 60 + sec)
 }
 
 #[cfg(test)]

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -95,6 +95,7 @@ pub mod error;
 pub mod eviction;
 pub mod graph;
 pub mod in_memory_store;
+mod llm_judge;
 pub mod qdrant_ops;
 pub mod quality_gate;
 pub mod response_cache;
@@ -102,6 +103,7 @@ pub mod router;
 pub mod semantic;
 pub mod shadow;
 pub mod snapshot;
+mod sqlite_time;
 pub mod store;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;

--- a/crates/zeph-memory/src/llm_judge.rs
+++ b/crates/zeph-memory/src/llm_judge.rs
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared "bounded LLM call, fail open" scaffolding for write-path scoring gates.
+//!
+//! [`crate::admission`] and [`crate::quality_gate`] both score candidate memories with
+//! best-effort LLM/embedding calls that must never block a write: every external call is
+//! wrapped in a timeout, and any timeout or provider error falls back to a neutral score
+//! rather than propagating an error. This module owns that scaffolding so each gate only
+//! supplies its own prompts, similarity computation, or response parsing.
+
+use std::time::Duration;
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
+
+/// Embed `content` with a bounded timeout, failing open on any error.
+///
+/// Returns `Ok(vector)` on success. Returns `Err(fail_open_score)` on embed error or
+/// timeout — callers should treat `fail_open_score` as the final score for whatever
+/// factor they were computing, skipping any further similarity comparison.
+///
+/// `log_context` is prefixed to the tracing messages emitted on failure so each call site
+/// stays identifiable in logs (e.g. `"A-MAC: novelty"`, `"quality_gate: info_value"`).
+pub(crate) async fn embed_with_timeout_fail_open(
+    provider: &AnyProvider,
+    content: &str,
+    embed_timeout: Duration,
+    fail_open_score: f32,
+    log_context: &str,
+) -> Result<Vec<f32>, f32> {
+    match tokio::time::timeout(embed_timeout, provider.embed(content)).await {
+        Ok(Ok(v)) => Ok(v),
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, "{log_context}: embed failed, using fail-open score");
+            Err(fail_open_score)
+        }
+        Err(_) => {
+            tracing::warn!("{log_context}: embed timed out, using fail-open score");
+            Err(fail_open_score)
+        }
+    }
+}
+
+/// Run a single-shot LLM judge call: build a system/user message pair, call `provider.chat`
+/// under a timeout, and parse the response into a score.
+///
+/// Fails open to `fail_open_score` — returned as-is, unclamped — on any provider error or
+/// timeout. When a response is received, `parse` extracts a score from it; if `parse`
+/// returns `None` the result also falls back to `fail_open_score`, but (matching the
+/// original per-call-site behavior) this fallback is clamped to `[0.0, 1.0]` same as a
+/// successfully parsed score.
+///
+/// `log_context` is prefixed to the tracing messages emitted on failure.
+pub(crate) async fn llm_judge_score(
+    provider: &AnyProvider,
+    system_prompt: &str,
+    user_prompt: String,
+    timeout: Duration,
+    fail_open_score: f32,
+    log_context: &str,
+    parse: impl Fn(&str) -> Option<f32>,
+) -> f32 {
+    let messages = vec![
+        Message {
+            role: Role::System,
+            content: system_prompt.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+        Message {
+            role: Role::User,
+            content: user_prompt,
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+    ];
+
+    let result = match tokio::time::timeout(timeout, provider.chat(&messages)).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, "{log_context}: LLM call failed, using fail-open score");
+            return fail_open_score;
+        }
+        Err(_) => {
+            tracing::debug!("{log_context}: LLM call timed out, using fail-open score");
+            return fail_open_score;
+        }
+    };
+
+    parse(&result).unwrap_or(fail_open_score).clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn embed_with_timeout_fail_open_returns_ok_on_success() {
+        let mock = zeph_llm::mock::MockProvider::default().with_embedding(vec![1.0, 2.0, 3.0]);
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let result =
+            embed_with_timeout_fail_open(&provider, "hello", Duration::from_secs(5), 0.5, "test")
+                .await;
+        assert_eq!(result, Ok(vec![1.0, 2.0, 3.0]));
+    }
+
+    #[tokio::test]
+    async fn embed_with_timeout_fail_open_fails_open_on_timeout() {
+        tokio::time::pause();
+        let mock = zeph_llm::mock::MockProvider::default()
+            .with_embed_delay(10_000)
+            .with_embedding(vec![0.0; 4]);
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let fut = async move {
+            embed_with_timeout_fail_open(&provider, "hello", Duration::from_secs(5), 0.42, "test")
+                .await
+        };
+        let handle = tokio::spawn(fut); // EXEMPT: test-only tokio::time::pause harness
+        tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        let result = handle.await.expect("task panicked");
+        assert_eq!(result, Err(0.42));
+    }
+
+    #[tokio::test]
+    async fn embed_with_timeout_fail_open_fails_open_on_error() {
+        let mock = zeph_llm::mock::MockProvider::default().with_embed_invalid_input();
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let result =
+            embed_with_timeout_fail_open(&provider, "hello", Duration::from_secs(5), 0.77, "test")
+                .await;
+        assert_eq!(result, Err(0.77));
+    }
+
+    #[tokio::test]
+    async fn llm_judge_score_parses_valid_response() {
+        let mock = zeph_llm::mock::MockProvider::with_responses(vec!["0.75".into()]);
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let score = llm_judge_score(
+            &provider,
+            "system",
+            "user".to_owned(),
+            Duration::from_secs(5),
+            0.5,
+            "test",
+            |s| s.trim().parse::<f32>().ok(),
+        )
+        .await;
+        assert!((score - 0.75).abs() < f32::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn llm_judge_score_fails_open_on_provider_error() {
+        let mock = zeph_llm::mock::MockProvider::default()
+            .with_errors(vec![zeph_llm::LlmError::Other("boom".into())]);
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let score = llm_judge_score(
+            &provider,
+            "system",
+            "user".to_owned(),
+            Duration::from_secs(5),
+            0.33,
+            "test",
+            |s| s.trim().parse::<f32>().ok(),
+        )
+        .await;
+        assert!((score - 0.33).abs() < f32::EPSILON);
+    }
+
+    // Regression pair for the clamped-vs-unclamped fail-open asymmetry described in this
+    // module's doc comment: the SAME out-of-[0,1]-range fail_open_score (1.5) must come back
+    // unclamped on timeout/error, but clamped when it's used as the parse-failure fallback.
+    // If someone "fixes" this asymmetry later (e.g. by clamping both, or neither), exactly one
+    // of these two tests will fail.
+
+    #[tokio::test]
+    async fn llm_judge_score_falls_back_unclamped_on_timeout() {
+        tokio::time::pause();
+        let mock = zeph_llm::mock::MockProvider::default().with_delay(10_000);
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let fut = async move {
+            llm_judge_score(
+                &provider,
+                "system",
+                "user".to_owned(),
+                Duration::from_secs(5),
+                1.5,
+                "test",
+                |s| s.trim().parse::<f32>().ok(),
+            )
+            .await
+        };
+        let handle = tokio::spawn(fut); // EXEMPT: test-only tokio::time::pause harness
+        tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        let score = handle.await.expect("task panicked");
+        assert!(
+            (score - 1.5).abs() < f32::EPSILON,
+            "timeout fail-open must be returned unclamped, got {score}"
+        );
+    }
+
+    #[tokio::test]
+    async fn llm_judge_score_clamps_unparseable_response_fallback() {
+        let mock = zeph_llm::mock::MockProvider::with_responses(vec!["not-a-number".into()]);
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let score = llm_judge_score(
+            &provider,
+            "system",
+            "user".to_owned(),
+            Duration::from_secs(5),
+            1.5,
+            "test",
+            |s| s.trim().parse::<f32>().ok(),
+        )
+        .await;
+        assert!(
+            (score - 1.0).abs() < f32::EPSILON,
+            "unparseable-response fallback must be clamped to [0,1], got {score}"
+        );
+    }
+}

--- a/crates/zeph-memory/src/quality_gate.rs
+++ b/crates/zeph-memory/src/quality_gate.rs
@@ -354,16 +354,17 @@ async fn compute_information_value(
     if !provider.supports_embeddings() {
         return 1.0;
     }
-    let candidate = match tokio::time::timeout(embed_timeout, provider.embed(content)).await {
-        Ok(Ok(v)) => v,
-        Ok(Err(e)) => {
-            tracing::debug!(error = %e, "quality_gate: embed failed, treating info_val = 1.0 (fail-open)");
-            return 1.0;
-        }
-        Err(_) => {
-            tracing::warn!("quality_gate: embed timed out, treating info_val = 1.0 (fail-open)");
-            return 1.0;
-        }
+    let candidate = match crate::llm_judge::embed_with_timeout_fail_open(
+        provider,
+        content,
+        embed_timeout,
+        1.0,
+        "quality_gate: information_value",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(fail_open) => return fail_open,
     };
     let max_sim = recent_embeddings
         .iter()
@@ -570,8 +571,6 @@ fn extract_predicate_token(content_lower: &str) -> Option<String> {
 ///
 /// Returns `0.5` (neutral) on timeout or any error — ensures fail-open behavior.
 async fn call_llm_scorer(content: &str, provider: &AnyProvider, timeout_ms: u64) -> f32 {
-    use zeph_llm::provider::{Message, MessageMetadata, Role};
-
     let system = "You are a memory quality judge. Rate the quality of the following message \
         for long-term storage on a scale of 0.0 to 1.0. Consider: information density, \
         completeness of references, factual clarity. \
@@ -584,35 +583,16 @@ async fn call_llm_scorer(content: &str, provider: &AnyProvider, timeout_ms: u64)
         content.chars().take(500).collect::<String>()
     );
 
-    let messages = vec![
-        Message {
-            role: Role::System,
-            content: system.to_owned(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::User,
-            content: user,
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-    ];
-
-    let timeout = Duration::from_millis(timeout_ms);
-    let result = match tokio::time::timeout(timeout, provider.chat(&messages)).await {
-        Ok(Ok(r)) => r,
-        Ok(Err(e)) => {
-            tracing::debug!(error = %e, "quality_gate: LLM scorer failed, using 0.5");
-            return 0.5;
-        }
-        Err(_) => {
-            tracing::debug!("quality_gate: LLM scorer timed out, using 0.5");
-            return 0.5;
-        }
-    };
-
-    parse_llm_score(&result)
+    crate::llm_judge::llm_judge_score(
+        provider,
+        system,
+        user,
+        Duration::from_millis(timeout_ms),
+        0.5,
+        "quality_gate: LLM scorer",
+        |s| Some(parse_llm_score(s)),
+    )
+    .await
 }
 
 /// Parse LLM JSON response into a combined quality score.

--- a/crates/zeph-memory/src/sqlite_time.rs
+++ b/crates/zeph-memory/src/sqlite_time.rs
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared `SQLite` `datetime('now')` TEXT-timestamp parsing.
+//!
+//! Used by [`crate::graph::types`], [`crate::graph::activation`], and [`crate::eviction`] to
+//! convert `SQLite` TEXT timestamps into Unix seconds without pulling in `chrono`.
+
+/// Parse a `SQLite` `datetime('now')` string to Unix seconds.
+///
+/// Accepts:
+/// - `"YYYY-MM-DD HH:MM:SS"` (19 chars, standard `SQLite` format)
+/// - `"YYYY-MM-DD HH:MM:SS.fff"` (fractional seconds — truncated, not rounded)
+/// - `"YYYY-MM-DD HH:MM:SSZ"` or `"YYYY-MM-DD HH:MM:SS+HH:MM"` (timezone suffix — treated as UTC)
+///
+/// Leading/trailing whitespace is trimmed before parsing.
+///
+/// Returns `None` if the string cannot be parsed.
+#[must_use]
+pub(crate) fn parse_sqlite_datetime_to_unix(s: &str) -> Option<i64> {
+    let s = s.trim();
+    // Minimum: "YYYY-MM-DD HH:MM:SS" (19 chars)
+    if s.len() < 19 {
+        return None;
+    }
+    let year: i64 = s[0..4].parse().ok()?;
+    let month: i64 = s[5..7].parse().ok()?;
+    let day: i64 = s[8..10].parse().ok()?;
+    let hour: i64 = s[11..13].parse().ok()?;
+    let min: i64 = s[14..16].parse().ok()?;
+    // Only parse the base seconds; ignore fractional seconds and timezone suffix.
+    let sec: i64 = s[17..19].parse().ok()?;
+
+    // Days since Unix epoch (1970-01-01) via civil calendar algorithm.
+    // Reference: https://howardhinnant.github.io/date_algorithms.html#days_from_civil
+    let (y, m) = if month <= 2 {
+        (year - 1, month + 9)
+    } else {
+        (year, month - 3)
+    };
+    let era = y.div_euclid(400);
+    let yoe = y - era * 400;
+    let doy = (153 * m + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe - 719_468;
+
+    Some(days * 86_400 + hour * 3_600 + min * 60 + sec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_epoch() {
+        assert_eq!(
+            parse_sqlite_datetime_to_unix("1970-01-01 00:00:00"),
+            Some(0)
+        );
+        assert_eq!(
+            parse_sqlite_datetime_to_unix("1970-01-02 00:00:00"),
+            Some(86_400)
+        );
+    }
+
+    #[test]
+    fn known_value() {
+        // 2024-01-01 00:00:00 UTC = 1704067200
+        assert_eq!(
+            parse_sqlite_datetime_to_unix("2024-01-01 00:00:00"),
+            Some(1_704_067_200)
+        );
+    }
+
+    #[test]
+    fn invalid_returns_none() {
+        assert_eq!(parse_sqlite_datetime_to_unix("not-a-date"), None);
+        assert_eq!(parse_sqlite_datetime_to_unix(""), None);
+    }
+
+    #[test]
+    fn pre_1970_produces_negative_value_not_none() {
+        // A syntactically valid but pre-epoch date parses successfully to a negative
+        // Unix timestamp — it is not treated as an error. Callers that need a `u64` (e.g.
+        // `eviction::parse_sqlite_timestamp_secs`) must convert and handle the negative
+        // case explicitly; they must not assume this function only ever returns `None` for
+        // "bad" input.
+        assert_eq!(
+            parse_sqlite_datetime_to_unix("1969-12-31 23:59:59"),
+            Some(-1)
+        );
+        assert!(parse_sqlite_datetime_to_unix("1900-01-01 00:00:00").unwrap() < 0);
+    }
+
+    #[test]
+    fn fractional_seconds_truncated() {
+        assert_eq!(
+            parse_sqlite_datetime_to_unix("1970-01-01 00:00:00.999"),
+            Some(0)
+        );
+        assert_eq!(
+            parse_sqlite_datetime_to_unix("1970-01-02 00:00:00.123"),
+            Some(86_400)
+        );
+    }
+
+    #[test]
+    fn timezone_suffix_treated_as_utc() {
+        assert_eq!(
+            parse_sqlite_datetime_to_unix("1970-01-01 00:00:00Z"),
+            Some(0)
+        );
+        assert_eq!(
+            parse_sqlite_datetime_to_unix("1970-01-01 00:00:00+05:30"),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn whitespace_is_trimmed() {
+        assert_eq!(
+            parse_sqlite_datetime_to_unix("  1970-01-01 00:00:00  "),
+            Some(0)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Consolidates three independent DRY/tech-debt findings from the zeph-memory architecture rotation into shared helpers, with no intended behavior change:

- **#5523**: unifies three duplicate SQLite-datetime-to-Unix-seconds parsers (`graph/types.rs`, `graph/activation.rs`, `eviction.rs`) into a single canonical parser in new `sqlite_time.rs`, keeping the more robust civil-calendar algorithm. `eviction.rs`'s `u64`-returning wrapper is now a thin conversion over the canonical `i64` parser.
- **#5515**: extracts `build_ingest_documents()` in `graph/ingest/adapter.rs`, replacing the near-identical context-window document-assembly loop duplicated across all three `IngestSourceAdapter` implementations (`SubagentJsonl`, `ClaudeCodeJsonl`, `CodexJsonl`).
- **#5514**: extracts `embed_with_timeout_fail_open` and `llm_judge_score` into new `llm_judge.rs`, consolidating four embed-timeout-fail-open call sites and three single-shot LLM-judge call sites duplicated across `admission.rs` and `quality_gate.rs`, preserving the clamped-vs-unclamped fail-open asymmetry in `refine_goal_utility_llm` exactly.

## Behavior notes

- One deliberate, documented edge-case change: `eviction.rs`'s datetime fallback now returns `None` (falls through to the next signal in its `last_accessed -> created_at -> now_secs` chain) instead of silently returning `Some(0)`/epoch for a malformed or pre-1970 timestamp string. This is unreachable in practice (`datetime('now')` never produces such strings) and is documented with a regression test.
- Everything else is a pure structural extraction verified against pre-refactor source by an independent adversarial critique and code review pass.

## Follow-ups (not in scope for this PR)

- `graph/types.rs`'s original 4 datetime tests are now redundant with `sqlite_time.rs`'s tests — harmless duplication, candidate for a future cleanup pass.
- The consolidated `sqlite_time.rs` parser has a pre-existing (not introduced here) panic on non-ASCII input straddling a byte-slice boundary; low risk since all call sites read DB-generated timestamps, not raw ingest content. Reasonable candidate for a standalone P3 follow-up issue.

## Test plan

- [x] `cargo +nightly fmt --check` (workspace)
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12048 passed, 0 failed, 34 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-memory --features "pdf,testing"`
- [x] Adversarial critique pass (1 significant finding, resolved with doc comment + regression test)
- [x] Code review pass (approved)

Closes #5523, #5515, #5514