### PR TITLE
feat(plugins,skills,config,cli): add opt-in skill/plugin discovery-and-install marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Note: this closes the isolation gap for genuine multi-token **HTTP/WS** deployments only — the
   literal Zed-over-stdio scenario from the issue is unaffected by this change (stdio has no
   token multiplexing to redesign; use distinct `sqlite_path` values per window instead).
+- `feat(plugins,skills,config,cli)`: added an opt-in skill/plugin discovery-and-install
+  marketplace (spec-045, #5869) — `zeph skill search <query>` / `zeph skill get <registry-id>`
+  and `zeph plugin search <query>` / `zeph plugin get <registry-id>`, closing the "no discovery
+  path, only `--plugin-url`" gap identified against Cline's marketplace and Vercel's
+  `skills.sh` in a competitive parity scan. A new `crates/zeph-plugins/src/marketplace` module
+  defines a dyn-compatible `RegistryClient` trait (mirroring `VaultProvider`'s boxed-future
+  pattern) with a `SkillsShClient` implementation for the public skills.sh registry, gated
+  behind a new `registry` Cargo feature (included in the `full` bundle) that gates only the
+  network-touching client code — CLI arg definitions and `[skills.registry]` config parsing
+  always compile, printing an actionable "rebuild with `--features registry`" message when the
+  feature is off. Registry lookups are strictly opt-in and off by default
+  (`skills.registry.enabled = false`): zero network calls and zero vault access occur unless
+  explicitly enabled. Fetched packages route through the existing, unmodified install
+  pipelines — `SkillManager::install_from_path` (frontmatter validation + Quarantined-trust
+  upsert) for skills, `PluginManager::add` (manifest validation, MCP allowlist, injection scan)
+  for plugins — so no new content-safety bypass is introduced. Auth token resolved exclusively
+  via `VaultProvider` (`skills.registry.auth_vault_key`), never a plain config field. Adds the
+  `--init` wizard step, a `--migrate-config` step (idempotent, always writes `enabled = false`
+  in the advisory template), and `MockRegistryClient` proving the trait boundary is real.
+
 - `feat(llm,commands,core)`: added runtime `/think-tokens [N|Nk|NM|off]` and
   `/reasoning-effort [low|medium|high]` slash commands that mutate the active LLM provider's
   thinking-token budget or reasoning-effort level mid-session, taking effect on the very next

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6489,6 +6489,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ ide     = ["acp", "acp-http"]
 server  = ["gateway", "a2a", "otel", "prometheus", "session"]
 chat    = ["discord", "slack"]
 ml      = ["candle", "pdf"]
-full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "sandbox", "gonka", "cocoon", "testing"]
+full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "sandbox", "gonka", "cocoon", "testing", "registry"]
 testing = ["zeph-llm/testing"]
 sandbox    = ["zeph-tools/sandbox"]
 bench      = ["dep:zeph-bench"]
@@ -235,6 +235,9 @@ slack = ["zeph-channels/slack"]
 gateway = ["dep:zeph-gateway"]
 prometheus = ["gateway", "dep:prometheus-client", "zeph-gateway/prometheus"]
 scheduler = ["dep:zeph-scheduler", "dep:blake3", "dep:cron", "dep:schemars", "zeph-core/scheduler", "zeph-scheduler/daemon", "zeph-memory/scheduler"]
+# Skill/plugin marketplace discovery (spec-045, #5869): gates zeph-plugins' `marketplace`
+# module (skills.sh registry client). CLI args and RegistryConfig parsing always compile.
+registry = ["zeph-plugins/registry"]
 # Session persistence, event-log replay, and `zeph serve` (spec-068, #5343). Independent of `acp`:
 # `acp` gates ACP protocol transports, `session` gates the persistence CLI verbs and `zeph serve`.
 # The `zeph-session` crate/agent-loop dual-write is always compiled and config-gated
@@ -402,6 +405,7 @@ zeph-commands.workspace = true
 zeph-core.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }
 zeph-memory.workspace = true
+zeph-plugins = { workspace = true, features = ["registry", "mock"] }
 zeph-skills.workspace = true
 # Features are declared by the crates that use them, see workspace dependencies
 

--- a/book/src/concepts/skills.md
+++ b/book/src/concepts/skills.md
@@ -88,6 +88,44 @@ Installed skills start at the `quarantined` trust level. Use `zeph skill verify`
 
 See [CLI Reference — `zeph skill`](../reference/cli.md#zeph-skill) for the full subcommand list, or use the in-session `/skill install` and `/skill remove` commands for hot-reloaded management without restart.
 
+## Skill & Plugin Registry Discovery
+
+Zeph supports opt-in discovery and installation of skills and plugins from external registries (like [skills.sh](https://www.skills.sh)) without needing to know the exact git URL or file path beforehand.
+
+**Key points:**
+
+- **Opt-in only** — Registry lookups are disabled by default. No network calls are made unless you explicitly enable `[skills.registry] enabled = true` in `config.toml`.
+- **Two-step workflow** — Use `zeph skill search <query>` to find skills by keyword, then install one by its registry ID with `zeph skill get <registry-id>`. The same flow works for plugins: `zeph plugin search` and `zeph plugin get`.
+- **Same security gates** — Fetched packages route through the existing frontmatter validation and injection-pattern scan before install, so no new content-safety bypass is introduced.
+- **Distinct from `install`** — The existing `zeph skill install <url|path>` and `zeph plugin add <path>` commands remain unchanged. Registry-based install uses the separate `get` commands (`zeph skill get`, `zeph plugin get`) to avoid ambiguity.
+
+### Setting up registry access
+
+Edit `config.toml` or run `zeph init` / `zeph --migrate-config` to add:
+
+```toml
+[skills.registry]
+enabled = true
+backend_kind = "skills-sh"              # public skills.sh registry
+# auth_vault_key = "ZEPH_SKILL_REGISTRY_TOKEN"  # optional: vault key for auth token if registry requires it
+```
+
+### Using registry search and install
+
+```bash
+# Search for skills by keyword
+zeph skill search "json"
+
+# Install a skill by registry ID (as printed by search)
+zeph skill get skills-sh/json-formatter
+
+# Same flow for plugins
+zeph plugin search "github"
+zeph plugin get skills-sh/github-integration
+```
+
+If the registry is not enabled, these commands print an actionable message explaining how to opt in.
+
 ## Next Steps
 
 - [Add Custom Skills](../guides/custom-skills.md) — create your own skills

--- a/book/src/reference/cli.md
+++ b/book/src/reference/cli.md
@@ -95,6 +95,8 @@ Manage external skills. Installed skills are stored in `~/.config/zeph/skills/`.
 | `skill block <name>` | Block a skill (deny all tool access) |
 | `skill unblock <name>` | Unblock a skill (revert to `quarantined`) |
 | `skill promote-heuristics [--skill <name>]` | Dry-run: show skills eligible for A6 heuristic → full promotion (requires `[skills.learning.heuristic_promotion_enabled = true]`) |
+| `skill search <query>` | Search the configured external registry by keyword (requires `[skills.registry] enabled = true`) |
+| `skill get <registry-id>` | Install a skill by registry ID returned by `skill search` (requires `[skills.registry] enabled = true`) |
 
 ```bash
 # Install from git
@@ -118,6 +120,15 @@ zeph skill promote-heuristics
 
 # Show eligibility for a specific skill
 zeph skill promote-heuristics --skill my-skill
+
+# Search the external registry for skills (requires registry enabled in config)
+zeph skill search "json parsing"
+
+# Install a skill by registry ID
+zeph skill get skills-sh/json-formatter
+
+# View registry configuration
+zeph init                              # or use --migrate-config to add the [skills.registry] section
 ```
 
 ### `zeph plugin`
@@ -131,6 +142,8 @@ Manage plugin packages (collections of skills, MCP servers, and config overlays)
 | `plugin add <path>` | Install a plugin from a local directory path (must contain `plugin.toml`) |
 | `plugin remove <name>` | Remove an installed plugin by name |
 | `plugin disable <name> [--force]` | Disable a plugin (optional `--force` to skip confirmation and enforcement checks) |
+| `plugin search <query>` | Search the configured external registry by keyword (requires `[skills.registry] enabled = true`) |
+| `plugin get <registry-id>` | Install a plugin by registry ID returned by `plugin search` (requires `[skills.registry] enabled = true`) |
 
 ```bash
 # List installed plugins
@@ -150,6 +163,15 @@ zeph plugin disable my-plugin
 
 # Force-disable a plugin (skip confirmation)
 zeph plugin disable my-plugin --force
+
+# Search the external registry for plugins (requires registry enabled in config)
+zeph plugin search "github-tools"
+
+# Install a plugin by registry ID
+zeph plugin get skills-sh/github-integration
+
+# View registry configuration
+zeph init                              # or use --migrate-config to add the [skills.registry] section
 ```
 
 **Overlay flag note:** `--overlay` shows which plugins contributed to the active config and which were skipped (with reasons like "integrity mismatch", "invalid manifest", etc.). This is evaluated against the default config — use `--config <path>` in the agent to see the live intersection with your active config.

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -276,6 +276,16 @@ heuristic_promotion_provider = ""       # Provider name for promotion LLM calls;
 heuristic_promotion_threshold = 5       # Minimum heuristics collected before promotion eligibility (default: 5)
 heuristic_promotion_interval_hours = 24 # Background job interval in hours (default: 24)
 
+# External skill/plugin registry discovery (opt-in).
+# Provides `zeph skill search` / `zeph skill get` and `zeph plugin search` / `zeph plugin get`.
+# Always off by default — zero network calls until explicitly enabled.
+# [skills.registry]
+# enabled = false                        # Enable registry search/install (default: false)
+# backend_kind = "skills-sh"             # Registry backend: "skills-sh" (public registry)
+# backend_url = "https://www.skills.sh"  # Override registry URL (optional; uses backend default if omitted)
+# auth_vault_key = ""                    # Vault key for bearer token (e.g., "ZEPH_SKILL_REGISTRY_TOKEN"); optional for public registries
+# registry_timeout_secs = 30             # Per-request timeout for registry search/fetch calls (default: 30)
+
 [memory]
 # Defaults to the user data dir when omitted
 # (for example ~/.local/share/zeph/data/zeph.db on Linux,

--- a/book/src/reference/feature-flags.md
+++ b/book/src/reference/feature-flags.md
@@ -75,6 +75,7 @@ The following capabilities compile unconditionally into every build. They are **
 | `a2a` | [A2A protocol](https://github.com/a2aproject/A2A) client and server for agent-to-agent communication |
 | `gateway` | HTTP gateway for webhook ingestion with bearer auth and rate limiting ([guide](../advanced/gateway.md)) |
 | `scheduler` | Cron-based periodic task scheduler with SQLite persistence, including the `update_check` handler for automatic version notifications ([guide](../advanced/daemon.md#cron-scheduler)) |
+| `registry` | Skill and plugin discovery-and-install marketplace via external registries (e.g., skills.sh) — provides `zeph skill search`/`get` and `zeph plugin search`/`get` commands; opt-in via config, no network calls by default ([guide](../concepts/skills.md#skill--plugin-registry-discovery)) |
 | `otel` | OpenTelemetry tracing export via OTLP/gRPC ([guide](../advanced/observability.md)) |
 | `pdf` | PDF document loading via [pdf-extract](https://crates.io/crates/pdf-extract) for the document ingestion pipeline |
 | `classifiers` | ML-based content classifiers via local candle inference (implies `candle`) |

--- a/config/default.toml
+++ b/config/default.toml
@@ -302,6 +302,18 @@ injection_patterns = true
 # Check that loaded skills don't declare tools exceeding their trust level
 # capability_escalation_check = false
 
+# External skill/plugin registry discovery (spec-045, #5869). Off by default — no network
+# call is ever made to any registry unless explicitly opted in below. See
+# `zeph skill search --help` / `zeph plugin search --help`. Requires building with
+# `--features registry` (included in `full`); a build without it prints an actionable
+# message instead of erroring.
+# [skills.registry]
+# enabled = false
+# backend_kind = "skills-sh"
+# backend_url = "https://www.skills.sh"
+# auth_vault_key = "ZEPH_SKILL_REGISTRY_TOKEN"  # set via `zeph vault set <key> <token>`
+# registry_timeout_secs = 30
+
 [memory]
 # SQLite database path for conversation history
 # Defaults to the user data dir (for example ~/.local/share/zeph/data/zeph.db on Linux,

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -255,6 +255,88 @@ pub enum SkillPromptMode {
     Auto,
 }
 
+/// Identifies which `zeph_plugins::marketplace::RegistryClient` implementation to use for
+/// `[skills.registry]` (FR-005, NFR-003). Not an intra-doc link: `zeph-plugins` is not a
+/// dependency of this crate (layering) and the type is additionally feature-gated there.
+///
+/// Deliberately a plain enum defined here in `zeph-config` (Layer 1), never re-exported from
+/// the feature-gated `zeph-plugins::marketplace` module — config parsing must always compile
+/// regardless of whether the `registry` Cargo feature is enabled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum RegistryBackendKind {
+    /// The public [skills.sh](https://www.skills.sh) registry.
+    #[default]
+    SkillsSh,
+}
+
+impl std::fmt::Display for RegistryBackendKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SkillsSh => f.write_str("skills-sh"),
+        }
+    }
+}
+
+fn default_registry_timeout_secs() -> u64 {
+    30
+}
+
+/// External skill/plugin registry connection settings, nested under `[skills.registry]` in
+/// TOML (spec-045, #5869).
+///
+/// Registry search/install is strictly opt-in (NFR-001): `enabled` defaults to `false`, and no
+/// field on this type is read — no network call is made — unless `enabled = true`.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [skills.registry]
+/// enabled = true
+/// backend_kind = "skills-sh"
+/// auth_vault_key = "ZEPH_SKILL_REGISTRY_TOKEN"
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RegistryConfig {
+    /// Enable registry search/install. Default: `false`.
+    ///
+    /// When `false`, `zeph skill search`/`add` and `zeph plugin search`/`add` refuse to make
+    /// any network call and print an actionable opt-in message instead (FR-004).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Which registry backend implementation (`zeph_plugins::marketplace::RegistryClient`,
+    /// crate not depended on here — see [`RegistryBackendKind`]) to use.
+    #[serde(default)]
+    pub backend_kind: RegistryBackendKind,
+    /// Registry base URL. `None` uses the backend's built-in default (for
+    /// [`RegistryBackendKind::SkillsSh`], `https://www.skills.sh`).
+    #[serde(default)]
+    pub backend_url: Option<String>,
+    /// Vault key name to resolve the registry's bearer credential from, e.g.
+    /// `"ZEPH_SKILL_REGISTRY_TOKEN"`. `None` means an anonymous (unauthenticated) request is
+    /// attempted; the backend may reject it if it requires a credential.
+    ///
+    /// Always resolved via `VaultProvider` — never stored as a plain config field.
+    #[serde(default)]
+    pub auth_vault_key: Option<String>,
+    /// Per-request timeout in seconds for registry `search`/`fetch` HTTP calls.
+    #[serde(default = "default_registry_timeout_secs")]
+    pub registry_timeout_secs: u64,
+}
+
+impl Default for RegistryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            backend_kind: RegistryBackendKind::default(),
+            backend_url: None,
+            auth_vault_key: None,
+            registry_timeout_secs: default_registry_timeout_secs(),
+        }
+    }
+}
+
 /// Skill discovery and matching configuration, nested under `[skills]` in TOML.
 ///
 /// Controls where skills are loaded from, how they are ranked during retrieval,
@@ -295,6 +377,13 @@ pub struct SkillsConfig {
     pub learning: LearningConfig,
     #[serde(default)]
     pub trust: TrustConfig,
+    /// External skill/plugin registry discovery (`zeph skill search`/`add`,
+    /// `zeph plugin search`/`add`), nested under `[skills.registry]` in TOML (spec-045, #5869).
+    ///
+    /// Off by default: no network call is ever made to a registry unless `enabled = true`
+    /// (NFR-001).
+    #[serde(default)]
+    pub registry: RegistryConfig,
     #[serde(default)]
     pub prompt_mode: SkillPromptMode,
     /// Enable two-stage category-first skill matching (requires `category` set in SKILL.md).
@@ -1240,6 +1329,54 @@ mod tests {
             !cfg.enabled,
             "scheduler must be opt-in (enabled = false by default)"
         );
+    }
+
+    // ── RegistryConfig tests (spec-045, #5869) ────────────────────────────
+
+    #[test]
+    fn registry_config_default_is_disabled() {
+        // Highest-priority test per the architect handoff: the registry must be strictly
+        // opt-in (NFR-001) — zero network calls unless explicitly enabled.
+        let cfg = RegistryConfig::default();
+        assert!(
+            !cfg.enabled,
+            "skill/plugin registry must be opt-in (enabled = false by default)"
+        );
+        assert_eq!(cfg.backend_kind, RegistryBackendKind::SkillsSh);
+        assert!(cfg.backend_url.is_none());
+        assert!(cfg.auth_vault_key.is_none());
+        assert_eq!(cfg.registry_timeout_secs, 30);
+    }
+
+    #[test]
+    fn registry_config_serde_roundtrip_with_defaults() {
+        let cfg: RegistryConfig = toml::from_str("").unwrap();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.backend_kind, RegistryBackendKind::SkillsSh);
+    }
+
+    #[test]
+    fn registry_config_serde_roundtrip_explicit() {
+        let toml = r#"
+            enabled = true
+            backend_kind = "skills-sh"
+            backend_url = "https://example.internal"
+            auth_vault_key = "ZEPH_SKILL_REGISTRY_TOKEN"
+            registry_timeout_secs = 10
+        "#;
+        let cfg: RegistryConfig = toml::from_str(toml).unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.backend_url.as_deref(), Some("https://example.internal"));
+        assert_eq!(
+            cfg.auth_vault_key.as_deref(),
+            Some("ZEPH_SKILL_REGISTRY_TOKEN")
+        );
+        assert_eq!(cfg.registry_timeout_secs, 10);
+    }
+
+    #[test]
+    fn registry_backend_kind_display() {
+        assert_eq!(RegistryBackendKind::SkillsSh.to_string(), "skills-sh");
     }
 }
 

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -139,9 +139,10 @@ pub use experiment::{
 };
 pub use features::{
     CavemanConfig, CompressionSpectrumConfig, CostConfig, DaemonConfig, DebugConfig, GatewayConfig,
-    IndexConfig, ProactiveExplorationConfig, ScheduledTaskConfig, ScheduledTaskKind,
-    SchedulerConfig, SchedulerDaemonConfig, SchedulerSecurityConfig, SkillEvaluationConfig,
-    SkillMiningConfig, SkillPromptMode, SkillsConfig, TraceConfig, VaultBackend, VaultConfig,
+    IndexConfig, ProactiveExplorationConfig, RegistryBackendKind, RegistryConfig,
+    ScheduledTaskConfig, ScheduledTaskKind, SchedulerConfig, SchedulerDaemonConfig,
+    SchedulerSecurityConfig, SkillEvaluationConfig, SkillMiningConfig, SkillPromptMode,
+    SkillsConfig, TraceConfig, VaultBackend, VaultConfig,
 };
 pub use fidelity::FidelityConfig;
 pub use hooks::{FileChangedConfig, HooksConfig};

