### PR TITLE
test(core): add real-Agent NFR-P7 idle-session memory bench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   own owned conversation-history state is a separate, session-length-dependent quantity not
   covered by the "idle session" framing (follow-up bench tracked in #5840). No source change was
   needed for either finding (#5445).
+- `test(session)`: added a real-`Agent`-based NFR-P7 memory bench
+  (`crates/zeph-core/src/serve.rs::tests::nfr_p7_real_agent_idle_session_memory_floor`, `#[ignore]`d,
+  run via `cargo nextest run -p zeph-core -E 'test(nfr_p7)' --run-ignored ignored-only`) closing
+  the measurement gap the #5445 standalone harness left open — that harness could not construct a
+  real `Agent<LoopbackChannel>` (private to `zeph-core`), so it measured `SessionActor::spawn`'s
+  housing cost only. The new test spawns real `SessionActor`s wrapping real `Agent<LoopbackChannel>`
+  instances (idle, mock-provider-backed, one shared `Arc<RwLock<SkillRegistry>>` across all actors
+  via `Agent::new_with_registry_arc`, mirroring `src/serve/agent_factory.rs`'s production sharing
+  pattern rather than a private registry per actor) via the production `SessionActor::spawn` path
+  and samples RSS via `sysinfo`, matching `system_metrics::spawn_system_metrics_task`'s existing
+  production RSS-sampling technique. Measured combined floor (housing + `Agent`'s owned state):
+  ~875-905 KiB — under the 1 MiB budget, but with far less headroom than the ~65-93 KiB
+  housing-only figure implied. This composite is a distinct, larger quantity than NFR-P7's own
+  housing-only budget; `specs/068-session-persistence/nfr.md` gained a new rationale paragraph
+  making that scope distinction explicit rather than silently redefining NFR-P7 (#5840).
 
 ### Fixed
 

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -104,6 +104,7 @@ rmcp.workspace = true
 schemars.workspace = true
 serial_test.workspace = true
 sqlx.workspace = true
+sysinfo = { workspace = true, features = ["system"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true, features = ["parking_lot", "registry"] }

--- a/crates/zeph-core/src/serve.rs
+++ b/crates/zeph-core/src/serve.rs
@@ -862,4 +862,136 @@ mod tests {
             .expect("session actor must finish within the timeout after its own token cancels")
             .expect("session actor task must not panic or be aborted");
     }
+
+    /// Samples this process's own RSS via `sysinfo` — the same technique
+    /// `system_metrics::spawn_system_metrics_task` uses in production — so results are directly
+    /// comparable to other in-process RSS measurements.
+    fn sample_rss(sys: &mut sysinfo::System, pid: sysinfo::Pid) -> u64 {
+        sys.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
+        sys.process(pid).map_or(0, sysinfo::Process::memory)
+    }
+
+    // TODO(critic): decompose idle floor (stack-resident vs Agent heap vs skill registry) and
+    // add a production-realistic (non-mock) upper-bound variant.
+    //
+    /// NFR-P7 follow-up (#5840): the #5445 standalone harness measured `SessionActor::spawn`'s
+    /// structural housing cost in isolation (thread stack, runtime, channels — ~65-93 KiB/actor,
+    /// see `specs/068-session-persistence/nfr.md`) but could not construct a real
+    /// `Agent<LoopbackChannel>`, which is private to this crate. This test closes that gap: it
+    /// spawns real `SessionActor`s wrapping real (mock-provider-backed, since no live LLM/Qdrant
+    /// is needed to measure idle housing) `Agent<LoopbackChannel>` instances in-process, so the
+    /// measured RSS also includes `Agent`'s own owned state — not just the actor's housing.
+    ///
+    /// **This is a zero-conversation-turn floor** (no prompts are ever sent), so the ~875-905 KiB
+    /// measured here is *not* `Agent`'s message-history buffer, which is empty throughout. The
+    /// dominant contributor is not yet decomposed (see the `TODO` above) but is more likely extra
+    /// resident pages of the actor's 8 MiB thread stack ([`SESSION_ACTOR_STACK_SIZE`]) touched by
+    /// the deeper `Agent::new`/`drive` call chain, and/or the shared `SkillRegistry` load —
+    /// neither of which #5445's Agent-less harness ever touched.
+    ///
+    /// **Lower bound, not an upper bound**: `mock_provider` has no HTTP client/connection pool,
+    /// [`MockToolExecutor::no_tools`] carries no tool definitions, and the shared registry below
+    /// loads exactly one trivial skill with no embedding vectors. A production session's real
+    /// `SkillRegistry` (many skills + embeddings), real provider (reqwest client + pool), and any
+    /// `SemanticMemory` state will all measure higher than what this test reports — a pass here is
+    /// not proof that a production idle session stays under NFR-P7's budget.
+    ///
+    /// **Composite vs. NFR-P7's own scope**: `specs/068-session-persistence/nfr.md`'s NFR-P7 is
+    /// defined as housing-only (thread stack + runtime + channels); the composite this test
+    /// measures (housing + `Agent`'s owned state) is a distinct, larger quantity the spec's #5445
+    /// rationale explicitly separates out. The `assert!` below reuses NFR-P7's 1 MiB number as a
+    /// convenience threshold for this composite measurement, not as a formal claim that NFR-P7
+    /// (as specified) is satisfied — see the "NFR-P7 follow-up (#5840)" rationale note in
+    /// `nfr.md` for the recorded distinction. This test is also `#[ignore]`d and matched by no CI
+    /// workflow filter, so it never runs automatically — it is a manual tripwire for whoever
+    /// invokes it by hand, not an automated regression gate.
+    ///
+    /// Mirrors the #5445 harness's approach of measuring marginal RSS across growing cumulative
+    /// batches (10, 25, 50, 100 actors) so one-time fixed costs (allocator warmup, first-touch
+    /// page faults) amortize out. The reported floor is the delta between the *last two*
+    /// checkpoints (50→100), not an earlier window — the 50→100 and 25→50 deltas agree to within
+    /// noise (confirming convergence), whereas the 10→25 window still carries first-batch fixed
+    /// costs and reads noticeably higher; using the converged tail avoids attributing one-time
+    /// warmup cost to the per-session marginal figure.
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "spawns up to 100 real OS threads; run explicitly to verify NFR-P7, e.g. \
+                `cargo nextest run -p zeph-core -E 'test(nfr_p7)' --run-ignored ignored-only \
+                --no-capture`"]
+    async fn nfr_p7_real_agent_idle_session_memory_floor() {
+        use crate::agent::Agent;
+        use crate::agent::agent_tests::{MockToolExecutor, create_test_registry, mock_provider};
+
+        let supervisor = TaskSupervisor::new(CancellationToken::new());
+        let registry = Arc::new(LiveSessionRegistry::new());
+        let pid = sysinfo::get_current_pid().expect("current pid must be resolvable");
+        let mut sys = sysinfo::System::new();
+
+        // Shared across every spawned Agent, mirroring production (`src/serve/agent_factory.rs`'s
+        // `build_agent_factory`, which passes one `Clone`-shared `deps.registry` to
+        // `Agent::new_with_registry_arc` for every session) rather than each actor building its
+        // own private registry via the simpler `Agent::new`. A 101st real session costs one `Arc`
+        // clone, not a whole new registry — this keeps the measured marginal cost representative
+        // of production instead of overstating it with a per-actor registry that doesn't scale.
+        let skill_registry = Arc::new(parking_lot::RwLock::new(create_test_registry()));
+
+        let mut actors = Vec::new();
+        let mut checkpoints: Vec<(usize, u64)> = Vec::new();
+
+        for target in [10usize, 25, 50, 100] {
+            while actors.len() < target {
+                let session_id = SessionId::new(format!("nfr-p7-{}", actors.len()));
+                let shared_registry = Arc::clone(&skill_registry);
+                let (handle, blocking) = SessionActor::spawn(
+                    &supervisor,
+                    &registry,
+                    &session_id,
+                    move |channel| {
+                        let provider = mock_provider(vec!["ok".to_owned()]);
+                        let embedding_provider = provider.clone();
+                        let executor = MockToolExecutor::no_tools();
+                        Agent::new_with_registry_arc(
+                            provider,
+                            embedding_provider,
+                            channel,
+                            shared_registry,
+                            None,
+                            5,
+                            executor,
+                        )
+                    },
+                    4,
+                );
+                actors.push((handle, blocking));
+            }
+            // Let newly spawned dedicated threads finish constructing their Agent and settle into
+            // `drive`'s idle `select!` loop before sampling.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            checkpoints.push((target, sample_rss(&mut sys, pid)));
+        }
+
+        for (handle, _) in &actors {
+            let _ = handle.tx.send(SessionCommand::Shutdown).await;
+        }
+        for (_, blocking) in actors {
+            let _ = tokio::time::timeout(Duration::from_secs(10), blocking.join()).await;
+        }
+
+        let (n_prev, rss_prev) = checkpoints[checkpoints.len() - 2];
+        let (n_last, rss_last) = checkpoints[checkpoints.len() - 1];
+        let marginal_per_session = rss_last.saturating_sub(rss_prev) / (n_last - n_prev) as u64;
+
+        eprintln!("NFR-P7 real-Agent memory floor checkpoints: {checkpoints:?}");
+        eprintln!(
+            "NFR-P7 real-Agent per-session marginal floor (housing + Agent owned state, \
+             synthetic mock-backed lower bound): {marginal_per_session} bytes ({} KiB)",
+            marginal_per_session / 1024
+        );
+
+        assert!(
+            marginal_per_session < 1_048_576,
+            "NFR-P7 composite budget (informational threshold, see nfr.md's #5840 rationale) \
+             exceeded: measured {marginal_per_session} bytes/session >= 1 MiB \
+             (checkpoints: {checkpoints:?})"
+        );
+    }
 }

--- a/specs/068-session-persistence/nfr.md
+++ b/specs/068-session-persistence/nfr.md
@@ -66,6 +66,33 @@ of quantity than this NFR's "idle session" framing assumes. Closing that gap req
 real-`Agent`-based bench (tracked as a follow-up, not blocking this NFR revision since the
 measured housing floor is the actual object described by "idle session actor").
 
+**NFR-P7 follow-up (#5840):** a new in-tree test
+(`crates/zeph-core/src/serve.rs::tests::nfr_p7_real_agent_idle_session_memory_floor`) closes the
+gap above by spawning real `SessionActor`s wrapping real `Agent<LoopbackChannel>` instances (mock
+provider/tool-executor, one shared `SkillRegistry` across all sessions — mirroring production's
+`Agent::new_with_registry_arc` sharing, not a private registry per actor) and measuring the same
+marginal-batched RSS delta as the #5445 harness above. Measured composite (housing + `Agent`'s
+owned state) floor: **~875–905 KiB/session**, stable across repeated runs — this is a
+**zero-conversation-turn** measurement (no prompts sent), so the figure is *not* dominated by
+message-history growth; the dominant contributor is not yet decomposed (tracked as a follow-up in
+the test's own `TODO`) but is more likely resident thread-stack pages and/or `SkillRegistry`/agent
+subsystem defaults touched by the deeper construction/drive call chain #5445's Agent-less harness
+never exercised.
+
+This number is explicitly **not** a claim that NFR-P7 (as defined above, housing-only) is
+satisfied for the composite quantity — the composite is a different, larger quantity than this
+NFR's own budget covers, exactly as the paragraph above anticipated. It is also a **lower bound
+only**: the mock provider has no connection pool, the shared registry loads a single trivial
+skill with no embeddings, and no `SemanticMemory` state is present — a production session with a
+realistic skill count and a real provider will measure higher, and with only ~119–149 KiB of
+headroom under the 1 MiB figure, a production idle floor plausibly exceeds it. The in-tree test's
+`assert!` reuses NFR-P7's 1 MiB number only as a convenience tripwire threshold for this
+informational composite measurement (and, since the test is `#[ignore]`d and matched by no CI
+workflow filter, only ever fires when a human runs it by hand) — it is not a redefinition of
+NFR-P7's own scope. Formally extending NFR-P7 (or adding a distinct NFR-P7b) to cover the
+composite idle floor, and decomposing/re-measuring against production-realistic (non-mock) state,
+remain open follow-up work.
+
 ---
 
 ## 2. Reliability


### PR DESCRIPTION
## Summary

- Closes #5840. #5445's standalone housing-cost harness could not construct a real `Agent<LoopbackChannel>` (private to `zeph-core`), so it only measured `SessionActor::spawn`'s own housing (~65-93 KiB/actor). This adds an in-crate `#[ignore]`d test, `nfr_p7_real_agent_idle_session_memory_floor`, that spawns real `SessionActor`s wrapping real `Agent<LoopbackChannel>` instances (one shared `SkillRegistry` across sessions via `Agent::new_with_registry_arc`, mirroring production's sharing pattern rather than a private registry per actor) and samples RSS the same way production's `system_metrics` module does, using the same batched/marginal methodology as the #5445 harness.
- Measured combined (housing + `Agent`'s owned state) floor: **~875-905 KiB/session** — under NFR-P7's 1 MiB budget, but with far less headroom than the ~65-93 KiB housing-only figure implied. `specs/068-session-persistence/nfr.md` gains a rationale paragraph making explicit that this composite is a distinct, larger quantity than NFR-P7's own housing-only scope, rather than silently redefining it — and that this measurement is a synthetic lower bound (mock provider, one trivial skill, no real conversation history), not a production compliance proof.
- The test is `#[ignore]`d and matched by no CI workflow filter, so it never runs automatically; it's a manual tripwire, run via `cargo nextest run -p zeph-core -E 'test(nfr_p7)' --run-ignored ignored-only --no-capture`.

## Review notes

- Team review (developer, tester, perf, security, impl-critic, code-reviewer) surfaced and resolved several issues before this PR: an initial per-actor-private-`SkillRegistry` construction was replaced with the shared-`Arc` pattern production actually uses; a doc comment mis-attributing the measured cost to the message-history buffer (this is a zero-conversation-turn floor, so history is empty) was corrected; the composite-vs-housing-only scope mismatch against NFR-P7's own budget was made explicit in both the test doc comment and the spec; a synthetic-lower-bound caveat and a decomposition TODO were added.
- A pre-existing, unrelated `cargo deny` advisory (RUSTSEC-2026-0204, via `zeph-index`→`ignore`→`crossbeam-epoch`) still fails the deny gate; this PR's diff does not touch that dependency chain.
- `.local/testing/coverage-status.md` and `.local/testing/playbooks/session-persistence.md` were updated in the main repository (not part of this diff, per project convention for shared testing docs).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12368 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc -p zeph-core`
- [x] Manually ran the new bench: `cargo nextest run -p zeph-core -E 'test(nfr_p7)' --run-ignored ignored-only --no-capture` — passes, ~876-905 KiB/session across multiple runs