### PR TITLE
fix(llm): fix CandleNerClassifier bias-tensor bug and dedupe Claude retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -695,6 +695,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   for a JSON consumer to correlate a `tool_result` event with its originating `tool_call` when
   multiple calls to the same tool occurred in one turn. Both events now emit the real
   `tool_call_id`. (#5680)
+- `fix(llm)`: `CandleNerClassifier` (`crates/zeph-llm/src/classifier/ner.rs`) — wired into the
+  opt-in tool-output PII union-merge pipeline (`[classifiers] enabled` +
+  `security.pii_filter.enabled`, both off by default, `classifiers` feature) via
+  `apply_pii_ner_classifier` (`src/agent_setup.rs`, reachable from `runner.rs`/`daemon.rs`/
+  `acp.rs`) — loaded its DeBERTa-v2 NER model via the upstream
+  `candle_transformers::models::debertav2::DebertaV2NERModel::load`, which builds its
+  classifier head with `candle_nn::linear_no_bias`, silently dropping the `classifier.bias`
+  tensor present in real checkpoints (e.g.
+  `iiiorg/piiranha-v1-detect-personal-information`) and corrupting every token's logits.
+  `crates/zeph-llm/src/classifier/candle_pii.rs`'s `CandlePiiClassifier` (a separate
+  `PiiDetector`-based pipeline for assistant-response PII detection) had already diagnosed and
+  fixed this for itself with a hand-rolled bias-including head, but `CandleNerClassifier` never
+  received the same fix — two independent DeBERTa-v2 NER model loaders, only one correct.
+  Extracted the bias-correct model into a new shared `DebertaV2TokenClassifier`
+  (`crates/zeph-llm/src/classifier/deberta_token_model.rs`); both classifiers now load through
+  it, so `ner.rs` no longer calls the broken upstream loader. No config, trait, or public API
+  changes — issue #5691 was originally filed as "remove dead code", but `CandleNerClassifier`
+  is live; this closes it as a bug fix instead. (#5691)
 
 ### Changed
 
@@ -718,6 +736,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `SemanticMemory::base()` helper that builds the struct once from the handful of
   parameters that vary; all four constructors now delegate to it. Pure extraction — no
   behavior change. Closes #5504.
+- `refactor(llm)`: `ClaudeProvider`'s five request call sites (`crates/zeph-llm/src/claude/mod.rs`
+  — `send_request`, `chat_with_tools_stream`, `send_stream_request`, `chat_typed`,
+  `chat_with_tools`) each duplicated the same "detect a `compact-2026-01-12` beta rejection, set
+  `server_compaction_rejected`, warn, retry once" sequence. Extracted a private
+  `handle_compact_beta_rejection` method encapsulating the detect/store/warn/retry-once
+  decision; all five call sites now delegate to it, differing only in a `variant` label passed
+  through to the warning text. Pure extraction — warning text and retry semantics unchanged.
+  Closes #5683.
 
 ### Added
 

--- a/crates/zeph-llm/src/classifier/candle_pii.rs
+++ b/crates/zeph-llm/src/classifier/candle_pii.rs
@@ -7,19 +7,59 @@
 //! from `HuggingFace` Hub. Returns per-span PII results via [`PiiDetector`].
 //!
 //! Inference runs in `tokio::task::spawn_blocking`. Model is loaded lazily on first call.
