### PR TITLE
fix(llm): populate provider_name across all remaining LLM backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   4.6-generation pricing rows in `crates/zeph-core/src/cost.rs` and the legacy capability arms in
   `crates/zeph-llm/src/claude/types.rs` are intentionally retained alongside the new ones since
   those models are still Active (#5889).
+- `fix(llm)`: `OpenAiProvider`, `ClaudeProvider`, `GeminiProvider`, `CandleProvider`,
+  `GonkaProvider`, and `CocoonProvider` no longer hardcode `LlmProvider::name()` to their
+  type literal (`"openai"`, `"claude"`, `"gemini"`, `"candle"`, `"gonka"`, `"cocoon"`). Each
+  now carries a `provider_name` field populated from the TOML-configured `name` field of its
+  `[[llm.providers]]` entry via a new `with_provider_name` builder method, mirroring the
+  fix already applied to `OllamaProvider`/`CompatibleProvider` (#5859). Without this, router
+  reputation tracking, embed-provider selection, and the `/think-tokens`/`/reasoning-effort`
+  delegation lookup in `RouterProvider::capability_target_index`
+  (`crates/zeph-llm/src/router/builder.rs`) could not distinguish between multiple
+  configured instances of the same provider type. Unnamed entries keep falling back to the
+  provider-type literal, so legacy configs are unaffected (#5892).
 - `fix(llm)`: `AnyProvider::Router` and `AnyProvider::Triage` no longer silently reject
   `/think-tokens` and `/reasoning-effort` regardless of the selected inner provider's
   capabilities. The four capability-mutating/-querying methods on `AnyProvider`

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -299,6 +299,7 @@ fn build_claude_provider(
         .unwrap_or_else(|| "claude-haiku-4-5-20251001".to_owned());
     let max_tokens = entry.max_tokens.unwrap_or(4096);
     let provider = ClaudeProvider::new(api_key, model, max_tokens)
+        .with_provider_name(entry.effective_name())
         .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
         .with_extended_context(entry.enable_extended_context)
         .with_thinking_opt(entry.thinking.clone())
@@ -349,6 +350,7 @@ fn build_openai_provider(
             context_window: None,
             completion_tokens_param: None,
         })
+        .with_provider_name(entry.effective_name())
         .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
         .with_output_schema_forwarding(
             config.mcp.forward_output_schema,
@@ -379,6 +381,7 @@ fn build_gemini_provider(
         .clone()
         .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_owned());
     let mut provider = GeminiProvider::new(api_key, model, max_tokens)
+        .with_provider_name(entry.effective_name())
         .with_base_url(base_url)
         .with_client(llm_client(config.timeouts.llm_request_timeout_secs));
     if let Some(ref em) = entry.embedding_model {
@@ -519,7 +522,8 @@ fn build_gonka_provider(
         max_tokens,
         embedding_model: entry.embedding_model.clone(),
         timeout,
-    });
+    })
+    .with_provider_name(entry.effective_name());
 
     Ok(AnyProvider::Gonka(provider))
 }
@@ -635,7 +639,8 @@ fn build_cocoon_provider(
         .clone()
         .unwrap_or_else(|| "Qwen/Qwen3-0.6B".to_owned());
     let max_tokens = entry.max_tokens.unwrap_or(4096);
-    let provider = CocoonProvider::new(model, max_tokens, entry.embedding_model.clone(), client);
+    let provider = CocoonProvider::new(model, max_tokens, entry.embedding_model.clone(), client)
+        .with_provider_name(entry.effective_name());
 
     Ok(AnyProvider::Cocoon(provider))
 }
@@ -789,7 +794,7 @@ fn build_candle_provider(
         device,
         params.inference_timeout,
     )
-    .map(AnyProvider::Candle)
+    .map(|provider| AnyProvider::Candle(provider.with_provider_name(entry.effective_name())))
     .map_err(|e| BootstrapError::Provider(e.to_string()))
 }
 
@@ -1019,6 +1024,26 @@ mod tests {
             let provider = result.unwrap();
             assert_eq!(provider.name(), "gonka");
         }
