### PR TITLE
fix(llm): sweep stale Claude model IDs and generalize staleness warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(llm)`: swept superseded Claude model IDs (`claude-sonnet-4-6`, `claude-opus-4-6`) to the
+  current recommended defaults (`claude-sonnet-5`, `claude-opus-4-8`) across docs, config
+  examples, source comments, and test fixtures. `ClaudeProvider::new()`'s staleness warning
+  (previously a hardcoded `claude-3` prefix check from #1625) is now generalized: a compiled
+  per-family `MODERN_MODEL_FLOORS` table plus `stale_model_suggestion()` warns whenever a
+  configured model falls below its family's current-version floor, so future retirements are a
+  one-line table bump instead of a new hardcoded literal. `ThinkingCapability::prefers_effort`
+  (`crates/zeph-llm/src/claude/types.rs`) now also covers Opus 4.7/4.8 and Sonnet 5, which remove
+  `budget_tokens` entirely (400 if sent) and require `Extended` thinking config to auto-convert
+  to an effort level; `needs_interleaved_beta` is intentionally left scoped to legacy Sonnet 4.6
+  since the new generation enables interleaved thinking automatically with no beta header. The
+  4.6-generation pricing rows in `crates/zeph-core/src/cost.rs` and the legacy capability arms in
+  `crates/zeph-llm/src/claude/types.rs` are intentionally retained alongside the new ones since
+  those models are still Active (#5889).
 - `fix(llm)`: `AnyProvider::Router` and `AnyProvider::Triage` no longer silently reject
   `/think-tokens` and `/reasoning-effort` regardless of the selected inner provider's
   capabilities. The four capability-mutating/-querying methods on `AnyProvider`

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ embed = true
 [[llm.providers]]
 name = "quality"         # reserved for planning, code, hard reasoning
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 default = true
 
 [llm]

--- a/book/src/advanced/acp.md
+++ b/book/src/advanced/acp.md
@@ -302,8 +302,8 @@ Response:
       "name": "claude",
       "type": "claude",
       "models": [
-        {"id": "claude-sonnet-4-6", "display_name": "Claude Sonnet 4.6", "context_tokens": 200000},
-        {"id": "claude-opus-4-6", "display_name": "Claude Opus 4.6", "context_tokens": 200000}
+        {"id": "claude-sonnet-5", "display_name": "Claude Sonnet 5", "context_tokens": 200000},
+        {"id": "claude-opus-4-8", "display_name": "Claude Opus 4.8", "context_tokens": 200000}
       ]
     },
     {

--- a/book/src/advanced/adaptive-inference.md
+++ b/book/src/advanced/adaptive-inference.md
@@ -29,7 +29,7 @@ routing = "thompson"
 [[llm.providers]]
 name = "claude"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 
 [[llm.providers]]
 name = "openai"
@@ -102,7 +102,7 @@ router_reorder_interval = 10    # re-order every N requests
 [[llm.providers]]
 name = "claude"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 
 [[llm.providers]]
 name = "openai"
@@ -140,7 +140,7 @@ model = "qwen3:8b"
 [[llm.providers]]
 name = "claude"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 ```
 
 #### `cost_tiers`
@@ -248,7 +248,7 @@ embed = true
 [[llm.providers]]
 name = "quality"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 ```
 
 ### State Persistence

--- a/book/src/advanced/complexity-triage.md
+++ b/book/src/advanced/complexity-triage.md
@@ -61,7 +61,7 @@ model = "claude-haiku-4-5-20251001"
 [[llm.providers]]
 name = "expert"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 ```
 
 Each tier value must match a `name` field in one of the `[[llm.providers]]` entries. Tiers are optional — any omitted tier resolves to the first configured tier provider (simple).

--- a/book/src/advanced/orchestrator.md
+++ b/book/src/advanced/orchestrator.md
@@ -19,7 +19,7 @@ embed = true        # use this provider for all embedding operations
 [[llm.providers]]
 name = "claude"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 default = true      # default provider for chat
 ```
@@ -105,7 +105,7 @@ model = "qwen3:1.7b"
 [[llm.providers]]
 name = "quality"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 default = true
 
 [orchestration]
@@ -164,7 +164,7 @@ Each Zeph subsystem that calls an LLM exposes a `*_provider` config field. Match
 | Orchestration planning | `[orchestration] planner_provider` | Quality / expert | Multi-step DAG planning requires high-capability models |
 | MCP tool discovery (`Llm` strategy) | `[mcp.tool_discovery]` | Fast / medium | Relevance ranking from a short list |
 
-A typical cost-optimized setup uses a local Ollama model (e.g., `qwen3:1.7b`) for all fast-tier subsystems and a cloud model (e.g., `claude-sonnet-4-6`) for quality-tier tasks:
+A typical cost-optimized setup uses a local Ollama model (e.g., `qwen3:1.7b`) for all fast-tier subsystems and a cloud model (e.g., `claude-sonnet-5`) for quality-tier tasks:
 
 ```toml
 [[llm.providers]]
@@ -176,7 +176,7 @@ embed = true
 [[llm.providers]]
 name = "quality"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 default = true
 
 # Route cheap subsystems to the local model
@@ -213,7 +213,7 @@ embed = true
 [[llm.providers]]
 name = "claude"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 default = true
 ```

--- a/book/src/concepts/providers.md
+++ b/book/src/concepts/providers.md
@@ -150,14 +150,14 @@ Change the `type` field in the `[[llm.providers]]` entry. All skills, memory, an
 [llm]
 [[llm.providers]]
 type = "claude"   # ollama, claude, openai, gemini, gonka, candle, compatible
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 ```
 
 At runtime, use the `/provider <name>` command to switch providers:
 
 ```
 > /provider claude
-Switched to Claude (claude-sonnet-4-6)
+Switched to Claude (claude-sonnet-5)
 ```
 
 The chosen provider is now the active provider for this channel. On the next session start, Zeph automatically restores the last-used provider for that channel.

--- a/book/src/guides/cloud-provider.md
+++ b/book/src/guides/cloud-provider.md
@@ -16,10 +16,10 @@ Or in config:
 [llm]
 [[llm.providers]]
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 # server_compaction = true          # Server-side context compaction (Claude API beta)
-# enable_extended_context = true    # 1M token context window (Sonnet/Opus 4.6 only)
+# enable_extended_context = true    # 1M token context window (Claude Opus and Sonnet models, not Haiku)
 ```
 
 Claude does not support embeddings. Use a multi-provider setup to combine Claude chat with Ollama embeddings, or use OpenAI embeddings.
@@ -32,7 +32,7 @@ Enable `server_compaction = true` to let the Claude API manage context length on
 
 ### 1M Extended Context
 
-For Sonnet 4.6 and Opus 4.6, enable `enable_extended_context = true` to unlock the 1M token context window. The `auto_budget` feature scales accordingly. Enable with `--extended-context` CLI flag or in the provider entry in config.
+For Claude Opus and Sonnet models (not Haiku), enable `enable_extended_context = true` to unlock the 1M token context window. The `auto_budget` feature scales accordingly. Enable with `--extended-context` CLI flag or in the provider entry in config.
 
 ## Gemini
 
@@ -160,7 +160,7 @@ embed = true          # use this provider for embeddings
 [[llm.providers]]
 name = "cloud"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 default = true        # use this provider for chat by default
 ```

--- a/book/src/guides/config-recipes.md
+++ b/book/src/guides/config-recipes.md
@@ -70,7 +70,7 @@ See [LLM Providers](../concepts/providers.md) for other Ollama-compatible models
 # For semantic memory, combine with an Ollama embedding model (see recipe #5).
 [[llm.providers]]
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 8192
 # server_compaction = true  # let Claude API manage context instead of client-side compaction
 
