### PR TITLE
feat(core): log RL re-rank success path for cross-backend parity verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `feat(core)`: `Agent::match_and_rank_skills`'s RL re-rank success path now emits a
+  `tracing::debug!` on every turn it fires, logging the candidate count, the active
+  `vector_backend` (`"qdrant"`/`"sqlite"`), and a per-skill `(name, pre_score, post_score)`
+  breakdown after `RoutingHead::rerank()` reorders `scored`. Previously the three existing
+  log sites on this path (embed timeout, embed dim mismatch, and the embeddings-unavailable
+  skip branch) only covered failure/skip cases, so a successful RL re-rank was
+  indistinguishable from the feature being silently inactive — blocking live cross-backend
+  parity verification for #5812/#5805 (#5834).
 - `test(core)`: extracted a `build_daemon_agent`/`BuildDaemonAgentDeps`-taking function from
   `run_daemon()`'s `AgentBuilder` construction chain (`src/daemon.rs`), completing #5819's
   remaining half left out of PR #5831 (`build_agent`/`BuildAgentDeps` for the CLI path,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `build`: bumped `crossbeam-epoch` to 0.9.20 (from 0.9.18) to resolve RUSTSEC-2026-0204
+  (invalid pointer dereference in `fmt::Pointer`/`fmt::Display` impls for `Atomic`/`Shared`
+  when the underlying pointer is null), a newly-published advisory that started failing the
+  `cargo-deny` gate on every PR via the `ignore`/`rayon`/`zeph-index` dependency chain. Lockfile
+  bump only, no source changes.
 - `ci`: `release-build`'s `needs:` list now includes `lint-fmt` and `lint-clippy`, so a
   trivially-broken PR fails fast instead of burning the full ~40-minute release-profile build
   first. Added a companion `release-build-full` job that builds with `--features full`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `feat(core)`: `Agent::match_and_rank_skills`'s RL re-rank success path now emits a
   `tracing::debug!` on every turn it fires, logging the candidate count, the active
-  `vector_backend` (`"qdrant"`/`"sqlite"`), and a per-skill `(name, pre_score, post_score)`
-  breakdown after `RoutingHead::rerank()` reorders `scored`. Previously the three existing
-  log sites on this path (embed timeout, embed dim mismatch, and the embeddings-unavailable
-  skip branch) only covered failure/skip cases, so a successful RL re-rank was
-  indistinguishable from the feature being silently inactive — blocking live cross-backend
-  parity verification for #5812/#5805 (#5834).
+  `vector_backend` (`"qdrant"`/`"sqlite"`), a per-skill `(name, pre_score, post_score)`
+  breakdown after `RoutingHead::rerank()` reorders `scored`, and a `blended` flag (with
+  `update_count`/`warmup` values) distinguishing genuine cosine+RL blended output from the
+  pure cosine passthrough `rerank()` returns while `update_count < warmup_updates` — without
+  it, a short live-testing session run entirely inside the warmup window would log as if
+  blending had occurred when it hadn't, reintroducing the same "success indistinguishable
+  from inactive" ambiguity one level deeper. Previously the three existing log sites on this
+  path (embed timeout, embed dim mismatch, and the embeddings-unavailable skip branch) only
+  covered failure/skip cases, so a successful RL re-rank was indistinguishable from the
+  feature being silently inactive — blocking live cross-backend parity verification for
+  #5812/#5805 (#5834).
 - `test(core)`: extracted a `build_daemon_agent`/`BuildDaemonAgentDeps`-taking function from
   `run_daemon()`'s `AgentBuilder` construction chain (`src/daemon.rs`), completing #5819's
   remaining half left out of PR #5831 (`build_agent`/`BuildAgentDeps` for the CLI path,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1242,6 +1242,27 @@ impl<C: Channel> Agent<C> {
                             let pos_b = reranked.iter().position(|(i, _)| *i == b.index);
                             pos_a.cmp(&pos_b)
                         });
