### PR TITLE
fix(tools): close utility gate mcp_* stall with opt-in high_gain_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   silently reintroduce a context-overflow the prior escalation stage had already fixed; returns
   `LlmError::NoProviders` if no tier both supports tools and fits context, matching
   `RouterProvider`'s existing behavior for the equivalent case. (#5688)
+- `fix(tools)`: `UtilityScoringConfig` gains `high_gain_tools: Vec<String>` — an opt-in list of
+  tool ids that always receive the same `0.75` "direct action" gain as
+  `diagnostics`/`edit`/etc, checked in `UtilityScorer::score` before falling through to the
+  hardcoded `default_gain` table. #5658 fixed this stall for a handful of built-in tool names,
+  but the hardcoded table structurally cannot cover dynamically registered tools — most
+  notably MCP tools, whose ids are `{server_id}_{name}` (`McpTool::sanitized_id`), not a
+  literal `"mcp_"` prefix. Any MCP tool (or future built-in tool without a table entry) still
+  fell to the neutral `0.5` bucket and could stall behind a `Retrieve -> redundant retry ->
+  vetoed` cycle on its first call. `high_gain_tools` lets operators opt individual tool ids
+  into the high-gain tier via config, with case-insensitive matching mirroring the existing
+  `exempt_tools` list (both now share a private `contains_tool_name` lookup). Also removed the
+  `default_gain` `tool_name.starts_with("mcp_")` branch — dead code, since it returned the same
+  `0.5` as the fallthrough arm and no real MCP tool id has that literal prefix. Migration step
+  76 adds a commented `high_gain_tools = []` advisory under `[tools.utility]`; default is an
+  empty list, so existing configs are unaffected. (#5659)
 - `fix(llm)`: `OpenAiProvider::chat_with_tools` (`crates/zeph-llm/src/openai/mod.rs`) sent its
   request directly via `.send().await?` with a manual one-shot 429 special case, instead of
   going through the shared `send_with_retry` helper used by every other request path on the

--- a/config/default.toml
+++ b/config/default.toml
@@ -744,6 +744,13 @@ enabled = false
 threshold = 0.1
 # Consecutive low-utility calls before early-stopping the whole tool loop for the turn. 0 = disabled.
 # utility_window = 0
+# Tool ids that always receive the 0.75 "direct action" gain tier, bypassing the Retrieve
+# detour on their first call. Useful for MCP-registered tools, whose ids ("{server_id}_{name}")
+# never match the built-in default_gain table (#5659).
+# Note: the TUI command palette's "mcp:list" entry displays "server_id:name" (qualified_name),
+# but the id actually dispatched at runtime — and required here — is the sanitized
+# "server_id_name" form (colon replaced with underscore).
+# high_gain_tools = []
 
 [tools.retry]
 # Maximum retry attempts for transient errors per tool call (0 = disabled)

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -619,10 +619,11 @@ use steps::{
     MigrateShellCheckpointsConfig, MigrateShellTransactional, MigrateSttToProvider,
     MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
     MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig,
-    MigrateTuiThemeDefaults, MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
+    MigrateTuiThemeDefaults, MigrateUtilityHighGainTools, MigrateVigilConfig,
+    MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–75).
+/// Ordered registry of all sequential migration steps (steps 1–76).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -756,6 +757,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigratePiiFilterNames),
             // Step 75 — add qdrant_timeout_secs advisory under [memory]
             Box::new(MigrateQdrantTimeoutSecs),
+            // Step 76 — add high_gain_tools advisory under [tools.utility] (#5659)
+            Box::new(MigrateUtilityHighGainTools),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -35,7 +35,8 @@
 //! step 73 adds a `[security.content_isolation.secret_masking]` advisory block (#5437);
 //! step 74 adds a commented `filter_names = false` advisory to an existing
 //! `[security.pii_filter]` table (#5530);
-//! step 75 adds a commented `qdrant_timeout_secs = 10` advisory under `[memory]`.
+//! step 75 adds a commented `qdrant_timeout_secs = 10` advisory under `[memory]`;
+//! step 76 adds a commented `high_gain_tools = []` advisory under `[tools.utility]` (#5659).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -69,8 +70,8 @@ use super::{
     migrate_shell_checkpoints_config, migrate_shell_transactional, migrate_stt_to_provider,
     migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
     migrate_trace_metadata, migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config,
-    migrate_tui_theme_defaults, migrate_vigil_config, migrate_worktree_config,
-    migrate_worktree_git_timeout,
+    migrate_tui_theme_defaults, migrate_utility_high_gain_tools, migrate_vigil_config,
+    migrate_worktree_config, migrate_worktree_git_timeout,
 };
 
 // ── Wrapper structs for all 73 sequential migration steps ───────────────────────────────────────
