### PR TITLE
fix(core,tools,mcp): identify MCP tools via ToolDef.server_id, not name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`ToolCall::skill_name`) in the denial message instead of implying the targeted tool/skill is
   itself untrusted. Documented the weakest-link policy in `trust_gate.rs`, `assembly.rs`,
   `specs/005-skills/spec.md`, and a new `specs/006-tools/spec.md` "Trust Gate" section.
+- `fix(core,tools,mcp)`: `Agent::extract_mcp_tool_names`
+  (`crates/zeph-core/src/agent/subagent_commands.rs`) identified MCP-registered tools by
+  checking `tool_id.starts_with("mcp_")`, but real MCP tool ids are built by
+  `McpTool::sanitized_id()` as `"{server_id}_{name}"` and never carry a literal `"mcp_"`
+  prefix — the filter never matched any tool, so spawned sub-agents never received an
+  "Available MCP Tools" annotation in their system prompt regardless of how many MCP servers
+  were connected (#5712). Added `server_id: Option<String>` to `zeph_tools::registry::ToolDef`
+  (`ToolDef::is_mcp_tool()` helper) as the authoritative MCP-origin marker, set at
+  construction time in `McpToolExecutor::tool_definitions` (`crates/zeph-mcp/src/executor.rs`)
+  and `MockMcpServer::tool_definitions` (`crates/zeph-mcp/src/testing.rs`); all other `ToolDef`
+  construction sites default it to `None`. `extract_mcp_tool_names` now filters on
+  `ToolDef::is_mcp_tool` instead of the dead name-prefix check.
 - `fix(core)`: `Agent::build_experiment_engine` (`crates/zeph-core/src/agent/experiment_cmd.rs`)
   read the configured benchmark TOML synchronously via `BenchmarkSet::from_file`, which performs
   blocking filesystem I/O (`std::fs::canonicalize` x2, `std::fs::metadata`, `std::fs::

--- a/crates/zeph-acp/src/fs.rs
+++ b/crates/zeph-acp/src/fs.rs
@@ -293,6 +293,7 @@ impl zeph_tools::ToolExecutor for AcpFileExecutor {
                 schema: schemars::schema_for!(ReadFileParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             });
             defs.push(ToolDef {
                 id: "list_directory".into(),
@@ -300,6 +301,7 @@ impl zeph_tools::ToolExecutor for AcpFileExecutor {
                 schema: schemars::schema_for!(ListDirectoryParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             });
             defs.push(ToolDef {
                 id: "find_path".into(),
@@ -307,6 +309,7 @@ impl zeph_tools::ToolExecutor for AcpFileExecutor {
                 schema: schemars::schema_for!(FindPathParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             });
         }
         // REQ-P31-1: write_file requires a permission gate (diff preview must have an approver).
@@ -317,6 +320,7 @@ impl zeph_tools::ToolExecutor for AcpFileExecutor {
                 schema: schemars::schema_for!(WriteFileParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             });
         }
         defs

--- a/crates/zeph-acp/src/terminal.rs
+++ b/crates/zeph-acp/src/terminal.rs
@@ -341,6 +341,7 @@ impl zeph_tools::ToolExecutor for AcpShellExecutor {
             schema: schemars::schema_for!(BashParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         }];
         // REQ-P23-2: bash_stdin only available when a permission gate is present.
         if self.permission_gate.is_some() {
@@ -350,6 +351,7 @@ impl zeph_tools::ToolExecutor for AcpShellExecutor {
                 schema: schemars::schema_for!(BashStdinParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             });
         }
         defs

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/tools.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/tools.rs
@@ -196,6 +196,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(CalculateParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "cancel_pending_order".into(),
@@ -203,6 +204,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(CancelPendingOrderParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "exchange_delivered_order_items".into(),
@@ -210,6 +212,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(ExchangeDeliveredOrderItemsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "find_user_id_by_email".into(),
@@ -217,6 +220,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(FindUserIdByEmailParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "find_user_id_by_name_zip".into(),
@@ -224,6 +228,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(FindUserIdByNameZipParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "get_order_details".into(),
@@ -231,6 +236,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(GetOrderDetailsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "get_product_details".into(),
@@ -238,6 +244,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(GetProductDetailsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "get_item_details".into(),
@@ -245,6 +252,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(GetItemDetailsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "get_user_details".into(),
@@ -252,6 +260,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(GetUserDetailsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "list_all_product_types".into(),
@@ -259,6 +268,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: empty_object_schema(),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "modify_pending_order_address".into(),
@@ -266,6 +276,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(ModifyPendingOrderAddressParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "modify_pending_order_items".into(),
@@ -273,6 +284,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(ModifyPendingOrderItemsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "modify_pending_order_payment".into(),
@@ -280,6 +292,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(ModifyPendingOrderPaymentParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "modify_user_address".into(),
@@ -287,6 +300,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(ModifyUserAddressParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "return_delivered_order_items".into(),
@@ -294,6 +308,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(ReturnDeliveredOrderItemsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "transfer_to_human_agents".into(),
@@ -301,6 +316,7 @@ pub fn retail_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(TransferToHumanAgentsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
     ]
 }
@@ -421,6 +437,7 @@ pub(super) struct GetFlightStatusParams {
 
 /// Return all tool definitions for the airline domain.
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn airline_definitions() -> Vec<ToolDef> {
     vec![
         ToolDef {
@@ -429,6 +446,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(BookReservationParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "calculate".into(),
@@ -436,6 +454,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(CalculateParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "cancel_reservation".into(),
@@ -443,6 +462,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(CancelReservationParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "get_reservation_details".into(),
@@ -450,6 +470,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(GetReservationDetailsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "get_user_details".into(),
@@ -457,6 +478,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(GetAirlineUserDetailsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "list_all_airports".into(),
@@ -464,6 +486,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: empty_object_schema(),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "search_direct_flight".into(),
@@ -471,6 +494,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(SearchDirectFlightParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "search_onestop_flight".into(),
@@ -478,6 +502,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(SearchOnestopFlightParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "send_certificate".into(),
@@ -485,6 +510,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(SendCertificateParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "transfer_to_human_agents".into(),
@@ -492,6 +518,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(TransferToHumanAgentsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "update_reservation_baggages".into(),
@@ -499,6 +526,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(UpdateReservationBaggagesParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "update_reservation_flights".into(),
@@ -506,6 +534,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(UpdateReservationFlightsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "update_reservation_passengers".into(),
@@ -513,6 +542,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(UpdateReservationPassengersParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
         ToolDef {
             id: "get_flight_status".into(),
@@ -520,6 +550,7 @@ pub fn airline_definitions() -> Vec<ToolDef> {
             schema: schemars::schema_for!(GetFlightStatusParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         },
     ]
 }

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -10,6 +10,8 @@
 
 use std::sync::Arc;
 
+use zeph_tools::registry::ToolDef;
+
 use super::{Agent, error};
 use crate::channel::Channel;
 
@@ -676,7 +678,7 @@ impl<C: Channel> Agent<C> {
         self.tool_executor
             .tool_definitions_erased()
             .into_iter()
-            .filter(|t| t.id.starts_with("mcp_"))
+            .filter(ToolDef::is_mcp_tool)
             .map(|t| t.id.to_string())
             .collect()
     }
@@ -945,6 +947,38 @@ fn sanitize_parent_messages(
 mod tests {
     use super::*;
     use crate::agent::agent_tests::*;
+
+    /// #5712 regression: MCP tool identification must key off `ToolDef::server_id`, not a
+    /// `"mcp_"` name prefix that real `McpTool::sanitized_id()` output never produces.
+    #[tokio::test]
+    async fn extract_mcp_tool_names_uses_server_id_not_name_prefix() {
+        use zeph_tools::registry::InvocationHint;
+
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools().with_definitions(vec![
+            ToolDef {
+                id: "read".into(),
+                description: "built-in tool".into(),
+                schema: schemars::Schema::default(),
+                invocation: InvocationHint::ToolCall,
+                output_schema: None,
+                server_id: None,
+            },
+            ToolDef {
+                id: "github_create_issue".into(),
+                description: "MCP tool".into(),
+                schema: schemars::Schema::default(),
+                invocation: InvocationHint::ToolCall,
+                output_schema: None,
+                server_id: Some("github".into()),
+            },
+        ]);
+        let agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        assert_eq!(agent.extract_mcp_tool_names(), vec!["github_create_issue"]);
+    }
 
     /// Agent with `durable_ctx` populated via the real `ensure_session_durable_ctx` bootstrap
     /// path (mirrors `durable_bootstrap::tests::agent_with_conversation`), with

--- a/crates/zeph-core/src/agent/tests/confirmation_propagation_tests.rs
+++ b/crates/zeph-core/src/agent/tests/confirmation_propagation_tests.rs
@@ -61,6 +61,7 @@ impl ToolExecutor for DagAwareToolExecutor {
                 schema: schemars::Schema::default(),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "tool_b".into(),
@@ -68,6 +69,7 @@ impl ToolExecutor for DagAwareToolExecutor {
                 schema: schemars::Schema::default(),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "tool_c".into(),
@@ -75,6 +77,7 @@ impl ToolExecutor for DagAwareToolExecutor {
                 schema: schemars::Schema::default(),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
         ]
     }

--- a/crates/zeph-core/src/agent/tests/pre_execution_audit_tests.rs
+++ b/crates/zeph-core/src/agent/tests/pre_execution_audit_tests.rs
@@ -28,6 +28,7 @@ impl ToolExecutor for NoOpExecutor {
             schema: schemars::Schema::default(),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         }]
     }
 

--- a/crates/zeph-core/src/agent/tool_execution/tests/pure_helpers_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/pure_helpers_tests.rs
@@ -25,6 +25,7 @@ fn tool_def_strips_schema_and_title() {
         schema,
         invocation: InvocationHint::ToolCall,
         output_schema: None,
+        server_id: None,
     };
 
     let result = tool_def_to_definition(&def);

--- a/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
@@ -1929,6 +1929,7 @@ fn tool_def_to_definition_with_tafc_augments_when_enabled() {
         schema,
         invocation: InvocationHint::ToolCall,
         output_schema: None,
+        server_id: None,
     };
     let tafc = TafcConfig {
         enabled: true,
@@ -1955,6 +1956,7 @@ fn tool_def_to_definition_with_tafc_skips_when_disabled() {
         schema,
         invocation: InvocationHint::ToolCall,
         output_schema: None,
+        server_id: None,
     };
     let tafc = TafcConfig {
         enabled: false,

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -3608,6 +3608,7 @@ mod tests {
                 schema: schemars::Schema::default(),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             }
         }
 

--- a/crates/zeph-core/src/memory_tools.rs
+++ b/crates/zeph-core/src/memory_tools.rs
@@ -96,6 +96,7 @@ impl ToolExecutor for MemoryToolExecutor {
                 schema: schemars::schema_for!(MemorySearchParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "memory_save".into(),
@@ -103,6 +104,7 @@ impl ToolExecutor for MemoryToolExecutor {
                 schema: schemars::schema_for!(MemorySaveParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
         ]
     }

--- a/crates/zeph-core/src/overflow_tools.rs
+++ b/crates/zeph-core/src/overflow_tools.rs
@@ -50,6 +50,7 @@ impl ToolExecutor for OverflowToolExecutor {
             schema: schemars::schema_for!(ReadOverflowParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         }]
     }
 

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -183,6 +183,7 @@ impl ToolExecutor for SkillInvokeExecutor {
             schema: schemars::schema_for!(InvokeSkillParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         }]
     }
 

--- a/crates/zeph-core/src/skill_loader.rs
+++ b/crates/zeph-core/src/skill_loader.rs
@@ -44,6 +44,7 @@ impl ToolExecutor for SkillLoaderExecutor {
             schema: schemars::schema_for!(LoadSkillParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         }]
     }
 

--- a/crates/zeph-index/src/mcp_server.rs
+++ b/crates/zeph-index/src/mcp_server.rs
@@ -241,6 +241,7 @@ fn tool_symbol_definition() -> ToolDef {
         schema: schemars::schema_for!(SymbolDefinitionParams),
         invocation: InvocationHint::ToolCall,
         output_schema: None,
+        server_id: None,
     }
 }
 
@@ -251,6 +252,7 @@ fn tool_find_text_references() -> ToolDef {
         schema: schemars::schema_for!(FindTextReferencesParams),
         invocation: InvocationHint::ToolCall,
         output_schema: None,
+        server_id: None,
     }
 }
 
@@ -265,6 +267,7 @@ fn tool_call_graph() -> ToolDef {
         schema: schemars::schema_for!(CallGraphParams),
         invocation: InvocationHint::ToolCall,
         output_schema: None,
+        server_id: None,
     }
 }
 
@@ -277,6 +280,7 @@ fn tool_module_summary() -> ToolDef {
         schema: schemars::schema_for!(ModuleSummaryParams),
         invocation: InvocationHint::ToolCall,
         output_schema: None,
+        server_id: None,
     }
 }
 

--- a/crates/zeph-mcp/src/executor.rs
+++ b/crates/zeph-mcp/src/executor.rs
@@ -84,6 +84,7 @@ impl ToolExecutor for McpToolExecutor {
                     .unwrap_or_else(|_| schemars::Schema::default()),
                 invocation: InvocationHint::ToolCall,
                 output_schema: t.output_schema.clone(),
+                server_id: Some(t.server_id.clone()),
             })
             .collect()
     }

--- a/crates/zeph-mcp/src/testing.rs
+++ b/crates/zeph-mcp/src/testing.rs
@@ -126,6 +126,7 @@ impl ToolExecutor for MockMcpServer {
                     .unwrap_or_else(|_| schemars::Schema::default()),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: Some(t.server_id.clone()),
             })
             .collect()
     }

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -865,3 +865,48 @@ mod make_hook_env_tests {
         assert!(args.is_char_boundary(args.len()));
     }
 }
+
+#[cfg(test)]
+mod build_effective_system_prompt_tests {
+    use super::*;
+
+    /// #5712 regression: confirms the "Available MCP Tools" annotation actually reaches
+    /// the effective system prompt when `extract_mcp_tool_names` returns non-empty names —
+    /// the end of the pipeline that the dead `"mcp_"` prefix check silently starved.
+    #[test]
+    fn appends_mcp_tool_annotation_when_names_present() {
+        let mcp_tool_names = vec!["github_create_issue".to_owned(), "slack_post".to_owned()];
+        let effective =
+            build_effective_system_prompt("base prompt".to_owned(), None, &mcp_tool_names);
+
+        assert!(effective.starts_with("base prompt"));
+        assert!(effective.contains("## Available MCP Tools"));
+        assert!(effective.contains("- github_create_issue"));
+        assert!(effective.contains("- slack_post"));
+    }
+
+    #[test]
+    fn omits_mcp_annotation_when_names_empty() {
+        let effective = build_effective_system_prompt("base prompt".to_owned(), None, &[]);
+        assert_eq!(effective, "base prompt");
+    }
+
+    #[test]
+    fn combines_skills_block_and_mcp_annotation() {
+        let skills = Some(vec!["skill body".to_owned()]);
+        let mcp_tool_names = vec!["github_create_issue".to_owned()];
+        let effective =
+            build_effective_system_prompt("base prompt".to_owned(), skills, &mcp_tool_names);
+
+        let skills_idx = effective
+            .find("```skills")
+            .expect("skills block must be present");
+        let mcp_idx = effective
+            .find("## Available MCP Tools")
+            .expect("mcp annotation must be present");
+        assert!(
+            skills_idx < mcp_idx,
+            "skills block must precede the mcp annotation"
+        );
+    }
+}

