### PR TITLE
fix(llm): retry chat_with_tools and classify 429/503 correctly in send_with_retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(llm)`: `OpenAiProvider::chat_with_tools` (`crates/zeph-llm/src/openai/mod.rs`) sent its
+  request directly via `.send().await?` with a manual one-shot 429 special case, instead of
+  going through the shared `send_with_retry` helper used by every other request path on the
+  same provider (`chat()`/`chat_with_extras` via `send_request`, `chat_stream()` via
+  `send_stream_request`). Since `chat_with_tools` is the path used whenever the agent has any
+  tools registered — virtually every real turn — a single transient rate-limit response failed
+  the entire tool-calling turn immediately with zero retries, unlike the tool-less path.
+  `chat_with_tools` now routes through `send_with_retry`, matching `ClaudeProvider`'s existing
+  behavior; `CompatibleProvider::chat_with_tools` is fixed transitively since it delegates to
+  the same method. (#5684)
+- `fix(llm)`: `send_with_retry` (`crates/zeph-llm/src/retry.rs`) retried on both `429 Too Many
+  Requests` and `503 Service Unavailable`, but once retries were exhausted it unconditionally
+  returned `LlmError::RateLimited` regardless of which status code caused the exhaustion — a
+  genuine server outage was indistinguishable from a quota/rate-limit condition to every
+  downstream caller, including `RouterProvider::embed`/`embed_batch`
+  (`crates/zeph-llm/src/router/provider_impl.rs`), which branches on `is_rate_limited()` to
+  retry the same provider instead of falling back immediately. `send_with_retry` now returns
+  `LlmError::Unavailable` when the last-seen status before exhaustion was 503, and
+  `LlmError::RateLimited` only when it was 429, so the router takes the correct
+  retry-vs-fallback branch. (#5685)
 - `fix(channels)`: `JsonCliChannel::try_recv` (`crates/zeph-channels/src/json_cli.rs`) did not
   recognize `exit`/`quit`/`/exit`/`/quit` the way `recv` already did, so an exit command
   arriving via the queued/merge path (`Agent::drain_channel`'s 500ms merge window in

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -1040,17 +1040,14 @@ impl LlmProvider for OpenAiProvider {
             presence_penalty,
         };
 
-        let response = self
-            .openai_post(format!("{}/chat/completions", self.base_url))
-            .json(&body)
-            .send()
-            .await?;
+        let response = send_with_retry("OpenAI", MAX_RETRIES, self.status_tx.as_ref(), || {
+            self.openai_post(format!("{}/chat/completions", self.base_url))
+                .json(&body)
+                .send()
+        })
+        .await?;
 
         let (status, text) = crate::http::read_response_body(response).await?;
-
-        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            return Err(LlmError::RateLimited);
-        }
 
         if status == reqwest::StatusCode::BAD_REQUEST {
             tracing::warn!("OpenAI tool chat 400 bad request: {text}");

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -1471,6 +1471,105 @@ async fn chat_500_server_error_propagates() {
     assert!(result.is_err());
 }
 
+/// Spawn a minimal HTTP server that returns a fixed response for each connection in order.
+/// Mirrors the mock server used in `retry.rs` and `gemini/tests.rs` to exercise real
+/// retry-then-succeed behavior over the wire (wiremock has no built-in way to fail N
+/// times then succeed on the same route).
+async fn spawn_sequenced_mock_server(
+    responses: Vec<&'static str>,
+) -> (u16, tokio::task::JoinHandle<()>) {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let handle = tokio::spawn(async move {
+        for resp in responses {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let (reader, mut writer) = stream.split();
+                let mut buf_reader = BufReader::new(reader);
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    buf_reader.read_line(&mut line).await.unwrap_or(0);
+                    if line == "\r\n" || line == "\n" || line.is_empty() {
+                        break;
+                    }
+                }
+                writer.write_all(resp.as_bytes()).await.ok();
+            });
+        }
+    });
+
+    (port, handle)
+}
+
+#[tokio::test]
+async fn chat_with_tools_retries_on_429_then_succeeds() {
+    let rate_limit_response =
+        "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 0\r\nContent-Length: 0\r\n\r\n";
+    let ok_body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "content": "done",
+                "tool_calls": null
+            }
+        }]
+    })
+    .to_string();
+    let ok_response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        ok_body.len(),
+        ok_body
+    );
+    let (port, _handle) = spawn_sequenced_mock_server(vec![
+        rate_limit_response,
+        Box::leak(ok_response.into_boxed_str()),
+    ])
+    .await;
+
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test".into(),
+        base_url: format!("http://127.0.0.1:{port}"),
+        model: "gpt-4o".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    let messages = vec![Message {
+        role: Role::User,
+        content: "hi".into(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    }];
+    let tools = vec![ToolDefinition {
+        name: "bash".into(),
+        description: "Execute a shell command".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"]
+        }),
+        output_schema: None,
+    }];
+
+    let result = p.chat_with_tools(&messages, &tools).await;
+    assert!(
+        result.is_ok(),
+        "expected chat_with_tools to retry past a transient 429 and succeed, got: {result:?}"
+    );
+    match result.unwrap() {
+        ChatResponse::Text(text) => assert_eq!(text, "done"),
+        other => panic!("expected Text response, got {other:?}"),
+    }
+}
+
 #[test]
 fn with_generation_overrides_stores_overrides() {
     let provider = OpenAiProvider::new(OpenAiConfig {

--- a/crates/zeph-llm/src/retry.rs
+++ b/crates/zeph-llm/src/retry.rs
@@ -20,16 +20,18 @@ pub(crate) fn retry_delay(response: &reqwest::Response, attempt: u32) -> Duratio
     Duration::from_secs(BASE_BACKOFF_SECS << attempt)
 }
 
-/// Send an HTTP request, retrying up to `max_retries` times on 429 responses.
+/// Send an HTTP request, retrying up to `max_retries` times on 429 or 503 responses.
 ///
-/// `f` must return a `reqwest::Response`. On each rate-limited attempt, emits a status
-/// message and waits before retrying. Returns the successful `Response` for further
-/// processing by the caller, or an error.
+/// `f` must return a `reqwest::Response`. On each rate-limited or unavailable attempt,
+/// emits a status message and waits before retrying. Returns the successful `Response`
+/// for further processing by the caller, or an error.
 ///
 /// # Errors
 ///
-/// Returns `LlmError::RateLimited` if all attempts are exhausted, or the underlying
-/// `reqwest::Error` wrapped as `LlmError::Http` for other failures.
+/// If all attempts are exhausted, returns `LlmError::RateLimited` when the last response
+/// was `429 Too Many Requests`, or `LlmError::Unavailable` when it was `503 Service
+/// Unavailable`. The underlying `reqwest::Error` is wrapped as `LlmError::Http` for other
+/// failures.
 pub(crate) async fn send_with_retry<F, Fut>(
     provider_name: &str,
     max_retries: u32,
@@ -48,7 +50,11 @@ where
             || status == reqwest::StatusCode::SERVICE_UNAVAILABLE
         {
             if attempt == max_retries {
-                return Err(LlmError::RateLimited);
+                return Err(if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+                    LlmError::Unavailable
+                } else {
+                    LlmError::RateLimited
+                });
             }
             let delay = retry_delay(&response, attempt);
             let msg = format!(
@@ -160,6 +166,93 @@ mod tests {
         assert!(
             matches!(result, Err(LlmError::RateLimited)),
             "expected RateLimited, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_exhausts_retries_returns_unavailable() {
+        // All responses are 503 with Retry-After: 0 to not slow down the test
+        let unavailable_response =
+            "HTTP/1.1 503 Service Unavailable\r\nRetry-After: 0\r\nContent-Length: 0\r\n\r\n";
+        let (port, _handle) =
+            spawn_mock_server(vec![unavailable_response, unavailable_response]).await;
+
+        let client = reqwest::Client::new();
+        let url = format!("http://127.0.0.1:{port}/test");
+
+        // max_retries=1 means: attempt 0 (503 → retry), attempt 1 (503 → fail)
+        let result = send_with_retry("test", 1, None, || {
+            let req = client.get(&url).build().unwrap();
+            let c = client.clone();
+            async move { c.execute(req).await }
+        })
+        .await;
+
+        assert!(
+            matches!(result, Err(LlmError::Unavailable)),
+            "expected Unavailable, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_mixed_429_then_503_returns_unavailable() {
+        // attempt 0: 429 (retry), attempt 1: 503 (retry), attempt 2: 503 (exhausted).
+        // The LAST status seen (503), not the first (429), must decide the error variant.
+        let rate_limit_response =
+            "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 0\r\nContent-Length: 0\r\n\r\n";
+        let unavailable_response =
+            "HTTP/1.1 503 Service Unavailable\r\nRetry-After: 0\r\nContent-Length: 0\r\n\r\n";
+        let (port, _handle) = spawn_mock_server(vec![
+            rate_limit_response,
+            unavailable_response,
+            unavailable_response,
+        ])
+        .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("http://127.0.0.1:{port}/test");
+
+        let result = send_with_retry("test", 2, None, || {
+            let req = client.get(&url).build().unwrap();
+            let c = client.clone();
+            async move { c.execute(req).await }
+        })
+        .await;
+
+        assert!(
+            matches!(result, Err(LlmError::Unavailable)),
+            "last status (503) must win over the earlier 429, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_mixed_503_then_429_returns_rate_limited() {
+        // attempt 0: 503 (retry), attempt 1: 429 (retry), attempt 2: 429 (exhausted).
+        // The LAST status seen (429), not the first (503), must decide the error variant.
+        let rate_limit_response =
+            "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 0\r\nContent-Length: 0\r\n\r\n";
+        let unavailable_response =
+            "HTTP/1.1 503 Service Unavailable\r\nRetry-After: 0\r\nContent-Length: 0\r\n\r\n";
+        let (port, _handle) = spawn_mock_server(vec![
+            unavailable_response,
+            rate_limit_response,
+            rate_limit_response,
+        ])
+        .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("http://127.0.0.1:{port}/test");
+
+        let result = send_with_retry("test", 2, None, || {
+            let req = client.get(&url).build().unwrap();
+            let c = client.clone();
+            async move { c.execute(req).await }
+        })
+        .await;
+
+        assert!(
+            matches!(result, Err(LlmError::RateLimited)),
+            "last status (429) must win over the earlier 503, got: {result:?}"
         );
     }
 

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -848,6 +848,42 @@ async fn embed_falls_back_after_all_retries_exhausted() {
     assert_eq!(result, vec![9.0, 8.0]);
 }
 
+/// A genuine outage (`Unavailable`, e.g. exhausted 503 retries at the HTTP layer) must
+/// not be treated as `RateLimited`: the router should fall back to the next provider on
+/// the very first `Unavailable` error instead of retrying the same provider up to
+/// `EMBED_MAX_RETRIES` times. Giving `p1` only one error (not four, unlike the
+/// `RateLimited` exhaustion test above) proves this — if the router mistakenly retried,
+/// the second call to `p1` would succeed (its error queue would be empty) and return
+/// `p1`'s own embedding instead of falling back to `p2`.
+#[tokio::test]
+async fn embed_falls_back_immediately_on_unavailable() {
+    use crate::mock::MockProvider;
+
+    let p1_mock = {
+        let mut m = MockProvider::default()
+            .with_errors(vec![LlmError::Unavailable])
+            .with_name("p1");
+        m.supports_embeddings = true;
+        m
+    };
+    let p1_embed_calls = Arc::clone(&p1_mock.embed_call_count);
+    let p1 = AnyProvider::Mock(p1_mock);
+    let p2 = AnyProvider::Mock({
+        let mut m = MockProvider::default().with_name("p2");
+        m.supports_embeddings = true;
+        m.embedding = vec![9.0, 8.0];
+        m
+    });
+    let r = RouterProvider::new(vec![p1, p2]);
+    let result = r.embed("text").await.unwrap();
+    assert_eq!(result, vec![9.0, 8.0]);
+    assert_eq!(
+        p1_embed_calls.load(Ordering::Relaxed),
+        1,
+        "p1 must be called exactly once — Unavailable must not enter the embed-retry loop"
+    );
+}
+
 /// Provider returns `RateLimited` twice then succeeds via `embed_batch`.
 #[tokio::test]
 async fn embed_batch_retries_on_rate_limited_then_succeeds() {


### PR DESCRIPTION
## Summary

- `OpenAiProvider::chat_with_tools` bypassed the shared `send_with_retry` helper, sending its request directly and special-casing a single 429 response into an immediate failure with zero retries — unlike `chat()`/`chat_stream()` on the same provider, and unlike `ClaudeProvider::chat_with_tools` which already used `send_with_retry`. Since `chat_with_tools` is the path used whenever the agent has tools registered, this made the OpenAI backend's real-world rate-limit resilience much weaker than the tool-less path suggested. `chat_with_tools` now routes through `send_with_retry`; `CompatibleProvider::chat_with_tools` is fixed transitively since it delegates to the same method.
- `send_with_retry` conflated exhausted `503 Service Unavailable` responses with `429 Too Many Requests`, always returning `LlmError::RateLimited` on exhaustion regardless of which status code caused it. `RouterProvider::embed`/`embed_batch` branches on `is_rate_limited()` to decide whether to retry the same provider (genuine rate limit) or fall back immediately (genuine outage) — a real 503 outage was retried under the wrong assumption before ever falling back. `send_with_retry` now returns `LlmError::Unavailable` when the last-seen status before exhaustion was 503, and `LlmError::RateLimited` only when it was 429.

Closes #5684, #5685.

## Known follow-ups (out of scope for this PR)

- Router reputation-penalty bookkeeping (`provider_impl.rs`) applies the extra availability penalty only on `is_rate_limited()`, so a 503-exhaustion (`Unavailable`) currently gets a lighter penalty than a 429-exhaustion (`RateLimited`) — arguably backwards, no correctness bug.
- `OpenAiProvider::embed`/`embed_batch` bypass `send_with_retry` entirely (raw `.send()`, mapping all non-success codes to `ApiError`), making the router's embed rate-limit retry logic permanently unreachable for OpenAI's embed path — a separate pre-existing latent bug.

## Test plan

- [x] `cargo nextest run -p zeph-llm` — 920 passed (new: `send_with_retry_exhausts_retries_returns_unavailable`, `send_with_retry_mixed_429_then_503_returns_unavailable`, `send_with_retry_mixed_503_then_429_returns_rate_limited`, `chat_with_tools_retries_on_429_then_succeeds`, `embed_falls_back_immediately_on_unavailable`)
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12078 passed
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Testing playbook added: `.local/testing/playbooks/llm-provider-retry-classification.md`; `coverage-status.md` updated