### PR TITLE
fix(acp): scope persisted session listing/loading to owning client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Added
 
+- `feat(acp)`: `[[acp.auth_clients]]` — named bearer-token clients for the ACP HTTP/WS
+  transport (#5868), enabling genuine multi-tenant/multi-window isolation of persisted ACP
+  session listing. `crates/zeph-acp/src/transport/auth.rs`'s `BearerAuthLayer` now authenticates
+  against a named-client credential set instead of one server-wide token; the matched client's
+  stable `id` becomes the connection's `owner_key`, threaded through `build_agent_state` and
+  scoping every session-persistence access path (`list_sessions`, `load_session`,
+  `resume_session`, `fork_session`, the REST `/sessions*` CRUD handlers, and the deprecated
+  `_session/*` ext methods). The legacy `[acp] auth_token` scalar keeps working unchanged,
+  synthesized as a client with id `"default"`; unauthenticated HTTP and stdio both resolve to
+  the `"acp-local"` bucket, matching pre-#5868 behavior for every deployment that does not
+  configure `auth_clients`. Each entry accepts an inline `token` or a `token_vault_key` resolved
+  from the age vault at startup (mirrors `[serve] auth_token_vault_key`). Config validation
+  rejects the reserved ids `"default"`/`"acp-local"`, duplicate ids, and duplicate tokens across
+  `auth_token` + `auth_clients` (inline collisions at config-load time; vault-resolved
+  collisions at startup, after the vault unlocks). `--init` gained a matching wizard prompt and
+  `migrate-config` a new step (77) that surfaces the new array as a commented block.
+  Note: this closes the isolation gap for genuine multi-token **HTTP/WS** deployments only — the
+  literal Zed-over-stdio scenario from the issue is unaffected by this change (stdio has no
+  token multiplexing to redesign; use distinct `sqlite_path` values per window instead).
 - `feat(llm,commands,core)`: added runtime `/think-tokens [N|Nk|NM|off]` and
   `/reasoning-effort [low|medium|high]` slash commands that mutate the active LLM provider's
   thinking-token budget or reasoning-effort level mid-session, taking effect on the very next
@@ -70,6 +89,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`crates/zeph-gateway/src/server.rs`), discarding the original `std::io::Error` entirely — it
   now carries the typed error through directly, matching the convention already used by sibling
   crates (`zeph-orchestration`, `zeph-mcp`) (#5863).
+- `fix(acp,memory,db)`: ACP persisted-session listing and loading (`do_list_sessions`,
+  `do_load_session`, `do_resume_session`, `do_fork_session` in `crates/zeph-acp/src/agent/mod.rs`,
+  the REST `/sessions*` handlers, and the deprecated `_session/*` ext methods) previously queried
+  the shared `acp_sessions` table with no owner scoping at all — every ACP connection (any
+  bearer token, or any stdio process sharing the same SQLite path) could list, load, resume, or
+  delete every other connection's persisted sessions (#5868). Added a nullable `owner_key`
+  column (migration 108, sqlite + postgres) stamped with the connection's authenticated identity
+  (see the `[[acp.auth_clients]]` entry above); `NULL` rows are legacy pre-fix rows or
+  non-ACP-channel rows (CLI/TUI/Telegram via `zeph_session::SessionStore::create`, spec-068
+  Decision D1) and are never scoped by ACP handlers. Loading/resuming/forking a legacy
+  `NULL`-owner row atomically claims it for the current connection via a single
+  `UPDATE ... WHERE (owner_key IS NULL OR owner_key = ?) RETURNING id` statement — no
+  read-then-claim race window — and uniformly reports "not found" for both a missing session and
+  one owned by a different connection, so a foreign `owner_key` can never be distinguished from a
+  nonexistent id. Also corrected the `ZephAcpAgentState` doc comment, which incorrectly claimed
+  the struct is shared across all connections — a fresh instance is built per connection by
+  `build_agent_state`.
 - `fix(skills)`: `skills.group_structured`, `skills.support_similarity_threshold`, and
   `skills.min_injection_score` are now wired into the `Agent` at cold start (`src/runner.rs`,
   `src/daemon.rs`, `src/acp.rs`, `src/serve/agent_factory.rs`), matching how `Agent::reload_config`

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -550,10 +550,11 @@ impl SessionEntry {
 
 type SessionMap = Arc<Mutex<std::collections::HashMap<acp::schema::v1::SessionId, SessionEntry>>>;
 
-/// ACP agent state shared across all connections.
+/// Per-connection ACP agent state.
 ///
-/// Wraps session management, configuration, and per-session tool executors.
-/// Pass an `Arc<ZephAcpAgentState>` to [`run_agent`] to drive the dispatch loop.
+/// A fresh instance is built per ACP connection by `build_agent_state` — it is **not** shared
+/// across connections. Wraps session management, configuration, and per-session tool
+/// executors. Pass an `Arc<ZephAcpAgentState>` to [`run_agent`] to drive the dispatch loop.
 pub struct ZephAcpAgentState {
     pub(crate) spawner: AgentSpawner,
     pub(crate) sessions: SessionMap,
@@ -617,6 +618,10 @@ pub struct ZephAcpAgentState {
     /// Connection-scoped provider overrides (no `session_id` in ACP schema).
     #[cfg(feature = "unstable-llm-providers")]
     pub(crate) global_provider_overrides: Mutex<HashMap<String, ProviderSetOverride>>,
+    /// Authenticated identity of this connection (#5868), scoping persisted ACP session
+    /// list/load/resume. `"acp-local"` for stdio and unauthenticated HTTP; the matched
+    /// bearer-token client id for authenticated HTTP/WS. Set once in `build_agent_state`.
+    pub(crate) owner_key: String,
 }
 
 /// Backward-compatible alias.
@@ -670,7 +675,15 @@ impl ZephAcpAgentState {
             global_disabled_providers: Mutex::new(HashSet::new()),
             #[cfg(feature = "unstable-llm-providers")]
             global_provider_overrides: Mutex::new(HashMap::new()),
+            owner_key: crate::transport::OWNER_KEY_LOCAL.to_owned(),
         }
+    }
+
+    /// Set this connection's owner identity (#5868) — see the `owner_key` field doc.
+    #[must_use]
+    pub fn with_owner_key(mut self, owner_key: impl Into<String>) -> Self {
+        self.owner_key = owner_key.into();
+        self
     }
 
     /// Configure the additional-directories allowlist policy.
@@ -1738,15 +1751,18 @@ impl ZephAcpAgentState {
             return Err(acp::Error::internal_error().data("session not found"));
         };
 
-        let exists = store
-            .acp_session_exists(&args.session_id.to_string())
+        // Atomic claim-on-load (#5868): scopes access to this connection's owner_key and
+        // self-heals legacy NULL-owner rows by claiming them on first load. Returns false
+        // uniformly for "doesn't exist" and "owned by a different owner" — no info leak.
+        let claimed = store
+            .claim_acp_session_for_owner(&args.session_id.to_string(), &self.owner_key)
             .await
             .map_err(|e| {
                 tracing::warn!(error = %e, session_id = %args.session_id, "failed to check ACP session existence");
                 acp::Error::internal_error().data("internal error")
             })?;
 
-        if !exists {
+        if !claimed {
             return Err(acp::Error::internal_error().data("session not found"));
         }
 
@@ -1859,7 +1875,10 @@ impl ZephAcpAgentState {
         };
 
         if let Some(ref store) = self.store {
-            match store.list_acp_sessions(self.max_history).await {
+            match store
+                .list_acp_sessions_for_owner(self.max_history, &self.owner_key)
+                .await
+            {
                 Ok(persisted) => {
                     for persisted_info in persisted {
                         let sid = acp::schema::v1::SessionId::new(&*persisted_info.id);
@@ -1971,14 +1990,15 @@ impl ZephAcpAgentState {
             match self.store.as_ref() {
                 None => return Err(acp::Error::internal_error().data("session not found")),
                 Some(s) => {
-                    let exists = s
-                        .acp_session_exists(&args.session_id.to_string())
+                    // Atomic claim-on-fork (#5868): same self-healing scoping as do_load_session.
+                    let claimed = s
+                        .claim_acp_session_for_owner(&args.session_id.to_string(), &self.owner_key)
                         .await
                         .map_err(|e| {
                             tracing::warn!(error = %e, "failed to check ACP session existence");
                             acp::Error::internal_error().data("internal error")
                         })?;
-                    if !exists {
+                    if !claimed {
                         return Err(acp::Error::internal_error().data("session not found"));
                     }
                 }
@@ -2104,15 +2124,16 @@ impl ZephAcpAgentState {
             return Err(acp::Error::internal_error().data("session not found"));
         };
 
-        let exists = store
-            .acp_session_exists(&args.session_id.to_string())
+        // Atomic claim-on-resume (#5868) — see do_load_session.
+        let claimed = store
+            .claim_acp_session_for_owner(&args.session_id.to_string(), &self.owner_key)
             .await
             .map_err(|e| {
                 tracing::warn!(error = %e, session_id = %args.session_id, "failed to check ACP session existence");
                 acp::Error::internal_error().data("internal error")
             })?;
 
-        if !exists {
+        if !claimed {
             return Err(acp::Error::internal_error().data("session not found"));
         }
 
@@ -2508,13 +2529,17 @@ impl ZephAcpAgentState {
                 if let Some(ref store) = self.store {
                     let sid = session_id.to_string();
                     let store = store.clone();
+                    let owner_key = self.owner_key.clone();
                     // EXEMPT(#5144): fire-and-forget DB delete+recreate; independent per-session
                     // operation — supervisor adds no meaningful lifecycle observability here.
                     tokio::spawn(async move {
-                        if let Err(e) = store.delete_acp_session_checked(&sid).await {
+                        // Scoped to owner (#5868): this is our own session (already established
+                        // for this connection), so `_for_owner` here is a defense-in-depth match
+                        // of the create below, not a new access-control decision.
+                        if let Err(e) = store.delete_acp_session_for_owner(&sid, &owner_key).await {
                             tracing::warn!(error = %e, "failed to clear session history");
                         }
-                        if let Err(e) = store.create_acp_session(&sid).await {
+                        if let Err(e) = store.create_acp_session(&sid, Some(&owner_key)).await {
                             tracing::warn!(error = %e, "failed to recreate session after clear");
                         }
                     });
@@ -2949,6 +2974,7 @@ impl ZephAcpAgentState {
                 &new_id_str,
                 None,
                 &session_store,
+                Some(self.owner_key.as_str()),
             )
             .await
             {
@@ -2978,7 +3004,11 @@ impl ZephAcpAgentState {
                         tracing::warn!(error = %e, "failed to link conversation to forked session");
                     }
                 } else if let Err(e) = s
-                    .create_acp_session_with_conversation(&new_id_str, forked_cid)
+                    .create_acp_session_with_conversation(
+                        &new_id_str,
+                        forked_cid,
+                        Some(&self.owner_key),
+                    )
                     .await
                 {
                     tracing::warn!(error = %e, "failed to persist forked ACP session mapping");
@@ -2993,7 +3023,9 @@ impl ZephAcpAgentState {
             Err(e) => {
                 tracing::warn!(error = %e, "failed to create conversation for forked session; history will not be copied");
                 if self.session_data_dir.is_none()
-                    && let Err(e2) = s.create_acp_session(&new_id_str).await
+                    && let Err(e2) = s
+                        .create_acp_session(&new_id_str, Some(&self.owner_key))
+                        .await
                 {
                     tracing::warn!(error = %e2, "failed to persist forked ACP session");
                 }
@@ -3183,14 +3215,17 @@ impl ZephAcpAgentState {
         let sid = session_id.to_string();
         match store.create_conversation().await {
             Ok(cid) => {
-                if let Err(e) = store.create_acp_session_with_conversation(&sid, cid).await {
+                if let Err(e) = store
+                    .create_acp_session_with_conversation(&sid, cid, Some(&self.owner_key))
+                    .await
+                {
                     tracing::warn!(error = %e, "failed to persist ACP session mapping; history may not survive restart");
                 }
                 Some(cid)
             }
             Err(e) => {
                 tracing::warn!(error = %e, "failed to create conversation for ACP session; session will have no persistent history");
-                if let Err(e2) = store.create_acp_session(&sid).await {
+                if let Err(e2) = store.create_acp_session(&sid, Some(&self.owner_key)).await {
                     tracing::warn!(error = %e2, "failed to persist ACP session");
                 }
                 None

--- a/crates/zeph-acp/src/custom.rs
+++ b/crates/zeph-acp/src/custom.rs
@@ -211,9 +211,11 @@ async fn handle_session_list(
     let mut sessions: std::collections::HashMap<String, SessionListEntry> =
         std::collections::HashMap::with_capacity(in_memory.len());
 
-    // Load persisted sessions first (lower priority, overridden by in-memory).
+    // Load persisted sessions first (lower priority, overridden by in-memory). Scoped to this
+    // connection's owner (#5868) — this deprecated ext method predates owner scoping and was
+    // otherwise as unscoped as the native `list_sessions` handler it is superseded by.
     if let Some(ref store) = agent.store {
-        match store.list_acp_sessions(0).await {
+        match store.list_acp_sessions_for_owner(0, &agent.owner_key).await {
             Ok(rows) => {
                 sessions.reserve(rows.len());
                 for row in rows {
@@ -272,11 +274,12 @@ async fn handle_session_get(
     if !in_memory {
         match &agent.store {
             Some(store) => {
-                let exists = store
-                    .acp_session_exists(sid)
+                // Read-only gate (#5868): does not claim a legacy NULL row.
+                let accessible = store
+                    .acp_session_accessible_for_owner(sid, &agent.owner_key)
                     .await
                     .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
-                if !exists {
+                if !accessible {
                     return Err(session_not_found());
                 }
             }
@@ -327,7 +330,10 @@ async fn handle_session_delete(
     }
 
     let removed_store = if let Some(ref store) = agent.store {
-        match store.delete_acp_session_checked(&params.session_id).await {
+        match store
+            .delete_acp_session_for_owner(&params.session_id, &agent.owner_key)
+            .await
+        {
             Ok(existed) => existed,
             Err(e) => {
                 tracing::warn!(error = %e, session_id = %params.session_id, "failed to delete ACP session from store");
@@ -351,16 +357,28 @@ async fn handle_session_export(
     validate_session_id(&params.session_id)?;
 
     let events = match &agent.store {
-        Some(store) => store
-            .load_acp_events(&params.session_id)
-            .await
-            .map_err(|e| acp::Error::internal_error().data(e.to_string()))?
-            .into_iter()
-            .map(|e| SessionEventEntry {
-                event_type: e.event_type,
-                payload: e.payload,
-            })
-            .collect(),
+        Some(store) => {
+            // Read-only gate (#5868): `load_acp_events` itself has no owner column to filter
+            // on (it's keyed by session_id only), so ownership must be checked here before
+            // reading — this handler previously had no existence/ownership check at all.
+            let accessible = store
+                .acp_session_accessible_for_owner(&params.session_id, &agent.owner_key)
+                .await
+                .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
+            if !accessible {
+                return Err(session_not_found());
+            }
+            store
+                .load_acp_events(&params.session_id)
+                .await
+                .map_err(|e| acp::Error::internal_error().data(e.to_string()))?
+                .into_iter()
+                .map(|e| SessionEventEntry {
+                    event_type: e.event_type,
+                    payload: e.payload,
+                })
+                .collect()
+        }
         None => vec![],
     };
 
@@ -386,7 +404,7 @@ async fn handle_session_import(
 
     if let Some(ref store) = agent.store {
         store
-            .create_acp_session(&new_id)
+            .create_acp_session(&new_id, Some(&agent.owner_key))
             .await
             .map_err(|e| acp::Error::internal_error().data(e.to_string()))?;
         let pairs: Vec<(&str, &str)> = params

--- a/crates/zeph-acp/src/lib.rs
+++ b/crates/zeph-acp/src/lib.rs
@@ -94,7 +94,10 @@ pub use lsp::{AcpLspProvider, DiagnosticsCache, LspProvider};
 pub use mcp_bridge::acp_mcp_servers_to_entries;
 pub use permission::AcpPermissionGate;
 pub use terminal::AcpShellExecutor;
-pub use transport::{AcpServerConfig, serve_connection, serve_stdio};
+pub use transport::{
+    AcpClientToken, AcpServerConfig, OWNER_KEY_DEFAULT, OWNER_KEY_LOCAL, serve_connection,
+    serve_stdio,
+};
 
 #[cfg(feature = "acp-http")]
 pub use agent::SendAgentSpawner;

--- a/crates/zeph-acp/src/transport/auth.rs
+++ b/crates/zeph-acp/src/transport/auth.rs
@@ -7,6 +7,14 @@
 //! timing side-channels. Both the provided and expected tokens are hashed to
 //! fixed-length digests before comparison, eliminating the length side-channel
 //! present in direct byte comparison.
+//!
+//! Supports multiple named clients (#5868): each configured
+//! [`AcpClientToken`](crate::transport::AcpClientToken) authenticates its own token, and on
+//! match the matched client's `id` is injected as [`TokenIdentity`] into the request's
+//! extensions — downstream handlers read it to derive the connection's `owner_key` for ACP
+//! session-persistence scoping.
+
+use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, Response, StatusCode, header};
@@ -14,17 +22,28 @@ use axum::response::IntoResponse;
 use subtle::ConstantTimeEq as _;
 use tower::{Layer, Service};
 
-/// Tower middleware layer that validates `Authorization: Bearer <token>` headers
-/// using constant-time comparison to prevent timing attacks.
+use crate::transport::AcpClientToken;
+
+/// Authenticated client identity, injected into request extensions by [`BearerAuthLayer`] on
+/// a successful bearer-token match. Absent when no auth layer is applied (empty client list).
+///
+/// `pub` (not `pub(crate)`) solely so it can appear as an `axum` extractor parameter type on
+/// the `pub` HTTP handler functions in this crate; it is not part of the crate's documented
+/// public API (not re-exported at the crate root).
+#[derive(Clone, Debug)]
+pub struct TokenIdentity(pub(crate) String);
+
+/// Tower middleware layer that validates `Authorization: Bearer <token>` headers against a
+/// named-client credential set, using constant-time comparison to prevent timing attacks.
 #[derive(Clone)]
 pub(crate) struct BearerAuthLayer {
-    token: String,
+    clients: Arc<Vec<AcpClientToken>>,
 }
 
 impl BearerAuthLayer {
-    pub(crate) fn new(token: impl Into<String>) -> Self {
+    pub(crate) fn new(clients: Vec<AcpClientToken>) -> Self {
         Self {
-            token: token.into(),
+            clients: Arc::new(clients),
         }
     }
 }
@@ -35,7 +54,7 @@ impl<S> Layer<S> for BearerAuthLayer {
     fn layer(&self, inner: S) -> Self::Service {
         BearerAuthMiddleware {
             inner,
-            token: self.token.clone(),
+            clients: Arc::clone(&self.clients),
         }
     }
 }
@@ -44,7 +63,19 @@ impl<S> Layer<S> for BearerAuthLayer {
 #[derive(Clone)]
 pub(crate) struct BearerAuthMiddleware<S> {
     inner: S,
-    token: String,
+    clients: Arc<Vec<AcpClientToken>>,
+}
+
+/// Find the first configured client whose token matches `provided`, in configured order.
+/// Every candidate is compared via hashed constant-time equality (no early exit on token
+/// bytes) — only the outer `find` short-circuits on which candidate matched, which config
+/// validation (unique tokens) already makes a non-issue in practice.
+fn match_client<'a>(clients: &'a [AcpClientToken], provided: &str) -> Option<&'a AcpClientToken> {
+    let h_provided = blake3::hash(provided.as_bytes());
+    clients.iter().find(|c| {
+        let h_expected = blake3::hash(c.token.as_bytes());
+        bool::from(h_provided.as_bytes().ct_eq(h_expected.as_bytes()))
+    })
 }
 
 impl<S> Service<Request<Body>> for BearerAuthMiddleware<S>
@@ -65,23 +96,17 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
-        let expected = self.token.clone();
-
-        let authorized = req
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        let matched = req
             .headers()
             .get(header::AUTHORIZATION)
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "))
-            // Hash both sides first so ct_eq operates on fixed-length digests,
-            // eliminating the length side-channel present in direct byte comparison.
-            .is_some_and(|provided| {
-                let h_provided = blake3::hash(provided.as_bytes());
-                let h_expected = blake3::hash(expected.as_bytes());
-                h_provided.as_bytes().ct_eq(h_expected.as_bytes()).into()
-            });
+            .and_then(|provided| match_client(&self.clients, provided))
+            .map(|c| c.id.clone());
 
-        if authorized {
+        if let Some(id) = matched {
+            req.extensions_mut().insert(TokenIdentity(id));
             let fut = self.inner.call(req);
             Box::pin(fut)
         } else {
@@ -99,47 +124,87 @@ mod tests {
 
     use super::*;
 
+    fn client(id: &str, token: &str) -> AcpClientToken {
+        AcpClientToken {
+            id: id.to_owned(),
+            token: token.to_owned(),
+        }
+    }
+
     fn ok_handler() -> axum::Router {
-        axum::Router::new().route("/", get(|| async { StatusCode::OK }))
+        axum::Router::new().route(
+            "/",
+            get(|req: Request<Body>| async move {
+                req.extensions()
+                    .get::<TokenIdentity>()
+                    .map_or_else(String::new, |id| id.0.clone())
+            }),
+        )
     }
 
-    fn app_with_token(token: &str) -> axum::Router {
-        ok_handler().layer(BearerAuthLayer::new(token))
+    fn app_with_clients(clients: Vec<AcpClientToken>) -> axum::Router {
+        ok_handler().layer(BearerAuthLayer::new(clients))
     }
 
-    async fn send(app: axum::Router, auth: Option<&str>) -> StatusCode {
+    async fn send(app: axum::Router, auth: Option<&str>) -> (StatusCode, String) {
         let mut builder = Request::builder().method("GET").uri("/");
         if let Some(v) = auth {
             builder = builder.header("authorization", v);
         }
         let req = builder.body(Body::empty()).unwrap();
-        app.oneshot(req).await.unwrap().status()
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        (status, String::from_utf8_lossy(&body).into_owned())
     }
 
     #[tokio::test]
-    async fn correct_token_accepted() {
-        let app = app_with_token("my-secret");
-        assert_eq!(send(app, Some("Bearer my-secret")).await, StatusCode::OK);
+    async fn correct_token_accepted_and_identifies_client() {
+        let app = app_with_clients(vec![client("default", "my-secret")]);
+        let (status, body) = send(app, Some("Bearer my-secret")).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "default");
     }
 
     #[tokio::test]
     async fn wrong_token_rejected() {
-        let app = app_with_token("my-secret");
+        let app = app_with_clients(vec![client("default", "my-secret")]);
         assert_eq!(
-            send(app, Some("Bearer wrong")).await,
+            send(app, Some("Bearer wrong")).await.0,
             StatusCode::UNAUTHORIZED
         );
     }
 
     #[tokio::test]
     async fn empty_token_rejected() {
-        let app = app_with_token("my-secret");
-        assert_eq!(send(app, Some("Bearer ")).await, StatusCode::UNAUTHORIZED);
+        let app = app_with_clients(vec![client("default", "my-secret")]);
+        assert_eq!(send(app, Some("Bearer ")).await.0, StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
     async fn missing_header_rejected() {
-        let app = app_with_token("my-secret");
-        assert_eq!(send(app, None).await, StatusCode::UNAUTHORIZED);
+        let app = app_with_clients(vec![client("default", "my-secret")]);
+        assert_eq!(send(app, None).await.0, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn multi_client_each_token_identifies_its_own_client() {
+        let app = app_with_clients(vec![client("alice", "token-a"), client("bob", "token-b")]);
+        let (status_a, body_a) = send(app.clone(), Some("Bearer token-a")).await;
+        assert_eq!(status_a, StatusCode::OK);
+        assert_eq!(body_a, "alice");
+
+        let (status_b, body_b) = send(app, Some("Bearer token-b")).await;
+        assert_eq!(status_b, StatusCode::OK);
+        assert_eq!(body_b, "bob");
+    }
+
+    #[tokio::test]
+    async fn multi_client_unknown_token_rejected() {
+        let app = app_with_clients(vec![client("alice", "token-a"), client("bob", "token-b")]);
+        assert_eq!(
+            send(app, Some("Bearer token-c")).await.0,
+            StatusCode::UNAUTHORIZED
+        );
     }
 }

--- a/crates/zeph-acp/src/transport/crud.rs
+++ b/crates/zeph-acp/src/transport/crud.rs
@@ -169,6 +169,7 @@ async fn validate_working_dir(
 /// Returns `500 Internal Server Error` if the database write fails.
 pub async fn create_session_handler(
     State(state): State<AcpHttpState>,
+    token_identity: Option<axum::extract::Extension<super::auth::TokenIdentity>>,
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<impl IntoResponse, StatusCode> {
     if !state.ready.load(std::sync::atomic::Ordering::Acquire) {
@@ -182,17 +183,24 @@ pub async fn create_session_handler(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
+    let owner_key = super::http::derive_owner_key(token_identity.as_ref().map(|e| &e.0));
     let session_id = uuid::Uuid::new_v4().to_string();
 
-    store.create_acp_session(&session_id).await.map_err(|e| {
-        tracing::warn!(error = %e, "failed to create ACP session");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    store
+        .create_acp_session(&session_id, Some(&owner_key))
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "failed to create ACP session");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
-    let info = store.get_acp_session_info(&session_id).await.map_err(|e| {
-        tracing::warn!(error = %e, "failed to retrieve created ACP session");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let info = store
+        .get_acp_session_info_for_owner(&session_id, &owner_key)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "failed to retrieve created ACP session");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     let Some(info) = info else {
         tracing::warn!(session_id, "created ACP session not found immediately");
@@ -213,6 +221,7 @@ pub async fn create_session_handler(
 /// Returns `500 Internal Server Error` if the database query fails.
 pub async fn get_session_handler(
     State(state): State<AcpHttpState>,
+    token_identity: Option<axum::extract::Extension<super::auth::TokenIdentity>>,
     Path(session_id): Path<String>,
 ) -> Result<impl IntoResponse, StatusCode> {
     if !state.ready.load(std::sync::atomic::Ordering::Acquire) {
@@ -225,8 +234,9 @@ pub async fn get_session_handler(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
+    let owner_key = super::http::derive_owner_key(token_identity.as_ref().map(|e| &e.0));
     let info = store
-        .get_acp_session_info(&session_id)
+        .get_acp_session_info_for_owner(&session_id, &owner_key)
         .await
         .map_err(|e| {
             tracing::warn!(error = %e, "failed to get ACP session info");
@@ -251,6 +261,7 @@ pub async fn get_session_handler(
 /// Returns `500 Internal Server Error` if the database write or subsequent query fails.
 pub async fn update_session_handler(
     State(state): State<AcpHttpState>,
+    token_identity: Option<axum::extract::Extension<super::auth::TokenIdentity>>,
     Path(session_id): Path<String>,
     Json(req): Json<UpdateSessionRequest>,
 ) -> Result<impl IntoResponse, StatusCode> {
@@ -270,26 +281,30 @@ pub async fn update_session_handler(
         return Err(StatusCode::BAD_REQUEST);
     }
 
+    let owner_key = super::http::derive_owner_key(token_identity.as_ref().map(|e| &e.0));
     let found = if let Some(title) = req.title {
         store
-            .update_session_title_checked(&session_id, &title)
+            .update_session_title_for_owner(&session_id, &title, &owner_key)
             .await
             .map_err(|e| {
                 tracing::warn!(error = %e, "failed to update ACP session title");
                 StatusCode::INTERNAL_SERVER_ERROR
             })?
     } else {
-        store.acp_session_exists(&session_id).await.map_err(|e| {
-            tracing::warn!(error = %e, "failed to check ACP session existence");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?
+        store
+            .acp_session_accessible_for_owner(&session_id, &owner_key)
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, "failed to check ACP session existence");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?
     };
     if !found {
         return Err(StatusCode::NOT_FOUND);
     }
 
     let info = store
-        .get_acp_session_info(&session_id)
+        .get_acp_session_info_for_owner(&session_id, &owner_key)
         .await
         .map_err(|e| {
             tracing::warn!(error = %e, "failed to fetch updated ACP session info");
@@ -306,7 +321,9 @@ pub async fn update_session_handler(
 /// Active in-memory connections for the session are also dropped.
 /// Returns `204 No Content` on success.
 ///
-/// Single-tenant only: any authenticated caller can delete any session.
+/// Scoped to the caller's owner identity (#5868): only sessions owned by the caller, or
+/// unowned legacy/non-ACP rows, can be deleted — a session owned by a different client is
+/// reported as `404 Not Found`, identical to a nonexistent id.
 ///
 /// # Errors
 ///
@@ -316,6 +333,7 @@ pub async fn update_session_handler(
 /// Returns `500 Internal Server Error` if the database delete fails.
 pub async fn delete_session_handler(
     State(state): State<AcpHttpState>,
+    token_identity: Option<axum::extract::Extension<super::auth::TokenIdentity>>,
     Path(session_id): Path<String>,
 ) -> Result<impl IntoResponse, StatusCode> {
     if !state.ready.load(std::sync::atomic::Ordering::Acquire) {
@@ -328,8 +346,9 @@ pub async fn delete_session_handler(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
+    let owner_key = super::http::derive_owner_key(token_identity.as_ref().map(|e| &e.0));
     let deleted = store
-        .delete_acp_session_checked(&session_id)
+        .delete_acp_session_for_owner(&session_id, &owner_key)
         .await
         .map_err(|e| {
             tracing::warn!(error = %e, "failed to delete ACP session");
@@ -691,7 +710,7 @@ mod tests {
             .store
             .as_ref()
             .unwrap()
-            .create_acp_session(&session_id)
+            .create_acp_session(&session_id, Some(crate::transport::OWNER_KEY_LOCAL))
             .await
             .unwrap();
 
@@ -724,7 +743,7 @@ mod tests {
             .store
             .as_ref()
             .unwrap()
-            .create_acp_session(&session_id)
+            .create_acp_session(&session_id, Some(crate::transport::OWNER_KEY_LOCAL))
             .await
             .unwrap();
 
@@ -742,5 +761,174 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    // ── Cross-owner scoping (#5868) ────────────────────────────────────────────
+
+    fn two_clients() -> Vec<crate::transport::AcpClientToken> {
+        vec![
+            crate::transport::AcpClientToken {
+                id: "alice".into(),
+                token: "token-a".into(),
+            },
+            crate::transport::AcpClientToken {
+                id: "bob".into(),
+                token: "token-b".into(),
+            },
+        ]
+    }
+
+    fn build_router_with_auth(
+        state: AcpHttpState,
+        clients: Vec<crate::transport::AcpClientToken>,
+    ) -> Router {
+        build_router(state).layer(crate::transport::auth::BearerAuthLayer::new(clients))
+    }
+
+    fn authed(method: &str, uri: String, bearer: &str) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("authorization", format!("Bearer {bearer}"))
+            .header("content-type", "application/json")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn get_session_cross_owner_returns_404() {
+        let state = state_with_store().await;
+        let app = build_router_with_auth(state, two_clients());
+
+        // alice creates a session.
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sessions")
+                    .header("authorization", "Bearer token-a")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_resp.status(), StatusCode::CREATED);
+        let bytes = axum::body::to_bytes(create_resp.into_body(), 4096)
+            .await
+            .unwrap();
+        let info: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let session_id = info["id"].as_str().unwrap().to_owned();
+
+        // alice can read her own session.
+        let own_resp = app
+            .clone()
+            .oneshot(authed("GET", format!("/sessions/{session_id}"), "token-a"))
+            .await
+            .unwrap();
+        assert_eq!(own_resp.status(), StatusCode::OK);
+
+        // bob cannot — indistinguishable from a missing session.
+        let foreign_resp = app
+            .oneshot(authed("GET", format!("/sessions/{session_id}"), "token-b"))
+            .await
+            .unwrap();
+        assert_eq!(foreign_resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn patch_session_cross_owner_returns_404_and_does_not_update() {
+        let state = state_with_store().await;
+        let app = build_router_with_auth(state, two_clients());
+
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sessions")
+                    .header("authorization", "Bearer token-a")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(create_resp.into_body(), 4096)
+            .await
+            .unwrap();
+        let info: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let session_id = info["id"].as_str().unwrap().to_owned();
+
+        let body = serde_json::json!({ "title": "hijacked" });
+        let foreign_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/sessions/{session_id}"))
+                    .header("authorization", "Bearer token-b")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(foreign_resp.status(), StatusCode::NOT_FOUND);
+
+        // Confirm the title was NOT changed — read it back as the rightful owner.
+        let own_resp = app
+            .oneshot(authed("GET", format!("/sessions/{session_id}"), "token-a"))
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(own_resp.into_body(), 4096)
+            .await
+            .unwrap();
+        let info: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_ne!(info["title"], "hijacked");
+    }
+
+    #[tokio::test]
+    async fn delete_session_cross_owner_returns_404_and_does_not_delete() {
+        let state = state_with_store().await;
+        let app = build_router_with_auth(state, two_clients());
+
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sessions")
+                    .header("authorization", "Bearer token-a")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(create_resp.into_body(), 4096)
+            .await
+            .unwrap();
+        let info: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let session_id = info["id"].as_str().unwrap().to_owned();
+
+        let foreign_resp = app
+            .clone()
+            .oneshot(authed(
+                "DELETE",
+                format!("/sessions/{session_id}"),
+                "token-b",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(foreign_resp.status(), StatusCode::NOT_FOUND);
+
+        // Still there for the rightful owner.
+        let own_resp = app
+            .oneshot(authed("GET", format!("/sessions/{session_id}"), "token-a"))
+            .await
+            .unwrap();
+        assert_eq!(own_resp.status(), StatusCode::OK);
     }
 }

--- a/crates/zeph-acp/src/transport/discovery.rs
+++ b/crates/zeph-acp/src/transport/discovery.rs
@@ -24,10 +24,10 @@ use crate::transport::http::AcpHttpState;
 /// Returns a JSON document describing the agent's identity, supported transports,
 /// and authentication requirements. This endpoint is never behind auth middleware.
 pub async fn discovery_handler(State(state): State<AcpHttpState>) -> impl IntoResponse {
-    let auth = if state.server_config.auth_bearer_token.is_some() {
-        json!({ "type": "bearer" })
-    } else {
+    let auth = if state.server_config.auth_clients.is_empty() {
         Value::Null
+    } else {
+        json!({ "type": "bearer" })
     };
 
     let manifest = json!({

--- a/crates/zeph-acp/src/transport/http.rs
+++ b/crates/zeph-acp/src/transport/http.rs
@@ -328,6 +328,20 @@ pub async fn health_handler(State(state): State<AcpHttpState>) -> impl IntoRespo
     (status, Json(body))
 }
 
+/// Derive the connection's `owner_key` (#5868) from the auth layer's matched identity.
+///
+/// `token_identity` is `Some` only when [`BearerAuthLayer`](super::auth::BearerAuthLayer)
+/// ran and matched a configured client — i.e. `auth_clients` is non-empty. When
+/// `auth_clients` is empty (unauthenticated deployment) or no layer ran, falls back to
+/// [`crate::transport::OWNER_KEY_LOCAL`], the same bucket stdio uses.
+#[cfg(feature = "acp-http")]
+pub(crate) fn derive_owner_key(token_identity: Option<&super::auth::TokenIdentity>) -> String {
+    token_identity.map_or_else(
+        || crate::transport::OWNER_KEY_LOCAL.to_owned(),
+        |t| t.0.clone(),
+    )
+}
+
 /// Spawn an in-process ACP agent connection on a dedicated thread.
 ///
 /// Agent futures are `!Send` (they call `spawn_local` internally), so each connection
@@ -341,6 +355,7 @@ pub async fn health_handler(State(state): State<AcpHttpState>) -> impl IntoRespo
 pub(crate) fn spawn_agent_connection(
     spawner: crate::agent::SendAgentSpawner,
     server_config: AcpServerConfig,
+    owner_key: String,
 ) -> std::io::Result<(DuplexStream, DuplexStream)> {
     let (client_w, agent_r) = tokio::io::duplex(BRIDGE_BUFFER_SIZE);
     let (agent_w, client_r) = tokio::io::duplex(BRIDGE_BUFFER_SIZE);
@@ -360,6 +375,7 @@ pub(crate) fn spawn_agent_connection(
                     server_config,
                     writer,
                     reader,
+                    owner_key,
                 )
                 .await
                 {
@@ -379,18 +395,21 @@ pub(crate) fn spawn_agent_connection(
 #[cfg(feature = "acp-http")]
 pub(crate) fn create_connection(
     state: &AcpHttpState,
+    owner_key: &str,
 ) -> Result<(String, Arc<ConnectionHandle>), StatusCode> {
     if state.connections.len() >= state.server_config.max_sessions {
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
 
-    let (reader, writer) =
-        spawn_agent_connection(state.spawner.clone(), (*state.server_config).clone()).map_err(
-            |e| {
-                tracing::error!("failed to spawn ACP agent thread: {e}");
-                StatusCode::SERVICE_UNAVAILABLE
-            },
-        )?;
+    let (reader, writer) = spawn_agent_connection(
+        state.spawner.clone(),
+        (*state.server_config).clone(),
+        owner_key.to_owned(),
+    )
+    .map_err(|e| {
+        tracing::error!("failed to spawn ACP agent thread: {e}");
+        StatusCode::SERVICE_UNAVAILABLE
+    })?;
 
     let (tx, _) = broadcast::channel(256);
     let tx2 = tx.clone();
@@ -432,6 +451,7 @@ pub(crate) fn create_connection(
 #[tracing::instrument(skip_all, name = "acp.http.post")]
 pub async fn post_handler(
     State(state): State<AcpHttpState>,
+    token_identity: Option<axum::extract::Extension<super::auth::TokenIdentity>>,
     headers: HeaderMap,
     body: String,
 ) -> Result<impl IntoResponse, StatusCode> {
@@ -448,7 +468,8 @@ pub async fn post_handler(
                 .ok_or(StatusCode::NOT_FOUND)?;
             (id.to_owned(), handle)
         } else {
-            create_connection(&state)?
+            let owner_key = derive_owner_key(token_identity.as_ref().map(|e| &e.0));
+            create_connection(&state, &owner_key)?
         };
 
     {
@@ -543,6 +564,7 @@ pub async fn get_handler(
 #[tracing::instrument(skip_all, name = "acp.http.list_sessions")]
 pub async fn list_sessions_handler(
     State(state): State<AcpHttpState>,
+    token_identity: Option<axum::extract::Extension<super::auth::TokenIdentity>>,
 ) -> Result<impl IntoResponse, StatusCode> {
     if !state.ready.load(Ordering::Acquire) {
         return Err(StatusCode::SERVICE_UNAVAILABLE);
@@ -551,8 +573,9 @@ pub async fn list_sessions_handler(
         .store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let owner_key = derive_owner_key(token_identity.as_ref().map(|e| &e.0));
     let sessions = store
-        .list_acp_sessions(state.server_config.max_history)
+        .list_acp_sessions_for_owner(state.server_config.max_history, &owner_key)
         .await
         .map_err(|e| {
             tracing::warn!(error = %e, "failed to list ACP sessions");
@@ -580,6 +603,7 @@ pub async fn list_sessions_handler(
 #[tracing::instrument(skip_all, name = "acp.http.session_messages", fields(session_id = %session_id))]
 pub async fn session_messages_handler(
     State(state): State<AcpHttpState>,
+    token_identity: Option<axum::extract::Extension<super::auth::TokenIdentity>>,
     Path(session_id): Path<String>,
 ) -> Result<impl IntoResponse, StatusCode> {
     if !state.ready.load(Ordering::Acquire) {
@@ -592,11 +616,16 @@ pub async fn session_messages_handler(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
-    let exists = store.acp_session_exists(&session_id).await.map_err(|e| {
-        tracing::warn!(error = %e, "failed to check ACP session existence");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-    if !exists {
+    // Read-only gate (#5868): does not claim a legacy NULL row.
+    let owner_key = derive_owner_key(token_identity.as_ref().map(|e| &e.0));
+    let accessible = store
+        .acp_session_accessible_for_owner(&session_id, &owner_key)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "failed to check ACP session existence");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    if !accessible {
         return Err(StatusCode::NOT_FOUND);
     }
 

--- a/crates/zeph-acp/src/transport/mod.rs
+++ b/crates/zeph-acp/src/transport/mod.rs
@@ -59,6 +59,37 @@ pub struct ReadyNotification {
 /// Thread-safe, shared list of available model identifiers advertised in `new_session`.
 pub type SharedAvailableModels = std::sync::Arc<parking_lot::RwLock<Vec<String>>>;
 
+/// Reserved owner-key sentinels (#5868): the synthesized legacy `auth_token` client id, and
+/// the unauthenticated/stdio owner bucket. `[[acp.auth_clients]]` entries must not use either
+/// (enforced by `zeph_config::AcpConfig::validate_auth_clients`).
+pub const OWNER_KEY_DEFAULT: &str = "default";
+/// See [`OWNER_KEY_DEFAULT`].
+pub const OWNER_KEY_LOCAL: &str = "acp-local";
+
+/// A single named ACP HTTP/WS bearer-token credential (#5868).
+///
+/// Authenticates one `Authorization: Bearer <token>` value against
+/// `BearerAuthLayer` (feature `acp-http`); on match, `id` becomes the request's `owner_key`
+/// for ACP session-persistence scoping. Not gated behind `acp-http` itself because it lives on
+/// the transport-agnostic [`AcpServerConfig`]; only the HTTP/WS transport actually
+/// authenticates against it.
+#[derive(Clone)]
+pub struct AcpClientToken {
+    /// Stable owner label surviving token rotation.
+    pub id: String,
+    /// The bearer token this client authenticates with.
+    pub token: String,
+}
+
+impl std::fmt::Debug for AcpClientToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AcpClientToken")
+            .field("id", &self.id)
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
+}
+
 /// Configuration for the ACP server, threaded through to the agent on every connection.
 ///
 /// Construct with `AcpServerConfig::default()` and override the fields you need.
@@ -102,12 +133,13 @@ pub struct AcpServerConfig {
     pub provider_names: Vec<(String, agent_client_protocol_schema::v1::LlmProtocol)>,
     /// Optional shared MCP manager for `ext_method` add/remove/list.
     pub mcp_manager: Option<std::sync::Arc<zeph_mcp::McpManager>>,
-    /// Bearer token for HTTP and WebSocket transport authentication.
+    /// Named bearer-token clients for HTTP and WebSocket transport authentication (#5868).
     ///
-    /// When `Some`, all `/acp` and `/acp/ws` requests must include the token in
-    /// an `Authorization: Bearer <token>` header. When `None`, the endpoints are
-    /// publicly accessible and a warning is logged at startup.
-    pub auth_bearer_token: Option<String>,
+    /// When non-empty, all `/acp` and `/acp/ws` requests must include a matching token in an
+    /// `Authorization: Bearer <token>` header; the matched client's `id` becomes the
+    /// connection's `owner_key`. When empty, the endpoints are publicly accessible
+    /// (`owner_key` falls back to [`OWNER_KEY_LOCAL`]) and a warning is logged at startup.
+    pub auth_clients: Vec<AcpClientToken>,
     /// Whether to serve the `/.well-known/acp.json` discovery manifest.
     pub discovery_enabled: bool,
     /// Timeout in seconds for terminal command execution before the process is killed.
@@ -156,7 +188,7 @@ impl Clone for AcpServerConfig {
             #[cfg(feature = "unstable-llm-providers")]
             provider_names: self.provider_names.clone(),
             mcp_manager: self.mcp_manager.clone(),
-            auth_bearer_token: self.auth_bearer_token.clone(),
+            auth_clients: self.auth_clients.clone(),
             discovery_enabled: self.discovery_enabled,
             terminal_timeout_secs: self.terminal_timeout_secs,
             project_rules: self.project_rules.clone(),
@@ -187,7 +219,7 @@ impl Default for AcpServerConfig {
             #[cfg(feature = "unstable-llm-providers")]
             provider_names: Vec::new(),
             mcp_manager: None,
-            auth_bearer_token: None,
+            auth_clients: Vec::new(),
             discovery_enabled: true,
             terminal_timeout_secs: 120,
             project_rules: Vec::new(),

--- a/crates/zeph-acp/src/transport/router.rs
+++ b/crates/zeph-acp/src/transport/router.rs
@@ -66,7 +66,7 @@ const MAX_BODY_BYTES: usize = 1_048_576;
 ///
 /// - `DefaultBodyLimit::max(1_048_576)` — rejects oversized POST bodies
 /// - `CorsLayer` with empty origin list — denies all cross-origin requests by default
-/// - `BearerAuthLayer` — applied to `/acp` routes when `auth_bearer_token` is `Some`
+/// - `BearerAuthLayer` — applied to `/acp` routes when `auth_clients` is non-empty
 ///
 /// # Examples
 ///
@@ -106,14 +106,16 @@ pub fn acp_router(state: AcpHttpState) -> Router {
         .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
         .layer(CorsLayer::new());
 
-    let acp_routes = if let Some(token) = state.server_config.auth_bearer_token.clone() {
-        acp_routes.layer(BearerAuthLayer::new(token))
-    } else {
+    let acp_routes = if state.server_config.auth_clients.is_empty() {
         tracing::warn!(
             "ACP HTTP server started without bearer token authentication; \
              session history endpoints are publicly accessible"
         );
         acp_routes
+    } else {
+        acp_routes.layer(BearerAuthLayer::new(
+            state.server_config.auth_clients.clone(),
+        ))
     };
 
     let mut router = Router::new()

--- a/crates/zeph-acp/src/transport/stdio.rs
+++ b/crates/zeph-acp/src/transport/stdio.rs
@@ -70,10 +70,13 @@ where
 
 /// Build a [`ZephAcpAgentState`] from the provided configuration.
 ///
-/// Shared by stdio and HTTP transports.
+/// Shared by stdio and HTTP transports. `owner_key` (#5868) is the authenticated ACP
+/// connection identity that scopes persisted session list/load/resume — `"acp-local"` for
+/// stdio, the matched bearer-token client id for authenticated HTTP/WS.
 pub(crate) async fn build_agent_state(
     spawner: AgentSpawner,
     server_config: AcpServerConfig,
+    owner_key: String,
 ) -> Arc<ZephAcpAgentState> {
     let mut agent = ZephAcpAgentState::new(
         spawner,
@@ -83,7 +86,8 @@ pub(crate) async fn build_agent_state(
     )
     .with_agent_info(server_config.agent_name, server_config.agent_version)
     .with_title_max_chars(server_config.title_max_chars)
-    .with_max_history(server_config.max_history);
+    .with_max_history(server_config.max_history)
+    .with_owner_key(owner_key);
 
     if let Some(ref path) = server_config.sqlite_path {
         match SqliteStore::new(path).await {
@@ -156,7 +160,12 @@ pub async fn serve_stdio(
         );
     }
 
-    let state = build_agent_state(spawner, server_config).await;
+    let state = build_agent_state(
+        spawner,
+        server_config,
+        crate::transport::OWNER_KEY_LOCAL.to_owned(),
+    )
+    .await;
 
     // Run the agent on a dedicated thread with a larger stack.
     // Agent session tasks use spawn_local (futures are !Send), so the thread
@@ -203,6 +212,9 @@ pub async fn serve_stdio(
 /// The HTTP transport satisfies this requirement by running each connection
 /// on a dedicated thread with a `current_thread` runtime and `LocalSet`.
 ///
+/// `owner_key` (#5868) scopes this connection's persisted session list/load/resume — see
+/// [`build_agent_state`].
+///
 /// # Errors
 ///
 /// Returns `AcpError::Transport` if the underlying JSON-RPC I/O fails.
@@ -211,12 +223,13 @@ pub async fn serve_connection<W, R>(
     server_config: AcpServerConfig,
     writer: W,
     reader: R,
+    owner_key: String,
 ) -> Result<(), AcpError>
 where
     W: futures::AsyncWrite + Unpin + Send + 'static,
     R: futures::AsyncRead + Unpin + Send + 'static,
 {
-    let state = build_agent_state(spawner, server_config).await;
+    let state = build_agent_state(spawner, server_config, owner_key).await;
     tokio::task::LocalSet::new()
         .run_until(run_agent(state, acp::ByteStreams::new(writer, reader)))
         .await

--- a/crates/zeph-acp/src/transport/tests.rs
+++ b/crates/zeph-acp/src/transport/tests.rs
@@ -42,7 +42,7 @@ fn test_state() -> AcpHttpState {
             provider_factory: None,
             available_models: shared_models(vec![]),
             mcp_manager: None,
-            auth_bearer_token: None,
+            auth_clients: Vec::new(),
             discovery_enabled: true,
             terminal_timeout_secs: 120,
             project_rules: vec![],
@@ -68,7 +68,7 @@ fn test_state_with_session_data_dir(data_dir: std::path::PathBuf) -> AcpHttpStat
             provider_factory: None,
             available_models: shared_models(vec![]),
             mcp_manager: None,
-            auth_bearer_token: None,
+            auth_clients: Vec::new(),
             discovery_enabled: true,
             terminal_timeout_secs: 120,
             project_rules: vec![],
@@ -95,7 +95,7 @@ fn state_with_max_sessions(max: usize) -> AcpHttpState {
             provider_factory: None,
             available_models: shared_models(vec![]),
             mcp_manager: None,
-            auth_bearer_token: None,
+            auth_clients: Vec::new(),
             discovery_enabled: true,
             terminal_timeout_secs: 120,
             project_rules: vec![],
@@ -365,7 +365,10 @@ fn state_with_auth(token: &str) -> AcpHttpState {
             provider_factory: None,
             available_models: shared_models(vec![]),
             mcp_manager: None,
-            auth_bearer_token: Some(token.into()),
+            auth_clients: vec![crate::transport::AcpClientToken {
+                id: "default".into(),
+                token: (token).into(),
+            }],
             discovery_enabled: true,
             terminal_timeout_secs: 120,
             project_rules: vec![],
@@ -428,7 +431,7 @@ async fn auth_wrong_token_returns_401() {
 
 #[tokio::test]
 async fn auth_none_mode_allows_all_requests() {
-    // test_state() has auth_bearer_token: None — no auth layer applied.
+    // test_state() has auth_clients: Vec::new() — no auth layer applied.
     let router = acp_router(test_state());
 
     let req = Request::builder()
@@ -492,7 +495,10 @@ async fn health_returns_503_when_not_ready() {
             provider_factory: None,
             available_models: std::sync::Arc::new(parking_lot::RwLock::new(Vec::new())),
             mcp_manager: None,
-            auth_bearer_token: Some("secret".into()),
+            auth_clients: vec![crate::transport::AcpClientToken {
+                id: "default".into(),
+                token: ("secret").into(),
+            }],
             discovery_enabled: true,
             terminal_timeout_secs: 120,
             project_rules: vec![],
@@ -532,7 +538,7 @@ async fn acp_post_returns_503_when_server_not_ready() {
             provider_factory: None,
             available_models: std::sync::Arc::new(parking_lot::RwLock::new(Vec::new())),
             mcp_manager: None,
-            auth_bearer_token: None,
+            auth_clients: Vec::new(),
             discovery_enabled: true,
             terminal_timeout_secs: 120,
             project_rules: vec![],
@@ -631,7 +637,7 @@ async fn discovery_disabled_returns_404() {
             provider_factory: None,
             available_models: shared_models(vec![]),
             mcp_manager: None,
-            auth_bearer_token: None,
+            auth_clients: Vec::new(),
             discovery_enabled: false,
             terminal_timeout_secs: 120,
             project_rules: vec![],
@@ -705,7 +711,7 @@ async fn agent_json_disabled_returns_404() {
             provider_factory: None,
             available_models: shared_models(vec![]),
             mcp_manager: None,
-            auth_bearer_token: None,
+            auth_clients: Vec::new(),
             discovery_enabled: false,
             terminal_timeout_secs: 120,
             project_rules: vec![],
@@ -747,7 +753,7 @@ async fn reaper_removes_expired_connections() {
             provider_factory: None,
             available_models: shared_models(vec![]),
             mcp_manager: None,
-            auth_bearer_token: None,
+            auth_clients: Vec::new(),
             discovery_enabled: true,
             terminal_timeout_secs: 120,
             project_rules: vec![],
@@ -836,7 +842,10 @@ async fn list_sessions_returns_session_data() {
     let store = zeph_memory::store::SqliteStore::new(":memory:")
         .await
         .expect("SqliteStore::new");
-    store.create_acp_session("sess-1").await.unwrap();
+    store
+        .create_acp_session("sess-1", Some(crate::transport::OWNER_KEY_LOCAL))
+        .await
+        .unwrap();
     // Regression guard for the S1 false-green (spec-068 §12.3 / D-2): `list_acp_sessions`
     // now derives `message_count` from `acp_sessions.event_count`, so the fixture must drive
     // it through `zeph_session::SessionStore::update_seq` — the same primitive
@@ -868,6 +877,116 @@ async fn list_sessions_returns_session_data() {
     assert_eq!(arr[0]["id"], "sess-1");
     assert_eq!(arr[0]["title"], "Test Session");
     assert_eq!(arr[0]["message_count"], 1);
+}
+
+// ── Owner scoping tests (#5868) ───────────────────────────────────────────────
+
+fn state_with_two_clients() -> AcpHttpState {
+    AcpHttpState::new(
+        noop_spawner(),
+        AcpServerConfig {
+            agent_name: "test".into(),
+            agent_version: "0.0.1".into(),
+            max_sessions: 4,
+            session_idle_timeout_secs: 1800,
+            permission_file: None,
+            provider_factory: None,
+            available_models: shared_models(vec![]),
+            mcp_manager: None,
+            auth_clients: vec![
+                crate::transport::AcpClientToken {
+                    id: "alice".into(),
+                    token: "token-a".into(),
+                },
+                crate::transport::AcpClientToken {
+                    id: "bob".into(),
+                    token: "token-b".into(),
+                },
+            ],
+            discovery_enabled: true,
+            terminal_timeout_secs: 120,
+            project_rules: vec![],
+            title_max_chars: 60,
+            max_history: 100,
+            sqlite_path: None,
+            ready_notification: None,
+            ..Default::default()
+        },
+    )
+    .with_ready(true)
+}
+
+#[tokio::test]
+async fn list_sessions_isolates_distinct_token_clients() {
+    use axum::body::to_bytes;
+
+    let store = zeph_memory::store::SqliteStore::new(":memory:")
+        .await
+        .expect("SqliteStore::new");
+    store
+        .create_acp_session("alice-sess", Some("alice"))
+        .await
+        .unwrap();
+    store
+        .create_acp_session("bob-sess", Some("bob"))
+        .await
+        .unwrap();
+
+    let state = state_with_two_clients().with_store(store);
+    let router = acp_router(state);
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/sessions")
+        .header("authorization", "Bearer token-a")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 65536).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"], "alice-sess");
+
+    let req2 = Request::builder()
+        .method("GET")
+        .uri("/sessions")
+        .header("authorization", "Bearer token-b")
+        .body(Body::empty())
+        .unwrap();
+    let response2 = router.oneshot(req2).await.unwrap();
+    assert_eq!(response2.status(), StatusCode::OK);
+    let body2 = to_bytes(response2.into_body(), 65536).await.unwrap();
+    let json2: serde_json::Value = serde_json::from_slice(&body2).unwrap();
+    let arr2 = json2.as_array().unwrap();
+    assert_eq!(arr2.len(), 1);
+    assert_eq!(arr2[0]["id"], "bob-sess");
+}
+
+#[tokio::test]
+async fn session_messages_cross_owner_returns_404() {
+    let store = zeph_memory::store::SqliteStore::new(":memory:")
+        .await
+        .expect("SqliteStore::new");
+    let session_id = "00000000-0000-0000-0000-000000000002";
+    store
+        .create_acp_session(session_id, Some("alice"))
+        .await
+        .unwrap();
+
+    let state = state_with_two_clients().with_store(store);
+    let router = acp_router(state);
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/sessions/{session_id}/messages"))
+        .header("authorization", "Bearer token-b")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 // ── GET /sessions/{id}/messages tests ────────────────────────────────────────
@@ -930,7 +1049,10 @@ async fn session_messages_returns_events_for_known_session() {
         .await
         .expect("SqliteStore::new");
     let session_id = "00000000-0000-0000-0000-000000000001";
-    store.create_acp_session(session_id).await.unwrap();
+    store
+        .create_acp_session(session_id, Some(crate::transport::OWNER_KEY_LOCAL))
+        .await
+        .unwrap();
 
     // Regression guard for the S1-class false-green: message_messages_handler now reads the
     // durable JSONL event log (spec-068 §12.3 / D-2), not the legacy acp_session_events table —

--- a/crates/zeph-acp/src/transport/ws.rs
+++ b/crates/zeph-acp/src/transport/ws.rs
@@ -62,6 +62,7 @@ const WS_PONG_TIMEOUT: Duration = Duration::from_secs(90);
 pub async fn ws_upgrade_handler(
     ws: WebSocketUpgrade,
     State(state): State<AcpHttpState>,
+    token_identity: Option<axum::extract::Extension<super::auth::TokenIdentity>>,
 ) -> Response {
     if !state.ready.load(Ordering::Acquire) {
         return StatusCode::SERVICE_UNAVAILABLE.into_response();
@@ -69,8 +70,9 @@ pub async fn ws_upgrade_handler(
     if !state.try_reserve_ws_slot() {
         return StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
+    let owner_key = super::http::derive_owner_key(token_identity.as_ref().map(|e| &e.0));
     ws.max_message_size(WS_MAX_MESSAGE_SIZE)
-        .on_upgrade(move |socket| handle_ws(socket, state))
+        .on_upgrade(move |socket| handle_ws(socket, state, owner_key))
         .into_response()
 }
 
@@ -105,20 +107,23 @@ fn register_ws_session(state: &AcpHttpState, session_id: &str) {
 
 #[cfg(feature = "acp-http")]
 #[allow(clippy::too_many_lines)]
-async fn handle_ws(socket: WebSocket, state: AcpHttpState) {
+async fn handle_ws(socket: WebSocket, state: AcpHttpState, owner_key: String) {
     let session_id = uuid::Uuid::new_v4().to_string();
     register_ws_session(&state, &session_id);
 
-    let (reader, mut writer) =
-        match spawn_agent_connection(state.spawner.clone(), (*state.server_config).clone()) {
-            Ok(streams) => streams,
-            Err(e) => {
-                tracing::error!("failed to spawn ACP agent thread: {e}");
-                state.release_ws_slot();
-                state.remove_connection(&session_id);
-                return;
-            }
-        };
+    let (reader, mut writer) = match spawn_agent_connection(
+        state.spawner.clone(),
+        (*state.server_config).clone(),
+        owner_key,
+    ) {
+        Ok(streams) => streams,
+        Err(e) => {
+            tracing::error!("failed to spawn ACP agent thread: {e}");
+            state.release_ws_slot();
+            state.remove_connection(&session_id);
+            return;
+        }
+    };
 
     let (mut ws_tx, mut ws_rx) = socket.split();
 

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -158,7 +158,13 @@ async fn initialize_handshake() {
     local
         .run_until(async {
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 let resp = cx
                     .send_request(acp::schema::v1::InitializeRequest::new(
@@ -189,7 +195,13 @@ async fn new_session_returns_session_id() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -225,7 +237,13 @@ async fn cancel_notification_does_not_panic() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -259,7 +277,13 @@ async fn unknown_ext_method_returns_null() {
     local
         .run_until(async {
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -306,7 +330,8 @@ async fn providers_list_reflects_configured_provider_names() {
                 "test-agent",
                 vec![("openai", zeph_acp::LlmProtocol::OpenAi)],
             );
-            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let server_fut =
+                serve_connection(noop_spawner(), config, sw, sr, "acp-local".to_owned());
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -347,7 +372,13 @@ async fn load_session_unknown_id_returns_error() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -386,7 +417,13 @@ async fn session_list_contains_created_sessions() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -435,7 +472,13 @@ async fn prompt_round_trip_returns_end_turn() {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
             // echo_spawner reads the message and signals Flush so drain_agent_events exits.
-            let server_fut = serve_connection(echo_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                echo_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -488,6 +531,7 @@ async fn drain_until_stop_collects_text_chunks() {
                 test_config("test-agent"),
                 sw,
                 sr,
+                "acp-local".to_owned(),
             );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
@@ -548,7 +592,13 @@ async fn cancel_before_prompt_is_a_no_op() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(echo_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                echo_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -608,8 +658,13 @@ async fn late_cancel_after_prompt_completion_does_not_affect_next_prompt() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut =
-                serve_connection(multi_turn_echo_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                multi_turn_echo_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -680,7 +735,13 @@ async fn authenticate_returns_default_response() {
     local
         .run_until(async {
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -710,7 +771,13 @@ async fn logout_returns_default_response() {
     local
         .run_until(async {
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -742,7 +809,13 @@ async fn close_session_removes_session_from_memory() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -793,7 +866,13 @@ async fn delete_session_removes_session_from_list() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -844,7 +923,13 @@ async fn fork_session_creates_distinct_session_id() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -912,7 +997,8 @@ async fn fork_session_copies_event_log_when_persistence_enabled() {
                 session_data_dir: Some(session_data_dir.clone()),
                 ..test_config("test-agent")
             };
-            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let server_fut =
+                serve_connection(noop_spawner(), config, sw, sr, "acp-local".to_owned());
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -1013,7 +1099,13 @@ async fn resume_session_reconnects_to_existing_session() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -1077,7 +1169,8 @@ async fn resume_session_reconstructs_from_store_after_restart() {
                     sqlite_path: Some(sqlite_path.clone()),
                     ..test_config("test-agent")
                 };
-                let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+                let server_fut =
+                    serve_connection(noop_spawner(), config, sw, sr, "acp-local".to_owned());
                 let client_fut =
                     acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                         cx.send_request(acp::schema::v1::InitializeRequest::new(
@@ -1106,7 +1199,8 @@ async fn resume_session_reconstructs_from_store_after_restart() {
                 sqlite_path: Some(sqlite_path.clone()),
                 ..test_config("test-agent")
             };
-            let server_fut = serve_connection(echo_spawner(), config, sw, sr);
+            let server_fut =
+                serve_connection(echo_spawner(), config, sw, sr, "acp-local".to_owned());
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -1178,7 +1272,8 @@ async fn load_session_succeeds_from_event_log_with_no_legacy_rows() {
                     session_data_dir: Some(session_data_dir.clone()),
                     ..test_config("test-agent")
                 };
-                let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+                let server_fut =
+                    serve_connection(noop_spawner(), config, sw, sr, "acp-local".to_owned());
                 let client_fut =
                     acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                         cx.send_request(acp::schema::v1::InitializeRequest::new(
@@ -1225,7 +1320,8 @@ async fn load_session_succeeds_from_event_log_with_no_legacy_rows() {
                 session_data_dir: Some(session_data_dir),
                 ..test_config("test-agent")
             };
-            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let server_fut =
+                serve_connection(noop_spawner(), config, sw, sr, "acp-local".to_owned());
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -1269,6 +1365,7 @@ async fn fork_session_inherits_config_from_in_memory_source() {
                 test_config_with_models("test-agent", vec!["claude:sonnet"]),
                 sw,
                 sr,
+                "acp-local".to_owned(),
             );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
@@ -1371,7 +1468,8 @@ async fn resume_session_inherits_temperature_preset_after_close() {
             config.provider_factory = Some(factory);
             config.sqlite_path = Some(":memory:".to_owned());
 
-            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let server_fut =
+                serve_connection(noop_spawner(), config, sw, sr, "acp-local".to_owned());
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -1438,7 +1536,13 @@ async fn set_session_mode_switches_mode() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -1484,6 +1588,7 @@ async fn set_session_config_option_model_switches_active_model() {
                 test_config_with_models("test-agent", vec!["claude:sonnet", "ollama:llama3"]),
                 sw,
                 sr,
+                "acp-local".to_owned(),
             );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
@@ -1543,6 +1648,7 @@ async fn set_session_config_option_temperature_preset_changes() {
                 test_config_with_models("test-agent", vec!["claude:sonnet"]),
                 sw,
                 sr,
+            "acp-local".to_owned(),
             );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
@@ -1630,7 +1736,8 @@ async fn default_temperature_preset_is_primed_at_session_creation() {
                 default_temperature_preset: zeph_config::AcpTemperaturePreset::Creative,
             };
 
-            let server_fut = serve_connection(noop_spawner(), config, sw, sr);
+            let server_fut =
+                serve_connection(noop_spawner(), config, sw, sr, "acp-local".to_owned());
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -1676,7 +1783,13 @@ async fn set_session_config_option_unknown_config_id_errors() {
         .run_until(async {
             let workdir = temp_workdir();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(noop_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                noop_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -1723,7 +1836,13 @@ async fn cancel_request_during_prompt_cancels() {
             let (sw, sr, cw, cr) = duplex_pair();
             // echo_spawner reads the message and flushes; the $/cancel_request watcher in
             // handle_prompt notifies the same cancel_signal session/cancel uses.
-            let server_fut = serve_connection(echo_spawner(), test_config("test-agent"), sw, sr);
+            let server_fut = serve_connection(
+                echo_spawner(),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -1774,6 +1893,326 @@ async fn cancel_request_during_prompt_cancels() {
                 res = server_fut => panic!("server exited before client: {res:?}"),
                 result = client_fut => {
                     assert!(result.is_ok(), "cancel_request test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+// ── Cross-owner scoping at the stdio JSON-RPC layer (#5868) ──────────────────────────
+
+/// Creates a fresh connection with the given `owner`, issues `session/new`, and disconnects.
+/// Helper for the cross-owner tests below — a shared `sqlite_path` means the resulting session
+/// persists with `owner` stamped as its `owner_key`.
+async fn create_owned_session(
+    sqlite_path: &str,
+    owner: &str,
+    workdir: &std::path::Path,
+) -> acp::schema::v1::SessionId {
+    let (sw, sr, cw, cr) = duplex_pair();
+    let config = AcpServerConfig {
+        sqlite_path: Some(sqlite_path.to_owned()),
+        ..test_config("test-agent")
+    };
+    let server_fut = serve_connection(noop_spawner(), config, sw, sr, owner.to_owned());
+    let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+        cx.send_request(acp::schema::v1::InitializeRequest::new(
+            acp::schema::ProtocolVersion::LATEST,
+        ))
+        .block_task()
+        .await?;
+        let session_id = cx
+            .send_request(acp::schema::v1::NewSessionRequest::new(workdir))
+            .block_task()
+            .await?
+            .session_id;
+        Ok(session_id)
+    });
+    tokio::select! {
+        res = server_fut => panic!("server exited before client: {res:?}"),
+        result = client_fut => result.expect("session/new failed"),
+    }
+}
+
+/// `session/list` scopes persisted sessions to the calling connection's `owner_key`: a session
+/// created by one connection's owner must not appear in a different owner's list, even when
+/// both connections share the same `sqlite_path`.
+#[tokio::test(flavor = "current_thread")]
+async fn list_sessions_isolated_by_owner_across_stdio_connections() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let db_dir = tempfile::tempdir().expect("failed to create temp db dir");
+            let sqlite_path = db_dir
+                .path()
+                .join("acp-owner-list-test.db")
+                .to_string_lossy()
+                .into_owned();
+
+            // Two distinct owners each create a session on the shared store, then disconnect.
+            let alice_session = create_owned_session(&sqlite_path, "alice", workdir.path()).await;
+            let bob_session = create_owned_session(&sqlite_path, "bob", workdir.path()).await;
+
+            // A fresh connection as "alice" lists sessions: must see her own, not bob's.
+            let (sw, sr, cw, cr) = duplex_pair();
+            let config = AcpServerConfig {
+                sqlite_path: Some(sqlite_path.clone()),
+                ..test_config("test-agent")
+            };
+            let server_fut = serve_connection(noop_spawner(), config, sw, sr, "alice".to_owned());
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+                let resp = cx
+                    .send_request(acp::schema::v1::ListSessionsRequest::new())
+                    .block_task()
+                    .await?;
+                let ids: Vec<&acp::schema::v1::SessionId> =
+                    resp.sessions.iter().map(|s| &s.session_id).collect();
+                assert!(
+                    ids.contains(&&alice_session),
+                    "alice's own session missing from her list: {ids:?}"
+                );
+                assert!(
+                    !ids.contains(&&bob_session),
+                    "bob's session leaked into alice's list: {ids:?}"
+                );
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "cross-owner list_sessions test failed: {result:?}");
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/resume` on a session owned by a different connection must fail — a foreign
+/// `owner_key` is indistinguishable from a nonexistent session id.
+#[tokio::test(flavor = "current_thread")]
+async fn resume_session_cross_owner_fails() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let db_dir = tempfile::tempdir().expect("failed to create temp db dir");
+            let sqlite_path = db_dir
+                .path()
+                .join("acp-owner-resume-test.db")
+                .to_string_lossy()
+                .into_owned();
+
+            let session_id = {
+                let (sw, sr, cw, cr) = duplex_pair();
+                let config = AcpServerConfig {
+                    sqlite_path: Some(sqlite_path.clone()),
+                    ..test_config("test-agent")
+                };
+                let server_fut =
+                    serve_connection(noop_spawner(), config, sw, sr, "alice".to_owned());
+                let client_fut =
+                    acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                        cx.send_request(acp::schema::v1::InitializeRequest::new(
+                            acp::schema::ProtocolVersion::LATEST,
+                        ))
+                        .block_task()
+                        .await?;
+                        let session_id = cx
+                            .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                            .block_task()
+                            .await?
+                            .session_id;
+                        Ok(session_id)
+                    });
+                tokio::select! {
+                    res = server_fut => panic!("server exited before client: {res:?}"),
+                    result = client_fut => result.expect("session/new failed"),
+                }
+            };
+
+            // A different owner ("bob") tries to resume alice's session on the same store.
+            let (sw, sr, cw, cr) = duplex_pair();
+            let config = AcpServerConfig {
+                sqlite_path: Some(sqlite_path.clone()),
+                ..test_config("test-agent")
+            };
+            let server_fut = serve_connection(echo_spawner(), config, sw, sr, "bob".to_owned());
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+                cx.send_request(acp::schema::v1::ResumeSessionRequest::new(
+                    session_id,
+                    workdir.path(),
+                ))
+                .block_task()
+                .await
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(
+                        result.is_err(),
+                        "bob must not be able to resume alice's session, got: {result:?}"
+                    );
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/load` on a session owned by a different connection must fail (mirrors
+/// `resume_session_cross_owner_fails` for the `load_session` handler).
+#[tokio::test(flavor = "current_thread")]
+async fn load_session_cross_owner_fails() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let db_dir = tempfile::tempdir().expect("failed to create temp db dir");
+            let sqlite_path = db_dir
+                .path()
+                .join("acp-owner-load-test.db")
+                .to_string_lossy()
+                .into_owned();
+
+            let session_id = {
+                let (sw, sr, cw, cr) = duplex_pair();
+                let config = AcpServerConfig {
+                    sqlite_path: Some(sqlite_path.clone()),
+                    ..test_config("test-agent")
+                };
+                let server_fut =
+                    serve_connection(noop_spawner(), config, sw, sr, "alice".to_owned());
+                let client_fut =
+                    acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                        cx.send_request(acp::schema::v1::InitializeRequest::new(
+                            acp::schema::ProtocolVersion::LATEST,
+                        ))
+                        .block_task()
+                        .await?;
+                        let session_id = cx
+                            .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                            .block_task()
+                            .await?
+                            .session_id;
+                        Ok(session_id)
+                    });
+                tokio::select! {
+                    res = server_fut => panic!("server exited before client: {res:?}"),
+                    result = client_fut => result.expect("session/new failed"),
+                }
+            };
+
+            let (sw, sr, cw, cr) = duplex_pair();
+            let config = AcpServerConfig {
+                sqlite_path: Some(sqlite_path.clone()),
+                ..test_config("test-agent")
+            };
+            let server_fut = serve_connection(echo_spawner(), config, sw, sr, "bob".to_owned());
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+                cx.send_request(acp::schema::v1::LoadSessionRequest::new(
+                    session_id,
+                    workdir.path(),
+                ))
+                .block_task()
+                .await
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(
+                        result.is_err(),
+                        "bob must not be able to load alice's session, got: {result:?}"
+                    );
+                }
+            }
+        })
+        .await;
+}
+
+/// `session/fork` sourced from a session owned by a different connection must fail.
+#[cfg(feature = "unstable-session-fork")]
+#[tokio::test(flavor = "current_thread")]
+async fn fork_session_cross_owner_fails() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let db_dir = tempfile::tempdir().expect("failed to create temp db dir");
+            let sqlite_path = db_dir
+                .path()
+                .join("acp-owner-fork-test.db")
+                .to_string_lossy()
+                .into_owned();
+
+            let session_id = {
+                let (sw, sr, cw, cr) = duplex_pair();
+                let config = AcpServerConfig {
+                    sqlite_path: Some(sqlite_path.clone()),
+                    ..test_config("test-agent")
+                };
+                let server_fut =
+                    serve_connection(noop_spawner(), config, sw, sr, "alice".to_owned());
+                let client_fut =
+                    acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                        cx.send_request(acp::schema::v1::InitializeRequest::new(
+                            acp::schema::ProtocolVersion::LATEST,
+                        ))
+                        .block_task()
+                        .await?;
+                        let session_id = cx
+                            .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                            .block_task()
+                            .await?
+                            .session_id;
+                        Ok(session_id)
+                    });
+                tokio::select! {
+                    res = server_fut => panic!("server exited before client: {res:?}"),
+                    result = client_fut => result.expect("session/new failed"),
+                }
+            };
+
+            let (sw, sr, cw, cr) = duplex_pair();
+            let config = AcpServerConfig {
+                sqlite_path: Some(sqlite_path.clone()),
+                ..test_config("test-agent")
+            };
+            let server_fut = serve_connection(noop_spawner(), config, sw, sr, "bob".to_owned());
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+                cx.send_request(acp::schema::v1::ForkSessionRequest::new(
+                    session_id,
+                    workdir.path(),
+                ))
+                .block_task()
+                .await
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(
+                        result.is_err(),
+                        "bob must not be able to fork alice's session, got: {result:?}"
+                    );
                 }
             }
         })

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -194,10 +194,10 @@ pub use subagent::{
 pub use telemetry::{TelemetryBackend, TelemetryConfig};
 pub use tools::{AuditDestination, SandboxBackend, ToolCompressionConfig};
 pub use ui::{
-    AcpAuthMethod, AcpConfig, AcpLspConfig, AcpModelConfigConfig, AcpSubagentsConfig,
-    AcpTemperaturePreset, AcpTimeoutsConfig, AcpTransport, AdditionalDir, AdditionalDirError,
-    ColorMode, DelightsConfig, FleetConfig, Motion, SubagentPresetConfig, ThemeConfig, ToolDensity,
-    TuiConfig,
+    ACP_AUTH_CLIENT_ID_DEFAULT, ACP_AUTH_CLIENT_ID_LOCAL, AcpAuthClient, AcpAuthMethod, AcpConfig,
+    AcpLspConfig, AcpModelConfigConfig, AcpSubagentsConfig, AcpTemperaturePreset,
+    AcpTimeoutsConfig, AcpTransport, AdditionalDir, AdditionalDirError, ColorMode, DelightsConfig,
+    FleetConfig, Motion, SubagentPresetConfig, ThemeConfig, ToolDensity, TuiConfig,
 };
 pub use ui::{DiagnosticSeverity, DiagnosticsConfig, HoverConfig, LspConfig};
 pub use vigil::VigilConfig;

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -82,6 +82,9 @@ impl Config {
         self.validate_provider_names()?;
         self.validate_mcp_misc()?;
         self.validate_scheduler()?;
+        self.acp
+            .validate_auth_clients()
+            .map_err(ConfigError::Validation)?;
         Ok(())
     }
 

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -596,20 +596,21 @@ pub trait Migration: Send + Sync {
 
 mod steps;
 use steps::{
-    MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
-    MigrateAutodreamConfig, MigrateCavemanConfig, MigrateCocoonProviderNotice,
-    MigrateCocoonShowBalance, MigrateCompressionPredictorConfig, MigrateDatabaseUrl,
-    MigrateDeepLinkConfig, MigrateDurableConfig, MigrateEgressConfig, MigrateEmbedProviderRename,
-    MigrateEvalModelToProvider, MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig,
-    MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig, MigrateGoalsConfig,
-    MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
-    MigrateKnowledgeConfig, MigrateLlmStreamLimits, MigrateMagicDocsConfig,
-    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpRetryAndToolTimeout,
-    MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryGraphRecallIncludeImported,
-    MigrateMemoryHebbian, MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread,
-    MigrateMemoryPersonaConfig, MigrateMemoryReasoning, MigrateMemoryReasoningJudge,
-    MigrateMemoryRetrieval, MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig,
-    MigrateNliConfig, MigrateOrchestrationAssetSensitivity, MigrateOrchestrationPersistence,
+    MigrateAcpAuthClientsConfig, MigrateAcpSubagentsConfig, MigrateAgentBudgetHint,
+    MigrateAgentRetryToToolsRetry, MigrateAutodreamConfig, MigrateCavemanConfig,
+    MigrateCocoonProviderNotice, MigrateCocoonShowBalance, MigrateCompressionPredictorConfig,
+    MigrateDatabaseUrl, MigrateDeepLinkConfig, MigrateDurableConfig, MigrateEgressConfig,
+    MigrateEmbedProviderRename, MigrateEvalModelToProvider, MigrateFidelityTimeoutDefaults,
+    MigrateFiveSignalConfig, MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig,
+    MigrateGoalsConfig, MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig,
+    MigrateHooksTurnComplete, MigrateKnowledgeConfig, MigrateLlmStreamLimits,
+    MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
+    MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels, MigrateMemoryGraph,
+    MigrateMemoryGraphRecallIncludeImported, MigrateMemoryHebbian,
+    MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
+    MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
+    MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateNliConfig,
+    MigrateOrchestrationAssetSensitivity, MigrateOrchestrationPersistence,
     MigrateOrchestratorProvider, MigrateOtelFilter, MigratePiiFilterNames,
     MigratePlannerModelToProvider, MigratePolicyProviderAndUtilityWindow,
     MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQdrantTimeoutSecs,
@@ -623,7 +624,7 @@ use steps::{
     MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–76).
+/// Ordered registry of all sequential migration steps (steps 1–77).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -759,6 +760,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateQdrantTimeoutSecs),
             // Step 76 — add high_gain_tools advisory under [tools.utility] (#5659)
             Box::new(MigrateUtilityHighGainTools),
+            // Step 77 — add [[acp.auth_clients]] advisory block (#5868)
+            Box::new(MigrateAcpAuthClientsConfig),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/session.rs
+++ b/crates/zeph-config/src/migrate/session.rs
@@ -83,6 +83,49 @@ pub fn migrate_acp_subagents_config(toml_src: &str) -> Result<MigrationResult, M
     })
 }
 
+/// Add a commented-out `[[acp.auth_clients]]` block if the config lacks it (#5868).
+///
+/// Introduced alongside named-client bearer-token isolation for ACP HTTP/WS session
+/// persistence scoping. `AcpConfig::auth_clients` has `#[serde(default)]` so existing
+/// configs (including those with only the legacy scalar `[acp] auth_token`) parse without
+/// changes; this migration only surfaces the new array for discoverability.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the
+/// migration function convention for use in chained pipelines.
+pub fn migrate_acp_auth_clients_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src
+        .lines()
+        .any(|l| l.trim() == "[[acp.auth_clients]]" || l.trim() == "# [[acp.auth_clients]]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [[acp.auth_clients]] — named bearer-token clients for genuine \
+         multi-tenant/multi-window\n\
+         # isolation of ACP HTTP/WS persisted session listing (#5868). Coexists with the \
+         legacy\n\
+         # scalar `auth_token` above (synthesized as the \"default\" client). Reserved ids: \
+         \"default\",\n\
+         # \"acp-local\". Exactly one of `token` / `token_vault_key` must be set per entry.\n\
+         # [[acp.auth_clients]]\n\
+         # id = \"zed-alice\"\n\
+         # token = \"...\"                # inline, or:\n\
+         # token_vault_key = \"ZEPH_ACP_TOKEN_ALICE\"  # resolved from the age vault at startup\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["acp.auth_clients".to_owned()],
+    })
+}
+
 /// Add a commented-out `[[hooks.permission_denied]]` block if the config lacks it (#3309).
 ///
 /// Introduced alongside the reactive env hooks and MCP tool dispatch feature (#3303).

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -36,19 +36,21 @@
 //! step 74 adds a commented `filter_names = false` advisory to an existing
 //! `[security.pii_filter]` table (#5530);
 //! step 75 adds a commented `qdrant_timeout_secs = 10` advisory under `[memory]`;
-//! step 76 adds a commented `high_gain_tools = []` advisory under `[tools.utility]` (#5659).
+//! step 76 adds a commented `high_gain_tools = []` advisory under `[tools.utility]` (#5659);
+//! step 77 adds a commented `[[acp.auth_clients]]` advisory block (#5868).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
 //! registry can hold `Box<dyn Migration>` values.
 
 use super::{
-    MigrateError, Migration, MigrationResult, migrate_acp_subagents_config,
-    migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_autodream_config,
-    migrate_caveman_config, migrate_cocoon_provider_notice, migrate_cocoon_show_balance,
-    migrate_compression_predictor_config, migrate_database_url, migrate_deep_link_config,
-    migrate_durable_config, migrate_egress_config, migrate_embed_provider_rename,
-    migrate_eval_model_to_provider, migrate_fidelity_timeout_defaults, migrate_five_signal_config,
+    MigrateError, Migration, MigrationResult, migrate_acp_auth_clients_config,
+    migrate_acp_subagents_config, migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry,
+    migrate_autodream_config, migrate_caveman_config, migrate_cocoon_provider_notice,
+    migrate_cocoon_show_balance, migrate_compression_predictor_config, migrate_database_url,
+    migrate_deep_link_config, migrate_durable_config, migrate_egress_config,
+    migrate_embed_provider_rename, migrate_eval_model_to_provider,
+    migrate_fidelity_timeout_defaults, migrate_five_signal_config,
     migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
     migrate_knowledge_config, migrate_llm_stream_limits, migrate_magic_docs_config,
@@ -923,5 +925,17 @@ impl Migration for MigrateUtilityHighGainTools {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_utility_high_gain_tools(toml_src)
+    }
+}
+
+/// Step 77 — adds a commented `[[acp.auth_clients]]` advisory block (#5868).
+pub(super) struct MigrateAcpAuthClientsConfig;
+impl Migration for MigrateAcpAuthClientsConfig {
+    fn name(&self) -> &'static str {
+        "migrate_acp_auth_clients_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_acp_auth_clients_config(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        76,
-        "MIGRATIONS registry must contain all 76 sequential steps"
+        77,
+        "MIGRATIONS registry must contain all 77 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1410,6 +1410,39 @@ fn migrate_acp_subagents_idempotent_on_existing_block() {
     assert_eq!(result.output, src);
 }
 
+// ── migrate_acp_auth_clients_config ───────────────────────────────────────
+
+#[test]
+fn migrate_acp_auth_clients_adds_block_when_absent() {
+    let src = "[acp]\nauth_token = \"legacy\"\n";
+    let result = migrate_acp_auth_clients_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result
+            .sections_changed
+            .contains(&"acp.auth_clients".to_owned())
+    );
+    assert!(result.output.contains("# [[acp.auth_clients]]"));
+    assert!(result.output.contains("token_vault_key"));
+}
+
+#[test]
+fn migrate_acp_auth_clients_idempotent_on_existing_block() {
+    let src = "[acp]\nauth_token = \"legacy\"\n# [[acp.auth_clients]]\n# id = \"x\"\n";
+    let result = migrate_acp_auth_clients_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn migrate_acp_auth_clients_skipped_when_live_block_present() {
+    let src =
+        "[acp]\nauth_token = \"legacy\"\n[[acp.auth_clients]]\nid = \"alice\"\ntoken = \"t\"\n";
+    let result = migrate_acp_auth_clients_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
 // ── migrate_hooks_permission_denied_config ────────────────────────────────
 
 #[test]
@@ -1645,7 +1678,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 76);
+    assert_eq!(MIGRATIONS.len(), 77);
 }
 
 #[test]
@@ -1684,7 +1717,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–76).
+    // Names must follow the documented step order (steps 1–77).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1762,6 +1795,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_pii_filter_names",
         "migrate_qdrant_timeout_secs",
         "migrate_utility_high_gain_tools",
+        "migrate_acp_auth_clients_config",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);

--- a/crates/zeph-config/src/ui.rs
+++ b/crates/zeph-config/src/ui.rs
@@ -39,6 +39,41 @@ fn default_acp_discovery_enabled() -> bool {
     true
 }
 
+/// Reserved `[[acp.auth_clients]]` id colliding with the synthesized legacy `auth_token` client.
+pub const ACP_AUTH_CLIENT_ID_DEFAULT: &str = "default";
+/// Reserved `[[acp.auth_clients]]` id colliding with the unauthenticated/stdio owner bucket.
+pub const ACP_AUTH_CLIENT_ID_LOCAL: &str = "acp-local";
+
+/// A single named ACP HTTP/WS bearer-token credential (#5868).
+///
+/// Each entry authenticates one `Authorization: Bearer <token>` value and, on match, becomes
+/// the request's owner identity for ACP session-persistence scoping (`owner_key`). Exactly one
+/// of `token` / `token_vault_key` must be set — `token` is inline (parity with the legacy
+/// `[acp] auth_token` field), `token_vault_key` resolves the secret from the age vault at
+/// startup, mirroring `[serve] auth_token_vault_key`.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct AcpAuthClient {
+    /// Stable owner label surviving token rotation. Must be non-empty, unique among
+    /// `auth_clients`, and must not be `"default"` or `"acp-local"` (reserved sentinels).
+    pub id: String,
+    /// Inline bearer token. Mutually exclusive with `token_vault_key`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    /// Vault key to resolve the bearer token from at startup. Mutually exclusive with `token`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_vault_key: Option<String>,
+}
+
+impl std::fmt::Debug for AcpAuthClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AcpAuthClient")
+            .field("id", &self.id)
+            .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
+            .field("token_vault_key", &self.token_vault_key)
+            .finish()
+    }
+}
+
 fn default_acp_lsp_max_diagnostics_per_file() -> usize {
     20
 }
@@ -645,6 +680,11 @@ pub struct AcpConfig {
     /// reverse proxy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_token: Option<String>,
+    /// Named ACP HTTP/WS bearer-token clients (#5868), for genuine multi-tenant/multi-window
+    /// isolation of persisted session listing. Coexists with the legacy `auth_token` field,
+    /// which is synthesized as a client with id `"default"`. See [`AcpAuthClient`].
+    #[serde(default)]
+    pub auth_clients: Vec<AcpAuthClient>,
     /// Whether to serve the /.well-known/acp.json agent discovery manifest.
     /// Only effective when transport is "http" or "both". Default: true.
     #[serde(default = "default_acp_discovery_enabled")]
@@ -703,6 +743,7 @@ impl Default for AcpConfig {
             transport: default_acp_transport(),
             http_bind: default_acp_http_bind(),
             auth_token: None,
+            auth_clients: Vec::new(),
             discovery_enabled: default_acp_discovery_enabled(),
             lsp: AcpLspConfig::default(),
             additional_directories: Vec::new(),
@@ -732,6 +773,7 @@ impl std::fmt::Debug for AcpConfig {
                 "auth_token",
                 &self.auth_token.as_ref().map(|_| "[REDACTED]"),
             )
+            .field("auth_clients", &self.auth_clients)
             .field("discovery_enabled", &self.discovery_enabled)
             .field("lsp", &self.lsp)
             .field("additional_directories", &self.additional_directories)
@@ -741,6 +783,90 @@ impl std::fmt::Debug for AcpConfig {
             .field("timeouts", &self.timeouts)
             .field("model_config", &self.model_config)
             .finish()
+    }
+}
+
+impl AcpConfig {
+    /// Validate `auth_token` / `auth_clients` coexistence (#5868).
+    ///
+    /// Checks only what is decidable from the config file alone — `id` uniqueness, the
+    /// reserved-sentinel rule, exactly-one-of `token`/`token_vault_key` per entry, non-empty
+    /// inline tokens, and duplicate *inline* tokens (including the legacy `auth_token`).
+    /// Vault-resolved tokens are cross-checked for collisions at startup instead (after the
+    /// vault is unlocked), since that value isn't known here.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable message describing the first violation found.
+    pub fn validate_auth_clients(&self) -> Result<(), String> {
+        let mut seen_ids = std::collections::HashSet::new();
+        let mut seen_inline_tokens = std::collections::HashSet::new();
+
+        if let Some(ref token) = self.auth_token {
+            if token.trim().is_empty() {
+                return Err("[acp] auth_token must not be empty or whitespace-only".to_owned());
+            }
+            seen_inline_tokens.insert(token.as_str());
+        }
+
+        for client in &self.auth_clients {
+            if client.id.is_empty() {
+                return Err("[[acp.auth_clients]] entry has an empty id".to_owned());
+            }
+            if client.id == ACP_AUTH_CLIENT_ID_DEFAULT || client.id == ACP_AUTH_CLIENT_ID_LOCAL {
+                return Err(format!(
+                    "[[acp.auth_clients]] id {:?} is reserved (collides with the legacy \
+                     auth_token client or the unauthenticated/stdio owner bucket)",
+                    client.id
+                ));
+            }
+            if client.id.contains(':') {
+                return Err(format!(
+                    "[[acp.auth_clients]] id {:?} must not contain ':'",
+                    client.id
+                ));
+            }
+            if !seen_ids.insert(client.id.as_str()) {
+                return Err(format!(
+                    "[[acp.auth_clients]] id {:?} is duplicated",
+                    client.id
+                ));
+            }
+            match (&client.token, &client.token_vault_key) {
+                (Some(_), Some(_)) => {
+                    return Err(format!(
+                        "[[acp.auth_clients]] id {:?} sets both token and token_vault_key; \
+                         exactly one must be set",
+                        client.id
+                    ));
+                }
+                (None, None) => {
+                    return Err(format!(
+                        "[[acp.auth_clients]] id {:?} sets neither token nor token_vault_key; \
+                         exactly one must be set",
+                        client.id
+                    ));
+                }
+                (Some(token), None) => {
+                    if token.trim().is_empty() {
+                        return Err(format!(
+                            "[[acp.auth_clients]] id {:?} has an empty or whitespace-only token",
+                            client.id
+                        ));
+                    }
+                    if !seen_inline_tokens.insert(token.as_str()) {
+                        return Err(format!(
+                            "[[acp.auth_clients]] id {:?} has a token that collides with \
+                             another configured client's inline token",
+                            client.id
+                        ));
+                    }
+                }
+                (None, Some(_)) => {}
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -1000,6 +1126,201 @@ mod tests {
     fn acp_auth_method_known_variant_succeeds() {
         let m = serde_json::from_str::<AcpAuthMethod>(r#""agent""#).unwrap();
         assert_eq!(m, AcpAuthMethod::Agent);
+    }
+
+    // ── AcpConfig::validate_auth_clients (#5868) ──────────────────────────────
+
+    fn client(id: &str, token: &str) -> AcpAuthClient {
+        AcpAuthClient {
+            id: id.to_owned(),
+            token: Some(token.to_owned()),
+            token_vault_key: None,
+        }
+    }
+
+    #[test]
+    fn validate_auth_clients_empty_config_ok() {
+        assert!(AcpConfig::default().validate_auth_clients().is_ok());
+    }
+
+    #[test]
+    fn validate_auth_clients_legacy_auth_token_only_ok() {
+        let cfg = AcpConfig {
+            auth_token: Some("secret".to_owned()),
+            ..AcpConfig::default()
+        };
+        assert!(cfg.validate_auth_clients().is_ok());
+    }
+
+    #[test]
+    fn validate_auth_clients_single_client_ok() {
+        let cfg = AcpConfig {
+            auth_clients: vec![client("alice", "token-a")],
+            ..AcpConfig::default()
+        };
+        assert!(cfg.validate_auth_clients().is_ok());
+    }
+
+    #[test]
+    fn validate_auth_clients_coexist_with_legacy_ok() {
+        let cfg = AcpConfig {
+            auth_token: Some("legacy".to_owned()),
+            auth_clients: vec![client("alice", "token-a"), client("bob", "token-b")],
+            ..AcpConfig::default()
+        };
+        assert!(cfg.validate_auth_clients().is_ok());
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_reserved_id_default() {
+        let cfg = AcpConfig {
+            auth_clients: vec![client(ACP_AUTH_CLIENT_ID_DEFAULT, "token-a")],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("reserved"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_reserved_id_acp_local() {
+        let cfg = AcpConfig {
+            auth_clients: vec![client(ACP_AUTH_CLIENT_ID_LOCAL, "token-a")],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("reserved"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_duplicate_id() {
+        let cfg = AcpConfig {
+            auth_clients: vec![client("alice", "token-a"), client("alice", "token-b")],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("duplicated"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_id_containing_colon() {
+        let cfg = AcpConfig {
+            auth_clients: vec![client("alice:2", "token-a")],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("':'"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_empty_id() {
+        let cfg = AcpConfig {
+            auth_clients: vec![client("", "token-a")],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("empty id"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_neither_token_nor_vault_key() {
+        let cfg = AcpConfig {
+            auth_clients: vec![AcpAuthClient {
+                id: "alice".to_owned(),
+                token: None,
+                token_vault_key: None,
+            }],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("neither"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_both_token_and_vault_key() {
+        let cfg = AcpConfig {
+            auth_clients: vec![AcpAuthClient {
+                id: "alice".to_owned(),
+                token: Some("token-a".to_owned()),
+                token_vault_key: Some("ZEPH_ACP_TOKEN_ALICE".to_owned()),
+            }],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("both"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_vault_key_only_ok() {
+        let cfg = AcpConfig {
+            auth_clients: vec![AcpAuthClient {
+                id: "alice".to_owned(),
+                token: None,
+                token_vault_key: Some("ZEPH_ACP_TOKEN_ALICE".to_owned()),
+            }],
+            ..AcpConfig::default()
+        };
+        assert!(cfg.validate_auth_clients().is_ok());
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_duplicate_inline_tokens_across_clients() {
+        let cfg = AcpConfig {
+            auth_clients: vec![client("alice", "shared"), client("bob", "shared")],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("collides"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_inline_token_colliding_with_legacy_default_token() {
+        let cfg = AcpConfig {
+            auth_token: Some("shared".to_owned()),
+            auth_clients: vec![client("alice", "shared")],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("collides"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_empty_legacy_auth_token() {
+        let cfg = AcpConfig {
+            auth_token: Some(String::new()),
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("empty"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_whitespace_only_legacy_auth_token() {
+        let cfg = AcpConfig {
+            auth_token: Some("   ".to_owned()),
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("empty"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_empty_inline_client_token() {
+        let cfg = AcpConfig {
+            auth_clients: vec![client("alice", "")],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("empty"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_auth_clients_rejects_whitespace_only_inline_client_token() {
+        let cfg = AcpConfig {
+            auth_clients: vec![client("alice", "   ")],
+            ..AcpConfig::default()
+        };
+        let err = cfg.validate_auth_clients().unwrap_err();
+        assert!(err.contains("empty"), "unexpected error: {err}");
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1941,7 +1941,7 @@ impl<C: Channel> Agent<C> {
         let new_id = zeph_common::SessionId::generate();
 
         let fork_result =
-            zeph_session::ForkEngine::fork(&data_dir, id, new_id.as_str(), None, &store)
+            zeph_session::ForkEngine::fork(&data_dir, id, new_id.as_str(), None, &store, None)
                 .await
                 .map_err(|e| CommandError::new(e.to_string()))?;
 

--- a/crates/zeph-db/migrations/postgres/108_acp_session_owner.sql
+++ b/crates/zeph-db/migrations/postgres/108_acp_session_owner.sql
@@ -1,0 +1,10 @@
+-- Adds connection/tenant-scoped ownership to `acp_sessions` (#5868): ACP session listing and
+-- loading was previously global across every connection sharing one SQLite store. `owner_key`
+-- is the authenticated ACP client identity (bearer-token client id, or "acp-local" for stdio /
+-- unauthenticated HTTP). NULL means either a legacy pre-fix row or a non-ACP-channel row
+-- (CLI/TUI/Telegram via `zeph_session::SessionStore::create`, spec-068 Decision D1 — no second
+-- sessions table) — those rows are never scoped/filtered by ACP handlers.
+ALTER TABLE acp_sessions ADD COLUMN IF NOT EXISTS owner_key TEXT;
+
+-- Serves the scoped list query `WHERE owner_key = ? ORDER BY updated_at DESC`.
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_owner_updated ON acp_sessions(owner_key, updated_at);

--- a/crates/zeph-db/migrations/sqlite/108_acp_session_owner.sql
+++ b/crates/zeph-db/migrations/sqlite/108_acp_session_owner.sql
@@ -1,0 +1,10 @@
+-- Adds connection/tenant-scoped ownership to `acp_sessions` (#5868): ACP session listing and
+-- loading was previously global across every connection sharing one SQLite store. `owner_key`
+-- is the authenticated ACP client identity (bearer-token client id, or "acp-local" for stdio /
+-- unauthenticated HTTP). NULL means either a legacy pre-fix row or a non-ACP-channel row
+-- (CLI/TUI/Telegram via `zeph_session::SessionStore::create`, spec-068 Decision D1 — no second
+-- sessions table) — those rows are never scoped/filtered by ACP handlers.
+ALTER TABLE acp_sessions ADD COLUMN owner_key TEXT;
+
+-- Serves the scoped list query `WHERE owner_key = ? ORDER BY updated_at DESC`.
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_owner_updated ON acp_sessions(owner_key, updated_at);

--- a/crates/zeph-memory/src/store/acp_sessions.rs
+++ b/crates/zeph-memory/src/store/acp_sessions.rs
@@ -35,17 +35,28 @@ pub struct AcpSessionConfigSnapshot {
 impl SqliteStore {
     /// Create a new ACP session record.
     ///
+    /// `owner` stamps `owner_key` (#5868): the authenticated ACP client identity that may
+    /// list/load this session. `None` leaves it unowned — used by non-ACP channels
+    /// (CLI/TUI/Telegram via `zeph_session::SessionStore::create`, which does not call this
+    /// method at all and so is unaffected either way; `None` here is for ACP callers that
+    /// intentionally create an unowned row, e.g. none today, but kept for forward compat).
+    ///
     /// # Errors
     ///
     /// Returns an error if the database write fails.
-    pub async fn create_acp_session(&self, session_id: &str) -> Result<(), MemoryError> {
+    pub async fn create_acp_session(
+        &self,
+        session_id: &str,
+        owner: Option<&str>,
+    ) -> Result<(), MemoryError> {
         let sql = zeph_db::rewrite_placeholders(&format!(
-            "{} INTO acp_sessions (id) VALUES (?){}",
+            "{} INTO acp_sessions (id, owner_key) VALUES (?, ?){}",
             <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
             <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
         ));
         zeph_db::query(sqlx::AssertSqlSafe(sql))
             .bind(session_id)
+            .bind(owner)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -357,7 +368,217 @@ impl SqliteStore {
         Ok(count > 0)
     }
 
+    /// List ACP sessions owned by `owner`, ordered by last activity descending (#5868).
+    ///
+    /// Unlike [`Self::list_acp_sessions`], this is strictly scoped: rows owned by another
+    /// `owner_key` or left `NULL` (legacy/non-ACP rows) are never returned. Pass `limit = 0`
+    /// for unlimited results.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn list_acp_sessions_for_owner(
+        &self,
+        limit: usize,
+        owner: &str,
+    ) -> Result<Vec<AcpSessionInfo>, MemoryError> {
+        #[allow(clippy::cast_possible_wrap)]
+        let sql_limit: i64 = if limit == 0 { -1 } else { limit as i64 };
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let updated_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let raw = format!(
+            "SELECT s.id, s.title, s.{created_at_sel}, s.{updated_at_sel}, \
+             s.event_count AS message_count \
+             FROM acp_sessions s \
+             WHERE s.owner_key = ? \
+             ORDER BY s.updated_at DESC \
+             LIMIT ?"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let rows = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
+            sqlx::AssertSqlSafe(query_sql),
+        )
+        .bind(owner)
+        .bind(sql_limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(id, title, created_at, updated_at, message_count)| AcpSessionInfo {
+                    id,
+                    title,
+                    created_at,
+                    updated_at,
+                    message_count,
+                },
+            )
+            .collect())
+    }
+
+    /// Fetch metadata for a session, scoped to `owner` (#5868).
+    ///
+    /// Returns `None` both when the session does not exist and when it is owned by a
+    /// different `owner_key` — the two cases are indistinguishable to the caller by design,
+    /// to avoid leaking existence of another owner's session (mirrors
+    /// [`Self::claim_acp_session_for_owner`]'s uniform not-found semantics). A `NULL`
+    /// (legacy/non-ACP) `owner_key` is treated as accessible.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn get_acp_session_info_for_owner(
+        &self,
+        session_id: &str,
+        owner: &str,
+    ) -> Result<Option<AcpSessionInfo>, MemoryError> {
+        let created_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        let updated_at_sel =
+            <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let raw = format!(
+            "SELECT s.id, s.title, s.{created_at_sel}, s.{updated_at_sel}, \
+             s.event_count AS message_count \
+             FROM acp_sessions s \
+             WHERE s.id = ? AND (s.owner_key = ? OR s.owner_key IS NULL)"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
+            sqlx::AssertSqlSafe(query_sql),
+        )
+        .bind(session_id)
+        .bind(owner)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(
+            |(id, title, created_at, updated_at, message_count)| AcpSessionInfo {
+                id,
+                title,
+                created_at,
+                updated_at,
+                message_count,
+            },
+        ))
+    }
+
+    /// Non-mutating accessibility gate: `true` iff `session_id` exists and is owned by
+    /// `owner` or is unowned (`NULL`, legacy/non-ACP row) (#5868).
+    ///
+    /// Use for read-only access gates that must NOT silently claim a legacy row (e.g. the
+    /// HTTP `session_messages_handler`). For load/resume/fork, prefer
+    /// [`Self::claim_acp_session_for_owner`], which additionally claims unowned rows
+    /// atomically.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn acp_session_accessible_for_owner(
+        &self,
+        session_id: &str,
+        owner: &str,
+    ) -> Result<bool, MemoryError> {
+        let count: i64 = zeph_db::query_scalar(sql!(
+            "SELECT COUNT(*) FROM acp_sessions WHERE id = ? AND (owner_key = ? OR owner_key IS NULL)"
+        ))
+        .bind(session_id)
+        .bind(owner)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(count > 0)
+    }
+
+    /// Atomically grant `owner` access to `session_id`, claiming it if currently unowned
+    /// (`NULL`, legacy/non-ACP row) (#5868).
+    ///
+    /// A single `UPDATE ... RETURNING` statement — no read-then-claim race window. Returns
+    /// `true` iff the row exists AND is accessible: either it was `NULL` and is now claimed
+    /// for `owner`, or it was already owned by `owner` (a redundant, harmless no-op write).
+    /// Returns `false` uniformly for "session does not exist" and "owned by a different
+    /// owner" — callers must map both to the same not-found response so a foreign
+    /// `owner_key` can never be distinguished from a missing session.
+    ///
+    /// Use for load/resume/fork existence checks. For read-only gates that must not claim,
+    /// use [`Self::acp_session_accessible_for_owner`] instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database write fails.
+    pub async fn claim_acp_session_for_owner(
+        &self,
+        session_id: &str,
+        owner: &str,
+    ) -> Result<bool, MemoryError> {
+        let row: Option<(String,)> = zeph_db::query_as(sql!(
+            "UPDATE acp_sessions SET owner_key = ? \
+             WHERE id = ? AND (owner_key IS NULL OR owner_key = ?) \
+             RETURNING id"
+        ))
+        .bind(owner)
+        .bind(session_id)
+        .bind(owner)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.is_some())
+    }
+
+    /// Delete an ACP session scoped to `owner`, returning `true` iff a row was deleted
+    /// (#5868).
+    ///
+    /// Matches [`Self::delete_acp_session_checked`]'s TOCTOU-free single-statement shape,
+    /// additionally restricted to rows owned by `owner` or unowned (`NULL`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database write fails.
+    pub async fn delete_acp_session_for_owner(
+        &self,
+        session_id: &str,
+        owner: &str,
+    ) -> Result<bool, MemoryError> {
+        let result = zeph_db::query(sql!(
+            "DELETE FROM acp_sessions WHERE id = ? AND (owner_key = ? OR owner_key IS NULL)"
+        ))
+        .bind(session_id)
+        .bind(owner)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Update the title of a session scoped to `owner`, returning `true` iff a row was
+    /// updated (#5868).
+    ///
+    /// Matches [`Self::update_session_title_checked`]'s TOCTOU-free single-statement shape,
+    /// additionally restricted to rows owned by `owner` or unowned (`NULL`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database write fails.
+    pub async fn update_session_title_for_owner(
+        &self,
+        session_id: &str,
+        title: &str,
+        owner: &str,
+    ) -> Result<bool, MemoryError> {
+        let result = zeph_db::query(sql!(
+            "UPDATE acp_sessions SET title = ? \
+             WHERE id = ? AND (owner_key = ? OR owner_key IS NULL)"
+        ))
+        .bind(title)
+        .bind(session_id)
+        .bind(owner)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Create a new ACP session record with an associated conversation.
+    ///
+    /// `owner` stamps `owner_key` (#5868) — see [`Self::create_acp_session`].
     ///
     /// # Errors
     ///
@@ -366,15 +587,17 @@ impl SqliteStore {
         &self,
         session_id: &str,
         conversation_id: ConversationId,
+        owner: Option<&str>,
     ) -> Result<(), MemoryError> {
         let sql = zeph_db::rewrite_placeholders(&format!(
-            "{} INTO acp_sessions (id, conversation_id) VALUES (?, ?){}",
+            "{} INTO acp_sessions (id, conversation_id, owner_key) VALUES (?, ?, ?){}",
             <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
             <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
         ));
         zeph_db::query(sqlx::AssertSqlSafe(sql))
             .bind(session_id)
             .bind(conversation_id)
+            .bind(owner)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -494,7 +717,7 @@ mod tests {
     #[tokio::test]
     async fn create_and_exists() {
         let store = make_store().await;
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
         assert!(store.acp_session_exists("sess-1").await.unwrap());
         assert!(!store.acp_session_exists("sess-2").await.unwrap());
     }
@@ -502,7 +725,7 @@ mod tests {
     #[tokio::test]
     async fn session_config_round_trips() {
         let store = make_store().await;
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
         let snapshot = AcpSessionConfigSnapshot {
             current_model: "claude:opus".to_owned(),
             temperature_preset: "creative".to_owned(),
@@ -528,7 +751,7 @@ mod tests {
     #[tokio::test]
     async fn session_config_missing_snapshot_returns_none() {
         let store = make_store().await;
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
         assert!(store.get_session_config("sess-1").await.unwrap().is_none());
     }
 
@@ -541,7 +764,7 @@ mod tests {
     #[tokio::test]
     async fn save_and_load_events() {
         let store = make_store().await;
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
         store
             .save_acp_event("sess-1", "user_message", "hello")
             .await
@@ -562,7 +785,7 @@ mod tests {
     #[tokio::test]
     async fn delete_cascades_events() {
         let store = make_store().await;
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
         store
             .save_acp_event("sess-1", "user_message", "hello")
             .await
@@ -584,13 +807,13 @@ mod tests {
     #[tokio::test]
     async fn list_sessions_includes_title_and_message_count() {
         let store = make_store().await;
-        store.create_acp_session("sess-b").await.unwrap();
+        store.create_acp_session("sess-b", None).await.unwrap();
 
         // Sleep so that sess-a's events land in a different second than sess-b's
         // created_at, making the updated_at DESC ordering deterministic.
         tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
 
-        store.create_acp_session("sess-a").await.unwrap();
+        store.create_acp_session("sess-a", None).await.unwrap();
         bump_event_count(&store, "sess-a", 2).await;
         store
             .update_session_title("sess-a", "My Chat")
@@ -614,7 +837,7 @@ mod tests {
         let store = make_store().await;
         for i in 0..5u8 {
             store
-                .create_acp_session(&format!("sess-{i}"))
+                .create_acp_session(&format!("sess-{i}"), None)
                 .await
                 .unwrap();
         }
@@ -627,7 +850,7 @@ mod tests {
         let store = make_store().await;
         for i in 0..3u8 {
             store
-                .create_acp_session(&format!("sess-{i}"))
+                .create_acp_session(&format!("sess-{i}"), None)
                 .await
                 .unwrap();
         }
@@ -640,7 +863,7 @@ mod tests {
         let store = make_store().await;
         for i in 0..5u8 {
             store
-                .create_acp_session(&format!("sess-{i}"))
+                .create_acp_session(&format!("sess-{i}"), None)
                 .await
                 .unwrap();
         }
@@ -658,7 +881,7 @@ mod tests {
     #[tokio::test]
     async fn get_acp_session_info_returns_data() {
         let store = make_store().await;
-        store.create_acp_session("sess-x").await.unwrap();
+        store.create_acp_session("sess-x", None).await.unwrap();
         bump_event_count(&store, "sess-x", 1).await;
         store.update_session_title("sess-x", "Test").await.unwrap();
 
@@ -671,7 +894,7 @@ mod tests {
     #[tokio::test]
     async fn updated_at_trigger_fires_on_event_insert() {
         let store = make_store().await;
-        store.create_acp_session("sess-t").await.unwrap();
+        store.create_acp_session("sess-t", None).await.unwrap();
 
         let before = store
             .get_acp_session_info("sess-t")
@@ -707,7 +930,7 @@ mod tests {
         let store = make_store().await;
         let cid = store.create_conversation().await.unwrap();
         store
-            .create_acp_session_with_conversation("sess-1", cid)
+            .create_acp_session_with_conversation("sess-1", cid, None)
             .await
             .unwrap();
         let retrieved = store
@@ -720,7 +943,7 @@ mod tests {
     #[tokio::test]
     async fn get_conversation_id_returns_none_for_legacy_session() {
         let store = make_store().await;
-        store.create_acp_session("legacy").await.unwrap();
+        store.create_acp_session("legacy", None).await.unwrap();
         let cid = store
             .get_acp_session_conversation_id("legacy")
             .await
@@ -741,7 +964,7 @@ mod tests {
     #[tokio::test]
     async fn set_conversation_id_updates_existing_session() {
         let store = make_store().await;
-        store.create_acp_session("sess-2").await.unwrap();
+        store.create_acp_session("sess-2", None).await.unwrap();
         let cid = store.create_conversation().await.unwrap();
         store
             .set_acp_session_conversation_id("sess-2", cid)
@@ -822,11 +1045,11 @@ mod tests {
         let cid1 = store.create_conversation().await.unwrap();
         let cid2 = store.create_conversation().await.unwrap();
         store
-            .create_acp_session_with_conversation("sess-a", cid1)
+            .create_acp_session_with_conversation("sess-a", cid1, None)
             .await
             .unwrap();
         store
-            .create_acp_session_with_conversation("sess-b", cid2)
+            .create_acp_session_with_conversation("sess-b", cid2, None)
             .await
             .unwrap();
 
@@ -845,5 +1068,254 @@ mod tests {
             retrieved1, retrieved2,
             "concurrent sessions must get distinct conversation_ids"
         );
+    }
+
+    // ── Owner-scoped access (#5868) ────────────────────────────────────────────
+
+    /// Regression guard (#5868): the unscoped CLI-facing methods (`list_acp_sessions`,
+    /// `acp_session_exists`, `delete_acp_session_checked`) must keep seeing every row
+    /// regardless of `owner_key` — CLI/operator access is intentionally global, and a future
+    /// change that accidentally scoped these instead of the `_for_owner` siblings would break
+    /// `zeph sessions list`/`zeph sessions delete` silently.
+    #[tokio::test]
+    async fn cli_facing_unscoped_methods_see_all_owners_and_legacy_rows() {
+        let store = make_store().await;
+        store
+            .create_acp_session("mine", Some("owner-a"))
+            .await
+            .unwrap();
+        store
+            .create_acp_session("theirs", Some("owner-b"))
+            .await
+            .unwrap();
+        store.create_acp_session("legacy", None).await.unwrap();
+
+        let sessions = store.list_acp_sessions(0).await.unwrap();
+        assert_eq!(sessions.len(), 3);
+
+        assert!(store.acp_session_exists("mine").await.unwrap());
+        assert!(store.acp_session_exists("theirs").await.unwrap());
+        assert!(store.acp_session_exists("legacy").await.unwrap());
+
+        assert!(store.delete_acp_session_checked("theirs").await.unwrap());
+        assert!(!store.acp_session_exists("theirs").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn list_for_owner_excludes_other_owners_and_legacy_rows() {
+        let store = make_store().await;
+        store
+            .create_acp_session("mine", Some("owner-a"))
+            .await
+            .unwrap();
+        store
+            .create_acp_session("theirs", Some("owner-b"))
+            .await
+            .unwrap();
+        store.create_acp_session("legacy", None).await.unwrap();
+
+        let sessions = store
+            .list_acp_sessions_for_owner(0, "owner-a")
+            .await
+            .unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, "mine");
+    }
+
+    #[tokio::test]
+    async fn get_info_for_owner_returns_none_for_foreign_owner() {
+        let store = make_store().await;
+        store
+            .create_acp_session("theirs", Some("owner-b"))
+            .await
+            .unwrap();
+        let info = store
+            .get_acp_session_info_for_owner("theirs", "owner-a")
+            .await
+            .unwrap();
+        assert!(info.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_info_for_owner_accessible_for_legacy_null_row() {
+        let store = make_store().await;
+        store.create_acp_session("legacy", None).await.unwrap();
+        let info = store
+            .get_acp_session_info_for_owner("legacy", "owner-a")
+            .await
+            .unwrap();
+        assert!(info.is_some());
+    }
+
+    #[tokio::test]
+    async fn accessible_for_owner_true_for_own_and_legacy_false_for_foreign() {
+        let store = make_store().await;
+        store
+            .create_acp_session("mine", Some("owner-a"))
+            .await
+            .unwrap();
+        store.create_acp_session("legacy", None).await.unwrap();
+        store
+            .create_acp_session("theirs", Some("owner-b"))
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .acp_session_accessible_for_owner("mine", "owner-a")
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .acp_session_accessible_for_owner("legacy", "owner-a")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .acp_session_accessible_for_owner("theirs", "owner-a")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .acp_session_accessible_for_owner("no-such", "owner-a")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_for_owner_claims_legacy_null_row() {
+        let store = make_store().await;
+        store.create_acp_session("legacy", None).await.unwrap();
+
+        assert!(
+            store
+                .claim_acp_session_for_owner("legacy", "owner-a")
+                .await
+                .unwrap()
+        );
+
+        // Now owned by owner-a: a foreign owner can no longer claim or list it.
+        assert!(
+            !store
+                .claim_acp_session_for_owner("legacy", "owner-b")
+                .await
+                .unwrap()
+        );
+        let sessions = store
+            .list_acp_sessions_for_owner(0, "owner-a")
+            .await
+            .unwrap();
+        assert_eq!(sessions.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn claim_for_owner_is_idempotent_for_the_same_owner() {
+        let store = make_store().await;
+        store
+            .create_acp_session("mine", Some("owner-a"))
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .claim_acp_session_for_owner("mine", "owner-a")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_for_owner_returns_false_for_missing_session() {
+        let store = make_store().await;
+        assert!(
+            !store
+                .claim_acp_session_for_owner("no-such", "owner-a")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_for_owner_refuses_foreign_owner() {
+        let store = make_store().await;
+        store
+            .create_acp_session("theirs", Some("owner-b"))
+            .await
+            .unwrap();
+
+        assert!(
+            !store
+                .delete_acp_session_for_owner("theirs", "owner-a")
+                .await
+                .unwrap()
+        );
+        assert!(store.acp_session_exists("theirs").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_for_owner_deletes_own_and_legacy_rows() {
+        let store = make_store().await;
+        store
+            .create_acp_session("mine", Some("owner-a"))
+            .await
+            .unwrap();
+        store.create_acp_session("legacy", None).await.unwrap();
+
+        assert!(
+            store
+                .delete_acp_session_for_owner("mine", "owner-a")
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .delete_acp_session_for_owner("legacy", "owner-a")
+                .await
+                .unwrap()
+        );
+        assert!(!store.acp_session_exists("mine").await.unwrap());
+        assert!(!store.acp_session_exists("legacy").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn update_title_for_owner_refuses_foreign_owner() {
+        let store = make_store().await;
+        store
+            .create_acp_session("theirs", Some("owner-b"))
+            .await
+            .unwrap();
+
+        assert!(
+            !store
+                .update_session_title_for_owner("theirs", "new title", "owner-a")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn update_title_for_owner_updates_own_row() {
+        let store = make_store().await;
+        store
+            .create_acp_session("mine", Some("owner-a"))
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .update_session_title_for_owner("mine", "new title", "owner-a")
+                .await
+                .unwrap()
+        );
+        let info = store
+            .get_acp_session_info_for_owner("mine", "owner-a")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(info.title.as_deref(), Some("new title"));
     }
 }

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -1153,9 +1153,9 @@ mod pg {
         let (pool, _container) = start_pg().await;
         let store = SqliteStore::from_pool(pool.clone()).await.unwrap();
 
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
         // Calling twice must not error (INSERT_IGNORE / ON CONFLICT DO NOTHING).
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
 
         let count: i64 = sqlx::query_scalar(zeph_db::sql!(
             "SELECT COUNT(*) FROM acp_sessions WHERE id = ?"
@@ -1168,7 +1168,7 @@ mod pg {
 
         let cid = store.create_conversation().await.unwrap();
         store
-            .create_acp_session_with_conversation("sess-2", cid)
+            .create_acp_session_with_conversation("sess-2", cid, None)
             .await
             .unwrap();
         let linked_cid: (Option<i64>,) = sqlx::query_as(zeph_db::sql!(
@@ -1194,7 +1194,7 @@ mod pg {
         let (pool, _container) = start_pg().await;
         let store = SqliteStore::from_pool(pool).await.unwrap();
 
-        store.create_acp_session("sess-ts-1").await.unwrap();
+        store.create_acp_session("sess-ts-1", None).await.unwrap();
 
         let list = store.list_acp_sessions(10).await.unwrap();
         assert_eq!(list.len(), 1);
@@ -1231,7 +1231,7 @@ mod pg {
         let (pool, _container) = start_pg().await;
         let store = SqliteStore::from_pool(pool).await.unwrap();
 
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
         let snapshot = AcpSessionConfigSnapshot {
             current_model: "claude:opus".to_owned(),
             temperature_preset: "creative".to_owned(),
@@ -1263,7 +1263,7 @@ mod pg {
         let (pool, _container) = start_pg().await;
         let store = SqliteStore::from_pool(pool).await.unwrap();
 
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
         let snapshot = AcpSessionConfigSnapshot {
             current_model: "claude:sonnet".to_owned(),
             temperature_preset: "precise".to_owned(),
@@ -1295,7 +1295,7 @@ mod pg {
         let (pool, _container) = start_pg().await;
         let store = SqliteStore::from_pool(pool).await.unwrap();
 
-        store.create_acp_session("sess-1").await.unwrap();
+        store.create_acp_session("sess-1", None).await.unwrap();
         assert!(
             store.get_session_config("sess-1").await.unwrap().is_none(),
             "session with no saved config must return None, not a zeroed snapshot"

--- a/crates/zeph-session/src/fork.rs
+++ b/crates/zeph-session/src/fork.rs
@@ -41,6 +41,8 @@ impl ForkEngine {
     /// `LoopbackChannel`/entry), and the CLI mints a fresh `SessionId::generate()` before calling
     /// in.
     ///
+    /// `owner` stamps the child row's `owner_key` (#5868) — see [`SessionStore::record_fork`].
+    ///
     /// # Errors
     ///
     /// Returns [`SessionError::NotFound`] if `src_id` has no session-store row,
@@ -53,6 +55,7 @@ impl ForkEngine {
         new_id: &str,
         at_seq: Option<u64>,
         store: &SessionStore,
+        owner: Option<&str>,
     ) -> Result<ForkResult, SessionError> {
         if store.get(src_id).await?.is_none() {
             return Err(SessionError::NotFound(src_id.to_owned()));
@@ -111,7 +114,7 @@ impl ForkEngine {
                 .await?;
         }
 
-        store.record_fork(new_id, src_id, at_seq).await?;
+        store.record_fork(new_id, src_id, at_seq, owner).await?;
         store
             .update_seq(
                 new_id,
@@ -218,7 +221,7 @@ mod tests {
         let data_dir = tempfile::tempdir().unwrap();
         seed_parent(data_dir.path(), &store, "parent").await;
 
-        let result = ForkEngine::fork(data_dir.path(), "parent", "child", Some(3), &store)
+        let result = ForkEngine::fork(data_dir.path(), "parent", "child", Some(3), &store, None)
             .await
             .unwrap();
         assert_eq!(result.events_copied, 3);
@@ -237,7 +240,7 @@ mod tests {
         let data_dir = tempfile::tempdir().unwrap();
         seed_parent(data_dir.path(), &store, "parent").await;
 
-        ForkEngine::fork(data_dir.path(), "parent", "child", Some(2), &store)
+        ForkEngine::fork(data_dir.path(), "parent", "child", Some(2), &store, None)
             .await
             .unwrap();
 
@@ -246,13 +249,44 @@ mod tests {
         assert_eq!(meta.forked_at_seq, Some(2));
     }
 
+    /// Regression test (#5868): `ForkEngine::fork`'s `owner` argument must reach the child
+    /// row's `owner_key` column end-to-end (through `record_fork`), not just at the
+    /// `SessionStore::record_fork` unit level.
+    #[tokio::test]
+    async fn fork_propagates_owner_to_child_row() {
+        let pool = make_pool().await;
+        let store = SessionStore::new(pool.clone());
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        ForkEngine::fork(
+            data_dir.path(),
+            "parent",
+            "child",
+            Some(2),
+            &store,
+            Some("alice"),
+        )
+        .await
+        .unwrap();
+
+        let owner_key: Option<String> = zeph_db::query_scalar(zeph_db::sql!(
+            "SELECT owner_key FROM acp_sessions WHERE id = ?"
+        ))
+        .bind("child")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(owner_key.as_deref(), Some("alice"));
+    }
+
     #[tokio::test]
     async fn test_fork_appends_forkpoint_to_parent() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
         seed_parent(data_dir.path(), &store, "parent").await;
 
-        ForkEngine::fork(data_dir.path(), "parent", "child", Some(2), &store)
+        ForkEngine::fork(data_dir.path(), "parent", "child", Some(2), &store, None)
             .await
             .unwrap();
 
@@ -271,7 +305,7 @@ mod tests {
         let data_dir = tempfile::tempdir().unwrap();
         seed_parent(data_dir.path(), &store, "parent").await;
 
-        let err = ForkEngine::fork(data_dir.path(), "parent", "child", Some(100), &store)
+        let err = ForkEngine::fork(data_dir.path(), "parent", "child", Some(100), &store, None)
             .await
             .unwrap_err();
         assert!(matches!(err, SessionError::InvalidForkPoint(_)));
@@ -282,7 +316,7 @@ mod tests {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
 
-        let err = ForkEngine::fork(data_dir.path(), "no-such", "child", Some(0), &store)
+        let err = ForkEngine::fork(data_dir.path(), "no-such", "child", Some(0), &store, None)
             .await
             .unwrap_err();
         assert!(matches!(err, SessionError::NotFound(_)));
@@ -294,7 +328,7 @@ mod tests {
         let data_dir = tempfile::tempdir().unwrap();
         seed_parent(data_dir.path(), &store, "parent").await;
 
-        let result = ForkEngine::fork(data_dir.path(), "parent", "child", None, &store)
+        let result = ForkEngine::fork(data_dir.path(), "parent", "child", None, &store, None)
             .await
             .unwrap();
         // seed_parent appends 4 events total.

--- a/crates/zeph-session/src/store.rs
+++ b/crates/zeph-session/src/store.rs
@@ -297,6 +297,11 @@ impl SessionStore {
     /// Does not touch the parent's log (the `ForkPoint` provenance event is appended by
     /// [`crate::replay`]'s `ForkEngine`, which owns the parent's [`crate::log::SessionEventLog`]).
     ///
+    /// `owner` stamps `owner_key` (#5868): ACP's `fork_conversation` passes its connection's
+    /// owner identity so the freshly forked child is immediately listable by its creator;
+    /// the CLI's `sessions fork` passes `None` (operator-scoped, unowned — consistent with
+    /// every other CLI-side session row).
+    ///
     /// # Errors
     ///
     /// Returns [`SessionError::Db`] if either write fails.
@@ -307,9 +312,11 @@ impl SessionStore {
         new_session_id: &str,
         src_session_id: &str,
         forked_at_seq: u64,
+        owner: Option<&str>,
     ) -> Result<(), SessionError> {
         let stmt = zeph_db::rewrite_placeholders(&format!(
-            "{} INTO acp_sessions (id, status, forked_from, forked_at_seq) VALUES (?, 'active', ?, ?){}",
+            "{} INTO acp_sessions (id, status, forked_from, forked_at_seq, owner_key) \
+             VALUES (?, 'active', ?, ?, ?){}",
             <ActiveDialect as Dialect>::INSERT_IGNORE,
             <ActiveDialect as Dialect>::CONFLICT_NOTHING,
         ));
@@ -317,6 +324,7 @@ impl SessionStore {
             .bind(new_session_id)
             .bind(src_session_id)
             .bind(forked_at_seq as i64)
+            .bind(owner)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -438,10 +446,59 @@ mod tests {
     async fn record_fork_sets_provenance() {
         let store = SessionStore::new(make_pool().await);
         store.create("parent").await.unwrap();
-        store.record_fork("child", "parent", 12).await.unwrap();
+        store
+            .record_fork("child", "parent", 12, None)
+            .await
+            .unwrap();
         let meta = store.get("child").await.unwrap().unwrap();
         assert_eq!(meta.forked_from.as_deref(), Some("parent"));
         assert_eq!(meta.forked_at_seq, Some(12));
+    }
+
+    /// Regression test (#5868): `record_fork`'s own `INSERT` must stamp `owner_key` on the
+    /// child row, mirroring `create_acp_session`. Found mid-implementation: `record_fork`
+    /// (used by `ForkEngine::fork`, ACP's `fork_conversation` under `[session] enabled = true`)
+    /// has a separate INSERT statement that bypassed `create_acp_session` entirely — every fork
+    /// would have landed `owner_key = NULL` regardless of the `owner` argument, making it
+    /// invisible in the fork-creator's own scoped `list_sessions` immediately after forking.
+    #[tokio::test]
+    async fn record_fork_stamps_owner_key_on_child_row() {
+        let pool = make_pool().await;
+        let store = SessionStore::new(pool.clone());
+        store.create("parent").await.unwrap();
+        store
+            .record_fork("child", "parent", 12, Some("alice"))
+            .await
+            .unwrap();
+
+        let owner_key: Option<String> =
+            zeph_db::query_scalar(sql!("SELECT owner_key FROM acp_sessions WHERE id = ?"))
+                .bind("child")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(owner_key.as_deref(), Some("alice"));
+    }
+
+    /// `record_fork(owner: None)` (the CLI / non-ACP fork path) must leave the child row
+    /// unowned, matching every other non-ACP write path (spec-068 Decision D1).
+    #[tokio::test]
+    async fn record_fork_with_no_owner_leaves_child_row_unowned() {
+        let pool = make_pool().await;
+        let store = SessionStore::new(pool.clone());
+        store.create("parent").await.unwrap();
+        store
+            .record_fork("child", "parent", 12, None)
+            .await
+            .unwrap();
+
+        let owner_key: Option<String> =
+            zeph_db::query_scalar(sql!("SELECT owner_key FROM acp_sessions WHERE id = ?"))
+                .bind("child")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(owner_key.is_none());
     }
 
     #[tokio::test]

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -27,6 +27,83 @@ fn resolve_runtime_path(path: &std::path::Path, cwd: &std::path::Path) -> std::p
     }
 }
 
+/// Resolve `[acp] auth_token` and `[[acp.auth_clients]]` into the named-client credential set
+/// consumed by [`zeph_acp::AcpServerConfig::auth_clients`] (#5868).
+///
+/// The legacy scalar `auth_token` is synthesized as the `"default"` client. Each
+/// `auth_clients` entry resolves its token from either the inline `token` field or, when
+/// `token_vault_key` is set, the age vault. A vault key that fails to resolve (missing or
+/// backend error) disables that one client (warned, not fatal) — mirrors
+/// `serve::deps::resolve_auth_token`'s soft-fail precedent for the same class of vault
+/// lookup. `zeph_config::AcpConfig::validate_auth_clients` already rejects inline-token
+/// collisions and reserved ids at config-load time; the cross-set duplicate check here catches
+/// the one thing that validation cannot (a vault-resolved token colliding with another token),
+/// since the vault is not unlocked at config-load time.
+///
+/// # Errors
+///
+/// Returns an error if two configured clients (across `auth_token` and `auth_clients`,
+/// inline or vault-resolved) end up with the same resolved token.
+#[cfg(any(feature = "acp", feature = "acp-http"))]
+async fn resolve_acp_auth_clients(
+    acp_config: &zeph_config::AcpConfig,
+    vault: &dyn zeph_core::vault::VaultProvider,
+) -> anyhow::Result<Vec<zeph_acp::AcpClientToken>> {
+    let mut clients = Vec::new();
+    let mut seen_tokens: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    if let Some(ref token) = acp_config.auth_token {
+        seen_tokens.insert(token.clone());
+        clients.push(zeph_acp::AcpClientToken {
+            id: zeph_config::ACP_AUTH_CLIENT_ID_DEFAULT.to_owned(),
+            token: token.clone(),
+        });
+    }
+
+    for client in &acp_config.auth_clients {
+        let token = if let Some(ref t) = client.token {
+            Some(t.clone())
+        } else if let Some(ref key) = client.token_vault_key {
+            match vault.get_secret(key).await {
+                Ok(Some(t)) => Some(t),
+                Ok(None) => {
+                    tracing::warn!(
+                        id = %client.id, vault_key = %key,
+                        "acp.auth_clients: vault key not found; client disabled"
+                    );
+                    None
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        id = %client.id, vault_key = %key, error = %e,
+                        "acp.auth_clients: failed to resolve token from vault; client disabled"
+                    );
+                    None
+                }
+            }
+        } else {
+            // Unreachable in practice: AcpConfig::validate_auth_clients rejects entries with
+            // neither field set before this function ever runs.
+            None
+        };
+
+        let Some(token) = token else { continue };
+
+        anyhow::ensure!(
+            seen_tokens.insert(token.clone()),
+            "[[acp.auth_clients]] id {:?} resolves to a token that collides with another \
+             configured client's token",
+            client.id
+        );
+        clients.push(zeph_acp::AcpClientToken {
+            id: client.id.clone(),
+            token,
+        });
+    }
+
+    Ok(clients)
+}
+
 #[cfg(feature = "acp")]
 fn log_acp_runtime_paths(config: &zeph_core::config::Config, config_path: &std::path::Path) {
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
@@ -295,7 +372,7 @@ pub(crate) struct SharedAgentDeps {
     acp_session_idle_timeout_secs: u64,
     acp_permission_file: Option<std::path::PathBuf>,
     acp_available_models: std::sync::Arc<RwLock<Vec<String>>>,
-    acp_auth_bearer_token: Option<String>,
+    acp_auth_clients: Vec<zeph_acp::AcpClientToken>,
     acp_discovery_enabled: bool,
     /// Maximum characters for auto-generated session titles.
     acp_title_max_chars: usize,
@@ -859,6 +936,7 @@ async fn build_acp_deps(
     // `src/runner.rs`'s CLI-path snapshot construction, so ACP sessions get a populated
     // `provider_pool` too (previously left empty, breaking `resolve_background_provider`).
     let provider_config_snapshot = agent_setup::build_provider_config_snapshot(config);
+    let acp_auth_clients = resolve_acp_auth_clients(&config.acp, app.vault()).await?;
 
     let deps = SharedAgentDeps {
         provider,
@@ -978,7 +1056,7 @@ async fn build_acp_deps(
                 config.acp.available_models.clone()
             },
         )),
-        acp_auth_bearer_token: config.acp.auth_token.clone(),
+        acp_auth_clients,
         acp_discovery_enabled: config.acp.discovery_enabled,
         acp_title_max_chars: config.memory.sessions.title_max_chars,
         acp_max_history: config.memory.sessions.max_history,
@@ -2056,7 +2134,7 @@ pub(crate) async fn run_acp_server(
         available_models: std::sync::Arc::clone(&deps.acp_available_models),
         provider_names: deps.acp_provider_names.clone(),
         mcp_manager: Some(mcp_manager_for_acp),
-        auth_bearer_token: deps.acp_auth_bearer_token.clone(),
+        auth_clients: deps.acp_auth_clients.clone(),
         discovery_enabled: deps.acp_discovery_enabled,
         terminal_timeout_secs: deps.acp_timeouts.terminal_secs,
         project_rules: deps.acp_project_rules.clone(),
@@ -2097,6 +2175,7 @@ pub(crate) async fn run_acp_server(
 ///
 /// Returns an error if the agent stack cannot be built or the server fails to bind.
 #[cfg(feature = "acp-http")]
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn run_acp_http_server(
     config_path: Option<&std::path::Path>,
     vault_backend: Option<&str>,
@@ -2112,8 +2191,25 @@ pub(crate) async fn run_acp_http_server(
     log_acp_runtime_paths(app.config(), app.config_path());
     let bind_addr = bind_override.map_or_else(|| app.config().acp.http_bind.clone(), str::to_owned);
 
-    // CLI flag overrides config/env values for auth token.
-    let auth_bearer_token = auth_token_override.or(app.config().acp.auth_token.clone());
+    // CLI flag overrides config/env values for the "default" client's token; other
+    // configured `[[acp.auth_clients]]` entries are unaffected.
+    let mut auth_clients = resolve_acp_auth_clients(&app.config().acp, app.vault()).await?;
+    if let Some(override_token) = auth_token_override {
+        auth_clients.retain(|c| c.id != zeph_config::ACP_AUTH_CLIENT_ID_DEFAULT);
+        // Same collision guard `resolve_acp_auth_clients` applies to every other client —
+        // the CLI override must not silently bypass it and reintroduce a shared-owner_key leak.
+        anyhow::ensure!(
+            !auth_clients.iter().any(|c| c.token == override_token),
+            "--acp-auth-token collides with a configured [[acp.auth_clients]] token"
+        );
+        auth_clients.insert(
+            0,
+            zeph_acp::AcpClientToken {
+                id: zeph_config::ACP_AUTH_CLIENT_ID_DEFAULT.to_owned(),
+                token: override_token,
+            },
+        );
+    }
     let mcp_manager_for_acp = Arc::new(crate::bootstrap::create_mcp_manager_with_vault(
         app.config(),
         false,
@@ -2138,7 +2234,7 @@ pub(crate) async fn run_acp_http_server(
         )),
         provider_names: acp_provider_names(app.config()),
         mcp_manager: Some(Arc::clone(&mcp_manager_for_acp)),
-        auth_bearer_token,
+        auth_clients,
         discovery_enabled: app.config().acp.discovery_enabled,
         terminal_timeout_secs: app.config().acp.timeouts.terminal_secs,
         project_rules: collect_project_rules(&app.skill_paths_for_registry()),
@@ -2255,7 +2351,7 @@ pub(crate) fn acp_http_server_config(deps: &mut SharedAgentDeps) -> zeph_acp::Ac
         available_models: std::sync::Arc::clone(&deps.acp_available_models),
         provider_names: deps.acp_provider_names.clone(),
         mcp_manager: Some(std::sync::Arc::clone(&deps.mcp_manager)),
-        auth_bearer_token: deps.acp_auth_bearer_token.clone(),
+        auth_clients: deps.acp_auth_clients.clone(),
         discovery_enabled: deps.acp_discovery_enabled,
         terminal_timeout_secs: deps.acp_timeouts.terminal_secs,
         project_rules: deps.acp_project_rules.clone(),
@@ -2331,6 +2427,203 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
     use zeph_tools::executor::ToolExecutor;
+
+    // ── resolve_acp_auth_clients (#5868) ──────────────────────────────────────
+
+    /// In-memory `VaultProvider` for `resolve_acp_auth_clients` tests — implements the real
+    /// trait directly rather than pulling in `MockVaultProvider` (which needs the `zeph-core
+    /// mock` feature threaded into this binary crate's dev-dependencies).
+    #[derive(Default)]
+    struct TestVault {
+        secrets: std::collections::HashMap<String, String>,
+        /// Keys that simulate a backend error (as opposed to a plain miss) on lookup.
+        erroring_keys: std::collections::HashSet<String>,
+    }
+
+    impl TestVault {
+        fn with_secret(mut self, key: &str, value: &str) -> Self {
+            self.secrets.insert(key.to_owned(), value.to_owned());
+            self
+        }
+
+        fn with_erroring_key(mut self, key: &str) -> Self {
+            self.erroring_keys.insert(key.to_owned());
+            self
+        }
+    }
+
+    impl zeph_core::vault::VaultProvider for TestVault {
+        fn get_secret(
+            &self,
+            key: &str,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<Option<String>, zeph_core::vault::VaultError>,
+                    > + Send
+                    + '_,
+            >,
+        > {
+            let result = if self.erroring_keys.contains(key) {
+                Err(zeph_core::vault::VaultError::Backend(
+                    "simulated backend failure".to_owned(),
+                ))
+            } else {
+                Ok(self.secrets.get(key).cloned())
+            };
+            Box::pin(async move { result })
+        }
+    }
+
+    fn acp_config_with(
+        auth_token: Option<&str>,
+        auth_clients: Vec<zeph_config::AcpAuthClient>,
+    ) -> zeph_config::AcpConfig {
+        zeph_config::AcpConfig {
+            auth_token: auth_token.map(str::to_owned),
+            auth_clients,
+            ..zeph_config::AcpConfig::default()
+        }
+    }
+
+    fn inline_client(id: &str, token: &str) -> zeph_config::AcpAuthClient {
+        zeph_config::AcpAuthClient {
+            id: id.to_owned(),
+            token: Some(token.to_owned()),
+            token_vault_key: None,
+        }
+    }
+
+    fn vault_client(id: &str, vault_key: &str) -> zeph_config::AcpAuthClient {
+        zeph_config::AcpAuthClient {
+            id: id.to_owned(),
+            token: None,
+            token_vault_key: Some(vault_key.to_owned()),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_empty_config_returns_empty() {
+        let cfg = acp_config_with(None, vec![]);
+        let clients = resolve_acp_auth_clients(&cfg, &TestVault::default())
+            .await
+            .unwrap();
+        assert!(clients.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_legacy_token_becomes_default_client() {
+        let cfg = acp_config_with(Some("legacy-secret"), vec![]);
+        let clients = resolve_acp_auth_clients(&cfg, &TestVault::default())
+            .await
+            .unwrap();
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].id, zeph_config::ACP_AUTH_CLIENT_ID_DEFAULT);
+        assert_eq!(clients[0].token, "legacy-secret");
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_inline_token_resolved_directly() {
+        let cfg = acp_config_with(None, vec![inline_client("alice", "token-a")]);
+        let clients = resolve_acp_auth_clients(&cfg, &TestVault::default())
+            .await
+            .unwrap();
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].id, "alice");
+        assert_eq!(clients[0].token, "token-a");
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_vault_key_resolved_from_vault() {
+        let cfg = acp_config_with(None, vec![vault_client("alice", "ZEPH_ACP_TOKEN_ALICE")]);
+        let vault = TestVault::default().with_secret("ZEPH_ACP_TOKEN_ALICE", "vault-token-a");
+        let clients = resolve_acp_auth_clients(&cfg, &vault).await.unwrap();
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].id, "alice");
+        assert_eq!(clients[0].token, "vault-token-a");
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_missing_vault_key_soft_disables_client() {
+        let cfg = acp_config_with(
+            None,
+            vec![
+                vault_client("alice", "ZEPH_ACP_TOKEN_ALICE"),
+                inline_client("bob", "token-b"),
+            ],
+        );
+        // No secret registered for ZEPH_ACP_TOKEN_ALICE -> Ok(None) -> alice silently dropped.
+        let clients = resolve_acp_auth_clients(&cfg, &TestVault::default())
+            .await
+            .unwrap();
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].id, "bob");
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_vault_backend_error_soft_disables_client() {
+        let cfg = acp_config_with(
+            None,
+            vec![
+                vault_client("alice", "ZEPH_ACP_TOKEN_ALICE"),
+                inline_client("bob", "token-b"),
+            ],
+        );
+        let vault = TestVault::default().with_erroring_key("ZEPH_ACP_TOKEN_ALICE");
+        let clients = resolve_acp_auth_clients(&cfg, &vault).await.unwrap();
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].id, "bob");
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_rejects_vault_token_colliding_with_inline_token() {
+        let cfg = acp_config_with(
+            None,
+            vec![
+                inline_client("alice", "shared-secret"),
+                vault_client("bob", "ZEPH_ACP_TOKEN_BOB"),
+            ],
+        );
+        let vault = TestVault::default().with_secret("ZEPH_ACP_TOKEN_BOB", "shared-secret");
+        let err = resolve_acp_auth_clients(&cfg, &vault).await.unwrap_err();
+        assert!(
+            err.to_string().contains("collides"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_rejects_two_vault_tokens_resolving_to_same_secret() {
+        let cfg = acp_config_with(
+            None,
+            vec![
+                vault_client("alice", "ZEPH_ACP_TOKEN_ALICE"),
+                vault_client("bob", "ZEPH_ACP_TOKEN_BOB"),
+            ],
+        );
+        let vault = TestVault::default()
+            .with_secret("ZEPH_ACP_TOKEN_ALICE", "same-secret")
+            .with_secret("ZEPH_ACP_TOKEN_BOB", "same-secret");
+        let err = resolve_acp_auth_clients(&cfg, &vault).await.unwrap_err();
+        assert!(
+            err.to_string().contains("collides"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_rejects_vault_token_colliding_with_legacy_default() {
+        let cfg = acp_config_with(
+            Some("legacy-secret"),
+            vec![vault_client("alice", "ZEPH_ACP_TOKEN_ALICE")],
+        );
+        let vault = TestVault::default().with_secret("ZEPH_ACP_TOKEN_ALICE", "legacy-secret");
+        let err = resolve_acp_auth_clients(&cfg, &vault).await.unwrap_err();
+        assert!(
+            err.to_string().contains("collides"),
+            "unexpected error: {err}"
+        );
+    }
 
     fn make_rules_dir(dir: &std::path::Path, files: &[&str]) {
         let rules = dir.join(".claude").join("rules");

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -204,9 +204,10 @@ async fn fork_session_cli(
     at: Option<u64>,
 ) -> anyhow::Result<()> {
     let new_id = zeph_common::SessionId::generate();
-    let result = zeph_session::ForkEngine::fork(data_dir, id, new_id.as_str(), at, session_store)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to fork session: {e}"))?;
+    let result =
+        zeph_session::ForkEngine::fork(data_dir, id, new_id.as_str(), at, session_store, None)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to fork session: {e}"))?;
 
     println!(
         "Forked session {id} -> {} ({} event(s) copied).",

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -73,6 +73,8 @@ pub(crate) struct WizardState {
     pub(crate) acp_agent_name: String,
     pub(crate) acp_agent_version: String,
     pub(crate) acp_additional_directories: Vec<std::path::PathBuf>,
+    /// Named bearer-token clients for HTTP/WS multi-tenant isolation (#5868).
+    pub(crate) acp_auth_clients: Vec<zeph_config::AcpAuthClient>,
     pub(crate) acp_auth_methods: Vec<zeph_config::AcpAuthMethod>,
     pub(crate) acp_message_ids_enabled: bool,
     pub(crate) acp_subagents_enabled: bool,
@@ -363,6 +365,7 @@ impl Default for WizardState {
             acp_agent_name: String::new(),
             acp_agent_version: String::new(),
             acp_additional_directories: Vec::new(),
+            acp_auth_clients: Vec::new(),
             acp_auth_methods: vec![zeph_config::AcpAuthMethod::Agent],
             acp_message_ids_enabled: true,
             acp_subagents_enabled: false,
@@ -1328,6 +1331,7 @@ fn apply_acp_config(config: &mut Config, state: &WizardState) {
             agent_name: state.acp_agent_name.clone(),
             agent_version: state.acp_agent_version.clone(),
             additional_directories,
+            auth_clients: state.acp_auth_clients.clone(),
             auth_methods: state.acp_auth_methods.clone(),
             message_ids_enabled: state.acp_message_ids_enabled,
             subagents: zeph_config::AcpSubagentsConfig {
@@ -1446,6 +1450,36 @@ fn step_acp(state: &mut WizardState) -> anyhow::Result<()> {
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(std::path::PathBuf::from)
+            .collect();
+
+        // Named bearer-token clients (#5868) — enables genuine multi-tenant/multi-window
+        // isolation of persisted ACP sessions over HTTP/WS. Skippable: single-token or
+        // stdio-only deployments need no entries here.
+        let auth_clients_input: String = Input::new()
+            .with_prompt(
+                "Named bearer-token clients for HTTP/WS multi-tenant isolation \
+                 (comma-separated \"id:token\" pairs; empty = none, use [acp] auth_token instead)",
+            )
+            .default(String::new())
+            .allow_empty(true)
+            .interact_text()?;
+        state.acp_auth_clients = auth_clients_input
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .filter_map(|pair| match pair.split_once(':') {
+                Some((id, token)) if !id.is_empty() && !token.is_empty() => {
+                    Some(zeph_config::AcpAuthClient {
+                        id: id.to_owned(),
+                        token: Some(token.to_owned()),
+                        token_vault_key: None,
+                    })
+                }
+                _ => {
+                    eprintln!("Warning: skipping malformed auth client entry {pair:?} (expected \"id:token\")");
+                    None
+                }
+            })
             .collect();
 
         // PR 4 MVP: only "agent" is offered; kept as a prompt for discoverability.

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -378,6 +378,7 @@ pub(super) async fn fork_session_handler(
         new_id.as_str(),
         body.at_seq,
         &store,
+        None,
     )
     .await
     .map_err(|e| match e {

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -219,7 +219,11 @@ async fn run_serve_with_acp(
     .await?;
     let serve_config = app.config().serve.clone();
     let acp_bind_addr = app.config().acp.http_bind.clone();
-    let acp_auth_token = app.config().acp.auth_token.clone();
+    // Only checks whether *some* auth is configured (not that it resolves) — cheap enough to
+    // do before `acp_deps` exists; the multi-client set (with vault resolution) is built later
+    // by `build_combined_deps` -> `resolve_acp_auth_clients`.
+    let acp_has_auth_configured =
+        app.config().acp.auth_token.is_some() || !app.config().acp.auth_clients.is_empty();
 
     check_acp_http_port_clash(http_addr, &acp_bind_addr)?;
 
@@ -230,7 +234,7 @@ async fn run_serve_with_acp(
     // operator false confidence that the whole combined process is authenticated, while the
     // ACP listener — sharing the same `acp_sessions` table serve's guard protects — could be
     // reachable non-loopback with no token at all.
-    check_acp_auth_guard(&acp_bind_addr, acp_auth_token.is_some())?;
+    check_acp_auth_guard(&acp_bind_addr, acp_has_auth_configured)?;
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let supervisor = Arc::new(TaskSupervisor::new(cancel.clone()));


### PR DESCRIPTION
## Summary

Persisted ACP sessions (`acp_sessions` table) had no ownership scoping: `list_sessions`, `load_session`, and `resume_session` queried the shared store unconditionally, so any connection authenticated against an ACP HTTP/WS server could enumerate and resume any other connection's persisted session — full history, working directory, and config snapshot included.

- Redesigns `BearerAuthLayer` around a named-client credential set (`[[acp.auth_clients]]`, id + inline token or vault-resolved `token_vault_key`) instead of one server-wide token; the matched client id becomes the session's `owner_key`. The existing single `auth_token` keeps working, synthesized as a `"default"` client.
- Adds a nullable `owner_key` column to `acp_sessions` (migration 108, sqlite + postgres) with a composite `(owner_key, updated_at)` index; non-ACP rows (CLI/TUI/Telegram) stay `NULL` per the shared session-store invariant.
- Scopes every session-touching callsite: `do_list_sessions`/`do_load_session`/`do_resume_session`/`do_fork_session` (stdio JSON-RPC), the REST `/sessions*` handlers, and the `_session/*` ext methods — load/resume/delete use an atomic claim-on-load `UPDATE ... RETURNING` that also adopts pre-existing unowned rows without a read-before-claim race, and returns a uniform not-found for both nonexistent and foreign-owned sessions (no info leak).
- Fixes a related gap found during implementation: `ForkEngine::fork` previously bypassed session creation and left forked sessions with `owner_key = NULL`, invisible to their own creator's session list.
- Config validation rejects reserved client ids (`default`, `acp-local`), empty/whitespace tokens, and duplicate tokens (including against the synthesized legacy default) at load time.

**Scope note:** this closes the isolation gap for genuine multi-client HTTP/WS deployments. It does not change the stdio transport's behavior — Zed and similar IDE-per-window clients are already process-isolated at the OS level over stdio, and per-window session separation there is controlled by pointing each window at a distinct `sqlite_path`, not by this fix.

Fixes #5868

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12500 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New unit/integration coverage: `validate_auth_clients` config validation (18 tests), `resolve_acp_auth_clients` vault-collision resolution (9 tests), stdio JSON-RPC cross-owner isolation (4 end-to-end tests), REST CRUD cross-owner isolation (3 tests), fork-owner-propagation regression
- [ ] Live IDE/vault verification (multi-token HTTP/WS deployment, `--init` wizard, `--migrate-config`) — pending next testing cycle, tracked in `.local/testing/coverage-status.md`