### PR TITLE
fix(skills): stamp stable proactive_domain marker to close has_knowledge() idempotency gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tool-execution gate (`effective_trust` in `crates/zeph-core/src/agent/context/assembly.rs`) was
   already fail-open to `Trusted` on a missing entry before this fix, so this change aligns
   display/invocation behavior with the existing security boundary rather than weakening it.
+- `fix(skills)`: `has_knowledge()` (`crates/zeph-skills/src/proactive.rs`) compared an
+  already-explored domain against the deterministic `domain.to_skill_name()`
+  (`"world-knowledge-{slug}"`), but `explore()` wrote the generated skill under whatever
+  free-form name the LLM chose in its `SKILL.md` frontmatter — the two never agreed, so the
+  proactive world-knowledge exploration gate (`crates/zeph-agent-context/src/service.rs:552-562`)
+  never recognized a domain as already known and re-ran a full LLM skill-generation call on
+  every subsequent turn classifying to the same domain. `SkillMeta` gains a
+  `proactive_domain: Option<String>` field (`crates/zeph-skills/src/loader.rs`), stamped into
+  generated frontmatter by a new `stamp_proactive_domain` helper inside `explore()` (mirroring
+  the existing `parent_skill` traceability-marker pattern in `heuristic_promotion.rs`);
+  `has_knowledge()` now matches on this stable per-domain marker instead of the LLM-chosen name,
+  so a follow-up turn on a known domain skips exploration entirely and no longer risks creating
+  a second skill directory for the same domain under a differently-named regeneration. (#5707)
 - `fix(llm)`: `TriageRouter::chat_with_tools` (`crates/zeph-llm/src/router/triage.rs`) delegated
   a tool call to whichever tier was selected by classification with no check that the tier's
   provider actually supports tool use, unlike `RouterProvider::chat_with_tools` which explicitly

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -2739,5 +2739,109 @@ mod tests {
                 "the pre-existing skill must still be present, unreplaced by the mock's canned skill"
             );
         }
+
+        #[tokio::test]
+        async fn prepare_context_proactive_explore_does_not_retrigger_for_known_domain() {
+            // Regression test for #5707: has_knowledge() used to compare against
+            // `domain.to_skill_name()` (e.g. "world-knowledge-git"), which never matched the
+            // LLM-chosen skill name ("world-knowledge-git" here happens to match by luck in the
+            // other fixture tests, but in general the LLM picks its own name) — so every
+            // subsequent turn classifying to the same domain re-ran a full LLM generation call.
+            // Drive `prepare_context` twice with a query that classifies to the same domain and
+            // assert the second call makes zero additional LLM requests.
+            let (mock_provider, recorder) =
+                MockProvider::with_responses(vec![mock_skill_content("terraform-quickref")])
+                    .with_recording();
+            let fixture = setup_fixture(mock_provider);
+
+            let sanitizer = ContentSanitizer::new(&ContentIsolationConfig::default());
+
+            // First turn: domain "terraform" is unknown, explore() must run and the registry
+            // must be reloaded with the stamped `proactive_domain` field.
+            {
+                let mut msgs: Vec<Message> = vec![];
+                let mut cached = 0u64;
+                let mut completed = HashSet::new();
+                let mut window = make_window(&mut msgs, &mut cached, &mut completed);
+                let mut ctx_mgr = ContextManager::new();
+                ctx_mgr.budget = Some(ContextBudget::new(100_000, 0.1));
+                let mut sink = NoopSink;
+                let mut last_confidence = None::<f32>;
+                let mut last_skills_prompt = String::new();
+                let mut active_skill_names = Vec::new();
+
+                let mut view = make_view(
+                    &fixture,
+                    &mut last_confidence,
+                    &mut last_skills_prompt,
+                    &mut active_skill_names,
+                    &sanitizer,
+                    &mut ctx_mgr,
+                    &mut sink,
+                );
+
+                let result = ContextService::new()
+                    .prepare_context("tell me about terraform modules", &mut window, &mut view)
+                    .await;
+                assert!(
+                    result.is_ok(),
+                    "first prepare_context must succeed: {result:?}"
+                );
+            }
+
+            assert_eq!(
+                recorder.lock().unwrap().len(),
+                1,
+                "first turn must trigger exactly one LLM generation call"
+            );
+            assert!(
+                fixture
+                    .registry
+                    .read()
+                    .all_meta()
+                    .iter()
+                    .any(|m| m.proactive_domain.as_deref() == Some("terraform")),
+                "reloaded registry must carry the stamped proactive_domain field"
+            );
+
+            // Second turn: same domain, now known via the reloaded registry. has_knowledge()
+            // must short-circuit before explore() is ever called, so no new LLM request fires.
+            {
+                let mut msgs: Vec<Message> = vec![];
+                let mut cached = 0u64;
+                let mut completed = HashSet::new();
+                let mut window = make_window(&mut msgs, &mut cached, &mut completed);
+                let mut ctx_mgr = ContextManager::new();
+                ctx_mgr.budget = Some(ContextBudget::new(100_000, 0.1));
+                let mut sink = NoopSink;
+                let mut last_confidence = None::<f32>;
+                let mut last_skills_prompt = String::new();
+                let mut active_skill_names = Vec::new();
+
+                let mut view = make_view(
+                    &fixture,
+                    &mut last_confidence,
+                    &mut last_skills_prompt,
+                    &mut active_skill_names,
+                    &sanitizer,
+                    &mut ctx_mgr,
+                    &mut sink,
+                );
+
+                let result = ContextService::new()
+                    .prepare_context("tell me more about terraform state", &mut window, &mut view)
+                    .await;
+                assert!(
+                    result.is_ok(),
+                    "second prepare_context must succeed: {result:?}"
+                );
+            }
+
+            assert_eq!(
+                recorder.lock().unwrap().len(),
+                1,
+                "second turn for an already-known domain must NOT trigger another LLM generation call"
+            );
+        }
     }
 }

