### PR TITLE
fix(llm): resolve OllamaProvider::name() hardcoding and embed misrouting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Added `AgentBuilder::with_skill_group_config` (mirrors the existing
   `with_skill_matching_config`) and a `/skills injection` subcommand to make the wired values
   observable from outside `zeph-core` (#5867, #5862).
+- `fix(llm)`: `OllamaProvider::name()` (`crates/zeph-llm/src/ollama.rs`) no longer returns the
+  hardcoded literal `"ollama"` — it now returns the TOML-configured `[[llm.providers]]` `name`
+  via a new `provider_name` field / `with_provider_name()` builder, mirroring
+  `CompatibleProvider`. This broke two things whenever a config declared more than one
+  `type = "ollama"` provider: router reputation/Thompson-sampling state (keyed on
+  `provider.name()`) cross-contaminated between distinct Ollama instances, and the router's
+  generic embed path could route to a chat-only Ollama instance instead of a dedicated
+  embedder. Fixed the latter by adding a `dedicated_embed_provider` side-channel
+  (`RouterState`/`RouterProvider::with_embed_provider()`/`embed_candidates()`,
+  `TriageRouter::with_embed_provider()`) so any pool entry explicitly flagged `embed = true` is
+  preferred over the generic `supports_embeddings()` scan across all routing strategies
+  (Ema/Thompson/Cascade/Bandit/Triage). Also warns when more than one `embed = true` entry
+  exists in the pool (only the first is used) and logs which provider serves embeds when no
+  dedicated entry is configured (#5859).
 - `fix(session)`: `hydrate_from_event_log` (`crates/zeph-agent-persistence/src/hydrate.rs`) now
   folds the replayed `messages` via `ReplayEngine::replay`'s bounded/chunked reader (spec-068
   §6.2, ≤ 100 envelopes in memory at once) instead of `ReplayEngine::fold(events.clone(), up_to)`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10290,6 +10290,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wiremock",
  "zeph-a2a",
  "zeph-acp",
  "zeph-agent-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -397,6 +397,7 @@ serial_test.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true
 tower = { workspace = true, features = ["util"] }
+wiremock.workspace = true
 zeph-commands.workspace = true
 zeph-core.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -3214,10 +3214,14 @@ mod tests {
             .fidelity_semantic_provider
             .as_ref()
             .expect("fidelity_semantic_provider must be Some for registered provider name");
+        // Post-#5859: OllamaProvider::name() returns the configured `[[llm.providers]]`
+        // name ("named-test"), not the hardcoded literal "ollama" — the model check below
+        // is what actually proves resolution reached the registered Ollama entry.
         assert_eq!(
             sem.name(),
-            "ollama",
-            "registered named provider must resolve to Ollama, not the Mock primary fallback"
+            "named-test",
+            "registered named provider must resolve to the registered Ollama entry, \
+             not the Mock primary fallback"
         );
         assert_eq!(
             sem.model_identifier(),
@@ -3234,8 +3238,9 @@ mod tests {
             .expect("fidelity_compress_provider must be Some for registered provider name");
         assert_eq!(
             cmp.name(),
-            "ollama",
-            "registered named compress provider must resolve to Ollama, not the Mock primary fallback"
+            "named-test",
+            "registered named compress provider must resolve to the registered Ollama entry, \
+             not the Mock primary fallback"
         );
 
         // Unregistered name → both fields fall back to the primary (Mock) provider.
@@ -3302,9 +3307,13 @@ mod tests {
 
         // Looked up with different casing than the registered entry's name.
         let resolved = agent.resolve_background_provider("named-test");
+        // Post-#5859: OllamaProvider::name() returns the registered entry's configured name
+        // ("Named-Test", original casing preserved), not the hardcoded literal "ollama" — this
+        // is what actually proves the case-insensitive lookup matched the registered entry
+        // rather than falling back to the primary (which would report a different name).
         assert_eq!(
             resolved.name(),
-            "ollama",
+            "Named-Test",
             "resolve_background_provider must match pool entries case-insensitively"
         );
     }

--- a/crates/zeph-core/src/agent/provider_cmd.rs
+++ b/crates/zeph-core/src/agent/provider_cmd.rs
@@ -736,27 +736,23 @@ mod tests {
         let entry_b = make_entry("mock2", ProviderKind::Ollama, Some("llama3.2"));
         let snapshot = ollama_snapshot();
 
-        // Build a real Ollama provider for entry_b to switch to.
+        // Build a real Ollama provider for entry_b to switch to. Post-#5859,
+        // provider_b.name() == "mock2" (entry_b's configured name), not the literal "ollama".
         let provider_b =
             crate::provider_factory::build_provider_for_switch(&entry_b, &snapshot, None).unwrap();
 
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-        // embedding_provider defaults to provider.clone() (mock). After switch the chat
-        // provider becomes Ollama("llama3.2") with name "ollama".
-        // Embedding stays as mock (name "mock") != "ollama" → notice expected.
-        // Instead, let's directly set embedding_provider to the same provider we switch to.
+        // Set embedding_provider to the same provider we are about to "switch" to, so
+        // embedding_provider.name() ("mock2") matches the configured_name passed to
+        // build_switch_message below — the critical invariant under test: notice is
+        // omitted iff embedding_provider.name() == configured_name. No reasoning-effort
+        // override is set in this scenario.
         agent = agent.with_embedding_provider(provider_b.clone());
         agent.runtime.config.active_provider_name = "mock2".to_owned();
         agent.runtime.providers.provider_pool = vec![entry_a, entry_b];
         agent.runtime.providers.provider_config_snapshot = Some(snapshot);
 
-        // Manually invoke build_switch_message — the provider names match since we assigned
-        // embed = provider_b and we will switch to "mock2". provider_b.name() == "ollama"
-        // and the configured_name is "mock2". They differ in this case, so we test the
-        // scenario where names match by asserting the message format for a successful switch
-        // where both sides resolve to the same LlmProvider::name().
-        // The critical invariant: notice is omitted iff embedding_provider.name() == configured_name.
-        let msg = agent.build_switch_message("ollama", false);
+        let msg = agent.build_switch_message("mock2", false);
         assert!(
             !msg.contains("Embedding operations"),
             "no notice when embedding provider name == new chat provider name: {msg}"

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -268,7 +268,8 @@ fn build_ollama_provider(entry: &ProviderEntry, config: &Config) -> AnyProvider 
         .embedding_model
         .clone()
         .unwrap_or_else(|| config.llm.embedding_model.clone());
-    let mut provider = OllamaProvider::new(base_url, model, embed);
+    let mut provider =
+        OllamaProvider::new(base_url, model, embed).with_provider_name(entry.effective_name());
     if let Some(ref vm) = entry.vision_model {
         provider = provider.with_vision_model(vm.clone());
     }
@@ -1097,6 +1098,42 @@ mod tests {
         let primary = build_provider_from_entry(&entry, &config, None).unwrap();
         let resolved = resolve_named_provider(&config, &primary, "fast");
         assert_eq!(resolved.name(), primary.name());
+    }
+
+    /// Regression for #5859: two `[[llm.providers]]` entries of `type = "ollama"` with
+    /// distinct configured `name` fields must build `AnyProvider`s with distinct
+    /// `.name()` values. Before the fix, `OllamaProvider::name()` returned the hardcoded
+    /// literal `"ollama"` for every instance regardless of `entry.effective_name()`,
+    /// corrupting router reputation tracking and embed-provider selection whenever more
+    /// than one Ollama entry was configured.
+    #[test]
+    fn build_provider_from_entry_ollama_distinct_entries_yield_distinct_provider_names() {
+        let config = Config::default();
+        let entry_a = ProviderEntry {
+            provider_type: ProviderKind::Ollama,
+            name: Some("ollama-chat".into()),
+            model: Some("qwen3:8b".into()),
+            ..ProviderEntry::default()
+        };
+        let entry_b = ProviderEntry {
+            provider_type: ProviderKind::Ollama,
+            name: Some("ollama-embed".into()),
+            model: Some("nomic-embed-text".into()),
+            embed: true,
+            ..ProviderEntry::default()
+        };
+
+        let provider_a = build_provider_from_entry(&entry_a, &config, None).unwrap();
+        let provider_b = build_provider_from_entry(&entry_b, &config, None).unwrap();
+
+        assert_ne!(
+            provider_a.name(),
+            provider_b.name(),
+            "two distinct Ollama [[llm.providers]] entries must yield distinct \
+             AnyProvider::name() values"
+        );
+        assert_eq!(provider_a.name(), "ollama-chat");
+        assert_eq!(provider_b.name(), "ollama-embed");
     }
 
     #[cfg(feature = "cocoon")]

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -91,6 +91,11 @@ pub struct OllamaProvider {
     vision_model: Option<String>,
     generation_overrides: Option<GenerationOverrides>,
     usage: UsageTracker,
+    /// Name reported by [`LlmProvider::name`]. Defaults to `"ollama"`; set the TOML-configured
+    /// `name` via [`with_provider_name`](Self::with_provider_name) so that router reputation
+    /// tracking and provider selection can distinguish between multiple configured Ollama
+    /// instances (#5859).
+    provider_name: String,
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -136,7 +141,21 @@ impl OllamaProvider {
             vision_model: None,
             generation_overrides: None,
             usage: UsageTracker::default(),
+            provider_name: "ollama".to_owned(),
         }
+    }
+
+    /// Set the name reported by [`LlmProvider::name`].
+    ///
+    /// Populate this from the TOML-configured `name` field of the `[[llm.providers]]` entry
+    /// so that router reputation tracking and generic embed-provider selection can
+    /// distinguish between multiple configured Ollama instances. Without this, every
+    /// `OllamaProvider` reports the same literal `"ollama"`, which corrupts per-provider
+    /// availability tracking and embed routing when more than one Ollama entry is configured.
+    #[must_use]
+    pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = name.into();
+        self
     }
 
     /// Override generation parameters (temperature, top-p, top-k) for this provider.
@@ -554,9 +573,8 @@ impl LlmProvider for OllamaProvider {
         true
     }
 
-    #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
-        "ollama"
+        &self.provider_name
     }
 
     fn model_identifier(&self) -> &str {
@@ -834,6 +852,25 @@ mod tests {
         let provider =
             OllamaProvider::new("http://localhost:11434", "test".into(), "test-embed".into());
         assert_eq!(provider.name(), "ollama");
+    }
+
+    #[test]
+    fn with_provider_name_overrides_name() {
+        let provider =
+            OllamaProvider::new("http://localhost:11434", "test".into(), "test-embed".into())
+                .with_provider_name("local-chat");
+        assert_eq!(provider.name(), "local-chat");
+    }
+
+    #[test]
+    fn with_provider_name_distinguishes_multiple_instances() {
+        let chat = OllamaProvider::new("http://localhost:11434", "chat-model".into(), "e".into())
+            .with_provider_name("chat");
+        let embed = OllamaProvider::new("http://localhost:11434", "m".into(), "embed-model".into())
+            .with_provider_name("embedder");
+        assert_ne!(chat.name(), embed.name());
+        assert_eq!(chat.name(), "chat");
+        assert_eq!(embed.name(), "embedder");
     }
 
     #[test]

--- a/crates/zeph-llm/src/router/builder.rs
+++ b/crates/zeph-llm/src/router/builder.rs
@@ -80,6 +80,32 @@ impl RouterProvider {
         self
     }
 
+    /// Register the provider explicitly flagged `embed = true` in `[[llm.providers]]`.
+    ///
+    /// `embed()`/`embed_batch()` try this provider first, ahead of the generic scan over
+    /// `providers` for any backend that merely reports `supports_embeddings() == true`.
+    /// Without this, a chat-only provider sharing a backend type with the dedicated
+    /// embedding provider (e.g. two `OllamaProvider` instances) can shadow it and silently
+    /// fall back to an unconfigured default embedding model (#5859).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use zeph_llm::router::RouterProvider;
+    /// # use zeph_llm::any::AnyProvider;
+    /// # use zeph_llm::ollama::OllamaProvider;
+    /// let embedder = AnyProvider::Ollama(
+    ///     OllamaProvider::new("http://localhost:11434", "chat-model".into(), "nomic-embed-text".into())
+    ///         .with_provider_name("embedder"),
+    /// );
+    /// let router = RouterProvider::new(vec![]).with_embed_provider(embedder);
+    /// ```
+    #[must_use]
+    pub fn with_embed_provider(mut self, provider: AnyProvider) -> Self {
+        self.state.dedicated_embed_provider = Some(Arc::new(provider));
+        self
+    }
+
     /// Set the maximum number of concurrent `embed_batch` calls.
     ///
     /// A value of 0 disables the semaphore (unlimited). Default is no semaphore.

--- a/crates/zeph-llm/src/router/provider_impl.rs
+++ b/crates/zeph-llm/src/router/provider_impl.rs
@@ -312,7 +312,7 @@ impl LlmProvider for RouterProvider {
         &self,
         text: &str,
     ) -> impl std::future::Future<Output = Result<Vec<f32>, LlmError>> + Send {
-        let providers = self.ordered_providers();
+        let providers = self.embed_candidates();
         let status_tx = self.status_tx.clone();
         let text = text.to_owned();
         let router = self.clone();
@@ -429,7 +429,7 @@ impl LlmProvider for RouterProvider {
         &self,
         texts: &[&str],
     ) -> impl std::future::Future<Output = Result<Vec<Vec<f32>>, LlmError>> + Send {
-        let providers = self.ordered_providers();
+        let providers = self.embed_candidates();
         let status_tx = self.status_tx.clone();
         let owned = owned_strs(texts);
         let router = self.clone();

--- a/crates/zeph-llm/src/router/select.rs
+++ b/crates/zeph-llm/src/router/select.rs
@@ -230,6 +230,22 @@ impl RouterProvider {
         }
     }
 
+    /// Candidate providers for `embed`/`embed_batch`, with the dedicated `embed = true`
+    /// provider (if configured via [`crate::router::RouterProvider::with_embed_provider`])
+    /// moved to the front.
+    ///
+    /// This keeps the existing `supports_embeddings()` fallback loop intact while ensuring
+    /// a provider explicitly configured for embeddings is tried before any provider that
+    /// merely reports `supports_embeddings() == true` (#5859).
+    pub(crate) fn embed_candidates(&self) -> Vec<AnyProvider> {
+        let mut providers = self.ordered_providers();
+        if let Some(dedicated) = self.state.dedicated_embed_provider.as_deref() {
+            providers.retain(|p| p.name() != dedicated.name());
+            providers.insert(0, dedicated.clone());
+        }
+        providers
+    }
+
     fn ema_ordered_providers(&self) -> Vec<AnyProvider> {
         let order = self.state.provider_order.lock();
         let mut ordered: Vec<AnyProvider> = order

--- a/crates/zeph-llm/src/router/state.rs
+++ b/crates/zeph-llm/src/router/state.rs
@@ -90,6 +90,15 @@ pub struct RouterState {
 
     /// Cache hits from `TurnEmbedCache` this session.
     pub embed_cache_hits: Arc<AtomicU64>,
+
+    /// Provider explicitly flagged `embed = true` in `[[llm.providers]]`, if configured.
+    ///
+    /// When set, `RouterProvider::embed`/`embed_batch` try this provider first, ahead of
+    /// the generic `supports_embeddings()` scan over `providers`. This prevents a chat-only
+    /// provider that merely reports `supports_embeddings() == true` (e.g. every
+    /// [`crate::ollama::OllamaProvider`], regardless of its configured `embedding_model`)
+    /// from shadowing a dedicated embedding provider in the pool (#5859).
+    pub dedicated_embed_provider: Option<Arc<AnyProvider>>,
 }
 
 impl RouterState {
@@ -114,6 +123,7 @@ impl RouterState {
             embed_semaphore: None,
             embed_call_count: Arc::new(AtomicU64::new(0)),
             embed_cache_hits: Arc::new(AtomicU64::new(0)),
+            dedicated_embed_provider: None,
         }
     }
 }

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -913,6 +913,56 @@ async fn embed_falls_back_immediately_on_unavailable() {
     );
 }
 
+// ── Dedicated embed provider tests (#5859) ────────────────────────────────
+
+/// A chat-only provider that also (incorrectly, like every `OllamaProvider`) reports
+/// `supports_embeddings() == true` must not shadow a provider explicitly registered via
+/// `with_embed_provider`. The dedicated provider's embedding must win.
+#[tokio::test]
+async fn embed_prefers_dedicated_provider_over_chat_only_fallback() {
+    use crate::mock::MockProvider;
+
+    let chat_only = AnyProvider::Mock({
+        let mut m = MockProvider::default().with_name("chat");
+        m.supports_embeddings = true;
+        m.embedding = vec![1.0, 0.0];
+        m
+    });
+    let dedicated = AnyProvider::Mock({
+        let mut m = MockProvider::default().with_name("embedder");
+        m.supports_embeddings = true;
+        m.embedding = vec![0.0, 1.0];
+        m
+    });
+    let r = RouterProvider::new(vec![chat_only]).with_embed_provider(dedicated);
+    let result = r.embed("text").await.unwrap();
+    assert_eq!(
+        result,
+        vec![0.0, 1.0],
+        "embed() must route to the dedicated provider, not the chat-only fallback"
+    );
+}
+
+/// `embed_candidates()` prepends the dedicated provider ahead of the generic ordered
+/// scan, and dedupes it out of its original position when it is also present in
+/// `providers` (e.g. because a caller registered the same instance twice).
+#[test]
+fn embed_candidates_prepends_and_dedupes_dedicated_provider() {
+    use crate::mock::MockProvider;
+
+    let dedicated = AnyProvider::Mock(MockProvider::default().with_name("embedder"));
+    let other = AnyProvider::Mock(MockProvider::default().with_name("chat"));
+    let r = RouterProvider::new(vec![other, dedicated.clone()]).with_embed_provider(dedicated);
+
+    let candidates = r.embed_candidates();
+    let names: Vec<&str> = candidates.iter().map(AnyProvider::name).collect();
+    assert_eq!(
+        names,
+        vec!["embedder", "chat"],
+        "dedicated provider must be first and not duplicated"
+    );
+}
+
 /// Provider returns `RateLimited` twice then succeeds via `embed_batch`.
 #[tokio::test]
 async fn embed_batch_retries_on_rate_limited_then_succeeds() {

--- a/crates/zeph-llm/src/router/triage.rs
+++ b/crates/zeph-llm/src/router/triage.rs
@@ -144,6 +144,15 @@ pub struct TriageRouter {
     last_provider_idx: Arc<AtomicUsize>,
     /// Router display name.
     name: String,
+    /// Provider explicitly flagged `embed = true` in `[[llm.providers]]`, if configured.
+    ///
+    /// When set, [`Self::embed`]/[`Self::embed_batch`] use it directly instead of scanning
+    /// `tier_providers` for the first one reporting `supports_embeddings() == true`. Without
+    /// this, a chat-only tier provider sharing a backend type with the dedicated embedding
+    /// provider (e.g. an `OllamaProvider` tier alongside a dedicated Ollama embedder) can
+    /// shadow it, since `supports_embeddings()` conveys no information about which instance
+    /// was actually configured for embeddings (#5859).
+    dedicated_embed_provider: Option<Arc<AnyProvider>>,
 }
 
 impl std::fmt::Debug for TriageRouter {
@@ -189,7 +198,20 @@ impl TriageRouter {
             metrics: Arc::new(TriageMetrics::default()),
             last_provider_idx: Arc::new(AtomicUsize::new(NO_LAST_PROVIDER)),
             name: "triage".to_owned(),
+            dedicated_embed_provider: None,
         }
+    }
+
+    /// Register the provider explicitly flagged `embed = true` in `[[llm.providers]]`.
+    ///
+    /// `embed()`/`embed_batch()` use this provider directly instead of scanning
+    /// `tier_providers` for the first one reporting `supports_embeddings() == true`, which
+    /// conveys no information about which tier instance was actually configured for
+    /// embeddings (#5859).
+    #[must_use]
+    pub fn with_embed_provider(mut self, provider: AnyProvider) -> Self {
+        self.dedicated_embed_provider = Some(Arc::new(provider));
+        self
     }
 
     /// Propagate a status sender to all tier providers.
@@ -197,6 +219,27 @@ impl TriageRouter {
         for (_, provider) in &mut self.tier_providers {
             provider.set_status_tx(tx.clone());
         }
+    }
+
+    /// Resolve the provider to use for `embed`/`embed_batch`.
+    ///
+    /// Prefers the dedicated `embed = true` provider, when configured via
+    /// [`with_embed_provider`](Self::with_embed_provider), over the first embedding-capable
+    /// tier provider, then the triage provider (the latter so that tool schema filter
+    /// initialization works when `routing = "triage"` even without a dedicated embedder).
+    fn select_embed_provider(&self) -> Option<AnyProvider> {
+        if let Some(dedicated) = self.dedicated_embed_provider.as_deref() {
+            return Some(dedicated.clone());
+        }
+        self.tier_providers
+            .iter()
+            .find(|(_, p)| p.supports_embeddings())
+            .map(|(_, p)| p.clone())
+            .or_else(|| {
+                self.triage_provider
+                    .supports_embeddings()
+                    .then(|| self.triage_provider.clone())
+            })
     }
 
     /// Returns a reference to the metrics.
@@ -498,18 +541,7 @@ impl LlmProvider for TriageRouter {
         &self,
         text: &str,
     ) -> impl std::future::Future<Output = Result<Vec<f32>, LlmError>> + Send {
-        // Delegate to the first embedding-capable tier provider, then to the triage provider,
-        // so that tool schema filter initialization works when routing = "triage".
-        let embed_provider = self
-            .tier_providers
-            .iter()
-            .find(|(_, p)| p.supports_embeddings())
-            .map(|(_, p)| p.clone())
-            .or_else(|| {
-                self.triage_provider
-                    .supports_embeddings()
-                    .then(|| self.triage_provider.clone())
-            });
+        let embed_provider = self.select_embed_provider();
 
         let name = self.name.clone();
         let text = text.to_owned();
@@ -525,16 +557,7 @@ impl LlmProvider for TriageRouter {
         &self,
         texts: &[&str],
     ) -> impl std::future::Future<Output = Result<Vec<Vec<f32>>, LlmError>> + Send {
-        let embed_provider = self
-            .tier_providers
-            .iter()
-            .find(|(_, p)| p.supports_embeddings())
-            .map(|(_, p)| p.clone())
-            .or_else(|| {
-                self.triage_provider
-                    .supports_embeddings()
-                    .then(|| self.triage_provider.clone())
-            });
+        let embed_provider = self.select_embed_provider();
 
         let name = self.name.clone();
         let owned = owned_strs(texts);
@@ -984,6 +1007,59 @@ mod tests {
                     mock_with_embedding(expected.clone()),
                 ),
             ],
+            5,
+            50,
+        );
+        let result = router.embed("test query").await.unwrap();
+        assert_eq!(result, expected);
+    }
+
+    // ── dedicated embed provider (#5859 critic F1) ────────────────────────────
+
+    #[tokio::test]
+    async fn embed_prefers_dedicated_provider_over_embedding_capable_tier() {
+        // A chat-only tier that merely reports supports_embeddings() == true must not
+        // shadow an explicitly configured dedicated embed provider.
+        let tier_embedding = vec![1.0_f32, 2.0, 3.0];
+        let dedicated_embedding = vec![9.0_f32, 9.0, 9.0];
+        let router = TriageRouter::new(
+            triage_mock(r#"{"tier":"simple"}"#),
+            vec![(ComplexityTier::Simple, mock_with_embedding(tier_embedding))],
+            5,
+            50,
+        )
+        .with_embed_provider(mock_with_embedding(dedicated_embedding.clone()));
+        let result = router.embed("test query").await.unwrap();
+        assert_eq!(result, dedicated_embedding);
+    }
+
+    #[tokio::test]
+    async fn embed_batch_prefers_dedicated_provider_over_embedding_capable_tier() {
+        let tier_embedding = vec![1.0_f32, 2.0, 3.0];
+        let dedicated_embedding = vec![9.0_f32, 9.0, 9.0];
+        let router = TriageRouter::new(
+            triage_mock(r#"{"tier":"simple"}"#),
+            vec![(ComplexityTier::Simple, mock_with_embedding(tier_embedding))],
+            5,
+            50,
+        )
+        .with_embed_provider(mock_with_embedding(dedicated_embedding.clone()));
+        let result = router.embed_batch(&["a", "b"]).await.unwrap();
+        assert_eq!(
+            result,
+            vec![dedicated_embedding.clone(), dedicated_embedding]
+        );
+    }
+
+    #[tokio::test]
+    async fn embed_falls_back_to_tier_scan_without_dedicated_provider() {
+        let expected = vec![4.0_f32, 5.0, 6.0];
+        let router = TriageRouter::new(
+            triage_mock(r#"{"tier":"simple"}"#),
+            vec![(
+                ComplexityTier::Simple,
+                mock_with_embedding(expected.clone()),
+            )],
             5,
             50,
         );

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -158,6 +158,79 @@ fn apply_coe(router: RouterProvider, config: &Config) -> RouterProvider {
     }
 }
 
+/// Look up the pool's dedicated `embed = true` provider entry.
+///
+/// Warns when more than one entry is flagged `embed = true`: only the first (in pool
+/// order) is ever used by [`apply_dedicated_embed_provider`] or `build_triage_provider`,
+/// so any additional `embed = true` entry is dead configuration — it is also excluded from
+/// the router's chat pool by `build_all_pool_providers`, meaning it is never dispatched to
+/// at all (#5859 critic finding F3).
+fn find_dedicated_embed_entry(pool: &[ProviderEntry]) -> Option<&ProviderEntry> {
+    let mut embed_entries = pool.iter().filter(|e| e.embed);
+    let first = embed_entries.next()?;
+    let rest: Vec<String> = embed_entries.map(ProviderEntry::effective_name).collect();
+    if !rest.is_empty() {
+        tracing::warn!(
+            used = first.effective_name(),
+            unused = ?rest,
+            "multiple [[llm.providers]] entries flagged embed = true; only the first is \
+             used, the rest are dead configuration (never dispatched to)"
+        );
+    }
+    Some(first)
+}
+
+/// Log the pool of chat providers that could be selected by the generic
+/// `supports_embeddings()` scan when no dedicated `embed = true` provider is configured.
+///
+/// Without this, an operator running multiple providers of the same backend type (e.g. two
+/// Ollama entries) has no way to tell from the logs which instance will actually serve
+/// `embed()` calls, since selection happens dynamically per call from the router's ordered
+/// pool (#5859 critic finding F5).
+fn log_no_dedicated_embed_provider(pool: &[ProviderEntry]) {
+    let candidates: Vec<String> = pool
+        .iter()
+        .filter(|e| !e.embed)
+        .map(ProviderEntry::effective_name)
+        .collect();
+    tracing::info!(
+        candidates = ?candidates,
+        "no dedicated embed = true provider configured; embed() will use the first chat \
+         provider reporting supports_embeddings() == true from this list, in router order"
+    );
+}
+
+/// Attach the pool's dedicated `embed = true` provider to a `RouterProvider`, if configured.
+///
+/// `build_all_pool_providers` excludes `embed = true` entries from the router's chat
+/// pool (they are not meant to be dispatched to for `chat`/`chat_stream`), which means the
+/// generic `supports_embeddings()` scan in `RouterProvider::embed`/`embed_batch` would
+/// otherwise never see them and could fall back to any chat provider of the same backend
+/// type that happens to also report `supports_embeddings() == true` (#5859). Wiring the
+/// dedicated provider in separately via `with_embed_provider` closes that gap without
+/// admitting embed-only entries into the chat pool.
+fn apply_dedicated_embed_provider(
+    router: RouterProvider,
+    pool: &[ProviderEntry],
+    config: &Config,
+) -> RouterProvider {
+    let Some(entry) = find_dedicated_embed_entry(pool) else {
+        log_no_dedicated_embed_provider(pool);
+        return router;
+    };
+    match build_provider_from_entry(entry, config, None) {
+        Ok(p) => router.with_embed_provider(p),
+        Err(e) => {
+            tracing::warn!(
+                provider = entry.effective_name(),
+                error = %e,
+                "failed to build dedicated embed provider, generic embed selection will be used"
+            );
+            router
+        }
+    }
+}
+
 /// Apply ASI and `quality_gate` configuration to a `RouterProvider` from `[llm.routing]` config.
 fn apply_routing_signals(router: RouterProvider, config: &Config) -> RouterProvider {
     let router_cfg = config.llm.router.as_ref();
@@ -345,6 +418,7 @@ fn create_provider_from_pool(config: &Config) -> Result<AnyProvider, BootstrapEr
             let router =
                 RouterProvider::new(providers).with_ema(alpha, config.llm.router_reorder_interval);
             let router = apply_coe(router, config);
+            let router = apply_dedicated_embed_provider(router, pool, config);
             Ok(AnyProvider::Router(Box::new(apply_routing_signals(
                 router, config,
             ))))
@@ -359,6 +433,7 @@ fn create_provider_from_pool(config: &Config) -> Result<AnyProvider, BootstrapEr
                 .map(std::path::Path::new);
             let router = RouterProvider::new(providers).with_thompson(state_path);
             let router = apply_coe(router, config);
+            let router = apply_dedicated_embed_provider(router, pool, config);
             Ok(AnyProvider::Router(Box::new(apply_routing_signals(
                 router, config,
             ))))
@@ -377,11 +452,11 @@ fn create_provider_from_pool(config: &Config) -> Result<AnyProvider, BootstrapEr
                 .router
                 .as_ref()
                 .map_or(4, |r| r.embed_concurrency);
-            Ok(AnyProvider::Router(Box::new(
-                RouterProvider::new(providers)
-                    .with_cascade(router_cascade_cfg)
-                    .with_embed_concurrency(embed_concurrency),
-            )))
+            let router = RouterProvider::new(providers)
+                .with_cascade(router_cascade_cfg)
+                .with_embed_concurrency(embed_concurrency);
+            let router = apply_dedicated_embed_provider(router, pool, config);
+            Ok(AnyProvider::Router(Box::new(router)))
         }
         LlmRoutingStrategy::Bandit => {
             let providers = build_all_pool_providers(pool, config)?;
@@ -433,11 +508,11 @@ fn create_provider_from_pool(config: &Config) -> Result<AnyProvider, BootstrapEr
                 .router
                 .as_ref()
                 .map_or(4, |r| r.embed_concurrency);
-            Ok(AnyProvider::Router(Box::new(
-                RouterProvider::new(providers)
-                    .with_bandit(router_bandit_cfg, state_path, embed_provider)
-                    .with_embed_concurrency(embed_concurrency),
-            )))
+            let router = RouterProvider::new(providers)
+                .with_bandit(router_bandit_cfg, state_path, embed_provider)
+                .with_embed_concurrency(embed_concurrency);
+            let router = apply_dedicated_embed_provider(router, pool, config);
+            Ok(AnyProvider::Router(Box::new(router)))
         }
         LlmRoutingStrategy::Triage => build_triage_provider(pool, config),
         _ => build_single_provider_from_pool(pool, config),
@@ -558,12 +633,29 @@ fn build_triage_provider(
         return build_single_provider_from_pool(pool, config);
     }
 
-    let router = TriageRouter::new(
+    let mut router = TriageRouter::new(
         triage_provider,
         tier_providers,
         cr.triage_timeout_secs,
         cr.max_triage_tokens,
     );
+    // #5859 critic F1: without this, TriageRouter::embed/embed_batch re-implement the same
+    // "first supports_embeddings() == true tier wins" scan that RouterProvider used to have,
+    // which can shadow a dedicated embed = true provider with a chat-only same-backend tier.
+    match find_dedicated_embed_entry(pool) {
+        Some(entry) => match build_provider_from_entry(entry, config, None) {
+            Ok(p) => router = router.with_embed_provider(p),
+            Err(e) => {
+                tracing::warn!(
+                    provider = entry.effective_name(),
+                    error = %e,
+                    "failed to build dedicated embed provider for triage routing, \
+                     generic embed selection will be used"
+                );
+            }
+        },
+        None => log_no_dedicated_embed_provider(pool),
+    }
     Ok(AnyProvider::Triage(Box::new(router)))
 }
 
@@ -788,6 +880,212 @@ mod tests {
             result.model_identifier(),
             "nomic-embed-text",
             "should use configured model"
+        );
+    }
+
+    // ── apply_dedicated_embed_provider / embed routing (#5859) ────────────────
+
+    /// End-to-end regression for #5859 symptom 1: `build_all_pool_providers` excludes
+    /// `embed = true` entries from the router's chat pool, so without
+    /// `apply_dedicated_embed_provider` wiring the dedicated embedding entry, `embed()`
+    /// falls through to whichever chat-only provider happens to also report
+    /// `supports_embeddings() == true` (every `OllamaProvider`, unconditionally).
+    ///
+    /// The chat-only entry here points at an unreachable address, so if the router ever
+    /// fell back to it for embedding, the call would fail instead of returning the mock
+    /// server's fixed vector — a network-observable proxy for provider selection.
+    #[tokio::test]
+    async fn create_provider_from_pool_ema_routes_embed_to_dedicated_entry() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use zeph_core::config::LlmRoutingStrategy;
+        use zeph_llm::provider::LlmProvider as _;
+
+        use super::create_provider_from_pool;
+
+        let embed_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "embeddings": [[4.2, 4.2]] })),
+            )
+            .mount(&embed_server)
+            .await;
+
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.llm.routing = LlmRoutingStrategy::Ema;
+        config.llm.providers = vec![
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("embedder".into()),
+                base_url: Some(embed_server.uri()),
+                model: Some("nomic-embed-text".into()),
+                embed: true,
+                ..ProviderEntry::default()
+            },
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("chat".into()),
+                base_url: Some("http://127.0.0.1:1".into()),
+                model: Some("qwen3:8b".into()),
+                embed: false,
+                ..ProviderEntry::default()
+            },
+        ];
+
+        let provider =
+            create_provider_from_pool(&config).expect("router construction must succeed");
+        assert!(
+            matches!(provider, AnyProvider::Router(_)),
+            "Ema routing must produce a Router-wrapped provider"
+        );
+
+        let result = provider.embed("hello").await;
+        assert_eq!(
+            result.unwrap(),
+            vec![4.2, 4.2],
+            "embed() must route to the embed=true entry via the dedicated-embed-provider \
+             side channel, not the unreachable chat-only entry"
+        );
+    }
+
+    /// Same regression as above under the Cascade strategy, whose provider pool and
+    /// `apply_dedicated_embed_provider` wiring path (`create_provider_from_pool`'s
+    /// `LlmRoutingStrategy::Cascade` arm) is independent of the Ema arm.
+    #[tokio::test]
+    async fn create_provider_from_pool_cascade_routes_embed_to_dedicated_entry() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use zeph_core::config::LlmRoutingStrategy;
+        use zeph_llm::provider::LlmProvider as _;
+
+        use super::create_provider_from_pool;
+
+        let embed_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "embeddings": [[1.5, 2.5]] })),
+            )
+            .mount(&embed_server)
+            .await;
+
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.llm.routing = LlmRoutingStrategy::Cascade;
+        config.llm.providers = vec![
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("embedder".into()),
+                base_url: Some(embed_server.uri()),
+                model: Some("nomic-embed-text".into()),
+                embed: true,
+                ..ProviderEntry::default()
+            },
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("chat".into()),
+                base_url: Some("http://127.0.0.1:1".into()),
+                model: Some("qwen3:8b".into()),
+                embed: false,
+                ..ProviderEntry::default()
+            },
+        ];
+
+        let provider =
+            create_provider_from_pool(&config).expect("router construction must succeed");
+        assert!(
+            matches!(provider, AnyProvider::Router(_)),
+            "Cascade routing must produce a Router-wrapped provider"
+        );
+
+        let result = provider.embed("hello").await;
+        assert_eq!(
+            result.unwrap(),
+            vec![1.5, 2.5],
+            "embed() must route to the embed=true entry via the dedicated-embed-provider \
+             side channel, not the unreachable chat-only entry"
+        );
+    }
+
+    /// End-to-end regression for #5859 critic finding F1 under `routing = "triage"`:
+    /// `build_triage_provider` wires the pool's `embed = true` entry into
+    /// `TriageRouter::with_embed_provider` so `embed()` uses it directly instead of
+    /// `TriageRouter::select_embed_provider`'s fallback scan for the first tier reporting
+    /// `supports_embeddings() == true` — a scan that would otherwise be shadowed by an
+    /// unrelated chat-only Ollama tier, exactly like the original `RouterProvider` bug.
+    /// The `triage.rs` unit tests prove the `TriageRouter` selection logic in isolation;
+    /// this test proves the bootstrap wiring (`find_dedicated_embed_entry` →
+    /// `build_provider_from_entry` → `with_embed_provider`) is actually invoked.
+    #[tokio::test]
+    async fn build_triage_provider_routes_embed_to_dedicated_entry() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use zeph_config::{ComplexityRoutingConfig, TierMapping};
+        use zeph_core::config::LlmRoutingStrategy;
+        use zeph_llm::provider::LlmProvider as _;
+
+        use super::create_provider_from_pool;
+
+        let embed_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "embeddings": [[7.0, 8.0]] })),
+            )
+            .mount(&embed_server)
+            .await;
+
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.llm.routing = LlmRoutingStrategy::Triage;
+        config.llm.providers = vec![
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("chat".into()),
+                base_url: Some("http://127.0.0.1:1".into()),
+                model: Some("qwen3:8b".into()),
+                embed: false,
+                ..ProviderEntry::default()
+            },
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("embedder".into()),
+                base_url: Some(embed_server.uri()),
+                model: Some("nomic-embed-text".into()),
+                embed: true,
+                ..ProviderEntry::default()
+            },
+        ];
+        // bypass_single_provider = false: a single "simple" tier mapped to the sole
+        // non-embed entry would otherwise be collapsed to build_single_provider_from_pool,
+        // which does not exercise the TriageRouter/with_embed_provider path at all.
+        config.llm.complexity_routing = Some(ComplexityRoutingConfig {
+            triage_provider: None,
+            bypass_single_provider: false,
+            tiers: TierMapping {
+                simple: Some("chat".into()),
+                ..TierMapping::default()
+            },
+            max_triage_tokens: 50,
+            triage_timeout_secs: 5,
+            fallback_strategy: None,
+        });
+
+        let provider =
+            create_provider_from_pool(&config).expect("triage router construction must succeed");
+        assert!(
+            matches!(provider, AnyProvider::Triage(_)),
+            "routing = \"triage\" must produce a Triage-wrapped provider"
+        );
+
+        let result = provider.embed("hello").await;
+        assert_eq!(
+            result.unwrap(),
+            vec![7.0, 8.0],
+            "embed() must route to the embed=true entry via the dedicated-embed-provider \
+             side channel, not the first tier reporting supports_embeddings() == true"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `OllamaProvider::name()` always returned the hardcoded literal `"ollama"` instead of the TOML-configured `[[llm.providers]]` name, unlike `CompatibleProvider::name()`. With more than one `type = "ollama"` provider declared, this cross-contaminated router reputation/Thompson-sampling state (keyed on `provider.name()`) between distinct Ollama instances.
- The router's generic embed path could also select a chat-only Ollama instance instead of a dedicated embedder, since `OllamaProvider::supports_embeddings()` is unconditionally `true` — silently falling back to an unconfigured default embedding model and failing embed calls.
- Added `OllamaProvider::provider_name` / `with_provider_name()` (mirrors `CompatibleProvider`), wired into `build_ollama_provider`.
- Added a `dedicated_embed_provider` side-channel (`RouterState` / `RouterProvider::with_embed_provider()` / `embed_candidates()`, and the equivalent on `TriageRouter`) so a pool entry explicitly flagged `embed = true` is preferred over the generic `supports_embeddings()` scan, across all routing strategies (Ema/Thompson/Cascade/Bandit/Triage).
- Added a warn when more than one `embed = true` entry exists in the pool, and an info log naming the fallback candidate pool when no dedicated embedder is configured.

Closes #5859

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler"` (targeted + full relevant filters, 916+ tests passing)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] 6 new regression tests: `OllamaProvider::with_provider_name` unit tests, `RouterProvider`/`TriageRouter` dedicated-embed-provider unit tests, `wiremock`-backed bootstrap-level E2E tests for Ema/Cascade/Triage routing strategies, distinct-provider-names end-to-end test in `provider_factory.rs`
- [x] Corrected 3 pre-existing tests that had asserted the pre-fix hardcoded `"ollama"` literal as expected behavior
- [x] Live-verified against a real local Ollama server (two providers: chat-only `qwen2.5:7b` + dedicated embedder `nomic-embed-text-v2-moe`, `qwen3-embedding` deliberately not pulled): dedicated embed provider correctly selected, zero `qwen3-embedding not found` errors, chat log correctly shows the configured provider name instead of the hardcoded literal
- [x] `.local/testing/coverage-status.md` and `.local/testing/playbooks/llm-routing.md` (Scenario F) updated in the main repo with live-test results