### PR TITLE
fix(db): restore cfg guards dropped by #5633, fixing --all-features doc build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(db)`: `cargo doc --all-features` (and any `--all-features` build) failed to compile
+  `zeph-db` with 17 errors — `E0428` duplicate definitions (`begin_write`, `run_migrations`,
+  `ActiveDriver`, the `sql!` macro, `numbered_placeholder`, and 8 `fts.rs` helpers) plus
+  cascading `E0308` mismatches — even though the crate already has an intentional
+  `compile_error!` rejecting the `sqlite`+`postgres` combination (#5633, spec-031).
+  `compile_error!` does not halt further type-checking, so rustc still tried to compile both
+  backend-specific definitions of each item. `#5793`: restored the
+  `#[cfg(all(feature = "sqlite", not(feature = "postgres")))]` guards on the affected items in
+  `pool.rs`, `transaction.rs`, `migrate.rs`, `lib.rs`, and `fts.rs` (removed as a "dead code"
+  simplification in #5633) so a both-features build now fails with only the single intended
+  `compile_error!` message. Does not change the mutual-exclusivity semantics — `--all-features`
+  is still unsupported by design.
+
 - `fix(llm)`: OpenAI Chat Completions rejects the combination of `reasoning_effort` and
   tool-calling (`tools`) for some reasoning models (e.g. `gpt-5.4-mini`), responding with an
   opaque HTTP 400 body directing callers to `/v1/responses` — an endpoint Zeph does not

--- a/crates/zeph-db/src/fts.rs
+++ b/crates/zeph-db/src/fts.rs
@@ -10,7 +10,7 @@
 /// `PostgreSQL`: `plainto_tsquery` handles most sanitization; strip obvious
 /// injection attempts (single quotes).
 #[must_use]
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn sanitize_fts_query(query: &str) -> String {
     query
         .split(|c: char| !c.is_alphanumeric())
@@ -42,7 +42,7 @@ pub fn sanitize_fts_query(query: &str) -> String {
 /// `SQLite`: `messages_fts MATCH ?`
 /// `PostgreSQL`: `m.tsv @@ plainto_tsquery('english', $1)`
 #[must_use]
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn messages_fts_where() -> &'static str {
     "messages_fts MATCH ?"
 }
@@ -58,7 +58,7 @@ pub fn messages_fts_where() -> &'static str {
 /// `SQLite`: `JOIN messages_fts f ON f.rowid = m.id`
 /// `PostgreSQL`: empty string (tsv column is on messages directly)
 #[must_use]
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn messages_fts_join() -> &'static str {
     "JOIN messages_fts f ON f.rowid = m.id"
 }
@@ -74,7 +74,7 @@ pub fn messages_fts_join() -> &'static str {
 /// `SQLite`: `-rank AS score` (FTS5 `rank` is negative; negate for positive-is-better)
 /// `PostgreSQL`: `ts_rank(m.tsv, plainto_tsquery('english', $1)) AS score`
 #[must_use]
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn messages_fts_rank_select() -> &'static str {
     "-rank AS score"
 }
@@ -90,7 +90,7 @@ pub fn messages_fts_rank_select() -> &'static str {
 /// `SQLite`: `rank` (ascending — FTS5 rank is negative so ASC = best first)
 /// `PostgreSQL`: `score DESC` (`ts_rank` is positive so DESC = best first)
 #[must_use]
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn messages_fts_order_by() -> &'static str {
     "rank"
 }
@@ -108,7 +108,7 @@ pub fn messages_fts_order_by() -> &'static str {
 /// `SQLite`: `graph_entities_fts MATCH ?`
 /// `PostgreSQL`: `e.tsv @@ plainto_tsquery('english', $1)`
 #[must_use]
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn graph_entities_fts_where() -> &'static str {
     "graph_entities_fts MATCH ?"
 }
@@ -124,7 +124,7 @@ pub fn graph_entities_fts_where() -> &'static str {
 /// `SQLite`: `JOIN graph_entities_fts fts ON fts.rowid = e.id`
 /// `PostgreSQL`: empty string (tsv column lives on `graph_entities`)
 #[must_use]
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn graph_entities_fts_join() -> &'static str {
     "JOIN graph_entities_fts fts ON fts.rowid = e.id"
 }
@@ -142,7 +142,7 @@ pub fn graph_entities_fts_join() -> &'static str {
 /// `PostgreSQL`: `ts_rank(ARRAY[0,0,1,10], e.tsv, plainto_tsquery('english', $1)) AS fts_rank`
 ///   (weight array: [D, C, B, A]; A=name weight 10, B=summary weight 1)
 #[must_use]
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn graph_entities_fts_rank_select() -> &'static str {
     "-bm25(graph_entities_fts, 10.0, 1.0) AS fts_rank"
 }