--- a/crates/zeph-skills/src/loader.rs
+++ b/crates/zeph-skills/src/loader.rs
@@ -47,6 +47,8 @@
 //! | `x-git-hash` | no | Git commit hash captured at install time |
 //! | `metadata` | no | Arbitrary key-value block for custom attributes |
 //! | `triggers` | no | Comma-separated trigger phrases for embedding-based matching (max 20, each 3–200 chars) |
+//! | `parent_skill` | no | Originating skill name for heuristic-promoted skills |
+//! | `proactive_domain` | no | Canonical domain slug for proactively-generated world-knowledge skills |
 //!
 //! ## Trigger Phrases
 //!
@@ -115,6 +117,15 @@ pub struct SkillMeta {
     /// Set when `source = "heuristic_promotion"`. Used for traceability only — no effect on
     /// skill matching or trust governance.
     pub parent_skill: Option<String>,
+    /// Canonical domain slug for proactively-generated world-knowledge skills
+    /// (`proactive_domain` frontmatter field).
+    ///
+    /// Set by [`crate::proactive::ProactiveExplorer::explore`] to the raw domain slug (the
+    /// `DomainLabel` inner string, e.g. `"terraform"` — not the `world-knowledge-{slug}` form
+    /// produced by `DomainLabel::to_skill_name`) so that `ProactiveExplorer::has_knowledge` can
+    /// identify an already-explored domain regardless of the LLM-chosen skill `name`. `None`
+    /// for skills not produced by proactive exploration.
+    pub proactive_domain: Option<String>,
     /// Optional platform-extension manifest declared in the skill's `extensions:` frontmatter block.
     ///
     /// `None` when the block is absent or fails to parse (a warning is logged on parse failure).
@@ -170,6 +181,7 @@ impl Default for SkillMeta {
             category: None,
             triggers: vec![],
             parent_skill: None,
+            proactive_domain: None,
             extensions: None,
         }
     }
@@ -240,6 +252,7 @@ struct RawFrontmatter {
     category: Option<String>,
     triggers: Vec<String>,
     parent_skill: Option<String>,
+    proactive_domain: Option<String>,
 }
 
 /// Validate a skill category name.
@@ -466,6 +479,11 @@ fn apply_field(raw: &mut RawFrontmatter, key: &str, value: String) {
                 raw.parent_skill = Some(value);
             }
         }
