### PR TITLE
ci: harden release-build gating and bump nextest leak-timeout

### DIFF
--- a/.github/nextest.toml
+++ b/.github/nextest.toml
@@ -6,6 +6,9 @@
 # No default filter - run all unit tests
 # Integration tests are in separate test binaries (tests/*_integration.rs)
 # and can be run explicitly with --test flag or using the ci profile
+# Blanket bump from nextest's 100ms default to tolerate process-teardown
+# latency under concurrent load (see #5617).
+leak-timeout = "500ms"
 
 [[profile.default.overrides]]
 # tokio::task::spawn_blocking worker-thread teardown can outlast the default
@@ -65,6 +68,9 @@ path = "target/nextest/ci/junit.xml"
 # Used by the partitioned test matrix in CI (unit tests only).
 # Each shard receives --partition hash:K/8 on the command line.
 test-threads = 8
+# Blanket bump from nextest's 100ms default to tolerate process-teardown
+# latency under concurrent load (see #5617).
+leak-timeout = "500ms"
 
 [[profile.ci-partition.overrides]]
 # Warn (but don't fail) if any test exceeds 30s — surfaces slow tests early.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,7 +523,7 @@ jobs:
 
   release-build:
     name: Release Build Check
-    needs: detect-changes
+    needs: [detect-changes, lint-fmt, lint-clippy]
     if: needs.detect-changes.outputs.run-full-ci == 'true' && github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -547,6 +547,33 @@ jobs:
         # real `cargo build --release` with this workspace's `[profile.release]` (lto = true,
         # codegen-units = 1) exercises the same query depth CI is meant to gate on.
         run: cargo build --release --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing,deep-link"
+
+  release-build-full:
+    name: Release Build Check (full)
+    needs: [detect-changes, lint-fmt, lint-clippy]
+    if: needs.detect-changes.outputs.run-full-ci == 'true' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-targets: "false"
+          shared-key: "release-build-full"
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: cargo build (release, --all-targets, full)
+        # Best-effort candle/ml coverage under the release profile, mirroring the
+        # bundle-check `ml` matrix leg (#5418): step-level continue-on-error keeps
+        # this job's overall result `success` so it never blocks ci-status, while
+        # still surfacing genuine full-feature release-build breakage in the logs.
+        continue-on-error: true
+        run: cargo build --release --workspace --all-targets --features full
 
   build-postgres:
     name: Build (postgres)
@@ -634,7 +661,7 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    needs: [cla, lint-shellcheck, lint-fmt, lint-clippy, msrv, build-tests, build-tests-postgres, test, integration, coverage, docker-build-and-scan, bundle-check, validate-specs, build-postgres, rustdoc, release-build]
+    needs: [cla, lint-shellcheck, lint-fmt, lint-clippy, msrv, build-tests, build-tests-postgres, test, integration, coverage, docker-build-and-scan, bundle-check, validate-specs, build-postgres, rustdoc, release-build, release-build-full]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
@@ -657,6 +684,7 @@ jobs:
             "${{ needs.build-postgres.result }}"
             "${{ needs.rustdoc.result }}"
             "${{ needs.release-build.result }}"
+            "${{ needs.release-build-full.result }}"
           )
           for r in "${results[@]}"; do
             if [[ "$r" != "success" && "$r" != "skipped" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `ci`: `release-build`'s `needs:` list now includes `lint-fmt` and `lint-clippy`, so a
+  trivially-broken PR fails fast instead of burning the full ~40-minute release-profile build
+  first. Added a companion `release-build-full` job that builds with `--features full`
+  (covering `candle`/`ml`, which the original job deliberately excludes) using step-level
+  `continue-on-error: true` on its build step — mirroring `bundle-check`'s existing `ml`
+  matrix-leg pattern — so release-profile regressions in that feature slice are visible in CI
+  logs without making the gate hard-blocking (#5418).
+- `ci`: added a blanket `leak-timeout = "500ms"` under `.github/nextest.toml`'s `[profile.default]`
+  and `[profile.ci-partition]`, raising the workspace-wide leak-timeout from nextest's 100ms
+  default to tolerate process-teardown latency under concurrent test load. The existing narrow
+  `zeph-index` per-test `1s` overrides for the diagnosed `spawn_blocking` teardown case (#5425)
+  are unchanged (#5617).
+
+### Fixed
+
 - `fix(core)`: the `SAFETY` comment on `handle_url_open()`'s `ZEPH_URL_OPEN_DEPTH` `set_var`
   call (`src/runner.rs`) still said `set_var` runs "on the main thread", which stopped being
   accurate once #5406 moved `main()` off the OS main thread onto a dedicated `zeph-main` thread.


### PR DESCRIPTION
## Summary
- `release-build`'s `needs:` now includes `lint-fmt` and `lint-clippy`, so a trivially-broken PR fails fast instead of burning the ~40-minute release-profile build first.
- Added `release-build-full`, a best-effort job that builds with `--features full` (covering `candle`/`ml`, which `release-build` deliberately excludes) using step-level `continue-on-error: true` on its build step, mirroring `bundle-check`'s existing `ml` matrix-leg pattern. Wired into `ci-status`'s needs/results array alongside `release-build` since its `continue-on-error` keeps the job result `success` regardless of build outcome.
- Bumped nextest's `leak-timeout` to `500ms` workspace-wide in `.github/nextest.toml`'s `[profile.default]` and `[profile.ci-partition]`, after an unrelated synchronous test (`zeph-tui app::tests::q_quits_in_normal_mode`) was independently observed flagged as `LEAK` under load. The existing narrow `zeph-index` per-test `1s` overrides for the diagnosed `spawn_blocking` teardown case (#5425) are untouched.

Closes #5418
Closes #5617

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`)
- [x] `cargo nextest list --config-file .github/nextest.toml --workspace --profile ci-partition` parses cleanly
- [x] `git diff --stat` confirms only `.github/workflows/ci.yml`, `.github/nextest.toml`, and `CHANGELOG.md` changed — no Rust source touched
- [ ] CI run on this PR exercises the new `release-build-full` job and the updated `release-build` gating