### PR TITLE
fix(core): apply semantic_scan config at initial agent construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   a no-op for `InMemory`), so the fix scopes `#[allow(unused_variables, clippy::unused_async)]`
   to the `not(feature = "qdrant")` build via `cfg_attr` rather than prefixing the parameters
   with `_`, which would have silenced the lint in the `qdrant`-enabled build too.
+- `fix(core)`: Stage-2 semantic-scan configuration (`[skills] semantic_scan` /
+  `semantic_scan_provider`) was only ever applied to a running agent via a config-file
+  hot-reload event (`crates/zeph-core/src/agent/config_reload.rs`) or a test-only builder setter
+  (`AgentBuilder::with_semantic_scan`, previously called only from unit tests) — the real startup
+  construction paths in `src/runner.rs` and `src/daemon.rs` never called it, so
+  `services.skill.semantic_scan` stayed at its hardcoded default `false` for the entire process
+  lifetime unless a hot-reload happened to fire first (#5813). This meant `plugin add` silently
+  skipped the Stage-2 LLM compliance scan on a fresh process even with `semantic_scan = true`
+  configured. Both real startup `AgentBuilder` chains now call
+  `.with_semantic_scan(config.skills.semantic_scan, config.skills.semantic_scan_provider.as_str())`
+  alongside the existing `.with_skill_matching_config(...)`/`.with_skill_provider_names(...)`
+  calls. User-visible behavior change: a user with `semantic_scan = true` and an empty or unknown
+  `semantic_scan_provider` will now correctly have `plugin add` refused at startup (fail-closed,
+  per `with_semantic_scan`'s documented contract) instead of silently succeeding with no scan.
+
 - `fix(orchestration,mcp)`: follow-up to the `record_skill_usage` fix above (#5802) — the same
   Postgres `ON CONFLICT DO UPDATE` self-reference ambiguity existed at two more call sites
   (#5803), found via adversarial review of #5802's fix. `PlanCache::cache_plan`

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -743,6 +743,10 @@ pub(crate) async fn run_daemon(
             config.skills.generation_provider.as_str().to_owned(),
             config.skills.disambiguate_provider.as_str().to_owned(),
         )
+        .with_semantic_scan(
+            config.skills.semantic_scan,
+            config.skills.semantic_scan_provider.as_str(),
+        )
         .with_skill_reload(skill_paths, reload_rx)
         .with_plugin_dirs_supplier(plugin_dirs_supplier)
         .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2744,6 +2744,10 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         config.skills.generation_provider.as_str().to_owned(),
         config.skills.disambiguate_provider.as_str().to_owned(),
     )
+    .with_semantic_scan(
+        config.skills.semantic_scan,
+        config.skills.semantic_scan_provider.as_str(),
+    )
     .with_skill_reload(skill_paths, reload_rx)
     .with_plugin_dirs_supplier(plugin_dirs_supplier)
     .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())


### PR DESCRIPTION
## Summary

- Stage-2 semantic-scan config (`[skills] semantic_scan` / `semantic_scan_provider`) was only ever applied via a config-file hot-reload event or a test-only builder setter — the real startup construction paths in `src/runner.rs` and `src/daemon.rs` never called `AgentBuilder::with_semantic_scan`, so it stayed at its hardcoded `false` default for the entire process lifetime unless a hot-reload happened to fire.
- Both real startup `AgentBuilder` chains now call `.with_semantic_scan(config.skills.semantic_scan, config.skills.semantic_scan_provider.as_str())` alongside the existing `.with_skill_matching_config(...)`/`.with_skill_provider_names(...)` calls, so the scan is active from the very first `plugin add` in a session where it's configured.
- User-visible behavior change: a user with `semantic_scan = true` and an empty/unknown `semantic_scan_provider` will now correctly have `plugin add` refused at startup (fail-closed) instead of silently succeeding with no scan ever run.

Out of scope for this PR (follow-ups to be filed separately):
- `src/acp.rs` and `src/serve/agent_factory.rs` are two more real `Agent` construction paths that wire no `config.skills` matching/scan knobs at all — a pre-existing, broader gap, not introduced by this fix.
- `run()`/`run_daemon()` have no test seam to exercise this regression class directly; a `build_agent`-style testable seam (mirroring `build_agent_factory`) would close this for future changes.

Closes #5813

## Test plan

- [x] `cargo check --workspace --features full`
- [x] `cargo +nightly fmt --check`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12341 passed, 0 failed, 34 skipped
- [x] Adversarial review confirmed no hidden gate/cache prevents immediate activation, no new panic risk on misconfigured provider, and the ACP/serve gap is genuinely pre-existing and out of scope