### PR TITLE
docs(orchestration): correct llm-planning feature flag default claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `crates/zeph-session/src/log.rs` for the identical torn-tail warn+repair epilogue duplicated
   between `read_events` and `read_events_chunked` (#5852).
 
+### Fixed
+
+- `docs(orchestration)`: corrected `zeph-orchestration` crate-level doc comment claiming `llm-planning` feature is enabled by default; it is not (default feature set is `sqlite` only). Updated docs to clarify opt-in behavior and reference `LlmPlanner`/`LlmAggregator` APIs (#5856).
+
 ## [0.22.0] - 2026-07-07
 ### Added
 

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -47,9 +47,10 @@
 //!
 //! # Feature flags
 //!
-//! - `llm-planning` *(default)*: enables LLM-dependent modules (`planner`, `aggregator`,
+//! - `llm-planning`: enables LLM-dependent modules (`planner`, `aggregator`,
 //!   `verifier`, `verify_predicate`, `plan_cache`, `adaptorch`) and the `zeph-llm` dependency.
-//!   Disable with `default-features = false` to get the pure-DAG subset with no LLM dep.
+//!   Not enabled by default (the crate's default feature set is `sqlite` only) — opt in
+//!   explicitly with `features = ["llm-planning"]` to use `LlmPlanner`/`LlmAggregator`.
 //!
 //! # Example: build a plan and run the scheduler
 //!


### PR DESCRIPTION
## Summary
- Corrects the crate-level doc comment in `zeph-orchestration` that wrongly claimed the `llm-planning` feature flag is enabled by default (docs.rs is the primary API reference per project convention, so this is a real correctness issue, not cosmetic)
- The crate's actual default feature set is `sqlite` only; `llm-planning` (and the LLM-dependent modules `planner`, `aggregator`, `verifier`, `verify_predicate`, `plan_cache`, `adaptorch`, plus the `zeph-llm` dependency) must be opted into explicitly

## Test plan
- [x] `cargo +nightly fmt --check -p zeph-orchestration`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-orchestration --features llm-planning`
- [x] Verified against `crates/zeph-orchestration/Cargo.toml` that `default = ["sqlite"]` and `llm-planning` is not part of it
- [x] Verified all six modules named in the doc comment are gated behind `#[cfg(feature = "llm-planning")]`
- [x] CHANGELOG.md updated under `[Unreleased]`

Closes #5856