### PR TITLE
fix(tools,core): honor mandated-retry contract in utility gate, fix MCP id matching and cancel ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -820,6 +820,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   worker thread rather than being bounded by the timeout. `refresh_git_branch` is now `async`
   and dispatches the git subprocess call via `tokio::task::spawn_blocking`, keeping the tokio
   worker thread free while awaiting the blocking-pool result. (#5670)
+- `fix(tools,core)`: `UtilityScorer::recommend_action`'s `Retrieve` rule (gain `>= 0.5` tier,
+  covering `find_path`/`list_directory`/`grep`/`glob`/`search_code`) skipped a tool call and
+  injected a hint mandating the LLM retry it with the same arguments — but the retry's
+  identical `(tool_id, params)` hash then scored `redundancy == 1.0`, and the redundancy rule
+  vetoed the mandated retry as a duplicate before it ever executed, stalling the tool
+  permanently and producing a fabricated "restriction" apology from the LLM (4th occurrence of
+  the Retrieve-then-redundant-Respond defect class after #2620/#5650/#5659). `UtilityScorer`
+  now tracks a per-turn set of call hashes vetoed by the `Retrieve` rule
+  (`mark_mandated_retry`/`take_mandated_retry`); `UtilityContext` gained a `mandated_retry`
+  field that `recommend_action` checks before every other rule, unconditionally allowing the
+  one mandated retry through as `ToolCall`. Also fixed a related cache-poisoning bug found
+  while testing the retry path: `apply_tier_results` (`crates/zeph-core/src/agent/tool_execution/tier_loop.rs`)
+  cached the utility gate's synthetic `[skipped]`/`[stopped]` output for any cacheable tool
+  (none of the affected tools are in the cache's deny-list), so even with the bypass in place
+  the mandated retry could still replay stale skip text from the result cache instead of
+  executing; the cache-store guard now excludes both prefixes. (#5719)
+- `fix(tools)`: `UtilityScorer::contains_tool_name` (backing both `is_exempt` and
+  `is_high_gain`) matched `high_gain_tools`/`exempt_tools` entries only case-insensitively,
+  with no normalization between the colon-separated `McpTool::qualified_name()` form
+  (`"{server_id}:{name}"`, the only form ever displayed to an operator, via the TUI's
+  `mcp:list` command) and the underscore-separated `McpTool::sanitized_id()` form
+  (`"{server_id}_{name}"`, the only form ever dispatched as `call.tool_id`). An id copied
+  straight from `mcp:list` into config therefore never matched at runtime. Both the configured
+  entries and the incoming tool id are now normalized (`:` → `_`, lowercased) before
+  comparison, so either written form matches. (#5713)
+- `fix(core)`: `Agent::cancel_tool_batch` (`crates/zeph-core/src/agent/tool_execution/tier_loop.rs`,
+  the shared cancellation-checkpoint helper introduced by #5654/#5715's dedup pass) sent the
+  `[Cancelled]` channel notification with `.await?` *before* persisting the tombstone
+  `ToolResult`s, so a channel-send failure (closed mpsc receiver, a disconnected
+  Telegram/Discord adapter) propagated immediately via `?` and skipped
+  `persist_cancelled_tool_results` entirely — reintroducing the orphaned-`tool_calls` defect
+  class already fixed 3 times over (#5464, #5513, #5646). The tombstone persist now runs first,
+  and a subsequent notification-send failure is logged rather than propagated, so it can never
+  again suppress the tombstone write. (#5717)
 
 ### Changed
 

--- a/crates/zeph-core/src/agent/tests/agent_tests/common.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/common.rs
@@ -95,6 +95,11 @@ pub(crate) struct MockChannel {
     pub(crate) tool_starts: Arc<Mutex<Vec<ToolStartEvent>>>,
     pub(crate) exit_supported: bool,
     pub(crate) input_sanitization_required: bool,
+    /// When `true`, `send()` fails with `ChannelError::ChannelClosed` instead of recording the
+    /// message — simulates a disconnected adapter (closed mpsc receiver, dropped
+    /// Telegram/Discord connection) for testing that callers do not depend on the notification
+    /// send succeeding (#5717).
+    pub(crate) fail_send: bool,
 }
 
 impl MockChannel {
@@ -108,7 +113,14 @@ impl MockChannel {
             tool_starts: Arc::new(Mutex::new(Vec::new())),
             exit_supported: true,
             input_sanitization_required: false,
+            fail_send: false,
         }
+    }
+
+    /// Make every call to `Channel::send` fail with `ChannelError::ChannelClosed` (#5717).
+    pub(crate) fn with_failing_send(mut self) -> Self {
+        self.fail_send = true;
+        self
     }
 
     pub(crate) fn without_exit_support(mut self) -> Self {
@@ -163,6 +175,9 @@ impl Channel for MockChannel {
     }
 
     async fn send(&mut self, text: &str) -> Result<(), crate::channel::ChannelError> {
+        if self.fail_send {
+            return Err(crate::channel::ChannelError::ChannelClosed);
+        }
         self.sent.lock().unwrap().push(text.to_string());
         Ok(())
     }
@@ -226,6 +241,26 @@ impl MockToolExecutor {
 
     pub(crate) fn no_tools() -> Self {
         Self::new(vec![Ok(None)])
+    }
+
+    /// Executor that returns a single successful tool output with the given summary.
+    pub(crate) fn with_output(
+        tool_name: impl Into<zeph_tools::ToolName>,
+        summary: impl Into<String>,
+    ) -> Self {
+        let output = ToolOutput {
+            tool_name: tool_name.into(),
+            summary: summary.into(),
+            blocks_executed: 1,
+            filter_stats: None,
+            diff: None,
+            streamed: false,
+            terminal_id: None,
+            locations: None,
+            raw_response: None,
+            claim_source: None,
+        };
+        Self::new(vec![Ok(Some(output))])
     }
 
     /// Attach tool definitions returned by `tool_definitions()`/`tool_definitions_erased()`, for

--- a/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
@@ -403,6 +403,7 @@ fn clear_utility_state_resets_per_turn_redundancy_tracking() {
         tokens_consumed: 0,
         token_budget: 1000,
         user_requested: false,
+        mandated_retry: false,
     };
 
     // Record the call to create redundancy state.

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -77,11 +77,15 @@ impl<C: Channel> Agent<C> {
         Ok(false)
     }
 
-    /// Resets skill env, records the cancellation, sends the `[Cancelled]` notice, and
-    /// persists the tombstone tool results — the fixed sequence every cancellation
-    /// checkpoint in this file must follow (#5654). Skipping or reordering a step here
-    /// has previously left orphaned `ToolUse` messages with no matching `ToolResult`
-    /// (#5464, #5513, #5646) — see the recurring defect-class notes in issue history.
+    /// Resets skill env, records the cancellation, persists the tombstone tool results, and
+    /// sends the `[Cancelled]` notice — the fixed sequence every cancellation checkpoint in
+    /// this file must follow (#5654). Skipping or reordering a step here has previously left
+    /// orphaned `ToolUse` messages with no matching `ToolResult` (#5464, #5513, #5646) — see
+    /// the recurring defect-class notes in issue history.
+    ///
+    /// The tombstone persist runs before the notification send and its failure is logged
+    /// rather than propagated: a closed/dropped channel receiver or disconnected adapter must
+    /// never skip the tombstone and reintroduce the orphaned-`tool_calls` defect (#5717).
     async fn cancel_tool_batch(
         &mut self,
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
@@ -90,8 +94,13 @@ impl<C: Channel> Agent<C> {
         self.tool_executor.set_skill_env(None);
         tracing::info!("{log_msg}");
         self.update_metrics(|m| m.cancellations += 1);
-        self.channel.send("[Cancelled]").await?;
         self.persist_cancelled_tool_results(tool_calls, None).await;
+        if let Err(e) = self.channel.send("[Cancelled]").await {
+            tracing::warn!(
+                error = %e,
+                "cancel_tool_batch: failed to notify channel of cancellation"
+            );
+        }
         Ok(())
     }
 
@@ -623,11 +632,20 @@ impl<C: Channel> Agent<C> {
                 actions.push(zeph_tools::UtilityAction::ToolCall);
                 continue;
             }
+            // Consume any pending mandated-retry marker before scoring: a call that was vetoed
+            // by the Retrieve rule earlier this turn, and that the injected hint told the LLM
+            // to retry with the same arguments, must not be re-vetoed as a redundant duplicate
+            // when the LLM complies (#5719).
+            let mandated_retry = self
+                .tool_orchestrator
+                .utility_scorer
+                .take_mandated_retry(call);
             let ctx = zeph_tools::UtilityContext {
                 tool_calls_this_turn: tool_calls_this_turn + idx,
                 tokens_consumed,
                 token_budget,
                 user_requested: explicit_request,
+                mandated_retry,
             };
             let score = self.tool_orchestrator.utility_scorer.score(call, &ctx);
             let action = self
@@ -1455,6 +1473,7 @@ impl<C: Channel> Agent<C> {
         &mut self,
         idx: usize,
         tc: &zeph_llm::provider::ToolUseRequest,
+        call: &ToolCall,
         pending_system_hints: &mut Vec<String>,
     ) -> Result<Option<(usize, ToolExecFut)>, crate::agent::error::AgentError> {
         if self.tool_orchestrator.has_retryable_failure_this_turn() {
@@ -1485,6 +1504,11 @@ impl<C: Channel> Agent<C> {
              the '{}' tool again with the same arguments.",
             tc.name, tc.name
         ));
+        // The hint above mandates a retry of this exact call — mark it so the utility gate
+        // does not re-veto the compliant retry as a redundant duplicate (#5719).
+        self.tool_orchestrator
+            .utility_scorer
+            .mark_mandated_retry(call);
         Ok(Some(ready_fut(
             idx,
             skipped_output(
@@ -1502,6 +1526,7 @@ impl<C: Channel> Agent<C> {
         &mut self,
         idx: usize,
         tc: &zeph_llm::provider::ToolUseRequest,
+        call: &ToolCall,
         utility_actions: &[zeph_tools::UtilityAction],
         pending_system_hints: &mut Vec<String>,
     ) -> Result<Option<(usize, ToolExecFut)>, crate::agent::error::AgentError> {
@@ -1524,7 +1549,7 @@ impl<C: Channel> Agent<C> {
                 )))
             }
             zeph_tools::UtilityAction::Retrieve => {
-                self.handle_retrieve_action(idx, tc, pending_system_hints)
+                self.handle_retrieve_action(idx, tc, call, pending_system_hints)
                     .await
             }
             zeph_tools::UtilityAction::Verify => {
@@ -1618,6 +1643,7 @@ impl<C: Channel> Agent<C> {
         &mut self,
         idx: usize,
         tc: &zeph_llm::provider::ToolUseRequest,
+        call: &ToolCall,
         has_failed_dep: bool,
         quota_blocked: bool,
         pre_exec_blocked: &[bool],
@@ -1679,7 +1705,7 @@ impl<C: Channel> Agent<C> {
             )));
         }
         if let Some(fut) = self
-            .handle_utility_gate(idx, tc, utility_actions, pending_system_hints)
+            .handle_utility_gate(idx, tc, call, utility_actions, pending_system_hints)
             .await?
         {
             let reason = format!(
@@ -1864,6 +1890,7 @@ impl<C: Channel> Agent<C> {
                 .check_call_gates(
                     idx,
                     tc,
+                    call,
                     has_failed_dep,
                     quota_blocked,
                     pre_exec_blocked,
@@ -2030,11 +2057,17 @@ impl<C: Channel> Agent<C> {
                 failed_ids.insert(tool_calls[idx].id.clone());
             }
 
-            // Store successful, non-cached results in the tool result cache.
+            // Store successful, non-cached results in the tool result cache. Utility-gate
+            // synthetic outputs ("[skipped]"/"[stopped]") are never real execution results and
+            // must not be cached: caching one would make a later mandated retry (#5719) replay
+            // the stale skip text under the same args hash instead of actually executing the
+            // tool, silently reintroducing the exact stall the mandated-retry bypass fixes.
             if !is_failed
                 && cache_hits[idx].is_none()
                 && zeph_tools::is_cacheable(tool_calls[idx].name.as_str())
                 && let Ok(Some(ref out)) = result
+                && !out.summary.starts_with("[skipped]")
+                && !out.summary.starts_with("[stopped]")
             {
                 let key =
                     zeph_tools::CacheKey::new(tool_calls[idx].name.to_string(), args_hashes[idx]);
@@ -3262,6 +3295,13 @@ mod tests {
         }
     }
 
+    fn make_tool_call(name: &str) -> ToolCall {
+        ToolCall {
+            tool_id: zeph_common::ToolName::new(name),
+            ..Default::default()
+        }
+    }
+
     fn make_agent_with_shadow(enabled: bool) -> Agent<crate::testing::MockChannel> {
         use crate::testing::{MockChannel, MockToolExecutor, mock_provider};
         use zeph_skills::registry::SkillRegistry;
@@ -3459,7 +3499,7 @@ mod tests {
         let tc = make_tool_req("bash");
         let mut hints = Vec::new();
         let result = agent
-            .handle_retrieve_action(0, &tc, &mut hints)
+            .handle_retrieve_action(0, &tc, &make_tool_call("bash"), &mut hints)
             .await
             .unwrap();
 
@@ -3497,7 +3537,7 @@ mod tests {
         let tc = make_tool_req("bash");
         let mut hints = Vec::new();
         let result = agent
-            .handle_retrieve_action(0, &tc, &mut hints)
+            .handle_retrieve_action(0, &tc, &make_tool_call("bash"), &mut hints)
             .await
             .unwrap();
 
@@ -3539,7 +3579,7 @@ mod tests {
         let tc = make_tool_req("bash");
         let mut hints = Vec::new();
         let result = agent
-            .handle_retrieve_action(0, &tc, &mut hints)
+            .handle_retrieve_action(0, &tc, &make_tool_call("bash"), &mut hints)
             .await
             .unwrap();
 
@@ -4368,6 +4408,164 @@ mod tests {
             assert!(
                 has_tombstone,
                 "last message must be the [Cancelled] tombstone for id-e2e, got: {last:?}"
+            );
+        }
+
+        /// #5717 regression: `cancel_tool_batch` previously ran
+        /// `self.channel.send("[Cancelled]").await?` before `persist_cancelled_tool_results`,
+        /// using `?` to propagate any send failure immediately. A channel-send failure (closed
+        /// mpsc receiver, dropped Telegram/Discord connection) therefore short-circuited the
+        /// function and skipped the tombstone persist entirely, leaving the in-flight `ToolUse`
+        /// batch without a matching `ToolResult` — the same orphaned-`tool_calls` defect class
+        /// already fixed 3 times over (#5464, #5513, #5646). The fix persists the tombstone
+        /// first and only logs (never propagates) a subsequent send failure.
+        #[tokio::test]
+        async fn cancel_tool_batch_persists_tombstone_even_when_channel_send_fails() {
+            let provider = mock_provider(vec![]);
+            let channel = MockChannel::new(vec![]).with_failing_send();
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::no_tools();
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+            let tool_calls = vec![zeph_llm::provider::ToolUseRequest {
+                id: "id-cancel".to_owned(),
+                name: "bash".to_owned().into(),
+                input: serde_json::json!({}),
+            }];
+
+            let result = agent
+                .cancel_tool_batch(&tool_calls, "test cancellation with failing channel")
+                .await;
+            assert!(
+                result.is_ok(),
+                "cancel_tool_batch must not fail even when channel.send fails, got {result:?}"
+            );
+
+            let matches = tool_result_ids(&agent, "id-cancel");
+            assert_eq!(
+                matches.len(),
+                1,
+                "tombstone must be persisted even when the notification send fails, got {}",
+                matches.len()
+            );
+        }
+    }
+
+    mod mandated_retry_regression_tests {
+        use super::*;
+        use crate::agent::agent_tests::*;
+
+        fn tool_result_content(agent: &Agent<MockChannel>, id: &str) -> Option<(String, bool)> {
+            agent.msg.messages.iter().find_map(|m| {
+                m.parts.iter().find_map(|p| match p {
+                    MessagePart::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error,
+                    } if tool_use_id == id => Some((content.clone(), *is_error)),
+                    _ => None,
+                })
+            })
+        }
+
+        /// #5719 end-to-end regression: `find_path` (`default_gain` 0.65) triggers the
+        /// `Retrieve` rule on a fresh first call and is skipped with a hint instructing the LLM
+        /// to call it again with the same arguments. Before the fix, that mandated retry was
+        /// re-vetoed by the redundancy (`Respond`) rule on the very next round — the tool never
+        /// executed and the turn ended with a fabricated "restriction" apology. The retry must
+        /// now execute for real.
+        #[tokio::test]
+        async fn find_path_mandated_retry_executes_instead_of_redundant_respond() {
+            let provider = mock_provider(vec![]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::with_output("find_path", "src/main.rs\nsrc/lib.rs");
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent
+                .tool_orchestrator
+                .set_utility_config(zeph_tools::UtilityScoringConfig {
+                    enabled: true,
+                    ..zeph_tools::UtilityScoringConfig::default()
+                });
+
+            let args = serde_json::json!({"pattern": "*.rs"});
+            let round1 = vec![zeph_llm::provider::ToolUseRequest {
+                id: "call-1".to_owned(),
+                name: "find_path".to_owned().into(),
+                input: args.clone(),
+            }];
+            agent.handle_native_tool_calls(None, &round1).await.unwrap();
+
+            let (content1, _) =
+                tool_result_content(&agent, "call-1").expect("call-1 must have a ToolResult");
+            assert!(
+                content1.contains("[skipped]"),
+                "first call must be skipped by the Retrieve rule, got: {content1}"
+            );
+
+            // Second round: identical tool name + args under a fresh tool_use_id, as a real LLM
+            // would assign, mimicking compliance with the injected "you MUST call it again" hint.
+            let round2 = vec![zeph_llm::provider::ToolUseRequest {
+                id: "call-2".to_owned(),
+                name: "find_path".to_owned().into(),
+                input: args,
+            }];
+            agent.handle_native_tool_calls(None, &round2).await.unwrap();
+
+            let (content2, is_error2) =
+                tool_result_content(&agent, "call-2").expect("call-2 must have a ToolResult");
+            assert!(
+                content2.contains("src/main.rs") && !is_error2,
+                "mandated retry must execute for real instead of being re-vetoed as a \
+                 redundant duplicate, got: {content2}"
+            );
+        }
+
+        /// #5719 companion regression, found while writing the test above: the utility gate's
+        /// synthetic `[skipped]` output must never be written into the tool result cache.
+        /// `find_path`/`list_directory`/`grep`/`glob`/`search_code` are all cacheable (none are
+        /// in the cache's deny-list), so a Retrieve-skipped call poisoned the cache under the
+        /// real args hash — even after the mandated-retry bypass correctly recommended
+        /// `ToolCall`, the tier loop served the stale `[skipped]` text back from cache instead
+        /// of actually executing the tool, silently reintroducing the stall the bypass fixes.
+        #[tokio::test]
+        async fn retrieve_skip_output_is_never_cached() {
+            let provider = mock_provider(vec![]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::with_output("find_path", "src/main.rs");
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent
+                .tool_orchestrator
+                .set_utility_config(zeph_tools::UtilityScoringConfig {
+                    enabled: true,
+                    ..zeph_tools::UtilityScoringConfig::default()
+                });
+
+            let args = serde_json::json!({"pattern": "*.rs"});
+            let round1 = vec![zeph_llm::provider::ToolUseRequest {
+                id: "call-1".to_owned(),
+                name: "find_path".to_owned().into(),
+                input: args.clone(),
+            }];
+            agent.handle_native_tool_calls(None, &round1).await.unwrap();
+
+            let (content1, _) =
+                tool_result_content(&agent, "call-1").expect("call-1 must have a ToolResult");
+            assert!(content1.contains("[skipped]"));
+
+            let params = match &args {
+                serde_json::Value::Object(m) => m.clone(),
+                _ => serde_json::Map::new(),
+            };
+            let hash = tool_args_hash(&params);
+            let cached = agent
+                .tool_orchestrator
+                .result_cache
+                .get(&zeph_tools::CacheKey::new("find_path", hash));
+            assert!(
+                cached.is_none(),
+                "utility-gate skip output must never be cached, got: {cached:?}"
             );
         }
     }

--- a/crates/zeph-tools/src/utility.rs
+++ b/crates/zeph-tools/src/utility.rs
@@ -6,7 +6,7 @@
 //! Computes a scalar utility score for each candidate tool call before execution.
 //! Calls below the configured threshold are skipped (fail-closed on scoring errors).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::LazyLock;
 
@@ -122,6 +122,16 @@ pub struct UtilityContext {
     /// command or when the user message contains an unambiguous tool-invocation phrase detected
     /// by [`has_explicit_tool_request`]. Must NOT be set from LLM call content or tool outputs.
     pub user_requested: bool,
+    /// True when this exact call is the mandated retry the `Retrieve` rule itself asked for:
+    /// the same `(tool_id, params)` call was vetoed by rule 8 earlier this turn, and the
+    /// injected system hint explicitly instructed the LLM to call it again with the same
+    /// arguments. Set via [`UtilityScorer::take_mandated_retry`].
+    ///
+    /// When `true`, `recommend_action` must not re-veto the retry through the redundancy
+    /// (`Respond`) rule — doing so fabricates a rejection despite the model correctly
+    /// complying with the gate's own hint, stalling tools like `find_path`/`list_directory`
+    /// in a doomed Retrieve-then-redundant-Respond cycle (#5719).
+    pub mandated_retry: bool,
 }
 
 #[non_exhaustive]
@@ -162,6 +172,11 @@ pub struct UtilityScorer {
     recent_calls: HashMap<u64, u32>,
     /// Count of consecutive non-`ToolCall` recommendations since the last `ToolCall` or turn reset.
     consecutive_low: usize,
+    /// Hashes of `(tool_name, params)` calls vetoed by the `Retrieve` rule this turn that are
+    /// awaiting the mandated retry the injected hint requested (#5719). Entries are consumed by
+    /// [`take_mandated_retry`](Self::take_mandated_retry) so the bypass applies exactly once per
+    /// veto — a genuine subsequent duplicate call is scored normally.
+    mandated_retries: HashSet<u64>,
 }
 
 impl UtilityScorer {
@@ -172,6 +187,7 @@ impl UtilityScorer {
             config,
             recent_calls: HashMap::new(),
             consecutive_low: 0,
+            mandated_retries: HashSet::new(),
         }
     }
 
@@ -238,14 +254,17 @@ impl UtilityScorer {
     /// Decision tree (thresholds from arXiv:2603.19896):
     /// 1. `user_requested` → always `ToolCall` (bypass policy).
     /// 2. Scoring disabled → always `ToolCall`.
-    /// 3. `score` is `None` (invalid score, scoring enabled) → `Stop` (fail-closed).
-    /// 4. `cost > 0.9` (budget nearly exhausted) → `Stop`.
-    /// 5. `redundancy == 1.0` (duplicate call) → `Respond`.
-    /// 6. `gain >= 0.7 && total >= threshold` → `ToolCall`.
-    /// 7. `gain >= 0.5 && uncertainty > 0.5` → `Retrieve`.
-    /// 8. `total < threshold && tool_calls_this_turn > 0` → `Verify`.
-    /// 9. `total >= threshold` → `ToolCall`.
-    /// 10. Default → `Respond`.
+    /// 3. `mandated_retry` → always `ToolCall` — this is the retry the `Retrieve` rule (8)
+    ///    itself demanded via the injected hint; the gate must honor its own contract instead
+    ///    of re-vetoing compliance as a redundant duplicate (#5719).
+    /// 4. `score` is `None` (invalid score, scoring enabled) → `Stop` (fail-closed).
+    /// 5. `cost > 0.9` (budget nearly exhausted) → `Stop`.
+    /// 6. `redundancy == 1.0` (duplicate call) → `Respond`.
+    /// 7. `gain >= 0.7 && total >= threshold` → `ToolCall`.
+    /// 8. `gain >= 0.5 && uncertainty > 0.5` → `Retrieve`.
+    /// 9. `total < threshold && tool_calls_this_turn > 0` → `Verify`.
+    /// 10. `total >= threshold` → `ToolCall`.
+    /// 11. Default → `Respond`.
     #[must_use]
     pub fn recommend_action(
         &self,
@@ -258,6 +277,10 @@ impl UtilityScorer {
         }
         // Pass-through: scoring disabled → always execute.
         if !self.config.enabled {
+            return UtilityAction::ToolCall;
+        }
+        // Bypass: this call is the mandated retry the Retrieve rule itself asked for (#5719).
+        if ctx.mandated_retry {
             return UtilityAction::ToolCall;
         }
         let Some(s) = score else {
@@ -305,6 +328,26 @@ impl UtilityScorer {
     pub fn clear(&mut self) {
         self.recent_calls.clear();
         self.consecutive_low = 0;
+        self.mandated_retries.clear();
+    }
+
+    /// Marks `call` as an in-flight mandated retry after the `Retrieve` rule instructs the LLM
+    /// to call it again with the same arguments (#5719).
+    ///
+    /// Called by the tool loop when it injects the "you MUST call it again" hint. The next
+    /// occurrence of the identical call this turn bypasses the redundancy veto — see
+    /// [`take_mandated_retry`](Self::take_mandated_retry).
+    pub fn mark_mandated_retry(&mut self, call: &ToolCall) {
+        self.mandated_retries.insert(call_hash(call));
+    }
+
+    /// Returns `true` and consumes the pending mandated-retry marker for `call`, if any.
+    ///
+    /// Consuming rather than merely peeking ensures the bypass applies exactly once per
+    /// `Retrieve` veto: a genuine third identical call afterward is scored normally instead of
+    /// being exempted forever.
+    pub fn take_mandated_retry(&mut self, call: &ToolCall) -> bool {
+        self.mandated_retries.remove(&call_hash(call))
     }
 
     /// Record the recommended action and check whether the consecutive-low-utility window is
@@ -330,9 +373,17 @@ impl UtilityScorer {
     ///
     /// Shared lookup behind `is_exempt` and `is_high_gain` — both are "does a configured
     /// tool-name list contain this `tool_id`" checks and must use identical matching rules.
+    ///
+    /// Normalizes `:` to `_` on both sides before comparing (#5713): MCP tool ids are dispatched
+    /// as `McpTool::sanitized_id()` ("`{server_id}_{name}`", underscore-separated), but the only
+    /// runtime surface that lists them to an operator — the TUI `mcp:list` command — displays
+    /// `McpTool::qualified_name()` ("`{server_id}:{name}`", colon-separated). Without this
+    /// normalization, an id copied straight from `mcp:list` into config never matches the
+    /// incoming `tool_id`.
     fn contains_tool_name(list: &[String], tool_name: &str) -> bool {
-        let lower = tool_name.to_lowercase();
-        list.iter().any(|e| e.to_lowercase() == lower)
+        let normalize = |s: &str| s.to_lowercase().replace(':', "_");
+        let normalized = normalize(tool_name);
+        list.iter().any(|e| normalize(e) == normalized)
     }
 
     /// Returns `true` when `tool_name` is in the exempt list (case-insensitive).
@@ -395,6 +446,7 @@ mod tests {
             tokens_consumed: 0,
             token_budget: 1000,
             user_requested: false,
+            mandated_retry: false,
         }
     }
 
@@ -1116,6 +1168,187 @@ mod tests {
             (score.gain - 0.5).abs() < f32::EPSILON,
             "unlisted tool must keep its default_gain value, got {}",
             score.gain
+        );
+    }
+
+    // ── high_gain_tools colon/underscore dual-form matching (#5713) ─────────
+
+    #[test]
+    fn is_high_gain_matches_qualified_name_config_against_sanitized_id_call() {
+        // Operator copies the colon-separated `McpTool::qualified_name()` form from `mcp:list`
+        // into config, but the incoming tool_id is always the underscore-separated
+        // `McpTool::sanitized_id()` dispatch form.
+        let scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            high_gain_tools: vec!["myserver:mytool".to_owned()],
+            ..UtilityScoringConfig::default()
+        });
+        assert!(scorer.is_high_gain("myserver_mytool"));
+    }
+
+    #[test]
+    fn is_high_gain_matches_sanitized_id_config_against_qualified_name_call() {
+        // Symmetric case: config already uses the underscore form, incoming id uses colons.
+        let scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            high_gain_tools: vec!["myserver_mytool".to_owned()],
+            ..UtilityScoringConfig::default()
+        });
+        assert!(scorer.is_high_gain("myserver:mytool"));
+    }
+
+    #[test]
+    fn is_exempt_matches_qualified_name_config_against_sanitized_id_call() {
+        // is_exempt shares contains_tool_name with is_high_gain and must get the same fix.
+        let scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            exempt_tools: vec!["myserver:mytool".to_owned()],
+            ..UtilityScoringConfig::default()
+        });
+        assert!(scorer.is_exempt("myserver_mytool"));
+    }
+
+    #[test]
+    fn is_high_gain_dual_form_still_case_insensitive() {
+        let scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            high_gain_tools: vec!["MyServer:MyTool".to_owned()],
+            ..UtilityScoringConfig::default()
+        });
+        assert!(scorer.is_high_gain("myserver_mytool"));
+        assert!(scorer.is_high_gain("MYSERVER_MYTOOL"));
+    }
+
+    #[test]
+    fn is_high_gain_dual_form_does_not_match_unrelated_tool() {
+        let scorer = UtilityScorer::new(UtilityScoringConfig {
+            enabled: true,
+            high_gain_tools: vec!["myserver:mytool".to_owned()],
+            ..UtilityScoringConfig::default()
+        });
+        assert!(!scorer.is_high_gain("otherserver_othertool"));
+    }
+
+    // ── mandated-retry bypass (#5719) ────────────────────────────────────────
+    //
+    // Reproduces the stall reported in #5719: find_path/list_directory (default_gain 0.65)
+    // trigger rule 8 (Retrieve) on a fresh first call. The injected hint tells the LLM to
+    // retry with the same arguments, but record_call() already logged the call hash, so the
+    // identical retry scores redundancy=1.0 and rule 6 (Respond) vetoes it a second time —
+    // the tool never executes and the turn ends with a fabricated "restriction" apology.
+
+    #[test]
+    fn mark_and_take_mandated_retry_is_consumed_exactly_once() {
+        let mut scorer = UtilityScorer::new(default_config());
+        let call = make_call("find_path", json!({"pattern": "*.rs"}));
+
+        assert!(
+            !scorer.take_mandated_retry(&call),
+            "no marker set yet — must not report a pending retry"
+        );
+
+        scorer.mark_mandated_retry(&call);
+        assert!(
+            scorer.take_mandated_retry(&call),
+            "marker set — first take must report the pending retry"
+        );
+        assert!(
+            !scorer.take_mandated_retry(&call),
+            "marker consumed — second take must not report a pending retry again"
+        );
+    }
+
+    #[test]
+    fn recommend_action_mandated_retry_bypasses_redundancy_veto() {
+        let scorer = UtilityScorer::new(default_config());
+        // Simulate the exact retry scenario: identical call already recorded (redundancy=1.0),
+        // which alone would trigger rule 6 (Respond).
+        let score = UtilityScore {
+            gain: 0.65,
+            cost: 0.1,
+            redundancy: 1.0,
+            uncertainty: 0.7,
+            total: 0.5,
+        };
+        let ctx = UtilityContext {
+            mandated_retry: true,
+            ..default_ctx()
+        };
+        assert_eq!(
+            scorer.recommend_action(Some(&score), &ctx),
+            UtilityAction::ToolCall,
+            "mandated retry must bypass the redundancy veto and execute"
+        );
+    }
+
+    #[test]
+    fn find_path_retrieve_then_mandated_retry_executes_not_redundant_respond() {
+        let mut scorer = UtilityScorer::new(default_config());
+        let ctx = default_ctx(); // tool_calls_this_turn: 0 -> uncertainty == 1.0
+        let call = make_call("find_path", json!({"pattern": "*.rs"}));
+
+        // First attempt: gain 0.65 (>= 0.5) with high uncertainty -> Retrieve (rule 8).
+        let first_score = scorer.score(&call, &ctx).unwrap();
+        assert_eq!(
+            scorer.recommend_action(Some(&first_score), &ctx),
+            UtilityAction::Retrieve
+        );
+        // record_call() always runs regardless of the recommended action (mirrors
+        // compute_utility_actions in tier_loop.rs), and the tool loop marks the call as an
+        // in-flight mandated retry when it injects the "you MUST call it again" hint.
+        scorer.record_call(&call);
+        scorer.mark_mandated_retry(&call);
+
+        // Without the fix: the retry's redundancy is 1.0 (same hash already recorded), which
+        // would trigger rule 6 (Respond) — reproducing the fabricated-restriction stall.
+        let retry_ctx = UtilityContext {
+            mandated_retry: scorer.take_mandated_retry(&call),
+            ..default_ctx()
+        };
+        assert!(
+            retry_ctx.mandated_retry,
+            "retry must be recognized as mandated"
+        );
+        let retry_score = scorer.score(&call, &retry_ctx).unwrap();
+        assert!(
+            (retry_score.redundancy - 1.0).abs() < f32::EPSILON,
+            "retry is indeed flagged redundant by the raw score — the bypass must come from \
+             recommend_action, not from suppressing the redundancy component"
+        );
+        assert_eq!(
+            scorer.recommend_action(Some(&retry_score), &retry_ctx),
+            UtilityAction::ToolCall,
+            "mandated retry must execute instead of being re-vetoed as a redundant duplicate"
+        );
+
+        // A genuine third identical call afterward (not requested by any hint) is scored
+        // normally again — the bypass must not persist beyond the one mandated retry.
+        scorer.record_call(&call);
+        let third_ctx = UtilityContext {
+            mandated_retry: scorer.take_mandated_retry(&call),
+            ..default_ctx()
+        };
+        assert!(
+            !third_ctx.mandated_retry,
+            "marker was consumed by the mandated retry — a third call is not exempted"
+        );
+        let third_score = scorer.score(&call, &third_ctx).unwrap();
+        assert_eq!(
+            scorer.recommend_action(Some(&third_score), &third_ctx),
+            UtilityAction::Respond,
+            "a genuine third identical call must be treated as a redundant duplicate"
+        );
+    }
+
+    #[test]
+    fn clear_resets_mandated_retries() {
+        let mut scorer = UtilityScorer::new(default_config());
+        let call = make_call("find_path", json!({}));
+        scorer.mark_mandated_retry(&call);
+        scorer.clear();
+        assert!(
+            !scorer.take_mandated_retry(&call),
+            "clear() must reset mandated-retry state at turn start"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes the 4th occurrence of the Retrieve-then-redundant-Respond stall defect class (#2620, #5650, #5659): `UtilityScorer`'s `Retrieve` rule injects a hint mandating the LLM retry a skipped tool call with the same arguments, but the redundancy rule then vetoed that exact mandated retry as a duplicate, permanently stalling `find_path`/`list_directory`/`grep`/`glob`/`search_code` and causing the agent to fabricate a restriction that doesn't exist in config. Fixed structurally (not another per-tool gain-tier bump): `UtilityScorer` now tracks per-turn call hashes vetoed by `Retrieve` and unconditionally allows the one mandated retry through. Also fixes a compounding cache-poisoning bug found while testing this: the tier loop's result cache stored and replayed the gate's synthetic `[skipped]`/`[stopped]` output, which would have silently defeated the bypass for the exact tools named in the issue.
- Normalizes colon (`qualified_name`) vs underscore (`sanitized_id`) MCP tool id forms in `high_gain_tools`/`exempt_tools` matching, so an id copied from the TUI's `mcp:list` output actually matches.
- Reorders `cancel_tool_batch` to persist the cancellation tombstone before the channel notification send (was: send-then-persist via `?`), so a channel-send failure can no longer suppress the tombstone — 4th trigger of the orphaned-`tool_calls` defect class (#5464, #5513, #5646).

Closes #5719, Closes #5713, Closes #5717

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12131 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] New unit tests for the mandated-retry bypass (one-shot consumption, full Retrieve-then-retry repro via `handle_native_tool_calls`, cache-poisoning regression) in `zeph-tools`/`zeph-core`
- [x] New unit tests for dual-form MCP id matching (both directions, case-insensitivity, false-positive check)
- [x] New regression test for `cancel_tool_batch` tombstone persistence under simulated channel-send failure
- [x] CHANGELOG.md updated
- [x] `.local/testing/playbooks/bats-budget-hint-utility-action.md` and `.local/testing/playbooks/tool-call-cancellation-ordering.md` updated with new scenarios; `.local/testing/coverage-status.md` rows added
- [ ] Live multi-turn LLM session verification of the exact #5719 repro (pending — CI live-testing cycle)