### PR TITLE
fix(core): offload benchmark file load to spawn_blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(core)`: `Agent::build_experiment_engine` (`crates/zeph-core/src/agent/experiment_cmd.rs`)
+  read the configured benchmark TOML synchronously via `BenchmarkSet::from_file`, which performs
+  blocking filesystem I/O (`std::fs::canonicalize` x2, `std::fs::metadata`, `std::fs::
+  read_to_string`), directly on the agent turn loop from the `/experiment start` slash-command
+  handler — violating the project's non-blocking-hot-path contract and contending with any other
+  work scheduled on that tokio worker for the duration of the read (#5721). Wrapped the call in
+  `tokio::task::spawn_blocking`, matching the two other call sites that already did this correctly
+  (`src/scheduler.rs`, `src/runner.rs`).
 - `fix(skills)`: a skill missing from the trust map (e.g. `memory.persistence.memory` not yet
   wired, or a transient `load_all_skill_trust` read failure) was treated as
   `SkillTrustLevel::Quarantined` at 4 call sites (`crates/zeph-skills/src/prompt.rs`'s

--- a/crates/zeph-core/src/agent/experiment_cmd.rs
+++ b/crates/zeph-core/src/agent/experiment_cmd.rs
@@ -14,7 +14,7 @@ use zeph_experiments::{
 
 impl<C: Channel> Agent<C> {
     /// Build an [`ExperimentEngine`] from validated config, returning `Err(message)` on failure.
-    fn build_experiment_engine(
+    async fn build_experiment_engine(
         &mut self,
         config: crate::config::ExperimentConfig,
     ) -> Result<ExperimentEngine, String> {
@@ -24,8 +24,13 @@ impl<C: Channel> Agent<C> {
             return Err("experiments.benchmark_file is not set in config.".to_owned());
         };
 
-        let benchmark = BenchmarkSet::from_file(&benchmark_path)
-            .map_err(|e| format!("Failed to load benchmark: {e}"))?;
+        // Load benchmark via spawn_blocking: from_file uses blocking std::fs I/O
+        // (canonicalize, metadata, read_to_string), which must not run on the async worker.
+        let benchmark =
+            tokio::task::spawn_blocking(move || BenchmarkSet::from_file(&benchmark_path))
+                .await
+                .map_err(|e| format!("Benchmark load task panicked: {e}"))?
+                .map_err(|e| format!("Failed to load benchmark: {e}"))?;
 
         let provider_arc = Arc::new(self.provider.clone());
         // Use a dedicated eval provider when `eval_provider` is configured, so the judge is
@@ -71,7 +76,7 @@ impl<C: Channel> Agent<C> {
                 let max_override = args
                     .strip_prefix("start")
                     .and_then(|s| s.trim().parse::<u32>().ok());
-                Ok(self.experiment_start(max_override))
+                Ok(self.experiment_start(max_override).await)
             }
             _ => Ok(
                 "Unknown /experiment subcommand. Available: /experiment start [N], \
@@ -193,7 +198,7 @@ impl<C: Channel> Agent<C> {
         Ok(msg)
     }
 
-    fn experiment_start(&mut self, max_override: Option<u32>) -> String {
+    async fn experiment_start(&mut self, max_override: Option<u32>) -> String {
         if self
             .services
             .experiments
@@ -215,7 +220,7 @@ impl<C: Channel> Agent<C> {
             return format!("Experiment config is invalid: {e}");
         }
         let max_n = config.max_experiments;
-        let engine = match self.build_experiment_engine(config) {
+        let engine = match self.build_experiment_engine(config).await {
             Ok(e) => e,
             Err(msg) => return msg,
         };
@@ -396,8 +401,8 @@ mod tests {
     /// Uses a real temporary benchmark TOML so the code reaches the `.with_tolerate_subject_errors`
     /// call site. Success (no error returned) confirms the builder chain is invoked correctly;
     /// the underlying field value is passed through without transformation.
-    #[test]
-    fn build_experiment_engine_forwards_tolerate_subject_errors() {
+    #[tokio::test]
+    async fn build_experiment_engine_forwards_tolerate_subject_errors() {
         use std::io::Write as _;
         use zeph_config::ExperimentConfig;
 
@@ -413,10 +418,35 @@ mod tests {
 
         let mut agent = make_agent();
         // build_experiment_engine must succeed and silently forward the flag to the Evaluator.
-        let result = agent.build_experiment_engine(config);
+        let result = agent.build_experiment_engine(config).await;
         assert!(
             result.is_ok(),
             "build_experiment_engine must succeed with a valid benchmark file"
         );
+    }
+
+    /// Verify that a missing benchmark file surfaces its error through the
+    /// `spawn_blocking(...).await.map_err(...)?.map_err(...)?` chain, rather than being
+    /// swallowed or turned into a panic message by the async conversion.
+    #[tokio::test]
+    async fn build_experiment_engine_missing_benchmark_file_surfaces_error() {
+        use zeph_config::ExperimentConfig;
+
+        let config = ExperimentConfig {
+            enabled: true,
+            benchmark_file: Some(std::path::PathBuf::from("/nonexistent/path/benchmark.toml")),
+            ..ExperimentConfig::default()
+        };
+
+        let mut agent = make_agent();
+        match agent.build_experiment_engine(config).await {
+            Err(msg) => assert!(
+                msg.contains("Failed to load benchmark"),
+                "expected benchmark-load error to surface through spawn_blocking, got: {msg}"
+            ),
+            Ok(_) => {
+                panic!("expected build_experiment_engine to fail for a missing benchmark file")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `Agent::build_experiment_engine` read the configured benchmark TOML synchronously via `BenchmarkSet::from_file` (blocking `canonicalize`/`metadata`/`read_to_string`), called directly from the async `/experiment start` slash-command handler on the agent turn loop.
- Wraps the call in `tokio::task::spawn_blocking`, matching the two other call sites that already did this correctly (`src/scheduler.rs:90`, `src/runner.rs:4215`), propagating `JoinError`/`EvalError` into the existing `Result<_, String>` convention.
- Adds a regression test covering the missing-benchmark-file error path through the new async chain.

Closes #5721

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci -p zeph-core -p zeph-experiments --all-targets --features scheduler -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-core -p zeph-experiments` (full zeph-core suite passes at reduced parallelism; some unrelated tests hit known nextest leak-timeout false positives under load, tracked separately in #5617)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-core -p zeph-experiments --features scheduler`
- [x] CHANGELOG.md updated