+//!
+//! The backbone-plus-head model itself (`DebertaV2TokenClassifier`) lives in the sibling
+//! `deberta_token_model` module, shared with `ner.rs`'s `CandleNerClassifier` — see that
+//! module for the bias-tensor rationale.
+//!
+//! ## #5457 investigation: closed, no candle-port bug found
+//!
+//! After the bias-tensor fix (see `super::deberta_token_model`), the original regression test
+//! (`real_model_detects_email`, checking `"Contact John Smith at john@example.com for
+//! details."`) still failed to detect any PII. Two independent investigations followed:
+//!
+//! 1. A line-by-line audit of `candle-transformers`'s DeBERTa-v2 port (relative
+//!    position building, log-bucket positions, disentangled attention bias, `XSoftmax`,
+//!    embeddings) against the published `HuggingFace` `transformers` reference found every
+//!    path to be a faithful port.
+//! 2. A `model.safetensors` header inspection confirmed every `vb.pp(...)`/`vb.get(...)`
+//!    path in this module and in `candle-transformers`' `DebertaV2Model::load` resolves to
+//!    an existing tensor with the expected shape — no silent prefix/key mismatch.
+//! 3. **Conclusive**: a throwaway `torch`+`transformers` reference harness ran the actual
+//!    `iiiorg/piiranha-v1-detect-personal-information` checkpoint through the real
+//!    `HuggingFace` `PyTorch` implementation on the same input. Its per-token predictions
+//!    matched this crate's candle port *exactly*, to four decimal places, for every one of
+//!    the 14 tokens produced by the test sentence. Only two representative values were
+//!    recorded in this comment (`▁John` → `O` @ 0.9891 in both; `▁john` → `I-USERNAME` @
+//!    0.4839 in both) — the full 14-token comparison table was observed in the terminal
+//!    during the investigation but the throwaway venv was deleted afterward, so it is not
+//!    reproducible from this repository without rebuilding the reference harness. The
+//!    candle port is numerically correct.
+//!
+//! The real finding: this checkpoint is weak at free-text given-name/surname/email
+//! recognition in casual sentences (even in the reference `PyTorch` implementation) but
+//! reliably flags structured PII — SSNs, street addresses, phone numbers — with >0.99
+//! confidence. The original test exercised the model's weak spot, not a code defect.
+//! The regression test was replaced with `real_model_detects_ssn`, which uses an input
+//! verified against the real `PyTorch` model to produce confident, stable predictions. A
+//! characterization test (`free_text_names_yield_no_confident_span`) locks in the known
+//! current weak-spot behavior on the original email/name sentence so a future change in
+//! either direction (regression or improvement) is caught by CI instead of drifting
+//! silently.
 
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use candle_core::{DType, Device, Module, Tensor};
+use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::models::debertav2::{Config as DebertaConfig, DebertaV2Model};
+use candle_transformers::models::debertav2::Config as DebertaConfig;
 use tokenizers::Tokenizer;
 
 use crate::error::LlmError;
 
+use super::deberta_token_model::DebertaV2TokenClassifier;
 use super::{PiiDetector, PiiResult, PiiSpan, verify_sha256};
 
 /// Maximum number of tokens per chunk for NER inference.
@@ -27,102 +67,8 @@ const MAX_CHUNK_TOKENS: usize = 448;
 /// Token overlap between adjacent chunks for NER.
 const CHUNK_OVERLAP_TOKENS: usize = 64;
 