--- a/crates/zeph-config/src/migrate/features.rs
+++ b/crates/zeph-config/src/migrate/features.rs
@@ -766,3 +766,47 @@ pub fn migrate_orchestration_asset_sensitivity(
         sections_changed: vec!["orchestration.default_asset_sensitivity".to_owned()],
     })
 }
+
+/// Step 78 — add a commented-out `[skills.registry]` section with defaults if absent
+/// (spec-045, #5869).
+///
+/// All `RegistryConfig` fields have `#[serde(default)]`, so existing configs parse without
+/// changes; this step only surfaces the new opt-in section for users upgrading from older
+/// configs. Always writes `enabled = false` in the commented template — a migration must never
+/// silently opt a config into a network-calling feature.
+///
+/// Idempotent: checks both an active and a previously-injected commented header before doing
+/// anything, mirroring `migrate_worktree_config` (`infra.rs`).
+///
+/// # Errors
+///
+/// Returns [`MigrateError::Parse`] if the TOML cannot be parsed.
+pub fn migrate_skills_registry(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    let commented_present = toml_src.lines().any(|l| l.trim() == "# [skills.registry]");
+    if toml_src.contains("[skills.registry]") || commented_present {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+    let raw = doc.to_string();
+    let comment = "\n# External skill/plugin registry discovery (spec-045, #5869). Off by\n\
+         # default — no network call is made to any registry unless explicitly opted in. See\n\
+         # `zeph skill search --help` / `zeph plugin search --help`.\n\
+         # [skills.registry]\n\
+         # enabled = false\n\
+         # backend_kind = \"skills-sh\"\n\
+         # backend_url = \"https://www.skills.sh\"\n\
+         # auth_vault_key = \"ZEPH_SKILL_REGISTRY_TOKEN\"  # set via `zeph vault set <key> <token>`\n\
+         # registry_timeout_secs = 30\n";
+    let output = format!("{raw}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["skills.registry".to_owned()],
+    })
+}

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -25,7 +25,8 @@ pub use features::{
     migrate_deep_link_config, migrate_five_signal_config, migrate_goals_config,
     migrate_knowledge_config, migrate_magic_docs_config, migrate_microcompact_config,
     migrate_orchestration_asset_sensitivity, migrate_orchestration_persistence,
-    migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults,
+    migrate_skills_registry, migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config,
+    migrate_tui_theme_defaults,
 };
 pub use infra::*;
 /// Advisory `GonkaGate` migration is crate-internal (registered via the [`MIGRATIONS`] registry).
@@ -617,14 +618,14 @@ use steps::{
     MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
     MigrateSecretMaskingConfig, MigrateServeConfig, MigrateSessionPersistProviderOverrides,
     MigrateSessionPersistenceConfig, MigrateSessionProviderPersistence, MigrateSessionRecapConfig,
-    MigrateShellCheckpointsConfig, MigrateShellTransactional, MigrateSttToProvider,
-    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
-    MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig,
-    MigrateTuiThemeDefaults, MigrateUtilityHighGainTools, MigrateVigilConfig,
-    MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
+    MigrateShellCheckpointsConfig, MigrateShellTransactional, MigrateSkillsRegistry,
+    MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
+    MigrateToolsCompressionConfig, MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse,
+    MigrateTuiThemeConfig, MigrateTuiThemeDefaults, MigrateUtilityHighGainTools,
+    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–77).
+/// Ordered registry of all sequential migration steps (steps 1–78).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -762,6 +763,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateUtilityHighGainTools),
             // Step 77 — add [[acp.auth_clients]] advisory block (#5868)
             Box::new(MigrateAcpAuthClientsConfig),
+            // Step 78 — add [skills.registry] advisory block (spec-045, #5869)
+            Box::new(MigrateSkillsRegistry),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -37,7 +37,8 @@
 //! `[security.pii_filter]` table (#5530);
 //! step 75 adds a commented `qdrant_timeout_secs = 10` advisory under `[memory]`;
 //! step 76 adds a commented `high_gain_tools = []` advisory under `[tools.utility]` (#5659);
-//! step 77 adds a commented `[[acp.auth_clients]]` advisory block (#5868).
+//! step 77 adds a commented `[[acp.auth_clients]]` advisory block (#5868);
+//! step 78 adds a commented `[skills.registry]` advisory block (spec-045, #5869).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -69,11 +70,12 @@ use super::{
     migrate_scheduler_daemon_config, migrate_secret_masking_config, migrate_serve_config,
     migrate_session_persist_provider_overrides, migrate_session_persistence_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
-    migrate_shell_checkpoints_config, migrate_shell_transactional, migrate_stt_to_provider,
-    migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
-    migrate_trace_metadata, migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config,
-    migrate_tui_theme_defaults, migrate_utility_high_gain_tools, migrate_vigil_config,
-    migrate_worktree_config, migrate_worktree_git_timeout,
+    migrate_shell_checkpoints_config, migrate_shell_transactional, migrate_skills_registry,
+    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
+    migrate_tools_compression_config, migrate_trace_metadata, migrate_tui_delights,
+    migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults,
+    migrate_utility_high_gain_tools, migrate_vigil_config, migrate_worktree_config,
+    migrate_worktree_git_timeout,
 };
 
 // ── Wrapper structs for all 73 sequential migration steps ───────────────────────────────────────
@@ -836,6 +838,18 @@ impl Migration for MigrateOrchestrationAssetSensitivity {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_orchestration_asset_sensitivity(toml_src)
+    }
+}
+
+/// Step 78 — add a commented-out `[skills.registry]` advisory block (spec-045, #5869).
+pub(super) struct MigrateSkillsRegistry;
+impl Migration for MigrateSkillsRegistry {
+    fn name(&self) -> &'static str {
+        "migrate_skills_registry"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_skills_registry(toml_src)
     }
 }
 

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        77,
-        "MIGRATIONS registry must contain all 77 sequential steps"
+        78,
+        "MIGRATIONS registry must contain all 78 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1678,7 +1678,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 77);
+    assert_eq!(MIGRATIONS.len(), 78);
 }
 
 #[test]
@@ -1717,7 +1717,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–77).
+    // Names must follow the documented step order (steps 1–78).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1796,6 +1796,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_qdrant_timeout_secs",
         "migrate_utility_high_gain_tools",
         "migrate_acp_auth_clients_config",
