### PR TITLE
fix(agent): repair orphaned tool_calls after process-kill-and-resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   re-acquires the write lock to swap in the new registry once the blocking work has finished
   off the async path. A panicked rebuild now logs and leaves the existing registry unchanged
   instead of losing the lock's contents. (#5640)
+- `fix(agent)`: killing `zeph` mid-tool-call and resuming the same session (e.g.
+  `--json --auto` default continuation, ACP resume, `/conv resume`, `zeph serve` reactivation)
+  no longer permanently corrupts message history with orphaned `tool_calls` (3rd occurrence of
+  the defect class previously fixed by #5476 and #5541). Two compounding bugs, both in the
+  spec-068/D-10 unified resume pipeline: (1) `hydrate_from_event_log`
+  (`crates/zeph-agent-persistence/src/hydrate.rs`) never ran `sanitize_tool_pairs` on replayed
+  messages — every D-10 resume path bypassed the sanitizer entirely, since it was wired only
+  into the older SQLite-only `PersistenceService::load_history` path. (2) the shutdown-flush
+  repair (`flush_orphaned_tool_use_on_shutdown` /
+  `persist_cancelled_tool_results`, `crates/zeph-core/src/agent/{shutdown.rs,
+  tool_execution/focus.rs}`) always appended its `[Cancelled]` tombstone at the true end of
+  history via `push_message`, which is only correct when the orphaned `ToolUse` is the last
+  message — not true once a new turn's message has already been appended after it. Fixed by
+  wiring `sanitize_tool_pairs` into `hydrate_from_event_log` (a single shared choke point
+  covering all D-10 resume paths, including the `hydrate_and_condense` D-6 path) and by adding
+  `Agent::insert_message` so the tombstone splices in immediately after the orphaned assistant
+  message instead of always appending at the end. A provider-level pre-serialization guard for
+  OpenAI/compatible (Claude's request builder already has one) is a valid follow-up, deliberately
+  deferred — the two fixes above repair the persisted/replayed history at its source. (#5646)
 - `fix(memory)`: three async/DB hygiene issues in `zeph-memory`.
   - `EntityResolver::llm_disambiguate` (`crates/zeph-memory/src/graph/resolver/mod.rs`) called
     `provider.chat()` with no timeout, violating this project's Await Discipline convention.

--- a/crates/zeph-agent-persistence/src/condense.rs
+++ b/crates/zeph-agent-persistence/src/condense.rs
@@ -437,4 +437,89 @@ mod tests {
             SessionEvent::Condensation { .. }
         ));
     }
+
+    /// #5646 regression, D-6 path: `hydrate_and_condense` — the function `context/assembly.rs`'s
+    /// resume-with-condense path actually calls, per `hydrate_and_condense`'s own module doc —
+    /// must inherit the orphaned-`ToolUse` sanitization from `hydrate_from_event_log` rather
+    /// than replaying it verbatim into the condensation input. Locks in the developer's claim
+    /// that this path needs no separate wiring because it delegates straight into
+    /// `hydrate_from_event_log`.
+    #[tokio::test]
+    async fn hydrate_and_condense_sanitizes_orphaned_tool_use_before_condensing() {
+        let memory = zeph_memory::semantic::SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            None,
+            AnyProvider::Mock(MockProvider::default()),
+            "test-model",
+        )
+        .await
+        .unwrap();
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let store = SessionStore::new(memory.sqlite().pool().clone());
+        store.create("s1").await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "run a slow tool".to_owned(),
+                image_refs: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::AssistantMessage {
+                parts: vec![MessagePart::ToolUse {
+                    id: "call_1".to_owned(),
+                    name: "bash".to_owned(),
+                    input: serde_json::json!({}),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        // No ToolResult event: simulates the process being killed mid-tool-call, same as
+        // hydrate.rs's `orphaned_tool_use_from_killed_session_is_sanitized_on_resume`, but
+        // driven through the condense-wrapping entry point instead.
+        drop(log);
+
+        let condenser = make_condenser(&summary_json());
+        let token_counter = WordCountTokenCounter;
+
+        let hydrated = hydrate_and_condense(
+            dir.path(),
+            &store,
+            "s1",
+            cid,
+            &memory,
+            None,
+            &condenser,
+            &token_counter,
+            10,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            hydrated.messages.len(),
+            1,
+            "the orphaned assistant ToolUse message must be stripped before reaching the \
+             condensation input, leaving only the user turn"
+        );
+        assert_eq!(hydrated.messages[0].role, Role::User);
+        assert!(
+            hydrated
+                .messages
+                .iter()
+                .flat_map(|m| m.parts.iter())
+                .all(|p| !matches!(p, MessagePart::ToolUse { .. })),
+            "no ToolUse part may survive into the returned Hydrated.messages unpaired"
+        );
+    }
 }

--- a/crates/zeph-agent-persistence/src/hydrate.rs
+++ b/crates/zeph-agent-persistence/src/hydrate.rs
@@ -123,7 +123,19 @@ pub async fn hydrate_from_event_log(
         if let Err(e) = reconcile_projection(memory, conversation_id, session_id, &events).await {
             tracing::warn!(error = %e, session_id, "INV-SP-3 projection reconciliation failed");
         }
-        state.messages
+        let mut messages = state.messages;
+        // Messages folded here never carry `metadata.db_id` (populated only when loading from
+        // SQLite) — replay is in-memory-only and the durable log itself is not mutated, so any
+        // ids returned by `sanitize_tool_pairs` are safe to drop rather than soft-delete.
+        let (removed, _db_ids) = crate::sanitize::sanitize_tool_pairs(&mut messages);
+        if removed > 0 {
+            tracing::warn!(
+                session_id,
+                removed,
+                "sanitized orphaned tool_use/tool_result messages on hydrate"
+            );
+        }
+        messages
     };
 
     Ok(Hydrated {
@@ -268,5 +280,67 @@ mod tests {
         // wrote through SessionSink/PersistenceService.
         let history = memory.sqlite().load_history(cid, 10).await.unwrap();
         assert_eq!(history.len(), 2);
+    }
+
+    /// #5646 regression: a session killed mid-tool-call (no `ToolResult` event ever appended)
+    /// must have its orphaned assistant `ToolUse` sanitized away on the very next resume,
+    /// instead of being replayed verbatim into a live agent — which previously produced a
+    /// `tool_calls` message with no matching `tool` response and a 400 from `OpenAI`.
+    #[tokio::test]
+    async fn orphaned_tool_use_from_killed_session_is_sanitized_on_resume() {
+        use zeph_llm::provider::{MessagePart, Role};
+        use zeph_session::SessionEvent;
+
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let store = SessionStore::new(memory.sqlite().pool().clone());
+        store.create("s1").await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        let log = SessionEventLog::open(dir.path()).await.unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::UserMessage {
+                text: "run a slow tool".to_owned(),
+                image_refs: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        log.append(
+            None,
+            None,
+            SessionEvent::AssistantMessage {
+                parts: vec![MessagePart::ToolUse {
+                    id: "call_1".to_owned(),
+                    name: "bash".to_owned(),
+                    input: serde_json::json!({}),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        // No ToolResult event: simulates the process being killed mid-tool-call.
+        drop(log);
+
+        let hydrated = hydrate_from_event_log(dir.path(), &store, "s1", cid, &memory, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hydrated.messages.len(),
+            1,
+            "the orphaned assistant ToolUse message must be stripped, leaving only the user turn"
+        );
+        assert_eq!(hydrated.messages[0].role, Role::User);
+        assert!(
+            hydrated
+                .messages
+                .iter()
+                .flat_map(|m| m.parts.iter())
+                .all(|p| !matches!(p, MessagePart::ToolUse { .. })),
+            "no ToolUse part may survive into the replayed history unpaired"
+        );
     }
 }

--- a/crates/zeph-core/src/agent/persistence/tests.rs
+++ b/crates/zeph-core/src/agent/persistence/tests.rs
@@ -2151,7 +2151,9 @@ async fn persist_cancelled_tool_results_pairs_tool_use() {
         },
     ];
 
-    agent.persist_cancelled_tool_results(&tool_calls).await;
+    agent
+        .persist_cancelled_tool_results(&tool_calls, None)
+        .await;
 
     let history = agent
         .services

--- a/crates/zeph-core/src/agent/shutdown.rs
+++ b/crates/zeph-core/src/agent/shutdown.rs
@@ -147,7 +147,12 @@ impl<C: Channel> Agent<C> {
             count = unpaired.len(),
             "shutdown: persisting tombstone ToolResults for unpaired in-flight tool calls"
         );
-        self.persist_cancelled_tool_results(&unpaired).await;
+        // Splice immediately after the orphaned assistant message rather than appending at the
+        // true end: a later turn may already have appended its own message past `asst_idx` by
+        // the time shutdown runs (see #5646), and appending there would still leave the ToolUse
+        // not immediately followed by its ToolResult.
+        self.persist_cancelled_tool_results(&unpaired, Some(asst_idx + 1))
+            .await;
     }
     /// Generate and store a lightweight session summary at shutdown when no hard compaction fired.
     ///

--- a/crates/zeph-core/src/agent/tests/flush_orphaned_tests.rs
+++ b/crates/zeph-core/src/agent/tests/flush_orphaned_tests.rs
@@ -246,3 +246,72 @@ async fn flush_orphaned_noop_when_tool_use_already_paired() {
         "no tombstone must be persisted when all ToolUse parts are already paired"
     );
 }
+
+/// FO5 (#5646 regression): if a later turn's message has already been appended after the
+/// still-orphaned assistant `ToolUse` by the time shutdown runs (e.g. resume-then-dispatch
+/// before the previous orphan was sanitized away), the tombstone must be spliced in
+/// immediately after the orphan — not appended at the true end of history, which would leave
+/// the `ToolUse` still not immediately followed by its `ToolResult`.
+#[tokio::test]
+async fn flush_orphaned_inserts_tombstone_immediately_after_orphan_not_at_end() {
+    use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
+
+    let provider = mock_provider(vec![]);
+    let memory = flush_test_memory().await;
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+        std::sync::Arc::new(memory),
+        cid,
+        50,
+        5,
+        100,
+    );
+
+    let messages_before = agent.msg.messages.len();
+    agent.msg.messages.push(Message {
+        role: Role::Assistant,
+        content: "[tool_use]".into(),
+        parts: vec![MessagePart::ToolUse {
+            id: "orphan_1".into(),
+            name: "shell".into(),
+            input: serde_json::json!({}),
+        }],
+        metadata: MessageMetadata::default(),
+    });
+    let orphan_idx = agent.msg.messages.len() - 1;
+    // Simulates a later, unrelated turn's message already appended after the orphan before
+    // shutdown fires (the exact #5646 shape).
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "a later, unrelated turn's message".into(),
+        parts: vec![MessagePart::Text {
+            text: "a later, unrelated turn's message".into(),
+        }],
+        metadata: MessageMetadata::default(),
+    });
+
+    agent.flush_orphaned_tool_use_on_shutdown().await;
+
+    assert_eq!(
+        agent.msg.messages.len(),
+        messages_before + 3,
+        "the tombstone must be added without displacing the later message"
+    );
+    assert!(
+        agent.msg.messages[orphan_idx + 1].parts.iter().any(
+            |p| matches!(p, MessagePart::ToolResult { tool_use_id, is_error, .. }
+                if tool_use_id == "orphan_1" && *is_error)
+        ),
+        "the tombstone must be spliced in immediately after the orphan, not appended after the \
+         later message"
+    );
+    assert_eq!(
+        agent.msg.messages[orphan_idx + 2].content,
+        "a later, unrelated turn's message",
+        "the later message must remain after the tombstone, not before it"
+    );
+}

--- a/crates/zeph-core/src/agent/tool_execution/focus.rs
+++ b/crates/zeph-core/src/agent/tool_execution/focus.rs
@@ -364,6 +364,14 @@ impl<C: Channel> Agent<C> {
     /// (e.g. Ollama, which assigns `tool_call` ids as `format!("call_{i}")` by batch index) reuse
     /// the same `tool_use_id` across turns; scanning full history would treat an earlier turn's
     /// legitimate result as covering this turn's call and wrongly skip its tombstone.
+    ///
+    /// `insert_at` places the tombstone at a specific index instead of the true end of history —
+    /// required by `flush_orphaned_tool_use_on_shutdown`, which can run after a later turn's
+    /// message has already been appended past the still-orphaned assistant `ToolUse`; splicing the
+    /// tombstone immediately after that assistant message (rather than after the later message)
+    /// preserves the "`ToolUse` immediately followed by `ToolResult`" invariant. All in-turn
+    /// callers (`tier_loop.rs`) pass `None`: nothing can have been appended after the `ToolUse`
+    /// message yet at that point in the turn, so append-at-end and insert-after-orphan coincide.
     #[tracing::instrument(
         name = "core.tool.persist_cancelled_tool_results",
         skip_all,
@@ -372,6 +380,7 @@ impl<C: Channel> Agent<C> {
     pub(crate) async fn persist_cancelled_tool_results(
         &mut self,
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        insert_at: Option<usize>,
     ) {
         let turn_start = self
             .msg
@@ -406,7 +415,10 @@ impl<C: Channel> Agent<C> {
         let user_msg = Message::from_parts(Role::User, result_parts);
         self.persist_message(Role::User, &user_msg.content, &user_msg.parts, false)
             .await;
-        self.push_message(user_msg);
+        match insert_at {
+            Some(index) => self.insert_message(index, user_msg),
+            None => self.push_message(user_msg),
+        }
     }
 
     /// Handle the `request_compaction` tool call (ARC #4020).

--- a/crates/zeph-core/src/agent/tool_execution/tests/focus_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/focus_tests.rs
@@ -152,7 +152,7 @@ async fn persist_cancelled_tool_results_is_noop_when_all_ids_already_resolved() 
     let message_count_before = agent.msg.messages.len();
 
     agent
-        .persist_cancelled_tool_results(&[tool_use_request("call-1")])
+        .persist_cancelled_tool_results(&[tool_use_request("call-1")], None)
         .await;
 
     assert_eq!(
@@ -175,7 +175,10 @@ async fn persist_cancelled_tool_results_only_tombstones_unresolved_ids() {
     push_tool_result(&mut agent, "call-1", "real output", false);
 
     agent
-        .persist_cancelled_tool_results(&[tool_use_request("call-1"), tool_use_request("call-2")])
+        .persist_cancelled_tool_results(
+            &[tool_use_request("call-1"), tool_use_request("call-2")],
+            None,
+        )
         .await;
 
     assert_eq!(
@@ -210,7 +213,10 @@ async fn persist_cancelled_tool_results_tombstones_all_ids_when_none_resolved() 
     let mut agent = make_agent();
 
     agent
-        .persist_cancelled_tool_results(&[tool_use_request("call-1"), tool_use_request("call-2")])
+        .persist_cancelled_tool_results(
+            &[tool_use_request("call-1"), tool_use_request("call-2")],
+            None,
+        )
         .await;
 
     assert_eq!(tool_result_count(&agent, "call-1"), 1);
@@ -249,7 +255,7 @@ async fn persist_cancelled_tool_results_writes_tombstone_for_id_reused_in_a_new_
 
     // Turn 2's dispatch gets cancelled before completion.
     agent
-        .persist_cancelled_tool_results(&[tool_use_request("call_0")])
+        .persist_cancelled_tool_results(&[tool_use_request("call_0")], None)
         .await;
 
     assert_eq!(
@@ -258,5 +264,65 @@ async fn persist_cancelled_tool_results_writes_tombstone_for_id_reused_in_a_new_
         "turn 2's cancelled call_0 must still receive its own tombstone ToolResult, \
          separate from turn 1's real result — the guard must not treat a new turn's \
          id-reused call as already resolved"
+    );
+}
+
+/// #5646 regression: `persist_cancelled_tool_results`'s `insert_at: Some(index)` branch must
+/// splice the tombstone message at that exact index rather than appending it at the true end —
+/// direct coverage of the branch itself, complementing the indirect coverage via
+/// `flush_orphaned_tests::flush_orphaned_inserts_tombstone_immediately_after_orphan_not_at_end`,
+/// which only exercises it through `flush_orphaned_tool_use_on_shutdown`.
+#[tokio::test]
+async fn persist_cancelled_tool_results_some_index_inserts_at_that_position() {
+    let mut agent = make_agent();
+
+    // system (idx 0), assistant ToolUse (idx 1), a later unrelated message already appended
+    // after it (idx 2) — mirrors the #5646 shape where a later turn's message lands after the
+    // still-orphaned assistant ToolUse before the tombstone is spliced in.
+    agent.msg.messages.push(Message {
+        role: Role::Assistant,
+        content: "[tool_use]".to_owned(),
+        parts: vec![MessagePart::ToolUse {
+            id: "call-1".to_owned(),
+            name: "bash".to_owned(),
+            input: serde_json::json!({}),
+        }],
+        metadata: MessageMetadata::default(),
+    });
+    let orphan_idx = agent.msg.messages.len() - 1;
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "later unrelated message".to_owned(),
+        parts: vec![MessagePart::Text {
+            text: "later unrelated message".to_owned(),
+        }],
+        metadata: MessageMetadata::default(),
+    });
+    let messages_before = agent.msg.messages.len();
+
+    agent
+        .persist_cancelled_tool_results(&[tool_use_request("call-1")], Some(orphan_idx + 1))
+        .await;
+
+    assert_eq!(
+        agent.msg.messages.len(),
+        messages_before + 1,
+        "exactly one tombstone message must be inserted"
+    );
+    assert!(
+        agent.msg.messages[orphan_idx + 1]
+            .parts
+            .iter()
+            .any(|p| matches!(
+                p,
+                MessagePart::ToolResult { tool_use_id, is_error, .. }
+                    if tool_use_id == "call-1" && *is_error
+            )),
+        "the tombstone must be spliced in at insert_at, not appended at the true end"
+    );
+    assert_eq!(
+        agent.msg.messages[orphan_idx + 2].content,
+        "later unrelated message",
+        "the later message must be pushed one slot forward by the insertion, not displaced"
     );
 }

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -97,7 +97,7 @@ impl<C: Channel> Agent<C> {
                 tracing::info!("tool execution cancelled by user");
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls).await;
+                self.persist_cancelled_tool_results(tool_calls, None).await;
                 return Ok(true);
             }
             let new_result =
@@ -167,7 +167,7 @@ impl<C: Channel> Agent<C> {
                 tracing::info!("tool execution cancelled by user");
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls).await;
+                self.persist_cancelled_tool_results(tool_calls, None).await;
                 return Ok(true);
             }
             let is_transient = matches!(
@@ -197,7 +197,7 @@ impl<C: Channel> Agent<C> {
                         tracing::info!("tool retry cancelled by user");
                         self.update_metrics(|m| m.cancellations += 1);
                         self.channel.send("[Cancelled]").await?;
-                        self.persist_cancelled_tool_results(tool_calls).await;
+                        self.persist_cancelled_tool_results(tool_calls, None).await;
                         return Ok(true);
                     }
                 };
@@ -232,7 +232,7 @@ impl<C: Channel> Agent<C> {
                                 tracing::info!("retry backoff interrupted by cancellation");
                                 self.update_metrics(|m| m.cancellations += 1);
                                 self.channel.send("[Cancelled]").await?;
-                                self.persist_cancelled_tool_results(tool_calls).await;
+                                self.persist_cancelled_tool_results(tool_calls, None).await;
                                 return Ok(true);
                             }
                         }
@@ -278,7 +278,7 @@ impl<C: Channel> Agent<C> {
                 tracing::info!("parameter reformat phase cancelled by user");
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls).await;
+                self.persist_cancelled_tool_results(tool_calls, None).await;
                 return Ok(true);
             }
             let needs_reformat = matches!(
@@ -313,7 +313,7 @@ impl<C: Channel> Agent<C> {
                 tracing::info!("parameter reformat phase cancelled by user");
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls).await;
+                self.persist_cancelled_tool_results(tool_calls, None).await;
                 return Ok(true);
             }
 
@@ -1180,7 +1180,7 @@ impl<C: Channel> Agent<C> {
                 tracing::info!("tool execution cancelled by user");
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls).await;
+                self.persist_cancelled_tool_results(tool_calls, None).await;
                 return Ok(None);
             }
 
