### PR TITLE
fix(llm): preserve last provider error in chat/chat_stream fallback loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   it survives across providers and is returned via `Err(last_err.unwrap_or(LlmError::NoProviders))`
   on exhaustion — falling back to `NoProviders` only when no provider was ever attempted (e.g.
   none support embeddings).
+- `fix(llm)`: the router's `chat`/`chat_stream` fallback loops
+  (`crates/zeph-llm/src/router/provider_impl.rs`) had the identical defect as the
+  `embed`/`embed_batch` fix above (#5821) — the last provider's actual error was discarded on
+  total exhaustion, always returning a hardcoded `LlmError::NoProviders`. Same fix applied:
+  `last_err: Option<LlmError>` is hoisted to function scope in both `chat` and `chat_stream` and
+  returned via `Err(last_err.unwrap_or(LlmError::NoProviders))` on exhaustion. `chat_stream`'s
+  early `NoProviders` for an empty provider list (no providers ever attempted) is unaffected.
 - `fix(orchestration,mcp)`: follow-up to the `record_skill_usage` fix above (#5802) — the same
   Postgres `ON CONFLICT DO UPDATE` self-reference ambiguity existed at two more call sites
   (#5803), found via adversarial review of #5802's fix. `PlanCache::cache_plan`

--- a/crates/zeph-llm/src/router/provider_impl.rs
+++ b/crates/zeph-llm/src/router/provider_impl.rs
@@ -106,6 +106,9 @@ impl LlmProvider for RouterProvider {
 
             // Best response seen so far (for quality gate exhaustion fallback, M2).
             let mut best_response: Option<(f32, String)> = None;
+            // Preserve the most recent error across the fallback loop so an exhausted
+            // loop surfaces the actionable diagnostic instead of a generic `NoProviders`.
+            let mut last_err: Option<LlmError> = None;
 
             for p in &providers {
                 let start = std::time::Instant::now();
@@ -206,6 +209,7 @@ impl LlmProvider for RouterProvider {
                             status_tx.as_ref(),
                             "router fallback",
                         );
+                        last_err = Some(e);
                     }
                 }
             }
@@ -215,7 +219,7 @@ impl LlmProvider for RouterProvider {
                 return Ok(response);
             }
 
-            Err(LlmError::NoProviders)
+            Err(last_err.unwrap_or(LlmError::NoProviders))
         });
         {
             use tracing::Instrument as _;
@@ -255,6 +259,9 @@ impl LlmProvider for RouterProvider {
                 return p.chat_stream(&messages).await;
             }
             let providers = router.ordered_providers();
+            // Preserve the most recent error across the fallback loop so an exhausted
+            // loop surfaces the actionable diagnostic instead of a generic `NoProviders`.
+            let mut last_err: Option<LlmError> = None;
             for p in &providers {
                 let start = std::time::Instant::now();
                 match p.chat_stream(&messages).await {
@@ -281,10 +288,11 @@ impl LlmProvider for RouterProvider {
                             status_tx.as_ref(),
                             "router stream fallback",
                         );
+                        last_err = Some(e);
                     }
                 }
             }
