### PR TITLE
fix(channels): recognize exit/quit commands in JsonCliChannel::try_recv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(channels)`: `JsonCliChannel::try_recv` (`crates/zeph-channels/src/json_cli.rs`) did not
+  recognize `exit`/`quit`/`/exit`/`/quit` the way `recv` already did, so an exit command
+  arriving via the queued/merge path (`Agent::drain_channel`'s 500ms merge window in
+  `crates/zeph-core/src/agent/message_queue.rs`) was merged as literal text and sent to the LLM
+  as prompt content instead of ending the session. `try_recv` now matches the same exit strings
+  before constructing a message and sets a persistent flag that `recv` checks first, so the
+  session ends promptly once the queue drains instead of only incidentally via stdin EOF. (#5657)
 - `fix(tools)`: `UtilityScorer::default_gain` (`crates/zeph-tools/src/utility.rs`) fell through
   to a generic `0.5` gain for `diagnostics` and other direct-action tools with no exploratory
   semantics, which satisfied `recommend_action`'s `Retrieve` rule before the direct-`ToolCall`

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -38,6 +38,10 @@ pub struct JsonCliChannel {
     /// `ResponseEnd`. `ResponseEnd` must never be emitted when this is `false`.
     /// Both `send()` and `send_chunk()` set this to `true`; `flush_chunks()` resets it to `false`.
     pending_chunks: bool,
+    /// Set by `try_recv()` when an exit/quit line is drained. Once set, `recv()`
+    /// returns `Ok(None)` immediately instead of waiting on stdin, so an exit
+    /// command discarded mid-drain still ends the session.
+    exit_requested: bool,
 }
 
 impl JsonCliChannel {
@@ -75,12 +79,16 @@ impl JsonCliChannel {
             rx,
             auto,
             pending_chunks: false,
+            exit_requested: false,
         }
     }
 }
 
 impl Channel for JsonCliChannel {
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
+        if self.exit_requested {
+            return Ok(None);
+        }
         loop {
             match self.rx.recv().await {
                 Some(Some(line)) => {
@@ -108,22 +116,31 @@ impl Channel for JsonCliChannel {
     }
 
     fn try_recv(&mut self) -> Option<ChannelMessage> {
+        if self.exit_requested {
+            return None;
+        }
         match self.rx.try_recv() {
             Ok(Some(line)) => {
                 let trimmed = line.trim().to_owned();
-                if trimmed.is_empty() {
-                    return None;
+                match trimmed.as_str() {
+                    "" => None,
+                    "exit" | "quit" | "/exit" | "/quit" => {
+                        self.exit_requested = true;
+                        None
+                    }
+                    _ => {
+                        self.sink.emit(&JsonEvent::Query {
+                            text: &trimmed,
+                            queue_len: 0,
+                        });
+                        Some(ChannelMessage {
+                            text: trimmed,
+                            attachments: Vec::new(),
+                            is_guest_context: false,
+                            is_from_bot: false,
+                        })
+                    }
                 }
-                self.sink.emit(&JsonEvent::Query {
-                    text: &trimmed,
-                    queue_len: 0,
-                });
-                Some(ChannelMessage {
-                    text: trimmed,
-                    attachments: Vec::new(),
-                    is_guest_context: false,
-                    is_from_bot: false,
-                })
             }
             _ => None,
         }
@@ -465,5 +482,106 @@ mod tests {
         let (sink, _) = make_test_sink();
         let mut ch = JsonCliChannel::new(sink, false);
         assert!(ch.try_recv().is_none());
+    }
+
+    /// Constructs a channel with a directly-controlled sender, bypassing the
+    /// background stdin-reading thread spawned by `new()`.
+    fn make_test_channel(
+        sink: Arc<JsonEventSink>,
+    ) -> (JsonCliChannel, tokio::sync::mpsc::Sender<Option<String>>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        let ch = JsonCliChannel {
+            sink,
+            rx,
+            auto: false,
+            pending_chunks: false,
+            exit_requested: false,
+        };
+        (ch, tx)
+    }
+
+    #[tokio::test]
+    async fn try_recv_exit_is_discarded_not_returned_as_message() {
+        // Regression for #5657: an exit/quit line drained via try_recv() must never
+        // surface as a ChannelMessage that could be merged into pending queue content.
+        let (sink, _read) = make_test_sink();
+        let (mut ch, tx) = make_test_channel(sink);
+        tx.send(Some("hello".to_owned())).await.unwrap();
+        tx.send(Some("/exit".to_owned())).await.unwrap();
+
+        let first = ch.try_recv();
+        assert_eq!(first.map(|m| m.text), Some("hello".to_owned()));
+
+        assert!(
+            ch.try_recv().is_none(),
+            "exit string must not be returned as a ChannelMessage"
+        );
+    }
+
+    #[tokio::test]
+    async fn recv_ends_session_after_try_recv_saw_exit() {
+        // Once try_recv() has drained an exit/quit line, the next recv() must end the
+        // session immediately (Ok(None)) rather than waiting on or returning further
+        // buffered stdin lines.
+        let (sink, _read) = make_test_sink();
+        let (mut ch, tx) = make_test_channel(sink);
+        tx.send(Some("/exit".to_owned())).await.unwrap();
+        tx.send(Some("should never be read".to_owned()))
+            .await
+            .unwrap();
+
+        assert!(ch.try_recv().is_none());
+        let result = ch.recv().await.unwrap();
+        assert!(
+            result.is_none(),
+            "recv() must end the session once exit_requested is set"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_recv_recognizes_all_exit_synonyms() {
+        for word in ["exit", "quit", "/exit", "/quit"] {
+            let (sink, _read) = make_test_sink();
+            let (mut ch, tx) = make_test_channel(sink);
+            tx.send(Some(word.to_owned())).await.unwrap();
+            assert!(
+                ch.try_recv().is_none(),
+                "{word:?} must be recognized as an exit synonym"
+            );
+            assert!(ch.exit_requested, "{word:?} must set exit_requested");
+        }
+    }
+
+    #[tokio::test]
+    async fn try_recv_recognizes_exit_synonyms_with_surrounding_whitespace() {
+        // recv() matches on `line.trim()`; try_recv() must trim identically so the
+        // two entry points never disagree on what counts as an exit line.
+        for word in [" /exit", "/exit ", "  quit  ", "\texit\n"] {
+            let (sink, _read) = make_test_sink();
+            let (mut ch, tx) = make_test_channel(sink);
+            tx.send(Some(word.to_owned())).await.unwrap();
+            assert!(
+                ch.try_recv().is_none(),
+                "{word:?} must be recognized as an exit synonym after trimming"
+            );
+            assert!(ch.exit_requested, "{word:?} must set exit_requested");
+        }
+    }
+
+    #[tokio::test]
+    async fn try_recv_after_exit_requested_does_not_leak_buffered_content() {
+        // Regression for #5657: once try_recv() has seen an exit line, a *further*
+        // try_recv() call (not just recv()) must not surface any buffered lines
+        // that arrived after the exit command.
+        let (sink, _read) = make_test_sink();
+        let (mut ch, tx) = make_test_channel(sink);
+        tx.send(Some("/exit".to_owned())).await.unwrap();
+        tx.send(Some("should never leak".to_owned())).await.unwrap();
+
+        assert!(ch.try_recv().is_none(), "exit line must not be returned");
+        assert!(
+            ch.try_recv().is_none(),
+            "a second try_recv() after exit_requested must not return buffered content"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `JsonCliChannel::try_recv` (`crates/zeph-channels/src/json_cli.rs`) did not special-case `exit`/`quit`/`/exit`/`/quit` the way `recv` already did. When one of these strings arrived via the queued/merge path (`Agent::drain_channel`'s 500ms merge window in `crates/zeph-core/src/agent/message_queue.rs`), it was merged as literal text and sent to the LLM as prompt content instead of ending the session.
- `try_recv` now matches the same exit strings (same arms, order, whitespace trimming, and case-sensitivity as `recv`) before ever constructing a `ChannelMessage`, and sets a persistent `exit_requested` flag. `recv` checks this flag first and short-circuits to `Ok(None)`, so the session ends promptly once the queue drains rather than only incidentally via stdin EOF.
- Scope kept to `json_cli.rs`; the shared `message_queue.rs`/`Channel` trait were left untouched since that logic is shared by every channel (e.g. `TuiChannel`, which has legitimate chat text containing those words) — giving it a new "bare exit ends session" behavior was out of scope for this bug.

## Test plan

- [x] Added regression tests in `crates/zeph-channels/src/json_cli.rs`: exit discarded but preceding legit message still returned; `recv()` ends session without reading further buffered lines once `exit_requested` is set; all 4 synonyms recognized; whitespace-trim parity with `recv()`; repeated `try_recv()` calls after exit don't leak buffered content.
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12063 passed, 0 failed.
- [x] `cargo +nightly fmt --check` — clean.
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean.
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`) — clean.
- [ ] Live end-to-end binary repro (piping `/exit` through `--json --auto`) — not run; no vault-backed config available in this worktree. Unit-level coverage exercises the exact bug mechanism directly.