### PR TITLE
fix(skills): treat missing skill trust-map entry as Trusted, not Quarantined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(skills)`: a skill missing from the trust map (e.g. `memory.persistence.memory` not yet
+  wired, or a transient `load_all_skill_trust` read failure) was treated as
+  `SkillTrustLevel::Quarantined` at 4 call sites (`crates/zeph-skills/src/prompt.rs`'s
+  `format_skills_prompt`, `format_grouped_skills_prompt`, `format_active_skill_tag`, and
+  `crates/zeph-core/src/skill_invoker.rs`'s `SkillInvokeExecutor::execute_tool_call`), via
+  `.unwrap_or_default()` — contradicting `format_skills_prompt`'s own documented contract that a
+  missing entry means `Trusted`. On a transient trust-map miss, every skill matched into
+  `active_skills` that turn was spuriously wrapped by `wrap_quarantined()`, injecting literal
+  "quarantined ... restricted tool access (no bash, file_write, web_scrape)" text into the
+  system prompt for skills that were never actually quarantined — which the model could then
+  echo when declining an unrelated tool call, as though a real restriction applied (#5694). Added
+  a shared `SkillTrustLevel::MISSING_ENTRY_FALLBACK` (`Trusted`) constant used at all 4 sites, and
+  `tracing::warn!` on `build_skill_trust_map`'s (`crates/zeph-core/src/agent/trust_commands.rs`)
+  previously-silent DB-read-error fallback so a future occurrence is observable. The real
+  tool-execution gate (`effective_trust` in `crates/zeph-core/src/agent/context/assembly.rs`) was
+  already fail-open to `Trusted` on a missing entry before this fix, so this change aligns
+  display/invocation behavior with the existing security boundary rather than weakening it.
 - `fix(llm)`: `TriageRouter::chat_with_tools` (`crates/zeph-llm/src/router/triage.rs`) delegated
   a tool call to whichever tier was selected by classification with no check that the tier's
   provider actually supports tool use, unlike `RouterProvider::chat_with_tools` which explicitly

--- a/crates/zeph-common/src/trust_level.rs
+++ b/crates/zeph-common/src/trust_level.rs
@@ -43,6 +43,28 @@ pub enum SkillTrustLevel {
 }
 
 impl SkillTrustLevel {
+    /// Trust level to assume when a skill has no entry in the trust map.
+    ///
+    /// A missing entry means "never classified yet" (e.g. persistence not wired, or a
+    /// transient trust-map read failure), not "known untrusted" — callers must not fall
+    /// back to [`SkillTrustLevel::default`] ([`Quarantined`](Self::Quarantined)) for this
+    /// case, as that would misclassify legitimately trusted, already-vetted skills.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_common::SkillTrustLevel;
+    ///
+    /// let trust_levels: std::collections::HashMap<String, SkillTrustLevel> =
+    ///     std::collections::HashMap::new();
+    /// let trust = trust_levels
+    ///     .get("some-skill")
+    ///     .copied()
+    ///     .unwrap_or(SkillTrustLevel::MISSING_ENTRY_FALLBACK);
+    /// assert_eq!(trust, SkillTrustLevel::Trusted);
+    /// ```
+    pub const MISSING_ENTRY_FALLBACK: Self = Self::Trusted;
+
     /// Ordered severity: lower value = more trusted.
     ///
     /// # Examples

