### PR TITLE
test(memory): close low-severity test-coverage gaps from #5815 FK-violation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `test(memory)`: closed three low-severity test-coverage gaps left over from #5815's fix for
+  the stale cross-DB entity-id FK-violation bug (#5801, #5816). `resolve_local_target_id`
+  (`crates/zeph-memory/src/semantic/graph.rs`) had no test for its third outcome — a stale or
+  mismatched payload id whose `canonical_name` already resolves to an existing local row, so
+  the slow path reuses it instead of creating a duplicate
+  (`link_memory_notes_stale_id_resolves_existing_canonical_without_creating`).
+  `EntityResolver::handle_ambiguous_candidate`, the LLM-disambiguated call site touched by the
+  same fix, had no stale-id coverage either — every existing ambiguous-path test seeds a real
+  matching row (`resolve_ambiguous_llm_disambiguated_corrects_stale_cross_db_id`). The
+  FK-violation WARN branches added to `insert_edges` (both the APEX-MEM and legacy paths) had
+  no test manufacturing a genuine FK violation on those specific call sites
+  (`insert_edges_apex_mem_logs_warn_on_genuine_fk_violation`,
+  `insert_edges_legacy_logs_warn_on_genuine_fk_violation`), unlike `insert_similarity_edges`.
+  Also added a Postgres-backend regression test for the original #5801 scenario
+  (`note_linking_corrects_stale_cross_db_target_id_postgres`, gated behind the existing
+  `test-utils`/Docker `#[ignore]` convention) — lower-risk since `EntityResolver`/
+  `resolve_local_target_id` share a single backend-agnostic `upsert_entity` implementation
+  already exercised by ~20 other Postgres tests, but this proves the full note-linking path
+  round-trips against a real instance. A full `extract_and_store` -> `insert_edges` end-to-end
+  pipeline test (nice-to-have) was not added: `MockProvider::embed()` returns one fixed vector
+  regardless of input text, so a two-entity extraction batch cannot have only one entity match
+  a seeded stale-id phantom without both colliding at cosine 1.0 — closing this gap needs
+  input-dependent embedding support in `zeph-llm`'s test mock, out of scope for this test-only
+  change. Test-only change, no production code modified.
+
 ### Fixed
 
 - `fix(acp,server,skills)`: ACP sessions (`src/acp.rs::spawn_acp_agent`) and HTTP `/sessions`

--- a/crates/zeph-memory/src/graph/resolver/tests.rs
+++ b/crates/zeph-memory/src/graph/resolver/tests.rs
@@ -878,6 +878,77 @@ async fn merge_corrects_stale_cross_db_entity_id() {
     );
 }
 
+// ── #5816 (gap 2): the LLM-disambiguated ambiguous-score path must also correct a
+// stale cross-DB payload entity_id. Every other ambiguous-path test
+// (`resolve_ambiguous_score_llm_says_merge` et al.) seeds a real matching row via
+// `seed_entity_with_vector`, so `payload_entity_id` is never stale there — this is the
+// only test exercising `handle_ambiguous_candidate` -> `merge_entity` with a payload id
+// that has no corresponding local SQLite row.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn resolve_ambiguous_llm_disambiguated_corrects_stale_cross_db_id() {
+    // No local row exists under this id — simulates a Qdrant point left over from a
+    // different, now-gone SQLite instance (mirrors `merge_corrects_stale_cross_db_entity_id`,
+    // but through the LLM-disambiguated ambiguous-score path instead of the direct
+    // above-threshold `EmbeddingMatch` path).
+    const STALE_CROSS_DB_ID: i64 = 135_791_357;
+
+    let (gs, emb) = setup_with_embedding().await;
+
+    let mock_vec = vec![1.0_f32, 0.0, 0.0, 0.0];
+    emb.ensure_named_collection(ENTITY_COLLECTION, 4)
+        .await
+        .unwrap();
+    let payload = serde_json::json!({
+        "entity_id": STALE_CROSS_DB_ID,
+        "canonical_name": "stale ambiguous entity",
+        "name": "stale ambiguous entity",
+        "entity_type": "concept",
+        "summary": "old info",
+    });
+    emb.store_to_collection(ENTITY_COLLECTION, payload, mock_vec.clone())
+        .await
+        .unwrap();
+
+    // new entity embeds to [1,1,0,0] -> cosine ~= 0.707 vs [1,0,0,0] -- lands in the
+    // ambiguous range [0.50, 0.85), triggering `handle_ambiguous_candidate`.
+    let provider = make_mock_with_embedding_and_chat(
+        vec![1.0, 1.0, 0.0, 0.0],
+        vec![r#"{"same_entity": true}"#.to_owned()],
+    );
+    let any_provider = zeph_llm::any::AnyProvider::Mock(provider);
+
+    let resolver = EntityResolver::new(&gs)
+        .with_embedding_store(&emb)
+        .with_provider(&any_provider)
+        .with_thresholds(0.85, 0.50);
+
+    let (returned_id, outcome) = resolver
+        .resolve(
+            "stale ambiguous entity variant",
+            "concept",
+            Some("new info"),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome, ResolutionOutcome::LlmDisambiguated);
+    assert_ne!(
+        returned_id, STALE_CROSS_DB_ID,
+        "resolve() must not return the stale Qdrant-payload entity id verbatim"
+    );
+    assert!(
+        gs.find_entity_by_id(returned_id).await.unwrap().is_some(),
+        "returned entity id must reference a row that actually exists in the local SQLite database"
+    );
+    assert!(
+        logs_contain("corrected to the locally authoritative id"),
+        "drift-correction WARN must fire when the payload id does not match the local row"
+    );
+}
+
 #[tokio::test]
 async fn entity_type_filter_prevents_cross_type_merge() {
     let (gs, emb) = setup_with_embedding().await;

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -2844,4 +2844,96 @@ mod tests {
             "dry-run must not write to knowledge_ingest_ledger (FR-026 / C2)"
         );
     }
