### PR TITLE
fix(llm): add explicit supports_tool_use() override to CandleProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `with_db_instance_id` builder (no constructor signature change). Legacy Qdrant points written
   before this fix lack the field and simply stop matching scoped searches — same accepted
   degradation pattern as #5732, no backfill needed.
+- `fix(llm)`: `CandleProvider` now explicitly overrides `supports_tool_use()` to return `false`
+  (#5698), matching every other `LlmProvider` implementation which declares this explicitly
+  rather than relying on the trait default — closing the gap that caused the #5687 regression.
+- `test(llm)`: confirmed the `candle_provider/mod.rs` module doc-test (#5709) already passes
+  under `--features "candle,classifiers,gonka,cocoon,metal,testing"`; the stale `revision` field
+  reference was already resolved by the `ModelSource::HuggingFace` field rename in #5705.
 - `fix(index)`: full-repo indexing at session start could push ordinary interactive tool-calling
   turns to 200-400+s wall-clock on large workspaces (500-800% CPU), caused by a quadratic
   `merge_small_chunks` chunker algorithm and unthrottled full-repo batch processing (#5720). The

--- a/crates/zeph-llm/src/candle_provider/mod.rs
+++ b/crates/zeph-llm/src/candle_provider/mod.rs
@@ -305,6 +305,12 @@ impl LlmProvider for CandleProvider {
         true
     }
 
+    // Explicit override, not reliance on the trait default: CandleProvider has no
+    // chat_with_tools() implementation, so this must stay false even if the default changes.
+    fn supports_tool_use(&self) -> bool {
+        false
+    }
+
     #[tracing::instrument(
         name = "llm.candle.embed",
         skip_all,


### PR DESCRIPTION
## Summary

- CandleProvider now explicitly overrides `supports_tool_use()` to return `false`,
  matching every other LlmProvider implementation (Claude/OpenAI/Compatible/Ollama/
  Gemini/Mock/Cocoon/Gonka), instead of silently relying on the trait default. Closes #5698.
- No code change was needed for #5709 (candle_provider/mod.rs doctest failure under
  candle/classifiers features): the stale `revision` field reference was already resolved
  by the `ModelSource::HuggingFace` field rename in #5705. Verified `cargo test --doc -p
  zeph-llm --features "candle,classifiers,gonka,cocoon,metal,testing"` passes 44/44. Closes #5709.

## Test plan

- [x] `cargo test --doc -p zeph-llm --features "candle,classifiers,gonka,cocoon,metal,testing"` - 44 passed
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` - 12195 passed, 34 skipped
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` - clean
- [x] `cargo +nightly fmt --check` - clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` - clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` - clean