### PR TITLE
refactor(a2a): deduplicate processor-drain and artifact-finalization logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   input-dependent embedding support in `zeph-llm`'s test mock, out of scope for this test-only
   change. Test-only change, no production code modified.
 
+### Changed
+
+- `refactor(a2a)`: `handle_send_message` (`message/send`) and `stream_task`/
+  `drain_processor_events` (`message/stream`) in `crates/zeph-a2a/src/server/handlers.rs` each
+  reimplemented the same processor spawn/abort-handle setup, `proc_handle.await` ->
+  `TaskState` resolution (with identical Completed/Failed/panic logging), and
+  completed-artifact attachment (#5716). Extracted three shared helpers —
+  `spawn_processor`, `resolve_processor_outcome`, `finalize_artifact` — now called from both
+  handlers; the streaming-specific SSE event forwarding and the differing timeout mechanics
+  (`tokio::time::timeout` vs. `tokio::select!` with a disconnect branch) were left untouched.
+  Behavior-preserving: identical logging, artifact id format (`{task_id}-artifact`), and
+  error/panic handling at both call sites; all existing tests pass unchanged.
+
 ### Removed
 
 - `refactor(memory)`: removed the `SqliteStore = DbStore` type alias in

--- a/crates/zeph-a2a/src/server/handlers.rs
+++ b/crates/zeph-a2a/src/server/handlers.rs
@@ -131,6 +131,65 @@ pub async fn jsonrpc_handler(
     Json(response)
 }
 
+/// Spawns the processor future for `task_id`/`message` and returns its join handle,
+/// an abort handle for out-of-band cancellation (timeout or client disconnect), and
+/// the event receiver.
+fn spawn_processor(
+    state: &AppState,
+    task_id: String,
+    message: crate::types::Message,
+) -> (
+    tokio::task::JoinHandle<Result<(), crate::error::A2aError>>,
+    tokio::task::AbortHandle,
+    mpsc::Receiver<ProcessorEvent>,
+) {
+    let (event_tx, event_rx) = mpsc::channel::<ProcessorEvent>(32);
+    let proc_future = state.processor.process(task_id, message, event_tx);
+    let proc_handle = tokio::spawn(proc_future); // EXEMPT: awaited/aborted by the caller within the same request scope
+    let abort_handle = proc_handle.abort_handle();
+    (proc_handle, abort_handle, event_rx)
+}
+
+/// Resolves the processor's join result into a terminal [`TaskState`], logging failures
+/// and panics under `label` (e.g. `"task"` or `"stream task"`) for call-site context.
+async fn resolve_processor_outcome(
+    proc_handle: tokio::task::JoinHandle<Result<(), crate::error::A2aError>>,
+    task_id: &str,
+    label: &str,
+) -> TaskState {
+    match proc_handle.await {
+        Ok(Ok(())) => TaskState::Completed,
+        Ok(Err(e)) => {
+            tracing::error!(task_id = %task_id, "{label} processing failed: {e}");
+            TaskState::Failed
+        }
+        Err(e) => {
+            tracing::error!(task_id = %task_id, "{label} processor panicked: {e}");
+            TaskState::Failed
+        }
+    }
+}
+
+/// Attaches `accumulated` text as an artifact on `task_id` when processing completed
+/// successfully and produced non-empty output; otherwise a no-op.
+async fn finalize_artifact(
+    state: &AppState,
+    task_id: &str,
+    final_state: TaskState,
+    accumulated: String,
+) {
+    if final_state == TaskState::Completed && !accumulated.is_empty() {
+        use crate::types::{Artifact, Part};
+        let artifact = Artifact {
+            artifact_id: format!("{task_id}-artifact"),
+            name: None,
+            parts: vec![Part::text(accumulated)],
+            metadata: None,
+        };
+        state.task_manager.add_artifact(task_id, artifact).await;
+    }
+}
+
 #[tracing::instrument(name = "a2a.handle_send_message", skip_all)]
 async fn handle_send_message(
     state: AppState,
@@ -152,13 +211,8 @@ async fn handle_send_message(
         .update_status(&task.id, TaskState::Working, None)
         .await;
 
-    let (event_tx, mut event_rx) = mpsc::channel::<ProcessorEvent>(32);
-    let proc_future = state
-        .processor
-        .process(task.id.clone(), params.message, event_tx);
-
-    let proc_handle = tokio::spawn(proc_future); // EXEMPT: awaited inside timeout block below
-    let abort_handle = proc_handle.abort_handle();
+    let (proc_handle, abort_handle, mut event_rx) =
+        spawn_processor(&state, task.id.clone(), params.message);
 
     let (accumulated, final_state) = match tokio::time::timeout(state.request_timeout, async {
         let mut accumulated = String::new();
@@ -170,17 +224,7 @@ async fn handle_send_message(
                 ProcessorEvent::StatusUpdate { .. } => {}
             }
         }
-        let final_state = match proc_handle.await {
-            Ok(Ok(())) => TaskState::Completed,
-            Ok(Err(e)) => {
-                tracing::error!(task_id = %task.id, "task processing failed: {e}");
-                TaskState::Failed
-            }
-            Err(e) => {
-                tracing::error!(task_id = %task.id, "task processor panicked: {e}");
-                TaskState::Failed
-            }
-        };
+        let final_state = resolve_processor_outcome(proc_handle, &task.id, "task").await;
         (accumulated, final_state)
     })
     .await
@@ -197,16 +241,7 @@ async fn handle_send_message(
         }
     };
 
-    if final_state == TaskState::Completed && !accumulated.is_empty() {
-        use crate::types::{Artifact, Part};
-        let artifact = Artifact {
-            artifact_id: format!("{}-artifact", task.id),
-            name: None,
-            parts: vec![Part::text(accumulated)],
-            metadata: None,
-        };
-        state.task_manager.add_artifact(&task.id, artifact).await;
-    }
+    finalize_artifact(&state, &task.id, final_state, accumulated).await;
 
     state
         .task_manager
@@ -419,28 +454,8 @@ async fn drain_processor_events(
         }
     }
 
