### PR TITLE
refactor(core): dedup conversation reset, graph lookup, and sentinel persist logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   JSON example contains literal braces) is preserved unchanged (#5427). Pure refactor, no
   behavior change; covered by 5 new unit tests targeting the extracted helpers directly.
 - `refactor(core)`: deduplicated three independently-duplicated code paths in the agent
+  conversation/graph/sentinel layer. `Agent::reset_conversation` (`/new`) and the former
+  `reset_swap_state` (`/conv resume`, `/conv fork`) shared the same ~45-line session-reset
+  block; both now call a single `reset_session_scoped_state(keep_plan)`
+  (`crates/zeph-core/src/agent/context/assembly.rs`), which the removed
+  `reset_swap_state` invoked with `keep_plan: false` (#5655).
+  `graph_facts`/`graph_history` (`crates/zeph-core/src/agent/agent_access_impl.rs`) shared an
+  entity-resolution-by-name block (5s timeout + "Qdrant unreachable" fallback) and an
+  entity-name-lookup-map-with-fallback block; both are now `resolve_entity_by_name` and
+  `build_entity_name_map`, reproducing the original per-call-site early-return semantics
+  exactly (#5656). `ShadowSentinel::check_tool_call`/`record_tool_event`
+  (`crates/zeph-core/src/agent/shadow_sentinel.rs`) shared an identical
+  clone-store-and-spawn-persist-with-warn-log block, now `persist_event(event,
+  warn_context)` (#5660). Pure refactor, no behavior change.
+- `refactor(core)`: deduplicated three independently-duplicated code paths in the agent
   tool-dispatch pipeline. Merged `call_non_streaming`/`call_non_streaming_with_span`
   (`crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs`) into a single function
   taking an explicit `tracing::Span` parameter; the SSE-fallback call site now passes

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -20,7 +20,7 @@ use zeph_commands::CommandError;
 use zeph_commands::traits::agent::AgentAccess;
 use zeph_db;
 use zeph_memory::semantic::SemanticMemory;
-use zeph_memory::{GraphExtractionConfig, GraphStore, MessageId, extract_and_store};
+use zeph_memory::{Edge, Entity, GraphExtractionConfig, GraphStore, MessageId, extract_and_store};
 
 use super::{Agent, error::AgentError};
 use crate::channel::Channel;
@@ -41,6 +41,68 @@ impl<C: Channel + Send + 'static> Agent<C> {
         };
         Ok((memory, store))
     }
+}
+
+/// Outcome of resolving an entity by display name against the graph store: either the
+/// entity was found, or a user-facing message that the caller should return as-is (no
+/// match, or the store timed out).
+enum EntityLookup {
+    Found(Entity),
+    Message(String),
+}
+
+/// Resolves `name` to an [`Entity`] via [`GraphStore::find_entity_by_name`], bounded by a
+/// 5s timeout — the lookup block shared by `graph_facts` and `graph_history`.
+async fn resolve_entity_by_name(
+    store: &GraphStore,
+    name: &str,
+) -> Result<EntityLookup, CommandError> {
+    let matches =
+        match tokio::time::timeout(Duration::from_secs(5), store.find_entity_by_name(name)).await {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => return Err(CommandError::new(e.to_string())),
+            Err(_) => {
+                tracing::warn!("graph store call timed out after 5s (Qdrant unreachable)");
+                return Ok(EntityLookup::Message(
+                    "Graph store unavailable (Qdrant unreachable).".to_owned(),
+                ));
+            }
+        };
+    let Some(entity) = matches.into_iter().next() else {
+        return Ok(EntityLookup::Message(format!(
+            "No entity found matching '{name}'."
+        )));
+    };
+    Ok(EntityLookup::Found(entity))
+}
+
+/// Builds the `entity_id -> display_name` lookup map shared by `graph_facts` and
+/// `graph_history`: seeds `entity`'s own name, inserts a placeholder for every edge
+/// endpoint, then resolves each placeholder via [`GraphStore::find_entity_by_id`] (5s
+/// timeout), falling back to `#{id}` when the lookup fails or times out.
+async fn build_entity_name_map(
+    store: &GraphStore,
+    entity: &Entity,
+    edges: &[Edge],
+) -> std::collections::HashMap<i64, String> {
+    let mut entity_names: std::collections::HashMap<i64, String> = std::collections::HashMap::new();
+    entity_names.insert(entity.id.0, entity.name.clone());
+    for edge in edges {
+        entity_names.entry(edge.source_entity_id).or_default();
+        entity_names.entry(edge.target_entity_id).or_default();
+    }
+    for (&id, name_val) in &mut entity_names {
+        if name_val.is_empty() {
+            let result =
+                tokio::time::timeout(Duration::from_secs(5), store.find_entity_by_id(id)).await;
+            if let Ok(Ok(Some(other))) = result {
+                *name_val = other.name;
+            } else {
+                *name_val = format!("#{id}");
+            }
+        }
+    }
+    entity_names
 }
 
 /// Run Stage-2 LLM semantic scan for all skills in the plugin at `source`.
@@ -306,24 +368,11 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     Err(msg) => return Ok(msg),
                 };
 
