### PR TITLE
fix(sanitizer,core): scrub PII before spotlight-wrapping tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `0.5` as the fallthrough arm and no real MCP tool id has that literal prefix. Migration step
   76 adds a commented `high_gain_tools = []` advisory under `[tools.utility]`; default is an
   empty list, so existing configs are unaffected. (#5659)
+- `fix(sanitizer,core)`: tool output PII scrubbing ran on the fully spotlight-wrapped
+  `<tool-output>`/`<external-data>` string (`sanitize_tool_output`,
+  `crates/zeph-core/src/agent/tool_execution/sanitize.rs`) instead of on the raw payload,
+  so the regex/NER scan could redact structural wrapper text — the tool identifier in the
+  `name`/`ref` attribute got misclassified and replaced with `[PII:USERNAME]`-style markers
+  (#5647), and command-echo/preamble noise around the actual output confused the NER model.
+  Combined with `PHONE_RE` (`crates/zeph-sanitizer/src/pii.rs`) matching any bare,
+  undelimited run of 10 digits — including Unix epoch timestamps, PIDs, and byte counts —
+  ordinary tool output such as `date +%s.%N`'s timestamp was corrupted into
+  `[PII:phone]` before ever reaching the LLM, causing the agent to falsely report that the
+  command had failed (#5702). PII scrubbing now runs on the raw tool-output body before
+  `ContentSanitizer::sanitize` wraps it, so the tool identifier and wrapper markup never
+  enter the PII scan; `PHONE_RE` now requires at least one delimiter (a separator between
+  digit groups, or a closing parenthesis after the area code) so a bare 10-digit run is no
+  longer treated as a phone number, while `555-123-4567`, `(555) 123-4567`,
+  `+1 555 123 4567`, and `555.123.4567` are still detected. The reorder alone stopped the
+  wrapper from being scanned, but the `bash`/`shell` command-echo line itself (`"$
+  {command}\n"`, prepended to real output by `crates/zeph-tools/src/shell/mod.rs`) is
+  Zeph-generated text, not command output, and symbol-heavy tokens in it (e.g. `+%s.%N`)
+  could still be NER-misclassified as `[PII:PASSWORD]`-style markers. A new
+  `split_bash_echo_prefix` helper (`sanitize.rs`) now splits that literal echo line off
+  before PII scrubbing and reattaches it unscanned — deliberately narrower than exempting
+  the tool's entire output (as the ML injection classifier's `is_internal_tool` does),
+  since real `bash`/`shell` command output (e.g. `cat customer_data.csv`) can legitimately
+  contain real PII and must remain fully scanned.
 - `fix(llm)`: `OpenAiProvider::chat_with_tools` (`crates/zeph-llm/src/openai/mod.rs`) sent its
   request directly via `.send().await?` with a manual one-shot 429 special case, instead of
   going through the shared `send_with_retry` helper used by every other request path on the

--- a/crates/zeph-core/src/agent/state/security.rs
+++ b/crates/zeph-core/src/agent/state/security.rs
@@ -134,6 +134,14 @@ impl SecurityState {
     ///
     /// Updates `ner_timeouts` and `circuit_breaker_tripped` accumulators in place.
     /// No-op when the circuit breaker is already tripped or no backend is configured.
+    ///
+    /// Callers are responsible for excluding any Zeph-generated (non-command-output) text
+    /// from `text` before calling this — e.g. `sanitize_tool_output`
+    /// (`crates/zeph-core/src/agent/tool_execution/sanitize.rs`) strips the bash/shell
+    /// command-echo line via `split_bash_echo_prefix` before invoking the PII scrub, since
+    /// that echo line is Zeph-generated and NER-prone to false positives on it (#5702), while
+    /// the rest of `bash`/`shell` output is genuine command output that can legitimately
+    /// contain real PII and must still be fully scanned here.
     #[cfg(feature = "classifiers")]
     async fn run_ner_classifier(
         &mut self,

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -53,6 +53,34 @@ fn is_internal_tool(tool_name: &str) -> bool {
     !tool_name.contains(':') && INTERNAL_TOOLS.contains(&tool_name)
 }
 
+/// Splits off the literal `"$ {command}\n"` echo line that `bash`/`shell` tool output is
+/// prefixed with (`crates/zeph-tools/src/shell/mod.rs`'s `execute_block`/
+/// `execute_block_with_context`, `format!("$ {command}\n{filtered}")`), so that this
+/// Zeph-generated echo text is never subject to PII scanning (regex or NER) — only the
+/// actual command output after it is.
+///
+/// Unlike [`is_internal_tool`], which exempts an internal tool's *entire* output from the
+/// ML injection classifier (safe there because injection payloads must be attacker-authored
+/// text), `bash`/`shell` output legitimately CAN contain real PII from the command's actual
+/// output (e.g. `cat customer_data.csv`). So only the literal echo line — never real command
+/// output — is exempt here; everything after the first line still goes through full PII
+/// scanning unchanged (#5702).
+///
+/// Returns `(prefix, remainder)`: `prefix` must be reattached unscanned (includes the
+/// trailing newline), and `remainder` is what the PII scrubber should run on. For any tool
+/// other than `bash`/`shell`, or when the body doesn't start with the exact `"$ "` echo
+/// marker (e.g. a snapshot-rollback warning line precedes it — a narrow, accepted gap since
+/// that shape is rare), returns `("", body)` unchanged so full PII scanning applies as before.
+fn split_bash_echo_prefix<'a>(body: &'a str, tool_name: &str) -> (&'a str, &'a str) {
+    if !matches!(tool_name, "bash" | "shell") || !body.starts_with("$ ") {
+        return ("", body);
+    }
+    match body.find('\n') {
+        Some(idx) => body.split_at(idx + 1),
+        None => ("", body),
+    }
+}
+
 /// Build the `ContentSource` that describes a tool's trust level for the sanitizer.
 fn build_tool_output_source(tool_name: &str) -> ContentSource {
     if tool_name.contains(':') || tool_name == "mcp" {
@@ -87,7 +115,27 @@ impl<C: Channel> Agent<C> {
         let memory_hint = source.memory_hint;
         #[cfg(not(feature = "classifiers"))]
         let _ = source.memory_hint;
-        let sanitized = self.services.security.sanitizer.sanitize(body, source);
+
+        // Scrub PII on the raw payload BEFORE `ContentSanitizer::sanitize` wraps it in the
+        // <tool-output>/<external-data> spotlight XML. Scanning after wrapping (the previous
+        // order) let the regex/NER scan redact structural wrapper text — including the tool
+        // identifier in the `name` attribute (#5647) — instead of only the actual tool output
+        // content, which is also how ordinary numeric output got misredacted (#5702).
+        //
+        // For bash/shell, the leading "$ {command}\n" echo line is Zeph-generated text (not
+        // real command output) and is split off first so it's never PII-scanned either —
+        // command-echo tokens like `+%s.%N` were otherwise misclassified by the NER model as
+        // e.g. `[PII:PASSWORD]` (#5702). Everything after that line is real command output and
+        // still goes through full PII scanning, since it can legitimately contain real PII.
+        let (echo_prefix, scrub_target) = split_bash_echo_prefix(body, tool_name);
+        let scrubbed_remainder = self.scrub_pii_union(scrub_target, tool_name).await;
+        let body = if echo_prefix.is_empty() {
+            scrubbed_remainder
+        } else {
+            format!("{echo_prefix}{scrubbed_remainder}")
+        };
+
+        let sanitized = self.services.security.sanitizer.sanitize(&body, source);
         let has_injection_flags = !sanitized.injection_flags.is_empty();
         self.record_injection_flags(&sanitized, tool_name);
         if sanitized.was_truncated {
@@ -102,7 +150,7 @@ impl<C: Channel> Agent<C> {
 
         #[cfg(feature = "classifiers")]
         if let Some(result) = self
-            .apply_classifier_verdict(body, tool_name, memory_hint)
+            .apply_classifier_verdict(&body, tool_name, memory_hint)
             .await
         {
             return result;
@@ -133,7 +181,7 @@ impl<C: Channel> Agent<C> {
             return result;
         }
 
-        let body = self.scrub_pii_union(&sanitized.body, tool_name).await;
+        let body = sanitized.body;
         self.record_nli_verdict(&body, tool_name).await;
         let body = self.apply_guardrail_to_tool_output(body, tool_name).await;
 
@@ -417,6 +465,52 @@ impl<C: Channel> Agent<C> {
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod split_bash_echo_prefix_tests {
+    use super::split_bash_echo_prefix;
+
+    #[test]
+    fn splits_bash_echo_line() {
+        let body = "$ date +%s.%N\n1783259155.445901000\n";
+        let (prefix, remainder) = split_bash_echo_prefix(body, "bash");
+        assert_eq!(prefix, "$ date +%s.%N\n");
+        assert_eq!(remainder, "1783259155.445901000\n");
+    }
+
+    #[test]
+    fn splits_shell_echo_line() {
+        let body = "$ ls -la\ntotal 0\n";
+        let (prefix, remainder) = split_bash_echo_prefix(body, "shell");
+        assert_eq!(prefix, "$ ls -la\n");
+        assert_eq!(remainder, "total 0\n");
+    }
+
+    #[test]
+    fn non_bash_shell_tool_not_split() {
+        let body = "$ date +%s.%N\n1783259155.445901000\n";
+        let (prefix, remainder) = split_bash_echo_prefix(body, "web-scrape");
+        assert_eq!(prefix, "");
+        assert_eq!(remainder, body);
+    }
+
+    #[test]
+    fn body_without_dollar_prefix_not_split() {
+        let body = "no echo line here\nsome output\n";
+        let (prefix, remainder) = split_bash_echo_prefix(body, "bash");
+        assert_eq!(prefix, "");
+        assert_eq!(remainder, body);
+    }
+
+    #[test]
+    fn body_without_newline_not_split() {
+        // No trailing newline after the echo line — nothing to safely split off.
+        let body = "$ date +%s.%N";
+        let (prefix, remainder) = split_bash_echo_prefix(body, "bash");
+        assert_eq!(prefix, "");
+        assert_eq!(remainder, body);
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -878,6 +878,123 @@ mod pii_ner_circuit_breaker {
             "circuit breaker must not trip when threshold = 0"
         );
     }
+
+    // --- bash/shell command-echo line exemption from NER PII scanning (#5702) ---
+    //
+    // A real NER model tends to misclassify symbol-heavy command-echo tokens (e.g. `+%s.%N`
+    // from `date +%s.%N`) as PII categories such as PASSWORD. That echo line
+    // (`"$ {command}\n"`) is Zeph-generated text, not real command output — see
+    // `split_bash_echo_prefix` in `crates/zeph-core/src/agent/tool_execution/sanitize.rs`,
+    // called from `sanitize_tool_output` before PII scrubbing. Unlike the ML injection
+    // classifier's `is_internal_tool` exemption (which excludes an internal tool's *entire*
+    // output), only the literal echo line is exempt here: `bash`/`shell` output after that
+    // line is genuine command output that can legitimately contain real PII (e.g.
+    // `cat customer_data.csv`) and must still be fully scanned. These tests exercise the
+    // actual `sanitize_tool_output` pipeline with a mock NER backend that flags a marker
+    // token, proving the echo line is exempt, real output after it is not, and the
+    // exemption is scoped to `bash`/`shell` only.
+
+    /// Backend that flags a fixed marker substring as a positive NER span, simulating a real
+    /// model misclassifying a symbol-heavy command-echo token as PII.
+    struct MarkerFlaggingBackend;
+
+    const NER_TEST_MARKER: &str = "+%s.%N";
+
+    impl ClassifierBackend for MarkerFlaggingBackend {
+        fn classify<'a>(
+            &'a self,
+            text: &'a str,
+        ) -> Pin<
+            Box<
+                dyn Future<Output = Result<ClassificationResult, zeph_llm::error::LlmError>>
+                    + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                if let Some(byte_pos) = text.find(NER_TEST_MARKER) {
+                    // The marker is ASCII-only, so byte offset == char offset here.
+                    let start = byte_pos;
+                    let end = start + NER_TEST_MARKER.len();
+                    Ok(ClassificationResult {
+                        label: "PASSWORD".into(),
+                        score: 0.97,
+                        is_positive: true,
+                        spans: vec![zeph_llm::classifier::NerSpan {
+                            label: "PASSWORD".into(),
+                            score: 0.97,
+                            start,
+                            end,
+                        }],
+                    })
+                } else {
+                    Ok(ClassificationResult {
+                        label: "O".into(),
+                        score: 0.0,
+                        is_positive: false,
+                        spans: vec![],
+                    })
+                }
+            })
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "marker_flagging"
+        }
+    }
+
+    #[tokio::test]
+    async fn bash_command_echo_line_exempt_from_ner_pii() {
+        let mut agent = make_agent_with_ner(Arc::new(MarkerFlaggingBackend), 5000, 2);
+        let body = "$ date +%s.%N\n1783259155.445901000\n";
+
+        let (result, _) = agent.sanitize_tool_output(body, "bash").await;
+
+        assert!(
+            result.contains(NER_TEST_MARKER),
+            "echo line must survive unredacted: {result}"
+        );
+        assert!(
+            !result.contains("[PII:PASSWORD]"),
+            "echo line must not be NER-scanned: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_output_after_echo_line_still_scanned_by_ner() {
+        // Proves the exemption is scoped to the echo line only — real command output after
+        // it (which can legitimately contain PII) must still be fully NER-scanned.
+        let mut agent = make_agent_with_ner(Arc::new(MarkerFlaggingBackend), 5000, 2);
+        let body = format!("$ cat notes.txt\nvalue {NER_TEST_MARKER} here\n");
+
+        let (result, _) = agent.sanitize_tool_output(&body, "bash").await;
+
+        assert!(
+            result.contains("[PII:PASSWORD]"),
+            "real command output must still be NER-scanned: {result}"
+        );
+        assert!(!result.contains(NER_TEST_MARKER));
+        assert!(
+            result.contains("$ cat notes.txt"),
+            "echo line itself must remain untouched: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_bash_tool_output_not_exempted_even_with_dollar_prefix() {
+        // Proves the echo-line split is scoped by tool name, not just by a leading "$ "
+        // marker — a non-bash/shell tool whose body happens to start with "$ " must still
+        // be fully NER-scanned.
+        let mut agent = make_agent_with_ner(Arc::new(MarkerFlaggingBackend), 5000, 2);
+        let body = format!("$ {NER_TEST_MARKER} looks like an echo but isn't\n");
+
+        let (result, _) = agent.sanitize_tool_output(&body, "web-scrape").await;
+
+        assert!(
+            result.contains("[PII:PASSWORD]"),
+            "non-bash/shell tool output must not get the echo-line exemption: {result}"
+        );
+    }
 }
 
 // ── HistogramRecorder wiring tests (#2874) ────────────────────────────────

--- a/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
@@ -110,6 +110,57 @@ async fn sanitize_tool_output_bash_uses_tool_output_wrapper() {
     assert_tool_output!("bash", "command output");
 }
 
+// Regression test for #5702 + #5647: PII scrubbing must run on the raw tool-output
+// payload before the spotlight wrapper is applied. Previously it ran on the fully
+// wrapped string, so a bare epoch-timestamp-shaped digit run in the body was misredacted
+// as `[PII:phone]`, and the wrapper's `name="bash"` attribute was itself in-scope for
+// scanning. This test exercises only the regex `PiiFilter` path (no NER backend is
+// attached here, so `pii_ner_backend` stays `None` and `run_ner_classifier` is a no-op);
+// the NER-specific misclassification of symbol-heavy tokens (e.g. `+%s.%N`) and the
+// bash/shell echo-line exemption (`split_bash_echo_prefix`) are covered separately by
+// `pii_ner_circuit_breaker::bash_command_echo_line_exempt_from_ner_pii` in
+// `boundary_and_classifier_tests.rs`, which requires the `classifiers` feature to attach a
+// mock NER backend.
+#[tokio::test]
+async fn sanitize_tool_output_does_not_redact_epoch_timestamp_or_tool_identifier() {
+    use crate::agent::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+    let cfg = zeph_sanitizer::ContentIsolationConfig {
+        enabled: true,
+        spotlight_untrusted: true,
+        flag_injection_patterns: false,
+        ..Default::default()
+    };
+    agent.services.security.sanitizer = zeph_sanitizer::ContentSanitizer::new(&cfg);
+    agent.services.security.pii_filter =
+        zeph_sanitizer::pii::PiiFilter::new(zeph_sanitizer::pii::PiiFilterConfig {
+            enabled: true,
+            ..Default::default()
+        });
+
+    let body = "$ date +%s.%N\n1783259155.445901000\n";
+    let (result, _) = agent.sanitize_tool_output(body, "bash").await;
+
+    assert!(
+        result.contains("1783259155.445901000"),
+        "bare epoch timestamp must not be misredacted as phone PII: {result}"
+    );
+    assert!(
+        result.contains("name=\"bash\""),
+        "tool identifier must never be routed through PII scanning: {result}"
+    );
+    assert!(
+        !result.contains("[PII:"),
+        "no PII should be flagged for this body: {result}"
+    );
+}
+
 // R-06: disabled sanitizer returns raw body unchanged
 #[tokio::test]
 async fn sanitize_tool_output_disabled_returns_raw_body() {
@@ -218,6 +269,72 @@ async fn sanitize_tool_output_quarantine_web_scrape_invoked() {
     assert_eq!(
         snap.quarantine_failures, 0,
         "quarantine_failures should be 0"
+    );
+}
+
+// Regression test for the #5702/#5647 reorder's side effect: quarantine paths used to
+// return early *before* `scrub_pii_union` ran, so quarantined content was never
+// PII-scrubbed at all. After the reorder, PII scrubbing happens unconditionally before
+// quarantine can short-circuit, so the quarantine LLM must only ever see already-scrubbed
+// content. Uses `with_recording` to inspect the actual prompt sent to the quarantine
+// provider, since the mock response itself doesn't reflect input content.
+#[tokio::test]
+async fn sanitize_tool_output_quarantine_receives_pii_scrubbed_content() {
+    use crate::agent::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use zeph_llm::mock::MockProvider;
+    use zeph_sanitizer::QuarantineConfig;
+    use zeph_sanitizer::quarantine::QuarantinedSummarizer;
+    use zeph_sanitizer::{ContentIsolationConfig, ContentSanitizer};
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let (quarantine_provider, recorded) =
+        MockProvider::with_responses(vec!["Fact: page title is Zeph".to_owned()]).with_recording();
+    let quarantine_provider = zeph_llm::any::AnyProvider::Mock(quarantine_provider);
+    let qcfg = QuarantineConfig {
+        enabled: true,
+        sources: vec!["web_scrape".to_owned()],
+        model: "claude".to_owned(),
+        timeout_ms: 30_000,
+    };
+    let qs = QuarantinedSummarizer::new(quarantine_provider, &qcfg);
+
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_quarantine_summarizer(qs);
+    agent.services.security.sanitizer = ContentSanitizer::new(&ContentIsolationConfig {
+        enabled: true,
+        spotlight_untrusted: true,
+        flag_injection_patterns: false,
+        ..Default::default()
+    });
+    agent.services.security.pii_filter =
+        zeph_sanitizer::pii::PiiFilter::new(zeph_sanitizer::pii::PiiFilterConfig {
+            enabled: true,
+            ..Default::default()
+        });
+
+    let body = "contact us at 555-123-4567 for details";
+    let _ = agent.sanitize_tool_output(body, "web_scrape").await;
+
+    let calls = recorded.lock().unwrap();
+    assert_eq!(calls.len(), 1, "quarantine provider should be called once");
+    let prompt = calls[0]
+        .iter()
+        .map(|m| m.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !prompt.contains("555-123-4567"),
+        "quarantine LLM must not see raw PII in the prompt: {prompt}"
+    );
+    assert!(
+        prompt.contains("[PII:phone]"),
+        "quarantine LLM prompt should contain the scrubbed marker: {prompt}"
     );
 }
 

--- a/crates/zeph-sanitizer/src/pii.rs
+++ b/crates/zeph-sanitizer/src/pii.rs
@@ -56,8 +56,26 @@ pub(crate) static EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 /// US phone numbers, optional country code.
+///
+/// At least one delimiter (a closing parenthesis after the area code, or a separator
+/// between digit groups) is required somewhere in the number. A bare, undelimited run of
+/// 10 digits (e.g. a Unix epoch timestamp such as `1783259155`, a PID, or a byte count)
+/// satisfies `\d{3}\d{3}\d{4}` and is indistinguishable from a real phone number without
+/// this requirement — this was the root cause of ordinary numeric tool output being
+/// misredacted as `[PII:phone]` (#5702). The three alternatives below each force a
+/// delimiter in a different position so that `555-123-4567`, `(555) 123-4567`, and
+/// `555.123.4567` all still match.
+///
+/// `\b` cannot match immediately before a leading `(` (both are non-word-adjacent-to-space,
+/// so no boundary exists there); as with the pre-existing `+` handling below, the opening
+/// parenthesis is therefore left unredacted and the match starts at the digits, using the
+/// closing `)` as the delimiter signal instead — consistent with the already-documented
+/// behavior that a leading `+` is left in the clear (see `scrubs_us_phone_with_country_code`).
 static PHONE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"\b(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b").expect("valid PHONE_RE")
+    Regex::new(
+        r"\b(\+?1[-.\s]?)?(?:\d{3}\)[-.\s]?\d{3}[-.\s]?\d{4}|\d{3}[-.\s]\d{3}[-.\s]?\d{4}|\d{3}[-.\s]?\d{3}[-.\s]\d{4})\b",
+    )
+    .expect("valid PHONE_RE")
 });
 
 /// US Social Security Number (NNN-NN-NNNN).
@@ -623,6 +641,55 @@ mod tests {
         let result = f.scrub("call +1-800-555-1234 now");
         // The regex uses \b which won't anchor before '+', so '+' is left behind.
         assert_eq!(result, "call +[PII:phone] now");
+    }
+
+    #[test]
+    fn scrubs_phone_with_parens() {
+        let f = filter_all();
+        let result = f.scrub("call (555) 123-4567 now");
+        // The regex uses \b which won't anchor before '(', so '(' is left behind —
+        // same documented leak behavior as the leading '+' in scrubs_us_phone_with_country_code.
+        assert_eq!(result, "call ([PII:phone] now");
+    }
+
+    #[test]
+    fn scrubs_phone_with_dots() {
+        let f = filter_all();
+        let result = f.scrub("call 555.123.4567 now");
+        assert_eq!(result, "call [PII:phone] now");
+    }
+
+    #[test]
+    fn scrubs_phone_with_country_code_and_spaces() {
+        let f = filter_all();
+        let result = f.scrub("call +1 555 123 4567 now");
+        assert_eq!(result, "call +[PII:phone] now");
+    }
+
+    // --- phone false positive: bare digit runs (#5702) ---
+
+    #[test]
+    fn does_not_scrub_bare_epoch_timestamp_as_phone() {
+        let f = filter_all();
+        // Unix epoch seconds — a bare 10-digit run with no delimiters must not be
+        // misclassified as a phone number (#5702 root cause).
+        let text = "timestamp 1783259155.445901000 recorded";
+        let result = f.scrub(text);
+        assert_eq!(
+            result, text,
+            "bare undelimited 10-digit run must not be detected as phone: {result}"
+        );
+    }
+
+    #[test]
+    fn does_not_scrub_bare_digit_run_without_country_code_as_phone() {
+        let f = filter_all();
+        let text = "pid 5551234567 exited";
+        let result = f.scrub(text);
+        assert_eq!(
+            result, text,
+            "bare undelimited digit run must not be detected as phone: {result}"
+        );
     }
 
     // --- SSN ---


### PR DESCRIPTION
## Summary

- PII scrubbing (regex + NER) previously ran on the fully spotlight-wrapped `<tool-output>` string instead of the raw tool-output payload, so the scan could redact structural wrapper text — the tool identifier in the `name` attribute got misclassified and replaced with a PII marker (#5647), and wrapper/preamble markup confused the NER model.
- Combined with `PHONE_RE` matching any bare, undelimited run of 10 digits, ordinary numeric tool output (e.g. a Unix epoch timestamp from `date +%s.%N`) was corrupted into a phone-number redaction before reaching the LLM, causing the agent to falsely report that the command had failed (#5702).
- PII scrubbing now runs on the raw tool-output body *before* `ContentSanitizer::sanitize` wraps it, so the tool identifier and wrapper markup never enter the PII scan. `PHONE_RE` now requires at least one delimiter, so bare digit runs no longer match while real phone number formats (`555-123-4567`, `(555) 123-4567`, `+1 555 123 4567`, `555.123.4567`) still do.
- A new `split_bash_echo_prefix` helper splits off the `bash`/`shell` command-echo line (`"$ {command}\n"`, Zeph-generated text) before scrubbing and reattaches it unscanned, since symbol-heavy tokens in it (e.g. `+%s.%N`) could still be NER-misclassified. This is deliberately narrower than exempting a tool's entire output — real command output (e.g. `cat customer_data.csv`) can legitimately contain real PII and must remain fully scanned by both regex and NER.

Closes #5702, closes #5647

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12092 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing unrelated warnings only)
- [x] `cargo clippy --profile ci -p zeph-core -p zeph-sanitizer --features classifiers -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-core -p zeph-sanitizer --features classifiers` — 2051 passed, 0 failed
- [x] New regression tests cover: bare-digit timestamp survives unredacted, tool identifier survives unredacted, real phone number formats still redacted, quarantine-path output still gets PII-scrubbed, bash echo-line marker exempt while real output after it is still NER-scanned, non-bash tools with a `$ `-prefixed body are not exempted