+        "migrate_skills_registry",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -1968,6 +1969,56 @@ fn migrate_utility_high_gain_tools_idempotent_on_commented_output() {
     let second = migrate_utility_high_gain_tools(&first.output).unwrap();
     assert_eq!(second.changed_count, 0, "second run must not double-append");
     assert_eq!(second.output, first.output);
+}
+
+// ── migrate_skills_registry tests (spec-045, #5869) ──────────────────────
+
+#[test]
+fn migrate_skills_registry_adds_commented_block_when_absent() {
+    let src = "[skills]\npaths = []\n";
+    let result = migrate_skills_registry(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert_eq!(result.sections_changed, vec!["skills.registry".to_owned()]);
+    assert!(result.output.contains("# [skills.registry]"));
+    result
+        .output
+        .parse::<toml_edit::DocumentMut>()
+        .expect("migrated output must remain valid TOML");
+}
+
+#[test]
+fn migrate_skills_registry_never_sets_enabled_true() {
+    // A migration must never silently opt a config into a network-calling feature (NFR-001).
+    let src = "[skills]\npaths = []\n";
+    let result = migrate_skills_registry(src).expect("migrate");
+    assert!(result.output.contains("# enabled = false"));
+    assert!(!result.output.contains("enabled = true"));
+}
+
+#[test]
+fn migrate_skills_registry_idempotent_on_commented_output() {
+    let base = "[skills]\npaths = []\n";
+    let first = migrate_skills_registry(base).unwrap();
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_skills_registry(&first.output).unwrap();
+    assert_eq!(second.changed_count, 0, "second run must not double-append");
+    assert_eq!(second.output, first.output);
+}
+
+#[test]
+fn migrate_skills_registry_idempotent_on_active_section() {
+    let src = "[skills.registry]\nenabled = true\n";
+    let result = migrate_skills_registry(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn migrate_skills_registry_works_without_skills_section() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let result = migrate_skills_registry(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("# [skills.registry]"));
 }
 
 #[test]

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -19,8 +19,8 @@ use crate::defaults::{default_skill_paths, default_sqlite_path_field};
 use crate::execution::ExecutionConfig;
 use crate::experiment::{ExperimentConfig, OrchestrationConfig};
 use crate::features::{
-    CostConfig, DaemonConfig, DebugConfig, GatewayConfig, IndexConfig, SchedulerConfig,
-    SkillPromptMode, SkillsConfig, VaultConfig,
+    CostConfig, DaemonConfig, DebugConfig, GatewayConfig, IndexConfig, RegistryConfig,
+    SchedulerConfig, SkillPromptMode, SkillsConfig, VaultConfig,
 };
 use crate::hooks::HooksConfig;
 use crate::learning::LearningConfig;
@@ -184,6 +184,10 @@ pub struct ResolvedSecrets {
     pub gonka_address: Option<Secret>,
     /// Cocoon sidecar access hash resolved from the vault key `ZEPH_COCOON_ACCESS_HASH`.
     pub cocoon_access_hash: Option<Secret>,
+    /// Skill/plugin registry bearer credential, resolved from the vault key named by
+    /// `skills.registry.auth_vault_key` when `skills.registry.enabled = true` (spec-045,
+    /// #5869). `None` when the registry is disabled or `auth_vault_key` is unset.
+    pub skill_registry_token: Option<Secret>,
     /// Arbitrary skill secrets resolved from `ZEPH_SECRET_*` vault keys.
     /// Key is the lowercased name after stripping the prefix (e.g. `github_token`).
     pub custom: HashMap<String, Secret>,
@@ -239,6 +243,7 @@ impl Default for Config {
                 bm25_alpha: 0.7,
                 learning: LearningConfig::default(),
                 trust: TrustConfig::default(),
+                registry: RegistryConfig::default(),
                 prompt_mode: SkillPromptMode::Auto,
                 two_stage_matching: false,
                 confusability_threshold: 0.0,

--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -18,13 +18,14 @@ pub use zeph_config::{
     LoggingConfig, MAX_TOKENS_CAP, McpConfig, McpOAuthConfig, McpServerConfig, McpTrustLevel,
     MemoryConfig, MemoryScope, NoteLinkingConfig, OAuthTokenStorage, OrchestrationConfig,
     PermissionMode, ProviderEntry, ProviderKind, ProviderName, PruningStrategy, RateLimitConfig,
-    ResolvedSecrets, RetrievalConfig, RouterConfig, RouterStrategyConfig, ScheduledTaskConfig,
-    ScheduledTaskKind, SchedulerConfig, SchedulerDaemonConfig, SchedulerSecurityConfig,
-    SecurityConfig, SemanticConfig, SessionsConfig, SidequestConfig, SkillFilter, SkillPromptMode,
-    SkillsConfig, SlackConfig, StoreRoutingConfig, StoreRoutingStrategy, SttConfig, SubAgentConfig,
-    SubAgentLifecycleHooks, SubagentHooks, TaskSupervisorConfig, TelegramConfig, TimeoutConfig,
-    ToolDiscoveryConfig, ToolDiscoveryStrategyConfig, ToolFilterConfig, ToolPolicy, TraceConfig,
-    TrustConfig, TuiConfig, VaultConfig, VectorBackend,
+    RegistryBackendKind, RegistryConfig, ResolvedSecrets, RetrievalConfig, RouterConfig,
+    RouterStrategyConfig, ScheduledTaskConfig, ScheduledTaskKind, SchedulerConfig,
+    SchedulerDaemonConfig, SchedulerSecurityConfig, SecurityConfig, SemanticConfig, SessionsConfig,
+    SidequestConfig, SkillFilter, SkillPromptMode, SkillsConfig, SlackConfig, StoreRoutingConfig,
+    StoreRoutingStrategy, SttConfig, SubAgentConfig, SubAgentLifecycleHooks, SubagentHooks,
+    TaskSupervisorConfig, TelegramConfig, TimeoutConfig, ToolDiscoveryConfig,
+    ToolDiscoveryStrategyConfig, ToolFilterConfig, ToolPolicy, TraceConfig, TrustConfig, TuiConfig,
+    VaultConfig, VectorBackend,
 };
 
 pub use zeph_config::{
@@ -162,6 +163,15 @@ impl SecretResolver for Config {
         if let Some(val) = vault.get_secret("ZEPH_COCOON_ACCESS_HASH").await? {
             register_masked_secret(registry, "ZEPH_COCOON_ACCESS_HASH", &val);
             self.secrets.cocoon_access_hash = Some(Secret::new(val));
+        }
+        // Registry lookups are strictly opt-in (NFR-001): only touch the vault when the
+        // registry is enabled AND a key name is configured, never unconditionally.
+        if self.skills.registry.enabled
+            && let Some(key_name) = self.skills.registry.auth_vault_key.clone()
+            && let Some(val) = vault.get_secret(&key_name).await?
+        {
+            register_masked_secret(registry, &key_name, &val);
+            self.secrets.skill_registry_token = Some(Secret::new(val));
         }
         log_gonka_credential_status(
             self.secrets.gonka_private_key.is_some(),

--- a/crates/zeph-plugins/Cargo.toml
+++ b/crates/zeph-plugins/Cargo.toml
@@ -44,6 +44,16 @@ wiremock.workspace = true
 default = ["sqlite"]
 sqlite = ["zeph-skills/sqlite", "zeph-tools/sqlite"]
 postgres = ["zeph-skills/postgres", "zeph-tools/postgres"]
+# Skill/plugin marketplace discovery (spec-045, #5869). Gates only the `marketplace` module
+# body — `reqwest`/`serde_json` are already unconditional dependencies of this crate. The only
+# additive dependency surface is `reqwest`'s own `query` Cargo feature (a thin wrapper around
+# `serde_urlencoded`, no new crate), needed to build the skills.sh search request.
+registry = ["reqwest/query"]
+# Exposes `marketplace::mock::MockRegistryClient` outside `#[cfg(test)]` so downstream crates
+# (the `zeph` binary) can drive it from their own `dev-dependencies`. Mirrors `zeph-vault`'s
+# `mock` feature. No-op unless `registry` is also enabled (the `marketplace` module itself is
+# gated on `registry`).
+mock = []
 
 [lints]
 workspace = true

--- a/crates/zeph-plugins/src/lib.rs
+++ b/crates/zeph-plugins/src/lib.rs
@@ -22,6 +22,8 @@ pub mod error;
 pub(crate) mod integrity;
 pub mod manager;
 pub mod manifest;
+#[cfg(feature = "registry")]
+pub mod marketplace;
 pub mod overlay;
 pub mod types;
 
@@ -32,5 +34,7 @@ pub use manager::{
     download_and_extract, validate_url_scheme_ephemeral,
 };
 pub use manifest::PluginManifest;
+#[cfg(feature = "registry")]
+pub use marketplace::{PackageArchive, RegistryClient, RegistryEntry, RegistryError};
 pub use overlay::{ResolvedOverlay, apply_plugin_config_overlays};
 pub use types::PluginName;

--- a/crates/zeph-plugins/src/marketplace/mock.rs
+++ b/crates/zeph-plugins/src/marketplace/mock.rs
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Test-only [`RegistryClient`] implementation proving the trait boundary is real
+//! (SC-004/NFR-003): a second, independent backend that plugs in without touching any call
+//! site in `zeph skill search`/`zeph skill get`/`zeph plugin search`/`zeph plugin get`.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use super::{PackageArchive, RegistryClient, RegistryEntry, RegistryError, materialize_package};
+
+/// In-memory registry backend for tests.
+///
+/// Holds a fixed set of [`RegistryEntry`] results and, for each `registry_id`, the set of
+/// `(path, content)` pairs that [`fetch`](RegistryClient::fetch) materializes into a
+/// [`tempfile::TempDir`].
+#[derive(Default)]
+pub struct MockRegistryClient {
+    entries: Vec<RegistryEntry>,
+    packages: HashMap<String, Vec<(String, String)>>,
+    /// When `Some`, every call returns this error instead of touching `entries`/`packages`.
+    fail_with: Option<String>,
+}
+
+impl MockRegistryClient {
+    /// Create an empty mock (search returns no results, fetch always returns `NotFound`).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a search result. `search()` matches on substring containment against
+    /// `entry.name`/`entry.description`, case-insensitively.
+    #[must_use]
+    pub fn with_entry(mut self, entry: RegistryEntry) -> Self {
+        self.entries.push(entry);
+        self
+    }
+
+    /// Register the files that `fetch(registry_id)` materializes.
+    #[must_use]
+    pub fn with_package(
+        mut self,
+        registry_id: impl Into<String>,
+        files: Vec<(String, String)>,
+    ) -> Self {
+        self.packages.insert(registry_id.into(), files);
+        self
+    }
+
+    /// Force every `search`/`fetch` call to fail with [`RegistryError::Backend`] carrying
+    /// `message` in the body. Used to test error-propagation paths.
+    #[must_use]
+    pub fn failing(mut self, message: impl Into<String>) -> Self {
+        self.fail_with = Some(message.into());
+        self
+    }
+}
+
+impl RegistryClient for MockRegistryClient {
+    fn search(
+        &self,
+        query: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<RegistryEntry>, RegistryError>> + Send + '_>> {
+        let query = query.to_lowercase();
+        Box::pin(async move {
+            if let Some(msg) = &self.fail_with {
+                return Err(RegistryError::Backend {
+                    status: 500,
+                    body: msg.clone(),
+                });
+            }
+            Ok(self
+                .entries
+                .iter()
+                .filter(|e| {
+                    e.name.to_lowercase().contains(&query)
+                        || e.description.to_lowercase().contains(&query)
+                })
+                .cloned()
+                .collect())
+        })
+    }
+
+    fn fetch(
+        &self,
+        registry_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<PackageArchive, RegistryError>> + Send + '_>> {
+        let registry_id = registry_id.to_owned();
+        Box::pin(async move {
+            if let Some(msg) = &self.fail_with {
+                return Err(RegistryError::Backend {
+                    status: 500,
+                    body: msg.clone(),
+                });
+            }
+            let files = self
+                .packages
+                .get(&registry_id)
+                .ok_or_else(|| RegistryError::NotFound(registry_id.clone()))?;
+
+            let tmp = tempfile::tempdir()?;
+            let (has_plugin_manifest, install_dir) = materialize_package(tmp.path(), files)?;
+
+            Ok(PackageArchive {
+                registry_id,
+                has_plugin_manifest,
+                extracted_dir: tmp,
+                install_dir,
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry(id: &str, name: &str) -> RegistryEntry {
+        RegistryEntry {
+            registry_id: id.to_owned(),
+            name: name.to_owned(),
+            description: "a test skill".to_owned(),
+            tags: vec![],
+            author: None,
+            security_audit_status: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn search_filters_by_name_case_insensitively() {
+        let mock = MockRegistryClient::new().with_entry(sample_entry("a/b", "PDF Tools"));
+        let results = mock.search("pdf").await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(mock.search("nomatch").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_not_found_for_unregistered_id() {
+        let mock = MockRegistryClient::new();
+        let err = mock.fetch("missing").await.unwrap_err();
+        assert!(matches!(err, RegistryError::NotFound(id) if id == "missing"));
+    }
+
+    #[tokio::test]
+    async fn fetch_materializes_registered_package() {
+        let mock = MockRegistryClient::new().with_package(
+            "a/b",
+            vec![(
+                "SKILL.md".to_owned(),
+                "---\nname: b\ndescription: a test skill\n---\nbody".to_owned(),
+            )],
+        );
+        let archive = mock.fetch("a/b").await.unwrap();
+        // install_dir is named after the skill (`b`), not extracted_dir's random tmp name —
+        // see PackageArchive::install_dir docs.
+        assert!(archive.install_dir.join("SKILL.md").is_file());
+        assert!(!archive.has_plugin_manifest);
+    }
+
+    #[tokio::test]
+    async fn failing_mock_returns_configured_error() {
+        let mock = MockRegistryClient::new().failing("boom");
+        let err = mock.search("x").await.unwrap_err();
+        assert!(matches!(err, RegistryError::Backend { .. }));
+        let err = mock.fetch("x").await.unwrap_err();
+        assert!(matches!(err, RegistryError::Backend { .. }));
+    }
+}

--- a/crates/zeph-plugins/src/marketplace/mod.rs
+++ b/crates/zeph-plugins/src/marketplace/mod.rs
@@ -1,0 +1,548 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Pluggable skill/plugin discovery-and-fetch registry client (spec-045, #5869).
+//!
+//! This module defines the trait boundary a registry backend must implement to plug into
+//! `zeph skill search`/`zeph skill get`/`zeph plugin search`/`zeph plugin get` (FR-005,
+//! NFR-003). It intentionally stops at "search" and "fetch a package to a local directory" —
+//! everything downstream (frontmatter validation, injection scanning, trust upsert) reuses the
+//! existing [`zeph_skills::manager::SkillManager`] and [`crate::manager::PluginManager`]
+//! install pipelines unchanged (NFR-002).
+//!
+//! # Compile-time gate
+//!
+//! The entire module body is gated by the `registry` Cargo feature (see `Cargo.toml`). This is
+//! a *thin* feature: `reqwest` is already an unconditional dependency of this crate, and the
+//! only additive surface it enables is `reqwest`'s own `query` Cargo feature (a thin wrapper
+//! around `serde_urlencoded`, not a new crate) — the feature's purpose is to satisfy the
+//! project convention that every new optional network capability gets a dedicated feature
+//! flag, not to gate a heavyweight dependency. The CLI argument variants and
+//! [`zeph_config::RegistryConfig`] parsing are **not** gated by this feature and always
+//! compile, so `--help` and `--migrate-config` keep working in a build without it.
+//!
+//! # Backends
+//!
+//! - [`skills_sh::SkillsShClient`] — the only shipped backend, targeting the public
+//!   [skills.sh](https://www.skills.sh) registry.
+//! - `mock::MockRegistryClient` (test-only, not linkable here — compiled under
+//!   `#[cfg(any(test, feature = "mock"))]`, see that module) — proves the trait boundary is
+//!   real by providing a second, independent implementation (SC-004). The `mock` feature (not
+//!   just `#[cfg(test)]`) exists so downstream crates like the `zeph` binary can depend on it
+//!   from their own `dev-dependencies`, mirroring `zeph-vault`'s `MockVaultProvider` pattern.
+
+use std::path::{Component, Path};
+use std::pin::Pin;
+
+pub mod skills_sh;
+
+#[cfg(any(test, feature = "mock"))]
+pub mod mock;
+
+/// A single search result returned by a registry backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryEntry {
+    /// Backend-assigned identifier, opaque to the caller. Pass verbatim to
+    /// [`RegistryClient::fetch`].
+    pub registry_id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Short description.
+    pub description: String,
+    /// Free-form tags/categories, when the backend provides them.
+    pub tags: Vec<String>,
+    /// Author or publisher, when the backend provides it.
+    pub author: Option<String>,
+    /// Security audit status string, when the backend provides one (e.g. `"pass"`, `"warn"`,
+    /// `"fail"`). `None` when the backend has no audit concept or the search response did not
+    /// include it.
+    pub security_audit_status: Option<String>,
+}
+
+/// A fetched package, extracted to a local temporary directory.
+///
+/// Ownership of `extracted_dir` is returned to the caller; the directory (and everything in
+/// it) is deleted when this value is dropped. Callers that want to keep it must install the
+/// contents elsewhere (e.g. via [`zeph_skills::manager::SkillManager::install_from_path`])
+/// before dropping this value.
+pub struct PackageArchive {
+    /// The `registry_id` this package was fetched for.
+    pub registry_id: String,
+    /// Temporary directory owning the package's materialized files. Do not pass this path
+    /// directly to `SkillManager::install_from_path`/`PluginManager::add` — use the
+    /// `install_dir` field instead (see its docs for why).
+    pub extracted_dir: tempfile::TempDir,
+    /// `true` when the package contains a `plugin.toml` (a Zeph plugin package), `false` when
+    /// it is a bare `SKILL.md` package.
+    pub has_plugin_manifest: bool,
+    /// The directory to pass to `SkillManager::install_from_path` (bare skill package) or
+    /// `PluginManager::add` (plugin bundle).
+    ///
+    /// For a **bare skill package** this is a subdirectory of `extracted_dir` named after the
+    /// skill's frontmatter `name` — `zeph_skills::loader::load_skill_meta`'s
+    /// `validate_skill_name` requires the source directory's own basename to equal the
+    /// declared skill name, and `extracted_dir`'s basename is an OS-assigned random string that
+    /// will never satisfy that by chance. Without this indirection, `SkillManager::install_from_path`
+    /// would fail with "skill name '<x>' does not match directory name '<random-tmp-name>'" for
+    /// every real registry fetch — found via this crate's own test suite, not a live session
+    /// (fix accompanying review issue #4's testability work).
+    ///
+    /// For a **plugin bundle** this is `extracted_dir.path()` itself — `PluginManager::add`
+    /// does not require its source directory to be named any particular way.
+    pub install_dir: std::path::PathBuf,
+}
+
+impl std::fmt::Debug for PackageArchive {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PackageArchive")
+            .field("registry_id", &self.registry_id)
+            .field("extracted_dir", &self.extracted_dir.path())
+            .field("has_plugin_manifest", &self.has_plugin_manifest)
+            .field("install_dir", &self.install_dir)
+            .finish()
+    }
+}
+
+/// Errors that can occur during a registry search or fetch.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    /// The HTTP request itself failed (connection, DNS, TLS).
+    #[error("registry request failed: {0}")]
+    Request(String),
+
+    /// The request timed out.
+    #[error("registry request timed out")]
+    Timeout,
+
+    /// The backend returned a non-success HTTP status not otherwise classified below.
+    #[error("registry returned HTTP {status}: {body}")]
+    Backend { status: u16, body: String },
+
+    /// The backend requires authentication and no credential was configured, or the configured
+    /// credential was rejected.
+    #[error(
+        "registry requires authentication; set skills.registry.auth_vault_key in config.toml \
+         and store the token with `zeph vault set <KEY> <token>`"
+    )]
+    AuthRequired,
+
+    /// The requested `registry_id` does not exist in the backend.
+    #[error("package {0:?} not found in registry")]
+    NotFound(String),
+
+    /// The backend's response body could not be parsed into the expected shape.
+    #[error("registry response could not be parsed: {0}")]
+    InvalidResponse(String),
+
+    /// A response (search page or package detail) exceeded the accepted size limit, or a
+    /// package contained more files or total bytes than the accepted cap. Rejected before the
+    /// body is read into memory / before a file is written, to prevent OOM or disk/inode
+    /// exhaustion from a malicious, compromised, or MITM'd registry (review fix #2).
+    #[error("registry response exceeded the size limit: {0}")]
+    TooLarge(String),
+
+    /// A package file path in the response was unsafe to materialize (absolute or contained a
+    /// `..` component).
+    #[error("registry package contains an unsafe file path: {0}")]
+    UnsafePath(String),
+
+    /// `skills.registry.backend_url` (or a value derived from it) uses a scheme other than
+    /// `http`/`https` (review fix #6 — SSRF hardening).
+    #[error("unsafe registry backend URL: {0}")]
+    UnsafeBackendUrl(String),
+
+    /// A user-supplied `registry_id` contained characters (`?`, `#`, whitespace) that could
+    /// alter the request URL's query string or fragment when interpolated into the path
+    /// (review fix #8).
+    #[error("invalid registry id {0:?}: must not contain '?', '#', or whitespace")]
+    InvalidRegistryId(String),
+
+    /// A filesystem operation failed while materializing the fetched package.
+    #[error("filesystem error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Pluggable registry backend for skill/plugin discovery and fetch (FR-005, NFR-003).
+///
+/// Implement this trait to integrate a private or self-hosted registry. The crate ships
+/// [`skills_sh::SkillsShClient`] out of the box.
+///
+/// Uses boxed futures (rather than native `async fn` in trait) because callers need to select
+/// a backend at runtime behind `dyn RegistryClient` based on `[skills.registry] backend_kind` —
+/// this mirrors the `zeph_vault::VaultProvider` pattern already used elsewhere in this
+/// workspace for the same reason (not an intra-doc link: `zeph-vault` is not a dependency of
+/// this crate; async trait objects are not natively object-safe, which is why both traits use
+/// boxed futures instead of native `async fn` in trait).
+///
+/// # Implementing
+///
+/// ```
+/// use std::pin::Pin;
+/// use std::future::Future;
+/// use zeph_plugins::marketplace::{RegistryClient, RegistryEntry, RegistryError, PackageArchive};
+///
+/// struct EmptyRegistry;
+///
+/// impl RegistryClient for EmptyRegistry {
+///     fn search(
+///         &self,
+///         _query: &str,
+///     ) -> Pin<Box<dyn Future<Output = Result<Vec<RegistryEntry>, RegistryError>> + Send + '_>> {
+///         Box::pin(async move { Ok(Vec::new()) })
+///     }
+///
+///     fn fetch(
+///         &self,
+///         registry_id: &str,
+///     ) -> Pin<Box<dyn Future<Output = Result<PackageArchive, RegistryError>> + Send + '_>> {
+///         let id = registry_id.to_owned();
+///         Box::pin(async move { Err(RegistryError::NotFound(id)) })
+///     }
+/// }
+/// ```
+pub trait RegistryClient: Send + Sync {
+    /// Search the registry by free-text `query`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryError`] on network failure, timeout, or an unparseable response.
+    fn search(
+        &self,
+        query: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<RegistryEntry>, RegistryError>> + Send + '_>>;
+
+    /// Fetch the package identified by `registry_id` and materialize it into a local temporary
+    /// directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryError::NotFound`] when the id does not exist, and other
+    /// [`RegistryError`] variants on network, auth, or parsing failure.
+    fn fetch(
+        &self,
+        registry_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<PackageArchive, RegistryError>> + Send + '_>>;
+}
+
+/// Maximum number of files a single registry-fetched package may contain.
+///
+/// Defense in depth independent of `skills_sh`'s own response-size pre-check (not an intra-doc
+/// link: that constant is private to its module): `write_files_safe` is a shared primitive any
+/// future [`RegistryClient`] backend could call, not necessarily one that already capped its
+/// HTTP response size the same way (review fix #2).
+const MAX_PACKAGE_FILES: usize = 500;
+
+/// Maximum total byte size across all files in a single registry-fetched package.
+const MAX_PACKAGE_TOTAL_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Write `files` (relative path, content) pairs into `dest`, creating parent directories as
+/// needed.
+///
+/// Rejects any path that is absolute or contains a `..` component — the same tar-slip class of
+/// protection [`crate::manager::security`]'s `extract_archive_safe` applies to tar entries,
+/// applied here to registry-supplied JSON file lists instead (skills.sh serves package
+/// contents inline in JSON rather than as a tar archive; see `skills_sh` module docs). Also
+/// rejects a package with more than [`MAX_PACKAGE_FILES`] entries or more than
+/// [`MAX_PACKAGE_TOTAL_BYTES`] combined content bytes, before any file is written (review fix
+/// #2 — prevents disk/inode exhaustion from a malicious or compromised registry).
+///
+/// # Errors
+///
+/// Returns [`RegistryError::TooLarge`] when the file-count or total-bytes cap is exceeded,
+/// [`RegistryError::UnsafePath`] for a rejected entry, or [`RegistryError::Io`] if a file
+/// cannot be written.
+pub(crate) fn write_files_safe(
+    dest: &Path,
+    files: &[(String, String)],
+) -> Result<(), RegistryError> {
+    if files.len() > MAX_PACKAGE_FILES {
+        return Err(RegistryError::TooLarge(format!(
+            "package contains {} files (max {MAX_PACKAGE_FILES})",
+            files.len()
+        )));
+    }
+    let total_bytes: u64 = files.iter().map(|(_, content)| content.len() as u64).sum();
+    if total_bytes > MAX_PACKAGE_TOTAL_BYTES {
+        return Err(RegistryError::TooLarge(format!(
+            "package content totals {total_bytes} bytes (max {MAX_PACKAGE_TOTAL_BYTES})"
+        )));
+    }
+    for (rel_path, content) in files {
+        let candidate = Path::new(rel_path);
+        if candidate.is_absolute()
+            || candidate
+                .components()
+                .any(|c| matches!(c, Component::ParentDir))
+        {
+            return Err(RegistryError::UnsafePath(rel_path.clone()));
+        }
+        let target = dest.join(candidate);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&target, content)?;
+    }
+    Ok(())
+}
+
+/// Reject a registry-supplied skill `name` before it is ever joined onto a filesystem path.
+///
+/// # Security
+///
+/// `name` originates from an untrusted registry response's `SKILL.md` frontmatter, parsed via
+/// [`zeph_skills::loader::load_skill_meta_from_str`] — the *string*-based parser, chosen
+/// specifically because it has no directory context and therefore does **not** call
+/// `zeph_skills::loader`'s private `validate_skill_name` (that check only runs on the
+/// file-path-based `load_skill_meta`, once a directory already exists to compare against).
+/// This function is the substitute gate that must run before `name` is used anywhere near a
+/// path, most importantly `tmp_root.join(name)` in [`materialize_package`]. `PathBuf::join`
+/// has two exploitable behaviors with an unvalidated `name`: a relative-traversal segment like
+/// `"../../etc"` walks the join outside `tmp_root`, and an **absolute** path like
+/// `"/etc/cron.d"` *replaces* the base path outright — `tmp_root.join("/etc/cron.d")` yields
+/// exactly `/etc/cron.d`, not a path under `tmp_root`. Either one, unguarded, turns a
+/// malicious/MITM'd registry response into an arbitrary-file-write primitive once
+/// `write_files_safe` writes the package's files under the resulting `install_dir`.
+///
+/// # Errors
+///
+/// Returns [`RegistryError::InvalidResponse`] when `name` is empty, is `"."`, contains a path
+/// separator (`/` or `\`), or contains a `..` component.
+fn validate_registry_skill_name(name: &str) -> Result<(), RegistryError> {
+    if name.is_empty() || name == "." || name.contains(['/', '\\']) || name.contains("..") {
+        return Err(RegistryError::InvalidResponse(format!(
+            "package SKILL.md declares an unsafe name {name:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Materialize `files` under `tmp_root` and determine the directory to pass to
+/// `SkillManager::install_from_path`/`PluginManager::add` — see [`PackageArchive`]'s
+/// `install_dir` field docs for why a bare skill package needs a different directory than a
+/// plugin bundle.
+///
+/// Classification is based on the presence of a `"plugin.toml"` entry in `files` (checked
+/// before any write, not via a post-write filesystem scan — equally correct here since `files`
+/// is already the full authoritative entry list, and avoids a redundant filesystem read).
+///
+/// # Errors
+///
+/// Returns [`RegistryError::InvalidResponse`] when a bare skill package (no `plugin.toml`) has
+/// no `SKILL.md` entry, its frontmatter cannot be parsed, or its declared `name` fails
+/// [`validate_registry_skill_name`] (see that function's docs for why this check is mandatory
+/// and cannot be delegated to `SkillManager::install_from_path`'s later validation). Failing
+/// fast with a clear message here is preferable to letting the caller's later
+/// `SkillManager::install_from_path` call fail with a confusing directory-name-mismatch error.
+/// Otherwise propagates [`write_files_safe`]'s errors.
+pub(crate) fn materialize_package(
+    tmp_root: &Path,
+    files: &[(String, String)],
+) -> Result<(bool, std::path::PathBuf), RegistryError> {
+    let has_plugin_manifest = files.iter().any(|(path, _)| path == "plugin.toml");
+    if has_plugin_manifest {
+        write_files_safe(tmp_root, files)?;
+        return Ok((true, tmp_root.to_path_buf()));
+    }
+
+    let skill_md_content = files
+        .iter()
+        .find(|(path, _)| path == "SKILL.md")
+        .map(|(_, content)| content.as_str())
+        .ok_or_else(|| {
+            RegistryError::InvalidResponse(
+                "package has neither plugin.toml nor SKILL.md at its root".to_owned(),
+            )
+        })?;
+    let (meta, _body) = zeph_skills::loader::load_skill_meta_from_str(skill_md_content)
+        .map_err(|e| RegistryError::InvalidResponse(format!("invalid SKILL.md: {e}")))?;
+    validate_registry_skill_name(&meta.name)?;
+
+    let install_dir = tmp_root.join(&meta.name);
+    write_files_safe(&install_dir, files)?;
+    Ok((false, install_dir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_files_safe_rejects_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = vec![("/etc/passwd".to_owned(), "evil".to_owned())];
+        let err = write_files_safe(dir.path(), &files).unwrap_err();
+        assert!(matches!(err, RegistryError::UnsafePath(_)));
+    }
+
+    #[test]
+    fn write_files_safe_rejects_parent_dir_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = vec![("../../etc/passwd".to_owned(), "evil".to_owned())];
+        let err = write_files_safe(dir.path(), &files).unwrap_err();
+        assert!(matches!(err, RegistryError::UnsafePath(_)));
+    }
+
+    #[test]
+    fn write_files_safe_writes_nested_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = vec![
+            ("SKILL.md".to_owned(), "---\nname: x\n---\nbody".to_owned()),
+            ("scripts/run.sh".to_owned(), "#!/bin/sh\necho hi".to_owned()),
+        ];
+        write_files_safe(dir.path(), &files).unwrap();
+        assert!(dir.path().join("SKILL.md").is_file());
+        assert!(dir.path().join("scripts/run.sh").is_file());
+    }
+
+    #[test]
+    fn materialize_package_installs_skill_into_name_matching_subdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = vec![(
+            "SKILL.md".to_owned(),
+            "---\nname: pdf-tools\ndescription: a test skill\n---\nbody".to_owned(),
+        )];
+        let (has_plugin_manifest, install_dir) = materialize_package(dir.path(), &files).unwrap();
+        assert!(!has_plugin_manifest);
+        assert_eq!(install_dir, dir.path().join("pdf-tools"));
+        assert!(install_dir.join("SKILL.md").is_file());
+    }
+
+    #[test]
+    fn materialize_package_installs_plugin_bundle_at_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = vec![
+            (
+                "plugin.toml".to_owned(),
+                "[plugin]\nname = \"x\"\nversion = \"0.1.0\"".to_owned(),
+            ),
+            (
+                "skills/y/SKILL.md".to_owned(),
+                "---\nname: y\ndescription: a test skill\n---\nbody".to_owned(),
+            ),
+        ];
+        let (has_plugin_manifest, install_dir) = materialize_package(dir.path(), &files).unwrap();
+        assert!(has_plugin_manifest);
+        assert_eq!(install_dir, dir.path());
+        assert!(install_dir.join("plugin.toml").is_file());
+    }
+
+    #[test]
+    fn materialize_package_rejects_package_with_neither_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = vec![("README.md".to_owned(), "hello".to_owned())];
+        let err = materialize_package(dir.path(), &files).unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidResponse(_)));
+    }
+
+    #[test]
+    fn materialize_package_rejects_unparseable_skill_md() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = vec![("SKILL.md".to_owned(), "not frontmatter at all".to_owned())];
+        let err = materialize_package(dir.path(), &files).unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidResponse(_)));
+    }
+
+    // ── Arbitrary-file-write via unvalidated SKILL.md `name` (security fix) ──
+
+    #[test]
+    fn validate_registry_skill_name_rejects_parent_dir_traversal() {
+        let err = validate_registry_skill_name("../../../../etc").unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidResponse(_)));
+    }
+
+    #[test]
+    fn validate_registry_skill_name_rejects_absolute_path() {
+        let err = validate_registry_skill_name("/etc/cron.d").unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidResponse(_)));
+    }
+
+    #[test]
+    fn validate_registry_skill_name_rejects_backslash_traversal() {
+        let err = validate_registry_skill_name("..\\..\\Windows").unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidResponse(_)));
+    }
+
+    #[test]
+    fn validate_registry_skill_name_rejects_empty_and_dot() {
+        assert!(validate_registry_skill_name("").is_err());
+        assert!(validate_registry_skill_name(".").is_err());
+    }
+
+    #[test]
+    fn validate_registry_skill_name_accepts_normal_name() {
+        validate_registry_skill_name("pdf-tools").unwrap();
+    }
+
+    #[test]
+    fn materialize_package_rejects_traversal_name_with_zero_filesystem_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = vec![(
+            "SKILL.md".to_owned(),
+            "---\nname: ../../../../tmp/zeph-marketplace-poc\ndescription: evil\n---\nbody"
+                .to_owned(),
+        )];
+        let err = materialize_package(dir.path(), &files).unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidResponse(_)));
+        // Prove nothing escaped tmp_root: the tempdir must still be completely empty — not
+        // just that install_dir construction "failed" in isolation, but that no write ever
+        // reached the filesystem for this malicious package.
+        assert!(
+            dir.path().read_dir().unwrap().next().is_none(),
+            "tmp_root must be empty after a rejected malicious name — no partial write"
+        );
+        assert!(
+            !std::path::Path::new("/tmp/zeph-marketplace-poc").exists(),
+            "traversal must not have escaped to /tmp"
+        );
+    }
+
+    #[test]
+    fn materialize_package_rejects_absolute_path_name_with_zero_filesystem_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let poc_path = "/tmp/zeph-marketplace-poc-absolute";
+        let files = vec![(
+            "SKILL.md".to_owned(),
+            format!("---\nname: {poc_path}\ndescription: evil\n---\nbody"),
+        )];
+        let err = materialize_package(dir.path(), &files).unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidResponse(_)));
+        assert!(
+            dir.path().read_dir().unwrap().next().is_none(),
+            "tmp_root must be empty after a rejected malicious name — no partial write"
+        );
+        assert!(
+            !std::path::Path::new(poc_path).exists(),
+            "absolute-path name must not have replaced the base path and written to {poc_path}"
+        );
+    }
+
+    #[test]
+    fn write_files_safe_rejects_too_many_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let files: Vec<(String, String)> = (0..=MAX_PACKAGE_FILES)
+            .map(|i| (format!("f{i}.txt"), "x".to_owned()))
+            .collect();
+        let err = write_files_safe(dir.path(), &files).unwrap_err();
+        assert!(matches!(err, RegistryError::TooLarge(_)));
+    }
+
+    #[test]
+    fn write_files_safe_rejects_excessive_total_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let huge = "x".repeat(usize::try_from(MAX_PACKAGE_TOTAL_BYTES).unwrap() + 1);
+        let files = vec![("big.txt".to_owned(), huge)];
+        let err = write_files_safe(dir.path(), &files).unwrap_err();
+        assert!(matches!(err, RegistryError::TooLarge(_)));
+    }
+
+    #[test]
+    fn write_files_safe_accepts_package_at_the_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let files: Vec<(String, String)> = (0..MAX_PACKAGE_FILES)
+            .map(|i| (format!("f{i}.txt"), "x".to_owned()))
+            .collect();
+        write_files_safe(dir.path(), &files).unwrap();
+        assert!(dir.path().join("f0.txt").is_file());
+    }
+}

