### PR TITLE
fix(orchestration): gate llm-planning test sites and cover postgres feature in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
           retention-days: 1
 
   build-tests-postgres:
-    # The three postgres archives build RUNNABLE test binaries (with
+    # The four postgres archives build RUNNABLE test binaries (with
     # test-utils = testcontainers) consumed by the integration matrix. They do
     # not duplicate the build-postgres job, which is check-only: it type-checks
     # the whole workspace under the postgres backend and produces no artifacts.
@@ -283,6 +283,18 @@ jobs:
         with:
           name: nextest-archive-zeph-index-postgres
           path: nextest-archive-zeph-index-postgres.tar.zst
+          retention-days: 1
+      - name: Build and archive zeph-orchestration postgres integration tests
+        # sqlite and postgres are mutually exclusive; default features (which
+        # include "sqlite") must be disabled so only postgres is active.
+        # test-utils implies llm-planning: tests/postgres_integration.rs exercises
+        # PlanCache, which lives behind that feature gate (#5839).
+        run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci -p zeph-orchestration --no-default-features --features test-utils --tests --archive-file nextest-archive-zeph-orchestration-postgres.tar.zst
+      - name: Upload zeph-orchestration postgres test archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: nextest-archive-zeph-orchestration-postgres
+          path: nextest-archive-zeph-orchestration-postgres.tar.zst
           retention-days: 1
 
   test:
@@ -353,6 +365,10 @@ jobs:
           - suite: zeph-index-postgres
             archive: nextest-archive-zeph-index-postgres
             file: nextest-archive-zeph-index-postgres.tar.zst
+            run_args: "-E 'binary(postgres_integration)'"
+          - suite: zeph-orchestration-postgres
+            archive: nextest-archive-zeph-orchestration-postgres
+            file: nextest-archive-zeph-orchestration-postgres.tar.zst
             run_args: "-E 'binary(postgres_integration)'"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(orchestration)`: two `zeph-orchestration` test sites referenced `llm-planning`-gated items
+  (`PlanCache`/`normalize_goal` in `plan_cache`, `crate::planner`) without being gated behind that
+  feature themselves, so `cargo check -p zeph-orchestration --tests --no-default-features
+  --features postgres,test-utils` failed to compile. `test-utils` now implies `llm-planning` in
+  `Cargo.toml` (the only `test-utils`-gated suite, `tests/postgres_integration.rs`, exercises
+  `PlanCache` end-to-end, so the two features are never meaningfully independent); the single
+  `scheduler::tick::tests` case exercising `crate::planner` got its own narrow
+  `#[cfg(feature = "llm-planning")]` gate instead, since the rest of that test file does not need
+  the feature (#5839).
+- `ci`: `zeph-orchestration` was never built with `--features postgres` in isolation anywhere in
+  `.github/workflows/ci.yml` — the only postgres coverage it got was via the workspace-wide
+  `build-postgres` check job, which would silently mask a per-crate `postgres` feature-forward
+  drifting out of sync with the root bundle (the exact bug class #5596/#5837 fixed). Added a
+  `zeph-orchestration` archive step to `build-tests-postgres` (mirroring the existing
+  `zeph-db`/`zeph-memory`/`zeph-index` per-crate postgres entries) and a matching
+  `zeph-orchestration-postgres` entry to the `integration` job's matrix, so
+  `tests/postgres_integration.rs`'s `#[ignore = "requires Docker"]` tests now run in CI.
+  Archived with `--features test-utils` — `test-utils` now implies `llm-planning`
+  (`PlanCache`/`normalize_goal`'s feature gate, #5839) — matching the same `--no-default-features
+  --features test-utils --tests` pattern used by the `zeph-db`/`zeph-index` entries (#5838).
 - `ci`: `release-build`'s `needs:` list now includes `lint-fmt` and `lint-clippy`, so a
   trivially-broken PR fails fast instead of burning the full ~40-minute release-profile build
   first. Added a companion `release-build-full` job that builds with `--features full`

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -48,7 +48,9 @@ sqlite = ["zeph-db/sqlite", "zeph-durable/sqlite", "zeph-memory/sqlite", "zeph-s
 postgres = ["zeph-db/postgres", "zeph-durable/postgres", "zeph-memory/postgres", "zeph-subagent/postgres"]
 llm-planning = ["dep:zeph-llm"]
 # Enables test utilities and testcontainers for PostgreSQL integration tests.
-test-utils = ["dep:testcontainers-modules", "postgres"]
+# Implies `llm-planning`: the only test-utils-gated suite (postgres_integration.rs)
+# exercises `PlanCache`, which lives behind that feature.
+test-utils = ["dep:testcontainers-modules", "postgres", "llm-planning"]
 default = ["sqlite"]
 
 [lints]

--- a/crates/zeph-orchestration/src/scheduler/tick/tests.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/tests.rs
@@ -111,6 +111,7 @@ fn test_completion_event_marks_deps_ready() {
     );
 }
 
+#[cfg(feature = "llm-planning")]
 #[test]
 fn test_plan_with_verify_criteria_and_predicate_disabled_reaches_completed() {
     // End-to-end regression for #5403: a planner response where a task has a

--- a/crates/zeph-orchestration/tests/postgres_integration.rs
+++ b/crates/zeph-orchestration/tests/postgres_integration.rs
@@ -6,7 +6,7 @@
 //! These tests require Docker to be running. Run locally with:
 //! ```bash
 //! cargo nextest run -p zeph-orchestration --no-default-features \
-//!     --features test-utils,llm-planning --test postgres_integration --run-ignored ignored-only
+//!     --features test-utils --test postgres_integration --run-ignored ignored-only
 //! ```
 //!
 //! Regression coverage for issue #5803: `PlanCache::cache_plan`'s


### PR DESCRIPTION
## Summary
- `test-utils` now implies `llm-planning` in `zeph-orchestration/Cargo.toml`, and a narrow `#[cfg(feature = "llm-planning")]` gate was added to the one `scheduler::tick::tests` case that needs it — fixes two test sites that unconditionally referenced `llm-planning`-gated items (`PlanCache`/`normalize_goal`, `crate::planner`) without a cfg guard, breaking `cargo check -p zeph-orchestration --tests --no-default-features --features postgres,test-utils`
- Added a `zeph-orchestration` entry to CI's `build-tests-postgres` per-crate matrix (alongside `zeph-db`/`zeph-memory`/`zeph-index`) so the crate's own `--features postgres` is built and tested in isolation, closing a structural gap where only the workspace-wide `full,postgres` bundle exercised it

Closes #5839, #5838

## Test plan
- [x] `cargo check -p zeph-orchestration --tests --no-default-features --features postgres,test-utils` compiles (original #5839 repro)
- [x] `cargo check -p zeph-orchestration --no-default-features --features postgres` compiles in isolation (#5838 target)
- [x] `cargo nextest run -p zeph-orchestration --features llm-planning` — 403/403 pass, including the newly-gated test
- [x] Reproduced the exact CI archive + integration-job commands locally, confirmed clean
- [x] `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, rustdoc gate — all clean
- [x] `fy lint .github/workflows/ci.yml` — 0 errors