### PR TITLE
fix(core,tools): refresh TrustGateExecutor MCP tool-id registry after startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   chunk-dispatch concurrency from `embed_concurrency` for future configurability; at the current
   shipped defaults (both 2) it has no additional effect beyond the existing `embed_concurrency`
   gate.
+- `fix(core,tools)`: `TrustGateExecutor::mcp_tool_ids` (`crates/zeph-tools/src/trust_gate.rs`) —
+  the set of MCP-sourced tool ids force-denied when a Quarantined skill is active — was
+  populated exactly once, at agent startup (`register_mcp_tool_ids`), and never refreshed. MCP
+  servers connected later via `/mcp add` or a `tools/list_changed` notification bypassed
+  Quarantine denial entirely, since their tool ids never entered the deny-set (#5747). Added a
+  `SecurityState.mcp_tool_ids` handle and `AgentBuilder::with_mcp_tool_ids_handle` (mirroring the
+  existing `with_shadow_sentinel` attach pattern), wired at all three agent-construction call
+  sites (`src/runner.rs`, `src/daemon.rs`, `src/acp.rs`). `Agent::check_tool_refresh`
+  (`crates/zeph-core/src/agent/mcp.rs`), already called once per turn, now also rebuilds the
+  deny-set from the live `self.services.mcp.tools` via the same `McpTool::sanitized_id`
+  derivation and replace-not-union semantics `register_mcp_tool_ids` uses at startup — both for
+  the `tools/list_changed` trigger and the `/mcp add`/`/mcp remove` trigger.
 - `fix(tools,skills)`: `TrustGateExecutor`'s quarantine-denial message for `QUARANTINE_DENIED`
   tools (`invoke_skill`, `load_skill`, `bash`, `write`, etc.) read `"{tool_id} denied
   (trust=quarantined)"`, which misattributed the denial to the specifically-invoked tool/skill

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -913,6 +913,22 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Attach the shared handle into `TrustGateExecutor`'s MCP tool-id registry
+    /// (`zeph_tools::TrustGateExecutor::mcp_tool_ids_handle`).
+    ///
+    /// Without this, the registry is populated once at startup and never updated, so MCP
+    /// servers connected later (`/mcp add`, `tools/list_changed`) are invisible to the
+    /// Quarantine-deny check (#5747). When attached, `check_tool_refresh` keeps the set in
+    /// sync with the live MCP tool list every turn.
+    #[must_use]
+    pub fn with_mcp_tool_ids_handle(
+        mut self,
+        handle: Arc<RwLock<std::collections::HashSet<String>>>,
+    ) -> Self {
+        self.services.security.mcp_tool_ids = Some(handle);
+        self
+    }
+
     /// Attach a per-turn risk chain accumulator for multi-step attack detection.
     ///
     /// Pass the same `Arc` to `ShellExecutor::with_risk_chain` so the executor records

--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -267,11 +267,16 @@ impl<C: Channel> Agent<C> {
     ///   via `AgentAccess::handle_mcp` (which cannot call `rebuild_semantic_index` directly
     ///   because the future would be `!Send`).
     ///
+    /// Both branches also call [`refresh_mcp_tool_ids`](Self::refresh_mcp_tool_ids) so
+    /// `TrustGateExecutor`'s Quarantine-deny set stays current with MCP servers connected
+    /// after startup (#5747) — otherwise it is only ever populated once, at agent construction.
+    ///
     /// If neither trigger fires, this is a no-op.
     pub(super) async fn check_tool_refresh(&mut self) {
         // Handle deferred rebuild from /mcp add|remove via AgentAccess.
         if self.services.mcp.pending_semantic_rebuild {
             self.services.mcp.pending_semantic_rebuild = false;
+            self.refresh_mcp_tool_ids();
             self.rebuild_semantic_index().await;
             self.sync_mcp_registry().await;
             self.refresh_shadow_sentinel_mcp_tool_ids();
@@ -300,6 +305,13 @@ impl<C: Channel> Agent<C> {
         if new_tools.is_empty() {
             // Guard against replacing a non-empty initial tool list with the watch's empty
             // initial value. The watch is only updated after a real tools/list_changed event.
+            //
+            // This early return also means `refresh_mcp_tool_ids` below is skipped, so
+            // `mcp_tool_ids` can retain stale ids past this point — but only fail-safe (over-deny
+            // of ids that no longer map to a live tool), never fail-open. In practice this branch
+            // is unreachable with an empty list anyway: the `tools/list_changed` producer never
+            // sends an empty vec, and removing the last server goes through the
+            // `pending_semantic_rebuild` branch above, which has no such guard.
             return;
         }
         tracing::info!(
@@ -309,6 +321,7 @@ impl<C: Channel> Agent<C> {
         self.services.mcp.tools = new_tools;
         self.services.mcp.sync_executor_tools();
         self.services.mcp.pruning_cache.reset();
+        self.refresh_mcp_tool_ids();
         self.rebuild_semantic_index().await;
         self.sync_mcp_registry().await;
         self.refresh_shadow_sentinel_mcp_tool_ids();
@@ -331,11 +344,9 @@ impl<C: Channel> Agent<C> {
     /// `services.mcp.tools` list, so a server connected after startup (via `/mcp add` or a live
     /// `tools/list_changed` notification) is reflected without waiting for a process restart.
     ///
-    /// Only covers `ShadowSentinel` — `TrustGateExecutor`'s own equivalent set
-    /// (`zeph_tools::TrustGateExecutor::mcp_tool_ids`) has the same startup-only limitation but
-    /// lives entirely inside the binary crate's tool-executor chain, unreachable from here
-    /// without new cross-crate plumbing; tracked as a separate follow-up (#5747), not fixed by
-    /// this call.
+    /// Only covers `ShadowSentinel`'s own tool-id set, used for risk classification.
+    /// `TrustGateExecutor`'s separate Quarantine-deny set is refreshed independently by
+    /// [`refresh_mcp_tool_ids`](Self::refresh_mcp_tool_ids) (#5747).
     fn refresh_shadow_sentinel_mcp_tool_ids(&self) {
         let Some(ref sentinel) = self.services.security.shadow_sentinel else {
             return;
@@ -348,6 +359,26 @@ impl<C: Channel> Agent<C> {
             .map(zeph_mcp::McpTool::sanitized_id)
             .collect();
         *sentinel.mcp_tool_ids_handle().write() = ids;
+    }
+
+    /// Rebuilds `TrustGateExecutor`'s MCP tool-id registry (`self.services.security.mcp_tool_ids`)
+    /// from the current `self.services.mcp.tools`, using the same id derivation
+    /// (`McpTool::sanitized_id`) and replace-not-union semantics as the startup-time
+    /// `register_mcp_tool_ids` (binary crate `agent_setup.rs`). Replace semantics correctly
+    /// drop ids for servers that disconnected since the last refresh. A no-op when no handle
+    /// was attached via `AgentBuilder::with_mcp_tool_ids_handle`.
+    fn refresh_mcp_tool_ids(&self) {
+        let Some(ref handle) = self.services.security.mcp_tool_ids else {
+            return;
+        };
+        let ids: std::collections::HashSet<String> = self
+            .services
+            .mcp
+            .tools
+            .iter()
+            .map(zeph_mcp::McpTool::sanitized_id)
+            .collect();
+        *handle.write() = ids;
     }
 
     pub(super) async fn sync_mcp_registry(&mut self) {
@@ -1032,6 +1063,141 @@ mod tests {
             sentinel.mcp_tool_ids_handle().read().contains(&expected_id),
             "ShadowSentinel's mcp_tool_ids must be refreshed after a tools/list_changed event"
         );
+    }
+
+    #[tokio::test]
+    async fn check_tool_refresh_without_mcp_tool_ids_handle_does_not_panic() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        // No handle attached (services.security.mcp_tool_ids is None by default) — refresh
+        // must be a no-op w.r.t. that field, and the tool list update must still apply.
+        assert!(agent.services.security.mcp_tool_ids.is_none());
+
+        let (tx, rx) = tokio::sync::watch::channel(Vec::<zeph_mcp::McpTool>::new());
+        agent.services.mcp.tool_rx = Some(rx);
+        let new_tools = vec![zeph_mcp::McpTool {
+            server_id: "srv".into(),
+            name: "refreshed_tool".into(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+            output_schema: None,
+            security_meta: zeph_config::mcp_security::ToolSecurityMeta::default(),
+        }];
+        tx.send(new_tools).unwrap();
+
+        agent.check_tool_refresh().await;
+        assert_eq!(agent.services.mcp.tool_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn check_tool_refresh_updates_attached_mcp_tool_ids_handle() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let handle =
+            std::sync::Arc::new(parking_lot::RwLock::new(std::collections::HashSet::new()));
+        agent.services.security.mcp_tool_ids = Some(std::sync::Arc::clone(&handle));
+
+        let (tx, rx) = tokio::sync::watch::channel(Vec::<zeph_mcp::McpTool>::new());
+        agent.services.mcp.tool_rx = Some(rx);
+        let new_tools = vec![zeph_mcp::McpTool {
+            server_id: "srv".into(),
+            name: "refreshed_tool".into(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+            output_schema: None,
+            security_meta: zeph_config::mcp_security::ToolSecurityMeta::default(),
+        }];
+        tx.send(new_tools).unwrap();
+
+        agent.check_tool_refresh().await;
+
+        assert!(
+            handle.read().contains("srv_refreshed_tool"),
+            "expected the sanitized id of the newly-connected tool in the handle, got: {:?}",
+            *handle.read()
+        );
+    }
+
+    #[tokio::test]
+    async fn check_tool_refresh_drops_disconnected_tool_from_mcp_tool_ids_handle() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        // Simulate a stale id left over from an earlier (startup-time) population, for a
+        // server that has since disconnected.
+        let handle =
+            std::sync::Arc::new(parking_lot::RwLock::new(std::collections::HashSet::from([
+                "stale_server_old_tool".to_owned(),
+            ])));
+        agent.services.security.mcp_tool_ids = Some(std::sync::Arc::clone(&handle));
+
+        let (tx, rx) = tokio::sync::watch::channel(Vec::<zeph_mcp::McpTool>::new());
+        agent.services.mcp.tool_rx = Some(rx);
+        let new_tools = vec![zeph_mcp::McpTool {
+            server_id: "srv".into(),
+            name: "refreshed_tool".into(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+            output_schema: None,
+            security_meta: zeph_config::mcp_security::ToolSecurityMeta::default(),
+        }];
+        tx.send(new_tools).unwrap();
+
+        agent.check_tool_refresh().await;
+
+        let ids = handle.read();
+        assert!(
+            !ids.contains("stale_server_old_tool"),
+            "disconnected server's tool id must be dropped (replace, not union), got: {ids:?}"
+        );
+        assert!(ids.contains("srv_refreshed_tool"));
+    }
+
+    /// Covers the `pending_semantic_rebuild` trigger (set by `/mcp add`/`/mcp remove`), the
+    /// second of the two `check_tool_refresh` branches that call `refresh_mcp_tool_ids` — the
+    /// other tests above only exercise the `tools/list_changed` (`tool_rx`) branch.
+    #[tokio::test]
+    async fn check_tool_refresh_updates_mcp_tool_ids_handle_via_pending_semantic_rebuild() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let handle =
+            std::sync::Arc::new(parking_lot::RwLock::new(std::collections::HashSet::new()));
+        agent.services.security.mcp_tool_ids = Some(std::sync::Arc::clone(&handle));
+
+        // Mirrors what handle_mcp_add/handle_mcp_remove already do before setting the flag:
+        // self.services.mcp.tools is updated first, then pending_semantic_rebuild = true.
+        agent.services.mcp.tools = vec![zeph_mcp::McpTool {
+            server_id: "srv".into(),
+            name: "added_tool".into(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+            output_schema: None,
+            security_meta: zeph_config::mcp_security::ToolSecurityMeta::default(),
+        }];
+        agent.services.mcp.pending_semantic_rebuild = true;
+
+        agent.check_tool_refresh().await;
+
+        assert!(
+            handle.read().contains("srv_added_tool"),
+            "expected the sanitized id of the /mcp add-connected tool in the handle, got: {:?}",
+            *handle.read()
+        );
+        assert!(!agent.services.mcp.pending_semantic_rebuild);
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -426,6 +426,16 @@ pub(crate) struct SecurityState {
     /// When `Some`, `process_tool_result_batch` records a `ShadowEvent` after each tool batch,
     /// then calls `goal_drift_score()` and emits a `GoalDrift` security event when alerted.
     pub(crate) shadow_memory: Option<zeph_sanitizer::ShadowMemory>,
+    /// Handle into `TrustGateExecutor`'s MCP tool-id registry
+    /// (`crates/zeph-tools/src/trust_gate.rs`), used to force-deny all MCP-sourced tools when
+    /// the active skill trust is Quarantined.
+    ///
+    /// `None` when the caller didn't attach a handle (e.g. tests, or an executor tree built
+    /// without `apply_common_tool_gating`). When `Some`, `check_tool_refresh` keeps it in sync
+    /// with `self.services.mcp.tools` so MCP servers connected after startup (`/mcp add`,
+    /// `tools/list_changed`) are folded into the Quarantine-deny set — the handle is otherwise
+    /// only ever populated once, at startup, and goes stale (#5747).
+    pub(crate) mcp_tool_ids: Option<Arc<RwLock<HashSet<String>>>>,
 }
 
 /// Groups debug/diagnostics subsystems (dumper, trace collector, anomaly detector, logging config).

--- a/crates/zeph-core/src/agent/state/security.rs
+++ b/crates/zeph-core/src/agent/state/security.rs
@@ -60,6 +60,7 @@ impl Default for SecurityState {
             risk_chain_accumulator: None,
             mage_accumulator: zeph_memory::shadow::TrajectoryRiskAccumulator::new_noop(),
             shadow_memory: None,
+            mcp_tool_ids: None,
         }
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1537,6 +1537,9 @@ async fn spawn_acp_agent(
     }
 
     agent = agent.with_hooks_config(&hooks_config);
+    // Keep TrustGateExecutor's MCP tool-id registry in sync with MCP servers connected after
+    // startup (#5747) — without this, check_tool_refresh has no handle to update.
+    agent = agent.with_mcp_tool_ids_handle(mcp_ids_handle);
 
     drop(d);
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -913,7 +913,10 @@ pub(crate) async fn run_daemon(
 
     let mut agent = agent
         .with_document_config(config.memory.documents.clone())
-        .with_hooks_config(&config.hooks);
+        .with_hooks_config(&config.hooks)
+        // Keep TrustGateExecutor's MCP tool-id registry in sync with MCP servers connected
+        // after startup (#5747) — without this, check_tool_refresh has no handle to update.
+        .with_mcp_tool_ids_handle(mcp_ids_handle);
 
     // #5566: daemon mode (the process that actually serves `[gateway]` long-lived, since
     // `spawn_gateway_server` only forwards webhooks into an already-built agent) never wired

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2902,6 +2902,9 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     } else {
         agent
     };
+    // Keep TrustGateExecutor's MCP tool-id registry in sync with MCP servers connected after
+    // startup (#5747) — without this, check_tool_refresh has no handle to update.
+    let agent = agent.with_mcp_tool_ids_handle(mcp_ids_handle);
 
     // Load provider-specific and explicit instruction files.
     // base_dir is the process CWD at startup — the most natural project root for local tools.


### PR DESCRIPTION
## Summary

- `TrustGateExecutor::mcp_tool_ids` (the Quarantine force-deny set for MCP-sourced tools) was populated once at agent startup and never refreshed, so an MCP server connected later (`/mcp add`, or a `tools/list_changed` notification) had its tools invisible to the Quarantine-deny check — a Quarantined skill could invoke that server's tools despite the weakest-link Quarantine policy documenting it should block ALL MCP-sourced tools unconditionally.
- Adds `SecurityState.mcp_tool_ids` + `AgentBuilder::with_mcp_tool_ids_handle` to attach the shared handle to an `Agent`, mirroring the existing `with_shadow_sentinel` pattern.
- `Agent::check_tool_refresh` (already invoked once per turn) now also rebuilds the deny-set from the live MCP tool list via the same `McpTool::sanitized_id` derivation and replace-not-union semantics `register_mcp_tool_ids` already uses at startup, for both the `tools/list_changed` trigger and the `/mcp add`/`/mcp remove` trigger.
- Wired at all three agent-construction call sites: `src/runner.rs`, `src/daemon.rs`, `src/acp.rs`.
- Note: the issue's own "Proposed Fix" cited a `refresh_shadow_sentinel_mcp_tool_ids` function that did not exist in the codebase at the time; that function was added independently and concurrently by #5748 (for `ShadowSentinel`'s own, separate MCP-tool-id set). Both refresh calls now coexist in `check_tool_refresh` after rebasing onto that change.

Closes #5747

## Test plan

- [x] `cargo nextest run -p zeph-core -p zeph-tools --features classifiers -E 'test(check_tool_refresh) or test(mcp_tool_ids)'` — 10/10 pass, including 4 new tests covering: no-handle no-op, `tools/list_changed` update, disconnected-tool drop (proves replace-not-union), and the `pending_semantic_rebuild`/`/mcp add`/`/mcp remove` branch
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — full workspace suite green (12198 passed, 0 failed)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] Adversarial critique confirmed: shared-Arc chain (writer/reader identity), full-snapshot replace semantics, `/mcp add`/`remove` timing race-freedom, and end-to-end gap closure (no TOCTOU) all independently verified against the actual diff
- [x] Rebased onto `origin/main` past two concurrently-merged commits (#5748, #5751) touching the same function/area; both merges resolved with all tests from every side intact and passing together
- [ ] Live-session verification (playbook `.local/testing/playbooks/trust-gate.md`, new Scenario 3: `/mcp add`/`tools/list_changed` mid-session against a Quarantined skill) — not yet run this cycle, tracked in `.local/testing/coverage-status.md`