### PR TITLE
ci: migrate lint-warning gate from RUSTFLAGS to build.warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+warnings = "deny"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-D warnings"
   RUSTC_WRAPPER: ""
   CARGO_INCREMENTAL: "0"
 
@@ -438,13 +437,16 @@ jobs:
     timeout-minutes: 20
     # coverage uses -C instrument-coverage which produces different artifacts than
     # normal builds; sccache still helps for unchanged crates between main pushes.
-    # RUSTFLAGS is reset to empty to prevent -D warnings from promoting workspace
-    # lint warnings to errors during instrumented compilation — linting is enforced
-    # by the dedicated lint-clippy job.
+    # This job also builds with `--features full`, which includes crates (classifiers,
+    # profiling, sandbox, gonka, cocoon) outside the lint-clippy matrix, so a warning
+    # could appear here that lint-clippy never sees. CARGO_BUILD_WARNINGS overrides the
+    # repo-wide `.cargo/config.toml` deny-by-default to prevent that from promoting
+    # workspace lint warnings to errors during instrumented compilation — linting is
+    # enforced by the dedicated lint-clippy job.
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
-      RUSTFLAGS: ""
+      CARGO_BUILD_WARNINGS: "allow"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
@@ -643,8 +645,17 @@ jobs:
     if: needs.detect-changes.outputs.run-full-ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # `build.warnings` (repo-wide .cargo/config.toml) denies ALL local-package rustdoc
+    # warnings, not just `rustdoc::broken_intra_doc_links` — it independently catches
+    # `rustdoc::private_intra_doc_links` and `rustdoc::redundant_explicit_links` too, which
+    # this job's own RUSTDOCFLAGS never enforced. Pre-existing (unrelated to any single PR)
+    # instances of those two lints exist workspace-wide; overriding to "allow" here keeps
+    # this job's enforcement scoped to exactly what RUSTDOCFLAGS denies, unchanged from
+    # before this migration (#5873) — fixing the pre-existing instances is a separate,
+    # larger doc-cleanup effort, not in scope for a CI-gate-mechanism migration.
     env:
       RUSTDOCFLAGS: "--deny rustdoc::broken_intra_doc_links"
+      CARGO_BUILD_WARNINGS: "allow"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `ci`: migrate the workspace lint-warning gate from the global `RUSTFLAGS: "-D warnings"`
+  CI env var to Cargo's native `build.warnings = "deny"` (new `.cargo/config.toml`, stabilized
+  in Rust 1.97, cargo PR rust-lang/cargo#16796). Unlike `RUSTFLAGS`, toggling `build.warnings`
+  does not change rustc's invocation fingerprint, so it no longer forces a full recompile of
+  unchanged units when switching between a plain `cargo build` and a warnings-denied one —
+  verified locally via `cargo build -v` fingerprint comparison (`Fresh` in both directions vs.
+  full recompile on `RUSTFLAGS` toggle). Coverage-parity verified for the warning classes the
+  previous gate caught (unused imports, dead code, unused variables); `build.warnings` was also
+  found to independently catch `rustdoc::broken_intra_doc_links` and `cargo clippy` lints, wider
+  than expected, but `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"` and clippy's own
+  `-- -D warnings` CLI flag are left unchanged as defense-in-depth (#5873). The `coverage` job's
+  former `RUSTFLAGS: ""` reset (needed because it builds `--features full`, a superset of the
+  `lint-clippy` matrix, and must not fail on lint status — that's `lint-clippy`'s job) is now
+  `CARGO_BUILD_WARNINGS: "allow"`, the per-job env override for the same repo-wide config key.
+  The `rustdoc` job gets the same override: `build.warnings` being wider than `RUSTDOCFLAGS`
+  means it independently denies `rustdoc::private_intra_doc_links`/`redundant_explicit_links`
+  too, and 37 pre-existing instances across 10 crates (unrelated to this change) would have
+  newly failed that job; the override keeps it enforcing exactly what it always has pending a
+  separate doc-cleanup pass.
 - `chore`: raise the workspace MSRV from Rust 1.96 to 1.97 (`Cargo.toml`
   `rust-version`, CI `msrv` job, all crate README badges/notes, `specs/constitution.md`).
   Rust 1.97 (stable 2026-07-07) is now the minimum supported toolchain. This also unifies


### PR DESCRIPTION
## Summary

- Replace the global `RUSTFLAGS="-D warnings"` CI env var with Cargo's native `build.warnings = "deny"` (new committed `.cargo/config.toml`), stabilized in Rust 1.97 (cargo PR rust-lang/cargo#16796). Unlike `RUSTFLAGS`, toggling `build.warnings` does not change rustc's invocation fingerprint, so it no longer forces a full recompile of unchanged units when switching between a plain build and a warnings-denied one — verified locally via `cargo build -v` fingerprint comparison.
- Phase A verification (empirical, documented in `.local/specs/047-cargo-build-warnings-migration/spec.md`) confirmed 100% coverage parity for the warning classes the previous gate caught (unused imports, dead code, unused variables), and found `build.warnings` is *wider* than expected: it independently catches `rustdoc::broken_intra_doc_links` and clippy lints too, not just plain rustc build warnings.
- That wider scope surfaced 37 pre-existing `rustdoc::private_intra_doc_links`/`redundant_explicit_links` warnings across 10 crates that would have newly failed the `rustdoc` CI job. Both the `coverage` and `rustdoc` jobs now opt out via a job-local `CARGO_BUILD_WARNINGS: "allow"` override, preserving their exact pre-migration enforcement scope (`RUSTDOCFLAGS`/clippy's own `-D warnings` CLI flag stay unchanged and untouched).
- `CHANGELOG.md` updated under `[Unreleased] / Changed`.

Follow-up (not filed by this PR, suggested in the migration handoff): a doc-cleanup issue for the 37 pre-existing rustdoc warnings, which would let the `rustdoc` job's override eventually be retired.

Note: a proposed diff for `CLAUDE.md`/`.claude/rules/branching.md` pre-commit command lists (dropping the now-redundant `RUSTFLAGS="-D warnings"` prefix) was drafted during development but intentionally NOT applied in this PR — those are user-owned governance docs requiring separate explicit approval, out of scope for this change.

Closes #5873

## Test plan

- [x] Phase A verification: warning-class coverage parity (unused import/dead code/unused variable) — 100% match, no gap
- [x] Cache-invalidation behavior confirmed via `cargo build -v` fingerprint comparison (`Fresh` on `build.warnings` toggle vs. real recompile on `RUSTFLAGS` toggle)
- [x] Rustdoc/clippy interaction empirically tested
- [x] `.cargo/config.toml` validated safe re: `Swatinem/rust-cache` fingerprinting (no hash-key side effect)
- [x] `fy lint .github/workflows/ci.yml` — 0 errors
- [x] Full-workspace validation builds under the new gate, matching every CI feature-matrix entry (lint-clippy/msrv set, `full,postgres`, `full,sqlite`, `bench`) — all pass cleanly
- [x] `coverage`/`rustdoc` job overrides verified to restore exact pre-migration enforcement scope
- [x] Independent reviewer re-verification of the override mechanism, job coverage, YAML validity, and spec resolution