### PR TITLE
fix(skills): close RL rerank warmup TOCTOU and add test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   break, which stays within the ≤ 100-in-memory bound but is worth flagging for future refactors
   (#5841).
 
+### Fixed
+
+- `fix(skills)`: `RoutingHead::rerank()` (`crates/zeph-skills/src/rl_head.rs`) now returns a
+  `RerankOutcome` carrying `blended`/`update_count` captured under the same lock acquisition
+  used to rank candidates. The `assembly.rs` call site (`match_and_rank_skills`) previously
+  logged `blended`/`update_count` from a second, independently-locked `update_count()` call
+  made after `rerank()` had already released its lock — a concurrent background
+  `rl_head.update()` landing in that gap could make the logged values inconsistent with the
+  warmup decision `rerank()` itself branched on (TOCTOU, #5846).
+
+### Testing
+
+- `test(skills)`: added `rl_head.rs` coverage for a case where cosine order and RL-blended
+  order disagree (previously only `len()`/`update_count` were asserted for the post-warmup
+  path, never actual sort order) and a regression test asserting `RerankOutcome`'s
+  `blended`/`update_count` match the head's own counter with no drift from a second lock
+  acquisition (#5845, #5846).
+- `test(core)`: added `zeph-core` coverage for `match_and_rank_skills`'s previously-untested
+  `rl_head`-enabled branch — the RL-rerank success path plus its three skip/error paths (query
+  embed timeout, query/head embed-dim mismatch, and per-candidate skill-embedding dim
+  mismatch) — via a new `with_rl_head()`-wired `Agent` test harness (#5845).
+
 ### Docs
 
 - `docs(sanitizer)`: updated `crates/zeph-sanitizer/src/shadow_memory.rs` doc comment to reflect

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1229,13 +1229,14 @@ impl<C: Channel> Agent<C> {
                             .iter()
                             .map(|(idx, emb, score)| (*idx, emb.as_slice(), *score))
                             .collect();
-                        let reranked = rl_head.rerank(
+                        let outcome = rl_head.rerank(
                             &query_embed,
                             &candidate_refs,
                             &stats,
                             rl_weight,
                             warmup,
                         );
+                        let reranked = &outcome.ranked;
                         // Apply new order to scored.
                         scored.sort_by(|a, b| {
                             let pos_a = reranked.iter().position(|(i, _)| *i == a.index);
@@ -1244,11 +1245,17 @@ impl<C: Channel> Agent<C> {
                         });
                         // Positive-confirmation log: without this, RL re-rank success is
                         // indistinguishable from the feature being silently inactive (#5834).
-                        // `rerank()` returns pure cosine order (no blending) while
-                        // `update_count < warmup_updates`; checked here right after the call so
-                        // `blended` reflects the same condition `rerank()` itself branched on.
-                        let update_count = rl_head.update_count();
-                        let blended = update_count >= warmup;
+                        // `blended`/`update_count` come straight from `outcome`, captured by
+                        // `rerank()` under its own lock acquisition — this avoids a second,
+                        // independent `update_count()` call that could race with a concurrent
+                        // `update()` and report a value inconsistent with what `rerank()` itself
+                        // branched on (#5846).
+                        //
+                        // Do not "simplify" this back to a separate `rl_head.update_count()`
+                        // call — the atomicity guarantee only holds as long as both fields are
+                        // read from this single `outcome`.
+                        let update_count = outcome.update_count;
+                        let blended = outcome.blended;
                         let rerank_summary: Vec<(String, f32, f32)> = reranked
                             .iter()
                             .map(|(idx, post_score)| {
@@ -2952,5 +2959,220 @@ mod tests {
             "history must be cleared down to the system prompt"
         );
         assert_eq!(agent.msg.messages[0].role, Role::System);
+    }
+
+    // ── #5845: match_and_rank_skills's rl_head-enabled branch had zero test coverage —
+    // neither the RL-rerank success path nor its three skip/error paths were ever exercised.
+
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+    use zeph_skills::matcher::{SkillMatcher, SkillMatcherBackend};
+    use zeph_skills::registry::SkillRegistry;
+    use zeph_skills::rl_head::RoutingHead;
+
+    /// Builds a registry with two skills ("skill-a", "skill-b") whose descriptions get
+    /// distinct, test-controlled embeddings via a custom `embed_fn` (independent of the
+    /// agent's own embedding provider). Keeps the backing `TempDir` alive, mirroring
+    /// `create_registry_with_live_dir` in `skill_fallback_tests.rs`.
+    fn create_two_skill_registry() -> (SkillRegistry, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        for (name, desc) in [
+            ("skill-a", "First test skill"),
+            ("skill-b", "Second test skill"),
+        ] {
+            let dir = temp_dir.path().join(name);
+            std::fs::create_dir(&dir).unwrap();
+            std::fs::write(
+                dir.join("SKILL.md"),
+                format!(
+                    "---\nname: {name}\ndescription: {desc}\n---\n<instructions>\nbody\n</instructions>"
+                ),
+            )
+            .unwrap();
+        }
+        let registry = SkillRegistry::load(&[temp_dir.path().to_path_buf()]);
+        (registry, temp_dir)
+    }
+
+    /// Constructs an `Agent<MockChannel>` wired with an in-memory two-skill matcher, ready to
+    /// exercise `match_and_rank_skills`'s rl_head-enabled branch. `embed_dims` sets the
+    /// (skill-a, skill-b) embedding dimensions — mismatched dims let a test trigger the
+    /// "`candidates.len()` != `scored.len()`" skip path. Disambiguation and the injection-score
+    /// floor are disabled so they never interfere with these RL-focused assertions.
+    async fn build_rl_test_agent(
+        provider: AnyProvider,
+        embed_dims: (usize, usize),
+    ) -> (Agent<MockChannel>, Vec<SkillMeta>, tempfile::TempDir) {
+        let (registry, dir) = create_two_skill_registry();
+        let mut agent = Agent::new(
+            provider,
+            MockChannel::new(vec![]),
+            registry,
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+        let all_meta_owned: Vec<SkillMeta> = {
+            let guard = agent.services.skill.registry.read();
+            guard.all_meta().into_iter().cloned().collect()
+        };
+        let embed_fn = move |text: &str| -> zeph_skills::matcher::EmbedFuture {
+            let dim = if text.starts_with("First") {
+                embed_dims.0
+            } else {
+                embed_dims.1
+            };
+            Box::pin(async move { Ok(vec![1.0_f32; dim]) })
+        };
+        let matcher = SkillMatcher::new(&all_meta_owned.iter().collect::<Vec<_>>(), embed_fn)
+            .await
+            .map(SkillMatcherBackend::InMemory);
+        agent.services.skill.matcher = matcher;
+        // Never disambiguate and never drop a candidate for scoring below the floor — these
+        // tests assert on the RL-rerank branch specifically, not on unrelated skill-selection
+        // features.
+        agent.services.skill.disambiguation_threshold = -1.0;
+        agent.services.skill.min_injection_score = -1.0;
+        (agent, all_meta_owned, dir)
+    }
+
+    #[tokio::test]
+    async fn match_and_rank_skills_applies_rl_rerank_when_healthy() {
+        let embed_dim = 4;
+        let provider = AnyProvider::Mock(
+            MockProvider::with_responses(vec!["ok".to_string()])
+                .with_embedding(vec![1.0_f32; embed_dim]),
+        );
+        let (mut agent, all_meta_owned, _dir) =
+            Box::pin(build_rl_test_agent(provider, (embed_dim, embed_dim))).await;
+
+        let rl_head = RoutingHead::new(embed_dim);
+        agent = agent.with_rl_head(rl_head.clone());
+        agent.services.skill.rl_warmup_updates = 0; // already past warmup
+
+        let all_meta_refs: Vec<&SkillMeta> = all_meta_owned.iter().collect();
+        let (indices, fallback, skills_to_record) = agent
+            .match_and_rank_skills("query", "effective query", &all_meta_refs)
+            .await;
+
+        assert!(
+            !fallback,
+            "healthy matcher + provider must not trigger fallback mode"
+        );
+        assert_eq!(indices.len(), 2, "both skills must be returned");
+        assert_eq!(skills_to_record.len(), 2);
+        // rerank() populates last_forward for the winning candidate only when it actually runs
+        // (both the cold-start and post-warmup branches do this) — the skip/error paths below
+        // never call rerank() at all, so update() stays a no-op (false). This is the most
+        // direct, log-independent signal that the RL-rerank success path executed.
+        assert!(
+            rl_head.update(1.0, 0.01),
+            "rerank() must have populated last_forward when the RL-rerank success path runs"
+        );
+    }
+
+    #[tokio::test]
+    async fn match_and_rank_skills_skips_rl_rerank_on_query_embed_timeout() {
+        let embed_dim = 4;
+        // First embed() call (skill-matching's own query embed) succeeds instantly; the
+        // second (RL's separate query embed) sleeps long enough to exceed the configured
+        // timeout — see assembly.rs's `rl_query_embed` construction.
+        let provider = AnyProvider::Mock(
+            MockProvider::with_responses(vec!["ok".to_string()])
+                .with_per_call_embed_delays(vec![0, 5_000]),
+        );
+        let (mut agent, all_meta_owned, _dir) =
+            Box::pin(build_rl_test_agent(provider, (embed_dim, embed_dim))).await;
+        agent.runtime.config.timeouts.embedding_seconds = 1;
+
+        let rl_head = RoutingHead::new(embed_dim);
+        agent = agent.with_rl_head(rl_head.clone());
+
+        tokio::time::pause();
+        let handle = tokio::spawn(async move {
+            let all_meta_refs: Vec<&SkillMeta> = all_meta_owned.iter().collect();
+            agent
+                .match_and_rank_skills("query", "effective query", &all_meta_refs)
+                .await
+        });
+        tokio::time::advance(std::time::Duration::from_secs(2)).await;
+        let (indices, fallback, _) = handle.await.expect("task panicked");
+
+        assert!(!fallback);
+        assert_eq!(
+            indices.len(),
+            2,
+            "cosine order must still be used when the RL query embed times out"
+        );
+        assert!(
+            !rl_head.update(1.0, 0.01),
+            "rerank() must never run when the RL query embed times out"
+        );
+    }
+
+    #[tokio::test]
+    async fn match_and_rank_skills_skips_rl_rerank_on_query_head_dim_mismatch() {
+        let matcher_embed_dim = 4;
+        let provider = AnyProvider::Mock(
+            MockProvider::with_responses(vec!["ok".to_string()])
+                .with_embedding(vec![1.0_f32; matcher_embed_dim]),
+        );
+        let (mut agent, all_meta_owned, _dir) = Box::pin(build_rl_test_agent(
+            provider,
+            (matcher_embed_dim, matcher_embed_dim),
+        ))
+        .await;
+
+        // rl_head expects a different embedding dimension than what the (mock) embedding
+        // provider actually returns for the query — e.g. the embedding model changed since
+        // the head was trained/saved.
+        let rl_head = RoutingHead::new(matcher_embed_dim + 1);
+        agent = agent.with_rl_head(rl_head.clone());
+
+        let all_meta_refs: Vec<&SkillMeta> = all_meta_owned.iter().collect();
+        let (indices, fallback, _) = agent
+            .match_and_rank_skills("query", "effective query", &all_meta_refs)
+            .await;
+
+        assert!(!fallback);
+        assert_eq!(indices.len(), 2);
+        assert!(
+            !rl_head.update(1.0, 0.01),
+            "rerank() must never run when query/head embed dims mismatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn match_and_rank_skills_skips_rl_rerank_when_some_skill_embeddings_mismatch_dim() {
+        let embed_dim = 4;
+        let provider = AnyProvider::Mock(
+            MockProvider::with_responses(vec!["ok".to_string()])
+                .with_embedding(vec![1.0_f32; embed_dim]),
+        );
+        // skill-a gets an embed_dim-length embedding (matches rl_head); skill-b gets a
+        // mismatched length — simulates a partial embedding-model migration where only some
+        // skills were re-embedded, so `matcher.skill_embedding()` returns a vector `rerank()`
+        // cannot safely consume for that candidate.
+        let (mut agent, all_meta_owned, _dir) =
+            Box::pin(build_rl_test_agent(provider, (embed_dim, embed_dim + 4))).await;
+
+        let rl_head = RoutingHead::new(embed_dim);
+        agent = agent.with_rl_head(rl_head.clone());
+
+        let all_meta_refs: Vec<&SkillMeta> = all_meta_owned.iter().collect();
+        let (indices, fallback, _) = agent
+            .match_and_rank_skills("query", "effective query", &all_meta_refs)
+            .await;
+
+        assert!(!fallback);
+        assert_eq!(
+            indices.len(),
+            2,
+            "both skills still returned via cosine order"
+        );
+        assert!(
+            !rl_head.update(1.0, 0.01),
+            "rerank() must never run when some skill embeddings don't match rl_head's dim"
+        );
     }
 }

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -71,6 +71,9 @@ pub struct MockProvider {
     embed_tracking_enabled: bool,
     /// Per-call delay sequence. Each `chat()` call pops from the front; when empty, falls back to `delay_ms`.
     per_call_delays: Arc<Mutex<VecDeque<u64>>>,
+    /// Per-call delay sequence for `embed()`. Each call pops from the front; when empty, falls
+    /// back to `embed_delay_ms`. See [`MockProvider::with_per_call_embed_delays`].
+    per_call_embed_delays: Arc<Mutex<VecDeque<u64>>>,
     /// Captures the most recent [`GenerationOverrides`] applied via
     /// [`MockProvider::with_generation_overrides`]. Shared with the test via
     /// [`MockProvider::with_overrides_capture`] — the mock otherwise ignores overrides entirely.
@@ -106,6 +109,7 @@ impl Default for MockProvider {
             peak_concurrent_embed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             embed_tracking_enabled: false,
             per_call_delays: Arc::new(Mutex::new(VecDeque::new())),
+            per_call_embed_delays: Arc::new(Mutex::new(VecDeque::new())),
             captured_overrides: Arc::new(Mutex::new(None)),
         }
     }
@@ -187,6 +191,20 @@ impl MockProvider {
     #[must_use]
     pub fn with_embed_delay(mut self, ms: u64) -> Self {
         self.embed_delay_ms = ms;
+        self.supports_embeddings = true;
+        self
+    }
+
+    /// Assign a distinct delay (ms) to each successive `embed()` call: the Nth call sleeps
+    /// `delays[N]` ms before returning; once `delays` is exhausted, falls back to
+    /// `embed_delay_ms`. Mirrors [`Self::with_per_call_delays`] for `chat()`.
+    ///
+    /// Useful when a single turn issues multiple `embed()` calls through the same provider
+    /// (e.g. skill matching's query embed followed by a separate RL re-rank query embed) and a
+    /// test needs an early call to succeed quickly while a later one times out.
+    #[must_use]
+    pub fn with_per_call_embed_delays(mut self, delays: Vec<u64>) -> Self {
+        self.per_call_embed_delays = Arc::new(Mutex::new(VecDeque::from(delays)));
         self.supports_embeddings = true;
         self
     }
@@ -446,7 +464,13 @@ impl LlmProvider for MockProvider {
 
         self.embed_call_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        if self.embed_delay_ms > 0 {
+        let call_delay = self
+            .per_call_embed_delays
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(self.embed_delay_ms);
+        if call_delay > 0 {
             if self.embed_tracking_enabled {
                 // Yield before sleeping so concurrent tasks can register in-flight before
                 // any of them finish, enabling accurate peak measurement. Gated on the
@@ -454,7 +478,7 @@ impl LlmProvider for MockProvider {
                 // scheduling.
                 tokio::task::yield_now().await;
             }
-            tokio::time::sleep(std::time::Duration::from_millis(self.embed_delay_ms)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(call_delay)).await;
         }
         let result = if let Ok(mut errors) = self.errors.lock()
             && !errors.is_empty()

--- a/crates/zeph-skills/src/rl_head.rs
+++ b/crates/zeph-skills/src/rl_head.rs
@@ -251,6 +251,24 @@ pub struct RoutingHead {
     inner: Arc<Mutex<RoutingHeadInner>>,
 }
 
+/// Result of a [`RoutingHead::rerank`] call.
+///
+/// `blended` and `update_count` are captured under the **same** lock acquisition used to
+/// rank `ranked`, so a caller that needs to log or branch on the warmup decision can rely on
+/// them being consistent with the returned order — no second `update_count()` call (and its
+/// own separate lock acquisition) is needed, which would otherwise race with a concurrent
+/// [`RoutingHead::update`] landing between the two calls.
+#[derive(Debug, Clone)]
+pub struct RerankOutcome {
+    /// Candidate indices paired with their score, sorted descending.
+    pub ranked: Vec<(usize, f32)>,
+    /// Whether RL blending was applied (`true`) or the cosine order was kept as-is because
+    /// the head is still warming up (`false`).
+    pub blended: bool,
+    /// `update_count` observed under the same lock acquisition that produced `blended`.
+    pub update_count: u32,
+}
+
 impl RoutingHead {
     /// Initialize with Xavier-initialized weights.
     #[must_use]
@@ -286,11 +304,17 @@ impl RoutingHead {
             )
     }
 
-    /// Re-rank candidates using RL scores. Returns indices sorted by blended score descending.
+    /// Re-rank candidates using RL scores. Returns the ranked indices plus the warmup state
+    /// used to produce them.
     ///
     /// `rl_weight`: final_score = (1-rl_weight)*cosine + rl_weight*rl_score
     ///
     /// Skips RL blending and returns original cosine order when `update_count < warmup_updates`.
+    /// The `blended`/`update_count` fields of the returned [`RerankOutcome`] reflect the exact
+    /// `update_count` snapshot taken under this call's own lock acquisition — callers that need
+    /// to report the warmup decision must use those fields rather than calling
+    /// [`RoutingHead::update_count`] separately afterward, which would race with a concurrent
+    /// [`RoutingHead::update`] (see #5846).
     ///
     /// # Panics
     ///
@@ -303,10 +327,11 @@ impl RoutingHead {
         stats: &[(f32, u32)],
         rl_weight: f32,
         warmup_updates: u32,
-    ) -> Vec<(usize, f32)> {
+    ) -> RerankOutcome {
         let mut inner = self.inner.lock().expect("RoutingHead mutex poisoned");
+        let update_count = inner.update_count;
 
-        if inner.update_count < warmup_updates {
+        if update_count < warmup_updates {
             // Cold start: use pure cosine order.
             // Still run a forward pass on the top cosine candidate so last_forward is populated
             // and update() can increment update_count — otherwise warmup never ends.
@@ -322,7 +347,11 @@ impl RoutingHead {
                 let (success_rate, use_count) = stats[pos];
                 inner.score(query_embed, skill_embed, cosine, success_rate, use_count);
             }
-            return ranked;
+            return RerankOutcome {
+                ranked,
+                blended: false,
+                update_count,
+            };
         }
 
         // Score all candidates under a single lock acquisition, capturing each forward cache.
@@ -348,10 +377,14 @@ impl RoutingHead {
         }
         drop(inner);
 
-        ranked
-            .into_iter()
-            .map(|(idx, score, _)| (idx, score))
-            .collect()
+        RerankOutcome {
+            ranked: ranked
+                .into_iter()
+                .map(|(idx, score, _)| (idx, score))
+                .collect(),
+            blended: true,
+            update_count,
+        }
     }
 
     /// REINFORCE update for the skill that was actually selected.
@@ -592,7 +625,7 @@ mod tests {
             vec![(0, &s1, 0.9), (1, &s2, 0.5), (2, &s3, 0.7)];
         let stats = vec![(0.8, 5u32), (0.6, 3), (0.7, 4)];
 
-        let ranked = head.rerank(&q, &candidates, &stats, 0.3, 50);
+        let ranked = head.rerank(&q, &candidates, &stats, 0.3, 50).ranked;
         assert_eq!(
             ranked[0].0, 0,
             "highest cosine should be first during warmup"
@@ -647,7 +680,7 @@ mod tests {
             "update_count must reach warmup threshold"
         );
         // One more rerank should now use blended scores (post-warmup).
-        let ranked = head.rerank(&q, &candidates, &stats, 0.3, warmup);
+        let ranked = head.rerank(&q, &candidates, &stats, 0.3, warmup).ranked;
         assert_eq!(ranked.len(), 2);
     }
 
@@ -704,7 +737,7 @@ mod tests {
         let q = dummy_embed(0.1, 4);
         let candidates: Vec<(usize, &[f32], f32)> = vec![];
         let stats: Vec<(f32, u32)> = vec![];
-        let ranked = head.rerank(&q, &candidates, &stats, 0.3, 10);
+        let ranked = head.rerank(&q, &candidates, &stats, 0.3, 10).ranked;
         assert!(
             ranked.is_empty(),
             "empty candidates must produce empty ranked list"
@@ -726,7 +759,7 @@ mod tests {
         let candidates: Vec<(usize, &[f32], f32)> = vec![(42, &s, 0.95)];
         let stats = vec![(1.0, 10u32)];
 
-        let ranked = head.rerank(&q, &candidates, &stats, 0.3, 5);
+        let ranked = head.rerank(&q, &candidates, &stats, 0.3, 5).ranked;
         assert_eq!(ranked.len(), 1);
         assert_eq!(ranked[0].0, 42);
         assert!(
@@ -754,7 +787,7 @@ mod tests {
             vec![(0, &sa, 0.3), (1, &sb, 0.9), (2, &sc, 0.6)];
         let stats = vec![(0.5, 1u32), (0.7, 2), (0.6, 3)];
 
-        let ranked = head.rerank(&q, &candidates, &stats, 0.3, 20);
+        let ranked = head.rerank(&q, &candidates, &stats, 0.3, 20).ranked;
         assert_eq!(
             ranked[0].0, 1,
             "idx 1 has highest cosine 0.9, must be first"
@@ -782,12 +815,100 @@ mod tests {
         assert_eq!(head.update_count(), warmup);
 
         // Now in post-warmup mode: rerank then update.
-        let ranked = head.rerank(&q, &candidates, &stats, 0.3, warmup);
+        let ranked = head.rerank(&q, &candidates, &stats, 0.3, warmup).ranked;
         assert_eq!(ranked.len(), 2);
         assert!(
             head.update(1.0, 0.01),
             "update() must succeed after post-warmup rerank"
         );
         assert_eq!(head.update_count(), warmup + 1);
+    }
+
+    #[test]
+    fn rerank_post_warmup_blended_order_can_disagree_with_cosine_order() {
+        // Regression test for #5845: prior tests only asserted `len()`/`update_count` for the
+        // post-warmup path, never that blending actually changes the order relative to raw
+        // cosine. Construct a `RoutingHead` whose weights make the RL score *inversely*
+        // correlated with cosine similarity (by directly setting weights on the private
+        // `RoutingHeadInner`, bypassing Xavier init), so a candidate with low cosine but a
+        // favorable RL score can outrank one with high cosine but an unfavorable RL score.
+        let embed_dim = 1;
+        let hidden_dim = 1;
+        let input_dim = 2 * embed_dim + N_FEATURES; // [query, skill, cosine, success_rate, log_use]
+
+        // pre_relu = b1 + w1 . input. Only the cosine feature (index 2) has a nonzero weight,
+        // and it is negative, so higher cosine yields a *lower* hidden activation and thus a
+        // lower final RL score — the opposite of cosine similarity.
+        let mut w1 = vec![0.0f32; input_dim * hidden_dim];
+        w1[2] = -5.0;
+        let b1 = vec![5.0f32]; // keeps pre_relu >= 0 for cosine in [0, 1], so ReLU is a no-op
+        let w2 = vec![1.0f32];
+        let b2 = 0.0f32;
+
+        let inner = RoutingHeadInner {
+            w1,
+            b1,
+            w2,
+            b2,
+            embed_dim,
+            hidden_dim,
+            baseline: 0.0,
+            update_count: 50, // past any warmup threshold used below
+            last_forward: None,
+        };
+        let head = RoutingHead {
+            inner: Arc::new(Mutex::new(inner)),
+        };
+
+        let q = dummy_embed(0.0, embed_dim);
+        let s_high_cosine = dummy_embed(0.0, embed_dim);
+        let s_low_cosine = dummy_embed(0.0, embed_dim);
+        // idx 0: high cosine (0.9) but low RL score; idx 1: low cosine (0.1) but high RL score.
+        let candidates: Vec<(usize, &[f32], f32)> =
+            vec![(0, &s_high_cosine, 0.9), (1, &s_low_cosine, 0.1)];
+        let stats = vec![(0.5, 0u32), (0.5, 0u32)];
+
+        // rl_weight close to 1.0 so the RL signal dominates the blend, flipping cosine order.
+        let outcome = head.rerank(&q, &candidates, &stats, 0.9, 10);
+        assert!(outcome.blended, "update_count (50) is past warmup (10)");
+        assert_eq!(
+            outcome.ranked[0].0, 1,
+            "candidate with low cosine but favorable RL score must rank first: {:?}",
+            outcome.ranked
+        );
+        assert_eq!(outcome.ranked[1].0, 0);
+    }
+
+    #[test]
+    fn rerank_outcome_reports_atomic_blended_and_update_count() {
+        // Regression test for #5846: `blended`/`update_count` on `RerankOutcome` must reflect
+        // the exact values `rerank()` branched on internally under its own lock acquisition,
+        // not a value from a second, separately-locked `update_count()` call that could observe
+        // a different value if a concurrent `update()` landed in between (TOCTOU).
+        let head = make_head();
+        let q = dummy_embed(0.1, 4);
+        let s = dummy_embed(0.2, 4);
+        let candidates: Vec<(usize, &[f32], f32)> = vec![(0, &s, 0.8)];
+        let stats = vec![(0.5, 0u32)];
+
+        // Before warmup: blended must be false, update_count must be 0 (fresh head).
+        let outcome = head.rerank(&q, &candidates, &stats, 0.3, 5);
+        assert!(!outcome.blended, "fresh head must not blend before warmup");
+        assert_eq!(outcome.update_count, 0);
+        assert_eq!(outcome.update_count, head.update_count());
+
+        // Advance past warmup.
+        for _ in 0..5 {
+            let _ = head.rerank(&q, &candidates, &stats, 0.3, 5);
+            let _ = head.update(1.0, 0.01);
+        }
+        assert_eq!(head.update_count(), 5);
+
+        // Past warmup: blended must be true, and the reported update_count must match the
+        // head's own counter — no drift from a second, independent lock acquisition.
+        let outcome = head.rerank(&q, &candidates, &stats, 0.3, 5);
+        assert!(outcome.blended, "head is past warmup, blending must apply");
+        assert_eq!(outcome.update_count, 5);
+        assert_eq!(outcome.update_count, head.update_count());
     }
 }


### PR DESCRIPTION
## Summary

- `RoutingHead::rerank()` (`crates/zeph-skills/src/rl_head.rs`) now returns a `RerankOutcome { ranked, blended, update_count }` capturing `blended`/`update_count` under the same lock acquisition used to rank candidates, closing a narrow TOCTOU where the `assembly.rs` positive-confirmation log (added in #5834) computed those values via a second, independently-locked `update_count()` call that could race with a concurrent background `rl_head.update()`.
- Added the RL-rerank branch's first automated test coverage: `Agent::with_rl_head()` (previously zero callers anywhere) is now exercised via a new `zeph-core` test harness covering `match_and_rank_skills`' success path and all three skip/error paths, plus an `rl_head.rs` test constructing a case where cosine order and RL-blended order disagree.

Closes #5845, closes #5846.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12372 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`