### PR TITLE
fix(skills): implement Qdrant vector retrieval for RL rerank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   simplification in #5633) so a both-features build now fails with only the single intended
   `compile_error!` message. Does not change the mutual-exclusivity semantics — `--all-features`
   is still unsupported by design.
+- `fix(skills)`: `SkillMatcherBackend::skill_embedding()` returned `None` unconditionally for
+  the Qdrant matcher backend (`crates/zeph-skills/src/matcher.rs`), which made the RL routing
+  head's rerank candidate-building guard in `crates/zeph-core/src/agent/context/assembly.rs`
+  never pass when `vector_backend = "qdrant"` — the recommended backend for large skill
+  libraries — silently disabling RL rerank in that configuration despite `rl_routing_enabled`
+  being on (#5786, the "Preferred fix" left unimplemented by #3032). `QdrantSkillMatcher` now
+  issues a bounded follow-up Qdrant `get_points` call (`EmbeddingRegistry::get_vectors_by_keys`
+  in `crates/zeph-memory/src/embedding_registry.rs`, reusing the existing `VectorStore::get_points`
+  impl) scoped to just the top-K candidate IDs returned by the preceding search, and caches the
+  retrieved vectors for `skill_embedding()` to serve for the remainder of that turn. Vector
+  fetch failures or partial results degrade gracefully to the prior "RL re-rank skipped"
+  behavior rather than erroring. `SkillMatcherBackend::skill_embedding()` and
+  `zeph_skills::group::group_skills()`'s embedding-lookup closure now return owned `Vec<f32>`
+  instead of a borrowed `&[f32]` to accommodate the per-turn Qdrant cache; the interim startup
+  log in `crates/zeph-core/src/agent/builder.rs` was reworded to reflect that Qdrant vectors are
+  now available rather than unimplemented.
+  - Follow-up hardening (#5786): the Qdrant candidate vectors built for RL rerank in
+    `crates/zeph-core/src/agent/context/assembly.rs` are now filtered to exactly
+    `rl_head.embed_dim()` before being handed to `rl_head.rerank()` — a shorter Qdrant vector
+    (e.g. after an embedding-model change since the collection was last synced) previously
+    indexed out of bounds inside `RoutingHeadInner::score()`, crashing the agent turn; a longer
+    one silently misaligned the trailing feature scalars. `QdrantSkillMatcher::match_skills`
+    (`crates/zeph-skills/src/qdrant_matcher.rs`) no longer refreshes its vector cache
+    unconditionally on every call — the fetch is now a separate
+    `SkillMatcherBackend::refresh_skill_embeddings` call, invoked from `assembly.rs` only when
+    RL rerank or `GoSkills` grouping is actually enabled, and only *after* BM25 hybrid-search
+    fusion so skills introduced by fusion (outside the original vector-search top-K) get
+    vectors too — previously they never did, silently skipping RL rerank on any turn where
+    hybrid search surfaced a BM25-only match. This also removes an unconditional extra Qdrant
+    round-trip that was paid by every turn on the Qdrant skill-matcher backend regardless of
+    whether RL rerank was configured. Added live-Qdrant integration tests for
+    `EmbeddingRegistry::get_vectors_by_keys` (happy path and partial-miss) in
+    `crates/zeph-memory/tests/qdrant_integration.rs`.
 
 - `fix(llm)`: OpenAI Chat Completions rejects the combination of `reasoning_effort` and
   tool-calling (`tools`) for some reasoning models (e.g. `gpt-5.4-mini`), responding with an

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2034,8 +2034,11 @@ impl<C: Channel> Agent<C> {
                 .is_some_and(zeph_skills::matcher::SkillMatcherBackend::is_qdrant)
         {
             tracing::info!(
-                "RL re-rank is configured but the Qdrant backend does not expose in-process skill \
-                 vectors; RL will be inactive until vector retrieval from Qdrant is implemented"
+                "RL re-rank is configured with the Qdrant skill-matcher backend: skill vectors \
+                 are retrieved via a bounded follow-up Qdrant lookup for the final candidate \
+                 set each turn (including any BM25-fused skills); RL re-rank is skipped for \
+                 turns where that lookup fails, returns a partial result, or returns vectors \
+                 whose dimension doesn't match the routing head's (issue #5786)"
             );
         }
         self.runtime.metrics.metrics_tx = Some(tx);

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1106,6 +1106,16 @@ impl<C: Channel> Agent<C> {
                     );
                 }
 
+                // Refresh the Qdrant per-skill vector cache (no-op for the in-memory backend)
+                // now that `scored` reflects the final candidate set for this turn, including
+                // any BM25-fused indices outside the original vector-search top-K. Only
+                // fetched when a consumer of `skill_embedding()` is actually enabled (RL
+                // rerank and/or GoSkills grouping) so plain skill matching never pays for the
+                // extra Qdrant round-trip.
+                if self.services.skill.rl_head.is_some() || self.services.skill.group_structured {
+                    matcher.refresh_skill_embeddings(all_meta, &scored).await;
+                }
+
                 let metrics_map: std::collections::HashMap<String, (u32, u32)> =
                     if let Some(memory) = &self.services.memory.persistence.memory {
                         memory
@@ -1176,22 +1186,30 @@ impl<C: Channel> Agent<C> {
                 {
                     let rl_weight = self.services.skill.rl_weight;
                     let warmup = self.services.skill.rl_warmup_updates;
+                    let embed_dim = rl_head.embed_dim();
                     // Build candidates: (skill_index, skill_embed, cosine_score).
-                    // Skills without a stored embedding are skipped (Qdrant backend).
-                    let candidates: Vec<(usize, &[f32], f32)> = scored
+                    // Skills without a stored embedding are skipped (e.g. a Qdrant vector
+                    // fetch failure or partial result for this turn), as are any whose
+                    // embedding dimension doesn't match rl_head's — e.g. the embedding model
+                    // changed since the Qdrant collection was synced. `rl_head.rerank()`
+                    // indexes its input buffer assuming every candidate embedding is exactly
+                    // `embed_dim` long, so an unchecked mismatched-length vector would panic
+                    // (too short) or silently misalign the trailing feature scalars (too long).
+                    let candidates: Vec<(usize, Vec<f32>, f32)> = scored
                         .iter()
                         .filter_map(|s| {
                             matcher
                                 .skill_embedding(s.index)
+                                .filter(|emb| emb.len() == embed_dim)
                                 .map(|emb| (s.index, emb, s.score))
                         })
                         .collect();
                     if candidates.len() == scored.len() {
                         let stats: Vec<(f32, u32)> = candidates
                             .iter()
-                            .map(|&(idx, _, _)| {
+                            .map(|(idx, _, _)| {
                                 let (succ, fail) = all_meta
-                                    .get(idx)
+                                    .get(*idx)
                                     .and_then(|m| metrics_map.get(&m.name))
                                     .copied()
                                     .unwrap_or((0, 0));
@@ -1207,8 +1225,17 @@ impl<C: Channel> Agent<C> {
                                 (rate, total)
                             })
                             .collect();
-                        let reranked =
-                            rl_head.rerank(&query_embed, &candidates, &stats, rl_weight, warmup);
+                        let candidate_refs: Vec<(usize, &[f32], f32)> = candidates
+                            .iter()
+                            .map(|(idx, emb, score)| (*idx, emb.as_slice(), *score))
+                            .collect();
+                        let reranked = rl_head.rerank(
+                            &query_embed,
+                            &candidate_refs,
+                            &stats,
+                            rl_weight,
+                            warmup,
+                        );
                         // Apply new order to scored.
                         scored.sort_by(|a, b| {
                             let pos_a = reranked.iter().position(|(i, _)| *i == a.index);
@@ -1219,7 +1246,8 @@ impl<C: Channel> Agent<C> {
                         tracing::debug!(
                             total = scored.len(),
                             with_embeddings = candidates.len(),
-                            "RL re-rank skipped: skill embeddings unavailable (Qdrant backend does not expose in-process vectors)"
+                            "RL re-rank skipped: skill embeddings unavailable for some \
+                             candidates this turn"
                         );
                     }
                 }
@@ -2421,8 +2449,8 @@ mod tests {
             &skills,
             &indices,
             |idx: usize| match idx {
-                0 => Some(EMBED_A),
-                1 => Some(EMBED_B),
+                0 => Some(EMBED_A.to_vec()),
+                1 => Some(EMBED_B.to_vec()),
                 _ => None,
             },
             threshold,
@@ -2489,8 +2517,8 @@ mod tests {
             &skills,
             &indices,
             |idx: usize| match idx {
-                0 => Some(EMBED_A),
-                1 => Some(EMBED_C),
+                0 => Some(EMBED_A.to_vec()),
+                1 => Some(EMBED_C.to_vec()),
                 _ => None,
             },
             threshold,
@@ -2603,8 +2631,8 @@ mod tests {
             &active_skills,
             &fixed_indices,
             |idx: usize| match idx {
-                1 => Some(EMBED_ENTRY),
-                2 => Some(EMBED_SUPPORT),
+                1 => Some(EMBED_ENTRY.to_vec()),
+                2 => Some(EMBED_SUPPORT.to_vec()),
                 _ => None,
             },
             0.50_f32,
@@ -2622,9 +2650,9 @@ mod tests {
             &active_skills,
             &stale_indices_again,
             |idx: usize| match idx {
-                0 => Some(EMBED_FILTERED),
-                1 => Some(EMBED_ENTRY),
-                2 => Some(EMBED_SUPPORT),
+                0 => Some(EMBED_FILTERED.to_vec()),
+                1 => Some(EMBED_ENTRY.to_vec()),
+                2 => Some(EMBED_SUPPORT.to_vec()),
                 _ => None,
             },
             0.50_f32,

--- a/crates/zeph-memory/src/embedding_registry.rs
+++ b/crates/zeph-memory/src/embedding_registry.rs
@@ -17,7 +17,7 @@ use futures::StreamExt as _;
 use qdrant_client::qdrant::{PointStruct, value::Kind};
 
 use crate::QdrantOps;
-use crate::vector_store::VectorStoreError;
+use crate::vector_store::{VectorStore, VectorStoreError};
 
 /// Boxed future returned by an embedding function.
 pub type EmbedFuture = Pin<
@@ -396,6 +396,34 @@ impl EmbeddingRegistry {
 
     fn point_id(&self, key: &str) -> String {
         uuid::Uuid::new_v5(&self.namespace, key.as_bytes()).to_string()
+    }
+
+    /// Retrieve stored vectors for a bounded set of keys via a single Qdrant `get_points`
+    /// round-trip (e.g. the candidate IDs returned by a prior [`Self::search_raw`] call).
+    ///
+    /// Keys with no matching point, or whose point carries no dense vector, are silently
+    /// omitted from the result — callers should treat a missing key as "vector unavailable"
+    /// rather than an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmbeddingRegistryError::VectorStore`] if the underlying Qdrant call fails.
+    #[tracing::instrument(name = "memory.embed_registry.get_vectors_by_keys", skip_all, err)]
+    pub async fn get_vectors_by_keys(
+        &self,
+        keys: &[String],
+    ) -> Result<HashMap<String, Vec<f32>>, EmbeddingRegistryError> {
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let id_to_key: HashMap<String, String> =
+            keys.iter().map(|k| (self.point_id(k), k.clone())).collect();
+        let ids: Vec<String> = id_to_key.keys().cloned().collect();
+        let points = self.ops.get_points(&self.collection, ids).await?;
+        Ok(points
+            .into_iter()
+            .filter_map(|p| id_to_key.get(&p.id).map(|k| (k.clone(), p.vector)))
+            .collect())
     }
 
     #[tracing::instrument(
@@ -788,6 +816,29 @@ mod tests {
         assert!(
             !matches!(result, Err(EmbeddingRegistryError::DimensionProbe(_))),
             "guard must not fire when dimensions match"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_vectors_by_keys_empty_input_short_circuits() {
+        // Unreachable Qdrant instance: if this didn't short-circuit it would error/hang.
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        let ns = uuid::Uuid::from_bytes([0u8; 16]);
+        let reg = EmbeddingRegistry::new(ops, "test_empty_keys", ns);
+        let result = reg.get_vectors_by_keys(&[]).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_vectors_by_keys_unreachable_qdrant_errors() {
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        let ns = uuid::Uuid::from_bytes([0u8; 16]);
+        let reg = EmbeddingRegistry::new(ops, "test_vec_fetch", ns);
+        let keys = vec!["skill-a".to_string(), "skill-b".to_string()];
+        let result = reg.get_vectors_by_keys(&keys).await;
+        assert!(
+            matches!(result, Err(EmbeddingRegistryError::VectorStore(_))),
+            "expected VectorStore error, got: {result:?}"
         );
     }
 

--- a/crates/zeph-memory/tests/qdrant_integration.rs
+++ b/crates/zeph-memory/tests/qdrant_integration.rs
@@ -7,6 +7,8 @@ use testcontainers::core::{ContainerPort, WaitFor};
 use testcontainers::runners::AsyncRunner;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::mock::MockProvider;
+use zeph_memory::QdrantOps;
+use zeph_memory::embedding_registry::{EmbedFuture, Embeddable, EmbeddingRegistry};
 use zeph_memory::embedding_store::{EmbeddingStore, MessageKind};
 use zeph_memory::semantic::SemanticMemory;
 use zeph_memory::store::SqliteStore;
@@ -320,4 +322,136 @@ async fn search_session_summaries_returns_empty_when_no_data() {
         results.is_empty(),
         "search on empty collection must return empty results"
     );
+}
+
+// --- EmbeddingRegistry::get_vectors_by_keys integration tests (issue #5786) ---
+//
+// These prove the `id_to_key` remapping logic against a real Qdrant instance: unit tests
+// against an unreachable Qdrant (in embedding_registry.rs) only exercise the error path,
+// never the happy path where points are actually found and remapped back to caller keys.
+
+struct TestSkill {
+    key: String,
+    text: String,
+}
+
+impl Embeddable for TestSkill {
+    fn key(&self) -> &str {
+        &self.key
+    }
+
+    fn content_hash(&self) -> String {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.text.as_bytes());
+        hasher.finalize().to_hex().to_string()
+    }
+
+    fn embed_text(&self) -> &str {
+        &self.text
+    }
+
+    fn to_payload(&self) -> serde_json::Value {
+        serde_json::json!({"key": self.key, "text": self.text})
+    }
+}
+
+fn make_skill(key: &str, text: &str) -> TestSkill {
+    TestSkill {
+        key: key.into(),
+        text: text.into(),
+    }
+}
+
+async fn setup_registry_with_qdrant(
+    collection: &str,
+) -> (EmbeddingRegistry, ContainerAsync<GenericImage>) {
+    let container = qdrant_image().start().await.unwrap();
+    let grpc_port = container.get_host_port_ipv4(6334).await.unwrap();
+    let url = format!("http://127.0.0.1:{grpc_port}");
+
+    let ops = QdrantOps::new(&url, None).unwrap();
+    let ns = uuid::Uuid::from_bytes([0u8; 16]);
+    let registry = EmbeddingRegistry::new(ops, collection, ns);
+
+    (registry, container)
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn embed_fn_fixed(dim: usize) -> impl Fn(&str) -> EmbedFuture {
+    move |text: &str| -> EmbedFuture {
+        // Deterministic per-text vector so distinct skills get distinct (but stable) vectors.
+        let seed = text.bytes().map(u32::from).sum::<u32>() as f32;
+        let vec = (0..dim)
+            .map(|i| (seed + i as f32) / 1000.0)
+            .collect::<Vec<f32>>();
+        Box::pin(async move { Ok(vec) })
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Docker for Qdrant"]
+async fn get_vectors_by_keys_happy_path_returns_stored_vectors() {
+    let (mut registry, _container) = setup_registry_with_qdrant("test_get_vectors_happy").await;
+
+    let skills = vec![
+        make_skill("skill-a", "alpha description"),
+        make_skill("skill-b", "beta description"),
+        make_skill("skill-c", "gamma description"),
+    ];
+    let embed_fn = embed_fn_fixed(4);
+    let stats = registry
+        .sync(&skills, "test-model", &embed_fn, None)
+        .await
+        .unwrap();
+    assert_eq!(stats.added, 3);
+
+    let keys = vec!["skill-a".to_string(), "skill-b".to_string()];
+    let result = registry.get_vectors_by_keys(&keys).await.unwrap();
+
+    assert_eq!(result.len(), 2, "must return exactly the requested keys");
+    assert!(result.contains_key("skill-a"));
+    assert!(result.contains_key("skill-b"));
+    assert!(!result.contains_key("skill-c"), "must not over-fetch");
+
+    // Qdrant collections created with `Distance::Cosine` normalize stored vectors to unit
+    // length, so the retrieved vector isn't byte-identical to what was embedded — only
+    // direction is preserved. Assert dimension and direction (cosine similarity ~= 1.0)
+    // rather than raw equality.
+    let expected_a = embed_fn("alpha description").await.unwrap();
+    let expected_b = embed_fn("beta description").await.unwrap();
+    assert_eq!(result["skill-a"].len(), expected_a.len());
+    assert_eq!(result["skill-b"].len(), expected_b.len());
+    assert!(
+        (zeph_common::math::cosine_similarity(&result["skill-a"], &expected_a) - 1.0).abs() < 1e-4,
+        "retrieved vector must point in the same direction as the embedded one"
+    );
+    assert!(
+        (zeph_common::math::cosine_similarity(&result["skill-b"], &expected_b) - 1.0).abs() < 1e-4,
+        "retrieved vector must point in the same direction as the embedded one"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker for Qdrant"]
+async fn get_vectors_by_keys_partial_miss_omits_unstored_keys() {
+    let (mut registry, _container) = setup_registry_with_qdrant("test_get_vectors_partial").await;
+
+    let skills = vec![make_skill("skill-real", "real skill description")];
+    let embed_fn = embed_fn_fixed(4);
+    registry
+        .sync(&skills, "test-model", &embed_fn, None)
+        .await
+        .unwrap();
+
+    // Request one key that was synced and one that was never stored.
+    let keys = vec!["skill-real".to_string(), "skill-never-stored".to_string()];
+    let result = registry.get_vectors_by_keys(&keys).await.unwrap();
+
+    assert_eq!(
+        result.len(),
+        1,
+        "must silently omit keys with no matching point, not error"
+    );
+    assert!(result.contains_key("skill-real"));
+    assert!(!result.contains_key("skill-never-stored"));
 }

--- a/crates/zeph-skills/src/group.rs
+++ b/crates/zeph-skills/src/group.rs
@@ -87,18 +87,18 @@ pub enum GroupResult {
 /// use zeph_skills::group::{GroupResult, group_skills};
 ///
 /// // With fewer than 2 skills the result is always flat.
-/// let result = group_skills(&[], &[], |_| None::<&[f32]>, 0.5);
+/// let result = group_skills(&[], &[], |_| None::<Vec<f32>>, 0.5);
 /// assert!(matches!(result, GroupResult::Flat(_)));
 /// ```
 #[must_use]
-pub fn group_skills<'e, F>(
+pub fn group_skills<F>(
     skills: &[Skill],
     skill_indices: &[usize],
     get_embedding: F,
     threshold: f32,
 ) -> GroupResult
 where
-    F: Fn(usize) -> Option<&'e [f32]>,
+    F: Fn(usize) -> Option<Vec<f32>>,
 {
     if skills.len() < 2 {
         return GroupResult::Flat(skills.to_vec());
@@ -120,7 +120,7 @@ where
         let Some(embed) = get_embedding(idx) else {
             continue;
         };
-        let sim = zeph_common::math::cosine_similarity(entry_embed, embed);
+        let sim = zeph_common::math::cosine_similarity(&entry_embed, &embed);
         if sim > threshold {
             role_labels.insert(skill.name().to_string(), SkillRole::Support);
             support.push(skill.clone());
@@ -165,13 +165,13 @@ mod tests {
     static EMBED_D: &[f32] = &[0.95, 0.05, 0.0]; // high similarity to A
     static EMBED_E: &[f32] = &[0.0, 1.0, 0.0]; // orthogonal to A
 
-    fn embedding_for_index(idx: usize) -> Option<&'static [f32]> {
+    fn embedding_for_index(idx: usize) -> Option<Vec<f32>> {
         match idx {
-            0 => Some(EMBED_A),
-            1 => Some(EMBED_B),
-            2 => Some(EMBED_C),
-            3 => Some(EMBED_D),
-            4 => Some(EMBED_E),
+            0 => Some(EMBED_A.to_vec()),
+            1 => Some(EMBED_B.to_vec()),
+            2 => Some(EMBED_C.to_vec()),
+            3 => Some(EMBED_D.to_vec()),
+            4 => Some(EMBED_E.to_vec()),
             _ => None,
         }
     }

--- a/crates/zeph-skills/src/matcher.rs
+++ b/crates/zeph-skills/src/matcher.rs
@@ -573,13 +573,18 @@ pub enum SkillMatcherBackend {
 
 impl SkillMatcherBackend {
     /// Return the embedding vector for a skill at the given index, if available.
-    /// Only works for in-memory backends; returns `None` for Qdrant.
+    ///
+    /// For [`Self::InMemory`], this is the pre-computed description embedding. For
+    /// [`Self::Qdrant`], this is served from a per-turn cache populated by
+    /// [`Self::refresh_skill_embeddings`] — `None` if that hasn't been called yet,
+    /// `skill_index` wasn't among its candidates, or the fetch failed or returned a partial
+    /// result (see issue #5786).
     #[must_use]
-    pub fn skill_embedding(&self, skill_index: usize) -> Option<&[f32]> {
+    pub fn skill_embedding(&self, skill_index: usize) -> Option<Vec<f32>> {
         match self {
-            Self::InMemory(m) => m.skill_embedding(skill_index),
+            Self::InMemory(m) => m.skill_embedding(skill_index).map(<[f32]>::to_vec),
             #[cfg(feature = "qdrant")]
-            Self::Qdrant(_) => None,
+            Self::Qdrant(m) => m.skill_embedding(skill_index),
         }
     }
 
@@ -590,6 +595,26 @@ impl SkillMatcherBackend {
             Self::InMemory(_) => false,
             #[cfg(feature = "qdrant")]
             Self::Qdrant(_) => true,
+        }
+    }
+
+    /// Populate per-skill vectors for `scored` so a subsequent [`Self::skill_embedding`] call
+    /// can serve them.
+    ///
+    /// Callers must pass the **final** candidate set — after any BM25 hybrid-search fusion, if
+    /// enabled — since fusion can introduce skill indices outside the original vector-search
+    /// top-K that [`Self::match_skills`] alone would have cached.
+    ///
+    /// No-op for [`Self::InMemory`], whose embeddings are already resident in memory. For
+    /// [`Self::Qdrant`], this issues a bounded `get_points` round-trip scoped to `scored` — only
+    /// call it when a consumer of [`Self::skill_embedding`] is actually enabled (RL rerank
+    /// and/or `GoSkills` grouping), so turns using neither feature don't pay for the extra
+    /// Qdrant round-trip (see issue #5786).
+    pub async fn refresh_skill_embeddings(&self, meta: &[&SkillMeta], scored: &[ScoredMatch]) {
+        match self {
+            Self::InMemory(_) => {}
+            #[cfg(feature = "qdrant")]
+            Self::Qdrant(m) => m.refresh_vector_cache(meta, scored).await,
         }
     }
 
@@ -1016,6 +1041,50 @@ mod tests {
                 .await,
         );
         assert_eq!(matches.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn backend_in_memory_skill_embedding_returns_owned_vec() {
+        let metas = [make_meta("a", "alpha"), make_meta("b", "beta")];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+
+        let inner = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
+        let backend = SkillMatcherBackend::InMemory(inner);
+
+        let emb = backend
+            .skill_embedding(0)
+            .expect("skill 0 must be embedded");
+        assert_eq!(emb, vec![1.0, 0.0, 0.0]); // "alpha"
+    }
+
+    #[tokio::test]
+    async fn backend_in_memory_skill_embedding_out_of_range_is_none() {
+        let metas = [make_meta("a", "alpha")];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+
+        let inner = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
+        let backend = SkillMatcherBackend::InMemory(inner);
+
+        assert!(backend.skill_embedding(99).is_none());
+    }
+
+    #[tokio::test]
+    async fn backend_in_memory_refresh_skill_embeddings_is_noop() {
+        // In-memory embeddings are already resident; refresh_skill_embeddings must not alter
+        // skill_embedding()'s behavior (still served from the pre-computed index, not a cache).
+        let metas = [make_meta("a", "alpha")];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+
+        let inner = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
+        let backend = SkillMatcherBackend::InMemory(inner);
+
+        let scored = vec![ScoredMatch {
+            index: 0,
+            score: 0.9,
+        }];
+        backend.refresh_skill_embeddings(&refs, &scored).await;
+
+        assert_eq!(backend.skill_embedding(0), Some(vec![1.0, 0.0, 0.0]));
     }
 
     #[test]

--- a/crates/zeph-skills/src/qdrant_matcher.rs
+++ b/crates/zeph-skills/src/qdrant_matcher.rs
@@ -3,6 +3,9 @@
 
 #![cfg(feature = "qdrant")]
 
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
 pub use zeph_memory::SyncStats;
 use zeph_memory::{Embeddable, EmbeddingRegistry, QdrantOps};
 
@@ -46,6 +49,14 @@ impl Embeddable for &SkillMeta {
 #[derive(Clone)]
 pub struct QdrantSkillMatcher {
     registry: EmbeddingRegistry,
+    /// Vectors for the candidates most recently passed to [`Self::refresh_vector_cache`],
+    /// keyed by skill index into the caller's `meta` slice. Populated by a bounded
+    /// `get_points` request scoped to exactly those candidates, so that
+    /// [`Self::skill_embedding`] can serve the RL rerank / `GoSkills` grouping paths
+    /// (see issue #5786). The fetch only happens when a caller explicitly requests it —
+    /// `match_skills` itself never populates this cache, to avoid paying for a Qdrant
+    /// round-trip that most turns (no RL rerank, no grouping) don't need.
+    last_vectors: Arc<RwLock<HashMap<usize, Vec<f32>>>>,
 }
 
 impl std::fmt::Debug for QdrantSkillMatcher {
@@ -62,6 +73,7 @@ impl QdrantSkillMatcher {
     pub fn with_ops(ops: QdrantOps) -> Self {
         Self {
             registry: EmbeddingRegistry::new(ops, COLLECTION_NAME, SKILL_NAMESPACE),
+            last_vectors: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -115,6 +127,12 @@ impl QdrantSkillMatcher {
 
     /// Search for relevant skills using Qdrant native vector search.
     /// Returns scored matches with indices into the provided meta slice.
+    ///
+    /// Does **not** populate the vector cache read by [`Self::skill_embedding`] — callers that
+    /// need per-skill vectors (RL rerank, `GoSkills` grouping) must call
+    /// [`Self::refresh_vector_cache`] explicitly with the final candidate set once it's known
+    /// (e.g. after BM25 hybrid-search fusion), so the extra `get_points` round-trip is only
+    /// paid when one of those features is actually enabled.
     #[cfg_attr(
         feature = "profiling",
         tracing::instrument(name = "skill.qdrant_match", skip_all, fields(query_len = %query.len(), result_count = tracing::field::Empty))
@@ -147,7 +165,7 @@ impl QdrantSkillMatcher {
             }
         };
 
-        let scored = results
+        let scored: Vec<ScoredMatch> = results
             .into_iter()
             .filter_map(|point| {
                 let name = point.payload.get("key")?.as_str()?;
@@ -158,7 +176,66 @@ impl QdrantSkillMatcher {
                 })
             })
             .collect();
+
         MatchResult::Scored(scored)
+    }
+
+    /// Fetch vectors for the given scored candidates via a single bounded Qdrant `get_points`
+    /// round-trip and populate the cache read by [`Self::skill_embedding`].
+    ///
+    /// The request is scoped to exactly the candidate IDs in `scored` — callers must pass the
+    /// final candidate set (e.g. after BM25 hybrid-search fusion, since fusion can introduce
+    /// skill indices outside the original vector-search top-K) — never a full collection scan.
+    /// Failures are logged and degrade to an empty cache: RL rerank / grouping simply stay
+    /// inactive for that turn, same as today's "no embeddings available" fallback in
+    /// `assembly.rs`.
+    ///
+    /// Only call this when a consumer of [`Self::skill_embedding`] is actually enabled (RL
+    /// rerank and/or `GoSkills` grouping) — it is not called automatically by
+    /// [`Self::match_skills`] so that turns using neither feature don't pay for the extra
+    /// round-trip.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "skill.qdrant_refresh_vectors", skip_all, fields(candidates = scored.len()))
+    )]
+    pub(crate) async fn refresh_vector_cache(&self, meta: &[&SkillMeta], scored: &[ScoredMatch]) {
+        let keys: Vec<String> = scored
+            .iter()
+            .filter_map(|m| meta.get(m.index).map(|s| s.name.clone()))
+            .collect();
+
+        let vectors_by_key = match self.registry.get_vectors_by_keys(&keys).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::debug!("Qdrant get_points for RL rerank vectors failed: {e:#}");
+                HashMap::new()
+            }
+        };
+
+        let mut cache = HashMap::with_capacity(vectors_by_key.len());
+        for m in scored {
+            if let Some(name) = meta.get(m.index).map(|s| s.name.as_str())
+                && let Some(v) = vectors_by_key.get(name)
+            {
+                cache.insert(m.index, v.clone());
+            }
+        }
+
+        if let Ok(mut guard) = self.last_vectors.write() {
+            *guard = cache;
+        }
+    }
+
+    /// Return the cached vector for `skill_index` from the most recent [`Self::match_skills`]
+    /// call, if available.
+    ///
+    /// Populated by a bounded follow-up Qdrant `get_points` request scoped to the top-K
+    /// candidates returned by that call. Returns `None` if `skill_index` wasn't part of the
+    /// most recent result set, or if the follow-up vector fetch failed or returned a partial
+    /// result — callers must treat this the same as "no embedding available".
+    #[must_use]
+    pub fn skill_embedding(&self, skill_index: usize) -> Option<Vec<f32>> {
+        self.last_vectors.read().ok()?.get(&skill_index).cloned()
     }
 }
 
@@ -254,5 +331,46 @@ mod tests {
         };
         let results = matcher.match_skills(&refs, "query", 5, embed_fn).await;
         assert_matches!(results, crate::matcher::MatchResult::InfraError);
+    }
+
+    #[test]
+    fn skill_embedding_none_before_any_match_skills_call() {
+        let matcher = make_matcher();
+        assert!(matcher.skill_embedding(0).is_none());
+    }
+
+    fn make_unreachable_matcher() -> QdrantSkillMatcher {
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
+        QdrantSkillMatcher::with_ops(ops)
+    }
+
+    #[tokio::test]
+    async fn refresh_vector_cache_unreachable_qdrant_degrades_to_empty() {
+        // The RL rerank gate treats a missing vector the same as "backend unavailable" — a
+        // failed follow-up get_points call must not panic and must leave the cache empty
+        // rather than poisoning it with stale data.
+        let matcher = make_unreachable_matcher();
+        let metas = [make_meta("s", "desc")];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let scored = vec![ScoredMatch {
+            index: 0,
+            score: 0.9,
+        }];
+
+        matcher.refresh_vector_cache(&refs, &scored).await;
+
+        assert!(matcher.skill_embedding(0).is_none());
+    }
+
+    #[tokio::test]
+    async fn refresh_vector_cache_empty_scored_is_noop() {
+        let matcher = make_unreachable_matcher();
+        let metas = [make_meta("s", "desc")];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+
+        // Empty candidate set must short-circuit before any Qdrant round-trip.
+        matcher.refresh_vector_cache(&refs, &[]).await;
+
+        assert!(matcher.skill_embedding(0).is_none());
     }
 }


### PR DESCRIPTION
## Summary

- `SkillMatcherBackend::skill_embedding()` returned `None` unconditionally for the Qdrant matcher backend, so the RL routing head's rerank candidate-building guard never passed with `vector_backend = "qdrant"` (the recommended backend for large skill libraries), silently disabling RL rerank despite `rl_routing_enabled = true`. This was the "Preferred fix" left unimplemented by #3032.
- `QdrantSkillMatcher` now issues a bounded follow-up Qdrant `get_points` call (`EmbeddingRegistry::get_vectors_by_keys`, reusing the existing `VectorStore::get_points` impl) scoped to the top-K candidate IDs, caching the retrieved vectors for `skill_embedding()` to serve for the rest of the turn.
- The refresh runs after BM25 hybrid-search fusion (so fused candidates get vectors too) and only when RL rerank or GoSkills grouping is actually enabled, avoiding an unconditional extra Qdrant round-trip on the skill-matching hot path.
- Candidate vectors are filtered to `rl_head.embed_dim()` before reaching `rl_head.rerank()`, closing a new panic risk (out-of-bounds indexing in `RoutingHeadInner::score()` on a dimension-mismatched vector) that could not occur before this feature existed.
- Vector fetch failures or partial results degrade gracefully to the prior "RL re-rank skipped" behavior rather than erroring.

## Process notes

This PR went through two implementation rounds. The first round implemented the core fix; parallel validation (tester, perf, security, impl-critic) found three real issues before this could pass review — a new panic-risk (unchecked vector dimension reaching array indexing), a hybrid-search gap (BM25-fused candidates never got cached vectors), and a performance regression (the Qdrant round-trip ran unconditionally regardless of RL config). The second round fixed all three with one structural change (moving the cache refresh to after BM25 fusion, gated on actual RL/grouping usage) and added live-Qdrant integration tests for the previously-untested end-to-end path. Code review re-verified the fixes independently and approved.

One follow-up was surfaced but deliberately left out of scope: Qdrant normalizes vectors to unit length for `Distance::Cosine` collections, while the in-memory backend's `SkillEmbedding::from_raw` stores raw magnitude — a potential train/inference scale mismatch between backends feeding `rl_head.score()`. Not a regression (RL rerank was 100% inert on Qdrant before this PR) and not a crash risk; recommending a separate follow-up issue rather than blocking this PR on it.

Closes #5786

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12321 passed, 0 failed, 34 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New live-Qdrant integration tests (`crates/zeph-memory/tests/qdrant_integration.rs`, testcontainers-based): `get_vectors_by_keys` happy path and partial-miss remapping, both passing
- [ ] Live agent session confirming `routing_head_weights` gains rows against a real Qdrant skill collection (tracked as a follow-up verification, not blocking merge)