--- a/crates/zeph-subagent/src/filter.rs
+++ b/crates/zeph-subagent/src/filter.rs
@@ -445,6 +445,7 @@ mod tests {
                 schema: schemars::Schema::default(),
                 invocation: InvocationHint::FencedBlock(self.tag),
                 output_schema: None,
+                server_id: None,
             }]
         }
 
@@ -518,6 +519,7 @@ mod tests {
                     schema: schemars::Schema::default(),
                     invocation: InvocationHint::ToolCall,
                     output_schema: None,
+                    server_id: None,
                 })
                 .collect()
         }

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -1947,6 +1947,7 @@ async fn run_agent_loop_passes_tools_to_provider() {
                 schema: schemars::Schema::default(),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             }]
         }
 

--- a/crates/zeph-tools/src/cwd.rs
+++ b/crates/zeph-tools/src/cwd.rs
@@ -78,6 +78,7 @@ impl ToolExecutor for SetCwdExecutor {
             schema: schemars::schema_for!(SetCwdParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         }]
     }
 

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -195,6 +195,7 @@ impl ToolExecutor for DiagnosticsExecutor {
             schema: schemars::schema_for!(DiagnosticsParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         }]
     }
 }

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -664,6 +664,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(ReadParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "write".into(),
@@ -671,6 +672,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(WriteParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "edit".into(),
@@ -678,6 +680,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(EditParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "find_path".into(),
@@ -685,6 +688,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(FindPathParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "grep".into(),
@@ -692,6 +696,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(GrepParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "list_directory".into(),
@@ -699,6 +704,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(ListDirectoryParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "create_directory".into(),
@@ -706,6 +712,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(CreateDirectoryParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "delete_path".into(),
@@ -713,6 +720,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(DeletePathParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "move_path".into(),
@@ -720,6 +728,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(MovePathParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "copy_path".into(),
@@ -727,6 +736,7 @@ impl ToolExecutor for FileExecutor {
                 schema: schemars::schema_for!(CopyPathParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
         ]
     }

--- a/crates/zeph-tools/src/moderation.rs
+++ b/crates/zeph-tools/src/moderation.rs
@@ -273,6 +273,7 @@ impl<B: ReactionModerationBackend + std::fmt::Debug> ToolExecutor for Moderation
                 schema: schemars::schema_for!(DeleteReactionParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "telegram_delete_all_reactions".into(),
@@ -287,6 +288,7 @@ impl<B: ReactionModerationBackend + std::fmt::Debug> ToolExecutor for Moderation
                 schema: schemars::schema_for!(DeleteAllReactionsParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
         ]
     }

--- a/crates/zeph-tools/src/registry.rs
+++ b/crates/zeph-tools/src/registry.rs
@@ -23,6 +23,20 @@ pub struct ToolDef {
     ///
     /// DO NOT convert to `schemars::Schema` — lossy; see #2931 critique P0-1.
     pub output_schema: Option<serde_json::Value>,
+    /// ID of the MCP server that registered this tool, or `None` for built-in tools.
+    ///
+    /// This is the authoritative way to determine whether a tool originates from an MCP
+    /// server — `id` is a sanitized, server-namespaced string with no reliable prefix to
+    /// pattern-match on (see #5712).
+    pub server_id: Option<String>,
+}
+
+impl ToolDef {
+    /// Returns `true` if this tool was registered by an MCP server.
+    #[must_use]
+    pub fn is_mcp_tool(&self) -> bool {
+        self.server_id.is_some()
+    }
 }
 
 #[derive(Debug, Default)]
@@ -151,6 +165,7 @@ mod tests {
                 schema: schemars::schema_for!(BashParams),
                 invocation: InvocationHint::FencedBlock("bash"),
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "read".into(),
@@ -158,6 +173,7 @@ mod tests {
                 schema: schemars::schema_for!(ReadParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
         ]
     }

--- a/crates/zeph-tools/src/scope.rs
+++ b/crates/zeph-tools/src/scope.rs
@@ -731,6 +731,7 @@ mod tests {
             schema: schemars::schema_for!(String),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         }
     }
 

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -242,6 +242,7 @@ impl ToolExecutor for WebScrapeExecutor {
                 schema: schemars::schema_for!(ScrapeInstruction),
                 invocation: InvocationHint::FencedBlock("scrape"),
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "fetch".into(),
@@ -249,6 +250,7 @@ impl ToolExecutor for WebScrapeExecutor {
                 schema: schemars::schema_for!(FetchParams),
                 invocation: InvocationHint::ToolCall,
                 output_schema: None,
+                server_id: None,
             },
         ]
     }

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -484,6 +484,7 @@ impl ToolExecutor for SearchCodeExecutor {
             schema: schemars::schema_for!(SearchCodeParams),
             invocation: InvocationHint::ToolCall,
             output_schema: None,
+            server_id: None,
         }]
     }
 }

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -1760,6 +1760,7 @@ impl ToolExecutor for ShellExecutor {
             schema: schemars::schema_for!(BashParams),
             invocation: InvocationHint::FencedBlock("bash"),
             output_schema: None,
+            server_id: None,
         }]
     }
 

--- a/crates/zeph-tools/src/tool_filter.rs
+++ b/crates/zeph-tools/src/tool_filter.rs
@@ -66,6 +66,7 @@ mod tests {
                     schema: schemars::schema_for!(String),
                     invocation: crate::registry::InvocationHint::ToolCall,
                     output_schema: None,
+                    server_id: None,
                 },
                 ToolDef {
                     id: "glob".into(),
@@ -73,6 +74,7 @@ mod tests {
                     schema: schemars::schema_for!(String),
                     invocation: crate::registry::InvocationHint::ToolCall,
                     output_schema: None,
+                    server_id: None,
                 },
                 ToolDef {
                     id: "edit".into(),
@@ -80,6 +82,7 @@ mod tests {
                     schema: schemars::schema_for!(String),
                     invocation: crate::registry::InvocationHint::ToolCall,
                     output_schema: None,
+                    server_id: None,
                 },
             ]
         }

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -475,6 +475,7 @@ impl ToolExecutor for SchedulerExecutor {
                 schema: schemars::schema_for!(PeriodicParams),
                 invocation: InvocationHint::FencedBlock("schedule_periodic"),
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "schedule_deferred".into(),
@@ -482,6 +483,7 @@ impl ToolExecutor for SchedulerExecutor {
                 schema: schemars::schema_for!(DeferredParams),
                 invocation: InvocationHint::FencedBlock("schedule_deferred"),
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "cancel_task".into(),
@@ -489,6 +491,7 @@ impl ToolExecutor for SchedulerExecutor {
                 schema: schemars::schema_for!(CancelParams),
                 invocation: InvocationHint::FencedBlock("cancel_task"),
                 output_schema: None,
+                server_id: None,
             },
             ToolDef {
                 id: "list_tasks".into(),
@@ -496,6 +499,7 @@ impl ToolExecutor for SchedulerExecutor {
                 schema: schemars::schema_for!(ListTasksParams),
                 invocation: InvocationHint::FencedBlock("list_tasks"),
                 output_schema: None,
+                server_id: None,
             },
         ]
     }


### PR DESCRIPTION
## Summary

- `extract_mcp_tool_names` (`crates/zeph-core/src/agent/subagent_commands.rs`) filtered tool ids via `starts_with("mcp_")`, but real MCP tool ids are built as `"{server_id}_{name}"` by `McpTool::sanitized_id()` and never carry that prefix — the filter never matched, so spawned sub-agents never received an "Available MCP Tools" annotation in their system prompt regardless of how many MCP servers were connected.
- Added `server_id: Option<String>` to `zeph_tools::registry::ToolDef` (plus a `ToolDef::is_mcp_tool()` helper) as the authoritative MCP-origin marker, set at construction time in `McpToolExecutor::tool_definitions` and `MockMcpServer::tool_definitions`; `extract_mcp_tool_names` now filters on `ToolDef::is_mcp_tool` instead of the dead name-prefix check.
- Since `ToolDef` struct literals are exhaustive, adding the field required a mechanical `server_id: None,` insertion at ~93 pre-existing construction sites across ~26 files (built-in tool executors, bench fixtures, ACP executors, test stubs) — no behavior change there.

Closes #5712

## Follow-ups filed (out of scope for this PR)

The same class of dead prefix-based MCP-origin detection was found at three more sites during review, all filed separately rather than scope-creeping this PR:
- #5733 (P2) — `zeph-tools/src/cache.rs::is_cacheable` never matches, so MCP tool results are cached despite the doc saying they shouldn't be.
- #5736 (P2, security) — `zeph-core/src/agent/shadow_sentinel.rs::classify_tool` never matches, so MCP write/edit tools never escalate to the `ExfilCapable` risk category.
- #5734 (P3) — `zeph-tui/src/widgets/tool_view.rs::ToolKind::classify` never matches (cosmetic TUI grouping only).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12158 passed, 34 skipped, 0 failed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] New regression test `extract_mcp_tool_names_uses_server_id_not_name_prefix` (uses a real MCP-shaped id that does not start with `mcp_`, fails pre-fix / passes post-fix)
- [x] New `build_effective_system_prompt_tests` covering annotation-present, annotation-omitted-when-empty, and skills+MCP ordering in `crates/zeph-subagent/src/agent_loop.rs`