### PR TITLE
fix(core,tui): thread MCP tool origin through ToolStartEvent to TUI classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `classify_tool`'s pattern-based categorization was also extended to treat a `"delete"` substring
   the same as `"write"`/`"edit"` (escalating to `FileWrite`/`ExfilCapable` rather than falling to
   the catch-all `ExfilCapable` branch regardless of MCP origin).
+- `fix(core,tui)`: MCP-origin tools were never classified as `ToolKind::Mcp` in the running TUI
+  because `zeph_tui::types::ChatMessage` had no field carrying MCP-origin metadata, so
+  `widgets::chat::group_messages`'s two `ToolKind::classify(...)` call sites always passed a
+  hardcoded `false` (#5743, follow-up to #5748/#5736). Added `is_mcp: bool` to `ToolStartEvent`
+  (`crates/zeph-core/src/channel.rs`), threaded from the `mcp_tool_ids: HashSet<String>` already
+  resolved per dispatch batch in `Agent::prepare_tool_dispatch` through `run_tier_execution_loop`
+  → `stamp_and_send_tier_start`/`commit_speculative_tier`
+  (`crates/zeph-core/src/agent/tool_execution/tier_loop.rs`). `TuiChannel::send_tool_start`
+  (`crates/zeph-tui/src/channel.rs`) forwards it onto a new `AgentEvent::ToolStart.is_mcp` field,
+  and a new `ChatMessage::with_is_mcp` builder (`crates/zeph-tui/src/types.rs`) carries it onto
+  the chat message so `group_messages` can classify grouped tool cells correctly.
+  `AgentChannelView::send_tool_start`/`send_tool_output` (`crates/zeph-core/src/agent/channel_impl.rs`)
+  is dead code with no production callers and no `ToolDef`/server-id data available at its
+  input type, so it sets `is_mcp: false` with an explanatory comment rather than inventing new
+  cross-crate plumbing for an unreachable path. `ToolOutputEvent` intentionally does NOT carry
+  `is_mcp` — output events locate-and-mutate an already-classified `ChatMessage` by
+  `tool_call_id` rather than creating a new one, so there is no consumer for the value on that
+  path (an initial revision added and threaded it through `process_one_tool_result` before
+  review caught it as write-only dead weight; reverted before merge). Added regression tests
+  proving the field actually flows end-to-end rather than only compiling: a mixed-batch
+  `stamp_and_send_tier_start` test asserting `ToolStartEvent.is_mcp` is `true`/`false` per tool
+  name (`crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs`), and two
+  `group_messages` tests asserting `ToolKind::Mcp` classification and that same-named
+  MCP/native calls are not folded into one group (`crates/zeph-tui/src/widgets/chat.rs`).
 - `fix(tools)`: `is_cacheable` (`crates/zeph-tools/src/cache.rs`) checked
   `tool_name.starts_with("mcp_")` to exclude MCP tool results from caching — real MCP tool ids
   are `"{server_id}_{name}"` and never carry that prefix, so the check silently never matched

--- a/crates/zeph-channels/src/any.rs
+++ b/crates/zeph-channels/src/any.rs
@@ -289,6 +289,7 @@ mod tests {
                 started_at: std::time::Instant::now(),
                 speculative: false,
                 sandbox_profile: None,
+                is_mcp: false,
             })
             .await
             .is_ok()
@@ -347,6 +348,7 @@ mod tests {
             started_at: std::time::Instant::now(),
             speculative: false,
             sandbox_profile: None,
+            is_mcp: false,
         })
         .await
         .unwrap();

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -408,6 +408,7 @@ mod tests {
                 started_at: std::time::Instant::now(),
                 speculative: false,
                 sandbox_profile: None,
+                is_mcp: false,
             })
             .await
             .is_ok()

--- a/crates/zeph-core/src/agent/channel_impl.rs
+++ b/crates/zeph-core/src/agent/channel_impl.rs
@@ -101,6 +101,8 @@ impl<C: Channel + Send> AgentChannel for AgentChannelView<'_, C> {
             started_at: Instant::now(),
             speculative: false,
             sandbox_profile: None,
+            // ToolEventStart carries no ToolDef/server-id data, so MCP origin is unknown here.
+            is_mcp: false,
         };
         self.channel
             .send_tool_start(canonical)

