### PR TITLE
refactor(core): dedup trust rollout, hover line-parsing, and graph-timeout helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `test(core)`: added timeout-branch coverage for the graph-query timeout helper
+  (`crates/zeph-core/src/agent/agent_access_impl.rs`) via a `tokio::time::pause()` +
+  `advance(6s)` test against a synthetic never-resolving future, forcing the real
+  `tokio::time::timeout(5s, ...)` arm shared by `resolve_entity_by_name`, `graph_facts`, and
+  `graph_history` instead of only exercising the "no store configured" short-circuit (#5770).
+  A real `GraphStore`-backed integration test was not attempted — `GraphStore` is a concrete
+  type with no trait seam, and combining `tokio::time::pause()` with the SQLite-backed store
+  is a known source of flakiness elsewhere in the workspace — so this proves the shared
+  timeout mechanism deterministically but does not itself invoke `graph_facts`/`graph_history`.
 - `feat(serve,acp)`: `zeph serve-sessions --acp` now runs the ACP protocol transport in-process
   instead of hard-erroring (#5420). Combined mode runs ACP-over-HTTP (`zeph_acp::acp_router`)
   on a **second** `axum::serve` listener bound to `[acp] http_bind`, sharing one
@@ -45,6 +54,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `refactor(core)`: deduplicated two independently-duplicated code paths. `trust.rs`'s
+  `cross_session_rollout_ok_for_promote`/`_for_demote`
+  (`crates/zeph-core/src/agent/learning/trust.rs`) — identical except for which config
+  field they read (`min_sessions_before_promote` vs `_demote`) and their log message — are
+  now a single `cross_session_rollout_ok(memory, skill_name, cross_session_rollout,
+  min_sessions, action)` helper (#5662). `extract_symbol_positions_regex`
+  (`crates/zeph-core/src/lsp_hooks/hover.rs`) now calls `strip_cat_n_prefix` once instead of
+  re-deriving the same tab-prefix/digit-check/line-number logic inline (#5673). Pure
+  refactor, no behavior change.
 - `refactor(core,common,context,agent-context,mcp,memory,index)`: deduplicated three more
   independently-duplicated code paths (epic #5714 cluster 1 remainder). Seven call sites across
   six crates (`zeph-context`, `zeph-agent-context`, `zeph-core`, `zeph-mcp`, `zeph-memory`,

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -109,6 +109,7 @@ schemars.workspace = true
 serial_test.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true, features = ["parking_lot", "registry"] }
 zeph-llm = { workspace = true, features = ["testing"] }
 zeph-memory = { workspace = true, features = ["testing"] }

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -51,23 +51,44 @@ enum EntityLookup {
     Message(String),
 }
 
+/// Outcome of a graph-store call bounded by [`with_graph_store_timeout`]'s 5s deadline:
+/// either it completed, or it timed out (Qdrant unreachable).
+enum StoreCallOutcome<T> {
+    Completed(T),
+    TimedOut,
+}
+
+/// Runs `fut` under a 5s timeout — the deadline shared by `resolve_entity_by_name` and the
+/// edge lookups in `graph_facts`/`graph_history`. Maps a store error to [`CommandError`];
+/// logs and reports a timeout via [`StoreCallOutcome::TimedOut`] so callers only need to
+/// turn that into their own user-facing message.
+async fn with_graph_store_timeout<T>(
+    fut: impl Future<Output = Result<T, zeph_memory::MemoryError>>,
+) -> Result<StoreCallOutcome<T>, CommandError> {
+    match tokio::time::timeout(Duration::from_secs(5), fut).await {
+        Ok(Ok(v)) => Ok(StoreCallOutcome::Completed(v)),
+        Ok(Err(e)) => Err(CommandError::new(e.to_string())),
+        Err(_) => {
+            tracing::warn!("graph store call timed out after 5s (Qdrant unreachable)");
+            Ok(StoreCallOutcome::TimedOut)
+        }
+    }
+}
+
 /// Resolves `name` to an [`Entity`] via [`GraphStore::find_entity_by_name`], bounded by a
 /// 5s timeout — the lookup block shared by `graph_facts` and `graph_history`.
 async fn resolve_entity_by_name(
     store: &GraphStore,
     name: &str,
 ) -> Result<EntityLookup, CommandError> {
-    let matches =
-        match tokio::time::timeout(Duration::from_secs(5), store.find_entity_by_name(name)).await {
-            Ok(Ok(v)) => v,
-            Ok(Err(e)) => return Err(CommandError::new(e.to_string())),
-            Err(_) => {
-                tracing::warn!("graph store call timed out after 5s (Qdrant unreachable)");
-                return Ok(EntityLookup::Message(
-                    "Graph store unavailable (Qdrant unreachable).".to_owned(),
-                ));
-            }
-        };
+    let matches = match with_graph_store_timeout(store.find_entity_by_name(name)).await? {
+        StoreCallOutcome::Completed(v) => v,
+        StoreCallOutcome::TimedOut => {
+            return Ok(EntityLookup::Message(
+                "Graph store unavailable (Qdrant unreachable).".to_owned(),
+            ));
+        }
+    };
     let Some(entity) = matches.into_iter().next() else {
         return Ok(EntityLookup::Message(format!(
             "No entity found matching '{name}'."
@@ -373,19 +394,13 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     EntityLookup::Message(msg) => return Ok(msg),
                 };
 
-                let edges = match tokio::time::timeout(
-                    Duration::from_secs(5),
-                    store.edges_for_entity(entity.id.0),
-                )
-                .await
-                {
-                    Ok(Ok(v)) => v,
-                    Ok(Err(e)) => return Err(CommandError::new(e.to_string())),
-                    Err(_) => {
-                        tracing::warn!("graph store call timed out after 5s (Qdrant unreachable)");
-                        return Ok("Graph store unavailable (Qdrant unreachable).".to_owned());
-                    }
-                };
+                let edges =
+                    match with_graph_store_timeout(store.edges_for_entity(entity.id.0)).await? {
+                        StoreCallOutcome::Completed(v) => v,
+                        StoreCallOutcome::TimedOut => {
+                            return Ok("Graph store unavailable (Qdrant unreachable).".to_owned());
+                        }
+                    };
                 if edges.is_empty() {
                     return Ok(format!("Entity '{}' has no known facts.", entity.name));
                 }
@@ -435,19 +450,15 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     EntityLookup::Message(msg) => return Ok(msg),
                 };
 
-                let edges = match tokio::time::timeout(
-                    Duration::from_secs(5),
-                    store.edge_history_for_entity(entity.id.0, 50),
-                )
-                .await
-                {
-                    Ok(Ok(v)) => v,
-                    Ok(Err(e)) => return Err(CommandError::new(e.to_string())),
-                    Err(_) => {
-                        tracing::warn!("graph store call timed out after 5s (Qdrant unreachable)");
-                        return Ok("Graph store unavailable (Qdrant unreachable).".to_owned());
-                    }
-                };
+                let edges =
+                    match with_graph_store_timeout(store.edge_history_for_entity(entity.id.0, 50))
+                        .await?
+                    {
+                        StoreCallOutcome::Completed(v) => v,
+                        StoreCallOutcome::TimedOut => {
+                            return Ok("Graph store unavailable (Qdrant unreachable).".to_owned());
+                        }
+                    };
                 if edges.is_empty() {
                     return Ok(format!("Entity '{}' has no edge history.", entity.name));
                 }
@@ -2377,6 +2388,44 @@ mod tests {
         assert!(
             result.is_err(),
             "timeout must fire on a never-resolving future"
+        );
+    }
+
+    // ── #5770: with_graph_store_timeout had zero coverage of its own timeout branch —
+    // existing tests only reached the "no store configured" short-circuit in
+    // resolve_graph_store(), never the 5s deadline shared by resolve_entity_by_name,
+    // graph_facts, and graph_history. Exercise the extracted helper directly with a
+    // paused clock so the deadline fires deterministically without a real wall-clock wait.
+
+    #[tokio::test]
+    async fn with_graph_store_timeout_completes_on_success() {
+        let result = with_graph_store_timeout(async { Ok::<_, zeph_memory::MemoryError>(42) })
+            .await
+            .unwrap();
+        assert!(matches!(result, StoreCallOutcome::Completed(42)));
+    }
+
+    #[tokio::test]
+    async fn with_graph_store_timeout_maps_store_error_to_command_error() {
+        let result = with_graph_store_timeout(async {
+            Err::<i32, _>(zeph_memory::MemoryError::GraphStore("boom".to_owned()))
+        })
+        .await;
+        assert!(result.is_err(), "store error must surface as CommandError");
+    }
+
+    #[tokio::test]
+    async fn with_graph_store_timeout_times_out_on_pending_future() {
+        tokio::time::pause();
+        let fut = with_graph_store_timeout(std::future::pending::<
+            Result<i32, zeph_memory::MemoryError>,
+        >());
+        let handle = tokio::spawn(fut); // EXEMPT: test-only tokio::time::pause harness
+        tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        let result = handle.await.expect("task panicked");
+        assert!(
+            matches!(result, Ok(StoreCallOutcome::TimedOut)),
+            "call must resolve to TimedOut once the 5s deadline elapses"
         );
     }
 

--- a/crates/zeph-core/src/agent/learning/trust.rs
+++ b/crates/zeph-core/src/agent/learning/trust.rs
@@ -46,14 +46,30 @@ impl<C: Channel> Agent<C> {
             let posterior = zeph_skills::trust_score::posterior_mean(successes, failures);
 
             if total >= config.auto_promote_min_uses && posterior > config.auto_promote_threshold {
-                if !cross_session_rollout_ok_for_promote(memory, config, skill_name).await {
+                if !cross_session_rollout_ok(
+                    memory,
+                    skill_name,
+                    config.cross_session_rollout,
+                    config.min_sessions_before_promote,
+                    "promotion",
+                )
+                .await
+                {
                     return;
                 }
                 try_auto_promote(memory, skill_name, posterior, total).await;
             }
 
             if total >= config.auto_demote_min_uses && posterior < config.auto_demote_threshold {
-                if !cross_session_rollout_ok_for_demote(memory, config, skill_name).await {
+                if !cross_session_rollout_ok(
+                    memory,
+                    skill_name,
+                    config.cross_session_rollout,
+                    config.min_sessions_before_demote,
+                    "demotion",
+                )
+                .await
+                {
                     return;
                 }
                 try_auto_demote(memory, skill_name, posterior, total).await;
@@ -64,49 +80,25 @@ impl<C: Channel> Agent<C> {
     }
 }
 
-/// Returns `true` when cross-session rollout is disabled or enough sessions exist for promotion.
-async fn cross_session_rollout_ok_for_promote(
+/// Returns `true` when cross-session rollout is disabled or enough sessions exist for the
+/// given `action` ("promotion" or "demotion").
+async fn cross_session_rollout_ok(
     memory: &zeph_memory::semantic::SemanticMemory,
-    config: &crate::config::LearningConfig,
     skill_name: &str,
+    cross_session_rollout: bool,
+    min_sessions: u32,
+    action: &str,
 ) -> bool {
-    if !config.cross_session_rollout {
+    if !cross_session_rollout {
         return true;
     }
     match memory.sqlite().distinct_session_count(skill_name).await {
-        Ok(sessions) if sessions < i64::from(config.min_sessions_before_promote) => {
+        Ok(sessions) if sessions < i64::from(min_sessions) => {
             tracing::debug!(
                 skill = skill_name,
                 sessions,
-                required = config.min_sessions_before_promote,
-                "cross-session rollout: insufficient sessions for promotion"
-            );
-            false
-        }
-        Ok(_) => true,
-        Err(e) => {
-            tracing::warn!("cross-session count query failed for {skill_name}: {e:#}");
-            true
-        }
-    }
-}
-
-/// Returns `true` when cross-session rollout is disabled or enough sessions exist for demotion.
-async fn cross_session_rollout_ok_for_demote(
-    memory: &zeph_memory::semantic::SemanticMemory,
-    config: &crate::config::LearningConfig,
-    skill_name: &str,
-) -> bool {
-    if !config.cross_session_rollout {
-        return true;
-    }
-    match memory.sqlite().distinct_session_count(skill_name).await {
-        Ok(sessions) if sessions < i64::from(config.min_sessions_before_demote) => {
-            tracing::debug!(
-                skill = skill_name,
-                sessions,
-                required = config.min_sessions_before_demote,
-                "cross-session rollout: insufficient sessions for demotion"
+                required = min_sessions,
+                "cross-session rollout: insufficient sessions for {action}"
             );
             false
         }

--- a/crates/zeph-core/src/lsp_hooks/hover.rs
+++ b/crates/zeph-core/src/lsp_hooks/hover.rs
@@ -98,22 +98,14 @@ fn extract_symbol_positions_regex(
         return vec![];
     }
 
+    let (clean_source, line_map) = strip_cat_n_prefix(content);
+
     let mut positions = Vec::new();
-    for (raw_idx, raw_line) in content.lines().enumerate() {
+    for (raw_idx, source_line) in clean_source.lines().enumerate() {
         if positions.len() >= max_symbols {
             break;
         }
-        let (lsp_line, source_line) = if let Some(tab) = raw_line.find('\t') {
-            let prefix = raw_line[..tab].trim();
-            if !prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_digit()) {
-                let one_based: u64 = prefix.parse().unwrap_or(0);
-                (one_based.saturating_sub(1), &raw_line[tab + 1..])
-            } else {
-                (raw_idx as u64, raw_line)
-            }
-        } else {
-            (raw_idx as u64, raw_line)
-        };
+        let lsp_line = line_map.get(raw_idx).copied().unwrap_or(raw_idx as u64);
         if let Some(m) = SYMBOL_LINE_RE.find(source_line) {
             positions.push((lsp_line, m.start() as u64));
         }


### PR DESCRIPTION
## Summary

- `trust.rs`'s `cross_session_rollout_ok_for_promote`/`_for_demote` were identical except for which config field they read (`min_sessions_before_promote` vs `_demote`) and their log message; both now delegate to a single `cross_session_rollout_ok(memory, skill_name, cross_session_rollout, min_sessions, action)` helper (#5662).
- `extract_symbol_positions_regex` (`lsp_hooks/hover.rs`) now calls `strip_cat_n_prefix` once instead of re-deriving the same tab-prefix/digit-check/line-number logic inline (#5673).
- `agent_access_impl.rs`'s three `tokio::time::timeout(5s, ...)` call sites (`resolve_entity_by_name`, and the edge lookups inside `graph_facts`/`graph_history`) now share a `with_graph_store_timeout` helper. Added a `tokio::time::pause()` + `advance(6s)` test against a synthetic never-resolving future that deterministically forces the real timeout arm, which previously had zero coverage — existing tests only reached the "no store configured" short-circuit (#5770).

All three are behavior-preserving except for the new test in #5770. `GraphStore` is a concrete type with no trait seam, so the new test proves the shared timeout mechanism directly rather than invoking `graph_facts`/`graph_history` end-to-end — a real integration test combining `tokio::time::pause()` with the SQLite-backed store is a known source of flakiness elsewhere in the workspace, so that path was deliberately not attempted. This is a smaller residual gap than what #5770 originally reported (the timeout/error-mapping logic is now proven once instead of zero times, shared by all three call sites).

Closes #5662, #5673, #5770

## Test plan

- [x] `cargo +nightly fmt --check` (workspace)
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12259 passed, 34 skipped, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean (only pre-existing unrelated warnings in untouched files)
- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] `.local/testing/coverage-status.md` updated in place for the `AgentAccess`/`agent_access_impl.rs` row