### PR TITLE
fix(tools,skills): name active skill set in quarantine-denial message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tools,skills)`: `TrustGateExecutor`'s quarantine-denial message for `QUARANTINE_DENIED`
+  tools (`invoke_skill`, `load_skill`, `bash`, `write`, etc.) read `"{tool_id} denied
+  (trust=quarantined)"`, which misattributed the denial to the specifically-invoked tool/skill
+  when `effective_trust` is actually a weakest-link fold (`SkillTrustLevel::min_trust`) across
+  ALL skills active in the turn (`crates/zeph-core/src/agent/context/assembly.rs`) — an
+  `invoke_skill` call for a brand-new, non-active, trust-map-missing skill was denied solely
+  because two entirely unrelated co-active skills happened to be quarantined (#5729). The gate's
+  turn-wide weakest-link policy itself is intentional defense-in-depth (documented in
+  `crates/zeph-common/src/quarantine.rs`: prevents a quarantined skill's content from using
+  `invoke_skill`/`load_skill` as a side channel) and is unchanged. `check_trust`
+  (`crates/zeph-tools/src/trust_gate.rs`) now names the turn's active skill set
+  (`ToolCall::skill_name`) in the denial message instead of implying the targeted tool/skill is
+  itself untrusted. Documented the weakest-link policy in `trust_gate.rs`, `assembly.rs`,
+  `specs/005-skills/spec.md`, and a new `specs/006-tools/spec.md` "Trust Gate" section.
 - `fix(core)`: `Agent::build_experiment_engine` (`crates/zeph-core/src/agent/experiment_cmd.rs`)
   read the configured benchmark TOML synchronously via `BenchmarkSet::from_file`, which performs
   blocking filesystem I/O (`std::fs::canonicalize` x2, `std::fs::metadata`, `std::fs::

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1483,7 +1483,15 @@ impl<C: Channel> Agent<C> {
             .cloned()
             .collect();
 
-        // Apply the most restrictive trust level among active skills to the executor gate.
+        // Deliberate weakest-link policy: fold the most restrictive trust level among ALL
+        // skills active this turn into a single `effective_trust` value applied to the
+        // executor gate (`TrustGateExecutor::set_effective_trust`). If ANY co-active skill is
+        // Quarantined, QUARANTINE_DENIED tools are denied for the WHOLE turn, regardless of
+        // which specific skill/tool a call targets — this prevents a Quarantined (potentially
+        // prompt-injected) skill's content from steering the model into invoking other
+        // tools/skills as a side channel. See #5729 for the resulting UX gap (an unrelated,
+        // non-quarantined skill's own `invoke_skill` call is also denied) and
+        // `TrustGateExecutor::check_trust`'s doc comment for the matching rationale.
         let effective_trust = if self.services.skill.active_skill_names.is_empty() {
             zeph_common::SkillTrustLevel::Trusted
         } else {

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -30,6 +30,30 @@ fn is_quarantine_denied(tool_id: &str) -> bool {
         .any(|denied| tool_id == *denied || tool_id.ends_with(&format!("_{denied}")))
 }
 
+/// Builds the denial message for a Quarantined-trust block.
+///
+/// `active_skills` is the turn's full active-skill list (`ToolCall::skill_name`), not just
+/// the specific skill(s) whose trust caused the fold — `TrustGateExecutor` only tracks the
+/// already-folded `effective_trust`, not per-skill levels, so it cannot name exactly which
+/// skill(s) are Quarantined, nor whether `tool_id`'s own target skill (e.g. `invoke_skill`'s
+/// `skill_name` param) is among them. Naming the turn's active skill set instead of flatly
+/// blaming `tool_id` resolves the misattribution from #5729 without asserting anything the
+/// gate cannot verify: this denial means the turn's *combined* trust floor is quarantined
+/// (weakest-link policy, see `assembly.rs` and this module's doc comment) — it may or may not
+/// be about the specific tool/skill targeted by this call.
+fn quarantine_denial_message(tool_id: &str, active_skills: &[String]) -> String {
+    if active_skills.is_empty() {
+        format!("{tool_id} denied (trust=quarantined)")
+    } else {
+        format!(
+            "{tool_id} denied: this turn's active skill set {active_skills:?} has a combined \
+             trust floor of quarantined (weakest-link policy over all co-active skills this \
+             turn; this reflects the turn's overall trust floor and may not be about the \
+             specific tool/skill you targeted)"
+        )
+    }
+}
+
 fn trust_to_u8(level: SkillTrustLevel) -> u8 {
     match level {
         SkillTrustLevel::Trusted => 0,
@@ -104,7 +128,26 @@ impl<T: ToolExecutor> TrustGateExecutor<T> {
         self.mcp_tool_ids.read().contains(tool_id)
     }
 
-    fn check_trust(&self, tool_id: &str, input: &str) -> Result<(), ToolError> {
+    /// Enforces per-call trust policy.
+    ///
+    /// `effective_trust` (see [`set_effective_trust`](Self::set_effective_trust)) is a single
+    /// value folded via `SkillTrustLevel::min_trust` across ALL skills active in the current
+    /// turn — computed in `zeph_core::agent::context::assembly`. This is a deliberate
+    /// weakest-link policy: if ANY skill active this turn is Quarantined,
+    /// [`QUARANTINE_DENIED`] tools (including `invoke_skill`/`load_skill`) are denied for the
+    /// WHOLE turn, regardless of which specific skill/tool a call targets — this guards
+    /// against a Quarantined (potentially prompt-injected) skill's content steering the model
+    /// into invoking other tools/skills as a side channel. See #5729 for the resulting UX gap
+    /// (an unrelated, non-quarantined skill's own `invoke_skill` call is also denied) and why
+    /// the policy itself is intentionally kept — `active_skills` is used only to make the
+    /// denial message name the turn's active skill set instead of misattributing the block to
+    /// `tool_id` itself.
+    fn check_trust(
+        &self,
+        tool_id: &str,
+        input: &str,
+        active_skills: &[String],
+    ) -> Result<(), ToolError> {
         match self.effective_trust() {
             SkillTrustLevel::Blocked => {
                 return Err(ToolError::Blocked {
@@ -115,7 +158,7 @@ impl<T: ToolExecutor> TrustGateExecutor<T> {
                 if is_quarantine_denied(tool_id) || self.is_mcp_tool(tool_id) =>
             {
                 return Err(ToolError::Blocked {
-                    command: format!("{tool_id} denied (trust=quarantined)"),
+                    command: quarantine_denial_message(tool_id, active_skills),
                 });
             }
             _ => {}
@@ -199,7 +242,11 @@ impl<T: ToolExecutor> ToolExecutor for TrustGateExecutor<T> {
             .or_else(|| call.params.get("uri"))
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        self.check_trust(call.tool_id.as_str(), input)?;
+        self.check_trust(
+            call.tool_id.as_str(),
+            input,
+            call.skill_name.as_deref().unwrap_or(&[]),
+        )?;
         self.inner.execute_tool_call(call).await
     }
 
@@ -208,7 +255,8 @@ impl<T: ToolExecutor> ToolExecutor for TrustGateExecutor<T> {
         call: &ToolCall,
     ) -> Result<Option<ToolOutput>, ToolError> {
         // Bypass check_trust: caller already obtained user approval.
-        // Still enforce Blocked/Quarantined trust level constraints.
+        // Still enforce Blocked/Quarantined trust level constraints. This match intentionally
+        // mirrors check_trust's Blocked/Quarantined branches above — keep the two in sync.
         match self.effective_trust() {
             SkillTrustLevel::Blocked => {
                 return Err(ToolError::Blocked {
@@ -220,7 +268,10 @@ impl<T: ToolExecutor> ToolExecutor for TrustGateExecutor<T> {
                     || self.is_mcp_tool(call.tool_id.as_str()) =>
             {
                 return Err(ToolError::Blocked {
-                    command: format!("{} denied (trust=quarantined)", call.tool_id),
+                    command: quarantine_denial_message(
+                        call.tool_id.as_str(),
+                        call.skill_name.as_deref().unwrap_or(&[]),
+                    ),
                 });
             }
             _ => {}
@@ -261,7 +312,11 @@ impl<T: ToolExecutor> ToolExecutor for TrustGateExecutor<T> {
             .and_then(|v| v.as_str())
             .unwrap_or("");
         matches!(
-            self.check_trust(call.tool_id.as_str(), input),
+            self.check_trust(
+                call.tool_id.as_str(),
+                input,
+                call.skill_name.as_deref().unwrap_or(&[]),
+            ),
             Err(ToolError::ConfirmationRequired { .. })
         )
     }
@@ -320,6 +375,25 @@ mod tests {
 
             tool_call_id: String::new(),
             skill_name: None,
+        }
+    }
+
+    fn make_call_with_skills(tool_id: &str, skills: &[&str]) -> ToolCall {
+        ToolCall {
+            tool_id: tool_id.into(),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: Some(skills.iter().map(ToString::to_string).collect()),
+        }
+    }
+
+    fn blocked_command(result: Result<Option<ToolOutput>, ToolError>) -> String {
+        match result {
+            Err(ToolError::Blocked { command }) => command,
+            other => panic!("expected Err(ToolError::Blocked {{ .. }}), got {other:?}"),
         }
     }
 
@@ -529,6 +603,99 @@ mod tests {
 
         let result = gate.execute_tool_call(&make_call("web_scrape")).await;
         assert_matches!(result, Err(ToolError::Blocked { .. }));
+    }
+
+    /// Regression test for #5729: the denial message must name the turn's actual co-active
+    /// skill set instead of implying `invoke_skill` itself is the untrusted party. The gate
+    /// behavior (deny) is unchanged — only the message wording is under test here.
+    #[tokio::test]
+    async fn quarantined_denial_message_names_active_skills_not_target_tool() {
+        let gate = TrustGateExecutor::new(MockExecutor, PermissionPolicy::default());
+        gate.set_effective_trust(SkillTrustLevel::Quarantined);
+
+        let call =
+            make_call_with_skills("invoke_skill", &["disk-usage", "persona-customer-support"]);
+        let result = gate.execute_tool_call(&call).await;
+        let message = blocked_command(result);
+
+        assert!(
+            message.contains("disk-usage") && message.contains("persona-customer-support"),
+            "message should name the actual active skills, got: {message}"
+        );
+        assert_ne!(
+            message, "invoke_skill denied (trust=quarantined)",
+            "message must not read as if invoke_skill itself is the untrusted party"
+        );
+    }
+
+    /// Regression test for #5729: when no active skills are recorded on the call
+    /// (`skill_name: None`), the denial message must remain exactly the pre-fix format —
+    /// this guards backward compatibility for all pre-existing tests in this module, which
+    /// all use `make_call`/`make_call_with_cmd` (both hardcode `skill_name: None`).
+    #[tokio::test]
+    async fn quarantined_denial_message_unchanged_when_no_active_skills() {
+        let gate = TrustGateExecutor::new(MockExecutor, PermissionPolicy::default());
+        gate.set_effective_trust(SkillTrustLevel::Quarantined);
+
+        let result = gate.execute_tool_call(&make_call("invoke_skill")).await;
+        let message = blocked_command(result);
+
+        assert_eq!(message, "invoke_skill denied (trust=quarantined)");
+    }
+
+    /// Same as `quarantined_denial_message_unchanged_when_no_active_skills`, but with an
+    /// explicit empty skill list rather than `None` — both must produce the old message.
+    #[tokio::test]
+    async fn quarantined_denial_message_unchanged_when_active_skills_empty() {
+        let gate = TrustGateExecutor::new(MockExecutor, PermissionPolicy::default());
+        gate.set_effective_trust(SkillTrustLevel::Quarantined);
+
+        let result = gate
+            .execute_tool_call(&make_call_with_skills("invoke_skill", &[]))
+            .await;
+        let message = blocked_command(result);
+
+        assert_eq!(message, "invoke_skill denied (trust=quarantined)");
+    }
+
+    /// Regression test for #5729 via the `execute_tool_call_confirmed` path, which has its
+    /// own duplicate inline Quarantined check rather than routing through `check_trust`.
+    #[tokio::test]
+    async fn quarantined_denial_message_names_active_skills_confirmed_path() {
+        let gate = TrustGateExecutor::new(MockExecutor, PermissionPolicy::default());
+        gate.set_effective_trust(SkillTrustLevel::Quarantined);
+
+        let call =
+            make_call_with_skills("invoke_skill", &["disk-usage", "persona-customer-support"]);
+        let result = gate.execute_tool_call_confirmed(&call).await;
+        let message = blocked_command(result);
+
+        assert!(
+            message.contains("disk-usage") && message.contains("persona-customer-support"),
+            "confirmed path message should name the actual active skills, got: {message}"
+        );
+        assert_ne!(
+            message, "invoke_skill denied (trust=quarantined)",
+            "confirmed path message must not read as if invoke_skill itself is untrusted"
+        );
+    }
+
+    /// Regression test for #5729: the message fix must apply uniformly to any
+    /// `QUARANTINE_DENIED` tool, not just `invoke_skill` — verified here with `bash`.
+    #[tokio::test]
+    async fn quarantined_denial_message_names_active_skills_for_non_skill_tool() {
+        let gate = TrustGateExecutor::new(MockExecutor, PermissionPolicy::default());
+        gate.set_effective_trust(SkillTrustLevel::Quarantined);
+
+        let call = make_call_with_skills("bash", &["disk-usage", "persona-customer-support"]);
+        let result = gate.execute_tool_call(&call).await;
+        let message = blocked_command(result);
+
+        assert!(
+            message.contains("disk-usage") && message.contains("persona-customer-support"),
+            "message for a non-skill tool should also name the active skills, got: {message}"
+        );
+        assert_ne!(message, "bash denied (trust=quarantined)");
     }
 
     #[derive(Debug)]

--- a/specs/005-skills/spec.md
+++ b/specs/005-skills/spec.md
@@ -452,6 +452,7 @@ The tool returns a confirmation message with the skill's name and first 200 char
 
 - `invoke_skill` is always exempt from the utility gate and the adversarial policy gate — listed in both `UtilityScoringConfig::exempt_tools` and `AdversarialPolicyConfig::exempt_tools` by default
 - `invoke_skill` and `load_skill` are both in `QUARANTINE_DENIED` — they cannot be triggered by quarantined skill content
+- The trust check applied to `invoke_skill`/`load_skill` is a per-turn weakest-link fold (`TrustGateExecutor::effective_trust`, computed in `zeph_core::agent::context::assembly`), not a per-skill check: if ANY skill active this turn is `Quarantined`, the call is denied for the whole turn regardless of which skill is targeted. A denial reflects the turn's overall trust floor and is not necessarily about the specific skill/tool targeted by the call — it may or may not itself be the quarantined one — see #5729 and `TrustGateExecutor`'s doc comment
 - `invoke_skill` carries intent-to-apply semantics: the invoked skill IS injected; `load_skill` is preview-only and does NOT update the active skill
 - NEVER invoke a `Quarantined` skill via this tool — trust gate must check before injection
 

--- a/specs/006-tools/spec.md
+++ b/specs/006-tools/spec.md
@@ -718,6 +718,47 @@ exempt_tools = ["memory_save", "memory_search", "read_overflow", "load_skill", "
 
 ---
 
+## Trust Gate
+
+`TrustGateExecutor` (`crates/zeph-tools/src/trust_gate.rs`) wraps the inner executor chain and
+enforces per-call trust policy ahead of `PermissionPolicy` checks.
+
+### Executor Chain Order
+
+```
+PolicyGateExecutor → AdversarialPolicyGateExecutor → TrustGateExecutor → ...
+```
+
+### Config
+
+`effective_trust` is not user-configured directly — it is recomputed every turn by
+`zeph_core::agent::context::assembly` and pushed into the gate via
+`TrustGateExecutor::set_effective_trust`.
+
+### Key Invariants
+
+- `effective_trust` is a turn-scoped weakest-link fold, NOT a per-skill value: it is
+  `SkillTrustLevel::min_trust` folded across every skill active in the current turn (see
+  `assembly.rs`). A single `Quarantined` co-active skill drags the whole turn's
+  `effective_trust` to `Quarantined`.
+- When `effective_trust == Quarantined`, any tool in `QUARANTINE_DENIED` (see
+  `zeph_common::quarantine`), including `invoke_skill`/`load_skill`, is denied outright for the
+  WHOLE turn — independent of which specific tool call or skill is the actual target. This is
+  intentional defense-in-depth: it prevents a Quarantined (potentially prompt-injected) skill's
+  content from steering the model into invoking other tools/skills as a side channel.
+- The denial message names the turn's full active-skill set (`ToolCall::skill_name`) rather
+  than implying the specific tool/skill being invoked is itself untrusted — see #5729, which
+  fixed the prior misleading `"{tool_id} denied (trust=quarantined)"` message that read as if
+  `tool_id` (or its target skill) was the untrusted party.
+- `effective_trust == Blocked` denies ALL tools unconditionally, before any `QUARANTINE_DENIED`
+  or MCP-registry check.
+- `mcp_tool_ids` registers MCP-sourced tool IDs; under `Quarantined`, any registered MCP tool is
+  denied regardless of whether its name matches `QUARANTINE_DENIED` by pattern.
+- The legacy fenced-block paths (`execute`/`execute_confirmed`) have no `ToolCall`/`tool_id`
+  available, so they deny entirely under `Quarantined`/`Blocked` rather than selectively.
+
+---
+
 ## Tool Invocation Phase Taxonomy
 
 


### PR DESCRIPTION
## Summary

- `TrustGateExecutor::check_trust`'s denial message for `QUARANTINE_DENIED` tool calls (`invoke_skill`, `load_skill`, `bash`, `write`, etc.) read `"{tool_id} denied (trust=quarantined)"`, which reads as if the specifically-invoked tool/skill is the untrusted party. In reality `effective_trust` is a weakest-link fold (`SkillTrustLevel::min_trust`) across ALL skills active in the current turn — a call to invoke a brand-new, non-active, trust-map-missing skill could be denied purely because two entirely unrelated co-active skills were quarantined.
- The gate's turn-wide weakest-link policy itself is intentional defense-in-depth (documented in `crates/zeph-common/src/quarantine.rs`: prevents a quarantined skill's content from using `invoke_skill`/`load_skill` as a side channel to trigger other skills) and is **unchanged** by this PR — confirmed with the reporter that scoping the check to the specific invoked skill would remove that protection.
- The denial message now names the turn's active skill set (via the pre-existing `ToolCall::skill_name` field) instead of implying the targeted tool/skill itself is untrusted. Documented the weakest-link policy in `trust_gate.rs`, `assembly.rs`, `specs/005-skills/spec.md`, and a new `specs/006-tools/spec.md` "Trust Gate" section.

Fixes #5729.

## Test plan

- [x] `cargo nextest run -p zeph-tools -E 'test(trust_gate)'` — 51/51 pass (46 pre-existing + 5 new regression tests covering the issue repro, the confirmed-path duplicate check, a non-`invoke_skill` tool, and the unchanged-message case when no skills are active)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12147 passed, 0 failed
- [x] rustdoc gate (`RUSTFLAGS="-D warnings"` + `--deny rustdoc::broken_intra_doc_links`) — clean
- [x] Adversarial critique caught and the fix addresses an overclaiming edge case: the message no longer asserts the invoked skill is definitely not the quarantined one (which would be false when a user directly invokes the actual co-active quarantined skill)