### PR TITLE
fix(core,tools,tui): detect MCP tool origin via ToolDef.is_mcp_tool, not name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `calls.len() == tool_calls.len()` is now an unconditional invariant; tafc-stripped positions are
   tracked separately and folded into the existing `pre_exec_blocked` mechanism, which already
   returns a synthetic skip result without dispatching, instead of dropping the entry.
+- `fix(core)`: `ShadowSentinel::classify_tool` (`crates/zeph-core/src/agent/shadow_sentinel.rs`)
+  escalated MCP write/edit tools to `ToolRiskCategory::ExfilCapable` by checking
+  `qualified_tool_id.starts_with("mcp:")` — real MCP tool ids are `"{server_id}_{name}"`
+  (`McpTool::sanitized_id`) and never carry that prefix, so the check silently never matched and
+  MCP write/edit tools were classified as the weaker `FileWrite` category instead (#5736).
+  `ShadowSentinel` now keeps its own registered-MCP-tool-id set (mirroring
+  `TrustGateExecutor::mcp_tool_ids`), exposed via `mcp_tool_ids_handle()`, populated at startup
+  in `src/runner.rs` from the same `mcp_tools` list used for `TrustGateExecutor`, and refreshed
+  on every subsequent tool-list change: `Agent::refresh_shadow_sentinel_mcp_tool_ids`
+  (`crates/zeph-core/src/agent/mcp.rs`) runs from `check_tool_refresh` whenever `/mcp add`/
+  `/mcp remove` or a live `tools/list_changed` notification updates the tool list, so a server
+  connected mid-session is picked up without a process restart. **Known gap**:
+  `TrustGateExecutor`'s own equivalent set has no such refresh path — it lives entirely inside
+  the binary crate's tool-executor chain (`src/agent_setup.rs`), unreachable from `zeph-core`'s
+  `Agent` without new cross-crate plumbing, so a Quarantined skill can still reach a
+  dynamically-connected MCP server's tools via the weakest-link Quarantine-deny check; filed as
+  a separate, higher-priority follow-up (#5747) since that gap is a security-enforcement bypass,
+  not just a defense-in-depth classification miss like `ShadowSentinel`'s (which
+  `PolicyGateExecutor`/`TrajectorySentinel` continue to back up regardless).
+- `fix(tools)`: `is_cacheable` (`crates/zeph-tools/src/cache.rs`) checked
+  `tool_name.starts_with("mcp_")` to exclude MCP tool results from caching — real MCP tool ids
+  are `"{server_id}_{name}"` and never carry that prefix, so the check silently never matched
+  and MCP tool results WERE being cached, the opposite of the function's documented intent
+  (#5733). `is_cacheable` now takes an explicit `is_mcp: bool` parameter that callers resolve via
+  `ToolDef::is_mcp_tool()`. `ToolDispatchContext` (`crates/zeph-core/src/agent/tool_execution/
+  mod.rs`) gained an `mcp_tool_ids` field, resolved once per dispatch batch in
+  `prepare_tool_dispatch` and threaded through `run_tier_execution_loop` into both call sites
+  (`prepare_tool_dispatch`'s cache-lookup gate and `apply_tier_results`'s cache-store gate) so
+  they share one tool-registry scan per batch instead of each re-scanning
+  `tool_definitions_erased()` independently.
+- `fix(tui)`: `ToolKind::classify` (`crates/zeph-tui/src/widgets/tool_view.rs`) checked
+  `tool_name.starts_with("mcp__")` to group MCP tools under a distinct icon in the TUI — real
+  MCP tool ids never carry that (or any) reliable prefix, so MCP tools were never classified as
+  `ToolKind::Mcp`. `classify` now takes an explicit `is_mcp: bool` parameter instead of guessing
+  from the name, closing the dead-heuristic part of #5734. **Partial fix**: `chat.rs`'s two call
+  sites still pass `false` unconditionally, since `ChatMessage` does not yet carry MCP-origin
+  metadata from the agent event stream — so `ToolKind::Mcp` is still never actually produced in
+  the running TUI today. Threading real data through would require adding an `is_mcp` field to
+  `ToolStartEvent`/`ToolOutputEvent` (`crates/zeph-core/src/channel.rs`), which is shared by
+  every channel implementation (CLI, Telegram, Discord, Slack, ACP, TUI) — filed as a follow-up
+  (#5743) rather than bundled into this fix, which only corrects the classification logic itself
+  and its test coverage.
 - `fix(core)`: `Agent::build_experiment_engine` (`crates/zeph-core/src/agent/experiment_cmd.rs`)
   read the configured benchmark TOML synchronously via `BenchmarkSet::from_file`, which performs
   blocking filesystem I/O (`std::fs::canonicalize` x2, `std::fs::metadata`, `std::fs::

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,7 +223,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   dynamically-connected MCP server's tools via the weakest-link Quarantine-deny check; filed as
   a separate, higher-priority follow-up (#5747) since that gap is a security-enforcement bypass,
   not just a defense-in-depth classification miss like `ShadowSentinel`'s (which
-  `PolicyGateExecutor`/`TrajectorySentinel` continue to back up regardless).
+  `PolicyGateExecutor`/`TrajectorySentinel` continue to back up regardless). **Follow-up**: a live
+  verification session found the `is_mcp_tool()` fix above was necessary but not sufficient —
+  `default_shadow_probe_patterns()` (`crates/zeph-config/src/security.rs`) shipped
+  `"mcp:*/file_*"`/`"mcp:*/exec_*"`, glob patterns that assumed the same wrong
+  `"mcp:"`-prefixed id shape the original bug assumed. Since real MCP tool ids never carry that
+  prefix, the outer glob-matching loop in `classify_tool` never matched any real MCP tool id at
+  all under the shipped default config, so every MCP tool (write/edit/exec included) fell through
+  to `ToolRiskCategory::Low` and the safety probe was skipped entirely — a complete bypass, not
+  just a downgrade to `FileWrite` as originally described. Replaced the two `mcp:`-prefixed
+  patterns with substring patterns (`"*write*"`, `"*edit*"`, `"*delete*"`, `"*exec*"`) that match
+  the real `"{server_id}_{name}"` id shape regardless of origin; scoped to write/edit/delete/exec
+  keywords (not a bare `"*file*"`) so pure-read tools like `fs-test_read_file` are not swept in.
+  `classify_tool`'s pattern-based categorization was also extended to treat a `"delete"` substring
+  the same as `"write"`/`"edit"` (escalating to `FileWrite`/`ExfilCapable` rather than falling to
+  the catch-all `ExfilCapable` branch regardless of MCP origin).
 - `fix(tools)`: `is_cacheable` (`crates/zeph-tools/src/cache.rs`) checked
   `tool_name.starts_with("mcp_")` to exclude MCP tool results from caching — real MCP tool ids
   are `"{server_id}_{name}"` and never carry that prefix, so the check silently never matched

--- a/crates/zeph-config/src/security.rs
+++ b/crates/zeph-config/src/security.rs
@@ -326,8 +326,15 @@ fn default_shadow_probe_patterns() -> Vec<String> {
         "builtin:shell".to_owned(),
         "builtin:write".to_owned(),
         "builtin:edit".to_owned(),
-        "mcp:*/file_*".to_owned(),
-        "mcp:*/exec_*".to_owned(),
+        // Substring patterns (not `mcp:`-prefixed): real MCP tool ids are
+        // `"{server_id}_{name}"` and never carry a `mcp:` prefix or `/` separator, so a
+        // prefix/segment-based glob can never match them. Scoped to write/edit/delete/exec
+        // keywords (not a bare `*file*`) so pure-read tools like `fs-test_read_file` are not
+        // swept in.
+        "*write*".to_owned(),
+        "*edit*".to_owned(),
+        "*delete*".to_owned(),
+        "*exec*".to_owned(),
     ]
 }
 
@@ -368,7 +375,9 @@ pub struct ShadowSentinelConfig {
     pub max_probes_per_turn: usize,
     /// Glob patterns over fully-qualified tool ids that trigger the safety probe.
     ///
-    /// Default covers shell execution, file writes, and MCP file/exec tools.
+    /// Default covers shell execution and write/edit/delete/exec-capable tools, matched by
+    /// substring on the tool id so both builtin ids (`builtin:write`) and real MCP tool ids
+    /// (`"{server_id}_{name}"`, e.g. `fs-test_write_file` — never `mcp:`-prefixed) are caught.
     #[serde(default = "default_shadow_probe_patterns")]
     pub probe_patterns: Vec<String>,
     /// When `true`, a probe timeout or LLM error causes the tool call to be denied.

--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -274,6 +274,7 @@ impl<C: Channel> Agent<C> {
             self.services.mcp.pending_semantic_rebuild = false;
             self.rebuild_semantic_index().await;
             self.sync_mcp_registry().await;
+            self.refresh_shadow_sentinel_mcp_tool_ids();
             let mcp_total = self.services.mcp.tools.len();
             let mcp_servers = self
                 .services
@@ -310,6 +311,7 @@ impl<C: Channel> Agent<C> {
         self.services.mcp.pruning_cache.reset();
         self.rebuild_semantic_index().await;
         self.sync_mcp_registry().await;
+        self.refresh_shadow_sentinel_mcp_tool_ids();
         let mcp_total = self.services.mcp.tools.len();
         let mcp_servers = self
             .services
@@ -323,6 +325,29 @@ impl<C: Channel> Agent<C> {
             m.mcp_tool_count = mcp_total;
             m.mcp_server_count = mcp_servers;
         });
+    }
+
+    /// Refreshes `ShadowSentinel`'s registered-MCP-tool-id set from the current
+    /// `services.mcp.tools` list, so a server connected after startup (via `/mcp add` or a live
+    /// `tools/list_changed` notification) is reflected without waiting for a process restart.
+    ///
+    /// Only covers `ShadowSentinel` — `TrustGateExecutor`'s own equivalent set
+    /// (`zeph_tools::TrustGateExecutor::mcp_tool_ids`) has the same startup-only limitation but
+    /// lives entirely inside the binary crate's tool-executor chain, unreachable from here
+    /// without new cross-crate plumbing; tracked as a separate follow-up (#5747), not fixed by
+    /// this call.
+    fn refresh_shadow_sentinel_mcp_tool_ids(&self) {
+        let Some(ref sentinel) = self.services.security.shadow_sentinel else {
+            return;
+        };
+        let ids: std::collections::HashSet<String> = self
+            .services
+            .mcp
+            .tools
+            .iter()
+            .map(zeph_mcp::McpTool::sanitized_id)
+            .collect();
+        *sentinel.mcp_tool_ids_handle().write() = ids;
     }
 
     pub(super) async fn sync_mcp_registry(&mut self) {
@@ -940,6 +965,73 @@ mod tests {
         agent.check_tool_refresh().await;
         assert_eq!(agent.services.mcp.tool_count(), 1);
         assert_eq!(agent.services.mcp.tools[0].name, "refreshed_tool");
+    }
+
+    /// #5736 follow-up (S1): a server connected after startup via a `tools/list_changed`
+    /// notification must be reflected in `ShadowSentinel`'s registered-MCP-tool-id set, not just
+    /// `services.mcp.tools` — otherwise the escalation fix in `classify_tool` stays blind to any
+    /// MCP tool the agent didn't already know about at process start.
+    #[tokio::test]
+    async fn check_tool_refresh_updates_shadow_sentinel_mcp_tool_ids() {
+        use crate::agent::shadow_sentinel::{
+            ProbeVerdict, SafetyProbe, ShadowEventStore, ShadowSentinel,
+        };
+
+        struct NoopProbe;
+        impl SafetyProbe for NoopProbe {
+            fn evaluate<'a>(
+                &'a self,
+                _: &'a str,
+                _: &'a serde_json::Value,
+                _: &'a [crate::agent::shadow_sentinel::SentinelEvent],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>
+            {
+                Box::pin(async { ProbeVerdict::Allow })
+            }
+        }
+
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .expect("connect + migrate in-memory sqlite pool");
+        let store = ShadowEventStore::new(pool);
+        let sentinel = std::sync::Arc::new(ShadowSentinel::new(
+            store,
+            Box::new(NoopProbe),
+            zeph_config::ShadowSentinelConfig::default(),
+            "test-session",
+        ));
+        agent.services.security.shadow_sentinel = Some(std::sync::Arc::clone(&sentinel));
+
+        let (tx, rx) = tokio::sync::watch::channel(Vec::<zeph_mcp::McpTool>::new());
+        agent.services.mcp.tool_rx = Some(rx);
+
+        let new_tool = zeph_mcp::McpTool {
+            server_id: "srv".into(),
+            name: "refreshed_tool".into(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+            output_schema: None,
+            security_meta: zeph_config::mcp_security::ToolSecurityMeta::default(),
+        };
+        let expected_id = new_tool.sanitized_id();
+        tx.send(vec![new_tool]).unwrap();
+
+        agent.check_tool_refresh().await;
+
+        assert!(
+            sentinel.mcp_tool_ids_handle().read().contains(&expected_id),
+            "ShadowSentinel's mcp_tool_ids must be refreshed after a tools/list_changed event"
+        );
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -29,6 +29,8 @@
 //! Exposing internal risk scores to the LLM would allow prompt injection attacks that
 //! manipulate probe verdicts by crafting tool outputs to lower the perceived risk level.
 
+use parking_lot::RwLock;
+use std::collections::HashSet;
 use std::sync::{
     Arc,
     atomic::{AtomicU32, Ordering},
@@ -481,6 +483,27 @@ pub struct ShadowSentinel {
     /// Bounded set of fire-and-forget DB persist tasks. Prevents unbounded task accumulation
     /// and ensures panics surface at `drain_pending()` instead of being silently swallowed.
     pending_writes: Mutex<JoinSet<()>>,
+    /// Sanitized ids (`ToolDef::server_id`-backed) of tools registered by MCP servers.
+    ///
+    /// Mirrors `TrustGateExecutor::mcp_tool_ids` (`zeph_tools::TrustGateExecutor`): empty until
+    /// populated post-construction via [`mcp_tool_ids_handle`](Self::mcp_tool_ids_handle). This
+    /// is the authoritative way to know a `qualified_tool_id` originates from an MCP server —
+    /// real ids are `{server_id}_{name}` (`McpTool::sanitized_id`) and carry no reliable string
+    /// prefix to pattern-match on (#5736).
+    ///
+    /// # Refresh
+    ///
+    /// Populated at startup from the initial `mcp_tools` list (`src/runner.rs`) and refreshed
+    /// on every subsequent tool-list change — `/mcp add`/`/mcp remove` and a live
+    /// `tools/list_changed` notification both route through
+    /// `Agent::refresh_shadow_sentinel_mcp_tool_ids` (`crates/zeph-core/src/agent/mcp.rs`,
+    /// called from `check_tool_refresh` once per turn) — so a server connected mid-session is
+    /// reflected without a process restart.
+    ///
+    /// **Known gap**: `TrustGateExecutor`'s own equivalent set has no such refresh path (it
+    /// lives entirely in the binary crate's tool-executor chain, unreachable from `Agent`) —
+    /// tracked separately (#5747), not fixed by this refresh.
+    mcp_tool_ids: Arc<RwLock<HashSet<String>>>,
 }
 
 impl ShadowSentinel {
@@ -506,7 +529,20 @@ impl ShadowSentinel {
             probes_this_turn: AtomicU32::new(0),
             session_id: session_id.into(),
             pending_writes: Mutex::new(JoinSet::new()),
+            mcp_tool_ids: Arc::new(RwLock::new(HashSet::new())),
         }
+    }
+
+    /// Returns the shared MCP tool-id set so the caller can populate it once MCP servers have
+    /// connected (mirrors `TrustGateExecutor::mcp_tool_ids_handle`).
+    #[must_use]
+    pub fn mcp_tool_ids_handle(&self) -> Arc<RwLock<HashSet<String>>> {
+        Arc::clone(&self.mcp_tool_ids)
+    }
+
+    /// Returns `true` when `tool_id` was registered by an MCP server.
+    fn is_mcp_tool(&self, tool_id: &str) -> bool {
+        self.mcp_tool_ids.read().contains(tool_id)
     }
 
     /// Classify a fully-qualified tool id into a risk tier.
@@ -545,7 +581,7 @@ impl ShadowSentinel {
                 }
                 if pattern.contains("write") || pattern.contains("edit") || pattern.contains("file")
                 {
-                    if qualified_tool_id.starts_with("mcp:") {
+                    if self.is_mcp_tool(qualified_tool_id) {
                         return ToolRiskCategory::ExfilCapable;
                     }
                     return ToolRiskCategory::FileWrite;
@@ -893,6 +929,34 @@ mod tests {
         assert_eq!(
             sentinel.classify_tool("delete"),
             ToolRiskCategory::FileWrite
+        );
+    }
+
+    /// #5736 regression: MCP-tool escalation must key off the registered `mcp_tool_ids` set
+    /// (`ToolDef::server_id`-backed), not a `"mcp:"` string prefix — real MCP tool ids are
+    /// `"{server_id}_{name}"` (`McpTool::sanitized_id`) and never carry that prefix, so the old
+    /// check silently never escalated any MCP write/edit tool to `ExfilCapable`.
+    #[tokio::test]
+    async fn classify_mcp_tool_write_pattern_escalates_to_exfil_capable() {
+        let config = zeph_config::ShadowSentinelConfig {
+            probe_patterns: vec!["*edit*".to_owned()],
+            ..zeph_config::ShadowSentinelConfig::default()
+        };
+        let sentinel = make_test_sentinel(config).await;
+        // Unregistered: a same-shaped id falls to the ordinary FileWrite tier, not ExfilCapable.
+        assert_eq!(
+            sentinel.classify_tool("github_edit_file"),
+            ToolRiskCategory::FileWrite
+        );
+        // Register it the same way the real MCP wiring does (via the shared handle) and the
+        // identical id must now escalate.
+        sentinel
+            .mcp_tool_ids_handle()
+            .write()
+            .insert("github_edit_file".to_owned());
+        assert_eq!(
+            sentinel.classify_tool("github_edit_file"),
+            ToolRiskCategory::ExfilCapable
         );
     }
 

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -579,7 +579,10 @@ impl ShadowSentinel {
                 if pattern.contains("shell") || pattern.contains("exec") {
                     return ToolRiskCategory::Shell;
                 }
-                if pattern.contains("write") || pattern.contains("edit") || pattern.contains("file")
+                if pattern.contains("write")
+                    || pattern.contains("edit")
+                    || pattern.contains("delete")
+                    || pattern.contains("file")
                 {
                     if self.is_mcp_tool(qualified_tool_id) {
                         return ToolRiskCategory::ExfilCapable;
@@ -956,6 +959,28 @@ mod tests {
             .insert("github_edit_file".to_owned());
         assert_eq!(
             sentinel.classify_tool("github_edit_file"),
+            ToolRiskCategory::ExfilCapable
+        );
+    }
+
+    /// #5736 follow-up (CI-1239): `ShadowSentinelConfig::default()` — not a hand-tuned override —
+    /// must escalate a real MCP write tool. Real MCP tool ids are `"{server_id}_{name}"`
+    /// (`McpTool::sanitized_id`), e.g. `"fs-test_write_file"`; the shipped default
+    /// `probe_patterns` (`"mcp:*/file_*"`, `"mcp:*/exec_*"`) assumed a `"mcp:"`-prefixed id
+    /// shape that no real id ever has, so the outer glob-matching loop in `classify_tool` never
+    /// even entered the branch containing the `is_mcp_tool()` check — every MCP tool silently
+    /// fell through to `ToolRiskCategory::Low` (probe skipped entirely), a complete bypass, not
+    /// just a downgrade to `FileWrite`.
+    #[tokio::test]
+    async fn classify_mcp_tool_write_under_default_config_escalates_to_exfil_capable() {
+        let config = zeph_config::ShadowSentinelConfig::default();
+        let sentinel = make_test_sentinel(config).await;
+        sentinel
+            .mcp_tool_ids_handle()
+            .write()
+            .insert("fs-test_write_file".to_owned());
+        assert_eq!(
+            sentinel.classify_tool("fs-test_write_file"),
             ToolRiskCategory::ExfilCapable
         );
     }

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -50,6 +50,11 @@ struct ToolDispatchContext {
     args_hashes: Vec<u64>,
     repeat_blocked: Vec<bool>,
     cache_hits: Vec<Option<zeph_tools::ToolOutput>>,
+    /// Sanitized ids (`ToolDef::server_id`-backed) of tools registered by MCP servers, resolved
+    /// once per dispatch batch from the tool registry. Reused by both the cache-lookup gate
+    /// (`is_cacheable`) and the cache-store gate later in `apply_tier_results`, so the tier
+    /// loop never re-scans the registry per call or per tier (#5733 follow-up, M1).
+    mcp_tool_ids: std::collections::HashSet<String>,
     /// MAGE trajectory risk gate (spec 004-16 FR-005).
     ///
     /// When `Some((score, top_signals))`, all tool calls in this batch are blocked with

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -720,6 +720,7 @@ impl<C: Channel> Agent<C> {
             args_hashes,
             repeat_blocked,
             cache_hits,
+            mcp_tool_ids,
             mage_blocked,
             mut early_stop_hints,
             window_exhausted,
@@ -762,6 +763,7 @@ impl<C: Channel> Agent<C> {
                 &args_hashes,
                 &repeat_blocked,
                 &cache_hits,
+                &mcp_tool_ids,
                 max_parallel,
                 &cancel,
                 &tool_call_ids,
@@ -1016,13 +1018,32 @@ impl<C: Channel> Agent<C> {
                 .push_tool_call(call.tool_id.as_str(), hash);
         }
 
+        // Resolved once per dispatch batch and threaded through `ToolDispatchContext` so both
+        // the cache-lookup gate below and the cache-store gate later in `apply_tier_results`
+        // share one registry scan instead of each re-scanning `tool_definitions_erased()`
+        // per call/per tier (#5733 follow-up, M1). Also sidesteps a borrow-checker conflict:
+        // capturing a whole-`self` method inside the closure below would conflict with that
+        // closure's existing `&mut self.tool_orchestrator` borrow.
+        let mcp_tool_ids: std::collections::HashSet<String> = self
+            .tool_executor
+            .tool_definitions_erased()
+            .into_iter()
+            .filter(zeph_tools::registry::ToolDef::is_mcp_tool)
+            .map(|d| d.id.into_owned())
+            .collect();
+
         // Cache lookup: hits pre-built before dispatch; cache store happens after join_all.
         let cache_hits: Vec<Option<zeph_tools::ToolOutput>> = calls
             .iter()
             .zip(args_hashes.iter())
             .zip(repeat_blocked.iter())
             .map(|((call, &hash), &blocked)| {
-                if blocked || !zeph_tools::is_cacheable(call.tool_id.as_str()) {
+                if blocked
+                    || !zeph_tools::is_cacheable(
+                        call.tool_id.as_str(),
+                        mcp_tool_ids.contains(call.tool_id.as_str()),
+                    )
+                {
                     return None;
                 }
                 let key = zeph_tools::CacheKey::new(call.tool_id.as_str(), hash);
@@ -1047,6 +1068,7 @@ impl<C: Channel> Agent<C> {
             args_hashes,
             repeat_blocked,
             cache_hits,
+            mcp_tool_ids,
             mage_blocked,
             early_stop_hints,
             window_exhausted,
@@ -1165,6 +1187,7 @@ impl<C: Channel> Agent<C> {
         args_hashes: &[u64],
         repeat_blocked: &[bool],
         cache_hits: &[Option<zeph_tools::ToolOutput>],
+        mcp_tool_ids: &std::collections::HashSet<String>,
         max_parallel: usize,
         cancel: &tokio_util::sync::CancellationToken,
         tool_call_ids: &[String],
@@ -1294,6 +1317,7 @@ impl<C: Channel> Agent<C> {
                 tool_calls,
                 calls,
                 cache_hits,
+                mcp_tool_ids,
                 args_hashes,
                 tool_started_ats,
                 &mut failed_ids,
@@ -2058,6 +2082,7 @@ impl<C: Channel> Agent<C> {
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
         calls: &[ToolCall],
         cache_hits: &[Option<zeph_tools::ToolOutput>],
+        mcp_tool_ids: &std::collections::HashSet<String>,
         args_hashes: &[u64],
         tool_started_ats: &[std::time::Instant],
         failed_ids: &mut std::collections::HashSet<String>,
@@ -2082,7 +2107,10 @@ impl<C: Channel> Agent<C> {
             // tool, silently reintroducing the exact stall the mandated-retry bypass fixes.
             if !is_failed
                 && cache_hits[idx].is_none()
-                && zeph_tools::is_cacheable(tool_calls[idx].name.as_str())
+                && zeph_tools::is_cacheable(
+                    tool_calls[idx].name.as_str(),
+                    mcp_tool_ids.contains(tool_calls[idx].name.as_str()),
+                )
                 && let Ok(Some(ref out)) = result
                 && !out.summary.starts_with("[skipped]")
                 && !out.summary.starts_with("[stopped]")

--- a/crates/zeph-tools/src/cache.rs
+++ b/crates/zeph-tools/src/cache.rs
@@ -12,8 +12,9 @@ use crate::executor::ToolOutput;
 /// Tools that must never have their results cached due to side effects.
 ///
 /// Any tool with side effects (writes, state mutations, external actions) MUST be listed here.
-/// MCP tools (`mcp_` prefix) are non-cacheable by default — they are third-party and opaque.
-/// `memory_search` is excluded to avoid stale results after `memory_save` calls.
+/// MCP-origin tools are non-cacheable by default — they are third-party and opaque — see
+/// `is_cacheable`'s `is_mcp` parameter. `memory_search` is excluded to avoid stale results
+/// after `memory_save` calls.
 static NON_CACHEABLE_TOOLS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     HashSet::from([
         "bash",          // shell commands have side effects and depend on mutable state
@@ -26,11 +27,15 @@ static NON_CACHEABLE_TOOLS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
 
 /// Returns `true` if the tool's results can be safely cached.
 ///
-/// MCP tools (identified by `mcp_` prefix) are always non-cacheable by default
-/// since they are third-party and may have unknown side effects.
+/// `is_mcp` must be resolved by the caller via
+/// [`ToolDef::is_mcp_tool`](crate::registry::ToolDef::is_mcp_tool) (`server_id.is_some()`).
+/// Real MCP tool ids are `{server_id}_{name}` (`McpTool::sanitized_id`) and carry no reliable
+/// string prefix to pattern-match on here (#5712, #5733), so this function cannot infer MCP
+/// origin from `tool_name` alone. MCP-origin tools are always non-cacheable by default since
+/// they are third-party and may have unknown side effects.
 #[must_use]
-pub fn is_cacheable(tool_name: &str) -> bool {
-    if tool_name.starts_with("mcp_") {
+pub fn is_cacheable(tool_name: &str, is_mcp: bool) -> bool {
+    if is_mcp {
         return false;
     }
     !NON_CACHEABLE_TOOLS.contains(tool_name)
@@ -327,27 +332,32 @@ mod tests {
 
     #[test]
     fn is_cacheable_returns_false_for_deny_list() {
-        assert!(!is_cacheable("bash"));
-        assert!(!is_cacheable("memory_save"));
-        assert!(!is_cacheable("memory_search"));
-        assert!(!is_cacheable("scheduler"));
-        assert!(!is_cacheable("write"));
+        assert!(!is_cacheable("bash", false));
+        assert!(!is_cacheable("memory_save", false));
+        assert!(!is_cacheable("memory_search", false));
+        assert!(!is_cacheable("scheduler", false));
+        assert!(!is_cacheable("write", false));
     }
 
+    /// #5733 regression: MCP origin must be resolved by the caller (`ToolDef::is_mcp_tool`),
+    /// not inferred from a `"mcp_"` string prefix — real MCP tool ids are `{server_id}_{name}`
+    /// (`McpTool::sanitized_id`) and never carry that prefix, so the old check silently never
+    /// matched and MCP results WERE being cached, the opposite of the intended behavior.
     #[test]
-    fn is_cacheable_returns_false_for_mcp_prefix() {
-        assert!(!is_cacheable("mcp_github_list_issues"));
-        assert!(!is_cacheable("mcp_send_email"));
-        assert!(!is_cacheable("mcp_"));
+    fn is_cacheable_returns_false_for_mcp_origin() {
+        assert!(!is_cacheable("github_list_issues", true));
+        assert!(!is_cacheable("send_email", true));
+        // A non-deny-listed, non-MCP tool with the exact same real-world id shape is cacheable.
+        assert!(is_cacheable("github_list_issues", false));
     }
 
     #[test]
     fn is_cacheable_returns_true_for_read_only_tools() {
-        assert!(is_cacheable("read"));
-        assert!(is_cacheable("web_scrape"));
-        assert!(is_cacheable("search_code"));
-        assert!(is_cacheable("load_skill"));
-        assert!(is_cacheable("diagnostics"));
+        assert!(is_cacheable("read", false));
+        assert!(is_cacheable("web_scrape", false));
+        assert!(is_cacheable("search_code", false));
+        assert!(is_cacheable("load_skill", false));
+        assert!(is_cacheable("diagnostics", false));
     }
 
     #[test]

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -504,10 +504,15 @@ fn group_messages(messages: &[crate::app::ChatMessage]) -> Vec<MessageGroup<'_>>
         }
         // tool_name: None maps to ToolKind::Other which is not groupable —
         // intentionally keeping nameless tool messages as individual cells.
+        //
+        // is_mcp: false — `ChatMessage` does not yet carry MCP-origin metadata from the agent
+        // event stream (see #5734); real MCP tool ids have no reliable string marker to infer
+        // it from `tool_name` alone, so passing `false` here is honest rather than guessing.
         let kind = ToolKind::classify(
             msg.tool_name
                 .as_ref()
                 .map_or("tool", zeph_common::ToolName::as_str),
+            false,
         );
         if !kind.is_groupable() {
             groups.push(MessageGroup::Single { idx: i, msg });
@@ -526,6 +531,7 @@ fn group_messages(messages: &[crate::app::ChatMessage]) -> Vec<MessageGroup<'_>>
                 next.tool_name
                     .as_ref()
                     .map_or("tool", zeph_common::ToolName::as_str),
+                false,
             );
             if next_kind != kind {
                 break;

--- a/crates/zeph-tui/src/widgets/tool_view.rs
+++ b/crates/zeph-tui/src/widgets/tool_view.rs
@@ -33,12 +33,12 @@ pub use zeph_config::ToolDensity;
 /// ```rust
 /// use zeph_tui::widgets::tool_view::ToolKind;
 ///
-/// assert_eq!(ToolKind::classify("bash"), ToolKind::Run);
-/// assert_eq!(ToolKind::classify("read_file"), ToolKind::Explore);
-/// assert_eq!(ToolKind::classify("write_file"), ToolKind::Edit);
-/// assert_eq!(ToolKind::classify("web_search"), ToolKind::Web);
-/// assert_eq!(ToolKind::classify("mcp__github__list_prs"), ToolKind::Mcp);
-/// assert_eq!(ToolKind::classify("unknown_tool"), ToolKind::Other);
+/// assert_eq!(ToolKind::classify("bash", false), ToolKind::Run);
+/// assert_eq!(ToolKind::classify("read_file", false), ToolKind::Explore);
+/// assert_eq!(ToolKind::classify("write_file", false), ToolKind::Edit);
+/// assert_eq!(ToolKind::classify("web_search", false), ToolKind::Web);
+/// assert_eq!(ToolKind::classify("github_list_prs", true), ToolKind::Mcp);
+/// assert_eq!(ToolKind::classify("unknown_tool", false), ToolKind::Other);
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,28 +51,35 @@ pub enum ToolKind {
     Edit,
     /// Web browsing and search tools (`web_search`, `web_scrape`, `fetch`).
     Web,
-    /// MCP-namespaced tools (name starts with `mcp__`).
+    /// Tools registered by an MCP server (`is_mcp` was `true`).
     Mcp,
     /// Any tool that does not match the above categories.
     Other,
 }
 
 impl ToolKind {
-    /// Classify a tool by its canonical name.
+    /// Classify a tool by its canonical name and MCP origin.
     ///
-    /// Matching is case-sensitive and prefix-based for MCP tools.
+    /// `is_mcp` must be resolved by the caller — real MCP tool ids are `{server_id}_{name}`
+    /// (`McpTool::sanitized_id`) and carry no reliable string prefix to pattern-match on
+    /// (#5712, #5734), so `tool_name` alone can never distinguish an MCP tool from a
+    /// similarly-shaped built-in one. Callers with access to the tool's `ToolDef` should pass
+    /// `ToolDef::is_mcp_tool()`; callers without it (e.g. no wiring yet from the event that
+    /// produced `tool_name`) should pass `false` rather than guess.
+    ///
+    /// Name matching for the non-MCP categories is case-sensitive.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use zeph_tui::widgets::tool_view::ToolKind;
     ///
-    /// assert_eq!(ToolKind::classify("bash"), ToolKind::Run);
-    /// assert_eq!(ToolKind::classify("read_file"), ToolKind::Explore);
+    /// assert_eq!(ToolKind::classify("bash", false), ToolKind::Run);
+    /// assert_eq!(ToolKind::classify("read_file", false), ToolKind::Explore);
     /// ```
     #[must_use]
-    pub fn classify(tool_name: &str) -> Self {
-        if tool_name.starts_with("mcp__") {
+    pub fn classify(tool_name: &str, is_mcp: bool) -> Self {
+        if is_mcp {
             return Self::Mcp;
         }
         match tool_name {
@@ -194,43 +201,52 @@ mod tests {
 
     #[test]
     fn tool_kind_classify_run() {
-        assert_eq!(ToolKind::classify("bash"), ToolKind::Run);
-        assert_eq!(ToolKind::classify("shell"), ToolKind::Run);
-        assert_eq!(ToolKind::classify("run_command"), ToolKind::Run);
+        assert_eq!(ToolKind::classify("bash", false), ToolKind::Run);
+        assert_eq!(ToolKind::classify("shell", false), ToolKind::Run);
+        assert_eq!(ToolKind::classify("run_command", false), ToolKind::Run);
     }
 
     #[test]
     fn tool_kind_classify_explore() {
-        assert_eq!(ToolKind::classify("read_file"), ToolKind::Explore);
-        assert_eq!(ToolKind::classify("list_dir"), ToolKind::Explore);
-        assert_eq!(ToolKind::classify("grep"), ToolKind::Explore);
-        assert_eq!(ToolKind::classify("glob"), ToolKind::Explore);
+        assert_eq!(ToolKind::classify("read_file", false), ToolKind::Explore);
+        assert_eq!(ToolKind::classify("list_dir", false), ToolKind::Explore);
+        assert_eq!(ToolKind::classify("grep", false), ToolKind::Explore);
+        assert_eq!(ToolKind::classify("glob", false), ToolKind::Explore);
     }
 
     #[test]
     fn tool_kind_classify_edit() {
-        assert_eq!(ToolKind::classify("write_file"), ToolKind::Edit);
-        assert_eq!(ToolKind::classify("edit_file"), ToolKind::Edit);
-        assert_eq!(ToolKind::classify("patch"), ToolKind::Edit);
+        assert_eq!(ToolKind::classify("write_file", false), ToolKind::Edit);
+        assert_eq!(ToolKind::classify("edit_file", false), ToolKind::Edit);
+        assert_eq!(ToolKind::classify("patch", false), ToolKind::Edit);
     }
 
     #[test]
     fn tool_kind_classify_web() {
-        assert_eq!(ToolKind::classify("web_search"), ToolKind::Web);
-        assert_eq!(ToolKind::classify("web_scrape"), ToolKind::Web);
-        assert_eq!(ToolKind::classify("fetch"), ToolKind::Web);
+        assert_eq!(ToolKind::classify("web_search", false), ToolKind::Web);
+        assert_eq!(ToolKind::classify("web_scrape", false), ToolKind::Web);
+        assert_eq!(ToolKind::classify("fetch", false), ToolKind::Web);
     }
 
+    /// #5734 regression: MCP origin must come from the caller-supplied `is_mcp` flag (ultimately
+    /// backed by `ToolDef::is_mcp_tool()`), not a `"mcp__"` string prefix — real MCP tool ids are
+    /// `{server_id}_{name}` (`McpTool::sanitized_id`) and never carry that prefix, so the old
+    /// check silently never matched any real MCP tool.
     #[test]
     fn tool_kind_classify_mcp() {
-        assert_eq!(ToolKind::classify("mcp__github__list_prs"), ToolKind::Mcp);
-        assert_eq!(ToolKind::classify("mcp__slack__send"), ToolKind::Mcp);
+        assert_eq!(ToolKind::classify("github_list_prs", true), ToolKind::Mcp);
+        assert_eq!(ToolKind::classify("slack_send", true), ToolKind::Mcp);
+        // A real-world-shaped MCP id without the caller-supplied flag is not misclassified.
+        assert_eq!(
+            ToolKind::classify("github_list_prs", false),
+            ToolKind::Other
+        );
     }
 
     #[test]
     fn tool_kind_classify_other() {
-        assert_eq!(ToolKind::classify("unknown_tool"), ToolKind::Other);
-        assert_eq!(ToolKind::classify("memory_search"), ToolKind::Other);
+        assert_eq!(ToolKind::classify("unknown_tool", false), ToolKind::Other);
+        assert_eq!(ToolKind::classify("memory_search", false), ToolKind::Other);
     }
 
     #[test]

--- a/specs/050-security-capability-governance/spec.md
+++ b/specs/050-security-capability-governance/spec.md
@@ -849,9 +849,19 @@ probe_provider = "fast"          # [[llm.providers]] name; empty = main provider
 max_context_events = 50
 probe_timeout_ms = 2000
 max_probes_per_turn = 3
-probe_patterns = ["builtin:shell*", "builtin:write", "builtin:edit", "mcp:*/file_*", "builtin:exec*"]
+probe_patterns = ["builtin:shell", "builtin:write", "builtin:edit", "*write*", "*edit*", "*delete*", "*exec*"]
 deny_on_timeout = false
 ```
+
+**Pattern shape (fix #5736)**: `probe_patterns` entries must match the real qualified tool id
+shape they are checked against. Built-in ids are `"builtin:{name}"`; MCP tool ids are
+`"{server_id}_{name}"` (`McpTool::sanitized_id`) — never `"mcp:"`-prefixed or `/`-separated, so a
+pattern like `"mcp:*/file_*"` never matches a real MCP tool id and silently disables the probe
+for every MCP tool. The default patterns above are substring globs (`"*write*"` etc.) that match
+the risky-keyword regardless of whether the tool is built-in or MCP-origin; `classify_tool`
+additionally uses `ToolDef::is_mcp_tool()` (not string matching) to decide whether a
+write/edit-capable match escalates to `ExfilCapable` (MCP-origin) or the ordinary `FileWrite`
+(local-origin).
 
 ### `classify_tool` fast-path — bare tool IDs (fix #3744)
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2612,6 +2612,12 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     // Register MCP tool IDs so TrustGateExecutor can block ALL MCP tools for
     // Quarantined skills — not just those matching QUARANTINE_DENIED suffixes.
     crate::agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &mcp_tools);
+    // #5736: ShadowSentinel keeps its own MCP tool-id set (mirroring TrustGateExecutor's)
+    // so `classify_tool` can escalate MCP write/edit tools to `ExfilCapable` without a
+    // cross-crate `ToolDef` dependency at its call site.
+    if let Some(ref sentinel) = shadow_sentinel_arc {
+        crate::agent_setup::register_mcp_tool_ids(&sentinel.mcp_tool_ids_handle(), &mcp_tools);
+    }
     let mcp_manager = tool_setup.mcp_manager;
     let mcp_shared_tools = tool_setup.mcp_shared_tools;
     let mcp_tool_rx = tool_setup.mcp_tool_rx;


### PR DESCRIPTION
## Summary

Three independent sites checked for a literal name prefix (`"mcp:"`, `"mcp_"`, `"mcp__"`) to detect MCP tool origin. Real MCP tool ids are built as `"{server_id}_{name}"` via `McpTool::sanitized_id`, so none of those checks ever matched — the same defect class already fixed once in #5712/#5738 for `extract_mcp_tool_names` and `UtilityScorer::default_gain`.

- **`ShadowSentinel::classify_tool`** (#5736, security-relevant): MCP write/edit tools silently fell through to the weaker `FileWrite` risk category instead of escalating to `ExfilCapable`. `ShadowSentinel` now keeps its own registered-MCP-tool-id set, refreshed on `/mcp add`/`/mcp remove` and live `tools/list_changed` notifications via `check_tool_refresh`, so a server connected mid-session is picked up without a restart.
- **`is_cacheable`** (#5733, correctness): MCP tool results were being cached, the opposite of the function's documented intent. Now takes an explicit `is_mcp: bool` resolved via `ToolDef::is_mcp_tool()`. Both dispatch-loop call sites share a single per-batch registry scan through `ToolDispatchContext` instead of two divergent resolution paths.
- **`ToolKind::classify`** (#5734, cosmetic, partial): now takes an explicit `is_mcp: bool` instead of guessing from the name. Both TUI call sites still pass `false` unconditionally since `ChatMessage` does not yet carry MCP-origin metadata from the agent event stream — this closes the dead-heuristic logic but does not make `ToolKind::Mcp` reachable in production yet. Follow-up filed as #5743.

## Second root cause found post-review (#5736 continued)

After the first commit landed, a live verification session found the `classify_tool` fix above was necessary but not sufficient: `default_shadow_probe_patterns()` (`crates/zeph-config/src/security.rs`) shipped `"mcp:*/file_*"`/`"mcp:*/exec_*"`, glob patterns assuming the same wrong `"mcp:"`-prefixed id shape the original bug assumed. Since `classify_tool`'s `is_mcp_tool()` check is gated by these patterns matching first, and real MCP ids never match them, every MCP tool fell through to `ToolRiskCategory::Low` under the shipped default config — a complete probe bypass, not just a downgrade to `FileWrite`. Verified independently by extracting `glob_matches` and testing it against real ids before assigning the fix.

Fixed by replacing the two dead patterns with substring globs (`"*write*"`, `"*edit*"`, `"*delete*"`, `"*exec*"`) that match the real id shape, scoped to write/edit/delete/exec keywords so pure-read tools aren't swept in. Added a regression test using `ShadowSentinelConfig::default()` (no override) against a realistic MCP id, confirmed to fail before this fix and pass after. Also updated spec-050's example config and pattern-shape documentation to match.

## Follow-ups filed during review

- #5743 — thread real MCP-origin data through `ToolStartEvent`/`ToolOutputEvent` so `ToolKind::Mcp` can actually be produced in the TUI.
- #5744 — 4th instance of the same defect class in `sanitize.rs::handle_cross_boundary_quarantine` (`tool_name.split(':').next()`), observability-only blast radius, out of scope here.
- #5747 — `TrustGateExecutor`'s equivalent MCP-tool-id set has the same static-registration gap as `ShadowSentinel` had, but is constructed entirely inside the binary crate (`src/agent_setup.rs`) and can't be refreshed from `zeph-core::Agent` without new cross-crate plumbing. Higher priority than #5743/#5744 since it is a Quarantine-bypass, not just a classification/caching miss.
- #5749 — `ToolRiskCategory::ExfilCapable` and `FileWrite` have zero distinct consumers today; the probe-engagement fix in this PR (`Low` vs. non-`Low`) is unaffected, but the specific escalation the original issue asked for has no additional runtime effect yet.
- #5750 — the new default keyword set (`write`/`edit`/`delete`/`exec`) is still a fixed guess with under/over-inclusion gaps, and interacts with the fail-open probe budget (`max_probes_per_turn`, `deny_on_timeout`).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12178 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Regression tests: all three original sites, `check_tool_refresh`-driven live refresh of `ShadowSentinel`'s MCP-tool-id set, and `classify_tool` under `ShadowSentinelConfig::default()` against a realistic MCP tool id