### PR TITLE
fix(tools): forward checkpoint and confirmation methods through executor wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Fixed
+
+- `fix(tools)`: `checkpoint_undo`/`checkpoint_redo`/`checkpoint_list` are now forwarded to the
+  wrapped inner executor by `TrustGateExecutor`, `PolicyGateExecutor`,
+  `AdversarialPolicyGateExecutor` (#5899), `ScopedToolExecutor`, and `ShadowProbeExecutor`
+  (#5905). Previously none of these `ToolExecutor` wrappers overrode the three checkpoint
+  methods, so calls fell through to the trait's no-op default instead of reaching
+  `ShellExecutor` — `/undo`, `/redo`, and `/undo list` always reported "Checkpoints are not
+  enabled" whenever trust/policy/adversarial gating, `capability_scopes`, or `shadow_sentinel`
+  wrapped the executor chain, even with `[tools.shell] checkpoints_enabled = true` set — the
+  standard, default-recommended production configuration, not an edge case. Also fixes
+  `ScopedToolExecutor::requires_confirmation` (#5906), previously hardcoded to the trait
+  default `false` regardless of the real policy underneath, affecting the (currently dormant)
+  speculative-dispatch engine.
+
 ### Added
 
 - `feat(acp)`: `[[acp.auth_clients]]` — named bearer-token clients for the ACP HTTP/WS

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -243,6 +243,18 @@ impl<T: ToolExecutor> ToolExecutor for AdversarialPolicyGateExecutor<T> {
     fn is_tool_retryable(&self, tool_id: &str) -> bool {
         self.inner.is_tool_retryable(tool_id)
     }
+
+    fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_undo(n)
+    }
+
+    fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_redo()
+    }
+
+    fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+        self.inner.checkpoint_list()
+    }
 }
 
 fn params_summary(params: &serde_json::Map<String, serde_json::Value>) -> String {
@@ -523,6 +535,57 @@ mod tests {
         let gate = AdversarialPolicyGateExecutor::new(inner, make_validator(false), Arc::new(llm));
         let retryable = gate.is_tool_retryable("shell");
         assert!(!retryable, "MockInner returns false for is_tool_retryable");
+    }
+
+    #[derive(Debug)]
+    struct CheckpointingInner;
+
+    impl ToolExecutor for CheckpointingInner {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        async fn execute_tool_call(&self, _: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult {
+                supported: true,
+                message: "stub".into(),
+                reverted_commands: n,
+                ..Default::default()
+            }
+        }
+        fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult {
+                supported: true,
+                message: "stub".into(),
+                ..Default::default()
+            }
+        }
+        fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+            crate::executor::CheckpointListResult {
+                supported: true,
+                ..Default::default()
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn delegation_checkpoint_methods() {
+        let (_, llm) = MockLlm::new("ALLOW");
+        let gate = AdversarialPolicyGateExecutor::new(
+            CheckpointingInner,
+            make_validator(false),
+            Arc::new(llm),
+        );
+        let undo_result = gate.checkpoint_undo(7);
+        assert!(undo_result.supported);
+        assert_eq!(
+            undo_result.reverted_commands, 7,
+            "n must be forwarded, not hardcoded"
+        );
+        assert!(gate.checkpoint_redo().supported);
+        assert!(gate.checkpoint_list().supported);
     }
 
     #[tokio::test]

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -380,6 +380,18 @@ impl<T: ToolExecutor> ToolExecutor for PolicyGateExecutor<T> {
     fn is_tool_speculatable(&self, tool_id: &str) -> bool {
         self.inner.is_tool_speculatable(tool_id)
     }
+
+    fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_undo(n)
+    }
+
+    fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_redo()
+    }
+
+    fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+        self.inner.checkpoint_list()
+    }
 }
 
 fn truncate_params(params: &serde_json::Map<String, serde_json::Value>) -> String {
@@ -465,6 +477,64 @@ mod tests {
             tool_call_id: String::new(),
             skill_name: None,
         }
+    }
+
+    #[derive(Debug)]
+    struct CheckpointingExecutor;
+
+    impl ToolExecutor for CheckpointingExecutor {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        async fn execute_tool_call(&self, _: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult {
+                supported: true,
+                message: "stub".into(),
+                reverted_commands: n,
+                ..Default::default()
+            }
+        }
+        fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult {
+                supported: true,
+                message: "stub".into(),
+                ..Default::default()
+            }
+        }
+        fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+            crate::executor::CheckpointListResult {
+                supported: true,
+                ..Default::default()
+            }
+        }
+    }
+
+    #[test]
+    fn checkpoint_methods_delegated_to_inner() {
+        let config = PolicyConfig {
+            enabled: false,
+            default_effect: DefaultEffect::Allow,
+            rules: vec![],
+            policy_file: None,
+            policy_provider: ProviderName::default(),
+        };
+        let enforcer = Arc::new(PolicyEnforcer::compile(&config).unwrap());
+        let context = Arc::new(RwLock::new(PolicyContext {
+            trust_level: SkillTrustLevel::Trusted,
+            env: HashMap::new(),
+        }));
+        let gate = PolicyGateExecutor::new(CheckpointingExecutor, enforcer, context);
+        let undo_result = gate.checkpoint_undo(7);
+        assert!(undo_result.supported);
+        assert_eq!(
+            undo_result.reverted_commands, 7,
+            "n must be forwarded, not hardcoded"
+        );
+        assert!(gate.checkpoint_redo().supported);
+        assert!(gate.checkpoint_list().supported);
     }
 
     #[tokio::test]

