### PR TITLE
fix(llm): router falls back on model capability mismatches, add CandleProvider vision override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     for `cache_plan`, `apply_delta`, and `load_and_apply_delta`, plus `load_all`'s INT4 decode,
     against a real Postgres 16 container.
 
+- `fix(llm)`: the router's `chat_with_tools` fallback loop
+  (`crates/zeph-llm/src/router/provider_impl.rs`) short-circuited on ANY
+  `LlmError::InvalidInput`, but PR #5795's `reasoning_effort`+`tools`
+  incompatibility error is model/config-specific — the same request can succeed on a different
+  model or provider, unlike a genuinely malformed request — so the router was aborting instead of
+  falling back (#5796). Added `LlmError::ModelCapabilityMismatch { provider, message }`
+  (`crates/zeph-llm/src/error.rs`) for this class of retryable-elsewhere error, with an
+  `is_model_capability_mismatch()` predicate mirroring `is_invalid_input()`.
+  `OpenAiProvider::chat_with_tools` (`crates/zeph-llm/src/openai/mod.rs`) now returns this variant
+  instead of `InvalidInput` for the reasoning_effort+tools 400 (message text unchanged); the
+  router falls through to the next tool-capable provider instead of aborting. Also fixed a related
+  exhaustion bug in the same loop: when every provider failed, it returned a generic
+  `LlmError::NoProviders` instead of the last provider's actual error, discarding PR #5795's
+  actionable diagnostic exactly when no other provider was available to fall back to (the single-
+  provider and all-providers-misconfigured cases) — the loop now tracks `last_err` across
+  providers, mirroring the pattern already used in the `embed`/`embed_batch` fallback loops, and
+  returns it on exhaustion instead of `NoProviders`.
+- `fix(llm)`: `CandleProvider` now explicitly overrides `supports_vision()` to return `false`
+  (#5755), matching every other `LlmProvider` implementation which declares this explicitly rather
+  than relying on the trait default — same gap and same fix shape as the `supports_tool_use()`
+  override added for this provider in #5754.
 - `fix(memory)`: `record_skill_usage` (`crates/zeph-memory/src/store/skills.rs`) failed against
   `PostgreSQL` with `column reference "invocation_count" is ambiguous`. Its
   `INSERT ... ON CONFLICT DO UPDATE SET invocation_count = invocation_count + 1` referenced the

--- a/crates/zeph-llm/src/candle_provider/mod.rs
+++ b/crates/zeph-llm/src/candle_provider/mod.rs
@@ -309,6 +309,12 @@ impl LlmProvider for CandleProvider {
         false
     }
 
+    // Explicit override, not reliance on the trait default: candle_provider/mod.rs has no
+    // image/vision handling, so this must stay false even if the default changes.
+    fn supports_vision(&self) -> bool {
+        false
+    }
+
     #[tracing::instrument(
         name = "llm.candle.embed",
         skip_all,

--- a/crates/zeph-llm/src/error.rs
+++ b/crates/zeph-llm/src/error.rs
@@ -8,6 +8,7 @@
 /// Use the predicate methods ([`is_rate_limited`](Self::is_rate_limited),
 /// [`is_context_length_error`](Self::is_context_length_error),
 /// [`is_invalid_input`](Self::is_invalid_input),
+/// [`is_model_capability_mismatch`](Self::is_model_capability_mismatch),
 /// [`is_beta_header_rejected`](Self::is_beta_header_rejected)) to classify errors
 /// before deciding whether to retry, fall back, or propagate.
 #[non_exhaustive]
@@ -96,6 +97,13 @@ pub enum LlmError {
     #[error("invalid input for {provider}: {message}")]
     InvalidInput { provider: String, message: String },
 
+    /// The request is well-formed but rejected due to a model- or config-specific
+    /// capability gap (e.g. `reasoning_effort` combined with tool calls on `OpenAI`'s Chat
+    /// Completions API). Unlike [`Self::InvalidInput`], the same request may succeed on a
+    /// different model or provider, so the router should fall back instead of aborting.
+    #[error("model capability mismatch for {provider}: {message}")]
+    ModelCapabilityMismatch { provider: String, message: String },
+
     /// A provider returned a non-success HTTP status that does not map to any more specific variant.
     ///
     /// This covers non-retriable API failures such as authentication errors (401/403),
@@ -137,6 +145,16 @@ impl LlmError {
     #[must_use]
     pub fn is_invalid_input(&self) -> bool {
         matches!(self, Self::InvalidInput { .. })
+    }
+
+    /// Returns true if this error indicates a model- or config-specific capability gap.
+    ///
+    /// Unlike [`Self::is_invalid_input`], callers (e.g. the router fallback loop) should
+    /// retry with another provider when this is true — the same request may succeed
+    /// elsewhere (different model, or without the offending config option).
+    #[must_use]
+    pub fn is_model_capability_mismatch(&self) -> bool {
+        matches!(self, Self::ModelCapabilityMismatch { .. })
     }
 
     #[must_use]
@@ -255,6 +273,40 @@ mod tests {
         let s = e.to_string();
         assert!(s.contains("openai"));
         assert!(s.contains("input too long"));
+    }
+
+    #[test]
+    fn model_capability_mismatch_is_detected() {
+        let e = LlmError::ModelCapabilityMismatch {
+            provider: "openai".into(),
+            message: "reasoning_effort incompatible with tools".into(),
+        };
+        assert!(e.is_model_capability_mismatch());
+        assert!(!e.is_invalid_input());
+    }
+
+    #[test]
+    fn other_errors_are_not_model_capability_mismatch() {
+        assert!(!LlmError::Unavailable.is_model_capability_mismatch());
+        assert!(!LlmError::RateLimited.is_model_capability_mismatch());
+        assert!(
+            !LlmError::InvalidInput {
+                provider: "openai".into(),
+                message: "bad request".into(),
+            }
+            .is_model_capability_mismatch()
+        );
+    }
+
+    #[test]
+    fn model_capability_mismatch_display_includes_provider_and_message() {
+        let e = LlmError::ModelCapabilityMismatch {
+            provider: "openai".into(),
+            message: "reasoning_effort incompatible with tools".into(),
+        };
+        let s = e.to_string();
+        assert!(s.contains("openai"));
+        assert!(s.contains("reasoning_effort incompatible with tools"));
     }
 
     #[test]

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -1049,7 +1049,7 @@ impl LlmProvider for OpenAiProvider {
             if self.reasoning_effort.is_some()
                 && crate::error::body_is_reasoning_effort_tools_incompatible(&text)
             {
-                return Err(LlmError::InvalidInput {
+                return Err(LlmError::ModelCapabilityMismatch {
                     provider: self.name().to_owned(),
                     message: format!(
                         "model '{}' does not support `reasoning_effort` together with tool \

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -1493,7 +1493,7 @@ async fn chat_with_tools_reasoning_effort_400_enriches_message() {
 
     let err = p.chat_with_tools(&messages, &tools).await.unwrap_err();
     match err {
-        LlmError::InvalidInput { message, .. } => {
+        LlmError::ModelCapabilityMismatch { message, .. } => {
             assert!(
                 message.contains("reasoning_effort"),
                 "expected enriched message to mention reasoning_effort, got: {message}"
@@ -1503,7 +1503,7 @@ async fn chat_with_tools_reasoning_effort_400_enriches_message() {
                 "expected enriched message to suggest unsetting reasoning_effort, got: {message}"
             );
         }
-        other => panic!("expected InvalidInput, got: {other:?}"),
+        other => panic!("expected ModelCapabilityMismatch, got: {other:?}"),
     }
 }
 

--- a/crates/zeph-llm/src/router/provider_impl.rs
+++ b/crates/zeph-llm/src/router/provider_impl.rs
@@ -609,6 +609,10 @@ impl LlmProvider for RouterProvider {
             // different heuristics than text quality. Skipping cascade for tool calls
             // avoids inappropriate escalation based on text signals (HIGH-04).
             let providers = router.ordered_providers();
+            // Preserve the most recent error across the fallback loop so an exhausted
+            // loop surfaces the actionable diagnostic (e.g. `ModelCapabilityMismatch`'s
+            // enriched message from #5795) instead of a generic `NoProviders`.
+            let mut last_err: Option<LlmError> = None;
             for p in &providers {
                 if !p.supports_tool_use() {
                     continue;
@@ -639,6 +643,17 @@ impl LlmProvider for RouterProvider {
                             );
                             return Err(e);
                         }
+                        // A model capability mismatch (e.g. `reasoning_effort` + `tools` on
+                        // this specific model/provider) is retryable elsewhere — the same
+                        // request may succeed on a different model or provider, unlike
+                        // `InvalidInput` which is malformed regardless of destination.
+                        if e.is_model_capability_mismatch() {
+                            tracing::warn!(
+                                provider = p.name(),
+                                error = %e,
+                                "chat_with_tools: model capability mismatch, falling back to next provider"
+                            );
+                        }
                         if e.is_rate_limited() {
                             router.record_availability(p.name(), false, 0);
                         }
@@ -649,10 +664,11 @@ impl LlmProvider for RouterProvider {
                             ));
                         }
                         tracing::warn!(provider = p.name(), error = %e, "router tool fallback");
+                        last_err = Some(e);
                     }
                 }
             }
-            Err(LlmError::NoProviders)
+            Err(last_err.unwrap_or(LlmError::NoProviders))
         });
         {
             use tracing::Instrument as _;

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -792,9 +792,10 @@ async fn cascade_chat_with_tools_unaffected_by_cost_tiers() {
         ..CascadeRouterConfig::default()
     });
     let msgs = vec![Message::from_legacy(Role::User, "hi")];
-    // Both providers fail → NoProviders, not a cascade-specific error.
+    // Both providers fail → the last provider's error is preserved (not a
+    // cascade-specific error, and not a generic NoProviders that would discard it).
     let err = r.chat_with_tools(&msgs, &[]).await.unwrap_err();
-    assert_matches!(err, LlmError::NoProviders);
+    assert_matches!(err, LlmError::Other(_));
 }
 
 // ── Embed retry / rate-limit tests ────────────────────────────────────────
@@ -977,6 +978,98 @@ async fn embed_invalid_input_does_not_fall_through_to_second_provider() {
     assert!(
         matches!(&err, LlmError::InvalidInput { provider, .. } if provider == "p1"),
         "expected InvalidInput from p1, got {err:?}"
+    );
+}
+
+/// Unlike `InvalidInput`, a `ModelCapabilityMismatch` from `chat_with_tools()` is
+/// model/config-specific (e.g. `reasoning_effort` + `tools` on one provider) — the router
+/// must fall through to the next provider instead of aborting.
+#[tokio::test]
+async fn chat_with_tools_model_capability_mismatch_falls_through_to_second_provider() {
+    use crate::mock::MockProvider;
+    use crate::provider::ToolDefinition;
+
+    let p1 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ModelCapabilityMismatch {
+                provider: "p1".into(),
+                message: "reasoning_effort incompatible with tools".into(),
+            }])
+            .with_name("p1"),
+    );
+    let p2 = AnyProvider::Mock(MockProvider::default().with_name("p2"));
+
+    let r = RouterProvider::new(vec![p1, p2]);
+    let result = r.chat_with_tools(&[], &[] as &[ToolDefinition]).await;
+
+    assert!(
+        result.is_ok(),
+        "expected fallback to p2 to succeed, got {result:?}"
+    );
+}
+
+/// When the sole provider returns `ModelCapabilityMismatch` and the fallback loop exhausts,
+/// the router must surface that error's actionable diagnostic — not a generic `NoProviders`
+/// that discards it (regression for the #5795 enriched-message loss).
+#[tokio::test]
+async fn chat_with_tools_single_provider_mismatch_exhaustion_preserves_error() {
+    use crate::mock::MockProvider;
+    use crate::provider::ToolDefinition;
+
+    let p = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ModelCapabilityMismatch {
+                provider: "p1".into(),
+                message: "reasoning_effort incompatible with tools".into(),
+            }])
+            .with_name("p1"),
+    );
+    let r = RouterProvider::new(vec![p]).with_thompson(None);
+    let err = r
+        .chat_with_tools(&[], &[] as &[ToolDefinition])
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(&err, LlmError::ModelCapabilityMismatch { provider, message }
+            if provider == "p1" && message.contains("reasoning_effort")),
+        "expected ModelCapabilityMismatch from p1 to survive exhaustion, got {err:?}"
+    );
+}
+
+/// When every provider in the fallback loop returns `ModelCapabilityMismatch`, the router
+/// must exhaust the loop and return the last provider's error, not `NoProviders`.
+#[tokio::test]
+async fn chat_with_tools_all_providers_mismatch_exhaustion_preserves_last_error() {
+    use crate::mock::MockProvider;
+    use crate::provider::ToolDefinition;
+
+    let p1 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ModelCapabilityMismatch {
+                provider: "p1".into(),
+                message: "p1 reasoning_effort incompatible with tools".into(),
+            }])
+            .with_name("p1"),
+    );
+    let p2 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ModelCapabilityMismatch {
+                provider: "p2".into(),
+                message: "p2 reasoning_effort incompatible with tools".into(),
+            }])
+            .with_name("p2"),
+    );
+
+    let r = RouterProvider::new(vec![p1, p2]);
+    let err = r
+        .chat_with_tools(&[], &[] as &[ToolDefinition])
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(&err, LlmError::ModelCapabilityMismatch { provider, .. } if provider == "p2"),
+        "expected the last provider's (p2) ModelCapabilityMismatch to survive exhaustion, got {err:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Adds `LlmError::ModelCapabilityMismatch { provider, message }` for model/config-specific errors (e.g. the `reasoning_effort` + `tools` incompatibility on OpenAI's Chat Completions API, surfaced by PR #5795) that are retryable on another configured provider — unlike `InvalidInput`, which is genuinely malformed regardless of destination. `OpenAiProvider::chat_with_tools` now returns this variant instead of `InvalidInput` for that case (message text unchanged), and the router's `chat_with_tools` fallback loop falls through to the next tool-capable provider instead of short-circuiting.
- Fixes a related fallback-exhaustion bug found during adversarial review: when every provider failed, the loop returned a generic `LlmError::NoProviders` instead of the last provider's actual error, which would have made PR #5795's actionable diagnostic message unreachable in the single-provider or all-providers-affected case. The loop now tracks `last_err` across providers (mirroring the existing pattern in the `embed`/`embed_batch` fallback loops) and returns it on exhaustion.
- Adds an explicit `CandleProvider::supports_vision() -> false` override, matching every other `LlmProvider` implementation and mirroring the `supports_tool_use()` override added for this provider in #5754.

## Test plan

- [x] `cargo nextest run -p zeph-llm --features "candle,gonka,cocoon,testing"` — new/changed tests: `model_capability_mismatch_is_detected`, `other_errors_are_not_model_capability_mismatch`, `model_capability_mismatch_display_includes_provider_and_message`, `chat_with_tools_model_capability_mismatch_falls_through_to_second_provider`, `chat_with_tools_single_provider_mismatch_exhaustion_preserves_error`, `chat_with_tools_all_providers_mismatch_exhaustion_preserves_last_error`, plus a corrected assertion in `cascade_chat_with_tools_unaffected_by_cost_tiers`
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12335 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Adversarial critique pass (caught and this PR fixes the exhaustion bug above)
- [x] Code review approved

Closes #5796
Closes #5755