### PR TITLE
refactor(memory,core): dedup graph edge-fold, count-sync, and sanitize logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(memory,core)`: deduplicated three independently-drifting code paths in the graph
+  subsystem. `build_entity_graph_and_maps` (`crates/zeph-memory/src/graph/community.rs`) now
+  folds each edge into the graph/fact/id maps through a single `fold_edge` helper shared by its
+  streaming and paginated branches, instead of two identical inline copies (#5503). The
+  entity/edge/community count-then-publish sequence used by `Agent::sync_graph_counts` and the
+  two graph-count-sync sites in `persistence/extract.rs` is now a single `fetch_graph_counts`
+  helper (`crates/zeph-core/src/agent/utils.rs`), preserving the existing per-field
+  fallback-to-zero-on-error semantics at each of the 3 call sites (#5677). The relation/fact
+  sanitization pattern (`strip_control_chars` + trim/lowercase + `truncate_to_bytes_ref`) and its
+  `MAX_RELATION_BYTES`/`MAX_FACT_BYTES` caps are now defined once in
+  `crates/zeph-memory/src/graph/resolver/mod.rs` (`sanitize_relation`/`sanitize_fact`, both
+  `pub(crate)`) instead of being duplicated at 3 call sites across `graph/resolver/mod.rs` and
+  `semantic/graph.rs`, which previously carried a second independent `const` declaration tracked
+  only by a "mirrors the constant from..." doc comment. Pure refactor, no behavior change;
+  covered by 11 new unit tests targeting the extracted helpers directly. (#5503, #5677, #5492)
 - `refactor(core)`: split `Agent::rebuild_system_prompt` (`crates/zeph-core/src/agent/context/assembly.rs`,
   formerly 877 lines under `#[allow(clippy::too_many_lines)]`) into 9 private methods — query
   rewrite, embedding-based skill matching/rerank, secret-based filtering, channel-allowlist