-/// DeBERTa-v2 backbone plus a token-classification head, loaded with a bias term.
-///
-/// `candle_transformers::models::debertav2::DebertaV2NERModel` cannot be used directly:
-/// it builds its classifier layer with `candle_nn::linear_no_bias`, which silently skips
-/// the `classifier.bias` tensor present in real NER checkpoints (confirmed against
-/// `iiiorg/piiranha-v1-detect-personal-information`'s `model.safetensors`). Dropping a
-/// trained bias term corrupts every token's logits, so this type re-implements the same
-/// head using `candle_nn::linear` (with bias) instead to stay faithful to the checkpoint.
-///
-/// ## #5457 investigation: closed, no candle-port bug found
-///
-/// After the bias-tensor fix above, the original regression test (`real_model_detects_email`,
-/// checking `"Contact John Smith at john@example.com for details."`) still failed to detect
-/// any PII. Two independent investigations followed:
-///
-/// 1. A line-by-line audit of `candle-transformers` v0.11.0's DeBERTa-v2 port (relative
-///    position building, log-bucket positions, disentangled attention bias, `XSoftmax`,
-///    embeddings) against the published `HuggingFace` `transformers` reference found every
-///    path to be a faithful port.
-/// 2. A `model.safetensors` header inspection confirmed every `vb.pp(...)`/`vb.get(...)`
-///    path in this module and in `candle-transformers`' `DebertaV2Model::load` resolves to
-///    an existing tensor with the expected shape — no silent prefix/key mismatch.
-/// 3. **Conclusive**: a throwaway `torch`+`transformers` reference harness ran the actual
-///    `iiiorg/piiranha-v1-detect-personal-information` checkpoint through the real
-///    `HuggingFace` `PyTorch` implementation on the same input. Its per-token predictions
-///    matched this crate's candle port *exactly*, to four decimal places, for every one of
-///    the 14 tokens produced by the test sentence. Only two representative values were
-///    recorded in this comment (`▁John` → `O` @ 0.9891 in both; `▁john` → `I-USERNAME` @
-///    0.4839 in both) — the full 14-token comparison table was observed in the terminal
-///    during the investigation but the throwaway venv was deleted afterward, so it is not
-///    reproducible from this repository without rebuilding the reference harness. The
-///    candle port is numerically correct.
-///
-/// The real finding: this checkpoint is weak at free-text given-name/surname/email
-/// recognition in casual sentences (even in the reference `PyTorch` implementation) but
-/// reliably flags structured PII — SSNs, street addresses, phone numbers — with >0.99
-/// confidence. The original test exercised the model's weak spot, not a code defect.
-/// The regression test was replaced with `real_model_detects_ssn`, which uses an input
-/// verified against the real `PyTorch` model to produce confident, stable predictions. A
-/// characterization test (`free_text_names_yield_no_confident_span`) locks in the known
-/// current weak-spot behavior on the original email/name sentence so a future change in
-/// either direction (regression or improvement) is caught by CI instead of drifting
-/// silently.
-struct PiiNerHead {
-    deberta: DebertaV2Model,
-    dropout: candle_nn::Dropout,
-    classifier: candle_nn::Linear,
-}
-
-impl PiiNerHead {
-    /// Load the DeBERTa-v2 backbone under `vb` and a bias-including linear classifier
-    /// head at `vb`'s root `classifier.*` keys, mirroring the checkpoint layout that
-    /// `DebertaV2NERModel::load` targets internally.
-    ///
-    /// Trade-off versus the upstream `linear_no_bias`-based loader: a checkpoint whose
-    /// classifier head has no `classifier.bias` tensor now fails to load
-    /// (`candle_core::Error` from `candle_nn::linear`'s `vb.get_with_hints(.., "bias", ..)`)
-    /// instead of loading silently without it. This is intentional — fail loud on an
-    /// unsupported checkpoint shape rather than silently producing degraded predictions —
-    /// but it does narrow the set of `pii_model` repo IDs this classifier can load.
-    fn load(
-        vb: &VarBuilder,
-        config: &DebertaConfig,
-        id2label_len: usize,
-    ) -> candle_core::Result<Self> {
-        let deberta = DebertaV2Model::load(vb.clone(), config)?;
-        // Dropout probability precision loss from f64 -> f32 is immaterial here.
-        #[allow(clippy::cast_possible_truncation)]
-        let dropout = candle_nn::Dropout::new(config.hidden_dropout_prob as f32);
-        let classifier =
-            candle_nn::linear(config.hidden_size, id2label_len, vb.root().pp("classifier"))?;
-        Ok(Self {
-            deberta,
-            dropout,
-            classifier,
-        })
-    }
-
-    /// Run the backbone followed by the classification head, returning per-token logits
-    /// of shape `[batch, seq_len, num_labels]`.
-    fn forward(
-        &self,
-        input_ids: &Tensor,
-        token_type_ids: Option<Tensor>,
-        attention_mask: Option<Tensor>,
-    ) -> candle_core::Result<Tensor> {
-        let output = self
-            .deberta
-            .forward(input_ids, token_type_ids, attention_mask)?;
-        let output = self.dropout.forward(&output, false)?;
-        self.classifier.forward(&output)
-    }
-}
-
 struct CandlePiiInner {
-    model: PiiNerHead,
+    model: DebertaV2TokenClassifier,
     tokenizer: Tokenizer,
     device: Device,
     /// Index → BIO label string (e.g. `0 → "O"`, `1 → "B-GIVENNAME"`).
@@ -242,7 +188,7 @@ impl CandlePiiClassifier {
 
         // HuggingFace DeBERTa v2/v3 safetensors store backbone weights under the deberta.* namespace
         let deberta_vb = vb.pp("deberta");
-        let model = PiiNerHead::load(&deberta_vb, &config, id2label.len())
+        let model = DebertaV2TokenClassifier::load(&deberta_vb, &config, id2label.len())
             .map_err(|e| LlmError::ModelLoad(format!("failed to load DeBERTa NER model: {e}")))?;
 
         let load_ms = load_t0.elapsed().as_millis();

--- a/crates/zeph-llm/src/classifier/deberta_token_model.rs
+++ b/crates/zeph-llm/src/classifier/deberta_token_model.rs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared bias-correct DeBERTa-v2 token-classification model.
+//!
+//! Used by both `CandlePiiClassifier` (trait `PiiDetector`, in `candle_pii.rs`) and
+//! `CandleNerClassifier` (trait `ClassifierBackend`, in `ner.rs`) — the two NER-style
+//! classifiers differ in download orchestration, chunking, and span decoding, but both need the
+//! same backbone-plus-head forward pass, so that single model implementation lives here to avoid
+//! the two call sites drifting out of sync (see the bias-tensor rationale below, which is exactly
+//! how they drifted before this module existed).
+
+use candle_core::{Module, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::debertav2::{Config as DebertaConfig, DebertaV2Model};
+
+/// DeBERTa-v2 backbone plus a token-classification head, loaded with a bias term.
+///
+/// `candle_transformers::models::debertav2::DebertaV2NERModel` cannot be used directly:
+/// it builds its classifier layer with `candle_nn::linear_no_bias`, which silently skips
+/// the `classifier.bias` tensor present in real NER checkpoints (confirmed against
+/// `iiiorg/piiranha-v1-detect-personal-information`'s `model.safetensors`). Dropping a
+/// trained bias term corrupts every token's logits, so this type re-implements the same
+/// head using `candle_nn::linear` (with bias) instead to stay faithful to the checkpoint.
+pub(crate) struct DebertaV2TokenClassifier {
+    deberta: DebertaV2Model,
+    dropout: candle_nn::Dropout,
+    classifier: candle_nn::Linear,
+}
+
+impl DebertaV2TokenClassifier {
+    /// Load the DeBERTa-v2 backbone under `vb` and a bias-including linear classifier
+    /// head at `vb`'s root `classifier.*` keys, mirroring the checkpoint layout that
+    /// `DebertaV2NERModel::load` targets internally.
+    ///
+    /// Trade-off versus the upstream `linear_no_bias`-based loader: a checkpoint whose
+    /// classifier head has no `classifier.bias` tensor now fails to load
+    /// (`candle_core::Error` from `candle_nn::linear`'s `vb.get_with_hints(.., "bias", ..)`)
+    /// instead of loading silently without it. This is intentional — fail loud on an
+    /// unsupported checkpoint shape rather than silently producing degraded predictions —
+    /// but it does narrow the set of model repo IDs this classifier can load.
+    pub(crate) fn load(
+        vb: &VarBuilder,
+        config: &DebertaConfig,
+        id2label_len: usize,
+    ) -> candle_core::Result<Self> {
+        let deberta = DebertaV2Model::load(vb.clone(), config)?;
+        // Dropout probability precision loss from f64 -> f32 is immaterial here.
+        #[allow(clippy::cast_possible_truncation)]
+        let dropout = candle_nn::Dropout::new(config.hidden_dropout_prob as f32);
+        let classifier =
+            candle_nn::linear(config.hidden_size, id2label_len, vb.root().pp("classifier"))?;
+        Ok(Self {
+            deberta,
+            dropout,
+            classifier,
+        })
+    }
+
+    /// Run the backbone followed by the classification head, returning per-token logits
+    /// of shape `[batch, seq_len, num_labels]`.
+    pub(crate) fn forward(
+        &self,
+        input_ids: &Tensor,
+        token_type_ids: Option<Tensor>,
+        attention_mask: Option<Tensor>,
+    ) -> candle_core::Result<Tensor> {
+        let output = self
+            .deberta
+            .forward(input_ids, token_type_ids, attention_mask)?;
+        let output = self.dropout.forward(&output, false)?;
+        self.classifier.forward(&output)
+    }
+}

--- a/crates/zeph-llm/src/classifier/mod.rs
+++ b/crates/zeph-llm/src/classifier/mod.rs
@@ -14,6 +14,8 @@
 pub mod candle;
 #[cfg(feature = "classifiers")]
 pub mod candle_pii;
+#[cfg(feature = "classifiers")]
+pub(crate) mod deberta_token_model;
 pub mod llm;
 pub mod metrics;
 #[cfg(feature = "classifiers")]

--- a/crates/zeph-llm/src/classifier/ner.rs
+++ b/crates/zeph-llm/src/classifier/ner.rs
@@ -33,19 +33,20 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 
-use candle_core::{DType, Tensor};
+use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::models::debertav2::{Config as DebertaConfig, DebertaV2NERModel};
+use candle_transformers::models::debertav2::Config as DebertaConfig;
 use tokenizers::Tokenizer;
 
 use crate::error::LlmError;
 
+use super::deberta_token_model::DebertaV2TokenClassifier;
 use super::{ClassificationResult, ClassifierBackend, NerSpan};
 
 use super::{CHUNK_OVERLAP_TOKENS, MAX_CHUNK_CONTENT_TOKENS};
 
 struct CandleNerClassifierInner {
-    model: DebertaV2NERModel,
+    model: DebertaV2TokenClassifier,
     tokenizer: Tokenizer,
     /// Maps label index → label string (e.g. `0 → "O"`, `1 → "B-PER"`).
     id2label: Vec<String>,
@@ -53,6 +54,8 @@ struct CandleNerClassifierInner {
     cls_token_id: u32,
     /// Token ID for `[SEP]` special token, resolved at load time.
     sep_token_id: u32,
+    /// Compute device the model tensors live on, resolved at load time.
+    device: Device,
 }
 
 /// Candle-backed DeBERTa-v2 NER classifier.
@@ -273,6 +276,10 @@ impl CandleNerClassifier {
             .map_err(|e| LlmError::ModelLoad(format!("failed to read DeBERTa config: {e}")))?;
         let config: DebertaConfig = serde_json::from_str(&config_str)?;
 
+        // Falls back to a single "O" label when config.json lacks `id2label`. Real DeBERTa NER
+        // checkpoints always carry `id2label`; this fallback sizes the classifier head to a
+        // single class, which fails to load against any real multi-class checkpoint anyway
+        // (surfaced as `LlmError::ModelLoad` below, same net effect as the missing-config case).
         let id2label: Vec<String> = config.id2label.as_ref().map_or_else(
             || vec!["O".into()],
             |m| {
@@ -301,7 +308,8 @@ impl CandleNerClassifier {
             unsafe { VarBuilder::from_mmaped_safetensors(&[weights_path], DType::F32, &device)? };
 
         // HuggingFace DeBERTa v2/v3 safetensors store backbone weights under the deberta.* namespace
-        let model = DebertaV2NERModel::load(vb.pp("deberta"), &config, None)
+        let deberta_vb = vb.pp("deberta");
+        let model = DebertaV2TokenClassifier::load(&deberta_vb, &config, id2label.len())
             .map_err(|e| LlmError::ModelLoad(format!("failed to load DeBERTa NER model: {e}")))?;
 
         Ok(CandleNerClassifierInner {
@@ -310,6 +318,7 @@ impl CandleNerClassifier {
             id2label,
             cls_token_id,
             sep_token_id,
+            device,
         })
     }
 
@@ -321,9 +330,9 @@ impl CandleNerClassifier {
         input_ids: &[u32],
     ) -> Result<Vec<(usize, f32)>, LlmError> {
         let seq_len = input_ids.len();
-        let ids_tensor = Tensor::new(input_ids, &inner.model.device)?.unsqueeze(0)?;
-        let token_type_ids = Tensor::zeros((1, seq_len), DType::I64, &inner.model.device)?;
-        let attention_mask = Tensor::ones((1, seq_len), DType::I64, &inner.model.device)?;
+        let ids_tensor = Tensor::new(input_ids, &inner.device)?.unsqueeze(0)?;
+        let token_type_ids = Tensor::zeros((1, seq_len), DType::I64, &inner.device)?;
+        let attention_mask = Tensor::ones((1, seq_len), DType::I64, &inner.device)?;
 
         // logits: [1, seq_len, num_labels]
         let logits =

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -332,6 +332,40 @@ impl ClaudeProvider {
                 || body.contains("context_management"))
     }
 
+    /// Handle a `compact-2026-01-12` beta rejection at a request call site.
+    ///
+    /// When `*retried` is still `false` and `status`/`text` indicate a beta rejection,
+    /// permanently disables server-side compaction for this session, warns once, sets
+    /// `*retried = true`, and returns `true` so the caller can `continue` its retry loop.
+    /// Returns `false` otherwise, in which case the caller must fall through to normal
+    /// error handling. `variant` labels the call site in the warning (e.g. `"streaming"`,
+    /// `"typed"`); pass `""` for the non-streaming, non-tool call site.
+    fn handle_compact_beta_rejection(
+        &self,
+        status: reqwest::StatusCode,
+        text: &str,
+        retried: &mut bool,
+        variant: &str,
+    ) -> bool {
+        if *retried || !Self::is_compact_beta_rejection(status, text) {
+            return false;
+        }
+        self.server_compaction_rejected
+            .store(true, Ordering::Relaxed);
+        let suffix = if variant.is_empty() {
+            String::new()
+        } else {
+            format!(" ({variant})")
+        };
+        tracing::warn!(
+            "compact-2026-01-12 beta header rejected by Claude API{suffix}; \
+            disabling server-side compaction for this session. \
+            Update your config to set `server_compaction = false`."
+        );
+        *retried = true;
+        true
+    }
+
     #[must_use]
     pub fn with_extended_context(mut self, enabled: bool) -> Self {
         self.enable_extended_context = enabled;
@@ -843,15 +877,7 @@ impl ClaudeProvider {
             let (status, text) = crate::http::read_response_body(response).await?;
 
             if !status.is_success() {
-                if !retried && Self::is_compact_beta_rejection(status, &text) {
-                    self.server_compaction_rejected
-                        .store(true, Ordering::Relaxed);
-                    tracing::warn!(
-                        "compact-2026-01-12 beta header rejected by Claude API; \
-                        disabling server-side compaction for this session. \
-                        Update your config to set `server_compaction = false`."
-                    );
-                    retried = true;
+                if self.handle_compact_beta_rejection(status, &text, &mut retried, "") {
                     continue;
                 }
                 tracing::error!("Claude API error {status}: {text}");
@@ -961,15 +987,7 @@ impl ClaudeProvider {
             let status = response.status();
             if !status.is_success() {
                 let text = response.text().await.map_err(LlmError::Http)?;
-                if !retried && Self::is_compact_beta_rejection(status, &text) {
-                    self.server_compaction_rejected
-                        .store(true, Ordering::Relaxed);
-                    tracing::warn!(
-                        "compact-2026-01-12 beta header rejected by Claude API (tool stream); \
-                        disabling server-side compaction for this session. \
-                        Update your config to set `server_compaction = false`."
-                    );
-                    retried = true;
+                if self.handle_compact_beta_rejection(status, &text, &mut retried, "tool stream") {
                     continue;
                 }
                 tracing::error!("Claude API error {status}: {text}");
@@ -995,15 +1013,7 @@ impl ClaudeProvider {
             let status = response.status();
             if !status.is_success() {
                 let text = response.text().await.map_err(LlmError::Http)?;
-                if !retried && Self::is_compact_beta_rejection(status, &text) {
-                    self.server_compaction_rejected
-                        .store(true, Ordering::Relaxed);
-                    tracing::warn!(
-                        "compact-2026-01-12 beta header rejected by Claude API (streaming); \
-                        disabling server-side compaction for this session. \
-                        Update your config to set `server_compaction = false`."
-                    );
-                    retried = true;
+                if self.handle_compact_beta_rejection(status, &text, &mut retried, "streaming") {
                     continue;
                 }
                 tracing::error!("Claude API streaming request error {status}: {text}");
@@ -1160,15 +1170,7 @@ impl LlmProvider for ClaudeProvider {
             .await?;
             let (status, text) = crate::http::read_response_body(response).await?;
             if !status.is_success() {
-                if !retried && Self::is_compact_beta_rejection(status, &text) {
-                    self.server_compaction_rejected
-                        .store(true, Ordering::Relaxed);
-                    tracing::warn!(
-                        "compact-2026-01-12 beta header rejected by Claude API (typed); \
-                        disabling server-side compaction for this session. \
-                        Update your config to set `server_compaction = false`."
-                    );
-                    retried = true;
+                if self.handle_compact_beta_rejection(status, &text, &mut retried, "typed") {
                     continue;
                 }
                 tracing::error!("Claude API error {status}: {text}");
@@ -1353,15 +1355,7 @@ impl LlmProvider for ClaudeProvider {
             let (status, text) = crate::http::read_response_body(response).await?;
 
             if !status.is_success() {
-                if !retried && Self::is_compact_beta_rejection(status, &text) {
-                    self.server_compaction_rejected
-                        .store(true, Ordering::Relaxed);
-                    tracing::warn!(
-                        "compact-2026-01-12 beta header rejected by Claude API (tool use); \
-                        disabling server-side compaction for this session. \
-                        Update your config to set `server_compaction = false`."
-                    );
-                    retried = true;
+                if self.handle_compact_beta_rejection(status, &text, &mut retried, "tool use") {
                     continue;
                 }
                 tracing::error!("Claude API error {status}: {text}");

--- a/crates/zeph-llm/src/claude/tests.rs
+++ b/crates/zeph-llm/src/claude/tests.rs
@@ -2907,6 +2907,62 @@ fn clone_shares_rejection_flag() {
 }
 
 #[test]
+fn handle_compact_beta_rejection_sets_flags_and_returns_true_on_first_rejection() {
+    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+        .with_server_compaction(true);
+    let mut retried = false;
+    let handled = provider.handle_compact_beta_rejection(
+        reqwest::StatusCode::BAD_REQUEST,
+        "unknown beta: compact-2026-01-12",
+        &mut retried,
+        "typed",
+    );
+    assert!(handled, "must return true on first observed rejection");
+    assert!(retried, "must flip the retry-once flag");
+    assert!(
+        provider.is_server_compaction_rejected(),
+        "must permanently disable server-side compaction"
+    );
+}
+
+#[test]
+fn handle_compact_beta_rejection_returns_false_when_already_retried() {
+    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+        .with_server_compaction(true);
+    let mut retried = true;
+    let handled = provider.handle_compact_beta_rejection(
+        reqwest::StatusCode::BAD_REQUEST,
+        "unknown beta: compact-2026-01-12",
+        &mut retried,
+        "",
+    );
+    assert!(!handled, "must not retry a second time");
+    assert!(
+        !provider.is_server_compaction_rejected(),
+        "must not touch the rejection flag once retry budget is exhausted"
+    );
+}
+
+#[test]
+fn handle_compact_beta_rejection_returns_false_for_non_rejection_error() {
+    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+        .with_server_compaction(true);
+    let mut retried = false;
+    let handled = provider.handle_compact_beta_rejection(
+        reqwest::StatusCode::BAD_REQUEST,
+        r#"{"error":{"message":"max_tokens: field required"}}"#,
+        &mut retried,
+        "streaming",
+    );
+    assert!(
+        !handled,
+        "unrelated 400s must fall through to normal error handling"
+    );
+    assert!(!retried);
+    assert!(!provider.is_server_compaction_rejected());
+}
+
+#[test]
 fn split_messages_structured_compaction_round_trip() {
     // Compaction in an assistant message must be emitted verbatim as an
     // AnthropicContentBlock::Compaction so the API can prune history correctly.


### PR DESCRIPTION
## Summary

Two independent zeph-llm fixes grouped into one PR (triage-and-solve, same crate, non-overlapping files):

- **#5691** (premise-corrected): filed as "CandleNerClassifier is dead code" — investigation found the premise was false. `CandleNerClassifier` is live code wired into the tool-output PII union-merge pipeline (`apply_pii_ner_classifier_with_cfg` in `src/agent_setup.rs`, reachable from `runner.rs`/`daemon.rs`/`acp.rs`, gated by `[classifiers] enabled` + the `classifiers` feature, both off by default). It loaded its DeBERTa-v2 model via the upstream `DebertaV2NERModel::load`, which drops the trained `classifier.bias` tensor and corrupts every token's logits — the same defect `classifier/candle_pii.rs` had already diagnosed and fixed for itself. Fix: extracted the bias-correct model (`PiiNerHead`, renamed `DebertaV2TokenClassifier`) into a new shared `crates/zeph-llm/src/classifier/deberta_token_model.rs`; both `CandlePiiClassifier` and `CandleNerClassifier` now build on it. No API changes.
- **#5683**: `ClaudeProvider` duplicated the same "detect compact-2026-01-12 beta rejection → store flag → warn → retry once" sequence across 5 call sites in `claude/mod.rs`. Extracted into a single `handle_compact_beta_rejection` helper. Pure refactor, byte-identical warn-message text and retry-once semantics preserved.

## Process notes

- #5691's design went through architect → adversarial critic (verdict: minor) before implementation, and the implementation itself was independently critiqued (verdict: approved) and code-reviewed (approved).
- Branch was rebased onto `origin/main` twice during development to pick up two unrelated PRs that landed concurrently and touched overlapping files (`#5703` flipped `LlmProvider::supports_tool_use()`'s default and added an explicit override to `ClaudeProvider`; `#5705` added SHA-256 verification touching `classifier/mod.rs`). Both rebases were verified conflict-free and line-by-line reviewed for accidental loss.

## Test plan

- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci -p zeph-llm --all-targets --features classifiers -- -D warnings` clean (note: `classifiers` is NOT in the default CI feature set, only in `full` — required explicitly to compile-verify the #5691 fix)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm --features classifiers` — 1070 passed, 25 skipped, 0 failed
- [x] Rustdoc gate with `classifiers` feature — clean
- [x] Workspace-wide CI feature set (`desktop,ide,server,chat,pdf,scheduler,testing`) — clippy clean, nextest 12093 passed / 34 skipped, rustdoc gate clean
- [x] 3 new unit tests for `handle_compact_beta_rejection` (retry-once state transition, boolean contract)
- [x] LLM Serialization Gate (required — this PR touches `claude/mod.rs`): live session against the real Claude API, non-tool chat + `chat_with_tools`/`chat_with_tools_stream` with real tool_call/tool_result round-trips — zero 400/422 errors
- [ ] Live verification of the #5691 NER load-path fix with a real checkpoint download — not done in this session (playbook added: `.local/testing/playbooks/ner-classifier-bias-fix.md`); existing decode-only unit tests pass unchanged but cannot catch a missing-bias-tensor regression without a real model

## Follow-ups (out of scope, not filed yet)

- Pre-existing, unrelated doctest failure in `candle_provider/mod.rs:37` (confirmed untouched by this branch)
- Utility-gate scoring gap causing a tool-call loop timeout when `bash`/`list_directory` aren't in the #5658 fix's 0.75-tier list (observed during the live serialization-gate test, unrelated to either fix here)

Closes #5691
Closes #5683