+        "proactive_domain" => {
+            if !value.is_empty() {
+                raw.proactive_domain = Some(value);
+            }
+        }
         "metadata" if value.is_empty() => {
             // Handled by caller — sets in_metadata flag.
         }
@@ -495,6 +513,7 @@ fn parse_frontmatter(yaml_str: &str) -> RawFrontmatter {
         category: None,
         triggers: Vec::new(),
         parent_skill: None,
+        proactive_domain: None,
     };
     let mut in_metadata = false;
 
@@ -687,6 +706,7 @@ pub fn load_skill_meta_from_str(content: &str) -> Result<(SkillMeta, String), Sk
         category: raw.category,
         triggers: raw.triggers,
         parent_skill: raw.parent_skill,
+        proactive_domain: raw.proactive_domain,
         extensions,
     };
 
@@ -771,6 +791,7 @@ pub fn load_skill_meta(path: &Path) -> Result<SkillMeta, SkillError> {
         category: raw.category,
         triggers: raw.triggers,
         parent_skill: raw.parent_skill,
+        proactive_domain: raw.proactive_domain,
         extensions,
     })
 }
@@ -1725,6 +1746,34 @@ mod tests {
         );
         let meta = load_skill_meta(&path).unwrap();
         assert!(meta.parent_skill.is_none());
+    }
+
+    #[test]
+    fn proactive_domain_parsed_from_frontmatter() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "terraform-quickref",
+            "---\nname: terraform-quickref\ndescription: Terraform quick reference.\nproactive_domain: terraform\n---\nbody",
+        );
+        let meta = load_skill_meta(&path).unwrap();
+        assert_eq!(
+            meta.proactive_domain.as_deref(),
+            Some("terraform"),
+            "proactive_domain must be parsed from frontmatter regardless of the skill's own name"
+        );
+    }
+
+    #[test]
+    fn proactive_domain_absent_when_not_in_frontmatter() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "regular-skill",
+            "---\nname: regular-skill\ndescription: A normal skill.\n---\nbody",
+        );
+        let meta = load_skill_meta(&path).unwrap();
+        assert!(meta.proactive_domain.is_none());
     }
 
     #[test]

--- a/crates/zeph-skills/src/merger.rs
+++ b/crates/zeph-skills/src/merger.rs
@@ -38,6 +38,7 @@
 //!     category: None,
 //!     triggers: vec![],
 //!     parent_skill: None,
+//!     proactive_domain: None,
 //!     extensions: None,
 //! };
 //!
@@ -217,6 +218,7 @@ mod tests {
             category: None,
             triggers: vec![],
             parent_skill: None,
+            proactive_domain: None,
             extensions: None,
         }
     }

--- a/crates/zeph-skills/src/proactive.rs
+++ b/crates/zeph-skills/src/proactive.rs
@@ -174,10 +174,16 @@ impl ProactiveExplorer {
     }
 
     /// Return `true` if the registry already contains a skill for `domain`.
+    ///
+    /// Matches on the `proactive_domain` frontmatter field stamped by [`Self::explore`],
+    /// not on the skill's `name` — the LLM generating the skill picks its own descriptive
+    /// name, so `name` cannot be relied on to identify the domain it covers.
     #[must_use]
     pub fn has_knowledge(&self, registry: &SkillRegistry, domain: &DomainLabel) -> bool {
-        let name = domain.to_skill_name();
-        registry.all_meta().iter().any(|m| m.name == name)
+        registry
+            .all_meta()
+            .iter()
+            .any(|m| m.proactive_domain.as_deref() == Some(domain.0.as_str()))
     }
 
     /// Return `true` if `domain` is in the configured exclusion list.
@@ -248,7 +254,8 @@ impl ProactiveExplorer {
         }
         tokio::fs::create_dir_all(&skill_dir).await?;
         let skill_path = skill_dir.join("SKILL.md");