+
+        /// Regression for #5892: `GonkaProvider::name()` was hardcoded to `"gonka"`; two
+        /// distinct `[[llm.providers]]` entries with distinct configured `name` fields must
+        /// build `AnyProvider`s with distinct `.name()` values.
+        #[test]
+        fn build_gonka_provider_distinct_entries_yield_distinct_provider_names() {
+            let mut entry_a = gonka_entry_with_nodes(valid_nodes());
+            entry_a.name = Some("gonka-a".into());
+            let mut entry_b = gonka_entry_with_nodes(valid_nodes());
+            entry_b.name = Some("gonka-b".into());
+            let mut config = Config::default();
+            config.secrets.gonka_private_key = Some(Secret::new(VALID_PRIV_KEY));
+
+            let provider_a = build_provider_from_entry(&entry_a, &config, None).unwrap();
+            let provider_b = build_provider_from_entry(&entry_b, &config, None).unwrap();
+
+            assert_eq!(provider_a.name(), "gonka-a");
+            assert_eq!(provider_b.name(), "gonka-b");
+            assert_ne!(provider_a.name(), provider_b.name());
+        }
     }
 
     fn make_provider_entry(
@@ -1136,6 +1161,85 @@ mod tests {
         assert_eq!(provider_b.name(), "ollama-embed");
     }
 
+    /// Regression for #5892: Claude, `OpenAI`, and Gemini backends hardcoded `name()` to
+    /// their type literal, unlike `OllamaProvider`/`CompatibleProvider` (fixed for #5859).
+    /// Two distinct `[[llm.providers]]` entries of the same `provider_type` with distinct
+    /// configured `name` fields must build `AnyProvider`s with distinct `.name()` values.
+    #[test]
+    fn build_provider_from_entry_claude_openai_gemini_distinct_entries_yield_distinct_provider_names()
+     {
+        use zeph_common::secret::Secret;
+
+        let mut config = Config::default();
+        config.secrets.claude_api_key = Some(Secret::new("test-claude-key"));
+        config.secrets.openai_api_key = Some(Secret::new("test-openai-key"));
+        config.secrets.gemini_api_key = Some(Secret::new("test-gemini-key"));
+
+        let claude_a = ProviderEntry {
+            provider_type: ProviderKind::Claude,
+            name: Some("claude-quality".into()),
+            ..ProviderEntry::default()
+        };
+        let claude_b = ProviderEntry {
+            provider_type: ProviderKind::Claude,
+            name: Some("claude-fast".into()),
+            ..ProviderEntry::default()
+        };
+        let provider_claude_a = build_provider_from_entry(&claude_a, &config, None).unwrap();
+        let provider_claude_b = build_provider_from_entry(&claude_b, &config, None).unwrap();
+        assert_eq!(provider_claude_a.name(), "claude-quality");
+        assert_eq!(provider_claude_b.name(), "claude-fast");
+        assert_ne!(provider_claude_a.name(), provider_claude_b.name());
+
+        let openai_a = ProviderEntry {
+            provider_type: ProviderKind::OpenAi,
+            name: Some("openai-quality".into()),
+            ..ProviderEntry::default()
+        };
+        let openai_b = ProviderEntry {
+            provider_type: ProviderKind::OpenAi,
+            name: Some("openai-fast".into()),
+            ..ProviderEntry::default()
+        };
+        let provider_openai_a = build_provider_from_entry(&openai_a, &config, None).unwrap();
+        let provider_openai_b = build_provider_from_entry(&openai_b, &config, None).unwrap();
+        assert_eq!(provider_openai_a.name(), "openai-quality");
+        assert_eq!(provider_openai_b.name(), "openai-fast");
+        assert_ne!(provider_openai_a.name(), provider_openai_b.name());
+
+        let gemini_a = ProviderEntry {
+            provider_type: ProviderKind::Gemini,
+            name: Some("gemini-quality".into()),
+            ..ProviderEntry::default()
+        };
+        let gemini_b = ProviderEntry {
+            provider_type: ProviderKind::Gemini,
+            name: Some("gemini-fast".into()),
+            ..ProviderEntry::default()
+        };
+        let provider_gemini_a = build_provider_from_entry(&gemini_a, &config, None).unwrap();
+        let provider_gemini_b = build_provider_from_entry(&gemini_b, &config, None).unwrap();
+        assert_eq!(provider_gemini_a.name(), "gemini-quality");
+        assert_eq!(provider_gemini_b.name(), "gemini-fast");
+        assert_ne!(provider_gemini_a.name(), provider_gemini_b.name());
+    }
+
+    /// Regression for #5892: an unnamed entry (no `name` field in `[[llm.providers]]`) must
+    /// fall back to the provider-type literal, matching pre-fix behavior for legacy configs.
+    #[test]
+    fn build_provider_from_entry_claude_unnamed_falls_back_to_type_literal() {
+        use zeph_common::secret::Secret;
+
+        let mut config = Config::default();
+        config.secrets.claude_api_key = Some(Secret::new("test-claude-key"));
+        let entry = ProviderEntry {
+            provider_type: ProviderKind::Claude,
+            ..ProviderEntry::default()
+        };
+        let provider = build_provider_from_entry(&entry, &config, None).unwrap();
+        assert_eq!(provider.name(), "claude");
+    }
+
     #[cfg(feature = "cocoon")]
     mod cocoon_tests {
         use super::*;
@@ -1180,6 +1284,25 @@ mod tests {
                 "expected success when no access hash requested: {:?}",
                 result.err()
             );
+        }
+
+        /// Regression for #5892: `CocoonProvider::name()` was hardcoded to `"cocoon"`; two
+        /// distinct `[[llm.providers]]` entries with distinct configured `name` fields must
+        /// build `AnyProvider`s with distinct `.name()` values.
+        #[test]
+        fn build_provider_from_entry_cocoon_distinct_entries_yield_distinct_provider_names() {
+            let mut entry_a = cocoon_entry(None);
+            entry_a.name = Some("cocoon-a".into());
+            let mut entry_b = cocoon_entry(None);
+            entry_b.name = Some("cocoon-b".into());
+            let config = Config::default();
+
+            let provider_a = build_provider_from_entry(&entry_a, &config, None).unwrap();
+            let provider_b = build_provider_from_entry(&entry_b, &config, None).unwrap();
+
+            assert_eq!(provider_a.name(), "cocoon-a");
+            assert_eq!(provider_b.name(), "cocoon-b");
+            assert_ne!(provider_a.name(), provider_b.name());
         }
 
         /// `spawn_cocoon_health_checks` must share the same vault-miss gating as

--- a/crates/zeph-llm/src/candle_provider/mod.rs
+++ b/crates/zeph-llm/src/candle_provider/mod.rs
@@ -107,6 +107,11 @@ pub struct CandleProvider {
     generation_config: GenerationConfig,
     embed_model: Option<std::sync::Arc<EmbedModel>>,
     device: Device,
+    /// Name reported by [`LlmProvider::name`]. Defaults to `"candle"`; set the TOML-configured
+    /// `name` via [`with_provider_name`](Self::with_provider_name) so that router reputation
+    /// tracking and provider selection can distinguish between multiple configured Candle
+    /// instances (#5892).
+    provider_name: String,
 }
 
 impl std::fmt::Debug for CandleProvider {
@@ -116,6 +121,7 @@ impl std::fmt::Debug for CandleProvider {
             .field("generation_config", &self.generation_config)
             .field("device", &format!("{:?}", self.device))
             .field("embed_model", &self.embed_model)
+            .field("provider_name", &self.provider_name)
             .finish_non_exhaustive()
     }
 }
@@ -136,6 +142,7 @@ impl Clone for CandleProvider {
             generation_config: self.generation_config.clone(),
             embed_model: self.embed_model.clone(),
             device: self.device.clone(),
+            provider_name: self.provider_name.clone(),
         }
     }
 }
