### PR TITLE
fix(memory): HELA timeout budgets and turn_index provenance gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,6 +423,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Now computes and respects `prune_protection_boundary()` before evicting, matching every other
   pruning path. Added two regression tests confirming both strategies leave the protected tail
   untouched (#5664).
+- `fix(memory)`: HELA spreading-activation timeout budgets were unrealistically tight, causing
+  the DeepReasoning query-conditioned recall path to silently fall back to normal recall on
+  every call even when Qdrant was healthy (#5785). `HelaSpreadParams::step_budget`
+  (`crates/zeph-memory/src/graph/activation.rs`) and the mirrored
+  `HebbianConfig::step_budget_ms` (`crates/zeph-config/src/memory/hebbian.rs`) default raised
+  from `8 ms` to `80 ms` — headroom over realistic local-Qdrant round-trip latency for each
+  step the budget independently gates. Also fixed the outer/inner timeout inversion in
+  `recall_graph_hela` (`crates/zeph-memory/src/semantic/recall.rs`): the outer hard timeout
+  was hardcoded to `200 ms` while wrapping an embed step whose own default timeout is `5 s` —
+  25x tighter than the inner bound it was supposed to enclose. Extracted a `hela_outer_timeout`
+  helper that derives the outer bound from the same `HelaSpreadParams` passed to the inner call
+  (embed timeout + `(spread_depth.clamp(1, 6) + 2)` × step budget + a fixed margin), so it
+  always stays strictly larger than everything it wraps. The multiplier accounts for every
+  stage `hela_spreading_recall` actually gates — the anchor ANN, one edge-fetch check per BFS
+  hop (not a single fixed check), and the final vectors-batch — rather than a fixed count that
+  under-provisioned the bound for any `spread_depth > 1`. Added a live-Qdrant regression test
+  (`hela_default_budget_returns_facts_against_real_qdrant` in
+  `crates/zeph-memory/tests/hela_spreading_activation.rs`) asserting the unmodified default
+  params return non-empty results against a populated real collection, plus unit tests proving
+  `hela_outer_timeout` scales with `spread_depth`, clamps above `6`, and falls back to safe
+  finite defaults when the inner timeouts are disabled.
+- `fix(core,memory)`: `graph_edges.turn_index` was always `NULL` on the live per-turn
+  extraction path, on both the APEX-MEM and default (non-APEX) storage paths (#5784).
+  `build_graph_extraction_config` (`crates/zeph-agent-persistence/src/graph.rs`) hardcoded
+  `turn_index: None` unconditionally; fixed by adding a `turn_index: Option<u32>` parameter,
+  with `Agent::enqueue_graph_extraction_task`
+  (`crates/zeph-core/src/agent/persistence/extract.rs`) passing
+  `self.services.sidequest.turn_counter` through. Separately, `insert_edges`'s default
+  (`apex_mem.enabled = false`, the out-of-the-box default) branch routed through
+  `resolve_edge_typed`/`GraphStore::insert_edge_typed`
+  (`crates/zeph-memory/src/graph/resolver/mod.rs`, `crates/zeph-memory/src/graph/store/mod.rs`),
+  neither of which had a `turn_index` parameter at all — `config.turn_index` was silently
+  dropped even after the config-threading fix above, so the bug persisted for any deployment
+  that had not explicitly opted into `[memory.graph.apex_mem] enabled = true`. Both functions
+  now accept and forward `turn_index`, writing it on the initial insert (reassertions/updates
+  still leave it untouched, matching the APEX-MEM path's semantics). The backfill/reprocess
+  call site (`crates/zeph-core/src/agent/agent_access_impl.rs`) and the standalone
+  knowledge-ingest CLI (`src/commands/knowledge.rs`) intentionally keep passing `None` — both
+  iterate historical messages out of live turn order, where a real turn index would be
+  misleading.
 
 ### Removed
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -442,7 +442,7 @@ enabled = false                        # opt-in master switch; no DB writes when
 # spreading_activation = false           # HL-F5 (#3346): BFS from top-1 ANN anchor; requires enabled=true
 # spread_depth = 2                       # BFS hops for spreading activation, clamped [1, 6]
 # spread_edge_types = []                 # MAGMA edge types to traverse; empty = all types
-# step_budget_ms = 8                     # per-step circuit-breaker (anchor ANN / edges batch / vectors batch)
+# step_budget_ms = 80                    # per-step circuit-breaker (anchor ANN / edges batch / vectors batch)
 
 # User persona profile: drives query-bias correction (MM-F3, #3341) and
 # first-person query reweighting toward the user's profile centroid.

--- a/crates/zeph-agent-persistence/src/graph.rs
+++ b/crates/zeph-agent-persistence/src/graph.rs
@@ -19,14 +19,16 @@ use zeph_llm::provider::{Message, MessagePart, Role};
 /// use zeph_config::memory::GraphConfig;
 ///
 /// let cfg = GraphConfig::default();
-/// let extraction_cfg = build_graph_extraction_config(&cfg, Some(42), 5);
+/// let extraction_cfg = build_graph_extraction_config(&cfg, Some(42), 5, Some(3));
 /// assert_eq!(extraction_cfg.conversation_id, Some(42));
+/// assert_eq!(extraction_cfg.turn_index, Some(3));
 /// ```
 #[must_use]
 pub fn build_graph_extraction_config(
     cfg: &zeph_config::memory::GraphConfig,
     conversation_id: Option<i64>,
     embed_timeout_secs: u64,
+    turn_index: Option<u32>,
 ) -> zeph_memory::semantic::GraphExtractionConfig {
     zeph_memory::semantic::GraphExtractionConfig {
         max_entities: cfg.max_entities_per_message,
@@ -52,7 +54,7 @@ pub fn build_graph_extraction_config(
         apex_mem_enabled: cfg.apex_mem.enabled,
         llm_timeout_secs: cfg.llm_timeout_secs,
         embed_timeout_secs,
-        turn_index: None,
+        turn_index,
         write_gate_min_relevance: cfg
             .write_gate
             .enabled
@@ -135,7 +137,7 @@ mod tests {
     #[test]
     fn build_graph_extraction_config_maps_non_zero_entity_and_edge_limits() {
         let cfg = zeph_config::memory::GraphConfig::default();
-        let extraction_cfg = build_graph_extraction_config(&cfg, None, 5);
+        let extraction_cfg = build_graph_extraction_config(&cfg, None, 5, None);
 
         assert_eq!(extraction_cfg.max_entities, cfg.max_entities_per_message);
         assert_eq!(extraction_cfg.max_edges, cfg.max_edges_per_message);
@@ -152,10 +154,20 @@ mod tests {
     #[test]
     fn build_graph_extraction_config_threads_conversation_id_and_embed_timeout() {
         let cfg = zeph_config::memory::GraphConfig::default();
-        let extraction_cfg = build_graph_extraction_config(&cfg, Some(7), 42);
+        let extraction_cfg = build_graph_extraction_config(&cfg, Some(7), 42, None);
 
         assert_eq!(extraction_cfg.conversation_id, Some(7));
         assert_eq!(extraction_cfg.embed_timeout_secs, 42);
+    }
+
+    /// #5784 regression: the live per-turn extraction path must be able to pass a real
+    /// turn index through so `graph_edges.turn_index` is not always `NULL`.
+    #[test]
+    fn build_graph_extraction_config_threads_turn_index() {
+        let cfg = zeph_config::memory::GraphConfig::default();
+        let extraction_cfg = build_graph_extraction_config(&cfg, Some(7), 5, Some(12));
+
+        assert_eq!(extraction_cfg.turn_index, Some(12));
     }
 
     #[test]

--- a/crates/zeph-config/src/memory/hebbian.rs
+++ b/crates/zeph-config/src/memory/hebbian.rs
@@ -190,7 +190,9 @@ pub struct HebbianConfig {
     /// Per-step circuit-breaker timeout for HL-F5 in milliseconds.
     ///
     /// Any internal step (anchor ANN, edges batch, vectors batch) that exceeds this
-    /// duration triggers an `Ok(Vec::new())` fallback with a `WARN`. Default: `8`.
+    /// duration triggers an `Ok(Vec::new())` fallback with a `WARN`. Default: `80`
+    /// (headroom over realistic local-Qdrant round-trip latency; the previous `8`
+    /// default aborted almost every call even when Qdrant was healthy, #5785).
     pub step_budget_ms: u64,
     /// Timeout for the initial query embedding call in HL-F5, in seconds.
     ///
@@ -213,7 +215,7 @@ impl Default for HebbianConfig {
             spreading_activation: false,
             spread_depth: 2,
             spread_edge_types: Vec::new(),
-            step_budget_ms: 8,
+            step_budget_ms: 80,
             embed_timeout_secs: 5,
         }
     }

--- a/crates/zeph-config/src/migrate/memory.rs
+++ b/crates/zeph-config/src/migrate/memory.rs
@@ -423,7 +423,7 @@ pub fn migrate_memory_hebbian_spread_config(
         # spreading_activation = false   # opt-in BFS from top-1 ANN anchor; requires enabled=true\n\
         # spread_depth = 2               # BFS hops, clamped [1,6]\n\
         # spread_edge_types = []         # MAGMA edge types to traverse; empty = all\n\
-        # step_budget_ms = 8             # per-step circuit-breaker timeout (anchor ANN / edges / vectors)\n\
+        # step_budget_ms = 80            # per-step circuit-breaker timeout (anchor ANN / edges / vectors)\n\
         # embed_timeout_secs = 5         # timeout for the initial query embedding call (0 = disabled)\n";
 
     let output = format!("{toml_src}{extra}");

--- a/crates/zeph-core/src/agent/persistence/extract.rs
+++ b/crates/zeph-core/src/agent/persistence/extract.rs
@@ -54,6 +54,7 @@ impl<C: Channel> Agent<C> {
             .memory
             .as_ref()
             .map_or(5, |m| m.embed_timeout().as_secs());
+        let turn_index = u32::try_from(self.services.sidequest.turn_counter).unwrap_or(u32::MAX);
         let extraction_cfg = build_graph_extraction_config(
             cfg,
             self.services
@@ -62,6 +63,7 @@ impl<C: Channel> Agent<C> {
                 .conversation_id
                 .map(|c| c.0),
             embed_timeout_secs,
+            Some(turn_index),
         );
         // Resolve a clean provider that bypasses quality_gate for JSON extraction tasks.
         // When extract_provider is empty, falls back to the primary provider (existing behavior).

--- a/crates/zeph-memory/src/graph/activation.rs
+++ b/crates/zeph-memory/src/graph/activation.rs
@@ -96,7 +96,9 @@ pub struct HelaSpreadParams {
     pub max_visited: usize,
     /// Per-step circuit breaker. Any internal step (anchor ANN, edges batch,
     /// vectors batch) that exceeds this duration triggers an `Ok(Vec::new())`
-    /// fallback with a `WARN`. Default: `Some(8 ms)`.
+    /// fallback with a `WARN`. Default: `Some(80 ms)` — headroom over realistic
+    /// local-Qdrant round-trip latency (the previous `8 ms` default aborted
+    /// almost every call even when Qdrant was healthy, #5785).
     pub step_budget: Option<std::time::Duration>,
     /// Timeout for the initial query embedding call. `None` = no timeout.
     /// Default: `Some(5 s)`.
@@ -109,7 +111,7 @@ impl Default for HelaSpreadParams {
             spread_depth: 2,
             edge_types: Vec::new(),
             max_visited: 200,
-            step_budget: Some(std::time::Duration::from_millis(8)),
+            step_budget: Some(std::time::Duration::from_millis(80)),
             embed_timeout: Some(std::time::Duration::from_secs(5)),
         }
     }
@@ -1481,6 +1483,7 @@ mod tests {
             None,
             crate::graph::types::EdgeType::Semantic,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1493,6 +1496,7 @@ mod tests {
             0.9,
             None,
             crate::graph::types::EdgeType::Semantic,
+            None,
             None,
         )
         .await

--- a/crates/zeph-memory/src/graph/resolver/mod.rs
+++ b/crates/zeph-memory/src/graph/resolver/mod.rs
@@ -1018,6 +1018,10 @@ impl<'a> EntityResolver<'a> {
     /// This ensures that different MAGMA edge types for the same entity pair are stored
     /// independently (critic mitigation: dedup key includes `edge_type`).
     ///
+    /// `turn_index` (#5784) is forwarded to [`GraphStore::insert_edge_typed`] so the default
+    /// (non-APEX-MEM) extraction path also records turn-level provenance, matching the
+    /// APEX-MEM path's `insert_or_supersede_with_turn_index_and_metrics`.
+    ///
     /// # Errors
     ///
     /// Returns an error if any database operation fails.
@@ -1032,6 +1036,7 @@ impl<'a> EntityResolver<'a> {
         episode_id: Option<crate::types::MessageId>,
         edge_type: crate::graph::EdgeType,
         belief_revision: Option<&crate::graph::BeliefRevisionConfig>,
+        turn_index: Option<u32>,
         provenance: Option<&GraphProvenance>,
     ) -> Result<Option<i64>, MemoryError> {
         let normalized_relation = sanitize_relation(relation);
@@ -1101,6 +1106,7 @@ impl<'a> EntityResolver<'a> {
                 confidence,
                 episode_id,
                 edge_type,
+                turn_index,
                 provenance,
             )
             .await?;

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -504,6 +504,7 @@ impl GraphStore {
             confidence,
             episode_id,
             EdgeType::Semantic,
+            None,
             provenance,
         )
         .await
@@ -513,6 +514,10 @@ impl GraphStore {
     ///
     /// Identical semantics to [`Self::insert_edge`] but with an explicit `edge_type` parameter.
     /// The dedup key is `(source_entity_id, target_entity_id, relation, edge_type, valid_to IS NULL)`.
+    ///
+    /// `turn_index` (#5784) is stored only on the newly inserted row; the dedup UPDATE branch
+    /// (re-encountering an identical active edge) does not overwrite it, matching
+    /// [`Self::insert_or_supersede_with_turn_index_and_metrics`]'s reassertion semantics.
     ///
     /// The `provenance` parameter stamps `origin`, `import_batch_id`, and `source_uri` on the new
     /// row. Pass `None` for conversation-origin edges (the default). The dedup UPDATE branch does
@@ -533,6 +538,7 @@ impl GraphStore {
         confidence: f32,
         episode_id: Option<MessageId>,
         edge_type: EdgeType,
+        turn_index: Option<u32>,
         provenance: Option<&GraphProvenance>,
     ) -> Result<i64, MemoryError> {
         if source_entity_id == target_entity_id {
@@ -593,11 +599,13 @@ impl GraphStore {
         }
 
         let episode_raw: Option<i64> = episode_id.map(|m| m.0);
+        let turn_index_raw: Option<i64> = turn_index.map(i64::from);
         let id: i64 = zeph_db::query_scalar(sql!(
             "INSERT INTO graph_edges
              (source_entity_id, target_entity_id, relation, fact, confidence,
-              confidence_fast, confidence_slow, episode_id, edge_type, origin, import_batch_id, source_uri)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              confidence_fast, confidence_slow, episode_id, edge_type, turn_index,
+              origin, import_batch_id, source_uri)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              RETURNING id"
         ))
         .bind(source_entity_id)
@@ -609,6 +617,7 @@ impl GraphStore {
         .bind(f64::from(confidence))
         .bind(episode_raw)
         .bind(edge_type_str)
+        .bind(turn_index_raw)
         .bind(origin)
         .bind(batch_id)
         .bind(source_uri)

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -2866,6 +2866,7 @@ async fn insert_edge_typed_stores_edge_type() {
             None,
             EdgeType::Causal,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2933,6 +2934,7 @@ async fn insert_edge_typed_dedup_key_includes_edge_type() {
             None,
             EdgeType::Semantic,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2945,6 +2947,7 @@ async fn insert_edge_typed_dedup_key_includes_edge_type() {
             0.9,
             None,
             EdgeType::Causal,
+            None,
             None,
         )
         .await
@@ -2990,6 +2993,7 @@ async fn insert_edge_typed_deduplicates_same_type() {
             None,
             EdgeType::Causal,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3002,6 +3006,7 @@ async fn insert_edge_typed_deduplicates_same_type() {
             0.95,
             None,
             EdgeType::Causal,
+            None,
             None,
         )
         .await
@@ -3035,6 +3040,7 @@ async fn edges_for_entity_includes_edge_type() {
         None,
         EdgeType::Temporal,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -3065,6 +3071,7 @@ async fn bfs_typed_empty_types_behaves_like_bfs_with_depth() {
         0.9,
         None,
         EdgeType::Semantic,
+        None,
         None,
     )
     .await
@@ -3108,6 +3115,7 @@ async fn bfs_typed_filters_by_edge_type() {
         None,
         EdgeType::Semantic,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -3120,6 +3128,7 @@ async fn bfs_typed_filters_by_edge_type() {
         0.9,
         None,
         EdgeType::Causal,
+        None,
         None,
     )
     .await
@@ -3179,6 +3188,7 @@ async fn bfs_typed_entity_type_filter() {
         1.0,
         None,
         EdgeType::Entity,
+        None,
         None,
     )
     .await
@@ -3710,6 +3720,7 @@ async fn insert_edge_typed_rejects_self_loop() {
             0.9,
             None,
             EdgeType::Semantic,
+            None,
             None,
         )
         .await
@@ -4797,6 +4808,7 @@ async fn benna_fusi_update_diverges_fast_and_slow() {
         None,
         EdgeType::Semantic,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -4810,6 +4822,7 @@ async fn benna_fusi_update_diverges_fast_and_slow() {
         0.9,
         None,
         EdgeType::Semantic,
+        None,
         None,
     )
     .await

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -672,6 +672,7 @@ async fn insert_edges(
                     None,
                     edge_type,
                     belief_cfg.as_ref(),
+                    config.turn_index,
                     config.provenance.as_ref(),
                 )
                 .await
@@ -1944,6 +1945,7 @@ mod tests {
                 None,
                 EdgeType::Semantic,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -1957,6 +1959,7 @@ mod tests {
                 0.8,
                 None,
                 EdgeType::Semantic,
+                None,
                 None,
             )
             .await
@@ -2126,6 +2129,156 @@ mod tests {
             (edge.confidence_fast - 0.3_f32).abs() < 0.01,
             "confidence_fast must be ~0.3 (from ExtractedEdge.confidence), got {} (regression for #4723 APEX path)",
             edge.confidence_fast
+        );
+    }
+
+    /// Regression for #5784 (APEX-MEM path): `GraphExtractionConfig::turn_index` must be
+    /// forwarded all the way through `extract_and_store` to the persisted
+    /// `graph_edges.turn_index` column, not just threaded through the config-builder signature.
+    ///
+    /// The sibling test `extract_and_store_non_apex_path_persists_turn_index` below covers the
+    /// same invariant for the default (`apex_mem.enabled = false`) path, which originally had a
+    /// separate gap: `resolve_edge_typed`/`GraphStore::insert_edge_typed` had no `turn_index`
+    /// parameter at all and silently dropped it even when this APEX-MEM test passed.
+    #[tokio::test]
+    async fn extract_and_store_persists_turn_index_to_graph_edges() {
+        use crate::graph::{EntityType, GraphStore};
+
+        let sqlite = crate::store::SqliteStore::new(":memory:").await.unwrap();
+        let pool = sqlite.pool().clone();
+
+        let extraction_json = r#"{
+            "entities":[
+                {"name":"Alice","type":"person","summary":"person"},
+                {"name":"Bob","type":"person","summary":"person"}
+            ],
+            "edges":[{"source":"Alice","target":"Bob","relation":"knows","fact":"Alice knows Bob","edge_type":"semantic","confidence":0.9}]
+        }"#;
+        let mock = zeph_llm::mock::MockProvider::with_responses(vec![extraction_json.to_owned()]);
+        let provider = AnyProvider::Mock(mock);
+        let config = GraphExtractionConfig {
+            max_entities: 10,
+            max_edges: 10,
+            extraction_timeout_secs: 10,
+            turn_index: Some(7),
+            apex_mem_enabled: true,
+            ..Default::default()
+        };
+
+        let result = extract_and_store(
+            "Alice knows Bob.".to_owned(),
+            vec![],
+            provider,
+            pool.clone(),
+            config,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.stats.edges_inserted, 1, "one edge must be inserted");
+
+        let gs = GraphStore::new(pool);
+        let alice_id: i64 = gs
+            .find_entity("alice", EntityType::Person)
+            .await
+            .unwrap()
+            .expect("alice must exist")
+            .id
+            .0;
+        let bob_id: i64 = gs
+            .find_entity("bob", EntityType::Person)
+            .await
+            .unwrap()
+            .expect("bob must exist")
+            .id
+            .0;
+
+        let mut edges = gs.edges_exact(alice_id, bob_id).await.unwrap();
+        assert_eq!(edges.len(), 1, "exactly one active edge expected");
+        let edge = edges.remove(0);
+
+        assert_eq!(
+            edge.turn_index,
+            Some(7),
+            "turn_index from GraphExtractionConfig must reach the persisted graph_edges row \
+             (regression for #5784 — was always NULL on the live per-turn extraction path)"
+        );
+    }
+
+    /// #5784 follow-up: with `apex_mem_enabled: false` (the out-of-the-box default — see
+    /// `ApexMemConfig::default()` and the live call site's `build_graph_extraction_config`),
+    /// `insert_edges` routes through `resolve_edge_typed`. This used to have no `turn_index`
+    /// parameter at all, so `config.turn_index` was silently dropped and `graph_edges.turn_index`
+    /// stayed `NULL` even after the initial #5784 fix, for any deployment that has not explicitly
+    /// opted into `[memory.graph.apex_mem] enabled = true`. `resolve_edge_typed` and
+    /// `GraphStore::insert_edge_typed` now both accept and forward `turn_index`, closing the gap
+    /// for the default configuration too.
+    #[tokio::test]
+    async fn extract_and_store_non_apex_path_persists_turn_index() {
+        use crate::graph::{EntityType, GraphStore};
+
+        let sqlite = crate::store::SqliteStore::new(":memory:").await.unwrap();
+        let pool = sqlite.pool().clone();
+
+        let extraction_json = r#"{
+            "entities":[
+                {"name":"Carol","type":"person","summary":"person"},
+                {"name":"Dave","type":"person","summary":"person"}
+            ],
+            "edges":[{"source":"Carol","target":"Dave","relation":"knows","fact":"Carol knows Dave","edge_type":"semantic","confidence":0.9}]
+        }"#;
+        let mock = zeph_llm::mock::MockProvider::with_responses(vec![extraction_json.to_owned()]);
+        let provider = AnyProvider::Mock(mock);
+        let config = GraphExtractionConfig {
+            max_entities: 10,
+            max_edges: 10,
+            extraction_timeout_secs: 10,
+            turn_index: Some(9),
+            // apex_mem_enabled defaults to false — matches production default config.
+            ..Default::default()
+        };
+
+        let result = extract_and_store(
+            "Carol knows Dave.".to_owned(),
+            vec![],
+            provider,
+            pool.clone(),
+            config,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.stats.edges_inserted, 1, "one edge must be inserted");
+
+        let gs = GraphStore::new(pool);
+        let carol_id: i64 = gs
+            .find_entity("carol", EntityType::Person)
+            .await
+            .unwrap()
+            .expect("carol must exist")
+            .id
+            .0;
+        let dave_id: i64 = gs
+            .find_entity("dave", EntityType::Person)
+            .await
+            .unwrap()
+            .expect("dave must exist")
+            .id
+            .0;
+
+        let mut edges = gs.edges_exact(carol_id, dave_id).await.unwrap();
+        assert_eq!(edges.len(), 1, "exactly one active edge expected");
+        let edge = edges.remove(0);
+
+        assert_eq!(
+            edge.turn_index,
+            Some(9),
+            "turn_index from GraphExtractionConfig must reach the persisted graph_edges row \
+             on the default (apex_mem.enabled=false) path too, not just APEX-MEM (#5784)"
         );
     }
 

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -188,6 +188,23 @@ enum AdmissionOutcome {
     Proceed(Option<AdmissionDecision>),
 }
 
+/// Compute `recall_graph_hela`'s outer hard timeout from the same [`crate::graph::HelaSpreadParams`]
+/// that bound the inner call, so the outer bound can never again be tighter than what it wraps
+/// (#5785). `hela_spreading_recall` checks `step_budget` once for the anchor ANN, once per BFS hop
+/// (up to `spread_depth`, clamped to `[1, 6]`) for the edge-fetch, and once for the final
+/// vectors-batch — `spread_depth + 2` gated stages in the worst case, not a fixed count.
+fn hela_outer_timeout(params: &crate::graph::HelaSpreadParams) -> std::time::Duration {
+    let embed_component = params
+        .embed_timeout
+        .unwrap_or(std::time::Duration::from_secs(5));
+    let step_stages = params.spread_depth.clamp(1, 6) + 2;
+    let step_component = params
+        .step_budget
+        .unwrap_or(std::time::Duration::from_millis(80))
+        * step_stages;
+    embed_component + step_component + std::time::Duration::from_millis(250)
+}
+
 impl SemanticMemory {
     /// Save a message to `SQLite` and optionally embed and store in Qdrant.
     ///
@@ -1941,8 +1958,12 @@ impl SemanticMemory {
     /// Retrieve graph facts via HL-F5 spreading activation from the top-1 ANN anchor (#3346).
     ///
     /// Returns an empty vec when no graph store is configured, Qdrant is unavailable,
-    /// or `hebbian_spread.enabled = false`.  The outer 200 ms timeout ensures the
-    /// agent loop is never blocked by a slow Qdrant response.
+    /// or `hebbian_spread.enabled = false`. The outer timeout is derived from `params`
+    /// (embed timeout + `(spread_depth.clamp(1, 6) + 2)` × step budget + a fixed margin) so
+    /// it always stays strictly larger than the inner timeouts it wraps — a hardcoded outer
+    /// bound tighter than the inner `embed_timeout` default silently aborted every call
+    /// (#5785). This still ensures the agent loop is never blocked indefinitely by a stalled
+    /// Qdrant response.
     ///
     /// # Errors
     ///
@@ -1974,8 +1995,14 @@ impl SemanticMemory {
         let hebbian_enabled = self.hebbian_reinforcement.is_enabled();
         let hebbian_lr = self.hebbian_lr;
 
+        // Single source of truth for the outer bound: see `hela_outer_timeout` — it must
+        // exceed everything it wraps (the embed call plus every step-budget-gated stage,
+        // scaled by `spread_depth`), or the outer timeout fires before the inner ones ever
+        // get a chance to run (#5785).
+        let outer_timeout = hela_outer_timeout(&params);
+
         let results = tokio::time::timeout(
-            std::time::Duration::from_millis(200),
+            outer_timeout,
             crate::graph::hela_spreading_recall(
                 &store,
                 &embeddings,
@@ -1989,7 +2016,10 @@ impl SemanticMemory {
         )
         .await
         .unwrap_or_else(|_| {
-            tracing::warn!("memory.recall_graph_hela: outer 200ms timeout exceeded");
+            tracing::warn!(
+                outer_timeout_ms = outer_timeout.as_millis(),
+                "memory.recall_graph_hela: outer timeout exceeded"
+            );
             Ok(Vec::new())
         })?;
 
@@ -2120,6 +2150,75 @@ impl SemanticMemory {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #5785 edge case: the outer timeout multiplier must scale with `spread_depth`, not stay
+    /// fixed at 3 — `hela_spreading_recall` gates `spread_depth + 2` stages (anchor ANN + one
+    /// edge-fetch check per BFS hop + vectors-batch), so a fixed 3× multiplier under-provisions
+    /// the outer bound for any `spread_depth > 1` and can reintroduce the outer/inner inversion.
+    #[test]
+    fn hela_outer_timeout_scales_with_spread_depth() {
+        let step_budget = std::time::Duration::from_millis(80);
+        let embed_timeout = std::time::Duration::from_secs(5);
+        let margin = std::time::Duration::from_millis(250);
+
+        for depth in 1..=6u32 {
+            let params = crate::graph::HelaSpreadParams {
+                spread_depth: depth,
+                step_budget: Some(step_budget),
+                embed_timeout: Some(embed_timeout),
+                ..Default::default()
+            };
+            let expected = embed_timeout + step_budget * (depth + 2) + margin;
+            assert_eq!(
+                hela_outer_timeout(&params),
+                expected,
+                "outer timeout must scale with spread_depth={depth}"
+            );
+        }
+    }
+
+    /// `spread_depth` above the algorithm's own `[1, 6]` clamp must not blow up the outer
+    /// timeout unboundedly — the formula clamps identically to `hela_spreading_recall`'s own
+    /// `spread_depth.clamp(1, 6)`.
+    #[test]
+    fn hela_outer_timeout_clamps_spread_depth_above_six() {
+        let step_budget = std::time::Duration::from_millis(80);
+        let embed_timeout = std::time::Duration::from_secs(5);
+        let params_over = crate::graph::HelaSpreadParams {
+            spread_depth: 50,
+            step_budget: Some(step_budget),
+            embed_timeout: Some(embed_timeout),
+            ..Default::default()
+        };
+        let params_clamped = crate::graph::HelaSpreadParams {
+            spread_depth: 6,
+            step_budget: Some(step_budget),
+            embed_timeout: Some(embed_timeout),
+            ..Default::default()
+        };
+        assert_eq!(
+            hela_outer_timeout(&params_over),
+            hela_outer_timeout(&params_clamped),
+            "spread_depth above 6 must clamp identically to the algorithm's own [1, 6] bound"
+        );
+    }
+
+    /// When `step_budget`/`embed_timeout` are `None` (disabled), the outer timeout must fall
+    /// back to safe finite defaults rather than becoming unbounded — the outer bound is a hard
+    /// safety net independent of whether the caller opted out of the inner per-step guards.
+    #[test]
+    fn hela_outer_timeout_falls_back_when_params_disabled() {
+        let params = crate::graph::HelaSpreadParams {
+            spread_depth: 2,
+            step_budget: None,
+            embed_timeout: None,
+            ..Default::default()
+        };
+        let expected = std::time::Duration::from_secs(5)
+            + std::time::Duration::from_millis(80) * 4
+            + std::time::Duration::from_millis(250);
+        assert_eq!(hela_outer_timeout(&params), expected);
+    }
 
     #[test]
     fn embed_context_default_all_none() {

--- a/crates/zeph-memory/tests/hela_spreading_activation.rs
+++ b/crates/zeph-memory/tests/hela_spreading_activation.rs
@@ -20,6 +20,7 @@ use zeph_memory::embedding_store::EmbeddingStore;
 use zeph_memory::graph::GraphStore;
 use zeph_memory::graph::activation::{HelaSpreadParams, hela_spreading_recall};
 use zeph_memory::graph::types::EntityType;
+use zeph_memory::semantic::SemanticMemory;
 use zeph_memory::store::SqliteStore;
 
 const QDRANT_GRPC_PORT: ContainerPort = ContainerPort::Tcp(6334);
@@ -218,6 +219,128 @@ async fn hela_depth_one_excludes_two_hop() {
             "C must not appear in depth-1 results"
         );
     }
+}
+
+/// #5785 regression: the default `step_budget` (previously `8 ms`) must leave enough
+/// headroom for a real Qdrant round-trip that a populated, non-trivial graph requires —
+/// otherwise the per-step circuit breaker aborts the call before it ever returns facts.
+#[ignore = "requires Qdrant container"]
+#[tokio::test]
+async fn hela_default_budget_returns_facts_against_real_qdrant() {
+    let (graph, embeddings, _sqlite, _ctr) = setup().await;
+    let embed_vec = vec![1.0_f32, 0.0, 0.0];
+    let provider = mock_provider(embed_vec.clone());
+
+    embeddings
+        .ensure_named_collection(ENTITY_COLLECTION, 3)
+        .await
+        .unwrap();
+
+    let (anchor_id, _) = seed_entity(&graph, &embeddings, "Anchor", embed_vec.clone()).await;
+    let (neighbor_id, _) = seed_entity(&graph, &embeddings, "Neighbor", embed_vec.clone()).await;
+    graph
+        .insert_edge(
+            anchor_id,
+            neighbor_id,
+            "relates_to",
+            "test edge",
+            0.9,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Deliberately use the unmodified default params (real step_budget/embed_timeout),
+    // not an override, so this test fails again if the default is ever tightened back down.
+    let params = HelaSpreadParams::default();
+    let results = hela_spreading_recall(
+        &graph,
+        &embeddings,
+        &provider,
+        "anchor",
+        10,
+        &params,
+        false,
+        0.1,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "default step_budget must leave enough headroom for a real Qdrant round-trip"
+    );
+}
+
+/// #5785 regression, other half: `SemanticMemory::recall_graph_hela` derives its *outer*
+/// `tokio::time::timeout` from `params` (`embed_timeout` + `(spread_depth.clamp(1, 6) + 2)` ×
+/// `step_budget` + margin) instead of the old hardcoded `200 ms`. None of the sibling tests in
+/// this file exercise this — they all call the lower-level `hela_spreading_recall` free function
+/// directly, bypassing the outer-timeout wrapper entirely. This test goes through
+/// `SemanticMemory::recall_graph_hela` itself against a real Qdrant round-trip so the
+/// outer-timeout-derivation fix has at least one live exerciser.
+#[ignore = "requires Qdrant container"]
+#[tokio::test]
+async fn recall_graph_hela_outer_timeout_headroom_returns_facts_against_real_qdrant() {
+    let container = qdrant_image().start().await.unwrap();
+    let grpc_port = container.get_host_port_ipv4(6334).await.unwrap();
+    let url = format!("http://127.0.0.1:{grpc_port}");
+
+    // File-backed SQLite (not `:memory:`) so the seeding pool and the pool
+    // `SemanticMemory::new` opens internally both see the same database.
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let db_path = tmp_dir.path().join("hela_outer_timeout.db");
+    let db_path_str = db_path.to_str().unwrap();
+
+    let seed_sqlite = SqliteStore::new(db_path_str).await.unwrap();
+    let seed_pool = seed_sqlite.pool().clone();
+    let graph = GraphStore::new(seed_pool.clone());
+    let embeddings = EmbeddingStore::new(&url, None, seed_pool).unwrap();
+
+    let embed_vec = vec![1.0_f32, 0.0, 0.0];
+    let provider = mock_provider(embed_vec.clone());
+
+    embeddings
+        .ensure_named_collection(ENTITY_COLLECTION, 3)
+        .await
+        .unwrap();
+
+    let (anchor_id, _) = seed_entity(&graph, &embeddings, "Anchor", embed_vec.clone()).await;
+    let (neighbor_id, _) = seed_entity(&graph, &embeddings, "Neighbor", embed_vec.clone()).await;
+    graph
+        .insert_edge(
+            anchor_id,
+            neighbor_id,
+            "relates_to",
+            "test edge",
+            0.9,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Second pool against the same on-disk file, for the `GraphStore` attached below —
+    // `SemanticMemory::new` opens its own internal pool against `db_path_str` too.
+    let memory_side_pool = SqliteStore::new(db_path_str).await.unwrap().pool().clone();
+    let memory = SemanticMemory::new(db_path_str, &url, None, provider, "test-model")
+        .await
+        .unwrap()
+        .with_graph_store(std::sync::Arc::new(GraphStore::new(memory_side_pool)));
+
+    let results = memory
+        .recall_graph_hela("anchor", 10, HelaSpreadParams::default())
+        .await
+        .unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "recall_graph_hela's param-derived outer timeout must leave enough headroom for a \
+         real Qdrant round-trip (regression for #5785 outer-timeout-derivation fix)"
+    );
+
+    drop(container);
 }
 
 /// `max_visited` cap is respected — results never exceed the cap.

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -1111,6 +1111,7 @@ async fn run_graph_ingest(
             &config.memory.graph,
             None,
             memory.embed_timeout().as_secs(),
+            None,
         ),
         dry_run,
         dry_run_hub_top_n: Some(10),
@@ -1560,6 +1561,7 @@ async fn handle_external_agent_ingest(
             &app_config.memory.graph,
             None,
             mem.embed_timeout().as_secs(),
+            None,
         ),
         ..IngestBatchConfig::default()
     };


### PR DESCRIPTION
## Summary

- Fixes #5785: HELA spreading-activation recall used a `step_budget_ms=8` per-step circuit breaker and a hardcoded 200ms outer timeout wrapping a 5s inner embed timeout, both far tighter than realistic Qdrant I/O latency. The feature silently fell back to normal recall on every call, even with a healthy Qdrant backend. `step_budget` now defaults to 80ms, and the outer timeout in `recall_graph_hela` is derived from `HelaSpreadParams` via a new `hela_outer_timeout` helper that scales with `spread_depth`, so the outer bound can no longer be tighter than the inner timeouts it wraps at any `spread_depth`.
- Fixes #5784: `graph_edges.turn_index` was always NULL on the live per-turn extraction path, on both the APEX-MEM and default (non-APEX) storage paths. `turn_index` is now threaded from the agent's turn counter through `build_graph_extraction_config` down to both DB write paths (`insert_edge_typed`, the APEX-MEM supersession path).

## Out of scope (documented as follow-up candidates, not fixed here)

- `HebbianConfig::step_budget_ms` is still dead config, never wired at the `tiered_retrieval.rs` call site (the only live caller uses `HelaSpreadParams::default()` directly).
- `source_message_id`/`episode_id` empty-on-repro is a separate, unconfirmed root cause, not the same as `turn_index`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12268/12268 passed
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`)
- [x] Live-Qdrant `#[ignore]`-gated suite run against a real testcontainer: 6/6 passed
- [x] `.local/testing/playbooks/memory-graph.md` and `.local/testing/coverage-status.md` updated