### PR TITLE
refactor(core,common,context,agent-context,mcp,memory,index): dedup spawn_oneshot, ChatJsonError conversion, and context-budget resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(core,common,context,agent-context,mcp,memory,index)`: deduplicated three more
+  independently-duplicated code paths (epic #5714 cluster 1 remainder). Seven call sites across
+  six crates (`zeph-context`, `zeph-agent-context`, `zeph-core`, `zeph-mcp`, `zeph-memory`,
+  `zeph-index`) that reimplemented `TaskSupervisor::spawn`'s `Fn`-bound workaround for one-shot
+  futures via `Arc<Mutex<Option<Fut>>>` now call `TaskSupervisor::spawn_oneshot` directly (#5661).
+  `run_proposer`/`run_checker` (`crates/zeph-core/src/quality/`) now share a
+  `chat_json_error_outcome` helper (`quality/parser.rs`) instead of duplicating the
+  `ChatJsonError`-to-`StageOutcome` conversion (#5666). `AppBuilder::auto_budget_tokens`
+  (`src/bootstrap/mod.rs`) and `resolve_context_budget` (`crates/zeph-core/src/agent/mod.rs`)
+  now both delegate to a shared `resolve_context_budget_tokens` helper, closing a
+  `provider.context_window() == Some(0)` gap where the extraction had briefly let a
+  misconfigured zero-context-window provider through as a real budget instead of the documented
+  128k fallback (#5653). Pure refactor, no behavior change.
 - `refactor(commands,core,skills)`: deduplicated three independently-drifting code paths in the
   commands/skills subsystem (epic #5714 duplication-backlog cluster 5). The empty-string-to-
   `CommandOutput::Silent` branch, previously copy-pasted across 8 call sites in 7

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -686,23 +686,12 @@ impl ContextService {
         // before `apply_prepared_context` consumes `prepared` to avoid silent drops.
         for handle in prepared.background_tasks.drain(..) {
             let task_supervisor = std::sync::Arc::clone(&view.task_supervisor);
-            task_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "context.assembly.background",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: {
-                    let cell = std::sync::Arc::new(std::sync::Mutex::new(Some(async move {
-                        let _ = handle.await;
-                    })));
-                    move || {
-                        let f = cell.lock().ok().and_then(|mut g| g.take());
-                        async move {
-                            if let Some(f) = f {
-                                f.await;
-                            }
-                        }
-                    }
+            drop(task_supervisor.spawn_oneshot(
+                std::sync::Arc::from("context.assembly.background"),
+                move || async move {
+                    let _ = handle.await;
                 },
-            });
+            ));
         }
 
         let (delta, inserted_count) = self.apply_prepared_context(window, view, prepared).await;

--- a/crates/zeph-context/src/typed_page.rs
+++ b/crates/zeph-context/src/typed_page.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};
+use zeph_common::task_supervisor::TaskSupervisor;
 use zeph_common::text::truncate_to_bytes_ref;
 
 // ── PageType ──────────────────────────────────────────────────────────────────
@@ -979,19 +979,7 @@ impl CompactionAuditSink {
         };
 
         if let Some(sup) = supervisor {
-            let fut_cell = Arc::new(parking_lot::Mutex::new(Some(fut)));
-            sup.spawn(TaskDescriptor {
-                name: "context.audit_sink",
-                restart: RestartPolicy::RunOnce,
-                factory: move || {
-                    let f = fut_cell.lock().take();
-                    async move {
-                        if let Some(f) = f {
-                            f.await;
-                        }
-                    }
-                },
-            });
+            drop(sup.spawn_oneshot(Arc::from("context.audit_sink"), move || fut));
         } else {
             tokio::spawn(fut); // EXEMPT: supervisor=None fallback (test environments only)
         }

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -250,19 +250,12 @@ impl<C: Channel> Agent<C> {
                 let _ = tx.send(String::new());
             }
         };
-        let cell = std::sync::Arc::new(std::sync::Mutex::new(Some(digest_future)));
-        task_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "agent.session.digest",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                let f = cell.lock().ok().and_then(|mut g| g.take());
-                async move {
-                    if let Some(f) = f {
-                        f.await;
-                    }
-                }
-            },
-        });
+        drop(
+            task_supervisor
+                .spawn_oneshot(std::sync::Arc::from("agent.session.digest"), move || {
+                    digest_future
+                }),
+        );
     }
 
     /// Reset the conversation window for `/new`.

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2007,11 +2007,6 @@ pub(crate) async fn recv_optional<T>(rx: &mut Option<mpsc::Receiver<T>>) -> Opti
     }
 }
 
-/// Resolve the effective context budget from config, applying the `auto_budget` fallback.
-///
-/// Mirrors `AppBuilder::auto_budget_tokens` so hot-reload and initial startup use the same
-/// logic: if `auto_budget = true` and `context_budget_tokens == 0`, query the provider's
-/// context window; if still 0, fall back to 128 000 tokens.
 /// Truncate a background run command to at most 80 characters for TUI display.
 fn truncate_shell_command(cmd: &str) -> String {
     if cmd.len() <= 80 {
@@ -2026,28 +2021,59 @@ fn truncate_shell_run_id(id: &str) -> String {
     id.chars().take(8).collect()
 }
 
-pub(crate) fn resolve_context_budget(config: &Config, provider: &AnyProvider) -> usize {
-    let tokens = if config.memory.auto_budget && config.memory.context_budget_tokens == 0 {
-        if let Some(ctx_size) = provider.context_window() {
-            tracing::info!(
-                model_context = ctx_size,
-                "auto-configured context budget on reload"
-            );
-            ctx_size
-        } else {
-            0
-        }
-    } else {
-        config.memory.context_budget_tokens
-    };
-    if tokens == 0 {
-        tracing::warn!(
-            "context_budget_tokens resolved to 0 on reload — using fallback of 128000 tokens"
-        );
-        128_000
-    } else {
-        tokens
+/// How the effective context-token budget was determined by [`resolve_context_budget_tokens`].
+///
+/// Callers use this to choose a diagnostic log message appropriate to their call site
+/// (initial startup vs. config hot-reload) while sharing the same resolution algorithm.
+pub enum ContextBudgetSource {
+    /// Auto-detected from the provider's advertised context window.
+    AutoDetected(usize),
+    /// Explicit `memory.context_budget_tokens` config value, or `auto_budget` disabled.
+    Configured,
+    /// Neither the config nor the provider yielded a usable value; the hardcoded fallback was used.
+    Fallback,
+}
+
+/// Resolve the effective context-token budget, shared by initial startup
+/// (`AppBuilder::auto_budget_tokens`) and config hot-reload (`resolve_context_budget`).
+///
+/// If `auto_budget` is enabled and no explicit budget is configured, uses the provider's
+/// reported context window. Falls back to a hardcoded 128 000 tokens if the resolved value
+/// would otherwise be 0, to guarantee that compaction fires rather than being silently skipped.
+pub fn resolve_context_budget_tokens(
+    config: &Config,
+    provider: &AnyProvider,
+) -> (usize, ContextBudgetSource) {
+    if config.memory.auto_budget && config.memory.context_budget_tokens == 0 {
+        return match provider.context_window() {
+            Some(ctx_size) if ctx_size > 0 => {
+                (ctx_size, ContextBudgetSource::AutoDetected(ctx_size))
+            }
+            _ => (128_000, ContextBudgetSource::Fallback),
+        };
     }
+    if config.memory.context_budget_tokens == 0 {
+        return (128_000, ContextBudgetSource::Fallback);
+    }
+    (
+        config.memory.context_budget_tokens,
+        ContextBudgetSource::Configured,
+    )
+}
+
+pub(crate) fn resolve_context_budget(config: &Config, provider: &AnyProvider) -> usize {
+    let (tokens, source) = resolve_context_budget_tokens(config, provider);
+    match source {
+        ContextBudgetSource::AutoDetected(ctx_size) => tracing::info!(
+            model_context = ctx_size,
+            "auto-configured context budget on reload"
+        ),
+        ContextBudgetSource::Fallback => tracing::warn!(
+            "context_budget_tokens resolved to 0 on reload — using fallback of 128000 tokens"
+        ),
+        ContextBudgetSource::Configured => {}
+    }
+    tokens
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -139,19 +139,10 @@ impl<C: crate::channel::Channel> Agent<C> {
                         );
                     }
                 };
-                let cell = std::sync::Arc::new(std::sync::Mutex::new(Some(send_event)));
-                sup.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                    name: "agent.scheduler.task_event_send",
-                    restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                    factory: move || {
-                        let f = cell.lock().ok().and_then(|mut g| g.take());
-                        async move {
-                            if let Some(f) = f {
-                                f.await;
-                            }
-                        }
-                    },
-                });
+                drop(sup.spawn_oneshot(
+                    std::sync::Arc::from("agent.scheduler.task_event_send"),
+                    move || send_event,
+                ));
             }
         };
 

--- a/crates/zeph-core/src/agent/tests/small_misc_tests.rs
+++ b/crates/zeph-core/src/agent/tests/small_misc_tests.rs
@@ -42,6 +42,17 @@ fn auto_budget_false_budget_zero_falls_back_to_128k() {
     assert_eq!(resolve_context_budget(&config, &provider), 128_000);
 }
 
+#[test]
+fn auto_budget_true_budget_zero_provider_window_zero_falls_back_to_128k() {
+    let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+    config.memory.auto_budget = true;
+    config.memory.context_budget_tokens = 0;
+    // Provider reports Some(0) — a misconfigured window, not "unknown" (None).
+    // Must still fall back to 128k rather than resolving to a real 0-token budget.
+    let provider = AnyProvider::Mock(MockProvider::default().with_context_window(0));
+    assert_eq!(resolve_context_budget(&config, &provider), 128_000);
+}
+
 #[tokio::test]
 async fn subagent_no_args_returns_usage() {
     let mut h = QuickTestAgent::minimal("");

--- a/crates/zeph-core/src/quality/checker.rs
+++ b/crates/zeph-core/src/quality/checker.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use zeph_llm::any::AnyProvider;
 
-use super::parser::{ChatJsonError, chat_json};
+use super::parser::{chat_json, chat_json_error_outcome};
 use super::prompts::{CHECKER_SYSTEM, checker_user};
 use super::types::{Assertion, AssertionVerdict, StageOutcome};
 
@@ -54,13 +54,6 @@ pub async fn run_checker(
             let retries = attempt.saturating_sub(1);
             (out.verdicts, tokens, StageOutcome::Ok, retries)
         }
-        Err(ChatJsonError::Llm(e)) => (vec![], 0, StageOutcome::LlmError { msg: e.to_string() }, 0),
-        Err(ChatJsonError::Timeout(ms)) => (vec![], 0, StageOutcome::Timeout { ms }, 0),
-        Err(ChatJsonError::Parse(raw)) => (
-            vec![],
-            0,
-            StageOutcome::ParseError { raw_truncated: raw },
-            1,
-        ),
+        Err(e) => chat_json_error_outcome(e),
     }
 }

--- a/crates/zeph-core/src/quality/parser.rs
+++ b/crates/zeph-core/src/quality/parser.rs
@@ -165,6 +165,29 @@ pub async fn chat_json<T: DeserializeOwned>(
     }
 }
 
+/// Convert a [`ChatJsonError`] into the `(items, tokens, outcome, retries)` shape shared by
+/// every stage's `Err` arm (Proposer, Checker, ...).
+#[must_use]
+pub fn chat_json_error_outcome<T>(
+    e: ChatJsonError,
+) -> (Vec<T>, u64, super::types::StageOutcome, u32) {
+    match e {
+        ChatJsonError::Llm(e) => (
+            vec![],
+            0,
+            super::types::StageOutcome::LlmError { msg: e.to_string() },
+            0,
+        ),
+        ChatJsonError::Timeout(ms) => (vec![], 0, super::types::StageOutcome::Timeout { ms }, 0),
+        ChatJsonError::Parse(raw) => (
+            vec![],
+            0,
+            super::types::StageOutcome::ParseError { raw_truncated: raw },
+            1,
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/zeph-core/src/quality/proposer.rs
+++ b/crates/zeph-core/src/quality/proposer.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use zeph_llm::any::AnyProvider;
 
-use super::parser::{ChatJsonError, chat_json};
+use super::parser::{chat_json, chat_json_error_outcome};
 use super::prompts::{PROPOSER_SYSTEM, proposer_user};
 use super::types::{Assertion, StageOutcome};
 
@@ -34,13 +34,6 @@ pub async fn run_proposer(
             let retries = attempt.saturating_sub(1);
             (out.assertions, tokens, StageOutcome::Ok, retries)
         }
-        Err(ChatJsonError::Llm(e)) => (vec![], 0, StageOutcome::LlmError { msg: e.to_string() }, 0),
-        Err(ChatJsonError::Timeout(ms)) => (vec![], 0, StageOutcome::Timeout { ms }, 0),
-        Err(ChatJsonError::Parse(raw)) => (
-            vec![],
-            0,
-            StageOutcome::ParseError { raw_truncated: raw },
-            1,
-        ),
+        Err(e) => chat_json_error_outcome(e),
     }
 }

--- a/crates/zeph-index/src/watcher.rs
+++ b/crates/zeph-index/src/watcher.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
 use tokio::sync::mpsc;
-use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};
+use zeph_common::task_supervisor::TaskSupervisor;
 
 use crate::error::Result;
 use crate::indexer::CodeIndexer;
@@ -64,7 +64,7 @@ fn is_gitignored(gitignore: &Gitignore, root: &Path, path: &Path) -> bool {
 /// Opaque handle keeping the background watcher task alive.
 #[allow(dead_code)]
 enum WatcherHandle {
-    Supervised(zeph_common::task_supervisor::TaskHandle),
+    Supervised(zeph_common::task_supervisor::BlockingHandle<()>),
     Unsupervised(tokio::task::JoinHandle<()>),
 }
 
@@ -203,21 +203,7 @@ impl IndexWatcher {
         };
 
         let handle = if let Some(sup) = supervisor {
-            // Wrap the one-shot future so the `Fn` factory can hand it off exactly once.
-            // `parking_lot::Mutex` is available transitively via `zeph_common`.
-            let fut_cell = std::sync::Arc::new(std::sync::Mutex::new(Some(fut)));
-            let task_handle = sup.spawn(TaskDescriptor {
-                name: "index.watcher",
-                restart: RestartPolicy::RunOnce,
-                factory: move || {
-                    let f = fut_cell.lock().ok().and_then(|mut g| g.take());
-                    async move {
-                        if let Some(f) = f {
-                            f.await;
-                        }
-                    }
-                },
-            });
+            let task_handle = sup.spawn_oneshot(std::sync::Arc::from("index.watcher"), move || fut);
             WatcherHandle::Supervised(task_handle)
         } else {
             WatcherHandle::Unsupervised(tokio::spawn(fut)) // EXEMPT: supervisor=None fallback (test environments only)

--- a/crates/zeph-mcp/src/manager/connect.rs
+++ b/crates/zeph-mcp/src/manager/connect.rs
@@ -169,21 +169,7 @@ impl McpManager {
         };
 
         if let Some(sup) = supervisor {
-            let cell = std::sync::Arc::new(parking_lot::Mutex::new(Some(task)));
-            // spawn() requires Fn; wrap the FnOnce payload in Arc<Mutex<Option>> so the
-            // factory can be called once for RunOnce without capturing by move.
-            sup.spawn(zeph_common::TaskDescriptor {
-                name: "mcp.refresh_task",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    let fut = cell.lock().take();
-                    async move {
-                        if let Some(f) = fut {
-                            f.await;
-                        }
-                    }
-                },
-            });
+            drop(sup.spawn_oneshot(std::sync::Arc::from("mcp.refresh_task"), move || task));
         } else {
             tokio::spawn(task); // EXEMPT(test): no supervisor available in unit-test context
         }

--- a/crates/zeph-memory/src/retrieval_failure_logger.rs
+++ b/crates/zeph-memory/src/retrieval_failure_logger.rs
@@ -7,12 +7,12 @@
 //! [`RetrievalFailureLogger::log`] on the hot path without blocking. A
 //! background task coalesces records into batches and flushes them to `SQLite`.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{Notify, mpsc};
 use tracing::Instrument as _;
-use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};
+use zeph_common::task_supervisor::TaskSupervisor;
 
 use crate::store::SqliteStore;
 use crate::store::retrieval_failures::RetrievalFailureRecord;
@@ -61,19 +61,7 @@ impl RetrievalFailureLogger {
             retention_days,
             Arc::clone(&done),
         );
-        let cell = Arc::new(Mutex::new(Some(fut)));
-        supervisor.spawn(TaskDescriptor {
-            name: "memory.retrieval-failure-logger",
-            restart: RestartPolicy::RunOnce,
-            factory: move || {
-                let f = cell.lock().ok().and_then(|mut g| g.take());
-                async move {
-                    if let Some(f) = f {
-                        f.await;
-                    }
-                }
-            },
-        });
+        drop(supervisor.spawn_oneshot(Arc::from("memory.retrieval-failure-logger"), move || fut));
         Self { tx: Some(tx), done }
     }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -371,25 +371,20 @@ impl AppBuilder {
     /// window cannot be determined, to guarantee that compaction fires rather than being
     /// silently skipped.
     pub fn auto_budget_tokens(&self, provider: &AnyProvider) -> usize {
-        let tokens =
-            if self.config.memory.auto_budget && self.config.memory.context_budget_tokens == 0 {
-                if let Some(ctx_size) = provider.context_window() {
-                    tracing::info!(model_context = ctx_size, "auto-configured context budget");
-                    ctx_size
-                } else {
-                    0
-                }
-            } else {
-                self.config.memory.context_budget_tokens
-            };
-        if tokens == 0 {
-            tracing::warn!(
-                "context_budget_tokens resolved to 0 — using fallback of 128000 tokens to ensure compaction runs"
-            );
-            128_000
-        } else {
-            tokens
+        let (tokens, source) =
+            zeph_core::agent::resolve_context_budget_tokens(&self.config, provider);
+        match source {
+            zeph_core::agent::ContextBudgetSource::AutoDetected(ctx_size) => {
+                tracing::info!(model_context = ctx_size, "auto-configured context budget");
+            }
+            zeph_core::agent::ContextBudgetSource::Fallback => {
+                tracing::warn!(
+                    "context_budget_tokens resolved to 0 — using fallback of 128000 tokens to ensure compaction runs"
+                );
+            }
+            zeph_core::agent::ContextBudgetSource::Configured => {}
         }
+        tokens
     }
 
     /// # Errors

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -748,6 +748,19 @@ fn auto_budget_tokens_explicit_zero_falls_back_to_128k() {
     assert_eq!(builder.auto_budget_tokens(&provider), 128_000);
 }
 
+#[test]
+fn auto_budget_tokens_provider_window_zero_falls_back_to_128k() {
+    let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+    config.memory.auto_budget = true;
+    config.memory.context_budget_tokens = 0;
+    let builder = super::AppBuilder::for_test(config);
+    // Provider reports Some(0) — a misconfigured window, not "unknown" (None).
+    // Must still fall back to 128k rather than resolving to a real 0-token budget.
+    let provider =
+        AnyProvider::Mock(zeph_llm::mock::MockProvider::default().with_context_window(0));
+    assert_eq!(builder.auto_budget_tokens(&provider), 128_000);
+}
+
 // ── build_judge_provider ──────────────────────────────────────────────────────
 
 fn make_builder_with_judge_config(


### PR DESCRIPTION
## Summary

Three independent, no-behavior-change dedup refactors closing out the remainder of epic #5714 cluster 1 (zeph-core agent-loop duplication backlog).

- **#5661**: seven call sites across six crates (`zeph-context`, `zeph-agent-context`, `zeph-core`, `zeph-mcp`, `zeph-memory`, `zeph-index`) reimplemented `TaskSupervisor::spawn`'s `Fn`-bound workaround for one-shot futures via `Arc<Mutex<Option<Fut>>>`; all now call `TaskSupervisor::spawn_oneshot` directly.
- **#5666**: `run_proposer`/`run_checker` (`crates/zeph-core/src/quality/`) duplicated an identical `ChatJsonError`-to-`StageOutcome` conversion; extracted into a shared `chat_json_error_outcome` helper in `quality/parser.rs`.
- **#5653**: `AppBuilder::auto_budget_tokens` (`src/bootstrap/mod.rs`) and `resolve_context_budget` (`crates/zeph-core/src/agent/mod.rs`) independently implemented the same context-budget resolution algorithm; both now delegate to a shared `resolve_context_budget_tokens` helper.

During review, the adversarial critic caught a real behavior-preservation regression in the first draft of the #5653 extraction: it let `provider.context_window() == Some(0)` through as a real zero-token budget instead of the original's documented 128k fallback (reachable via a misconfigured OpenAI/Ollama context-window override). Fixed with an explicit `ctx_size > 0` guard plus a regression test at both call sites.

Closes #5661, #5666, #5653.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12244 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (only pre-existing warnings in untouched files)
- [x] New regression tests added for the `Some(0)` context-window edge case (`small_misc_tests.rs`, `bootstrap/tests.rs`)
- [x] Adversarial critique + independent code review both completed with no unresolved issues