@@ -910,5 +911,17 @@ impl Migration for MigrateQdrantTimeoutSecs {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_qdrant_timeout_secs(toml_src)
+    }
+}
+
+/// Step 76 — adds a commented `high_gain_tools = []` advisory under `[tools.utility]` (#5659).
+pub(super) struct MigrateUtilityHighGainTools;
+impl Migration for MigrateUtilityHighGainTools {
+    fn name(&self) -> &'static str {
+        "migrate_utility_high_gain_tools"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_utility_high_gain_tools(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        75,
-        "MIGRATIONS registry must contain all 75 sequential steps"
+        76,
+        "MIGRATIONS registry must contain all 76 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1645,7 +1645,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 75);
+    assert_eq!(MIGRATIONS.len(), 76);
 }
 
 #[test]
@@ -1684,7 +1684,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–74).
+    // Names must follow the documented step order (steps 1–76).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1761,6 +1761,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_secret_masking_config",
         "migrate_pii_filter_names",
         "migrate_qdrant_timeout_secs",
+        "migrate_utility_high_gain_tools",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -1881,6 +1882,56 @@ fn migrate_qdrant_timeout_secs_idempotent_on_commented_output() {
     let first = migrate_qdrant_timeout_secs(base).unwrap();
     assert_eq!(first.changed_count, 1);
     let second = migrate_qdrant_timeout_secs(&first.output).unwrap();
+    assert_eq!(second.changed_count, 0, "second run must not double-append");
+    assert_eq!(second.output, first.output);
+}
+
+// ── migrate_utility_high_gain_tools tests (#5659) ─────────────────────────
+
+#[test]
+fn migrate_utility_high_gain_tools_adds_comment_when_absent() {
+    let src = "[tools.utility]\nenabled = false\nthreshold = 0.1\n";
+    let result = migrate_utility_high_gain_tools(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result
+            .sections_changed
+            .contains(&"tools.utility.high_gain_tools".to_owned())
+    );
+    assert!(result.output.contains("# high_gain_tools = []"));
+}
+
+#[test]
+fn migrate_utility_high_gain_tools_is_noop_when_present() {
+    let src = "[tools.utility]\nhigh_gain_tools = [\"github_create_issue\"]\n";
+    let result = migrate_utility_high_gain_tools(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert!(result.sections_changed.is_empty());
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn migrate_utility_high_gain_tools_appends_when_tools_utility_section_absent() {
+    // Unlike migrate_qdrant_timeout_secs (step 75), this migration never parses the TOML
+    // with toml_edit — it only string-matches "high_gain_tools" and appends a fully
+    // commented-out block. Confirm this holds even when [tools.utility] is missing
+    // entirely, and that the output remains valid TOML.
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let result = migrate_utility_high_gain_tools(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("# high_gain_tools = []"));
+    result
+        .output
+        .parse::<toml_edit::DocumentMut>()
+        .expect("migrated output must remain valid TOML");
+}
+
+#[test]
+fn migrate_utility_high_gain_tools_idempotent_on_commented_output() {
+    let base = "[tools.utility]\nenabled = false\n";
+    let first = migrate_utility_high_gain_tools(base).unwrap();
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_utility_high_gain_tools(&first.output).unwrap();
     assert_eq!(second.changed_count, 0, "second run must not double-append");
     assert_eq!(second.output, first.output);
 }

--- a/crates/zeph-config/src/migrate/tools.rs
+++ b/crates/zeph-config/src/migrate/tools.rs
@@ -271,6 +271,40 @@ pub fn migrate_policy_provider_and_utility_window(
     })
 }
 