--- a/crates/zeph-core/src/agent/persistence/extract.rs
+++ b/crates/zeph-core/src/agent/persistence/extract.rs
@@ -143,17 +143,14 @@ impl<C: Channel> Agent<C> {
                 // After extraction completes, refresh graph count metrics.
                 if let (Some(store), Some(tx)) = (graph_store, metrics_tx) {
                     let _ = extraction_handle.await;
-                    let (entities, edges, communities) = tokio::join!(
-                        store.entity_count(),
-                        store.active_edge_count(),
-                        store.community_count()
-                    );
+                    let (entities, edges, communities) =
+                        super::super::utils::fetch_graph_counts(&store).await;
                     let elapsed = start_time.elapsed().as_secs();
                     tx.send_modify(|m| {
                         m.uptime_seconds = elapsed;
-                        m.graph_entities_total = entities.unwrap_or(0).cast_unsigned();
-                        m.graph_edges_total = edges.unwrap_or(0).cast_unsigned();
-                        m.graph_communities_total = communities.unwrap_or(0).cast_unsigned();
+                        m.graph_entities_total = entities;
+                        m.graph_edges_total = edges;
+                        m.graph_communities_total = communities;
                     });
                 } else {
                     let _ = extraction_handle.await;
@@ -183,17 +180,14 @@ impl<C: Channel> Agent<C> {
                 };
                 let Some(tx) = metrics_tx_sync else { return };
 
-                let (entities, edges, communities) = tokio::join!(
-                    store.entity_count(),
-                    store.active_edge_count(),
-                    store.community_count()
-                );
+                let (entities, edges, communities) =
+                    super::super::utils::fetch_graph_counts(&store).await;
                 let elapsed = start_time_sync.elapsed().as_secs();
                 tx.send_modify(|m| {
                     m.uptime_seconds = elapsed;
-                    m.graph_entities_total = entities.unwrap_or(0).cast_unsigned();
-                    m.graph_edges_total = edges.unwrap_or(0).cast_unsigned();
-                    m.graph_communities_total = communities.unwrap_or(0).cast_unsigned();
+                    m.graph_entities_total = entities;
+                    m.graph_edges_total = edges;
+                    m.graph_communities_total = communities;
                 });
 
                 // Sync guidelines status.

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -9,6 +9,24 @@ use crate::metrics::{MetricsSnapshot, SECURITY_EVENT_CAP, SecurityEvent};
 use zeph_common::SecurityEventCategory;
 use zeph_tools::FilterStats;
 
+/// Fetch entity/edge/community counts from `store`, defaulting each to `0` on a per-metric error.
+///
+/// Shared by [`Agent::sync_graph_counts`] and the background graph-count-sync tasks in
+/// `persistence::extract` (post-extraction refresh and the periodic count-sync task) so the
+/// three call sites cannot drift apart.
+pub(super) async fn fetch_graph_counts(store: &zeph_memory::graph::GraphStore) -> (u64, u64, u64) {
+    let (entities, edges, communities) = tokio::join!(
+        store.entity_count(),
+        store.active_edge_count(),
+        store.community_count()
+    );
+    (
+        entities.unwrap_or(0).cast_unsigned(),
+        edges.unwrap_or(0).cast_unsigned(),
+        communities.unwrap_or(0).cast_unsigned(),
+    )
+}
+
 impl<C: Channel> Agent<C> {
     /// Read the community-detection failure counter from `SemanticMemory` and update metrics.
     pub fn sync_community_detection_failures(&self) {
@@ -40,15 +58,11 @@ impl<C: Channel> Agent<C> {
         let Some(store) = memory.graph_store.as_ref() else {
             return;
         };
-        let (entities, edges, communities) = tokio::join!(
-            store.entity_count(),
-            store.active_edge_count(),
-            store.community_count()
-        );
+        let (entities, edges, communities) = fetch_graph_counts(store).await;
         self.update_metrics(|m| {
-            m.graph_entities_total = entities.unwrap_or(0).cast_unsigned();
-            m.graph_edges_total = edges.unwrap_or(0).cast_unsigned();
-            m.graph_communities_total = communities.unwrap_or(0).cast_unsigned();
+            m.graph_entities_total = entities;
+            m.graph_edges_total = edges;
+            m.graph_communities_total = communities;
         });
     }
 
@@ -417,6 +431,76 @@ mod tests {
     };
     use super::*;
     use zeph_llm::provider::{MessageMetadata, MessagePart};
+    use zeph_memory::graph::GraphStore;
+    use zeph_memory::graph::types::EntityType;
+    use zeph_memory::store::SqliteStore;
+
+    async fn setup_graph_store() -> GraphStore {
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        GraphStore::new(sqlite.pool().clone())
+    }
+
+    #[tokio::test]
+    async fn fetch_graph_counts_empty_store_returns_zeros() {
+        let store = setup_graph_store().await;
+        assert_eq!(fetch_graph_counts(&store).await, (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn fetch_graph_counts_reflects_actual_counts() {
+        let store = setup_graph_store().await;
+        let a = store
+            .upsert_entity("Alice", "Alice", EntityType::Person, None, None)
+            .await
+            .unwrap()
+            .0;
+        let b = store
+            .upsert_entity("Bob", "Bob", EntityType::Person, None, None)
+            .await
+            .unwrap()
+            .0;
+        store
+            .insert_edge(a, b, "knows", "Alice knows Bob", 1.0, None, None)
+            .await
+            .unwrap();
+        store
+            .upsert_community("cluster", "summary", &[a, b], None)
+            .await
+            .unwrap();
+
+        assert_eq!(fetch_graph_counts(&store).await, (2, 1, 1));
+    }
+
+    /// #5677 follow-up: each of the 3 metrics must fall back to `0` independently on its own
+    /// query error, not abort the other two — verified by breaking only `graph_communities`
+    /// while `graph_entities`/`graph_edges` stay intact and populated.
+    #[tokio::test]
+    async fn fetch_graph_counts_falls_back_to_zero_per_field_on_error() {
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        let pool = sqlite.pool().clone();
+        let store = GraphStore::new(pool.clone());
+        let a = store
+            .upsert_entity("Alice", "Alice", EntityType::Person, None, None)
+            .await
+            .unwrap()
+            .0;
+        let b = store
+            .upsert_entity("Bob", "Bob", EntityType::Person, None, None)
+            .await
+            .unwrap()
+            .0;
+        store
+            .insert_edge(a, b, "knows", "Alice knows Bob", 1.0, None, None)
+            .await
+            .unwrap();
+
+        sqlx::query("DROP TABLE graph_communities")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(fetch_graph_counts(&store).await, (2, 1, 0));
+    }
 
     #[test]
     fn push_message_increments_cached_tokens() {

--- a/crates/zeph-memory/src/graph/community.rs
+++ b/crates/zeph-memory/src/graph/community.rs
@@ -19,7 +19,7 @@ use zeph_llm::provider::{Message, Role};
 use crate::error::MemoryError;
 
 use super::store::GraphStore;
-use super::types::Entity;
+use super::types::{Edge, Entity};
 
 const MAX_LABEL_PROPAGATION_ITERATIONS: usize = 50;
 
@@ -99,6 +99,31 @@ struct CommunityData {
 
 type UndirectedGraph = Graph<i64, (), petgraph::Undirected>;
 
+/// Fold a single edge into the graph and the fact/id accumulator maps.
+///
+/// Shared by both the streaming and paginated branches of
+/// `build_entity_graph_and_maps` so their per-edge handling cannot drift apart.
+fn fold_edge(
+    edge: &Edge,
+    node_map: &HashMap<i64, NodeIndex>,
+    graph: &mut UndirectedGraph,
+    edge_facts_map: &mut HashMap<(i64, i64), Vec<String>>,
+    edge_id_map: &mut HashMap<(i64, i64), Vec<i64>>,
+) {
+    if let (Some(&src_idx), Some(&tgt_idx)) = (
+        node_map.get(&edge.source_entity_id),
+        node_map.get(&edge.target_entity_id),
+    ) {
+        graph.add_edge(src_idx, tgt_idx, ());
+    }
+    let key = (edge.source_entity_id, edge.target_entity_id);
+    edge_facts_map
+        .entry(key)
+        .or_default()
+        .push(edge.fact.clone());
+    edge_id_map.entry(key).or_default().push(edge.id);
+}
+
 async fn build_entity_graph_and_maps(
     store: &GraphStore,
     entities: &[Entity],
@@ -125,18 +150,13 @@ async fn build_entity_graph_and_maps(
     if edge_chunk_size == 0 {
         let edges: Vec<_> = store.all_active_edges_stream().try_collect().await?;
         for edge in &edges {
-            if let (Some(&src_idx), Some(&tgt_idx)) = (
-                node_map.get(&edge.source_entity_id),
-                node_map.get(&edge.target_entity_id),
-            ) {
-                graph.add_edge(src_idx, tgt_idx, ());
-            }
-            let key = (edge.source_entity_id, edge.target_entity_id);
-            edge_facts_map
-                .entry(key)
-                .or_default()
-                .push(edge.fact.clone());
-            edge_id_map.entry(key).or_default().push(edge.id);
+            fold_edge(
+                edge,
+                &node_map,
+                &mut graph,
+                &mut edge_facts_map,
+                &mut edge_id_map,
+            );
         }
     } else {
         let limit = i64::try_from(edge_chunk_size).unwrap_or(i64::MAX);
@@ -148,18 +168,13 @@ async fn build_entity_graph_and_maps(
             }
             last_id = chunk.last().expect("non-empty chunk has a last element").id;
             for edge in &chunk {
-                if let (Some(&src_idx), Some(&tgt_idx)) = (
-                    node_map.get(&edge.source_entity_id),
-                    node_map.get(&edge.target_entity_id),
-                ) {
-                    graph.add_edge(src_idx, tgt_idx, ());
-                }
-                let key = (edge.source_entity_id, edge.target_entity_id);
-                edge_facts_map
-                    .entry(key)
-                    .or_default()
-                    .push(edge.fact.clone());
-                edge_id_map.entry(key).or_default().push(edge.id);
+                fold_edge(
+                    edge,
+                    &node_map,
+                    &mut graph,
+                    &mut edge_facts_map,
+                    &mut edge_id_map,
+                );
             }
         }
     }

--- a/crates/zeph-memory/src/graph/resolver/mod.rs
+++ b/crates/zeph-memory/src/graph/resolver/mod.rs
@@ -26,9 +26,26 @@ const MIN_ENTITY_NAME_BYTES: usize = 3;
 /// Maximum byte length for entity names stored in the graph.
 const MAX_ENTITY_NAME_BYTES: usize = 512;
 /// Maximum byte length for relation strings.
-const MAX_RELATION_BYTES: usize = 256;
+///
+/// `pub(crate)` so `semantic::graph` can share this cap instead of re-declaring it.
+pub(crate) const MAX_RELATION_BYTES: usize = 256;
 /// Maximum byte length for fact strings.
-const MAX_FACT_BYTES: usize = 2048;
+///
+/// `pub(crate)` so `semantic::graph` can share this cap instead of re-declaring it.
+pub(crate) const MAX_FACT_BYTES: usize = 2048;
+
+/// Sanitize a relation string for use as an edge dedup key: strip control chars, lowercase,
+/// trim, then truncate to [`MAX_RELATION_BYTES`].
+pub(crate) fn sanitize_relation(relation: &str) -> String {
+    let cleaned = strip_control_chars(&relation.trim().to_lowercase());
+    truncate_to_bytes_ref(&cleaned, MAX_RELATION_BYTES).to_owned()
+}
+
+/// Sanitize a fact string: strip control chars, trim, then truncate to [`MAX_FACT_BYTES`].
+pub(crate) fn sanitize_fact(fact: &str) -> String {
+    let cleaned = strip_control_chars(fact.trim());
+    truncate_to_bytes_ref(&cleaned, MAX_FACT_BYTES).to_owned()
+}
 
 /// Qdrant collection for entity embeddings.
 const ENTITY_COLLECTION: &str = "zeph_graph_entities";
@@ -954,12 +971,8 @@ impl<'a> EntityResolver<'a> {
         confidence: f32,
         episode_id: Option<MessageId>,
     ) -> Result<Option<i64>, MemoryError> {
-        let relation_clean = strip_control_chars(&relation.trim().to_lowercase());
-        let normalized_relation =
-            truncate_to_bytes_ref(&relation_clean, MAX_RELATION_BYTES).to_owned();
-
-        let fact_clean = strip_control_chars(fact.trim());
-        let normalized_fact = truncate_to_bytes_ref(&fact_clean, MAX_FACT_BYTES).to_owned();
+        let normalized_relation = sanitize_relation(relation);
+        let normalized_fact = sanitize_fact(fact);
 
         // Fetch only exact-direction edges — no reverse edges to filter out
         let existing_edges = self.store.edges_exact(source_id, target_id).await?;
@@ -1021,12 +1034,8 @@ impl<'a> EntityResolver<'a> {
         belief_revision: Option<&crate::graph::BeliefRevisionConfig>,
         provenance: Option<&GraphProvenance>,
     ) -> Result<Option<i64>, MemoryError> {
-        let relation_clean = strip_control_chars(&relation.trim().to_lowercase());
-        let normalized_relation =
-            truncate_to_bytes_ref(&relation_clean, MAX_RELATION_BYTES).to_owned();
-
-        let fact_clean = strip_control_chars(fact.trim());
-        let normalized_fact = truncate_to_bytes_ref(&fact_clean, MAX_FACT_BYTES).to_owned();
+        let normalized_relation = sanitize_relation(relation);
+        let normalized_fact = sanitize_fact(fact);
 
         let existing_edges = self.store.edges_exact(source_id, target_id).await?;
 

--- a/crates/zeph-memory/src/graph/resolver/tests.rs
+++ b/crates/zeph-memory/src/graph/resolver/tests.rs
@@ -29,6 +29,60 @@ fn make_mock_provider_with_embedding(embedding: Vec<f32>) -> zeph_llm::mock::Moc
     p
 }
 
+// ── #5492: sanitize_relation / sanitize_fact ────────────────────────────────
+
+#[test]
+fn sanitize_relation_lowercases_and_trims() {
+    assert_eq!(sanitize_relation("  Uses  "), "uses");
+}
+
+#[test]
+fn sanitize_relation_strips_control_chars() {
+    let dirty = "us\u{0007}es"; // embedded ASCII BEL control char
+    assert_eq!(sanitize_relation(dirty), "uses");
+}
+
+#[test]
+fn sanitize_relation_strips_bidi_override_chars() {
+    let dirty = "us\u{202A}es"; // LEFT-TO-RIGHT EMBEDDING bidi override
+    assert_eq!(sanitize_relation(dirty), "uses");
+}
+
+#[test]
+fn sanitize_relation_truncates_oversized_input() {
+    let long = "a".repeat(MAX_RELATION_BYTES + 100);
+    let result = sanitize_relation(&long);
+    assert_eq!(result.len(), MAX_RELATION_BYTES);
+}
+
+#[test]
+fn sanitize_relation_truncates_at_utf8_char_boundary() {
+    // Each '日' is 3 bytes — a naive byte-index truncation at MAX_RELATION_BYTES would
+    // split a char and panic; the shared helper must clamp to a valid boundary instead.
+    let long = "日".repeat(MAX_RELATION_BYTES);
+    let result = sanitize_relation(&long);
+    assert!(result.len() <= MAX_RELATION_BYTES);
+    assert!(!result.is_empty());
+}
+
+#[test]
+fn sanitize_fact_trims_and_strips_control_chars() {
+    let dirty = "  Alice us\u{0007}es Rust  ";
+    assert_eq!(sanitize_fact(dirty), "Alice uses Rust");
+}
+
+#[test]
+fn sanitize_fact_preserves_case() {
+    assert_eq!(sanitize_fact("Alice Uses Rust"), "Alice Uses Rust");
+}
+
+#[test]
+fn sanitize_fact_truncates_oversized_input() {
+    let long = "b".repeat(MAX_FACT_BYTES + 100);
+    let result = sanitize_fact(&long);
+    assert_eq!(result.len(), MAX_FACT_BYTES);
+}
+
 // ── Existing tests (resolve() with no embedding store — exact match only) ──
 
 #[tokio::test]

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -18,6 +18,7 @@ use zeph_llm::provider::LlmProvider as _;
 use crate::embedding_store::EmbeddingStore;
 use crate::error::MemoryError;
 use crate::graph::extractor::ExtractionResult as ExtractorResult;
+use crate::graph::resolver::{MAX_RELATION_BYTES, sanitize_fact, sanitize_relation};
 use crate::graph::types::GraphProvenance;
 use crate::vector_store::VectorFilter;
 
@@ -164,10 +165,6 @@ pub struct LinkingStats {
 /// Qdrant collection name for entity embeddings (mirrors the constant in `resolver.rs`).
 const ENTITY_COLLECTION: &str = "zeph_graph_entities";
 
-/// Mirrors the constant from `graph/resolver/mod.rs` — used for sanitizing APEX-MEM inputs.
-const MAX_RELATION_BYTES: usize = 256;
-/// Mirrors the constant from `graph/resolver/mod.rs` — used for sanitizing APEX-MEM inputs.
-const MAX_FACT_BYTES: usize = 2048;
 /// Fallback confidence used when the LLM omits the `confidence` field in an extracted edge.
 const DEFAULT_EDGE_CONFIDENCE: f32 = 0.8;
 
@@ -633,11 +630,8 @@ async fn insert_edges(
             let relation_display_clean = strip_control_chars(relation_trimmed);
             let relation_display =
                 truncate_to_bytes_ref(&relation_display_clean, MAX_RELATION_BYTES).to_owned();
-            let canonical_clean = strip_control_chars(&relation_trimmed.to_lowercase());
-            let canonical_relation =
-                truncate_to_bytes_ref(&canonical_clean, MAX_RELATION_BYTES).to_owned();
-            let fact_clean = strip_control_chars(edge.fact.trim());
-            let normalized_fact = truncate_to_bytes_ref(&fact_clean, MAX_FACT_BYTES).to_owned();
+            let canonical_relation = sanitize_relation(relation_trimmed);
+            let normalized_fact = sanitize_fact(&edge.fact);
             match resolver
                 .graph_store()
                 .insert_or_supersede_with_turn_index_and_metrics(


### PR DESCRIPTION
## Summary

Zeph-memory/graph dedup cluster from epic #5714 (cluster 3) — three independent, behavior-preserving refactors:

- Closes #5503: `build_entity_graph_and_maps` (`crates/zeph-memory/src/graph/community.rs`) now folds each edge into the graph/fact/id maps through a single `fold_edge` helper, shared by the streaming and paginated branches instead of two identical inline copies.
- Closes #5677: the entity/edge/community count-fetch-then-publish sequence used by `Agent::sync_graph_counts` and the two graph-count-sync sites in `persistence/extract.rs` is now a single `fetch_graph_counts` helper (`crates/zeph-core/src/agent/utils.rs`), preserving the existing independent per-field fallback-to-zero-on-error semantics at each call site.
- Closes #5492: `MAX_RELATION_BYTES`/`MAX_FACT_BYTES` and the relation/fact sanitize pattern (`strip_control_chars` + trim/lowercase + `truncate_to_bytes_ref`) are now defined once in `crates/zeph-memory/src/graph/resolver/mod.rs` (`sanitize_relation`/`sanitize_fact`, `pub(crate)`) instead of being duplicated at 3 call sites across `graph/resolver/mod.rs` and `semantic/graph.rs` (previously a second independent `const` tracked only by a "mirrors the constant from..." comment).

No behavior change. Adds 11 unit tests covering the two newly-extracted shared helpers directly (they were previously untestable in isolation — the tester found 0/3 `fetch_graph_counts` call sites had test coverage before this refactor, and `sanitize_relation`/`sanitize_fact` lacked control-char/oversized-string edge case coverage).

## Test plan

- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12217 passed, 0 failed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`) clean — pre-existing unrelated warnings in zeph-bench/zeph-tui/zeph-channels only
- [x] Adversarial critic pass: verified byte-for-byte behavior equivalence at every extracted call site, including the `Arc<GraphStore>` deref-coercion risk area and the deliberately-non-shared non-lowercased `relation_display` variant in `semantic/graph.rs`
- [x] 11 new unit tests added for `fetch_graph_counts` and `sanitize_relation`/`sanitize_fact`