### PR TITLE
fix(skills): make symlinked SKILL.md discoverable and traversal warning reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `reasoning_effort` for the provider, or use a different model for tool-calling turns),
   instead of surfacing the raw OpenAI error text.
 
+- `fix(zeph-skills)`: `SkillRegistry::load` (`crates/zeph-skills/src/registry.rs`) now discovers
+  symlinked `SKILL.md` files during its `WalkDir` scan instead of silently dropping every symlink
+  before `validate_path_within` could run. With `follow_links(false)`, `WalkDir` reports a
+  symlinked entry's type via `symlink_metadata`, so `entry.file_type().is_file()` was `false` for
+  any symlinked `SKILL.md` — the entry was discarded by that guard before the path-traversal check
+  was ever reached, making the `"skipping skill path traversal"` warning unreachable dead code from
+  the real scan loop (only exercised by a direct unit test call). Net effect was safety-benign (the
+  symlinked file was never read, so no information disclosure) but a symlink escaping the base
+  directory produced no log signal, and — more surprising — a legitimate symlinked `SKILL.md`
+  resolving *within* the base directory was silently skipped too, never loaded at all. The loop now
+  accepts both regular files and symlinks named `SKILL.md` and resolves the target via the existing
+  `validate_path_within` helper: a target that actually escapes the base directory is rejected with
+  the `WARN`-level `"skipping skill path traversal"` log (the real security signal); a symlink that
+  cannot be resolved at all (e.g. dangling) is logged at `DEBUG` instead, since a broken link is not
+  itself a traversal attempt; and a symlink resolving to something other than a regular file (e.g. a
+  directory) within the base is skipped quietly, no log (#5783).
+
 - `fix(core)`: the utility gate's `Retrieve` action (`crates/zeph-core/src/agent/tool_execution/tier_loop.rs`,
   `handle_retrieve_action`) could enter an unbreakable loop when the mandated `memory_search`
   detour itself failed with `confirmation_required` (e.g. the query content trips a

--- a/crates/zeph-skills/src/registry.rs
+++ b/crates/zeph-skills/src/registry.rs
@@ -18,7 +18,10 @@
 //!
 //! Symlinked *directories* are not followed (walkdir default). Symlinked `SKILL.md`
 //! *files* are resolved by [`validate_path_within`] and must canonicalize to a path
-//! inside the base directory, otherwise they are rejected with a warning.
+//! inside the base directory, otherwise they are rejected. A path that actually escapes
+//! the base directory is logged at `WARN` (a real traversal attempt); a symlink that
+//! cannot be resolved at all (e.g. dangling) is logged at `DEBUG`, since a broken link
+//! is not itself a security signal.
 //!
 //! Traversal is limited to [`MAX_SKILL_DEPTH`] levels to prevent runaway recursion on
 //! adversarial directory trees. A directory at exactly that depth is still descended into;
@@ -192,15 +195,36 @@ impl SkillRegistry {
                         continue;
                     }
                 };
