### PR TITLE
fix(tools): scale adversarial policy timeout by provider type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `docs(orchestration)`: corrected `zeph-orchestration` crate-level doc comment claiming `llm-planning` feature is enabled by default; it is not (default feature set is `sqlite` only). Updated docs to clarify opt-in behavior and reference `LlmPlanner`/`LlmAggregator` APIs (#5856).
+- `fix(tools)`: `[tools.adversarial_policy]`'s fixed 3s `timeout_ms` made the fail-closed
+  adversarial gate deny effectively every tool call when `policy_provider` pointed at a local
+  Ollama model (local completions routinely take 10-30s+, up to 31_928ms observed in the
+  issue's own reproduction). `timeout_ms` is now `Option<u64>`: left unset (the new default),
+  the effective timeout is auto-scaled from the resolved `policy_provider`'s **type** — 45s for
+  local providers (Ollama/Candle), 3s for cloud providers — via
+  `zeph_config::tools::adversarial_timeout_for_provider_kind`. This is keyed on the configured
+  provider *type*, not on whether its endpoint is actually local: a `type = "openai"`/`"claude"`
+  entry pointed at a self-hosted/localhost `base_url` still gets the 3s cloud budget, so
+  operators in that setup should set `timeout_ms` explicitly. An explicit `timeout_ms` always
+  overrides auto-scaling. Also: `PolicyDecision::Error` now carries a `timed_out: bool`
+  discriminant so a policy-LLM timeout is distinguishable from a genuine network/protocol error;
+  the operator-facing audit log reason (and `/status`'s `Adv gate:` line, which now also shows
+  the effective `timeout_ms`) surface this distinction with an actionable hint, while the
+  LLM-visible denial message stays generic per MED-03 (#5870).
 
 ## [0.22.0] - 2026-07-07
 ### Added

--- a/book/src/concepts/tools.md
+++ b/book/src/concepts/tools.md
@@ -187,9 +187,20 @@ The adversarial policy agent is an optional pre-execution validation layer that 
 ```toml
 [tools.adversarial_policy]
 enabled = true
-provider = "fast"              # Provider name for validation LLM
-block_on_reject = true         # Block rejected calls (false = warn only)
+policy_provider = "fast"        # Provider name from [[llm.providers]] for validation LLM
+policy_file = "policies.txt"    # Plain-text file with one policy per line
+fail_open = false               # Block tool calls on LLM/timeout error (fail-closed, default)
+# timeout_ms = 5000              # Optional: override the auto-scaled policy LLM timeout
 ```
+
+`timeout_ms` is optional. Left unset, the timeout is auto-scaled from `policy_provider`'s
+resolved **type**: local providers (Ollama, Candle) get 45s, cloud providers get 3s, since
+local inference routinely takes 10-30s+ per completion — a fixed cloud-tuned timeout would
+otherwise deny nearly every tool call under `fail_open = false`. This is keyed on the
+provider's configured `type`, not on whether its endpoint happens to be local — a
+`type = "openai"`/`"claude"` entry pointed at a self-hosted/localhost `base_url` still gets
+the 3s cloud budget, so set `timeout_ms` explicitly in that setup. The resolved timeout and
+provider are shown by `/status`.
 
 The adversarial policy agent is distinct from the permission system — permissions are pattern-based and static, while the policy agent uses LLM reasoning to evaluate context-dependent risk.
 

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -764,8 +764,55 @@ impl Default for RetryConfig {
     }
 }
 
+/// Fixed fallback timeout (ms) used for cloud policy providers, and whenever the
+/// provider kind cannot be determined.
 fn default_adversarial_timeout_ms() -> u64 {
     3_000
+}
+
+/// Timeout (ms) used for local policy providers (Ollama, Candle, or any other
+/// locally-hosted model). Local inference routinely takes 10-30s+ per completion,
+/// far above the fixed default that was tuned for cloud APIs — see #5870. Set with
+/// margin above the worst-case latency observed in #5870's own reproduction
+/// (`qwen2.5:7b` took up to `31928` ms): 45s clears that by ~13s (~41%) so the
+/// fix closes the failure window instead of merely narrowing it.
+const LOCAL_PROVIDER_ADVERSARIAL_TIMEOUT_MS: u64 = 45_000;
+
+/// Resolve the effective adversarial policy timeout for a resolved provider kind.
+///
+/// `provider_kind` is the value returned by `AnyProvider::provider_kind_str()`:
+/// `"ollama"` / `"candle"` / `"local"` for locally-hosted inference, `"cloud"` for
+/// metered API providers. Local providers get a much longer fail-closed budget,
+/// since a fixed 3s timeout made the fail-closed adversarial gate deny effectively
+/// every tool call when `policy_provider` pointed at a local Ollama model (#5870).
+///
+/// This classification is keyed on the provider's configured **type**
+/// (`[[llm.providers]].type`), not on whether its endpoint happens to be local.
+/// A `type = "openai"`/`"claude"` entry pointed at a self-hosted or localhost
+/// `base_url` (e.g. an OpenAI-compatible proxy in front of a local model) still
+/// resolves to `"cloud"` here and gets the short 3s budget. Operators running a
+/// cloud-provider-typed client against a slow self-hosted endpoint should set
+/// [`AdversarialPolicyConfig::timeout_ms`] explicitly rather than relying on
+/// auto-scaling.
+///
+/// Only used when [`AdversarialPolicyConfig::timeout_ms`] is left unset — an
+/// explicit value always takes precedence over provider-based scaling.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_config::tools::adversarial_timeout_for_provider_kind;
+///
+/// assert_eq!(adversarial_timeout_for_provider_kind("ollama"), 45_000);
+/// assert_eq!(adversarial_timeout_for_provider_kind("cloud"), 3_000);
+/// ```
+#[must_use]
+pub fn adversarial_timeout_for_provider_kind(provider_kind: &str) -> u64 {
+    if matches!(provider_kind, "ollama" | "candle" | "local") {
+        LOCAL_PROVIDER_ADVERSARIAL_TIMEOUT_MS
+    } else {
+        default_adversarial_timeout_ms()
+    }
 }
 
 /// Configuration for the LLM-based adversarial policy agent.
@@ -782,9 +829,14 @@ pub struct AdversarialPolicyConfig {
     /// Whether to allow tool calls when the policy LLM fails. Default: `false` (fail-closed).
     #[serde(default)]
     pub fail_open: bool,
-    /// Timeout in milliseconds for a single policy LLM call. Default: `3000`.
-    #[serde(default = "default_adversarial_timeout_ms")]
-    pub timeout_ms: u64,
+    /// Timeout in milliseconds for a single policy LLM call.
+    ///
+    /// When unset (the default), the effective timeout is derived at startup from the
+    /// resolved `policy_provider`'s kind via [`adversarial_timeout_for_provider_kind`]:
+    /// local providers get a much longer fail-closed budget than cloud providers. Set
+    /// this explicitly to override auto-scaling with a fixed value.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
     /// Tool names always allowed through the adversarial policy gate.
     #[serde(default = "AdversarialPolicyConfig::default_exempt_tools")]
     pub exempt_tools: Vec<String>,
@@ -797,7 +849,7 @@ impl Default for AdversarialPolicyConfig {
             policy_provider: ProviderName::default(),
             policy_file: None,
             fail_open: false,
-            timeout_ms: default_adversarial_timeout_ms(),
+            timeout_ms: None,
             exempt_tools: Self::default_exempt_tools(),
         }
     }
@@ -1616,5 +1668,40 @@ destination = "/var/log/zeph-audit.log""#,
             w.adversarial_policy.policy_provider.is_empty(),
             "omitted policy_provider must default to empty (→ primary provider used)"
         );
+    }
+
+    #[test]
+    fn adversarial_policy_timeout_ms_defaults_to_none() {
+        // None means "auto-scale by resolved policy_provider kind" — see #5870.
+        let config = AdversarialPolicyConfig::default();
+        assert_eq!(config.timeout_ms, None);
+    }
+
+    #[test]
+    fn adversarial_policy_timeout_ms_explicit_override_roundtrips() {
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            adversarial_policy: AdversarialPolicyConfig,
+        }
+        let toml_str = r"
+            [adversarial_policy]
+            enabled = true
+            timeout_ms = 90000
+        ";
+        let w: Wrapper = toml::from_str(toml_str).unwrap();
+        assert_eq!(w.adversarial_policy.timeout_ms, Some(90_000));
+
+        let json = serde_json::to_string(&w.adversarial_policy).unwrap();
+        let back: AdversarialPolicyConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.timeout_ms, Some(90_000));
+    }
+
+    #[test]
+    fn adversarial_timeout_for_provider_kind_scales_local_vs_cloud() {
+        assert_eq!(adversarial_timeout_for_provider_kind("ollama"), 45_000);
+        assert_eq!(adversarial_timeout_for_provider_kind("candle"), 45_000);
+        assert_eq!(adversarial_timeout_for_provider_kind("local"), 45_000);
+        assert_eq!(adversarial_timeout_for_provider_kind("cloud"), 3_000);
+        assert_eq!(adversarial_timeout_for_provider_kind("unknown"), 3_000);
     }
 }

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -219,8 +219,8 @@ impl<C: crate::channel::Channel> Agent<C> {
             };
             let _ = writeln!(
                 out,
-                "Adv gate:  enabled (provider={}, policies={}, fail_open={})",
-                provider_display, adv.policy_count, adv.fail_open
+                "Adv gate:  enabled (provider={}, policies={}, fail_open={}, timeout_ms={})",
+                provider_display, adv.policy_count, adv.fail_open, adv.timeout_ms
             );
         }
         append_cost_section(&mut out, metrics.cost_cents, &metrics.provider_breakdown);

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -233,6 +233,11 @@ pub struct AdversarialPolicyInfo {
     pub provider: String,
     pub policy_count: usize,
     pub fail_open: bool,
+    /// Effective policy-LLM call timeout in milliseconds — either the explicitly
+    /// configured `timeout_ms`, or the value auto-scaled for `provider`'s kind
+    /// (local vs cloud). Surfaced so operators can tell at a glance whether a slow
+    /// local `policy_provider` got a realistic budget (see #5870).
+    pub timeout_ms: u64,
 }
 
 #[allow(clippy::struct_excessive_bools)] // independent boolean flags; bitflags or enum would obscure semantics without reducing complexity

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -99,10 +99,11 @@ impl<T: ToolExecutor> AdversarialPolicyGateExecutor<T> {
                     command: "[adversarial] Tool call denied by policy".to_owned(),
                 })
             }
