### PR TITLE
fix(llm): add SHA-256 integrity verification to Candle model loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `tokio::time::timeout` gated on `embed_timeout_ms` — violating the project's await-discipline
   rule that every external `.await` must have a bound. `embed_batch()` now applies the same
   timeout wrapping as `embed()`. (#5686)
+- `fix(llm)`: Candle-backed model loaders downloaded `HuggingFace` weights with no (or only
+  structural) integrity verification, so a compromised or tampered mirror could silently swap
+  in malicious weights. `CandleClassifier` (`crates/zeph-llm/src/classifier/candle.rs`, the
+  Phase 1 injection detector) gained a `with_sha256` builder mirroring its
+  `CandleThreeClassClassifier`/`CandlePiiClassifier` siblings, closing the gap where
+  `classifiers.injection_model_sha256` was already a config field but had no code path to
+  consume it (#5690). `candle_provider::loader::load_chat_model` (GGUF chat models),
+  `candle_provider::embed::EmbedModel::load` (BERT embedding models), and
+  `candle_whisper::CandleWhisperProvider::load` (Whisper STT) now accept an optional expected
+  SHA-256 digest and verify it — via the shared `classifier::verify_sha256` helper, now
+  `pub(crate)` and gated on the `candle` feature instead of `classifiers` so every loader in
+  the crate can reuse it — right after download and before the file is memory-mapped. New
+  `chat_model_sha256`/`embedding_model_sha256` fields on `CandleInlineConfig` (the
+  `[[llm.providers]]` inline `candle` section — the only Candle config path that actually builds
+  a provider) and `stt_model_sha256` on `ProviderEntry` plumb the digest from config through
+  `provider_factory::build_candle_provider` and `agent_setup::apply_candle_stt`; all three are
+  optional and verification is skipped (as before) when unset. (#5692, #5690)
 - `fix(channels)`: `JsonCliChannel::try_recv` (`crates/zeph-channels/src/json_cli.rs`) did not
   recognize `exit`/`quit`/`/exit`/`/quit` the way `recv` already did, so an exit command
   arriving via the queued/merge path (`Agent::drain_channel`'s 500ms merge window in

--- a/crates/zeph-config/src/providers/candle.rs
+++ b/crates/zeph-config/src/providers/candle.rs
@@ -186,12 +186,23 @@ pub struct CandleInlineConfig {
     pub local_path: String,
     #[serde(default)]
     pub filename: Option<String>,
+    /// Optional SHA-256 hex digest of the chat model file (GGUF).
+    ///
+    /// When set, the file is verified before loading. Mismatch aborts startup with an error.
+    /// Useful for security-sensitive deployments to detect corruption or tampering.
+    #[serde(default)]
+    pub chat_model_sha256: Option<String>,
     #[serde(default = "default_chat_template")]
     pub chat_template: String,
     #[serde(default)]
     pub device: CandleDevice,
     #[serde(default)]
     pub embedding_repo: Option<String>,
+    /// Optional SHA-256 hex digest of the embedding model safetensors file.
+    ///
+    /// When set, the file is verified before loading. Mismatch aborts startup with an error.
+    #[serde(default)]
+    pub embedding_model_sha256: Option<String>,
     /// Resolved `HuggingFace` Hub API token for authenticated model downloads.
     #[serde(default)]
     pub hf_token: Option<String>,
@@ -211,9 +222,11 @@ impl Default for CandleInlineConfig {
             source: CandleSource::default(),
             local_path: String::new(),
             filename: None,
+            chat_model_sha256: None,
             chat_template: default_chat_template(),
             device: CandleDevice::default(),
             embedding_repo: None,
+            embedding_model_sha256: None,
             hf_token: None,
             generation: GenerationParams::default(),
             inference_timeout_secs: default_inference_timeout_secs(),

--- a/crates/zeph-config/src/providers/entry.rs
+++ b/crates/zeph-config/src/providers/entry.rs
@@ -88,6 +88,13 @@ pub struct ProviderEntry {
     #[serde(default)]
     pub stt_model: Option<String>,
 
+    /// Optional SHA-256 hex digest of the Candle-local Whisper model safetensors file.
+    ///
+    /// Only consulted when `provider_type = "candle"`. When set, the file is verified
+    /// before loading; mismatch aborts startup with an error.
+    #[serde(default)]
+    pub stt_model_sha256: Option<String>,
+
     /// Mark this entry as the embedding provider (handles `embed()` calls).
     #[serde(default)]
     pub embed: bool,
@@ -201,6 +208,7 @@ impl Default for ProviderEntry {
             max_tokens: None,
             embedding_model: None,
             stt_model: None,
+            stt_model_sha256: None,
             embed: false,
             default: false,
             thinking: None,

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -26,7 +26,7 @@ use zeroize::Zeroizing;
 
 use crate::agent::state::ProviderConfigSnapshot;
 #[cfg(feature = "candle")]
-use crate::config::{CandleDevice, CandleSource};
+use crate::config::{CandleDevice, CandleInlineConfig, CandleSource};
 use crate::config::{Config, ProviderEntry, ProviderKind};
 
 #[non_exhaustive]
@@ -662,16 +662,28 @@ pub fn spawn_cocoon_health_checks(
     }
 }
 
+/// Pure data resolved from a `[[llm.providers]]` Candle entry, prior to the fallible device
+/// selection and model-loading steps in [`build_candle_provider`].
+///
+/// Split out so the config → loader-args mapping (including SHA-256 threading) is unit-testable
+/// without touching the network-calling `CandleProvider::new_with_timeout`.
 #[cfg(feature = "candle")]
-fn build_candle_provider(
+struct CandleLoadParams {
+    source: zeph_llm::candle_provider::loader::ModelSource,
+    template: zeph_llm::candle_provider::template::ChatTemplate,
+    gen_config: zeph_llm::candle_provider::generate::GenerationConfig,
+    embedding_repo: Option<String>,
+    embedding_sha256: Option<String>,
+    hf_token: Option<String>,
+    inference_timeout: std::time::Duration,
+}
+
+#[cfg(feature = "candle")]
+fn resolve_candle_load_params(
     entry: &ProviderEntry,
+    candle: &CandleInlineConfig,
     config: &Config,
-) -> Result<AnyProvider, BootstrapError> {
-    let candle = entry.candle.as_ref().ok_or_else(|| {
-        BootstrapError::Provider(
-            "candle provider requires 'candle' section in [[llm.providers]]".into(),
-        )
-    })?;
+) -> CandleLoadParams {
     let source = match candle.source {
         CandleSource::Local => zeph_llm::candle_provider::loader::ModelSource::Local {
             path: std::path::PathBuf::from(&candle.local_path),
@@ -682,6 +694,7 @@ fn build_candle_provider(
                 .clone()
                 .unwrap_or_else(|| config.llm.effective_model().to_owned()),
             filename: candle.filename.clone(),
+            sha256: candle.chat_model_sha256.clone(),
         },
     };
     let template =
@@ -695,18 +708,41 @@ fn build_candle_provider(
         repeat_penalty: candle.generation.repeat_penalty,
         repeat_last_n: candle.generation.repeat_last_n,
     };
-    let device = select_device(candle.device)?;
     // Floor at 1s so that inference_timeout_secs = 0 does not cause every request to
     // immediately time out.
     let inference_timeout = std::time::Duration::from_secs(candle.inference_timeout_secs.max(1));
-    zeph_llm::candle_provider::CandleProvider::new_with_timeout(
-        &source,
+    CandleLoadParams {
+        source,
         template,
         gen_config,
-        candle.embedding_repo.as_deref(),
-        candle.hf_token.as_deref(),
-        device,
+        embedding_repo: candle.embedding_repo.clone(),
+        embedding_sha256: candle.embedding_model_sha256.clone(),
+        hf_token: candle.hf_token.clone(),
         inference_timeout,
+    }
+}
+
+#[cfg(feature = "candle")]
+fn build_candle_provider(
+    entry: &ProviderEntry,
+    config: &Config,
+) -> Result<AnyProvider, BootstrapError> {
+    let candle = entry.candle.as_ref().ok_or_else(|| {
+        BootstrapError::Provider(
+            "candle provider requires 'candle' section in [[llm.providers]]".into(),
+        )
+    })?;
+    let params = resolve_candle_load_params(entry, candle, config);
+    let device = select_device(candle.device)?;
+    zeph_llm::candle_provider::CandleProvider::new_with_timeout(
+        &params.source,
+        params.template,
+        params.gen_config,
+        params.embedding_repo.as_deref(),
+        params.embedding_sha256.as_deref(),
+        params.hf_token.as_deref(),
+        device,
+        params.inference_timeout,
     )
     .map(AnyProvider::Candle)
     .map_err(|e| BootstrapError::Provider(e.to_string()))
@@ -786,6 +822,68 @@ mod tests {
         let result = select_device(CandleDevice::Cuda);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("cuda feature"));
+    }
+
+    // --- sha256 config threading (issues #5692/#5690 follow-up: guards against a future
+    // field-drop regression in `resolve_candle_load_params`) ---
+
+    #[cfg(feature = "candle")]
+    #[test]
+    fn resolve_candle_load_params_threads_chat_and_embedding_sha256() {
+        use super::resolve_candle_load_params;
+        use crate::config::{CandleInlineConfig, Config};
+        use zeph_config::providers::ProviderEntry;
+
+        let candle = CandleInlineConfig {
+            chat_model_sha256: Some("deadbeef".into()),
+            embedding_repo: Some("org/embed-model".into()),
+            embedding_model_sha256: Some("cafef00d".into()),
+            ..CandleInlineConfig::default()
+        };
+        let entry = ProviderEntry {
+            model: Some("org/chat-model".into()),
+            candle: Some(candle.clone()),
+            ..ProviderEntry::default()
+        };
+        let config = Config::default();
+
+        let params = resolve_candle_load_params(&entry, &candle, &config);
+
+        if let zeph_llm::candle_provider::loader::ModelSource::HuggingFace { sha256, .. } =
+            params.source
+        {
+            assert_eq!(sha256.as_deref(), Some("deadbeef"));
+        } else {
+            panic!("expected HuggingFace source for CandleSource::default()")
+        }
+        assert_eq!(params.embedding_sha256.as_deref(), Some("cafef00d"));
+    }
+
+    #[cfg(feature = "candle")]
+    #[test]
+    fn resolve_candle_load_params_sha256_absent_by_default() {
+        use super::resolve_candle_load_params;
+        use crate::config::{CandleInlineConfig, Config};
+        use zeph_config::providers::ProviderEntry;
+
+        let candle = CandleInlineConfig::default();
+        let entry = ProviderEntry {
+            model: Some("org/chat-model".into()),
+            candle: Some(candle.clone()),
+            ..ProviderEntry::default()
+        };
+        let config = Config::default();
+
+        let params = resolve_candle_load_params(&entry, &candle, &config);
+
+        if let zeph_llm::candle_provider::loader::ModelSource::HuggingFace { sha256, .. } =
+            params.source
+        {
+            assert!(sha256.is_none());
+        } else {
+            panic!("expected HuggingFace source for CandleSource::default()")
+        }
+        assert!(params.embedding_sha256.is_none());
     }
 
     use super::{build_provider_from_entry, resolve_named_provider};

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [features]
 profiling = []
-candle = ["dep:audioadapter-buffers", "dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:hf-hub", "dep:tokenizers", "dep:symphonia", "dep:rubato"]
-classifiers = ["candle", "dep:hex", "dep:sha2"]
+candle = ["dep:audioadapter-buffers", "dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:hf-hub", "dep:tokenizers", "dep:symphonia", "dep:rubato", "dep:hex", "dep:sha2"]
+classifiers = ["candle"]
 cuda = ["candle", "candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
 gonka = ["dep:bech32", "dep:k256", "dep:ripemd", "dep:hex", "dep:sha2", "dep:zeroize"]
 cocoon = []

--- a/crates/zeph-llm/src/candle_provider/embed.rs
+++ b/crates/zeph-llm/src/candle_provider/embed.rs
@@ -28,11 +28,19 @@ impl std::fmt::Debug for EmbedModel {
 impl EmbedModel {
     /// Load a BERT embedding model from `HuggingFace` Hub.
     ///
+    /// When `expected_sha256` is set, the downloaded safetensors file is verified against
+    /// it before loading; a mismatch aborts the load without ever memory-mapping the file.
+    ///
     /// # Errors
     ///
-    /// Returns an error if model download or loading fails.
+    /// Returns an error if model download, hash verification, or loading fails.
     #[allow(unsafe_code)]
-    pub fn load(repo_id: &str, hf_token: Option<&str>, device: &Device) -> Result<Self, LlmError> {
+    pub fn load(
+        repo_id: &str,
+        hf_token: Option<&str>,
+        device: &Device,
+        expected_sha256: Option<&str>,
+    ) -> Result<Self, LlmError> {
         let api = hf_hub::api::sync::ApiBuilder::new()
             .with_token(hf_token.map(str::to_owned))
             .build()
@@ -56,6 +64,10 @@ impl EmbedModel {
                 "failed to download model.safetensors from {repo_id}: {e}"
             ))
         })?;
+
+        if let Some(expected_hash) = expected_sha256 {
+            crate::classifier::verify_sha256(&weights_path, expected_hash)?;
+        }
 
         let config_str = std::fs::read_to_string(&config_path)
             .map_err(|e| LlmError::ModelLoad(format!("failed to read BERT config: {e}")))?;

--- a/crates/zeph-llm/src/candle_provider/loader.rs
+++ b/crates/zeph-llm/src/candle_provider/loader.rs
@@ -19,6 +19,11 @@ pub enum ModelSource {
     HuggingFace {
         repo_id: String,
         filename: Option<String>,
+        /// Optional expected SHA-256 hex digest of the downloaded model file.
+        ///
+        /// When set, [`load_chat_model`] verifies the digest before parsing the GGUF
+        /// weights. Mismatch aborts the load — see `classifier::verify_sha256`.
+        sha256: Option<String>,
     },
 }
 
@@ -53,7 +58,11 @@ pub fn load_chat_model(
                 eos_token_id,
             })
         }
-        ModelSource::HuggingFace { repo_id, filename } => {
+        ModelSource::HuggingFace {
+            repo_id,
+            filename,
+            sha256,
+        } => {
             let api = hf_hub::api::sync::ApiBuilder::new()
                 .with_token(hf_token.map(str::to_owned))
                 .build()
@@ -74,6 +83,10 @@ pub fn load_chat_model(
                     "failed to download tokenizer.json from {repo_id}: {e}"
                 ))
             })?;
+
+            if let Some(expected_hash) = sha256 {
+                crate::classifier::verify_sha256(&model_path, expected_hash)?;
+            }
 
             let weights = load_gguf_weights(&model_path, device)?;
             let tokenizer = load_tokenizer(&tokenizer_path)?;
@@ -143,6 +156,7 @@ mod tests {
         let source = ModelSource::HuggingFace {
             repo_id: "TheBloke/Mistral-7B".into(),
             filename: Some("model.Q4_K_M.gguf".into()),
+            sha256: None,
         };
         let debug = format!("{source:?}");
         assert!(debug.contains("HuggingFace"));

--- a/crates/zeph-llm/src/candle_provider/mod.rs
+++ b/crates/zeph-llm/src/candle_provider/mod.rs
@@ -36,7 +36,7 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(feature = "candle")]
-//! # {
+//! # fn example() -> Result<(), zeph_llm::LlmError> {
 //! use zeph_llm::candle_provider::{CandleProvider, Device};
 //! use zeph_llm::candle_provider::loader::ModelSource;
 //! use zeph_llm::candle_provider::template::ChatTemplate;
@@ -44,18 +44,22 @@
 //!
 //! let source = ModelSource::HuggingFace {
 //!     repo_id: "microsoft/Phi-3-mini-4k-instruct".into(),
-//!     revision: None,
+//!     filename: None,
+//!     sha256: None, // set to verify the downloaded weights before loading
 //! };
 //! let provider = CandleProvider::new(
 //!     &source,
 //!     ChatTemplate::Phi3,
 //!     GenerationConfig::default(),
 //!     Some("sentence-transformers/all-MiniLM-L6-v2"),
+//!     None, // no embedding-model hash pinned
 //!     None, // no HF token needed for public models
 //!     Device::Cpu,
 //! )?;
-//! # Ok::<(), zeph_llm::LlmError>(())
+//! # Ok(())
 //! # }
+//! # #[cfg(not(feature = "candle"))]
+//! # fn example() {}
 //! ```
 
 pub mod embed;
@@ -146,6 +150,7 @@ impl CandleProvider {
         template: ChatTemplate,
         generation_config: GenerationConfig,
         embedding_repo: Option<&str>,
+        embedding_sha256: Option<&str>,
         hf_token: Option<&str>,
         device: Device,
     ) -> Result<Self, LlmError> {
@@ -154,6 +159,7 @@ impl CandleProvider {
             template,
             generation_config,
             embedding_repo,
+            embedding_sha256,
             hf_token,
             device,
             Duration::from_secs(DEFAULT_INFERENCE_TIMEOUT_SECS),
@@ -165,11 +171,13 @@ impl CandleProvider {
     /// # Errors
     ///
     /// Returns an error if model loading or embedding model initialization fails.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_timeout(
         source: &ModelSource,
         template: ChatTemplate,
         generation_config: GenerationConfig,
         embedding_repo: Option<&str>,
+        embedding_sha256: Option<&str>,
         hf_token: Option<&str>,
         device: Device,
         inference_timeout: Duration,
@@ -182,7 +190,10 @@ impl CandleProvider {
 
         let embed_model = if let Some(repo) = embedding_repo {
             Some(std::sync::Arc::new(EmbedModel::load(
-                repo, hf_token, &device,
+                repo,
+                hf_token,
+                &device,
+                embedding_sha256,
             )?))
         } else {
             None

--- a/crates/zeph-llm/src/candle_whisper.rs
+++ b/crates/zeph-llm/src/candle_whisper.rs
@@ -43,11 +43,19 @@ fn device_name(d: &Device) -> &'static str {
 impl CandleWhisperProvider {
     /// Load a Whisper model from a `HuggingFace` repo.
     ///
+    /// When `expected_sha256` is set, the downloaded safetensors file is verified against
+    /// it before loading; a mismatch aborts the load without ever memory-mapping the file.
+    ///
     /// # Errors
     ///
-    /// Returns `LlmError::ModelLoad` if downloading or loading fails.
+    /// Returns `LlmError::ModelLoad` if downloading, hash verification, or loading fails.
     #[allow(unsafe_code)]
-    pub fn load(repo_id: &str, device: Option<Device>, language: &str) -> Result<Self, LlmError> {
+    pub fn load(
+        repo_id: &str,
+        device: Option<Device>,
+        language: &str,
+        expected_sha256: Option<&str>,
+    ) -> Result<Self, LlmError> {
         let device = device.unwrap_or_else(crate::device::detect_device);
         tracing::info!(
             repo = repo_id,
@@ -68,6 +76,10 @@ impl CandleWhisperProvider {
         let weights_path = repo
             .get("model.safetensors")
             .map_err(|e| LlmError::ModelLoad(format!("model.safetensors: {e}")))?;
+
+        if let Some(expected_hash) = expected_sha256 {
+            crate::classifier::verify_sha256(&weights_path, expected_hash)?;
+        }
 
         let config: Config = serde_json::from_reader(std::io::BufReader::new(
             std::fs::File::open(&config_path)

--- a/crates/zeph-llm/src/classifier/candle.rs
+++ b/crates/zeph-llm/src/classifier/candle.rs
@@ -58,6 +58,7 @@ struct CandleClassifierInner {
 pub struct CandleClassifier {
     repo_id: Arc<str>,
     hf_token: Option<Arc<str>>,
+    sha256: Option<Arc<str>>,
     inner: Arc<OnceLock<Result<Arc<CandleClassifierInner>, String>>>,
 }
 
@@ -76,6 +77,7 @@ impl CandleClassifier {
         Self {
             repo_id: repo_id.into(),
             hf_token: None,
+            sha256: None,
             inner: Arc::new(OnceLock::new()),
         }
     }
@@ -84,6 +86,16 @@ impl CandleClassifier {
     #[must_use]
     pub fn with_hf_token(mut self, token: impl Into<Arc<str>>) -> Self {
         self.hf_token = Some(token.into());
+        self
+    }
+
+    /// Set expected SHA-256 hex digest of the model safetensors file.
+    ///
+    /// When set, the file is verified before loading. Mismatch aborts the load with
+    /// `LlmError::ModelLoad` (cached by the `OnceLock` like any other load failure).
+    #[must_use]
+    pub fn with_sha256(mut self, digest: impl Into<Arc<str>>) -> Self {
+        self.sha256 = Some(digest.into());
         self
     }
 
@@ -211,6 +223,7 @@ impl CandleClassifier {
     fn load_inner(
         repo_id: &str,
         hf_token: Option<&str>,
+        sha256: Option<&str>,
     ) -> Result<CandleClassifierInner, LlmError> {
         let api = hf_hub::api::sync::ApiBuilder::new()
             .with_token(hf_token.map(str::to_owned))
@@ -235,6 +248,10 @@ impl CandleClassifier {
                 "failed to download model.safetensors from {repo_id}: {e}"
             ))
         })?;
+
+        if let Some(expected_hash) = sha256 {
+            super::verify_sha256(&weights_path, expected_hash)?;
+        }
 
         let config_str = std::fs::read_to_string(&config_path)
             .map_err(|e| LlmError::ModelLoad(format!("failed to read DeBERTa config: {e}")))?;
@@ -339,13 +356,14 @@ impl ClassifierBackend for CandleClassifier {
         let inner_lock = Arc::clone(&self.inner);
         let repo_id = Arc::clone(&self.repo_id);
         let hf_token = self.hf_token.clone();
+        let sha256 = self.sha256.clone();
 
         Box::pin(async move {
             // spawn_blocking: model is already loaded (OnceLock), inference is CPU-bound.
             // Uses tokio's bounded blocking pool (default 512 threads, shared across callers).
             tokio::task::spawn_blocking(move || {
                 let loaded = inner_lock.get_or_init(|| {
-                    CandleClassifier::load_inner(&repo_id, hf_token.as_deref())
+                    CandleClassifier::load_inner(&repo_id, hf_token.as_deref(), sha256.as_deref())
                         .map(Arc::new)
                         .map_err(|e| e.to_string())
                 });
@@ -389,7 +407,7 @@ pub fn download_model(
 
     std::thread::spawn(move || {
         let result =
-            CandleClassifier::load_inner(&repo_id_owned, token_owned.as_deref()).map(|_| ());
+            CandleClassifier::load_inner(&repo_id_owned, token_owned.as_deref(), None).map(|_| ());
         let _ = tx.send(result);
     });
 
@@ -553,6 +571,23 @@ mod tests {
         assert!(
             classifier.hf_token.is_none(),
             "hf_token must be None when not explicitly set"
+        );
+    }
+
+    // --- sha256 propagation (issue #5690) ---
+
+    #[test]
+    fn candle_classifier_with_sha256() {
+        let classifier = CandleClassifier::new("test/model").with_sha256("abc123");
+        assert_eq!(classifier.sha256.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn candle_classifier_sha256_absent_by_default() {
+        let classifier = CandleClassifier::new("test/model");
+        assert!(
+            classifier.sha256.is_none(),
+            "sha256 must be None when not explicitly set"
         );
     }
 

--- a/crates/zeph-llm/src/classifier/mod.rs
+++ b/crates/zeph-llm/src/classifier/mod.rs
@@ -91,11 +91,15 @@ pub trait PiiDetector: Send + Sync {
 
 /// Verify the SHA-256 digest of a file against an expected hex string.
 ///
+/// Shared by every Candle model loader in this crate (classifiers, chat/embed models,
+/// Whisper STT) so downloaded `HuggingFace` weights can be checked for tampering or
+/// corruption before being memory-mapped.
+///
 /// # Errors
 ///
 /// Returns `LlmError::ModelLoad` if the file cannot be read or the digest mismatches.
-#[cfg(feature = "classifiers")]
-pub(super) fn verify_sha256(path: &std::path::Path, expected: &str) -> Result<(), LlmError> {
+#[cfg(feature = "candle")]
+pub(crate) fn verify_sha256(path: &std::path::Path, expected: &str) -> Result<(), LlmError> {
     use hex;
     use sha2::{Digest, Sha256};
     use std::io::Read;
@@ -114,7 +118,7 @@ pub(super) fn verify_sha256(path: &std::path::Path, expected: &str) -> Result<()
         hasher.update(&buf[..n]);
     }
     let computed = hex::encode(hasher.finalize());
-    if computed != expected.to_lowercase() {
+    if computed != expected.trim().to_lowercase() {
         return Err(LlmError::ModelLoad(format!(
             "SHA-256 mismatch for {}: expected {}, got {} \
              (file may be corrupt or tampered — do not auto-retry)",
@@ -187,7 +191,7 @@ pub trait ClassifierBackend: Send + Sync {
     fn backend_name(&self) -> &'static str;
 }
 
-#[cfg(all(test, feature = "classifiers"))]
+#[cfg(all(test, feature = "candle"))]
 mod sha256_tests {
     use std::io::Write;
 
@@ -219,6 +223,14 @@ mod sha256_tests {
         let data = b"case test";
         let f = write_tmp(data);
         let expected = sha256_hex(data).to_uppercase();
+        assert!(verify_sha256(f.path(), &expected).is_ok());
+    }
+
+    #[test]
+    fn verify_sha256_whitespace_padded_expected_accepted() {
+        let data = b"padded case";
+        let f = write_tmp(data);
+        let expected = format!("  {}\n", sha256_hex(data));
         assert!(verify_sha256(f.path(), &expected).is_ok());
     }
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -863,6 +863,9 @@ pub(crate) fn apply_injection_classifier_with_cfg<C: Channel>(
     }
     let mut classifier =
         zeph_llm::classifier::candle::CandleClassifier::new(classifiers.injection_model.as_str());
+    if let Some(hash) = &classifiers.injection_model_sha256 {
+        classifier = classifier.with_sha256(hash.as_str());
+    }
     if let Some(token) = &classifiers.hf_token {
         classifier = classifier.with_hf_token(token.as_str());
     }
@@ -1725,7 +1728,12 @@ pub(crate) fn apply_candle_stt<C: Channel>(
     language: &str,
 ) -> zeph_core::agent::Agent<C> {
     let model = entry.stt_model.as_deref().unwrap_or("openai/whisper-tiny");
-    match zeph_llm::candle_whisper::CandleWhisperProvider::load(model, None, language) {
+    match zeph_llm::candle_whisper::CandleWhisperProvider::load(
+        model,
+        None,
+        language,
+        entry.stt_model_sha256.as_deref(),
+    ) {
         Ok(provider) => {
             tracing::info!("STT enabled via candle-whisper (model: {model})");
             agent.with_stt(Box::new(provider))

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -300,6 +300,7 @@ async fn health_check_candle_logs_device() {
     let source = zeph_llm::candle_provider::loader::ModelSource::HuggingFace {
         repo_id: "test/model".to_string(),
         filename: Some("model.gguf".to_string()),
+        sha256: None,
     };
     let template = zeph_llm::candle_provider::template::ChatTemplate::parse_str(
         "{{ bos_token }}{{ messages[0].content }}",
@@ -320,6 +321,7 @@ async fn health_check_candle_logs_device() {
         template,
         gen_config,
         Some("embed/model"),
+        None,
         None,
         device,
     );


### PR DESCRIPTION
## Summary

Candle-backed HuggingFace model loaders in `crates/zeph-llm` downloaded weights with no (or only structural) integrity verification, even though the crate already has a working SHA-256 pinning mechanism (`classifier::verify_sha256` / `with_sha256()`) used by `CandleThreeClassClassifier` and `CandlePiiClassifier`. A compromised or tampered mirror could silently swap in malicious weights on the primary inference path.

- `CandleClassifier` (Phase 1 injection detector) gains a `with_sha256` builder mirroring its siblings, closing the gap where `classifiers.injection_model_sha256` was already a config field with no code path consuming it.
- `candle_provider::loader::load_chat_model` (GGUF chat models), `candle_provider::embed::EmbedModel::load` (BERT embedding models), and `candle_whisper::CandleWhisperProvider::load` (Whisper STT) now accept an optional expected SHA-256 digest and verify it via the shared `classifier::verify_sha256` helper, right after download and before the file is memory-mapped.
- New `chat_model_sha256`/`embedding_model_sha256` fields on `CandleInlineConfig` (the `[[llm.providers]]` inline candle section — the only Candle config path that actually builds a provider) and `stt_model_sha256` on `ProviderEntry` plumb the digest from config through `provider_factory::build_candle_provider` and `agent_setup::apply_candle_stt`. All three fields are optional; verification is skipped, as before, when unset.
- `verify_sha256`'s visibility/feature-gate was widened from `pub(super)`+`classifiers` to `pub(crate)`+`candle` so the non-classifier loaders can reuse it, and the expected digest is now trimmed before comparison to tolerate whitespace in hand-typed config values.

Closes #5692, closes #5690.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing,candle,classifiers" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm -p zeph-config -p zeph-core --features "candle,classifiers,scheduler"` — 3351 passed, 0 failed
- [x] `cargo build --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,classifiers,candle"`
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps`) + `cargo test --doc` — clean
- [x] New unit tests: `CandleClassifier::with_sha256` builder tests, `resolve_candle_load_params` config-threading regression tests, `verify_sha256` whitespace-trim test
- [x] `.local/testing/coverage-status.md` row + `playbooks/candle-model-integrity.md` added (live-session verification against a real downloaded model still pending, tracked as `Untested`)