### PR TITLE
fix(core): timeout, provider-match, and tool_call_id fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -632,6 +632,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `$query` would silently freeze at its first-seen value) — all ~620 `sql!(` invocations
   pass a string literal. Delivers the per-call-site caching acceptance criterion
   originally stated but never implemented for #2387. Closes #5431.
+- `fix(core)`: `evaluate_with_llm_classifier` (`crates/zeph-core/src/agent/corrections.rs`)
+  awaited `LlmClassifier::classify_feedback` with no timeout, unlike the sibling
+  `evaluate_with_judge` path which already bounds its LLM call. A hung or slow classification
+  provider could stall implicit-correction feedback detection indefinitely. Now wrapped in the
+  same bounded `tokio::time::timeout` used by `evaluate_with_judge`. (#5689)
+- `fix(core)`: `Agent::resolve_consolidation_provider` (`crates/zeph-core/src/agent/autodream.rs`)
+  duplicated `Agent::resolve_background_provider` (`crates/zeph-core/src/agent/learning/arise.rs`)
+  with a weaker, diverged match rule — case-sensitive `name` field comparison with no
+  `effective_name()` type-fallback and no warning logged on a failed lookup — silently
+  falling back to the primary provider for `consolidation_provider` names that only differed
+  in case or relied on the type-derived default name. Removed the duplicate method; autoDream
+  consolidation now resolves its provider via the same `resolve_background_provider` used
+  elsewhere. (#5681)
+- `fix(core)`: `--json` mode's `tool_call`/`tool_result` events emitted the tool's name
+  (e.g. `"shell"`) as the `id` field instead of the actual `tool_call_id`, making it impossible
+  for a JSON consumer to correlate a `tool_result` event with its originating `tool_call` when
+  multiple calls to the same tool occurred in one turn. Both events now emit the real
+  `tool_call_id`. (#5680)
 
 ### Changed
 

--- a/crates/zeph-core/src/agent/autodream.rs
+++ b/crates/zeph-core/src/agent/autodream.rs
@@ -110,7 +110,7 @@ impl<C: Channel> super::Agent<C> {
             .as_ref()
             .map(|tx| tx.send("Consolidating memories…".into()));
 
-        let provider = self.resolve_consolidation_provider(cfg.consolidation_provider.as_str());
+        let provider = self.resolve_background_provider(cfg.consolidation_provider.as_str());
 
         let store = memory.sqlite().clone();
         let consolidation_cfg = zeph_memory::ConsolidationConfig {
@@ -168,37 +168,6 @@ impl<C: Channel> super::Agent<C> {
             && let Err(e) = compressor.flush_hit_counts().await
         {
             tracing::warn!(error = %e, "autoDream: TACO flush_hit_counts failed");
-        }
-    }
-
-    /// Resolve the consolidation provider by name, falling back to the primary provider.
-    fn resolve_consolidation_provider(&self, name: &str) -> zeph_llm::any::AnyProvider {
-        if name.is_empty() {
-            return self.provider.clone();
-        }
-        if let (Some(entry), Some(snapshot)) = (
-            self.runtime
-                .providers
-                .provider_pool
-                .iter()
-                .find(|e| e.name.as_deref() == Some(name)),
-            self.runtime.providers.provider_config_snapshot.as_ref(),
-        ) {
-            crate::provider_factory::build_provider_for_switch(
-                entry,
-                snapshot,
-                self.services.security.secret_registry.as_ref(),
-            )
-            .unwrap_or_else(|e| {
-                tracing::warn!(
-                    provider = name,
-                    error = %e,
-                    "autoDream: failed to build consolidation_provider, falling back"
-                );
-                self.provider.clone()
-            })
-        } else {
-            self.provider.clone()
         }
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -3225,6 +3225,91 @@ mod tests {
         );
     }
 
+    /// Verify `resolve_background_provider` matches pool entries case-insensitively (#5681):
+    /// the call site previously used a case-sensitive helper, so a config-vs-lookup case
+    /// mismatch silently fell back to the primary provider instead of the registered one.
+    #[test]
+    fn resolve_background_provider_matches_case_insensitively() {
+        use zeph_llm::provider::LlmProvider;
+
+        let snapshot = crate::agent::state::ProviderConfigSnapshot {
+            claude_api_key: None,
+            openai_api_key: None,
+            gemini_api_key: None,
+            compatible_api_keys: std::collections::HashMap::new(),
+            llm_request_timeout_secs: 30,
+            embedding_model: String::new(),
+            gonka_private_key: None,
+            gonka_address: None,
+            cocoon_access_hash: None,
+        };
+        let named_entry = ProviderEntry {
+            name: Some("Named-Test".into()),
+            model: Some("llama3.2".into()),
+            ..Default::default()
+        };
+        let agent = make_agent().with_provider_pool(vec![named_entry], snapshot);
+
+        // Looked up with different casing than the registered entry's name.
+        let resolved = agent.resolve_background_provider("named-test");
+        assert_eq!(
+            resolved.name(),
+            "ollama",
+            "resolve_background_provider must match pool entries case-insensitively"
+        );
+    }
+
+    /// Verify `resolve_background_provider` falls back to `effective_name()` (the provider-type
+    /// string) when a pool entry has no explicit `name` field — matching the convention used
+    /// throughout `[[llm.providers]]` config for single-provider-per-type setups.
+    #[test]
+    fn resolve_background_provider_matches_effective_name_fallback() {
+        use zeph_llm::provider::LlmProvider;
+
+        let snapshot = crate::agent::state::ProviderConfigSnapshot {
+            claude_api_key: None,
+            openai_api_key: None,
+            gemini_api_key: None,
+            compatible_api_keys: std::collections::HashMap::new(),
+            llm_request_timeout_secs: 30,
+            embedding_model: String::new(),
+            gonka_private_key: None,
+            gonka_address: None,
+            cocoon_access_hash: None,
+        };
+        // No explicit `name` — defaults to ProviderKind::Ollama, so effective_name() == "ollama".
+        let unnamed_entry = ProviderEntry {
+            name: None,
+            model: Some("llama3.2".into()),
+            ..Default::default()
+        };
+        let agent = make_agent().with_provider_pool(vec![unnamed_entry], snapshot);
+
+        let resolved = agent.resolve_background_provider("ollama");
+        assert_eq!(
+            resolved.name(),
+            "ollama",
+            "resolve_background_provider must match via effective_name() type-derived fallback"
+        );
+        assert_eq!(resolved.model_identifier(), "llama3.2");
+    }
+
+    /// Verify `resolve_background_provider` falls back to the primary provider (rather than
+    /// erroring) when `provider_name` does not match any pool entry — the acceptance criterion
+    /// for #5681's warn-on-miss behavior.
+    #[test]
+    fn resolve_background_provider_falls_back_on_unresolvable_name() {
+        use zeph_llm::provider::LlmProvider;
+
+        let agent = make_agent();
+        let resolved = agent.resolve_background_provider("totally-unregistered");
+        assert_eq!(
+            resolved.name(),
+            "mock",
+            "unresolvable provider name must fall back to the primary Mock provider"
+        );
+    }
+
     #[test]
     fn with_skill_matching_config_sets_fields() {
         let agent = make_agent().with_skill_matching_config(0.7, true, 0.85);

--- a/crates/zeph-core/src/agent/corrections.rs
+++ b/crates/zeph-core/src/agent/corrections.rs
@@ -131,6 +131,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                     user_msg_owned,
                     assistant_snippet,
                     confidence_threshold,
+                    judge_timeout,
                     classifier_metrics_bg,
                     metrics_tx_bg,
                     memory_arc,
@@ -447,17 +448,27 @@ async fn evaluate_with_llm_classifier(
     user_msg: String,
     assistant: String,
     confidence_threshold: f32,
+    timeout: std::time::Duration,
     classifier_metrics_bg: Option<std::sync::Arc<zeph_llm::ClassifierMetrics>>,
     metrics_tx_bg: Option<tokio::sync::watch::Sender<crate::metrics::MetricsSnapshot>>,
     memory_arc: Option<std::sync::Arc<zeph_memory::semantic::SemanticMemory>>,
     conv_id: Option<zeph_memory::ConversationId>,
     skill_name: String,
 ) {
-    match llm_classifier
-        .classify_feedback(&user_msg, &assistant, confidence_threshold)
-        .await
-    {
-        Ok(verdict) => {
+    let result = tokio::time::timeout(
+        timeout,
+        llm_classifier.classify_feedback(&user_msg, &assistant, confidence_threshold),
+    )
+    .await;
+
+    match result {
+        Err(_) => {
+            tracing::warn!(?timeout, "llm-classifier timed out");
+        }
+        Ok(Err(e)) => {
+            tracing::warn!("llm-classifier failed: {e:#}");
+        }
+        Ok(Ok(verdict)) => {
             if let (Some(ref cm), Some(ref tx)) = (classifier_metrics_bg, metrics_tx_bg) {
                 let snap = cm.snapshot();
                 tx.send_modify(|ms| ms.classifier = snap);
@@ -482,9 +493,6 @@ async fn evaluate_with_llm_classifier(
                 )
                 .await;
             }
-        }
-        Err(e) => {
-            tracing::warn!("llm-classifier failed: {e:#}");
         }
     }
 }
@@ -534,5 +542,107 @@ async fn evaluate_with_judge(
         Err(e) => {
             tracing::warn!("judge detector failed: {e:#}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::classifier::llm::LlmClassifier;
+    use zeph_llm::mock::MockProvider;
+    use zeph_memory::semantic::SemanticMemory;
+
+    use super::evaluate_with_llm_classifier;
+
+    /// A verdict that, if not discarded by the timeout, would be recorded as a correction.
+    fn correction_verdict_json() -> String {
+        serde_json::json!({
+            "is_correction": true,
+            "kind": "explicit_rejection",
+            "confidence": 0.9,
+            "reasoning": "user said no"
+        })
+        .to_string()
+    }
+
+    async fn test_memory() -> SemanticMemory {
+        let provider = AnyProvider::Mock(MockProvider::default());
+        SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            None,
+            provider,
+            "test-model",
+        )
+        .await
+        .unwrap()
+    }
+
+    /// Regression for #5689: an `LlmClassifier` backed by a provider that never responds in
+    /// time must not hang `evaluate_with_llm_classifier` indefinitely, and must not record a
+    /// correction for the (never-received) verdict. `MockProvider`'s artificial delay is kept
+    /// short (well above the timeout) so this test completes quickly on real wall-clock time
+    /// without needing tokio's `test-util` feature (not enabled for this crate's dev-dependencies).
+    #[tokio::test]
+    async fn evaluate_with_llm_classifier_timeout_skips_correction() {
+        let memory = Arc::new(test_memory().await);
+        let classifier = LlmClassifier::new(Arc::new(AnyProvider::Mock(
+            MockProvider::with_responses(vec![correction_verdict_json()]).with_delay(300),
+        )));
+
+        evaluate_with_llm_classifier(
+            classifier,
+            "no that's wrong".to_owned(),
+            "previous response".to_owned(),
+            0.6,
+            Duration::from_millis(20),
+            None,
+            None,
+            Some(memory.clone()),
+            None,
+            String::new(),
+        )
+        .await;
+
+        let recent = memory.sqlite().load_recent_corrections(10).await.unwrap();
+        assert!(
+            recent.is_empty(),
+            "timed-out classifier call must not record a correction"
+        );
+    }
+
+    /// Control for the test above: without a timeout in the way, the same correction verdict
+    /// is recorded. Confirms the timeout test actually exercises the `Err(_)` (elapsed) branch
+    /// rather than passing vacuously.
+    #[tokio::test]
+    async fn evaluate_with_llm_classifier_success_records_correction() {
+        let memory = Arc::new(test_memory().await);
+        let classifier = LlmClassifier::new(Arc::new(AnyProvider::Mock(
+            MockProvider::with_responses(vec![correction_verdict_json()]),
+        )));
+
+        evaluate_with_llm_classifier(
+            classifier,
+            "no that's wrong".to_owned(),
+            "previous response".to_owned(),
+            0.6,
+            Duration::from_millis(200),
+            None,
+            None,
+            Some(memory.clone()),
+            None,
+            String::new(),
+        )
+        .await;
+
+        let recent = memory.sqlite().load_recent_corrections(10).await.unwrap();
+        assert_eq!(
+            recent.len(),
+            1,
+            "non-timed-out classifier call with a correction verdict must record one correction"
+        );
     }
 }

--- a/crates/zeph-core/src/json_event_layer.rs
+++ b/crates/zeph-core/src/json_event_layer.rs
@@ -49,7 +49,7 @@ impl RuntimeLayer for JsonEventLayer {
         self.sink.emit(&JsonEvent::ToolCall {
             tool: call.tool_id.as_ref(),
             args: &args_value,
-            id: call.tool_id.as_ref(),
+            id: call.tool_call_id.as_str(),
         });
         Box::pin(std::future::ready(None))
     }
@@ -77,10 +77,82 @@ impl RuntimeLayer for JsonEventLayer {
         };
         self.sink.emit(&JsonEvent::ToolResult {
             tool: call.tool_id.as_ref(),
-            id: call.tool_id.as_ref(),
+            id: call.tool_call_id.as_str(),
             output,
             is_error,
         });
         Box::pin(std::future::ready(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    use crate::runtime_layer::LayerContext;
+
+    use super::*;
+
+    /// `Write` impl backed by a shared buffer so the test can read back what `JsonEventSink`
+    /// wrote after it takes ownership of the writer.
+    #[derive(Clone)]
+    struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().write(buf)
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_call(tool_id: &str, tool_call_id: &str) -> ToolCall {
+        ToolCall {
+            tool_id: zeph_common::ToolName::new(tool_id),
+            tool_call_id: tool_call_id.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn emitted_ids(buf: &[u8], event_name: &str) -> Vec<String> {
+        String::from_utf8_lossy(buf)
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|v| v["event"] == event_name)
+            .map(|v| v["id"].as_str().unwrap_or_default().to_owned())
+            .collect()
+    }
+
+    /// Regression for #5680: `before_tool`/`after_tool` must emit `tool_call_id` (unique per
+    /// invocation) as the JSON event `id`, not `tool_id` (the tool's name, shared across every
+    /// call to the same tool in a turn). Two calls to the same tool with distinct
+    /// `tool_call_id`s must produce distinct `id` values in the emitted events.
+    #[tokio::test]
+    async fn before_and_after_tool_emit_distinct_ids_for_same_tool() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::new(JsonEventSink::with_writer(SharedBuffer(buf.clone())));
+        let layer = JsonEventLayer::new(sink);
+        let ctx = LayerContext {
+            conversation_id: None,
+            turn_number: 0,
+        };
+
+        let call_a = make_call("shell", "call-a");
+        let call_b = make_call("shell", "call-b");
+        let ok_result: Result<Option<ToolOutput>, ToolError> = Ok(None);
+
+        layer.before_tool(&ctx, &call_a).await;
+        layer.before_tool(&ctx, &call_b).await;
+        layer.after_tool(&ctx, &call_a, &ok_result).await;
+        layer.after_tool(&ctx, &call_b, &ok_result).await;
+
+        let snapshot = buf.lock().unwrap().clone();
+        let call_ids = emitted_ids(&snapshot, "tool_call");
+        let result_ids = emitted_ids(&snapshot, "tool_result");
+
+        assert_eq!(call_ids, vec!["call-a", "call-b"]);
+        assert_eq!(result_ids, vec!["call-a", "call-b"]);
     }
 }


### PR DESCRIPTION
## Summary

Three independent P2 bugs in `zeph-core`, grouped into one PR:

- **#5689** — `evaluate_with_llm_classifier` (`crates/zeph-core/src/agent/corrections.rs`) awaited `LlmClassifier::classify_feedback` with no timeout, unlike the sibling `evaluate_with_judge` path which already bounds its LLM call. Now wrapped in the same bounded `tokio::time::timeout` used by `evaluate_with_judge`.
- **#5681** — `Agent::resolve_consolidation_provider` (`crates/zeph-core/src/agent/autodream.rs`) duplicated `Agent::resolve_background_provider` with a weaker, diverged match rule: case-sensitive comparison, no `effective_name()` type-fallback, no warning on a failed lookup. Removed the duplicate; autoDream consolidation now resolves its provider via the same `resolve_background_provider` used elsewhere.
- **#5680** — `JsonEventLayer::before_tool`/`after_tool` emitted the tool's name as the JSON event `id` instead of the actual `tool_call_id`, making it impossible for a `--json` consumer to correlate a `tool_result` with its originating `tool_call` when the same tool is invoked more than once in a turn. Both events now emit the real `tool_call_id`.

Fixes #5689, Fixes #5681, Fixes #5680

## Test plan

- [x] Added `evaluate_with_llm_classifier_timeout_skips_correction` + `evaluate_with_llm_classifier_success_records_correction` (corrections.rs)
- [x] Added `resolve_background_provider_matches_case_insensitively`, `resolve_background_provider_matches_effective_name_fallback`, `resolve_background_provider_falls_back_on_unresolvable_name` (builder.rs)
- [x] Added `before_and_after_tool_emit_distinct_ids_for_same_tool` (json_event_layer.rs)
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12079 passed, 0 failed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`) clean
- [x] CHANGELOG.md updated