--- a/crates/zeph-plugins/src/marketplace/skills_sh.rs
+++ b/crates/zeph-plugins/src/marketplace/skills_sh.rs
@@ -1,0 +1,705 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`SkillsShClient`] — [`RegistryClient`] implementation for the public
+//! [skills.sh](https://www.skills.sh) registry (`vercel-labs/skills`).
+//!
+//! # Verified API contract (S1, 2026-07-10)
+//!
+//! Per the project's live-inspection-first decision, this client is written against the
+//! **real** skills.sh public API, inspected directly at implementation time
+//! (<https://www.skills.sh/docs/api>, the Vercel changelog, and the `vercel-labs/skills`
+//! GitHub repository) rather than against `plan.md`'s earlier, unverified guesses. What
+//! follows is a record of what was confirmed live vs. what remains a documented,
+//! best-effort assumption — see the **"Live-testing gate"** note at the end, which is
+//! mandatory before this client is trusted in production per the architect/critic handoffs.
+//!
+//! ## Confirmed from `skills.sh/docs/api` (primary source)
+//!
+//! | Endpoint | Method | Purpose |
+//! |---|---|---|
+//! | `/api/v1/skills` | GET | paginated leaderboard of all skills |
+//! | `/api/v1/skills/search` | GET | search by name/description; params `q` (required, min 2 chars), `limit` (1-200, default 50), `owner` |
+//! | `/api/v1/skills/curated` | GET | official curated skills |
+//! | `/api/v1/skills/{source}/{skill}` | GET | detail for a single skill |
+//! | `/api/v1/skills/audit/{source}/{skill}` | GET | security audit results |
+//!
+//! Search response: `{ "data": [...], "query": str, "searchType": "fuzzy"|"semantic", "count": int, "durationMs": int }`.
+//!
+//! Detail response fields confirmed by name: `id` (format `"{source}/{slug}"`), `source`,
+//! `slug`, `installs`, `hash`, `files`. The docs explicitly say "endpoint paths vary based on
+//! source type, and you can use the `id` field from any listing or search response to
+//! construct paths" — so [`SkillsShClient::fetch`] forwards `registry_id` (`=id`) verbatim as
+//! the path suffix rather than re-splitting it, since a skill slug found via the GitHub
+//! `find-skills` example page (`skills.sh/vercel-labs/skills/find-skills`) shows `source`
+//! itself can contain an embedded `/` (an `owner/repo` pair).
+//!
+//! Auth: a Vercel-minted short-lived OIDC JWT sent as `Authorization: Bearer <token>` (or
+//! `x-vercel-oidc-token`). From this (non-Vercel-hosted) client's point of view that token is
+//! just an opaque bearer string — Zeph does not and cannot run `@vercel/oidc`'s
+//! `getVercelOidcToken()` (a Vercel-deployment-only Node API); the user is expected to obtain a
+//! token out-of-band (e.g. via the Vercel CLI) and store it with
+//! `zeph vault set <key> <token>`, referenced by `skills.registry.auth_vault_key`.
+//!
+//! ## NOT independently verified — flagged, not guessed silently
+//!
+//! - The exact JSON shape of an individual **search result** object (`data[]` entries) beyond
+//!   the detail-endpoint field names above. [`SkillSummary`] deserializes `name`/`description`/
+//!   `tags`/`author`/`installs` as `#[serde(default)]` so a shape mismatch degrades to an empty
+//!   value instead of a hard parse failure; `id`/`source`/`slug` are treated as required since
+//!   the docs page named them explicitly.
+//! - The exact shape of the detail endpoint's `files` field. The docs page states responses
+//!   "contain file contents as strings within JSON" but does not show a worked example. This
+//!   client accepts **both** a JSON array of `{"path": ..., "content": ...}` objects and a flat
+//!   JSON object mapping `path -> content`, via [`parse_files`], to hedge against either shape.
+//! - `security_audit_status` is served by the separate `/audit/{source}/{skill}` endpoint
+//!   (fields: `audits: [{provider, slug, status: "pass"|"warn"|"fail", summary, auditedAt,
+//!   riskLevel}]`), not embedded in search or detail responses. Calling it per search result
+//!   would add an N+1 request fan-out for a single `search()` call, which NFR-004/NFR-005 do
+//!   not require — [`SkillsShClient::search`] leaves `security_audit_status: None` and does not
+//!   call the audit endpoint. A future enhancement could wire it in for `zeph skill get`
+//!   specifically (a single lookup, not N).
+//!
+//! ## Live-testing gate (non-skippable, S1)
+//!
+//! The above is the best-effort-verified contract achievable from public documentation
+//! without an available Vercel OIDC token in this environment. Per the architect/critic
+//! handoffs, a live `zeph skill search`/`zeph skill get` round-trip against real skills.sh
+//! with `skills.registry.enabled = true` is a **required, non-skippable** gate before this
+//! client is considered production-verified — see
+//! `.local/testing/playbooks/skills-plugin-registry.md`. The wiremock tests below are
+//! regression fixtures for the contract as documented here; they cannot catch a documentation
+//! error, only a code regression against it.
+
+use std::pin::Pin;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tracing::Instrument as _;
+use zeph_common::secret::Secret;
+
+use super::{PackageArchive, RegistryClient, RegistryEntry, RegistryError, materialize_package};
+
+/// Default skills.sh base URL, used when `skills.registry.backend_url` is unset.
+pub const DEFAULT_BASE_URL: &str = "https://www.skills.sh";
+
+/// Maximum accepted response body size for a single registry request (search results page or
+/// one package's detail response).
+///
+/// JSON skill packages are source text (`SKILL.md` plus a handful of small scripts) — a few
+/// MiB is ample headroom. Mirrors the spirit of [`crate::manager::MAX_ARCHIVE_BYTES`] (52 MiB
+/// for binary plugin archives), scaled down for a text-only payload. Checked against
+/// `Content-Length` before the body is read, matching the pre-check pattern in
+/// `crate::manager::registry::download_and_extract` (review fix #2 — this path previously read
+/// an unbounded body into memory).
+const MAX_RESPONSE_BYTES: u64 = 8 * 1024 * 1024;
+
+/// [`RegistryClient`] implementation targeting the public skills.sh registry.
+///
+/// See the module docs for the verified API contract this client implements against.
+pub struct SkillsShClient {
+    base_url: String,
+    token: Option<Secret>,
+    client: reqwest::Client,
+}
+
+impl SkillsShClient {
+    /// Create a new client.
+    ///
+    /// `base_url` should have no trailing slash (e.g. `"https://www.skills.sh"`); a trailing
+    /// slash is stripped defensively. `token` is the bearer credential resolved from the vault
+    /// via `skills.registry.auth_vault_key`, or `None` for an anonymous request (some
+    /// skills.sh endpoints may reject this with 401 — see [`RegistryError::AuthRequired`]).
+    /// Held as a [`Secret`] (Debug/Display-redacted), matching the newtype used for every other
+    /// vault-resolved credential in this workspace (review fix #7).
+    ///
+    /// The underlying `reqwest::Client` refuses any redirect that downgrades from `https` to a
+    /// non-`https` scheme, mirroring `crate::manager::registry::download_and_extract`'s
+    /// redirect policy (review fix #6).
+    ///
+    /// # Errors
+    ///
+    /// This constructor itself cannot fail; malformed `base_url` values surface as
+    /// [`RegistryError::Request`] on the first call. A non-`https`/`http` `base_url` scheme is
+    /// rejected lazily on first use via [`RegistryError::UnsafeBackendUrl`] rather than here, to
+    /// keep this constructor infallible like its sibling `PluginManager::new`.
+    #[must_use]
+    pub fn new(base_url: impl Into<String>, token: Option<Secret>, timeout_secs: u64) -> Self {
+        let mut base_url = base_url.into();
+        while base_url.ends_with('/') {
+            base_url.pop();
+        }
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(timeout_secs.max(1)))
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                if attempt.url().scheme() == "https" {
+                    attempt.follow()
+                } else {
+                    let redirect_url = attempt.url().to_string();
+                    attempt.error(format!(
+                        "redirect to non-HTTPS URL is not permitted: {redirect_url}"
+                    ))
+                }
+            }))
+            .build()
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    error = %e,
+                    "SkillsShClient: failed to build HTTP client with configured timeout/redirect \
+                     policy; falling back to reqwest::Client::default() (no timeout guarantee)"
+                );
+                reqwest::Client::default()
+            });
+        Self {
+            base_url,
+            token,
+            client,
+        }
+    }
+
+    /// Reject `base_url` schemes other than `http`/`https` (SSRF hardening — review fix #6).
+    /// `backend_url` is self-configured, not attacker-supplied, but a compromised/hostile
+    /// registry could still 3xx-redirect to an internal scheme if we didn't also gate the
+    /// initial request; the redirect policy in [`Self::new`] handles the redirect leg.
+    fn validate_base_url_scheme(&self) -> Result<(), RegistryError> {
+        let parsed = reqwest::Url::parse(&self.base_url)
+            .map_err(|e| RegistryError::UnsafeBackendUrl(format!("{}: {e}", self.base_url)))?;
+        if matches!(parsed.scheme(), "http" | "https") {
+            Ok(())
+        } else {
+            Err(RegistryError::UnsafeBackendUrl(format!(
+                "scheme {:?} is not allowed; only http and https are permitted",
+                parsed.scheme()
+            )))
+        }
+    }
+
+    fn request(&self, url: &str) -> reqwest::RequestBuilder {
+        let builder = self.client.get(url);
+        match &self.token {
+            Some(token) => builder.bearer_auth(token.expose()),
+            None => builder,
+        }
+    }
+
+    #[tracing::instrument(name = "plugins.marketplace.get_json_text", skip(self), fields(url))]
+    async fn get_json_text(&self, url: &str) -> Result<String, RegistryError> {
+        let response = self
+            .request(url)
+            .send()
+            .await
+            .map_err(|e| classify_send_error(&e))?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(RegistryError::AuthRequired);
+        }
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(RegistryError::NotFound(url.to_owned()));
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(RegistryError::Backend {
+                status: status.as_u16(),
+                body,
+            });
+        }
+        reject_oversized(&response)?;
+        response
+            .text()
+            .await
+            .map_err(|e| RegistryError::Request(e.to_string()))
+    }
+}
+
+/// Reject a response whose declared `Content-Length` exceeds [`MAX_RESPONSE_BYTES`] before the
+/// body is read into memory (review fix #2). A missing `Content-Length` (chunked transfer) is
+/// allowed through unchecked, matching the same tradeoff `download_and_extract` makes for
+/// binary archives — a fully adversarial chunked-transfer cap would require switching to a
+/// streaming read, which is disproportionate for this text-only JSON payload class.
+fn reject_oversized(response: &reqwest::Response) -> Result<(), RegistryError> {
+    if let Some(len) = response.content_length()
+        && len > MAX_RESPONSE_BYTES
+    {
+        return Err(RegistryError::TooLarge(format!(
+            "response declared {len} bytes (max {MAX_RESPONSE_BYTES})"
+        )));
+    }
+    Ok(())
+}
+
+fn classify_send_error(e: &reqwest::Error) -> RegistryError {
+    if e.is_timeout() {
+        RegistryError::Timeout
+    } else {
+        RegistryError::Request(e.to_string())
+    }
+}
+
+/// Reject a `registry_id` containing characters that could alter the request's query string or
+/// fragment when interpolated verbatim into the URL path (review fix #8). Not a general
+/// percent-encoding pass — skills.sh's own docs say to forward `id` verbatim as a path suffix
+/// (see module docs), so encoding legitimate `/` separators would break that contract; this
+/// only blocks the specific characters that change URL *structure*.
+fn validate_registry_id(registry_id: &str) -> Result<(), RegistryError> {
+    if registry_id.is_empty()
+        || registry_id
+            .chars()
+            .any(|c| c == '?' || c == '#' || c.is_whitespace())
+    {
+        return Err(RegistryError::InvalidRegistryId(registry_id.to_owned()));
+    }
+    Ok(())
+}
+
+impl RegistryClient for SkillsShClient {
+    fn search(
+        &self,
+        query: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<RegistryEntry>, RegistryError>> + Send + '_>> {
+        let query = query.to_owned();
+        let span = tracing::info_span!("plugins.marketplace.search", query = %query);
+        Box::pin(
+            async move {
+                self.validate_base_url_scheme()?;
+                let url = format!("{}/api/v1/skills/search", self.base_url);
+                let response = self
+                    .request(&url)
+                    .query(&[("q", query.as_str()), ("limit", "50")])
+                    .send()
+                    .await
+                    .map_err(|e| classify_send_error(&e))?;
+
+                let status = response.status();
+                if status == reqwest::StatusCode::UNAUTHORIZED
+                    || status == reqwest::StatusCode::FORBIDDEN
+                {
+                    return Err(RegistryError::AuthRequired);
+                }
+                if !status.is_success() {
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(RegistryError::Backend {
+                        status: status.as_u16(),
+                        body,
+                    });
+                }
+                reject_oversized(&response)?;
+                let text = response
+                    .text()
+                    .await
+                    .map_err(|e| RegistryError::Request(e.to_string()))?;
+                let parsed: SearchResponse = serde_json::from_str(&text)
+                    .map_err(|e| RegistryError::InvalidResponse(e.to_string()))?;
+
+                Ok(parsed
+                    .data
+                    .into_iter()
+                    .map(SkillSummary::into_entry)
+                    .collect())
+            }
+            .instrument(span),
+        )
+    }
+
+    fn fetch(
+        &self,
+        registry_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<PackageArchive, RegistryError>> + Send + '_>> {
+        let registry_id = registry_id.to_owned();
+        let span = tracing::info_span!("plugins.marketplace.fetch", registry_id = %registry_id);
+        Box::pin(
+            async move {
+                self.validate_base_url_scheme()?;
+                validate_registry_id(&registry_id)?;
+                let suffix = registry_id.trim_start_matches('/');
+                let url = format!("{}/api/v1/skills/{suffix}", self.base_url);
+                let text = self.get_json_text(&url).await.map_err(|e| {
+                    if matches!(e, RegistryError::NotFound(_)) {
+                        RegistryError::NotFound(registry_id.clone())
+                    } else {
+                        e
+                    }
+                })?;
+                let detail: SkillDetail = serde_json::from_str(&text)
+                    .map_err(|e| RegistryError::InvalidResponse(e.to_string()))?;
+
+                let files = parse_files(&detail.files)?;
+                if files.is_empty() {
+                    return Err(RegistryError::InvalidResponse(
+                        "package response contained no files".to_owned(),
+                    ));
+                }
+
+                let tmp = tempfile::tempdir()?;
+                let (has_plugin_manifest, install_dir) = materialize_package(tmp.path(), &files)?;
+
+                Ok(PackageArchive {
+                    registry_id,
+                    has_plugin_manifest,
+                    extracted_dir: tmp,
+                    install_dir,
+                })
+            }
+            .instrument(span),
+        )
+    }
+}
+
+/// `{ "data": [...], "query": ..., "searchType": ..., "count": ..., "durationMs": ... }`
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    data: Vec<SkillSummary>,
+}
+
+/// One entry of `SearchResponse.data`. See module docs — fields beyond `id`/`source`/`slug`
+/// are `#[serde(default)]` because the exact search-result shape was not independently
+/// verified beyond the primary docs page's field list for the *detail* endpoint.
+#[derive(Debug, Deserialize)]
+struct SkillSummary {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    author: Option<String>,
+}
+
+impl SkillSummary {
+    fn into_entry(self) -> RegistryEntry {
+        let fallback_name = self
+            .id
+            .rsplit('/')
+            .next()
+            .unwrap_or(self.id.as_str())
+            .to_owned();
+        RegistryEntry {
+            registry_id: self.id,
+            name: self.name.unwrap_or(fallback_name),
+            description: self.description.unwrap_or_default(),
+            tags: self.tags,
+            author: self.author,
+            // Not fetched here — see module docs on the separate `/audit/*` endpoint.
+            security_audit_status: None,
+        }
+    }
+}
+
+/// Detail response for `/api/v1/skills/{source}/{skill}`.
+#[derive(Debug, Deserialize)]
+struct SkillDetail {
+    #[serde(default)]
+    files: serde_json::Value,
+}
+
+/// Parse the detail endpoint's `files` field into `(path, content)` pairs.
+///
+/// Accepts either a JSON array of `{"path": ..., "content": ...}` objects, or a flat JSON
+/// object mapping `path -> content` string — see module docs for why both are supported.
+///
+/// # Errors
+///
+/// Returns [`RegistryError::InvalidResponse`] when `files` is neither shape.
+fn parse_files(files: &serde_json::Value) -> Result<Vec<(String, String)>, RegistryError> {
+    match files {
+        serde_json::Value::Array(entries) => entries
+            .iter()
+            .map(|entry| {
+                let path = entry
+                    .get("path")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| {
+                        RegistryError::InvalidResponse(
+                            "files[] entry missing string \"path\"".to_owned(),
+                        )
+                    })?;
+                let content = entry
+                    .get("content")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| {
+                        RegistryError::InvalidResponse(
+                            "files[] entry missing string \"content\"".to_owned(),
+                        )
+                    })?;
+                Ok((path.to_owned(), content.to_owned()))
+            })
+            .collect(),
+        serde_json::Value::Object(map) => map
+            .iter()
+            .map(|(path, content)| {
+                let content = content.as_str().ok_or_else(|| {
+                    RegistryError::InvalidResponse(format!("files[{path:?}] value is not a string"))
+                })?;
+                Ok((path.clone(), content.to_owned()))
+            })
+            .collect(),
+        other => Err(RegistryError::InvalidResponse(format!(
+            "unexpected \"files\" shape: {other}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client_for(server: &MockServer, token: Option<&str>) -> SkillsShClient {
+        SkillsShClient::new(server.uri(), token.map(Secret::new), 5)
+    }
+
+    #[tokio::test]
+    async fn search_parses_confirmed_response_shape() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/search"))
+            .and(query_param("q", "pdf"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    {"id": "acme/pdf-tools", "source": "acme", "slug": "pdf-tools",
+                     "name": "PDF Tools", "description": "Manipulate PDFs", "tags": ["pdf"]}
+                ],
+                "query": "pdf",
+                "searchType": "fuzzy",
+                "count": 1,
+                "durationMs": 12
+            })))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server, None);
+        let results = client.search("pdf").await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].registry_id, "acme/pdf-tools");
+        assert_eq!(results[0].name, "PDF Tools");
+    }
+
+    #[tokio::test]
+    async fn search_degrades_gracefully_on_missing_optional_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"id": "acme/bare", "source": "acme", "slug": "bare"}],
+                "query": "bare", "searchType": "fuzzy", "count": 1, "durationMs": 1
+            })))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server, None);
+        let results = client.search("bare").await.unwrap();
+        assert_eq!(results[0].name, "bare");
+        assert_eq!(results[0].description, "");
+    }
+
+    #[tokio::test]
+    async fn search_sends_bearer_token_when_configured() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/search"))
+            .and(header("authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [], "query": "x", "searchType": "fuzzy", "count": 0, "durationMs": 1
+            })))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server, Some("test-token"));
+        let results = client.search("x").await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_maps_401_to_auth_required() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/search"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server, None);
+        let err = client.search("x").await.unwrap_err();
+        assert!(matches!(err, RegistryError::AuthRequired));
+    }
+
+    #[tokio::test]
+    async fn search_rejects_oversized_response_before_reading_body() {
+        let server = MockServer::start().await;
+        // A real oversized body (hyper enforces Content-Length/body-length coherence server
+        // side, so a lying header alone panics the mock server task instead of exercising the
+        // client's pre-check) — rejection must fire from the Content-Length header alone,
+        // before `.text()` reads the (large) body, which this test cannot directly observe but
+        // is exercised by construction: reject_oversized runs before the `.text()` call.
+        let oversized = vec![b' '; usize::try_from(MAX_RESPONSE_BYTES + 1).unwrap()];
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(oversized))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server, None);
+        let err = client.search("x").await.unwrap_err();
+        assert!(matches!(err, RegistryError::TooLarge(_)));
+    }
+
+    #[tokio::test]
+    async fn search_maps_connect_failure_to_request_error() {
+        // Port 0 never accepts connections — deterministic connect failure, no live network.
+        let client = SkillsShClient::new("http://127.0.0.1:0", None, 1);
+        let err = client.search("x").await.unwrap_err();
+        assert!(matches!(err, RegistryError::Request(_)));
+    }
+
+    #[tokio::test]
+    async fn search_rejects_non_http_backend_url() {
+        let client = SkillsShClient::new("file:///etc/passwd", None, 1);
+        let err = client.search("x").await.unwrap_err();
+        assert!(matches!(err, RegistryError::UnsafeBackendUrl(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_registry_id_with_query_separator() {
+        let server = MockServer::start().await;
+        let client = client_for(&server, None);
+        let err = client.fetch("acme/x?evil=1").await.unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidRegistryId(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_registry_id_with_fragment() {
+        let server = MockServer::start().await;
+        let client = client_for(&server, None);
+        let err = client.fetch("acme/x#frag").await.unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidRegistryId(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_materializes_array_shaped_files() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/acme/pdf-tools"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "acme/pdf-tools", "source": "acme", "slug": "pdf-tools",
+                "installs": 10, "hash": "abc123",
+                "files": [
+                    {"path": "SKILL.md", "content": "---\nname: pdf-tools\ndescription: x\n---\nbody"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server, None);
+        let archive = client.fetch("acme/pdf-tools").await.unwrap();
+        assert!(!archive.has_plugin_manifest);
+        // install_dir, not extracted_dir directly — must be named after the skill (see
+        // PackageArchive::install_dir docs) for SkillManager::install_from_path to accept it.
+        assert_eq!(
+            archive.install_dir,
+            archive.extracted_dir.path().join("pdf-tools")
+        );
+        assert!(archive.install_dir.join("SKILL.md").is_file());
+    }
+
+    #[tokio::test]
+    async fn fetch_materializes_map_shaped_files_and_detects_plugin_manifest() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/acme/full-plugin"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "acme/full-plugin", "source": "acme", "slug": "full-plugin",
+                "files": {
+                    "plugin.toml": "[plugin]\nname=\"full-plugin\"\nversion=\"0.1.0\"",
+                    "skills/x/SKILL.md": "---\nname: x\ndescription: y\n---\nbody"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server, None);
+        let archive = client.fetch("acme/full-plugin").await.unwrap();
+        assert!(archive.has_plugin_manifest);
+        assert!(
+            archive
+                .extracted_dir
+                .path()
+                .join("skills/x/SKILL.md")
+                .is_file()
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_maps_404_to_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/nope/nope"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server, None);
+        let err = client.fetch("nope/nope").await.unwrap_err();
+        assert!(matches!(err, RegistryError::NotFound(id) if id == "nope/nope"));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_oversized_detail_response() {
+        let server = MockServer::start().await;
+        let oversized = vec![b' '; usize::try_from(MAX_RESPONSE_BYTES + 1).unwrap()];
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/acme/huge"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(oversized))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server, None);
+        let err = client.fetch("acme/huge").await.unwrap_err();
+        assert!(matches!(err, RegistryError::TooLarge(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_surfaces_io_error_when_write_target_unwritable() {
+        // write_files_safe's own Io-mapping is exercised via a path component that cannot be
+        // created: a regular file used as a parent "directory" fails create_dir_all with an
+        // io::Error, which RegistryError::Io(#[from]) surfaces without downcasting.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/skills/acme/x"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "acme/x", "source": "acme", "slug": "x",
+                "files": [{"path": "SKILL.md", "content": "body"}]
+            })))
+            .mount(&server)
+            .await;
+
+        // Force tempdir() itself to fail by pointing TMPDIR at a path that doesn't exist and
+        // cannot be created (a file, not a directory, as the parent).
+        let bogus_parent = tempfile::NamedTempFile::new().unwrap();
+        // SAFETY-equivalent: std::env::set_var is unsafe in edition 2024; safe here because
+        // nextest runs each test in its own process (full env isolation from other tests), and
+        // the mutation is restored before this test function returns.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("TMPDIR", bogus_parent.path());
+        }
+        let client = client_for(&server, None);
+        let result = client.fetch("acme/x").await;
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var("TMPDIR");
+        }
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, RegistryError::Io(_)));
+    }
+
+    #[test]
+    fn parse_files_rejects_unexpected_shape() {
+        let value = serde_json::json!("not files");
+        let err = parse_files(&value).unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidResponse(_)));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -892,6 +892,24 @@ pub(crate) enum SkillCommand {
         #[arg(long)]
         skill: Option<String>,
     },
+    /// Search the configured external skill registry by keyword (spec-045, #5869)
+    ///
+    /// Requires `[skills.registry] enabled = true` in config.toml; see `zeph --init` or
+    /// `--migrate-config`. Distinct from `install`, which installs from a git URL/local path.
+    Search {
+        /// Search query (min 2 characters)
+        query: String,
+    },
+    /// Install a skill by registry ID returned by `skill search` (spec-045, #5869)
+    ///
+    /// Named `get` (not `add`) to stay unambiguous with `install`, which installs from a git
+    /// URL/local path. Requires `[skills.registry] enabled = true` in config.toml. Fetched
+    /// packages route through the same frontmatter validation, injection scan, and
+    /// Quarantined-trust upsert as `skill install`.
+    Get {
+        /// Registry-assigned skill ID (as printed by `skill search`)
+        registry_id: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -913,6 +931,23 @@ pub(crate) enum PluginCommand {
     Remove {
         /// Plugin name
         name: String,
+    },
+    /// Search the configured external skill/plugin registry by keyword (spec-045, #5869)
+    ///
+    /// Requires `[skills.registry] enabled = true` in config.toml; see `zeph --init` or
+    /// `--migrate-config`.
+    Search {
+        /// Search query (min 2 characters)
+        query: String,
+    },
+    /// Install a plugin by registry ID returned by `plugin search` (spec-045, #5869)
+    ///
+    /// Named `get` (not `add`) to stay unambiguous with `plugin add <local-path>` above.
+    /// Requires `[skills.registry] enabled = true`. Fails with a pointer to `skill get` when
+    /// the fetched package has no `plugin.toml` (i.e. it is a bare skill package).
+    Get {
+        /// Registry-assigned plugin ID (as printed by `plugin search`)
+        registry_id: String,
     },
 }
 
@@ -1472,6 +1507,78 @@ mod tests {
             Some(Command::UrlScheme {
                 command: UrlSchemeCommand::Status { check: true }
             })
+        ));
+    }
+
+    // ── skill/plugin registry marketplace CLI parsing (spec-045, #5869) ─────
+
+    #[test]
+    fn cli_parses_skill_search() {
+        use super::{Command, SkillCommand};
+        let cli = Cli::try_parse_from(["zeph", "skill", "search", "pdf tools"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Skill {
+                command: SkillCommand::Search { query }
+            }) if query == "pdf tools"
+        ));
+    }
+
+    #[test]
+    fn cli_parses_skill_get() {
+        use super::{Command, SkillCommand};
+        let cli = Cli::try_parse_from(["zeph", "skill", "get", "acme/pdf-tools"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Skill {
+                command: SkillCommand::Get { registry_id }
+            }) if registry_id == "acme/pdf-tools"
+        ));
+    }
+
+    #[test]
+    fn cli_skill_add_no_longer_exists_as_registry_verb() {
+        // S1 rename: the registry-install verb is `get`, not `add` — `add` is not a valid
+        // `skill` subcommand at all (the local-path installer is `install`).
+        let err = Cli::try_parse_from(["zeph", "skill", "add", "acme/pdf-tools"])
+            .err()
+            .unwrap();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+    }
+
+    #[test]
+    fn cli_parses_plugin_search() {
+        use super::{Command, PluginCommand};
+        let cli = Cli::try_parse_from(["zeph", "plugin", "search", "pdf tools"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Plugin {
+                command: PluginCommand::Search { query }
+            }) if query == "pdf tools"
+        ));
+    }
+
+    #[test]
+    fn cli_parses_plugin_get() {
+        use super::{Command, PluginCommand};
+        let cli = Cli::try_parse_from(["zeph", "plugin", "get", "acme/full-plugin"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Plugin {
+                command: PluginCommand::Get { registry_id }
+            }) if registry_id == "acme/full-plugin"
+        ));
+    }
+
+    #[test]
+    fn cli_parses_plugin_add_as_local_path_install_unaffected_by_rename() {
+        use super::{Command, PluginCommand};
+        let cli = Cli::try_parse_from(["zeph", "plugin", "add", "/tmp/my-plugin"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Plugin {
+                command: PluginCommand::Add { source }
+            }) if source == "/tmp/my-plugin"
         ));
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,6 +20,8 @@ pub(crate) mod memory;
 pub(crate) mod migrate;
 pub(crate) mod plugin;
 pub(crate) mod project;