-        tokio::fs::write(&skill_path, &skill.content).await?;
+        let content = stamp_proactive_domain(&skill.content, &domain.0);
+        tokio::fs::write(&skill_path, &content).await?;
         tracing::info!(
             domain = %domain.0,
             skill = %skill.name,
@@ -257,6 +264,42 @@ impl ProactiveExplorer {
         );
         Ok(())
     }
+}
+
+/// Insert or overwrite the `proactive_domain:` field in generated SKILL.md frontmatter.
+///
+/// The LLM never emits this field itself — it is stamped in after generation so
+/// [`ProactiveExplorer::has_knowledge`] has a stable identifier independent of the
+/// LLM-chosen `name:`. Inserted right after `name:`; falls back to returning `skill_md`
+/// unchanged if no frontmatter delimiters are found.
+fn stamp_proactive_domain(skill_md: &str, domain: &str) -> String {
+    let Some(after_open) = skill_md.strip_prefix("---") else {
+        return skill_md.to_string();
+    };
+    let Some(close_pos) = after_open.find("---") else {
+        return skill_md.to_string();
+    };
+    let yaml = &after_open[..close_pos];
+    let rest = &after_open[close_pos..];
+
+    let mut lines: Vec<String> = yaml
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("proactive_domain:"))
+        .map(str::to_string)
+        .collect();
+
+    let insert_after = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with("name:"))
+        .map_or(lines.len(), |p| p + 1);
+
+    lines.insert(insert_after, format!("proactive_domain: {domain}"));
+
+    format!(
+        "---{}\n---{}",
+        lines.join("\n"),
+        rest.trim_start_matches("---")
+    )
 }
 
 #[cfg(test)]
@@ -368,6 +411,95 @@ mod tests {
             vec![],
         );
 
+        assert!(!explorer.has_knowledge(&registry, &DomainLabel("rust".into())));
+    }
+
+    #[test]
+    fn has_knowledge_matches_by_proactive_domain_not_llm_chosen_name() {
+        // Regression test for #5707: the skill directory/name is whatever the LLM picked
+        // ("terraform-quickref"), never "world-knowledge-terraform" — has_knowledge must
+        // still recognize the domain via the stamped `proactive_domain` field.
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("terraform-quickref");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: terraform-quickref\ndescription: Terraform quick reference.\nproactive_domain: terraform\n---\nbody",
+        )
+        .unwrap();
+        let registry = SkillRegistry::load(&[dir.path()]);
+
+        let generator = SkillGenerator::new(
+            zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            PathBuf::from("/tmp"),
+        );
+        let explorer = ProactiveExplorer::new(
+            generator,
+            None,
+            PathBuf::from("/tmp"),
+            8_000,
+            30_000,
+            vec![],
+        );
+
+        assert!(explorer.has_knowledge(&registry, &DomainLabel("terraform".into())));
+        assert!(!explorer.has_knowledge(&registry, &DomainLabel("rust".into())));
+    }
+
+    #[test]
+    fn stamp_proactive_domain_inserts_after_name() {
+        let skill_md =
+            "---\nname: terraform-quickref\ndescription: Terraform quick reference.\n---\nbody";
+        let stamped = stamp_proactive_domain(skill_md, "terraform");
+        assert!(
+            stamped.contains("name: terraform-quickref\nproactive_domain: terraform\n"),
+            "stamped: {stamped}"
+        );
+        assert!(stamped.contains("body"), "body missing: {stamped}");
+    }
+
+    #[test]
+    fn stamp_proactive_domain_replaces_existing_value() {
+        let skill_md = "---\nname: terraform-quickref\nproactive_domain: stale\ndescription: Terraform quick reference.\n---\nbody";
+        let stamped = stamp_proactive_domain(skill_md, "terraform");
+        assert_eq!(stamped.matches("proactive_domain:").count(), 1);
+        assert!(stamped.contains("proactive_domain: terraform"));
+        assert!(!stamped.contains("stale"));
+    }
+
+    #[tokio::test]
+    async fn explore_then_reload_closes_has_knowledge_gate() {
+        // End-to-end regression guard for #5707: drives the real explore() -> stamp ->
+        // write -> registry reload -> has_knowledge() path with a mocked LLM response whose
+        // frontmatter `name:` deliberately differs from `domain.to_skill_name()`. A
+        // regression that reintroduced name-based matching on either side of the
+        // stamp/has_knowledge pair would fail this test even though the hand-fixture unit
+        // tests above stay green.
+        let dir = tempfile::tempdir().unwrap();
+        let llm_response = "---\nname: terraform-quickref\ndescription: Terraform quick reference.\nallowed-tools: bash\n---\n\n## Usage\n\nRun `terraform plan`.\n";
+        let provider =
+            zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::with_responses(vec![
+                llm_response.to_string(),
+            ]));
+        let generator = SkillGenerator::new(provider, dir.path().to_path_buf());
+        let explorer = ProactiveExplorer::new(
+            generator,
+            None,
+            dir.path().to_path_buf(),
+            8_000,
+            30_000,
+            vec![],
+        );
+
+        let domain = DomainLabel("terraform".into());
+        explorer.explore(&domain).await.unwrap();
+
+        // The skill must be written under the LLM's own name, not "world-knowledge-terraform".
+        assert!(!dir.path().join(domain.to_skill_name()).exists());
+        assert!(dir.path().join("terraform-quickref").exists());
+
+        let registry = SkillRegistry::load(&[dir.path()]);
+        assert!(explorer.has_knowledge(&registry, &domain));
         assert!(!explorer.has_knowledge(&registry, &DomainLabel("rust".into())));
     }
 }

