### PR TITLE
refactor(common,memory,mcp,context,llm,core): dedup truncation, similarity, and JSON extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(common,memory,mcp,context,llm,core)`: deduplicated three hand-rolled utility
+  patterns onto shared helpers. UTF-8 char-boundary truncation (5 call sites in
+  `zeph-context`, `zeph-llm`, `zeph-memory`, `zeph-core`) now calls the existing
+  `zeph_common::text::truncate_to_bytes`/`truncate_to_bytes_ref` (#5672). Char-level
+  Levenshtein edit distance (`zeph-memory/src/graph/implicit_conflict.rs` and
+  `belief_revision.rs`) now shares its DP computation via a new
+  `zeph_memory::graph::string_similarity` module; `belief_revision::relation_similarity`
+  keeps its original byte-length normalization (only the distance computation is shared,
+  not the normalization) to avoid changing behavior for non-ASCII relation strings (#5536).
+  Bracket-matching JSON-array extraction from LLM prose (5 call sites in `zeph-memory` and
+  `zeph-mcp`) now calls a new `zeph_common::llm_response::extract_json_array_slice`; each
+  call site keeps its own existing failure policy (hard error in `zeph-mcp::pruning`,
+  empty-result fallback elsewhere) (#5520). No behavior change.
 - `refactor(core)`: split `Agent::rebuild_system_prompt` (`crates/zeph-core/src/agent/context/assembly.rs`,
   formerly 877 lines under `#[allow(clippy::too_many_lines)]`) into 9 private methods — query
   rewrite, embedding-based skill matching/rerank, secret-based filtering, channel-allowlist

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -19,6 +19,7 @@ pub mod fs_secure;
 pub mod hash;
 #[cfg(feature = "http-middleware")]
 pub mod http_middleware;
+pub mod llm_response;
 pub mod math;
 pub mod memory;
 pub mod net;