@@ -157,7 +157,7 @@ pub fn graph_entities_fts_rank_select() -> &'static str {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
     mod sqlite {
         use super::*;
 

--- a/crates/zeph-db/src/lib.rs
+++ b/crates/zeph-db/src/lib.rs
@@ -53,7 +53,7 @@ pub use sqlx;
 // --- Active driver type alias ---
 
 /// The active database driver, selected at compile time.
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub type ActiveDriver = driver::SqliteDriver;
 #[cfg(feature = "postgres")]
 pub type ActiveDriver = driver::PostgresDriver;
@@ -105,7 +105,7 @@ pub type ActiveDialect = <ActiveDriver as DatabaseDriver>::Dialect;
 ///     .fetch_all(&pool)
 ///     .await?;
 /// ```
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 #[macro_export]
 macro_rules! sql {
     ($query:expr) => {
@@ -190,7 +190,7 @@ pub fn rewrite_placeholders(query: &str) -> String {
 ///
 /// `SQLite`: `?N`, `PostgreSQL`: `$N`
 #[must_use]
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn numbered_placeholder(n: usize) -> String {
     format!("?{n}")
 }
@@ -267,7 +267,7 @@ mod tests {
     fn numbered_placeholder_one_based() {
         let p1 = numbered_placeholder(1);
         let p3 = numbered_placeholder(3);
-        #[cfg(feature = "sqlite")]
+        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
         {
             assert_eq!(p1, "?1");
             assert_eq!(p3, "?3");
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn placeholder_list_range() {
         let list = placeholder_list(2, 3);
-        #[cfg(feature = "sqlite")]
+        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
         assert_eq!(list, "?2, ?3, ?4");
         #[cfg(feature = "postgres")]
         assert_eq!(list, "$2, $3, $4");

--- a/crates/zeph-db/src/migrate.rs
+++ b/crates/zeph-db/src/migrate.rs
@@ -15,7 +15,7 @@ use crate::{DbPool, error::DbError};
 /// # Errors
 ///
 /// Returns [`DbError::Migration`] if any migration fails.
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 #[tracing::instrument(name = "db.migrate.run", skip_all, err)]
 pub async fn run_migrations(pool: &DbPool) -> Result<(), DbError> {
     sqlx::migrate!("./migrations/sqlite")

--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -35,7 +35,7 @@ impl DbConfig {
     /// Returns [`DbError`] if connection or migration fails.
     #[tracing::instrument(name = "db.pool.connect", skip_all, err)]
     pub async fn connect(&self) -> Result<DbPool, DbError> {
-        #[cfg(feature = "sqlite")]
+        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
         {
             Self::connect_sqlite(&self.url, self.max_connections, self.pool_size).await
         }
@@ -45,7 +45,7 @@ impl DbConfig {
         }
     }
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
     async fn connect_sqlite(
         path: &str,
         max_connections: u32,
@@ -210,7 +210,7 @@ mod tests {
         assert!(redact_url(url).is_none());
     }
 
-    #[cfg(all(unix, feature = "sqlite"))]
+    #[cfg(all(unix, feature = "sqlite", not(feature = "postgres")))]
     #[tokio::test]
     async fn sqlite_precreated_with_0600() {
         use std::os::unix::fs::PermissionsExt as _;

--- a/crates/zeph-db/src/transaction.rs
+++ b/crates/zeph-db/src/transaction.rs
@@ -25,7 +25,7 @@ pub async fn begin(pool: &DbPool) -> Result<crate::DbTransaction<'_>, sqlx::Erro
 /// # Errors
 ///
 /// Returns a sqlx error if the transaction cannot be started.
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 #[tracing::instrument(name = "db.tx.begin_write", skip_all, err)]
 pub async fn begin_write(pool: &DbPool) -> Result<crate::DbTransaction<'_>, sqlx::Error> {
     pool.begin_with("BEGIN IMMEDIATE").await


### PR DESCRIPTION
## Summary

- `cargo doc --all-features -p zeph-db` (and any workspace `--all-features` build) failed with 17 cascading `E0428`/`E0308` errors instead of the single intended `compile_error!` that rejects the `sqlite`+`postgres` combination (per `specs/031-database-abstraction/spec.md` — `--all-features` is explicitly unsupported by design).
- Root cause: commit `e874bf7b` (#5633) stripped the `not(feature = "postgres")` half of several per-item `#[cfg(...)]` guards in `pool.rs`/`transaction.rs`/`migrate.rs`/`lib.rs`/`fts.rs` under the false assumption that `compile_error!` halts further compilation — rustc still name/type-checks the rest of the crate.
- Restored `#[cfg(all(feature = "sqlite", not(feature = "postgres")))]` on every sqlite-side item colliding by name with its postgres counterpart: `begin_write`, `run_migrations`, `ActiveDriver`, the `sql!` macro, `numbered_placeholder`, 8 `fts.rs` helpers, and 3 test-cfg blocks.
- This is a pure cfg-gating restoration with no behavioral change on any single-feature build. `--all-features` remains unsupported by design; a both-features build now fails with only the one intended `compile_error!`.
- Same defect class previously fixed in #2695 (build) and #2734 (test compilation) — this is the doc-build target regression that #2734 did not cover, subsequently reintroduced by #5633.

## Test plan

- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-db` fails with exactly 1 error (the intended `compile_error!`), not 17
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-skills` (exact issue repro) — same result
- [x] `cargo check -p zeph-db --no-default-features --features sqlite` (alone) passes
- [x] `cargo check -p zeph-db --no-default-features --features postgres` (alone) passes
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12304 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` (CI rustdoc gate)
- [x] CHANGELOG.md updated under `[Unreleased]`/`### Fixed`

Closes #5793