-    let final_state = match proc_handle.await {
-        Ok(Ok(())) => TaskState::Completed,
-        Ok(Err(e)) => {
-            tracing::error!(task_id = %task_id, "stream task processing failed: {e}");
-            TaskState::Failed
-        }
-        Err(e) => {
-            tracing::error!(task_id = %task_id, "stream task processor panicked: {e}");
-            TaskState::Failed
-        }
-    };
-
-    if final_state == TaskState::Completed && !accumulated.is_empty() {
-        use crate::types::{Artifact, Part};
-        let artifact = Artifact {
-            artifact_id: format!("{task_id}-artifact"),
-            name: None,
-            parts: vec![Part::text(accumulated)],
-            metadata: None,
-        };
-        state.task_manager.add_artifact(task_id, artifact).await;
-    }
+    let final_state = resolve_processor_outcome(proc_handle, task_id, "stream task").await;
+    finalize_artifact(state, task_id, final_state, accumulated).await;
 
     final_state
 }
@@ -463,11 +478,8 @@ async fn stream_task(state: AppState, message: crate::types::Message, tx: mpsc::
         ))
         .await;
 
-    let (event_tx, mut event_rx) = mpsc::channel::<ProcessorEvent>(32);
-    let proc_future = state.processor.process(task_id.clone(), message, event_tx);
-
-    let proc_handle = tokio::spawn(proc_future); // EXEMPT: awaited in drain_processor_events below
-    let abort_handle = proc_handle.abort_handle();
+    let (proc_handle, abort_handle, mut event_rx) =
+        spawn_processor(&state, task_id.clone(), message);
 
     let final_state = tokio::select! {
         result = tokio::time::timeout(
@@ -824,6 +836,65 @@ mod tests {
         assert_eq!(
             body["result"]["status"]["state"], "failed",
             "timed-out task must be in failed state"
+        );
+    }
+
+    // --- Direct unit tests for the extracted helpers (spawn_processor is covered
+    // indirectly through every handler test above; these close the branches that
+    // are otherwise unreachable via the public handlers: a panicking processor
+    // task, and finalize_artifact's no-op branches). ---
+
+    #[tokio::test]
+    async fn resolve_processor_outcome_panic_sets_failed() {
+        let handle: tokio::task::JoinHandle<Result<(), crate::error::A2aError>> =
+            tokio::spawn(async { panic!("boom") });
+        let state = super::resolve_processor_outcome(handle, "task-1", "task").await;
+        assert_eq!(state, crate::types::TaskState::Failed);
+    }
+
+    #[tokio::test]
+    async fn finalize_artifact_completed_empty_accumulated_is_noop() {
+        let state = super::super::testing::test_state();
+        let task = state
+            .task_manager
+            .create_task(crate::types::Message::user_text("hello"))
+            .await;
+
+        super::finalize_artifact(
+            &state,
+            &task.id,
+            crate::types::TaskState::Completed,
+            String::new(),
+        )
+        .await;
+
+        let fetched = state.task_manager.get_task(&task.id, None).await.unwrap();
+        assert!(
+            fetched.artifacts.is_empty(),
+            "finalize_artifact must not attach an artifact for empty accumulated text"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_artifact_failed_with_nonempty_accumulated_is_noop() {
+        let state = super::super::testing::test_state();
+        let task = state
+            .task_manager
+            .create_task(crate::types::Message::user_text("hello"))
+            .await;
+
+        super::finalize_artifact(
+            &state,
+            &task.id,
+            crate::types::TaskState::Failed,
+            "partial output before failure".to_owned(),
+        )
+        .await;
+
+        let fetched = state.task_manager.get_task(&task.id, None).await.unwrap();
+        assert!(
+            fetched.artifacts.is_empty(),
+            "finalize_artifact must not attach an artifact when the task did not complete"
         );
     }
 


### PR DESCRIPTION
## Summary

- `handle_send_message` (non-streaming `message/send`) and `stream_task`/`drain_processor_events` (streaming `message/stream`) in `crates/zeph-a2a/src/server/handlers.rs` each reimplemented the same processor-spawn, timeout-resolution, and completed-artifact-attachment sequence.
- Extracted three shared helpers now called from both paths: `spawn_processor`, `resolve_processor_outcome`, `finalize_artifact`.
- Streaming-specific SSE event forwarding and the differing timeout mechanics (`tokio::time::timeout` vs. `tokio::select!` with a disconnect branch) are left untouched, per the issue's guidance.
- Behavior-preserving refactor: identical logging text, artifact id format (`{task_id}-artifact`), and error/panic handling at both call sites.
- Added 3 unit tests closing previously-uncovered branches: the panic branch of `resolve_processor_outcome`, and the two no-op branches of `finalize_artifact`.

Closes #5716

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci -p zeph-a2a --all-targets --features server -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-a2a --features server` — 165/165 passed
- [x] Adversarial critique confirmed byte-for-byte behavior preservation across 6 drift vectors (log wording, timeout/abort separation, artifact condition, error-vs-panic distinction, SSE forwarding, ownership/refcount)
- [x] CHANGELOG.md updated under `[Unreleased] > Changed`