-                let matches = match tokio::time::timeout(
-                    Duration::from_secs(5),
-                    store.find_entity_by_name(name),
-                )
-                .await
-                {
-                    Ok(Ok(v)) => v,
-                    Ok(Err(e)) => return Err(CommandError::new(e.to_string())),
-                    Err(_) => {
-                        tracing::warn!("graph store call timed out after 5s (Qdrant unreachable)");
-                        return Ok("Graph store unavailable (Qdrant unreachable).".to_owned());
-                    }
+                let entity = match resolve_entity_by_name(&store, name).await? {
+                    EntityLookup::Found(e) => e,
+                    EntityLookup::Message(msg) => return Ok(msg),
                 };
-                if matches.is_empty() {
-                    return Ok(format!("No entity found matching '{name}'."));
-                }
 
-                let entity = &matches[0];
                 let edges = match tokio::time::timeout(
                     Duration::from_secs(5),
                     store.edges_for_entity(entity.id.0),
@@ -341,31 +390,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     return Ok(format!("Entity '{}' has no known facts.", entity.name));
                 }
 
-                let mut entity_names: std::collections::HashMap<i64, String> =
-                    std::collections::HashMap::new();
-                entity_names.insert(entity.id.0, entity.name.clone());
-                for edge in &edges {
-                    let other_id = if edge.source_entity_id == entity.id.0 {
-                        edge.target_entity_id
-                    } else {
-                        edge.source_entity_id
-                    };
-                    entity_names.entry(other_id).or_default();
-                }
-                for (&id, name_val) in &mut entity_names {
-                    if name_val.is_empty() {
-                        let result = tokio::time::timeout(
-                            Duration::from_secs(5),
-                            store.find_entity_by_id(id),
-                        )
-                        .await;
-                        if let Ok(Ok(Some(other))) = result {
-                            *name_val = other.name;
-                        } else {
-                            *name_val = format!("#{id}");
-                        }
-                    }
-                }
+                let entity_names = build_entity_name_map(&store, &entity, &edges).await;
 
                 let lines: Vec<String> = edges
                     .iter()
@@ -405,24 +430,11 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     Err(msg) => return Ok(msg),
                 };
 
