### PR TITLE
fix(skills): normalize in-memory skill embeddings to unit length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     `EmbeddingRegistry::get_vectors_by_keys` (happy path and partial-miss) in
     `crates/zeph-memory/tests/qdrant_integration.rs`.
 
+- `fix(skills)`: RL routing head (`RoutingHeadInner::score()` in
+  `crates/zeph-skills/src/rl_head.rs`) is a genuine learned linear layer over the raw,
+  concatenated `query_embed ++ skill_embed` components — not a cosine-only computation — so its
+  score is sensitive to vector magnitude. Qdrant `Distance::Cosine` collections return
+  unit-normalized vectors, but the in-memory `vector_backend` stored embedding-provider output
+  verbatim in `SkillEmbedding::from_raw` (`crates/zeph-skills/src/embedding.rs`), so switching
+  `vector_backend` changed the RL head's effective input scale and could shift its rerank
+  distribution (#5805, surfaced during #5786/#5804). `SkillEmbedding::from_raw` now L2-normalizes
+  its input via the existing `zeph_common::math::EmbeddingVector<Unnormalized>::normalize()`
+  helper, matching Qdrant's output scale. Cosine similarity is scale-invariant, so this does not
+  change any existing similarity/ranking result computed via `cosine_similarity` — only the RL
+  head's raw-vector input scale changes. `query_embed` is intentionally left unnormalized (see
+  `rl_head.rs` module docs); this pre-existing query/skill asymmetry is orthogonal to this fix.
+  Existing `routing_head_weights` trained on the old, un-normalized in-memory scale may need
+  retraining/reset for optimal RL rerank quality after this change ships — no automatic
+  migration is performed.
+
 - `fix(llm)`: OpenAI Chat Completions rejects the combination of `reasoning_effort` and
   tool-calling (`tools`) for some reasoning models (e.g. `gpt-5.4-mini`), responding with an
   opaque HTTP 400 body directing callers to `/v1/responses` — an endpoint Zeph does not