+/// Add a commented-out `high_gain_tools` hint under `[tools.utility]` when absent.
+///
+/// Introduced alongside `UtilityScoringConfig::high_gain_tools` (#5659): an opt-in list of
+/// tool ids that always receive the same `0.75` "direct action" gain tier as
+/// `diagnostics`/`edit`/etc, most useful for MCP-registered tools whose ids the built-in
+/// `default_gain` table can never match. The field has `#[serde(default)]` (empty `Vec`), so
+/// existing configs parse unchanged; this step only surfaces the option so users can
+/// discover it.
+///
+/// # Errors
+///
+/// Returns [`MigrateError::Parse`] when `toml_src` is not valid TOML.
+pub fn migrate_utility_high_gain_tools(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("high_gain_tools") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Tool ids that always receive the 0.75 \"direct action\" gain tier, bypassing\n\
+         # the Retrieve detour on their first call. Useful for MCP-registered tools, whose\n\
+         # ids (\"{server_id}_{name}\") never match the built-in default_gain table (#5659).\n\
+         # [tools.utility]\n\
+         # high_gain_tools = []\n";
+
+    Ok(MigrationResult {
+        output: format!("{toml_src}{comment}"),
+        changed_count: 1,
+        sections_changed: vec!["tools.utility.high_gain_tools".to_owned()],
+    })
+}
+
 /// Add `checkpoints_enabled` and `max_checkpoints` to `[tools.shell]` as commented-out defaults.
 ///
 /// # Errors

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -612,6 +612,17 @@ pub struct UtilityScoringConfig {
     /// The counter resets between outer loop iterations.
     #[serde(default)]
     pub utility_window: usize,
+    /// Tool names that always receive the `0.75` "direct action" gain tier, matching
+    /// `diagnostics`/`edit`/etc in the built-in `default_gain` table.
+    ///
+    /// Opt-in override for tool ids the built-in table has no entry for — most notably
+    /// MCP-registered tools, whose ids are `{server_id}_{name}` (see
+    /// `McpTool::sanitized_id`) and therefore never match a hardcoded name. Without an
+    /// entry here, such a tool falls to the generic `0.5` bucket and can stall behind a
+    /// `Retrieve -> redundant retry -> vetoed` cycle on its first call (#5659). Default:
+    /// empty (no behavior change for existing configs).
+    #[serde(default)]
+    pub high_gain_tools: Vec<String>,
 }
 
 impl Default for UtilityScoringConfig {
@@ -625,6 +636,7 @@ impl Default for UtilityScoringConfig {
             uncertainty_bonus: default_utility_uncertainty_bonus(),
             exempt_tools: default_utility_exempt_tools(),
             utility_window: 0,
+            high_gain_tools: Vec::new(),
         }
     }
 }
@@ -1536,6 +1548,32 @@ destination = "/var/log/zeph-audit.log""#,
         let json = serde_json::to_string(&w.utility_scoring).unwrap();
         let back: UtilityScoringConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(back.utility_window, 3);