--- a/crates/zeph-core/src/agent/trust_commands.rs
+++ b/crates/zeph-core/src/agent/trust_commands.rs
@@ -149,8 +149,16 @@ impl<C: Channel> Agent<C> {
         let Some(memory) = memory else {
             return HashMap::new();
         };
-        let Ok(rows) = memory.sqlite().load_all_skill_trust().await else {
-            return HashMap::new();
+        let rows = match memory.sqlite().load_all_skill_trust().await {
+            Ok(rows) => rows,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "build_skill_trust_map: load_all_skill_trust failed, skills will render \
+                     with no trust-map entry this turn"
+                );
+                return HashMap::new();
+            }
         };
         rows.into_iter()
             .map(|r| {

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -197,7 +197,9 @@ impl ToolExecutor for SkillInvokeExecutor {
         tracing::Span::current().record("skill", skill_name.as_str());
 
         let snapshot = self.resolve_snapshot(&skill_name);
-        let trust = snapshot.as_ref().map(|s| s.trust_level).unwrap_or_default();
+        let trust = snapshot
+            .as_ref()
+            .map_or(SkillTrustLevel::MISSING_ENTRY_FALLBACK, |s| s.trust_level);
         // Sanitize skill_name before it appears in any tool output: it originates from the LLM
         // and could carry injection markers (e.g. `<|im_start|>`).
         let skill_name_safe = sanitize_skill_text(&skill_name);
@@ -422,8 +424,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_trust_row_defaults_to_quarantined_behavior() {
-        // Default trust is Quarantined — fail-closed.
+    async fn no_trust_row_defaults_to_trusted_behavior() {
+        // A missing trust-map entry means "never classified yet", not "known untrusted" —
+        // it must resolve to Trusted (SkillTrustLevel::MISSING_ENTRY_FALLBACK), matching the
+        // documented contract in zeph-common. Falling back to Quarantined here would
+        // spuriously wrap legitimate skills whenever the trust map is transiently empty.
         let dir = tempfile::tempdir().unwrap();
         let body = "Some body";
         let registry = make_registry_with_skill(dir.path(), "unknown-skill", body);
@@ -433,8 +438,9 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        // Quarantined path: body is wrapped.
-        assert!(result.summary.contains("QUARANTINED"));
+        // Trusted path: body is returned unwrapped.
+        assert!(!result.summary.contains("QUARANTINED"));
+        assert!(result.summary.contains(body));
     }
 
     #[tokio::test]

--- a/crates/zeph-skills/src/prompt.rs
+++ b/crates/zeph-skills/src/prompt.rs
@@ -279,7 +279,10 @@ pub fn format_skills_prompt<S: std::hash::BuildHasher, S2: std::hash::BuildHashe
     let mut out = String::from("<available_skills>\n");
 
     for skill in skills {
-        let trust = trust_levels.get(skill.name()).copied().unwrap_or_default();
+        let trust = trust_levels
+            .get(skill.name())
+            .copied()
+            .unwrap_or(SkillTrustLevel::MISSING_ENTRY_FALLBACK);
         let raw_body = if trust == SkillTrustLevel::Trusted {
             skill.body.clone()
         } else {
@@ -398,7 +401,10 @@ pub fn format_grouped_skills_prompt<S: std::hash::BuildHasher, S2: std::hash::Bu
 
     // Emit support skills, skipping quarantined ones.
     for skill in &group.support {
-        let trust = trust_levels.get(skill.name()).copied().unwrap_or_default();
+        let trust = trust_levels
+            .get(skill.name())
+            .copied()
+            .unwrap_or(SkillTrustLevel::MISSING_ENTRY_FALLBACK);
         if trust == SkillTrustLevel::Quarantined {
             tracing::debug!(
                 skill = skill.name(),
@@ -439,7 +445,10 @@ fn format_active_skill_tag<S: std::hash::BuildHasher, S2: std::hash::BuildHasher
     trust_levels: &HashMap<String, SkillTrustLevel, S>,
     health_map: &HashMap<String, (f64, u32), S2>,
 ) {
-    let trust = trust_levels.get(skill.name()).copied().unwrap_or_default();
+    let trust = trust_levels
+        .get(skill.name())
+        .copied()
+        .unwrap_or(SkillTrustLevel::MISSING_ENTRY_FALLBACK);
     let raw_body = if trust == SkillTrustLevel::Trusted {
         skill.body.clone()
     } else {
@@ -597,12 +606,11 @@ mod tests {
     fn single_skill_format() {
         let skills = vec![make_skill("test", "A test.", "# Hello\nworld")];
 
-        // No trust entry → default (Quarantined) → description wrapped in data-description.
+        // No trust entry → MISSING_ENTRY_FALLBACK (Trusted) → description not wrapped.
         let output = format_skills_prompt(&skills, &HashMap::new(), &HashMap::new());
         assert!(output.starts_with("<available_skills>"));
         assert!(output.ends_with("</available_skills>"));
         assert!(output.contains("<skill name=\"test\">"));
-        // Untrusted: description is wrapped in data-description boundary tags.
         assert!(output.contains("<description>"));
         assert!(output.contains("A test."));
         assert!(output.contains("# Hello\nworld"));
@@ -718,6 +726,41 @@ mod tests {
         let output = format_skills_prompt(&skills, &trust, &HashMap::new());
         assert!(!output.contains("QUARANTINED"));
         assert!(output.contains("do stuff"));
+    }
+
+    // Regression test for #5694: a skill absent from `trust_levels` (e.g. because the
+    // trust DB read failed or memory isn't wired yet) must render exactly like an
+    // explicitly Trusted skill — not fall back to Quarantined and leak
+    // `wrap_quarantined()`'s "restricted tool access" wording into the system prompt.
+    #[test]
+    fn missing_trust_entry_not_quarantined() {
+        let body = "Some </skill> raw content.";
+        let skills = vec![make_skill("bundled-skill", "desc", body)];
+        // Empty map == "no trust DB row for this skill" (memory unset / transient DB error).
+        let output = format_skills_prompt(&skills, &HashMap::new(), &HashMap::new());
+        assert!(!output.contains("QUARANTINED"), "got: {output}");
+        assert!(!output.contains("restricted tool access"), "got: {output}");
+        assert!(!output.contains("data-description"), "got: {output}");
+        // Trusted path: body returned verbatim, not sanitized/escaped.
+        assert!(output.contains(body), "got: {output}");
+    }
+
+    #[test]
+    fn missing_trust_entry_distinct_from_explicit_quarantine() {
+        // Same skill name and body, only the trust map contents differ — proves the
+        // fallback path is hit strictly when the entry is *absent*, not whenever the
+        // resolved level happens to not be Trusted.
+        let body = "shared body";
+        let skills = vec![make_skill("shared-name", "desc", body)];
+
+        let missing = format_skills_prompt(&skills, &HashMap::new(), &HashMap::new());
+        let mut trust = HashMap::new();
+        trust.insert("shared-name".into(), SkillTrustLevel::Quarantined);
+        let explicit_quarantine = format_skills_prompt(&skills, &trust, &HashMap::new());
+
+        assert!(!missing.contains("QUARANTINED"));
+        assert!(explicit_quarantine.contains("[QUARANTINED SKILL: shared-name]"));
+        assert_ne!(missing, explicit_quarantine);
     }
 
     #[test]
@@ -1267,6 +1310,25 @@ mod tests {
             out.contains("name=\"safe\""),
             "trusted support skill must be present"
         );
+    }
+
+    // Regression test for #5694: a support skill with no entry in `trust_levels` at all
+    // (distinct from a genuinely Quarantined one) must NOT be excluded from the group —
+    // it must render as Trusted, matching format_skills_prompt's documented contract.
+    #[test]
+    fn grouped_prompt_missing_trust_entry_support_not_excluded() {
+        let group = make_skill_group("entry", &["safe", "unclassified"]);
+        let mut trust = HashMap::new();
+        trust.insert("entry".to_owned(), SkillTrustLevel::Trusted);
+        trust.insert("safe".to_owned(), SkillTrustLevel::Trusted);
+        // "unclassified" deliberately has no entry in `trust`.
+        let out = format_grouped_skills_prompt(&group, &trust, &HashMap::new());
+        assert!(
+            out.contains("name=\"unclassified\""),
+            "support skill missing from trust map must not be excluded like a quarantined one: {out}"
+        );
+        assert!(!out.contains("QUARANTINED"), "got: {out}");
+        assert!(!out.contains("restricted tool access"), "got: {out}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #5694: the agent fabricated a "quarantined due to restricted tool access" refusal for a benign bash command. Root cause: `format_skills_prompt`, `format_grouped_skills_prompt`, `format_active_skill_tag` (`crates/zeph-skills/src/prompt.rs`) and `SkillInvokeExecutor::execute_tool_call` (`crates/zeph-core/src/skill_invoker.rs`) resolved a skill missing from the trust map via `.unwrap_or_default()`, and `SkillTrustLevel::default()` is `Quarantined` — contradicting `format_skills_prompt`'s own documented contract that a missing entry means `Trusted`.
- On a transient trust-map miss (memory not yet wired, or a `load_all_skill_trust` read failure), every skill matched into `active_skills` that turn was spuriously wrapped by `wrap_quarantined()`, injecting literal `"restricted tool access (no bash, file_write, web_scrape)"` text into the system prompt for skills that were never actually quarantined — the model then echoed this wording when declining an unrelated bash call.
- Added a shared `SkillTrustLevel::MISSING_ENTRY_FALLBACK` (`Trusted`) constant used at all 4 sites, and a `tracing::warn!` on `build_skill_trust_map`'s (`crates/zeph-core/src/agent/trust_commands.rs`) previously-silent DB-read-error fallback.
- Added 3 regression tests in `crates/zeph-skills/src/prompt.rs` and fixed 1 pre-existing test in `crates/zeph-core/src/skill_invoker.rs` that had encoded the old buggy behavior as intended.

## Security note

The real tool-execution gate (`effective_trust`, `crates/zeph-core/src/agent/context/assembly.rs:1487-1499`) already folds a missing trust-map entry to `Trusted` (via `filter_map` + a `Trusted` fold seed) — so the actual access-control boundary was already fail-open on a missing entry *before* this fix. This change brings the display/invocation-body-sanitization paths into agreement with that pre-existing gate; it does not weaken any existing access control. The only behavioral change is that a skill's body may be shown/returned unwrapped rather than sanitized+wrapped during a rare, now-logged, transient trust-map miss — bounded to content sanitization, not tool-call authorization (the separate `Blocked` state still hard-denies access and is untouched).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (2435 passed, 1 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-common` (new `MISSING_ENTRY_FALLBACK` doctest passes)
- [x] New regression test `missing_trust_entry_distinct_from_explicit_quarantine` directly reproduces and catches the original bug (fails against pre-fix code)