### PR TITLE
fix(tui): route slash-command autocomplete and typed submission through Action::Dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tui)`: selecting a slash-command entry from the autocomplete popup and pressing Enter
+  reconstituted the command as text (`command_id_to_slash_form`, e.g. `skill:list` →
+  `/skill list`) and re-parsed it, but most registry ids have no textual form the parser
+  recognizes, so the malformed text silently fell through and was sent to the LLM as an
+  ordinary chat message — wasting a real API call (#5779). `Action::SlashAutocompleteAccept`
+  (`crates/zeph-tui/src/widgets/slash_autocomplete.rs`, `crates/zeph-tui/src/app/reducer.rs`)
+  now clears the input and dispatches the selected entry's `TuiCommand` directly via
+  `Action::Dispatch`, the same path already used by the command palette. Commands needing an
+  argument (e.g. `agent:cancel`) still prefill the input for further typing instead of being
+  submitted incomplete. Removed the now-unused `command_id_to_slash_form` helper.
+- `fix(tui)`: typing a recognized slash command directly (e.g. `/motion minimal`, `/session
+  close`, `/acp status`, `/subagent spawn <cmd>`) and pressing Enter routed the parsed
+  `TuiCommand` through `Effect::SendCommand`, forwarding it over the mpsc channel to the binary
+  crate's `forward_tui_commands` task (`src/tui_bridge.rs`), which only implements 4 variants
+  (`ViewConfig`, `ViewAutonomy`, `TafcStatus`, `SandboxStatus`) — every other variant hit its
+  wildcard `_ => continue` arm and was silently dropped (#5782). `Action::SubmitInput`
+  (`crates/zeph-tui/src/app/reducer.rs`) now routes parsed commands through `Action::Dispatch`
+  instead, the same in-process path already used by the command palette and slash autocomplete,
+  which correctly handles every `TuiCommand` variant (state mutation, `execute_command`
+  prefill/prompt, or genuine bridge dispatch) without requiring a running agent-side bridge.
+  Removed the now-unconstructed `Effect::SendCommand` variant.
 - `fix(llm)`: OpenAI/compatible provider's `reasoning_effort` was serialized as the OpenAI
   Responses-API nested shape (`"reasoning":{"effort":"..."}`) instead of the Chat-Completions
   flat field (`"reasoning_effort":"..."`), causing every real reasoning-capable model (o-series,

--- a/crates/zeph-tui/src/app/reducer.rs
+++ b/crates/zeph-tui/src/app/reducer.rs
@@ -15,7 +15,7 @@ use super::{App, ChatMessage, InputMode, MessageRole, Panel, format_security_rep
 use crate::command::TuiCommand;
 use crate::file_picker::FilePickerState;
 use crate::widgets::command_palette::CommandPaletteState;
-use crate::widgets::slash_autocomplete::{SlashAutocompleteState, command_id_to_slash_form};
+use crate::widgets::slash_autocomplete::SlashAutocompleteState;
 
 const MAX_INPUT_HISTORY: usize = 500;
 
@@ -28,8 +28,6 @@ const MAX_INPUT_HISTORY: usize = 500;
 pub(crate) enum Effect {
     /// Forward the user's typed text to the agent loop.
     SendUserInput(String),
-    /// Forward a [`TuiCommand`] to the agent command channel.
-    SendCommand(TuiCommand),
     /// Copy `text` to the system clipboard.
     CopyToClipboard(String),
     /// Trigger the file indexer for the file picker.
@@ -271,14 +269,17 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
             if text.is_empty() {
                 return vec![];
             }
-            // Check for local session slash commands first.
+            // Check for local session slash commands first. Route through
+            // `Action::Dispatch` (the same path used by the command palette and
+            // slash autocomplete) so every `TuiCommand` variant gets its correct
+            // in-process handling instead of being force-fed to the agent bridge.
             if let Some(cmd) = App::parse_session_slash_pub(&text) {
                 app.sessions.current_mut().input.clear();
                 app.sessions.current_mut().cursor_position = 0;
                 app.sessions.current_mut().history_index = None;
                 app.sessions.current_mut().draft_input.clear();
                 app.sessions.current_mut().paste_state = None;
-                return vec![Effect::SendCommand(cmd)];
+                return reduce(app, Action::Dispatch(cmd));
             }
             app.sessions.current_mut().show_splash = false;
             app.sessions.current_mut().input_history.push(text.clone());
@@ -441,24 +442,28 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
             vec![]
         }
         Action::SlashAutocompleteAccept => {
-            let entry_id = app
+            // Dispatch the selected entry's command directly rather than
+            // reconstituting slash text and re-parsing it: most registry ids
+            // (e.g. `skill:list`) have no textual form the parser recognizes,
+            // so a round-trip through text silently sent the raw text as a
+            // chat message instead of running the command (#5779).
+            let cmd = app
                 .slash_autocomplete
                 .as_ref()
                 .and_then(SlashAutocompleteState::selected_entry)
-                .map(|e| e.id);
+                .map(|e| e.command.clone());
             app.slash_autocomplete = None;
-            if let Some(id) = entry_id {
-                let slash_form = command_id_to_slash_form(id);
-                app.sessions.current_mut().input = slash_form;
-                app.sessions.current_mut().cursor_position = app.char_count();
+            app.sessions.current_mut().input.clear();
+            app.sessions.current_mut().cursor_position = 0;
+            if let Some(cmd) = cmd {
+                return reduce(app, Action::Dispatch(cmd));
             }
             vec![]
         }
         Action::SlashAutocompleteAcceptAndSubmit => {
-            // Accept selection into input, then chain a SubmitInput.
-            let mut effects = reduce(app, Action::SlashAutocompleteAccept);
-            effects.extend(reduce(app, Action::SubmitInput));
-            effects
+            // Dispatch already executes the command (or prompts for further
+            // input via `prefill_input`), so no separate submit step is needed.
+            reduce(app, Action::SlashAutocompleteAccept)
         }
         Action::SlashAutocompletePopChar => {
             let dismiss = app
@@ -887,11 +892,6 @@ pub(crate) fn run_effects(app: &mut App, effects: Vec<Effect>) {
         match effect {
             Effect::SendUserInput(text) => {
                 let _ = app.user_input_tx.try_send(text);
-            }
-            Effect::SendCommand(cmd) => {
-                if let Some(ref tx) = app.command_tx {
-                    let _ = tx.try_send(cmd);
-                }
             }
             Effect::CopyToClipboard(text) => match app.clipboard.copy(&text) {
                 Ok(()) => app.push_system_message_pub("Copied to clipboard.".to_owned()),
@@ -1520,5 +1520,147 @@ mod tests {
         assert_eq!(msg, "/plan status");
         // No second message (exactly-once)
         assert!(rx.try_recv().is_err());
+    }
+
+    // ── Slash autocomplete accept dispatches directly (#5779) ───────────────
+
+    fn select_entry(app: &mut App, query: &str, expected_id: &str) {
+        let mut state = SlashAutocompleteState::new();
+        for c in query.chars() {
+            state.push_char(c);
+        }
+        assert_eq!(
+            state.selected_entry().map(|e| e.id),
+            Some(expected_id),
+            "query {query:?} must resolve to {expected_id:?} as the top match"
+        );
+        app.slash_autocomplete = Some(state);
+    }
+
+    #[test]
+    fn slash_autocomplete_accept_dispatches_command_directly() {
+        let (mut app, _rx) = make_app();
+        select_entry(&mut app, "skill:list", "skill:list");
+
+        let effects = reduce(&mut app, Action::SlashAutocompleteAccept);
+
+        assert!(effects.is_empty());
+        assert!(app.slash_autocomplete.is_none());
+        assert!(app.sessions.current().input.is_empty());
+        // The command ran in-process (pushed a system message) instead of being
+        // sent to the LLM as the literal text "/skill list".
+        assert!(
+            app.sessions
+                .current()
+                .messages
+                .iter()
+                .all(|m| m.role != MessageRole::User)
+        );
+        assert!(
+            app.sessions
+                .current()
+                .messages
+                .iter()
+                .any(|m| m.role == MessageRole::System)
+        );
+    }
+
+    #[test]
+    fn slash_autocomplete_accept_and_submit_dispatches_command_directly() {
+        let (mut app, _rx) = make_app();
+        select_entry(&mut app, "tasks", "tasks");
+        assert!(!app.show_task_panel);
+
+        let effects = reduce(&mut app, Action::SlashAutocompleteAcceptAndSubmit);
+
+        assert!(effects.is_empty());
+        assert!(app.show_task_panel);
+        assert!(app.sessions.current().input.is_empty());
+        assert!(
+            app.sessions
+                .current()
+                .messages
+                .iter()
+                .all(|m| m.role != MessageRole::User)
+        );
+    }
+
+    #[test]
+    fn slash_autocomplete_accept_and_submit_on_arg_command_prefills_without_submitting() {
+        // Commands that need an argument (e.g. "agent:cancel") prefill the input
+        // for further typing instead of being submitted as an incomplete command.
+        let (mut app, _rx) = make_app();
+        select_entry(&mut app, "agent:cancel", "agent:cancel");
+
+        let effects = reduce(&mut app, Action::SlashAutocompleteAcceptAndSubmit);
+
+        assert!(effects.is_empty());
+        assert_eq!(app.sessions.current().input, "/agent cancel ");
+        assert!(
+            app.sessions
+                .current()
+                .messages
+                .iter()
+                .all(|m| m.role != MessageRole::User),
+            "incomplete prefilled command must not be sent as a chat message"
+        );
+    }
+
+    // ── SubmitInput routes parsed slash commands in-process (#5782) ─────────
+
+    #[test]
+    fn submit_input_motion_command_applies_directly_without_bridge() {
+        let (mut app, _rx) = make_app();
+        app.sessions.current_mut().input = "/motion minimal".to_owned();
+
+        let effects = reduce(&mut app, Action::SubmitInput);
+
+        assert!(effects.is_empty());
+        assert_eq!(app.motion, zeph_config::Motion::Minimal);
+    }
+
+    #[test]
+    fn submit_input_session_close_executes_in_process() {
+        let (mut app, _rx) = make_app();
+        app.sessions.current_mut().input = "/session close".to_owned();
+
+        let effects = reduce(&mut app, Action::SubmitInput);
+
+        assert!(effects.is_empty());
+        // Single-session default: close() refuses and reports in-process,
+        // proving the command ran locally rather than being dropped by the bridge.
+        assert!(app.sessions.current().messages.iter().any(|m| {
+            m.content
+                .contains("Cannot close the last remaining session")
+        }));
+    }
+
+    #[test]
+    fn submit_input_acp_dirs_forwards_via_agent_channel_in_process() {
+        // `AcpDirsList` is handled by `execute_command`'s `handle_acp_command`, which
+        // sends directly on `user_input_tx` rather than returning an `Effect`. This
+        // exercises a third distinct in-process code path (alongside direct state
+        // mutation and `Effect::SendUserInput`) that `forward_tui_commands`'s
+        // `_ => continue` wildcard used to silently swallow (#5782).
+        let (mut app, mut rx) = make_app();
+        app.sessions.current_mut().input = "/acp dirs".to_owned();
+
+        let effects = reduce(&mut app, Action::SubmitInput);
+
+        assert!(effects.is_empty());
+        let msg = rx.try_recv().expect("channel must have one message");
+        assert_eq!(msg, "/acp dirs");
+    }
+
+    #[test]
+    fn submit_input_subagent_spawn_forwards_command_via_agent_channel() {
+        let (mut app, mut rx) = make_app();
+        app.sessions.current_mut().input = "/subagent spawn review the diff".to_owned();
+
+        let effects = reduce(&mut app, Action::SubmitInput);
+
+        assert!(effects.is_empty());
+        let msg = rx.try_recv().expect("channel must have one message");
+        assert_eq!(msg, "/subagent spawn review the diff");
     }
 }

--- a/crates/zeph-tui/src/widgets/slash_autocomplete.rs
+++ b/crates/zeph-tui/src/widgets/slash_autocomplete.rs
@@ -109,12 +109,6 @@ impl Default for SlashAutocompleteState {
     }
 }
 
-/// Converts a command id to slash-form: `"skill:list"` → `"/skill list"`.
-#[must_use]
-pub fn command_id_to_slash_form(id: &str) -> String {
-    format!("/{}", id.replace(':', " "))
-}
-
 pub fn render(state: &SlashAutocompleteState, frame: &mut Frame, input_area: Rect, theme: &Theme) {
     if state.filtered.is_empty() {
         return;
@@ -205,13 +199,6 @@ mod tests {
         let expected = filter_commands("sk");
         assert_eq!(state.filtered.len(), expected.len());
         assert_eq!(state.selected, 0);
-    }
-
-    #[test]
-    fn command_id_to_slash_form_converts() {
-        assert_eq!(command_id_to_slash_form("skill:list"), "/skill list");
-        assert_eq!(command_id_to_slash_form("ingest"), "/ingest");
-        assert_eq!(command_id_to_slash_form("app:quit"), "/app quit");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Selecting an entry from the TUI's slash-command autocomplete popup and pressing Enter reconstituted the command as text (`command_id_to_slash_form`) and re-parsed it, but most registry ids (e.g. `app:theme`, `session:next`) have no textual form the parser recognizes, so the malformed text silently fell through and was sent to the LLM as a real chat message, wasting an API call (#5779).
- Typing a recognized slash command directly (e.g. `/motion minimal`, `/session close`, `/acp status`, `/subagent spawn ...`) routed the parsed `TuiCommand` through `Effect::SendCommand` to the binary crate's `forward_tui_commands` bridge, which only implements 4 of the possible variants — every other variant silently no-op'd via a wildcard arm (#5782).
- Both paths now dispatch the `TuiCommand` directly via `Action::Dispatch`, the same in-process path already used correctly by the command palette. Removed the now-dead `command_id_to_slash_form` helper and the now-unconstructed `Effect::SendCommand` variant.

## Test plan
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-tui` — 827 passed, 3 skipped (includes 5 new regression tests from implementation + 2 tester-added tests closing an `AcpDirsList`/`SubagentSpawn` coverage gap)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy -p zeph-tui --all-targets -- -D warnings`
- [x] `cargo build -p zeph-tui`
- [x] rustdoc gate clean for `zeph-tui`
- [x] Adversarial implementation critique (verdict: approved, 2 non-blocking notes)
- [x] Code review (verdict: approved)

Closes #5779
Closes #5782