### PR TITLE
refactor(durable): deduplicate notify-or-poll wait loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   hooks (`confirm_receiver`, `confirm_accepts`, `confirm_reply_text`, `confirm_send_prompt`) and
   its `Channel::confirm` now delegates to `run_confirm` in one line (#5652). Pure refactor, no
   behavior change.
+- `refactor(durable)`: deduplicated the "register on a `NotifyRegistry`, re-check the resolved
+  state to close the registration race, then race the notify against a poll-interval sleep,
+  falling back to pure polling above the parked cap" loop implemented independently in
+  `DurableContext::await_promise` and `DurableContext::sleep_until` (#5724). The shared logic
+  now lives in `wait_on_notify_or_poll` (new function in `crates/zeph-durable/src/waiters.rs`),
+  parameterized by the wait-duration computation, the parked-cap value, and two resolved-state
+  checks — a cheap pre-registration check and a race-closing post-registration recheck — so
+  `sleep_until`'s original asymmetry (a clock-only check before registering, a database read only
+  after) is preserved rather than paying for the database read on every iteration; the
+  post-registration recheck now also re-runs the clock check immediately before its database read
+  (previously database-only), a harmless addition that adds no extra database reads and can only
+  close the registration race faster. Pure refactor, no behavior change. Added
+  `sleep_until_wakes_on_concurrent_fire_before_due`
+  covering the in-process concurrent-wake path (previously only tested for `await_promise`).
 - `refactor(common,core,scheduler)`: deduplicated the `flock(2)`-backed pid-file guard
   implemented independently in `zeph-core::daemon::PidGuard` and
   `zeph-scheduler::pidfile::PidFile` — both opened the pid file with the same

--- a/crates/zeph-durable/src/handle.rs
+++ b/crates/zeph-durable/src/handle.rs
@@ -63,6 +63,7 @@ use crate::step::{
     DurableStep, PAYLOAD_VERSION, StepDescriptor, StepError, StepHandle, deserialize_result,
     serialize_result,
 };
+use crate::waiters::wait_on_notify_or_poll;
 use crate::writer::JournalWriterHandle;
 
 /// The `&self` durable execution context handed to a consumer's program.
@@ -289,32 +290,14 @@ impl DurableContext {
         let key = id.as_uuid();
         let cap = usize::try_from(self.max_parked_promises).unwrap_or(usize::MAX);
         let span = tracing::info_span!("durable.promise.await", promise_id = %key);
-        async move {
-            loop {
-                if let Some(value) = self.take_resolved_promise::<T>(id).await? {
-                    return Ok(value);
-                }
-                match self.backend.promise_waiters().register(key, Some(cap)) {
-                    Some(notify) => {
-                        let notified = notify.notified();
-                        tokio::pin!(notified);
-                        // Register interest, then re-check: this closes the window where a resolution
-                        // lands between the read above and the wait below.
-                        notified.as_mut().enable();
-                        if let Some(value) = self.take_resolved_promise::<T>(id).await? {
-                            self.backend.promise_waiters().cancel(key);
-                            return Ok(value);
-                        }
-                        tokio::select! {
-                            () = notified => {}
-                            () = tokio::time::sleep(self.poll_interval) => {}
-                        }
-                    }
-                    // Over the parked cap: pure poll, no registration.
-                    None => tokio::time::sleep(self.poll_interval).await,
-                }
-            }
-        }
+        wait_on_notify_or_poll(
+            self.backend.promise_waiters(),
+            key,
+            Some(cap),
+            || self.poll_interval,
+            || self.take_resolved_promise::<T>(id),
+            || self.take_resolved_promise::<T>(id),
+        )
         .instrument(span)
         .await
     }
@@ -378,33 +361,49 @@ impl DurableContext {
         }
 
         let key = timer_id.as_uuid();
-        loop {
-            let now = now_unix_millis();
-            if now >= due_ms {
-                // Due: fire it (idempotent — the service may race us; `WHERE fired = 0` dedups).
-                self.backend.mark_timer_fired(timer_id).await?;
-                return Ok(());
-            }
-            let notify = self.backend.timer_waiters().register(key, None);
-            let remaining = u64::try_from(due_ms.saturating_sub(now)).unwrap_or(u64::MAX);
-            let wait = self.poll_interval.min(Duration::from_millis(remaining));
-            match notify {
-                Some(notify) => {
-                    let notified = notify.notified();
-                    tokio::pin!(notified);
-                    notified.as_mut().enable();
-                    if matches!(self.backend.timer_state(timer_id).await?, Some((_, true))) {
-                        self.backend.timer_waiters().cancel(key);
-                        return Ok(());
-                    }
-                    tokio::select! {
-                        () = notified => {}
-                        () = tokio::time::sleep(wait) => {}
-                    }
+        wait_on_notify_or_poll(
+            self.backend.timer_waiters(),
+            key,
+            None,
+            || {
+                let remaining =
+                    u64::try_from(due_ms.saturating_sub(now_unix_millis())).unwrap_or(u64::MAX);
+                self.poll_interval.min(Duration::from_millis(remaining))
+            },
+            // Cheap, clock-only pre-register check: no database read (the common case while
+            // parked and not yet due).
+            || self.check_timer_due(timer_id, due_ms),
+            || async move {
+                // Race-closing recheck after registering: a database read catches a resolution
+                // (e.g. by DurableTimerService) that lands in the window between the clock check
+                // above and the wait below, even if our own clock has not yet reached `due_ms`.
+                if let Some(value) = self.check_timer_due(timer_id, due_ms).await? {
+                    return Ok(Some(value));
                 }
-                None => tokio::time::sleep(wait).await,
-            }
+                if matches!(self.backend.timer_state(timer_id).await?, Some((_, true))) {
+                    return Ok(Some(()));
+                }
+                Ok(None)
+            },
+        )
+        .await
+    }
+
+    /// If `due_ms` has passed, fire the timer (idempotent) and report it resolved; otherwise `None`.
+    ///
+    /// A purely clock-based check with no database read on the not-yet-due path — the cheap
+    /// pre-registration check in [`sleep_until`](Self::sleep_until)'s wait loop.
+    async fn check_timer_due(
+        &self,
+        timer_id: TimerId,
+        due_ms: i64,
+    ) -> Result<Option<()>, DurableError> {
+        if now_unix_millis() >= due_ms {
+            // Due: fire it (idempotent — the service may race us; `WHERE fired = 0` dedups).
+            self.backend.mark_timer_fired(timer_id).await?;
+            return Ok(Some(()));
         }
+        Ok(None)
     }
 
     /// Build an out-of-band [`DurableHandle`](crate::DurableHandle) over this context's backend.
@@ -1364,6 +1363,32 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), h.ctx.sleep_until(due))
             .await
             .expect("sleep_until completes before the test timeout")