--- a/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
@@ -769,6 +769,7 @@ async fn commit_speculative_tier_no_engine_returns_empty() {
             &tool_call_ids,
             &mut tool_started_ats,
             None,
+            &std::collections::HashSet::new(),
         )
         .await
         .expect("commit_speculative_tier must not fail with no engine");
@@ -799,6 +800,7 @@ async fn commit_speculative_tier_cache_miss_returns_empty() {
             &tool_call_ids,
             &mut tool_started_ats,
             Some(&engine),
+            &std::collections::HashSet::new(),
         )
         .await
         .expect("commit_speculative_tier must not fail on cache miss");
@@ -832,6 +834,7 @@ async fn commit_speculative_tier_ok_result_stamps_and_emits_event() {
             &tool_call_ids,
             &mut tool_started_ats,
             Some(&engine),
+            &std::collections::HashSet::new(),
         )
         .await
         .expect("commit_speculative_tier must not fail on cache hit");
@@ -890,6 +893,7 @@ async fn commit_speculative_tier_err_result_still_in_map() {
             &tool_call_ids,
             &mut tool_started_ats,
             Some(&engine),
+            &std::collections::HashSet::new(),
         )
         .await
         .expect("commit_speculative_tier must not fail when committed result is Err");
@@ -901,5 +905,43 @@ async fn commit_speculative_tier_err_result_still_in_map() {
     assert!(
         commits[&0].is_err(),
         "AlwaysErrSpecExec must produce Err result"
+    );
+}
+
+/// Regression test for #5743: `stamp_and_send_tier_start` must resolve `is_mcp` per call from
+/// `mcp_tool_ids`, not leave it always `false`. A mixed batch (one MCP-registered tool name, one
+/// not) must emit `ToolStartEvent.is_mcp == true` only for the contained id.
+#[tokio::test]
+async fn stamp_and_send_tier_start_sets_is_mcp_from_mcp_tool_ids() {
+    let mut agent = make_agent();
+    let tool_calls = [
+        test_tool_use_request("github_search_issues"),
+        test_tool_use_request("bash"),
+    ];
+    let tool_call_ids = ["id-mcp".to_string(), "id-native".to_string()];
+    let mut tool_started_ats = [Instant::now(), Instant::now()];
+    let mcp_tool_ids: std::collections::HashSet<String> =
+        std::iter::once("github_search_issues".to_string()).collect();
+
+    agent
+        .stamp_and_send_tier_start(
+            &[0, 1],
+            &tool_calls,
+            &tool_call_ids,
+            &mut tool_started_ats,
+            &mcp_tool_ids,
+        )
+        .await
+        .expect("stamp_and_send_tier_start must not fail");
+
+    let starts = agent.channel.tool_starts.lock().unwrap();
+    assert_eq!(starts.len(), 2, "one ToolStartEvent per tier index");
+    assert!(
+        starts[0].is_mcp,
+        "MCP-registered tool name must set is_mcp: true"
+    );
+    assert!(
+        !starts[1].is_mcp,
+        "non-MCP tool name must set is_mcp: false, not leak the prior call's value"
     );
 }

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -1263,6 +1263,7 @@ impl<C: Channel> Agent<C> {
                     tool_call_ids,
                     tool_started_ats,
                     speculation_engine.as_ref(),
+                    mcp_tool_ids,
                 )
                 .await?;
 
@@ -1278,6 +1279,7 @@ impl<C: Channel> Agent<C> {
                 tool_calls,
                 tool_call_ids,
                 tool_started_ats,
+                mcp_tool_ids,
             )
             .await?;
 
@@ -1402,12 +1404,13 @@ impl<C: Channel> Agent<C> {
         pending_focus_checkpoint
     }
 
