### PR TITLE
fix(subagent): route WorktreeCleanupGuard cleanup through TaskSupervisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(subagent)`: `WorktreeCleanupGuard::drop` (`crates/zeph-subagent/src/manager/worktree.rs`)
+  spawned the worktree-removal cleanup task via `tokio::runtime::Handle::try_current().spawn(...)`
+  instead of routing through `TaskSupervisor` (#5412), violating the project's mandatory
+  async-supervision rule (`/specs/039-background-task-supervisor/spec.md`) — the cleanup task was
+  invisible to TUI status/metrics and unabortable on shutdown. `WorktreeCleanupGuard` now carries
+  an `Option<TaskSupervisor>` sourced from `SubAgentManager`'s existing `task_supervisor` field and
+  dispatches cleanup via `TaskSupervisor::spawn_oneshot`, falling back to a transient local
+  supervisor when none is configured (mirroring `SubAgentManager::spawn_agent_task`'s existing
+  pattern) rather than a raw `tokio::spawn`. No behavior change from the caller's perspective —
+  same `enabled`/no-runtime early-return paths, same `wm.remove(&h, prune)` call and
+  warn-on-error logging.
 - `fix(acp,server,skills)`: ACP sessions (`src/acp.rs::spawn_acp_agent`) and HTTP `/sessions`
   gateway sessions (`src/serve/agent_factory.rs::build_agent_factory`) never called
   `Agent::with_skill_matching_config`/`with_skill_provider_names`, so skill matching in those

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -628,6 +628,7 @@ impl SubAgentManager {
         let permissions_worktree = def.permissions.worktree;
         let prune_branch_on_remove = config.worktree.prune_branch_on_remove;
         let cleanup_on_completion = config.worktree.cleanup_on_completion;
+        let task_supervisor_for_cleanup = self.task_supervisor.clone();
 
         // INV-3: disallow `set_working_directory` for agents that get a dedicated worktree.
         // Must push BEFORE build_filtered_executor reads def.disallowed_tools.
@@ -704,6 +705,7 @@ impl SubAgentManager {
                             handle: handle.clone(),
                             prune: prune_branch_on_remove,
                             enabled: cleanup_on_completion,
+                            task_supervisor: task_supervisor_for_cleanup,
                         };
 
                         let result = run_agent_loop(agent_loop_args).await;

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -3521,6 +3521,7 @@ mod worktree_cleanup_guard_tests {
             handle,
             prune: false,
             enabled: false,
+            task_supervisor: None,
         });
     }
 
@@ -3539,6 +3540,7 @@ mod worktree_cleanup_guard_tests {
             handle,
             prune: false,
             enabled: true,
+            task_supervisor: None,
         });
     }
 
@@ -3555,9 +3557,50 @@ mod worktree_cleanup_guard_tests {
             handle,
             prune: false,
             enabled: true,
+            task_supervisor: None,
         });
         // Yield to allow the spawned task to complete.
         tokio::task::yield_now().await;
+    }
+
+    /// `enabled = true` with an injected `Some(task_supervisor)`: Drop must route the
+    /// cleanup task through that supervisor (`TaskSupervisor::spawn_oneshot`) rather than
+    /// a bare untracked `tokio::spawn`, so the task is visible via `snapshot()`.
+    ///
+    /// `spawn_oneshot` registers the task entry synchronously (under lock) before
+    /// returning, and this test never awaits between `drop(guard)` and `snapshot()` —
+    /// on the single-threaded `#[tokio::test]` runtime, no other task (including the
+    /// reap driver or the cleanup task itself) can run until this test yields. So the
+    /// entry is guaranteed to still be present, deterministically, without relying on
+    /// timing/delays.
+    #[tokio::test]
+    async fn cleanup_registers_task_in_injected_supervisor() {
+        use tokio_util::sync::CancellationToken;
+        use zeph_common::TaskSupervisor;
+
+        let cancel = CancellationToken::new();
+        let supervisor = TaskSupervisor::new(cancel.clone());
+
+        let (_dir, wm) = make_dummy_wm().await;
+        let dir2 = TempDir::new().unwrap();
+        let handle = dummy_handle(&dir2);
+        let expected_name = format!("worktree-cleanup-{}", handle.subagent_id);
+
+        drop(WorktreeCleanupGuard {
+            wm,
+            handle,
+            prune: false,
+            enabled: true,
+            task_supervisor: Some(supervisor.clone()),
+        });
+
+        let snaps = supervisor.snapshot();
+        assert!(
+            snaps.iter().any(|s| s.name.as_ref() == expected_name),
+            "cleanup task must be registered in the injected TaskSupervisor; got: {snaps:?}"
+        );
+
+        cancel.cancel();
     }
 }
 

