### PR TITLE
fix(memory): use locally-authoritative entity id for graph edge FK targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `repeated_decline_still_trips_circuit_breaker`, that alternates 3 Retrieve-mandate rounds
   (each a distinct tool) with 3 real `memory_search` dispatch-and-decline rounds through the real
   `handle_native_tool_calls` pipeline and confirms the 4th distinct tool dispatches directly.
+- `fix(memory)`: entity resolution and A-MEM note-linking could silently lose or mis-link
+  graph facts whenever `SQLite` was reset, restored, or migrated independently of a shared
+  Qdrant collection (#5801). `EntityResolver::merge_entity`'s embedding-match path
+  (`crates/zeph-memory/src/graph/resolver/mod.rs`) returned the `entity_id` read straight off
+  the Qdrant point payload instead of the id `upsert_entity` (keyed on `canonical_name` +
+  `entity_type`) actually wrote to the *local* database; when the payload id referenced a row
+  absent from the current `SQLite` instance, that stale id was later used as an edge FK target
+  in `insert_edges`, failing with a `FOREIGN KEY constraint failed` and silently dropping the
+  edge at `DEBUG` level — a user-requested fact permanently lost with no error surfaced.
+  `merge_entity` now returns the locally-authoritative id from `upsert_entity`, and both
+  callers (`resolve_via_embedding`, `handle_ambiguous_candidate`) use it instead of the payload
+  id. The same defect class existed in A-MEM note-linking's `insert_similarity_edges`
+  (`crates/zeph-memory/src/semantic/graph.rs`), which read a similarity-search candidate's
+  `entity_id` directly from its Qdrant payload with no local-existence check; a new
+  `resolve_local_target_id` helper now validates the candidate's id AND canonical identity
+  (`canonical_name` + `entity_type`) against the local row before trusting it — existence
+  alone is insufficient, since after a reset local ids restart from 1 and a stale payload id
+  can coincidentally collide with a valid but unrelated local entity, which would otherwise
+  silently link a `similar_to` edge to the wrong entity with no error and no log signal. On
+  genuine drift or an absent local row, both paths re-resolve by `canonical_name` (falling
+  back to local entity creation when no local row exists under that name either) instead of
+  dropping the fact. Added `MemoryError::is_foreign_key_violation()` and upgraded the residual
+  FK-violation log paths in `insert_edges` (APEX-MEM and legacy branches) and
+  `insert_similarity_edges` from `DEBUG` to `WARN`, so any remaining failure of this class is
+  no longer silent.
 
 ### Added
 

--- a/crates/zeph-memory/src/error.rs
+++ b/crates/zeph-memory/src/error.rs
@@ -100,6 +100,22 @@ pub enum MemoryError {
     ValidationRejected(String),
 }
 
+impl MemoryError {
+    /// Returns `true` when this error is a database foreign-key constraint violation.
+    ///
+    /// Used to distinguish silent-drop-worthy edge/entity write failures (e.g. a stale
+    /// cross-database entity id) from ordinary transient DB errors, so callers can log the
+    /// former at `WARN` instead of `DEBUG` (#5801).
+    #[must_use]
+    pub fn is_foreign_key_violation(&self) -> bool {
+        use sqlx::error::DatabaseError;
+
+        matches!(self, Self::Sqlx(err) if err
+            .as_database_error()
+            .is_some_and(DatabaseError::is_foreign_key_violation))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::MemoryError;
@@ -121,6 +137,41 @@ mod tests {
         assert!(
             err.to_string().starts_with("db error:"),
             "unexpected display: {err}"
+        );
+    }
+
+    #[test]
+    fn is_foreign_key_violation_false_for_non_constraint_error() {
+        let err = MemoryError::Sqlx(zeph_db::SqlxError::RowNotFound);
+        assert!(!err.is_foreign_key_violation());
+    }
+
+    #[test]
+    fn is_foreign_key_violation_false_for_non_sqlx_variant() {
+        let err = MemoryError::GraphStore("unrelated failure".into());
+        assert!(!err.is_foreign_key_violation());
+    }
+
+    /// Regression test for #5801: `is_foreign_key_violation()` must recognize a genuine
+    /// FK constraint violation (not just a manufactured/mocked one), since it is the
+    /// linchpin of the WARN-vs-DEBUG observability fix.
+    #[tokio::test]
+    async fn is_foreign_key_violation_true_for_real_fk_violation() {
+        use crate::graph::GraphStore;
+        use crate::store::SqliteStore;
+
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        let store = GraphStore::new(sqlite.pool().clone());
+
+        // Neither entity id exists in this fresh database — a genuine FK violation.
+        let err = store
+            .insert_edge(999_999, 888_888, "related_to", "fact", 0.9, None, None)
+            .await
+            .expect_err("inserting an edge between nonexistent entities must fail");
+
+        assert!(
+            err.is_foreign_key_violation(),
+            "expected a foreign-key violation, got: {err:#}"
         );
     }
 }

--- a/crates/zeph-memory/src/graph/resolver/mod.rs
+++ b/crates/zeph-memory/src/graph/resolver/mod.rs
@@ -188,7 +188,12 @@ impl<'a> EntityResolver<'a> {
     }
 
     /// Parse an entity type string, falling back to `Concept` on unknown values.
-    fn parse_entity_type(entity_type: &str) -> EntityType {
+    ///
+    /// `pub(crate)` so callers outside this module facing the same "parse a `Qdrant`-payload
+    /// `entity_type` string, default to `Concept`" need (e.g. note-linking's
+    /// `resolve_local_target_id` in `semantic/graph.rs`, #5801) share this logic instead of
+    /// duplicating it.
+    pub(crate) fn parse_entity_type(entity_type: &str) -> EntityType {
         entity_type
             .trim()
             .to_lowercase()
@@ -357,7 +362,7 @@ impl<'a> EntityResolver<'a> {
         summary: Option<&str>,
         _provenance: Option<&GraphProvenance>,
     ) -> Result<Option<(i64, ResolutionOutcome)>, MemoryError> {
-        let entity_id = payload
+        let payload_entity_id = payload
             .get("entity_id")
             .and_then(serde_json::Value::as_i64)
             .ok_or_else(|| MemoryError::GraphStore("missing entity_id in payload".into()))?;
@@ -393,20 +398,24 @@ impl<'a> EntityResolver<'a> {
             .await
         {
             Some(true) => {
-                self.merge_entity(
-                    emb_store,
-                    provider,
-                    entity_id,
-                    surface_name,
-                    normalized,
-                    et,
-                    summary,
-                    existing_canonical,
-                    existing_summary_str,
-                    Some(point_id),
-                )
-                .await?;
-                Ok(Some((entity_id, ResolutionOutcome::LlmDisambiguated)))
+                let resolved_entity_id = self
+                    .merge_entity(
+                        emb_store,
+                        provider,
+                        payload_entity_id,
+                        surface_name,
+                        normalized,
+                        et,
+                        summary,
+                        existing_canonical,
+                        existing_summary_str,
+                        Some(point_id),
+                    )
+                    .await?;
+                Ok(Some((
+                    resolved_entity_id,
+                    ResolutionOutcome::LlmDisambiguated,
+                )))
             }
             Some(false) => Ok(None),
             None => {
@@ -475,7 +484,7 @@ impl<'a> EntityResolver<'a> {
         if let Some(best) = candidates.first() {
             let score = best.score;
             if score >= self.similarity_threshold {
-                let entity_id = best
+                let payload_entity_id = best
                     .payload
                     .get("entity_id")
                     .and_then(serde_json::Value::as_i64)
@@ -486,21 +495,22 @@ impl<'a> EntityResolver<'a> {
                     best.payload.get("canonical_name").and_then(|v| v.as_str());
                 let existing_summary = best.payload.get("summary").and_then(|v| v.as_str());
                 let existing_pid = Some(best.id.as_str());
-                self.merge_entity(
-                    emb_store,
-                    provider,
-                    entity_id,
-                    surface_name,
-                    normalized,
-                    et,
-                    summary,
-                    existing_canonical,
-                    existing_summary,
-                    existing_pid,
-                )
-                .await?;
+                let resolved_entity_id = self
+                    .merge_entity(
+                        emb_store,
+                        provider,
+                        payload_entity_id,
+                        surface_name,
+                        normalized,
+                        et,
+                        summary,
+                        existing_canonical,
+                        existing_summary,
+                        existing_pid,
+                    )
+                    .await?;
                 return Ok(Some((
-                    entity_id,
+                    resolved_entity_id,
                     ResolutionOutcome::EmbeddingMatch { score },
                 )));
             } else if score >= self.ambiguous_threshold
@@ -598,12 +608,22 @@ impl<'a> EntityResolver<'a> {
     /// the call site (hot path, no `SQLite` roundtrip). Pass `None` for either when the point
     /// predates the payload fields — a targeted `find_entity_by_id` read is then used as a
     /// one-time fallback (legacy transition path, removed after all points are rewritten).
-    #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
+    ///
+    /// `payload_entity_id` is the `entity_id` read off the Qdrant point payload — it may
+    /// reference a row in a *different* `SQLite` instance than the one this resolver is bound
+    /// to (e.g. `SQLite` was reset/restored independently of a shared Qdrant collection).
+    /// The returned `i64` is always the id of the row actually written by this call's
+    /// `upsert_entity` (keyed on `canonical_name` + `entity_type`, not on `payload_entity_id`),
+    /// so it is guaranteed to exist in the local `SQLite` database — callers MUST use the
+    /// returned id (not `payload_entity_id`) as the FK target for edge inserts (#5801).
+    #[allow(clippy::too_many_arguments)]
+    // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
+    #[allow(clippy::too_many_lines)] // cross-DB id correction (#5801) added a diagnostic branch
     async fn merge_entity(
         &self,
         emb_store: &EmbeddingStore,
         provider: &AnyProvider,
-        entity_id: i64,
+        payload_entity_id: i64,
         new_surface_name: &str,
         new_canonical_name: &str,
         entity_type: EntityType,
@@ -611,7 +631,7 @@ impl<'a> EntityResolver<'a> {
         existing_canonical_name: Option<&str>,
         existing_summary_payload: Option<&str>,
         existing_point_id: Option<&str>,
-    ) -> Result<(), MemoryError> {
+    ) -> Result<i64, MemoryError> {
         // Hot path: use values from the Qdrant payload (no SQLite roundtrip).
         // Both canonical_name AND summary must be present; if either is absent the point
         // predates the payload field — fall back to a targeted SQLite read to avoid
@@ -630,7 +650,7 @@ impl<'a> EntityResolver<'a> {
                 // fields; one targeted read is acceptable until the embedding is rewritten
                 // on the next merge. Also used when canonical_name is present but summary
                 // is absent — prevents overwriting a SQLite summary with empty string.
-                let existing = self.store.find_entity_by_id(entity_id).await?;
+                let existing = self.store.find_entity_by_id(payload_entity_id).await?;
                 let canonical = existing_canonical_name.map_or_else(
                     || {
                         existing.as_ref().map_or_else(
@@ -676,7 +696,12 @@ impl<'a> EntityResolver<'a> {
 
         // Preserve the existing display name from the payload; fall back to the incoming surface
         // name only for brand-new entities (where the payload had no "name" field).
-        self.store
+        //
+        // This upsert is keyed on (canonical_name, entity_type) and RETURNING id gives back
+        // the row actually present in the *local* SQLite database — authoritative regardless
+        // of whether `payload_entity_id` is stale (#5801).
+        let entity_id = self
+            .store
             .upsert_entity(
                 new_surface_name,
                 &existing_canonical,
@@ -684,7 +709,23 @@ impl<'a> EntityResolver<'a> {
                 summary_opt,
                 None,
             )
-            .await?;
+            .await?
+            .0;
+
+        if entity_id != payload_entity_id {
+            // The Qdrant payload pointed at an id absent from (or divergent from) the local
+            // SQLite row for this canonical_name/entity_type — most commonly because SQLite
+            // was reset/restored/migrated independently of a shared Qdrant collection. Using
+            // `payload_entity_id` as an edge FK target here would fail with a foreign-key
+            // violation; the corrected local id is used and re-stamped into Qdrant below.
+            tracing::warn!(
+                payload_entity_id,
+                resolved_entity_id = entity_id,
+                canonical_name = %existing_canonical,
+                "graph: Qdrant entity_id payload did not match local SQLite row \
+                 (cross-DB or stale resolution) — corrected to the locally authoritative id"
+            );
+        }
 
         // Re-embed merged text and upsert to Qdrant
         let embed_text = format!("{new_surface_name}: {merged_summary}");
@@ -722,7 +763,7 @@ impl<'a> EntityResolver<'a> {
             }
         }
 
-        Ok(())
+        Ok(entity_id)
     }
 
     /// Store an entity embedding in Qdrant and update `qdrant_point_id` in `SQLite`.

--- a/crates/zeph-memory/src/graph/resolver/tests.rs
+++ b/crates/zeph-memory/src/graph/resolver/tests.rs
@@ -822,6 +822,63 @@ async fn merge_preserves_older_entity_id() {
 }
 
 #[tokio::test]
+#[tracing_test::traced_test]
+async fn merge_corrects_stale_cross_db_entity_id() {
+    // Regression test for #5801: the Qdrant payload references an entity_id that does not
+    // exist in *this* SQLite database (e.g. SQLite was reset/restored independently of a
+    // shared Qdrant collection). `resolve()` must not return the stale payload id verbatim —
+    // doing so would later be used as an edge FK target and fail with a foreign-key violation.
+    //
+    // No local row exists for this id — simulates a Qdrant point left over from a different,
+    // now-gone SQLite instance.
+    const STALE_CROSS_DB_ID: i64 = 987_654_321;
+
+    let (gs, emb) = setup_with_embedding().await;
+
+    let mock_vec = vec![1.0_f32, 0.0, 0.0, 0.0];
+    emb.ensure_named_collection(ENTITY_COLLECTION, 4)
+        .await
+        .unwrap();
+    let payload = serde_json::json!({
+        "entity_id": STALE_CROSS_DB_ID,
+        "canonical_name": "stale entity",
+        "name": "stale entity",
+        "entity_type": "concept",
+        "summary": "old info",
+    });
+    emb.store_to_collection(ENTITY_COLLECTION, payload, mock_vec.clone())
+        .await
+        .unwrap();
+
+    let provider = make_mock_provider_with_embedding(mock_vec);
+    let any_provider = zeph_llm::any::AnyProvider::Mock(provider);
+
+    let resolver = EntityResolver::new(&gs)
+        .with_embedding_store(&emb)
+        .with_provider(&any_provider)
+        .with_thresholds(0.85, 0.70);
+
+    let (returned_id, outcome) = resolver
+        .resolve("stale entity variant", "concept", Some("new info"), None)
+        .await
+        .unwrap();
+
+    assert_matches!(outcome, ResolutionOutcome::EmbeddingMatch { .. });
+    assert_ne!(
+        returned_id, STALE_CROSS_DB_ID,
+        "resolve() must not return the stale Qdrant-payload entity id verbatim"
+    );
+    assert!(
+        gs.find_entity_by_id(returned_id).await.unwrap().is_some(),
+        "returned entity id must reference a row that actually exists in the local SQLite database"
+    );
+    assert!(
+        logs_contain("corrected to the locally authoritative id"),
+        "drift-correction WARN must fire when the payload id does not match the local row"
+    );
+}
+
+#[tokio::test]
 async fn entity_type_filter_prevents_cross_type_merge() {
     let (gs, emb) = setup_with_embedding().await;
 

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -355,7 +355,7 @@ async fn insert_similarity_edges(
             .take(cfg.top_k);
 
         for point in candidates {
-            let Some(target_id) = point
+            let Some(payload_entity_id) = point
                 .payload
                 .get("entity_id")
                 .and_then(serde_json::Value::as_i64)
@@ -364,6 +364,12 @@ async fn insert_similarity_edges(
                     "note_linking: missing entity_id in payload for point {}",
                     point.id
                 );
+                continue;
+            };
+
+            let Some(target_id) =
+                resolve_local_target_id(store, &point.payload, payload_entity_id).await
+            else {
                 continue;
             };
 
@@ -389,12 +395,124 @@ async fn insert_similarity_edges(
                 .await
             {
                 Ok(_) => stats.edges_created += 1,
+                Err(e) if e.is_foreign_key_violation() => {
+                    // `target_id` came straight from a Qdrant payload (no local-existence
+                    // check) — a stale cross-DB id silently drops this link edge (#5801).
+                    tracing::warn!(
+                        source = src,
+                        target = tgt,
+                        "note_linking: insert_edge rejected by FK constraint, dropping edge: {e:#}"
+                    );
+                }
                 Err(e) => {
                     tracing::debug!("note_linking: insert_edge failed: {e:#}");
                 }
             }
         }
     }
+}
+
+/// Re-resolve a Qdrant search-result candidate's entity id against the *local* `SQLite`
+/// database instead of trusting the payload's `entity_id` verbatim.
+///
+/// Mirrors the canonical-name-keyed correction `EntityResolver::merge_entity` applies to
+/// entity resolution (#5801): the payload's `entity_id` may reference a row in a different
+/// `SQLite` instance (e.g. after a `SQLite` reset/restore performed independently of a
+/// shared Qdrant collection), which would otherwise be used as an edge FK target and fail
+/// with a foreign-key violation — or, worse, silently collide with an unrelated local row
+/// reusing the same id. The fast path requires BOTH id-existence AND a matching
+/// `canonical_name`/`entity_type` (identity, not just existence) before trusting the payload
+/// id: under the reset trigger, local ids restart from 1, so a stale `payload_entity_id` can
+/// easily coincide with a valid but *different* local entity, and existence alone would
+/// silently link to the wrong entity. The correction path only triggers when the id is
+/// absent or its identity doesn't match, and falls back to creating the entity locally when
+/// no local row exists under its canonical name either.
+///
+/// Returns `None` when the candidate should be skipped (malformed payload, or a DB error
+/// while re-resolving/creating it) — logged at `debug!`, matching the existing skip
+/// behavior for a missing `entity_id` payload field.
+async fn resolve_local_target_id(
+    store: &crate::graph::GraphStore,
+    payload: &std::collections::HashMap<String, serde_json::Value>,
+    payload_entity_id: i64,
+) -> Option<i64> {
+    let Some(canonical_name) = payload.get("canonical_name").and_then(|v| v.as_str()) else {
+        tracing::debug!(
+            payload_entity_id,
+            "note_linking: missing canonical_name in payload, skipping candidate"
+        );
+        return None;
+    };
+    let entity_type = crate::graph::EntityResolver::parse_entity_type(
+        payload
+            .get("entity_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("concept"),
+    );
+
+    // Fast path: the payload id exists locally AND its canonical identity matches the
+    // candidate — the expected, synced case.
+    match store.find_entity_by_id(payload_entity_id).await {
+        Ok(Some(entity))
+            if entity.canonical_name == canonical_name && entity.entity_type == entity_type =>
+        {
+            return Some(payload_entity_id);
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::debug!(
+                payload_entity_id,
+                error = %e,
+                "note_linking: find_entity_by_id failed, skipping candidate"
+            );
+            return None;
+        }
+    }
+
+    // Slow path: the payload id is stale, absent, or identifies a different local entity.
+    // Re-resolve by canonical_name — the same key merge_entity uses — falling back to local
+    // entity creation only when no local row exists under that name either.
+    let resolved = match store.find_entity(canonical_name, entity_type).await {
+        Ok(Some(entity)) => entity.id.0,
+        Ok(None) => {
+            let name = payload
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(canonical_name);
+            let summary = payload.get("summary").and_then(|v| v.as_str());
+            match store
+                .upsert_entity(name, canonical_name, entity_type, summary, None)
+                .await
+            {
+                Ok(id) => id.0,
+                Err(e) => {
+                    tracing::debug!(
+                        canonical_name,
+                        error = %e,
+                        "note_linking: failed to create local entity for stale candidate, skipping"
+                    );
+                    return None;
+                }
+            }
+        }
+        Err(e) => {
+            tracing::debug!(
+                canonical_name,
+                error = %e,
+                "note_linking: find_entity failed while re-resolving candidate, skipping"
+            );
+            return None;
+        }
+    };
+
+    tracing::warn!(
+        payload_entity_id,
+        resolved_entity_id = resolved,
+        canonical_name,
+        "note_linking: Qdrant entity_id payload did not match local SQLite row \
+         (cross-DB or stale resolution) — corrected to the locally authoritative id"
+    );
+    Some(resolved)
 }
 
 /// Extract entities and edges from `content` and persist them to the graph store.
@@ -651,6 +769,15 @@ async fn insert_edges(
                 .await
             {
                 Ok(_) => edges_inserted += 1,
+                Err(e) if e.is_foreign_key_violation() => {
+                    // A resolved entity id was rejected as an FK target — this drops a
+                    // user-requested fact permanently and must not be silent (#5801).
+                    tracing::warn!(
+                        source = src_id,
+                        target = tgt_id,
+                        "graph: edge insert (apex) rejected by FK constraint, dropping edge: {e:#}"
+                    );
+                }
                 Err(e) => {
                     tracing::debug!("graph: skipping edge (apex): {e:#}");
                 }
@@ -679,6 +806,15 @@ async fn insert_edges(
             {
                 Ok(Some(_)) => edges_inserted += 1,
                 Ok(None) => {} // deduplicated
+                Err(e) if e.is_foreign_key_violation() => {
+                    // A resolved entity id was rejected as an FK target — this drops a
+                    // user-requested fact permanently and must not be silent (#5801).
+                    tracing::warn!(
+                        source = src_id,
+                        target = tgt_id,
+                        "graph: edge insert rejected by FK constraint, dropping edge: {e:#}"
+                    );
+                }
                 Err(e) => {
                     tracing::debug!("graph: skipping edge: {e:#}");
                 }

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -509,6 +509,7 @@ async fn seed_entity_with_zero_embedding(
     let point_id = uuid::Uuid::new_v4().to_string();
     let payload = json!({
         "entity_id": id,
+        "canonical_name": name,
         "entity_type": "concept",
         "name": name,
         "summary": "",
@@ -560,6 +561,7 @@ async fn seed_entity_no_db_point_id(
     let point_id = uuid::Uuid::new_v4().to_string();
     let payload = json!({
         "entity_id": id,
+        "canonical_name": name,
         "entity_type": "concept",
         "name": name,
         "summary": "",
@@ -836,5 +838,214 @@ async fn link_memory_notes_threshold_rejection() {
     assert_eq!(
         stats.edges_created, 0,
         "no edges must be created when all scores are below threshold"
+    );
+}
+
+// ── #5801: note-linking must correct a stale cross-DB candidate id ───────────
+//
+// `insert_similarity_edges` reads a candidate's `entity_id` straight off a Qdrant
+// search-result payload. If that payload was written by a different (now-gone) SQLite
+// instance sharing the same Qdrant collection, the id may not exist locally — using it
+// as an edge FK target would fail with a foreign-key violation and silently drop the
+// link edge. `resolve_local_target_id` must re-resolve such a candidate via its
+// `canonical_name` (falling back to local entity creation) rather than trusting the
+// stale payload id.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn link_memory_notes_corrects_stale_cross_db_target_id() {
+    // Phantom candidate: exists only in Qdrant with an entity_id that has no local row —
+    // simulates a Qdrant point left over from a different, now-gone SQLite instance.
+    const STALE_CROSS_DB_ID: i64 = 777_777_777;
+
+    let (memory, embedding_store) = memory_with_in_memory_vector_store().await;
+    let store = GraphStore::new(memory.sqlite.pool().clone());
+
+    let id_a = seed_entity_with_zero_embedding(&store, &embedding_store, "phantom_source").await;
+
+    let payload = serde_json::json!({
+        "entity_id": STALE_CROSS_DB_ID,
+        "canonical_name": "phantom target",
+        "name": "phantom target",
+        "entity_type": "concept",
+        "summary": "",
+    });
+    embedding_store
+        .upsert_to_collection(
+            "zeph_graph_entities",
+            &uuid::Uuid::new_v4().to_string(),
+            payload,
+            vec![0.0_f32; 384],
+        )
+        .await
+        .unwrap();
+
+    let cfg = NoteLinkingConfig {
+        enabled: true,
+        similarity_threshold: 0.0,
+        top_k: 5,
+        timeout_secs: 10,
+    };
+
+    let stats = link_memory_notes(
+        &[id_a],
+        memory.sqlite.pool().clone(),
+        embedding_store,
+        embedding_provider(),
+        &cfg,
+    )
+    .await;
+
+    assert_eq!(
+        stats.edges_created, 1,
+        "the link edge must still be created via the corrected local id, not silently dropped"
+    );
+    assert!(
+        logs_contain("note_linking: Qdrant entity_id payload did not match local SQLite row"),
+        "drift-correction WARN must fire for the stale candidate id"
+    );
+
+    let pool = memory.sqlite.pool();
+    let stale_id_referenced: i64 = zeph_db::query_scalar(sql!(
+        "SELECT COUNT(*) FROM graph_edges WHERE source_entity_id = ?1 OR target_entity_id = ?1"
+    ))
+    .bind(STALE_CROSS_DB_ID)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        stale_id_referenced, 0,
+        "the created edge must never reference the stale cross-DB id (would violate the FK)"
+    );
+
+    // The phantom entity must have been created locally under its canonical_name so the
+    // edge has a valid FK target.
+    let phantom = store
+        .find_entity("phantom target", EntityType::Concept)
+        .await
+        .unwrap();
+    assert!(
+        phantom.is_some(),
+        "a local entity must be created for the stale candidate so the edge has a valid FK target"
+    );
+}
+
+// ── #5801: id-existence is not identity — a colliding local id must not be trusted ──
+//
+// After a SQLite reset, local ids restart from 1, so a stale `payload_entity_id` can
+// coincidentally match an existing but UNRELATED local row instead of being absent.
+// `resolve_local_target_id`'s fast path must verify canonical_name/entity_type identity,
+// not just id existence, or it would silently link a `similar_to` edge to the wrong entity.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn link_memory_notes_id_collision_falls_through_to_slow_path() {
+    let (memory, embedding_store) = memory_with_in_memory_vector_store().await;
+    let store = GraphStore::new(memory.sqlite.pool().clone());
+
+    let id_a = seed_entity_with_zero_embedding(&store, &embedding_store, "collision_source").await;
+
+    // A local row that will collide by id with the phantom candidate below, but is an
+    // entirely unrelated entity. No Qdrant point of its own, so it never competes as a
+    // search candidate — only its id is relevant here.
+    let collided_id = store
+        .upsert_entity(
+            "collision_wrong_entity",
+            "collision_wrong_entity",
+            EntityType::Concept,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .0;
+
+    // Phantom candidate: payload `entity_id` happens to equal `collided_id`, but its
+    // `canonical_name` identifies a DIFFERENT entity — simulating the reset scenario where
+    // a stale small int coincides with a valid but unrelated local row.
+    let payload = serde_json::json!({
+        "entity_id": collided_id,
+        "canonical_name": "collision_correct_target",
+        "name": "collision_correct_target",
+        "entity_type": "concept",
+        "summary": "",
+    });
+    embedding_store
+        .upsert_to_collection(
+            "zeph_graph_entities",
+            &uuid::Uuid::new_v4().to_string(),
+            payload,
+            vec![0.0_f32; 384],
+        )
+        .await
+        .unwrap();
+
+    let cfg = NoteLinkingConfig {
+        enabled: true,
+        similarity_threshold: 0.0,
+        top_k: 5,
+        timeout_secs: 10,
+    };
+
+    let stats = link_memory_notes(
+        &[id_a],
+        memory.sqlite.pool().clone(),
+        embedding_store,
+        embedding_provider(),
+        &cfg,
+    )
+    .await;
+
+    assert_eq!(
+        stats.edges_created, 1,
+        "the link edge must be created via the correctly re-resolved entity"
+    );
+
+    // The edge must reference the entity re-resolved (or created) under the candidate's own
+    // canonical_name, not the unrelated row that happened to collide by id.
+    let correct_target = store
+        .find_entity("collision_correct_target", EntityType::Concept)
+        .await
+        .unwrap()
+        .expect("a local entity must be created for the mismatched-identity candidate");
+    assert_ne!(
+        correct_target.id.0, collided_id,
+        "the re-resolved entity must not be the unrelated collided row"
+    );
+
+    let pool = memory.sqlite.pool();
+    let edge_to_correct_target: i64 = zeph_db::query_scalar(sql!(
+        "SELECT COUNT(*) FROM graph_edges
+         WHERE (source_entity_id = ?1 AND target_entity_id = ?2)
+            OR (source_entity_id = ?2 AND target_entity_id = ?1)"
+    ))
+    .bind(id_a)
+    .bind(correct_target.id.0)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        edge_to_correct_target, 1,
+        "edge must link to the correctly re-resolved entity"
+    );
+
+    let edge_to_collided_id: i64 = zeph_db::query_scalar(sql!(
+        "SELECT COUNT(*) FROM graph_edges
+         WHERE (source_entity_id = ?1 AND target_entity_id = ?2)
+            OR (source_entity_id = ?2 AND target_entity_id = ?1)"
+    ))
+    .bind(id_a)
+    .bind(collided_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        edge_to_collided_id, 0,
+        "edge must NOT silently link to the unrelated entity that happened to collide by id"
+    );
+
+    assert!(
+        logs_contain("note_linking: Qdrant entity_id payload did not match local SQLite row"),
+        "drift-correction WARN must fire when identity does not match despite the id existing"
     );
 }


### PR DESCRIPTION
## Summary

- `EntityResolver::merge_entity` previously returned the `entity_id` read directly off a Qdrant point payload instead of the id `upsert_entity` actually wrote to the local SQLite database. When SQLite is reset, restored, or migrated independently of a shared Qdrant collection, that payload id can reference a row absent from the current database — using it as an edge FK target then failed with a silent `FOREIGN KEY constraint failed` (logged only at DEBUG), permanently and invisibly dropping a user-requested fact.
- The same defect class existed in A-MEM note-linking's `insert_similarity_edges`, which trusted a similarity-search candidate's payload `entity_id` with no local-existence check — and, since existence alone isn't sufficient (local ids restart from 1 after a reset), a stale id could also silently collide with an unrelated local entity and link a `similar_to` edge to the wrong target with no error at all.
- `merge_entity` now returns the locally-authoritative id from `upsert_entity` (keyed on `canonical_name` + `entity_type`); a new `resolve_local_target_id` helper applies the same identity-checked correction (existence AND canonical-name/entity_type match) to note-linking, falling back to local entity creation when no local row exists under the canonical name. Added `MemoryError::is_foreign_key_violation()` and upgraded the residual FK-violation log paths from DEBUG to WARN so any remaining failure of this class is no longer silent.

Closes #5801

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12333 passed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-memory` (sqlite and postgres features)
- [x] New regression tests: `merge_corrects_stale_cross_db_entity_id`, `link_memory_notes_corrects_stale_cross_db_target_id`, `link_memory_notes_id_collision_falls_through_to_slow_path`, `is_foreign_key_violation()` unit tests (2 false cases + 1 real FK violation against a live in-memory SQLite pool)