+
+    // ── #5816 (gap 3): insert_edges FK-violation WARN branches ──────────────────
+    //
+    // Both the APEX-MEM and legacy branches of `insert_edges` catch a genuine FK
+    // constraint violation and log it at WARN (#5801) instead of silently dropping the
+    // edge at DEBUG. Unlike `insert_similarity_edges` (covered by the stale-cross-DB-id
+    // tests in `semantic/tests/graph.rs`), no test manufactured a real FK violation on
+    // these specific call sites — these two do, by pointing `name_to_id` at ids that do
+    // not exist locally, mirroring the manufactured violation in
+    // `error::tests::is_foreign_key_violation_true_for_real_fk_violation`.
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn insert_edges_apex_mem_logs_warn_on_genuine_fk_violation() {
+        use crate::graph::EntityResolver;
+        use crate::graph::extractor::ExtractedEdge;
+
+        let (gs, _emb) = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        // Neither id exists in this fresh database — a genuine FK violation.
+        let mut name_to_id = std::collections::HashMap::new();
+        name_to_id.insert("Ghost A".to_owned(), 111_111_111);
+        name_to_id.insert("Ghost B".to_owned(), 222_222_222);
+
+        let edges = vec![ExtractedEdge {
+            source: "Ghost A".to_owned(),
+            target: "Ghost B".to_owned(),
+            relation: "knows".to_owned(),
+            fact: "Ghost A knows Ghost B".to_owned(),
+            temporal_hint: None,
+            edge_type: "semantic".to_owned(),
+            confidence: Some(0.9),
+        }];
+
+        let config = GraphExtractionConfig {
+            apex_mem_enabled: true,
+            ..Default::default()
+        };
+
+        let inserted = super::insert_edges(&resolver, &edges, &name_to_id, &config).await;
+
+        assert_eq!(
+            inserted, 0,
+            "edge rejected by the FK constraint must not be counted as inserted"
+        );
+        assert!(
+            logs_contain("graph: edge insert (apex) rejected by FK constraint, dropping edge"),
+            "APEX-MEM FK-violation WARN must fire when both endpoints are locally nonexistent"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn insert_edges_legacy_logs_warn_on_genuine_fk_violation() {
+        use crate::graph::EntityResolver;
+        use crate::graph::extractor::ExtractedEdge;
+
+        let (gs, _emb) = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        // Neither id exists in this fresh database — a genuine FK violation.
+        let mut name_to_id = std::collections::HashMap::new();
+        name_to_id.insert("Ghost C".to_owned(), 333_333_333);
+        name_to_id.insert("Ghost D".to_owned(), 444_444_444);
+
+        let edges = vec![ExtractedEdge {
+            source: "Ghost C".to_owned(),
+            target: "Ghost D".to_owned(),
+            relation: "knows".to_owned(),
+            fact: "Ghost C knows Ghost D".to_owned(),
+            temporal_hint: None,
+            edge_type: "semantic".to_owned(),
+            confidence: Some(0.9),
+        }];
+
+        let config = GraphExtractionConfig {
+            apex_mem_enabled: false,
+            ..Default::default()
+        };
+
+        let inserted = super::insert_edges(&resolver, &edges, &name_to_id, &config).await;
+
+        assert_eq!(
+            inserted, 0,
+            "edge rejected by the FK constraint must not be counted as inserted"
+        );
+        assert!(
+            logs_contain("graph: edge insert rejected by FK constraint, dropping edge"),
+            "legacy-path FK-violation WARN must fire when both endpoints are locally nonexistent"
+        );
+    }
 }

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -1049,3 +1049,125 @@ async fn link_memory_notes_id_collision_falls_through_to_slow_path() {
         "drift-correction WARN must fire when identity does not match despite the id existing"
     );
 }