--- a/crates/zeph-subagent/src/manager/worktree.rs
+++ b/crates/zeph-subagent/src/manager/worktree.rs
@@ -3,6 +3,9 @@
 
 use std::sync::Arc;
 
+use tokio_util::sync::CancellationToken;
+use zeph_common::TaskSupervisor;
+
 /// RAII guard that calls [`DefaultWorktreeManager::remove`] when dropped.
 ///
 /// Guarantees cleanup on normal return and on early `?` returns from the agent loop.
@@ -14,6 +17,12 @@ pub(crate) struct WorktreeCleanupGuard {
     pub(crate) handle: zeph_worktree::WorktreeHandle,
     pub(crate) prune: bool,
     pub(crate) enabled: bool,
+    /// Session [`TaskSupervisor`], sourced from [`SubAgentManager`][super::SubAgentManager],
+    /// so the cleanup task is registered and visible like any other supervised task.
+    ///
+    /// `None` (e.g. in unit tests that build the guard directly) falls back to a transient
+    /// local supervisor, mirroring [`SubAgentManager::spawn_agent_task`][super::SubAgentManager::spawn_agent_task].
+    pub(crate) task_supervisor: Option<TaskSupervisor>,
 }
 
 impl Drop for WorktreeCleanupGuard {
@@ -21,21 +30,27 @@ impl Drop for WorktreeCleanupGuard {
         if !self.enabled {
             return;
         }
+        if tokio::runtime::Handle::try_current().is_err() {
+            tracing::error!(
+                "no tokio runtime in WorktreeCleanupGuard::drop — worktree cleanup skipped"
+            );
+            return;
+        }
         let wm = Arc::clone(&self.wm);
         let h = self.handle.clone();
         let prune = self.prune;
-        match tokio::runtime::Handle::try_current() {
-            Ok(rt) => {
-                rt.spawn(async move {
-                    if let Err(e) = wm.remove(&h, prune).await {
-                        tracing::warn!(error = %e, "failed to remove sub-agent worktree");
-                    }
-                });
+        let name: Arc<str> = Arc::from(format!("worktree-cleanup-{}", h.subagent_id));
+        let factory = move || async move {
+            if let Err(e) = wm.remove(&h, prune).await {
+                tracing::warn!(error = %e, "failed to remove sub-agent worktree");
             }
-            Err(_) => {
-                tracing::error!(
-                    "no tokio runtime in WorktreeCleanupGuard::drop — worktree cleanup skipped"
-                );
+        };
+        match &self.task_supervisor {
+            Some(sup) => {
+                sup.spawn_oneshot(name, factory);
+            }
+            None => {
+                TaskSupervisor::new(CancellationToken::new()).spawn_oneshot(name, factory);
             }
         }
     }


### PR DESCRIPTION
## Summary
- `WorktreeCleanupGuard::drop` spawned the worktree-removal cleanup task via a raw `tokio::runtime::Handle::try_current().spawn(...)` instead of routing through `TaskSupervisor`, violating the project's mandatory async-supervision rule (`/specs/039-background-task-supervisor/spec.md`) — the cleanup task was invisible to TUI status/metrics and unabortable on shutdown.
- `WorktreeCleanupGuard` now carries an `Option<TaskSupervisor>` sourced from `SubAgentManager`'s existing `task_supervisor` field and dispatches cleanup via `TaskSupervisor::spawn_oneshot`, falling back to a transient local supervisor when none is configured (mirrors the existing `SubAgentManager::spawn_agent_task` fallback pattern).
- No behavior change from the caller's perspective: same `enabled`/no-runtime early-return paths, same `wm.remove(&h, prune)` call and warn-on-error logging.

Closes #5412.

## Test plan
- [x] `cargo nextest run -p zeph-subagent -E 'test(worktree_cleanup_guard) or test(supervised_subagent_task)'` — 5/5 passed, including new `cleanup_registers_task_in_injected_supervisor` regression test covering the previously-untested `Some(task_supervisor)` Drop branch
- [x] `cargo nextest run -p zeph-subagent` (full crate) — 410/410 passed
- [x] `cargo +nightly fmt --check` (workspace)
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12356 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-subagent` (default features; `--all-features` is not usable on this crate due to the pre-existing sqlite/postgres mutual-exclusion guard in `zeph-db`, unrelated to this change)