@@ -222,7 +229,21 @@ impl CandleProvider {
             generation_config,
             embed_model,
             device,
+            provider_name: "candle".to_owned(),
         })
+    }
+
+    /// Set the name reported by [`LlmProvider::name`].
+    ///
+    /// Populate this from the TOML-configured `name` field of the `[[llm.providers]]` entry
+    /// so that router reputation tracking and generic embed-provider selection can
+    /// distinguish between multiple configured Candle instances. Without this, every
+    /// `CandleProvider` reports the same literal `"candle"`, which corrupts per-provider
+    /// availability tracking and embed routing when more than one Candle entry is configured.
+    #[must_use]
+    pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = name.into();
+        self
     }
 
     /// Return a short string identifying the compute device: `"cpu"`, `"cuda"`, or `"metal"`.
@@ -339,7 +360,7 @@ impl LlmProvider for CandleProvider {
         self.embed_model.is_some()
     }
 
-    fn name(&self) -> &'static str {
-        "candle"
+    fn name(&self) -> &str {
+        &self.provider_name
     }
 }

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -133,6 +133,11 @@ pub struct ClaudeProvider {
     prompt_cache_ttl: Option<CacheTtl>,
     /// SSE buffer size caps (tool JSON, thinking, compaction). Sourced from config.
     stream_limits: zeph_config::StreamLimits,
+    /// Name reported by [`LlmProvider::name`]. Defaults to `"claude"`; set the TOML-configured
+    /// `name` via [`with_provider_name`](Self::with_provider_name) so that router reputation
+    /// tracking and provider selection can distinguish between multiple configured Claude
+    /// instances (#5892).
+    provider_name: String,
 }
 
 impl fmt::Debug for ClaudeProvider {
@@ -170,6 +175,7 @@ impl fmt::Debug for ClaudeProvider {
                 "max_tool_description_bytes",
                 &self.max_tool_description_bytes,
             )
+            .field("provider_name", &self.provider_name)
             .finish()
     }
 }
