### PR TITLE
fix(llm): preserve last provider error in cascade_chat fallback exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `last_err: Option<LlmError>` is hoisted to function scope in both `chat` and `chat_stream` and
   returned via `Err(last_err.unwrap_or(LlmError::NoProviders))` on exhaustion. `chat_stream`'s
   early `NoProviders` for an empty provider list (no providers ever attempted) is unaffected.
+- `fix(llm)`: `RouterProvider::cascade_chat`'s (`crates/zeph-llm/src/router/chat.rs`) provider
+  fallback loop had the same defect as the `chat`/`chat_stream`/`embed`/`embed_batch` fixes above
+  (#5826) — when every cascade provider failed and no `best`-seen response was ever produced, it
+  returned a hardcoded `LlmError::NoProviders` instead of the last provider's real error. Same
+  fix applied: `last_err: Option<LlmError>` is hoisted to function scope, set from the per-provider
+  `Err(e)` arm, and returned via `.ok_or_else(|| last_err.unwrap_or(LlmError::NoProviders))` when
+  `best` is `None` after the loop. `cascade_chat_stream` was audited and does not share this
+  defect — its final fallthrough already propagates the true last provider's error (or the
+  best-seen buffered response) rather than a hardcoded `NoProviders`.
 - `fix(orchestration,mcp)`: follow-up to the `record_skill_usage` fix above (#5802) — the same
   Postgres `ON CONFLICT DO UPDATE` self-reference ambiguity existed at two more call sites
   (#5803), found via adversarial review of #5802's fix. `PlanCache::cache_plan`

--- a/crates/zeph-llm/src/router/chat.rs
+++ b/crates/zeph-llm/src/router/chat.rs
@@ -154,6 +154,7 @@ impl RouterProvider {
         let mut escalations_remaining = cfg.max_escalations;
         let mut best: Option<(String, f64)> = None; // (response, score)
         let mut tokens_used: u32 = 0;
+        let mut last_err: Option<LlmError> = None;
 
         for (idx, p) in providers.iter().enumerate() {
             tracing::debug!(
@@ -174,6 +175,7 @@ impl RouterProvider {
                         let _ = tx.send(format!("cascade: {} unavailable, trying next", p.name()));
                     }
                     tracing::warn!(provider = p.name(), error = %e, "cascade: provider error");
+                    last_err = Some(e);
                 }
                 Ok(response) => {
                     let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
@@ -265,7 +267,8 @@ impl RouterProvider {
         } else {
             tracing::warn!("cascade: all providers failed, no response available");
         }
-        best.map(|(r, _)| r).ok_or(LlmError::NoProviders)
+        best.map(|(r, _)| r)
+            .ok_or_else(|| last_err.unwrap_or(LlmError::NoProviders))
     }
 
     /// Cascade `chat_stream`: buffer cheap response, classify, escalate or replay.

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -388,17 +388,40 @@ async fn cascade_stream_escalations_exhausted_returns_best_seen_not_current() {
     );
 }
 
+/// When every provider in the cascade fallback loop fails and no `best`-seen
+/// response was ever produced, `cascade_chat` must surface the *last*
+/// provider's actual error — not a generic `NoProviders` that discards the
+/// actionable diagnostic. Regression for #5826 (mirrors the `chat`/
+/// `chat_stream` fix from #5821 and `embed`/`embed_batch` from #5811).
 #[tokio::test]
-async fn cascade_all_providers_fail_returns_no_providers() {
+async fn cascade_all_providers_fail_preserves_last_error() {
     use crate::mock::MockProvider;
 
-    let p1 = AnyProvider::Mock(MockProvider::failing());
-    let p2 = AnyProvider::Mock(MockProvider::failing());
+    let p1 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p1".into(),
+                status: 500,
+            }])
+            .with_name("p1"),
+    );
+    let p2 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_errors(vec![LlmError::ApiError {
+                provider: "p2".into(),
+                status: 503,
+            }])
+            .with_name("p2"),
+    );
 
     let r = RouterProvider::new(vec![p1, p2]).with_cascade(CascadeRouterConfig::default());
     let msgs = vec![Message::from_legacy(Role::User, "test")];
     let err = r.chat(&msgs).await.unwrap_err();
-    assert_matches!(err, LlmError::NoProviders);
+
+    assert!(
+        matches!(&err, LlmError::ApiError { provider, status } if provider == "p2" && *status == 503),
+        "expected the last provider's (p2) ApiError to survive exhaustion, got {err:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `RouterProvider::cascade_chat` discarded each provider's real error during its fallback loop, returning a hardcoded `LlmError::NoProviders` when every provider failed and no best-seen response existed.
- Applies the same `last_err: Option<LlmError>` accumulator pattern already used in `chat`/`chat_stream`/`chat_with_tools`/`embed`/`embed_batch` (#5810, #5811, #5820, #5821) — 5th confirmed instance of this defect class.
- `cascade_chat_stream` was audited and confirmed to not share the defect; left untouched.

Closes #5826

## Test plan
- [x] `cargo build -p zeph-llm`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm` — 961 passed, 11 skipped
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] Rustdoc gate for `zeph-llm`
- [x] Rewrote `cascade_all_providers_fail_returns_no_providers` (previously encoded the buggy behavior) into `cascade_all_providers_fail_preserves_last_error`
- [x] Confirmed best-seen-wins-over-error path unaffected via existing tests