### PR TITLE
fix(llm): thread Cocoon STT status_tx and demote timed-out router providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(llm)`: `RouterProvider::embed`/`embed_batch` (`crates/zeph-llm/src/router/provider_impl.rs`)
+  did not call `record_availability(provider_name, false, ...)` on the per-call timeout branch,
+  unlike the retry-exhaustion and generic-error branches (#5699). A provider that timed out on
+  every embed call was never marked unavailable in Thompson/EMA router bookkeeping, so it kept
+  being tried at full priority instead of being deprioritized. Both timeout branches now record
+  the failure before falling back.
+- `fix(llm)`: `CocoonSttProvider::transcribe` (`crates/zeph-llm/src/cocoon/stt.rs`) passed `None`
+  for `CocoonClient::post_multipart`'s `status_tx` parameter, unlike the chat/embed calls in
+  `CocoonProvider` which thread `self.status_tx.as_ref()` (#5701). Retried STT requests showed no
+  "retrying" TUI status. Added a `status_tx` field and `set_status_tx()` setter to
+  `CocoonSttProvider`, mirroring `CocoonProvider`'s pattern, and threaded it through
+  `apply_cocoon_stt` (`src/agent_setup.rs`) from the agent's existing status channel.
+- `fix(llm)`: verified #5700 (Cocoon retry stacking — exhausted-retry error classified as
+  `RateLimited` instead of `Unavailable`, causing the router to retry an already-retried Cocoon
+  provider) is already resolved as a side effect of #5695's `send_with_retry` last-seen-status
+  classification; `crates/zeph-llm/src/cocoon/tests.rs`'s existing
+  `cocoon_retry_exhausted_returns_unavailable` test already covers the sustained-503 case through
+  a real `CocoonProvider::chat` call. No code change required. Corrected the stale `# Errors` doc
+  comments on `CocoonClient::post`/`post_multipart` (`crates/zeph-llm/src/cocoon/client.rs`),
+  which still claimed exhausted retries only return `RateLimited` — inaccurate since #5695 and
+  directly contradicting this verification.
 - `fix(core)`: `ShadowSentinel::classify_tool` (`crates/zeph-core/src/agent/shadow_sentinel.rs`)
   gated probe engagement for MCP-origin tools entirely on a fixed keyword-substring list
   (`*write*`/`*edit*`/`*delete*`/`*exec*`); a tool named with a different verb (`remove`,

--- a/crates/zeph-llm/src/cocoon/client.rs
+++ b/crates/zeph-llm/src/cocoon/client.rs
@@ -177,8 +177,9 @@ impl CocoonClient {
     ///
     /// # Errors
     ///
-    /// Returns [`LlmError::Http`] on connection failure, or [`LlmError::RateLimited`]
-    /// once retries against repeated 429/503 responses are exhausted.
+    /// Returns [`LlmError::Http`] on connection failure, or once retries against repeated
+    /// 429/503 responses are exhausted: [`LlmError::RateLimited`] if the last response was
+    /// 429, or [`LlmError::Unavailable`] if it was 503.
     pub async fn post_multipart<F>(
         &self,
         path: &str,
@@ -221,8 +222,9 @@ impl CocoonClient {
     ///
     /// # Errors
     ///
-    /// Returns [`LlmError::Http`] on connection failure, or [`LlmError::RateLimited`]
-    /// once retries against repeated 429/503 responses are exhausted.
+    /// Returns [`LlmError::Http`] on connection failure, or once retries against repeated
+    /// 429/503 responses are exhausted: [`LlmError::RateLimited`] if the last response was
+    /// 429, or [`LlmError::Unavailable`] if it was 503.
     pub async fn post(
         &self,
         path: &str,

--- a/crates/zeph-llm/src/cocoon/stt.rs
+++ b/crates/zeph-llm/src/cocoon/stt.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use crate::cocoon::client::CocoonClient;
 use crate::error::LlmError;
+use crate::provider::StatusTx;
 use crate::stt::{SpeechToText, Transcription};
 
 /// STT provider that routes audio through the Cocoon sidecar.
@@ -38,6 +39,7 @@ pub struct CocoonSttProvider {
     model: String,
     client: Arc<CocoonClient>,
     language: Option<String>,
+    status_tx: Option<StatusTx>,
 }
 
 impl std::fmt::Debug for CocoonSttProvider {
@@ -72,6 +74,7 @@ impl CocoonSttProvider {
             model: model.into(),
             client,
             language: None,
+            status_tx: None,
         }
     }
 
@@ -85,6 +88,11 @@ impl CocoonSttProvider {
             self.language = Some(lang);
         }
         self
+    }
+
+    /// Set the TUI status sender; retry/backoff messages are forwarded to the TUI when set.
+    pub fn set_status_tx(&mut self, tx: StatusTx) {
+        self.status_tx = Some(tx);
     }
 }
 
@@ -111,20 +119,24 @@ impl SpeechToText for CocoonSttProvider {
                 // cannot be cloned or reused.
                 let resp = self
                     .client
-                    .post_multipart("/v1/audio/transcriptions", None, move || {
-                        let part = reqwest::multipart::Part::bytes(audio.clone())
-                            .file_name(fname.clone())
-                            .mime_str("application/octet-stream")?;
+                    .post_multipart(
+                        "/v1/audio/transcriptions",
+                        self.status_tx.as_ref(),
+                        move || {
+                            let part = reqwest::multipart::Part::bytes(audio.clone())
+                                .file_name(fname.clone())
+                                .mime_str("application/octet-stream")?;
 
-                        let mut form = reqwest::multipart::Form::new()
-                            .text("model", model.clone())
-                            .text("response_format", "json")
-                            .part("file", part);
-                        if let Some(ref lang) = language {
-                            form = form.text("language", lang.clone());
-                        }
-                        Ok(form)
-                    })
+                            let mut form = reqwest::multipart::Form::new()
+                                .text("model", model.clone())
+                                .text("response_format", "json")
+                                .part("file", part);
+                            if let Some(ref lang) = language {
+                                form = form.text("language", lang.clone());
+                            }
+                            Ok(form)
+                        },
+                    )
                     .await?;
 
                 if !resp.status().is_success() {
@@ -164,6 +176,15 @@ mod tests {
         let stt = CocoonSttProvider::new("whisper-1", make_client());
         assert_eq!(stt.model, "whisper-1");
         assert!(stt.language.is_none());
+        assert!(stt.status_tx.is_none());
+    }
+
+    #[test]
+    fn set_status_tx_stores_sender() {
+        let mut stt = CocoonSttProvider::new("whisper-1", make_client());
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        stt.set_status_tx(tx);
+        assert!(stt.status_tx.is_some());
     }
 
     #[test]

--- a/crates/zeph-llm/src/router/provider_impl.rs
+++ b/crates/zeph-llm/src/router/provider_impl.rs
@@ -339,6 +339,11 @@ impl LlmProvider for RouterProvider {
                                     timeout_ms = embed_timeout_ms,
                                     "embed: provider timed out, falling back"
                                 );
+                                router.record_availability(
+                                    p.name(),
+                                    false,
+                                    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+                                );
                                 last_err = Some(LlmError::Timeout);
                                 break;
                             }
@@ -456,6 +461,11 @@ impl LlmProvider for RouterProvider {
                                     provider = p.name(),
                                     timeout_ms = embed_timeout_ms,
                                     "embed_batch: provider timed out, falling back"
+                                );
+                                router.record_availability(
+                                    p.name(),
+                                    false,
+                                    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
                                 );
                                 last_err = Some(LlmError::Timeout);
                                 break;

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -1161,6 +1161,62 @@ async fn embed_batch_timeout_falls_back_to_next_provider() {
     assert_eq!(result, vec![vec![1.0, 2.0, 3.0]]);
 }
 
+/// Regression for #5699: a provider whose `embed()` times out must be recorded as
+/// unavailable via `record_availability`, just like the retry-exhaustion and generic
+/// error branches — otherwise it keeps being tried at full priority forever.
+#[tokio::test]
+async fn embed_timeout_records_provider_unavailable() {
+    use crate::mock::MockProvider;
+
+    let p = AnyProvider::Mock(
+        MockProvider::default()
+            .with_embed_delay(200)
+            .with_name("slow"),
+    );
+    let r = RouterProvider::new(vec![p])
+        .with_thompson(None)
+        .with_embed_timeout(10);
+    let _ = r.embed("hello").await;
+
+    let stats = r.thompson_stats();
+    let entry = stats.iter().find(|(name, ..)| name == "slow");
+    let (_, alpha, beta) = entry.unwrap_or_else(|| {
+        panic!("embed timeout must call record_availability so 'slow' appears in thompson_stats")
+    });
+    assert!(
+        *beta > *alpha,
+        "timeout must be recorded as a failure (beta > alpha), got alpha={alpha}, beta={beta}"
+    );
+}
+
+/// Regression for #5699: same as above for `embed_batch()`.
+#[tokio::test]
+async fn embed_batch_timeout_records_provider_unavailable() {
+    use crate::mock::MockProvider;
+
+    let p = AnyProvider::Mock(
+        MockProvider::default()
+            .with_embed_delay(200)
+            .with_name("slow"),
+    );
+    let r = RouterProvider::new(vec![p])
+        .with_thompson(None)
+        .with_embed_timeout(10);
+    let _ = r.embed_batch(&["hello"]).await;
+
+    let stats = r.thompson_stats();
+    let entry = stats.iter().find(|(name, ..)| name == "slow");
+    let (_, alpha, beta) = entry.unwrap_or_else(|| {
+        panic!(
+            "embed_batch timeout must call record_availability so 'slow' appears in thompson_stats"
+        )
+    });
+    assert!(
+        *beta > *alpha,
+        "timeout must be recorded as a failure (beta > alpha), got alpha={alpha}, beta={beta}"
+    );
+}
+
 // ── quality_gate tests ────────────────────────────────────────────────────
 
 /// `with_quality_gate()` happy path: when cosine similarity >= threshold the

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1823,7 +1823,8 @@ pub(crate) fn apply_whisper_stt<C: Channel>(
 ///
 /// Constructs a [`CocoonClient`] from `entry`'s `cocoon_client_url` and `cocoon_access_hash`
 /// fields, then wires up a [`CocoonSttProvider`] using the LLM timeout so that large audio
-/// files are not cut off by a short health-check timeout.
+/// files are not cut off by a short health-check timeout. `status_tx`, when set, is forwarded
+/// to the provider so retried transcription requests surface a TUI status message.
 ///
 /// [`CocoonClient`]: zeph_llm::cocoon::CocoonClient
 /// [`CocoonSttProvider`]: zeph_llm::cocoon::CocoonSttProvider
@@ -1833,6 +1834,7 @@ pub(crate) fn apply_cocoon_stt<C: Channel>(
     entry: &zeph_core::config::ProviderEntry,
     language: &str,
     llm_timeout_secs: u64,
+    status_tx: Option<zeph_llm::provider::StatusTx>,
 ) -> zeph_core::agent::Agent<C> {
     let model = entry.stt_model.as_deref().unwrap_or("whisper-1");
     let base_url = entry
@@ -1844,7 +1846,10 @@ pub(crate) fn apply_cocoon_stt<C: Channel>(
         entry.cocoon_access_hash.clone(),
         std::time::Duration::from_secs(llm_timeout_secs),
     ));
-    let stt = zeph_llm::cocoon::CocoonSttProvider::new(model, client).with_language(language);
+    let mut stt = zeph_llm::cocoon::CocoonSttProvider::new(model, client).with_language(language);
+    if let Some(tx) = status_tx {
+        stt.set_status_tx(tx);
+    }
     tracing::info!(model, base_url, "STT enabled via Cocoon sidecar");
     agent.with_stt(Box::new(stt))
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3546,6 +3546,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                     stt_entry,
                     language,
                     config.timeouts.llm_request_timeout_secs,
+                    Some(agent_status_tx.clone()),
                 ),
                 #[cfg(not(feature = "cocoon"))]
                 zeph_core::config::ProviderKind::Cocoon => {


### PR DESCRIPTION
## Summary

Three zeph-llm robustness follow-ups filed during review of PR #5693 (Cocoon/router provider robustness):

- **#5701**: `CocoonSttProvider::transcribe` passed `None` for `status_tx` to `CocoonClient::post_multipart`, unlike `CocoonProvider`'s chat/embed calls which thread `self.status_tx.as_ref()`. Retried STT requests showed no "retrying" TUI status. Added a `status_tx` field + `set_status_tx()` to `CocoonSttProvider`, mirroring `CocoonProvider`'s pattern, threaded from the agent's existing status channel through `apply_cocoon_stt` (`src/agent_setup.rs`) and its caller (`src/runner.rs`).

- **#5699**: `RouterProvider::embed()`/`embed_batch()` (`crates/zeph-llm/src/router/provider_impl.rs`) skipped `record_availability(provider_name, false, elapsed_ms)` on their timeout branch, unlike the retry-exhaustion branch. A provider that timed out on every call was never demoted in Thompson/reputation bookkeeping and kept being tried at full priority indefinitely. Both timeout branches now record the failure; two new regression tests assert a chronically-timing-out provider shows up as demoted via `thompson_stats()`.

- **#5700**: originally reported that Cocoon's exhausted-retry error mapped to `RateLimited` instead of `Unavailable`, causing the router to retry an already-retried Cocoon provider (nested retry stacking up to ~30s on sustained 503). **No code change** — verified this was already resolved as a side effect of #5695's change to `send_with_retry`'s exhausted-retry classification (503→`Unavailable`, 429→`RateLimited`, based on last-seen status). Confirmed independently (by implementation, testing, and adversarial-critique passes) that Cocoon's `post`/`post_multipart` route through the shared `send_with_retry` with no bypass, and that `cocoon_retry_exhausted_returns_unavailable` in `crates/zeph-llm/src/cocoon/tests.rs` already exercises the sustained-503 case end-to-end through a real `CocoonProvider::chat` call. Also corrected the stale `# Errors` doc comments on `CocoonClient::post`/`post_multipart`, which still claimed exhausted retries only return `RateLimited`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12244 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-llm --features "cocoon,gonka,testing,classifiers"` (`--all-features` fails in this environment due to `cudarc` needing `nvcc`, unrelated to this change)
- [x] New regression tests added for #5699's timeout-demotion behavior
- [x] CHANGELOG.md updated

Closes #5701, #5700, #5699