+                        // Positive-confirmation log: without this, RL re-rank success is
+                        // indistinguishable from the feature being silently inactive (#5834).
+                        let rerank_summary: Vec<(String, f32, f32)> = reranked
+                            .iter()
+                            .map(|(idx, post_score)| {
+                                let name = all_meta
+                                    .get(*idx)
+                                    .map_or_else(|| "<unknown>".to_string(), |m| m.name.clone());
+                                let pre_score = candidates
+                                    .iter()
+                                    .find(|(cidx, _, _)| cidx == idx)
+                                    .map_or(0.0, |(_, _, score)| *score);
+                                (name, pre_score, *post_score)
+                            })
+                            .collect();
+                        tracing::debug!(
+                            vector_backend = if matcher.is_qdrant() { "qdrant" } else { "sqlite" },
+                            candidate_count = rerank_summary.len(),
+                            rerank = ?rerank_summary,
+                            "RL re-rank applied: candidates reordered by blended RL score (name, pre_score, post_score)"
+                        );
                     } else {
                         tracing::debug!(
                             total = scored.len(),

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1244,6 +1244,11 @@ impl<C: Channel> Agent<C> {
                         });
                         // Positive-confirmation log: without this, RL re-rank success is
                         // indistinguishable from the feature being silently inactive (#5834).
+                        // `rerank()` returns pure cosine order (no blending) while
+                        // `update_count < warmup_updates`; checked here right after the call so
+                        // `blended` reflects the same condition `rerank()` itself branched on.
+                        let update_count = rl_head.update_count();
+                        let blended = update_count >= warmup;
                         let rerank_summary: Vec<(String, f32, f32)> = reranked
                             .iter()
                             .map(|(idx, post_score)| {
@@ -1260,8 +1265,18 @@ impl<C: Channel> Agent<C> {
                         tracing::debug!(
                             vector_backend = if matcher.is_qdrant() { "qdrant" } else { "sqlite" },
                             candidate_count = rerank_summary.len(),
+                            blended,
+                            update_count,
+                            warmup,
                             rerank = ?rerank_summary,
-                            "RL re-rank applied: candidates reordered by blended RL score (name, pre_score, post_score)"
+                            "{}",
+                            if blended {
+                                "RL re-rank applied: candidates reordered by blended RL score \
+                                 (name, pre_score, post_score)"
+                            } else {
+                                "RL re-rank: cosine order retained, RL head still warming up \
+                                 (name, pre_score, post_score are equal)"
+                            }
                         );
                     } else {
                         tracing::debug!(


### PR DESCRIPTION
## Summary

- `Agent::match_and_rank_skills`'s RL-rerank success path (`crates/zeph-core/src/agent/context/assembly.rs`) previously emitted zero logging — only the three skip/error paths (embed timeout, embed dim mismatch, embeddings unavailable) logged anything, so a completed rerank was indistinguishable from the feature being silently inactive. This blocked live cross-backend parity verification of #5812/#5805's unit-normalization fix (Scenario 4 in `.local/testing/playbooks/skills-qdrant.md`) across CI-1259 through CI-1262.
- Added a `tracing::debug!` on that success path logging `vector_backend` (`"qdrant"`/`"sqlite"`, read from the in-scope `SkillMatcherBackend` rather than `zeph-core`'s narrower `RuntimeConfig`, which has no `memory` field), `candidate_count`, a per-skill `(name, pre_score, post_score)` breakdown, and a `blended` flag (with `update_count`/`warmup`) distinguishing genuine RL-blended output from `RoutingHead::rerank()`'s pure-cosine passthrough during its ~50-turn warmup window — without the latter, a short live-testing session would log as if blending occurred when it hadn't, reintroducing the same ambiguity one level deeper.
- Updated `.local/testing/playbooks/skills-qdrant.md` Scenario 4 with the new log's field shapes and the warmup requirement, and `.local/testing/coverage-status.md`'s SAGE RL row.

## Follow-ups filed (out of scope for this PR)

- #5845 — `match_and_rank_skills`' RL-rerank branch has zero automated test coverage (`Agent::with_rl_head()` has zero callers anywhere); `RoutingHead::rerank()`'s post-warmup blended-sort-order isn't regression-tested for the case where it disagrees with cosine order.
- #5846 — `RoutingHead::rerank()` and `update_count()` take separate mutex acquisitions, a narrow (self-detectable) TOCTOU at the single warmup-to-active transition turn.

Closes #5834

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12364 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [ ] Live cross-backend parity comparison itself (Scenario 4) — not run in this PR; this PR only unblocks the observability needed to run it. Next CI cycle should execute the updated playbook steps.