+#[cfg(feature = "registry")]
+pub(crate) mod registry_client;
 pub(crate) mod router;
 #[cfg(feature = "scheduler")]
 pub(crate) mod schedule;

--- a/src/commands/plugin.rs
+++ b/src/commands/plugin.rs
@@ -49,7 +49,12 @@ fn print_overlay_section(plugins_dir: &std::path::Path) -> anyhow::Result<()> {
 /// # Errors
 ///
 /// Returns an error if the plugin operation fails (invalid manifest, conflicts, etc.).
-pub(crate) fn handle_plugin_command(
+// `async` is unused when compiled without the `registry` feature (the Search/Get arms'
+// `.await` calls are cfg'd out, leaving the fn body synchronous) — the signature must stay
+// `async` regardless, since `runner.rs` always `.await`s this call and the feature is a
+// caller-invisible build-time choice (M1, critic handoff).
+#[allow(clippy::unused_async)]
+pub(crate) async fn handle_plugin_command(
     cmd: PluginCommand,
     config_path: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
@@ -123,7 +128,251 @@ pub(crate) fn handle_plugin_command(
                 );
             }
         }
+
+        PluginCommand::Search { query } => {
+            #[cfg(feature = "registry")]
+            {
+                registry_search(&config, &query).await?;
+            }
+            #[cfg(not(feature = "registry"))]
+            {
+                let _ = &query;
+                println!(
+                    "This zeph build was compiled without the `registry` feature; rebuild \
+                     with `--features registry` (or `full`) to use `zeph plugin search`."
+                );
+            }
+        }
+
+        PluginCommand::Get { registry_id } => {
+            #[cfg(feature = "registry")]
+            {
+                registry_get(&config, &mgr, &registry_id).await?;
+            }
+            #[cfg(not(feature = "registry"))]
+            {
+                let _ = &registry_id;
+                println!(
+                    "This zeph build was compiled without the `registry` feature; rebuild \
+                     with `--features registry` (or `full`) to use `zeph plugin get`."
+                );
+            }
+        }
     }
 
     Ok(())
