### PR TITLE
fix(memory): scope Key Facts recall to conversation_id

### DIFF
--- a/crates/zeph-core/src/memory_tools.rs
+++ b/crates/zeph-core/src/memory_tools.rs
@@ -134,7 +134,7 @@ impl ToolExecutor for MemoryToolExecutor {
 
                 let key_facts = self
                     .memory
-                    .search_key_facts(&params.query, limit)
+                    .search_key_facts(&params.query, limit, Some(self.conversation_id))
                     .await
                     .map_err(|e| ToolError::Execution(std::io::Error::other(e.to_string())))?;
 

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -36,9 +36,10 @@ use crate::embedding_store::EmbeddingStore;
 use crate::error::MemoryError;
 use crate::semantic::KEY_FACTS_COLLECTION;
 use crate::store::SqliteStore;
+use crate::types::ConversationId;
 
-/// Row fetched from `episodic_events`: `(id, session_id, event_type, summary, message_content, created_at)`.
-type CandidateRow = (i64, String, String, String, String, i64);
+/// Row fetched from `episodic_events`: `(id, conversation_id, session_id, event_type, summary, message_content, created_at)`.
+type CandidateRow = (i64, i64, String, String, String, String, i64);
 
 /// Configuration for the episodic consolidation daemon.
 ///
@@ -77,6 +78,12 @@ pub struct EpisodicConsolidationResult {
 struct ConsolidationCandidate {
     /// Row ID from `episodic_events.id` (NOT `ExperienceId` — these are different tables).
     event_id: i64,
+    /// Owning conversation, derived from the joined `messages.conversation_id`.
+    ///
+    /// Used to scope promoted facts to a single conversation in the Key Facts payload
+    /// when every source event of a fact shares the same conversation (see
+    /// [`promote_fact`]'s `conversation_id` parameter).
+    conversation_id: ConversationId,
     #[allow(dead_code)]
     session_id: String,
     event_type: String,
@@ -185,7 +192,9 @@ pub async fn run_episodic_consolidation_sweep(
 
     // Step 2: compute cognitive weight for each candidate.
     let mut candidates: Vec<ConsolidationCandidate> = Vec::with_capacity(raw_candidates.len());
-    for (event_id, session_id, event_type, summary, message_content, created_at) in raw_candidates {
+    for (event_id, conversation_id, session_id, event_type, summary, message_content, created_at) in
+        raw_candidates
+    {
         let weight = compute_cognitive_weight(&pool, &session_id, created_at).await?;
         if weight < -0.5 {
             result.negative_weight_skipped += 1;
@@ -195,6 +204,7 @@ pub async fn run_episodic_consolidation_sweep(
         }
         candidates.push(ConsolidationCandidate {
             event_id,
+            conversation_id: ConversationId(conversation_id),
             session_id,
             event_type,
             summary,
@@ -320,11 +330,13 @@ pub async fn run_episodic_consolidation_sweep(
         };
 
         for (p, embedding) in pending.into_iter().zip(embeddings) {
+            let conversation_id = single_source_conversation_id(&candidates, &p.valid_source_ids);
             promote_fact(
                 &pool,
                 &p.fact.fact,
                 p.cog_weight_f32,
                 &p.valid_source_ids,
+                conversation_id,
                 qdrant,
                 embedding,
             )
@@ -362,7 +374,7 @@ async fn fetch_candidates(
 
     let epoch_now = <ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
     let raw = format!(
-        "SELECT e.id, e.session_id, e.event_type, e.summary,
+        "SELECT e.id, m.conversation_id, e.session_id, e.event_type, e.summary,
                 COALESCE(m.compressed_content, m.content) AS message_content,
                 e.created_at
          FROM episodic_events e
@@ -562,17 +574,53 @@ fn is_jaccard_duplicate(fact: &str, existing: &[String], threshold: f32) -> bool
     false
 }
 
+/// Returns the single conversation that every one of `source_event_ids` belongs to, or `None`
+/// when the sources span more than one conversation (or there are no matching candidates).
+///
+/// A single extracted fact can draw on episodic events from different conversations because
+/// [`fetch_candidates`] batches events across sessions for one LLM extraction call. Such
+/// cross-conversation facts are genuinely not owned by a single conversation, so they are
+/// promoted without a `conversation_id` tag — this mirrors the accepted backward-compatibility
+/// behavior for pre-existing untagged points (issue #5732): a fact with no `conversation_id`
+/// simply never matches a conversation-scoped `search_key_facts` filter.
+///
+/// Note: `source_event_ids` is pre-filtered to events that survived candidate selection (see
+/// `valid_source_ids` in the caller), so if a fact's true sources spanned conversations but only
+/// one conversation's events survived filtering (e.g. dropped for negative cognitive weight or
+/// insufficient age), this can return `Some` for that single surviving conversation even though
+/// the fact was partly synthesized from another conversation's now-excluded event. This is judged
+/// an acceptable narrow tradeoff: the alternative (treating it as cross-conversation and storing
+/// untagged) is itself a mild exposure, and the fact is scoped to a conversation that genuinely
+/// contributed at least one surviving source event.
+fn single_source_conversation_id(
+    candidates: &[ConsolidationCandidate],
+    source_event_ids: &[i64],
+) -> Option<ConversationId> {
+    let mut ids = source_event_ids.iter().filter_map(|id| {
+        candidates
+            .iter()
+            .find(|c| c.event_id == *id)
+            .map(|c| c.conversation_id)
+    });
+    let first = ids.next()?;
+    ids.all(|cid| cid == first).then_some(first)
+}
+
 /// Promote a single accepted fact to `SQLite` and optionally Qdrant.
 ///
 /// All `SQLite` writes for one fact happen in one transaction. The `embedding`
 /// parameter carries a pre-computed vector (from `embed_batch` in the caller).
 /// When `None`, Qdrant upsert is skipped (no embedding support, or batch failed).
+/// `conversation_id` is `Some` only when every source event belongs to the same conversation
+/// (see [`single_source_conversation_id`]); it is stored in the Qdrant payload so
+/// `search_key_facts` can scope results to a single conversation.
 #[tracing::instrument(skip_all, name = "memory.episodic.promote_fact")]
 async fn promote_fact(
     pool: &DbPool,
     fact_text: &str,
     cognitive_weight: f32,
     source_event_ids: &[i64],
+    conversation_id: Option<ConversationId>,
     qdrant: Option<&EmbeddingStore>,
     embedding: Option<Vec<f32>>,
 ) -> Result<(), MemoryError> {
@@ -616,12 +664,15 @@ async fn promote_fact(
         {
             tracing::warn!(error = %e, "episodic consolidation: failed to ensure key_facts collection");
         } else {
-            let payload = serde_json::json!({
+            let mut payload = serde_json::json!({
                 "fact_text": fact_text,
                 "source": "episodic_consolidation",
                 "cognitive_weight": cognitive_weight,
                 "consolidated_fact_id": fact_id,
             });
+            if let Some(cid) = conversation_id {
+                payload["conversation_id"] = serde_json::json!(cid.0);
+            }
             if let Err(e) = qdrant
                 .store_to_collection(KEY_FACTS_COLLECTION, payload, vector)
                 .await
@@ -837,6 +888,161 @@ mod tests {
             &existing,
             0.6
         ));
+    }
+
+    // ── single_source_conversation_id (#5732) ──────────────────────────────────
+
+    fn candidate(event_id: i64, conversation_id: i64) -> ConsolidationCandidate {
+        ConsolidationCandidate {
+            event_id,
+            conversation_id: ConversationId(conversation_id),
+            session_id: "test_session".to_owned(),
+            event_type: "tool_call".to_owned(),
+            summary: "summary".to_owned(),
+            message_content: "content".to_owned(),
+            cognitive_weight: 0.0,
+        }
+    }
+
+    #[test]
+    fn single_source_conversation_id_all_sources_share_one_conversation() {
+        let candidates = vec![candidate(1, 10), candidate(2, 10), candidate(3, 10)];
+        assert_eq!(
+            single_source_conversation_id(&candidates, &[1, 2, 3]),
+            Some(ConversationId(10))
+        );
+    }
+
+    #[test]
+    fn single_source_conversation_id_spanning_two_conversations_returns_none() {
+        let candidates = vec![candidate(1, 10), candidate(2, 20)];
+        assert_eq!(single_source_conversation_id(&candidates, &[1, 2]), None);
+    }
+
+    #[test]
+    fn single_source_conversation_id_empty_sources_returns_none() {
+        let candidates = vec![candidate(1, 10)];
+        assert_eq!(single_source_conversation_id(&candidates, &[]), None);
+    }
+
+    #[test]
+    fn single_source_conversation_id_unmatched_ids_return_none() {
+        // source_event_ids referencing no known candidate (e.g. filtered out upstream).
+        let candidates = vec![candidate(1, 10)];
+        assert_eq!(single_source_conversation_id(&candidates, &[999]), None);
+    }
+
+    #[test]
+    fn single_source_conversation_id_single_source_returns_its_conversation() {
+        let candidates = vec![candidate(1, 10), candidate(2, 20)];
+        assert_eq!(
+            single_source_conversation_id(&candidates, &[1]),
+            Some(ConversationId(10))
+        );
+    }
+
+    // ── promote_fact Qdrant payload tagging (#5732) ────────────────────────────
+
+    fn embed_enabled_mock_provider(llm_response: &str) -> AnyProvider {
+        let mut p = MockProvider::default();
+        p.default_response = llm_response.to_owned();
+        p.supports_embeddings = true;
+        p.embedding = vec![0.1_f32; 384];
+        AnyProvider::Mock(p)
+    }
+
+    #[tokio::test]
+    async fn promote_fact_tags_conversation_id_when_sources_share_one_conversation() {
+        let (store, pool) = setup_db().await;
+        let conv_id = store.create_conversation().await.unwrap();
+
+        let (_, ev1) = insert_episodic_event(
+            &pool,
+            conv_id,
+            "Alice uses Rust for systems programming",
+            "Alice prefers Rust",
+            600,
+        )
+        .await;
+
+        let llm_response = format!(
+            r#"[{{"fact":"Alice uses Rust for systems programming","source_event_ids":[{ev1}]}}]"#
+        );
+        let provider = embed_enabled_mock_provider(&llm_response);
+        let config = EpisodicConsolidationConfig {
+            enabled: true,
+            consolidation_provider: ProviderName::default(),
+            interval_secs: 1800,
+            batch_size: 30,
+            min_age_secs: 300,
+            dedup_jaccard_threshold: 0.6,
+        };
+
+        let qdrant = crate::embedding_store::EmbeddingStore::new_sqlite(pool.clone());
+
+        let result =
+            run_episodic_consolidation_sweep(pool.clone(), &provider, &config, Some(&qdrant))
+                .await
+                .unwrap();
+        assert_eq!(result.facts_promoted, 1);
+
+        let points = qdrant
+            .search_collection(KEY_FACTS_COLLECTION, &[0.1_f32; 384], 10, None)
+            .await
+            .unwrap();
+        assert_eq!(points.len(), 1, "one point must be upserted into Qdrant");
+        assert_eq!(
+            points[0]
+                .payload
+                .get("conversation_id")
+                .and_then(serde_json::Value::as_i64),
+            Some(conv_id.0),
+            "conversation_id must be written when every source event shares one conversation"
+        );
+    }
+
+    #[tokio::test]
+    async fn promote_fact_omits_conversation_id_when_sources_span_conversations() {
+        let (store, pool) = setup_db().await;
+        let conv_a = store.create_conversation().await.unwrap();
+        let conv_b = store.create_conversation().await.unwrap();
+
+        let (_, ev1) =
+            insert_episodic_event(&pool, conv_a, "Alice uses Rust", "summary a", 600).await;
+        let (_, ev2) =
+            insert_episodic_event(&pool, conv_b, "Bob also uses Rust", "summary b", 600).await;
+
+        let llm_response = format!(
+            r#"[{{"fact":"Both Alice and Bob use Rust","source_event_ids":[{ev1},{ev2}]}}]"#
+        );
+        let provider = embed_enabled_mock_provider(&llm_response);
+        let config = EpisodicConsolidationConfig {
+            enabled: true,
+            consolidation_provider: ProviderName::default(),
+            interval_secs: 1800,
+            batch_size: 30,
+            min_age_secs: 300,
+            dedup_jaccard_threshold: 0.6,
+        };
+
+        let qdrant = crate::embedding_store::EmbeddingStore::new_sqlite(pool.clone());
+
+        let result =
+            run_episodic_consolidation_sweep(pool.clone(), &provider, &config, Some(&qdrant))
+                .await
+                .unwrap();
+        assert_eq!(result.facts_promoted, 1);
+
+        let points = qdrant
+            .search_collection(KEY_FACTS_COLLECTION, &[0.1_f32; 384], 10, None)
+            .await
+            .unwrap();
+        assert_eq!(points.len(), 1, "one point must be upserted into Qdrant");
+        assert!(
+            !points[0].payload.contains_key("conversation_id"),
+            "a fact whose source events span multiple conversations must not carry a \
+             conversation_id key at all, not merely a null one"
+        );
     }
 
     #[test]

--- a/crates/zeph-memory/src/semantic/summarization.rs
+++ b/crates/zeph-memory/src/semantic/summarization.rs
@@ -7,6 +7,7 @@ use super::{KEY_FACTS_COLLECTION, SemanticMemory};
 use crate::embedding_store::MessageKind;
 use crate::error::MemoryError;
 use crate::types::{ConversationId, MessageId};
+use crate::vector_store::{FieldCondition, FieldValue, VectorFilter};
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct StructuredSummary {
@@ -350,8 +351,19 @@ impl SemanticMemory {
         vector: Vec<f32>,
         threshold: f32,
     ) {
+        // Scope the near-duplicate check to this conversation, matching the read-side filter in
+        // `search_key_facts`. An unscoped (global) dedup search would let a fact stored under one
+        // conversation silently suppress a near-identical fact for a different conversation, which
+        // is then unrecoverable from that other conversation's conversation-scoped search (#5732).
+        let dedup_filter = Some(VectorFilter {
+            must: vec![FieldCondition {
+                field: "conversation_id".into(),
+                value: FieldValue::Integer(conversation_id.0),
+            }],
+            must_not: vec![],
+        });
         match qdrant
-            .search_collection(KEY_FACTS_COLLECTION, &vector, 1, None)
+            .search_collection(KEY_FACTS_COLLECTION, &vector, 1, dedup_filter)
             .await
         {
             Ok(hits) if hits.first().is_some_and(|h| h.score >= threshold) => {
@@ -383,6 +395,11 @@ impl SemanticMemory {
 
     /// Search key facts extracted from conversation summaries.
     ///
+    /// When `conversation_id` is `Some`, results are restricted to facts scoped to that
+    /// conversation; facts written without a `conversation_id` payload field (e.g. cross-session
+    /// episodic-consolidation facts, or points written before this scoping was introduced) will
+    /// not match. Pass `None` to search across all conversations.
+    ///
     /// # Errors
     ///
     /// Returns an error if embedding or Qdrant search fails.
@@ -390,6 +407,7 @@ impl SemanticMemory {
         &self,
         query: &str,
         limit: usize,
+        conversation_id: Option<ConversationId>,
     ) -> Result<Vec<String>, MemoryError> {
         let Some(qdrant) = &self.qdrant else {
             tracing::debug!("key-facts: skipped, no vector store");
@@ -417,11 +435,24 @@ impl SemanticMemory {
             .ensure_named_collection_for_vector(KEY_FACTS_COLLECTION, &vector)
             .await?;
 
+        let filter = conversation_id.map(|cid| VectorFilter {
+            must: vec![FieldCondition {
+                field: "conversation_id".into(),
+                value: FieldValue::Integer(cid.0),
+            }],
+            must_not: vec![],
+        });
+
         let points = qdrant
-            .search_collection(KEY_FACTS_COLLECTION, &vector, limit, None)
+            .search_collection(KEY_FACTS_COLLECTION, &vector, limit, filter)
             .await?;
 
-        tracing::debug!(results = points.len(), limit, "key-facts: search complete");
+        tracing::debug!(
+            results = points.len(),
+            limit,
+            conversation_id = conversation_id.map(|c| c.0),
+            "key-facts: search complete"
+        );
 
         let facts = points
             .into_iter()

--- a/crates/zeph-memory/src/semantic/tests/summarization.rs
+++ b/crates/zeph-memory/src/semantic/tests/summarization.rs
@@ -622,7 +622,7 @@ fn summary_debug() {
 #[tokio::test]
 async fn search_key_facts_no_qdrant_empty() {
     let memory = test_semantic_memory(false).await;
-    let facts = memory.search_key_facts("query", 5).await.unwrap();
+    let facts = memory.search_key_facts("query", 5, None).await.unwrap();
     assert!(facts.is_empty());
 }
 
@@ -702,7 +702,10 @@ async fn store_key_facts_first_fact_stored() {
     memory
         .store_key_facts(cid, 1, &["unique fact".to_string()])
         .await;
-    let results = memory.search_key_facts("unique fact", 5).await.unwrap();
+    let results = memory
+        .search_key_facts("unique fact", 5, Some(cid))
+        .await
+        .unwrap();
     assert!(!results.is_empty(), "first fact must be stored");
 }
 
@@ -719,8 +722,41 @@ async fn store_key_facts_duplicate_skipped_at_threshold() {
         .store_key_facts(cid, 2, &["fact A again".to_string()])
         .await;
     // Both embed to the same unit vector (v[0]=1.0); second should be deduplicated.
-    let results = memory.search_key_facts("fact A", 10).await.unwrap();
+    let results = memory
+        .search_key_facts("fact A", 10, Some(cid))
+        .await
+        .unwrap();
     assert_eq!(results.len(), 1, "duplicate fact must be skipped");
+}
+
+#[tokio::test]
+async fn store_key_facts_dedup_scoped_per_conversation() {
+    // S1 regression (#5732 follow-up): the near-duplicate dedup check must be scoped to the
+    // same conversation as the read-side filter. Before the fix, dedup searched globally, so a
+    // fact stored under conversation A would silently suppress storage of a near-identical fact
+    // under conversation B — and B's conversation-scoped search_key_facts would then never see
+    // its own fact at all.
+    let memory = make_embed_memory_with_threshold(0.95).await;
+    let conv_a = memory.sqlite().create_conversation().await.unwrap();
+    let conv_b = memory.sqlite().create_conversation().await.unwrap();
+
+    memory
+        .store_key_facts(conv_a, 1, &["shared fact".to_string()])
+        .await;
+    // Same mock embedding vector as conv_a's fact, so a global dedup search would find it and
+    // (incorrectly) skip storing this one under conv_b.
+    memory
+        .store_key_facts(conv_b, 2, &["shared fact again".to_string()])
+        .await;
+
+    let results_b = memory
+        .search_key_facts("shared fact", 10, Some(conv_b))
+        .await
+        .unwrap();
+    assert!(
+        !results_b.is_empty(),
+        "conversation B's own fact must not be suppressed by conversation A's near-duplicate"
+    );
 }
 
 #[tokio::test]
@@ -735,7 +771,10 @@ async fn store_key_facts_stored_when_threshold_above_one() {
     memory
         .store_key_facts(cid, 2, &["fact C twin".to_string()])
         .await;
-    let results = memory.search_key_facts("fact C", 10).await.unwrap();
+    let results = memory
+        .search_key_facts("fact C", 10, Some(cid))
+        .await
+        .unwrap();
     assert_eq!(
         results.len(),
         2,
@@ -816,6 +855,109 @@ async fn store_key_facts_fail_open_on_search_error() {
         .store_key_facts(cid, 1, &["fact stored despite search error".to_string()])
         .await;
     // Reaching this line confirms: no panic, no propagated error.
+}
+
+// ── Cross-conversation Key Facts isolation (#5732) ─────────────────────────────
+
+#[tokio::test]
+async fn search_key_facts_scoped_excludes_other_conversation_fact() {
+    // threshold=2.0 disables dedup (cosine similarity can never reach it), so the store
+    // is not the thing under test here — cross-conversation filtering is.
+    let memory = make_embed_memory_with_threshold(2.0).await;
+    let cid_a = memory.sqlite().create_conversation().await.unwrap();
+    let cid_b = memory.sqlite().create_conversation().await.unwrap();
+
+    memory
+        .store_key_facts(cid_a, 1, &["Alice's favorite color is blue".to_string()])
+        .await;
+
+    let results_b = memory
+        .search_key_facts("Alice's favorite color", 5, Some(cid_b))
+        .await
+        .unwrap();
+    assert!(
+        results_b.is_empty(),
+        "a fact stored under conversation A must not leak into conversation B's scoped search"
+    );
+
+    let results_a = memory
+        .search_key_facts("Alice's favorite color", 5, Some(cid_a))
+        .await
+        .unwrap();
+    assert!(
+        !results_a.is_empty(),
+        "a fact stored under conversation A must be found when searching scoped to A"
+    );
+    assert!(results_a[0].contains("Alice's favorite color"));
+}
+
+#[tokio::test]
+async fn search_key_facts_unscoped_still_sees_all_conversations() {
+    // Passing `None` preserves the pre-fix, cross-conversation search behavior.
+    let memory = make_embed_memory_with_threshold(2.0).await;
+    let cid_a = memory.sqlite().create_conversation().await.unwrap();
+
+    memory
+        .store_key_facts(cid_a, 1, &["Bob's favorite language is Rust".to_string()])
+        .await;
+
+    let results = memory
+        .search_key_facts("Bob's favorite language", 5, None)
+        .await
+        .unwrap();
+    assert!(
+        !results.is_empty(),
+        "unscoped search (conversation_id = None) must still find facts from any conversation"
+    );
+}
+
+#[tokio::test]
+async fn search_key_facts_excludes_untagged_points_when_scoped() {
+    // Simulates a point written before the #5732 fix (or a cross-conversation
+    // episodic-consolidation fact promoted with no `conversation_id` tag): it must never
+    // match a conversation-scoped search, but must still be visible to an unscoped search.
+    let memory = make_embed_memory_with_threshold(2.0).await;
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+
+    let qdrant = memory.qdrant.as_ref().expect("qdrant must be configured");
+    let vector = {
+        let mut v = vec![0.0f32; 384];
+        v[0] = 1.0;
+        v
+    };
+    qdrant
+        .ensure_named_collection_for_vector(KEY_FACTS_COLLECTION, &vector)
+        .await
+        .unwrap();
+    qdrant
+        .store_to_collection(
+            KEY_FACTS_COLLECTION,
+            serde_json::json!({
+                "fact_text": "untagged legacy fact",
+                "source_summary_id": 1,
+            }),
+            vector,
+        )
+        .await
+        .unwrap();
+
+    let scoped = memory
+        .search_key_facts("untagged legacy fact", 5, Some(cid))
+        .await
+        .unwrap();
+    assert!(
+        scoped.is_empty(),
+        "a point with no conversation_id payload field must not match any conversation-scoped filter"
+    );
+
+    let unscoped = memory
+        .search_key_facts("untagged legacy fact", 5, None)
+        .await
+        .unwrap();
+    assert!(
+        !unscoped.is_empty(),
+        "a point with no conversation_id payload field must still be visible to an unscoped search"
+    );
 }
 
 // ── is_policy_decision_fact ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`memory_search`'s Key Facts recall queried the shared `zeph_key_facts` Qdrant collection with no conversation filter, unlike the sibling `recall()`/`search_session_summaries()` calls in the same function which already scope by `conversation_id`. This let facts from an unrelated prior session leak into a fresh session's `memory_search` results — a real data-isolation gap in any deployment where multiple sessions share one Qdrant instance.

- `search_key_facts` (`zeph-memory/src/semantic/summarization.rs`) now takes `conversation_id: Option<ConversationId>` and applies a `must` `VectorFilter` on the `"conversation_id"` payload field, mirroring the existing pattern already used by `search_session_summaries`.
- Write side: `episodic_consolidation.rs`'s `promote_fact` now tags a fact's payload with `conversation_id` only when all of its source events share one conversation (`single_source_conversation_id` helper); facts that legitimately span conversations are stored untagged and are correctly excluded from any conversation-scoped search.
- `memory_tools.rs`'s `memory_search` Key Facts branch now passes `Some(self.conversation_id)`, matching its sibling calls.
- Adversarial review (impl-critic) found a related gap: `store_key_fact_if_unique`'s near-duplicate dedup search stayed globally unscoped while reads became scoped, which could silently suppress a different conversation's own near-duplicate fact. Fixed the dedup search the same way, with a dedicated pinning regression test.

## Known residual gap (filed as follow-up, not a regression)

`ConversationId` is a per-database autoincrementing `i64` (`zeph-db/migrations/sqlite/001_init.sql`). Two independent SQLite databases sharing one Qdrant instance can still collide on the same id — the exact multi-db topology in #5732's own repro. This mirrors the pre-existing scoping behavior of `recall()`/`search_session_summaries()` (not introduced by this PR), so it's out of scope here; filing a separate issue to track it.

Closes #5732

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12170 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] 8 new regression tests: cross-conversation isolation (positive + negative), untagged-legacy-point exclusion, `single_source_conversation_id` unit coverage (all-share-one / spans-two / empty), promote_fact payload-tagging (tagged vs. omitted), dedup-scoping pin (reverted the fix locally to confirm the test actually fails without it, then confirmed it passes with the fix)