### PR TITLE
fix(orchestration): forward zeph-memory sqlite/postgres features explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(orchestration)`: `zeph-orchestration`'s `sqlite`/`postgres` features
+  (`crates/zeph-orchestration/Cargo.toml`) relied on a multi-hop transitive chain
+  (`zeph-subagent` -> `zeph-sanitizer` -> `zeph-memory`) to activate `zeph-memory`'s
+  backend-specific code paths, rather than naming `zeph-memory/sqlite` and
+  `zeph-memory/postgres` directly — unlike the root crate's bundles, which forward to
+  `zeph-memory` explicitly. No build was actually missing backend activation (Cargo feature
+  unification already turned `zeph-memory`'s features on via the transitive path), but the
+  implicit dependency on that chain meant a future refactor of `zeph-subagent` or
+  `zeph-sanitizer` could silently drop `zeph-memory`'s backend feature without
+  `zeph-orchestration`'s own `Cargo.toml` reflecting the loss. Added direct forwards to make
+  the feature declaration self-documenting and resilient to that refactor (#5596).
+
+### Fixed
+
 - `fix(core)`: the `SAFETY` comment on `handle_url_open()`'s `ZEPH_URL_OPEN_DEPTH` `set_var`
   call (`src/runner.rs`) still said `set_var` runs "on the main thread", which stopped being
   accurate once #5406 moved `main()` off the OS main thread onto a dedicated `zeph-main` thread.

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -44,8 +44,8 @@ zeph-llm = { workspace = true, features = ["testing"] }
 zeph-memory.workspace = true
 
 [features]
-sqlite = ["zeph-db/sqlite", "zeph-durable/sqlite", "zeph-subagent/sqlite"]
-postgres = ["zeph-db/postgres", "zeph-durable/postgres", "zeph-subagent/postgres"]
+sqlite = ["zeph-db/sqlite", "zeph-durable/sqlite", "zeph-memory/sqlite", "zeph-subagent/sqlite"]
+postgres = ["zeph-db/postgres", "zeph-durable/postgres", "zeph-memory/postgres", "zeph-subagent/postgres"]
 llm-planning = ["dep:zeph-llm"]
 # Enables test utilities and testcontainers for PostgreSQL integration tests.
 test-utils = ["dep:testcontainers-modules", "postgres"]


### PR DESCRIPTION
## Summary

- `zeph-orchestration`'s `sqlite`/`postgres` features now name `zeph-memory/sqlite` and `zeph-memory/postgres` directly, instead of relying on the implicit multi-hop transitive chain `zeph-subagent -> zeph-sanitizer -> zeph-memory` to activate them.
- No build was actually missing backend activation today — `cargo tree -p zeph-orchestration -e normal --features {postgres,sqlite} -i zeph-memory` confirms the transitive chain was already unconditional (all three hops are mandatory, non-optional dependencies). This is a defensive/explicitness fix, not a behavior change: it guards against a future refactor of `zeph-subagent` or `zeph-sanitizer` silently dropping `zeph-memory`'s backend feature without `zeph-orchestration`'s own `Cargo.toml` reflecting the loss.
- CHANGELOG entry added under `[Unreleased] / Fixed`.

## Test plan

- [x] `cargo check -p zeph-orchestration` (default)
- [x] `cargo check -p zeph-orchestration --no-default-features --features postgres`
- [x] `cargo check -p zeph-orchestration --tests --no-default-features --features postgres,test-utils,llm-planning`
- [x] `cargo tree -p zeph-orchestration -e normal --features postgres -i zeph-memory` / same for `sqlite` — confirms pre-existing transitive activation, independently reproduced 3 times (developer, critic, reviewer)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12360 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`

Closes #5596