### PR TITLE
docs(sanitizer): fix shadow_memory wiring doc comment and spec-040 layer table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Docs
+
+- `docs(sanitizer)`: updated `crates/zeph-sanitizer/src/shadow_memory.rs` doc comment to reflect
+  that `ShadowMemory` is actively wired into the agent tool executor via `tier_loop.rs`, rather
+  than the stale claim that it was "intended for future integration". Added cross-reference to
+  the actual call site and security event emission (#5440).
+- `docs(spec-040)`: expanded `specs/040-sanitizer/spec.md` layer table to document 5 previously
+  undocumented defense layers: `IpiFilter` (implemented, unwired), `NliSanitizer` (wired via builder),
+  `SecretMaskRegistry` (wired at LLM boundary), `ShadowMemory` (wired in tool executor),
+  and `Pipeline`/`Stage` (internal utility framework). Updated layer numbering and added wiring
+  status for each (#5440).
+
 ### Fixed
 
 - `fix(orchestration)`: two `zeph-orchestration` test sites referenced `llm-planning`-gated items

--- a/crates/zeph-sanitizer/src/shadow_memory.rs
+++ b/crates/zeph-sanitizer/src/shadow_memory.rs
@@ -101,8 +101,9 @@ pub struct GoalDriftResult {
 /// Create via [`ShadowMemory::new`] with a [`ShadowMemoryConfig`]. Returns `None` when
 /// the config has `enabled = false`, so callers can wrap it in `Option<ShadowMemory>`.
 ///
-/// Note: this component is not currently wired into the agent tool executor; it is a
-/// standalone goal-drift analysis component intended for future integration.
+/// Wired into the agent tool executor via `crates/zeph-core/src/agent/tool_execution/tier_loop.rs`:
+/// after every tool batch completes, `goal_drift_score()` is called and a
+/// [`zeph_common::SecurityEventCategory::GoalDrift`] security event is emitted when an alert occurs.
 ///
 /// # Examples
 ///

--- a/specs/040-sanitizer/spec.md
+++ b/specs/040-sanitizer/spec.md
@@ -36,16 +36,21 @@ All content entering the agent context from external sources must pass through t
 before being added to the message history or memory. The pipeline is a defense-in-depth system with
 eight layers, each addressing different threat vectors:
 
-| Layer | Component | Purpose |
-|-------|-----------|---------|
-| 1 | `ContentSanitizer` | Regex-based injection detection + spotlighting |
-| 2 | `PiiFilter` | Regex PII scrubber (email, phone, SSN, credit card) |
-| 3 | `GuardrailFilter` | LLM-based pre-screener at input boundary |
-| 4 | `QuarantinedSummarizer` | Isolated LLM fact extractor for risky content |
-| 5 | `ResponseVerifier` | Post-LLM response scanner |
-| 6 | `ExfiltrationGuard` | Outbound channel guards (markdown images, tool URLs) |
-| 7 | `MemoryWriteValidator` | Structural write guards for memory store |
-| 8 | `TurnCausalAnalyzer` | Behavioral deviation detection at tool-return boundaries |
+| Layer | Component | Status | Purpose |
+|-------|-----------|--------|---------|
+| 1 | `ContentSanitizer` | Wired | Regex-based injection detection + spotlighting |
+| 2 | `PiiFilter` | Wired | Regex PII scrubber (email, phone, SSN, credit card) |
+| 3 | `GuardrailFilter` | Wired | LLM-based pre-screener at input boundary |
+| 4 | `QuarantinedSummarizer` | Wired | Isolated LLM fact extractor for risky content |
+| 5 | `ResponseVerifier` | Wired | Post-LLM response scanner |
+| 6 | `ExfiltrationGuard` | Wired | Outbound channel guards (markdown images, tool URLs) |
+| 7 | `MemoryWriteValidator` | Wired | Structural write guards for memory store |
+| 8 | `TurnCausalAnalyzer` | Wired | Behavioral deviation detection at tool-return boundaries |
+| 9 | `IpiFilter` | Unwired | Weighted-pattern Indirect Prompt Injection scorer for web-scraped content |
+| 10 | `NliSanitizer` | Wired | SONAR NLI entailment-based injection layer; can be attached via builder |
+| 11 | `SecretMaskRegistry` | Wired | Vault-secret placeholder masking at the LLM boundary |
+| 12 | `ShadowMemory` | Wired | Cross-turn goal-drift detector; complements Layer 8's single-batch analysis |
+| 13 | `Pipeline`/`Stage` | Internal | Generic composable synchronous stage framework for custom sanitization chains |
 
 ---
 


### PR DESCRIPTION
## Summary

- Corrected the stale doc comment on `ShadowMemory` (`crates/zeph-sanitizer/src/shadow_memory.rs`) that claimed it was "not currently wired into the agent tool executor" — it has been wired since spec 010-7 landed, via `tier_loop.rs`'s post-tool-batch `goal_drift_score()` call and `GoalDrift` security event emission.
- Expanded `specs/040-sanitizer/spec.md` section 1's layer table from 8 to 13 entries, adding `IpiFilter`, `NliSanitizer`, `SecretMaskRegistry`, `ShadowMemory`, and `Pipeline`/`Stage` with their verified current wiring status (verified against actual code, not assumed from prior issue text — `NliSanitizer` and `SecretMaskRegistry` are in fact wired; `IpiFilter` remains unwired).
- Added a CHANGELOG.md entry under `[Unreleased]`.

No behavioral code was changed — doc comments and specification markdown only.

Closes #5440

## Test plan

- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-sanitizer` builds cleanly, new intra-doc link resolves
- [x] Verified `ShadowMemory` wiring claim against `crates/zeph-core/src/agent/tool_execution/tier_loop.rs`
- [x] Verified `NliSanitizer` is invoked at `crates/zeph-core/src/agent/tool_execution/sanitize.rs:202`
- [x] Verified `SecretMaskRegistry` is invoked throughout `tier_loop.rs` and `provider_factory.rs`
- [x] Verified `IpiFilter` has no call sites outside its own module (genuinely unwired)
- [x] `git diff` confirmed to touch only doc comments, spec markdown, and CHANGELOG.md