+}
+
+/// `zeph plugin search <query>` (spec-045, #5869, FR-003 — shares the search implementation
+/// used by `zeph skill search`, NFR-006).
+///
+/// Prints [`crate::commands::registry_client::REGISTRY_NOT_CONFIGURED_MSG`] and makes zero
+/// network calls when `skills.registry.enabled = false` (FR-004, NFR-001). Thin wrapper around
+/// [`registry_search_with`] — see that fn's tests for `MockRegistryClient`-driven coverage.
+#[cfg(feature = "registry")]
+#[tracing::instrument(name = "plugin.registry_search", skip(config), fields(query))]
+async fn registry_search(config: &zeph_core::config::Config, query: &str) -> anyhow::Result<()> {
+    use crate::commands::registry_client::{
+        REGISTRY_NOT_CONFIGURED_MSG, build_registry_client, resolve_registry_token,
+    };
+
+    if !config.skills.registry.enabled {
+        println!("{REGISTRY_NOT_CONFIGURED_MSG}");
+        anyhow::bail!("skill registry is not configured");
+    }
+
+    let token = resolve_registry_token(config).await?;
+    let client = build_registry_client(config, token);
+    registry_search_with(client.as_ref(), query).await
+}
+
+/// Search logic parameterized over a [`zeph_plugins::marketplace::RegistryClient`] — split out
+/// of [`registry_search`] so tests can drive it with `MockRegistryClient` without network or a
+/// real `Config`/vault (review fix #4).
+#[cfg(feature = "registry")]
+async fn registry_search_with(
+    client: &dyn zeph_plugins::marketplace::RegistryClient,
+    query: &str,
+) -> anyhow::Result<()> {
+    use crate::commands::registry_client::print_search_results;
+
+    let results = client
+        .search(query)
+        .await
+        .map_err(|e| anyhow::anyhow!("registry search failed: {e}"))?;
+    print_search_results(&results);
+    Ok(())
+}
+
+/// `zeph plugin get <registry-id>` (spec-045, #5869, FR-003).
+///
+/// Fetches the package and, when it contains a `plugin.toml`, routes it through
+/// [`zeph_plugins::PluginManager::add`] unchanged (NFR-002 — same manifest validation, MCP
+/// allowlist, and injection scan as `zeph plugin add <local-path>`). Fails with a pointer to
+/// `zeph skill get` when the fetched package has no `plugin.toml` (a bare skill package).
+/// Thin wrapper around [`registry_get_with`] — see that fn's tests for `MockRegistryClient`-
+/// driven coverage.
+#[cfg(feature = "registry")]
+#[tracing::instrument(name = "plugin.registry_get", skip(config, mgr), fields(registry_id))]
+async fn registry_get(
+    config: &zeph_core::config::Config,
+    mgr: &zeph_plugins::PluginManager,
+    registry_id: &str,
+) -> anyhow::Result<()> {
+    use crate::commands::registry_client::{
+        REGISTRY_NOT_CONFIGURED_MSG, build_registry_client, resolve_registry_token,
+    };
+
+    if !config.skills.registry.enabled {
+        println!("{REGISTRY_NOT_CONFIGURED_MSG}");
+        anyhow::bail!("skill registry is not configured");
+    }
+
+    let token = resolve_registry_token(config).await?;
+    let client = build_registry_client(config, token);
+    registry_get_with(client.as_ref(), mgr, registry_id).await
+}
+
+/// Fetch-and-install logic parameterized over a [`zeph_plugins::marketplace::RegistryClient`] —
+/// split out of [`registry_get`] so tests can drive it with `MockRegistryClient` (review fix #4).
+#[cfg(feature = "registry")]
+async fn registry_get_with(
+    client: &dyn zeph_plugins::marketplace::RegistryClient,
+    mgr: &zeph_plugins::PluginManager,
+    registry_id: &str,
+) -> anyhow::Result<()> {
+    let archive = client
+        .fetch(registry_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("registry fetch failed: {e}"))?;
+
+    if !archive.has_plugin_manifest {
+        anyhow::bail!(
+            "package {registry_id:?} is a bare skill package (no plugin.toml); use \
+             `zeph skill get {registry_id}` instead"
+        );
+    }
+
+    let source = archive
+        .install_dir
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("registry temp dir path is not valid UTF-8"))?;
+    let result = mgr.add(source)?;
+    println!(
+        "Installed plugin \"{}\" from registry {registry_id:?}.",
+        result.name
+    );
+    if !result.installed_skills.is_empty() {
+        println!("  Skills: {}", result.installed_skills.join(", "));
+    }
+    if !result.mcp_server_ids.is_empty() {
+        println!(
+            "  MCP servers (restart required): {}",
+            result.mcp_server_ids.join(", ")
+        );
+    }
+    for w in &result.warnings {
+        eprintln!("warning: {w}");
+    }
+
+    Ok(())
+}
+
+#[cfg(all(test, feature = "registry"))]
+mod registry_tests {
+    use super::*;
+    use zeph_plugins::marketplace::RegistryEntry;
+    use zeph_plugins::marketplace::mock::MockRegistryClient;
+
+    fn sample_entry(id: &str, name: &str) -> RegistryEntry {
+        RegistryEntry {
+            registry_id: id.to_owned(),
+            name: name.to_owned(),
+            description: "a test plugin".to_owned(),
+            tags: vec![],
+            author: None,
+            security_audit_status: None,
+        }
+    }
+
+    fn test_manager(root: &std::path::Path) -> zeph_plugins::PluginManager {
+        zeph_plugins::PluginManager::new(
+            root.join("plugins"),
+            root.join("managed-skills"),
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    #[tokio::test]
+    async fn registry_search_with_calls_client_and_succeeds() {
+        let mock = MockRegistryClient::new().with_entry(sample_entry("acme/x", "X Plugin"));
+        registry_search_with(&mock, "x").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn registry_search_with_propagates_client_error() {
+        let mock = MockRegistryClient::new().failing("boom");
+        let err = registry_search_with(&mock, "x").await.unwrap_err();
+        assert!(err.to_string().contains("registry search failed"));
+    }
+
+    #[tokio::test]
+    async fn registry_get_with_installs_plugin_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = test_manager(dir.path());
+
+        let mock = MockRegistryClient::new().with_package(
+            "acme/full-plugin",
+            vec![
+                (
+                    "plugin.toml".to_owned(),
+                    "[plugin]\nname = \"full-plugin\"\nversion = \"0.1.0\"".to_owned(),
+                ),
+                (
+                    "skills/x/SKILL.md".to_owned(),
+                    "---\nname: x\ndescription: a test skill\n---\nbody".to_owned(),
+                ),
+            ],
+        );
+
+        registry_get_with(&mock, &mgr, "acme/full-plugin")
+            .await
+            .unwrap();
+
+        assert!(
+            dir.path()
+                .join("plugins/full-plugin/.plugin.toml")
+                .is_file()
+        );
+    }
+
+    #[tokio::test]
+    async fn registry_get_with_rejects_bare_skill_package_with_pointer_to_skill_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = test_manager(dir.path());
+
+        let mock = MockRegistryClient::new().with_package(
+            "acme/x",
+            vec![(
+                "SKILL.md".to_owned(),
+                "---\nname: x\ndescription: a test skill\n---\nbody".to_owned(),
+            )],
+        );
+
+        let err = registry_get_with(&mock, &mgr, "acme/x").await.unwrap_err();
+        assert!(err.to_string().contains("zeph skill get acme/x"));
+    }
+
+    #[tokio::test]
+    async fn registry_get_with_propagates_fetch_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = test_manager(dir.path());
+        let mock = MockRegistryClient::new();
+
+        let err = registry_get_with(&mock, &mgr, "missing/id")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("registry fetch failed"));
+    }
 }