--- a/crates/zeph-tools/src/scope.rs
+++ b/crates/zeph-tools/src/scope.rs
@@ -611,6 +611,22 @@ impl<E: ToolExecutor> ToolExecutor for ScopedToolExecutor<E> {
     fn is_tool_speculatable(&self, tool_id: &str) -> bool {
         self.inner.is_tool_speculatable(tool_id)
     }
+
+    fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_undo(n)
+    }
+
+    fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_redo()
+    }
+
+    fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+        self.inner.checkpoint_list()
+    }
+
+    fn requires_confirmation(&self, call: &ToolCall) -> bool {
+        self.inner.requires_confirmation(call)
+    }
 }
 
 // ── Config-driven builder ──────────────────────────────────────────────────────
@@ -721,6 +737,38 @@ mod tests {
                 raw_response: None,
                 claim_source: None,
             }))
+        }
+    }
+
+    struct CheckpointingExecutor;
+
+    impl ToolExecutor for CheckpointingExecutor {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult {
+                supported: true,
+                message: "stub".into(),
+                reverted_commands: n,
+                ..Default::default()
+            }
+        }
+        fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult {
+                supported: true,
+                message: "stub".into(),
+                ..Default::default()
+            }
+        }
+        fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+            crate::executor::CheckpointListResult {
+                supported: true,
+                ..Default::default()
+            }
+        }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            true
         }
     }
 
@@ -1058,6 +1106,25 @@ mod tests {
         assert!(updated.admits("builtin:read"));
         // "builtin:write" is not in the original pattern, so it remains excluded.
         assert!(!updated.admits("builtin:write"));
+    }
+
+    #[test]
+    fn checkpoint_methods_delegated_to_inner() {
+        let executor = ScopedToolExecutor::new(CheckpointingExecutor, ToolScope::full());
+        let undo_result = executor.checkpoint_undo(7);
+        assert!(undo_result.supported);
+        assert_eq!(
+            undo_result.reverted_commands, 7,
+            "n must be forwarded, not hardcoded"
+        );
+        assert!(executor.checkpoint_redo().supported);
+        assert!(executor.checkpoint_list().supported);
+    }
+
+    #[test]
+    fn requires_confirmation_delegated_to_inner() {
+        let executor = ScopedToolExecutor::new(CheckpointingExecutor, ToolScope::full());
+        assert!(executor.requires_confirmation(&make_call("builtin:shell")));
     }
 
     #[test]

--- a/crates/zeph-tools/src/shadow_probe.rs
+++ b/crates/zeph-tools/src/shadow_probe.rs
@@ -388,6 +388,18 @@ impl<T: ToolExecutor> ToolExecutor for ShadowProbeExecutor<T> {
     fn requires_confirmation(&self, call: &ToolCall) -> bool {
         self.inner.requires_confirmation(call)
     }
+
+    fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_undo(n)
+    }
+
+    fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_redo()
+    }
+
+    fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+        self.inner.checkpoint_list()
+    }
 }
 
 #[cfg(test)]
@@ -782,6 +794,52 @@ mod tests {
         let result = exec.execute_tool_call_confirmed(&call).await;
         assert!(matches!(result, Err(ToolError::SafetyDenied { .. })));
         assert_eq!(probe.recorded.lock().unwrap().len(), 1);
+    }
+
+    struct CheckpointingInner;
+    impl ToolExecutor for CheckpointingInner {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult {
+                supported: true,
+                message: "stub".into(),
+                reverted_commands: n,
+                ..Default::default()
+            }
+        }
+        fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult {
+                supported: true,
+                message: "stub".into(),
+                ..Default::default()
+            }
+        }
+        fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+            crate::executor::CheckpointListResult {
+                supported: true,
+                ..Default::default()
+            }
+        }
+    }
+
+    #[test]
+    fn checkpoint_methods_delegated_to_inner() {
+        let exec = ShadowProbeExecutor::new(
+            CheckpointingInner,
+            Arc::new(AllowProbe),
+            Arc::new(std::sync::atomic::AtomicU64::new(1)),
+            Arc::new(parking_lot::RwLock::new("calm".to_owned())),
+        );
+        let undo_result = exec.checkpoint_undo(7);
+        assert!(undo_result.supported);
+        assert_eq!(
+            undo_result.reverted_commands, 7,
+            "n must be forwarded, not hardcoded"
+        );
+        assert!(exec.checkpoint_redo().supported);
+        assert!(exec.checkpoint_list().supported);
     }
 
     #[test]

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -291,6 +291,18 @@ impl<T: ToolExecutor> ToolExecutor for TrustGateExecutor<T> {
         self.inner.is_tool_speculatable(tool_id)
     }
 
