### PR TITLE
fix(skills,core): dedupe SKILL.md frontmatter-patching logic, fix missing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(skills,core)`: `zeph-skills::proactive::stamp_proactive_domain` and
+  `zeph-core::agent::heuristic_promotion::patch_frontmatter` reimplemented the same
+  "patch a stable marker field into `SKILL.md` frontmatter" logic (#5725), and
+  `patch_frontmatter`'s reassembly (`format!("---{}---{}", ...)`) was missing the newline
+  before the closing `---` delimiter that `stamp_proactive_domain`'s equivalent already had,
+  producing malformed frontmatter (the closing `---` glued to the last YAML line) whenever
+  `patch_frontmatter` ran. Both call sites now delegate to a new shared
+  `zeph_common::text::patch_frontmatter_fields` helper, which fixes the missing newline and
+  removes the duplicated split/filter/insert/reassemble logic. Adversarial review of this
+  change found the identical missing-newline defect in the same file's `patch_version`
+  (`crates/zeph-core/src/agent/heuristic_promotion.rs`) — a third, structurally distinct
+  copy that runs on every versioned skill body before persistence — so its reassembly was
+  fixed in place too (not folded into the shared helper, since `patch_version` preserves
+  the `version:` line's original position rather than always moving it after `name:`).
 - `fix(subagent)`: `WorktreeCleanupGuard::drop` (`crates/zeph-subagent/src/manager/worktree.rs`)
   spawned the worktree-removal cleanup task via `tokio::runtime::Handle::try_current().spawn(...)`
   instead of routing through `TaskSupervisor` (#5412), violating the project's mandatory

--- a/crates/zeph-common/src/text.rs
+++ b/crates/zeph-common/src/text.rs
@@ -113,6 +113,67 @@ pub fn truncate_to_chars(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Insert or overwrite fields in a `SKILL.md` frontmatter block.
+///
+/// `fields` is an ordered list of `(key, value)` pairs. For each key, any existing
+/// line `key: ...` in the frontmatter is removed, then all fields are inserted (in
+/// the given order) immediately after the `name:` line — or at the end of the
+/// frontmatter block if `name:` is absent. Returns `skill_md` unchanged if it does
+/// not start with `---` or has no closing `---` delimiter.
+///
+/// Callers must pass distinct keys — duplicate keys in `fields` are not
+/// deduplicated and produce duplicate `key: value` lines in the output.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::text::patch_frontmatter_fields;
+///
+/// let md = "---\nname: foo\ndescription: Foo.\n---\n\n# Body\n";
+/// let patched = patch_frontmatter_fields(md, &[("source", "generator"), ("parent_skill", "bar")]);
+/// assert_eq!(
+///     patched,
+///     "---\nname: foo\nsource: generator\nparent_skill: bar\ndescription: Foo.\n---\n\n# Body\n"
+/// );
+/// ```
+#[must_use]
+pub fn patch_frontmatter_fields(skill_md: &str, fields: &[(&str, &str)]) -> String {
+    let Some(after_open) = skill_md.strip_prefix("---") else {
+        return skill_md.to_string();
+    };
+    let Some(close_pos) = after_open.find("---") else {
+        return skill_md.to_string();
+    };
+    let yaml = &after_open[..close_pos];
+    let rest = &after_open[close_pos..];
+
+    let mut lines: Vec<String> = yaml
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            !fields
+                .iter()
+                .any(|(key, _)| t.starts_with(&format!("{key}:")))
+        })
+        .map(str::to_string)
+        .collect();
+
+    let insert_after = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with("name:"))
+        .map_or(lines.len(), |p| p + 1);
+
+    for (i, (key, value)) in fields.iter().enumerate() {
+        lines.insert(insert_after + i, format!("{key}: {value}"));
+    }
+
+    format!(
+        "---{}\n---{}",
+        lines.join("\n"),
+        rest.trim_start_matches("---")
+    )
+}
+
 /// Escape XML special characters in a string.
 ///
 /// Replaces `&`, `<`, `>`, `"`, and `'` with their XML entity equivalents.