+            .expect("sleep_until succeeds");
+        h.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn sleep_until_wakes_on_concurrent_fire_before_due() {
+        // An external actor (e.g. DurableTimerService, or a concurrent process) marking the timer
+        // fired while sleep_until is already parked wakes it at once via the in-process notify,
+        // rather than waiting out the poll interval or the timer's own due instant.
+        let exec = ExecutionId::new();
+        let h = Harness::open(exec, false).await;
+        // Far enough out that only the notify wakes it, not sleep_until's own due-clock check.
+        let due = SystemTime::now() + Duration::from_secs(30);
+        let timer_id = TimerId::derive(exec, StepId::new(0));
+
+        let (result, marked) = tokio::join!(
+            tokio::time::timeout(Duration::from_secs(2), h.ctx.sleep_until(due)),
+            async {
+                // Give sleep_until time to arm the timer and register on the notify first.
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                h.backend.mark_timer_fired(timer_id).await
+            }
+        );
+        assert!(marked.unwrap(), "the timer transitions to fired");
+        result
+            .expect("sleep_until wakes on the concurrent fire before the test timeout")
             .expect("sleep_until succeeds");
         h.shutdown().await;
     }

--- a/crates/zeph-durable/src/waiters.rs
+++ b/crates/zeph-durable/src/waiters.rs
@@ -18,9 +18,12 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use tokio::sync::Notify;
 use uuid::Uuid;
