### PR TITLE
fix(skills): scope unused-lint allow to qdrant-off build in refresh_skill_embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(skills)`: `SkillMatcherBackend::refresh_skill_embeddings` (introduced by #5804) failed
+  `clippy -D warnings` when built without the `qdrant` feature (#5809) — with `Qdrant` cfg'd
+  out, the `meta`/`scored` parameters and the `async` marker had no user in the remaining
+  `InMemory` no-op arm. Both are genuinely qdrant-only (the doc comment already states this is
+  a no-op for `InMemory`), so the fix scopes `#[allow(unused_variables, clippy::unused_async)]`
+  to the `not(feature = "qdrant")` build via `cfg_attr` rather than prefixing the parameters
+  with `_`, which would have silenced the lint in the `qdrant`-enabled build too.
 - `fix(orchestration,mcp)`: follow-up to the `record_skill_usage` fix above (#5802) — the same
   Postgres `ON CONFLICT DO UPDATE` self-reference ambiguity existed at two more call sites
   (#5803), found via adversarial review of #5802's fix. `PlanCache::cache_plan`

--- a/crates/zeph-skills/src/matcher.rs
+++ b/crates/zeph-skills/src/matcher.rs
@@ -610,6 +610,7 @@ impl SkillMatcherBackend {
     /// call it when a consumer of [`Self::skill_embedding`] is actually enabled (RL rerank
     /// and/or `GoSkills` grouping), so turns using neither feature don't pay for the extra
     /// Qdrant round-trip (see issue #5786).
+    #[cfg_attr(not(feature = "qdrant"), allow(unused_variables, clippy::unused_async))]
     pub async fn refresh_skill_embeddings(&self, meta: &[&SkillMeta], scored: &[ScoredMatch]) {
         match self {
             Self::InMemory(_) => {}


### PR DESCRIPTION
## Summary

- `SkillMatcherBackend::refresh_skill_embeddings` (introduced by #5804) failed `cargo clippy -D warnings` when built without the `qdrant` feature: with the `Qdrant` variant cfg'd out, the `meta`/`scored` parameters and the `async` marker had no user in the remaining `InMemory` no-op arm.
- Both are genuinely qdrant-only (the existing doc comment already documents this as a no-op for `InMemory`), so the fix scopes `#[allow(unused_variables, clippy::unused_async)]` to the `not(feature = "qdrant")` build via `cfg_attr`, rather than prefixing the parameters with `_`, which would have silenced the lint in the `qdrant`-enabled build too.
- This idiom matches two existing precedents in the codebase (`zeph-core/src/agent/state/security.rs`, `zeph-acp/src/agent/handlers/prompt.rs`).

Closes #5809

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] Exact issue repro: `cargo clippy -p zeph-orchestration --no-default-features --features test-utils,llm-planning -- -D warnings` — clean
- [x] `cargo clippy -p zeph-skills --no-default-features --features qdrant,sqlite -- -D warnings` — clean (qdrant-on lint coverage unaffected)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-skills` — 558/558 passed, including existing `backend_in_memory_refresh_skill_embeddings_is_noop` regression coverage for this exact code path