@@ -197,6 +203,7 @@ impl Clone for ClaudeProvider {
             output_schema_hint_bytes: self.output_schema_hint_bytes,
             max_tool_description_bytes: self.max_tool_description_bytes,
             stream_limits: self.stream_limits.clone(),
+            provider_name: self.provider_name.clone(),
         }
     }
 }
@@ -275,7 +282,21 @@ impl ClaudeProvider {
             enable_extended_context: false,
             prompt_cache_ttl: None,
             stream_limits: zeph_config::StreamLimits::default(),
+            provider_name: "claude".to_owned(),
         }
+    }
+
+    /// Set the name reported by [`LlmProvider::name`].
+    ///
+    /// Populate this from the TOML-configured `name` field of the `[[llm.providers]]` entry
+    /// so that router reputation tracking and generic embed-provider selection can
+    /// distinguish between multiple configured Claude instances. Without this, every
+    /// `ClaudeProvider` reports the same literal `"claude"`, which corrupts per-provider
+    /// availability tracking and embed routing when more than one Claude entry is configured.
+    #[must_use]
+    pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = name.into();
+        self
     }
 
     /// Override generation parameters (temperature, top-p) for this provider.
@@ -1194,9 +1215,8 @@ impl LlmProvider for ClaudeProvider {
         false
     }
 
-    #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
-        "claude"
+        &self.provider_name
     }
 
     fn model_identifier(&self) -> &str {

--- a/crates/zeph-llm/src/claude/tests.rs
+++ b/crates/zeph-llm/src/claude/tests.rs
@@ -83,6 +83,19 @@ fn stale_model_suggestion_non_claude_or_alias_fails_open() {
 }
 
 #[test]
+fn name_defaults_to_claude() {
+    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-5-20250929".into(), 1024);
+    assert_eq!(provider.name(), "claude");
+}
+
+#[test]
+fn with_provider_name_overrides_name() {
+    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-5-20250929".into(), 1024)
+        .with_provider_name("quality-claude");
+    assert_eq!(provider.name(), "quality-claude");
+}
+
+#[test]
 fn split_messages_extracts_system() {
     let messages = vec![
         Message {

--- a/crates/zeph-llm/src/cocoon/provider.rs
+++ b/crates/zeph-llm/src/cocoon/provider.rs
@@ -114,6 +114,11 @@ pub struct CocoonProvider {
     usage: UsageTracker,
     /// Optional TUI status sender.
     pub(crate) status_tx: Option<StatusTx>,
+    /// Name reported by [`LlmProvider::name`]. Defaults to `"cocoon"`; set the TOML-configured
+    /// `name` via [`with_provider_name`](Self::with_provider_name) so that router reputation
+    /// tracking and provider selection can distinguish between multiple configured Cocoon
+    /// instances (#5892).
+    provider_name: String,
 }
 
 impl std::fmt::Debug for CocoonProvider {
@@ -121,6 +126,7 @@ impl std::fmt::Debug for CocoonProvider {
         f.debug_struct("CocoonProvider")
             .field("model", &self.inner.model_identifier())
             .field("embedding_model", &self.embedding_model)
+            .field("provider_name", &self.provider_name)
             .finish_non_exhaustive()
     }
 }
@@ -133,6 +139,7 @@ impl Clone for CocoonProvider {
             embedding_model: self.embedding_model.clone(),
             usage: UsageTracker::default(),
             status_tx: self.status_tx.clone(),
+            provider_name: self.provider_name.clone(),
         }
     }
 }
@@ -181,7 +188,21 @@ impl CocoonProvider {
             embedding_model,
             usage: UsageTracker::default(),
             status_tx: None,
+            provider_name: "cocoon".to_owned(),
         }
+    }
+
+    /// Set the name reported by [`LlmProvider::name`].
+    ///
+    /// Populate this from the TOML-configured `name` field of the `[[llm.providers]]` entry
+    /// so that router reputation tracking and generic embed-provider selection can
+    /// distinguish between multiple configured Cocoon instances. Without this, every
+    /// `CocoonProvider` reports the same literal `"cocoon"`, which corrupts per-provider
+    /// availability tracking and embed routing when more than one Cocoon entry is configured.
+    #[must_use]
+    pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = name.into();
+        self
     }
 
     /// Set the TUI status sender; lifecycle events are forwarded to the TUI when set.