+    fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_undo(n)
+    }
+
+    fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+        self.inner.checkpoint_redo()
+    }
+
+    fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+        self.inner.checkpoint_list()
+    }
+
     fn set_effective_trust(&self, level: crate::SkillTrustLevel) {
         self.effective_trust
             .store(trust_to_u8(level), Ordering::Relaxed);
@@ -742,6 +754,53 @@ mod tests {
         let gate = TrustGateExecutor::new(RetryableExecutor, PermissionPolicy::default());
         assert!(gate.is_tool_retryable("fetch"));
         assert!(!gate.is_tool_retryable("bash"));
+    }
+
+    #[test]
+    fn checkpoint_methods_delegated_to_inner() {
+        #[derive(Debug)]
+        struct CheckpointingExecutor;
+        impl ToolExecutor for CheckpointingExecutor {
+            async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+                Ok(None)
+            }
+            async fn execute_tool_call(
+                &self,
+                _: &ToolCall,
+            ) -> Result<Option<ToolOutput>, ToolError> {
+                Ok(None)
+            }
+            fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+                crate::executor::CheckpointActionResult {
+                    supported: true,
+                    message: "stub".into(),
+                    reverted_commands: n,
+                    ..Default::default()
+                }
+            }
+            fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+                crate::executor::CheckpointActionResult {
+                    supported: true,
+                    message: "stub".into(),
+                    ..Default::default()
+                }
+            }
+            fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+                crate::executor::CheckpointListResult {
+                    supported: true,
+                    ..Default::default()
+                }
+            }
+        }
+        let gate = TrustGateExecutor::new(CheckpointingExecutor, PermissionPolicy::default());
+        let undo_result = gate.checkpoint_undo(7);
+        assert!(undo_result.supported);
+        assert_eq!(
+            undo_result.reverted_commands, 7,
+            "n must be forwarded, not hardcoded"
+        );
+        assert!(gate.checkpoint_redo().supported);
+        assert!(gate.checkpoint_list().supported);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `TrustGateExecutor`, `PolicyGateExecutor`, and `AdversarialPolicyGateExecutor` never overrode `checkpoint_undo`/`checkpoint_redo`/`checkpoint_list`, so calls fell through to the `ToolExecutor` trait's no-op default instead of reaching `ShellExecutor`. `ScopedToolExecutor` and `ShadowProbeExecutor` had the same gap on the outer wrapper layers. Net effect: `/undo`, `/redo`, and `/undo list` always reported checkpoints as unsupported whenever trust/policy/adversarial gating, `capability_scopes`, or `shadow_sentinel` wrapped the executor chain — the standard, default-recommended production configuration — even with `checkpoints_enabled = true` set.
- `ScopedToolExecutor` also never overrode `requires_confirmation`, defaulting to `false` regardless of the real policy underneath, which would silently disable the speculative-dispatch engine's confirmation gate once any tool opts into speculative execution.
- Adds one-line `self.inner.<method>(...)` forwards to all five wrapper files, mirroring each file's existing pass-through style for `is_tool_retryable`/`set_skill_env`. Adds 6 regression tests (one per file, `scope.rs` has 2) using local stub inner executors that return distinguishable non-default values, including an argument round-trip check on `checkpoint_undo`'s `n` parameter.

Closes #5899, #5905, #5906

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12579 passed, 0 failed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] Reviewer mutation-tested the fix: hand-patched `checkpoint_undo` to hardcode the forwarded `n`, confirmed the new test fails, then confirmed the file was restored byte-identical
- [x] `.local/testing/coverage-status.md` and `.local/testing/playbooks/undo-redo.md` updated with a new regression scenario for gate/scope wrapper transparency

Note: local `cargo build`/rustdoc runs on this machine require `CARGO_BUILD_WARNINGS=allow` due to pre-existing, unrelated issues (#5894, #5895) from the `build.warnings` migration in #5891 — not touched by this PR.