### PR TITLE
fix(acp,server,skills): wire with_semantic_scan into ACP/serve agent construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   anyone relying on non-default skill-matching config outside the CLI/daemon paths. Both
   construction sites now source the same `config.skills.*` values already wired into
   `src/runner.rs`/`src/daemon.rs`.
+- `fix(acp,server,skills)`: ACP sessions (`src/acp.rs::spawn_acp_agent`) and HTTP `/sessions`
+  gateway sessions (`src/serve/agent_factory.rs::build_agent_factory`) never called
+  `Agent::with_semantic_scan`, so those channels always ran Stage-2 skill semantic-compliance
+  scanning on hardcoded builder defaults (effectively disabled) regardless of `[skills]`
+  `semantic_scan`/`semantic_scan_provider` in `config.toml` (#5827) — a residual gap left by
+  #5818/#5823's `with_skill_matching_config`/`with_skill_provider_names` fix. Both construction
+  sites now source the same `config.skills.semantic_scan*` values already wired into
+  `src/runner.rs`/`src/daemon.rs` (#5817).
 - `fix(skills)`: `SkillMatcherBackend::refresh_skill_embeddings` (introduced by #5804) failed
   `clippy -D warnings` when built without the `qdrant` feature (#5809) — with `Qdrant` cfg'd
   out, the `meta`/`scored` parameters and the `async` marker had no user in the remaining

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -151,6 +151,7 @@ pub(crate) async fn build_shared_core(
 /// - **ACP-specific** (`acp_*`) — transport-level config; not agent-level.
 /// - **Scheduler runtime** (`scheduler_*`) — runtime broadcast senders; not config-derived.
 #[cfg(feature = "acp")]
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct SharedAgentDeps {
     // Shared runtime objects
     provider: zeph_llm::any::AnyProvider,
@@ -171,6 +172,11 @@ pub(crate) struct SharedAgentDeps {
     /// `Agent::with_skill_provider_names` per session (#5818).
     skill_generation_provider: String,
     skill_disambiguate_provider: String,
+    /// `config.skills.semantic_scan`/`semantic_scan_provider`, wired into
+    /// `Agent::with_semantic_scan` per session — mirrors `src/runner.rs` and `src/daemon.rs`
+    /// (#5827: previously left on hardcoded builder defaults for ACP sessions).
+    semantic_scan: bool,
+    semantic_scan_provider: String,
     /// Base tool composite (file/shell/scrape/diagnostics + MCP + `search_code`), *not*
     /// wrapped in any gate. `spawn_acp_agent` composites this further with `skill_loader`/
     /// `memory`/`overflow`/ACP-native fs/shell per session, then wraps the FULL per-session
@@ -851,6 +857,8 @@ async fn build_acp_deps(
         skill_confusability_threshold: config.skills.confusability_threshold,
         skill_generation_provider: config.skills.generation_provider.as_str().to_owned(),
         skill_disambiguate_provider: config.skills.disambiguate_provider.as_str().to_owned(),
+        semantic_scan: config.skills.semantic_scan,
+        semantic_scan_provider: config.skills.semantic_scan_provider.as_str().to_owned(),
         tool_executor,
         permission_policy,
         policy_enforcer,
@@ -1087,6 +1095,8 @@ async fn spawn_acp_agent(
     let skill_confusability_threshold = d.skill_confusability_threshold;
     let skill_generation_provider = d.skill_generation_provider.clone();
     let skill_disambiguate_provider = d.skill_disambiguate_provider.clone();
+    let semantic_scan = d.semantic_scan;
+    let semantic_scan_provider = d.semantic_scan_provider.clone();
     let tool_executor = Arc::clone(&d.tool_executor);
     let permission_policy = d.permission_policy.clone();
     let skill_paths = d.skill_paths.clone();
@@ -1403,6 +1413,7 @@ async fn spawn_acp_agent(
             skill_confusability_threshold,
         )
         .with_skill_provider_names(skill_generation_provider, skill_disambiguate_provider)
+        .with_semantic_scan(semantic_scan, semantic_scan_provider)
         .with_working_dir(session_ctx.working_dir.clone())
         .with_skill_reload(skill_paths, reload_rx)
         .with_plugin_dirs_supplier(move || plugin_dirs_supplier())
@@ -3160,14 +3171,15 @@ mod tests {
         assert!(orch_cfg.enabled);
     }
 
-    /// #5818 regression: `build_acp_deps`/`assemble_serve_deps` must populate
+    /// #5818/#5827 regression: `build_acp_deps`/`assemble_serve_deps` must populate
     /// `SharedAgentDeps`'s/`ServeAgentDeps`'s `skill_disambiguation_threshold`/
     /// `skill_two_stage_matching`/`skill_confusability_threshold`/`skill_generation_provider`/
-    /// `skill_disambiguate_provider` from `config.skills.*` — previously these fields did not
-    /// exist on either deps struct at all, so neither `spawn_acp_agent` nor `build_agent_factory`
-    /// could call `Agent::with_skill_matching_config`/`with_skill_provider_names`, and every
-    /// ACP/`/sessions` agent silently ran skill matching on hardcoded builder defaults regardless
-    /// of config.
+    /// `skill_disambiguate_provider`/`semantic_scan`/`semantic_scan_provider` from
+    /// `config.skills.*` — previously these fields did not exist on either deps struct at all, so
+    /// neither `spawn_acp_agent` nor `build_agent_factory` could call
+    /// `Agent::with_skill_matching_config`/`with_skill_provider_names`/`with_semantic_scan`, and
+    /// every ACP/`/sessions` agent silently ran skill matching and semantic scanning on hardcoded
+    /// builder defaults regardless of config.
     ///
     /// Drives the real production `build_combined_deps` (mirroring
     /// `crate::serve::test_support::build_shared_pair`'s use of a mock-provider
@@ -3192,6 +3204,8 @@ mod tests {
         config.skills.confusability_threshold = 0.65;
         config.skills.generation_provider = zeph_common::ProviderName::new("gen-test");
         config.skills.disambiguate_provider = zeph_common::ProviderName::new("disamb-test");
+        config.skills.semantic_scan = true;
+        config.skills.semantic_scan_provider = zeph_common::ProviderName::new("scan-test");
 
         let app = crate::bootstrap::AppBuilder::for_test(config);
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -3215,6 +3229,11 @@ mod tests {
         );
         assert_eq!(serve_deps.skill_generation_provider, "gen-test");
         assert_eq!(serve_deps.skill_disambiguate_provider, "disamb-test");
+        assert!(
+            serve_deps.semantic_scan,
+            "config.skills.semantic_scan must flow into ServeAgentDeps"
+        );
+        assert_eq!(serve_deps.semantic_scan_provider, "scan-test");
 
         assert!(
             (acp_deps.skill_disambiguation_threshold - 0.55).abs() < f32::EPSILON,
@@ -3230,6 +3249,11 @@ mod tests {
         );
         assert_eq!(acp_deps.skill_generation_provider, "gen-test");
         assert_eq!(acp_deps.skill_disambiguate_provider, "disamb-test");
+        assert!(
+            acp_deps.semantic_scan,
+            "config.skills.semantic_scan must flow into SharedAgentDeps"
+        );
+        assert_eq!(acp_deps.semantic_scan_provider, "scan-test");
     }
 
     #[tokio::test]

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -108,6 +108,7 @@ pub(crate) async fn build_agent_factory(
             deps.skill_generation_provider,
             deps.skill_disambiguate_provider,
         )
+        .with_semantic_scan(deps.semantic_scan, deps.semantic_scan_provider)
         .with_memory(
             Arc::clone(&deps.memory),
             conversation_id,
@@ -498,6 +499,8 @@ mod tests {
             skill_confusability_threshold: 0.0,
             skill_generation_provider: String::new(),
             skill_disambiguate_provider: String::new(),
+            semantic_scan: false,
+            semantic_scan_provider: String::new(),
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             memory: Arc::clone(&memory),
             history_limit: 10,
@@ -563,6 +566,8 @@ mod tests {
             skill_confusability_threshold: 0.0,
             skill_generation_provider: String::new(),
             skill_disambiguate_provider: String::new(),
+            semantic_scan: false,
+            semantic_scan_provider: String::new(),
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             memory: Arc::clone(&memory),
             history_limit: 10,
@@ -655,6 +660,8 @@ mod tests {
             skill_confusability_threshold: 0.42,
             skill_generation_provider: "gen".to_owned(),
             skill_disambiguate_provider: "dis".to_owned(),
+            semantic_scan: false,
+            semantic_scan_provider: String::new(),
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             memory: Arc::clone(&memory),
             history_limit: 10,
@@ -681,6 +688,82 @@ mod tests {
             "ServeAgentDeps::skill_confusability_threshold = 0.42 must reach the built Agent's \
              ConfusabilityReport exactly (not e.g. 0.77, disambiguation_threshold's value, from a \
              swapped with_skill_matching_config argument); got: {output}"
+        );
+    }
+
+    /// #5827 regression: `build_agent_factory` must call `Agent::with_semantic_scan` so
+    /// `config.skills.semantic_scan`/`semantic_scan_provider` reach the built `Agent` —
+    /// previously `ServeAgentDeps` had no such fields and the builder chain never called
+    /// `with_semantic_scan`, so every `/sessions`-created agent silently ran Stage-2 skill
+    /// semantic-scanning on hardcoded builder defaults (`semantic_scan: false`) regardless of
+    /// config.
+    ///
+    /// `Agent` exposes no `pub` accessor for `semantic_scan`/`semantic_scan_provider` directly,
+    /// so this drives the same observable surface the real `/plugins add` command uses
+    /// ([`zeph_commands::AgentAccess::handle_plugins`]): with an empty `provider_pool`,
+    /// `handle_plugins("add <path>")` fails closed on the *unknown provider* branch
+    /// (`crates/zeph-core/src/agent/agent_access_impl.rs`) whenever `semantic_scan` is enabled,
+    /// and the error message echoes the exact configured provider name — so a dropped or
+    /// swapped `with_semantic_scan` argument would also be caught.
+    #[tokio::test]
+    async fn build_agent_factory_wires_semantic_scan_config() {
+        use zeph_commands::traits::agent::AgentAccess as _;
+
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let session_id = zeph_common::SessionId::new("semantic-scan-config-test-session");
+
+        let config = zeph_core::config::Config::default();
+        let session_config = zeph_core::AgentSessionConfig::from_config(&config, 4096);
+        let (condenser, token_counter) = make_test_condenser();
+
+        let deps = ServeAgentDeps {
+            provider: AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            embedding_provider: AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            registry: Arc::new(parking_lot::RwLock::new(
+                zeph_skills::registry::SkillRegistry::empty(),
+            )),
+            matcher: None,
+            max_active_skills: 5,
+            skill_disambiguation_threshold: 0.2,
+            skill_two_stage_matching: false,
+            skill_confusability_threshold: 0.0,
+            skill_generation_provider: String::new(),
+            skill_disambiguate_provider: String::new(),
+            // Non-default values (pre-fix builder default is `false`/`""`, see
+            // `crates/zeph-core/src/agent/state/mod.rs`): proves both fields are wired, not just
+            // left on their hardcoded defaults.
+            semantic_scan: true,
+            semantic_scan_provider: "scan-test-provider".to_owned(),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            memory: Arc::clone(&memory),
+            history_limit: 10,
+            recall_limit: 5,
+            summarization_threshold: 1000,
+            session_config,
+            session_persistence_config: zeph_config::SessionConfig::default(),
+            resume_condenser: Arc::new(condenser),
+            resume_token_counter: Arc::new(token_counter),
+            provider_pool: Vec::new(),
+            provider_config_snapshot: zeph_core::ProviderConfigSnapshot::default(),
+        };
+
+        let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
+        let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
+        let mut agent = build_agent(channel);
+
+        let err = agent
+            .handle_plugins("add /nonexistent/plugin/path")
+            .await
+            .expect_err(
+                "handle_plugins(\"add\") must fail closed when semantic_scan is enabled and \
+                 semantic_scan_provider is not in the (empty) provider pool",
+            );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("semantic_scan_provider") && msg.contains("scan-test-provider"),
+            "ServeAgentDeps::semantic_scan/semantic_scan_provider = true/\"scan-test-provider\" \
+             must reach the built Agent's fail-closed plugin-add check exactly; got: {msg}"
         );
     }
 }

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -48,6 +48,11 @@ pub(crate) struct ServeAgentDeps {
     /// `Agent::with_skill_provider_names` per session (#5818).
     pub(crate) skill_generation_provider: String,
     pub(crate) skill_disambiguate_provider: String,
+    /// `config.skills.semantic_scan`/`semantic_scan_provider`, wired into
+    /// `Agent::with_semantic_scan` per session — mirrors `src/runner.rs` and `src/daemon.rs`
+    /// (#5827: previously left on hardcoded builder defaults for `/sessions`).
+    pub(crate) semantic_scan: bool,
+    pub(crate) semantic_scan_provider: String,
     pub(crate) tool_executor: Arc<dyn ErasedToolExecutor>,
     pub(crate) memory: Arc<SemanticMemory>,
     pub(crate) history_limit: u32,
@@ -183,6 +188,8 @@ pub(crate) async fn assemble_serve_deps(
         skill_confusability_threshold: config.skills.confusability_threshold,
         skill_generation_provider: config.skills.generation_provider.as_str().to_owned(),
         skill_disambiguate_provider: config.skills.disambiguate_provider.as_str().to_owned(),
+        semantic_scan: config.skills.semantic_scan,
+        semantic_scan_provider: config.skills.semantic_scan_provider.as_str().to_owned(),
         tool_executor,
         memory: Arc::clone(&core.memory),
         history_limit,

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -496,6 +496,8 @@ mod tests {
             skill_confusability_threshold: 0.0,
             skill_generation_provider: String::new(),
             skill_disambiguate_provider: String::new(),
+            semantic_scan: false,
+            semantic_scan_provider: String::new(),
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             memory,
             history_limit: 50,

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -114,6 +114,8 @@ impl ServeTestHarness {
             skill_confusability_threshold: 0.0,
             skill_generation_provider: String::new(),
             skill_disambiguate_provider: String::new(),
+            semantic_scan: false,
+            semantic_scan_provider: String::new(),
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             memory,
             history_limit: 50,


### PR DESCRIPTION
## Summary
- `spawn_acp_agent` (`src/acp.rs`) and `build_agent_factory` (`src/serve/agent_factory.rs`) never called `Agent::with_semantic_scan`, so ACP (IDE-embedded) and HTTP `/sessions` gateway sessions silently ran Stage-2 skill semantic-compliance scanning on hardcoded builder defaults (effectively disabled), regardless of `[skills] semantic_scan`/`semantic_scan_provider` in `config.toml`.
- Mirrors the fix already applied to `src/runner.rs`/`src/daemon.rs` in #5817, and closes the residual `with_semantic_scan` slice that #5823 explicitly scoped out of #5818.
- Added `semantic_scan`/`semantic_scan_provider` fields to `SharedAgentDeps` (`src/acp.rs`) and `ServeAgentDeps` (`src/serve/deps.rs`), populated from config, and call `.with_semantic_scan(...)` at both construction sites.
- Added `#[allow(clippy::struct_excessive_bools)]` on `SharedAgentDeps` (now 5 bool fields, over clippy's default max of 3) — non-public config-mirror struct, no behavior change.

## Test plan
- [x] Extended `build_combined_deps_wires_skill_matching_config_from_config` (`src/acp.rs`) to assert `semantic_scan`/`semantic_scan_provider` flow into both deps structs
- [x] Added `build_agent_factory_wires_semantic_scan_config` (`src/serve/agent_factory.rs`), driving `handle_plugins` fail-closed path as an end-to-end proof the builder call took effect
- [x] Revert-check: temporarily removing both `.with_semantic_scan(...)` calls made the new serve-side test fail as expected
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12350/12350 passed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] CHANGELOG.md updated

Closes #5827