### PR TITLE
refactor(core): dedup digest pipeline, cancellation handling, fix blocking git call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   above) and the `DebugDumper::new` match arm across those three plus
   `serve/agent_factory.rs`. Pure refactor, no behavior change — verified byte-identical
   field mapping and `Ok`/`Err` semantics at every site. Refs #5610.
+- `refactor(core)`: deduplicated the 8 near-identical cancellation-handling blocks in
+  `crates/zeph-core/src/agent/tool_execution/tier_loop.rs` (`handle_confirmation_phase`,
+  `handle_retry_phase`'s entry check and its two `tokio::select!` branches,
+  `handle_reformat_phase`'s entry and post-await checks, `run_tier_execution_loop`'s
+  per-tier check, and `execute_tier_join`'s cancellation branch) into a single
+  `cancel_tool_batch` helper. Preserves the exact step order (skill-env reset, log,
+  metrics, `[Cancelled]` send, tombstone persist) at every call site — that ordering is
+  what prevents the recurring "orphaned tool_calls corrupts history" defect class
+  (#5464, #5513, #5646). Pure structural dedup, no behavior change; all existing
+  cancellation/tombstone tests pass unchanged. (#5654)
+- `refactor(core)`: deduplicated the session-digest generation pipeline in
+  `crates/zeph-core/src/agent/session_digest.rs`. The `/new`-triggered fire-and-forget
+  `generate_and_store_digest` and the shutdown-path `Agent::maybe_store_session_digest`
+  independently rebuilt the identical summarizer prompt, LLM-call-under-timeout, and
+  sanitize/truncate/store pipeline; both now delegate to a single private
+  `generate_and_persist_digest` helper, parameterized only by the log wording each call
+  site already used. Pure structural dedup, no behavior change — same prompt text, same
+  30s timeout semantics, same storage call per call site; added direct unit test coverage
+  for the shared helper's success and LLM-failure paths. (#5678)
 
 ### Fixed
 
@@ -728,6 +747,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   it, so `ner.rs` no longer calls the broken upstream loader. No config, trait, or public API
   changes — issue #5691 was originally filed as "remove dead code", but `CandleNerClassifier`
   is live; this closes it as a bug fix instead. (#5691)
+- `fix(core)`: `EnvironmentContext::refresh_git_branch` (`crates/zeph-core/src/context.rs`)
+  ran `git branch --show-current` via a blocking `std::process::Command::output()` call
+  directly inline on the async agent turn path (`Agent::rebuild_system_prompt`, invoked every
+  turn from `advance_context_lifecycle`), stalling the tokio worker thread for the duration of
+  the subprocess call. The surrounding `advance_context_lifecycle_guarded`'s
+  `tokio::time::timeout` cannot preempt a thread blocked in a synchronous syscall, so a
+  hung/slow git invocation (e.g. stale lock file, slow filesystem) would stall the whole
+  worker thread rather than being bounded by the timeout. `refresh_git_branch` is now `async`
+  and dispatches the git subprocess call via `tokio::task::spawn_blocking`, keeping the tokio
+  worker thread free while awaiting the blocking-pool result. (#5670)
 
 ### Changed
 

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -849,7 +849,7 @@ impl<C: Channel> Agent<C> {
             .skill
             .last_skills_prompt
             .clone_from(&skills_prompt);
-        self.services.session.env_context.refresh_git_branch();
+        self.services.session.env_context.refresh_git_branch().await;
         self.services
             .session
             .env_context

--- a/crates/zeph-core/src/agent/session_digest.rs
+++ b/crates/zeph-core/src/agent/session_digest.rs
@@ -106,6 +106,88 @@ fn format_and_sanitize_conversation(
     result
 }
 
+/// Core digest pipeline shared by the `/new`-triggered fire-and-forget path
+/// (`generate_and_store_digest`) and the shutdown path (`Agent::maybe_store_session_digest`).
+///
+/// Builds the summarizer prompt from `message_refs`, calls `provider.chat` under a fixed
+/// 30s timeout, sanitizes and truncates the response to `max_tokens`, and persists it via
+/// `memory.sqlite().save_session_digest`. `log_prefix` and `stored_msg` let each call site
+/// keep its own log wording. Returns the stored `(text, token_count)` on success, or `None`
+/// if the LLM call times out, fails, or storage fails — each logged as a warning.
+///
+/// PAAC secret masking (#5437) is structural at the provider boundary — callers pass an
+/// already-masked `provider`.
+#[allow(clippy::too_many_arguments)] // pipeline has many required, non-groupable inputs; a *Params struct would be more verbose without simplifying the call sites
+async fn generate_and_persist_digest(
+    provider: &zeph_llm::any::AnyProvider,
+    memory: &zeph_memory::semantic::SemanticMemory,
+    conversation_id: zeph_memory::ConversationId,
+    message_refs: &[&Message],
+    sanitizer: &zeph_sanitizer::ContentSanitizer,
+    max_tokens: usize,
+    tc: &zeph_memory::TokenCounter,
+    log_prefix: &str,
+    stored_msg: &str,
+) -> Option<(String, i64)> {
+    let conv_text = format_and_sanitize_conversation(message_refs, sanitizer);
+
+    let prompt = format!(
+        "You are a session summarizer. Read the following conversation excerpt and produce \
+         a compact digest (under {max_tokens} tokens) of the key facts, decisions, outcomes, \
+         and open questions from this session. Be specific and concise. \
+         Output ONLY the digest text, no preamble.\n\n\
+         Conversation:\n{conv_text}\n\
+         Digest:"
+    );
+
+    let chat_messages = vec![Message {
+        role: Role::User,
+        content: prompt,
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    }];
+
+    let timeout = Duration::from_secs(30);
+    let digest_text = tokio::select! {
+        () = async { tokio::time::sleep(timeout).await } => {
+            tracing::warn!("{log_prefix}: LLM call timed out");
+            return None;
+        }
+        result = provider.chat(&chat_messages) => {
+            match result {
+                Ok(text) => text,
+                Err(e) => {
+                    tracing::warn!("{log_prefix}: LLM call failed: {e:#}");
+                    return None;
+                }
+            }
+        }
+    };
+
+    let clean = sanitize_digest(&digest_text);
+    let final_text = truncate_digest(&clean, max_tokens, tc);
+    let token_count = i64::try_from(tc.count_tokens(&final_text)).unwrap_or(i64::MAX);
+
+    match memory
+        .sqlite()
+        .save_session_digest(conversation_id, &final_text, token_count)
+        .await
+    {
+        Ok(()) => {
+            tracing::info!(
+                conversation_id = conversation_id.0,
+                tokens = token_count,
+                "{stored_msg}"
+            );
+            Some((final_text, token_count))
+        }
+        Err(e) => {
+            tracing::warn!("{log_prefix}: storage failed: {e:#}");
+            None
+        }
+    }
+}
+
 /// Generate and persist a digest for a completed conversation from a background task.
 ///
 /// Called fire-and-forget from `reset_conversation`. All errors are logged as warnings
@@ -132,60 +214,20 @@ pub(super) async fn generate_and_store_digest(
         messages
     };
 
-    let refs: Vec<&zeph_llm::provider::Message> = slice.iter().collect();
-    let conv_text = format_and_sanitize_conversation(&refs, sanitizer);
+    let refs: Vec<&Message> = slice.iter().collect();
 
-    let prompt = format!(
-        "You are a session summarizer. Read the following conversation excerpt and produce \
-         a compact digest (under {max_tokens} tokens) of the key facts, decisions, outcomes, \
-         and open questions from this session. Be specific and concise. \
-         Output ONLY the digest text, no preamble.\n\n\
-         Conversation:\n{conv_text}\n\
-         Digest:"
-    );
-
-    let chat_messages = vec![zeph_llm::provider::Message {
-        role: zeph_llm::provider::Role::User,
-        content: prompt,
-        parts: vec![],
-        metadata: zeph_llm::provider::MessageMetadata::default(),
-    }];
-    // PAAC secret masking (#5437) is structural at the provider boundary — the caller passes an
-    // already-masked `provider` (the Agent's own, wrapped via `Agent::with_secret_registry`).
-    let timeout = Duration::from_secs(30);
-    let digest_text = tokio::select! {
-        () = async { tokio::time::sleep(timeout).await } => {
-            tracing::warn!("session digest (/new): LLM call timed out");
-            return;
-        }
-        result = provider.chat(&chat_messages) => {
-            match result {
-                Ok(text) => text,
-                Err(e) => {
-                    tracing::warn!("session digest (/new): LLM call failed: {e:#}");
-                    return;
-                }
-            }
-        }
-    };
-
-    let clean = sanitize_digest(&digest_text);
-    let final_text = truncate_digest(&clean, max_tokens, tc);
-    let token_count = i64::try_from(tc.count_tokens(&final_text)).unwrap_or(i64::MAX);
-
-    if let Err(e) = memory
-        .sqlite()
-        .save_session_digest(conversation_id, &final_text, token_count)
-        .await
-    {
-        tracing::warn!("session digest (/new): storage failed: {e:#}");
-    } else {
-        tracing::info!(
-            conversation_id = conversation_id.0,
-            tokens = token_count,
-            "session digest stored (via /new)"
-        );
-    }
+    generate_and_persist_digest(
+        provider,
+        memory,
+        conversation_id,
+        &refs,
+        sanitizer,
+        max_tokens,
+        tc,
+        "session digest (/new)",
+        "session digest stored (via /new)",
+    )
+    .await;
 }
 
 /// Pure predicate for the `/recap` deduplication check (#3144).
@@ -246,79 +288,36 @@ impl<C: Channel> Agent<C> {
             &non_system[..]
         };
 
-        let conv_text = format_and_sanitize_conversation(slice, &self.services.security.sanitizer);
-
-        let prompt = format!(
-            "You are a session summarizer. Read the following conversation excerpt and produce \
-             a compact digest (under {max_tokens} tokens) of the key facts, decisions, outcomes, \
-             and open questions from this session. Be specific and concise. \
-             Output ONLY the digest text, no preamble.\n\n\
-             Conversation:\n{conv_text}\n\
-             Digest:"
-        );
-
-        let chat_messages = vec![Message {
-            role: Role::User,
-            content: prompt,
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        }];
-        // PAAC secret masking (#5437) is structural at the provider boundary — `self.provider`
-        // masks registered secrets from `chat_messages` transparently before this dispatch.
-
         let _ = self
             .channel
             .send_status("Generating session digest...")
             .await;
 
-        let timeout = Duration::from_secs(30);
-        let digest_text = tokio::select! {
-            () = async { tokio::time::sleep(timeout).await } => {
-                tracing::warn!("session digest: LLM call timed out");
-                let _ = self.channel.send_status("").await;
-                return;
-            }
-            result = self.provider.chat(&chat_messages) => {
-                match result {
-                    Ok(text) => text,
-                    Err(e) => {
-                        tracing::warn!("session digest: LLM call failed: {e:#}");
-                        let _ = self.channel.send_status("").await;
-                        return;
-                    }
-                }
-            }
-        };
-
-        // Sanitize to prevent injection via LLM-generated content (strip role prefixes).
-        let sanitized = sanitize_digest(&digest_text);
-
-        // Truncate to max_tokens budget.
+        // PAAC secret masking (#5437) is structural at the provider boundary — `self.provider`
+        // masks registered secrets from `chat_messages` transparently before this dispatch.
         let tc = &self.runtime.metrics.token_counter;
-        let final_text = truncate_digest(&sanitized, max_tokens, tc);
+        let result = generate_and_persist_digest(
+            &self.provider,
+            &memory,
+            conversation_id,
+            slice,
+            &self.services.security.sanitizer,
+            max_tokens,
+            tc,
+            "session digest",
+            "session digest stored",
+        )
+        .await;
 
-        let token_count = i64::try_from(tc.count_tokens(&final_text)).unwrap_or(i64::MAX);
+        let _ = self.channel.send_status("").await;
 
-        if let Err(e) = memory
-            .sqlite()
-            .save_session_digest(conversation_id, &final_text, token_count)
-            .await
-        {
-            tracing::warn!("session digest: storage failed: {e:#}");
-        } else {
-            tracing::info!(
-                conversation_id = conversation_id.0,
-                tokens = token_count,
-                "session digest stored"
-            );
-            // Update the cached digest so it is available in the same session if re-used.
+        // Update the cached digest so it is available in the same session if re-used.
+        if let Some((final_text, token_count)) = result {
             self.services.memory.compaction.cached_session_digest = Some((
                 final_text,
                 usize::try_from(token_count).unwrap_or(max_tokens),
             ));
         }
-
-        let _ = self.channel.send_status("").await;
     }
 
     /// Load the session digest from `SQLite` and cache it in `MemoryState`.
@@ -536,11 +535,17 @@ impl<C: Channel> Agent<C> {
 
 #[cfg(test)]
 mod tests {
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
     use zeph_llm::provider::{Message, MessageMetadata, Role};
     use zeph_memory::TokenCounter;
+    use zeph_memory::semantic::SemanticMemory;
     use zeph_sanitizer::{ContentIsolationConfig, ContentSanitizer};
 
-    use super::{format_and_sanitize_conversation, sanitize_digest, truncate_digest};
+    use super::{
+        format_and_sanitize_conversation, generate_and_persist_digest, sanitize_digest,
+        truncate_digest,
+    };
 
     fn make_sanitizer() -> ContentSanitizer {
         ContentSanitizer::new(&ContentIsolationConfig::default())
@@ -675,6 +680,81 @@ mod tests {
         assert!(result.len() < text.len());
         // Must not panic or produce content longer than original.
         assert!(tc.count_tokens(&result) <= 5 || result.is_empty());
+    }
+
+    // ----- generate_and_persist_digest (shared pipeline, #5678) -----
+
+    async fn make_memory_with_conversation() -> (SemanticMemory, zeph_memory::ConversationId) {
+        let memory = SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            None,
+            AnyProvider::Mock(MockProvider::default()),
+            "test-model",
+        )
+        .await
+        .unwrap();
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        (memory, cid)
+    }
+
+    #[tokio::test]
+    async fn generate_and_persist_digest_success_round_trips_through_storage() {
+        let (memory, cid) = make_memory_with_conversation().await;
+        let provider = AnyProvider::Mock(MockProvider::with_responses(vec![
+            "a compact digest".into(),
+        ]));
+        let sanitizer = make_sanitizer();
+        let tc = make_token_counter();
+        let msg = user_msg("hello world");
+        let refs = [&msg];
+
+        let result = generate_and_persist_digest(
+            &provider,
+            &memory,
+            cid,
+            &refs,
+            &sanitizer,
+            100,
+            &tc,
+            "test digest",
+            "test digest stored",
+        )
+        .await;
+
+        let (text, token_count) = result.expect("success case must return Some");
+        assert_eq!(text, "a compact digest");
+        assert!(token_count > 0);
+
+        let stored = memory.sqlite().load_session_digest(cid).await.unwrap();
+        assert_eq!(stored.expect("digest must be persisted").digest, text);
+    }
+
+    #[tokio::test]
+    async fn generate_and_persist_digest_llm_failure_returns_none_and_stores_nothing() {
+        let (memory, cid) = make_memory_with_conversation().await;
+        let provider = AnyProvider::Mock(MockProvider::failing());
+        let sanitizer = make_sanitizer();
+        let tc = make_token_counter();
+        let msg = user_msg("hello world");
+        let refs = [&msg];
+
+        let result = generate_and_persist_digest(
+            &provider,
+            &memory,
+            cid,
+            &refs,
+            &sanitizer,
+            100,
+            &tc,
+            "test digest",
+            "test digest stored",
+        )
+        .await;
+
+        assert!(result.is_none());
+        let stored = memory.sqlite().load_session_digest(cid).await.unwrap();
+        assert!(stored.is_none());
     }
 
     // ----- T3: C3-bis invariant -----

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -77,6 +77,24 @@ impl<C: Channel> Agent<C> {
         Ok(false)
     }
 
+    /// Resets skill env, records the cancellation, sends the `[Cancelled]` notice, and
+    /// persists the tombstone tool results — the fixed sequence every cancellation
+    /// checkpoint in this file must follow (#5654). Skipping or reordering a step here
+    /// has previously left orphaned `ToolUse` messages with no matching `ToolResult`
+    /// (#5464, #5513, #5646) — see the recurring defect-class notes in issue history.
+    async fn cancel_tool_batch(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        log_msg: &str,
+    ) -> Result<(), crate::agent::error::AgentError> {
+        self.tool_executor.set_skill_env(None);
+        tracing::info!("{log_msg}");
+        self.update_metrics(|m| m.cancellations += 1);
+        self.channel.send("[Cancelled]").await?;
+        self.persist_cancelled_tool_results(tool_calls, None).await;
+        Ok(())
+    }
+
     #[tracing::instrument(
         name = "core.tool.handle_confirmation_phase",
         skip_all,
@@ -93,11 +111,8 @@ impl<C: Channel> Agent<C> {
     ) -> Result<bool, crate::agent::error::AgentError> {
         for idx in 0..tool_results.len() {
             if cancel.is_cancelled() {
-                self.tool_executor.set_skill_env(None);
-                tracing::info!("tool execution cancelled by user");
-                self.update_metrics(|m| m.cancellations += 1);
-                self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls, None).await;
+                self.cancel_tool_batch(tool_calls, "tool execution cancelled by user")
+                    .await?;
                 return Ok(true);
             }
             let new_result =
@@ -163,11 +178,8 @@ impl<C: Channel> Agent<C> {
         let retry_max_ms = self.tool_orchestrator.retry_max_ms;
         for idx in 0..tool_results.len() {
             if cancel.is_cancelled() {
-                self.tool_executor.set_skill_env(None);
-                tracing::info!("tool execution cancelled by user");
-                self.update_metrics(|m| m.cancellations += 1);
-                self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls, None).await;
+                self.cancel_tool_batch(tool_calls, "tool execution cancelled by user")
+                    .await?;
                 return Ok(true);
             }
             let is_transient = matches!(
@@ -193,11 +205,8 @@ impl<C: Channel> Agent<C> {
                         tracing::info_span!("tool_exec_retry", tool_name = %tc.name, idx = %tc.id)
                     ) => r,
                     () = cancel.cancelled() => {
-                        self.tool_executor.set_skill_env(None);
-                        tracing::info!("tool retry cancelled by user");
-                        self.update_metrics(|m| m.cancellations += 1);
-                        self.channel.send("[Cancelled]").await?;
-                        self.persist_cancelled_tool_results(tool_calls, None).await;
+                        self.cancel_tool_batch(tool_calls, "tool retry cancelled by user")
+                            .await?;
                         return Ok(true);
                     }
                 };
@@ -228,11 +237,11 @@ impl<C: Channel> Agent<C> {
                         tokio::select! {
                             () = tokio::time::sleep(std::time::Duration::from_millis(delay_ms)) => {}
                             () = cancel.cancelled() => {
-                                self.tool_executor.set_skill_env(None);
-                                tracing::info!("retry backoff interrupted by cancellation");
-                                self.update_metrics(|m| m.cancellations += 1);
-                                self.channel.send("[Cancelled]").await?;
-                                self.persist_cancelled_tool_results(tool_calls, None).await;
+                                self.cancel_tool_batch(
+                                    tool_calls,
+                                    "retry backoff interrupted by cancellation",
+                                )
+                                .await?;
                                 return Ok(true);
                             }
                         }
@@ -274,11 +283,8 @@ impl<C: Channel> Agent<C> {
         let reformat_start = std::time::Instant::now();
         for idx in 0..tool_results.len() {
             if cancel.is_cancelled() {
-                self.tool_executor.set_skill_env(None);
-                tracing::info!("parameter reformat phase cancelled by user");
-                self.update_metrics(|m| m.cancellations += 1);
-                self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls, None).await;
+                self.cancel_tool_batch(tool_calls, "parameter reformat phase cancelled by user")
+                    .await?;
                 return Ok(true);
             }
             let needs_reformat = matches!(
@@ -309,11 +315,8 @@ impl<C: Channel> Agent<C> {
             let _ = self.channel.send_status("").await;
 
             if cancel.is_cancelled() {
-                self.tool_executor.set_skill_env(None);
-                tracing::info!("parameter reformat phase cancelled by user");
-                self.update_metrics(|m| m.cancellations += 1);
-                self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls, None).await;
+                self.cancel_tool_batch(tool_calls, "parameter reformat phase cancelled by user")
+                    .await?;
                 return Ok(true);
             }
 
@@ -1176,11 +1179,8 @@ impl<C: Channel> Agent<C> {
 
         for (tier_idx, tier) in tiers.into_iter().enumerate() {
             if cancel.is_cancelled() {
-                self.tool_executor.set_skill_env(None);
-                tracing::info!("tool execution cancelled by user");
-                self.update_metrics(|m| m.cancellations += 1);
-                self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls, None).await;
+                self.cancel_tool_batch(tool_calls, "tool execution cancelled by user")
+                    .await?;
                 return Ok(None);
             }
 
@@ -1987,11 +1987,8 @@ impl<C: Channel> Agent<C> {
                 results = &mut join_fut => break results,
                 () = cancel.cancelled() => {
                     self.services.mcp.elicitation_rx = elicitation_rx;
-                    self.tool_executor.set_skill_env(None);
-                    tracing::info!("tool execution cancelled by user");
-                    self.update_metrics(|m| m.cancellations += 1);
-                    self.channel.send("[Cancelled]").await?;
-                    self.persist_cancelled_tool_results(tool_calls, None).await;
+                    self.cancel_tool_batch(tool_calls, "tool execution cancelled by user")
+                        .await?;
                     return Ok(None);
                 }
                 event = recv_elicitation(&mut elicitation_rx) => {

--- a/crates/zeph-core/src/context.rs
+++ b/crates/zeph-core/src/context.rs
@@ -175,14 +175,28 @@ impl EnvironmentContext {
     }
 
     /// Update only the git branch, leaving all other fields unchanged.
-    pub fn refresh_git_branch(&mut self) {
+    ///
+    /// The underlying `git` subprocess call is dispatched to the blocking thread
+    /// pool via [`tokio::task::spawn_blocking`] so it never stalls the tokio
+    /// worker thread driving the agent turn loop (this is called on every turn).
+    pub async fn refresh_git_branch(&mut self) {
         if matches!(self.working_dir.as_str(), "" | "unknown") {
             self.git_branch = None;
             return;
         }
-        let refreshed =
-            Self::gather_for_dir(&self.model_name, std::path::Path::new(&self.working_dir));
-        self.git_branch = refreshed.git_branch;
+        let model_name = self.model_name.clone();
+        let working_dir = self.working_dir.clone();
+        self.git_branch = match tokio::task::spawn_blocking(move || {
+            Self::gather_for_dir(&model_name, std::path::Path::new(&working_dir)).git_branch
+        })
+        .await
+        {
+            Ok(branch) => branch,
+            Err(e) => {
+                tracing::warn!("git branch refresh task panicked: {e:#}");
+                None
+            }
+        };
     }
 
     #[must_use]
@@ -232,14 +246,14 @@ mod tests {
         assert_eq!(env.model_name, "test-model");
     }
 
-    #[test]
-    fn refresh_git_branch_does_not_panic() {
+    #[tokio::test]
+    async fn refresh_git_branch_does_not_panic() {
         let mut env = EnvironmentContext::gather("test-model");
         let original_dir = env.working_dir.clone();
         let original_os = env.os.clone();
         let original_model = env.model_name.clone();
 
-        env.refresh_git_branch();
+        env.refresh_git_branch().await;
 
         // Other fields must remain unchanged.
         assert_eq!(env.working_dir, original_dir);
@@ -251,15 +265,15 @@ mod tests {
         assert!(formatted.ends_with("</environment>"));
     }
 
-    #[test]
-    fn refresh_git_branch_overwrites_previous_branch() {
+    #[tokio::test]
+    async fn refresh_git_branch_overwrites_previous_branch() {
         let mut env = EnvironmentContext {
             working_dir: "/tmp".into(),
             git_branch: Some("old-branch".into()),
             os: "linux".into(),
             model_name: "test".into(),
         };
-        env.refresh_git_branch();
+        env.refresh_git_branch().await;
         // After refresh, git_branch reflects the actual git state (Some or None).
         // Importantly the call must not panic and must no longer hold "old-branch"
         // when running outside a git repo with that branch name.


### PR DESCRIPTION
## Summary

Bundles three independent, behavior-preserving P2 fixes in `crates/zeph-core`, all found during architecture review (CI-1204/CI-1210/CI-1214):

- **#5678** — `session_digest.rs` had two independent copies of the digest-generation pipeline (fire-and-forget `/new` path and shutdown path), including a byte-for-byte duplicated prompt string. Extracted a shared `generate_and_persist_digest` helper; both call sites now delegate to it, parameterized only by the log wording each already used.
- **#5670** — `EnvironmentContext::refresh_git_branch` shelled out via a synchronous `std::process::Command::output()` directly on the async agent-turn hot path (every turn, via `rebuild_system_prompt`), blocking a tokio worker thread for the duration of the git subprocess call — violating the project's non-blocking contract. `refresh_git_branch` is now `async` and dispatches the subprocess call via `tokio::task::spawn_blocking`. Also logs (`tracing::warn!`) instead of silently swallowing a `JoinError` before defaulting to `None`.
- **#5654** — `tier_loop.rs` had 8 near-identical cancellation-handling blocks (skill-env reset, log, metrics, `[Cancelled]` channel send, tombstone persist) hand-copied across the tool-dispatch pipeline — the historically buggiest code path in the agent (the "orphaned tool_calls corrupts history" defect class has recurred 3 times: #5464, #5513, #5646). Extracted a `cancel_tool_batch` helper used at all 8 sites, preserving the exact step order that prevents that defect class.

All three are pure structural changes — no behavior change, verified by adversarial critique and full regression-test re-runs (details below).

## Verification

- Adversarial critique (independent pass): all three fixes approved/minor, no critical/significant behavioral drift, no regression of the orphaned-tool_calls defect class.
- Code review: one required change (log the `spawn_blocking` `JoinError` instead of silently defaulting) — applied and re-reviewed, approved.
- `cargo +nightly fmt --check` — clean
- `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12108 passed, 34 skipped, 0 failed (all #5654 cancellation/tombstone regression tests individually re-verified)
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (exit 0)
- `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all passed, 0 failed

## Known pre-existing gaps (not introduced by this PR, not blocking)

- #5670: no explicit test asserting the git-not-available error path resolves to `None` (same weakness existed pre-refactor).
- #5678: the fire-and-forget `/new` call site has no direct test coverage into the shared helper through that wrapper (pre-existing; the shutdown path is covered end-to-end).
- A separate P3 follow-up issue will be filed for the pre-existing (not introduced here) ordering in `tier_loop.rs` where `channel.send("[Cancelled]").await?` can short-circuit before `persist_cancelled_tool_results` on a channel-send error.

## Test plan

- [x] Full CI-matching check suite (fmt, clippy, nextest, rustdoc gate, doc-tests) — see above
- [x] Independent adversarial critique
- [x] Code review with one fix-review cycle

Closes #5678
Closes #5670
Closes #5654