### PR TITLE
fix(core): enforce atomic daemon single-instance guard via flock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `LlmError::Unavailable` when the last-seen status before exhaustion was 503, and
   `LlmError::RateLimited` only when it was 429, so the router takes the correct
   retry-vs-fallback branch. (#5685)
+- `fix(core)`: `run_daemon` (`src/daemon.rs`) guarded against a second `zeph --daemon`
+  instance with a check-then-act sequence — read the pid file, check liveness, remove if
+  stale, then write — that let two daemons started concurrently both pass the liveness
+  check before either wrote, and treated any `write_pid_file` failure as a non-fatal
+  warning, letting startup continue with no single-instance protection at all. Added
+  `DaemonError::AlreadyRunning` and `daemon::PidGuard` (`crates/zeph-core/src/daemon.rs`),
+  an exclusive `flock(2)`-backed guard mirroring `zeph-scheduler::pidfile::PidFile::acquire`:
+  mutual exclusion now comes entirely from kernel lock atomicity instead of a separate
+  read-check-remove-write sequence, closing the TOCTOU window. A second instance now fails
+  fast with a clear "another daemon instance is already running" error and non-zero exit
+  code instead of silently starting a duplicate set of background supervisors against the
+  same session state. Non-Unix builds keep the previous check-then-write sequence but now
+  propagate `write_pid_file` failure as fatal rather than logging and continuing. (#5679)
 - `fix(channels)`: `JsonCliChannel::try_recv` (`crates/zeph-channels/src/json_cli.rs`) did not
   recognize `exit`/`quit`/`/exit`/`/quit` the way `recv` already did, so an exit command
   arriving via the queued/merge path (`Agent::drain_channel`'s 500ms merge window in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10636,6 +10636,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.4",
  "rmcp",
+ "rustix 1.1.4",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -89,6 +89,10 @@ zeph-vault.workspace = true
 zeroize.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
+# Advisory `flock(2)` locking for the daemon pid file guard (`daemon::PidGuard`); Unix only.
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true, features = ["fs", "std"] }
+
 [[bench]]
 name = "context_building"
 harness = false

--- a/crates/zeph-core/src/daemon.rs
+++ b/crates/zeph-core/src/daemon.rs
@@ -19,13 +19,19 @@ pub enum ComponentStatus {
 }
 
 #[non_exhaustive]
-/// Error type for daemon component task failures.
+/// Error type for daemon component task failures and pid file guard acquisition.
 #[derive(Debug, thiserror::Error)]
 pub enum DaemonError {
     #[error("task error: {0}")]
     Task(String),
     #[error("shutdown error: {0}")]
     Shutdown(String),
+    #[error(
+        "another daemon instance is already running (PID {pid}); stop it before starting a new one"
+    )]
+    AlreadyRunning { pid: u32 },
+    #[error("pid file error: {0}")]
+    PidFile(#[from] std::io::Error),
 }
 
 pub struct ComponentHandle {
@@ -210,6 +216,125 @@ pub fn remove_pid_file(path: &str) -> std::io::Result<()> {
     }
 }
 
+/// Exclusive, `flock(2)`-backed guard on the daemon's pid file.
+///
+/// Replaces the previous check-then-act sequence (read pid file, check liveness, remove if
+/// stale, then write) with a single atomic lock acquisition: only one process can ever hold the
+/// advisory lock on the pid file, so a second concurrent `--daemon` invocation fails immediately
+/// with [`DaemonError::AlreadyRunning`] instead of racing the first to write the file. Dropping
+/// the guard unlinks the pid file and releases the lock.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_core::daemon::PidGuard;
+///
+/// let guard = PidGuard::acquire("/tmp/zeph-daemon.pid").expect("no other instance running");
+/// // ... run the daemon ...
+/// drop(guard); // releases the lock and removes the pid file
+/// ```
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct PidGuard {
+    #[allow(dead_code)] // held for its Drop impl (closes fd, releasing the flock)
+    fd: rustix::fd::OwnedFd,
+    path: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl PidGuard {
+    /// Acquire an exclusive lock on the pid file at `path`, creating it if necessary, and write
+    /// the current process id into it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DaemonError::AlreadyRunning`] if another process already holds the lock, or
+    /// [`DaemonError::PidFile`] for filesystem failures.
+    pub fn acquire(path: &str) -> Result<Self, DaemonError> {
+        use rustix::fs::{FlockOperation, Mode, OFlags};
+
+        let expanded = expand_tilde(path);
+        let path = std::path::Path::new(&expanded);
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let fd = rustix::fs::open(
+            path,
+            OFlags::RDWR | OFlags::CREATE | OFlags::CLOEXEC,
+            Mode::from_raw_mode(0o644),
+        )
+        .map_err(std::io::Error::from)?;
+
+        rustix::fs::flock(&fd, FlockOperation::NonBlockingLockExclusive).map_err(|e| {
+            if e == rustix::io::Errno::WOULDBLOCK {
+                let pid = read_pid_file(path.to_string_lossy().as_ref()).unwrap_or(0);
+                DaemonError::AlreadyRunning { pid }
+            } else {
+                DaemonError::PidFile(e.into())
+            }
+        })?;
+
+        rustix::fs::ftruncate(&fd, 0).map_err(std::io::Error::from)?;
+        rustix::io::write(&fd, std::process::id().to_string().as_bytes())
+            .map_err(std::io::Error::from)?;
+
+        Ok(Self {
+            fd,
+            path: path.to_owned(),
+        })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PidGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Exclusive guard on the daemon's pid file (non-Unix fallback).
+///
+/// `flock(2)` is unavailable outside Unix, so this falls back to the create-then-check
+/// sequence: [`write_pid_file`] already uses an atomic exclusive create, so two processes
+/// racing to start fresh are still serialized correctly; only recovery from a stale pid file
+/// left by a crashed process re-opens a (narrow) TOCTOU window between the liveness check and
+/// the write.
+#[cfg(not(unix))]
+#[derive(Debug)]
+pub struct PidGuard {
+    path: String,
+}
+
+#[cfg(not(unix))]
+impl PidGuard {
+    /// Acquire the pid file guard at `path`, removing a stale (dead-process) file first.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DaemonError::AlreadyRunning`] if the existing pid file names a live process, or
+    /// [`DaemonError::PidFile`] for filesystem failures.
+    pub fn acquire(path: &str) -> Result<Self, DaemonError> {
+        if let Ok(existing_pid) = read_pid_file(path) {
+            if is_process_alive(existing_pid) {
+                return Err(DaemonError::AlreadyRunning { pid: existing_pid });
+            }
+            remove_pid_file(path)?;
+        }
+        write_pid_file(path)?;
+        Ok(Self {
+            path: path.to_owned(),
+        })
+    }
+}
+
+#[cfg(not(unix))]
+impl Drop for PidGuard {
+    fn drop(&mut self) {
+        let _ = remove_pid_file(&self.path);
+    }
+}
+
 fn expand_tilde(path: &str) -> String {
     if let Some(rest) = path.strip_prefix("~/")
         && let Some(home) = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))
@@ -253,6 +378,35 @@ mod tests {
     #[test]
     fn remove_nonexistent_pid_file_ok() {
         assert!(remove_pid_file("/tmp/nonexistent_zeph_test.pid").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pid_guard_acquire_writes_pid_and_removes_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("guard.pid");
+        let path_str = path.to_string_lossy().to_string();
+
+        let guard = PidGuard::acquire(&path_str).expect("acquire should succeed");
+        let pid = read_pid_file(&path_str).expect("pid file must exist");
+        assert_eq!(pid, std::process::id());
+        drop(guard);
+        assert!(!path.exists(), "pid file must be removed on drop");
+    }
+
+    /// Regression test for #5679: a second concurrent acquisition attempt on a pid file
+    /// already locked by a live guard must fail closed with `AlreadyRunning`, not silently
+    /// overwrite the file or proceed.
+    #[cfg(unix)]
+    #[test]
+    fn pid_guard_second_acquire_fails_with_already_running() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("guard-race.pid");
+        let path_str = path.to_string_lossy().to_string();
+
+        let _first = PidGuard::acquire(&path_str).expect("first acquire must succeed");
+        let err = PidGuard::acquire(&path_str).expect_err("second acquire must fail");
+        assert_matches!(err, DaemonError::AlreadyRunning { .. });
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -265,33 +265,15 @@ pub(crate) async fn run_daemon(
     vault_key: Option<&std::path::Path>,
     vault_path: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
-    use zeph_core::daemon::{
-        ComponentHandle, DaemonSupervisor, is_process_alive, read_pid_file, remove_pid_file,
-        write_pid_file,
-    };
+    use zeph_core::daemon::{ComponentHandle, DaemonSupervisor, PidGuard};
 
     let app = AppBuilder::new(config_path, vault, vault_key, vault_path).await?;
     let config = app.config();
 
-    // Check for a stale or live PID file before writing a new one.
-    if let Ok(existing_pid) = read_pid_file(&config.daemon.pid_file) {
-        if is_process_alive(existing_pid) {
-            anyhow::bail!(
-                "another daemon instance is already running (PID {existing_pid}); \
-                 stop it before starting a new one"
-            );
-        }
-        tracing::info!(
-            pid = existing_pid,
-            "removing stale PID file from previous run"
-        );
-        if let Err(e) = remove_pid_file(&config.daemon.pid_file) {
-            tracing::warn!("failed to remove stale PID file: {e}");
-        }
-    }
-    if let Err(e) = write_pid_file(&config.daemon.pid_file) {
-        tracing::warn!("failed to write PID file: {e}");
-    }
+    // Atomically acquire the daemon pid file lock — fails fast with `AlreadyRunning` if another
+    // instance already holds it, instead of racing it via a separate check-then-write sequence.
+    let pid_guard = PidGuard::acquire(&config.daemon.pid_file)
+        .map_err(|e| anyhow::anyhow!("failed to acquire daemon pid file lock: {e}"))?;
     tracing::info!(pid_file = %config.daemon.pid_file, "daemon started");
 
     let (provider, status_tx, _status_rx) = app.build_provider().await?;
@@ -977,7 +959,6 @@ pub(crate) async fn run_daemon(
         );
     }
 
-    let pid_file = config.daemon.pid_file.clone();
     let mut supervisor = DaemonSupervisor::new(&config.daemon, shutdown_rx.clone());
 
     let shutdown_tx_signal = shutdown_tx.clone();
@@ -1041,9 +1022,8 @@ pub(crate) async fn run_daemon(
     shutdown_mcp_manager.shutdown_all_shared().await;
     agent.shutdown().await;
 
-    if let Err(e) = remove_pid_file(&pid_file) {
-        tracing::warn!("failed to remove PID file: {e}");
-    }
+    // Dropping the guard releases the flock and unlinks the pid file.
+    drop(pid_guard);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- `run_daemon`'s pid file guard (`src/daemon.rs`) used a check-then-act sequence — read the pid file, check liveness, remove if stale, then write — that let two daemons started concurrently both pass the liveness check before either wrote, and treated any `write_pid_file` failure as a non-fatal warning that let startup continue with no single-instance protection at all.
- Replaced with `daemon::PidGuard` (`crates/zeph-core/src/daemon.rs`), an exclusive `flock(2)`-backed guard mirroring `zeph-scheduler::pidfile::PidFile::acquire`: mutual exclusion now comes entirely from kernel lock atomicity instead of a separate read-check-remove-write sequence, closing the TOCTOU window rather than only narrowing it. A second concurrent instance now fails fast with `DaemonError::AlreadyRunning{pid}` and a non-zero exit code instead of racing to start a duplicate set of background supervisors against the same session state.
- Non-Unix builds keep the previous check-then-write sequence but now propagate `write_pid_file` failure as fatal rather than logging and continuing.

Closes #5679. Follow-up #5696 filed for the flock-logic duplication between the new `PidGuard` and the pre-existing `zeph-scheduler::pidfile::PidFile` (sharing the type needs a new `zeph-scheduler` -> `zeph-common` dependency edge, out of scope for this correctness fix).

## Test plan

- [x] 2 new unit tests: `pid_guard_acquire_writes_pid_and_removes_on_drop`, `pid_guard_second_acquire_fails_with_already_running` (direct regression test for the concurrent-acquire race)
- [x] `cargo nextest run -p zeph-core` — daemon test filter 14/14 PASS, full crate 1654 PASS / 0 failed
- [x] `cargo test --doc -p zeph-core` — 38 PASS including new `PidGuard` doctest
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-core` clean
- [x] Adversarial critique (rust-critic): core TOCTOU fix verified sound, Drop/SIGKILL semantics verified correct, no blocking correctness gaps
- [x] Independent code review: approved
- [ ] Live two-process e2e verification (playbook `.local/testing/playbooks/daemon-pidfile-guard.md`, Scenarios A-D) — intentionally deferred to a future CI cycle to avoid colliding with concurrent sessions sharing the default `~/.zeph/zeph.pid`/SQLite/Qdrant on this dev machine; the automated regression test already exercises the exact concurrent-acquire race directly