-    async fn stamp_and_send_tier_start(
+    pub(super) async fn stamp_and_send_tier_start(
         &mut self,
         tier_indices: &[usize],
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
         tool_call_ids: &[String],
         tool_started_ats: &mut [std::time::Instant],
+        mcp_tool_ids: &std::collections::HashSet<String>,
     ) -> Result<(), crate::agent::error::AgentError> {
         let tier_start = std::time::Instant::now();
         for &idx in tier_indices {
@@ -1424,6 +1427,7 @@ impl<C: Channel> Agent<C> {
                     started_at: std::time::Instant::now(),
                     speculative: false,
                     sandbox_profile: None,
+                    is_mcp: mcp_tool_ids.contains(tc.name.as_str()),
                 })
                 .await?;
         }
@@ -1437,6 +1441,7 @@ impl<C: Channel> Agent<C> {
         fields(tier_size = tier_indices.len()),
         err
     )]
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn commit_speculative_tier(
         &mut self,
         tier_indices: &[usize],
@@ -1445,6 +1450,7 @@ impl<C: Channel> Agent<C> {
         tool_call_ids: &[String],
         tool_started_ats: &mut [std::time::Instant],
         engine: Option<&std::sync::Arc<crate::agent::speculative::SpeculationEngine>>,
+        mcp_tool_ids: &std::collections::HashSet<String>,
     ) -> Result<
         std::collections::HashMap<
             usize,
@@ -1499,6 +1505,7 @@ impl<C: Channel> Agent<C> {
                         started_at: tool_started_ats[idx],
                         speculative: true,
                         sandbox_profile: None,
+                        is_mcp: mcp_tool_ids.contains(tc.name.as_str()),
                     })
                     .await?;
             }

--- a/crates/zeph-core/src/agent/tool_execution/tool_result.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_result.rs
@@ -667,6 +667,7 @@ impl<C: Channel> Agent<C> {
                 started_at: std::time::Instant::now(),
                 speculative: false,
                 sandbox_profile: None,
+                is_mcp: false,
             })
             .await?;
         if let Some(ref d) = self.runtime.debug.debug_dumper {
@@ -764,6 +765,7 @@ impl<C: Channel> Agent<C> {
                         started_at: std::time::Instant::now(),
                         speculative: false,
                         sandbox_profile: None,
+                        is_mcp: false,
                     })
                     .await?;
                 if let Some(ref d) = self.runtime.debug.debug_dumper {

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -514,6 +514,8 @@ pub struct ToolStartEvent {
     ///
     /// `None` means no sandbox was applied (not configured or not a subprocess executor).
     pub sandbox_profile: Option<zeph_tools::SandboxProfile>,
+    /// True when this tool call originates from an MCP server rather than a native tool.
+    pub is_mcp: bool,
 }
 
 /// Event carrying data for a completed tool output, emitted after execution.
@@ -1173,6 +1175,7 @@ mod tests {
                 started_at: std::time::Instant::now(),
                 speculative: false,
                 sandbox_profile: None,
+                is_mcp: false,
             })
             .await
             .unwrap();
@@ -1200,6 +1203,7 @@ mod tests {
                 started_at: std::time::Instant::now(),
                 speculative: false,
                 sandbox_profile: None,
+                is_mcp: false,
             })
             .await
             .unwrap();
@@ -1223,6 +1227,7 @@ mod tests {
                 started_at: std::time::Instant::now(),
                 speculative: false,
                 sandbox_profile: None,
+                is_mcp: false,
             })
             .await;
         assert_matches!(result, Err(ChannelError::ChannelClosed));

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -126,13 +126,15 @@ impl App {
                 tool_name,
                 command,
                 tool_call_id,
+                is_mcp,
             } => {
                 self.sessions.current_mut().status_label = None;
                 self.sessions.current_mut().messages.push(
                     ChatMessage::new(MessageRole::Tool, format!("$ {command}\n"))
                         .streaming()
                         .with_tool(tool_name)
-                        .with_tool_call_id(tool_call_id),
+                        .with_tool_call_id(tool_call_id)
+                        .with_is_mcp(is_mcp),
                 );
                 self.trim_messages();
                 self.auto_scroll();

--- a/crates/zeph-tui/src/app/tests.rs
+++ b/crates/zeph-tui/src/app/tests.rs
@@ -2000,6 +2000,7 @@ fn tool_output_with_prior_tool_start_no_chunks_appends_output() {
         tool_name: "bash".into(),
         command: "ls -la".into(),
         tool_call_id: "call-a".into(),
+        is_mcp: false,
     });
     // Path C: ToolOutput arrives with no prior chunks.
     app.handle_agent_event(AgentEvent::ToolOutput {
@@ -2027,6 +2028,7 @@ fn tool_output_with_prior_tool_start_and_chunks_does_not_duplicate() {
         tool_name: "bash".into(),
         command: "echo hello".into(),
         tool_call_id: "call-b".into(),
+        is_mcp: false,
     });
     // Path B: streaming chunks arrive.
     app.handle_agent_event(AgentEvent::ToolOutputChunk {

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -293,6 +293,7 @@ impl Channel for TuiChannel {
             tool_name: event.tool_name,
             command,
             tool_call_id: event.tool_call_id,
+            is_mcp: event.is_mcp,
         });
         Ok(())
     }
@@ -613,6 +614,7 @@ mod tests {
             started_at: std::time::Instant::now(),
             speculative: false,
             sandbox_profile: None,
+            is_mcp: false,
         })
         .await
         .unwrap();