@@ -219,8 +240,8 @@ impl CocoonProvider {
 }
 
 impl LlmProvider for CocoonProvider {
-    fn name(&self) -> &'static str {
-        "cocoon"
+    fn name(&self) -> &str {
+        &self.provider_name
     }
 
     fn model_identifier(&self) -> &str {

--- a/crates/zeph-llm/src/cocoon/tests.rs
+++ b/crates/zeph-llm/src/cocoon/tests.rs
@@ -30,6 +30,18 @@ fn make_provider(base_url: &str) -> CocoonProvider {
     )
 }
 
+#[test]
+fn name_defaults_to_cocoon() {
+    let provider = make_provider("http://localhost:10000");
+    assert_eq!(provider.name(), "cocoon");
+}
+
+#[test]
+fn with_provider_name_overrides_name() {
+    let provider = make_provider("http://localhost:10000").with_provider_name("cocoon-local");
+    assert_eq!(provider.name(), "cocoon-local");
+}
+
 fn user_message(text: &str) -> Vec<Message> {
     vec![Message {
         role: Role::User,

--- a/crates/zeph-llm/src/gemini/mod.rs
+++ b/crates/zeph-llm/src/gemini/mod.rs
@@ -35,6 +35,11 @@ pub struct GeminiProvider {
     thinking_level: Option<ThinkingLevel>,
     thinking_budget: Option<i32>,
     include_thoughts: Option<bool>,
+    /// Name reported by [`LlmProvider::name`]. Defaults to `"gemini"`; set the TOML-configured
+    /// `name` via [`with_provider_name`](Self::with_provider_name) so that router reputation
+    /// tracking and provider selection can distinguish between multiple configured Gemini
+    /// instances (#5892).
+    provider_name: String,
 }
 
 impl fmt::Debug for GeminiProvider {
@@ -52,6 +57,7 @@ impl fmt::Debug for GeminiProvider {
             .field("thinking_level", &self.thinking_level)
             .field("thinking_budget", &self.thinking_budget)
             .field("include_thoughts", &self.include_thoughts)
+            .field("provider_name", &self.provider_name)
             .finish()
     }
 }
@@ -71,6 +77,7 @@ impl Clone for GeminiProvider {
             thinking_level: self.thinking_level,
             thinking_budget: self.thinking_budget,
             include_thoughts: self.include_thoughts,
+            provider_name: self.provider_name.clone(),
         }
     }
 }
@@ -91,7 +98,21 @@ impl GeminiProvider {
             thinking_level: None,
             thinking_budget: None,
             include_thoughts: None,
+            provider_name: "gemini".to_owned(),
         }
+    }
+
+    /// Set the name reported by [`LlmProvider::name`].
+    ///
+    /// Populate this from the TOML-configured `name` field of the `[[llm.providers]]` entry
+    /// so that router reputation tracking and generic embed-provider selection can
+    /// distinguish between multiple configured Gemini instances. Without this, every
+    /// `GeminiProvider` reports the same literal `"gemini"`, which corrupts per-provider
+    /// availability tracking and embed routing when more than one Gemini entry is configured.
+    #[must_use]
+    pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = name.into();
+        self
     }
 
     #[must_use]
