### PR TITLE
refactor(core): dedup call_non_streaming, LayerContext, and spawn_oneshot dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(core)`: deduplicated three independently-duplicated code paths in the agent
+  tool-dispatch pipeline. Merged `call_non_streaming`/`call_non_streaming_with_span`
+  (`crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs`) into a single function
+  taking an explicit `tracing::Span` parameter; the SSE-fallback call site now passes
+  `tracing::Span::none()` (a documented no-op for `.instrument()`), which also removes a
+  now-redundant `core.tool.call_non_streaming` span on that one path — error visibility is
+  unchanged since it still surfaces once via the outer `core.tool.dispatch_chat` span (#5667).
+  Extracted `layer_context_parts()` (`layer_hooks.rs`), shared by `run_before_chat_layers`
+  and `run_after_chat_layers` instead of deriving the conversation-id/turn-number pair
+  twice (#5668). `SpeculationEngine::try_dispatch` (`speculative/mod.rs`) now resolves a
+  supervisor (real or throwaway) once before a single `spawn_oneshot` call, instead of
+  duplicating the identical spawn closure across both branches of an if/else (#5669). Pure
+  refactor, no behavior change.
 - `refactor(memory,core)`: deduplicated three independently-drifting code paths in the graph
   subsystem. `build_entity_graph_and_maps` (`crates/zeph-memory/src/graph/community.rs`) now
   folds each edge into the graph/fact/id maps through a single `fold_edge` helper shared by its

--- a/crates/zeph-core/src/agent/speculative/mod.rs
+++ b/crates/zeph-core/src/agent/speculative/mod.rs
@@ -211,30 +211,22 @@ impl SpeculationEngine {
             "agent.speculative.dispatch.{}",
             uuid::Uuid::new_v4()
         ));
-        let join = if let Some(sup) = &self.task_supervisor {
-            sup.spawn_oneshot(Arc::clone(&task_name), move || async move {
-                tokio::select! {
-                    result = exec.execute_tool_call_erased(&call_clone) => result,
-                    () = cancel_child.cancelled() => {
-                        Err(ToolError::Execution(std::io::Error::other("speculative cancelled")))
-                    }
+        // No supervisor available (test harness or early construction path): fall back to a
+        // throwaway supervisor so SpeculativeHandle retains a BlockingHandle<R> regardless of
+        // code path.
+        let sup = self.task_supervisor.clone().unwrap_or_else(|| {
+            Arc::new(zeph_common::TaskSupervisor::new(
+                tokio_util::sync::CancellationToken::new(),
+            ))
+        });
+        let join = sup.spawn_oneshot(task_name, move || async move {
+            tokio::select! {
+                result = exec.execute_tool_call_erased(&call_clone) => result,
+                () = cancel_child.cancelled() => {
+                    Err(ToolError::Execution(std::io::Error::other("speculative cancelled")))
                 }
-            })
-        } else {
-            // No supervisor available (test harness or early construction path):
-            // fall back to a throwaway supervisor so SpeculativeHandle retains a
-            // BlockingHandle<R> regardless of code path.
-            let tmp_cancel = tokio_util::sync::CancellationToken::new();
-            let tmp_sup = Arc::new(zeph_common::TaskSupervisor::new(tmp_cancel));
-            tmp_sup.spawn_oneshot(task_name, move || async move {
-                tokio::select! {
-                    result = exec.execute_tool_call_erased(&call_clone) => result,
-                    () = cancel_child.cancelled() => {
-                        Err(ToolError::Execution(std::io::Error::other("speculative cancelled")))
-                    }
-                }
-            })
-        };
+            }
+        });
 
         let handle = SpeculativeHandle {
             key: HandleKey {

--- a/crates/zeph-core/src/agent/tool_execution/layer_hooks.rs
+++ b/crates/zeph-core/src/agent/tool_execution/layer_hooks.rs
@@ -8,6 +8,21 @@ use crate::agent::Agent;
 use crate::channel::Channel;
 
 impl<C: Channel> Agent<C> {
+    /// Build the owned parts of a `LayerContext`: the stringified conversation id (if any)
+    /// and the current turn number. Callers construct `LayerContext` locally from these
+    /// owned values, since `LayerContext` borrows `conversation_id` and cannot be returned
+    /// directly without a self-referential struct.
+    fn layer_context_parts(&self) -> (Option<String>, u32) {
+        let conv_id_str = self
+            .services
+            .memory
+            .persistence
+            .conversation_id
+            .map(|id| id.0.to_string());
+        let turn_number = u32::try_from(self.services.sidequest.turn_counter).unwrap_or(u32::MAX);
+        (conv_id_str, turn_number)
+    }
+
     /// Run `RuntimeLayer::before_chat` hooks. Returns `Ok(Some(sc))` when a layer short-circuits
     /// the LLM call, `Ok(None)` when all hooks pass through.
     #[tracing::instrument(name = "core.tool.before_chat_layers", skip_all, level = "debug", err)]
@@ -18,15 +33,10 @@ impl<C: Channel> Agent<C> {
         if self.runtime.config.layers.is_empty() {
             return Ok(None);
         }
-        let conv_id_str = self
-            .services
-            .memory
-            .persistence
-            .conversation_id
-            .map(|id| id.0.to_string());
+        let (conv_id_str, turn_number) = self.layer_context_parts();
         let ctx = crate::runtime_layer::LayerContext {
             conversation_id: conv_id_str.as_deref(),
-            turn_number: u32::try_from(self.services.sidequest.turn_counter).unwrap_or(u32::MAX),
+            turn_number,
         };
         for layer in &self.runtime.config.layers {
             let hook_result = std::panic::AssertUnwindSafe(layer.before_chat(
@@ -54,15 +64,10 @@ impl<C: Channel> Agent<C> {
         if self.runtime.config.layers.is_empty() {
             return;
         }
-        let conv_id_str = self
-            .services
-            .memory
-            .persistence
-            .conversation_id
-            .map(|id| id.0.to_string());
+        let (conv_id_str, turn_number) = self.layer_context_parts();
         let ctx = crate::runtime_layer::LayerContext {
             conversation_id: conv_id_str.as_deref(),
-            turn_number: u32::try_from(self.services.sidequest.turn_counter).unwrap_or(u32::MAX),
+            turn_number,
         };
         for layer in &self.runtime.config.layers {
             let hook_result = std::panic::AssertUnwindSafe(layer.after_chat(&ctx, result))

--- a/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
+++ b/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
@@ -213,7 +213,8 @@ impl<C: Channel> Agent<C> {
                 Ok(Ok(resp)) => Ok(Some(resp)),
                 Ok(Err(e)) => {
                     tracing::warn!(error = %e, "speculative SSE stream failed, falling back");
-                    self.call_non_streaming(tool_defs, llm_timeout).await
+                    self.call_non_streaming(tool_defs, llm_timeout, tracing::Span::none())
+                        .await
                 }
                 Err(_) => {
                     self.channel
@@ -224,42 +225,15 @@ impl<C: Channel> Agent<C> {
             };
         }
         // Provider does not support tool streaming or speculative mode is off — normal path.
-        self.call_non_streaming_with_span(tool_defs, llm_timeout, llm_span)
+        self.call_non_streaming(tool_defs, llm_timeout, llm_span)
             .await
     }
 
-    #[tracing::instrument(name = "core.tool.call_non_streaming", skip_all, level = "debug", err)]
+    /// Dispatch a single non-streaming `chat_with_tools` call under a timeout, racing
+    /// cancellation. `llm_span` instruments the chat future; pass `tracing::Span::none()`
+    /// (a documented no-op for `.instrument()`) when no outer span should wrap the call,
+    /// e.g. the speculative-stream fallback path which is not part of the main LLM span.
     async fn call_non_streaming(
-        &mut self,
-        tool_defs: &[ToolDefinition],
-        llm_timeout: std::time::Duration,
-    ) -> Result<Option<ChatResponse>, crate::agent::error::AgentError> {
-        let chat_fut = tokio::time::timeout(
-            llm_timeout,
-            self.provider.chat_with_tools(&self.msg.messages, tool_defs),
-        );
-        let timeout_result = tokio::select! {
-            r = chat_fut => r,
-            () = self.runtime.lifecycle.cancel_token.cancelled() => {
-                tracing::info!("chat_with_tools cancelled by user");
-                self.update_metrics(|m| m.cancellations += 1);
-                self.channel.send("[Cancelled]").await?;
-                return Ok(None);
-            }
-        };
-        match timeout_result {
-            Ok(Ok(r)) => Ok(Some(r)),
-            Ok(Err(e)) => Err(e.into()),
-            Err(_) => {
-                self.channel
-                    .send("LLM request timed out. Please try again.")
-                    .await?;
-                Ok(None)
-            }
-        }
-    }
-
-    async fn call_non_streaming_with_span(
         &mut self,
         tool_defs: &[ToolDefinition],
         llm_timeout: std::time::Duration,


### PR DESCRIPTION
## Summary

Three small, independent, pure-refactor DRY cleanups in `crates/zeph-core/src/agent/`, part of the dedup-backlog epic (#5714, cluster 1 — zeph-core agent-loop).

- **#5667** `tool_execution/llm_dispatch.rs`: merged `call_non_streaming`/`call_non_streaming_with_span` into a single function taking an explicit `tracing::Span` parameter. The SSE-fallback call site now passes `tracing::Span::none()` (a documented no-op for `.instrument()`), which also removes a now-redundant `core.tool.call_non_streaming` span on that one path — error visibility is unchanged since it still surfaces once via the outer `core.tool.dispatch_chat` span.
- **#5668** `tool_execution/layer_hooks.rs`: extracted `layer_context_parts()`, shared by `run_before_chat_layers` and `run_after_chat_layers` instead of deriving the conversation-id/turn-number pair twice.
- **#5669** `speculative/mod.rs`: `SpeculationEngine::try_dispatch` now resolves a supervisor (real or throwaway) once before a single `spawn_oneshot` call, instead of duplicating the identical spawn closure across both branches of an if/else.

Pure refactor, no behavior change. No config/CLI/TUI/migration surface — internal-only structural cleanup.

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12237 passed, 0 failed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (pre-existing unrelated warnings in zeph-bench/zeph-channels/zeph-tui, not from this diff)
- [x] Independent adversarial critique confirmed all three call-site pairs are behaviorally identical, including the `spawn_oneshot` supervisor-lifetime and `tracing::Span::none()` no-op claims
- [x] Independent code review, second pass

Closes #5667
Closes #5668
Closes #5669