+
+// ── #5816 (gap 1): stale id, but canonical_name already resolves locally ────
+//
+// `resolve_local_target_id`'s slow path re-resolves by `canonical_name` when the fast
+// path fails. When that lookup already finds an existing local row, it must reuse that
+// row's id rather than creating a duplicate entity under the same canonical_name.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn link_memory_notes_stale_id_resolves_existing_canonical_without_creating() {
+    // No local row exists under this id — the fast path (`find_entity_by_id`) must fail
+    // and fall through to the slow path.
+    const STALE_ID: i64 = 555_555_555;
+
+    let (memory, embedding_store) = memory_with_in_memory_vector_store().await;
+    let store = GraphStore::new(memory.sqlite.pool().clone());
+
+    let id_a = seed_entity_with_zero_embedding(&store, &embedding_store, "existing_source").await;
+
+    // Pre-existing local row under the candidate's canonical_name — created independently
+    // of note-linking (e.g. by a prior extraction pass), with no Qdrant point of its own.
+    let existing_target_id = store
+        .upsert_entity(
+            "existing_target",
+            "existing_target",
+            EntityType::Concept,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .0;
+
+    // Phantom candidate: payload `entity_id` is stale (no local row), but `canonical_name`
+    // matches the pre-existing "existing_target" row above.
+    let payload = serde_json::json!({
+        "entity_id": STALE_ID,
+        "canonical_name": "existing_target",
+        "name": "existing_target",
+        "entity_type": "concept",
+        "summary": "",
+    });
+    embedding_store
+        .upsert_to_collection(
+            "zeph_graph_entities",
+            &uuid::Uuid::new_v4().to_string(),
+            payload,
+            vec![0.0_f32; 384],
+        )
+        .await
+        .unwrap();
+
+    let cfg = NoteLinkingConfig {
+        enabled: true,
+        similarity_threshold: 0.0,
+        top_k: 5,
+        timeout_secs: 10,
+    };
+
+    let stats = link_memory_notes(
+        &[id_a],
+        memory.sqlite.pool().clone(),
+        embedding_store,
+        embedding_provider(),
+        &cfg,
+    )
+    .await;
+
+    assert_eq!(
+        stats.edges_created, 1,
+        "the link edge must be created via the pre-existing local entity"
+    );
+
+    let pool = memory.sqlite.pool();
+
+    // The edge must reference the pre-existing entity, not the stale id.
+    let edge_to_existing: i64 = zeph_db::query_scalar(sql!(
+        "SELECT COUNT(*) FROM graph_edges
+         WHERE (source_entity_id = ?1 AND target_entity_id = ?2)
+            OR (source_entity_id = ?2 AND target_entity_id = ?1)"
+    ))
+    .bind(id_a)
+    .bind(existing_target_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        edge_to_existing, 1,
+        "edge must link to the pre-existing entity found via canonical_name"
+    );
+
+    let stale_id_referenced: i64 = zeph_db::query_scalar(sql!(
+        "SELECT COUNT(*) FROM graph_edges WHERE source_entity_id = ?1 OR target_entity_id = ?1"
+    ))
+    .bind(STALE_ID)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        stale_id_referenced, 0,
+        "the created edge must never reference the stale id"
+    );
+
+    // No duplicate entity must have been created under the same canonical_name — the slow
+    // path must reuse the existing row instead of calling upsert_entity to create a new one.
+    let entities_under_name: i64 = zeph_db::query_scalar(sql!(
+        "SELECT COUNT(*) FROM graph_entities WHERE canonical_name = ?1"
+    ))
+    .bind("existing_target")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        entities_under_name, 1,
+        "the slow path must not create a duplicate entity when canonical_name already resolves locally"
+    );
+
+    assert!(
+        logs_contain("note_linking: Qdrant entity_id payload did not match local SQLite row"),
+        "drift-correction WARN must fire even when no new entity needed to be created"
+    );
+}

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -80,12 +80,14 @@ mod pg {
     use zeph_llm::any::AnyProvider;
     use zeph_llm::mock::MockProvider;
     use zeph_memory::db_vector_store::DbVectorStore;
+    use zeph_memory::embedding_store::EmbeddingStore;
     use zeph_memory::graph::EntityLockManager;
     use zeph_memory::graph::activation::ActivatedFact;
     use zeph_memory::graph::belief::{BeliefMemConfig, BeliefStore};
     use zeph_memory::graph::implicit_conflict;
     use zeph_memory::graph::store::GraphStore;
     use zeph_memory::graph::types::{EdgeType, EntityType};
+    use zeph_memory::in_memory_store::InMemoryVectorStore;
     use zeph_memory::store::admission_training::AdmissionTrainingInput;
     use zeph_memory::store::{
         AcpSessionConfigSnapshot, AgentSessionRow, SessionChannel, SessionKind, SessionStatus,
@@ -93,8 +95,8 @@ mod pg {
     };
     use zeph_memory::types::MessageId;
     use zeph_memory::{
-        NewExperimentResult, RetrievalFailureRecord, RetrievalFailureType, VectorStore,
-        episodic_consolidation, episodic_graph, snapshot,
+        NewExperimentResult, NoteLinkingConfig, RetrievalFailureRecord, RetrievalFailureType,
+        VectorStore, episodic_consolidation, episodic_graph, link_memory_notes, snapshot,
     };
 
     // Generous startup timeout: under concurrent CI load (see #5546/#5547), the
@@ -113,6 +115,127 @@ mod pg {
         };
         let pool = config.connect().await.expect("failed to connect to PG");
         (pool, container)
+    }
+
+    // ── #5816 (gap 4): #5801 stale cross-DB entity id regression, on Postgres ──
+    //
+    // `resolve_local_target_id`/`EntityResolver::merge_entity` re-resolve a vector-store
+    // candidate's `entity_id` against the *local* database rather than trusting the
+    // payload verbatim (#5801). That resolution logic never touches backend-specific SQL
+    // directly — it goes through `upsert_entity`'s `RETURNING id`, a single shared
+    // implementation already exercised by the ~20 other tests in this file — but this
+    // test proves the full note-linking path (`link_memory_notes` ->
+    // `resolve_local_target_id` -> `upsert_entity`) round-trips correctly against a real
+    // Postgres instance, mirroring `link_memory_notes_corrects_stale_cross_db_target_id`
+    // in `semantic/tests/graph.rs` (SQLite-only).
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn note_linking_corrects_stale_cross_db_target_id_postgres() {
+        const STALE_CROSS_DB_ID: i64 = 777_777_777;
+
+        let (pool, _container) = start_pg().await;
+        let graph = GraphStore::new(pool.clone());
+
+        let mem_store = Box::new(InMemoryVectorStore::new());
+        let embedding_store =
+            std::sync::Arc::new(EmbeddingStore::with_store(mem_store, pool.clone()));
+        embedding_store
+            .ensure_named_collection("zeph_graph_entities", 384)
+            .await
+            .unwrap();
+
+        let source_id = graph
+            .upsert_entity(
+                "pg_phantom_source",
+                "pg_phantom_source",
+                EntityType::Concept,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+            .0;
+        let source_point_id = uuid::Uuid::new_v4().to_string();
+        let source_payload = serde_json::json!({
+            "entity_id": source_id,
+            "canonical_name": "pg_phantom_source",
+            "entity_type": "concept",
+            "name": "pg_phantom_source",
+            "summary": "",
+        });
+        embedding_store
+            .upsert_to_collection(
+                "zeph_graph_entities",
+                &source_point_id,
+                source_payload,
+                vec![0.0_f32; 384],
+            )
+            .await
+            .unwrap();
+        graph
+            .set_entity_qdrant_point_id(source_id, &source_point_id)
+            .await
+            .unwrap();
+
+        // Phantom candidate: exists only in the vector store, with an `entity_id` that has
+        // no local row — simulates a point left over from a different, now-gone Postgres
+        // database sharing the same vector collection.
+        let phantom_payload = serde_json::json!({
+            "entity_id": STALE_CROSS_DB_ID,
+            "canonical_name": "pg_phantom_target",
+            "name": "pg_phantom_target",
+            "entity_type": "concept",
+            "summary": "",
+        });
+        embedding_store
+            .upsert_to_collection(
+                "zeph_graph_entities",
+                &uuid::Uuid::new_v4().to_string(),
+                phantom_payload,
+                vec![0.0_f32; 384],
+            )
+            .await
+            .unwrap();
+
+        let mut mock = MockProvider::default();
+        mock.supports_embeddings = true;
+        let provider = AnyProvider::Mock(mock);
+
+        let cfg = NoteLinkingConfig {
+            enabled: true,
+            similarity_threshold: 0.0,
+            top_k: 5,
+            timeout_secs: 10,
+        };
+
+        let stats =
+            link_memory_notes(&[source_id], pool.clone(), embedding_store, provider, &cfg).await;
+
+        assert_eq!(
+            stats.edges_created, 1,
+            "the link edge must still be created via the corrected local id, not silently dropped"
+        );
+
+        let stale_id_referenced: i64 = sqlx::query_scalar(zeph_db::sql!(
+            "SELECT COUNT(*) FROM graph_edges WHERE source_entity_id = ?1 OR target_entity_id = ?1"
+        ))
+        .bind(STALE_CROSS_DB_ID)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            stale_id_referenced, 0,
+            "the created edge must never reference the stale cross-DB id (would violate the FK)"
+        );
+
+        let phantom = graph
+            .find_entity("pg_phantom_target", EntityType::Concept)
+            .await
+            .unwrap();
+        assert!(
+            phantom.is_some(),
+            "a local entity must be created for the stale candidate so the edge has a valid FK target"
+        );
     }
 
     // ── graph/store: add_alias + find_entity_by_alias + bfs + decay ────────────


### PR DESCRIPTION
## Summary

Closes #5816. Follow-up to PR #5815 (fix for #5801, the stale cross-DB entity-id causing silent graph-edge FK-violation data loss). During #5815's review cycles, several low-severity test-coverage gaps were identified but not required as merge blockers; this PR closes them.

- `resolve_local_target_id`'s third outcome (stale/mismatched payload id whose `canonical_name` already resolves to an existing local row, so the slow path reuses it rather than creating a duplicate) — `link_memory_notes_stale_id_resolves_existing_canonical_without_creating`.
- `EntityResolver::handle_ambiguous_candidate`'s stale-id path (every existing ambiguous-path test previously seeded a real matching row) — `resolve_ambiguous_llm_disambiguated_corrects_stale_cross_db_id`.
- The FK-violation WARN branches in `insert_edges` (both APEX-MEM and legacy) had no test manufacturing a genuine FK violation on those specific call sites — `insert_edges_apex_mem_logs_warn_on_genuine_fk_violation`, `insert_edges_legacy_logs_warn_on_genuine_fk_violation`.
- A Postgres-backend regression test for the original #5801 scenario — `note_linking_corrects_stale_cross_db_target_id_postgres` (`#[ignore]`d per the existing Docker-gated convention; executed against a real testcontainer during review and passed).

The full `extract_and_store` -> `insert_edges` end-to-end pipeline test (explicitly a nice-to-have in the issue) was not added: `MockProvider::embed()` is content-invariant, so a two-entity extraction batch cannot produce a fixture where only one entity collides with a seeded stale-id phantom without both colliding — closing this would require input-dependent embedding support in `zeph-llm`'s test mock, out of scope here. Documented in CHANGELOG.md as still open.

Test-only change — no production code modified.

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory` — 1630 passed, 31 skipped, 0 failed
- [x] New Postgres test executed against a real Docker testcontainer (not just compile-checked) — passed
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy -p zeph-memory --all-targets --features "pdf,jsonschema,testing" -- -D warnings` clean (sqlite feature set)
- [x] `cargo clippy -p zeph-memory --no-default-features --all-targets --features "test-utils,jsonschema" -- -D warnings` clean (postgres feature set)
- [x] `cargo doc --no-deps -p zeph-memory --features "pdf,jsonschema"` builds clean
- [x] CHANGELOG.md updated under `[Unreleased]`