### PR TITLE
fix(config): stop condense_provider defaulting to unresolvable "fast"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   as prompt content instead of ending the session. `try_recv` now matches the same exit strings
   before constructing a message and sets a persistent flag that `recv` checks first, so the
   session ends promptly once the queue drains instead of only incidentally via stdin EOF. (#5657)
+- `fix(config)`: `CondenseConfig::condense_provider` (`crates/zeph-config/src/session.rs`)
+  defaulted to `ProviderName::from("fast")`, but no shipped config defines a provider named
+  `"fast"`. Every session-open path that constructs the resume condenser
+  (`build_resume_condenser` in `crates/zeph-core/src/provider_factory.rs`, used by CLI `sessions
+  resume`, ACP `spawn_acp_agent`, and `zeph serve`'s `hydrate_session_sink`) resolved this via
+  `resolve_named_provider`, which always missed and logged a fallback WARN before falling back
+  to the primary provider anyway — as well as the mid-session live-condensation path
+  (`build_condense_deps` in `crates/zeph-core/src/agent/context/summarization/mod.rs`, called
+  from `assembly.rs`), which resolves via `Agent::resolve_background_provider`
+  (`crates/zeph-core/src/agent/learning/arise.rs`) and logs the identical fallback WARN on an
+  unmatched name. `condense_provider` now defaults to an empty `ProviderName`, matching the
+  sibling `recap.provider`/`feedback_provider`/`arise_trace_provider` fields — both resolvers
+  already fall back to the primary/background provider silently when the name is empty. (#5665)
 - `fix(tools)`: `UtilityScorer::default_gain` (`crates/zeph-tools/src/utility.rs`) fell through
   to a generic `0.5` gain for `diagnostics` and other direct-action tools with no exploratory
   semantics, which satisfied `recommend_action`'s `Retrieve` rule before the direct-`ToolCall`

--- a/book/src/advanced/session-persistence.md
+++ b/book/src/advanced/session-persistence.md
@@ -122,7 +122,7 @@ encrypt = false               # opt-in AEAD encryption — reserved, not yet imp
 max_event_log_mb = 256        # size guard that triggers condensation
 
 [session.condense]
-condense_provider = "fast"    # provider name from [[llm.providers]]; empty = primary provider
+condense_provider = ""        # provider name from [[llm.providers]]; empty = primary provider
 threshold = 0.85               # fraction of context budget that triggers condensation
 keep_recent = 20               # minimum recent events preserved after condensation
 ```

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -474,7 +474,7 @@ provider_persistence = true    # Persist channel-level provider overrides across
 persist_provider_overrides = true  # Store reasoning_effort per session; requires provider_persistence (default: true)
 
 [session.condense]
-# condense_provider = ""       # Provider name from [[llm.providers]] for condensation; empty = primary (default: "fast")
+# condense_provider = ""       # Provider name from [[llm.providers]] for condensation; empty = primary (default: "")
 threshold = 0.85               # Fraction of the context budget that triggers condensation (default: 0.85)
 keep_recent = 20               # Minimum recent events preserved after condensation (default: 20)
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -1516,7 +1516,7 @@ provider_persistence = true
 # [session.condense] — durable context condensation policy (spec-068 §8, #5343)
 # [session.condense]
 # Provider name from [[llm.providers]] for condensation calls; empty = primary provider
-# condense_provider = "fast"
+# condense_provider = ""
 # Fraction of the context budget that triggers condensation on resume/mid-session
 # threshold = 0.85
 # Minimum recent events preserved after condensation

--- a/crates/zeph-config/src/migrate/session.rs
+++ b/crates/zeph-config/src/migrate/session.rs
@@ -283,7 +283,7 @@ pub fn migrate_session_persistence_config(toml_src: &str) -> Result<MigrationRes
 
     let condense_block = "\n# [session.condense] — durable context condensation policy (spec-068 §8, #5343).\n\
          # [session.condense]\n\
-         # condense_provider = \"fast\"  # [[llm.providers]] name; empty falls back to the primary provider\n\
+         # condense_provider = \"\"  # [[llm.providers]] name; empty falls back to the primary provider\n\
          # threshold = 0.85            # fraction of context budget that triggers condensation\n\
          # keep_recent = 20            # minimum recent events preserved after condensation\n";
     let output = format!("{output}{condense_block}");

--- a/crates/zeph-config/src/session.rs
+++ b/crates/zeph-config/src/session.rs
@@ -77,7 +77,7 @@ impl Default for SessionConfig {
 pub struct CondenseConfig {
     /// Provider name from `[[llm.providers]]` for condensation LLM calls.
     ///
-    /// An empty [`ProviderName`] falls back to the primary provider. Default: `"fast"`.
+    /// An empty [`ProviderName`] falls back to the primary provider. Default: `""`.
     pub condense_provider: ProviderName,
     /// Fraction of the context budget that triggers condensation on resume/mid-session.
     /// Default: `0.85`.
@@ -89,7 +89,7 @@ pub struct CondenseConfig {
 impl Default for CondenseConfig {
     fn default() -> Self {
         Self {
-            condense_provider: ProviderName::from("fast"),
+            condense_provider: ProviderName::default(),
             threshold: 0.85,
             keep_recent: 20,
         }
@@ -145,5 +145,35 @@ impl Default for RecapConfig {
             provider: ProviderName::default(),
             max_input_messages: 20,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn condense_config_default_provider_is_empty() {
+        let cfg = CondenseConfig::default();
+        assert!(
+            cfg.condense_provider.is_empty(),
+            "condense_provider must default to empty (fallback to primary provider), matching \
+             the sibling recap/feedback/arise_trace provider fields — a non-empty default like \
+             \"fast\" spams a fallback WARN when no provider named \"fast\" is configured (#5665)"
+        );
+    }
+
+    #[test]
+    fn condense_config_empty_section_uses_defaults() {
+        let cfg: CondenseConfig = toml::from_str("").unwrap();
+        assert!(cfg.condense_provider.is_empty());
+        assert!((cfg.threshold - 0.85).abs() < f64::EPSILON);
+        assert_eq!(cfg.keep_recent, 20);
+    }
+
+    #[test]
+    fn condense_config_explicit_provider_roundtrip() {
+        let cfg: CondenseConfig = toml::from_str(r#"condense_provider = "fast""#).unwrap();
+        assert_eq!(cfg.condense_provider, "fast");
     }
 }

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -788,10 +788,10 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("cuda feature"));
     }
 
-    #[cfg(any(feature = "gonka", feature = "cocoon"))]
-    use super::build_provider_from_entry;
+    use super::{build_provider_from_entry, resolve_named_provider};
     use crate::config::{Config, ProviderKind};
     use zeph_config::providers::ProviderEntry;
+    use zeph_llm::LlmProvider;
 
     #[cfg(feature = "gonka")]
     mod gonka_tests {
@@ -935,6 +935,24 @@ mod tests {
             config.llm.stable_skill_embedding_model(),
             config.llm.effective_embedding_model()
         );
+    }
+
+    #[test]
+    fn resolve_named_provider_empty_name_falls_back_to_primary_silently() {
+        let config = Config::default();
+        let entry = make_provider_entry(false, Some("primary-model"), None);
+        let primary = build_provider_from_entry(&entry, &config, None).unwrap();
+        let resolved = resolve_named_provider(&config, &primary, "");
+        assert_eq!(resolved.name(), primary.name());
+    }
+
+    #[test]
+    fn resolve_named_provider_unmatched_name_falls_back_to_primary_with_warn() {
+        let config = Config::default(); // no [[llm.providers]] named "fast"
+        let entry = make_provider_entry(false, Some("primary-model"), None);
+        let primary = build_provider_from_entry(&entry, &config, None).unwrap();
+        let resolved = resolve_named_provider(&config, &primary, "fast");
+        assert_eq!(resolved.name(), primary.name());
     }
 
     #[cfg(feature = "cocoon")]


### PR DESCRIPTION
## Summary

- `CondenseConfig::condense_provider` (`crates/zeph-config/src/session.rs`) defaulted to `ProviderName::from("fast")`, but no shipped config (`config/default.toml`, `.local/config/testing.toml`) defines a provider by that name — every construction-time session-open path (`build_resume_condenser`) and the mid-session live-condensation path (`build_condense_deps` via `resolve_background_provider`) resolved this name, missed, and logged a fallback `WARN` on essentially every session, even though the fallback to primary/background provider was already functionally safe.
- Default changed to an empty `ProviderName`, matching the sibling `recap.provider`/`feedback_provider`/`arise_trace_provider` fields, which already fall back silently on an empty name.
- Added direct unit test coverage for `resolve_named_provider`'s empty-name and unmatched-name branches (`crates/zeph-core/src/provider_factory.rs`), which had zero tests before this fix despite being the exact mechanism the bug was about.
- Updated the migration-scaffold comment, `config/default.toml`, and both affected `book/` reference pages for consistency.

Closes #5665

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-config` — 627/627 pass (includes 3 new tests)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-core -E 'test(resolve_named_provider)'` — 2/2 pass (new)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12063/12063 pass, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] Updated `.local/testing/playbooks/session-persistence.md` and `.local/testing/coverage-status.md` with test scenarios and a new coverage row