@@ -636,6 +638,7 @@ mod tests {
             started_at: std::time::Instant::now(),
             speculative: false,
             sandbox_profile: None,
+            is_mcp: false,
         })
         .await
         .unwrap();
@@ -659,6 +662,7 @@ mod tests {
             started_at: std::time::Instant::now(),
             speculative: false,
             sandbox_profile: None,
+            is_mcp: false,
         })
         .await
         .unwrap();

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -164,6 +164,8 @@ pub enum AgentEvent {
         command: String,
         /// Opaque tool-call identifier for correlating subsequent events.
         tool_call_id: String,
+        /// True when this tool call originates from an MCP server rather than a native tool.
+        is_mcp: bool,
     },
     /// An incremental output chunk from a long-running tool (e.g. streaming shell output).
     ToolOutputChunk {

--- a/crates/zeph-tui/src/types.rs
+++ b/crates/zeph-tui/src/types.rs
@@ -116,6 +116,8 @@ pub struct ChatMessage {
     /// Whether the tool call succeeded. `None` while streaming, `Some(true)` on
     /// success, `Some(false)` on error.
     pub success: Option<bool>,
+    /// Whether this tool call originates from an MCP server rather than a native tool.
+    pub is_mcp: bool,
 }
 
 impl ChatMessage {
@@ -143,6 +145,7 @@ impl ChatMessage {
             paste_line_count: None,
             tool_call_id: None,
             success: None,
+            is_mcp: false,
         }
     }
 
@@ -199,6 +202,25 @@ impl ChatMessage {
     #[must_use]
     pub fn with_tool_call_id(mut self, id: String) -> Self {
         self.tool_call_id = Some(id);
+        self
+    }
+
+    /// Mark whether this tool call originates from an MCP server.
+    ///
+    /// Used by the chat widget to classify the message's `ToolKind` for icon/color
+    /// selection.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_tui::{ChatMessage, MessageRole};
+    ///
+    /// let msg = ChatMessage::new(MessageRole::Tool, "").with_is_mcp(true);
+    /// assert!(msg.is_mcp);
+    /// ```
+    #[must_use]
+    pub fn with_is_mcp(mut self, is_mcp: bool) -> Self {
+        self.is_mcp = is_mcp;
         self
     }
 }

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -504,15 +504,11 @@ fn group_messages(messages: &[crate::app::ChatMessage]) -> Vec<MessageGroup<'_>>
         }
         // tool_name: None maps to ToolKind::Other which is not groupable —
         // intentionally keeping nameless tool messages as individual cells.
