### PR TITLE
fix(llm): surface actionable error for reasoning_effort + tools on Chat Completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(llm)`: OpenAI Chat Completions rejects the combination of `reasoning_effort` and
+  tool-calling (`tools`) for some reasoning models (e.g. `gpt-5.4-mini`), responding with an
+  opaque HTTP 400 body directing callers to `/v1/responses` — an endpoint Zeph does not
+  implement (#5789). `OpenAiProvider::chat_with_tools`
+  (`crates/zeph-llm/src/openai/mod.rs`) now recognizes this specific 400 body
+  (`body_is_reasoning_effort_tools_incompatible` in `crates/zeph-llm/src/error.rs`, mirroring
+  the existing `body_is_context_length_error` pattern) and returns an actionable
+  `LlmError::InvalidInput` explaining the incompatibility and how to work around it (unset
+  `reasoning_effort` for the provider, or use a different model for tool-calling turns),
+  instead of surfacing the raw OpenAI error text.
+
 - `fix(core)`: the utility gate's `Retrieve` action (`crates/zeph-core/src/agent/tool_execution/tier_loop.rs`,
   `handle_retrieve_action`) could enter an unbreakable loop when the mandated `memory_search`
   detour itself failed with `confirmation_required` (e.g. the query content trips a

--- a/crates/zeph-llm/src/error.rs
+++ b/crates/zeph-llm/src/error.rs
@@ -159,6 +159,16 @@ pub(crate) fn body_is_context_length_error(body: &str) -> bool {
         || lower.contains("input too long")
 }
 
+/// Check whether a raw 400 body indicates `OpenAI`'s `reasoning_effort` + `tools`
+/// incompatibility on the Chat Completions endpoint (requires `/v1/responses`, which
+/// Zeph does not implement).
+pub(crate) fn body_is_reasoning_effort_tools_incompatible(body: &str) -> bool {
+    let lower = body.to_lowercase();
+    lower.contains("reasoning_effort")
+        && lower.contains("not supported")
+        && (lower.contains("/v1/responses") || lower.contains("responses instead"))
+}
+
 pub type Result<T> = std::result::Result<T, LlmError>;
 
 #[cfg(test)]
@@ -280,5 +290,51 @@ mod tests {
         assert!(!body_is_context_length_error("some unrelated error"));
         assert!(!body_is_context_length_error("rate limit exceeded"));
         assert!(!body_is_context_length_error("authentication failed"));
+    }
+
+    #[test]
+    fn body_is_reasoning_effort_tools_incompatible_detects_known_message() {
+        assert!(body_is_reasoning_effort_tools_incompatible(
+            "Function tools with reasoning_effort are not supported for gpt-5.4-mini in \
+             /v1/chat/completions. Please use /v1/responses instead."
+        ));
+    }
+
+    #[test]
+    fn body_is_reasoning_effort_tools_incompatible_ignores_unrelated_messages() {
+        assert!(!body_is_reasoning_effort_tools_incompatible(
+            "rate limit exceeded, please retry later"
+        ));
+        assert!(!body_is_reasoning_effort_tools_incompatible(
+            "invalid request: missing required parameter 'model'"
+        ));
+        assert!(!body_is_reasoning_effort_tools_incompatible(
+            "This model's maximum context length is 4096 tokens. context_length_exceeded"
+        ));
+    }
+
+    #[test]
+    fn body_is_reasoning_effort_tools_incompatible_is_case_insensitive() {
+        assert!(body_is_reasoning_effort_tools_incompatible(
+            "Function tools with REASONING_EFFORT are NOT SUPPORTED for gpt-5.4-mini in \
+             /V1/CHAT/COMPLETIONS. Please use /V1/RESPONSES instead."
+        ));
+    }
+
+    #[test]
+    fn body_is_reasoning_effort_tools_incompatible_requires_all_markers() {
+        // Mentions reasoning_effort and the responses endpoint, but not "not supported" —
+        // should not match, since this isn't necessarily the incompatibility error.
+        assert!(!body_is_reasoning_effort_tools_incompatible(
+            "reasoning_effort was applied; see /v1/responses for details"
+        ));
+        // Mentions "not supported" and the responses endpoint, but never reasoning_effort.
+        assert!(!body_is_reasoning_effort_tools_incompatible(
+            "tool_choice is not supported on /v1/responses for this model"
+        ));
+        // Mentions reasoning_effort and "not supported", but no responses-endpoint pointer.
+        assert!(!body_is_reasoning_effort_tools_incompatible(
+            "reasoning_effort is not supported for this model"
+        ));
     }
 }

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -1046,6 +1046,21 @@ impl LlmProvider for OpenAiProvider {
             if crate::error::body_is_context_length_error(&text) {
                 return Err(LlmError::ContextLengthExceeded);
             }
+            if self.reasoning_effort.is_some()
+                && crate::error::body_is_reasoning_effort_tools_incompatible(&text)
+            {
+                return Err(LlmError::InvalidInput {
+                    provider: self.name().to_owned(),
+                    message: format!(
+                        "model '{}' does not support `reasoning_effort` together with tool \
+                         calls on the Chat Completions API (OpenAI requires the /v1/responses \
+                         endpoint for this combination, which Zeph does not yet support). Unset \
+                         `reasoning_effort` for this provider in config.toml, or use a different \
+                         model for tool-calling turns. Original error: {text}",
+                        self.model
+                    ),
+                });
+            }
             return Err(LlmError::InvalidInput {
                 provider: self.name().to_owned(),
                 message: text,

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -1446,6 +1446,131 @@ async fn chat_with_tools_handles_null_assistant_content() {
 }
 
 #[tokio::test]
+async fn chat_with_tools_reasoning_effort_400_enriches_message() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let error_body = serde_json::json!({
+        "error": {
+            "message": "Function tools with reasoning_effort are not supported for \
+                        gpt-5.4-mini in /v1/chat/completions. Please use /v1/responses instead.",
+            "type": "invalid_request_error"
+        }
+    });
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(error_body))
+        .mount(&server)
+        .await;
+
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test".into(),
+        base_url: server.uri(),
+        model: "gpt-5.4-mini".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: Some("high".into()),
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    let messages = vec![Message {
+        role: Role::User,
+        content: "hi".into(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    }];
+    let tools = vec![ToolDefinition {
+        name: "bash".into(),
+        description: "Execute a shell command".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"]
+        }),
+        output_schema: None,
+    }];
+
+    let err = p.chat_with_tools(&messages, &tools).await.unwrap_err();
+    match err {
+        LlmError::InvalidInput { message, .. } => {
+            assert!(
+                message.contains("reasoning_effort"),
+                "expected enriched message to mention reasoning_effort, got: {message}"
+            );
+            assert!(
+                message.contains("Unset"),
+                "expected enriched message to suggest unsetting reasoning_effort, got: {message}"
+            );
+        }
+        other => panic!("expected InvalidInput, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn chat_with_tools_reasoning_effort_none_400_passes_through_raw_message() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let raw_message = "Function tools with reasoning_effort are not supported for \
+                        gpt-5.4-mini in /v1/chat/completions. Please use /v1/responses instead.";
+    let error_body = serde_json::json!({
+        "error": {
+            "message": raw_message,
+            "type": "invalid_request_error"
+        }
+    });
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(error_body))
+        .mount(&server)
+        .await;
+
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test".into(),
+        base_url: server.uri(),
+        model: "gpt-5.4-mini".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+    });
+    let messages = vec![Message {
+        role: Role::User,
+        content: "hi".into(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    }];
+    let tools = vec![ToolDefinition {
+        name: "bash".into(),
+        description: "Execute a shell command".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"]
+        }),
+        output_schema: None,
+    }];
+
+    let err = p.chat_with_tools(&messages, &tools).await.unwrap_err();
+    match err {
+        LlmError::InvalidInput { message, .. } => {
+            assert!(
+                message.contains(raw_message),
+                "expected raw passthrough message, got: {message}"
+            );
+            assert!(
+                !message.contains("Unset"),
+                "guard must not misfire when reasoning_effort is unset, got: {message}"
+            );
+        }
+        other => panic!("expected InvalidInput, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn chat_429_rate_limit_propagates() {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer};


### PR DESCRIPTION
## Summary

- OpenAI rejects `gpt-5.4-mini` requests that combine `reasoning_effort` with tool definitions on `/v1/chat/completions`, directing callers to the unimplemented `/v1/responses` endpoint. Since Zeph is an agentic tool-calling CLI, essentially every real turn sends tools, so the feature failed end-to-end even after the prior wire-shape fix (#5776).
- Detect the specific OpenAI error signature reactively in `OpenAiProvider::chat_with_tools`, mirroring the existing `body_is_context_length_error` pattern, and rewrite it into an actionable `InvalidInput` message (unset `reasoning_effort` or switch models) instead of passing through the raw OpenAI error body.
- No new error variant, no config-load-time model list (the affected-model set is unbounded and OpenAI-side), no changes needed to router fallback logic (`is_invalid_input()` short-circuit unaffected).
- `CompatibleProvider` delegates to the same `OpenAiProvider::chat_with_tools` implementation, so third-party OpenAI-compatible endpoints are covered for free.

Closes #5789

## Test plan

- [x] `cargo build -p zeph-llm`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm` — 951 passed, 11 skipped
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12291 passed, 34 skipped
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] LLM serialization gate: live round-trip against the real OpenAI API (tool-calling turn) confirmed no regression
- [x] New unit tests for the detection heuristic (positive, negative, case-insensitivity, partial-marker-combination controls) plus mocked-HTTP end-to-end tests proving the enriched error is returned through `chat_with_tools`, and that the guard does not misfire when `reasoning_effort` is unset