@@ -1229,9 +1250,8 @@ struct EmbedValues {
 // ---------------------------------------------------------------------------
 
 impl LlmProvider for GeminiProvider {
-    #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
-        "gemini"
+        &self.provider_name
     }
 
     fn context_window(&self) -> Option<usize> {

--- a/crates/zeph-llm/src/gemini/tests.rs
+++ b/crates/zeph-llm/src/gemini/tests.rs
@@ -21,6 +21,13 @@ fn gemini_name() {
 }
 
 #[test]
+fn gemini_with_provider_name_overrides_name() {
+    let p = GeminiProvider::new("key".into(), "gemini-2.0-flash".into(), 1024)
+        .with_provider_name("fast-gemini");
+    assert_eq!(p.name(), "fast-gemini");
+}
+
+#[test]
 fn gemini_supports_streaming_true() {
     let p = GeminiProvider::new("key".into(), "gemini-2.0-flash".into(), 1024);
     assert!(p.supports_streaming());

--- a/crates/zeph-llm/src/gonka/provider.rs
+++ b/crates/zeph-llm/src/gonka/provider.rs
@@ -152,6 +152,11 @@ pub struct GonkaProvider {
     usage: UsageTracker,
     /// Optional TUI status sender; when set, key lifecycle events are forwarded.
     pub(crate) status_tx: Option<StatusTx>,
+    /// Name reported by [`LlmProvider::name`]. Defaults to `"gonka"`; set the TOML-configured
+    /// `name` via [`with_provider_name`](Self::with_provider_name) so that router reputation
+    /// tracking and provider selection can distinguish between multiple configured Gonka
+    /// instances (#5892).
+    provider_name: String,
 }
 
 impl std::fmt::Debug for GonkaProvider {
@@ -160,6 +165,7 @@ impl std::fmt::Debug for GonkaProvider {
             .field("model", &self.inner.model_identifier())
             .field("embedding_model", &self.embedding_model)
             .field("timeout", &self.timeout)
+            .field("provider_name", &self.provider_name)
             .finish_non_exhaustive()
     }
 }
@@ -175,6 +181,7 @@ impl Clone for GonkaProvider {
             embedding_model: self.embedding_model.clone(),
             usage: UsageTracker::default(),
             status_tx: self.status_tx.clone(),
+            provider_name: self.provider_name.clone(),
         }
     }
 }
@@ -204,7 +211,21 @@ impl GonkaProvider {
             embedding_model: cfg.embedding_model,
             usage: UsageTracker::default(),
             status_tx: None,
+            provider_name: "gonka".to_owned(),
         }
+    }
+
+    /// Set the name reported by [`LlmProvider::name`].
+    ///
+    /// Populate this from the TOML-configured `name` field of the `[[llm.providers]]` entry
+    /// so that router reputation tracking and generic embed-provider selection can
+    /// distinguish between multiple configured Gonka instances. Without this, every
+    /// `GonkaProvider` reports the same literal `"gonka"`, which corrupts per-provider
+    /// availability tracking and embed routing when more than one Gonka entry is configured.
+    #[must_use]
+    pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = name.into();
+        self
     }
 
     /// Set the TUI status sender; when set, key lifecycle events are forwarded to the TUI.
@@ -319,8 +340,8 @@ impl GonkaProvider {
 }
 
 impl LlmProvider for GonkaProvider {
-    fn name(&self) -> &'static str {
-        "gonka"
+    fn name(&self) -> &str {
+        &self.provider_name
     }
 
     fn model_identifier(&self) -> &str {

--- a/crates/zeph-llm/src/gonka/tests.rs
+++ b/crates/zeph-llm/src/gonka/tests.rs
@@ -43,6 +43,18 @@ fn make_provider(base_url: &str) -> GonkaProvider {
     })
 }
 