-                let matches = match tokio::time::timeout(
-                    Duration::from_secs(5),
-                    store.find_entity_by_name(name),
-                )
-                .await
-                {
-                    Ok(Ok(v)) => v,
-                    Ok(Err(e)) => return Err(CommandError::new(e.to_string())),
-                    Err(_) => {
-                        tracing::warn!("graph store call timed out after 5s (Qdrant unreachable)");
-                        return Ok("Graph store unavailable (Qdrant unreachable).".to_owned());
-                    }
+                let entity = match resolve_entity_by_name(&store, name).await? {
+                    EntityLookup::Found(e) => e,
+                    EntityLookup::Message(msg) => return Ok(msg),
                 };
-                if matches.is_empty() {
-                    return Ok(format!("No entity found matching '{name}'."));
-                }
 
-                let entity = &matches[0];
                 let edges = match tokio::time::timeout(
                     Duration::from_secs(5),
                     store.edge_history_for_entity(entity.id.0, 50),
@@ -440,28 +452,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     return Ok(format!("Entity '{}' has no edge history.", entity.name));
                 }
 
-                let mut entity_names: std::collections::HashMap<i64, String> =
-                    std::collections::HashMap::new();
-                entity_names.insert(entity.id.0, entity.name.clone());
-                for edge in &edges {
-                    for &id in &[edge.source_entity_id, edge.target_entity_id] {
-                        entity_names.entry(id).or_default();
-                    }
-                }
-                for (&id, name_val) in &mut entity_names {
-                    if name_val.is_empty() {
-                        let result = tokio::time::timeout(
-                            Duration::from_secs(5),
-                            store.find_entity_by_id(id),
-                        )
-                        .await;
-                        if let Ok(Ok(Some(other))) = result {
-                            *name_val = other.name;
-                        } else {
-                            *name_val = format!("#{id}");
-                        }
-                    }
-                }
+                let entity_names = build_entity_name_map(&store, &entity, &edges).await;
 
                 let n = edges.len();
                 let lines: Vec<String> = edges

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -322,67 +322,14 @@ impl<C: Channel> Agent<C> {
             let _ = tx.send("Resetting conversation...".to_string());
         }
 
-        // --- Step 4: abort background compression tasks (context-compression) ---
-        {
-            if let Some(h) = self.services.compression.pending_task_goal.take() {
-                h.abort();
-            }
-            if let Some(h) = self.services.compression.pending_sidequest_result.take() {
-                h.abort();
-            }
-            if let Some(h) = self.services.compression.pending_subgoal.take() {
-                h.abort();
-            }
-            self.services.compression.current_task_goal = None;
-            self.services.compression.task_goal_user_msg_hash = None;
-            self.services.compression.subgoal_registry =
-                zeph_agent_context::SubgoalRegistry::default();
-            self.services.compression.subgoal_user_msg_hash = None;
-        }
-
-        // --- Step 5: cancel running plan and clear orchestration ---
-        if !keep_plan {
-            if let Some(token) = self.services.orchestration.plan_cancel_token.take() {
-                token.cancel();
-            }
-            self.services.orchestration.pending_graph = None;
-            self.services.orchestration.pending_goal_embedding = None;
-        }
-        // Cancel running sub-agents regardless of keep_plan.
-        if let Some(ref mut mgr) = self.services.orchestration.subagent_manager {
-            mgr.shutdown_all();
-        }
-
-        // --- Step 6: reset message history and caches ---
-        self.clear_history();
-        self.tool_orchestrator.clear_cache();
-
-        // Drain message queue, logging discarded entries.
-        let discarded = self.clear_queue();
+        // --- Steps 4-9: reset session-scoped state shared with the conversation-swap path ---
+        let discarded = self.reset_session_scoped_state(keep_plan);
         if discarded > 0 {
             tracing::debug!(
                 discarded,
                 "/new: discarded queued messages that arrived during reset"
             );
         }
-        self.msg.pending_image_parts.clear();
-
-        // --- Step 7: reset security URL sets ---
-        self.services.security.user_provided_urls.write().clear();
-        self.services.security.flagged_urls.clear();
-
-        // --- Step 8: reset compaction and compression states ---
-        self.context_manager.reset_compaction();
-        self.services.focus.reset();
-        self.services.sidequest.reset();
-
-        // --- Step 9: reset misc session-scoped fields ---
-        self.runtime.debug.iteration_counter = 0;
-        self.msg.last_persisted_message_id = None;
-        self.msg.deferred_db_hide_ids.clear();
-        self.msg.deferred_db_summaries.clear();
-        self.services.tool_state.cached_filtered_tool_ids = None;
-        self.runtime.providers.cached_prompt_tokens = 0;
 
         // --- Step 9b: detach the P1 durable execution (#5452 critic finding S1) — it is keyed
         // on the OLD conversation_id and must not keep journaling turns for the new one. ---
@@ -497,7 +444,13 @@ impl<C: Channel> Agent<C> {
 
         let old_conversation_id = self.services.memory.persistence.conversation_id;
         self.spawn_outgoing_digest(old_conversation_id);
-        self.reset_swap_state();
+        let discarded = self.reset_session_scoped_state(false);
+        if discarded > 0 {
+            tracing::debug!(
+                discarded,
+                "conversation swap: discarded queued messages that arrived during reset"
+            );
+        }
         // Detach the P1 durable execution (#5452 critic finding S1) — same reasoning as
         // `reset_conversation`: it is keyed on the OLD conversation_id and must not keep
         // journaling turns for the resumed/forked one.
@@ -535,11 +488,21 @@ impl<C: Channel> Agent<C> {
         Ok(())
     }
 
-    /// Clears message history/queues/caches shared by [`Self::reset_conversation`] (`/new`) and
+    /// Resets the session-scoped state shared by [`Self::reset_conversation`] (`/new`) and
     /// [`Self::load_and_resume_conversation`] (`/conv resume`/`/conv fork`, D-9) — the parts of
     /// a conversation swap that don't depend on where the new `conversation_id`/message history
-    /// comes from (mirrors `reset_conversation`'s steps 4-9).
-    fn reset_swap_state(&mut self) {
+    /// comes from (mirrors `reset_conversation`'s steps 4-9): abort background compression
+    /// tasks, cancel/clear the pending plan (unless `keep_plan`), shut down running sub-agents,
+    /// clear message history/queues/caches, reset security URL sets, and reset
+    /// compaction/session-scoped counters.
+    ///
+    /// `keep_plan` — when `true`, `orchestration.pending_graph` is preserved (`/new
+    /// --keep-plan`); the conversation-swap path always passes `false`.
+    ///
+    /// Returns the number of queued messages discarded by [`Self::clear_queue`] — callers log
+    /// this with their own context-specific message, since `/new` and the swap path use
+    /// different wording.
+    fn reset_session_scoped_state(&mut self, keep_plan: bool) -> usize {
         if let Some(h) = self.services.compression.pending_task_goal.take() {
             h.abort();
         }
@@ -554,11 +517,14 @@ impl<C: Channel> Agent<C> {
         self.services.compression.subgoal_registry = zeph_agent_context::SubgoalRegistry::default();
         self.services.compression.subgoal_user_msg_hash = None;
 
-        if let Some(token) = self.services.orchestration.plan_cancel_token.take() {
-            token.cancel();
+        if !keep_plan {
+            if let Some(token) = self.services.orchestration.plan_cancel_token.take() {
+                token.cancel();
+            }
+            self.services.orchestration.pending_graph = None;
+            self.services.orchestration.pending_goal_embedding = None;
         }
-        self.services.orchestration.pending_graph = None;
-        self.services.orchestration.pending_goal_embedding = None;
+        // Cancel running sub-agents regardless of keep_plan.
         if let Some(ref mut mgr) = self.services.orchestration.subagent_manager {
             mgr.shutdown_all();
         }
@@ -566,12 +532,6 @@ impl<C: Channel> Agent<C> {
         self.clear_history();
         self.tool_orchestrator.clear_cache();
         let discarded = self.clear_queue();
-        if discarded > 0 {
-            tracing::debug!(
-                discarded,
-                "conversation swap: discarded queued messages that arrived during reset"
-            );
-        }
         self.msg.pending_image_parts.clear();
 
         self.services.security.user_provided_urls.write().clear();
@@ -587,6 +547,8 @@ impl<C: Channel> Agent<C> {
         self.msg.deferred_db_summaries.clear();
         self.services.tool_state.cached_filtered_tool_ids = None;
         self.runtime.providers.cached_prompt_tokens = 0;
+
+        discarded
     }
 
     /// Gather context from all memory sources and inject into the message window.

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -830,13 +830,7 @@ impl ShadowSentinel {
             context_summary: Some(summary),
             created_at: unix_now(),
         };
-        let store = self.store.clone();
-        self.spawn_persist(async move {
-            if let Err(e) = store.record(&event).await {
-                tracing::warn!(error = %e, "ShadowSentinel: failed to persist probe result");
-            }
-        })
-        .await;
+        self.persist_event(event, "probe result").await;
 
         verdict
     }
@@ -866,13 +860,7 @@ impl ShadowSentinel {
             context_summary: Some(context_summary.chars().take(250).collect()),
             created_at: unix_now(),
         };
-        let store = self.store.clone();
-        self.spawn_persist(async move {
-            if let Err(e) = store.record(&event).await {
-                tracing::warn!(error = %e, "ShadowSentinel: failed to persist tool event");
-            }
-        })
-        .await;
+        self.persist_event(event, "tool event").await;
     }
 
     /// Await all queued fire-and-forget persist tasks.
@@ -885,6 +873,21 @@ impl ShadowSentinel {
             std::mem::take(&mut *guard)
         };
         while set.join_next().await.is_some() {}
+    }
+
+    /// Clones the store handle and spawns a fire-and-forget persist of `event` via
+    /// [`Self::spawn_persist`], logging `warn_context` on failure. Shared by
+    /// [`Self::check_tool_call`] (probe results) and [`Self::record_tool_event`]
+    /// (tool-call events) — the two call sites differ only in the event they persist
+    /// and the wording of the warn-log context.
+    async fn persist_event(&self, event: SentinelEvent, warn_context: &'static str) {
+        let store = self.store.clone();
+        self.spawn_persist(async move {
+            if let Err(e) = store.record(&event).await {
+                tracing::warn!(error = %e, "ShadowSentinel: failed to persist {warn_context}");
+            }
+        })
+        .await;
     }
 
     /// Spawn a background persist task into the bounded `JoinSet`.


### PR DESCRIPTION
## Summary

Continues the epic #5714 duplication backlog (cluster 1, zeph-core agent-loop). Three independent, behavior-preserving dedup fixes bundled into one PR since they touch different single files with no cross-dependencies.

- `Agent::reset_conversation` (`/new`) and the now-removed `reset_swap_state` (`/conv resume`, `/conv fork`) duplicated the same ~45-line session-reset block. Extracted `reset_session_scoped_state(keep_plan: bool)` (`crates/zeph-core/src/agent/context/assembly.rs`); the swap-path call site now passes `keep_plan: false`, reproducing the original unconditional behavior. Closes #5655.
- `graph_facts`/`graph_history` (`crates/zeph-core/src/agent/agent_access_impl.rs`) duplicated a 5-second-timeout entity-resolution-by-name block and an entity-name-lookup-map-with-fallback block. Extracted `resolve_entity_by_name`/`build_entity_name_map` (plus a small `EntityLookup` enum), reproducing the exact original timeout/fallback/early-return semantics. `graph_stats`/`graph_entities`/`graph_communities` intentionally left untouched (out of scope). Closes #5656.
- `ShadowSentinel::check_tool_call`/`record_tool_event` (`crates/zeph-core/src/agent/shadow_sentinel.rs`) duplicated an identical clone-store-and-spawn-persist-with-warn-log block, differing only in log wording. Extracted `persist_event(event, warn_context)`. Closes #5660.

No behavior change. No new configuration, CLI, or TUI surface — pure internal refactor.

## Verification

- `cargo +nightly fmt --check` — clean
- `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean, 0 warnings
- `cargo nextest run --config-file .github/nextest.toml -p zeph-core` — 1697 passed, 1 skipped, 0 failed (unchanged from pre-refactor baseline)
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean, no broken intra-doc links
- Independent adversarial critique confirmed behavior equivalence for all three changes, including the non-trivial `build_entity_name_map` endpoint-insertion equivalence (both `graph_facts`'s original single-other-endpoint insert and `graph_history`'s original both-endpoints insert are provably identical given every edge returned by `edges_for_entity`/`edge_history_for_entity` is incident to the queried entity)

## Test plan

- [x] Full `zeph-core` unit test suite passes unchanged (1697 passed)
- [x] Independent behavior-equivalence re-derivation from pre-refactor code (not just trusting the diff)
- [ ] Pre-existing test coverage gaps noted during review (not introduced by this PR, out of scope here): `graph_facts`/`graph_history` have no dedicated tests, `reset_conversation`'s actual command execution (vs. its flag parser) has no dedicated test, `record_tool_event`'s persist-failure path has no dedicated test — candidates for follow-up issues