@@ -290,7 +290,7 @@ See [LSP Code Intelligence](../guides/lsp.md) and [Code Indexing](../advanced/co
 [llm]
 [[llm.providers]]
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 
 [vault]

--- a/book/src/guides/migrate-config.md
+++ b/book/src/guides/migrate-config.md
@@ -24,14 +24,14 @@ Given a minimal config like:
 
 ```toml
 [agent]
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 ```
 
 After migration, missing sections appear as commented-out blocks:
 
 ```toml
 [agent]
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 
 # [llm]
 # # Maximum tokens allowed in a single LLM request.

--- a/book/src/guides/self-learning.md
+++ b/book/src/guides/self-learning.md
@@ -51,7 +51,7 @@ By default, correction detection uses regex patterns only. If you want higher re
 ```toml
 [skills.learning]
 detector_mode = "judge"
-judge_model = "claude-sonnet-4-6"   # leave empty to use the primary provider
+judge_model = "claude-sonnet-5"   # leave empty to use the primary provider
 judge_adaptive_low = 0.5            # regex confidence floor (default: 0.5)
 judge_adaptive_high = 0.8           # regex confidence ceiling (default: 0.8)
 ```

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -197,10 +197,10 @@ embedding_model = "qwen3-embedding"    # model for text embeddings
 # [[llm.providers]]
 # name = "cloud"
 # type = "claude"
-# model = "claude-sonnet-4-6"
+# model = "claude-sonnet-5"
 # max_tokens = 4096
 # server_compaction = false            # Enable Claude server-side context compaction (compact-2026-01-12 beta)
-# enable_extended_context = false      # Enable Claude 1M context window (context-1m-2025-08-07 beta, Sonnet/Opus 4.6)
+# enable_extended_context = false      # Enable Claude 1M context window (context-1m-2025-08-07 beta, Opus and Sonnet models, not Haiku)
 # prompt_cache_ttl = "1h"              # "1h" = extended TTL beta (writes ~2× cost); omit or "ephemeral" for default ~5 min
 # default = true
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -93,11 +93,11 @@ embedding_model = "qwen3-embedding"
 # Cloud provider (Claude)
 # [[llm.providers]]
 # type = "claude"
-# model = "claude-sonnet-4-6"
+# model = "claude-sonnet-5"
 # max_tokens = 4096
 # default = true
 # server_compaction = false             # Claude compact-2026-01-12 beta
-# enable_extended_context = false       # 1M token window (Opus 4.6 / Sonnet 4.6)
+# enable_extended_context = false       # 1M token window (Claude Opus and Sonnet models, not Haiku)
 # prompt_cache_ttl = "1h"              # "1h" = extended TTL beta (writes ~2× cost); omit for default ~5 min
 # thinking = { type = "enabled", budget_tokens = 10000 }
 
@@ -170,7 +170,7 @@ embedding_model = "qwen3-embedding"
 # [[llm.providers]]
 # name = "claude"
 # type = "claude"
-# model = "claude-sonnet-4-6"
+# model = "claude-sonnet-5"
 # max_tokens = 4096
 # default = true
 
@@ -215,7 +215,7 @@ cooldown_minutes = 60
 # Named provider from [[llm.providers]] for the judge detector. Takes precedence over judge_model.
 # Empty = fall back to judge_model, then to primary provider.
 # judge_provider = ""
-# LLM model for judge detector (e.g. "claude-sonnet-4-6"). Empty = use primary provider.
+# LLM model for judge detector (e.g. "claude-sonnet-5"). Empty = use primary provider.
 # judge_model = ""
 # HuggingFace repo ID for ML correction detector (requires detector_mode = "model" and classifiers feature).
 # When empty, falls back to classifiers.ner_model default.
@@ -1378,7 +1378,7 @@ sweep_batch_size = 100
 # [[llm.providers]]
 # name = "quality"
 # type = "claude"
-# model = "claude-opus-4-6"
+# model = "claude-opus-4-8"
 # default = true
 #
 # [llm.complexity_routing]

--- a/crates/zeph-agent-persistence/src/session_sink.rs
+++ b/crates/zeph-agent-persistence/src/session_sink.rs
@@ -433,11 +433,8 @@ mod tests {
         let messages = replayed_tool_call_messages().await;
         let tools = shell_tool_definition();
 
-        let provider = ClaudeProvider::new(
-            "sk-ant-test".to_owned(),
-            "claude-sonnet-4-6".to_owned(),
-            4096,
-        );
+        let provider =
+            ClaudeProvider::new("sk-ant-test".to_owned(), "claude-sonnet-5".to_owned(), 4096);
         let request = provider.debug_request_json(&messages, &tools, false);
 
         let api_messages = request["messages"]

--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -135,7 +135,7 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo {
         name: "/model",
         args: "[id|refresh]",
-        description: "Show or switch the active model. Examples: `/model claude-sonnet-4-6` to switch, `/model refresh` to re-query the provider model list",
+        description: "Show or switch the active model. Examples: `/model claude-sonnet-5` to switch, `/model refresh` to re-query the provider model list",
         category: SlashCategory::Configuration,
         feature_gate: None,
     },

--- a/crates/zeph-config/src/learning.rs
+++ b/crates/zeph-config/src/learning.rs
@@ -799,12 +799,12 @@ heuristic_promotion_interval_hours = 48
     #[test]
     fn judge_provider_and_judge_model_coexist() {
         let toml = r#"
-judge_model = "claude-sonnet-4-6"
+judge_model = "claude-sonnet-5"
 judge_provider = "quality"
 detector_mode = "judge"
 "#;
         let cfg: LearningConfig = toml::from_str(toml).unwrap();
-        assert_eq!(cfg.judge_model, "claude-sonnet-4-6");
+        assert_eq!(cfg.judge_model, "claude-sonnet-5");
         assert_eq!(cfg.judge_provider, "quality");
         assert_eq!(cfg.detector_mode, DetectorMode::Judge);
     }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -345,7 +345,7 @@ fn migrate_llm_claude_produces_providers_block() {
 provider = "claude"
 
 [llm.cloud]
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 8192
 server_compaction = true
 "#;
@@ -361,7 +361,7 @@ server_compaction = true
         result.output
     );
     assert!(
-        result.output.contains("model = \"claude-sonnet-4-6\""),
+        result.output.contains("model = \"claude-sonnet-5\""),
         "{}",
         result.output
     );
@@ -1238,7 +1238,7 @@ fn migrate_claude_prompt_cache_ttl_1h_survives() {
 provider = "claude"
 
 [llm.cloud]
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 prompt_cache_ttl = "1h"
 "#;
     let result = migrate_llm_to_providers(src).expect("migrate");
@@ -1256,7 +1256,7 @@ fn migrate_claude_prompt_cache_ttl_ephemeral_suppressed() {
 provider = "claude"
 
 [llm.cloud]
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 prompt_cache_ttl = "ephemeral"
 "#;
     let result = migrate_llm_to_providers(src).expect("migrate");
@@ -1272,7 +1272,7 @@ fn migrate_claude_prompt_cache_ttl_1h_idempotent() {
     let src = r#"
 [[llm.providers]]
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 prompt_cache_ttl = "1h"
 "#;
     let migrator = ConfigMigrator::new();

--- a/crates/zeph-config/src/providers/tests.rs
+++ b/crates/zeph-config/src/providers/tests.rs
@@ -17,7 +17,7 @@ fn claude_entry() -> ProviderEntry {
     ProviderEntry {
         provider_type: ProviderKind::Claude,
         name: Some("claude".into()),
-        model: Some("claude-sonnet-4-6".into()),
+        model: Some("claude-sonnet-5".into()),
         max_tokens: Some(8192),
         ..Default::default()
     }
@@ -137,10 +137,10 @@ fn validate_pool_propagates_entry_error() {
 fn effective_model_returns_explicit_when_set() {
     let entry = ProviderEntry {
         provider_type: ProviderKind::Claude,
-        model: Some("claude-sonnet-4-6".into()),
+        model: Some("claude-sonnet-5".into()),
         ..Default::default()
     };
-    assert_eq!(entry.effective_model(), "claude-sonnet-4-6");
+    assert_eq!(entry.effective_model(), "claude-sonnet-5");
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn effective_provider_reads_from_providers_first() {
 
 [[llm.providers]]
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 "#,
     );
     assert_eq!(cfg.effective_provider(), ProviderKind::Claude);
@@ -853,7 +853,7 @@ model = "qwen3:8b"
 [[llm.providers]]
 type = "claude"
 name = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 "#;
     let cfg = parse_llm(toml);
     assert_eq!(cfg.providers.len(), 2);

--- a/crates/zeph-core/README.md
+++ b/crates/zeph-core/README.md
@@ -240,7 +240,7 @@ Key `AgentConfig.learning` fields (TOML section `[agent.learning]`):
 | `correction_recall_limit` | usize | `5` | Max corrections retrieved per context-build turn |
 | `correction_min_similarity` | f64 | `0.75` | Minimum embedding similarity for correction recall |
 | `detector_mode` | `"regex"` / `"judge"` | `"regex"` | Detection strategy: regex-only or LLM-backed judge with adaptive regex fallback |
-| `judge_model` | string | `""` | Model for the judge detector (e.g. `"claude-sonnet-4-6"`); empty = use primary provider |
+| `judge_model` | string | `""` | Model for the judge detector (e.g. `"claude-sonnet-5"`); empty = use primary provider |
 | `judge_adaptive_low` | f32 | `0.5` | Regex confidence below this value skips judge invocation (treated as "not a correction") |
 | `judge_adaptive_high` | f32 | `0.8` | Regex confidence above this value skips judge invocation (high-confidence regex match accepted) |
 

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -44,7 +44,7 @@ max_tokens = 4096
 # Enable Claude server-side context compaction (compact-2026-01-12 beta).
 # When enabled, the API automatically summarizes long conversations; client-side compaction is skipped.
 # server_compaction = false
-# Enable 1M token extended context window (Opus 4.6 / Sonnet 4.6 only).
+# Enable 1M token extended context window (Claude Opus and Sonnet models, not Haiku).
 # Tokens above 200K use long-context pricing — see https://www.anthropic.com/pricing
 # enable_extended_context = false
 

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -3302,7 +3302,7 @@ path = "skill-second"
     fn claude_agent() -> Agent<MockChannel> {
         let provider = zeph_llm::any::AnyProvider::Claude(zeph_llm::claude::ClaudeProvider::new(
             "key".into(),
-            "claude-sonnet-4-6".into(),
+            "claude-sonnet-5".into(),
             4096,
         ));
         Agent::new(

--- a/crates/zeph-core/src/agent/provider_cmd.rs
+++ b/crates/zeph-core/src/agent/provider_cmd.rs
@@ -838,7 +838,7 @@ mod tests {
     async fn provider_switch_shows_reset_notice_when_think_tokens_override_was_active() {
         let mut claude_provider = AnyProvider::Claude(ClaudeProvider::new(
             "key".into(),
-            "claude-sonnet-4-6".into(),
+            "claude-sonnet-5".into(),
             4096,
         ));
         claude_provider.set_thinking_budget(Some(8000)).unwrap();
@@ -867,7 +867,7 @@ mod tests {
     async fn provider_switch_shows_reset_notice_when_reasoning_effort_override_was_active() {
         let mut claude_provider = AnyProvider::Claude(ClaudeProvider::new(
             "key".into(),
-            "claude-sonnet-4-6".into(),
+            "claude-sonnet-5".into(),
             4096,
         ));
         claude_provider

--- a/crates/zeph-core/src/agent/tests/agent_tests/model_help_status_exit_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/model_help_status_exit_tests.rs
@@ -14,8 +14,8 @@ fn set_model_updates_model_name() {
     let executor = MockToolExecutor::no_tools();
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-    assert!(agent.set_model("claude-opus-4-6").is_ok());
-    assert_eq!(agent.runtime.config.model_name, "claude-opus-4-6");
+    assert!(agent.set_model("claude-opus-4-8").is_ok());
+    assert_eq!(agent.runtime.config.model_name, "claude-opus-4-8");
 }
 
 #[test]

--- a/crates/zeph-core/src/cost.rs
+++ b/crates/zeph-core/src/cost.rs
@@ -99,6 +99,9 @@ fn default_pricing() -> HashMap<String, ModelPricing> {
     // Claude 4.6 family
     m.insert("claude-sonnet-4-6".into(), claude_pricing(0.3, 1.5));
     m.insert("claude-opus-4-6".into(), claude_pricing(0.5, 2.5));
+    // Claude 5 / Opus 4.8 family
+    m.insert("claude-sonnet-5".into(), claude_pricing(0.3, 1.5));
+    m.insert("claude-opus-4-8".into(), claude_pricing(0.5, 2.5));
     // OpenAI
     m.insert("gpt-4o".into(), openai_pricing(0.25, 1.0));
     m.insert("gpt-4o-mini".into(), openai_pricing(0.015, 0.06));
@@ -496,6 +499,63 @@ mod tests {
         tracker.record_usage("claude-provider", "cloud", "claude-opus-4-6", 0, 0, 1000, 0);
         let cost = tracker.current_spend();
         assert!((cost - 0.625).abs() < 0.001);
+    }
+
+    #[test]
+    fn claude_5_generation_pricing_matches_retained_4_6_rows() {
+        // The new claude-sonnet-5/claude-opus-4-8 rows must price identically to the
+        // retained claude-sonnet-4-6/claude-opus-4-6 rows (#5889: same rates, new IDs).
+        let sonnet_5 = CostTracker::new(true, 1000.0);
+        sonnet_5.record_usage(
+            "claude-provider",
+            "cloud",
+            "claude-sonnet-5",
+            1000,
+            0,
+            0,
+            1000,
+        );
+        let sonnet_4_6 = CostTracker::new(true, 1000.0);
+        sonnet_4_6.record_usage(
+            "claude-provider",
+            "cloud",
+            "claude-sonnet-4-6",
+            1000,
+            0,
+            0,
+            1000,
+        );
+        assert!((sonnet_5.current_spend() - sonnet_4_6.current_spend()).abs() < f64::EPSILON);
+        assert!(
+            sonnet_5.current_spend() > 0.0,
+            "must not fall back to zero-cost"
+        );
+
+        let opus_4_8 = CostTracker::new(true, 1000.0);
+        opus_4_8.record_usage(
+            "claude-provider",
+            "cloud",
+            "claude-opus-4-8",
+            1000,
+            0,
+            0,
+            1000,
+        );
+        let opus_4_6 = CostTracker::new(true, 1000.0);
+        opus_4_6.record_usage(
+            "claude-provider",
+            "cloud",
+            "claude-opus-4-6",
+            1000,
+            0,
+            0,
+            1000,
+        );
+        assert!((opus_4_8.current_spend() - opus_4_6.current_spend()).abs() < f64::EPSILON);
+        assert!(
+            opus_4_8.current_spend() > 0.0,
+            "must not fall back to zero-cost"
+        );
     }
 
     #[test]

--- a/crates/zeph-llm/README.md
+++ b/crates/zeph-llm/README.md
@@ -201,7 +201,7 @@ expert_providers  = ["claude"]
 
 | Mode | Description |
 |------|-------------|
-| `Extended { budget_tokens }` | Allocates a fixed token budget (1024–128000) for visible reasoning; emits `interleaved-thinking-2025-05-14` beta header on Sonnet 4.6 with tools |
+| `Extended { budget_tokens }` | Allocates a fixed token budget (1024–128000) for visible reasoning; emits `interleaved-thinking-2025-05-14` beta header on legacy Sonnet 4.6 with tools (current models use adaptive thinking and need no beta header) |
 | `Adaptive { effort? }` | Lets the model allocate thinking budget automatically |
 
 ```toml
@@ -223,7 +223,7 @@ CLI: `--thinking extended:16000` or `--thinking adaptive`. When thinking is enab
 ```toml
 [[llm.providers]]
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 prompt_cache_ttl = "1h"   # "ephemeral" (default) or "1h"
 ```
 

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -7,7 +7,7 @@
 //! - Standard chat and streaming via Server-Sent Events
 //! - Native tool use (function calling)
 //! - Vision (image input in messages)
-//! - Extended and adaptive thinking (`claude-sonnet-4-6`, `claude-opus-4-6`)
+//! - Extended and adaptive thinking (`claude-sonnet-5`, `claude-opus-4-8`)
 //! - Prompt caching (`cache_control` blocks) for cost reduction
 //! - Server-side context compaction (compact-2026-01-12 beta)
 //! - Extended context window (context-1m-2025-08-07 beta)
@@ -18,7 +18,7 @@
 //! [[llm.providers]]
 //! name = "claude"
 //! type = "claude"
-//! model = "claude-sonnet-4-6"
+//! model = "claude-sonnet-5"
 //! max_tokens = 8192
 //! api_key_vault = "ZEPH_CLAUDE_API_KEY"
 //! ```
@@ -32,8 +32,8 @@
 //! use zeph_llm::{ThinkingConfig, ThinkingEffort};
 //!
 //! # fn build() -> Result<ClaudeProvider, zeph_llm::LlmError> {
-//! let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 16_000)
-//!     .with_thinking(ThinkingConfig::Extended { budget_tokens: 10_000 })?;
+//! let provider = ClaudeProvider::new("key".into(), "claude-sonnet-5".into(), 16_000)
+//!     .with_thinking(ThinkingConfig::Adaptive { effort: Some(ThinkingEffort::High) })?;
 //! # Ok(provider)
 //! # }
 //! ```
@@ -201,20 +201,57 @@ impl Clone for ClaudeProvider {
     }
 }
 