-                if !entry.file_type().is_file() {
+                // `follow_links(false)` means `file_type()` reflects the entry itself
+                // (via symlink_metadata), so a symlinked SKILL.md reports as a symlink,
+                // not a file. Accept both here and let `validate_path_within` resolve
+                // and validate the symlink target below.
+                let file_type = entry.file_type();
+                if !file_type.is_file() && !file_type.is_symlink() {
                     continue;
                 }
                 if entry.file_name() != "SKILL.md" {
                     continue;
                 }
                 let skill_path = entry.path();
-                if let Err(e) = validate_path_within(skill_path, base) {
-                    tracing::warn!("skipping skill path traversal: {e:#}");
+                let canonical = match validate_path_within(skill_path, base) {
+                    Ok(p) => p,
+                    Err(e @ SkillError::Invalid(_)) => {
+                        tracing::warn!("skipping skill path traversal: {e:#}");
+                        continue;
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            "skipping unresolvable skill path {}: {e:#}",
+                            skill_path.display()
+                        );
+                        continue;
+                    }
+                };
+                // A symlink may legitimately resolve within `base` but point at a
+                // directory (or something else) rather than a file; skip it quietly
+                // since it is not a loadable SKILL.md.
+                if file_type.is_symlink() && !canonical.is_file() {
                     continue;
                 }
                 match load_skill_meta(skill_path) {
@@ -567,6 +591,86 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
         assert!(registry.all_meta().is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn load_follows_symlinked_skill_md_within_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_dir = dir.path().join("target-skill");
+        std::fs::create_dir(&target_dir).unwrap();
+        std::fs::write(
+            target_dir.join("REAL.md"),
+            "---\nname: linked-skill\ndescription: desc\n---\nbody",
+        )
+        .unwrap();
+
+        let skill_dir = dir.path().join("linked-skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::os::unix::fs::symlink(target_dir.join("REAL.md"), skill_dir.join("SKILL.md")).unwrap();
+
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        assert_eq!(
+            registry.all_meta().len(),
+            1,
+            "a symlinked SKILL.md resolving within base must be loaded, not silently dropped"
+        );
+        assert_eq!(registry.all_meta()[0].name, "linked-skill");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    #[tracing_test::traced_test]
+    fn load_skips_symlinked_skill_escaping_base() {
+        let base = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+
+        std::fs::write(
+            outside.path().join("SKILL.md"),
+            "---\nname: escaped\ndescription: desc\n---\nbody",
+        )
+        .unwrap();
+
+        let skill_dir = base.path().join("escaped");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::os::unix::fs::symlink(outside.path().join("SKILL.md"), skill_dir.join("SKILL.md"))
+            .unwrap();
+
+        let registry = SkillRegistry::load(&[base.path().to_path_buf()]);
+        assert!(
+            registry.all_meta().is_empty(),
+            "a symlinked SKILL.md escaping base must not be loaded"
+        );
+        // Pins the regression: without the fix, the symlink is dropped by the
+        // `is_file()`-only type guard before `validate_path_within` ever runs, so
+        // `all_meta().is_empty()` alone would pass for the wrong reason.
+        assert!(
+            logs_contain("skipping skill path traversal"),
+            "escaping symlink must be rejected by validate_path_within, not silently dropped earlier"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    #[tracing_test::traced_test]
+    fn load_skips_symlink_to_directory_within_base_quietly() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_dir = dir.path().join("target-dir");
+        std::fs::create_dir(&target_dir).unwrap();
+
+        let skill_dir = dir.path().join("linked-dir-skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::os::unix::fs::symlink(&target_dir, skill_dir.join("SKILL.md")).unwrap();
+
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        assert!(
+            registry.all_meta().is_empty(),
+            "a symlink resolving to a directory is not a loadable SKILL.md"
+        );
+        assert!(
+            !logs_contain("skipping skill path traversal"),
+            "a symlink resolving within base must not be logged as a traversal attempt"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`SkillRegistry::load`'s `WalkDir` loop filtered on `entry.file_type().is_file()` before calling `validate_path_within`. With `follow_links(false)`, a symlinked `SKILL.md` reports its own type via `symlink_metadata`, not the target's, so `is_file()` was always false for symlinks — the entry was discarded before the path-traversal check ever ran. This made the `"skipping skill path traversal"` warning unreachable dead code, and also silently dropped legitimate in-base symlinked skills that should have loaded.

- The `WalkDir` loop now accepts both regular files and symlinks named `SKILL.md`, and always resolves the target via the existing `validate_path_within` helper (no reimplementation).
- A target that actually escapes the base directory is still rejected with a `WARN`-level `"skipping skill path traversal"` log — now reachable for real.
- A symlink that cannot be resolved at all (e.g. dangling) is logged at `DEBUG` with neutral wording instead, since a broken link is not itself a traversal attempt.
- A symlink resolving to something other than a regular file (e.g. a directory) within the base is skipped quietly, no log.
- Added 3 unit tests covering: in-base symlink is loaded, escaping symlink is rejected and warns (asserted via `logs_contain`, so the test actually pins the regression), and symlink-to-directory-within-base is skipped silently.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12288 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-skills`

Closes #5783