### PR TITLE
fix(llm): preserve last provider error in embed/embed_batch fallback loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   calls. User-visible behavior change: a user with `semantic_scan = true` and an empty or unknown
   `semantic_scan_provider` will now correctly have `plugin add` refused at startup (fail-closed,
   per `with_semantic_scan`'s documented contract) instead of silently succeeding with no scan.
-
+- `fix(llm)`: the router's `embed`/`embed_batch` fallback loops
+  (`crates/zeph-llm/src/router/provider_impl.rs`) discarded the last provider's actual error on
+  total exhaustion (every provider failed), always returning a hardcoded `LlmError::NoProviders`
+  instead of the real diagnostic (e.g. `Timeout`, rate-limit info, provider-specific errors)
+  (#5811). Mirrors the `chat_with_tools` fix from #5810: `last_err: Option<LlmError>` is now
+  hoisted from the per-provider retry loop to function scope in both `embed` and `embed_batch`, so
+  it survives across providers and is returned via `Err(last_err.unwrap_or(LlmError::NoProviders))`
+  on exhaustion — falling back to `NoProviders` only when no provider was ever attempted (e.g.
+  none support embeddings).
 - `fix(orchestration,mcp)`: follow-up to the `record_skill_usage` fix above (#5802) — the same
   Postgres `ON CONFLICT DO UPDATE` self-reference ambiguity existed at two more call sites
   (#5803), found via adversarial review of #5802's fix. `PlanCache::cache_plan`

--- a/crates/zeph-llm/src/router/provider_impl.rs
+++ b/crates/zeph-llm/src/router/provider_impl.rs
@@ -311,11 +311,13 @@ impl LlmProvider for RouterProvider {
         let embed_timeout_ms = self.embed_timeout_ms;
         let model = self.model_identifier().to_owned();
         let fut = Box::pin(async move {
+            // Preserve the most recent error across the fallback loop so an exhausted
+            // loop surfaces the actionable diagnostic instead of a generic `NoProviders`.
+            let mut last_err: Option<LlmError> = None;
             for p in &providers {
                 if !p.supports_embeddings() {
                     continue;
                 }
-                let mut last_err: Option<LlmError> = None;
                 for attempt in 0..=EMBED_MAX_RETRIES {
                     if attempt > 0 {
                         let delay = EMBED_BASE_DELAY_MS * (1u64 << (attempt - 1));
@@ -406,7 +408,7 @@ impl LlmProvider for RouterProvider {
                     );
                 }
             }
-            Err(LlmError::NoProviders)
+            Err(last_err.unwrap_or(LlmError::NoProviders))
         });
         {
             use tracing::Instrument as _;
@@ -434,11 +436,13 @@ impl LlmProvider for RouterProvider {
                 None
             };
             let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+            // Preserve the most recent error across the fallback loop so an exhausted
+            // loop surfaces the actionable diagnostic instead of a generic `NoProviders`.
+            let mut last_err: Option<LlmError> = None;
             for p in &providers {
                 if !p.supports_embeddings() {
                     continue;
                 }
-                let mut last_err: Option<LlmError> = None;
                 for attempt in 0..=EMBED_MAX_RETRIES {
                     if attempt > 0 {
                         let delay = EMBED_BASE_DELAY_MS * (1u64 << (attempt - 1));
@@ -531,7 +535,7 @@ impl LlmProvider for RouterProvider {
                     );
                 }
             }
-            Err(LlmError::NoProviders)
+            Err(last_err.unwrap_or(LlmError::NoProviders))
         });
         {
             use tracing::Instrument as _;

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -1173,9 +1173,10 @@ async fn embed_invalid_input_does_not_record_availability() {
 // ── embed timeout tests ───────────────────────────────────────────────────
 
 /// When the only provider's `embed()` exceeds `embed_timeout_ms`, the router
-/// exhausts the fallback list and returns `LlmError::NoProviders`.
+/// exhausts the fallback list and returns the real `LlmError::Timeout` instead
+/// of a generic `NoProviders` (#5811).
 #[tokio::test]
-async fn embed_timeout_single_provider_returns_no_providers() {
+async fn embed_timeout_single_provider_preserves_timeout_error() {
     use crate::mock::MockProvider;
 
     let p = AnyProvider::Mock(
@@ -1186,8 +1187,8 @@ async fn embed_timeout_single_provider_returns_no_providers() {
     let r = RouterProvider::new(vec![p]).with_embed_timeout(10);
     let err = r.embed("hello").await.unwrap_err();
     assert!(
-        matches!(err, LlmError::NoProviders),
-        "expected NoProviders after timeout, got {err:?}"
+        matches!(err, LlmError::Timeout),
+        "expected Timeout after fallback exhaustion, got {err:?}"
     );
 }
 
@@ -1214,9 +1215,10 @@ async fn embed_timeout_falls_back_to_next_provider() {
 }
 
 /// When the only provider's `embed_batch()` exceeds `embed_timeout_ms`, the router
-/// exhausts the fallback list and returns `LlmError::NoProviders`.
+/// exhausts the fallback list and returns the real `LlmError::Timeout` instead
+/// of a generic `NoProviders` (#5811).
 #[tokio::test]
-async fn embed_batch_timeout_single_provider_returns_no_providers() {
+async fn embed_batch_timeout_single_provider_preserves_timeout_error() {
     use crate::mock::MockProvider;
 
     let p = AnyProvider::Mock(
@@ -1227,8 +1229,8 @@ async fn embed_batch_timeout_single_provider_returns_no_providers() {
     let r = RouterProvider::new(vec![p]).with_embed_timeout(10);
     let err = r.embed_batch(&["hello"]).await.unwrap_err();
     assert!(
-        matches!(err, LlmError::NoProviders),
-        "expected NoProviders after timeout, got {err:?}"
+        matches!(err, LlmError::Timeout),
+        "expected Timeout after fallback exhaustion, got {err:?}"
     );
 }
 
@@ -1307,6 +1309,84 @@ async fn embed_batch_timeout_records_provider_unavailable() {
     assert!(
         *beta > *alpha,
         "timeout must be recorded as a failure (beta > alpha), got alpha={alpha}, beta={beta}"
+    );
+}
+
+// ── #5811 embed/embed_batch last-error exhaustion tests ───────────────────
+
+/// When every provider in the `embed()` fallback loop fails with a generic
+/// (non-rate-limited, non-invalid-input) error, the router must surface the
+/// *last* provider's actual error — not a generic `NoProviders` that discards
+/// the actionable diagnostic. Regression for #5811 (mirrors the
+/// `chat_with_tools` fix from #5810).
+#[tokio::test]
+async fn embed_all_providers_exhausted_preserves_last_error() {
+    use crate::mock::MockProvider;
+
+    let p1 = AnyProvider::Mock({
+        let mut m = MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p1".into(),
+                status: 500,
+            }])
+            .with_name("p1");
+        m.supports_embeddings = true;
+        m
+    });
+    let p2 = AnyProvider::Mock({
+        let mut m = MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p2".into(),
+                status: 503,
+            }])
+            .with_name("p2");
+        m.supports_embeddings = true;
+        m
+    });
+
+    let r = RouterProvider::new(vec![p1, p2]);
+    let err = r.embed("text").await.unwrap_err();
+
+    assert!(
+        matches!(&err, LlmError::ApiError { provider, status } if provider == "p2" && *status == 503),
+        "expected the last provider's (p2) ApiError to survive exhaustion, got {err:?}"
+    );
+}
+
+/// Same as above for `embed_batch()`: every provider fails with a generic error,
+/// and the router must return the last provider's actual error, not `NoProviders`.
+/// Regression for #5811.
+#[tokio::test]
+async fn embed_batch_all_providers_exhausted_preserves_last_error() {
+    use crate::mock::MockProvider;
+
+    let p1 = AnyProvider::Mock({
+        let mut m = MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p1".into(),
+                status: 500,
+            }])
+            .with_name("p1");
+        m.supports_embeddings = true;
+        m
+    });
+    let p2 = AnyProvider::Mock({
+        let mut m = MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p2".into(),
+                status: 503,
+            }])
+            .with_name("p2");
+        m.supports_embeddings = true;
+        m
+    });
+
+    let r = RouterProvider::new(vec![p1, p2]);
+    let err = r.embed_batch(&["text"]).await.unwrap_err();
+
+    assert!(
+        matches!(&err, LlmError::ApiError { provider, status } if provider == "p2" && *status == 503),
+        "expected the last provider's (p2) ApiError to survive exhaustion, got {err:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- `RouterProvider::embed` and `embed_batch` (`crates/zeph-llm/src/router/provider_impl.rs`) discarded the last provider's actual error on fallback exhaustion, always returning a hardcoded `LlmError::NoProviders` instead of the real, actionable diagnostic (e.g. `Timeout`, rate-limit info).
- Mirrors the `chat_with_tools` fix from #5810: `last_err: Option<LlmError>` is now hoisted to function scope in both loops and returned via `Err(last_err.unwrap_or(LlmError::NoProviders))` on exhaustion, falling back to `NoProviders` only when no provider was ever attempted.
- Updated two pre-existing tests whose assertions encoded the old buggy behavior (`embed_timeout_single_provider_returns_no_providers` -> `embed_timeout_single_provider_preserves_timeout_error`, and the `embed_batch` equivalent), and added two new regression tests covering total-exhaustion error preservation for both `embed` and `embed_batch`.

Closes #5811

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12343 passed)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm` (959 passed, including 4 new/updated regression tests)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] CHANGELOG.md updated