--- a/src/commands/registry_client.rs
+++ b/src/commands/registry_client.rs
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared helpers for `zeph skill search`/`get` and `zeph plugin search`/`get` (spec-045,
+//! #5869): vault token resolution and [`RegistryClient`] construction from config.
+//!
+//! Gated by the `registry` Cargo feature (mirrors `zeph_plugins::marketplace`) — this module
+//! is the only place in the binary crate that names a `zeph_plugins::marketplace::` path, so
+//! `src/commands/skill.rs`/`plugin.rs` stay compilable with the feature off (M1, critic
+//! handoff `.local/handoff/2026-07-10T19-29-13-critic.md`).
+
+use zeph_config::RegistryBackendKind;
+use zeph_core::config::Config;
+use zeph_core::vault::{
+    AgeVaultProvider, EnvVaultProvider, Secret, VaultProvider, default_vault_dir,
+};
+use zeph_plugins::marketplace::RegistryClient;
+use zeph_plugins::marketplace::skills_sh::{DEFAULT_BASE_URL, SkillsShClient};
+
+/// Resolve the registry's bearer credential from the vault, honoring the opt-in gate.
+///
+/// Returns `Ok(None)` without touching the vault when the registry is disabled or no
+/// `auth_vault_key` is configured — this is what keeps `skills.registry.enabled = false` (the
+/// default) a true zero-network-and-zero-vault-access state (NFR-001). Returns a [`Secret`]
+/// (Debug/Display-redacted), matching the newtype used for every other vault-resolved
+/// credential in this workspace (review fix #7) — the CLI marketplace commands resolve their
+/// own token independently of `Config::resolve_secrets_masked`'s startup path (that path is
+/// only run for the main agent bootstrap, not these lightweight one-shot CLI verbs), so this is
+/// not registered with the LLM-context secret-mask registry; low risk, since a one-shot CLI
+/// invocation never feeds this value into an LLM-bound context.
+///
+/// # Errors
+///
+/// Returns an error if the configured vault backend cannot be loaded (e.g. missing age key
+/// file) or the lookup itself fails.
+#[tracing::instrument(name = "registry_client.resolve_token", skip(config))]
+pub(crate) async fn resolve_registry_token(config: &Config) -> anyhow::Result<Option<Secret>> {
+    let reg = &config.skills.registry;
+    if !reg.enabled {
+        return Ok(None);
+    }
+    let Some(key_name) = reg.auth_vault_key.as_deref() else {
+        return Ok(None);
+    };
+
+    let vault: Box<dyn VaultProvider> = match config.vault.backend {
+        zeph_config::VaultBackend::Env => Box::new(EnvVaultProvider),
+        zeph_config::VaultBackend::Age => {
+            let dir = default_vault_dir();
+            let provider =
+                AgeVaultProvider::load_async(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
+            Box::new(provider)
+        }
+        zeph_config::VaultBackend::Keyring => {
+            anyhow::bail!("keyring vault backend is not yet implemented");
+        }
+        // VaultBackend is #[non_exhaustive]; future backends fail loudly here rather than
+        // silently resolving no token.
+        other => anyhow::bail!("unsupported vault backend: {other}"),
+    };
+
+    let value = vault
+        .get_secret(key_name)
+        .await
+        .map_err(|e| anyhow::anyhow!("vault error resolving {key_name}: {e}"))?;
+    Ok(value.map(Secret::new))
+}
+
+/// Build the configured [`RegistryClient`] backend.
+///
+/// Currently the only backend is [`RegistryBackendKind::SkillsSh`] (FR-005's pluggability is
+/// proven by `MockRegistryClient` in `zeph-plugins`' test suite, not by a second shipped
+/// production backend — see spec-045 Open Questions).
+pub(crate) fn build_registry_client(
+    config: &Config,
+    token: Option<Secret>,
+) -> Box<dyn RegistryClient> {
+    let reg = &config.skills.registry;
+    match reg.backend_kind {
+        RegistryBackendKind::SkillsSh => {
+            let base_url = reg
+                .backend_url
+                .clone()
+                .unwrap_or_else(|| DEFAULT_BASE_URL.to_owned());
+            Box::new(SkillsShClient::new(
+                base_url,
+                token,
+                reg.registry_timeout_secs,
+            ))
+        }
+        // RegistryBackendKind is #[non_exhaustive]; fall back to the default (only shipped)
+        // backend rather than failing to compile when a future variant is added upstream.
+        _ => Box::new(SkillsShClient::new(
+            DEFAULT_BASE_URL.to_owned(),
+            token,
+            reg.registry_timeout_secs,
+        )),
+    }
+}
+
+/// The standard "registry not configured" message for FR-004.
+///
+/// Distinct from the "compiled without the `registry` feature" message printed by the
+/// `#[cfg(not(feature = "registry"))]` arm in `skill.rs`/`plugin.rs` — this one fires when the
+/// feature IS compiled in but `enabled = false` (the default).
+pub(crate) const REGISTRY_NOT_CONFIGURED_MSG: &str = "no skill/plugin registry is configured. Add `[skills.registry] enabled = true` (and a \
+     backend_kind/backend_url) to config.toml, or run `zeph --init` to configure it \
+     interactively. See `zeph skill search --help`.";
+
+/// Print search results in the shared format used by both `skill search` and `plugin search`
+/// (NFR-006 — one registry client implementation, one result-rendering path).
+pub(crate) fn print_search_results(entries: &[zeph_plugins::marketplace::RegistryEntry]) {
+    if entries.is_empty() {
+        println!("No results.");
+        return;
+    }
+    println!("Found {} result(s):\n", entries.len());
+    for entry in entries {
+        if entry.tags.is_empty() {
+            println!("  {} — {}", entry.registry_id, entry.description);
+        } else {
+            println!(
+                "  {} — {} [{}]",
+                entry.registry_id,
+                entry.description,
+                entry.tags.join(", ")
+            );
+        }
+        println!("      name: {}", entry.name);
+        if let Some(author) = &entry.author {
+            println!("      author: {author}");
+        }
+        if let Some(status) = &entry.security_audit_status {
+            println!("      security audit: {status}");
+        }
+    }
+}
+
+#[cfg(all(test, feature = "registry"))]
+mod tests {
+    use super::*;
+    use zeph_plugins::marketplace::RegistryEntry;
+
+    #[tokio::test]
+    async fn resolve_registry_token_returns_none_without_vault_access_when_disabled() {
+        // FR-004/NFR-001: the architect's stated highest-priority test — disabled registry must
+        // short-circuit before any vault backend is even constructed. `config.vault.backend`
+        // defaults to `Env`, which never touches disk, so a `None` result together with a
+        // config that has no auth_vault_key set proves the early return fired, not that the
+        // (trivial) Env lookup happened to also return None.
+        let mut config = Config::default();
+        config.skills.registry.enabled = false;
+        config.skills.registry.auth_vault_key = Some("ZEPH_SKILL_REGISTRY_TOKEN".to_owned());
+
+        let result = resolve_registry_token(&config).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_registry_token_returns_none_when_no_auth_key_configured() {
+        let mut config = Config::default();
+        config.skills.registry.enabled = true;
+        config.skills.registry.auth_vault_key = None;
+
+        let result = resolve_registry_token(&config).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_registry_token_resolves_from_env_backend() {
+        let key = "ZEPH_TEST_REGISTRY_TOKEN_RESOLVE";
+        #[allow(unsafe_code)] // scoped env mutation; nextest isolates tests per-process
+        unsafe {
+            std::env::set_var(key, "test-token-value");
+        }
+
+        let mut config = Config::default();
+        config.skills.registry.enabled = true;
+        config.skills.registry.auth_vault_key = Some(key.to_owned());
+        config.vault.backend = zeph_config::VaultBackend::Env;
+
+        let result = resolve_registry_token(&config).await.unwrap();
+
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var(key);
+        }
+
+        assert_eq!(
+            result.map(|s| s.expose().to_owned()),
+            Some("test-token-value".to_owned())
+        );
+    }
+
+    #[test]
+    fn print_search_results_handles_empty_slice() {
+        // Pure formatting — assert it doesn't panic on the empty-results path (review
+        // suggestion #13). No stdout capture; this is a crash-safety smoke test.
+        print_search_results(&[]);
+    }
+
+    #[test]
+    fn print_search_results_handles_populated_slice() {
+        let entries = vec![RegistryEntry {
+            registry_id: "acme/x".to_owned(),
+            name: "X".to_owned(),
+            description: "a tool".to_owned(),
+            tags: vec!["tag".to_owned()],
+            author: Some("acme".to_owned()),
+            security_audit_status: Some("pass".to_owned()),
+        }];
+        print_search_results(&entries);
+    }
+}

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -418,7 +418,284 @@ pub(crate) async fn handle_skill_command(
                 );
             }
         }
+
+        SkillCommand::Search { query } => {
+            #[cfg(feature = "registry")]
+            {
+                registry_search(&config, &query).await?;
+            }
+            #[cfg(not(feature = "registry"))]
+            {
+                let _ = &query;
+                println!(
+                    "This zeph build was compiled without the `registry` feature; rebuild \
+                     with `--features registry` (or `full`) to use `zeph skill search`."
+                );
+            }
+        }
+
+        SkillCommand::Get { registry_id } => {
+            #[cfg(feature = "registry")]
+            {
+                registry_get(&config, &mgr, &managed_dir, &sqlite_path, &registry_id).await?;
+            }
+            #[cfg(not(feature = "registry"))]
+            {
+                let _ = &registry_id;
+                println!(
+                    "This zeph build was compiled without the `registry` feature; rebuild \
+                     with `--features registry` (or `full`) to use `zeph skill get`."
+                );
+            }
+        }
     }
 
     Ok(())