-            Err(LlmError::NoProviders)
+            Err(last_err.unwrap_or(LlmError::NoProviders))
         });
         {
             use tracing::Instrument as _;

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -81,7 +81,12 @@ async fn router_falls_back_on_unreachable() {
     let r = RouterProvider::new(vec![p1, p2]);
     let msgs = vec![Message::from_legacy(Role::User, "hello")];
     let err = r.chat(&msgs).await.unwrap_err();
-    assert_matches!(err, LlmError::NoProviders);
+    // Fallback exhaustion must surface the last provider's actual error (#5821),
+    // not a generic `NoProviders` that discards the connection-failure diagnostic.
+    assert!(
+        matches!(&err, LlmError::Other(msg) if msg.contains("Ollama chat request failed")),
+        "expected the last provider's actual error to survive exhaustion, got {err:?}"
+    );
 }
 
 #[test]
@@ -1768,4 +1773,80 @@ async fn spawn_asi_update_embed_timeout_does_not_update_asi() {
         (coherence - 1.0).abs() < f32::EPSILON,
         "ASI window must be empty after embed timeout; coherence={coherence}"
     );
+}
+
+// ── #5821 chat/chat_stream last-error exhaustion tests ─────────────────────
+
+/// When every provider in the `chat()` fallback loop fails with a generic error,
+/// the router must surface the *last* provider's actual error — not a generic
+/// `NoProviders` that discards the actionable diagnostic. Regression for #5821
+/// (mirrors the `embed`/`embed_batch` fix from #5811 and `chat_with_tools` from #5810).
+#[tokio::test]
+async fn chat_all_providers_exhausted_preserves_last_error() {
+    use crate::mock::MockProvider;
+
+    let p1 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p1".into(),
+                status: 500,
+            }])
+            .with_name("p1"),
+    );
+    let p2 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p2".into(),
+                status: 503,
+            }])
+            .with_name("p2"),
+    );
+
+    let r = RouterProvider::new(vec![p1, p2]);
+    let err = r.chat(&[]).await.unwrap_err();
+
+    assert!(
+        matches!(&err, LlmError::ApiError { provider, status } if provider == "p2" && *status == 503),
+        "expected the last provider's (p2) ApiError to survive exhaustion, got {err:?}"
+    );
+}
+
+/// Same as above for `chat_stream()`: every provider fails with a generic error,
+/// and the router must return the last provider's actual error, not `NoProviders`.
+/// Regression for #5821.
+#[tokio::test]
+async fn chat_stream_all_providers_exhausted_preserves_last_error() {
+    use crate::mock::MockProvider;
+
+    let p1 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p1".into(),
+                status: 500,
+            }])
+            .with_name("p1"),
+    );
+    let p2 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p2".into(),
+                status: 503,
+            }])
+            .with_name("p2"),
+    );
+
+    let r = RouterProvider::new(vec![p1, p2]);
+    match r.chat_stream(&[]).await {
+        Err(LlmError::ApiError { provider, status }) => {
+            assert_eq!(provider, "p2");
+            assert_eq!(status, 503);
+        }
+        other => panic!(
+            "expected the last provider's (p2) ApiError to survive exhaustion, got {}",
+            match &other {
+                Ok(_) => "Ok(_)".to_owned(),
+                Err(e) => format!("{e:?}"),
+            }
+        ),
+    }
 }


### PR DESCRIPTION
## Summary

`RouterProvider::chat` and `chat_stream` (`crates/zeph-llm/src/router/provider_impl.rs`) discarded the last provider's actual error on fallback exhaustion, always returning a hardcoded `LlmError::NoProviders` instead of an actionable diagnostic (e.g. `ModelCapabilityMismatch`, `InvalidInput`, rate-limit/timeout details).

This mirrors the identical defect already fixed for `chat_with_tools` (#5810) and `embed`/`embed_batch` (#5811) in the same file. Same fix applied: `last_err: Option<LlmError>` is hoisted to function scope in both `chat` and `chat_stream`, set on each provider failure, and returned via `Err(last_err.unwrap_or(LlmError::NoProviders))` on exhaustion — falling back to `NoProviders` only when no provider was ever attempted. `chat_stream`'s early empty-provider-list `NoProviders` (a distinct code path) is left untouched.

Closes #5821

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy -p zeph-llm --all-targets --features "profiling,candle,classifiers,gonka,cocoon,metal,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm` — 961 passed, 11 skipped, 0 failed
- [x] Fixed one stale test (`router_falls_back_on_unreachable`) that asserted the old buggy `NoProviders`-only behavior
- [x] Added `chat_all_providers_exhausted_preserves_last_error` and `chat_stream_all_providers_exhausted_preserves_last_error`, each using distinct per-provider errors to prove the *last* provider's error specifically survives
- [x] CHANGELOG.md updated