+/// Per-family minimum non-stale `(major, minor)` for the modern
+/// `claude-<family>-<major>[-<minor>][-<date>]` scheme, plus the current
+/// recommended replacement ID. Bump the numbers here (a one-line change) when a
+/// family's current release moves up; this never false-positives on a model
+/// NEWER than the floor, so it ages better than a hardcoded prefix literal.
+const MODERN_MODEL_FLOORS: &[(&str, u32, u32, &str)] = &[
+    ("sonnet", 5, 0, "claude-sonnet-5"),
+    ("opus", 4, 8, "claude-opus-4-8"),
+    ("haiku", 4, 5, "claude-haiku-4-5-20251001"),
+    ("fable", 5, 0, "claude-fable-5"),
+];
+
+/// Returns the current recommended replacement when `model` is a recognizably
+/// stale Claude identifier — either a retired `claude-3*` model or a modern
+/// `claude-<family>-<version>` below its family floor. Returns `None` for
+/// current, newer-than-floor, or unrecognized model strings (fail-open).
+///
+/// Limitation: a trailing date suffix on a version-less ID (e.g.
+/// `claude-opus-4-20250514`) is misparsed as the minor version, which can
+/// mask a stale warning for that exact shape. In-scope IDs use the
+/// `major-minor` form and are unaffected.
+fn stale_model_suggestion(model: &str) -> Option<&'static str> {
+    // Legacy retired generation — preserve #1625 coverage exactly.
+    if model.starts_with("claude-3") {
+        return Some("claude-sonnet-5 or claude-haiku-4-5-20251001");
+    }
+    let rest = model.strip_prefix("claude-")?; // non-Claude → fail open
+    let mut parts = rest.split('-');
+    let family = parts.next()?; // "sonnet", "opus", ...
+    let &(_, floor_major, floor_minor, suggestion) =
+        MODERN_MODEL_FLOORS.iter().find(|(f, ..)| *f == family)?; // unknown family → fail open
+    let major: u32 = parts.next()?.parse().ok()?; // non-numeric (alias) → fail open
+    let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    ((major, minor) < (floor_major, floor_minor)).then_some(suggestion)
+}
+
 impl ClaudeProvider {
     const MAX_CACHE_CONTROL_BLOCKS: usize = 4;
 
     /// Create a new provider.
     ///
-    /// Warns at runtime when `model` starts with `"claude-3"` because those identifiers
-    /// refer to retired models that may cause API errors.
+    /// Warns at runtime when `model` is a recognizably stale Claude identifier
+    /// (retired `claude-3*`, or below its family's current-version floor) because
+    /// those identifiers may be retired or superseded by a newer default.
     #[must_use]
     pub fn new(api_key: String, model: String, max_tokens: u32) -> Self {
-        if model.starts_with("claude-3") {
+        if let Some(suggestion) = stale_model_suggestion(&model) {
             tracing::warn!(
                 model = %model,
-                "configured model is a retired Claude 3 identifier and may cause API errors; \
-                consider upgrading to claude-sonnet-4-6 or claude-haiku-4-5-20251001",
+                "configured Claude model is not a current release and may be retired or \
+                superseded; consider upgrading to {suggestion}",
             );
         }
         Self {
@@ -646,7 +683,7 @@ impl ClaudeProvider {
                     model = %self.model,
                     budget_tokens,
                     ?effort,
-                    "budget_tokens is deprecated for Opus 4.6; auto-converting to effort"
+                    "budget_tokens is unsupported for this model; auto-converting to effort"
                 );
                 (
                     Some(types::ThinkingParam {
@@ -856,8 +893,12 @@ impl ClaudeProvider {
         let output_config = effort.map(|e| OutputConfig { effort: e }); // lgtm[rust/cleartext-logging]
 
         let cap = thinking_capability(&self.model);
-        // Opus 4.6 with thinking enabled does not support prefill: strip trailing assistant
-        // messages so the conversation always ends with a user turn.
+        // Models that prefer `effort` over `budget_tokens` also reject assistant
+        // prefill when thinking is enabled: strip trailing assistant messages so
+        // the conversation always ends with a user turn.
+        // TODO: `prefers_effort` conflates two independent capabilities (effort
+        // preference and no-prefill); they happen to align for every model in the
+        // current set but a future model could decouple them.
         let no_prefill = cap.prefers_effort && thinking_param.is_some();
 
         if Self::has_image_parts(messages) {
@@ -1095,7 +1136,7 @@ impl LlmProvider for ClaudeProvider {
             || self.model.contains("sonnet")
             || self.model.contains("haiku")
         {
-            // Only Opus 4.6 and Sonnet 4.6 support the 1M context window.
+            // Only Opus and Sonnet models support the 1M context window.
             // Haiku does not support extended context even when the flag is set.
             let supports_1m = self.enable_extended_context && !self.model.contains("haiku");
             if supports_1m {
@@ -1105,7 +1146,7 @@ impl LlmProvider for ClaudeProvider {
                     tracing::warn!(
                         model = %self.model,
                         "enable_extended_context has no effect for Haiku models; \
-                        extended context (1M) is only supported by Opus 4.6 and Sonnet 4.6"
+                        extended context (1M) is only supported by Claude Opus and Sonnet models"
                     );
                 }
                 Some(200_000)

--- a/crates/zeph-llm/src/claude/tests.rs
+++ b/crates/zeph-llm/src/claude/tests.rs
@@ -13,6 +13,7 @@ use super::types::{
 use super::*;
 use crate::CacheTtl;
 use crate::provider::{ImageData, MessageMetadata, Role, ThinkingBlock};
+use crate::testing::TEST_CLAUDE_MODEL;
 use tokio_stream::StreamExt;
 
 #[test]
@@ -20,7 +21,7 @@ fn context_window_known_models() {
     let sonnet = ClaudeProvider::new("k".into(), "claude-sonnet-4-5-20250929".into(), 1024);
     assert_eq!(sonnet.context_window(), Some(200_000));
 
-    let opus = ClaudeProvider::new("k".into(), "claude-opus-4-6".into(), 1024);
+    let opus = ClaudeProvider::new("k".into(), "claude-opus-4-8".into(), 1024);
     assert_eq!(opus.context_window(), Some(200_000));
 
     let haiku = ClaudeProvider::new("k".into(), "claude-haiku-4-5".into(), 1024);
@@ -31,6 +32,54 @@ fn context_window_known_models() {
 fn context_window_unknown_model() {
     let provider = ClaudeProvider::new("k".into(), "unknown-model".into(), 1024);
     assert!(provider.context_window().is_none());
+}
+
+#[test]
+fn stale_model_suggestion_old_gen_below_floor_returns_some() {
+    assert_eq!(
+        stale_model_suggestion("claude-sonnet-4-6"),
+        Some("claude-sonnet-5")
+    );
+    assert_eq!(
+        stale_model_suggestion("claude-opus-4-6"),
+        Some("claude-opus-4-8")
+    );
+    assert_eq!(
+        stale_model_suggestion("claude-opus-4-7"),
+        Some("claude-opus-4-8")
+    );
+}
+
+#[test]
+fn stale_model_suggestion_current_gen_returns_none() {
+    assert_eq!(stale_model_suggestion("claude-sonnet-5"), None);
+    assert_eq!(stale_model_suggestion("claude-opus-4-8"), None);
+    assert_eq!(stale_model_suggestion("claude-haiku-4-5-20251001"), None);
+}
+
+#[test]
+fn stale_model_suggestion_future_version_fails_open() {
+    assert_eq!(stale_model_suggestion("claude-opus-4-9"), None);
+    assert_eq!(stale_model_suggestion("claude-sonnet-6"), None);
+}
+
+#[test]
+fn stale_model_suggestion_legacy_claude_3_returns_some() {
+    assert_eq!(
+        stale_model_suggestion("claude-3-opus"),
+        Some("claude-sonnet-5 or claude-haiku-4-5-20251001")
+    );
+    assert_eq!(
+        stale_model_suggestion("claude-3-5-sonnet"),
+        Some("claude-sonnet-5 or claude-haiku-4-5-20251001")
+    );
+}
+
+#[test]
+fn stale_model_suggestion_non_claude_or_alias_fails_open() {
+    assert_eq!(stale_model_suggestion("gpt-4o"), None);
+    assert_eq!(stale_model_suggestion("claude-opus-latest"), None);
+    assert_eq!(stale_model_suggestion("claude-unknownfamily-9"), None);
 }
 
 #[test]
@@ -413,7 +462,7 @@ fn request_body_serializes_with_stream_false_omits_stream() {
 fn split_system_no_markers_caches_entire_block() {
     // Text must meet the 2048-token threshold for sonnet (≈ 8192 chars).
     let long_text = format!("You are Zeph, an AI assistant. {}", "x".repeat(8200));
-    let blocks = split_system_into_blocks(&long_text, "claude-sonnet-4-6", None);
+    let blocks = split_system_into_blocks(&long_text, TEST_CLAUDE_MODEL, None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_some());
     assert!(blocks[0].text.contains("Zeph"));
@@ -422,7 +471,7 @@ fn split_system_no_markers_caches_entire_block() {
 #[test]
 fn split_system_no_markers_short_text_skips_cache() {
     let blocks =
-        split_system_into_blocks("You are Zeph, an AI assistant.", "claude-sonnet-4-6", None);
+        split_system_into_blocks("You are Zeph, an AI assistant.", TEST_CLAUDE_MODEL, None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_none());
 }
@@ -431,7 +480,7 @@ fn split_system_no_markers_short_text_skips_cache() {
 fn split_system_no_markers_exact_threshold_sonnet_caches() {
     // Exactly 8192 chars => 8192 / 4 = 2048 tokens == sonnet threshold: should cache.
     let exact_text = "A".repeat(8192);
-    let blocks = split_system_into_blocks(&exact_text, "claude-sonnet-4-6", None);
+    let blocks = split_system_into_blocks(&exact_text, TEST_CLAUDE_MODEL, None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_some());
 }
@@ -440,7 +489,7 @@ fn split_system_no_markers_exact_threshold_sonnet_caches() {
 fn split_system_no_markers_opus_skips_short_text() {
     // 8192 chars = 2048 tokens < 4096 opus minimum — no cache.
     let medium_text = "A".repeat(8192);
-    let blocks = split_system_into_blocks(&medium_text, "claude-opus-4-6", None);
+    let blocks = split_system_into_blocks(&medium_text, "claude-opus-4-8", None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_none());
 }
@@ -449,7 +498,7 @@ fn split_system_no_markers_opus_skips_short_text() {
 fn split_system_no_markers_opus_caches_long_text() {
     // 16384 chars = 4096 tokens >= 4096 opus minimum — should cache.
     let long_text = "A".repeat(16384);
-    let blocks = split_system_into_blocks(&long_text, "claude-opus-4-6", None);
+    let blocks = split_system_into_blocks(&long_text, "claude-opus-4-8", None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_some());
 }
@@ -463,7 +512,7 @@ fn split_system_with_all_markers() {
          {CACHE_MARKER_TOOLS}\ntool catalog {padding}\n\
          {CACHE_MARKER_VOLATILE}\nvolatile stuff"
     );
-    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", None);
+    let blocks = split_system_into_blocks(&system, TEST_CLAUDE_MODEL, None);
     assert_eq!(blocks.len(), 4);
     assert!(blocks[0].cache_control.is_some());
     assert!(blocks[0].text.contains("base prompt"));
@@ -479,7 +528,7 @@ fn split_system_with_all_markers() {
 fn split_system_partial_markers() {
     let padding = "x".repeat(8200);
     let system = format!("base prompt {padding}\n{CACHE_MARKER_VOLATILE}\nvolatile only");
-    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", None);
+    let blocks = split_system_into_blocks(&system, TEST_CLAUDE_MODEL, None);
     assert_eq!(blocks.len(), 2);
     assert!(blocks[0].cache_control.is_some());
     assert!(blocks[1].cache_control.is_none());
@@ -490,7 +539,7 @@ fn split_system_block1_padded_when_below_threshold() {
     // Block 1 is below 2048 tokens but gets padded with AGENT_IDENTITY_PREAMBLE,
     // so it must receive cache_control after padding.
     let system = format!("short text\n{CACHE_MARKER_STABLE}\nmore content");
-    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", None);
+    let blocks = split_system_into_blocks(&system, TEST_CLAUDE_MODEL, None);
     // Block 1 must be padded and cached
     assert!(blocks[0].cache_control.is_some());
     assert!(blocks[0].text.contains("short text"));
@@ -504,7 +553,7 @@ fn split_system_block2_not_padded_when_below_threshold() {
     let padding = "x".repeat(8200);
     let system =
         format!("base {padding}\n{CACHE_MARKER_STABLE}\nshort\n{CACHE_MARKER_TOOLS}\nmore");
-    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", None);
+    let blocks = split_system_into_blocks(&system, TEST_CLAUDE_MODEL, None);
     // Block 2 ("short") is below threshold and must NOT contain identity preamble
     assert!(!blocks[1].text.contains("Agent Identity"));
 }
@@ -1464,7 +1513,7 @@ fn messages_response_deserialization() {
         "id": "msg_test",
         "type": "message",
         "role": "assistant",
-        "model": "claude-sonnet-4-6",
+        "model": TEST_CLAUDE_MODEL,
         "content": [{"type": "text", "text": "hello claude"}],
         "stop_reason": "end_turn",
         "usage": {
@@ -1634,6 +1683,26 @@ fn thinking_capability_sonnet_4_6_no_prefers_effort() {
 }
 
 #[test]
+fn thinking_capability_opus_4_8_prefers_effort() {
+    let cap = thinking_capability("claude-opus-4-8");
+    assert!(cap.prefers_effort);
+    assert!(!cap.needs_interleaved_beta);
+}
+
+#[test]
+fn thinking_capability_opus_4_7_prefers_effort() {
+    let cap = thinking_capability("claude-opus-4-7");
+    assert!(cap.prefers_effort);
+}
+
+#[test]
+fn thinking_capability_sonnet_5_prefers_effort_no_interleaved_beta() {
+    let cap = thinking_capability("claude-sonnet-5");
+    assert!(cap.prefers_effort);
+    assert!(!cap.needs_interleaved_beta);
+}
+
+#[test]
 fn budget_to_effort_boundaries() {
     assert_eq!(budget_to_effort(4_999), ThinkingEffort::Low);
     assert_eq!(budget_to_effort(5_000), ThinkingEffort::Medium);
@@ -1645,7 +1714,7 @@ fn budget_to_effort_boundaries() {
 
 #[test]
 fn build_thinking_param_opus_extended_converts_to_adaptive() {
-    let p = ClaudeProvider::new("k".into(), "claude-opus-4-6".into(), 32_000)
+    let p = ClaudeProvider::new("k".into(), "claude-opus-4-8".into(), 32_000)
         .with_thinking(ThinkingConfig::Extended {
             budget_tokens: 5_000,
         })
@@ -1659,7 +1728,7 @@ fn build_thinking_param_opus_extended_converts_to_adaptive() {
 
 #[test]
 fn build_thinking_param_opus_adaptive_unchanged() {
-    let p = ClaudeProvider::new("k".into(), "claude-opus-4-6".into(), 32_000)
+    let p = ClaudeProvider::new("k".into(), "claude-opus-4-8".into(), 32_000)
         .with_thinking(ThinkingConfig::Adaptive {
             effort: Some(ThinkingEffort::High),
         })
@@ -1741,7 +1810,7 @@ fn with_thinking_rejects_budget_not_less_than_max_tokens() {
 
 #[test]
 fn with_thinking_bumps_max_tokens_when_too_low() {
-    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_thinking(ThinkingConfig::Extended {
             budget_tokens: 8000,
         })
@@ -1751,7 +1820,7 @@ fn with_thinking_bumps_max_tokens_when_too_low() {
 
 #[test]
 fn with_thinking_keeps_max_tokens_when_already_high() {
-    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 32_000)
+    let provider = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 32_000)
         .with_thinking(ThinkingConfig::Extended {
             budget_tokens: 8000,
         })
@@ -1763,7 +1832,7 @@ fn with_thinking_keeps_max_tokens_when_already_high() {
 fn set_thinking_none_restores_base_max_tokens_after_enable() {
     // S1 regression: enable (bumps max_tokens to the 16k floor) → off must restore the
     // originally configured max_tokens, not leave it stuck at the floor.
-    let mut provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024);
+    let mut provider = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024);
     provider
         .set_thinking(Some(ThinkingConfig::Extended {
             budget_tokens: 8000,
@@ -1783,7 +1852,7 @@ fn set_thinking_none_restores_base_max_tokens_after_enable() {
 fn set_thinking_enable_disable_enable_is_idempotent() {
     // S1: repeated enable/disable cycles must never ratchet max_tokens upward permanently —
     // every `Some(_)` step recomputes from the immutable base_max_tokens baseline.
-    let mut provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024);
+    let mut provider = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024);
     for budget in [8000, 12_000, 4000] {
         provider
             .set_thinking(Some(ThinkingConfig::Extended {
@@ -1810,13 +1879,13 @@ fn set_thinking_out_of_range_budget_rejected() {
 fn set_thinking_construction_parity_with_with_thinking() {
     // Construction-time behavior via `with_thinking` must remain byte-for-byte identical to
     // calling `set_thinking` directly after `new` (delegation must not change semantics).
-    let via_with_thinking = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024)
+    let via_with_thinking = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_thinking(ThinkingConfig::Extended {
             budget_tokens: 8000,
         })
         .unwrap();
 
-    let mut via_set_thinking = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024);
+    let mut via_set_thinking = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024);
     via_set_thinking
         .set_thinking(Some(ThinkingConfig::Extended {
             budget_tokens: 8000,
@@ -1924,7 +1993,7 @@ fn build_thinking_param_no_thinking_returns_none() {
 
 #[test]
 fn beta_header_without_thinking_returns_none() {
-    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024);
+    let provider = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024);
     let beta = provider.beta_header(true);
     assert!(beta.is_none());
 }
@@ -1956,7 +2025,7 @@ fn beta_header_sonnet_4_6_extended_no_tools_excludes_interleaved() {
 
 #[test]
 fn beta_header_adaptive_mode_excludes_interleaved() {
-    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 16_000)
+    let provider = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 16_000)
         .with_thinking(ThinkingConfig::Adaptive { effort: None })
         .unwrap();
     let beta = provider.beta_header(true);
@@ -1965,15 +2034,15 @@ fn beta_header_adaptive_mode_excludes_interleaved() {
 
 #[test]
 fn extended_context_disabled_no_beta_header() {
-    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024);
+    let provider = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024);
     let beta = provider.beta_header(true);
     assert!(beta.is_none());
 }
 
 #[test]
 fn extended_context_enabled_includes_beta_header() {
-    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024)
-        .with_extended_context(true);
+    let provider =
+        ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024).with_extended_context(true);
     let beta = provider.beta_header(true);
     assert!(
         beta.as_deref()
@@ -1999,14 +2068,14 @@ fn extended_context_with_interleaved_thinking_combines_headers() {
 
 #[test]
 fn extended_context_enabled_returns_1m_context_window() {
-    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024)
-        .with_extended_context(true);
+    let provider =
+        ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024).with_extended_context(true);
     assert_eq!(provider.context_window(), Some(1_000_000));
 }
 
 #[test]
 fn extended_context_disabled_returns_200k_context_window() {
-    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024);
+    let provider = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024);
     assert_eq!(provider.context_window(), Some(200_000));
 }
 
@@ -2158,7 +2227,7 @@ fn redacted_thinking_content_block_roundtrip() {
 
 #[test]
 fn build_request_does_not_include_anthropic_beta_header() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 256);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 256);
     let messages = vec![Message {
         role: Role::User,
         content: "hi".into(),
@@ -2176,7 +2245,7 @@ fn build_request_does_not_include_anthropic_beta_header() {
 
 #[test]
 fn build_request_with_extended_context_includes_beta_header() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 256)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 256)
         .with_extended_context(true);
     let messages = vec![Message {
         role: Role::User,
@@ -2260,13 +2329,13 @@ fn get_or_build_api_tools_single_tool_has_cache_control() {
 
 #[test]
 fn cache_min_tokens_sonnet_returns_2048() {
-    assert_eq!(cache_min_tokens("claude-sonnet-4-6"), 2048);
+    assert_eq!(cache_min_tokens(TEST_CLAUDE_MODEL), 2048);
     assert_eq!(cache_min_tokens("claude-sonnet-4-5-20250929"), 2048);
 }
 
 #[test]
 fn cache_min_tokens_non_sonnet_returns_4096() {
-    assert_eq!(cache_min_tokens("claude-opus-4-6"), 4096);
+    assert_eq!(cache_min_tokens("claude-opus-4-8"), 4096);
     assert_eq!(cache_min_tokens("claude-haiku-4-5"), 4096);
     assert_eq!(cache_min_tokens("unknown-model"), 4096);
 }
@@ -2276,7 +2345,7 @@ fn split_system_opus_block_above_threshold_gets_cache_control() {
     // opus threshold = 4096 tokens = 16384 chars
     let padding = "x".repeat(16400);
     let system = format!("{padding}\n{CACHE_MARKER_STABLE}\nmore");
-    let blocks = split_system_into_blocks(&system, "claude-opus-4-6", None);
+    let blocks = split_system_into_blocks(&system, "claude-opus-4-8", None);
     assert!(
         blocks[0].cache_control.is_some(),
         "block above opus threshold must be cached"
@@ -2287,7 +2356,7 @@ fn split_system_opus_block_above_threshold_gets_cache_control() {
 fn split_system_opus_block_below_threshold_skips_cache_control() {
     // text under 16384 chars is below opus threshold (4096 tokens)
     let system = format!("short\n{CACHE_MARKER_STABLE}\nmore content");
-    let blocks = split_system_into_blocks(&system, "claude-opus-4-6", None);
+    let blocks = split_system_into_blocks(&system, "claude-opus-4-8", None);
     assert!(
         blocks[0].cache_control.is_none(),
         "block below opus threshold must not be cached"
@@ -2298,7 +2367,7 @@ fn split_system_opus_block_below_threshold_skips_cache_control() {
 
 #[test]
 fn build_request_single_message_no_top_level_cache_control() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 256);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 256);
     let messages = vec![Message {
         role: Role::User,
         content: "hello".into(),
@@ -2316,7 +2385,7 @@ fn build_request_single_message_no_top_level_cache_control() {
 
 #[test]
 fn build_request_multi_turn_no_top_level_cache_control() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 256);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 256);
     let messages = vec![
         Message {
             role: Role::User,
@@ -2453,7 +2522,7 @@ fn count_cache_control_occurrences(value: &serde_json::Value) -> usize {
 
 #[test]
 fn debug_tool_request_caps_block_cache_controls_at_four() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 256);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 256);
     let padding = "x".repeat(8200);
     let system = format!(
         "base prompt {padding}\n{CACHE_MARKER_STABLE}\nskills here {padding}\n\
@@ -2530,7 +2599,7 @@ fn debug_tool_request_caps_block_cache_controls_at_four() {
 
 #[test]
 fn debug_vision_request_caps_total_cache_controls_at_four() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 256);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 256);
     let padding = "x".repeat(8200);
     let system = format!(
         "base prompt {padding}\n{CACHE_MARKER_STABLE}\nskills here {padding}\n\
@@ -2703,11 +2772,11 @@ fn store_cache_usage_updates_last_usage() {
     assert_eq!(provider.last_usage(), Some((42, 17)));
 }
 
-// ── Opus 4.6 no-prefill: trailing assistant messages must be stripped ──────
+// ── Opus no-prefill: trailing assistant messages must be stripped ──────────
 
 #[test]
 fn build_request_opus_thinking_strips_trailing_assistant() {
-    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-6".into(), 32_000)
+    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-8".into(), 32_000)
         .with_thinking(ThinkingConfig::Adaptive { effort: None })
         .unwrap();
     let messages = vec![
@@ -2732,13 +2801,13 @@ fn build_request_opus_thinking_strips_trailing_assistant() {
         msgs.last()
             .and_then(|m| m["role"].as_str())
             .is_none_or(|r| r != "assistant"),
-        "trailing assistant message must be stripped for Opus 4.6 with thinking"
+        "trailing assistant message must be stripped for Opus with thinking"
     );
 }
 
 #[test]
 fn build_request_opus_no_thinking_keeps_trailing_assistant() {
-    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-6".into(), 32_000);
+    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-8".into(), 32_000);
     let messages = vec![
         Message {
             role: Role::User,
@@ -2798,13 +2867,13 @@ fn build_request_sonnet_thinking_keeps_trailing_assistant() {
 
 #[test]
 fn server_compaction_disabled_by_default() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024);
     assert!(!provider.server_compaction_enabled());
 }
 
 #[test]
 fn with_server_compaction_enables_flag() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     assert!(provider.server_compaction_enabled());
 }
@@ -2819,13 +2888,13 @@ fn with_server_compaction_haiku_stays_disabled() {
 
 #[test]
 fn take_compaction_summary_empty_when_none() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024);
     assert!(provider.take_compaction_summary().is_none());
 }
 
 #[test]
 fn take_compaction_summary_returns_and_clears() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024);
     *provider.last_compaction.lock() = Some("Summary text".to_owned());
     let result = provider.take_compaction_summary();
     assert_eq!(result.as_deref(), Some("Summary text"));
@@ -2835,13 +2904,13 @@ fn take_compaction_summary_returns_and_clears() {
 
 #[test]
 fn context_management_absent_when_disabled() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024);
     assert!(provider.context_management().is_none());
 }
 
 #[test]
 fn context_management_present_when_enabled() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     let cm = provider.context_management().unwrap();
     // trigger value = context_window * 80 / 100 = 200_000 * 80 / 100 = 160_000
@@ -2870,7 +2939,7 @@ fn context_management_serializes_correctly() {
 
 #[test]
 fn beta_header_includes_compact_when_server_compaction_enabled() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     let header = provider.beta_header(false).unwrap_or_default();
     assert!(
@@ -2881,7 +2950,7 @@ fn beta_header_includes_compact_when_server_compaction_enabled() {
 
 #[test]
 fn beta_header_excludes_compact_when_disabled() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024);
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024);
     let header = provider.beta_header(false).unwrap_or_default();
     assert!(
         !header.contains("compact-2026-01-12"),
@@ -2902,14 +2971,14 @@ fn compaction_content_block_deserialized() {
 
 #[test]
 fn server_compaction_not_rejected_by_default() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     assert!(!provider.is_server_compaction_rejected());
 }
 
 #[test]
 fn beta_header_excluded_after_rejection() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     // Simulate API rejection.
     provider
@@ -2924,7 +2993,7 @@ fn beta_header_excluded_after_rejection() {
 
 #[test]
 fn context_management_absent_after_rejection() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     provider
         .server_compaction_rejected
@@ -2993,7 +3062,7 @@ fn is_compact_beta_rejection_ignores_unrelated_no_context_management() {
 
 #[test]
 fn clone_shares_rejection_flag() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     let clone = provider.clone();
     // Set flag on original; clone must see it.
@@ -3008,7 +3077,7 @@ fn clone_shares_rejection_flag() {
 
 #[test]
 fn handle_compact_beta_rejection_sets_flags_and_returns_true_on_first_rejection() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     let mut retried = false;
     let handled = provider.handle_compact_beta_rejection(
@@ -3027,7 +3096,7 @@ fn handle_compact_beta_rejection_sets_flags_and_returns_true_on_first_rejection(
 
 #[test]
 fn handle_compact_beta_rejection_returns_false_when_already_retried() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     let mut retried = true;
     let handled = provider.handle_compact_beta_rejection(
@@ -3045,7 +3114,7 @@ fn handle_compact_beta_rejection_returns_false_when_already_retried() {
 
 #[test]
 fn handle_compact_beta_rejection_returns_false_for_non_rejection_error() {
-    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_server_compaction(true);
     let mut retried = false;
     let handled = provider.handle_compact_beta_rejection(
@@ -3126,9 +3195,8 @@ fn output_schema_forwarding_enabled_appends_hint() {
         parameters: serde_json::json!({"type": "object"}),
         output_schema: Some(serde_json::json!({"type": "string"})),
     };
-    let provider =
-        crate::claude::ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1000)
-            .with_output_schema_forwarding(true, 512, usize::MAX);
+    let provider = crate::claude::ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1000)
+        .with_output_schema_forwarding(true, 512, usize::MAX);
     let api_tools = provider.get_or_build_api_tools(&[tool]);
     let desc = api_tools[0]["description"].as_str().unwrap();
     assert!(
@@ -3150,8 +3218,7 @@ fn output_schema_forwarding_disabled_no_hint() {
         parameters: serde_json::json!({"type": "object"}),
         output_schema: Some(serde_json::json!({"type": "string"})),
     };
-    let provider =
-        crate::claude::ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1000);
+    let provider = crate::claude::ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1000);
     let api_tools = provider.get_or_build_api_tools(&[tool]);
     let desc = api_tools[0]["description"].as_str().unwrap();
     assert!(
@@ -3170,9 +3237,8 @@ fn output_schema_forwarding_truncates_large_schema() {
         parameters: serde_json::json!({"type": "object"}),
         output_schema: Some(large_schema),
     };
-    let provider =
-        crate::claude::ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1000)
-            .with_output_schema_forwarding(true, 64, usize::MAX);
+    let provider = crate::claude::ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1000)
+        .with_output_schema_forwarding(true, 64, usize::MAX);
     let api_tools = provider.get_or_build_api_tools(&[tool]);
     let desc = api_tools[0]["description"].as_str().unwrap();
     assert!(
@@ -3239,9 +3305,8 @@ fn test_claude_default_output_schema_hint_bytes_is_1024() {
         parameters: serde_json::json!({"type": "object"}),
         output_schema: Some(schema),
     };
-    let provider =
-        crate::claude::ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1000)
-            .with_output_schema_forwarding(true, 1024, usize::MAX);
+    let provider = crate::claude::ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1000)
+        .with_output_schema_forwarding(true, 1024, usize::MAX);
     let api_tools = provider.get_or_build_api_tools(&[tool]);
     let desc = api_tools[0]["description"].as_str().unwrap();
     assert!(
@@ -3264,9 +3329,8 @@ fn test_claude_stub_used_when_schema_exceeds_1024_bytes() {
         parameters: serde_json::json!({"type": "object"}),
         output_schema: Some(large_schema),
     };
-    let provider =
-        crate::claude::ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1000)
-            .with_output_schema_forwarding(true, 1024, usize::MAX);
+    let provider = crate::claude::ClaudeProvider::new("key".into(), TEST_CLAUDE_MODEL.into(), 1000)
+        .with_output_schema_forwarding(true, 1024, usize::MAX);
     let api_tools = provider.get_or_build_api_tools(&[tool]);
     let desc = api_tools[0]["description"].as_str().unwrap();
     assert!(
@@ -3330,7 +3394,7 @@ fn cache_ttl_ephemeral_toml_round_trip() {
 
 #[test]
 fn beta_header_includes_extended_cache_ttl_for_one_hour() {
-    let p = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024)
+    let p = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_prompt_cache_ttl(Some(CacheTtl::OneHour));
     let header = p.beta_header(false).unwrap_or_default();
     assert!(
@@ -3341,7 +3405,7 @@ fn beta_header_includes_extended_cache_ttl_for_one_hour() {
 
 #[test]
 fn beta_header_omits_extended_cache_ttl_for_ephemeral() {
-    let p = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024);
+    let p = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024);
     let header = p.beta_header(false).unwrap_or_default();
     assert!(
         !header.contains("extended-cache-ttl-2025-04-25"),
@@ -3358,7 +3422,7 @@ fn tool_cache_control_uses_typed_path_for_one_hour() {
         parameters: serde_json::json!({"type": "object"}),
         output_schema: None,
     };
-    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024)
+    let provider = ClaudeProvider::new("k".into(), TEST_CLAUDE_MODEL.into(), 1024)
         .with_prompt_cache_ttl(Some(CacheTtl::OneHour));
     let api_tools = provider.get_or_build_api_tools(&[tool]);
     let cc = &api_tools[0]["cache_control"];
@@ -3371,7 +3435,7 @@ fn split_system_into_blocks_propagates_one_hour_ttl() {
     use super::cache::split_system_into_blocks;
     // Use a long enough string to exceed the cache threshold for any model
     let system = "A".repeat(20_000);
-    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", Some(CacheTtl::OneHour));
+    let blocks = split_system_into_blocks(&system, TEST_CLAUDE_MODEL, Some(CacheTtl::OneHour));
     let cached = blocks
         .iter()
         .find(|b| b.cache_control.is_some())

--- a/crates/zeph-llm/src/claude/types.rs
+++ b/crates/zeph-llm/src/claude/types.rs
@@ -12,14 +12,25 @@ use zeph_config::ThinkingEffort;
 pub(super) struct ThinkingCapability {
     /// Requires `interleaved-thinking-2025-05-14` beta header when `tool_use` is present.
     pub needs_interleaved_beta: bool,
-    /// Opus 4.6 uses `effort` instead of `budget_tokens`; `Extended` config is auto-converted.
+    /// Opus 4.6 and the 4.7+/5 generation use `effort` instead of `budget_tokens`
+    /// (4.7+/5 reject `budget_tokens` outright); `Extended` config is auto-converted.
     pub prefers_effort: bool,
 }
 
 pub(super) fn thinking_capability(model: &str) -> ThinkingCapability {
-    // Sonnet 4.6 with tools needs `interleaved-thinking-2025-05-14` beta header.
+    // Legacy Sonnet 4.6 with tools needs the interleaved-thinking-2025-05-14 beta
+    // header. Opus 4.7+/4.8 and Sonnet 5 enable interleaved thinking automatically
+    // under adaptive thinking (no header), so they are intentionally NOT listed.
     let needs_interleaved_beta = model.contains("claude-sonnet-4-6");
-    let prefers_effort = model.contains("claude-opus-4-6");
+
+    // Opus 4.6 deprecates budget_tokens in favor of effort; Opus 4.7/4.8 and
+    // Sonnet 5 REMOVE budget_tokens entirely (400 if sent), so `Extended` config
+    // MUST auto-convert to an effort level for these models.
+    let prefers_effort = model.contains("claude-opus-4-6")
+        || model.contains("claude-opus-4-7")
+        || model.contains("claude-opus-4-8")
+        || model.contains("claude-sonnet-5");
+
     ThinkingCapability {
         needs_interleaved_beta,
         prefers_effort,

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -818,7 +818,7 @@ pub trait LlmProvider: Send + Sync {
     /// Provider name for logging and identification.
     fn name(&self) -> &str;
 
-    /// Model identifier string (e.g. `gpt-4o-mini`, `claude-sonnet-4-6`).
+    /// Model identifier string (e.g. `gpt-4o-mini`, `claude-sonnet-5`).
     /// Used by cost-estimation heuristics. Returns `""` when not applicable.
     #[allow(clippy::unnecessary_literal_bound)]
     fn model_identifier(&self) -> &str {

--- a/crates/zeph-llm/src/provider_dyn.rs
+++ b/crates/zeph-llm/src/provider_dyn.rs
@@ -117,7 +117,7 @@ pub trait LlmProviderDyn: private::Sealed + std::fmt::Debug + Send + Sync {
     /// Provider name for logging and identification.
     fn name(&self) -> &str;
 
-    /// Model identifier string (e.g. `gpt-4o-mini`, `claude-sonnet-4-6`).
+    /// Model identifier string (e.g. `gpt-4o-mini`, `claude-sonnet-5`).
     fn model_identifier(&self) -> &str;
 
     /// Whether this provider supports image input (vision).

--- a/crates/zeph-llm/src/router/bandit.rs
+++ b/crates/zeph-llm/src/router/bandit.rs
@@ -1011,7 +1011,7 @@ mod tests {
         assert!(provider_cost_estimate("fast", "gpt-4o-mini") < 0.4);
         assert!(provider_cost_estimate("fast", "claude-haiku-3") < 0.4);
         // Mid tier.
-        assert!(provider_cost_estimate("quality", "claude-sonnet-4-6") >= 0.4);
+        assert!(provider_cost_estimate("quality", "claude-sonnet-5") >= 0.4);
         assert!(provider_cost_estimate("quality", "gpt-4o-2024") >= 0.4);
         // Expensive tier.
         assert!(provider_cost_estimate("best", "claude-opus-4") >= 0.7);

--- a/crates/zeph-llm/src/testing.rs
+++ b/crates/zeph-llm/src/testing.rs
@@ -11,6 +11,10 @@
 use std::fmt::Write as _;
 use wiremock::ResponseTemplate;
 
+/// Syntactically-valid current Claude model ID for tests that need *some*
+/// model string but do not assert on model freshness. Update in one place.
+pub const TEST_CLAUDE_MODEL: &str = "claude-sonnet-5";
+
 // ---------------------------------------------------------------------------
 // OpenAI-compatible response shapes
 // ---------------------------------------------------------------------------
@@ -118,7 +122,7 @@ pub fn claude_messages_response(content: &str) -> ResponseTemplate {
         "id": "msg_test",
         "type": "message",
         "role": "assistant",
-        "model": "claude-sonnet-4-6",
+        "model": TEST_CLAUDE_MODEL,
         "content": [{
             "type": "text",
             "text": content
@@ -155,7 +159,7 @@ pub fn claude_sse_stream_response(chunks: &[&str]) -> ResponseTemplate {
     let mut body = String::new();
 
     body.push_str(
-        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n",
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-5\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n",
     );
     body.push_str(
         "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",

--- a/crates/zeph-llm/tests/claude_live.rs
+++ b/crates/zeph-llm/tests/claude_live.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Live integration tests for the Claude provider against the real Anthropic API.
+//!
+//! Skipped by default — requires a real API key. Run with:
+//! ```shell
+//! ZEPH_CLAUDE_API_KEY=<key> cargo nextest run -p zeph-llm -- --ignored claude_live
+//! ```
+//!
+//! These cover the #5889 capability-gate change: `ThinkingCapability::prefers_effort` now
+//! also covers Opus 4.7/4.8 and Sonnet 5, which reject `budget_tokens` outright (400) and
+//! must auto-convert `Extended` thinking config to an `effort` level. The same flag also
+//! gates trailing-assistant-message stripping (`no_prefill` in `build_request`), so a
+//! prefill round-trip is exercised too — both behaviors changed together for the new
+//! generation and both are 400-prone if the conversion/stripping is wrong.
+
+use zeph_llm::ThinkingConfig;
+use zeph_llm::claude::ClaudeProvider;
+use zeph_llm::provider::{LlmProvider, Message, Role};
+
+fn api_key() -> Option<String> {
+    match std::env::var("ZEPH_CLAUDE_API_KEY") {
+        Ok(k) if !k.is_empty() => Some(k),
+        _ => {
+            eprintln!("ZEPH_CLAUDE_API_KEY not set, skipping");
+            None
+        }
+    }
+}
+
+/// Confirms `Extended { budget_tokens }` on `claude-opus-4-8` is auto-converted to an
+/// `effort` level before being sent — the model 400s if `budget_tokens` is sent as-is
+/// (S3, `prefers_effort`).
+#[tokio::test]
+#[ignore = "requires ZEPH_CLAUDE_API_KEY env var and live Anthropic API access"]
+async fn claude_live_opus_4_8_extended_thinking_converts_to_effort() {
+    let Some(api_key) = api_key() else { return };
+
+    let provider = ClaudeProvider::new(api_key, "claude-opus-4-8".into(), 1024)
+        .with_thinking(ThinkingConfig::Extended {
+            budget_tokens: 5_000,
+        })
+        .expect("valid thinking config");
+
+    let messages = vec![Message::from_legacy(Role::User, "Say hello in one word.")];
+
+    match provider.chat(&messages).await {
+        Ok(response) => assert!(!response.is_empty(), "response must not be empty"),
+        Err(err) => panic!(
+            "chat request against claude-opus-4-8 with Extended{{budget_tokens}} thinking \
+             failed: {err}\nIf this is a 400/422, prefers_effort likely stopped converting \
+             budget_tokens to effort for this model — check thinking_capability() in \
+             crates/zeph-llm/src/claude/types.rs."
+        ),
+    }
+}
+
+/// Confirms a trailing assistant message is correctly stripped for `claude-sonnet-5` with
+/// thinking enabled (the `no_prefill` gate at `mod.rs:861`, driven by the same
+/// `prefers_effort` flag S3 widened) — the API 400s on assistant-message prefill when
+/// thinking is active, so a passing round-trip confirms the strip fired.
+#[tokio::test]
+#[ignore = "requires ZEPH_CLAUDE_API_KEY env var and live Anthropic API access"]
+async fn claude_live_sonnet_5_thinking_strips_trailing_assistant_prefill() {
+    let Some(api_key) = api_key() else { return };
+
+    let provider = ClaudeProvider::new(api_key, "claude-sonnet-5".into(), 1024)
+        .with_thinking(ThinkingConfig::Adaptive { effort: None })
+        .expect("valid thinking config");
+
+    let messages = vec![
+        Message::from_legacy(Role::User, "Say hello in one word."),
+        Message::from_legacy(Role::Assistant, "Hel"),
+    ];
+
+    match provider.chat(&messages).await {
+        Ok(response) => assert!(!response.is_empty(), "response must not be empty"),
+        Err(err) => panic!(
+            "chat request against claude-sonnet-5 with a trailing assistant message and \
+             thinking enabled failed: {err}\nIf this is a 400, the no_prefill strip at \
+             build_request (mod.rs) is not firing for this model — check that \
+             thinking_capability(\"claude-sonnet-5\").prefers_effort is true."
+        ),
+    }
+}

--- a/crates/zeph-memory/src/store/agent_sessions.rs
+++ b/crates/zeph-memory/src/store/agent_sessions.rs
@@ -165,7 +165,7 @@ pub struct AgentSessionRow {
     pub status: SessionStatus,
     /// Channel over which the session runs.
     pub channel: SessionChannel,
-    /// LLM model name (e.g. `claude-sonnet-4-6`).
+    /// LLM model name (e.g. `claude-sonnet-5`).
     pub model: String,
     /// ISO-8601 creation timestamp (UTC).
     pub created_at: String,
@@ -421,7 +421,7 @@ mod tests {
             kind: SessionKind::Interactive,
             status: SessionStatus::Active,
             channel: SessionChannel::Cli,
-            model: "claude-sonnet-4-6".to_owned(),
+            model: "claude-sonnet-5".to_owned(),
             created_at: "2026-01-01T00:00:00".to_owned(),
             last_active_at: "2026-01-01T00:00:00".to_owned(),
             turns: 0,

--- a/crates/zeph-subagent/README.md
+++ b/crates/zeph-subagent/README.md
@@ -59,7 +59,7 @@ zeph agents delete researcher
 ---
 name: researcher
 description: Performs web research tasks
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 max_turns: 20
 tools: [web_scrape, read_file]
 skills: [research]

--- a/crates/zeph-subagent/src/def.rs
+++ b/crates/zeph-subagent/src/def.rs
@@ -1814,7 +1814,7 @@ mod tests {
             ---
             name: full-agent
             description: Full featured agent
-            model: claude-opus-4-6
+            model: claude-opus-4-8
             tools:
               allow:
                 - shell
@@ -1834,7 +1834,7 @@ mod tests {
         "};
         let def = SubAgentDef::parse(content).unwrap();
         let md = def.serialize_to_markdown();
-        assert!(md.contains("model: claude-opus-4-6"));
+        assert!(md.contains("model: claude-opus-4-8"));
         assert!(md.contains("except:"));
         assert!(md.contains("shell_sudo"));
         assert!(md.contains("background: true"));

--- a/crates/zeph-tui/src/app/tests.rs
+++ b/crates/zeph-tui/src/app/tests.rs
@@ -1930,7 +1930,7 @@ fn draw_header_shows_1m_ctx_badge_when_extended_context() {
 
     let (mut app, _rx, _tx) = make_app();
     app.metrics.provider_name = "claude".into();
-    app.metrics.model_name = "claude-sonnet-4-6".into();
+    app.metrics.model_name = "claude-sonnet-5".into();
     app.metrics.extended_context = true;
 
     let output = render_to_string(80, 1, |frame, area| {
@@ -1948,7 +1948,7 @@ fn draw_header_no_badge_without_extended_context() {
 
     let (mut app, _rx, _tx) = make_app();
     app.metrics.provider_name = "claude".into();
-    app.metrics.model_name = "claude-sonnet-4-6".into();
+    app.metrics.model_name = "claude-sonnet-5".into();
     app.metrics.extended_context = false;
 
     let output = render_to_string(80, 1, |frame, area| {

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -961,7 +961,7 @@ mod tests {
         let (_, agent_rx) = mpsc::channel(1);
         let app = App::new(user_tx, agent_rx);
         let metrics = MetricsSnapshot {
-            model_name: "claude-sonnet-4-6".into(),
+            model_name: "claude-sonnet-5".into(),
             context_tokens: 8_000,
             context_max_tokens: 100_000,
             total_tokens: 12_500,

--- a/specs/003-llm-providers/spec.md
+++ b/specs/003-llm-providers/spec.md
@@ -111,7 +111,7 @@ AnyProvider { Claude, OpenAI, Ollama, Compatible, Candle, Gemini }
 [[llm.providers]]
 name = "quality"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 prompt_cache_ttl = "1h"   # "ephemeral" (default) or "1h"
 ```
 
@@ -158,7 +158,7 @@ embed = true
 [[llm.providers]]
 name = "quality"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 default = true
 ```

--- a/specs/022-config-simplification/spec.md
+++ b/specs/022-config-simplification/spec.md
@@ -139,7 +139,7 @@ embedding_model = "qwen3-embedding"
 [llm]
 [[llm.providers]]
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 # thinking = { type = "enabled", budget_tokens = 10000 }
 # server_compaction = false
@@ -165,7 +165,7 @@ embed = true          # this provider handles embeddings
 [[llm.providers]]
 name = "cloud"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 default = true        # primary provider for chat (overrides position-based default)
 
@@ -213,7 +213,7 @@ max_tokens = 8192
 [[llm.providers]]
 name = "quality"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 ```
 
@@ -407,10 +407,10 @@ pub enum RoutingStrategy {
 [llm]
 provider = "orchestrator"
 base_url = "http://localhost:11434"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 
 [llm.cloud]
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 
 [llm.orchestrator]
@@ -419,7 +419,7 @@ embed = "ollama"
 
 [llm.orchestrator.providers.claude]
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 
 [llm.orchestrator.providers.ollama]
 type = "ollama"
@@ -443,7 +443,7 @@ chat = ["claude", "ollama"]
 [[llm.providers]]
 name = "claude"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 max_tokens = 4096
 default = true
 
@@ -694,7 +694,7 @@ embed = true
 [[llm.providers]]
 name = "quality"
 type = "claude"
-model = "claude-sonnet-4-6"
+model = "claude-sonnet-5"
 ```
 
 ### Bandit State Persistence

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -143,7 +143,7 @@ fn create_provider_claude_without_api_key_errors() {
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
     config.llm.providers = vec![ProviderEntry {
         provider_type: ProviderKind::Claude,
-        model: Some("claude-sonnet-4-6".into()),
+        model: Some("claude-sonnet-5".into()),
         max_tokens: Some(4096),
         ..ProviderEntry::default()
     }];

--- a/src/init/agents.rs
+++ b/src/init/agents.rs
@@ -237,7 +237,7 @@ pub(super) fn step_learning(state: &mut WizardState) -> anyhow::Result<()> {
             state.detector_mode = Some("judge".into());
             let judge_model: String = Input::new()
                 .with_prompt(
-                    "Judge model name (e.g. claude-sonnet-4-6; leave empty to use primary provider)",
+                    "Judge model name (e.g. claude-sonnet-5; leave empty to use primary provider)",
                 )
                 .default(String::new())
                 .interact_text()?;


### PR DESCRIPTION
## Summary

- Sweeps superseded Claude model IDs (`claude-sonnet-4-6`, `claude-opus-4-6`) to the current recommended defaults (`claude-sonnet-5`, `claude-opus-4-8`) across docs, config examples, source comments, and test fixtures.
- Replaces `ClaudeProvider::new()`'s hardcoded `claude-3`-prefix staleness check (from #1625) with a generalized per-family minimum-version-floor mechanism (`MODERN_MODEL_FLOORS` + `stale_model_suggestion()`), so future point-release retirements are a one-line table bump instead of a new hardcoded literal.
- Widens `ThinkingCapability::prefers_effort` to Opus 4.7/4.8 and Sonnet 5, which remove `budget_tokens` entirely (400 if sent) rather than just deprecating it. `needs_interleaved_beta` stays scoped to legacy Sonnet 4.6 since the new generation enables interleaved thinking automatically under adaptive thinking with no beta header.
- Adds `cost.rs` pricing rows for the new models alongside the retained 4.6 rows (still-Active, still priced) — an intentional exception, noted in the CHANGELOG.
- Adds permanent `#[ignore]`-gated live-API tests (`crates/zeph-llm/tests/claude_live.rs`) covering the effort-conversion and prefill-strip round-trips on the new generation, since `prefers_effort` also gates prefill handling (`mod.rs:861`).

Closes #5889.

## Why draft

This PR touches `crates/zeph-llm/src/claude/types.rs`'s capability-gate logic (`thinking_capability()`), which per this repo's LLM-serialization live-test gate requires a real API round-trip before merge — not just unit tests. **The vault's `ZEPH_CLAUDE_API_KEY` currently has a zero credit balance** (confirmed via raw `curl` against `api.anthropic.com` with three different request bodies, including a deliberately invalid model string — all three returned the identical billing error, so this is an account/billing issue, not a code defect). The two new tests in `claude_live.rs` are ready to run (`cargo nextest run -p zeph-llm -- --ignored claude_live`) as soon as a funded key is available. Will mark ready for review once that gate passes.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12515 passed, 0 failed, 35 skipped
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` (zeph-llm: 24/24)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] Unit tests for `stale_model_suggestion()` covering old-gen/current-gen/future-fail-open/legacy-claude-3/non-Claude-alias branches
- [x] Unit tests for `thinking_capability()`'s new arms (Opus 4.7/4.8, Sonnet 5)
- [x] Repo-wide grep confirms zero remaining stale 4-6 refs outside documented exceptions (retained 4-6 pricing/capability rows, historical CHANGELOG entries, out-of-scope adjacent-generation 4-5 examples)
- [ ] Live-API serialization gate (`claude_live.rs`, both tests) — **blocked on funded vault key**, see above

## Notes for reviewers

- Scope is strict 4-6-only per the issue; adjacent-generation `claude-sonnet-4-5`/`claude-opus-4-5` doc examples are intentionally untouched (pre-existing staleness, separate concern).
- `book/src/advanced/context.md:511` has a pre-existing incorrect model ID (`claude-sonnet-4-5-20250514`, wrong date) unrelated to this sweep — left untouched, follow-up issue to be filed separately.
- The prefill-strip gate (`mod.rs:859`) is *not* modified directly in this PR, but `prefers_effort`'s widening incidentally also affects it (both flow through the same field) — a residual gap (new-gen with thinking off; legacy `claude-sonnet-4-6`) is being tracked as a separate follow-up.