### PR TITLE
refactor(commands,core,skills): dedup command-output silence, skill version-activation, and prompt-template branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(commands,core,skills)`: deduplicated three independently-drifting code paths in the
+  commands/skills subsystem (epic #5714 duplication-backlog cluster 5). The empty-string-to-
+  `CommandOutput::Silent` branch, previously copy-pasted across 8 call sites in 7
+  `zeph-commands` handler modules, is now `CommandOutput::message_or_silent` (#5447). The
+  version-lookup-then-activate-and-write-file tail shared by `handle_skill_activate_as_string`,
+  `handle_skill_approve_as_string`, and `handle_skill_reset_as_string`
+  (`crates/zeph-core/src/agent/learning/skill_commands.rs`) is now a single
+  `activate_version_and_write` helper; each handler keeps its own version-selection predicate
+  and success message (#5663). The 8 `const TEMPLATE` + chained `.replace()` prompt builders in
+  `zeph-skills` (`evolution.rs`, `stem.rs`, `erl.rs`) now call a shared
+  `prompt_template::render` helper instead of repeating the substitution chain; the existing
+  curly-brace-safety property of `DOMAIN_GATE_PROMPT_TEMPLATE` (avoiding `format!()` because its
+  JSON example contains literal braces) is preserved unchanged (#5427). Pure refactor, no
+  behavior change; covered by 5 new unit tests targeting the extracted helpers directly.
 - `refactor(core)`: deduplicated three independently-duplicated code paths in the agent
   tool-dispatch pipeline. Merged `call_non_streaming`/`call_non_streaming_with_span`
   (`crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs`) into a single function

--- a/crates/zeph-commands/src/handlers/experiment.rs
+++ b/crates/zeph-commands/src/handlers/experiment.rs
@@ -56,11 +56,7 @@ impl CommandHandler<CommandContext<'_>> for ExperimentCommand {
                     format!("/experiment {args}")
                 };
                 let result = ctx.agent.handle_experiment(&input).await?;
-                if result.is_empty() {
-                    Ok(CommandOutput::Silent)
-                } else {
-                    Ok(CommandOutput::Message(result))
-                }
+                Ok(CommandOutput::message_or_silent(result))
             }
             .instrument(span),
         )

--- a/crates/zeph-commands/src/handlers/loop_cmd.rs
+++ b/crates/zeph-commands/src/handlers/loop_cmd.rs
@@ -50,10 +50,8 @@ impl CommandHandler<CommandContext<'_>> for LoopCommand {
         let span = tracing::info_span!("commands.loop.handle");
         Box::pin(
             async move {
-                match ctx.agent.handle_loop(args).await? {
-                    msg if msg.is_empty() => Ok(CommandOutput::Silent),
-                    msg => Ok(CommandOutput::Message(msg)),
-                }
+                let msg = ctx.agent.handle_loop(args).await?;
+                Ok(CommandOutput::message_or_silent(msg))
             }
             .instrument(span),
         )

--- a/crates/zeph-commands/src/handlers/lsp.rs
+++ b/crates/zeph-commands/src/handlers/lsp.rs
@@ -43,11 +43,7 @@ impl CommandHandler<CommandContext<'_>> for LspCommand {
         Box::pin(
             async move {
                 let result = ctx.agent.lsp_status().await?;
-                if result.is_empty() {
-                    Ok(CommandOutput::Silent)
-                } else {
-                    Ok(CommandOutput::Message(result))
-                }
+                Ok(CommandOutput::message_or_silent(result))
             }
             .instrument(span),
         )

--- a/crates/zeph-commands/src/handlers/model.rs
+++ b/crates/zeph-commands/src/handlers/model.rs
@@ -47,11 +47,7 @@ impl CommandHandler<CommandContext<'_>> for ModelCommand {
         Box::pin(
             async move {
                 let result = ctx.agent.handle_model(args).await;
-                if result.is_empty() {
-                    Ok(CommandOutput::Silent)
-                } else {
-                    Ok(CommandOutput::Message(result))
-                }
+                Ok(CommandOutput::message_or_silent(result))
             }
             .instrument(span),
         )
@@ -95,11 +91,7 @@ impl CommandHandler<CommandContext<'_>> for ProviderCommand {
         Box::pin(
             async move {
                 let result = ctx.agent.handle_provider(args).await;
-                if result.is_empty() {
-                    Ok(CommandOutput::Silent)
-                } else {
-                    Ok(CommandOutput::Message(result))
-                }
+                Ok(CommandOutput::message_or_silent(result))
             }
             .instrument(span),
         )

--- a/crates/zeph-commands/src/handlers/plan.rs
+++ b/crates/zeph-commands/src/handlers/plan.rs
@@ -49,11 +49,7 @@ impl CommandHandler<CommandContext<'_>> for PlanCommand {
                     format!("/plan {args}")
                 };
                 let result = ctx.agent.handle_plan(&input).await?;
-                if result.is_empty() {
-                    Ok(CommandOutput::Silent)
-                } else {
-                    Ok(CommandOutput::Message(result))
-                }
+                Ok(CommandOutput::message_or_silent(result))
             }
             .instrument(span),
         )

--- a/crates/zeph-commands/src/handlers/plugins.rs
+++ b/crates/zeph-commands/src/handlers/plugins.rs
@@ -38,10 +38,8 @@ impl CommandHandler<CommandContext<'_>> for PluginsCommand {
         let span = tracing::info_span!("commands.plugins.handle");
         Box::pin(
             async move {
-                match ctx.agent.handle_plugins(args).await? {
-                    msg if msg.is_empty() => Ok(CommandOutput::Silent),
-                    msg => Ok(CommandOutput::Message(msg)),
-                }
+                let msg = ctx.agent.handle_plugins(args).await?;
+                Ok(CommandOutput::message_or_silent(msg))
             }
             .instrument(span),
         )

--- a/crates/zeph-commands/src/handlers/policy.rs
+++ b/crates/zeph-commands/src/handlers/policy.rs
@@ -49,11 +49,7 @@ impl CommandHandler<CommandContext<'_>> for PolicyCommand {
         Box::pin(
             async move {
                 let result = ctx.agent.handle_policy(args).await?;
-                if result.is_empty() {
-                    Ok(CommandOutput::Silent)
-                } else {
-                    Ok(CommandOutput::Message(result))
-                }
+                Ok(CommandOutput::message_or_silent(result))
             }
             .instrument(span),
         )

--- a/crates/zeph-commands/src/lib.rs
+++ b/crates/zeph-commands/src/lib.rs
@@ -107,6 +107,18 @@ pub enum CommandOutput {
     Continue,
 }
 
+impl CommandOutput {
+    /// `Silent` for an empty string, `Message(s)` otherwise.
+    #[must_use]
+    pub fn message_or_silent(s: String) -> Self {
+        if s.is_empty() {
+            Self::Silent
+        } else {
+            Self::Message(s)
+        }
+    }
+}
+
 /// Category for grouping commands in `/help` output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -526,6 +538,22 @@ mod tests {
         let result = reg.dispatch(&mut ctx, "/secret", false).await;
         let err = result.unwrap().unwrap_err();
         assert!(err.0.contains("trusted"));
+    }
+
+    #[test]
+    fn message_or_silent_empty_is_silent() {
+        assert!(matches!(
+            CommandOutput::message_or_silent(String::new()),
+            CommandOutput::Silent
+        ));
+    }
+
+    #[test]
+    fn message_or_silent_non_empty_is_message() {
+        let CommandOutput::Message(msg) = CommandOutput::message_or_silent("hi".to_string()) else {
+            panic!("expected Message");
+        };
+        assert_eq!(msg, "hi");
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/learning/skill_commands.rs
+++ b/crates/zeph-core/src/agent/learning/skill_commands.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::fmt::Write as _;
+use std::sync::Arc;
+
+use zeph_memory::semantic::SemanticMemory;
 
 use super::super::{Agent, Channel, LlmProvider};
 use super::background::write_skill_file;
@@ -411,18 +414,8 @@ impl<C: Channel> Agent<C> {
             return Ok(format!("Version {ver} not found for \"{name}\"."));
         };
 
-        memory
-            .sqlite()
-            .activate_skill_version(name, target_id)
+        self.activate_version_and_write(&memory, name, target_id, &target_desc, &target_body)
             .await?;
-
-        write_skill_file(
-            &self.services.skill.skill_paths,
-            name,
-            &target_desc,
-            &target_body,
-        )
-        .await?;
 
         Ok(format!("Activated v{ver} for \"{name}\"."))
     }
@@ -451,18 +444,8 @@ impl<C: Channel> Agent<C> {
             return Ok(format!("No pending auto version for \"{name}\"."));
         };
 
-        memory
-            .sqlite()
-            .activate_skill_version(name, target_id)
+        self.activate_version_and_write(&memory, name, target_id, &target_desc, &target_body)
             .await?;
-
-        write_skill_file(
-            &self.services.skill.skill_paths,
-            name,
-            &target_desc,
-            &target_body,
-        )
-        .await?;
 
         Ok(format!(
             "Approved and activated v{target_ver} for \"{name}\"."
@@ -492,11 +475,38 @@ impl<C: Channel> Agent<C> {
             return Ok(format!("Original version not found for \"{name}\"."));
         };
 
-        memory.sqlite().activate_skill_version(name, v1_id).await?;
-
-        write_skill_file(&self.services.skill.skill_paths, name, &v1_desc, &v1_body).await?;
+        self.activate_version_and_write(&memory, name, v1_id, &v1_desc, &v1_body)
+            .await?;
 
         Ok(format!("Reset \"{name}\" to original v1."))
+    }
+
+    /// Activate `target_id` as the active skill version and rewrite `SKILL.md` to match.
+    ///
+    /// Shared by activate/approve/reset handlers, which each select `target_id` via a
+    /// different predicate before delegating the write-through here.
+    async fn activate_version_and_write(
+        &mut self,
+        memory: &Arc<SemanticMemory>,
+        name: &str,
+        target_id: i64,
+        target_desc: &str,
+        target_body: &str,
+    ) -> Result<(), super::super::error::AgentError> {
+        memory
+            .sqlite()
+            .activate_skill_version(name, target_id)
+            .await?;
+
+        write_skill_file(
+            &self.services.skill.skill_paths,
+            name,
+            target_desc,
+            target_body,
+        )
+        .await?;
+
+        Ok(())
     }
 }
 

--- a/crates/zeph-skills/src/erl.rs
+++ b/crates/zeph-skills/src/erl.rs
@@ -72,10 +72,14 @@ pub fn build_reflection_extract_prompt(
     tool_calls: &str,
     outcome: &str,
 ) -> String {
-    REFLECTION_EXTRACT_PROMPT_TEMPLATE
-        .replace("{task_summary}", task_summary)
-        .replace("{tool_calls}", tool_calls)
-        .replace("{outcome}", outcome)
+    crate::prompt_template::render(
+        REFLECTION_EXTRACT_PROMPT_TEMPLATE,
+        &[
+            ("task_summary", task_summary),
+            ("tool_calls", tool_calls),
+            ("outcome", outcome),
+        ],
+    )
 }
 
 /// Simple text similarity check for deduplication (word-set Jaccard coefficient).

--- a/crates/zeph-skills/src/evolution.rs
+++ b/crates/zeph-skills/src/evolution.rs
@@ -16,6 +16,8 @@
 
 use zeph_common::ToolName;
 
+use crate::prompt_template::render;
+
 /// Structured failure classification for tool execution errors.
 ///
 /// Used to decide whether a failure is attributable to the skill (systematic) or to
@@ -236,11 +238,15 @@ pub fn build_reflection_prompt(
     error_context: &str,
     tool_output: &str,
 ) -> String {
-    REFLECTION_PROMPT_TEMPLATE
-        .replace("{name}", name)
-        .replace("{body}", body)
-        .replace("{error_context}", error_context)
-        .replace("{tool_output}", tool_output)
+    render(
+        REFLECTION_PROMPT_TEMPLATE,
+        &[
+            ("name", name),
+            ("body", body),
+            ("error_context", error_context),
+            ("tool_output", tool_output),
+        ],
+    )
 }
 
 pub const IMPROVEMENT_PROMPT_TEMPLATE: &str = "\
@@ -272,12 +278,16 @@ pub fn build_improvement_prompt(
     let feedback_section = user_feedback.map_or_else(String::new, |fb| {
         format!("\nUser feedback on the current skill:\n{fb}\n")
     });
-    IMPROVEMENT_PROMPT_TEMPLATE
-        .replace("{name}", name)
-        .replace("{original_body}", original_body)
-        .replace("{error_context}", error_context)
-        .replace("{successful_response}", successful_response)
-        .replace("{user_feedback_section}", &feedback_section)
+    render(
+        IMPROVEMENT_PROMPT_TEMPLATE,
+        &[
+            ("name", name),
+            ("original_body", original_body),
+            ("error_context", error_context),
+            ("successful_response", successful_response),
+            ("user_feedback_section", &feedback_section),
+        ],
+    )
 }
 
 #[derive(Debug, Clone, serde::Deserialize, schemars::JsonSchema)]
@@ -313,22 +323,27 @@ pub fn build_evaluation_prompt(
     metrics: &SkillMetrics,
 ) -> String {
     let rate = format!("{:.0}", metrics.success_rate() * 100.0);
-    EVALUATION_PROMPT_TEMPLATE
-        .replace("{name}", name)
-        .replace("{body}", body)
-        .replace("{error_context}", error_context)
-        .replace("{tool_output}", tool_output)
-        .replace("{success_rate}", &rate)
+    render(
+        EVALUATION_PROMPT_TEMPLATE,
+        &[
+            ("name", name),
+            ("body", body),
+            ("error_context", error_context),
+            ("tool_output", tool_output),
+            ("success_rate", &rate),
+        ],
+    )
 }
 
 /// Domain gate prompt template for evaluating whether an auto-generated skill body stays
 /// within the domain of the original skill.
 ///
 /// Placeholders: `{description}`, `{name}`, `{body}` — substituted via
-/// [`build_domain_gate_prompt`] using `str::replace` (not `format!()`).
+/// [`build_domain_gate_prompt`] using [`render`] (`str::replace` per key, not `format!()`).
 ///
-/// The JSON example in the template uses literal curly braces, which is safe here
-/// because the string is never passed through `format!()`.
+/// The JSON example in the template (`{"domain_relevant": bool, "reasoning": string}`) uses
+/// literal curly braces, which is safe here: `render` only replaces the exact substrings
+/// `{description}`, `{name}`, and `{body}`, none of which appear inside the JSON example.
 pub const DOMAIN_GATE_PROMPT_TEMPLATE: &str = "\
 Evaluate whether the following auto-generated skill version stays within \
 the domain of the original skill.
@@ -355,14 +370,14 @@ pub struct DomainGateResult {
 
 /// Build a domain gate prompt by substituting template placeholders.
 ///
-/// Uses [`str::replace`] rather than `format!()` to avoid interpreting the JSON
-/// example braces in the template as format arguments.
+/// Uses [`render`] (per-key `str::replace`) rather than `format!()` to avoid interpreting the
+/// JSON example braces in the template as format arguments.
 #[must_use]
 pub fn build_domain_gate_prompt(name: &str, description: &str, body: &str) -> String {
-    DOMAIN_GATE_PROMPT_TEMPLATE
-        .replace("{description}", description)
-        .replace("{name}", name)
-        .replace("{body}", body)
+    render(
+        DOMAIN_GATE_PROMPT_TEMPLATE,
+        &[("description", description), ("name", name), ("body", body)],
+    )
 }
 
 // --- ARISE: trace-based improvement ---
@@ -389,10 +404,14 @@ Only output the improved skill body (no frontmatter, no explanation).";
 /// Build an ARISE trace improvement prompt.
 #[must_use]
 pub fn build_trace_improvement_prompt(name: &str, original_body: &str, tool_trace: &str) -> String {
-    TRACE_IMPROVEMENT_PROMPT_TEMPLATE
-        .replace("{name}", name)
-        .replace("{original_body}", original_body)
-        .replace("{tool_trace}", tool_trace)
+    render(
+        TRACE_IMPROVEMENT_PROMPT_TEMPLATE,
+        &[
+            ("name", name),
+            ("original_body", original_body),
+            ("tool_trace", tool_trace),
+        ],
+    )
 }
 
 /// Prompt template for extracting step corrections from a failure+success trace pair.
@@ -429,11 +448,15 @@ pub fn build_correction_extraction_prompt(
     failure_tool: &str,
     successful_approach: &str,
 ) -> String {
-    CORRECTION_EXTRACTION_PROMPT_TEMPLATE
-        .replace("{name}", name)
-        .replace("{failure_error}", failure_error)
-        .replace("{failure_tool}", failure_tool)
-        .replace("{successful_approach}", successful_approach)
+    render(
+        CORRECTION_EXTRACTION_PROMPT_TEMPLATE,
+        &[
+            ("name", name),
+            ("failure_error", failure_error),
+            ("failure_tool", failure_tool),
+            ("successful_approach", successful_approach),
+        ],
+    )
 }
 
 /// Absolute maximum body size to prevent exponential growth across generations.

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -70,6 +70,7 @@ pub mod miner;
 pub mod proactive;
 pub mod promoter;
 pub mod prompt;
+pub(crate) mod prompt_template;
 #[cfg(feature = "qdrant")]
 pub mod qdrant_matcher;
 pub mod registry;

--- a/crates/zeph-skills/src/prompt_template.rs
+++ b/crates/zeph-skills/src/prompt_template.rs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared placeholder-substitution helper for prompt template builders.
+
+/// Substitute `{key}` placeholders in `template` from an ordered list of `(key, value)` pairs.
+pub(crate) fn render(template: &str, substitutions: &[(&str, &str)]) -> String {
+    substitutions
+        .iter()
+        .fold(template.to_string(), |acc, (k, v)| {
+            acc.replace(&format!("{{{k}}}"), v)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_substitutes_all_keys() {
+        let out = render(
+            "Hello {name}, you are {age}",
+            &[("name", "Alice"), ("age", "30")],
+        );
+        assert_eq!(out, "Hello Alice, you are 30");
+    }
+
+    #[test]
+    fn render_leaves_unmatched_braces_untouched() {
+        let out = render("Data: {payload}", &[("payload", r#"{"key": "value"}"#)]);
+        assert_eq!(out, r#"Data: {"key": "value"}"#);
+    }
+
+    #[test]
+    fn render_missing_key_is_noop() {
+        let out = render("Hello {name}", &[]);
+        assert_eq!(out, "Hello {name}");
+    }
+}

--- a/crates/zeph-skills/src/stem.rs
+++ b/crates/zeph-skills/src/stem.rs
@@ -129,9 +129,13 @@ pub fn build_pattern_to_skill_prompt(tool_sequence: &str, sample_contexts: &[Str
             .collect::<Vec<_>>()
             .join("\n")
     };
-    PATTERN_TO_SKILL_PROMPT_TEMPLATE
-        .replace("{tool_sequence}", tool_sequence)
-        .replace("{sample_contexts}", &contexts)
+    crate::prompt_template::render(
+        PATTERN_TO_SKILL_PROMPT_TEMPLATE,
+        &[
+            ("tool_sequence", tool_sequence),
+            ("sample_contexts", &contexts),
+        ],
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Zeph-commands/zeph-skills dedup cluster from epic #5714 (cluster 5) — three independent, behavior-preserving refactors:

- Closes #5447: the empty-string-to-`CommandOutput::Silent` branch, copy-pasted across 8 call sites in 7 `zeph-commands` handler modules (`model.rs` x2, `experiment.rs`, `lsp.rs`, `policy.rs`, `plan.rs`, `loop_cmd.rs`, `plugins.rs`), is now `CommandOutput::message_or_silent`.
- Closes #5663: `handle_skill_activate_as_string`/`handle_skill_approve_as_string`/`handle_skill_reset_as_string` (`crates/zeph-core/src/agent/learning/skill_commands.rs`) now share a single `activate_version_and_write` helper for the activate-and-write-file tail; each handler keeps its own version-selection predicate and success message.
- Closes #5427: the 8 `const TEMPLATE` + chained `.replace()` prompt builders in `zeph-skills` (`evolution.rs`, `stem.rs`, `erl.rs`) now call a shared `prompt_template::render` helper. `DOMAIN_GATE_PROMPT_TEMPLATE`'s existing curly-brace-safety property (avoiding `format!()` because its JSON example contains literal braces) is preserved unchanged — independently re-verified by the adversarial critic against the literal template text and substitution key list.

No behavior change. Adds 5 unit tests covering the extracted helpers directly (`CommandOutput::message_or_silent`'s previously-untested `Message` branch, and 3 direct tests for `prompt_template::render` including brace-safety in isolation).

## Test plan

- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12242 passed, 0 failed
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all passed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`) — clean, pre-existing unrelated warnings in zeph-tui/zeph-channels/zeph-bench only
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` clean
- [x] Adversarial critic pass: verified byte-for-byte behavior equivalence at all 8+3+8 call sites, confirmed no whitespace-only-string drift in #5447, no locking-semantics change from the `&mut self` helper in #5663, and no substitution-order or key/value-swap regressions in #5427
- [x] Independent code review: approved, no blocking findings