### PR TITLE
fix(core): preserve calls/tool_calls index alignment on tafc strip failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and `MockMcpServer::tool_definitions` (`crates/zeph-mcp/src/testing.rs`); all other `ToolDef`
   construction sites default it to `None`. `extract_mcp_tool_names` now filters on
   `ToolDef::is_mcp_tool` instead of the dead name-prefix check.
+- `fix(core)`: `Agent::prepare_tool_dispatch` (`crates/zeph-core/src/agent/tool_execution/tier_loop.rs`)
+  used `.filter_map()` to silently drop a tool call from `calls` when the model produced a
+  tafc-stripped "think-only" call (no real arguments), shortening `calls` and every per-call
+  vector derived from iterating it (`pre_exec_blocked`, `args_hashes`, `repeat_blocked`,
+  `cache_hits`, `utility_actions`) below `tool_calls.len()` — while the rest of the tier loop
+  (including `ToolCallDag::build`) indexes these by the original, unfiltered `tool_calls`
+  position. If the dropped call wasn't last in the batch, every subsequent call was accessed one
+  slot early, executing under the wrong call's identity/timing/logging; if it was last, an
+  out-of-bounds panic (#5731). Changed `calls` construction from `.filter_map()` to `.map()` so
+  `calls.len() == tool_calls.len()` is now an unconditional invariant; tafc-stripped positions are
+  tracked separately and folded into the existing `pre_exec_blocked` mechanism, which already
+  returns a synthetic skip result without dispatching, instead of dropping the entry.
 - `fix(core)`: `Agent::build_experiment_engine` (`crates/zeph-core/src/agent/experiment_cmd.rs`)
   read the configured benchmark TOML synchronously via `BenchmarkSet::from_file`, which performs
   blocking filesystem I/O (`std::fs::canonicalize` x2, `std::fs::metadata`, `std::fs::

--- a/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
@@ -2136,3 +2136,240 @@ fn schema_complexity_many_flat_params_score() {
         "8 flat properties must score higher than 2"
     );
 }
+
+// ── #5731 regression: tafc-stripped call must not desync `calls` vs `tool_calls` ──
+//
+// `prepare_tool_dispatch` used to `filter_map` out a tool call whose input was
+// think-only (`strip_tafc_fields` erroring), shrinking `calls` relative to the
+// original `tool_calls`. Every per-call vector downstream (`tool_started_ats`,
+// `pre_exec_blocked`, `args_hashes`, `repeat_blocked`, `cache_hits`,
+// `utility_actions`) — plus the tool-call DAG itself, built from `tool_calls` — is
+// indexed by the *original* position, so the drop caused every subsequent real call
+// in the batch to execute under an earlier call's identity (or panic, if the dropped
+// call was last). These tests reproduce both shapes at the `handle_native_tool_calls`
+// entry point (`prepare_tool_dispatch` itself is private to `tier_loop`'s module tree
+// and unreachable from here).
+
+/// Records every dispatched `(tool_id, params)` pair, in dispatch order, so a test can
+/// assert that a call executed with its own arguments rather than a neighboring call's.
+/// Following the `MockToolExecutor::captured_env` convention: the recording `Arc` is a
+/// public field so a test can `Arc::clone` it before the executor is moved into
+/// `Agent::new` (which type-erases it behind `dyn ErasedToolExecutor`).
+struct RecordingExecutor {
+    calls: std::sync::Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>,
+}
+
+impl RecordingExecutor {
+    fn new() -> Self {
+        Self {
+            calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl ToolExecutor for RecordingExecutor {
+    fn execute(
+        &self,
+        _response: &str,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        std::future::ready(Ok(None))
+    }
+
+    fn execute_tool_call(
+        &self,
+        call: &ToolCall,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        let tool_id = call.tool_id.clone();
+        self.calls.lock().unwrap().push((
+            tool_id.as_str().to_owned(),
+            serde_json::Value::Object(call.params.clone()),
+        ));
+        async move {
+            Ok(Some(ToolOutput {
+                tool_name: tool_id,
+                summary: "ok".into(),
+                blocks_executed: 1,
+                diff: None,
+                filter_stats: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+    }
+}
+
+fn tafc_only_think_request(id: &str, name: &str) -> zeph_llm::provider::ToolUseRequest {
+    zeph_llm::provider::ToolUseRequest {
+        id: id.into(),
+        name: name.into(),
+        input: serde_json::json!({"_tafc_think": "reasoning only, no real params"}),
+    }
+}
+
+fn real_call_request(id: &str, name: &str, cmd: &str) -> zeph_llm::provider::ToolUseRequest {
+    zeph_llm::provider::ToolUseRequest {
+        id: id.into(),
+        name: name.into(),
+        input: serde_json::json!({"cmd": cmd}),
+    }
+}
+
+fn result_parts_by_id(
+    agent: &crate::agent::Agent<crate::agent::agent_tests::MockChannel>,
+) -> std::collections::HashMap<String, (String, bool)> {
+    agent
+        .msg
+        .messages
+        .iter()
+        .flat_map(|m| &m.parts)
+        .filter_map(|p| {
+            if let zeph_llm::provider::MessagePart::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } = p
+            {
+                Some((tool_use_id.clone(), (content.clone(), *is_error)))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+// #5731 case 1: the tafc-only-think call is in the MIDDLE of the batch. Before the fix,
+// `filter_map` dropped it from `calls`, so the real call after it (id-3/tool-c) was
+// executed one slot early under id-2's original DAG index — i.e. dispatched with
+// tool-c's identity but treated internally as occupying id-2's position, corrupting
+// `tool_started_ats`/`pre_exec_blocked`/etc. for every following index.
+#[tokio::test]
+async fn tafc_stripped_call_mid_batch_does_not_shift_subsequent_calls() {
+    use crate::agent::agent_tests::{MockChannel, create_test_registry, mock_provider};
+
+    let executor = RecordingExecutor::new();
+    let recorded_calls = std::sync::Arc::clone(&executor.calls);
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+    agent.tool_orchestrator.tafc.enabled = true;
+
+    let tool_calls = vec![
+        real_call_request("id-1", "tool-a", "echo a"),
+        tafc_only_think_request("id-2", "tool-b"),
+        real_call_request("id-3", "tool-c", "echo c"),
+    ];
+
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    let recorded = recorded_calls.lock().unwrap().clone();
+    assert_eq!(
+        recorded.len(),
+        2,
+        "only the two real calls should reach the executor, got: {recorded:?}"
+    );
+    assert!(
+        recorded
+            .iter()
+            .any(|(id, params)| id == "tool-a" && params["cmd"] == "echo a"),
+        "tool-a must dispatch with its own params, got: {recorded:?}"
+    );
+    assert!(
+        recorded
+            .iter()
+            .any(|(id, params)| id == "tool-c" && params["cmd"] == "echo c"),
+        "tool-c must dispatch with its own params, not id-2's slot, got: {recorded:?}"
+    );
+
+    let results = result_parts_by_id(&agent);
+    assert_eq!(
+        results.len(),
+        3,
+        "every original tool_use_id needs a ToolResult"
+    );
+
+    let (blocked_content, _) = &results["id-2"];
+    assert!(
+        blocked_content.contains("blocked by pre-execution verifier")
+            || blocked_content.contains("was blocked"),
+        "tafc-stripped call must be synthetically skipped, not dispatched: {blocked_content}"
+    );
+
+    let (first_result_content, first_result_is_error) = &results["id-1"];
+    assert!(
+        !first_result_is_error && !first_result_content.contains("blocked"),
+        "tool-a (before the stripped call) must complete normally: {first_result_content}"
+    );
+
+    let (last_result_content, last_result_is_error) = &results["id-3"];
+    assert!(
+        !last_result_is_error && !last_result_content.contains("blocked"),
+        "tool-c (after the stripped call) must complete normally, not inherit id-2's block: \
+         {last_result_content}"
+    );
+}
+
+// #5731 case 2: the tafc-only-think call is LAST in the batch. Before the fix, dropping
+// it from `calls` made `calls[idx]` (and every sibling vector sized to `calls.len()`)
+// out-of-bounds the moment tier execution reached the final original index — this test
+// guards against that panic as well as confirming correct behavior.
+#[tokio::test]
+async fn tafc_stripped_call_last_in_batch_does_not_panic() {
+    use crate::agent::agent_tests::{MockChannel, create_test_registry, mock_provider};
+
+    let executor = RecordingExecutor::new();
+    let recorded_calls = std::sync::Arc::clone(&executor.calls);
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+    agent.tool_orchestrator.tafc.enabled = true;
+
+    let tool_calls = vec![
+        real_call_request("id-1", "tool-a", "echo a"),
+        real_call_request("id-2", "tool-b", "echo b"),
+        tafc_only_think_request("id-3", "tool-c"),
+    ];
+
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    let recorded = recorded_calls.lock().unwrap().clone();
+    assert_eq!(
+        recorded.len(),
+        2,
+        "only the two real calls should reach the executor, got: {recorded:?}"
+    );
+    assert!(
+        recorded
+            .iter()
+            .any(|(id, params)| id == "tool-a" && params["cmd"] == "echo a")
+    );
+    assert!(
+        recorded
+            .iter()
+            .any(|(id, params)| id == "tool-b" && params["cmd"] == "echo b")
+    );
+
+    let results = result_parts_by_id(&agent);
+    assert_eq!(
+        results.len(),
+        3,
+        "every original tool_use_id needs a ToolResult"
+    );
+
+    let (blocked_content, _) = &results["id-3"];
+    assert!(
+        blocked_content.contains("blocked by pre-execution verifier")
+            || blocked_content.contains("was blocked"),
+        "trailing tafc-stripped call must be synthetically skipped, not panic: {blocked_content}"
+    );
+}

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -907,10 +907,18 @@ impl<C: Channel> Agent<C> {
         let mut unmask_misses = 0usize;
         let mut unmask_miss_tools: Vec<String> = Vec::new();
 
+        // INVARIANT: `calls` must stay the same length as `tool_calls`, with `calls[i]`
+        // always corresponding to `tool_calls[i]`. The tool-call DAG (built from `tool_calls`)
+        // and every per-call vector below (tool_started_ats, pre_exec_blocked, args_hashes,
+        // repeat_blocked, cache_hits, utility_actions) are all indexed by that same original
+        // position downstream — dropping an entry here would desynchronize every one of them
+        // against `tool_calls`, silently misattributing timing/state or executing the wrong
+        // tool call under another call's identity (#5731).
+        let mut tafc_stripped = vec![false; tool_calls.len()];
         let calls: Vec<ToolCall> = tool_calls
             .iter()
             .enumerate()
-            .filter_map(|(idx, tc)| {
+            .map(|(idx, tc)| {
                 let mut params: serde_json::Map<String, serde_json::Value> =
                     if let serde_json::Value::Object(map) = &tc.input {
                         map.clone()
@@ -931,17 +939,18 @@ impl<C: Channel> Agent<C> {
                     }
                 }
                 if tafc_enabled && strip_tafc_fields(&mut params, tc.name.as_str()).is_err() {
-                    // Model produced only think fields — skip this tool call.
-                    return None;
+                    // Model produced only think fields — keep the slot (see invariant above)
+                    // but mark it so the existing pre-exec gate skips it without dispatch.
+                    tafc_stripped[idx] = true;
                 }
-                Some(ToolCall {
+                ToolCall {
                     tool_id: tc.name.clone(),
                     params,
                     caller_id: None,
                     context: task_ctx.clone(),
                     tool_call_id: tool_call_ids[idx].clone(),
                     skill_name: self.skill_attribution(),
-                })
+                }
             })
             .collect();
 
@@ -964,6 +973,15 @@ impl<C: Channel> Agent<C> {
         let mut pre_exec_blocked = self.run_pre_execution_verifiers(&calls);
 
         self.apply_channel_tool_allowlist(&calls, &mut pre_exec_blocked);
+
+        // TAFC-stripped calls (kept as placeholders above to preserve index alignment)
+        // are routed through the existing pre-exec gate so they skip dispatch with a
+        // synthetic result instead of being silently dropped from `calls`.
+        for (idx, stripped) in tafc_stripped.into_iter().enumerate() {
+            if stripped {
+                pre_exec_blocked[idx] = true;
+            }
+        }
 
         // Utility gate: score each call and recommend an action (#2477).
         // user_requested is from the last user message only (prompt-injection guard).


### PR DESCRIPTION
## Summary

- `prepare_tool_dispatch` (`crates/zeph-core/src/agent/tool_execution/tier_loop.rs`) used `.filter_map()` to drop a tool call from `calls` when the model produced a tafc-stripped think-only call, shortening `calls` and every per-call vector derived from it (`pre_exec_blocked`, `args_hashes`, `repeat_blocked`, `cache_hits`, `utility_actions`) below `tool_calls.len()`
- The rest of the tier loop, including `ToolCallDag::build`, indexes these by the original unfiltered `tool_calls` position — a dropped non-last call caused every subsequent call to execute under the wrong identity/timing; a dropped last call caused an out-of-bounds panic
- Changed `calls` construction from `.filter_map()` to `.map()` so `calls.len() == tool_calls.len()` is now an unconditional invariant; tafc-stripped positions are tracked separately and folded into the existing `pre_exec_blocked` mechanism (which already returns a synthetic skip result without dispatching) instead of dropping the entry
- Note: the original issue's diagnosis (that `tool_started_ats` sizing was the bug) was incorrect — `tool_started_ats` was always indexed consistently against the original `tool_calls` positions. The actual root cause was the `calls` vector desync described above; this PR fixes that instead.

Closes #5731

## Test plan

- [x] Added `tafc_stripped_call_mid_batch_does_not_shift_subsequent_calls` — reproduces the original bug (mid-batch drop desyncs subsequent calls), confirmed to fail against pre-fix code with the exact reported panic symptom and pass against the fix
- [x] Added `tafc_stripped_call_last_in_batch_does_not_panic` — covers the out-of-bounds case when the stripped call is last in the batch
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12144 passed, 34 skipped, 0 failed)
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)