### PR TITLE
test(session): cover chunked-replay torn-tail and up_to boundary paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `test(session)`: closed two test-coverage gaps left over from #5445's chunked-replay perf pass
+  (`crates/zeph-session/src/replay.rs`, `log.rs`). `test_replay_torn_tail_across_chunk_boundary`
+  drives a torn trailing line through `ReplayEngine::replay`'s new `SessionEventLog::read_chunked`
+  path on a log spanning several `REPLAY_CHUNK_SIZE` (100) chunks, asserting it drops the torn
+  line identically to the old whole-file `read_all` + `fold` path — previously only exercised at
+  3-4 events via the pre-#5445 `read_all` path, never through `read_chunked`/`replay` at
+  multi-chunk scale. `test_replay_up_to_matches_fold_at_chunk_boundaries` asserts
+  `ReplayEngine::replay(dir, Some(up_to))` matches the Vec-based `ReplayEngine::fold` at `up_to`
+  values landing at/near six chunk boundaries (99/100/101, 199/200/201) on a >200-event log —
+  previously the only `up_to` test exercising `replay` used a ~5-event fixture, far below
+  `REPLAY_CHUNK_SIZE`. Also documented `SessionEventLog::read_chunked`'s over-read behavior: a
+  chunk still being accumulated is fully read/parsed before `on_chunk` can evaluate an `up_to`
+  break, which stays within the ≤ 100-in-memory bound but is worth flagging for future refactors
+  (#5841).
+
 ### Docs
 
 - `docs(sanitizer)`: updated `crates/zeph-sanitizer/src/shadow_memory.rs` doc comment to reflect

--- a/crates/zeph-session/src/log.rs
+++ b/crates/zeph-session/src/log.rs
@@ -217,6 +217,12 @@ impl SessionEventLog {
     /// `up_to` bound is reached) — remaining lines, including any torn tail beyond the stop
     /// point, are then left uninspected.
     ///
+    /// Note the over-read this implies: when `up_to` falls inside a chunk still being
+    /// accumulated, that entire chunk (up to [`REPLAY_CHUNK_SIZE`] events) is read and parsed
+    /// from disk before `on_chunk` gets a chance to evaluate the break — this never exceeds the
+    /// ≤ [`REPLAY_CHUNK_SIZE`]-in-memory bound, but a future refactor must not assume the read
+    /// stops the instant the `up_to` seq is reached.
+    ///
     /// Same torn-tail detection/repair gating as [`Self::read_all`]: only physically repairs
     /// the file when this handle was opened via [`Self::open_exclusive`].
     ///

--- a/crates/zeph-session/src/replay.rs
+++ b/crates/zeph-session/src/replay.rs
@@ -778,4 +778,89 @@ mod tests {
             "streaming replay must be byte-identical to the old Vec-based fold"
         );
     }
+
+    /// Regression test for #5841 finding 1: a torn trailing line on a log spanning multiple
+    /// `REPLAY_CHUNK_SIZE` chunks must be dropped identically whether read via
+    /// `ReplayEngine::replay` (new chunked-streaming path) or the old `SessionEventLog::open` +
+    /// `read_all` + `ReplayEngine::fold` whole-file path — the torn-tail check in
+    /// `read_events_chunked` only fires once, at EOF, so it must still catch a torn line that
+    /// falls beyond the last full chunk boundary.
+    #[tokio::test]
+    async fn test_replay_torn_tail_across_chunk_boundary() {
+        const N_TURNS: u64 = 250; // produces well over one REPLAY_CHUNK_SIZE (100) of events
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = seed_large_synthetic_log(dir.path(), N_TURNS).await;
+        let path = log.path().to_path_buf();
+        drop(log);
+
+        // Simulate a torn write: truncate the file mid-way through the last physical line.
+        let full = tokio::fs::read(&path).await.unwrap();
+        let cut = full.len() - 5;
+        tokio::fs::write(&path, &full[..cut]).await.unwrap();
+
+        // Old path: whole-file read (drops the torn line) + Vec-based fold.
+        let whole_file_log = SessionEventLog::open(dir.path()).await.unwrap();
+        let whole_file_events = whole_file_log.read_all().await.unwrap();
+        assert!(
+            whole_file_events.len() > 100,
+            "test must still exceed one REPLAY_CHUNK_SIZE after dropping the torn line"
+        );
+        let expected = ReplayEngine::fold(whole_file_events, None);
+        assert_eq!(
+            expected.last_seq,
+            Some(576),
+            "the torn line must be the trailing seq-577 ModelChanged event (verified against the \
+             real fixture) — a differential-only assertion below would pass vacuously if both \
+             paths regressed identically and stopped dropping the torn tail at all"
+        );
+
+        // New path: chunked-streaming replay on the same torn file.
+        let actual = ReplayEngine::replay(dir.path(), None).await.unwrap();
+
+        assert_eq!(
+            actual.last_seq, expected.last_seq,
+            "chunked replay must drop the torn tail at the same seq as the whole-file path"
+        );
+        assert_eq!(
+            serde_json::to_string(&actual.messages).unwrap(),
+            serde_json::to_string(&expected.messages).unwrap(),
+            "chunked replay must drop a torn tail beyond a chunk boundary identically to the \
+             whole-file read+fold path"
+        );
+    }
+
+    /// Regression test for #5841 finding 2: `ReplayEngine::replay`'s `up_to` bound must behave
+    /// identically to the old Vec-based `ReplayEngine::fold` at and around several
+    /// `REPLAY_CHUNK_SIZE` boundaries (99/100/101, 199/200/201) — `up_to` can land inside a
+    /// chunk still being accumulated, right at a chunk-flush point, or just past one, and the
+    /// chunked path must still stop the fold at the exact same seq the whole-file path does.
+    #[tokio::test]
+    async fn test_replay_up_to_matches_fold_at_chunk_boundaries() {
+        const N_TURNS: u64 = 250; // produces well over 200 events
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = seed_large_synthetic_log(dir.path(), N_TURNS).await;
+        let all_events = log.read_all().await.unwrap();
+        assert!(
+            all_events.len() > 200,
+            "synthetic log must exceed 200 events to exercise several REPLAY_CHUNK_SIZE boundaries"
+        );
+
+        for up_to in [99u64, 100, 101, 199, 200, 201] {
+            let expected = ReplayEngine::fold(all_events.clone(), Some(up_to));
+            let actual = ReplayEngine::replay(dir.path(), Some(up_to)).await.unwrap();
+
+            assert_eq!(
+                actual.last_seq, expected.last_seq,
+                "up_to={up_to}: last_seq mismatch between streamed replay and Vec-based fold"
+            );
+            assert_eq!(
+                serde_json::to_string(&actual.messages).unwrap(),
+                serde_json::to_string(&expected.messages).unwrap(),
+                "up_to={up_to}: streamed replay must match Vec-based fold exactly at/near chunk \
+                 boundaries"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #5841 — two test-coverage gaps left over from #5445's chunked-replay
perf pass (PR #5844). Both interactions were only hand-traced as correct
during #5445's review; neither was covered by an automated regression test.

- `test_replay_torn_tail_across_chunk_boundary` (finding 1): drives a torn
  trailing line through `ReplayEngine::replay`'s new
  `SessionEventLog::read_chunked` path on a log spanning several
  `REPLAY_CHUNK_SIZE` (100) chunks, asserting it drops the torn line at the
  same seq as the old whole-file `read_all` + `fold` path. Also asserts the
  exact expected `last_seq` positively (not just differentially), so the
  test cannot pass vacuously if torn-tail dropping regressed identically on
  both paths.
- `test_replay_up_to_matches_fold_at_chunk_boundaries` (finding 2): asserts
  `ReplayEngine::replay(dir, Some(up_to))` matches the Vec-based
  `ReplayEngine::fold` at `up_to` values landing at/near six chunk
  boundaries (99/100/101, 199/200/201) on a >200-event log.

Also added a doc-comment note on `SessionEventLog::read_chunked` documenting
its over-read behavior (a chunk still being accumulated is fully read/parsed
before `on_chunk` can evaluate an `up_to` break) — informational only, no
logic change.

No production behavior changed.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (zeph-session: 47/47 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`