+
+use crate::error::DurableError;
 
 /// A keyed map of one-shot [`Notify`] handles shared between waiters and resolvers.
 ///
@@ -92,6 +95,62 @@ impl NotifyRegistry {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .len()
+    }
+}
+
+/// Park until resolved, waking on `registry`'s notify for `key` or falling back to a
+/// `wait_duration`-interval sleep; above the parked cap it polls without registering.
+///
+/// Shared by [`DurableContext::await_promise`](crate::DurableContext::await_promise) and
+/// [`DurableContext::sleep_until`](crate::DurableContext::sleep_until): both register on a
+/// [`NotifyRegistry`], re-check the resolved state to close the registration race (a resolution that
+/// lands between the initial check and the registration must not be missed), then race the notify
+/// against a poll-interval sleep.
+///
+/// `check_before` is the cheap, pre-registration check run every iteration; `check_after` is the
+/// race-closing recheck run immediately after a successful registration, before parking — callers
+/// whose post-registration check is identical to their pre-registration one (e.g. a promise's
+/// resolved-state read) should pass the same closure for both; a caller with a cheaper pre-check
+/// (e.g. a timer's local due-clock check, versus a database read to close the race) can pass two
+/// distinct closures to avoid paying for the more expensive check on every iteration.
+pub(crate) async fn wait_on_notify_or_poll<T, FBefore, FutBefore, FAfter, FutAfter>(
+    registry: &NotifyRegistry,
+    key: Uuid,
+    cap: Option<usize>,
+    mut wait_duration: impl FnMut() -> Duration,
+    mut check_before: FBefore,
+    mut check_after: FAfter,
+) -> Result<T, DurableError>
+where
+    FBefore: FnMut() -> FutBefore,
+    FutBefore: Future<Output = Result<Option<T>, DurableError>>,
+    FAfter: FnMut() -> FutAfter,
+    FutAfter: Future<Output = Result<Option<T>, DurableError>>,
+{
+    loop {
+        if let Some(value) = check_before().await? {
+            return Ok(value);
+        }
+        let wait = wait_duration();
+        match registry.register(key, cap) {
+            Some(notify) => {
+                let notified = notify.notified();
+                tokio::pin!(notified);
+                // Register interest, then re-check: this closes the window where a resolution
+                // lands between the read above and the wait below.
+                notified.as_mut().enable();
+                if let Some(value) = check_after().await? {
+                    registry.cancel(key);
+                    return Ok(value);
+                }
+                tokio::select! {
+                    () = notified => {}
+                    () = tokio::time::sleep(wait) => {}
+                }
+            }
+            // Over the parked cap: pure poll, no registration.
+            None => tokio::time::sleep(wait).await,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- `DurableContext::await_promise` and `DurableContext::sleep_until` (`crates/zeph-durable/src/handle.rs`) independently implemented the same register-on-`NotifyRegistry` / recheck-to-close-the-registration-race / race-notify-against-poll-interval loop.
- Extracted the shared loop into `wait_on_notify_or_poll` (`crates/zeph-durable/src/waiters.rs`), parameterized by the wait-duration computation, the parked-cap value, and separate pre-registration/post-registration resolved-state checks.
- `sleep_until`'s original asymmetry (clock-only check before registering, database read only after) is preserved rather than paying for a database read on every poll iteration — this was caught and fixed during review after an initial single-closure version doubled the DB reads.
- Added `sleep_until_wakes_on_concurrent_fire_before_due`, covering the in-process concurrent-wake path that was previously only tested for `await_promise`.
- Pure refactor, no behavior change.

Closes #5724

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-durable --features sqlite` — 101 passed, 2 skipped
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12314 passed, 34 skipped
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`