### PR TITLE
fix(llm): provider robustness — Cocoon retry, supports_tool_use default, embed_batch timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   code instead of silently starting a duplicate set of background supervisors against the
   same session state. Non-Unix builds keep the previous check-then-write sequence but now
   propagate `write_pid_file` failure as fatal rather than logging and continuing. (#5679)
+- `fix(llm)`: `CocoonClient::post`/`post_multipart` (`crates/zeph-llm/src/cocoon/client.rs`) issued
+  a single `reqwest` request with no retry of any kind, unlike Claude/OpenAI/Gemini/Compatible
+  (`retry.rs::send_with_retry`) and Gonka (endpoint-pool retry), so a transient 429/503 from the
+  sidecar failed the request immediately. Both now route through `send_with_retry`
+  (`MAX_RETRIES=3`). `post_multipart`'s signature changed from an owned `reqwest::multipart::Form`
+  (not `Clone`) to a `build_form` closure rebuilt once per retry attempt; the sole caller
+  (`CocoonSttProvider::transcribe` in `stt.rs`) was updated accordingly. (#5693)
+- `fix(llm)`: `LlmProvider::supports_tool_use()`'s trait default (`crates/zeph-llm/src/provider.rs`)
+  returned `true` while `chat_with_tools()`'s default silently falls back to plain `chat()` and
+  drops tool definitions — a contradiction that let `CandleProvider` (the one provider relying on
+  both inherited defaults) report tool support it didn't have. The default now returns `false`,
+  matching `chat_with_tools()`'s actual behavior; explicit `true` overrides were added to
+  `ClaudeProvider`, `OpenAiProvider`, `CompatibleProvider`, `OllamaProvider`, `GeminiProvider`, and
+  `MockProvider`, which previously relied on the old default without declaring it. (#5687)
+- `fix(llm)`: `RouterProvider::embed_batch()` (`crates/zeph-llm/src/router/provider_impl.rs`) called
+  the provider directly with no timeout, unlike `embed()`, which already wraps its call in a
+  `tokio::time::timeout` gated on `embed_timeout_ms` — violating the project's await-discipline
+  rule that every external `.await` must have a bound. `embed_batch()` now applies the same
+  timeout wrapping as `embed()`. (#5686)
 - `fix(channels)`: `JsonCliChannel::try_recv` (`crates/zeph-channels/src/json_cli.rs`) did not
   recognize `exit`/`quit`/`/exit`/`/quit` the way `recv` already did, so an exit command
   arriving via the queued/merge path (`Agent::drain_channel`'s 500ms merge window in

--- a/book/src/advanced/tools.md
+++ b/book/src/advanced/tools.md
@@ -209,7 +209,7 @@ max_body_bytes = 1048576  # Maximum response body size in bytes (default: 1 MiB)
 
 ## Native Tool Use
 
-All providers use the native API-level tool mechanism for structured tool calling. `LlmProvider::supports_tool_use()` returns `true` by default. Tool definitions, execution, and result handling follow a single unified path.
+All providers use the native API-level tool mechanism for structured tool calling. `LlmProvider::supports_tool_use()` returns `false` by default and is overridden to `true` only by providers that implement `chat_with_tools` — the default keeps `chat_with_tools` and `supports_tool_use` fail-closed and in sync, so a provider without an override never silently drops tool definitions. Tool definitions, execution, and result handling follow a single unified path.
 
 In native mode:
 

--- a/book/src/architecture/crates.md
+++ b/book/src/architecture/crates.md
@@ -80,7 +80,7 @@ Slash command handlers and the CommandHandler registry (separated from `zeph-cor
 
 LLM provider abstraction and backend implementations.
 
-- `LlmProvider` trait — `chat()`, `chat_typed()`, `chat_stream()`, `embed()`, `supports_streaming()`, `supports_embeddings()`, `supports_vision()`, `supports_tool_use()` (default: `true`)
+- `LlmProvider` trait — `chat()`, `chat_typed()`, `chat_stream()`, `embed()`, `supports_streaming()`, `supports_embeddings()`, `supports_vision()`, `supports_tool_use()` (default: `false`)
 - `MessagePart::Image` — image content part (raw bytes + MIME type) for multimodal input
 - `EmbedFuture` / `EmbedFn` — canonical type aliases for embedding closures, re-exported by downstream crates (`zeph-skills`, `zeph-mcp`)
 - `OllamaProvider` — local inference via ollama-rs

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -1195,6 +1195,10 @@ impl LlmProvider for ClaudeProvider {
         true
     }
 
+    fn supports_tool_use(&self) -> bool {
+        true
+    }
+
     fn last_cache_usage(&self) -> Option<(u64, u64)> {
         self.usage.last_cache_usage()
     }

--- a/crates/zeph-llm/src/cocoon/client.rs
+++ b/crates/zeph-llm/src/cocoon/client.rs
@@ -15,6 +15,12 @@ use serde::Deserialize;
 use tracing::Instrument as _;
 
 use crate::error::LlmError;
+use crate::provider::StatusTx;
+use crate::retry::send_with_retry;
+
+/// Bounded retry count for transient 429/503 responses from the sidecar,
+/// matching the Claude/OpenAI/Gemini `send_with_retry` convention.
+const MAX_RETRIES: u32 = 3;
 
 /// Health status parsed from the sidecar `/stats` endpoint.
 #[derive(Debug, Clone, Deserialize)]
@@ -159,37 +165,55 @@ impl CocoonClient {
         .await
     }
 
-    /// POST a multipart form to `{base_url}{path}`.
+    /// POST a multipart form to `{base_url}{path}`, retrying transient 429/503 responses.
     ///
     /// Used for audio transcription (`/v1/audio/transcriptions`). Attaches
     /// `X-Access-Hash` header when `access_hash` is `Some`. The request is
     /// bounded by the same LLM timeout configured at construction.
     ///
+    /// [`reqwest::multipart::Form`] cannot be cloned or reused across retries, so
+    /// `build_form` is invoked once per attempt (up to `MAX_RETRIES` retries) to
+    /// construct a fresh form.
+    ///
     /// # Errors
     ///
-    /// Returns [`LlmError::Unavailable`] on connection failure or timeout.
-    pub async fn post_multipart(
+    /// Returns [`LlmError::Http`] on connection failure, or [`LlmError::RateLimited`]
+    /// once retries against repeated 429/503 responses are exhausted.
+    pub async fn post_multipart<F>(
         &self,
         path: &str,
-        form: reqwest::multipart::Form,
-    ) -> Result<reqwest::Response, LlmError> {
+        status_tx: Option<&StatusTx>,
+        mut build_form: F,
+    ) -> Result<reqwest::Response, LlmError>
+    where
+        F: FnMut() -> Result<reqwest::multipart::Form, reqwest::Error>,
+    {
         let span = tracing::info_span!("llm.cocoon.request", path);
         async {
             let url = format!("{}{path}", self.base_url);
-            let mut req = self.client.post(&url).multipart(form);
-            if let Some(ref hash) = self.access_hash {
-                req = req.header("X-Access-Hash", hash.as_str());
-            }
-            req.send().await.map_err(|e| {
+            send_with_retry("cocoon", MAX_RETRIES, status_tx, || {
+                // Build synchronously so the `FnMut` borrow of `build_form` doesn't
+                // need to escape into the returned future.
+                let form_result = build_form();
+                async {
+                    let form = form_result?;
+                    let mut req = self.client.post(&url).multipart(form);
+                    if let Some(ref hash) = self.access_hash {
+                        req = req.header("X-Access-Hash", hash.as_str());
+                    }
+                    req.send().await
+                }
+            })
+            .await
+            .inspect_err(|e| {
                 tracing::warn!(error = %e, "cocoon multipart HTTP error");
-                LlmError::Unavailable
             })
         }
         .instrument(span)
         .await
     }
 
-    /// POST `body` to `{base_url}{path}`.
+    /// POST `body` to `{base_url}{path}`, retrying transient 429/503 responses.
     ///
     /// Attaches `X-Access-Hash` header when `access_hash` is `Some`.
     /// The full request lifecycle (connect + send + body read) is bounded by the
@@ -197,27 +221,36 @@ impl CocoonClient {
     ///
     /// # Errors
     ///
-    /// Returns [`LlmError::Unavailable`] on connection failure or timeout.
-    pub async fn post(&self, path: &str, body: &[u8]) -> Result<reqwest::Response, LlmError> {
+    /// Returns [`LlmError::Http`] on connection failure, or [`LlmError::RateLimited`]
+    /// once retries against repeated 429/503 responses are exhausted.
+    pub async fn post(
+        &self,
+        path: &str,
+        body: &[u8],
+        status_tx: Option<&StatusTx>,
+    ) -> Result<reqwest::Response, LlmError> {
         let span = tracing::info_span!("llm.cocoon.request", path);
         async {
             let url = format!("{}{path}", self.base_url);
 
-            let mut req = self
-                .client
-                .post(&url)
-                .header("Content-Type", "application/json")
-                .body(body.to_vec());
+            send_with_retry("cocoon", MAX_RETRIES, status_tx, || {
+                let mut req = self
+                    .client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .body(body.to_vec());
 
-            if let Some(ref hash) = self.access_hash {
-                req = req.header("X-Access-Hash", hash.as_str());
-            }
+                if let Some(ref hash) = self.access_hash {
+                    req = req.header("X-Access-Hash", hash.as_str());
+                }
 
-            req.send().await.map_err(|e| {
+                req.send()
+            })
+            .await
+            .inspect_err(|e| {
                 // MINOR-1: log SSE/mid-stream drops as cocoon-specific so they are
                 // distinguishable from OpenAI failures in traces.
                 tracing::warn!(error = %e, "cocoon HTTP error (may be mid-stream drop)");
-                LlmError::Unavailable
             })
         }
         .instrument(span)

--- a/crates/zeph-llm/src/cocoon/provider.rs
+++ b/crates/zeph-llm/src/cocoon/provider.rs
@@ -277,7 +277,7 @@ impl LlmProvider for CocoonProvider {
 
             let response = self
                 .client
-                .post("/v1/chat/completions", &body_bytes)
+                .post("/v1/chat/completions", &body_bytes, self.status_tx.as_ref())
                 .await?;
             let status = response.status();
             let text = response.text().await.map_err(LlmError::Http)?;
@@ -317,7 +317,7 @@ impl LlmProvider for CocoonProvider {
 
             let response = self
                 .client
-                .post("/v1/chat/completions", &body_bytes)
+                .post("/v1/chat/completions", &body_bytes, self.status_tx.as_ref())
                 .await?;
             let status = response.status();
             if !status.is_success() {
@@ -350,7 +350,10 @@ impl LlmProvider for CocoonProvider {
             let body_bytes = serde_json::to_vec(&body)
                 .map_err(|e| LlmError::Other(format!("embed body serialization: {e}")))?;
 
-            let response = self.client.post("/v1/embeddings", &body_bytes).await?;
+            let response = self
+                .client
+                .post("/v1/embeddings", &body_bytes, self.status_tx.as_ref())
+                .await?;
             let status = response.status();
             let body_text = response.text().await.map_err(LlmError::Http)?;
 
@@ -407,7 +410,10 @@ impl LlmProvider for CocoonProvider {
             let body_bytes = serde_json::to_vec(&body)
                 .map_err(|e| LlmError::Other(format!("embed_batch body serialization: {e}")))?;
 
-            let response = self.client.post("/v1/embeddings", &body_bytes).await?;
+            let response = self
+                .client
+                .post("/v1/embeddings", &body_bytes, self.status_tx.as_ref())
+                .await?;
             let status = response.status();
             let body_text = response.text().await.map_err(LlmError::Http)?;
 
@@ -453,7 +459,10 @@ impl LlmProvider for CocoonProvider {
             let body = serde_json::to_vec(&self.inner.debug_request_json(messages, tools, false))
                 .map_err(|e| LlmError::Other(format!("body serialization: {e}")))?;
 
-            let response = self.client.post("/v1/chat/completions", &body).await?;
+            let response = self
+                .client
+                .post("/v1/chat/completions", &body, self.status_tx.as_ref())
+                .await?;
             let status = response.status();
             let text = response.text().await.map_err(LlmError::Http)?;
 
@@ -503,7 +512,7 @@ impl LlmProvider for CocoonProvider {
 
             let response = self
                 .client
-                .post("/v1/chat/completions", &body_bytes)
+                .post("/v1/chat/completions", &body_bytes, self.status_tx.as_ref())
                 .await?;
             let status = response.status();
             let text = response.text().await.map_err(LlmError::Http)?;

--- a/crates/zeph-llm/src/cocoon/stt.rs
+++ b/crates/zeph-llm/src/cocoon/stt.rs
@@ -103,24 +103,28 @@ impl SpeechToText for CocoonSttProvider {
         let span = tracing::info_span!("llm.cocoon.stt.transcribe", model = %self.model);
         let audio = audio.to_vec();
         let fname = filename.unwrap_or("audio.wav").to_string();
+        let model = self.model.clone();
+        let language = self.language.clone();
         Box::pin(
             async move {
-                let part = reqwest::multipart::Part::bytes(audio)
-                    .file_name(fname)
-                    .mime_str("application/octet-stream")
-                    .map_err(|e| LlmError::TranscriptionFailed(e.to_string()))?;
-
-                let mut form = reqwest::multipart::Form::new()
-                    .text("model", self.model.clone())
-                    .text("response_format", "json")
-                    .part("file", part);
-                if let Some(ref lang) = self.language {
-                    form = form.text("language", lang.clone());
-                }
-
+                // `build_form` runs once per retry attempt since `reqwest::multipart::Form`
+                // cannot be cloned or reused.
                 let resp = self
                     .client
-                    .post_multipart("/v1/audio/transcriptions", form)
+                    .post_multipart("/v1/audio/transcriptions", None, move || {
+                        let part = reqwest::multipart::Part::bytes(audio.clone())
+                            .file_name(fname.clone())
+                            .mime_str("application/octet-stream")?;
+
+                        let mut form = reqwest::multipart::Form::new()
+                            .text("model", model.clone())
+                            .text("response_format", "json")
+                            .part("file", part);
+                        if let Some(ref lang) = language {
+                            form = form.text("language", lang.clone());
+                        }
+                        Ok(form)
+                    })
                     .await?;
 
                 if !resp.status().is_success() {

--- a/crates/zeph-llm/src/cocoon/tests.rs
+++ b/crates/zeph-llm/src/cocoon/tests.rs
@@ -114,7 +114,7 @@ async fn cocoon_post_with_access_hash() {
 
     let client = make_client(&server.uri(), Some("test-hash-value".into()));
     let result = client
-        .post("/v1/chat/completions", b"{\"messages\":[]}")
+        .post("/v1/chat/completions", b"{\"messages\":[]}", None)
         .await;
     assert!(result.is_ok());
 }
@@ -136,13 +136,113 @@ async fn cocoon_post_without_access_hash() {
 
     let client = make_client(&server.uri(), None);
     let result = client
-        .post("/v1/chat/completions", b"{\"messages\":[]}")
+        .post("/v1/chat/completions", b"{\"messages\":[]}", None)
         .await;
     assert!(result.is_ok());
     let reqs = server.received_requests().await.unwrap();
     assert!(
         reqs[0].headers.get("x-access-hash").is_none(),
         "X-Access-Hash must not be present when access_hash is None"
+    );
+}
+
+/// Regression test for #5693: a transient 503 from the sidecar is retried and the
+/// request succeeds on the next attempt, instead of failing the whole call immediately.
+/// Modeled on `gonka_retry_on_endpoint_failure` in `gonka/tests.rs`.
+#[tokio::test]
+async fn cocoon_retry_on_transient_503_then_succeeds() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(503).insert_header("retry-after", "0"))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(CHAT_RESPONSE),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let result = provider.chat(&user_message("retry test")).await;
+    assert!(
+        result.is_ok(),
+        "expected success after retry, got: {result:?}"
+    );
+    assert_eq!(result.unwrap(), "hello");
+}
+
+/// Regression test for #5693: once retries against a persistently unavailable sidecar
+/// are exhausted, the call surfaces `LlmError::RateLimited` instead of hanging or
+/// failing on the very first 503.
+#[tokio::test]
+async fn cocoon_retry_exhausted_returns_rate_limited() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(503).insert_header("retry-after", "0"))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let result = provider.chat(&user_message("fail test")).await;
+    assert!(
+        matches!(result, Err(crate::error::LlmError::RateLimited)),
+        "expected RateLimited after exhausting retries, got: {result:?}"
+    );
+}
+
+/// Regression test for #5693: `post_multipart` also retries a transient 503, rebuilding
+/// the (non-cloneable) `Form` once per attempt via the `build_form` closure.
+#[tokio::test]
+async fn cocoon_post_multipart_retries_and_rebuilds_form() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(ResponseTemplate::new(503).insert_header("retry-after", "0"))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(r#"{"text":"hello"}"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server.uri(), None);
+    let build_calls = std::sync::atomic::AtomicU32::new(0);
+    let result = client
+        .post_multipart("/v1/audio/transcriptions", None, || {
+            build_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(reqwest::multipart::Form::new().text("model", "whisper-1"))
+        })
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "expected success after retry, got: {result:?}"
+    );
+    assert_eq!(
+        build_calls.load(std::sync::atomic::Ordering::SeqCst),
+        2,
+        "build_form must be invoked once per attempt"
     );
 }
 

--- a/crates/zeph-llm/src/cocoon/tests.rs
+++ b/crates/zeph-llm/src/cocoon/tests.rs
@@ -182,10 +182,11 @@ async fn cocoon_retry_on_transient_503_then_succeeds() {
 }
 
 /// Regression test for #5693: once retries against a persistently unavailable sidecar
-/// are exhausted, the call surfaces `LlmError::RateLimited` instead of hanging or
-/// failing on the very first 503.
+/// are exhausted, the call surfaces `LlmError::Unavailable` (per #5695's classification —
+/// the last-seen status before exhaustion was 503) instead of hanging or failing on the
+/// very first 503.
 #[tokio::test]
-async fn cocoon_retry_exhausted_returns_rate_limited() {
+async fn cocoon_retry_exhausted_returns_unavailable() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/v1/chat/completions"))
@@ -196,8 +197,8 @@ async fn cocoon_retry_exhausted_returns_rate_limited() {
     let provider = make_provider(&server.uri());
     let result = provider.chat(&user_message("fail test")).await;
     assert!(
-        matches!(result, Err(crate::error::LlmError::RateLimited)),
-        "expected RateLimited after exhausting retries, got: {result:?}"
+        matches!(result, Err(crate::error::LlmError::Unavailable)),
+        "expected Unavailable after exhausting retries, got: {result:?}"
     );
 }
 

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -313,6 +313,10 @@ impl LlmProvider for CompatibleProvider {
         self.inner.supports_vision()
     }
 
+    fn supports_tool_use(&self) -> bool {
+        self.inner.supports_tool_use()
+    }
+
     fn debug_request_json(
         &self,
         messages: &[Message],
@@ -476,6 +480,12 @@ mod tests {
     fn supports_vision_delegates_to_inner() {
         // OpenAiProvider always returns true for supports_vision.
         assert!(test_provider().supports_vision());
+    }
+
+    #[test]
+    fn supports_tool_use_delegates_to_inner() {
+        // OpenAiProvider always returns true for supports_tool_use.
+        assert!(test_provider().supports_tool_use());
     }
 
     #[test]

--- a/crates/zeph-llm/src/gemini/mod.rs
+++ b/crates/zeph-llm/src/gemini/mod.rs
@@ -1301,6 +1301,10 @@ impl LlmProvider for GeminiProvider {
         true
     }
 
+    fn supports_tool_use(&self) -> bool {
+        true
+    }
+
     fn list_models(&self) -> Vec<String> {
         let mut models = vec![
             "gemini-2.5-pro".to_owned(),

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -453,6 +453,10 @@ impl LlmProvider for MockProvider {
         self.supports_embeddings
     }
 
+    fn supports_tool_use(&self) -> bool {
+        true
+    }
+
     async fn chat_with_tools(
         &self,
         messages: &[Message],

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -267,6 +267,10 @@ impl LlmProvider for OllamaProvider {
         true
     }
 
+    fn supports_tool_use(&self) -> bool {
+        true
+    }
+
     #[tracing::instrument(
         name = "llm.chat",
         skip_all,

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -985,6 +985,10 @@ impl LlmProvider for OpenAiProvider {
         true
     }
 
+    fn supports_tool_use(&self) -> bool {
+        true
+    }
+
     #[tracing::instrument(
         name = "llm.chat_with_tools",
         skip_all,

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -720,7 +720,9 @@ impl Message {
 ///   (requires `Self: Sized`; use [`chat_typed_dyn`](crate::provider_dyn::chat_typed_dyn)
 ///   for trait objects)
 /// - [`supports_vision`](Self::supports_vision) — returns `false`
-/// - [`supports_tool_use`](Self::supports_tool_use) — returns `true`
+/// - [`supports_tool_use`](Self::supports_tool_use) — returns `false`, matching the
+///   [`chat_with_tools`](Self::chat_with_tools) default fallback which silently drops
+///   tool definitions; providers must override both together to opt into tool use
 ///
 /// # Examples
 ///
@@ -829,8 +831,13 @@ pub trait LlmProvider: Send + Sync {
     }
 
     /// Whether this provider supports native `tool_use` / function calling.
+    ///
+    /// Defaults to `false` because [`chat_with_tools`](Self::chat_with_tools) defaults
+    /// to falling back on [`chat`](Self::chat), which silently discards tool
+    /// definitions. Providers implementing real tool calling must override both
+    /// this method and `chat_with_tools` together.
     fn supports_tool_use(&self) -> bool {
-        true
+        false
     }
 
     /// Send messages with tool definitions, returning a structured response.
@@ -1036,6 +1043,19 @@ mod tests {
             response: String::new(),
         };
         assert!(!provider.supports_streaming());
+    }
+
+    #[test]
+    fn supports_tool_use_default_returns_false() {
+        // StubProvider overrides neither `supports_tool_use` nor `chat_with_tools`,
+        // mirroring CandleProvider (crates/zeph-llm/src/candle_provider/mod.rs). The
+        // default must report `false` so callers gating on this method skip providers
+        // that would otherwise silently drop tool definitions via the `chat_with_tools`
+        // fallback (issue #5687).
+        let provider = StubProvider {
+            response: String::new(),
+        };
+        assert!(!provider.supports_tool_use());
     }
 
     #[tokio::test]

--- a/crates/zeph-llm/src/router/provider_impl.rs
+++ b/crates/zeph-llm/src/router/provider_impl.rs
@@ -409,6 +409,7 @@ impl LlmProvider for RouterProvider {
         }
     }
 
+    #[allow(clippy::too_many_lines)] // retry + timeout + fallback + availability tracking: splitting would break the shared `last_err` accumulator
     fn embed_batch(
         &self,
         texts: &[&str],
@@ -418,6 +419,7 @@ impl LlmProvider for RouterProvider {
         let owned = owned_strs(texts);
         let router = self.clone();
         let semaphore = self.state.embed_semaphore.clone();
+        let embed_timeout_ms = self.embed_timeout_ms;
         let model = self.model_identifier().to_owned();
         let fut = Box::pin(async move {
             // Acquire embed semaphore permit before any HTTP work to cap concurrency.
@@ -444,7 +446,25 @@ impl LlmProvider for RouterProvider {
                         tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
                     }
                     let start = std::time::Instant::now();
-                    match p.embed_batch(&refs).await {
+                    // Apply per-call timeout when configured (embed_timeout_ms > 0).
+                    let embed_result: Result<Vec<Vec<f32>>, LlmError> = if embed_timeout_ms > 0 {
+                        let timeout = std::time::Duration::from_millis(embed_timeout_ms);
+                        match tokio::time::timeout(timeout, p.embed_batch(&refs)).await {
+                            Ok(inner) => inner,
+                            Err(_elapsed) => {
+                                tracing::warn!(
+                                    provider = p.name(),
+                                    timeout_ms = embed_timeout_ms,
+                                    "embed_batch: provider timed out, falling back"
+                                );
+                                last_err = Some(LlmError::Timeout);
+                                break;
+                            }
+                        }
+                    } else {
+                        p.embed_batch(&refs).await
+                    };
+                    match embed_result {
                         Ok(r) => {
                             router.record_availability(
                                 p.name(),

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -1120,6 +1120,47 @@ async fn embed_timeout_falls_back_to_next_provider() {
     assert_eq!(result, vec![1.0, 2.0, 3.0]);
 }
 
+/// When the only provider's `embed_batch()` exceeds `embed_timeout_ms`, the router
+/// exhausts the fallback list and returns `LlmError::NoProviders`.
+#[tokio::test]
+async fn embed_batch_timeout_single_provider_returns_no_providers() {
+    use crate::mock::MockProvider;
+
+    let p = AnyProvider::Mock(
+        MockProvider::default()
+            .with_embed_delay(200)
+            .with_name("slow"),
+    );
+    let r = RouterProvider::new(vec![p]).with_embed_timeout(10);
+    let err = r.embed_batch(&["hello"]).await.unwrap_err();
+    assert!(
+        matches!(err, LlmError::NoProviders),
+        "expected NoProviders after timeout, got {err:?}"
+    );
+}
+
+/// After a timeout on the first provider, the router falls back to the next
+/// embed-capable provider and returns its successful `embed_batch` result.
+#[tokio::test]
+async fn embed_batch_timeout_falls_back_to_next_provider() {
+    use crate::mock::MockProvider;
+
+    let p1 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_embed_delay(200)
+            .with_name("slow"),
+    );
+    let p2 = AnyProvider::Mock({
+        let mut m = MockProvider::default().with_name("fast");
+        m.supports_embeddings = true;
+        m.embedding = vec![1.0, 2.0, 3.0];
+        m
+    });
+    let r = RouterProvider::new(vec![p1, p2]).with_embed_timeout(10);
+    let result = r.embed_batch(&["hello"]).await.unwrap();
+    assert_eq!(result, vec![vec![1.0, 2.0, 3.0]]);
+}
+
 // ── quality_gate tests ────────────────────────────────────────────────────
 
 /// `with_quality_gate()` happy path: when cosine similarity >= threshold the

--- a/specs/003-llm-providers/spec.md
+++ b/specs/003-llm-providers/spec.md
@@ -65,7 +65,7 @@ trait LlmProvider: Send + Sync {
     fn embed(&self, text: &str) -> impl Future<Output = Result<Vec<f32>, LlmError>> + Send;
     fn supports_streaming(&self) -> bool;
     fn supports_embeddings(&self) -> bool;
-    fn supports_tool_use(&self) -> bool;  // default: true
+    fn supports_tool_use(&self) -> bool;  // default: false
     fn supports_vision(&self) -> bool;
     fn supports_structured_output(&self) -> bool;
     fn debug_request_json(&self, ...) -> serde_json::Value;


### PR DESCRIPTION
## Summary

Three independent P2 robustness fixes in `crates/zeph-llm`, all part of the "asymmetric sibling implementation" defect class (a resilience mechanism applied to some provider implementations but not all):

- Closes #5693 — `CocoonClient::post`/`post_multipart` had no retry logic, unlike every other provider (Claude/OpenAI/Gemini/Compatible use `send_with_retry`; Gonka has endpoint-pool retry). Now routes through `send_with_retry` (3 attempts). `post_multipart` takes a `build_form` closure instead of an owned `Form` (not `Clone`), rebuilt once per retry attempt.
- Closes #5687 — `LlmProvider::supports_tool_use()`'s trait default (`true`) contradicted `chat_with_tools()`'s default fallback behavior (plain chat, tools silently dropped), letting `CandleProvider` claim tool support it doesn't have. Default flipped to `false`; explicit `true` overrides added to Claude/OpenAI/Compatible/Ollama/Gemini/Mock, which previously relied on the old default without declaring it.
- Closes #5686 — `RouterProvider::embed_batch()` had no per-call timeout, unlike `embed()`, violating the project's await-discipline rule (every external `.await` must have a bound).

## Follow-ups filed (not blocking, out of scope for this PR)

- #5698 — `CandleProvider` should get an explicit `supports_tool_use() -> false` override instead of relying on the inherited default indefinitely.
- #5699 — `embed()`/`embed_batch()` timeout path skips `record_availability(false)`, so a chronically-timing-out provider is never demoted (pre-existing, confirmed identical in both functions).
- #5700 — Cocoon's new internal retry combined with the router's own retry loop can stack up to ~30s before fallback on a sustained 503 (bounded, low-probability sidecar-warmup scenario).
- #5701 — `CocoonSttProvider::transcribe` passes no `status_tx`, so transcription retries emit no TUI status (minor UX gap).

## Test plan

- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12077 passed, 34 skipped
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`) clean
- [x] `zeph-llm`-scoped suite with all provider features (`candle,gonka,cocoon,testing`) — 1059/1059 passed
- [x] New regression tests per issue: `cocoon_retry_on_transient_503_then_succeeds`, `cocoon_retry_exhausted_returns_rate_limited`, `cocoon_post_multipart_retries_and_rebuilds_form`; `provider::tests::supports_tool_use_default_returns_false`, `compatible::tests::supports_tool_use_delegates_to_inner`; `embed_batch_timeout_single_provider_returns_no_providers`, `embed_batch_timeout_falls_back_to_next_provider`
- [x] Spec docs (`specs/003-llm-providers/spec.md`, `book/src/advanced/tools.md`, `book/src/architecture/crates.md`) updated to match the new `supports_tool_use` default
- [x] CHANGELOG.md updated