### PR TITLE
fix(llm): delegate think-tokens/reasoning-effort through routed providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(llm)`: `AnyProvider::Router` and `AnyProvider::Triage` no longer silently reject
+  `/think-tokens` and `/reasoning-effort` regardless of the selected inner provider's
+  capabilities. The four capability-mutating/-querying methods on `AnyProvider`
+  (`crates/zeph-llm/src/any.rs`) now delegate to the router's/triage's currently active
+  provider — `RouterProvider::{set_thinking_budget,apply_reasoning_effort}_delegated`
+  (`crates/zeph-llm/src/router/builder.rs`) and the equivalent `TriageRouter` methods
+  (`crates/zeph-llm/src/router/triage.rs`) — instead of unconditionally returning "not
+  supported". A new `capability_delegation_advisory` surfaces a one-line note when the
+  provider a mutation was applied to may diverge from the next turn's dispatch target
+  (e.g. Thompson/EMA/Bandit routing strategies), threaded through the existing
+  cross-override-note pattern in `crates/zeph-core/src/agent/agent_access_impl.rs` with no
+  signature changes to `AgentAccess`/`CommandOutput` (#5883).
 - `fix(a2a,config)`: `zeph --tui --connect <URL>` no longer fails against its own documented
   plain-`http://` loopback usage example (`--connect http://127.0.0.1:8080/a2a/stream`) on a
   fresh/default config. `src/tui_remote.rs` previously built the client-side `A2aClient`'s

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -935,6 +935,9 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                              — Claude's Extended and Adaptive thinking share one config field.",
                         );
                     }
+                    if let Some(advisory) = self.provider.capability_delegation_advisory() {
+                        let _ = write!(msg, " Note: {advisory}.");
+                    }
                     msg
                 }
                 Err(zeph_llm::LlmError::ModelCapabilityMismatch { provider, message }) => {
@@ -977,6 +980,9 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                             " Note: this overrides the previously set thinking-token budget \
                              — Claude's Extended and Adaptive thinking share one config field.",
                         );
