### PR TITLE
chore: bump MSRV to 1.97

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         run: cargo clippy --profile ci --workspace --all-targets --features ${{ matrix.features }} -- -D warnings
 
   msrv:
-    name: MSRV check (1.96, ${{ matrix.label }})
+    name: MSRV check (1.97, ${{ matrix.label }})
     needs: detect-changes
     if: needs.detect-changes.outputs.run-full-ci == 'true'
     runs-on: ubuntu-latest
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "msrv-${{ matrix.label }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `chore`: raise the workspace MSRV from Rust 1.96 to 1.97 (`Cargo.toml`
+  `rust-version`, CI `msrv` job, all crate README badges/notes, `specs/constitution.md`).
+  Rust 1.97 (stable 2026-07-07) is now the minimum supported toolchain. This also unifies
+  MSRV references that had drifted between 1.95 and 1.96 across README/spec docs. No source
+  changes accompany the bump: a review against Rust 1.89-1.97 stabilizations found no
+  1.97-specific stdlib API with a real use site (the codebase already uses `floor_char_boundary`
+  for UTF-8-safe truncation; existing `compare_exchange` sites are one-shot guards, not
+  CAS-update loops; `with_extension` sites intentionally replace the suffix).
 - `refactor(session)`: extracted a shared `finish_torn_tail` helper in
   `crates/zeph-session/src/log.rs` for the identical torn-tail warn+repair epilogue duplicated
   between `read_events` and `read_events_chunked` (#5852).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97"
 version = "0.22.0"
 authors = ["bug-ops"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   [![docs](https://img.shields.io/badge/docs-book-blue)](https://bug-ops.github.io/zeph/)
   [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/zeph/ci.yml?branch=main&label=CI)](https://github.com/bug-ops/zeph/actions)
   [![codecov](https://codecov.io/gh/bug-ops/zeph/graph/badge.svg?token=S5O0GR9U6G)](https://codecov.io/gh/bug-ops/zeph)
-  [![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+  [![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
   [![Tests](https://img.shields.io/badge/tests-12621-brightgreen)](https://github.com/bug-ops/zeph/actions)
   [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](LICENSE)
 </div>
@@ -244,7 +244,7 @@ cd zeph && cargo build --release --features full
 Builds run only what you need via [feature bundles](https://bug-ops.github.io/zeph/reference/feature-flags.html): `desktop` (TUI), `ide` (ACP), `server` (gateway + A2A + telemetry), `chat` (Discord + Slack), `ml` (Candle + PDF), or `full`. Cross-platform: Linux, macOS, Windows on x86_64 and ARM64.
 
 > [!IMPORTANT]
-> Building from source requires Rust 1.95 or later. Pre-built binaries do not need a toolchain.
+> Building from source requires Rust 1.97 or later. Pre-built binaries do not need a toolchain.
 
 ## Common commands
 

--- a/crates/zeph-a2a/README.md
+++ b/crates/zeph-a2a/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-a2a)](https://crates.io/crates/zeph-a2a)
 [![docs.rs](https://img.shields.io/docsrs/zeph-a2a)](https://docs.rs/zeph-a2a)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 A2A protocol client and server with agent discovery for Zeph.
 

--- a/crates/zeph-acp/README.md
+++ b/crates/zeph-acp/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-acp)](https://crates.io/crates/zeph-acp)
 [![docs.rs](https://img.shields.io/docsrs/zeph-acp)](https://docs.rs/zeph-acp)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 ACP (Agent Client Protocol) server adapter for embedding Zeph in IDE environments.
 
@@ -22,7 +22,7 @@ zeph-acp = { version = "0.22", features = ["acp-http"] }
 ```
 
 **Important:**
-> Requires Rust 1.96 or later.
+> Requires Rust 1.97 or later.
 
 ## Features
 

--- a/crates/zeph-agent-context/README.md
+++ b/crates/zeph-agent-context/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-agent-context)](https://crates.io/crates/zeph-agent-context)
 [![docs.rs](https://img.shields.io/docsrs/zeph-agent-context)](https://docs.rs/zeph-agent-context)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Agent context-assembly service for the [Zeph](https://github.com/bug-ops/zeph) AI agent.
 
@@ -17,7 +17,7 @@ zeph-agent-context = { version = "0.22", workspace = true }
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.96 or later (Edition 2024). This crate does **not** depend on `zeph-core` — only on lower-level crates (`zeph-memory`, `zeph-llm`, `zeph-skills`, `zeph-context`, `zeph-sanitizer`, `zeph-config`, `zeph-common`).
+> Requires Rust 1.97 or later (Edition 2024). This crate does **not** depend on `zeph-core` — only on lower-level crates (`zeph-memory`, `zeph-llm`, `zeph-skills`, `zeph-context`, `zeph-sanitizer`, `zeph-config`, `zeph-common`).
 
 ## Usage
 

--- a/crates/zeph-agent-feedback/README.md
+++ b/crates/zeph-agent-feedback/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-agent-feedback)](https://crates.io/crates/zeph-agent-feedback)
 [![docs.rs](https://img.shields.io/docsrs/zeph-agent-feedback)](https://docs.rs/zeph-agent-feedback)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Implicit correction detection for the [Zeph](https://github.com/bug-ops/zeph) AI agent.
 
@@ -21,7 +21,7 @@ Detects when a user is implicitly correcting a previous agent response — witho
 zeph-agent-feedback = { version = "0.22", workspace = true }
 ```
 
-**Note:** Requires Rust 1.96 or later (Edition 2024).
+**Note:** Requires Rust 1.97 or later (Edition 2024).
 
 ## Usage
 

--- a/crates/zeph-agent-persistence/README.md
+++ b/crates/zeph-agent-persistence/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-agent-persistence)](https://crates.io/crates/zeph-agent-persistence)
 [![docs.rs](https://img.shields.io/docsrs/zeph-agent-persistence)](https://docs.rs/zeph-agent-persistence)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Agent persistence service for Zeph: loads conversation history from and writes messages to the
 `SemanticMemory` backend (SQLite + Qdrant), with tool-pair sanitization and embedding decisions.

--- a/crates/zeph-agent-tools/README.md
+++ b/crates/zeph-agent-tools/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-agent-tools)](https://crates.io/crates/zeph-agent-tools)
 [![docs.rs](https://img.shields.io/docsrs/zeph-agent-tools)](https://docs.rs/zeph-agent-tools)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Agent tool dispatcher for Zeph: provides the `AgentChannel` sealed trait, borrowed event
 carriers, and doom-loop detection utilities used by the tool dispatch loop in `zeph-core`.

--- a/crates/zeph-bench/README.md
+++ b/crates/zeph-bench/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-bench)](https://crates.io/crates/zeph-bench)
 [![docs.rs](https://img.shields.io/docsrs/zeph-bench)](https://docs.rs/zeph-bench)
 [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/zeph/ci.yml?branch=main)](https://github.com/bug-ops/zeph/actions)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 [![License](https://img.shields.io/crates/l/zeph-bench)](../../LICENSE)
 
 Benchmark harness for evaluating Zeph agent performance on standardized datasets.
@@ -129,7 +129,7 @@ impl Evaluator for MyEvaluator {
 | tau-bench | JSON | Task completion (exact) | Ready |
 
 > [!IMPORTANT]
-> Requires Rust 1.96 or later.
+> Requires Rust 1.97 or later.
 
 ## Architecture
 

--- a/crates/zeph-channels/README.md
+++ b/crates/zeph-channels/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-channels)](https://crates.io/crates/zeph-channels)
 [![docs.rs](https://img.shields.io/docsrs/zeph-channels)](https://docs.rs/zeph-channels)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Multi-channel I/O adapters (CLI, Telegram, Discord, Slack) for Zeph.
 

--- a/crates/zeph-commands/README.md
+++ b/crates/zeph-commands/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-commands)](https://crates.io/crates/zeph-commands)
 [![docs.rs](https://img.shields.io/docsrs/zeph-commands)](https://docs.rs/zeph-commands)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Slash command registry, handler trait, and channel sink abstraction for
 [Zeph](https://github.com/bug-ops/zeph).

--- a/crates/zeph-common/README.md
+++ b/crates/zeph-common/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-common)](https://crates.io/crates/zeph-common)
 [![docs.rs](https://img.shields.io/docsrs/zeph-common)](https://docs.rs/zeph-common)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Shared utility functions and security primitives for the Zeph workspace. Zero `zeph-*` dependencies — safe to depend on from any crate.
 

--- a/crates/zeph-config/README.md
+++ b/crates/zeph-config/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-config)](https://crates.io/crates/zeph-config)
 [![docs.rs](https://img.shields.io/docsrs/zeph-config)](https://docs.rs/zeph-config)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Pure-data configuration types for Zeph — all TOML config structs with serde derive, validation, and migration support.
 

--- a/crates/zeph-context/README.md
+++ b/crates/zeph-context/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-context)](https://crates.io/crates/zeph-context)
 [![docs.rs](https://img.shields.io/docsrs/zeph-context)](https://docs.rs/zeph-context)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Context budget, lifecycle management, compaction strategy, and stateless context assembler for the
 [Zeph](https://github.com/bug-ops/zeph) AI agent.

--- a/crates/zeph-core/README.md
+++ b/crates/zeph-core/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-core)](https://crates.io/crates/zeph-core)
 [![docs.rs](https://img.shields.io/docsrs/zeph-core)](https://docs.rs/zeph-core)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Core agent loop, configuration, context builder, metrics, vault, and sub-agent orchestration for Zeph.
 

--- a/crates/zeph-db/README.md
+++ b/crates/zeph-db/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-db)](https://crates.io/crates/zeph-db)
 [![docs.rs](https://img.shields.io/docsrs/zeph-db)](https://docs.rs/zeph-db)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Database abstraction layer for [Zeph](https://github.com/bug-ops/zeph) — unified SQLite and PostgreSQL backends with compile-time backend selection, automatic migrations, dialect-aware SQL helpers, and FTS support.
 
@@ -167,7 +167,7 @@ Migrations run automatically on first `DbConfig::connect` call. The active backe
 
 ## MSRV
 
-Rust **1.96** (Edition 2024, resolver 3).
+Rust **1.97** (Edition 2024, resolver 3).
 
 ## License
 

--- a/crates/zeph-durable/README.md
+++ b/crates/zeph-durable/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-durable)](https://crates.io/crates/zeph-durable)
 [![docs.rs](https://img.shields.io/docsrs/zeph-durable)](https://docs.rs/zeph-durable)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Native durable execution layer for [Zeph](https://github.com/bug-ops/zeph) — journals the *control
 flow* of an execution (steps, promises, timers) so a crashed or interrupted run can resume at the
@@ -170,7 +170,7 @@ let reply: String = ctx
 
 ## MSRV
 
-Rust **1.96** (Edition 2024, resolver 3).
+Rust **1.97** (Edition 2024, resolver 3).
 
 ## License
 

--- a/crates/zeph-experiments/README.md
+++ b/crates/zeph-experiments/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-experiments)](https://crates.io/crates/zeph-experiments)
 [![docs.rs](https://img.shields.io/docsrs/zeph-experiments)](https://docs.rs/zeph-experiments)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Experiment engine for adaptive agent behavior — autonomous hyperparameter search and A/B testing for Zeph.
 

--- a/crates/zeph-gateway/README.md
+++ b/crates/zeph-gateway/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-gateway)](https://crates.io/crates/zeph-gateway)
 [![docs.rs](https://img.shields.io/docsrs/zeph-gateway)](https://docs.rs/zeph-gateway)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 HTTP gateway for webhook ingestion with bearer auth for Zeph.
 

--- a/crates/zeph-index/README.md
+++ b/crates/zeph-index/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-index)](https://crates.io/crates/zeph-index)
 [![docs.rs](https://img.shields.io/docsrs/zeph-index)](https://docs.rs/zeph-index)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 AST-based code indexing, semantic retrieval, and repo map generation for Zeph.
 

--- a/crates/zeph-llm/README.md
+++ b/crates/zeph-llm/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-llm)](https://crates.io/crates/zeph-llm)
 [![docs.rs](https://img.shields.io/docsrs/zeph-llm)](https://docs.rs/zeph-llm)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 LLM provider abstraction with Ollama, Claude, OpenAI, Gemini, Gonka, and Candle backends.
 

--- a/crates/zeph-mcp/README.md
+++ b/crates/zeph-mcp/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-mcp)](https://crates.io/crates/zeph-mcp)
 [![docs.rs](https://img.shields.io/docsrs/zeph-mcp)](https://docs.rs/zeph-mcp)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 MCP client with multi-server lifecycle and Qdrant tool registry for Zeph.
 

--- a/crates/zeph-memory/README.md
+++ b/crates/zeph-memory/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-memory)](https://crates.io/crates/zeph-memory)
 [![docs.rs](https://img.shields.io/docsrs/zeph-memory)](https://docs.rs/zeph-memory)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Semantic memory with SQLite and Qdrant for Zeph agent.
 

--- a/crates/zeph-orchestration/README.md
+++ b/crates/zeph-orchestration/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-orchestration)](https://crates.io/crates/zeph-orchestration)
 [![docs.rs](https://img.shields.io/docsrs/zeph-orchestration)](https://docs.rs/zeph-orchestration)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 DAG-based task orchestration with failure propagation, LLM planning, and SQLite persistence for Zeph.
 

--- a/crates/zeph-plugins/README.md
+++ b/crates/zeph-plugins/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-plugins)](https://crates.io/crates/zeph-plugins)
 [![docs.rs](https://img.shields.io/docsrs/zeph-plugins)](https://docs.rs/zeph-plugins)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Plugin packaging, installation, and runtime config overlay for Zeph.
 

--- a/crates/zeph-sanitizer/README.md
+++ b/crates/zeph-sanitizer/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-sanitizer)](https://crates.io/crates/zeph-sanitizer)
 [![docs.rs](https://img.shields.io/docsrs/zeph-sanitizer)](https://docs.rs/zeph-sanitizer)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Content sanitization, exfiltration guard, PII filtering, and quarantine for Zeph — untrusted input isolation before LLM context injection.
 

--- a/crates/zeph-scheduler/README.md
+++ b/crates/zeph-scheduler/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-scheduler)](https://crates.io/crates/zeph-scheduler)
 [![docs.rs](https://img.shields.io/docsrs/zeph-scheduler)](https://docs.rs/zeph-scheduler)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Cron-based periodic and one-shot task scheduler with SQLite persistence for Zeph.
 
@@ -191,7 +191,7 @@ cargo add zeph-scheduler
 Enabled via the `scheduler` feature flag on the root `zeph` crate.
 
 > [!IMPORTANT]
-> Requires Rust 1.96 or later.
+> Requires Rust 1.97 or later.
 
 ## Features
 

--- a/crates/zeph-session/README.md
+++ b/crates/zeph-session/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-session)](https://crates.io/crates/zeph-session)
 [![docs.rs](https://img.shields.io/docsrs/zeph-session)](https://docs.rs/zeph-session)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Conversation-session persistence for [Zeph](https://github.com/bug-ops/zeph): an append-only JSONL
 event log, deterministic replay, and fork engine, shared by every channel (CLI, TUI, Telegram, ACP,

--- a/crates/zeph-skills/README.md
+++ b/crates/zeph-skills/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-skills)](https://crates.io/crates/zeph-skills)
 [![docs.rs](https://img.shields.io/docsrs/zeph-skills)](https://docs.rs/zeph-skills)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 SKILL.md parser, registry, embedding matcher, and hot-reload for Zeph.
 

--- a/crates/zeph-subagent/README.md
+++ b/crates/zeph-subagent/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-subagent)](https://crates.io/crates/zeph-subagent)
 [![docs.rs](https://img.shields.io/docsrs/zeph-subagent)](https://docs.rs/zeph-subagent)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Subagent management for Zeph — spawning, zero-trust grants, JSONL transcripts, scoped tool access, and lifecycle hooks.
 

--- a/crates/zeph-tools/README.md
+++ b/crates/zeph-tools/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-tools)](https://crates.io/crates/zeph-tools)
 [![docs.rs](https://img.shields.io/docsrs/zeph-tools)](https://docs.rs/zeph-tools)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Tool executor trait with shell, web scrape, and composite executors for Zeph.
 

--- a/crates/zeph-tui/README.md
+++ b/crates/zeph-tui/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-tui)](https://crates.io/crates/zeph-tui)
 [![docs.rs](https://img.shields.io/docsrs/zeph-tui)](https://docs.rs/zeph-tui)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Ratatui-based TUI dashboard with real-time metrics and multi-session support for Zeph.
 

--- a/crates/zeph-vault/README.md
+++ b/crates/zeph-vault/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-vault)](https://crates.io/crates/zeph-vault)
 [![docs.rs](https://img.shields.io/docsrs/zeph-vault)](https://docs.rs/zeph-vault)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 `VaultProvider` trait and backends (env, age) for Zeph secret management.
 

--- a/crates/zeph-worktree/README.md
+++ b/crates/zeph-worktree/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/zeph-worktree)](https://crates.io/crates/zeph-worktree)
 [![docs.rs](https://img.shields.io/docsrs/zeph-worktree)](https://docs.rs/zeph-worktree)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-yellow.svg)](../../LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-blue)](https://www.rust-lang.org)
 
 Git worktree lifecycle management for Zeph subagents.
 

--- a/specs/065-ephemeral-plugins-provider-overrides/brd.md
+++ b/specs/065-ephemeral-plugins-provider-overrides/brd.md
@@ -75,7 +75,7 @@ These deferrals are **explicit** (not silent omissions). They must be tracked as
 
 - No new SQLite schema migration needed (use existing `channel_preferences` key-value table with a new `pref_key`)
 - Implementation stays within `zeph-plugins`, `zeph-core`, `zeph-config`, `zeph-commands`, and the root binary crate
-- MSRV remains Rust 1.95
+- MSRV remains Rust 1.97
 - No new mandatory dependencies
 
 ## 8. Dependencies

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -42,7 +42,7 @@ related:
 
 ## II. Technology Stack
 
-- Language: Rust 1.95 (MSRV), Edition 2024
+- Language: Rust 1.97 (MSRV), Edition 2024
 - Async: tokio + native async traits; no `async-trait` crate for new code in library crates
 - HTTP: reqwest 0.13 (rustls, no openssl-sys)
 - Database: SQLite (sqlx 0.8) for persistence + Qdrant for semantic search


### PR DESCRIPTION
## Summary
- Bump `rust-version` from 1.96 to 1.97 across Cargo.toml, the CI msrv job/toolchain, root and all crate READMEs, specs/constitution.md, and the spec-065 BRD
- Audited the codebase against every rust-modern-apis skill trigger pattern for the 1.89-1.97 range (integer bit-isolation methods, const `char::is_control`, etc.) — no newly stabilized API has a real use site here, so no source changes were made
- Fixed pre-existing MSRV drift where README/constitution/BRD text still said 1.95 while root Cargo.toml said 1.96

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12375 passed, 35 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` (CI msrv job, on rustc 1.97.0)