### PR TITLE
fix(index): throttle full-repo indexing to stop blocking interactive turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(index)`: full-repo indexing at session start could push ordinary interactive tool-calling
+  turns to 200-400+s wall-clock on large workspaces (500-800% CPU), caused by a quadratic
+  `merge_small_chunks` chunker algorithm and unthrottled full-repo batch processing (#5720). The
+  `merge_small_chunks` pass (`crates/zeph-index/src/chunker.rs`) is now O(n) instead of O(n²).
+  The initial full-repo indexing pass now applies a short inter-batch throttle
+  (`initial_pass_batch_delay_ms`, default 75ms) between memory batches to reduce CPU contention
+  with the interactive turn; incremental single-file reindexing (the live file-watcher path) is
+  unaffected. Indexing progress is now surfaced via the existing cross-channel status mechanism
+  (TUI/Telegram/Discord), not just a one-shot CLI message. A new `chunk_semaphore` decouples
+  chunk-dispatch concurrency from `embed_concurrency` for future configurability; at the current
+  shipped defaults (both 2) it has no additional effect beyond the existing `embed_concurrency`
+  gate.
 - `fix(tools,skills)`: `TrustGateExecutor`'s quarantine-denial message for `QUARANTINE_DENIED`
   tools (`invoke_skill`, `load_skill`, `bash`, `write`, etc.) read `"{tool_id} denied
   (trust=quarantined)"`, which misattributed the denial to the specifically-invoked tool/skill

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -67,7 +67,7 @@ fn default_index_max_chunks() -> usize {
 }
 
 fn default_index_concurrency() -> usize {
-    4
+    2
 }
 
 fn default_index_batch_size() -> usize {
@@ -84,6 +84,10 @@ fn default_index_max_file_bytes() -> usize {
 
 fn default_index_embed_concurrency() -> usize {
     2
+}
+
+fn default_initial_pass_batch_delay_ms() -> u64 {
+    75
 }
 
 fn default_index_score_threshold() -> f32 {
@@ -668,9 +672,20 @@ pub struct IndexConfig {
     /// startup. Relative paths are resolved relative to the process working directory.
     #[serde(default)]
     pub workspace_root: Option<std::path::PathBuf>,
-    /// Number of files to process concurrently during initial indexing. Default: 4.
+    /// Bounds concurrent CPU-bound chunk-parse (tree-sitter) dispatches via an internal
+    /// semaphore. Default: 2.
+    ///
+    /// Only reduces concurrency below whatever `embed_concurrency` separately admits into
+    /// flight via `buffer_unordered` in `index_batch` — has no effect when set >=
+    /// `embed_concurrency` (the shipped default for both is 2).
     #[serde(default = "default_index_concurrency")]
     pub concurrency: usize,
+    /// Delay in milliseconds inserted after each memory batch during the *initial* full-repo
+    /// indexing pass only (not applied to incremental single-file reindex via the file
+    /// watcher). Spreads CPU-bound chunk parsing over more wall-clock time so an interactive
+    /// agent turn isn't starved for OS threads on large workspaces. Default: 75.
+    #[serde(default = "default_initial_pass_batch_delay_ms")]
+    pub initial_pass_batch_delay_ms: u64,
     /// Maximum number of new chunks to batch into a single Qdrant upsert per file. Default: 32.
     #[serde(default = "default_index_batch_size")]
     pub batch_size: usize,
@@ -710,6 +725,7 @@ impl Default for IndexConfig {
             mcp_enabled: false,
             workspace_root: None,
             concurrency: default_index_concurrency(),
+            initial_pass_batch_delay_ms: default_initial_pass_batch_delay_ms(),
             batch_size: default_index_batch_size(),
             memory_batch_size: default_index_memory_batch_size(),
             max_file_bytes: default_index_max_file_bytes(),
@@ -1123,8 +1139,9 @@ mod tests {
         assert!(!cfg.enabled);
         assert!(cfg.search_enabled);
         assert!(!cfg.watch);
-        assert_eq!(cfg.concurrency, 4);
+        assert_eq!(cfg.concurrency, 2);
         assert_eq!(cfg.batch_size, 32);
+        assert_eq!(cfg.initial_pass_batch_delay_ms, 75);
         assert!(cfg.workspace_root.is_none());
     }
 
@@ -1164,8 +1181,9 @@ mod tests {
         assert!(cfg.enabled);
         assert_eq!(cfg.max_chunks, 20);
         assert!(cfg.workspace_root.is_none());
-        assert_eq!(cfg.concurrency, 4);
+        assert_eq!(cfg.concurrency, 2);
         assert_eq!(cfg.batch_size, 32);
+        assert_eq!(cfg.initial_pass_batch_delay_ms, 75);
     }
 
     #[test]

--- a/crates/zeph-index/src/chunker.rs
+++ b/crates/zeph-index/src/chunker.rs
@@ -312,33 +312,47 @@ fn extend_scope(parent_scope: &str, node: &Node, source: &str) -> String {
     }
 }
 
+/// Merge adjacent chunks below `min_size` into their left neighbour, in a single forward pass.
+///
+/// Builds a new `Vec` instead of mutating in place: `Vec::remove` on the original approach
+/// shifts every trailing element on each merge, and rescanning `non_ws_len` over the
+/// already-merged, growing string on every iteration made the whole function O(n * merge-run
+/// length) for a file with many small consecutive items. Tracking each accumulator's
+/// non-whitespace length incrementally (simple addition per merge) avoids the rescan; only the
+/// `blake3_hex` recompute remains per-merge, since it must reflect the final merged content.
+#[tracing::instrument(name = "index.chunker.merge_small_chunks", skip_all)]
 fn merge_small_chunks(chunks: &mut Vec<CodeChunk>, config: &ChunkerConfig) {
     if chunks.len() < 2 {
         return;
     }
 
-    let mut i = 0;
-    while i < chunks.len() - 1 {
-        let cur_nws = non_ws_len(&chunks[i].code);
-        let next_nws = non_ws_len(&chunks[i + 1].code);
+    let mut merged: Vec<CodeChunk> = Vec::with_capacity(chunks.len());
+    let mut merged_nws: Vec<usize> = Vec::with_capacity(chunks.len());
 
-        if cur_nws < config.min_size
-            && cur_nws + next_nws <= config.target_size
-            && chunks[i].file_path == chunks[i + 1].file_path
+    for chunk in chunks.drain(..) {
+        let chunk_nws = non_ws_len(&chunk.code);
+
+        if let (Some(last), Some(last_nws)) = (merged.last_mut(), merged_nws.last_mut())
+            && *last_nws < config.min_size
+            && *last_nws + chunk_nws <= config.target_size
+            && last.file_path == chunk.file_path
         {
-            let next = chunks.remove(i + 1);
-            let cur = &mut chunks[i];
-            cur.code.push('\n');
-            cur.code.push_str(&next.code);
-            cur.line_range.1 = next.line_range.1;
-            cur.content_hash = blake3_hex(&cur.code);
-            if cur.entity_name.is_none() {
-                cur.entity_name = next.entity_name;
+            last.code.push('\n');
+            last.code.push_str(&chunk.code);
+            last.line_range.1 = chunk.line_range.1;
+            if last.entity_name.is_none() {
+                last.entity_name = chunk.entity_name;
             }
-        } else {
-            i += 1;
+            last.content_hash = blake3_hex(&last.code);
+            *last_nws += chunk_nws;
+            continue;
         }
+
+        merged_nws.push(chunk_nws);
+        merged.push(chunk);
     }
+
+    *chunks = merged;
 }
 
 #[cfg(test)]
@@ -515,5 +529,66 @@ class Greeter:
 "#;
         let chunks = chunk_file(source, "app.py", Lang::Python, &default_config()).unwrap();
         assert!(!chunks.is_empty());
+    }
+
+    /// Pins `merge_small_chunks`'s output for a long run of small consecutive chunks (the
+    /// pattern that made the old `Vec::remove` + per-iteration `non_ws_len` rescan quadratic,
+    /// common in files with many small `const`/`enum` items). Rather than asserting on timing,
+    /// this checks the correctness contract that must hold before and after the refactor: every
+    /// merged chunk is an exact, ordered, gap-free, newline-joined concatenation of the original
+    /// chunks, and no merged chunk exceeds `target_size`.
+    #[test]
+    fn merge_small_chunks_large_run_partitions_correctly() {
+        let config = ChunkerConfig::default();
+        let n = 60;
+        let originals: Vec<CodeChunk> = (0..n)
+            .map(|i| {
+                let code = format!("const A{i}: i32 = {i};");
+                CodeChunk {
+                    content_hash: blake3_hex(&code),
+                    code,
+                    file_path: "src/consts.rs".to_string(),
+                    language: Lang::Rust,
+                    node_type: "const_item".to_string(),
+                    entity_name: Some(format!("A{i}")),
+                    line_range: (i + 1, i + 1),
+                    scope_chain: String::new(),
+                    imports: String::new(),
+                }
+            })
+            .collect();
+
+        let mut chunks = originals.clone();
+        merge_small_chunks(&mut chunks, &config);
+
+        assert!(
+            chunks.len() < originals.len(),
+            "expected many small items to merge"
+        );
+
+        // Every merged chunk must reconstruct a contiguous, ordered, gap-free subsequence
+        // of `originals`, joined by '\n' exactly as `merge_small_chunks` does.
+        let mut cursor = 0usize;
+        for merged in &chunks {
+            let parts: Vec<&str> = merged.code.split('\n').collect();
+            for part in &parts {
+                assert_eq!(
+                    *part, originals[cursor].code,
+                    "chunk boundary mismatch at original index {cursor}"
+                );
+                cursor += 1;
+            }
+            assert_eq!(
+                merged.line_range.0,
+                originals[cursor - parts.len()].line_range.0
+            );
+            assert_eq!(merged.line_range.1, originals[cursor - 1].line_range.1);
+            assert!(non_ws_len(&merged.code) <= config.target_size);
+        }
+        assert_eq!(
+            cursor,
+            originals.len(),
+            "every original chunk must appear exactly once, in order"
+        );
     }
 }

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 
 use futures::StreamExt as _;
 use tokio::sync::watch;
+use tracing::Instrument as _;
 
 use crate::chunker::{ChunkerConfig, CodeChunk, chunk_file};
 use crate::context::contextualize_for_embedding;
@@ -71,7 +72,12 @@ static CHUNK_TASK_COUNTER: AtomicU64 = AtomicU64::new(0);
 pub struct IndexerConfig {
     /// Chunker configuration controlling chunk size thresholds.
     pub chunker: ChunkerConfig,
-    /// Number of files to process concurrently within each memory batch. Default: 2.
+    /// Bounds concurrent CPU-bound chunk-parse (tree-sitter) dispatches via an internal
+    /// semaphore. Default: 2.
+    ///
+    /// Only reduces concurrency below whatever `embed_concurrency` separately admits into
+    /// flight via `buffer_unordered` in `index_batch` — has no effect when set >=
+    /// `embed_concurrency` (the shipped default for both is 2).
     pub concurrency: usize,
     /// Maximum number of new chunks to upsert per Qdrant call. Default: 16.
     ///
@@ -105,6 +111,14 @@ pub struct IndexerConfig {
     /// [`crate::error::IndexError::EmbedTimeout`] and skips the batch rather than
     /// blocking the indexer indefinitely.
     pub embed_batch_timeout_secs: u64,
+    /// Delay in milliseconds inserted after each memory batch during the *initial*
+    /// full-repo pass ([`CodeIndexer::index_project`]) only. Default: 75.
+    ///
+    /// Not applied to [`CodeIndexer::reindex_file`] (the file-watcher's incremental,
+    /// single-file path), which must stay fast. Spreads CPU-bound chunk parsing over
+    /// more wall-clock time so the OS scheduler has slack to service an interactive
+    /// agent turn instead of round-robining against saturated blocking threads.
+    pub initial_pass_batch_delay_ms: u64,
 }
 
 impl Default for IndexerConfig {
@@ -118,6 +132,7 @@ impl Default for IndexerConfig {
             embed_concurrency: 1,
             embedding_provider: String::new(),
             embed_batch_timeout_secs: 60,
+            initial_pass_batch_delay_ms: 75,
         }
     }
 }
@@ -210,6 +225,10 @@ pub struct CodeIndexer {
     spawner: Option<Arc<dyn BlockingSpawner>>,
     /// Re-entrancy guard: prevents concurrent `index_project` runs on the same indexer.
     indexing: Arc<AtomicBool>,
+    /// Bounds the number of concurrent CPU-bound `chunk_file` dispatches, independent of
+    /// [`IndexerConfig::embed_concurrency`] (which bounds embedding-API call concurrency, not
+    /// parsing). Sized from [`IndexerConfig::concurrency`].
+    chunk_semaphore: Arc<tokio::sync::Semaphore>,
 }
 
 impl CodeIndexer {
@@ -219,12 +238,14 @@ impl CodeIndexer {
     /// the concurrent file-processing tasks.
     #[must_use]
     pub fn new(store: CodeStore, provider: Arc<AnyProvider>, config: IndexerConfig) -> Self {
+        let chunk_semaphore = Arc::new(tokio::sync::Semaphore::new(config.concurrency.max(1)));
         Self {
             store,
             provider,
             config,
             spawner: None,
             indexing: Arc::new(AtomicBool::new(false)),
+            chunk_semaphore,
         }
     }
 
@@ -389,6 +410,7 @@ impl CodeIndexer {
         let provider = Arc::clone(&self.provider);
         let config = self.config.clone();
         let spawner = self.spawner.clone();
+        let chunk_semaphore = Arc::clone(&self.chunk_semaphore);
         let concurrency = self.config.embed_concurrency.max(1);
 
         let file_pairs = make_file_pairs(batch, root);
@@ -399,12 +421,14 @@ impl CodeIndexer {
                 let provider = Arc::clone(&provider);
                 let config = config.clone();
                 let spawner = spawner.clone();
+                let chunk_semaphore = Arc::clone(&chunk_semaphore);
                 async move {
                     let worker = FileIndexWorker {
                         store,
                         provider,
                         config,
                         spawner,
+                        chunk_semaphore,
                     };
                     let result = worker.index_file(&abs_path, &rel_path).await;
                     (rel_path, result)
@@ -445,6 +469,16 @@ impl CodeIndexer {
         // Drop stream to release all in-flight future state before the next batch.
         drop(stream);
         tokio::task::yield_now().await;
+
+        let delay_ms = self.config.initial_pass_batch_delay_ms;
+        if delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms))
+                .instrument(tracing::info_span!(
+                    "index.indexer.batch_throttle",
+                    delay_ms
+                ))
+                .await;
+        }
     }
 
     #[tracing::instrument(name = "index.indexer.cleanup_removed_files", skip_all)]
@@ -485,6 +519,7 @@ impl CodeIndexer {
             provider: Arc::clone(&self.provider),
             config: self.config.clone(),
             spawner: self.spawner.clone(),
+            chunk_semaphore: Arc::clone(&self.chunk_semaphore),
         };
         let (created, _) = worker.index_file(abs_path, &rel_path).await?;
         Ok(created)
@@ -497,6 +532,8 @@ struct FileIndexWorker {
     provider: Arc<AnyProvider>,
     config: IndexerConfig,
     spawner: Option<Arc<dyn BlockingSpawner>>,
+    /// Shared with the parent [`CodeIndexer`]; gates concurrent `chunk_file` dispatches.
+    chunk_semaphore: Arc<tokio::sync::Semaphore>,
 }
 
 impl FileIndexWorker {
@@ -519,37 +556,9 @@ impl FileIndexWorker {
         let source = tokio::fs::read_to_string(abs_path).await?;
         let lang = detect_language(abs_path).ok_or(IndexError::UnsupportedLanguage)?;
 
-        let rel_path_owned = rel_path.to_owned();
-        let chunker_config = self.config.chunker.clone();
-        let chunks = if let Some(ref spawner) = self.spawner {
-            // Route through the supervised spawner so the task appears in registry.
-            // BlockingSpawner::spawn_blocking_named is object-safe (returns JoinHandle<()>),
-            // so we communicate the typed result via a oneshot channel.
-            //
-            // Each spawn gets a unique name to prevent the supervisor's "abort if same
-            // name already exists" logic from silently aborting concurrent in-flight tasks
-            // when embed_concurrency > 1.
-            let task_id = CHUNK_TASK_COUNTER.fetch_add(1, Ordering::Relaxed);
-            let task_name: std::sync::Arc<str> =
-                std::sync::Arc::from(format!("chunk_file_{task_id}").as_str());
-            let (result_tx, result_rx) = tokio::sync::oneshot::channel();
-            let _join = spawner.spawn_blocking_named(
-                task_name,
-                Box::new(move || {
-                    let result = chunk_file(&source, &rel_path_owned, lang, &chunker_config);
-                    let _ = result_tx.send(result);
-                }),
-            );
-            result_rx
-                .await
-                .map_err(|_| IndexError::Other("chunk_file task dropped result".to_owned()))??
-        } else {
-            tokio::task::spawn_blocking(move || {
-                chunk_file(&source, &rel_path_owned, lang, &chunker_config)
-            })
-            .await
-            .map_err(|e| IndexError::Other(format!("chunk_file panicked: {e}")))??
-        };
+        let chunks = self
+            .dispatch_chunk_file(source, rel_path.to_owned(), lang)
+            .await?;
 
         // Batch-check which hashes already exist to avoid N individual queries.
         let all_hashes: Vec<&str> = chunks.iter().map(|c| c.content_hash.as_str()).collect();
@@ -619,6 +628,55 @@ impl FileIndexWorker {
         }
 
         Ok((created, skipped))
+    }
+
+    /// Chunk a single file's source under `chunk_semaphore`, dispatching the CPU-bound
+    /// tree-sitter parse to a blocking thread (supervised when a spawner is attached, otherwise
+    /// bare `spawn_blocking`). The permit is held for the duration of the blocking call and
+    /// released as soon as it returns, before any embedding/storage work begins.
+    async fn dispatch_chunk_file(
+        &self,
+        source: String,
+        rel_path_owned: String,
+        lang: crate::languages::Lang,
+    ) -> Result<Vec<CodeChunk>> {
+        let chunker_config = self.config.chunker.clone();
+        let chunk_permit = self
+            .chunk_semaphore
+            .acquire()
+            .await
+            .map_err(|_| IndexError::Other("chunk_semaphore closed unexpectedly".to_owned()))?;
+        let chunks = if let Some(ref spawner) = self.spawner {
+            // Route through the supervised spawner so the task appears in registry.
+            // BlockingSpawner::spawn_blocking_named is object-safe (returns JoinHandle<()>),
+            // so we communicate the typed result via a oneshot channel.
+            //
+            // Each spawn gets a unique name to prevent the supervisor's "abort if same
+            // name already exists" logic from silently aborting concurrent in-flight tasks
+            // when embed_concurrency > 1.
+            let task_id = CHUNK_TASK_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let task_name: std::sync::Arc<str> =
+                std::sync::Arc::from(format!("chunk_file_{task_id}").as_str());
+            let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+            let _join = spawner.spawn_blocking_named(
+                task_name,
+                Box::new(move || {
+                    let result = chunk_file(&source, &rel_path_owned, lang, &chunker_config);
+                    let _ = result_tx.send(result);
+                }),
+            );
+            result_rx
+                .await
+                .map_err(|_| IndexError::Other("chunk_file task dropped result".to_owned()))??
+        } else {
+            tokio::task::spawn_blocking(move || {
+                chunk_file(&source, &rel_path_owned, lang, &chunker_config)
+            })
+            .await
+            .map_err(|e| IndexError::Other(format!("chunk_file panicked: {e}")))??
+        };
+        drop(chunk_permit);
+        Ok(chunks)
     }
 }
 
@@ -750,6 +808,7 @@ mod tests {
         assert_eq!(config.embed_concurrency, 1);
         assert_eq!(config.embedding_provider, "");
         assert_eq!(config.embed_batch_timeout_secs, 60);
+        assert_eq!(config.initial_pass_batch_delay_ms, 75);
     }
 
     #[test]
@@ -842,6 +901,7 @@ mod tests {
             provider,
             config: IndexerConfig::default(),
             spawner: None,
+            chunk_semaphore: Arc::new(tokio::sync::Semaphore::new(2)),
         };
 
         // First call: all hashes exist → (0, chunk_count).
@@ -903,6 +963,7 @@ mod tests {
             provider,
             config: IndexerConfig::default(),
             spawner: Some(Arc::new(MockBlockingSpawner)),
+            chunk_semaphore: Arc::new(tokio::sync::Semaphore::new(2)),
         };
 
         // With all hashes absent from SQLite the Qdrant upsert would be attempted, but
@@ -1032,6 +1093,7 @@ mod tests {
             provider: Arc::clone(&slow_provider),
             config,
             spawner: None,
+            chunk_semaphore: Arc::new(tokio::sync::Semaphore::new(2)),
         };
         let result = worker.index_file(&rs_path, "slow.rs").await;
 
@@ -1072,6 +1134,302 @@ mod tests {
             flag.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
                 .is_ok(),
             "third caller should succeed after reset"
+        );
+    }
+
+    /// `chunk_semaphore` must never be constructed with zero permits — a `concurrency: 0`
+    /// config would otherwise deadlock every `dispatch_chunk_file` call forever.
+    #[tokio::test]
+    async fn code_indexer_new_clamps_zero_concurrency_to_one_permit() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_memory::QdrantOps;
+
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_string(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap();
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        let store = crate::store::CodeStore::with_ops(ops, pool);
+        let provider = Arc::new(AnyProvider::Mock(
+            MockProvider::default().with_embedding(vec![0.0_f32; 384]),
+        ));
+        let config = IndexerConfig {
+            concurrency: 0,
+            ..IndexerConfig::default()
+        };
+        let indexer = CodeIndexer::new(store, provider, config);
+        assert_eq!(
+            indexer.chunk_semaphore.available_permits(),
+            1,
+            "concurrency: 0 must be clamped to at least 1 permit, not 0 (which would \
+             deadlock every chunk dispatch)"
+        );
+    }
+
+    /// Verify `chunk_semaphore` actually gates concurrent `chunk_file` dispatches: with more
+    /// concurrent callers than permits, a background sampler must observe the semaphore fully
+    /// saturated (`available_permits() == 0`) at some point — proving `acquire()` is really
+    /// exercised and not silently bypassed — and permits must fully return once every dispatch
+    /// completes, proving no permit leak.
+    #[tokio::test]
+    async fn dispatch_chunk_file_gates_concurrency_via_semaphore() {
+        use std::fmt::Write as _;
+        use std::sync::atomic::AtomicUsize;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_memory::QdrantOps;
+
+        const LIMIT: usize = 2;
+        const CALLERS: usize = 6;
+
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_string(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap();
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        let store = crate::store::CodeStore::with_ops(ops, pool);
+        let provider = Arc::new(AnyProvider::Mock(
+            MockProvider::default().with_embedding(vec![0.0_f32; 384]),
+        ));
+
+        let chunk_semaphore = Arc::new(tokio::sync::Semaphore::new(LIMIT));
+
+        // Large enough that tree-sitter parsing takes measurable wall-clock time, widening
+        // the window during which concurrent dispatches can overlap.
+        let mut source = String::new();
+        for i in 0..3000 {
+            let _ = writeln!(source, "const A{i}: i32 = {i};");
+        }
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let min_seen = Arc::new(AtomicUsize::new(LIMIT));
+        let monitor = tokio::spawn({
+            let chunk_semaphore = Arc::clone(&chunk_semaphore);
+            let stop = Arc::clone(&stop);
+            let min_seen = Arc::clone(&min_seen);
+            async move {
+                while !stop.load(Ordering::Relaxed) {
+                    let available = chunk_semaphore.available_permits();
+                    min_seen.fetch_min(available, Ordering::Relaxed);
+                    tokio::time::sleep(Duration::from_micros(200)).await;
+                }
+            }
+        });
+
+        let mut handles = Vec::new();
+        for i in 0..CALLERS {
+            let worker = FileIndexWorker {
+                store: store.clone(),
+                provider: Arc::clone(&provider),
+                config: IndexerConfig::default(),
+                spawner: None,
+                chunk_semaphore: Arc::clone(&chunk_semaphore),
+            };
+            let source = source.clone();
+            handles.push(tokio::spawn(async move {
+                worker
+                    .dispatch_chunk_file(source, format!("f{i}.rs"), crate::languages::Lang::Rust)
+                    .await
+            }));
+        }
+        for h in handles {
+            h.await.unwrap().unwrap();
+        }
+        stop.store(true, Ordering::Relaxed);
+        monitor.await.unwrap();
+
+        assert_eq!(
+            min_seen.load(Ordering::Relaxed),
+            0,
+            "with {CALLERS} concurrent dispatches against {LIMIT} permits, the semaphore \
+             must have been fully saturated at some point — a min > 0 means acquire() is \
+             not actually gating concurrency"
+        );
+        assert_eq!(
+            chunk_semaphore.available_permits(),
+            LIMIT,
+            "all permits must be released once every dispatch completes — no permit leak"
+        );
+    }
+
+    /// Pre-seed `chunk_metadata` with the hashes `chunk_file` will produce for `path`, so
+    /// `existing_hashes` short-circuits `FileIndexWorker::index_file` before any real `Qdrant`
+    /// call — mirrors `index_file_spawn_blocking_dedup_path` above. Returns the chunk count.
+    ///
+    /// Rows are stored under `stored_file_path`, which must differ from the `rel_path` the
+    /// caller will later pass to `reindex_file`/`index_batch`: `existing_hashes` matches by
+    /// content hash alone (file-path-agnostic), but `remove_file_chunks` filters by exact
+    /// `file_path` — using a distinct stored path means `remove_file_chunks(rel_path)` finds no
+    /// rows and returns `Ok(0)` without any real `Qdrant` delete call, while the hash is still
+    /// found by `existing_hashes` to keep the dedup path Qdrant-free end-to-end.
+    async fn preseed_chunk_hashes(
+        pool: &zeph_db::DbPool,
+        path: &Path,
+        rel_path: &str,
+        stored_file_path: &str,
+    ) -> usize {
+        let source = std::fs::read_to_string(path).unwrap();
+        let lang = crate::languages::detect_language(path).unwrap();
+        let chunks =
+            crate::chunker::chunk_file(&source, rel_path, lang, &ChunkerConfig::default()).unwrap();
+        for (i, chunk) in chunks.iter().enumerate() {
+            zeph_db::query(zeph_db::sql!(
+                "INSERT INTO chunk_metadata \
+                 (qdrant_id, file_path, content_hash, line_start, line_end, language, node_type) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?)"
+            ))
+            .bind(format!("preseed{i}"))
+            .bind(stored_file_path)
+            .bind(&chunk.content_hash)
+            .bind(i64::try_from(chunk.line_range.0).unwrap_or(i64::MAX))
+            .bind(i64::try_from(chunk.line_range.1).unwrap_or(i64::MAX))
+            .bind("rust")
+            .bind("function_item")
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+        chunks.len()
+    }
+
+    /// `index_batch` (the loop body driven by `index_project`) must apply
+    /// `initial_pass_batch_delay_ms` after processing each memory batch. Uses
+    /// `tokio::time::pause`/`advance` for deterministic virtual-time control (same technique
+    /// as `ensure_collection_timeout_returns_embed_timeout_error` above). Calls the private
+    /// `index_batch` directly (rather than `index_project`) to avoid `ensure_collection`'s
+    /// real `Qdrant` handshake; hashes are pre-seeded so `index_file` never reaches
+    /// `upsert_chunks_batch` either.
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn index_batch_applies_initial_pass_delay() {
+        use tempfile::TempDir;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_memory::QdrantOps;
+
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("a.rs");
+        std::fs::write(&file_path, "fn a() {}\n").unwrap();
+
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_string(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap();
+        preseed_chunk_hashes(&pool, &file_path, "a.rs", "a.rs").await;
+
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        let store = crate::store::CodeStore::with_ops(ops, pool);
+        let provider = Arc::new(AnyProvider::Mock(
+            MockProvider::default().with_embedding(vec![0.0_f32; 384]),
+        ));
+        let config = IndexerConfig {
+            initial_pass_batch_delay_ms: 200,
+            ..IndexerConfig::default()
+        };
+        let indexer = Arc::new(CodeIndexer::new(store, provider, config));
+
+        let entries: Vec<ignore::DirEntry> = ignore::WalkBuilder::new(dir.path())
+            .hidden(true)
+            .git_ignore(true)
+            .build()
+            .flatten()
+            .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
+            .collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "temp dir must contain exactly one walked file"
+        );
+
+        tokio::time::pause();
+
+        let root = dir.path().to_path_buf();
+        let batch_indexer = Arc::clone(&indexer);
+        let handle = tokio::spawn(async move {
+            let mut files_done = 0usize;
+            let mut report = IndexReport::default();
+            batch_indexer
+                .index_batch(&entries, &root, 1, &mut files_done, &mut report, None)
+                .await;
+            (files_done, report)
+        }); // EXEMPT: test-only mock time
+
+        // Advance just short of the configured delay: the task must still be waiting.
+        tokio::time::advance(Duration::from_millis(199)).await;
+        assert!(
+            !handle.is_finished(),
+            "index_batch must still be waiting on the inter-batch delay"
+        );
+        // Advance past the delay (plus slack) to let it finish.
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let (files_done, report) = handle.await.unwrap();
+        assert_eq!(files_done, 1);
+        assert_eq!(report.files_scanned, 1);
+    }
+
+    /// `reindex_file` (the file-watcher's single-file path) must NOT apply
+    /// `initial_pass_batch_delay_ms` — it must stay fast for live incremental updates. Uses a
+    /// generous configured delay (2 s) against a tight real-wall-clock timeout (300 ms) so a
+    /// regression that accidentally routes this path through the delayed loop fails fast
+    /// instead of hanging the test.
+    #[tokio::test]
+    async fn reindex_file_skips_initial_pass_delay() {
+        use tempfile::TempDir;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_memory::QdrantOps;
+
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("a.rs");
+        std::fs::write(&file_path, "fn a() {}\n").unwrap();
+
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_string(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap();
+        // Stored under a different file_path than "a.rs" so `reindex_file`'s
+        // `remove_file_chunks("a.rs")` call finds no rows and skips its `Qdrant` delete —
+        // `existing_hashes` still matches by content hash alone, keeping the dedup path
+        // `Qdrant`-free end-to-end (see `preseed_chunk_hashes` doc comment).
+        let chunk_count = preseed_chunk_hashes(&pool, &file_path, "a.rs", "other.rs").await;
+
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        let store = crate::store::CodeStore::with_ops(ops, pool);
+        let provider = Arc::new(AnyProvider::Mock(
+            MockProvider::default().with_embedding(vec![0.0_f32; 384]),
+        ));
+        let config = IndexerConfig {
+            initial_pass_batch_delay_ms: 2_000,
+            ..IndexerConfig::default()
+        };
+        let indexer = CodeIndexer::new(store, provider, config);
+
+        let created = tokio::time::timeout(
+            Duration::from_millis(300),
+            indexer.reindex_file(dir.path(), &file_path),
+        )
+        .await
+        .expect(
+            "reindex_file took >= 300ms with a 2s initial_pass_batch_delay_ms configured — \
+             it must not apply the batch delay",
+        )
+        .unwrap();
+        assert_eq!(
+            created, 0,
+            "hash was pre-seeded ({chunk_count} chunks) so no new chunk should be created"
         );
     }
 }

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1279,6 +1279,7 @@ pub(crate) async fn apply_code_indexer(
                 max_file_bytes: config.max_file_bytes,
                 embed_concurrency: config.embed_concurrency,
                 embedding_provider: embedding_provider_name,
+                initial_pass_batch_delay_ms: config.initial_pass_batch_delay_ms,
                 ..IndexerConfig::default()
             },
         );
@@ -1311,6 +1312,7 @@ pub(crate) async fn apply_code_indexer(
                 workspace_root.clone(),
                 progress_tx,
                 cli_mode,
+                status_tx.clone(),
                 supervisor.clone(),
             );
             tracing::info!("code indexer started");
@@ -1362,8 +1364,13 @@ fn spawn_background_indexer(
     root: std::path::PathBuf,
     progress_tx: tokio::sync::watch::Sender<zeph_index::IndexProgress>,
     cli_mode: bool,
+    status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
     supervisor: Option<zeph_common::TaskSupervisor>,
 ) {
+    if let Some(tx) = status_tx {
+        spawn_index_progress_status_forwarder(progress_tx.subscribe(), tx, supervisor.clone());
+    }
+
     let fut = async move {
         match indexer.index_project(&root, Some(&progress_tx)).await {
             Ok(report) => {
@@ -1409,6 +1416,49 @@ fn spawn_background_indexer(
         });
     } else {
         tokio::spawn(fut); // EXEMPT(#5143): no-supervisor fallback for spawn_background_indexer — None branch
+    }
+}
+
+/// Forward `IndexProgress` updates to `status_tx` during the initial full-repo pass, so TUI,
+/// Telegram, and Discord all see the same "Indexing repository…" signal (CLI additionally gets
+/// `spawn_index_progress_printer`'s one-shot eprintln, kept separate for its own convention).
+fn spawn_index_progress_status_forwarder(
+    mut progress_rx: tokio::sync::watch::Receiver<zeph_index::IndexProgress>,
+    status_tx: tokio::sync::mpsc::UnboundedSender<String>,
+    supervisor: Option<zeph_common::TaskSupervisor>,
+) {
+    let fut = async move {
+        while progress_rx.changed().await.is_ok() {
+            let p = progress_rx.borrow_and_update().clone();
+            if p.files_total == 0 {
+                continue;
+            }
+            let _ = status_tx.send(format!(
+                "Indexing repository… ({}/{} files)",
+                p.files_done, p.files_total
+            ));
+            if p.files_done >= p.files_total {
+                let _ = status_tx.send("Indexing complete".to_owned());
+                break;
+            }
+        }
+    };
+    if let Some(sup) = supervisor {
+        let fut_cell = std::sync::Arc::new(parking_lot::Mutex::new(Some(fut)));
+        sup.spawn(zeph_common::TaskDescriptor {
+            name: "index_project_progress",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                let f = fut_cell.lock().take();
+                async move {
+                    if let Some(f) = f {
+                        f.await;
+                    }
+                }
+            },
+        });
+    } else {
+        tokio::spawn(fut); // EXEMPT(#5143): no-supervisor fallback, mirrors spawn_background_indexer's None branch
     }
 }
 
@@ -2524,6 +2574,74 @@ mod tests {
         )
         .await;
         assert!(watcher.is_none()); // watch = false
+    }
+
+    /// `spawn_index_progress_status_forwarder` must forward each `IndexProgress` update as a
+    /// human-readable status string, then send a completion message once `files_done` reaches
+    /// `files_total` and stop — the next real status message (e.g. from the file watcher)
+    /// overwrites it naturally, matching `IndexWatcher`'s own convention. This is the mechanism
+    /// that closes the "no status visibility during the initial index pass" gap (#5720 item D)
+    /// for TUI/Telegram/Discord — previously only the CLI got a one-shot `eprintln!`.
+    #[tokio::test]
+    async fn spawn_index_progress_status_forwarder_forwards_progress_and_completes() {
+        let (progress_tx, _keepalive) =
+            tokio::sync::watch::channel(zeph_index::IndexProgress::default());
+        let (status_tx, mut status_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+        spawn_index_progress_status_forwarder(progress_tx.subscribe(), status_tx, None);
+
+        progress_tx
+            .send(zeph_index::IndexProgress {
+                files_done: 1,
+                files_total: 2,
+                chunks_created: 3,
+            })
+            .unwrap();
+        assert_eq!(
+            status_rx.recv().await.unwrap(),
+            "Indexing repository… (1/2 files)"
+        );
+
+        progress_tx
+            .send(zeph_index::IndexProgress {
+                files_done: 2,
+                files_total: 2,
+                chunks_created: 5,
+            })
+            .unwrap();
+        assert_eq!(
+            status_rx.recv().await.unwrap(),
+            "Indexing repository… (2/2 files)"
+        );
+        assert_eq!(status_rx.recv().await.unwrap(), "Indexing complete");
+
+        // The forwarder stops after sending the completion message — no further sends,
+        // and the channel closes once the forwarder task exits.
+        assert!(status_rx.recv().await.is_none());
+    }
+
+    /// A zero-file project (`files_total == 0`) never sends any `IndexProgress` update from
+    /// `index_project`'s batch loop (the `entries.chunks(..)` iterator is empty). In
+    /// `spawn_background_indexer`, `progress_tx` is owned by the `fut` async block and is
+    /// dropped once `index_project` returns and that block's scope ends — even having sent
+    /// zero updates. This test reproduces that by dropping `progress_tx` directly: the
+    /// forwarder's `progress_rx.changed()` must observe the closed channel and exit its loop
+    /// cleanly, without hanging forever and without emitting a spurious completion/clear
+    /// message for a project that had nothing to index.
+    #[tokio::test]
+    async fn spawn_index_progress_status_forwarder_exits_cleanly_for_zero_file_project() {
+        let (progress_tx, _keepalive) =
+            tokio::sync::watch::channel(zeph_index::IndexProgress::default());
+        let (status_tx, mut status_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+        spawn_index_progress_status_forwarder(progress_tx.subscribe(), status_tx, None);
+        drop(progress_tx); // closes the watch channel, as if index_project finished with no updates
+
+        assert!(
+            status_rx.recv().await.is_none(),
+            "with zero updates ever sent, the forwarder must exit on channel closure without \
+             emitting any status message"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Full-repo indexing at session start could push ordinary interactive tool-calling turns to 200-400+s wall-clock on large workspaces (~30+ crates), with the `zeph` process sustaining 500-800% CPU for several minutes. Root cause: a quadratic `merge_small_chunks` chunker algorithm plus unthrottled full-repo batch processing, with zero status visibility into what was actually happening.

- Rewrite `merge_small_chunks` (`crates/zeph-index/src/chunker.rs`) from O(n²) (`Vec::remove` + full rescans) to a single O(n) forward pass with an incrementally tracked non-whitespace length. This is the dominant fix — an isolated microbenchmark measured 29x faster at n=16000 for the pathological long-run-of-small-chunks case that a 30-crate Rust workspace triggers routinely.
- Throttle the initial full-repo index pass with a short inter-batch delay (`initial_pass_batch_delay_ms`, default 75ms) after the existing yield point. Incremental single-file reindexing via the live file watcher (`reindex_file`) is untouched and stays fast.
- Surface indexing progress through the existing cross-channel status mechanism (TUI/Telegram/Discord `status_tx`) instead of a one-shot CLI-only message, so the delay is attributed correctly instead of showing generic "thinking…"/"compacting context…".
- Add a `chunk_semaphore` that decouples chunk-dispatch concurrency from `embed_concurrency` for future configurability. At the currently shipped defaults (both 2) this has no additional effect beyond the existing `embed_concurrency` gate — documented honestly as such in code comments and the CHANGELOG rather than overclaiming.

## Process notes

Built via the team-develop performance chain (profile → implement → verify/tests/critique in parallel → review → fix → re-review). The adversarial critique caught that the semaphore (as initially scoped) doesn't change behavior at default config since `embed_concurrency`'s existing `buffer_unordered` gate already bounds the same fan-out; rewiring that gate was judged out of scope for this latency bugfix (chunk+embed aren't staged separately in the per-file future, so swapping the gating variable would have unintended side effects on `embed_concurrency`'s documented rate-limit-safety role). Resolved by keeping the semaphore as a decoupled, currently-inert addition and documenting the trade-off precisely, rather than expanding scope.

Closes #5720

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12183/12183 passed
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-index -p zeph-config` — 747/747 passed, including 6 new tests (semaphore concurrency bound, throttle scoping to the initial pass only, status-forwarder coverage incl. a zero-file edge case, and a chunker correctness test pinning `merge_small_chunks`'s output shape for a 60-item large run)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean, only pre-existing unrelated warnings in zeph-bench/zeph-channels/zeph-tui
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all passed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] `.local/testing/playbooks/index.md` — added Scenario 7 for this fix
- [x] `.local/testing/coverage-status.md` — added row, status `Partial`
- [ ] Live `--no-bare` end-to-end session reproducing the original 200-400s repro directly was not re-run in this fix cycle (judged impractical/risky mid-fix in a shared uncommitted worktree). Verification relied on an isolated microbenchmark of the algorithmic fix plus code-inspection of the throttle/semaphore scoping. **Follow-up**: a live session should confirm the end-to-end wall-clock improvement before closing this out as fully `Tested` in coverage-status.md.