### PR TITLE
fix(core): unify cocoon client gating and dedup correction-signal logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   supervisor (real or throwaway) once before a single `spawn_oneshot` call, instead of
   duplicating the identical spawn closure across both branches of an if/else (#5669). Pure
   refactor, no behavior change.
+- `fix(core)`: unified `CocoonClient` construction gating between `build_cocoon_provider` and
+  `spawn_cocoon_health_checks` (`crates/zeph-core/src/provider_factory.rs`) behind a single
+  `resolve_cocoon_client_params` helper. Previously the advisory health-check path ignored a
+  provider entry's own `cocoon_access_hash` opt-in gate — it unconditionally read the vault key
+  and never errored on a missing one — while the real provider-construction path gated on it and
+  hard-failed bootstrap when the entry opted in but the vault key was absent. The health check
+  now goes through the identical gating logic; on a resolution error it logs a warning and skips
+  just that health check instead of using a wrong or ungated client (#5671). Also deduplicated
+  the identical post-verdict logging + `store_correction_in_memory` block shared by
+  `evaluate_with_llm_classifier` and `evaluate_with_judge` (`crates/zeph-core/src/agent/
+  corrections.rs`) into a single `record_correction_signal` helper, differing only in the
+  `source` field (#5676).
 - `refactor(memory,core)`: deduplicated three independently-drifting code paths in the graph
   subsystem. `build_entity_graph_and_maps` (`crates/zeph-memory/src/graph/community.rs`) now
   folds each edge into the graph/fact/id maps through a single `fold_edge` helper shared by its

--- a/crates/zeph-core/src/agent/corrections.rs
+++ b/crates/zeph-core/src/agent/corrections.rs
@@ -40,6 +40,35 @@ pub(super) fn feedback_verdict_into_signal(
     })
 }
 
+/// Log and persist a detected correction signal (shared by judge and llm-classifier paths).
+async fn record_correction_signal(
+    signal: feedback_detector::CorrectionSignal,
+    assistant: &str,
+    user_msg: &str,
+    memory_arc: Option<std::sync::Arc<zeph_memory::semantic::SemanticMemory>>,
+    conv_id: Option<zeph_memory::ConversationId>,
+    skill_name: String,
+    source: &str,
+) {
+    let is_self_correction = signal.kind == feedback_detector::CorrectionKind::SelfCorrection;
+    tracing::info!(
+        kind = signal.kind.as_str(),
+        confidence = signal.confidence,
+        source,
+        is_self_correction,
+        "correction signal detected"
+    );
+    store_correction_in_memory(
+        memory_arc,
+        conv_id,
+        assistant,
+        user_msg,
+        skill_name,
+        signal.kind.as_str(),
+    )
+    .await;
+}
+
 /// Store a correction record in memory (shared by judge and llm-classifier paths).
 pub(super) async fn store_correction_in_memory(
     memory: Option<std::sync::Arc<zeph_memory::semantic::SemanticMemory>>,
@@ -474,22 +503,14 @@ async fn evaluate_with_llm_classifier(
                 tx.send_modify(|ms| ms.classifier = snap);
             }
             if let Some(signal) = feedback_verdict_into_signal(&verdict, &user_msg) {
-                let is_self_correction =
-                    signal.kind == feedback_detector::CorrectionKind::SelfCorrection;
-                tracing::info!(
-                    kind = signal.kind.as_str(),
-                    confidence = signal.confidence,
-                    source = "llm-classifier",
-                    is_self_correction,
-                    "correction signal detected"
-                );
-                store_correction_in_memory(
-                    memory_arc,
-                    conv_id,
+                record_correction_signal(
+                    signal,
                     &assistant,
                     &user_msg,
+                    memory_arc,
+                    conv_id,
                     skill_name,
-                    signal.kind.as_str(),
+                    "llm-classifier",
                 )
                 .await;
             }
@@ -519,22 +540,8 @@ async fn evaluate_with_judge(
     {
         Ok(verdict) => {
             if let Some(signal) = verdict.into_signal(&user_msg) {
-                let is_self_correction =
-                    signal.kind == feedback_detector::CorrectionKind::SelfCorrection;
-                tracing::info!(
-                    kind = signal.kind.as_str(),
-                    confidence = signal.confidence,
-                    source = "judge",
-                    is_self_correction,
-                    "correction signal detected"
-                );
-                store_correction_in_memory(
-                    memory_arc,
-                    conv_id,
-                    &assistant,
-                    &user_msg,
-                    skill_name,
-                    signal.kind.as_str(),
+                record_correction_signal(
+                    signal, &assistant, &user_msg, memory_arc, conv_id, skill_name, "judge",
                 )
                 .await;
             }

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -523,22 +523,32 @@ fn build_gonka_provider(
     Ok(AnyProvider::Gonka(provider))
 }
 
-/// Build a [`CocoonProvider`] from a `[[llm.providers]]` entry.
+/// Resolved connection parameters for a `CocoonClient`, shared by the provider-build and
+/// health-check call sites so both derive `access_hash`/`base_url`/`timeout` with identical
+/// gating logic.
+#[cfg(feature = "cocoon")]
+struct CocoonClientParams {
+    base_url: String,
+    access_hash: Option<String>,
+    timeout: std::time::Duration,
+}
+
+/// Resolve [`CocoonClientParams`] from a `[[llm.providers]]` entry.
 ///
 /// Resolves the access hash from the age vault when `cocoon_access_hash` is `Some(_)` in the
-/// entry. If the vault key is absent an explicit, actionable error is returned.
+/// entry. If the vault key is absent an explicit, actionable error is returned. Also validates
+/// `base_url` against a localhost allowlist and warns otherwise, and warns if the config file
+/// appears to contain a raw hash value instead of an opt-in marker.
 ///
 /// # Errors
 ///
 /// Returns [`BootstrapError::Provider`] when the vault key `ZEPH_COCOON_ACCESS_HASH` is
 /// expected (field is `Some`) but not present in the resolved secrets.
 #[cfg(feature = "cocoon")]
-fn build_cocoon_provider(
+fn resolve_cocoon_client_params(
     entry: &ProviderEntry,
     config: &Config,
-) -> Result<AnyProvider, BootstrapError> {
-    let _span = tracing::info_span!("core.provider_factory.build_cocoon").entered();
-
+) -> Result<CocoonClientParams, BootstrapError> {
     let base_url = entry
         .cocoon_client_url
         .as_deref()
@@ -591,7 +601,33 @@ fn build_cocoon_provider(
     };
 
     let timeout = std::time::Duration::from_secs(config.timeouts.llm_request_timeout_secs);
-    let client = std::sync::Arc::new(CocoonClient::new(base_url, access_hash, timeout));
+
+    Ok(CocoonClientParams {
+        base_url: base_url.to_owned(),
+        access_hash,
+        timeout,
+    })
+}
+
+/// Build a [`CocoonProvider`] from a `[[llm.providers]]` entry.
+///
+/// # Errors
+///
+/// Returns [`BootstrapError::Provider`] when the vault key `ZEPH_COCOON_ACCESS_HASH` is
+/// expected (field is `Some`) but not present in the resolved secrets.
+#[cfg(feature = "cocoon")]
+fn build_cocoon_provider(
+    entry: &ProviderEntry,
+    config: &Config,
+) -> Result<AnyProvider, BootstrapError> {
+    let _span = tracing::info_span!("core.provider_factory.build_cocoon").entered();
+
+    let params = resolve_cocoon_client_params(entry, config)?;
+    let client = std::sync::Arc::new(CocoonClient::new(
+        &params.base_url,
+        params.access_hash,
+        params.timeout,
+    ));
 
     let model = entry
         .model
@@ -607,7 +643,11 @@ fn build_cocoon_provider(
 ///
 /// Registers each check as a one-shot supervised task so it is observable via
 /// [`TaskSupervisor::snapshot`] and abortable on shutdown. Failures are logged at `warn` level
-/// and never propagated — the check is purely advisory.
+/// and never propagated — the check is purely advisory. Gating logic for `access_hash`/`base_url`
+/// is shared with [`build_cocoon_provider`] via [`resolve_cocoon_client_params`]; unlike the
+/// provider-build path, a resolution error here only skips that entry's health check (logged at
+/// `warn`) rather than failing bootstrap, since this path is advisory and runs after providers
+/// have already been built successfully.
 ///
 /// Call this once after [`build_provider_from_entry`] has succeeded for all providers, passing
 /// the session-level supervisor. The function is a no-op when `cocoon` feature is not enabled
@@ -622,18 +662,22 @@ pub fn spawn_cocoon_health_checks(
         if entry.provider_type != ProviderKind::Cocoon || !entry.cocoon_health_check {
             continue;
         }
-        let base_url = entry
-            .cocoon_client_url
-            .as_deref()
-            .unwrap_or("http://localhost:10000")
-            .to_owned();
-        let access_hash = config
-            .secrets
-            .cocoon_access_hash
-            .as_ref()
-            .map(|s| s.expose().to_owned());
-        let timeout = std::time::Duration::from_secs(config.timeouts.llm_request_timeout_secs);
-        let client = std::sync::Arc::new(CocoonClient::new(&base_url, access_hash, timeout));
+        let params = match resolve_cocoon_client_params(entry, config) {
+            Ok(params) => params,
+            Err(e) => {
+                tracing::warn!(
+                    name = entry.name.as_deref().unwrap_or("<unnamed>"),
+                    error = %e,
+                    "skipping cocoon health check: failed to resolve client params"
+                );
+                continue;
+            }
+        };
+        let client = std::sync::Arc::new(CocoonClient::new(
+            &params.base_url,
+            params.access_hash,
+            params.timeout,
+        ));
         supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
             name: "core.provider_factory.cocoon_health_check",
             restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
@@ -886,6 +930,8 @@ mod tests {
         assert!(params.embedding_sha256.is_none());
     }
 
+    #[cfg(feature = "cocoon")]
+    use super::spawn_cocoon_health_checks;
     use super::{build_provider_from_entry, resolve_named_provider};
     use crate::config::{Config, ProviderKind};
     use zeph_config::providers::ProviderEntry;
@@ -1096,6 +1142,26 @@ mod tests {
                 result.is_ok(),
                 "expected success when no access hash requested: {:?}",
                 result.err()
+            );
+        }
+
+        /// `spawn_cocoon_health_checks` must share the same vault-miss gating as
+        /// `build_cocoon_provider`: when the entry opts in but the vault key is absent, the
+        /// health check is skipped (logged) rather than spawned, and bootstrap is not disturbed.
+        #[test]
+        fn spawn_cocoon_health_checks_skips_on_vault_miss() {
+            let mut entry = cocoon_entry(Some(""));
+            entry.cocoon_health_check = true;
+            let config = Config::default(); // secrets.cocoon_access_hash = None
+            let supervisor = std::sync::Arc::new(zeph_common::TaskSupervisor::new(
+                tokio_util::sync::CancellationToken::new(),
+            ));
+
+            spawn_cocoon_health_checks(&[&entry], &config, &supervisor);
+
+            assert!(
+                supervisor.snapshot().is_empty(),
+                "expected no health-check task to be spawned when vault key is absent"
             );
         }
     }


### PR DESCRIPTION
## Summary

Epic #5714 cluster 4 (zeph-llm/cocoon dedup batch).

- **#5671**: `spawn_cocoon_health_checks` re-derived `CocoonClient` construction independently from `build_cocoon_provider`, ignoring the entry's own `cocoon_access_hash` opt-in gate and never erroring on a missing vault key. Extracted `resolve_cocoon_client_params` so both call sites share identical gating (localhost `base_url` validation, raw-hash-in-config warning, access-hash vault resolution). The health-check path now skips with a warning on a resolution error rather than probing with a wrong or ungated client — this is the intentional behavior correction the issue asked for.
- **#5676**: `evaluate_with_llm_classifier`/`evaluate_with_judge` (`crates/zeph-core/src/agent/corrections.rs`) duplicated an identical post-verdict logging + `store_correction_in_memory` block, differing only in the `source` field. Extracted into `record_correction_signal`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12237 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Added `spawn_cocoon_health_checks_skips_on_vault_miss` covering the new skip-and-warn-on-Err branch (previously untested new wiring)

Closes #5671
Closes #5676