### PR TITLE
fix(commands): require trusted session for /image path reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- `fix(commands)`: `/image` now requires a trusted (local) session, closing a remote arbitrary
+  file read (#5967, CWE-284). `ImageCommand` previously left `requires_auth()` at its default
+  `false`, so Telegram/Discord/Slack/gateway callers — none of which are trusted by
+  `CommandRegistry::dispatch` — could invoke `/image <path>` to read any file under the server's
+  working directory that the process could access. `ImageCommand` now overrides `requires_auth()`
+  to return `true`, matching the existing `/cache-stats` and `/notify-test` handlers in the same
+  module; the command remains available from local CLI/TUI/ACP-stdio sessions.
 - `fix(mcp)`: Qdrant-backed MCP tool registry now rehydrates real `input_schema` (plus
   `output_schema`/`security_meta`) for semantically-matched tools instead of surfacing them to
   the LLM with an empty `{}` schema (#5935). `Agent::match_mcp_tools()` no longer trusts

--- a/crates/zeph-commands/src/handlers/misc.rs
+++ b/crates/zeph-commands/src/handlers/misc.rs
@@ -106,6 +106,10 @@ impl CommandHandler<CommandContext<'_>> for ImageCommand {
         SlashCategory::Integration
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -129,6 +133,7 @@ impl CommandHandler<CommandContext<'_>> for ImageCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandRegistry;
     use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
     use crate::sink::NullSink;
     use std::assert_matches;
@@ -200,5 +205,38 @@ mod tests {
             .await
             .unwrap();
         assert_matches!(out, CommandOutput::Message(_));
+    }
+
+    #[tokio::test]
+    async fn image_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ImageCommand);
+
+        let result = reg.dispatch(&mut ctx, "/image photo.png", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn image_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ImageCommand);
+
+        let result = reg.dispatch(&mut ctx, "/image photo.png", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }


### PR DESCRIPTION
## Summary

- `ImageCommand` never overrode `CommandHandler::requires_auth()` (default `false`), so remote channels — Telegram, Discord, Slack — could invoke `/image <path>` and read any file reachable under the server's working directory via `load_image`'s `std::fs::read`, subject only to `path_guard::classify_relative_path`'s "no absolute path, no `..`" check (CWE-284).
- `ImageCommand::requires_auth()` now returns `true`, closing the remote vector at the existing dispatch gate (`CommandRegistry::dispatch`), matching the pattern already used by the sibling `/cache-stats` and `/notify-test` handlers in the same module. `/image` remains available from trusted local sessions (CLI/TUI/ACP-stdio).
- Added dispatch-level regression tests asserting `/image` is allowed when trusted and rejected when untrusted.

## Out of scope (filed separately)

- The CLI-layer duplicate implementation in `zeph-channels/src/cli.rs` is local-operator-only (intercepted at the stdin loop before dispatch) — not remote-exploitable, left unchanged.
- A related same-class gap was found during review: the gateway webhook path can inherit `trusted=true` from a local primary channel when no bearer token is configured, letting an unauthenticated webhook POST reach `/image` the same way. This is a pre-existing, broader gap not introduced or fixed by this change; a follow-up issue is being filed separately.

Fixes #5967

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12639 passed)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-commands` (133/133, includes new dispatch tests)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`