@@ -1991,7 +1991,7 @@ impl<C: Channel> Agent<C> {
                     tracing::info!("tool execution cancelled by user");
                     self.update_metrics(|m| m.cancellations += 1);
                     self.channel.send("[Cancelled]").await?;
-                    self.persist_cancelled_tool_results(tool_calls).await;
+                    self.persist_cancelled_tool_results(tool_calls, None).await;
                     return Ok(None);
                 }
                 event = recv_elicitation(&mut elicitation_rx) => {

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -257,6 +257,25 @@ impl<C: Channel> Agent<C> {
         self.detect_magic_docs_in_messages();
     }
 
+    /// Like [`Self::push_message`], but splices `msg` at `index` instead of appending it at the
+    /// true end — for repairing an out-of-order shutdown-flush tombstone (see
+    /// `shutdown::flush_orphaned_tool_use_on_shutdown`) where a later turn's message may already
+    /// have been appended after the orphaned assistant message this tombstone must immediately
+    /// follow. Token accounting and `MagicDoc` detection are position-independent, so both are
+    /// shared with `push_message`.
+    pub(super) fn insert_message(&mut self, index: usize, msg: Message) {
+        self.runtime.providers.cached_prompt_tokens +=
+            self.runtime
+                .metrics
+                .token_counter
+                .count_message_tokens(&msg) as u64;
+        if msg.role == zeph_llm::provider::Role::Assistant {
+            self.services.session.last_assistant_at = Some(std::time::Instant::now());
+        }
+        self.msg.messages.insert(index, msg);
+        self.detect_magic_docs_in_messages();
+    }
+
     pub(crate) fn record_cost_and_cache(&self, input_tokens: u64, output_tokens: u64) {
         let (cache_write, cache_read) = self.provider.last_cache_usage().unwrap_or((0, 0));
 
@@ -423,6 +442,63 @@ mod tests {
         assert_eq!(
             agent.runtime.providers.cached_prompt_tokens,
             before + expected_delta
+        );
+    }
+
+    /// #5646: `insert_message` must splice at the given index (not append at the end) while
+    /// still tracking token accounting identically to `push_message` — direct coverage of the
+    /// method itself, complementing its indirect exercise via
+    /// `flush_orphaned_tests::flush_orphaned_inserts_tombstone_immediately_after_orphan_not_at_end`
+    /// and `focus_tests::persist_cancelled_tool_results_some_index_inserts_at_that_position`.
+    #[test]
+    fn insert_message_splices_at_index_and_tracks_tokens() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: "first".to_string(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        });
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: "third".to_string(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        });
+        let insert_idx = agent.msg.messages.len() - 1;
+        let before_tokens = agent.runtime.providers.cached_prompt_tokens;
+
+        let msg = Message {
+            role: Role::User,
+            content: "second".to_string(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        };
+        let expected_delta = agent
+            .runtime
+            .metrics
+            .token_counter
+            .count_message_tokens(&msg) as u64;
+        agent.insert_message(insert_idx, msg);
+
+        assert_eq!(
+            agent.msg.messages[insert_idx].content, "second",
+            "message must be spliced at the given index"
+        );
+        assert_eq!(
+            agent.msg.messages[insert_idx + 1].content,
+            "third",
+            "the message previously at insert_idx must be pushed one slot forward"
+        );
+        assert_eq!(
+            agent.runtime.providers.cached_prompt_tokens,
+            before_tokens + expected_delta,
+            "insert_message must track token accounting identically to push_message"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #5646 — the 3rd occurrence of the "orphaned tool_calls corrupts message history" defect class (previously fixed by #5476 for #5464, and #5541 for #5513). This time the trigger is killing `zeph` mid-tool-call and resuming the same session (CLI default continuation incl. `--json --auto`, ACP resume, `/conv resume`, `zeph serve` reactivation), which previously left `assistant` messages with `tool_calls` not immediately followed by matching `tool` responses, causing a hard 400 from strict-ordering providers (OpenAI) on every subsequent turn with no self-healing.

Root cause was a compound of two distinct bugs in the spec-068/D-10 unified resume pipeline, not a single one:

1. **Routing gap**: `sanitize_tool_pairs` was wired only into the older SQLite-only `PersistenceService::load_history` path. Every D-10 resume path instead goes through `hydrate_from_event_log` (`crates/zeph-agent-persistence/src/hydrate.rs`), which replayed orphaned `tool_calls` verbatim with no sanitization at all.
2. **Positional bug**: the existing shutdown-flush repair (`flush_orphaned_tool_use_on_shutdown` / `persist_cancelled_tool_results`) always appended its `[Cancelled]` tombstone at the true end of history via `push_message`. That's only correct when the orphaned `tool_calls` message is literally the last message — not true once a new turn's message has already been appended after it (exactly what happens on resume, since bug #1 let the orphan survive into the new turn).

### Fix

- Wire `sanitize_tool_pairs` into `hydrate_from_event_log` — a single shared choke point covering every D-10 resume path (including the `hydrate_and_condense` D-6 path, verified to inherit the fix transitively and locked in with a dedicated test).
- Add `Agent::insert_message` (a sibling to `push_message` using `Vec::insert` instead of `Vec::push`) and route the shutdown-flush tombstone through it at `asst_idx + 1`, so it splices in immediately after the orphaned assistant message regardless of what was appended after it since.

### Deliberately deferred (follow-up, not blocking this PR)

Diagnosis surfaced a real provider asymmetry: Claude's request builder already has a wire-time orphan guard (`compute_matched_tool_ids`, downgrades unmatched `tool_use` to text); OpenAI/compatible have none. The two fixes above repair the persisted/replayed history at its source, which is what closes this specific issue — a shared, provider-agnostic pre-serialization guard (replacing Claude's bespoke check too, not just adding a third copy) is a valid defense-in-depth follow-up for a still-plausible 4th trigger path, intentionally left out of this PR's scope.

## Process notes

This was implemented via a debugger -> developer -> (tester + impl-critic) -> reviewer pipeline. Root cause was pinned by reading current HEAD source directly (not assumed from the issue's excerpts); the adversarial critique independently re-verified all disambiguating claims (transitive D-6 fix, `insert_message` index-shift safety, the `tier_loop.rs` `None`-site behavior, and the `db_id == None` replay assumption) against source and found no blocking gaps.

## Test plan

- [x] `cargo build --features full` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12063 passed, 0 failed (re-run after rebase onto latest main)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] Two new deterministic regression fixtures (`hydrate.rs`, `flush_orphaned_tests.rs`) confirmed to fail against pre-fix code and pass post-fix (non-vacuous), plus three more added during test validation (`focus_tests.rs` direct `Some(index)` coverage, `utils.rs` `insert_message` unit test, `condense.rs` end-to-end `hydrate_and_condense` coverage)
- [x] LLM Serialization Gate: ran a live session against the real OpenAI API (`cargo run --features full -- --config .local/config/testing.toml --json --auto`) and confirmed a clean round-trip with a well-formed request in the raw debug dump. Reproducing the exact process-kill race live (external `SIGTERM` timed precisely inside the tool-call window) proved impractical in this environment — tool calls against local/cached data resolve too fast for reliable external-timing repro, consistent with the original issue noting it "reproduces most reliably when Qdrant/network latency delays the pending tool call." The corrupted-history scenario itself is covered by the deterministic regression tests instead, which exercise the exact code path directly.