+    }
+
+    #[test]
+    fn high_gain_tools_default_is_empty() {
+        let config = UtilityScoringConfig::default();
+        assert!(config.high_gain_tools.is_empty());
+    }
+
+    #[test]
+    fn high_gain_tools_serde_roundtrip() {
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            utility_scoring: UtilityScoringConfig,
+        }
+
+        let toml_str =
+            "[utility_scoring]\nenabled = true\nhigh_gain_tools = [\"github_create_issue\"]\n";
+        let w: Wrapper = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            w.utility_scoring.high_gain_tools,
+            vec!["github_create_issue"]
+        );
+
+        let json = serde_json::to_string(&w.utility_scoring).unwrap();
+        let back: UtilityScoringConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.high_gain_tools, vec!["github_create_issue"]);
     }
 
     #[test]

--- a/crates/zeph-tools/src/utility.rs
+++ b/crates/zeph-tools/src/utility.rs
@@ -61,12 +61,17 @@ pub fn has_explicit_tool_request(user_message: &str) -> bool {
 /// through "retrieve context first, then retry": there is no missing context a
 /// memory search could supply, so forcing that detour only produces a stalled
 /// retry that then gets vetoed again as a redundant duplicate call (#5650).
+///
+/// This table only covers built-in tool ids known at compile time. Dynamically
+/// registered tools — most notably MCP tools, whose ids are `{server_id}_{name}`
+/// (see `McpTool::sanitized_id`) — never match a hardcoded name here and fall to the
+/// generic `0.5` bucket, exposing them to the same stall #5650 fixed for built-ins.
+/// `UtilityScorer::score` checks `UtilityScoringConfig::high_gain_tools` before
+/// calling this function so operators can opt individual MCP (or future built-in)
+/// tool ids into the `0.75` tier without a code change (#5659).
 fn default_gain(tool_name: &str) -> f32 {
     if tool_name.starts_with("memory") {
         return 0.8;
-    }
-    if tool_name.starts_with("mcp_") {
-        return 0.5;
     }
     match tool_name {
         "bash" | "shell" => 0.6,
@@ -187,7 +192,11 @@ impl UtilityScorer {
             return None;
         }
 
-        let gain = default_gain(call.tool_id.as_str());
+        let gain = if self.is_high_gain(call.tool_id.as_str()) {
+            0.75
+        } else {
+            default_gain(call.tool_id.as_str())
+        };
 
         let cost = if ctx.token_budget > 0 {
             #[allow(clippy::cast_precision_loss)]
@@ -317,16 +326,32 @@ impl UtilityScorer {
         self.config.utility_window > 0 && self.consecutive_low >= self.config.utility_window
     }
 
+    /// Returns `true` when `tool_name` case-insensitively matches an entry in `list`.
+    ///
+    /// Shared lookup behind `is_exempt` and `is_high_gain` — both are "does a configured
+    /// tool-name list contain this `tool_id`" checks and must use identical matching rules.
+    fn contains_tool_name(list: &[String], tool_name: &str) -> bool {
+        let lower = tool_name.to_lowercase();
+        list.iter().any(|e| e.to_lowercase() == lower)
+    }
+
     /// Returns `true` when `tool_name` is in the exempt list (case-insensitive).
     ///
     /// Exempt tools bypass the utility gate unconditionally and always receive `ToolCall`.
     #[must_use]
     pub fn is_exempt(&self, tool_name: &str) -> bool {
-        let lower = tool_name.to_lowercase();
-        self.config
-            .exempt_tools
-            .iter()
-            .any(|e| e.to_lowercase() == lower)
+        Self::contains_tool_name(&self.config.exempt_tools, tool_name)
+    }
+
+    /// Returns `true` when `tool_name` is in the `high_gain_tools` opt-in list (case-insensitive).
+    ///
+    /// Tools in this list receive the same `0.75` "direct action" gain as
+    /// `diagnostics`/`edit`/etc, regardless of whether `default_gain` has a hardcoded entry
+    /// for them. Intended for MCP-registered tools whose ids `default_gain` can never match
+    /// (#5659).
+    #[must_use]
+    pub fn is_high_gain(&self, tool_name: &str) -> bool {
+        Self::contains_tool_name(&self.config.high_gain_tools, tool_name)
     }
 
     /// The configured threshold.
@@ -1020,6 +1045,78 @@ mod tests {
     fn is_exempt_empty_list_returns_false() {
         let scorer = UtilityScorer::new(UtilityScoringConfig::default());
         assert!(!scorer.is_exempt("read"));
+    }
+
+    // ── high_gain_tools opt-in tests (#5659) ─────────────────────────────────
+
+    #[test]
+    fn is_high_gain_matches_case_insensitively() {
+        let scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            high_gain_tools: vec!["Github_create_issue".to_owned()],
+            ..UtilityScoringConfig::default()
+        });
+        assert!(scorer.is_high_gain("github_create_issue"));
+        assert!(scorer.is_high_gain("GITHUB_CREATE_ISSUE"));
+        assert!(!scorer.is_high_gain("bash"));
+    }
+
+    #[test]
+    fn is_high_gain_empty_list_returns_false() {
+        let scorer = UtilityScorer::new(UtilityScoringConfig::default());
+        assert!(!scorer.is_high_gain("github_create_issue"));
+    }
+
+    #[test]
+    fn default_gain_unconfigured_mcp_shaped_tool_id_stays_neutral() {
+        // Real MCP tool ids are "{server_id}_{name}" (McpTool::sanitized_id), not literally
+        // prefixed with "mcp_". Without an opt-in high_gain_tools entry, such an id has no
+        // hardcoded match and stays in the generic 0.5 bucket.
+        assert!((default_gain("github_create_issue") - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn score_high_gain_tools_overrides_default_gain_for_mcp_shaped_tool_id() {
+        // Reproduces the #5659 gap: an MCP tool id ("github_create_issue", shaped like
+        // McpTool::sanitized_id's "{server_id}_{name}") has no entry in default_gain's
+        // hardcoded table and would default to 0.5. Opting it into high_gain_tools must
+        // raise its gain to 0.75 and let it take the direct ToolCall branch on the first
+        // call, exactly like the #5650 fix does for built-in direct-action tools.
+        let scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            high_gain_tools: vec!["github_create_issue".to_owned()],
+            ..UtilityScoringConfig::default()
+        });
+        let ctx = default_ctx(); // tool_calls_this_turn: 0 -> uncertainty == 1.0
+        let call = make_call("github_create_issue", json!({}));
+        let score = scorer.score(&call, &ctx).unwrap();
+        assert!(
+            (score.gain - 0.75).abs() < f32::EPSILON,
+            "high_gain_tools entry should raise gain to 0.75, got {}",
+            score.gain
+        );
+        assert_eq!(
+            scorer.recommend_action(Some(&score), &ctx),
+            UtilityAction::ToolCall,
+            "high-gain MCP tool should execute immediately on first call, not stall on Retrieve"
+        );
+    }
+
+    #[test]
+    fn score_high_gain_tools_does_not_affect_unlisted_tools() {
+        let scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            high_gain_tools: vec!["github_create_issue".to_owned()],
+            ..UtilityScoringConfig::default()
+        });
+        let ctx = default_ctx();
+        let call = make_call("fetch", json!({}));
+        let score = scorer.score(&call, &ctx).unwrap();
+        assert!(
+            (score.gain - 0.5).abs() < f32::EPSILON,
+            "unlisted tool must keep its default_gain value, got {}",
+            score.gain
+        );
     }
 
     #[test]

--- a/specs/006-tools/spec.md
+++ b/specs/006-tools/spec.md
@@ -618,9 +618,25 @@ Write commands are detected via `WRITE_INDICATORS` heuristic (keywords like `rm`
 enabled = false
 threshold = 0.0   # calls below this score are skipped
 utility_window = 0  # consecutive low-utility calls before early-stopping the turn; 0 = disabled
+high_gain_tools = []  # tool ids opted into the 0.75 "direct action" gain tier
 ```
 
 `utility_window` — number of consecutive non-`ToolCall` recommendations (i.e., calls scored below threshold) before the entire tool loop terminates early for the current turn. Default `0` preserves the existing per-call skip behavior exactly — no loop break occurs.
+
+`high_gain_tools` — opt-in list of tool ids that always receive the same `0.75` gain as the
+built-in "direct action" tools (`diagnostics`, `edit`, `format`, etc), bypassing the `Retrieve`
+detour on their first call. The hardcoded `default_gain` table only recognizes built-in tool
+names; dynamically registered tools — most notably MCP tools, whose ids are
+`{server_id}_{name}` (see `McpTool::sanitized_id`) — never match it and default to the neutral
+`0.5` bucket, exposing them to the same `Retrieve -> redundant retry -> vetoed` stall #5650
+fixed for built-ins. `high_gain_tools` lets operators opt a specific MCP (or future built-in)
+tool id into the high-gain tier without a code change (#5659). Matching is case-insensitive,
+mirroring `exempt_tools`. Default: empty (no behavior change).
+
+**Note on id format**: the TUI command palette's `mcp:list` entry lists MCP tools via
+`McpTool::qualified_name()` (`"server_id:name"`, colon-separated). That is a *display* format
+only — the id actually dispatched at runtime, and therefore the value `high_gain_tools` must
+contain, is `McpTool::sanitized_id()` (`"server_id_name"`, colon replaced with underscore).
 
 ### Key Invariants
 


### PR DESCRIPTION
## Summary

- `UtilityScoringConfig` gains `high_gain_tools: Vec<String>` — an opt-in list of tool ids that always receive the `0.75` "direct action" gain tier, checked in `UtilityScorer::score` before falling through to `default_gain`'s hardcoded match table.
- `#5658` fixed the first-call `Retrieve -> redundant retry -> vetoed` stall for a handful of built-in tool names, but the hardcoded table structurally cannot cover dynamically registered tools — most notably MCP tools, whose ids are `{server_id}_{name}` (`McpTool::sanitized_id`), not enumerable at compile time. Any MCP tool (or future built-in tool without a table entry) still fell to the neutral `0.5` bucket.
- Removed `default_gain`'s dead `tool_name.starts_with("mcp_")` branch — real MCP tool ids never carry that literal prefix, and the branch already returned the same `0.5` as the fallthrough arm.
- Migration step 76 adds a commented `high_gain_tools = []` advisory under `[tools.utility]`; default is an empty list, so existing configs are unaffected.
- `exempt_tools` and the new `high_gain_tools` now share a private `contains_tool_name` lookup (both are "does this configured list contain this tool id" checks with identical case-insensitive matching semantics).

Out of scope, filed as follow-ups after this PR merges:
- `crates/zeph-core/src/agent/subagent_commands.rs:679` has the identical dead `starts_with("mcp_")` assumption in a different subsystem (`extract_mcp_tool_names`) — fixing it correctly needs a new `origin`/`server_id` field on `zeph_tools::registry::ToolDef`, out of scope for this config-driven fix.
- A more robust follow-up to accept both the `qualified_name()` (colon) and `sanitized_id()` (underscore) forms in the `high_gain_tools` lookup, since the only UI surface listing MCP tool ids (the TUI command palette's `mcp:list` entry) shows the colon form while the config field needs the underscore form. Documented in `config/default.toml` and `specs/006-tools/spec.md` in the meantime.

Closes #5659

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12101/12101 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` (and targeted `-p zeph-tools -p zeph-config`)
- [x] Added regression tests covering: opt-in list overrides `default_gain` end-to-end via `score()`, backward-compat default (empty list, no behavior change), case-insensitive matching pinned, migration step 76 (including the `[tools.utility]`-section-absent case)
- [x] `CHANGELOG.md`, `config/default.toml`, `specs/006-tools/spec.md` updated
- [x] `.local/testing/playbooks/` and `.local/testing/coverage-status.md` updated (main-repo paths per project convention)