+#[test]
+fn name_defaults_to_gonka() {
+    let provider = make_provider("http://localhost:1");
+    assert_eq!(provider.name(), "gonka");
+}
+
+#[test]
+fn with_provider_name_overrides_name() {
+    let provider = make_provider("http://localhost:1").with_provider_name("gonka-fast");
+    assert_eq!(provider.name(), "gonka-fast");
+}
+
 fn user_message(text: &str) -> Vec<Message> {
     vec![Message {
         role: Role::User,

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -164,6 +164,11 @@ pub struct OpenAiProvider {
     /// Override which token-limit field to use. `None` means infer from the model name prefix
     /// table via [`CompletionTokens::for_model`].
     completion_tokens_override: Option<CompletionTokensParam>,
+    /// Name reported by [`LlmProvider::name`]. Defaults to `"openai"`; set the TOML-configured
+    /// `name` via [`with_provider_name`](Self::with_provider_name) so that router reputation
+    /// tracking and provider selection can distinguish between multiple configured `OpenAI`
+    /// instances (#5892).
+    provider_name: String,
 }
 
 impl fmt::Debug for OpenAiProvider {
@@ -190,6 +195,7 @@ impl fmt::Debug for OpenAiProvider {
                 "completion_tokens_override",
                 &self.completion_tokens_override,
             )
+            .field("provider_name", &self.provider_name)
             .finish()
     }
 }
@@ -212,6 +218,7 @@ impl Clone for OpenAiProvider {
             max_tool_description_bytes: self.max_tool_description_bytes,
             context_window_override: self.context_window_override,
             completion_tokens_override: self.completion_tokens_override,
+            provider_name: self.provider_name.clone(),
         }
     }
 }
@@ -240,7 +247,21 @@ impl OpenAiProvider {
             max_tool_description_bytes: usize::MAX,
             context_window_override: cfg.context_window.map(|v| v as usize),
             completion_tokens_override: cfg.completion_tokens_param,
+            provider_name: "openai".to_owned(),
         }
+    }
+
+    /// Set the name reported by [`LlmProvider::name`].
+    ///
+    /// Populate this from the TOML-configured `name` field of the `[[llm.providers]]` entry
+    /// so that router reputation tracking and generic embed-provider selection can
+    /// distinguish between multiple configured `OpenAI` instances. Without this, every
+    /// `OpenAiProvider` reports the same literal `"openai"`, which corrupts per-provider
+    /// availability tracking and embed routing when more than one `OpenAI` entry is configured.
+    #[must_use]
+    pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = name.into();
+        self
     }
 
     /// Override generation parameters (temperature, top-p, frequency/presence penalty).
@@ -808,9 +829,8 @@ impl LlmProvider for OpenAiProvider {
         self.embedding_model.is_some()
     }
 
-    #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
-        "openai"
+        &self.provider_name
     }
 
     fn model_identifier(&self) -> &str {

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -183,6 +183,12 @@ fn name_returns_openai() {
 }
 
 #[test]
+fn with_provider_name_overrides_name() {
+    let provider = test_provider().with_provider_name("fast-gpt");
+    assert_eq!(provider.name(), "fast-gpt");
+}
+
+#[test]
 fn chat_request_serialization() {
     let msgs = [ApiMessage {
         role: "user",


### PR DESCRIPTION
## Summary

- `OpenaiProvider`, `ClaudeProvider`, `GeminiProvider`, `CandleProvider`, `GonkaProvider`, and `CocoonProvider` no longer hardcode `LlmProvider::name()` to their type literal (`"openai"`, `"claude"`, `"gemini"`, `"candle"`, `"gonka"`, `"cocoon"`).
- Each now carries a `provider_name` field populated from the TOML-configured `name` field of its `[[llm.providers]]` entry via a new `with_provider_name` builder, mirroring the fix already applied to `OllamaProvider`/`CompatibleProvider` in #5879.
- Without this, router reputation tracking, `last_active_provider`, embed-provider selection, and the `/think-tokens`/`/reasoning-effort` delegation lookup in `RouterProvider::capability_target_index` could not distinguish between multiple configured instances of the same provider type — a supported and documented config pattern.
- Unnamed entries keep falling back to the provider-type literal, so legacy configs are unaffected.

Closes #5892

## Test plan

- [x] `cargo build -p zeph-llm -p zeph-core` clean
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `cargo nextest run` — zeph-llm: 1013 passed / 0 failed; zeph-core provider_factory tests: 18 passed / 0 failed
- [x] `cargo test --doc -p zeph-llm` — 24 passed / 0 failed
- [x] Rustdoc gate run against touched crates — zero warnings attributed to this diff (workspace-wide gate failure on `zeph-worktree`/`zeph-durable` is pre-existing and unrelated, tracked separately in #5894)
- [x] New regression tests directly reproduce the bug: two same-type `[[llm.providers]]` entries with distinct configured names now yield distinct `name()` values