--- a/crates/zeph-skills/src/embedding.rs
+++ b/crates/zeph-skills/src/embedding.rs
@@ -95,6 +95,13 @@ impl SkillEmbedding {
     /// the same model, ensuring dimensional consistency throughout the
     /// collection.
     ///
+    /// The vector is L2-normalized to unit length before storage. This
+    /// matches the vectors Qdrant returns for `Distance::Cosine` collections,
+    /// so `RoutingHeadInner::score` (`rl_head.rs`) sees the same input scale
+    /// regardless of which `vector_backend` produced the embedding. Cosine
+    /// similarity is scale-invariant, so normalizing here doesn't change any
+    /// existing similarity/ranking result — see `zeph_common::math::normalize`.
+    ///
     /// # Examples
     ///
     /// ```
@@ -107,7 +114,11 @@ impl SkillEmbedding {
     /// ```
     #[must_use]
     pub fn from_raw(vec: Vec<f32>) -> Self {
-        Self(vec)
+        let normalized =
+            zeph_common::math::EmbeddingVector::<zeph_common::math::Unnormalized>::new(vec)
+                .normalize()
+                .into_inner();
+        Self(normalized)
     }
 
     /// The number of dimensions in this embedding.
@@ -132,9 +143,10 @@ impl SkillEmbedding {
     /// ```
     /// use zeph_skills::embedding::SkillEmbedding;
     ///
-    /// let v = vec![1.0_f32, 2.0, 3.0];
-    /// let emb = SkillEmbedding::from_raw(v.clone());
-    /// assert_eq!(emb.into_inner(), v);
+    /// // `from_raw` normalizes, so the returned vector is unit-length, not `v` itself.
+    /// let v = vec![3.0_f32, 4.0];
+    /// let emb = SkillEmbedding::from_raw(v);
+    /// assert_eq!(emb.into_inner(), vec![0.6_f32, 0.8]);
     /// ```
     #[must_use]
     pub fn into_inner(self) -> Vec<f32> {
@@ -233,17 +245,15 @@ mod tests {
     }
 
     #[test]
-    fn as_ref_returns_slice() {
-        let v = vec![1.0_f32, 2.0, 3.0];
-        let emb = SkillEmbedding::from_raw(v.clone());
-        assert_eq!(emb.as_ref(), v.as_slice());
+    fn as_ref_returns_normalized_slice() {
+        let emb = SkillEmbedding::from_raw(vec![3.0_f32, 4.0]);
+        assert_eq!(emb.as_ref(), &[0.6_f32, 0.8]);
     }
 
     #[test]
-    fn into_inner_returns_vec() {
-        let v = vec![0.5_f32, 1.0];
-        let emb = SkillEmbedding::from_raw(v.clone());
-        assert_eq!(emb.into_inner(), v);
+    fn into_inner_returns_normalized_vec() {
+        let emb = SkillEmbedding::from_raw(vec![3.0_f32, 4.0]);
+        assert_eq!(emb.into_inner(), vec![0.6_f32, 0.8]);
     }
 
     #[test]
@@ -253,8 +263,46 @@ mod tests {
     }
 
     #[test]
+    fn from_raw_normalizes_to_unit_length() {
+        let emb = SkillEmbedding::from_raw(vec![1.0_f32, 2.0, 3.0]);
+        let sum_sq: f32 = emb.as_ref().iter().map(|x| x * x).sum();
+        assert!(
+            (sum_sq - 1.0).abs() < 1e-6,
+            "L2 norm must be ~1.0, got sum_sq={sum_sq}"
+        );
+    }
+
+    #[test]
+    fn from_raw_zero_vector_stays_zero() {
+        let emb = SkillEmbedding::from_raw(vec![0.0_f32, 0.0, 0.0]);
+        assert_eq!(emb.as_ref(), &[0.0_f32, 0.0, 0.0]);
+        assert!(emb.as_ref().iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
     fn new_empty_dimension_zero() {
         let emb = SkillEmbedding::new(vec![], 0).unwrap();
         assert_eq!(emb.dim(), 0);
+    }
+
+    #[test]
+    fn from_raw_preserves_sign_of_negative_components() {
+        let emb = SkillEmbedding::from_raw(vec![-3.0_f32, 4.0]);
+        assert_eq!(emb.as_ref(), &[-0.6_f32, 0.8]);
+    }
+
+    #[test]
+    fn from_raw_normalizes_dominant_magnitude_component() {
+        // One huge-magnitude component alongside many small ones: normalization must not
+        // overflow/underflow and the unit-length invariant must still hold.
+        let mut raw = vec![1e6_f32];
+        raw.extend(vec![1e-3_f32; 10]);
+        let emb = SkillEmbedding::from_raw(raw);
+        let sum_sq: f32 = emb.as_ref().iter().map(|x| x * x).sum();
+        assert!(
+            (sum_sq - 1.0).abs() < 1e-5,
+            "L2 norm must be ~1.0 even with a dominant component, got sum_sq={sum_sq}"
+        );
+        assert!(emb.as_ref().iter().all(|x| x.is_finite()));
     }
 }

--- a/crates/zeph-skills/src/rl_head.rs
+++ b/crates/zeph-skills/src/rl_head.rs
@@ -9,6 +9,14 @@
 //!
 //! Forward pass: `score = sigmoid(w2 @ relu(w1 @ input + b1) + b2)`
 //!
+//! `query_embed` and `skill_embed` enter this MLP as raw vector components, not
+//! just through the `cosine_score` scalar feature, so the score is sensitive to
+//! their magnitude. `skill_embed` (`SkillEmbedding::from_raw`) is L2-normalized to
+//! unit length at construction to match Qdrant's `Distance::Cosine` collection
+//! output, keeping the scale consistent across `vector_backend` values.
+//! `query_embed` is left at the embedding provider's raw magnitude; this
+//! asymmetry is intentional and predates the skill-side backend-consistency fix.
+//!
 //! Training: REINFORCE with running baseline. Weights are shared via
 //! `Arc<std::sync::Mutex<RoutingHeadInner>>` for safe concurrent access.
 //!
@@ -500,6 +508,7 @@ fn read_f32_slice(data: &[u8], cursor: &mut usize) -> Option<Vec<f32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::embedding::SkillEmbedding;
 
     fn make_head() -> RoutingHead {
         RoutingHead::new(4)
@@ -640,6 +649,32 @@ mod tests {
         // One more rerank should now use blended scores (post-warmup).
         let ranked = head.rerank(&q, &candidates, &stats, 0.3, warmup);
         assert_eq!(ranked.len(), 2);
+    }
+
+    #[test]
+    fn score_is_scale_invariant_when_skill_embed_is_normalized_first() {
+        // Regression test for #5805: RoutingHeadInner::score() is a raw linear layer over
+        // query_embed ++ skill_embed, so it is scale-sensitive to whatever `skill_embed`
+        // slice it receives. The fix moves normalization to `SkillEmbedding::from_raw`
+        // (embedding.rs), *before* the vector ever reaches score(). This test proves that
+        // once two representations of the "same" skill embedding — one already unit-length
+        // (simulating Qdrant's `Distance::Cosine` output) and one scaled by an arbitrary
+        // factor (simulating raw in-memory provider magnitude) — are both routed through
+        // `SkillEmbedding::from_raw` as production code does, score() sees identical input
+        // and produces identical output, closing the cross-backend scale mismatch.
+        let mut head = RoutingHeadInner::new(4);
+        let q = dummy_embed(0.3, 4);
+
+        let unit_skill = SkillEmbedding::from_raw(vec![1.0_f32, 2.0, 3.0, 4.0]);
+        let scaled_skill = SkillEmbedding::from_raw(vec![5.0_f32, 10.0, 15.0, 20.0]); // same direction, 5x magnitude
+
+        let score_unit = head.score(&q, unit_skill.as_ref(), 0.7, 0.8, 3);
+        let score_scaled = head.score(&q, scaled_skill.as_ref(), 0.7, 0.8, 3);
+
+        assert!(
+            (score_unit - score_scaled).abs() < 1e-5,
+            "score must be identical regardless of pre-normalization magnitude: {score_unit} vs {score_scaled}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `RoutingHeadInner::score()` (`crates/zeph-skills/src/rl_head.rs`) is a learned linear layer over raw, concatenated `query_embed`/`skill_embed` components, so it is sensitive to embedding vector magnitude — not scale-invariant despite also including a cosine-similarity feature.
- Qdrant `Distance::Cosine` collections return unit-normalized vectors, but the in-memory `vector_backend`'s `SkillEmbedding::from_raw` stored the embedding provider's raw output verbatim, giving the RL head a different input scale depending on which `vector_backend` is active.
- `SkillEmbedding::from_raw` now L2-normalizes to unit length via the existing `zeph_common::math::EmbeddingVector::normalize()` helper, matching Qdrant's output scale. Every existing in-memory consumer reads the vector only through `cosine_similarity` (scale-invariant), so no ranking behavior changes outside the RL head. `query_embed` construction is intentionally untouched (pre-existing, orthogonal asymmetry, documented in `rl_head.rs`).
- Existing `routing_head_weights` trained on the old un-normalized in-memory scale may need retraining/reset for optimal RL rerank quality — no automatic migration performed (documented in CHANGELOG).

Closes #5805

## Test plan
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-skills --features qdrant --lib --bins` — 577/577 passed
- [x] `cargo test --doc -p zeph-skills --features qdrant` — 50/50 passed
- [x] `cargo clippy -p zeph-skills --all-targets --features qdrant -- -D warnings` — clean
- [x] `cargo +nightly fmt --check -p zeph-skills` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --features qdrant -p zeph-skills` — clean
- [x] New regression tests: unit-length + zero-vector + sign-preservation + dominant-magnitude edge cases in `embedding.rs`; end-to-end scale-invariance test in `rl_head.rs`
- [ ] Live cross-backend rerank parity re-verification (playbook Scenario 4, `skills-qdrant.md`) — left for a future CI cycle