--- a/crates/zeph-common/src/llm_response.rs
+++ b/crates/zeph-common/src/llm_response.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Helpers for extracting structured content embedded in free-form LLM prose.
+//!
+//! LLMs are prompted to return JSON but often wrap it in prose or markdown fences.
+//! This module provides the bracket-matching extraction step shared by callers that
+//! parse a JSON array out of a raw LLM response; each caller keeps its own policy for
+//! what to do when extraction fails (empty-result fallback vs. hard error).
+
+/// Extract the substring spanning the first `[` and the last `]` in `raw`.
+///
+/// Returns `None` when `raw` has no `[`, no `]` after it, or when the `]` does not come
+/// after the `[` (e.g. `"] before ["`). Does not validate that the slice is valid JSON —
+/// callers must still attempt to parse the returned slice.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::llm_response::extract_json_array_slice;
+///
+/// assert_eq!(
+///     extract_json_array_slice("Sure, here you go: [1, 2, 3] — hope that helps!"),
+///     Some("[1, 2, 3]")
+/// );
+/// assert_eq!(extract_json_array_slice("no brackets here"), None);
+/// ```
+#[must_use]
+pub fn extract_json_array_slice(raw: &str) -> Option<&str> {
+    let start = raw.find('[')?;
+    // Search only the suffix from `start` onward, so a stray `]` earlier in `raw`
+    // (before any `[`) can never produce an inverted (end < start) range.
+    let end = start + raw[start..].rfind(']')?;
+    Some(&raw[start..=end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_array_wrapped_in_prose() {
+        assert_eq!(
+            extract_json_array_slice("Sure! [1, 2, 3] there you go."),
+            Some("[1, 2, 3]")
+        );
+    }
+
+    #[test]
+    fn extracts_bare_array() {
+        assert_eq!(extract_json_array_slice("[]"), Some("[]"));
+    }
+
+    #[test]
+    fn none_when_no_open_bracket() {
+        assert_eq!(extract_json_array_slice("no brackets"), None);
+    }
+
+    #[test]
+    fn none_when_no_close_bracket_after_open() {
+        assert_eq!(extract_json_array_slice("] then ["), None);
+    }
+
+    #[test]
+    fn none_when_only_close_bracket() {
+        assert_eq!(extract_json_array_slice("no open bracket]"), None);
+    }
+}

--- a/crates/zeph-context/src/typed_page.rs
+++ b/crates/zeph-context/src/typed_page.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};
+use zeph_common::text::truncate_to_bytes_ref;
 
 // ── PageType ──────────────────────────────────────────────────────────────────
 
@@ -692,12 +693,8 @@ fn classify_with_role_inner(body: &str, is_system_role: bool) -> PageType {
         return PageType::SystemContext;
     }
 
-    let mut prefix_end = body.len().min(80);
-    while !body.is_char_boundary(prefix_end) {
-        prefix_end -= 1;
-    }
     tracing::warn!(
-        body_prefix = &body[..prefix_end],
+        body_prefix = truncate_to_bytes_ref(body, 80),
         "typed-page classification fallback to ConversationTurn"
     );
     PageType::ConversationTurn

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -11,6 +11,7 @@ mod tier_loop;
 mod tool_call_dag;
 mod tool_result;
 
+use zeph_common::text::truncate_to_bytes;
 use zeph_llm::provider::{LlmProvider, Message, MessageMetadata, Role, ToolDefinition};
 use zeph_tools::executor::ToolCall;
 
@@ -968,14 +969,7 @@ impl<C: Channel> Agent<C> {
 
 /// Truncate `s` to at most `max_bytes` bytes, preserving valid UTF-8 boundaries.
 fn truncate_utf8(s: &str, max_bytes: usize) -> String {
-    if s.len() <= max_bytes {
-        return s.to_owned();
-    }
-    let mut end = max_bytes;
-    while !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    s[..end].to_owned()
+    truncate_to_bytes(s, max_bytes)
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/agent/tool_execution/tests/pure_helpers_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/pure_helpers_tests.rs
@@ -1,8 +1,25 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::agent::tool_execution::{normalize_for_doom_loop, tool_def_to_definition};
+use crate::agent::tool_execution::{
+    normalize_for_doom_loop, tool_def_to_definition, truncate_utf8,
+};
 use zeph_agent_tools::doom_loop_hash;
+
+#[test]
+fn truncate_utf8_under_limit_returns_unchanged() {
+    assert_eq!(truncate_utf8("hello", 256), "hello");
+}
+
+#[test]
+fn truncate_utf8_truncates_at_char_boundary() {
+    // Each '日' is 3 bytes; 256 is not a multiple of 3, so a naive byte slice
+    // at exactly 256 would land mid-character and panic.
+    let s = "日".repeat(100); // 300 bytes
+    let truncated = truncate_utf8(&s, 256);
+    assert!(truncated.len() <= 256);
+    assert!(s.is_char_boundary(truncated.len()));
+}
 
 #[test]
 fn tool_def_strips_schema_and_title() {

--- a/crates/zeph-core/src/agent/tool_orchestrator.rs
+++ b/crates/zeph-core/src/agent/tool_orchestrator.rs
@@ -4,6 +4,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::time::Duration;
 
+use zeph_common::text::truncate_to_bytes_ref;
 use zeph_tools::{
     OverflowConfig, ResultCacheConfig, TafcConfig, ToolResultCache, UtilityScorer,
     UtilityScoringConfig,
@@ -77,14 +78,7 @@ pub(crate) struct ToolOrchestrator {
 /// names always match when the original name exceeds the limit.
 fn truncate_tool_name(name: &str) -> &str {
     const MAX_TOOL_NAME_BYTES: usize = 256;
-    if name.len() <= MAX_TOOL_NAME_BYTES {
-        return name;
-    }
-    let mut idx = MAX_TOOL_NAME_BYTES;
-    while !name.is_char_boundary(idx) {
-        idx -= 1;
-    }
-    &name[..idx]
+    truncate_to_bytes_ref(name, MAX_TOOL_NAME_BYTES)
 }
 
 impl ToolOrchestrator {

--- a/crates/zeph-llm/src/candle_provider/mod.rs
+++ b/crates/zeph-llm/src/candle_provider/mod.rs
@@ -72,6 +72,7 @@ pub use candle_core::Device;
 
 use std::time::Duration;
 use tokenizers::Tokenizer;
+use zeph_common::text::truncate_to_bytes_ref;
 
 use crate::error::LlmError;
 
@@ -291,10 +292,7 @@ impl LlmProvider for CandleProvider {
         let mut chunks: Vec<Result<StreamChunk, LlmError>> = Vec::new();
         let mut start = 0;
         while start < text.len() {
-            let mut end = (start + 32).min(text.len());
-            while !text.is_char_boundary(end) {
-                end -= 1;
-            }
+            let end = start + truncate_to_bytes_ref(&text[start..], 32).len();
             chunks.push(Ok(StreamChunk::Content(text[start..end].to_string())));
             start = end;
         }

--- a/crates/zeph-mcp/src/pruning.rs
+++ b/crates/zeph-mcp/src/pruning.rs
@@ -13,6 +13,7 @@
 
 use std::fmt::Write as _;
 
+use zeph_common::llm_response::extract_json_array_slice;
 use zeph_llm::LlmError;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 
@@ -367,13 +368,7 @@ fn parse_name_array(response: &str) -> Result<Vec<String>, PruningError> {
         .join("\n");
 
     // Find the first `[` and last `]` to isolate the JSON array.
-    let start = stripped.find('[').ok_or(PruningError::ParseError)?;
-    let end = stripped.rfind(']').ok_or(PruningError::ParseError)?;
-    if end <= start {
-        return Err(PruningError::ParseError);
-    }
-
-    let json_fragment = &stripped[start..=end];
+    let json_fragment = extract_json_array_slice(&stripped).ok_or(PruningError::ParseError)?;
     let names: Vec<String> =
         serde_json::from_str(json_fragment).map_err(|_| PruningError::ParseError)?;
     Ok(names)

--- a/crates/zeph-memory/src/episodic_graph.rs
+++ b/crates/zeph-memory/src/episodic_graph.rs
@@ -36,6 +36,7 @@ use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
 pub use zeph_config::memory::EmGraphConfig;
 
 use zeph_common::SessionId;
+use zeph_common::llm_response::extract_json_array_slice;
 use zeph_db::ActiveDialect;
 
 use crate::error::MemoryError;
@@ -157,10 +158,7 @@ pub async fn extract_events(
 }
 
 fn parse_events_response(raw: &str, session_id: &str, message_id: MessageId) -> Vec<EpisodicEvent> {
-    let json_str = raw
-        .find('[')
-        .and_then(|s| raw[s..].rfind(']').map(|e| &raw[s..=s + e]))
-        .unwrap_or("[]");
+    let json_str = extract_json_array_slice(raw).unwrap_or("[]");
 
     let values: Vec<serde_json::Value> = serde_json::from_str(json_str).unwrap_or_default();
 
@@ -281,10 +279,7 @@ pub async fn link_events(
 }
 
 fn parse_links_response(raw: &str) -> Vec<CausalLink> {
-    let json_str = raw
-        .find('[')
-        .and_then(|s| raw[s..].rfind(']').map(|e| &raw[s..=s + e]))
-        .unwrap_or("[]");
+    let json_str = extract_json_array_slice(raw).unwrap_or("[]");
 
     let values: Vec<serde_json::Value> = serde_json::from_str(json_str).unwrap_or_default();
 
@@ -589,6 +584,12 @@ mod tests {
     #[test]
     fn parse_links_response_empty() {
         let links = parse_links_response("[]");
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn parse_links_response_malformed_json() {
+        let links = parse_links_response("not json");
         assert!(links.is_empty());
     }
 

--- a/crates/zeph-memory/src/graph/belief_revision.rs
+++ b/crates/zeph-memory/src/graph/belief_revision.rs
@@ -26,6 +26,7 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
 
 use crate::error::MemoryError;
+use crate::graph::string_similarity::levenshtein_distance;
 use crate::graph::types::{Edge, EdgeType};
 
 pub use zeph_common::config::memory::BeliefRevisionConfig;
@@ -34,6 +35,14 @@ pub use zeph_common::config::memory::BeliefRevisionConfig;
 ///
 /// Returns 1.0 for equal strings, 0.0 when distance equals max length.
 /// Used to check whether two relation strings are in the same domain.
+///
+/// Normalizes by **byte** length, unlike [`string_similarity::normalized_similarity`]
+/// (char-based) — this preserves the original pre-dedup behavior of this call site
+/// exactly. Do not "fix" this into char-based normalization: for non-ASCII relation
+/// strings (e.g. Cyrillic, common since this project also runs in Russian) the two
+/// normalizations diverge and changing it would alter which edges get superseded.
+///
+/// [`string_similarity::normalized_similarity`]: crate::graph::string_similarity::normalized_similarity
 #[must_use]
 fn relation_similarity(a: &str, b: &str) -> f32 {
     if a == b {
@@ -43,35 +52,13 @@ fn relation_similarity(a: &str, b: &str) -> f32 {
     if max_len == 0 {
         return 1.0;
     }
-    let dist = edit_distance(a, b);
+    let dist = levenshtein_distance(a, b);
     // max_len <= string byte length, bounded by MAX_RELATION_BYTES (256); cast is safe.
     #[allow(clippy::cast_precision_loss)]
     let max_len_f = max_len as f32;
     #[allow(clippy::cast_precision_loss)]
     let dist_f = dist as f32;
     1.0 - dist_f / max_len_f
-}
-
-/// Simple byte-level edit distance (Levenshtein) between two strings.
-fn edit_distance(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    let m = a.len();
-    let n = b.len();
-    let mut prev: Vec<usize> = (0..=n).collect();
-    let mut curr = vec![0usize; n + 1];
-    for i in 1..=m {
-        curr[0] = i;
-        for j in 1..=n {
-            curr[j] = if a[i - 1] == b[j - 1] {
-                prev[j - 1]
-            } else {
-                1 + prev[j].min(curr[j - 1]).min(prev[j - 1])
-            };
-        }
-        std::mem::swap(&mut prev, &mut curr);
-    }
-    prev[n]
 }
 
 /// Embed a fact string with the given provider.
@@ -231,21 +218,7 @@ mod tests {
         assert!(!is_same_relation_domain("works_at", "knows"));
     }
 
-    #[test]
-    fn edit_distance_empty_strings() {
-        assert_eq!(edit_distance("", ""), 0);
-    }
-
-    #[test]
-    fn edit_distance_one_empty() {
-        assert_eq!(edit_distance("abc", ""), 3);
-        assert_eq!(edit_distance("", "xyz"), 3);
-    }
-
-    #[test]
-    fn edit_distance_single_substitution() {
-        assert_eq!(edit_distance("works_at", "work_at"), 1);
-    }
+    // Edit-distance algorithm coverage lives in `graph::string_similarity` tests.
 
     // --- find_superseded_edges tests (provider-free paths) ---
 

--- a/crates/zeph-memory/src/graph/implicit_conflict.rs
+++ b/crates/zeph-memory/src/graph/implicit_conflict.rs
@@ -21,6 +21,7 @@ use zeph_db::{DbTransaction, sql};
 
 use crate::error::MemoryError;
 use crate::graph::activation::ActivatedFact;
+use crate::graph::string_similarity::normalized_similarity;
 
 /// A candidate conflict pair detected at write time.
 #[derive(Debug, Clone)]
@@ -171,22 +172,7 @@ impl ImplicitConflictDetector {
     /// Returns `1.0` if both strings are empty, `0.0` if only one is empty.
     #[must_use]
     pub fn normalized_levenshtein(a: &str, b: &str) -> f64 {
-        if a == b {
-            return 1.0;
-        }
-        let len_a = a.chars().count();
-        let len_b = b.chars().count();
-        if len_a == 0 && len_b == 0 {
-            return 1.0;
-        }
-        if len_a == 0 || len_b == 0 {
-            return 0.0;
-        }
-        let dist = levenshtein_distance(a, b);
-        let max_len = len_a.max(len_b);
-        #[allow(clippy::cast_precision_loss)]
-        let result = 1.0 - (dist as f64 / max_len as f64);
-        result
+        normalized_similarity(a, b)
     }
 
     /// Returns `true` when detection is enabled.
@@ -264,28 +250,6 @@ pub async fn annotate_conflicts(
     Ok(())
 }
 
-/// Hand-rolled Levenshtein edit distance (char-level).
-fn levenshtein_distance(a: &str, b: &str) -> usize {
-    let a_chars: Vec<char> = a.chars().collect();
-    let b_chars: Vec<char> = b.chars().collect();
-    let m = a_chars.len();
-    let n = b_chars.len();
-
-    let mut prev: Vec<usize> = (0..=n).collect();
-    let mut curr = vec![0usize; n + 1];
-
-    for i in 1..=m {
-        curr[0] = i;
-        for j in 1..=n {
-            let cost = usize::from(a_chars[i - 1] != b_chars[j - 1]);
-            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
-        }
-        std::mem::swap(&mut prev, &mut curr);
-    }
-
-    prev[n]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -299,37 +263,14 @@ mod tests {
         })
     }
 
+    // Algorithm-level coverage (identical/empty/dissimilar strings) lives in
+    // `graph::string_similarity` tests; this wrapper only needs a delegation smoke test.
     #[test]
-    fn normalized_levenshtein_identical() {
+    fn normalized_levenshtein_delegates_to_shared_helper() {
         assert!(
             (ImplicitConflictDetector::normalized_levenshtein("uses", "uses") - 1.0).abs()
                 < f64::EPSILON
         );
-    }
-
-    #[test]
-    fn normalized_levenshtein_empty_both() {
-        assert!(
-            (ImplicitConflictDetector::normalized_levenshtein("", "") - 1.0).abs() < f64::EPSILON
-        );
-    }
-
-    #[test]
-    fn normalized_levenshtein_empty_one() {
-        assert!(
-            (ImplicitConflictDetector::normalized_levenshtein("", "abc") - 0.0).abs()
-                < f64::EPSILON
-        );
-        assert!(
-            (ImplicitConflictDetector::normalized_levenshtein("abc", "") - 0.0).abs()
-                < f64::EPSILON
-        );
-    }
-
-    #[test]
-    fn normalized_levenshtein_completely_different() {
-        let sim = ImplicitConflictDetector::normalized_levenshtein("uses", "xyz_unrelated_value");
-        assert!(sim < 0.5, "expected low similarity, got {sim}");
     }
 
     #[test]

--- a/crates/zeph-memory/src/graph/mod.rs
+++ b/crates/zeph-memory/src/graph/mod.rs
@@ -23,6 +23,7 @@ pub mod retrieval_beam;
 pub mod retrieval_watercircles;
 pub mod rpe;
 pub mod strategy_classifier;
+pub mod string_similarity;
 
 pub use store::GraphStore;
 pub use types::{

--- a/crates/zeph-memory/src/graph/string_similarity.rs
+++ b/crates/zeph-memory/src/graph/string_similarity.rs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared char-level Levenshtein edit distance and normalized similarity.
+//!
+//! Used by [`implicit_conflict`](crate::graph::implicit_conflict) (STALE/CUPMem predicate
+//! conflict detection) and [`belief_revision`](crate::graph::belief_revision) (Kumiho
+//! relation-domain check) to compare relation/predicate strings.
+//!
+//! Only [`levenshtein_distance`] is shared with `belief_revision`: its `relation_similarity`
+//! normalizes by **byte** length (not char length like [`normalized_similarity`] below) to
+//! preserve its original pre-existing behavior. Do not consolidate the two normalizations —
+//! they diverge for non-ASCII input and each caller's threshold was tuned against its own
+//! normalization.
+
+/// Char-level Levenshtein edit distance between two strings.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::graph::string_similarity::levenshtein_distance;
+///
+/// assert_eq!(levenshtein_distance("kitten", "sitting"), 3);
+/// assert_eq!(levenshtein_distance("", "abc"), 3);
+/// ```
+#[must_use]
+pub fn levenshtein_distance(a: &str, b: &str) -> usize {
+    let a_chars: Vec<char> = a.chars().collect();
+    let b_chars: Vec<char> = b.chars().collect();
+    let m = a_chars.len();
+    let n = b_chars.len();
+
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut curr = vec![0usize; n + 1];
+
+    for i in 1..=m {
+        curr[0] = i;
+        for j in 1..=n {
+            let cost = usize::from(a_chars[i - 1] != b_chars[j - 1]);
+            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[n]
+}
+
+/// Normalized Levenshtein similarity between two strings, in `[0.0, 1.0]`.
+///
+/// `1.0` means identical; the distance is normalized by the longer string's char count.
+/// Returns `1.0` if both strings are empty, `0.0` if only one is empty.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::graph::string_similarity::normalized_similarity;
+///
+/// assert!((normalized_similarity("uses", "uses") - 1.0).abs() < f64::EPSILON);
+/// assert!(normalized_similarity("uses", "xyz_unrelated_value") < 0.5);
+/// ```
+#[must_use]
+pub fn normalized_similarity(a: &str, b: &str) -> f64 {
+    if a == b {
+        return 1.0;
+    }
+    let len_a = a.chars().count();
+    let len_b = b.chars().count();
+    if len_a == 0 && len_b == 0 {
+        return 1.0;
+    }
+    if len_a == 0 || len_b == 0 {
+        return 0.0;
+    }
+    let dist = levenshtein_distance(a, b);
+    let max_len = len_a.max(len_b);
+    #[allow(clippy::cast_precision_loss)]
+    let result = 1.0 - (dist as f64 / max_len as f64);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn levenshtein_distance_empty_strings() {
+        assert_eq!(levenshtein_distance("", ""), 0);
+    }
+
+    #[test]
+    fn levenshtein_distance_one_empty() {
+        assert_eq!(levenshtein_distance("abc", ""), 3);
+        assert_eq!(levenshtein_distance("", "xyz"), 3);
+    }
+
+    #[test]
+    fn levenshtein_distance_single_substitution() {
+        assert_eq!(levenshtein_distance("works_at", "work_at"), 1);
+    }
+
+    #[test]
+    fn normalized_similarity_identical() {
+        assert!((normalized_similarity("uses", "uses") - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn normalized_similarity_empty_both() {
+        assert!((normalized_similarity("", "") - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn normalized_similarity_empty_one() {
+        assert!((normalized_similarity("", "abc") - 0.0).abs() < f64::EPSILON);
+        assert!((normalized_similarity("abc", "") - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn normalized_similarity_completely_different() {
+        let sim = normalized_similarity("uses", "xyz_unrelated_value");
+        assert!(sim < 0.5, "expected low similarity, got {sim}");
+    }
+
+    #[test]
+    fn normalized_similarity_partial_overlap() {
+        // "works_at" vs "work_at" — 1 char diff out of 8 → ~0.875
+        let s = normalized_similarity("works_at", "work_at");
+        assert!(s > 0.5, "expected > 0.5, got {s}");
+    }
+}

--- a/crates/zeph-memory/src/semantic/persona.rs
+++ b/crates/zeph-memory/src/semantic/persona.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
+use zeph_common::llm_response::extract_json_array_slice;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider as _, Message, Role};
 
@@ -219,13 +220,10 @@ fn parse_extraction_response(response: &str) -> Vec<ExtractedFact> {
     }
 
     // Try to find JSON array within the response (LLM may wrap in prose).
-    if let (Some(start), Some(end)) = (response.find('['), response.rfind(']'))
-        && end > start
+    if let Some(slice) = extract_json_array_slice(response)
+        && let Ok(facts) = serde_json::from_str::<Vec<ExtractedFact>>(slice)
     {
-        let slice = &response[start..=end];
-        if let Ok(facts) = serde_json::from_str::<Vec<ExtractedFact>>(slice) {
-            return facts;
-        }
+        return facts;
     }
 
     tracing::warn!(

--- a/crates/zeph-memory/src/semantic/trajectory.rs
+++ b/crates/zeph-memory/src/semantic/trajectory.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
+use zeph_common::llm_response::extract_json_array_slice;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider as _, Message, Role};
 
@@ -134,10 +135,8 @@ fn build_extraction_prompt(messages: &[&Message]) -> String {
 fn parse_extraction_response(response: &str) -> Vec<TrajectoryEntry> {
     let raw: Vec<RawEntry> = if let Ok(v) = serde_json::from_str(response) {
         v
-    } else if let (Some(start), Some(end)) = (response.find('['), response.rfind(']'))
-        && end > start
-    {
-        serde_json::from_str(&response[start..=end]).unwrap_or_default()
+    } else if let Some(slice) = extract_json_array_slice(response) {
+        serde_json::from_str(slice).unwrap_or_default()
     } else {
         tracing::warn!(
             "trajectory extraction: failed to parse response (len={}): {:.200}",

--- a/crates/zeph-memory/src/store/compression_guidelines.rs
+++ b/crates/zeph-memory/src/store/compression_guidelines.rs
@@ -9,6 +9,7 @@ use std::sync::LazyLock;
 use zeph_db::sql;
 
 use regex::Regex;
+use zeph_common::text::truncate_to_bytes_ref;
 
 use crate::error::MemoryError;
 use crate::store::SqliteStore;
@@ -74,11 +75,7 @@ pub struct CompressionFailurePair {
 const MAX_FIELD_CHARS: usize = 4096;
 
 fn truncate_field(s: &str) -> &str {
-    let mut idx = MAX_FIELD_CHARS;
-    while idx > 0 && !s.is_char_boundary(idx) {
-        idx -= 1;
-    }
-    &s[..idx.min(s.len())]
+    truncate_to_bytes_ref(s, MAX_FIELD_CHARS)
 }
 
 impl SqliteStore {


### PR DESCRIPTION
## Summary

Consolidates three independently-duplicated utility patterns onto shared helpers (epic #5714, cluster 2 "shared-utility-adoption"). Zero intended behavior change — pure dedup/refactoring.

- **#5672** — 5 call sites across `zeph-context`, `zeph-llm`, `zeph-memory`, `zeph-core` reimplemented UTF-8 char-boundary truncation instead of calling the existing `zeph_common::text::truncate_to_bytes`/`truncate_to_bytes_ref`. All 5 now delegate to the shared helper; byte-limit constants and behavior are unchanged.
- **#5536** — `zeph-memory`'s `implicit_conflict.rs` and `belief_revision.rs` independently implemented the same Levenshtein DP algorithm. Extracted into a new `zeph_memory::graph::string_similarity` module. `belief_revision::relation_similarity` keeps its original **byte-length** normalization (only the distance computation is shared, not the normalization) to avoid changing behavior for non-ASCII relation strings — this divergence is intentional and documented in a doc comment.
- **#5520** — 5 call sites across `zeph-memory` and `zeph-mcp` independently reimplemented "extract a JSON array embedded in LLM prose". Added `zeph_common::llm_response::extract_json_array_slice`, a pure bracket-matching extractor. Each call site keeps its own existing failure policy on `None` (hard error in `zeph-mcp::pruning`, empty-result fallback elsewhere).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12216 passed)
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` (new doctests in both shared modules)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`)
- [x] Two rounds of adversarial critique: caught and fixed a real behavior-preservation gap (byte-vs-char normalization in `relation_similarity`) before this was opened
- [x] Independent code review, re-ran full suite and re-traced every equivalence claim by hand

Closes #5672
Closes #5536
Closes #5520