--- a/crates/zeph-skills/src/trace_extractor.rs
+++ b/crates/zeph-skills/src/trace_extractor.rs
@@ -686,6 +686,7 @@ mod tests {
             category: None,
             triggers: vec![],
             parent_skill: None,
+            proactive_domain: None,
             extensions: None,
         };
         let emb = SkillEmbedding::from_raw(vec![1.0, 0.0]);


### PR DESCRIPTION
## Summary

- `has_knowledge()` (`crates/zeph-skills/src/proactive.rs`) compared an already-explored domain against the deterministic `domain.to_skill_name()` (`"world-knowledge-{slug}"`), but `explore()` wrote the generated skill under whatever free-form name the LLM chose in its `SKILL.md` frontmatter — the two never agreed, so the proactive world-knowledge exploration gate (`crates/zeph-agent-context/src/service.rs:552-562`) never recognized a domain as already known and re-ran a full LLM skill-generation call on every subsequent turn classifying to the same domain.
- `SkillMeta` gains a `proactive_domain: Option<String>` field (`crates/zeph-skills/src/loader.rs`), stamped into generated frontmatter by a new `stamp_proactive_domain` helper inside `explore()` (mirrors the existing `parent_skill` traceability-marker pattern in `heuristic_promotion.rs`). `has_knowledge()` now matches on this stable per-domain marker instead of the LLM-chosen name, so a follow-up turn on a known domain skips exploration entirely and no longer risks creating a second skill directory for the same domain under a differently-named regeneration.
- Closes #5707, which closes out the #5645 follow-up investigation (cross-turn skill-matcher visibility, tracked across CI-1201/1207/1211/1217/1224/1225/1226) — the "skill matcher" angle was never actually reached because the proactive-explore gate itself re-fired before any matcher/disambiguation logic ran.

## Test plan

- [x] `crates/zeph-skills/src/proactive.rs::explore_then_reload_closes_has_knowledge_gate` — drives the real `explore()` path with a mocked LLM response whose skill name deliberately differs from `domain.to_skill_name()`, reloads the registry, and asserts `has_knowledge()` symmetry (true for the explored domain, false for an unrelated one).
- [x] `crates/zeph-agent-context/src/service.rs::prepare_context_proactive_explore_does_not_retrigger_for_known_domain` — drives `ContextService::prepare_context` twice with same-domain queries and asserts exactly one LLM generation call total across both turns.
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12141 passed (1 pre-existing unrelated leaky test)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (only pre-existing unrelated private-intra-doc-link warnings)
- [x] Adversarial review caught and fixed a malformed-frontmatter bug (missing newline before the closing `---` delimiter) in the new stamping helper before merge
- Follow-up filed separately: #5725 (`stamp_proactive_domain`/`patch_frontmatter` duplication, dedup backlog)