-        //
-        // is_mcp: false — `ChatMessage` does not yet carry MCP-origin metadata from the agent
-        // event stream (see #5734); real MCP tool ids have no reliable string marker to infer
-        // it from `tool_name` alone, so passing `false` here is honest rather than guessing.
         let kind = ToolKind::classify(
             msg.tool_name
                 .as_ref()
                 .map_or("tool", zeph_common::ToolName::as_str),
-            false,
+            msg.is_mcp,
         );
         if !kind.is_groupable() {
             groups.push(MessageGroup::Single { idx: i, msg });
@@ -531,7 +527,7 @@ fn group_messages(messages: &[crate::app::ChatMessage]) -> Vec<MessageGroup<'_>>
                 next.tool_name
                     .as_ref()
                     .map_or("tool", zeph_common::ToolName::as_str),
-                false,
+                next.is_mcp,
             );
             if next_kind != kind {
                 break;
@@ -2018,6 +2014,18 @@ mod tests {
         msg
     }
 
+    fn make_mcp_msg(tool_name: &str) -> crate::app::ChatMessage {
+        let mut msg = crate::app::ChatMessage::new(
+            crate::app::MessageRole::Tool,
+            format!("{tool_name}\nout"),
+        );
+        msg.tool_name = Some(tool_name.into());
+        msg.is_mcp = true;
+        msg.success = Some(true);
+        msg.timestamp = "10:00".to_owned();
+        msg
+    }
+
     #[test]
     fn group_messages_folds_five_reads() {
         let msgs: Vec<_> = (0..5)
@@ -2100,6 +2108,48 @@ mod tests {
         let groups = group_messages(&msgs);
         assert_eq!(groups.len(), 1, "write_file is Edit — now groupable");
         assert_matches!(groups[0], MessageGroup::Grouped { .. });
+    }
+
+    /// Regression test for #5743: `group_messages` must read `ChatMessage.is_mcp` (set via
+    /// `with_is_mcp`/the agent-event path) rather than always classifying as a non-MCP kind.
+    #[test]
+    fn group_messages_mcp_tool_classified_as_mcp() {
+        let msgs = vec![
+            make_mcp_msg("github_search_issues"),
+            make_mcp_msg("github_create_issue"),
+        ];
+        let groups = group_messages(&msgs);
+        assert_eq!(
+            groups.len(),
+            1,
+            "two MCP tool calls must fold into one group"
+        );
+        match &groups[0] {
+            MessageGroup::Grouped { kind, members, .. } => {
+                assert_eq!(*kind, ToolKind::Mcp);
+                assert_eq!(members.len(), 2);
+            }
+            MessageGroup::Single { .. } => panic!("expected Grouped"),
+        }
+    }
+
+    /// An MCP-origin call and a native call sharing the same tool name must NOT be folded into
+    /// the same group — `is_mcp` must dominate `tool_name` in the `ToolKind` used for grouping.
+    #[test]
+    fn group_messages_mcp_and_native_same_name_not_grouped_together() {
+        let mut native = make_shell_msg("ls");
+        native.tool_name = Some("bash".into());
+        let mut mcp = make_mcp_msg("bash");
+        mcp.tool_name = Some("bash".into());
+        let msgs = vec![native, mcp];
+        let groups = group_messages(&msgs);
+        assert_eq!(
+            groups.len(),
+            2,
+            "same tool_name but different is_mcp must break the group"
+        );
+        assert_matches!(groups[0], MessageGroup::Single { .. });
+        assert_matches!(groups[1], MessageGroup::Single { .. });
     }
 
     #[test]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -318,6 +318,7 @@ mod tests {
                 started_at: std::time::Instant::now(),
                 speculative: false,
                 sandbox_profile: None,
+                is_mcp: false,
             })
             .await
             .is_ok()
@@ -375,6 +376,7 @@ mod tests {
             started_at: std::time::Instant::now(),
             speculative: false,
             sandbox_profile: None,
+            is_mcp: false,
         })
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

- `ChatMessage` carried no MCP-origin metadata, so `widgets::chat::group_messages`'s two `ToolKind::classify(...)` call sites always passed a hardcoded `false` and MCP tools never rendered as `ToolKind::Mcp` in the running TUI (follow-up to #5748/#5736).
- Added `is_mcp: bool` to `ToolStartEvent`, threaded from the `mcp_tool_ids: HashSet<String>` already resolved per dispatch batch through `run_tier_execution_loop` -> `stamp_and_send_tier_start`/`commit_speculative_tier`.
- `TuiChannel::send_tool_start` forwards it onto a new `AgentEvent::ToolStart.is_mcp` field, and a new `ChatMessage::with_is_mcp` builder carries it onto the chat message so `group_messages` classifies grouped tool cells correctly.
- `AgentChannelView` (dead code, no production callers, no `ToolDef`/server-id data at its input type) sets `is_mcp: false` with an explanatory comment rather than inventing new cross-crate plumbing for an unreachable path.
- `ToolOutputEvent` intentionally does not carry `is_mcp` - output events locate-and-mutate an already-classified `ChatMessage` by `tool_call_id` rather than creating a new one, so there is no consumer for the value on that path.

Closes #5743

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12209 passed, 34 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-tui`
- [x] New regression tests proving `is_mcp` flows end-to-end: a mixed-batch `stamp_and_send_tier_start` test asserting `ToolStartEvent.is_mcp` differs per tool name in the same batch, plus two `group_messages` tests asserting `ToolKind::Mcp` classification and that same-named MCP/native calls are not folded into one group.