-            PolicyDecision::Error { message } => {
+            PolicyDecision::Error { message, timed_out } => {
                 tracing::warn!(
                     tool = %call.tool_id,
                     error = %message,
+                    timed_out,
                     fail_open = self.validator.fail_open(),
                     "adversarial policy: LLM error"
                 );
@@ -116,12 +117,22 @@ impl<T: ToolExecutor> AdversarialPolicyGateExecutor<T> {
                     .await;
                     Ok(())
                 } else {
+                    // Operator-facing audit reason distinguishes a timeout (config/latency
+                    // problem, actionable) from a genuine LLM/network error — see #5870.
+                    // The main LLM never sees this: `ToolError::Blocked` below stays generic.
+                    let reason = if timed_out {
+                        format!(
+                            "adversarial policy check timed out (fail-closed): {message} — \
+                             raise [tools.adversarial_policy].timeout_ms or point policy_provider \
+                             at a faster model"
+                        )
+                    } else {
+                        format!("adversarial policy LLM error (fail-closed): {message}")
+                    };
                     self.write_audit(
                         call,
                         &format!("error:{message}"),
-                        AuditResult::Blocked {
-                            reason: "adversarial policy LLM error (fail-closed)".to_owned(),
-                        },
+                        AuditResult::Blocked { reason },
                         None,
                     )
                     .await;
@@ -421,10 +432,17 @@ mod tests {
             make_validator(false), // fail_open = false
             Arc::new(FailingLlm),
         );
-        let result = gate.execute_tool_call(&make_call("shell")).await;
-        assert!(
-            matches!(result, Err(ToolError::Blocked { .. })),
-            "fail-closed must block on LLM error"
+        let err = gate
+            .execute_tool_call(&make_call("shell"))
+            .await
+            .unwrap_err();
+        // #5870/MED-03: the timed_out=false (genuine error) branch must produce the exact
+        // same LLM-visible message as the timed_out=true branch (see
+        // audit_entry_distinguishes_timeout_from_generic_error) — the main LLM must never be
+        // able to distinguish an infra error from a policy error via this string.
+        assert_matches!(
+            err,
+            ToolError::Blocked { ref command } if command == "[adversarial] Tool call denied: policy check failed"
         );
     }
 
@@ -579,6 +597,71 @@ mod tests {
         assert!(
             content.contains("deny:"),
             "deny decision must be recorded in audit"
+        );
+    }
+
+    #[tokio::test]
+    async fn audit_entry_distinguishes_timeout_from_generic_error() {
+        // #5870: the operator-facing audit reason must tell a policy-LLM timeout apart
+        // from a genuine deny/error, with an actionable hint — while the LLM-visible
+        // ToolError stays generic (see error_message_is_opaque).
+        use tempfile::TempDir;
+
+        struct SlowLlm;
+        impl PolicyLlmClient for SlowLlm {
+            fn chat<'a>(
+                &'a self,
+                _: &'a [PolicyMessage],
+            ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>> {
+                Box::pin(async {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    Ok("ALLOW".to_owned())
+                })
+            }
+        }
+
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("audit.log");
+        let audit_config = crate::config::AuditConfig {
+            enabled: true,
+            destination: crate::config::AuditDestination::File(log_path.clone()),
+            ..Default::default()
+        };
+        let audit_logger = Arc::new(
+            crate::audit::AuditLogger::from_config(&audit_config, false)
+                .await
+                .unwrap(),
+        );
+
+        let validator = Arc::new(PolicyValidator::new(
+            vec!["test policy".to_owned()],
+            Duration::from_millis(20), // shorter than SlowLlm's 200ms response
+            false,                     // fail-closed
+            Vec::new(),
+        ));
+        let (_, inner) = MockInner::new();
+        let gate = AdversarialPolicyGateExecutor::new(inner, validator, Arc::new(SlowLlm))
+            .with_audit(Arc::clone(&audit_logger));
+
+        let err = gate
+            .execute_tool_call(&make_call("shell"))
+            .await
+            .unwrap_err();
+
+        // LLM-visible error stays generic (MED-03).
+        assert_matches!(
+            err,
+            ToolError::Blocked { ref command } if command == "[adversarial] Tool call denied: policy check failed"
+        );
+
+        let content = tokio::fs::read_to_string(&log_path).await.unwrap();
+        assert!(
+            content.contains("timed out"),
+            "operator-facing audit reason must say the check timed out, not a generic error: {content}"
+        );
+        assert!(
+            content.contains("timeout_ms"),
+            "operator-facing audit reason must hint at raising timeout_ms: {content}"
         );
     }
 

--- a/crates/zeph-tools/src/adversarial_policy.rs
+++ b/crates/zeph-tools/src/adversarial_policy.rs
@@ -26,7 +26,15 @@ pub enum PolicyDecision {
         reason: String,
     },
     /// LLM call failed (timeout, network error, or malformed response).
-    Error { message: String },
+    Error {
+        /// Error detail (audit/log only — do NOT surface to main LLM, see MED-03).
+        message: String,
+        /// `true` when the failure was the configured `timeout_ms` elapsing rather
+        /// than a network/protocol error. Lets callers give operators an actionable
+        /// diagnostic ("raise `timeout_ms` / use a faster `policy_provider`") instead of
+        /// a generic failure, without changing what the main LLM ever sees (#5870).
+        timed_out: bool,
+    },
 }
 
 /// Validates tool calls against plain-language policies using an LLM.
@@ -75,12 +83,18 @@ impl PolicyValidator {
             Err(_elapsed) => {
                 let msg = format!("policy LLM timeout after {}ms", self.timeout.as_millis());
                 tracing::warn!("{msg}");
-                PolicyDecision::Error { message: msg }
+                PolicyDecision::Error {
+                    message: msg,
+                    timed_out: true,
+                }
             }
             Ok(Err(err)) => {
                 let msg = format!("policy LLM error: {err}");
                 tracing::warn!("{msg}");
-                PolicyDecision::Error { message: msg }
+                PolicyDecision::Error {
+                    message: msg,
+                    timed_out: false,
+                }
             }
             Ok(Ok(response)) => parse_response(&response),
         }
@@ -330,6 +344,33 @@ mod tests {
         let params = serde_json::Map::new();
         let decision = v.validate("shell", &params, &client).await;
         assert_matches!(decision, PolicyDecision::Error { .. });
+    }
+
+    #[tokio::test]
+    async fn llm_failure_is_not_marked_as_timed_out() {
+        // #5870: a network/protocol error must be distinguishable from a timeout so
+        // operators aren't told to "raise timeout_ms" for a problem that isn't one.
+        let v = make_validator(false);
+        let client = FailingLlmClient;
+        let params = serde_json::Map::new();
+        let decision = v.validate("shell", &params, &client).await;
+        assert_matches!(decision, PolicyDecision::Error { timed_out, .. } if !timed_out);
+    }
+
+    #[tokio::test]
+    async fn timeout_is_marked_as_timed_out() {
+        // #5870: the timeout case must be distinguishable from a generic LLM error so
+        // the operator-facing diagnostic can point at timeout_ms/policy_provider.
+        let v = PolicyValidator::new(
+            vec!["test policy".to_owned()],
+            Duration::from_millis(50),
+            false,
+            Vec::new(),
+        );
+        let client = TimeoutLlmClient { delay_ms: 200 };
+        let params = serde_json::Map::new();
+        let decision = v.validate("shell", &params, &client).await;
+        assert_matches!(decision, PolicyDecision::Error { timed_out, .. } if timed_out);
     }
 
     #[tokio::test]

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -630,13 +630,9 @@ async fn build_acp_deps(
             tracing::warn!("adversarial policy enabled but no policies loaded; gate is a no-op");
         }
 
-        let validator = std::sync::Arc::new(zeph_tools::PolicyValidator::new(
-            policies,
-            std::time::Duration::from_millis(adv_cfg.timeout_ms),
-            adv_cfg.fail_open,
-            adv_cfg.exempt_tools.clone(),
-        ));
-
+        // Resolve the policy provider before the timeout: when `timeout_ms` is unset, the
+        // effective timeout is scaled by the resolved provider's kind (local vs cloud) —
+        // see #5870.
         let policy_provider = if adv_cfg.policy_provider.is_empty() {
             provider.clone()
         } else {
@@ -653,6 +649,18 @@ async fn build_acp_deps(
                 }
             }
         };
+
+        let timeout_ms = adv_cfg.timeout_ms.unwrap_or_else(|| {
+            zeph_config::tools::adversarial_timeout_for_provider_kind(
+                policy_provider.provider_kind_str(),
+            )
+        });
+        let validator = std::sync::Arc::new(zeph_tools::PolicyValidator::new(
+            policies,
+            std::time::Duration::from_millis(timeout_ms),
+            adv_cfg.fail_open,
+            adv_cfg.exempt_tools.clone(),
+        ));
 
         let llm_client: std::sync::Arc<dyn zeph_tools::PolicyLlmClient> =
             std::sync::Arc::new(agent_setup::AdversarialPolicyLlmAdapter {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -711,13 +711,9 @@ pub(crate) async fn run_daemon(
             tracing::warn!("adversarial policy enabled but no policies loaded; gate is a no-op");
         }
 
-        let validator = std::sync::Arc::new(zeph_tools::PolicyValidator::new(
-            policies,
-            std::time::Duration::from_millis(adv_cfg.timeout_ms),
-            adv_cfg.fail_open,
-            adv_cfg.exempt_tools.clone(),
-        ));
-
+        // Resolve the policy provider before the timeout: when `timeout_ms` is unset, the
+        // effective timeout is scaled by the resolved provider's kind (local vs cloud) —
+        // see #5870.
         let policy_provider = if adv_cfg.policy_provider.is_empty() {
             provider.clone()
         } else {
@@ -734,6 +730,18 @@ pub(crate) async fn run_daemon(
                 }
             }
         };
+
+        let timeout_ms = adv_cfg.timeout_ms.unwrap_or_else(|| {
+            zeph_config::tools::adversarial_timeout_for_provider_kind(
+                policy_provider.provider_kind_str(),
+            )
+        });
+        let validator = std::sync::Arc::new(zeph_tools::PolicyValidator::new(
+            policies,
+            std::time::Duration::from_millis(timeout_ms),
+            adv_cfg.fail_open,
+            adv_cfg.exempt_tools.clone(),
+        ));
 
         let llm_client: std::sync::Arc<dyn zeph_tools::PolicyLlmClient> =
             std::sync::Arc::new(agent_setup::AdversarialPolicyLlmAdapter {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2570,13 +2570,11 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             }
 
             let policy_count = policies.len();
-            let validator = std::sync::Arc::new(zeph_tools::PolicyValidator::new(
-                policies,
-                std::time::Duration::from_millis(adv_cfg.timeout_ms),
-                adv_cfg.fail_open,
-                adv_cfg.exempt_tools.clone(),
-            ));
 
+            // Resolve the policy provider first: the effective timeout (when not
+            // explicitly configured) is scaled by the resolved provider's kind, since a
+            // fixed cloud-tuned timeout made the fail-closed gate deny every tool call
+            // against a local Ollama policy_provider — see #5870.
             let (policy_provider, resolved_provider_name) = if adv_cfg.policy_provider.is_empty() {
                 let name = provider.name().to_string();
                 (provider.clone(), name)
@@ -2601,10 +2599,23 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                 }
             };
 
+            let timeout_ms = adv_cfg.timeout_ms.unwrap_or_else(|| {
+                zeph_config::tools::adversarial_timeout_for_provider_kind(
+                    policy_provider.provider_kind_str(),
+                )
+            });
+            let validator = std::sync::Arc::new(zeph_tools::PolicyValidator::new(
+                policies,
+                std::time::Duration::from_millis(timeout_ms),
+                adv_cfg.fail_open,
+                adv_cfg.exempt_tools.clone(),
+            ));
+
             adv_policy_info = Some(zeph_core::AdversarialPolicyInfo {
                 provider: resolved_provider_name,
                 policy_count,
                 fail_open: adv_cfg.fail_open,
+                timeout_ms,
             });
 
             let llm_client: std::sync::Arc<dyn zeph_tools::PolicyLlmClient> =


### PR DESCRIPTION
## Summary

- The fail-closed adversarial policy gate (`[tools.adversarial_policy]`) used a fixed 3s (5s in testing.toml) timeout for the policy LLM call, well below the 9-32s latency observed with local Ollama models. Every policy check timed out, hit `PolicyDecision::Error`, and with `fail_open = false` was denied identically to a genuine policy violation — producing a 100% deny rate on benign tool calls whenever `policy_provider` pointed at a local model.
- `timeout_ms` is now `Option<u64>` and auto-scales from the resolved `policy_provider`'s kind: 45s for local providers (ollama/candle/compatible — comfortably above the issue's own observed 31928ms worst case), 3s for cloud providers. An explicit `timeout_ms` still overrides the default.
- `PolicyDecision::Error` now carries a `timed_out` flag so the operator-facing audit log / tracing output can distinguish an infra timeout from a genuine LLM/network error. The message returned to the main LLM's tool-call error is unchanged, preserving the MED-03 opacity requirement (the main LLM cannot tell timeout apart from a real deny).
- Fixed the same provider-resolved-after-timeout-computed ordering bug in all three gate construction sites (`runner.rs`, `acp.rs`, `daemon.rs`) — the issue referenced only `runner.rs`.
- `/status`'s `Adv gate:` line now also shows the effective `timeout_ms`.
- Doc comment, CHANGELOG, and book docs clarify the auto-scaling is keyed on provider *type*, not endpoint locality — a cloud-typed client pointed at a self-hosted/localhost endpoint still gets the 3s budget and should set `timeout_ms` explicitly.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12443 passed / 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New unit tests: auto-scaling by provider kind, explicit override preserved, `timed_out` set correctly on timeout vs. genuine LLM error, MED-03 exact-message invariant on both branches, all three gate-construction sites verified for correct provider-before-timeout ordering