### PR TITLE
refactor(core): extract shared provider-pool and debug-dumper wiring helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `refine_goal_utility_llm` (now pinned by a dedicated regression test) (#5514). No
   behavior change beyond the one documented eviction.rs edge case above; added direct
   unit test coverage for all three new shared helpers.
+- `refactor(core)`: extracted `build_provider_config_snapshot` and `apply_debug_dumper`
+  into `src/agent_setup.rs`, deduplicating the `ProviderConfigSnapshot` construction
+  previously copy-pasted across `runner.rs`/`acp.rs`/`daemon.rs` (completes the
+  provider-pool-wiring slice left open by the `apply_common_tool_gating` extraction
+  above) and the `DebugDumper::new` match arm across those three plus
+  `serve/agent_factory.rs`. Pure refactor, no behavior change — verified byte-identical
+  field mapping and `Ok`/`Err` semantics at every site. Refs #5610.
 
 ### Fixed
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -828,46 +828,7 @@ async fn build_acp_deps(
     // #5450: built once here, where the full `Config` is still in scope — mirrors
     // `src/runner.rs`'s CLI-path snapshot construction, so ACP sessions get a populated
     // `provider_pool` too (previously left empty, breaking `resolve_background_provider`).
-    let provider_config_snapshot = zeph_core::ProviderConfigSnapshot {
-        claude_api_key: config
-            .secrets
-            .claude_api_key
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        openai_api_key: config
-            .secrets
-            .openai_api_key
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        gemini_api_key: config
-            .secrets
-            .gemini_api_key
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        compatible_api_keys: config
-            .secrets
-            .compatible_api_keys
-            .iter()
-            .map(|(k, v)| (k.clone(), v.expose().to_owned()))
-            .collect(),
-        llm_request_timeout_secs: config.timeouts.llm_request_timeout_secs,
-        embedding_model: config.llm.embedding_model.clone(),
-        gonka_private_key: config
-            .secrets
-            .gonka_private_key
-            .as_ref()
-            .map(|s| zeroize::Zeroizing::new(s.expose().to_owned())),
-        gonka_address: config
-            .secrets
-            .gonka_address
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        cocoon_access_hash: config
-            .secrets
-            .cocoon_access_hash
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-    };
+    let provider_config_snapshot = agent_setup::build_provider_config_snapshot(config);
 
     let deps = SharedAgentDeps {
         provider,
@@ -1570,13 +1531,9 @@ async fn spawn_acp_agent(
         let session_dump_dir = debug_config
             .output_dir
             .join(session_ctx.session_id.to_string());
-        match zeph_core::debug_dump::DebugDumper::new(
-            session_dump_dir.as_path(),
-            debug_config.format,
-        ) {
-            Ok(dumper) => agent = agent.with_debug_dumper(dumper),
-            Err(e) => tracing::warn!(error = %e, "debug dump initialization failed"),
-        }
+        agent =
+            agent_setup::apply_debug_dumper(agent, session_dump_dir.as_path(), debug_config.format)
+                .0;
     }
 
     agent = agent.with_hooks_config(&hooks_config);

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -1211,6 +1211,31 @@ pub(crate) fn apply_secret_masking<C: Channel>(
     }
 }
 
+/// Wires a [`zeph_core::debug_dump::DebugDumper`] into `agent` for `dir`/`format`, shared by
+/// every agent entry point that honors `[debug] enabled = true` (CLI, ACP, daemon, serve-sessions).
+///
+/// Logs and falls back to `agent` unchanged on initialization failure rather than propagating
+/// the error, matching the original per-site behavior. Returns the effective dump directory
+/// alongside the agent — the dumper's own per-run subdirectory on success, or `dir` unchanged on
+/// failure — so callers needing the directory for further wiring (e.g. `src/runner.rs`'s
+/// trace-collector setup) don't have to duplicate the `DebugDumper::new` match arm.
+pub(crate) fn apply_debug_dumper<C: Channel>(
+    agent: Agent<C>,
+    dir: &Path,
+    format: zeph_core::debug_dump::DumpFormat,
+) -> (Agent<C>, PathBuf) {
+    match zeph_core::debug_dump::DebugDumper::new(dir, format) {
+        Ok(dumper) => {
+            let session_dir = dumper.dir().to_owned();
+            (agent.with_debug_dumper(dumper), session_dir)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "debug dump initialization failed");
+            (agent, dir.to_owned())
+        }
+    }
+}
+
 pub(crate) async fn apply_code_indexer(
     full_config: &Config,
     qdrant_ops: Option<QdrantOps>,
@@ -1625,6 +1650,55 @@ pub(crate) fn register_mcp_tool_ids(handle: &McpToolIdsHandle, mcp_tools: &[zeph
         .map(zeph_mcp::McpTool::sanitized_id)
         .collect();
     *handle.write() = ids;
+}
+
+/// Builds the [`zeph_core::ProviderConfigSnapshot`] passed to `AgentBuilder::with_provider_pool`
+/// by every agent entry point (CLI, ACP, daemon).
+///
+/// Centralizes the provider-secret and embedding-model extraction from `config.secrets` /
+/// `config.timeouts` / `config.llm` so a populated snapshot reaches `resolve_background_provider`
+/// from all three sites — an empty snapshot broke background-provider lookups (#5450).
+pub(crate) fn build_provider_config_snapshot(config: &Config) -> zeph_core::ProviderConfigSnapshot {
+    zeph_core::ProviderConfigSnapshot {
+        claude_api_key: config
+            .secrets
+            .claude_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        openai_api_key: config
+            .secrets
+            .openai_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        gemini_api_key: config
+            .secrets
+            .gemini_api_key
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        compatible_api_keys: config
+            .secrets
+            .compatible_api_keys
+            .iter()
+            .map(|(k, v)| (k.clone(), v.expose().to_owned()))
+            .collect(),
+        llm_request_timeout_secs: config.timeouts.llm_request_timeout_secs,
+        embedding_model: config.llm.embedding_model.clone(),
+        gonka_private_key: config
+            .secrets
+            .gonka_private_key
+            .as_ref()
+            .map(|s| zeroize::Zeroizing::new(s.expose().to_owned())),
+        gonka_address: config
+            .secrets
+            .gonka_address
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+        cocoon_access_hash: config
+            .secrets
+            .cocoon_access_hash
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
+    }
 }
 
 fn resolve_search_lsp_server_id(config: &Config) -> Option<String> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -723,46 +723,7 @@ pub(crate) async fn run_daemon(
     // #5450: built here, where the full `Config` is still in scope — mirrors
     // `src/runner.rs`'s CLI-path snapshot construction, so the daemon's agent gets a populated
     // `provider_pool` too (previously left empty, breaking `resolve_background_provider`).
-    let provider_config_snapshot = zeph_core::ProviderConfigSnapshot {
-        claude_api_key: config
-            .secrets
-            .claude_api_key
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        openai_api_key: config
-            .secrets
-            .openai_api_key
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        gemini_api_key: config
-            .secrets
-            .gemini_api_key
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        compatible_api_keys: config
-            .secrets
-            .compatible_api_keys
-            .iter()
-            .map(|(k, v)| (k.clone(), v.expose().to_owned()))
-            .collect(),
-        llm_request_timeout_secs: config.timeouts.llm_request_timeout_secs,
-        embedding_model: config.llm.embedding_model.clone(),
-        gonka_private_key: config
-            .secrets
-            .gonka_private_key
-            .as_ref()
-            .map(|s| zeroize::Zeroizing::new(s.expose().to_owned())),
-        gonka_address: config
-            .secrets
-            .gonka_address
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        cocoon_access_hash: config
-            .secrets
-            .cocoon_access_hash
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-    };
+    let provider_config_snapshot = agent_setup::build_provider_config_snapshot(config);
 
     let (loopback_channel, loopback_handle) = zeph_core::LoopbackChannel::pair(64);
 
@@ -976,13 +937,12 @@ pub(crate) async fn run_daemon(
     // `spawn_gateway_server` only forwards webhooks into an already-built agent) never wired
     // `[debug]`, unlike the CLI (src/runner.rs) and ACP (src/acp.rs) agent-construction paths.
     if config.debug.enabled {
-        match zeph_core::debug_dump::DebugDumper::new(
+        agent = agent_setup::apply_debug_dumper(
+            agent,
             config.debug.output_dir.as_path(),
             config.debug.format,
-        ) {
-            Ok(dumper) => agent = agent.with_debug_dumper(dumper),
-            Err(e) => tracing::warn!(error = %e, "debug dump initialization failed"),
-        }
+        )
+        .0;
     }
 
     agent.load_history().await?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3474,16 +3474,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             });
         if let Some(ref dir) = dump_dir {
             let (agent, session_dir) =
-                match zeph_core::debug_dump::DebugDumper::new(dir.as_path(), effective_format) {
-                    Ok(dumper) => {
-                        let session_dir = dumper.dir().to_owned();
-                        (agent.with_debug_dumper(dumper), session_dir)
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "debug dump initialization failed");
-                        (agent, dir.clone())
-                    }
-                };
+                agent_setup::apply_debug_dumper(agent, dir.as_path(), effective_format);
             // Store trace config so runtime `/dump-format trace` can create a collector (CR-04).
             let agent = agent.with_trace_config(
                 dir.clone(),
@@ -3666,46 +3657,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         .providers
         .iter()
         .any(|e| e.enable_extended_context);
-    let provider_config_snapshot = zeph_core::ProviderConfigSnapshot {
-        claude_api_key: config
-            .secrets
-            .claude_api_key
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        openai_api_key: config
-            .secrets
-            .openai_api_key
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        gemini_api_key: config
-            .secrets
-            .gemini_api_key
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        compatible_api_keys: config
-            .secrets
-            .compatible_api_keys
-            .iter()
-            .map(|(k, v)| (k.clone(), v.expose().to_owned()))
-            .collect(),
-        llm_request_timeout_secs: config.timeouts.llm_request_timeout_secs,
-        embedding_model: config.llm.embedding_model.clone(),
-        gonka_private_key: config
-            .secrets
-            .gonka_private_key
-            .as_ref()
-            .map(|s| zeroize::Zeroizing::new(s.expose().to_owned())),
-        gonka_address: config
-            .secrets
-            .gonka_address
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-        cocoon_access_hash: config
-            .secrets
-            .cocoon_access_hash
-            .as_ref()
-            .map(|s| s.expose().to_owned()),
-    };
+    let provider_config_snapshot = agent_setup::build_provider_config_snapshot(config);
     let agent = agent
         .with_extended_context(extended_context)
         .with_metrics(metrics_tx)

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -116,13 +116,12 @@ pub(crate) async fn build_agent_factory(
             // Session-id subdirectory prefix (I2, matches spawn_acp_agent) so concurrent
             // `/sessions` agents never share the same timestamped dump directory.
             let session_dump_dir = debug_config.output_dir.join(session_id.as_str());
-            match zeph_core::debug_dump::DebugDumper::new(
+            agent = crate::agent_setup::apply_debug_dumper(
+                agent,
                 session_dump_dir.as_path(),
                 debug_config.format,
-            ) {
-                Ok(dumper) => agent = agent.with_debug_dumper(dumper),
-                Err(e) => tracing::warn!(error = %e, "debug dump initialization failed"),
-            }
+            )
+            .0;
         }
         agent
     }


### PR DESCRIPTION
## Summary

- Extracts `build_provider_config_snapshot(config: &Config) -> ProviderConfigSnapshot` in `src/agent_setup.rs`, deduplicating the ~38-line `ProviderConfigSnapshot` literal previously copy-pasted across `src/runner.rs`, `src/acp.rs`, and `src/daemon.rs`. This completes the provider-pool-wiring slice left open by the prior `apply_common_tool_gating` extraction under the same issue (PR #5604 wired provider-pool coverage into all three sites individually but left the construction code triplicated).
- Extracts `apply_debug_dumper<C: Channel>(agent, dir, format) -> (Agent<C>, PathBuf)` in `src/agent_setup.rs`, deduplicating an identical `DebugDumper::new(...) -> match { Ok => with_debug_dumper, Err => warn }` arm found (during the mandated audit of prior related issues #5585/#5589) to be duplicated across four sites: `runner.rs`, `acp.rs`, `daemon.rs`, and `serve/agent_factory.rs`.
- Pure refactor, no behavior change: mechanically verified byte-identical `ProviderConfigSnapshot` field mapping and identical `Ok`/`Err` semantics for the debug-dumper wiring at every call site.
- `.with_provider_pool(...)`'s apply step is deliberately left inline at each site (not further unified), since `acp.rs` defers the snapshot into `SharedAgentDeps` for later use in `spawn_acp_agent` while `runner.rs`/`daemon.rs` apply it immediately — unifying the apply step would restructure a different subsystem's data flow rather than dedupe construction.

Closes #5610.

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12036 passed, 0 failed, 34 skipped
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 0 failed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing unrelated `private_intra_doc_links` warnings only, none in touched files)
- [x] Adversarial critique confirmed byte-identical equivalence of pre/post `ProviderConfigSnapshot` literals and debug-dumper `Ok`/`Err` semantics at all four call sites