### PR TITLE
fix(llm): send flat reasoning_effort field to OpenAI Chat Completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(llm)`: OpenAI/compatible provider's `reasoning_effort` was serialized as the OpenAI
+  Responses-API nested shape (`"reasoning":{"effort":"..."}`) instead of the Chat-Completions
+  flat field (`"reasoning_effort":"..."`), causing every real reasoning-capable model (o-series,
+  gpt-5.x) to reject requests with a 400 `unknown_parameter` error (#5775). Removed the
+  `Reasoning<'a>` wrapper struct entirely; `reasoning_effort` is now a flat `Option<&str>` field
+  on `ChatRequest`/`VisionChatRequest`/`ToolChatRequest` (`crates/zeph-llm/src/openai/mod.rs`),
+  with all 4 request-building call sites (`send_request`, `send_stream_request`,
+  `debug_request_json`, `chat_with_tools`) updated consistently. Verified against the live
+  OpenAI API (`gpt-5-mini`): the flat shape returns 200 with `reasoning_tokens`, while the old
+  nested shape reproduces the original 400 error.
 - `fix(llm)`: `RouterProvider::embed`/`embed_batch` (`crates/zeph-llm/src/router/provider_impl.rs`)
   did not call `record_availability(provider_name, false, ...)` on the per-call timeout branch,
   unlike the retry-exhaustion and generic-error branches (#5699). A provider that timed out on

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -522,10 +522,7 @@ impl OpenAiProvider {
 
     #[tracing::instrument(name = "llm.openai.send_request", skip_all)]
     async fn send_request(&self, messages: &[Message]) -> Result<String, LlmError> {
-        let reasoning = self
-            .reasoning_effort
-            .as_deref()
-            .map(|effort| Reasoning { effort });
+        let reasoning_effort = self.reasoning_effort.as_deref();
 
         let (temperature, top_p, frequency_penalty, presence_penalty) = self.generation_params();
 
@@ -536,7 +533,7 @@ impl OpenAiProvider {
                 messages: vision_messages,
                 completion_tokens: self.completion_tokens(),
                 stream: false,
-                reasoning,
+                reasoning_effort,
                 temperature,
                 top_p,
                 frequency_penalty,
@@ -555,7 +552,7 @@ impl OpenAiProvider {
                 messages: &api_messages,
                 completion_tokens: self.completion_tokens(),
                 stream: false,
-                reasoning,
+                reasoning_effort,
                 temperature,
                 top_p,
                 frequency_penalty,
@@ -591,10 +588,7 @@ impl OpenAiProvider {
         messages: &[Message],
     ) -> Result<reqwest::Response, LlmError> {
         let api_messages = convert_messages(messages);
-        let reasoning = self
-            .reasoning_effort
-            .as_deref()
-            .map(|effort| Reasoning { effort });
+        let reasoning_effort = self.reasoning_effort.as_deref();
 
         let (temperature, top_p, frequency_penalty, presence_penalty) = self.generation_params();
 
@@ -603,7 +597,7 @@ impl OpenAiProvider {
             messages: &api_messages,
             completion_tokens: self.completion_tokens(),
             stream: true,
-            reasoning,
+            reasoning_effort,
             temperature,
             top_p,
             frequency_penalty,
@@ -845,10 +839,7 @@ impl LlmProvider for OpenAiProvider {
         tools: &[ToolDefinition],
         stream: bool,
     ) -> serde_json::Value {
-        let reasoning = self
-            .reasoning_effort
-            .as_deref()
-            .map(|effort| Reasoning { effort });
+        let reasoning_effort = self.reasoning_effort.as_deref();
         let (temperature, top_p, frequency_penalty, presence_penalty) = self.generation_params();
 
         if !tools.is_empty() {
@@ -883,7 +874,7 @@ impl LlmProvider for OpenAiProvider {
                 messages: &api_messages,
                 completion_tokens: self.completion_tokens(),
                 tools: &api_tools,
-                reasoning,
+                reasoning_effort,
                 temperature,
                 top_p,
                 frequency_penalty,
@@ -900,7 +891,7 @@ impl LlmProvider for OpenAiProvider {
                 messages: vision_messages,
                 completion_tokens: self.completion_tokens(),
                 stream,
-                reasoning,
+                reasoning_effort,
                 temperature,
                 top_p,
                 frequency_penalty,
@@ -916,7 +907,7 @@ impl LlmProvider for OpenAiProvider {
             messages: &api_messages,
             completion_tokens: self.completion_tokens(),
             stream,
-            reasoning,
+            reasoning_effort,
             temperature,
             top_p,
             frequency_penalty,
@@ -1000,10 +991,7 @@ impl LlmProvider for OpenAiProvider {
         tools: &[ToolDefinition],
     ) -> Result<ChatResponse, LlmError> {
         let api_messages = convert_messages_structured(messages);
-        let reasoning = self
-            .reasoning_effort
-            .as_deref()
-            .map(|effort| Reasoning { effort });
+        let reasoning_effort = self.reasoning_effort.as_deref();
 
         let descriptions: Vec<String> = tools
             .iter()
@@ -1037,7 +1025,7 @@ impl LlmProvider for OpenAiProvider {
             messages: &api_messages,
             completion_tokens: self.completion_tokens(),
             tools: &api_tools,
-            reasoning,
+            reasoning_effort,
             temperature,
             top_p,
             frequency_penalty,
@@ -1213,7 +1201,7 @@ struct VisionChatRequest<'a> {
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reasoning: Option<Reasoning<'a>>,
+    reasoning_effort: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1308,7 +1296,7 @@ struct ChatRequest<'a> {
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reasoning: Option<Reasoning<'a>>,
+    reasoning_effort: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1317,11 +1305,6 @@ struct ChatRequest<'a> {
     frequency_penalty: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     presence_penalty: Option<f64>,
-}
-
-#[derive(Serialize)]
-struct Reasoning<'a> {
-    effort: &'a str,
 }
 
 #[derive(Serialize)]
@@ -1394,7 +1377,7 @@ struct ToolChatRequest<'a> {
     completion_tokens: CompletionTokens,
     tools: &'a [OpenAiTool<'a>],
     #[serde(skip_serializing_if = "Option::is_none")]
-    reasoning: Option<Reasoning<'a>>,
+    reasoning_effort: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -193,7 +193,7 @@ fn chat_request_serialization() {
         messages: &msgs,
         completion_tokens: CompletionTokens::for_model("gpt-5.2", 1024),
         stream: false,
-        reasoning: None,
+        reasoning_effort: None,
         temperature: None,
         top_p: None,
         frequency_penalty: None,
@@ -219,7 +219,7 @@ fn chat_request_serialization_non_gpt5_uses_max_tokens() {
         messages: &msgs,
         completion_tokens: CompletionTokens::for_model("gpt-4o", 256),
         stream: false,
-        reasoning: None,
+        reasoning_effort: None,
         temperature: None,
         top_p: None,
         frequency_penalty: None,
@@ -238,7 +238,7 @@ fn chat_request_with_stream_flag() {
         messages: &msgs,
         completion_tokens: CompletionTokens::for_model("gpt-5.2", 100),
         stream: true,
-        reasoning: None,
+        reasoning_effort: None,
         temperature: None,
         top_p: None,
         frequency_penalty: None,
@@ -256,14 +256,90 @@ fn chat_request_with_reasoning_effort() {
         messages: &msgs,
         completion_tokens: CompletionTokens::for_model("gpt-5.2", 100),
         stream: false,
-        reasoning: Some(Reasoning { effort: "medium" }),
+        reasoning_effort: Some("medium"),
         temperature: None,
         top_p: None,
         frequency_penalty: None,
         presence_penalty: None,
     };
     let json = serde_json::to_string(&body).unwrap();
-    assert!(json.contains("\"reasoning\":{\"effort\":\"medium\"}"));
+    assert!(json.contains("\"reasoning_effort\":\"medium\""));
+    assert!(!json.contains("\"reasoning\":{"));
+}
+
+#[test]
+fn debug_request_json_plain_includes_flat_reasoning_effort() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-5.2".into(),
+        max_tokens: 4096,
+        embedding_model: None,
+        reasoning_effort: Some("medium".into()),
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    let messages = vec![Message::from_legacy(Role::User, "hi")];
+    let json = p.debug_request_json(&messages, &[], false).to_string();
+    assert!(json.contains("\"reasoning_effort\":\"medium\""));
+    assert!(!json.contains("\"reasoning\":{"));
+}
+
+#[test]
+fn debug_request_json_tools_includes_flat_reasoning_effort() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-5.2".into(),
+        max_tokens: 4096,
+        embedding_model: None,
+        reasoning_effort: Some("high".into()),
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    let messages = vec![Message::from_legacy(Role::User, "hi")];
+    let tools = vec![ToolDefinition {
+        name: "bash".into(),
+        description: "Execute a shell command".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"]
+        }),
+        output_schema: None,
+    }];
+    let json = p.debug_request_json(&messages, &tools, false).to_string();
+    assert!(json.contains("\"reasoning_effort\":\"high\""));
+    assert!(!json.contains("\"reasoning\":{"));
+}
+
+#[test]
+fn debug_request_json_vision_includes_flat_reasoning_effort() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-5.2".into(),
+        max_tokens: 4096,
+        embedding_model: None,
+        reasoning_effort: Some("low".into()),
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    let messages = vec![Message::from_parts(
+        Role::User,
+        vec![
+            MessagePart::Text {
+                text: "describe".into(),
+            },
+            MessagePart::Image(Box::new(ImageData {
+                data: vec![1, 2, 3],
+                mime_type: "image/png".into(),
+            })),
+        ],
+    )];
+    let json = p.debug_request_json(&messages, &[], false).to_string();
+    assert!(json.contains("\"reasoning_effort\":\"low\""));
+    assert!(!json.contains("\"reasoning\":{"));
 }
 
 #[test]
@@ -285,7 +361,7 @@ fn vision_chat_request_serialization_uses_gpt5_completion_tokens() {
         }],
         completion_tokens: CompletionTokens::for_model("gpt-5-mini", 55),
         stream: false,
-        reasoning: None,
+        reasoning_effort: None,
         temperature: None,
         top_p: None,
         frequency_penalty: None,
@@ -347,7 +423,7 @@ fn tool_chat_request_serialization_uses_gpt5_completion_tokens() {
         messages: &msgs,
         completion_tokens: CompletionTokens::for_model("gpt-5-mini", 77),
         tools: &tools,
-        reasoning: None,
+        reasoning_effort: None,
         temperature: None,
         top_p: None,
         frequency_penalty: None,


### PR DESCRIPTION
## Summary

- `OpenAiProvider` (and OpenAI-`compatible` providers) serialized `reasoning_effort` as a nested Responses-API object (`"reasoning":{"effort":"..."}`) instead of the flat top-level string (`"reasoning_effort":"..."`) the Chat Completions endpoint expects. Real reasoning-capable models (o1/o3/o4-mini, gpt-5.x) rejected every request with a 400 `unknown_parameter` error.
- Removed the `Reasoning<'a>` wrapper struct and flattened `reasoning_effort` to `Option<&'a str>` on `ChatRequest`, `VisionChatRequest`, and `ToolChatRequest`, covering all four request-building call sites (`send_request`, `send_stream_request`, `debug_request_json`, `chat_with_tools`).
- Added regression tests covering the vision and tool-call request paths (previously only the plain chat path had positive-value coverage), and verified the fix against the live OpenAI API: the flat shape returns 200 with `reasoning_tokens`, while the old nested shape reproduces the original 400.

Closes #5775

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm` — 945 passed, 0 failed
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci -p zeph-llm --all-targets --features "testing" -- -D warnings`
- [x] Live round-trip against `gpt-5-mini`: flat `reasoning_effort` accepted (200, reasoning tokens in usage), old nested shape reproduces the original 400 `unknown_parameter`