+}
+
+/// `zeph skill search <query>` (spec-045, #5869, FR-001).
+///
+/// Prints [`crate::commands::registry_client::REGISTRY_NOT_CONFIGURED_MSG`] and makes zero
+/// network calls when `skills.registry.enabled = false` (FR-004, NFR-001). Thin wrapper around
+/// [`registry_search_with`] so the fetch/search logic itself is testable in isolation from the
+/// config-gate and client construction — see that fn's tests for `MockRegistryClient`-driven
+/// coverage.
+#[cfg(feature = "registry")]
+#[tracing::instrument(name = "skill.registry_search", skip(config), fields(query))]
+async fn registry_search(config: &zeph_core::config::Config, query: &str) -> anyhow::Result<()> {
+    use crate::commands::registry_client::{
+        REGISTRY_NOT_CONFIGURED_MSG, build_registry_client, resolve_registry_token,
+    };
+
+    if !config.skills.registry.enabled {
+        println!("{REGISTRY_NOT_CONFIGURED_MSG}");
+        anyhow::bail!("skill registry is not configured");
+    }
+
+    let token = resolve_registry_token(config).await?;
+    let client = build_registry_client(config, token);
+    registry_search_with(client.as_ref(), query).await
+}
+
+/// Search logic parameterized over a [`zeph_plugins::marketplace::RegistryClient`] — split out
+/// of [`registry_search`] so tests can drive it with `MockRegistryClient` without network or a
+/// real `Config`/vault (review fix #4).
+#[cfg(feature = "registry")]
+async fn registry_search_with(
+    client: &dyn zeph_plugins::marketplace::RegistryClient,
+    query: &str,
+) -> anyhow::Result<()> {
+    use crate::commands::registry_client::print_search_results;
+
+    let results = client
+        .search(query)
+        .await
+        .map_err(|e| anyhow::anyhow!("registry search failed: {e}"))?;
+    print_search_results(&results);
+    Ok(())
+}
+
+/// `zeph skill get <registry-id>` (spec-045, #5869, FR-002).
+///
+/// Fetches the package then routes it through the exact same
+/// [`zeph_skills::manager::SkillManager::install_from_path`] + Quarantined-trust-upsert flow
+/// as `zeph skill install <local-path>` — no bypass of frontmatter validation or the
+/// injection-pattern scan (NFR-002). Thin wrapper around [`registry_get_with`] — see that fn's
+/// tests for `MockRegistryClient`-driven coverage.
+#[cfg(feature = "registry")]
+#[tracing::instrument(name = "skill.registry_get", skip(config, mgr), fields(registry_id))]
+async fn registry_get(
+    config: &zeph_core::config::Config,
+    mgr: &zeph_skills::manager::SkillManager,
+    managed_dir: &std::path::Path,
+    sqlite_path: &str,
+    registry_id: &str,
+) -> anyhow::Result<()> {
+    use crate::commands::registry_client::{
+        REGISTRY_NOT_CONFIGURED_MSG, build_registry_client, resolve_registry_token,
+    };
+
+    if !config.skills.registry.enabled {
+        println!("{REGISTRY_NOT_CONFIGURED_MSG}");
+        anyhow::bail!("skill registry is not configured");
+    }
+
+    let token = resolve_registry_token(config).await?;
+    let client = build_registry_client(config, token);
+    registry_get_with(client.as_ref(), mgr, managed_dir, sqlite_path, registry_id).await
+}
+
+/// Fetch-and-install logic parameterized over a [`zeph_plugins::marketplace::RegistryClient`] —
+/// split out of [`registry_get`] so tests can drive it with `MockRegistryClient` (review fix #4).
+#[cfg(feature = "registry")]
+async fn registry_get_with(
+    client: &dyn zeph_plugins::marketplace::RegistryClient,
+    mgr: &zeph_skills::manager::SkillManager,
+    managed_dir: &std::path::Path,
+    sqlite_path: &str,
+    registry_id: &str,
+) -> anyhow::Result<()> {
+    let archive = client
+        .fetch(registry_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("registry fetch failed: {e}"))?;
+
+    if archive.has_plugin_manifest {
+        anyhow::bail!(
+            "package {registry_id:?} is a full plugin bundle (contains plugin.toml); use \
+             `zeph plugin get {registry_id}` instead"
+        );
+    }
+
+    // install_from_path infers `SkillSource::File { path: <tempdir> }` since it only sees a
+    // local directory — that path is meaningless (deleted with the TempDir on drop). Record
+    // the real provenance as Hub{registry_id} instead (FR-008, architect-recommended minimal
+    // scope: reuse the existing Hub source kind rather than adding a dedicated Registry variant).
+    //
+    // Pass `install_dir`, not `extracted_dir.path()` directly: SkillManager::install_from_path
+    // requires its source directory to already be named after the skill's declared name (see
+    // PackageArchive::install_dir docs) — extracted_dir's basename is an OS-assigned random
+    // string.
+    let result = mgr
+        .install_from_path(&archive.install_dir)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let store = zeph_memory::store::SqliteStore::new(sqlite_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
+    store
+        .upsert_skill_trust(
+            &result.name,
+            zeph_common::SkillTrustLevel::Quarantined,
+            zeph_memory::store::SourceKind::Hub,
+            Some(registry_id),
+            None,
+            &result.blake3_hash,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("trust upsert failed: {e}"))?;
+
+    println!(
+        "Installed skill \"{}\" from registry {registry_id:?} (hash: {}..., trust: quarantined)",
+        result.name,
+        &result.blake3_hash[..8]
+    );
+
+    let skill_md = managed_dir.join(&result.name).join("SKILL.md");
+    if let Ok(meta) = zeph_skills::loader::load_skill_meta(&skill_md)
+        && !meta.requires_secrets.is_empty()
+    {
+        println!(
+            "  Note: this skill requires secrets: {}",
+            meta.requires_secrets.join(", ")
+        );
+        println!("  Run `zeph vault set ZEPH_SECRET_<NAME> <value>` for each.");
+    }
+
+    Ok(())
+}
+
+#[cfg(all(test, feature = "registry"))]
+mod registry_tests {
+    use super::*;
+    use zeph_plugins::marketplace::RegistryEntry;
+    use zeph_plugins::marketplace::mock::MockRegistryClient;
+
+    fn sample_entry(id: &str, name: &str) -> RegistryEntry {
+        RegistryEntry {
+            registry_id: id.to_owned(),
+            name: name.to_owned(),
+            description: "a test skill".to_owned(),
+            tags: vec![],
+            author: None,
+            security_audit_status: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn registry_search_with_calls_client_and_succeeds() {
+        let mock = MockRegistryClient::new().with_entry(sample_entry("acme/x", "X Tool"));
+        registry_search_with(&mock, "x").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn registry_search_with_propagates_client_error() {
+        let mock = MockRegistryClient::new().failing("boom");
+        let err = registry_search_with(&mock, "x").await.unwrap_err();
+        assert!(err.to_string().contains("registry search failed"));
+    }
+
+    #[tokio::test]
+    async fn registry_get_with_installs_bare_skill_package() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed_dir = dir.path().join("managed");
+        let sqlite_path = dir.path().join("test.db");
+        let mgr = zeph_skills::manager::SkillManager::new(managed_dir.clone());
+
+        let mock = MockRegistryClient::new().with_package(
+            "acme/x",
+            vec![(
+                "SKILL.md".to_owned(),
+                "---\nname: x\ndescription: a test skill\n---\nbody".to_owned(),
+            )],
+        );
+
+        registry_get_with(
+            &mock,
+            &mgr,
+            &managed_dir,
+            sqlite_path.to_str().unwrap(),
+            "acme/x",
+        )
+        .await
+        .unwrap();
+
+        assert!(managed_dir.join("x").join("SKILL.md").is_file());
+    }
+
+    #[tokio::test]
+    async fn registry_get_with_rejects_plugin_bundle_with_pointer_to_plugin_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed_dir = dir.path().join("managed");
+        let sqlite_path = dir.path().join("test.db");
+        let mgr = zeph_skills::manager::SkillManager::new(managed_dir.clone());
+
+        let mock = MockRegistryClient::new().with_package(
+            "acme/full-plugin",
+            vec![("plugin.toml".to_owned(), "[plugin]\nname=\"x\"".to_owned())],
+        );
+
+        let err = registry_get_with(
+            &mock,
+            &mgr,
+            &managed_dir,
+            sqlite_path.to_str().unwrap(),
+            "acme/full-plugin",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("zeph plugin get acme/full-plugin"));
+        assert!(!managed_dir.exists() || managed_dir.read_dir().unwrap().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn registry_get_with_propagates_fetch_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed_dir = dir.path().join("managed");
+        let sqlite_path = dir.path().join("test.db");
+        let mgr = zeph_skills::manager::SkillManager::new(managed_dir.clone());
+        let mock = MockRegistryClient::new();
+
+        let err = registry_get_with(
+            &mock,
+            &mgr,
+            &managed_dir,
+            sqlite_path.to_str().unwrap(),
+            "missing/id",
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("registry fetch failed"));
+    }
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -65,6 +65,7 @@ pub(crate) struct WizardState {
     pub(crate) scheduler_enabled: bool,
     pub(crate) scheduler_tick_interval_secs: u64,
     pub(crate) scheduler_max_tasks: usize,
+    pub(crate) skills_registry_enabled: bool,
     pub(crate) daemon_enabled: bool,
     pub(crate) daemon_host: String,
     pub(crate) daemon_port: u16,
@@ -357,6 +358,7 @@ impl Default for WizardState {
             scheduler_enabled: false,
             scheduler_tick_interval_secs: 0,
             scheduler_max_tasks: 0,
+            skills_registry_enabled: false,
             daemon_enabled: false,
             daemon_host: String::new(),
             daemon_port: 0,
@@ -580,6 +582,7 @@ pub fn run(output: Option<PathBuf>) -> anyhow::Result<()> {
     step_channel(&mut state)?;
     step_update_check(&mut state)?;
     step_scheduler(&mut state)?;
+    step_skills_registry(&mut state)?;
     step_orchestration(&mut state)?;
     step_durable(&mut state)?;
     step_daemon(&mut state)?;
@@ -1015,6 +1018,11 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
         security: SchedulerSecurityConfig::default(),
     };
 
+    config.skills.registry = zeph_core::config::RegistryConfig {
+        enabled: state.skills_registry_enabled,
+        ..zeph_core::config::RegistryConfig::default()
+    };
+
     config.agents.default_permission_mode = state.agents_default_permission_mode;
     config
         .agents
@@ -1388,6 +1396,32 @@ fn step_scheduler(state: &mut WizardState) -> anyhow::Result<()> {
     println!();
     Ok(())
 }
+fn step_skills_registry(state: &mut WizardState) -> anyhow::Result<()> {
+    println!("== Skill/Plugin Registry ==\n");
+
+    state.skills_registry_enabled = Confirm::new()
+        .with_prompt(
+            "Enable external skill/plugin registry search (`zeph skill search`/`add`, \
+             `zeph plugin search`/`get`)? Opt-in only — off by default, no network call is \
+             ever made unless enabled.",
+        )
+        .default(false)
+        .interact()?;
+
+    if state.skills_registry_enabled {
+        println!(
+            "  Registry enabled with the default backend (skills.sh). If the backend \
+             requires an auth token, store it with:\n    \
+             zeph vault set ZEPH_SKILL_REGISTRY_TOKEN <token>\n  \
+             then set skills.registry.auth_vault_key = \"ZEPH_SKILL_REGISTRY_TOKEN\" in \
+             config.toml. This wizard never prompts for the raw token."
+        );
+    }
+
+    println!();
+    Ok(())
+}
+
 fn step_daemon(state: &mut WizardState) -> anyhow::Result<()> {
     println!("== Step 7/10: Daemon / A2A Server ==\n");
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -821,7 +821,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             return crate::commands::plugin::handle_plugin_command(
                 plugin_cmd,
                 cli.config.as_deref(),
-            );
+            )
+            .await;
         }
         Some(Command::Memory { command: mem_cmd }) => {
             return handle_memory_command(mem_cmd, cli.config.as_deref()).await;


### PR DESCRIPTION
## Summary

Closes #5869. Adds a discovery-and-install layer for skills and plugins, closing the "no discovery path, only `--plugin-url`" gap found in a competitive parity scan against Cline's marketplace and Vercel's `skills.sh`.

- New CLI commands: `zeph skill search <query>` / `zeph skill get <registry-id>` and `zeph plugin search <query>` / `zeph plugin get <registry-id>`.
- New `crates/zeph-plugins/src/marketplace` module: a dyn-compatible `RegistryClient` trait (mirroring `VaultProvider`'s boxed-future pattern), a `SkillsShClient` implementation for the public skills.sh registry, and a `MockRegistryClient` for tests.
- New `registry` Cargo feature (added to the `full` bundle) gates only the network-touching client code — CLI arg definitions and `[skills.registry]` config parsing always compile, so `--help` and the opt-in guidance message are always available.
- Registry lookups are strictly opt-in and off by default: zero network calls or vault access occur unless `skills.registry.enabled = true`. Verified at three independent layers (CLI dispatch, token resolver, secret-masking config load).
- Fetched packages route through the existing, unmodified install pipelines (`SkillManager::install_from_path`, `PluginManager::add`), so registry-sourced content gets the same frontmatter validation, injection-pattern scan, and trust-quarantine treatment as any local install — no new content-safety bypass.
- Auth token resolved exclusively via `VaultProvider`, never a plain config field.
- All mandatory integration points delivered: config section, CLI subcommands, `--init` wizard step, `--migrate-config` step, live-testing playbook, coverage-status rows, and mdBook docs (`book/src/reference/cli.md`, `configuration.md`, `feature-flags.md`, `concepts/skills.md`).

## Security note

During review, a critical path-traversal / arbitrary-file-write vulnerability was found and fixed: a registry-response-derived skill name (from `SKILL.md` frontmatter) was joined onto a filesystem path without validation, allowing a malicious or MITM'd registry response to write files outside the intended install directory. Fixed by validating the name (single path component, no `..`, no separators) before it is used in any path construction, with tests proving zero filesystem writes occur on a malicious name.

## Test plan

- [x] Full workspace `cargo nextest` (12546/12546 passed)
- [x] `cargo clippy --profile ci` with and without `--features registry`
- [x] `cargo +nightly fmt --check`
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc`)
- [x] `cargo test --doc --workspace`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --locked`
- [x] Migration idempotency tests (`[skills.registry]` always defaults to `enabled = false`, never flipped implicitly)
- [x] New tests proving zero network calls when the registry is disabled
- [x] New tests proving the path-traversal fix rejects malicious names with zero filesystem writes
- [ ] Live skills.sh API round-trip (documented as a required, non-skippable gate in `.local/testing/playbooks/skills-plugin-registry.md` in the main repo — not runnable in this environment due to no Vercel OIDC token; the client was implemented against a live-inspected API contract, not a guessed one, per the module's doc comments)