### PR TITLE
fix(gateway): expose Error::source() on GatewayError variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   new `zeph_common::net::is_loopback_host` helper) always bypass TLS/SSRF checks and connect
   over plain HTTP regardless of `[a2a_client]` settings; non-loopback targets still require
   HTTPS and pass DNS-based SSRF validation by default, unchanged from before (#5878).
+- `fix(gateway)`: `GatewayError::Bind` and `GatewayError::Server` (`crates/zeph-gateway/src/error.rs`)
+  now tag their wrapped `std::io::Error` field with `#[source]`, so `std::error::Error::source()`
+  exposes the underlying I/O error instead of returning `None`. `GatewayError::Server` previously
+  flattened the error from `axum::serve(...).await` to a `String` via `format!("{e}")`
+  (`crates/zeph-gateway/src/server.rs`), discarding the original `std::io::Error` entirely — it
+  now carries the typed error through directly, matching the convention already used by sibling
+  crates (`zeph-orchestration`, `zeph-mcp`) (#5863).
 - `fix(skills)`: `skills.group_structured`, `skills.support_similarity_threshold`, and
   `skills.min_injection_score` are now wired into the `Agent` at cold start (`src/runner.rs`,
   `src/daemon.rs`, `src/acp.rs`, `src/serve/agent_factory.rs`), matching how `Agent::reload_config`

--- a/crates/zeph-gateway/src/error.rs
+++ b/crates/zeph-gateway/src/error.rs
@@ -14,11 +14,47 @@ pub enum GatewayError {
     /// The first field is the address string (e.g. `"127.0.0.1:8080"`) and the
     /// second is the underlying I/O error.
     #[error("failed to bind {0}: {1}")]
-    Bind(String, std::io::Error),
+    Bind(String, #[source] std::io::Error),
 
     /// The `axum` server returned a fatal error after binding succeeded.
     ///
     /// This typically indicates a listener failure or an OS-level socket error.
     #[error("server error: {0}")]
-    Server(String),
+    Server(#[source] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_error_exposes_io_error_as_source() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::AddrInUse, "address in use");
+        let err = GatewayError::Bind("127.0.0.1:8080".to_string(), io_err);
+
+        let source = std::error::Error::source(&err).expect("Bind must expose a source");
+        let downcast = source
+            .downcast_ref::<std::io::Error>()
+            .expect("source must downcast to std::io::Error");
+        assert_eq!(downcast.kind(), std::io::ErrorKind::AddrInUse);
+
+        assert_eq!(
+            err.to_string(),
+            "failed to bind 127.0.0.1:8080: address in use"
+        );
+    }
+
+    #[test]
+    fn server_error_exposes_io_error_as_source() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "broken pipe");
+        let err = GatewayError::Server(io_err);
+
+        let source = std::error::Error::source(&err).expect("Server must expose a source");
+        let downcast = source
+            .downcast_ref::<std::io::Error>()
+            .expect("source must downcast to std::io::Error");
+        assert_eq!(downcast.kind(), std::io::ErrorKind::BrokenPipe);
+
+        assert_eq!(err.to_string(), "server error: broken pipe");
+    }
 }

--- a/crates/zeph-gateway/src/server.rs
+++ b/crates/zeph-gateway/src/server.rs
@@ -351,7 +351,7 @@ impl GatewayServer {
             tracing::info!("gateway shutting down");
         })
         .await
-        .map_err(|e| GatewayError::Server(format!("{e}")))?;
+        .map_err(GatewayError::Server)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- `GatewayError::Bind` and `GatewayError::Server` now tag their wrapped `std::io::Error` field with `#[source]`, so `std::error::Error::source()` exposes the underlying I/O error instead of returning `None`.
- `GatewayError::Server` no longer discards the original error by flattening it to a `String` via `format!("{e}")` at the `axum::serve(...)` call site — it now carries the typed `std::io::Error` through directly, matching the convention already used by sibling crates (`zeph-orchestration`, `zeph-mcp`).

Closes #5863

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci -p zeph-gateway --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest -p zeph-gateway -E 'test(error)'` — 5/5 pass, including 2 new regression tests (`bind_error_exposes_io_error_as_source`, `server_error_exposes_io_error_as_source`) verifying both `source()` downcast and `Display` text
- [x] Rustdoc gate (`--deny rustdoc::broken_intra_doc_links`) — clean
- [x] Grepped for other `GatewayError::Server`/`Bind` construction sites and pattern matches — only one construction site existed, no breakage