@@ -246,5 +307,63 @@ mod tests {
     fn to_chars_unicode() {
         let s = "😀😁😂😃😄extra";
         assert_eq!(truncate_to_chars(s, 5), "😀😁😂😃😄\u{2026}");
+    }
+
+    // patch_frontmatter_fields tests
+    #[test]
+    fn frontmatter_inserts_after_name() {
+        let md = "---\nname: foo\ndescription: Foo.\n---\n\n# Body\n";
+        let patched = patch_frontmatter_fields(md, &[("source", "generator")]);
+        assert!(
+            patched.contains("name: foo\nsource: generator\n"),
+            "patched: {patched}"
+        );
+    }
+
+    #[test]
+    fn frontmatter_replaces_existing_values() {
+        let md = "---\nname: foo\nsource: old\nparent_skill: old-parent\ndescription: Foo.\n---\n\n# Body\n";
+        let patched =
+            patch_frontmatter_fields(md, &[("source", "new"), ("parent_skill", "new-parent")]);
+        assert_eq!(patched.matches("source:").count(), 1);
+        assert!(patched.contains("source: new"));
+        assert!(patched.contains("parent_skill: new-parent"));
+        assert!(!patched.contains("old-parent"));
+    }
+
+    #[test]
+    fn frontmatter_no_delimiters_unchanged() {
+        let md = "# No frontmatter\n\nbody";
+        assert_eq!(patch_frontmatter_fields(md, &[("source", "x")]), md);
+    }
+
+    #[test]
+    fn frontmatter_no_name_line_appends_at_end() {
+        let md = "---\ndescription: Foo.\n---\n\n# Body\n";
+        let patched = patch_frontmatter_fields(md, &[("source", "generator")]);
+        assert!(
+            patched.contains("description: Foo.\nsource: generator\n---"),
+            "patched: {patched}"
+        );
+    }
+
+    #[test]
+    fn frontmatter_missing_closing_delimiter_unchanged() {
+        let md = "---\nname: foo\ndescription: Foo.\n\nbody without closing delimiter";
+        assert_eq!(patch_frontmatter_fields(md, &[("source", "x")]), md);
+    }
+
+    #[test]
+    fn frontmatter_closing_delimiter_preceded_by_newline() {
+        // Regression test for #5725: the closing `---` must not be glued to the
+        // last frontmatter line.
+        let md = "---\nname: foo\ndescription: Foo.\n---\n\n# Body\n";
+        let patched =
+            patch_frontmatter_fields(md, &[("source", "generator"), ("parent_skill", "bar")]);
+        assert!(
+            patched.contains("Foo.\n---"),
+            "closing delimiter not preceded by newline: {patched}"
+        );
+        assert!(!patched.contains("Foo.---"), "patched: {patched}");
     }
 }

--- a/crates/zeph-core/src/agent/heuristic_promotion.rs
+++ b/crates/zeph-core/src/agent/heuristic_promotion.rs
@@ -594,36 +594,9 @@ fn build_generated_skill(name: &str, content: &str) -> Option<GeneratedSkill> {
 /// These fields are required by spec 061 for traceability of promoted skills.
 /// Existing values are replaced; missing values are inserted after `name:`.
 fn patch_frontmatter(skill_md: &str, source: &str, parent_skill: &str) -> String {
-    let Some(after_open) = skill_md.strip_prefix("---") else {
-        return skill_md.to_string();
-    };
-    let Some(close_pos) = after_open.find("---") else {
-        return skill_md.to_string();
-    };
-    let yaml = &after_open[..close_pos];
-    let rest = &after_open[close_pos..];
-
-    let mut lines: Vec<String> = yaml
-        .lines()
-        .filter(|l| {
-            let t = l.trim_start();
-            !t.starts_with("source:") && !t.starts_with("parent_skill:")
-        })
-        .map(str::to_string)
-        .collect();
-
-    let insert_after = lines
-        .iter()
-        .position(|l| l.trim_start().starts_with("name:"))
-        .map_or(lines.len(), |p| p + 1);
-
-    lines.insert(insert_after, format!("parent_skill: {parent_skill}"));
-    lines.insert(insert_after, format!("source: {source}"));
-
-    format!(
-        "---{}---{}",
-        lines.join("\n"),
-        rest.trim_start_matches("---")
+    zeph_common::text::patch_frontmatter_fields(
+        skill_md,
+        &[("source", source), ("parent_skill", parent_skill)],
     )
 }
 
@@ -660,7 +633,7 @@ fn patch_version(skill_md: &str, new_version: u32) -> String {
             lines.join("\n")
         };
 
-        return format!("---{new_yaml}{rest}");
+        return format!("---{new_yaml}\n---{}", rest.trim_start_matches("---"));
     }
     skill_md.to_string()
 }