+                    }
+                    if let Some(advisory) = self.provider.capability_delegation_advisory() {
+                        let _ = write!(msg, " Note: {advisory}.");
                     }
                     msg
                 }

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -548,6 +548,12 @@ impl AnyProvider {
     /// variants return [`crate::LlmError::ModelCapabilityMismatch`] — this command never silently
     /// no-ops.
     ///
+    /// `Self::Router` and `Self::Triage` delegate to their applicable inner provider (the one
+    /// that served the most recent call, or a deterministic fallback if none has yet) via
+    /// their internal `set_thinking_budget_delegated` helpers. Use
+    /// [`Self::capability_delegation_advisory`] after a successful call to check whether the
+    /// routing strategy may pick a different inner provider on the next turn.
+    ///
     /// # Errors
     ///
     /// Returns an error when `budget` is outside the active provider's valid range, or when
@@ -569,6 +575,8 @@ impl AnyProvider {
                 p.set_thinking_budget(Some(i))
             }
             Self::Masked(p) => p.inner.set_thinking_budget(budget),
+            Self::Router(r) => r.set_thinking_budget_delegated(budget),
+            Self::Triage(t) => t.set_thinking_budget_delegated(budget),
             other => Err(crate::LlmError::ModelCapabilityMismatch {
                 provider: other.name().to_owned(),
                 message: "does not support a thinking-token budget".into(),
@@ -583,6 +591,8 @@ impl AnyProvider {
     ///   see [`Self::set_thinking_budget`]).
     /// - `OpenAI` / `Compatible` → the existing string-based `reasoning_effort` field.
     /// - `Gemini` → `thinking_level`.
+    /// - `Router` / `Triage` → delegates to the applicable inner provider, mirroring
+    ///   [`Self::set_thinking_budget`]'s delegation behavior.
     /// - All other providers → [`crate::LlmError::ModelCapabilityMismatch`].
     ///
     /// This is the new session-only runtime entry point for `/reasoning-effort`. It is
@@ -614,6 +624,8 @@ impl AnyProvider {
                 Ok(())
             }
             Self::Masked(p) => p.inner.apply_reasoning_effort(effort),
+            Self::Router(r) => r.apply_reasoning_effort_delegated(effort),
+            Self::Triage(t) => t.apply_reasoning_effort_delegated(effort),
             other => Err(crate::LlmError::ModelCapabilityMismatch {
                 provider: other.name().to_owned(),
                 message: "does not support reasoning effort".into(),
@@ -626,6 +638,9 @@ impl AnyProvider {
     /// `None` means thinking is disabled, the provider is in effort-based mode (Claude
     /// `Adaptive`), or the provider does not support a token budget at all. Used by the
     /// `/think-tokens` no-arg display path and by the `/provider` switch's reset-notice check.
+    ///
+    /// `Self::Router` and `Self::Triage` return the value from their applicable inner
+    /// provider (see [`Self::set_thinking_budget`]).
     #[must_use]
     pub fn current_thinking_budget(&self) -> Option<u32> {
         match self {
@@ -637,6 +652,8 @@ impl AnyProvider {
                 .and_then(|b| u32::try_from(b).ok())
                 .filter(|&b| b > 0),
             Self::Masked(p) => p.inner().current_thinking_budget(),
+            Self::Router(r) => r.current_thinking_budget_delegated(),
+            Self::Triage(t) => t.current_thinking_budget_delegated(),
             _ => None,
         }
     }
@@ -647,6 +664,9 @@ impl AnyProvider {
     /// `Extended`), or the provider does not support an effort level at all. Used by the
     /// `/reasoning-effort` no-arg display path and by the `/provider` switch's reset-notice
     /// check.
+    ///
+    /// `Self::Router` and `Self::Triage` return the value from their applicable inner
+    /// provider (see [`Self::set_thinking_budget`]).
     #[must_use]
     pub fn current_reasoning_effort(&self) -> Option<String> {
         match self {
@@ -655,6 +675,28 @@ impl AnyProvider {
             Self::Compatible(p) => p.current_reasoning_effort(),
             Self::Gemini(p) => p.current_reasoning_effort(),
             Self::Masked(p) => p.inner().current_reasoning_effort(),
+            Self::Router(r) => r.current_reasoning_effort_delegated(),
+            Self::Triage(t) => t.current_reasoning_effort_delegated(),
+            _ => None,
+        }
+    }
+
+    /// Returns a short advisory when the active provider is a routed pool (`Self::Router` /
+    /// `Self::Triage`) whose selection strategy may pick a different inner provider on the
+    /// next turn than the one a mutating capability command ([`Self::set_thinking_budget`],
+    /// [`Self::apply_reasoning_effort`]) just configured.
+    ///
+    /// `None` for non-routed variants, deterministic strategies (`RouterStrategy::Cascade`),
+    /// and degenerate single-provider pools — in those cases the applicable provider on the
+    /// next dispatch is guaranteed to be the same one the command just mutated, so no warning
+    /// is needed. See spec `049-router-thinking-budget-delegation` §6 for the resolved
+    /// edge-case behavior this implements.
+    #[must_use]
+    pub fn capability_delegation_advisory(&self) -> Option<String> {
+        match self {
+            Self::Router(r) => r.capability_delegation_advisory(),
+            Self::Triage(t) => t.capability_delegation_advisory(),
+            Self::Masked(p) => p.inner().capability_delegation_advisory(),
             _ => None,
         }
     }

--- a/crates/zeph-llm/src/router/builder.rs
+++ b/crates/zeph-llm/src/router/builder.rs
@@ -583,6 +583,146 @@ impl RouterProvider {
         self.status_tx = Some(tx);
     }
 
+    /// Resolve the pool index that runtime capability commands (`/think-tokens`,
+    /// `/reasoning-effort`) target: the inner provider that served the most recent call, or
+    /// the first configured provider as a deterministic fallback (FR-006) when no dispatch has
+    /// happened yet this session, or when `last_active_provider` names a provider no longer in
+    /// the pool (config drift). Returns `None` only for an empty pool.
+    pub(crate) fn capability_target_index(&self) -> Option<usize> {
+        if self.state.providers.is_empty() {
+            return None;
+        }
+        let name = self.state.last_active_provider.lock().clone();
+        match name {
+            Some(name) => Some(
+                self.state
+                    .providers
+                    .iter()
+                    .position(|p| p.name() == name)
+                    .unwrap_or(0),
+            ),
+            None => Some(0),
+        }
+    }
+
+    /// Mutate the pooled provider at `idx` in place.
+    ///
+    /// `RouterState::providers` is `Arc<[AnyProvider]>`; `Arc::get_mut` succeeds at refcount 1
+    /// (the common case for a slash command holding `&mut` to the sole owned
+    /// `AnyProvider::Router`). The rebuild branch below is **not** a defensive fallback: any
+    /// in-flight `spawn_asi_update` background task clones `RouterProvider` (sharing this same
+    /// `providers` Arc) for up to `embed_timeout_ms` (default 5000ms) after every turn, so a
+    /// `/think-tokens`/`/reasoning-effort` issued shortly after a turn routinely takes this
+    /// path. The stale clone keeps its old (transient) slice; the authoritative router's *next*
+    /// dispatch reads the freshly rebuilt Arc, so the mutation still persists (FR-007).
+    ///
+    /// Correctness invariant: this mutates the authoritative `RouterProvider` instance. Dispatch
+    /// (`chat`/`chat_with_tools`) reads `self.state` on the same authoritative instance the
+    /// agent holds, so a setter call landing before the next dispatch is guaranteed to be
+    /// observed by it. A future refactor that caches a pre-cloned dispatch copy ahead of time
+    /// would silently break this.
+    fn with_target_provider_mut<T>(
+        &mut self,
+        idx: usize,
+        f: impl FnOnce(&mut AnyProvider) -> T,
+    ) -> T {
+        if let Some(providers) = Arc::get_mut(&mut self.state.providers) {
+            f(&mut providers[idx])
+        } else {
+            let mut v: Vec<_> = self.state.providers.iter().cloned().collect();
+            let out = f(&mut v[idx]);
+            self.state.providers = Arc::from(v);
+            out
+        }
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::set_thinking_budget`] for
+    /// `Self::Router`. See [`Self::capability_target_index`] for target resolution.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::ModelCapabilityMismatch`] naming `"router"` when the pool is empty,
+    /// or the real inner provider's own error when it does not support a thinking-token budget.
+    pub(crate) fn set_thinking_budget_delegated(
+        &mut self,
+        budget: Option<u32>,
+    ) -> Result<(), LlmError> {
+        let idx =
+            self.capability_target_index()
+                .ok_or_else(|| LlmError::ModelCapabilityMismatch {
+                    provider: "router".to_owned(),
+                    message: "router has no configured providers".into(),
+                })?;
+        tracing::debug!(
+            target_idx = idx,
+            strategy = ?self.strategy,
+            "router: delegating set_thinking_budget to applicable inner provider"
+        );
+        self.with_target_provider_mut(idx, |p| p.set_thinking_budget(budget))
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::apply_reasoning_effort`] for
+    /// `Self::Router`. See [`Self::capability_target_index`] for target resolution.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::ModelCapabilityMismatch`] naming `"router"` when the pool is empty,
+    /// or the real inner provider's own error when it does not support a reasoning-effort level.
+    pub(crate) fn apply_reasoning_effort_delegated(
+        &mut self,
+        effort: crate::any::ReasoningEffort,
+    ) -> Result<(), LlmError> {
+        let idx =
+            self.capability_target_index()
+                .ok_or_else(|| LlmError::ModelCapabilityMismatch {
+                    provider: "router".to_owned(),
+                    message: "router has no configured providers".into(),
+                })?;
+        tracing::debug!(
+            target_idx = idx,
+            strategy = ?self.strategy,
+            "router: delegating apply_reasoning_effort to applicable inner provider"
+        );
+        self.with_target_provider_mut(idx, |p| p.apply_reasoning_effort(effort))
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::current_thinking_budget`] for
+    /// `Self::Router`.
+    #[must_use]
+    pub(crate) fn current_thinking_budget_delegated(&self) -> Option<u32> {
+        let idx = self.capability_target_index()?;
+        self.state.providers[idx].current_thinking_budget()
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::current_reasoning_effort`] for
+    /// `Self::Router`.
+    #[must_use]
+    pub(crate) fn current_reasoning_effort_delegated(&self) -> Option<String> {
+        let idx = self.capability_target_index()?;
+        self.state.providers[idx].current_reasoning_effort()
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::capability_delegation_advisory`]
+    /// for `Self::Router`.
+    ///
+    /// Returns `None` when the pool has at most one provider, or when `self.strategy` is
+    /// [`RouterStrategy::Cascade`] (deterministic cheapest-first — always reselects the same
+    /// slot barring quality-driven escalation). For re-sampling strategies (`Ema`, `Thompson`,
+    /// `Bandit`) over a multi-provider pool, the next dispatch may pick a different provider
+    /// than the one just configured — see spec `049-router-thinking-budget-delegation` §6.
+    #[must_use]
+    pub(crate) fn capability_delegation_advisory(&self) -> Option<String> {
+        if self.state.providers.len() <= 1 || self.strategy == RouterStrategy::Cascade {
+            return None;
+        }
+        let idx = self.capability_target_index()?;
+        let name = self.state.providers.get(idx)?.name();
+        Some(format!(
+            "applied to {name}; routing={:?} may select a different provider on the next turn",
+            self.strategy
+        ))
+    }
+
     /// Aggregate model lists from all sub-providers, deduplicating by id.
     ///
     /// Individual sub-provider errors are logged as warnings and skipped.

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -1923,3 +1923,253 @@ async fn chat_stream_all_providers_exhausted_preserves_last_error() {
         ),
     }
 }
+
+// ── #5883: capability delegation (/think-tokens, /reasoning-effort) ────────
+
+#[test]
+fn router_set_thinking_budget_delegates_to_last_active_provider() {
+    use crate::claude::ClaudeProvider;
+    use crate::ollama::OllamaProvider;
+
+    let ollama = AnyProvider::Ollama(OllamaProvider::new(
+        "http://127.0.0.1:1",
+        "m".into(),
+        "e".into(),
+    ));
+    let claude = AnyProvider::Claude(ClaudeProvider::new("k".into(), "m".into(), 1024));
+    let mut r = RouterProvider::new(vec![ollama, claude]);
+    *r.state.last_active_provider.lock() = Some("claude".to_owned());
+
+    r.set_thinking_budget_delegated(Some(4096)).unwrap();
+
+    assert_eq!(r.state.providers[1].current_thinking_budget(), Some(4096));
+    // The un-targeted provider must be untouched.
+    assert_eq!(r.state.providers[0].current_thinking_budget(), None);
+}
+
+#[test]
+fn router_capability_target_falls_back_to_first_when_no_dispatch_yet() {
+    use crate::ollama::OllamaProvider;
+
+    let p1 = AnyProvider::Ollama(OllamaProvider::new(
+        "http://127.0.0.1:1",
+        "m".into(),
+        "e".into(),
+    ));
+    let p2 = AnyProvider::Ollama(OllamaProvider::new(
+        "http://127.0.0.1:2",
+        "m".into(),
+        "e".into(),
+    ));
+    let r = RouterProvider::new(vec![p1, p2]);
+    assert_eq!(r.capability_target_index(), Some(0));
+}
+
+#[test]
+fn router_capability_target_falls_back_to_first_on_config_drift() {
+    use crate::ollama::OllamaProvider;
+
+    let p1 = AnyProvider::Ollama(OllamaProvider::new(
+        "http://127.0.0.1:1",
+        "m".into(),
+        "e".into(),
+    ));
+    let r = RouterProvider::new(vec![p1]);
+    // Names a provider that is no longer (or never was) in the pool.
+    *r.state.last_active_provider.lock() = Some("stale-provider".to_owned());
+    assert_eq!(r.capability_target_index(), Some(0));
+}
+
+#[test]
+fn router_capability_target_none_for_empty_pool() {
+    let r = RouterProvider::new(vec![]);
+    assert_eq!(r.capability_target_index(), None);
+}
+
+/// M3: `capability_target_index`'s name->slot lookup is a pre-existing, shared assumption
+/// (also relied on by `last_selected_provider_kind`/`record_quality_outcome`) that duplicate
+/// provider names resolve to the FIRST matching slot. `OllamaProvider::new` defaults
+/// `provider_name` to `"ollama"` unless `.with_provider_name(...)` overrides it, so two
+/// default-named Ollama entries in the same pool naturally collide.
+#[test]
+fn router_capability_target_resolves_duplicate_name_to_first_slot() {
+    use crate::ollama::OllamaProvider;
+
+    let p1 = AnyProvider::Ollama(OllamaProvider::new(
+        "http://127.0.0.1:1",
+        "m1".into(),
+        "e".into(),
+    ));
+    let p2 = AnyProvider::Ollama(OllamaProvider::new(
+        "http://127.0.0.1:2",
+        "m2".into(),
+        "e".into(),
+    ));
+    assert_eq!(p1.name(), "ollama");
+    assert_eq!(p2.name(), "ollama");
+
+    let r = RouterProvider::new(vec![p1, p2]);
+    *r.state.last_active_provider.lock() = Some("ollama".to_owned());
+    assert_eq!(r.capability_target_index(), Some(0));
+}
+
+#[test]
+fn router_set_thinking_budget_names_real_inner_provider_on_mismatch() {
+    use crate::ollama::OllamaProvider;
+
+    // Ollama does not support a thinking-token budget — FR-005: the error must name the
+    // real inner provider, not the generic "router" string.
+    let ollama = AnyProvider::Ollama(OllamaProvider::new(
+        "http://127.0.0.1:1",
+        "m".into(),
+        "e".into(),
+    ));
+    let mut r = RouterProvider::new(vec![ollama]);
+    let err = r.set_thinking_budget_delegated(Some(1024)).unwrap_err();
+    match err {
+        LlmError::ModelCapabilityMismatch { provider, .. } => assert_eq!(provider, "ollama"),
+        other => panic!("expected ModelCapabilityMismatch naming ollama, got {other:?}"),
+    }
+}
+
+/// M2 regression: the setter must mutate the SAME authoritative `RouterProvider` instance
+/// that dispatch later clones-at-entry from, even when `Arc::get_mut` fails because another
+/// clone (e.g. an in-flight `spawn_asi_update` task) is sharing the `providers` Arc. This is
+/// the common runtime path (`spawn_asi_update` holds a clone for up to `embed_timeout_ms`
+/// after every turn), not a defensive fallback — see `with_target_provider_mut` doc comment.
+#[test]
+fn router_set_thinking_budget_rebuild_path_persists_on_authoritative_instance() {
+    use crate::claude::ClaudeProvider;
+
+    let claude = AnyProvider::Claude(ClaudeProvider::new("k".into(), "m".into(), 1024));
+    let mut r = RouterProvider::new(vec![claude]);
+
+    // Simulate an in-flight background clone (e.g. `spawn_asi_update`) holding a reference to
+    // the same `providers` Arc, bumping its refcount above 1 so `Arc::get_mut` fails.
+    let stale_clone = r.clone();
+    assert!(Arc::ptr_eq(
+        &r.state.providers,
+        &stale_clone.state.providers
+    ));
+
+    r.set_thinking_budget_delegated(Some(2048)).unwrap();
+
+    // The rebuild replaced `r.state.providers` with a new Arc — no longer the same allocation
+    // the stale clone holds.
+    assert!(!Arc::ptr_eq(
+        &r.state.providers,
+        &stale_clone.state.providers
+    ));
+    // The authoritative instance's next dispatch observes the mutation.
+    assert_eq!(r.state.providers[0].current_thinking_budget(), Some(2048));
+    // The stale clone's (now-orphaned) slice is untouched — expected: it will be dropped, not
+    // dispatched through again.
+    assert_eq!(
+        stale_clone.state.providers[0].current_thinking_budget(),
+        None
+    );
+}
+
+#[test]
+fn router_capability_delegation_advisory_present_for_resampling_multi_provider_pool() {
+    use crate::claude::ClaudeProvider;
+    use crate::ollama::OllamaProvider;
+
+    let claude = AnyProvider::Claude(ClaudeProvider::new("k".into(), "m".into(), 1024));
+    let ollama = AnyProvider::Ollama(OllamaProvider::new(
+        "http://127.0.0.1:1",
+        "m".into(),
+        "e".into(),
+    ));
+    let mut r = RouterProvider::new(vec![claude, ollama]);
+    r.strategy = RouterStrategy::Thompson;
+
+    let advisory = r.capability_delegation_advisory();
+    assert!(advisory.is_some());
+    assert!(advisory.unwrap().contains("claude"));
+}
+
+#[test]
+fn router_capability_delegation_advisory_absent_for_cascade() {
+    use crate::claude::ClaudeProvider;
+    use crate::ollama::OllamaProvider;
+
+    let claude = AnyProvider::Claude(ClaudeProvider::new("k".into(), "m".into(), 1024));
+    let ollama = AnyProvider::Ollama(OllamaProvider::new(
+        "http://127.0.0.1:1",
+        "m".into(),
+        "e".into(),
+    ));
+    let mut r = RouterProvider::new(vec![claude, ollama]);
+    r.strategy = RouterStrategy::Cascade;
+
+    assert_eq!(r.capability_delegation_advisory(), None);
+}
+
+#[test]
+fn router_capability_delegation_advisory_absent_for_single_provider_pool() {
+    use crate::claude::ClaudeProvider;
+
+    let claude = AnyProvider::Claude(ClaudeProvider::new("k".into(), "m".into(), 1024));
+    let mut r = RouterProvider::new(vec![claude]);
+    r.strategy = RouterStrategy::Thompson;
+
+    assert_eq!(r.capability_delegation_advisory(), None);
+}
+
+#[test]
+fn masked_router_set_thinking_budget_delegates_through_inner() {
+    use crate::claude::ClaudeProvider;
+    use crate::masking::MaskedProvider;
+
+    #[derive(Debug)]
+    struct NoopMasker;
+    impl crate::masking::OutboundMasker for NoopMasker {
+        fn mask(&self, _text: &str) -> Option<String> {
+            None
+        }
+    }
+
+    let claude = AnyProvider::Claude(ClaudeProvider::new("k".into(), "m".into(), 1024));
+    let router = RouterProvider::new(vec![claude]);
+    let mut masked = AnyProvider::Masked(Box::new(MaskedProvider::new(
+        AnyProvider::Router(Box::new(router)),
+        std::sync::Arc::new(NoopMasker),
+    )));
+
+    masked.set_thinking_budget(Some(4096)).unwrap();
+    assert_eq!(masked.current_thinking_budget(), Some(4096));
+}
+
+/// FR-008: `Masked(Triage(...))` must delegate transparently through `p.inner`/`p.inner()`,
+/// mirroring the `Masked(Router(...))` case above.
+#[test]
+fn masked_triage_set_thinking_budget_delegates_through_inner() {
+    use crate::claude::ClaudeProvider;
+    use crate::masking::MaskedProvider;
+    use crate::router::triage::{ComplexityTier, TriageRouter};
+
+    #[derive(Debug)]
+    struct NoopMasker;
+    impl crate::masking::OutboundMasker for NoopMasker {
+        fn mask(&self, _text: &str) -> Option<String> {
+            None
+        }
+    }
+
+    let triage_provider = AnyProvider::Claude(ClaudeProvider::new("k".into(), "m".into(), 1024));
+    let claude = AnyProvider::Claude(ClaudeProvider::new("k".into(), "m".into(), 1024));
+    let router = TriageRouter::new(
+        triage_provider,
+        vec![(ComplexityTier::Simple, claude)],
+        5,
+        100,
+    );
+    let mut masked = AnyProvider::Masked(Box::new(MaskedProvider::new(
+        AnyProvider::Triage(Box::new(router)),
+        std::sync::Arc::new(NoopMasker),
+    )));
+
+    masked.set_thinking_budget(Some(4096)).unwrap();
+    assert_eq!(masked.current_thinking_budget(), Some(4096));
+}

--- a/crates/zeph-llm/src/router/triage.rs
+++ b/crates/zeph-llm/src/router/triage.rs
@@ -248,6 +248,107 @@ impl TriageRouter {
         &self.metrics
     }
 
+    /// Resolve the pool index that runtime capability commands (`/think-tokens`,
+    /// `/reasoning-effort`) target: the tier provider that served the most recent request, or
+    /// `default_index` as a deterministic fallback (FR-006) when no request has completed yet
+    /// this session. Returns `None` only for an empty pool (unreachable in practice — `new`
+    /// panics on an empty `tier_providers`).
+    fn capability_target_index(&self) -> Option<usize> {
+        if self.tier_providers.is_empty() {
+            return None;
+        }
+        let idx = self.last_provider_idx.load(Ordering::Relaxed);
+        Some(if idx == NO_LAST_PROVIDER {
+            self.default_index
+        } else {
+            idx
+        })
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::set_thinking_budget`] for
+    /// `Self::Triage`. `tier_providers` is a plain owned `Vec`, so the mutation is a direct
+    /// `&mut self` index — no `Arc` rebuild dance is needed (unlike
+    /// [`crate::router::RouterProvider`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::ModelCapabilityMismatch`] naming `"triage"` when the pool is empty,
+    /// or the real inner provider's own error when it does not support a thinking-token budget.
+    pub(crate) fn set_thinking_budget_delegated(
+        &mut self,
+        budget: Option<u32>,
+    ) -> Result<(), LlmError> {
+        let idx =
+            self.capability_target_index()
+                .ok_or_else(|| LlmError::ModelCapabilityMismatch {
+                    provider: "triage".to_owned(),
+                    message: "triage router has no configured tier providers".into(),
+                })?;
+        tracing::debug!(
+            target_idx = idx,
+            "triage: delegating set_thinking_budget to applicable tier provider"
+        );
+        self.tier_providers[idx].1.set_thinking_budget(budget)
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::apply_reasoning_effort`] for
+    /// `Self::Triage`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::ModelCapabilityMismatch`] naming `"triage"` when the pool is empty,
+    /// or the real inner provider's own error when it does not support a reasoning-effort level.
+    pub(crate) fn apply_reasoning_effort_delegated(
+        &mut self,
+        effort: crate::any::ReasoningEffort,
+    ) -> Result<(), LlmError> {
+        let idx =
+            self.capability_target_index()
+                .ok_or_else(|| LlmError::ModelCapabilityMismatch {
+                    provider: "triage".to_owned(),
+                    message: "triage router has no configured tier providers".into(),
+                })?;
+        tracing::debug!(
+            target_idx = idx,
+            "triage: delegating apply_reasoning_effort to applicable tier provider"
+        );
+        self.tier_providers[idx].1.apply_reasoning_effort(effort)
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::current_thinking_budget`] for
+    /// `Self::Triage`.
+    #[must_use]
+    pub(crate) fn current_thinking_budget_delegated(&self) -> Option<u32> {
+        let idx = self.capability_target_index()?;
+        self.tier_providers.get(idx)?.1.current_thinking_budget()
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::current_reasoning_effort`] for
+    /// `Self::Triage`.
+    #[must_use]
+    pub(crate) fn current_reasoning_effort_delegated(&self) -> Option<String> {
+        let idx = self.capability_target_index()?;
+        self.tier_providers.get(idx)?.1.current_reasoning_effort()
+    }
+
+    /// Delegated implementation of [`crate::any::AnyProvider::capability_delegation_advisory`]
+    /// for `Self::Triage`.
+    ///
+    /// Returns `None` when there is at most one tier provider (unambiguous target). With more
+    /// than one, per-turn classification can select a different tier provider than the one just
+    /// configured — see spec `049-router-thinking-budget-delegation` §6.
+    #[must_use]
+    pub(crate) fn capability_delegation_advisory(&self) -> Option<String> {
+        if self.tier_providers.len() <= 1 {
+            return None;
+        }
+        let idx = self.capability_target_index()?;
+        let name = self.tier_providers.get(idx)?.1.name();
+        Some(format!(
+            "applied to {name}; routing=triage may select a different provider on the next turn"
+        ))
+    }
+
     /// Classify the last user message and return the selected provider index into `tier_providers`.
     /// On failure (timeout, parse error), returns `default_index`.
     #[tracing::instrument(name = "llm.router.triage.classify", skip_all)]
@@ -711,6 +812,100 @@ mod tests {
             parts: vec![],
             metadata: MessageMetadata::default(),
         }
+    }
+
+    // ── #5883: capability delegation (/think-tokens, /reasoning-effort) ────
+
+    #[test]
+    fn triage_capability_target_falls_back_to_default_index_before_first_call() {
+        let router = TriageRouter::new(
+            mock_provider("triage-model"),
+            vec![
+                (ComplexityTier::Simple, mock_provider("simple")),
+                (ComplexityTier::Expert, mock_provider("expert")),
+            ],
+            5,
+            100,
+        );
+        assert_eq!(router.capability_target_index(), Some(0));
+    }
+
+    #[test]
+    fn triage_set_thinking_budget_delegates_to_last_provider_idx() {
+        let mut router = TriageRouter::new(
+            mock_provider("triage-model"),
+            vec![
+                (ComplexityTier::Simple, mock_provider("simple")),
+                (
+                    ComplexityTier::Expert,
+                    AnyProvider::Claude(crate::claude::ClaudeProvider::new(
+                        "k".into(),
+                        "m".into(),
+                        1024,
+                    )),
+                ),
+            ],
+            5,
+            100,
+        );
+        router.last_provider_idx.store(1, Ordering::Relaxed);
+
+        router.set_thinking_budget_delegated(Some(2048)).unwrap();
+
+        assert_eq!(
+            router.tier_providers[1].1.current_thinking_budget(),
+            Some(2048)
+        );
+        // The un-targeted tier provider must be untouched.
+        assert_eq!(router.tier_providers[0].1.current_thinking_budget(), None);
+    }
+
+    #[test]
+    fn triage_set_thinking_budget_names_real_inner_provider_on_mismatch() {
+        // Mock does not support a thinking-token budget — FR-005: the error must name the
+        // real inner provider, not the generic "triage" string.
+        let mut router = TriageRouter::new(
+            mock_provider("triage-model"),
+            vec![(ComplexityTier::Simple, mock_provider("simple"))],
+            5,
+            100,
+        );
+        let err = router
+            .set_thinking_budget_delegated(Some(1024))
+            .unwrap_err();
+        match err {
+            LlmError::ModelCapabilityMismatch { provider, .. } => {
+                assert_eq!(provider, "simple");
+            }
+            other => panic!("expected ModelCapabilityMismatch naming simple, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn triage_capability_delegation_advisory_present_for_multi_tier_pool() {
+        let router = TriageRouter::new(
+            mock_provider("triage-model"),
+            vec![
+                (ComplexityTier::Simple, mock_provider("simple")),
+                (ComplexityTier::Expert, mock_provider("expert")),
+            ],
+            5,
+            100,
+        );
+        let advisory = router.capability_delegation_advisory();
+        assert!(advisory.is_some());
+        assert!(advisory.unwrap().contains("simple"));
+    }
+
+    #[test]
+    fn triage_capability_delegation_advisory_absent_for_single_tier_pool() {
+        let router = TriageRouter::new(
+            mock_provider("triage-model"),
+            vec![(ComplexityTier::Simple, mock_provider("simple"))],
+            5,
+            100,
+        );
+        assert_eq!(router.capability_delegation_advisory(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `AnyProvider::Router` and `AnyProvider::Triage` had no match arm in the four capability methods (`set_thinking_budget`, `apply_reasoning_effort`, `current_thinking_budget`, `current_reasoning_effort`) in `crates/zeph-llm/src/any.rs`, so both fell into the catch-all and every `/think-tokens`/`/reasoning-effort` invocation was rejected whenever `[llm] routing` was enabled (`thompson`, `ema`, `cascade`, `bandit`, `triage`) — a regression against #5876, invisible under single-provider configs.
- Both variants now delegate to the last-active inner provider (`RouterProvider`/`TriageRouter`), with a deterministic `providers[0]`/`default_index` fallback before any dispatch or on config drift, reusing that provider's own capability matrix so `ModelCapabilityMismatch` names the real inner provider instead of the generic string `"router"`.
- Setter mutation reuses the existing `Arc::get_mut`-with-rebuild pattern already proven in `RouterProvider::set_status_tx` — no new interior-mutability primitive introduced.
- A user-facing advisory is surfaced when a re-sampling strategy (Thompson/EMA/Bandit, or Triage's per-turn reclassification) could route the next turn to a different provider than the one `/think-tokens`/`/reasoning-effort` just configured. Deterministic strategies (Cascade, single-provider/single-tier pools) are exempt.
- Design decisions (delegation target, interior-mutability approach, Triage in-scope) are recorded in `.local/specs/049-router-thinking-budget-delegation/spec.md` (architect + critic sign-off, per the issue's own instruction — no separate human check needed for this scope).

## Test plan
- [x] `cargo nextest run -p zeph-llm --lib` — 1009 passed (baseline 1007 + 2 new)
- [x] `cargo nextest run -p zeph-core -E 'test(think_tokens) or test(reasoning_effort)'` — 13 passed, zero regression for single-provider Claude
- [x] Unit tests added: Router/Triage delegation, first-call/config-drift fallback, FR-005 error naming the real inner provider, Arc rebuild-path regression (M2), advisory present/absent per strategy, `Masked(Router(...))`/`Masked(Triage(...))` passthrough (FR-008), duplicate-provider-name resolution (M3)
- [x] Live session test with `routing = "triage"` (new `.local/config/testing-triage-5883.toml`): `/think-tokens 8k` and `/reasoning-effort high` both succeeded through `AnyProvider::Triage` (previously `ModelCapabilityMismatch`); `debug_request_json` dump confirms `"thinking":{"type":"adaptive"}` and `"output_config":{"effort":"high"}` reached the real Claude request payload — mandatory pre-merge gate per spec §9 OQ-3, satisfied
- [x] Live session comparison against `routing = "thompson"` (`AnyProvider::Router`), matching the original bug report's reproduction, now succeeds
- [x] `cargo +nightly fmt --check`, `cargo clippy --profile ci -p zeph-llm -p zeph-core --all-targets -- -D warnings`, rustdoc gate — all clean
- [x] `.local/testing/playbooks/thinking-reasoning-runtime.md` and `.local/testing/coverage-status.md` updated (main repo)

Closes #5883