@@ -728,6 +701,11 @@ mod tests {
             !patched.contains("version: 1"),
             "old version still present: {patched}"
         );
+        // Regression: the closing `---` must not be glued to the last frontmatter line.
+        assert!(
+            patched.contains("Foo.\n---"),
+            "closing delimiter not preceded by newline: {patched}"
+        );
     }
 
     #[test]
@@ -735,6 +713,11 @@ mod tests {
         let md = "---\nname: foo\ndescription: Foo.\n---\n\n# Body\n";
         let patched = patch_version(md, 3);
         assert!(patched.contains("version: 3"), "patched: {patched}");
+        // Regression: the closing `---` must not be glued to the last frontmatter line.
+        assert!(
+            patched.contains("Foo.\n---"),
+            "closing delimiter not preceded by newline: {patched}"
+        );
     }
 
     #[test]

--- a/crates/zeph-skills/src/proactive.rs
+++ b/crates/zeph-skills/src/proactive.rs
@@ -273,33 +273,7 @@ impl ProactiveExplorer {
 /// LLM-chosen `name:`. Inserted right after `name:`; falls back to returning `skill_md`
 /// unchanged if no frontmatter delimiters are found.
 fn stamp_proactive_domain(skill_md: &str, domain: &str) -> String {
-    let Some(after_open) = skill_md.strip_prefix("---") else {
-        return skill_md.to_string();
-    };
-    let Some(close_pos) = after_open.find("---") else {
-        return skill_md.to_string();
-    };
-    let yaml = &after_open[..close_pos];
-    let rest = &after_open[close_pos..];
-
-    let mut lines: Vec<String> = yaml
-        .lines()
-        .filter(|l| !l.trim_start().starts_with("proactive_domain:"))
-        .map(str::to_string)
-        .collect();
-
-    let insert_after = lines
-        .iter()
-        .position(|l| l.trim_start().starts_with("name:"))
-        .map_or(lines.len(), |p| p + 1);
-
-    lines.insert(insert_after, format!("proactive_domain: {domain}"));
-
-    format!(
-        "---{}\n---{}",
-        lines.join("\n"),
-        rest.trim_start_matches("---")
-    )
+    zeph_common::text::patch_frontmatter_fields(skill_md, &[("proactive_domain", domain)])
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- `stamp_proactive_domain` (zeph-skills) and `patch_frontmatter` (zeph-core) reimplemented the same split/filter/insert/reassemble logic for patching `SKILL.md` frontmatter fields; `patch_frontmatter`'s reassembly was missing the newline before the closing `---` delimiter, producing malformed frontmatter. Both now delegate to a new shared `zeph_common::text::patch_frontmatter_fields` helper with the newline fixed.
- Adversarial review found the identical missing-newline defect in `patch_version`, a third, structurally distinct frontmatter-patch function in the same file that runs on every versioned skill body before persistence. Fixed its reassembly in place, without folding it into the shared helper since it preserves the `version:` line's original position rather than always moving it after `name:`.

Closes #5725

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-common -p zeph-skills -p zeph-core` (2460 passed, 1 skipped, 0 failed)
- [x] `cargo test --doc -p zeph-common` (65 passed)
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps`)
- [x] Regression tests added for the newline bug in both the shared helper and `patch_version`
- [x] `.local/testing/` playbook and coverage-status.md updated