### PR TITLE
fix(subagent): deliver resolved vault secret value to sub-agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   dropping (with a `WARN` log) any hit that no longer has a live counterpart. This only affected
   the default/recommended deployment configuration (`memory.semantic.enabled = true` with a
   Qdrant backend); the in-memory `SemanticToolIndex` fallback path was never affected.
+- `fix(subagent)`: the sub-agent vault-secret request/approval flow now actually resolves
+  and delivers the secret's real value instead of discarding it (#5941, #5942). All three
+  approval call sites (`scheduler_loop::process_pending_secret_requests`,
+  `subagent_commands::poll_subagent_until_done`, `subagent_commands::handle_agent_approve`)
+  now resolve the requested key against the vault-backed custom-secrets map (the same
+  `ZEPH_SECRET_*`-derived store used for skill `requires_secrets`) before calling
+  `SubAgentManager::deliver_secret`, which now carries a `zeph_common::secret::Secret` value
+  instead of echoing back the key name. On the sub-agent side, `agent_loop.rs` no longer
+  discards the received value — it is attached as a per-tool-call `ExecutionContext` env
+  override (scoped to the requesting sub-agent's own tool calls, not the shared
+  `ShellExecutor::skill_env` slot the parent agent also uses) so a subsequent shell command
+  can reference `$KEY_NAME`. `PermissionGrants::is_active` is now load-bearing:
+  `deliver_secret` refuses to hand over a value unless there is a currently active grant for
+  that key, closing the gap where the TTL/grant bookkeeping was never actually consulted.
 - `fix(tools)`: `checkpoint_undo`/`checkpoint_redo`/`checkpoint_list` are now forwarded to the
   wrapped inner executor by `TrustGateExecutor`, `PolicyGateExecutor`,
   `AdversarialPolicyGateExecutor` (#5899), `ScopedToolExecutor`, and `ShadowProbeExecutor`

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -188,8 +188,12 @@ pub struct ResolvedSecrets {
     /// `skills.registry.auth_vault_key` when `skills.registry.enabled = true` (spec-045,
     /// #5869). `None` when the registry is disabled or `auth_vault_key` is unset.
     pub skill_registry_token: Option<Secret>,
-    /// Arbitrary skill secrets resolved from `ZEPH_SECRET_*` vault keys.
+    /// Arbitrary named secrets resolved from `ZEPH_SECRET_*` vault keys.
     /// Key is the lowercased name after stripping the prefix (e.g. `github_token`).
+    ///
+    /// Shared by two consumers: skill `requires_secrets` injection (see
+    /// `zeph-core::agent::tool_execution::inject_active_skill_env`) and sub-agent
+    /// `permissions.secrets` approval (see `zeph-core::agent::subagent_commands::resolve_subagent_secret`).
     pub custom: HashMap<String, Secret>,
 }
 

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -772,17 +772,28 @@ impl<C: crate::channel::Channel> Agent<C> {
                     false
                 }
             };
-            if let Some(mgr) = self.services.orchestration.subagent_manager.as_mut() {
-                if approved {
-                    let ttl = std::time::Duration::from_mins(5);
-                    let key = req.secret_key.clone();
-                    if mgr.approve_secret(&req_handle_id, &key, ttl).is_ok() {
-                        let _ = mgr.deliver_secret(&req_handle_id, key);
+            if approved {
+                let ttl = std::time::Duration::from_mins(5);
+                let key = req.secret_key.clone();
+                let resolved = self.resolve_subagent_secret(&key);
+                if let Some(mgr) = self.services.orchestration.subagent_manager.as_mut() {
+                    if let Some(secret) = resolved {
+                        if mgr.approve_secret(&req_handle_id, &key, ttl).is_ok()
+                            && let Err(e) = mgr.deliver_secret(&req_handle_id, &key, secret)
+                        {
+                            tracing::warn!(error = %e, "sub-agent secret delivery failed");
+                            let _ = mgr.deny_secret(&req_handle_id);
+                        }
+                    } else {
+                        tracing::warn!(
+                            "sub-agent requested secret not resolvable from vault; denying"
+                        );
+                        let _ = mgr.deny_secret(&req_handle_id);
                     }
-                } else {
-                    denied.insert(deny_key);
-                    let _ = mgr.deny_secret(&req_handle_id);
                 }
+            } else if let Some(mgr) = self.services.orchestration.subagent_manager.as_mut() {
+                denied.insert(deny_key);
+                let _ = mgr.deny_secret(&req_handle_id);
             }
         }
     }

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -16,6 +16,22 @@ use super::{Agent, error};
 use crate::channel::Channel;
 
 impl<C: Channel> Agent<C> {
+    /// Resolve a sub-agent's requested vault-secret key against the custom secrets already
+    /// resolved from the vault at startup (`ZEPH_SECRET_<NAME>` keys — the same pre-resolved
+    /// map used for skill `requires_secrets` injection, see `tool_execution::inject_active_skill_env`).
+    ///
+    /// Matching is case-insensitive with `-` normalized to `_`, mirroring the vault-key
+    /// naming convention (`ZEPH_SECRET_MY-KEY` and `ZEPH_SECRET_MY_KEY` both resolve to
+    /// `my_key`). Returns `None` when `key` was never resolved from the vault at startup.
+    pub(crate) fn resolve_subagent_secret(&self, key: &str) -> Option<crate::vault::Secret> {
+        let normalized = key.to_lowercase().replace('-', "_");
+        self.services
+            .skill
+            .available_custom_secrets
+            .get(&normalized)
+            .map(|s| crate::vault::Secret::new(s.expose().to_owned()))
+    }
+
     /// Poll all active sub-agents for completed/failed/canceled results.
     ///
     /// Non-blocking: returns immediately with a list of `(task_id, result)` pairs
@@ -140,16 +156,27 @@ impl<C: Channel> Agent<C> {
                     crate::text::truncate_to_chars(&req.secret_key, 100)
                 );
                 let approved = self.channel.confirm(&confirm_prompt).await.unwrap_or(false);
-                if let Some(mgr) = self.services.orchestration.subagent_manager.as_mut() {
-                    if approved {
-                        let ttl = std::time::Duration::from_mins(5);
-                        let key = req.secret_key.clone();
-                        if mgr.approve_secret(&req_task_id, &key, ttl).is_ok() {
-                            let _ = mgr.deliver_secret(&req_task_id, key);
+                if approved {
+                    let ttl = std::time::Duration::from_mins(5);
+                    let key = req.secret_key.clone();
+                    let resolved = self.resolve_subagent_secret(&key);
+                    if let Some(mgr) = self.services.orchestration.subagent_manager.as_mut() {
+                        if let Some(secret) = resolved {
+                            if mgr.approve_secret(&req_task_id, &key, ttl).is_ok()
+                                && let Err(e) = mgr.deliver_secret(&req_task_id, &key, secret)
+                            {
+                                tracing::warn!(error = %e, "sub-agent secret delivery failed");
+                                let _ = mgr.deny_secret(&req_task_id);
+                            }
+                        } else {
+                            tracing::warn!(
+                                "sub-agent requested secret not resolvable from vault; denying"
+                            );
+                            let _ = mgr.deny_secret(&req_task_id);
                         }
-                    } else {
-                        let _ = mgr.deny_secret(&req_task_id);
                     }
+                } else if let Some(mgr) = self.services.orchestration.subagent_manager.as_mut() {
+                    let _ = mgr.deny_secret(&req_task_id);
                 }
             }
 
@@ -272,23 +299,34 @@ impl<C: Channel> Agent<C> {
             Ok(fid) => fid,
             Err(msg) => return Some(msg),
         };
+        let req = {
+            let mgr = self.services.orchestration.subagent_manager.as_mut()?;
+            mgr.try_recv_secret_request()
+                .filter(|(tid, _)| *tid == full_id)
+        };
+        let Some((_, req)) = req else {
+            return Some(format!(
+                "No pending secret request for sub-agent '{full_id}'."
+            ));
+        };
+        let key = req.secret_key.clone();
+        let ttl = std::time::Duration::from_mins(5);
+        let Some(secret) = self.resolve_subagent_secret(&key) else {
+            let mgr = self.services.orchestration.subagent_manager.as_mut()?;
+            let _ = mgr.deny_secret(&full_id);
+            return Some(format!(
+                "Secret '{key}' could not be resolved from the vault; request denied."
+            ));
+        };
         let mgr = self.services.orchestration.subagent_manager.as_mut()?;
-        if let Some((tid, req)) = mgr.try_recv_secret_request()
-            && tid == full_id
-        {
-            let key = req.secret_key.clone();
-            let ttl = std::time::Duration::from_mins(5);
-            if let Err(e) = mgr.approve_secret(&full_id, &key, ttl) {
-                return Some(format!("Approve failed: {e}"));
-            }
-            if let Err(e) = mgr.deliver_secret(&full_id, key.clone()) {
-                return Some(format!("Secret delivery failed: {e}"));
-            }
-            return Some(format!("Secret '{key}' approved for sub-agent {full_id}."));
+        if let Err(e) = mgr.approve_secret(&full_id, &key, ttl) {
+            return Some(format!("Approve failed: {e}"));
         }
-        Some(format!(
-            "No pending secret request for sub-agent '{full_id}'."
-        ))
+        if let Err(e) = mgr.deliver_secret(&full_id, &key, secret) {
+            let _ = mgr.deny_secret(&full_id);
+            return Some(format!("Secret delivery failed: {e}"));
+        }
+        Some(format!("Secret '{key}' approved for sub-agent {full_id}."))
     }
     fn handle_agent_deny(&mut self, id: &str) -> Option<String> {
         let full_id = match self.resolve_agent_id_prefix(id)? {
@@ -947,6 +985,69 @@ fn sanitize_parent_messages(
 mod tests {
     use super::*;
     use crate::agent::agent_tests::*;
+
+    // ── resolve_subagent_secret tests (#5941/#5942) ─────────────────────────
+
+    fn agent_with_custom_secret(stored_key: &str, value: &str) -> Agent<MockChannel> {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.skill.available_custom_secrets.insert(
+            stored_key.to_owned(),
+            crate::vault::Secret::new(value.to_owned()),
+        );
+        agent
+    }
+
+    #[test]
+    fn resolve_subagent_secret_exact_match() {
+        let agent = agent_with_custom_secret("my_key", "the-value");
+        let resolved = agent.resolve_subagent_secret("my_key");
+        assert_eq!(
+            resolved.map(|s| s.expose().to_owned()),
+            Some("the-value".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_subagent_secret_normalizes_dash_to_underscore() {
+        // Stored key is underscored (as produced by ZEPH_SECRET_<NAME> normalization);
+        // the sub-agent may request it with dashes instead.
+        let agent = agent_with_custom_secret("my_api_key", "dash-value");
+        let resolved = agent.resolve_subagent_secret("my-api-key");
+        assert_eq!(
+            resolved.map(|s| s.expose().to_owned()),
+            Some("dash-value".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_subagent_secret_normalizes_case() {
+        let agent = agent_with_custom_secret("upper_key", "case-value");
+        let resolved = agent.resolve_subagent_secret("UPPER_KEY");
+        assert_eq!(
+            resolved.map(|s| s.expose().to_owned()),
+            Some("case-value".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_subagent_secret_missing_key_returns_none() {
+        let agent = agent_with_custom_secret("known_key", "value");
+        assert!(agent.resolve_subagent_secret("unknown_key").is_none());
+    }
+
+    #[test]
+    fn resolve_subagent_secret_empty_map_returns_none() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let agent = Agent::new(provider, channel, registry, None, 5, executor);
+        assert!(agent.resolve_subagent_secret("anything").is_none());
+    }
 
     /// #5712 regression: MCP tool identification must key off `ToolDef::server_id`, not a
     /// `"mcp_"` name prefix that real `McpTool::sanitized_id()` output never produces.

--- a/crates/zeph-core/src/agent/tests/compaction_e2e.rs
+++ b/crates/zeph-core/src/agent/tests/compaction_e2e.rs
@@ -216,8 +216,14 @@ async fn subagent_spawn_text_collect_e2e() {
 ///
 /// Verifies that when a sub-agent emits [`REQUEST_SECRET`: api-key], the bridge:
 /// - calls `channel.confirm()` with a prompt containing the key name
-/// - on approval, delivers the secret to the sub-agent
+/// - resolves the key against `available_custom_secrets` (the vault-backed map)
+/// - on approval, delivers the *resolved value* (not the bare key name) to the sub-agent
 /// The `MockChannel` `confirm()` is pre-loaded with `true` (approve).
+///
+/// #5941/#5942 regression: previously the raw key NAME was forwarded as if it were the
+/// value, and no vault resolution ever happened. `available_custom_secrets` is populated
+/// here specifically so this test would have caught that bug — the pre-fix version of this
+/// test passed regardless of whether the value was actually resolvable.
 #[tokio::test]
 async fn foreground_spawn_secret_bridge_approves() {
     use zeph_subagent::def::{SkillFilter, SubAgentPermissions, ToolPolicy};
@@ -227,10 +233,12 @@ async fn foreground_spawn_secret_bridge_approves() {
     // Sub-agent loop responses:
     //   turn 1: request a secret
     //   turn 2: final reply after secret delivered
-    let provider = mock_provider(vec![
+    let (mock, recorded) = MockProvider::with_responses(vec![
         "[REQUEST_SECRET: api-key]".into(),
         "done with secret".into(),
-    ]);
+    ])
+    .with_recording();
+    let provider = AnyProvider::Mock(mock);
 
     // MockChannel with confirm() → true (approve)
     let channel = MockChannel::new(vec![]).with_confirmations(vec![true]);
@@ -238,6 +246,13 @@ async fn foreground_spawn_secret_bridge_approves() {
     let registry = create_test_registry();
     let executor = MockToolExecutor::no_tools();
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    // Vault-resolved secret available under the normalized key — this is what
+    // `Agent::resolve_subagent_secret` looks up when the sub-agent requests "api-key".
+    agent.services.skill.available_custom_secrets.insert(
+        "api_key".to_owned(),
+        crate::vault::Secret::new("sk-live-resolved-value".to_owned()),
+    );
 
     let mut mgr = SubAgentManager::new(4);
     mgr.definitions_mut().push(SubAgentDef {
@@ -281,6 +296,33 @@ async fn foreground_spawn_secret_bridge_approves() {
     assert!(
         resp.contains("completed"),
         "sub-agent must complete successfully; got: {resp}"
+    );
+
+    // The second LLM call (turn 2) must have received an "approved" reply, not a
+    // "denied" one — proving the resolved value cleared the grant gate in
+    // `SubAgentManager::deliver_secret` (PermissionGrants::is_active) rather than being
+    // silently discarded or auto-denied due to an unresolvable key.
+    let calls = recorded.lock().unwrap();
+    assert!(
+        calls.len() >= 2,
+        "expected at least 2 LLM calls (request + post-approval turn), got {}",
+        calls.len()
+    );
+    let turn2_messages = &calls[1];
+    let reply_text: String = turn2_messages
+        .iter()
+        .map(|m| m.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        reply_text.contains("[secret:api-key] approved"),
+        "turn 2 must see an approval reply carrying the resolved value's availability, \
+         not a denial; got messages: {reply_text}"
+    );
+    assert!(
+        !reply_text.contains("[secret:api-key] request denied"),
+        "secret request must not have been denied when the key was resolvable from the \
+         vault-backed available_custom_secrets map; got: {reply_text}"
     );
 }
 

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::HashMap;
 use std::time::Instant;
 
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
+use zeph_common::secret::Secret;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{
     ChatResponse, LlmProvider, Message, MessageMetadata, MessagePart, Role, ToolDefinition,
@@ -57,7 +59,7 @@ pub(super) struct AgentLoopArgs {
     pub(super) status_tx: watch::Sender<SubAgentStatus>,
     pub(super) started_at: Instant,
     pub(super) secret_request_tx: mpsc::Sender<SecretRequest>,
-    pub(super) secret_rx: mpsc::Receiver<Option<String>>,
+    pub(super) secret_rx: mpsc::Receiver<Option<Secret>>,
     pub(super) background: bool,
     pub(super) hooks: SubagentHooks,
     pub(super) task_id: String,
@@ -192,8 +194,9 @@ async fn handle_secret_request(
     transcript_writer: Option<&TranscriptWriter>,
     seq: &mut u32,
     messages: &mut Vec<Message>,
+    granted_secrets: &mut HashMap<String, Secret>,
     secret_request_tx: &mpsc::Sender<SecretRequest>,
-    secret_rx: &mut mpsc::Receiver<Option<String>>,
+    secret_rx: &mut mpsc::Receiver<Option<Secret>>,
     cancel: &CancellationToken,
     background: bool,
     is_text_response: bool,
@@ -250,8 +253,17 @@ async fn handle_secret_request(
             }
         };
         let reply = match outcome {
-            Some(Some(_)) => {
-                format!("[secret:{key_name} approved — value available via grants]")
+            Some(Some(secret_value)) => {
+                // Accumulated for the loop's lifetime and attached to every subsequent tool
+                // call's `ExecutionContext` (see `handle_tool_step`) — a per-call override,
+                // never written into the shared `ShellExecutor::skill_env` slot, because that
+                // slot is on the same executor instance the parent agent uses and would leak
+                // the secret into unrelated tool calls made outside this sub-agent's run.
+                granted_secrets.insert(key_name.clone(), secret_value);
+                format!(
+                    "[secret:{key_name}] approved — available as ${key_name} in the tool \
+                     execution environment"
+                )
             }
             Some(None) | None => {
                 format!("[secret:{key_name}] request denied")
@@ -394,7 +406,8 @@ async fn run_turn(
     background: bool,
     started_at: Instant,
     secret_request_tx: &mpsc::Sender<SecretRequest>,
-    secret_rx: &mut mpsc::Receiver<Option<String>>,
+    secret_rx: &mut mpsc::Receiver<Option<Secret>>,
+    granted_secrets: &mut HashMap<String, Secret>,
     sanitizer: &ContentSanitizer,
     llm_timeout: std::time::Duration,
 ) -> Result<TurnOutcome, super::error::SubAgentError> {
@@ -424,6 +437,7 @@ async fn run_turn(
         transcript_writer,
         seq,
         messages,
+        granted_secrets,
         secret_request_tx,
         secret_rx,
         cancel,
@@ -440,7 +454,14 @@ async fn run_turn(
 
     let prev_len = messages.len();
     let no_tool = handle_tool_step(
-        executor, response, messages, hooks, task_id, agent_name, sanitizer,
+        executor,
+        response,
+        messages,
+        hooks,
+        task_id,
+        agent_name,
+        sanitizer,
+        &*granted_secrets,
     )
     .await;
 
@@ -473,7 +494,7 @@ async fn run_turn(
 
 // Returns `true` if no tool was called (loop should break).
 #[tracing::instrument(name = "subagent.agent_loop.handle_tool_step", skip_all)]
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 async fn handle_tool_step(
     executor: &FilteredToolExecutor,
     response: ChatResponse,
@@ -482,6 +503,7 @@ async fn handle_tool_step(
     task_id: &str,
     agent_name: &str,
     sanitizer: &ContentSanitizer,
+    granted_secrets: &HashMap<String, Secret>,
 ) -> bool {
     match response {
         ChatResponse::Text(text) => {
@@ -527,11 +549,26 @@ async fn handle_tool_step(
                     } else {
                         serde_json::Map::new()
                     };
+                // Approved sub-agent secrets are attached as a per-call `ExecutionContext`
+                // env override (highest-priority, call-scoped) rather than the executor's
+                // shared `skill_env` slot, which is aliased with the parent agent's own tool
+                // executor and would leak the secret beyond this sub-agent's run.
+                let exec_ctx = if granted_secrets.is_empty() {
+                    None
+                } else {
+                    Some(
+                        zeph_tools::ExecutionContext::new().with_envs(
+                            granted_secrets
+                                .iter()
+                                .map(|(k, v)| (k.clone(), v.expose().to_owned())),
+                        ),
+                    )
+                };
                 let call = ToolCall {
                     tool_id: tc.name.clone(),
                     params,
                     caller_id: None,
-                    context: None,
+                    context: exec_ctx,
                     tool_call_id: String::new(),
                     skill_name: None,
                 };
@@ -705,6 +742,10 @@ pub(super) async fn run_agent_loop(
     let mut turns: u32 = 0;
     let mut last_result = String::new();
     let mut any_tool_called = false;
+    // Accumulates resolved secret values across the loop's lifetime so a later approval
+    // does not evict an earlier one from the tool executor's environment (see
+    // `handle_secret_request`).
+    let mut granted_secrets: HashMap<String, Secret> = HashMap::new();
 
     loop {
         if cancel.is_cancelled() {
@@ -735,6 +776,7 @@ pub(super) async fn run_agent_loop(
             started_at,
             &secret_request_tx,
             &mut secret_rx,
+            &mut granted_secrets,
             &sanitizer,
             llm_timeout,
         )
@@ -863,6 +905,174 @@ mod make_hook_env_tests {
             "truncated value should end with ellipsis"
         );
         assert!(args.is_char_boundary(args.len()));
+    }
+}
+
+#[cfg(test)]
+mod handle_tool_step_granted_secrets_tests {
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+
+    use zeph_llm::provider::ToolUseRequest;
+    use zeph_tools::executor::{ErasedToolExecutor, ToolCall, ToolError, ToolOutput};
+    use zeph_tools::registry::ToolDef;
+
+    use super::*;
+    use crate::def::ToolPolicy;
+    use crate::filter::FilteredToolExecutor;
+    use crate::hooks::SubagentHooks;
+
+    /// Records every `ToolCall` it receives so tests can inspect `call.context`.
+    #[derive(Default)]
+    struct RecordingExecutor {
+        calls: Mutex<Vec<ToolCall>>,
+    }
+
+    impl ErasedToolExecutor for RecordingExecutor {
+        fn execute_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn execute_confirmed_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn tool_definitions_erased(&self) -> Vec<ToolDef> {
+            vec![]
+        }
+
+        fn execute_tool_call_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            self.calls.lock().unwrap().push(call.clone());
+            Box::pin(std::future::ready(Ok(Some(ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "ok".into(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))))
+        }
+
+        fn is_tool_retryable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
+
+        fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
+            false
+        }
+    }
+
+    fn tool_use_response() -> ChatResponse {
+        ChatResponse::ToolUse {
+            text: None,
+            tool_calls: vec![ToolUseRequest {
+                id: "call-1".into(),
+                name: "shell".into(),
+                input: serde_json::json!({"command": "echo $SOME_VAULT_KEY"}),
+            }],
+            thinking_blocks: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn granted_secret_is_attached_to_tool_call_context() {
+        let recorder = Arc::new(RecordingExecutor::default());
+        let executor = FilteredToolExecutor::new(
+            Arc::clone(&recorder) as Arc<dyn ErasedToolExecutor>,
+            ToolPolicy::InheritAll,
+        );
+        let hooks = SubagentHooks::default();
+        let mut messages = Vec::new();
+        let mut granted_secrets = HashMap::new();
+        granted_secrets.insert("SOME_VAULT_KEY".to_owned(), Secret::new("the-secret-value"));
+        let sanitizer = ContentSanitizer::new(&zeph_config::ContentIsolationConfig::default());
+
+        let no_tool = handle_tool_step(
+            &executor,
+            tool_use_response(),
+            &mut messages,
+            &hooks,
+            "task-1",
+            "bot",
+            &sanitizer,
+            &granted_secrets,
+        )
+        .await;
+        assert!(!no_tool, "a tool call was made");
+
+        let calls = recorder.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        let context = calls[0]
+            .context
+            .as_ref()
+            .expect("granted secrets must produce a Some(ExecutionContext)");
+        assert_eq!(
+            context
+                .env_overrides()
+                .get("SOME_VAULT_KEY")
+                .map(String::as_str),
+            Some("the-secret-value")
+        );
+    }
+
+    #[tokio::test]
+    async fn no_granted_secrets_leaves_tool_call_context_none() {
+        // Regression guard: with no granted secrets, handle_tool_step must build
+        // context: None — identical to pre-fix behavior.
+        let recorder = Arc::new(RecordingExecutor::default());
+        let executor = FilteredToolExecutor::new(
+            Arc::clone(&recorder) as Arc<dyn ErasedToolExecutor>,
+            ToolPolicy::InheritAll,
+        );
+        let hooks = SubagentHooks::default();
+        let mut messages = Vec::new();
+        let granted_secrets: HashMap<String, Secret> = HashMap::new();
+        let sanitizer = ContentSanitizer::new(&zeph_config::ContentIsolationConfig::default());
+
+        let no_tool = handle_tool_step(
+            &executor,
+            tool_use_response(),
+            &mut messages,
+            &hooks,
+            "task-1",
+            "bot",
+            &sanitizer,
+            &granted_secrets,
+        )
+        .await;
+        assert!(!no_tool);
+
+        let calls = recorder.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(
+            calls[0].context.is_none(),
+            "no granted secrets must leave context as None"
+        );
     }
 }
 

--- a/crates/zeph-subagent/src/manager/mod.rs
+++ b/crates/zeph-subagent/src/manager/mod.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
+use zeph_common::secret::Secret;
 use zeph_common::task_supervisor::BlockingHandle;
 use zeph_common::{SkillTrustLevel, TaskSupervisor};
 use zeph_config::{ContentIsolationConfig, McpServerConfig};
@@ -182,8 +183,9 @@ pub struct SubAgentHandle {
     pub grants: PermissionGrants,
     /// Receives secret requests from the sub-agent loop.
     pub pending_secret_rx: mpsc::Receiver<SecretRequest>,
-    /// Delivers approval outcome to the sub-agent loop: `None` = denied, `Some(_)` = approved.
-    pub secret_tx: mpsc::Sender<Option<String>>,
+    /// Delivers the approval outcome to the sub-agent loop: `None` = denied,
+    /// `Some(value)` = approved, carrying the resolved vault secret value.
+    pub secret_tx: mpsc::Sender<Option<Secret>>,
     /// ISO 8601 UTC timestamp recorded when the agent was spawned or resumed.
     pub started_at_str: String,
     /// Resolved transcript directory at spawn time; `None` if transcripts were disabled.

--- a/crates/zeph-subagent/src/manager/secrets.rs
+++ b/crates/zeph-subagent/src/manager/secrets.rs
@@ -4,9 +4,11 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use zeph_common::secret::Secret;
+
 use super::SubAgentManager;
 use crate::error::SubAgentError;
-use crate::grants::SecretRequest;
+use crate::grants::{GrantKind, SecretRequest};
 
 /// Build the standard hook environment for a sub-agent lifecycle event.
 pub(crate) fn make_hook_env(
@@ -64,22 +66,44 @@ impl SubAgentManager {
         Ok(())
     }
 
-    /// Deliver a secret value to a waiting sub-agent loop.
+    /// Deliver a resolved secret value to a waiting sub-agent loop.
     ///
-    /// Should be called after the user approves the request and the vault value
-    /// has been resolved. Returns an error if no such agent is found.
+    /// Should be called after the user approves the request and the caller has resolved
+    /// `key` to its actual vault value (see [`approve_secret`](Self::approve_secret)).
+    /// Requires an active grant for `key` — delivery is refused if
+    /// [`approve_secret`](Self::approve_secret) was never called or the grant's TTL has
+    /// already elapsed, making
+    /// [`PermissionGrants::is_active`][crate::grants::PermissionGrants::is_active]
+    /// load-bearing rather than unused bookkeeping.
     ///
     /// # Errors
     ///
-    /// Returns [`SubAgentError::NotFound`] if the task ID is unknown.
-    pub fn deliver_secret(&mut self, task_id: &str, key: String) -> Result<(), SubAgentError> {
+    /// Returns [`SubAgentError::NotFound`] if the task ID is unknown, or
+    /// [`SubAgentError::Invalid`] if there is no active grant for `key`.
+    pub fn deliver_secret(
+        &mut self,
+        task_id: &str,
+        key: &str,
+        value: Secret,
+    ) -> Result<(), SubAgentError> {
         let handle = self
             .agents
             .get_mut(task_id)
             .ok_or_else(|| SubAgentError::NotFound(task_id.to_owned()))?;
+
+        if !handle.grants.is_active(&GrantKind::Secret(key.to_owned())) {
+            tracing::warn!(
+                task_id,
+                "secret delivery denied: no active grant (missing approval or TTL expired)"
+            );
+            return Err(SubAgentError::Invalid(
+                "no active grant for this secret".to_owned(),
+            ));
+        }
+
         handle
             .secret_tx
-            .try_send(Some(key))
+            .try_send(Some(value))
             .map_err(|e| SubAgentError::Channel(e.to_string()))
     }
 

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
+use zeph_common::secret::Secret;
 use zeph_config::{BgIsolation, ContentIsolationConfig, SubAgentConfig};
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{Message, Role};
@@ -651,7 +652,7 @@ impl SubAgentManager {
         }
 
         let (secret_request_tx, pending_secret_rx) = mpsc::channel::<SecretRequest>(4);
-        let (secret_tx, secret_rx) = mpsc::channel::<Option<String>>(4);
+        let (secret_tx, secret_rx) = mpsc::channel::<Option<Secret>>(4);
 
         let transcript_writer = self.create_transcript_writer(config, &task_id, &def.name, None);
 
@@ -1040,7 +1041,7 @@ impl SubAgentManager {
         }
 
         let (secret_request_tx, pending_secret_rx) = mpsc::channel::<SecretRequest>(4);
-        let (secret_tx, secret_rx) = mpsc::channel::<Option<String>>(4);
+        let (secret_tx, secret_rx) = mpsc::channel::<Option<Secret>>(4);
 
         let transcript_writer =
             self.create_transcript_writer(config, &new_task_id, &def.name, Some(&original_id));

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -219,6 +219,87 @@ fn approve_secret_unknown_task_id_returns_not_found() {
     assert_matches!(err, SubAgentError::NotFound(_));
 }
 
+// ── deliver_secret grant-gating tests (#5941/#5942) ────────────────────────
+
+#[tokio::test]
+async fn deliver_secret_without_prior_approval_is_denied() {
+    // No approve_secret call at all — deliver_secret must refuse (no active grant).
+    let mut mgr = make_manager();
+    mgr.definitions.push(def_with_secrets());
+
+    let task_id = do_spawn(&mut mgr, "bot", "work").await.unwrap();
+    let err = mgr
+        .deliver_secret(
+            &task_id,
+            "api-key",
+            zeph_common::secret::Secret::new("sekrit"),
+        )
+        .unwrap_err();
+    assert_matches!(err, SubAgentError::Invalid(_));
+}
+
+#[tokio::test]
+async fn deliver_secret_for_different_key_than_approved_is_denied() {
+    // approve_secret grants "api-key"; deliver_secret is attempted for a different key.
+    let mut mgr = make_manager();
+    mgr.definitions.push(def_with_secrets());
+
+    let task_id = do_spawn(&mut mgr, "bot", "work").await.unwrap();
+    mgr.approve_secret(&task_id, "api-key", std::time::Duration::from_mins(1))
+        .unwrap();
+
+    let err = mgr
+        .deliver_secret(
+            &task_id,
+            "other-key",
+            zeph_common::secret::Secret::new("sekrit"),
+        )
+        .unwrap_err();
+    assert_matches!(err, SubAgentError::Invalid(_));
+}
+
+#[tokio::test]
+async fn deliver_secret_after_approval_sends_value_over_channel() {
+    // Positive path: approve_secret then deliver_secret with the SAME key succeeds and the
+    // resolved value is actually observable on the other end of secret_tx/secret_rx.
+    let mut mgr = make_manager();
+    mgr.definitions.push(def_with_secrets());
+
+    let task_id = do_spawn(&mut mgr, "bot", "work").await.unwrap();
+    mgr.approve_secret(&task_id, "api-key", std::time::Duration::from_mins(1))
+        .unwrap();
+
+    // Swap in a fresh channel pair we control so we can observe the receiver side —
+    // the handle's real secret_rx is owned by the (mocked) background agent loop task.
+    let (secret_tx, mut secret_rx) = tokio::sync::mpsc::channel(1);
+    mgr.agents.get_mut(&task_id).unwrap().secret_tx = secret_tx;
+
+    let result = mgr.deliver_secret(
+        &task_id,
+        "api-key",
+        zeph_common::secret::Secret::new("sekrit-value"),
+    );
+    assert!(
+        result.is_ok(),
+        "deliver_secret must succeed with an active grant"
+    );
+
+    let received = secret_rx
+        .try_recv()
+        .expect("value must be sent over the channel");
+    let secret = received.expect("delivered value must be Some, not a denial");
+    assert_eq!(secret.expose(), "sekrit-value");
+}
+
+#[test]
+fn deliver_secret_unknown_task_id_returns_not_found() {
+    let mut mgr = make_manager();
+    let err = mgr
+        .deliver_secret("unknown", "key", zeph_common::secret::Secret::new("sekrit"))
+        .unwrap_err();
+    assert_matches!(err, SubAgentError::NotFound(_));
+}
+
 #[tokio::test]
 async fn statuses_returns_active_agents() {
     let mut mgr = make_manager();
@@ -1881,7 +1962,8 @@ fn make_agent_loop_args(
         started_at: std::time::Instant::now(),
     });
     let (secret_request_tx, _secret_request_rx) = tokio::sync::mpsc::channel(1);
-    let (_secret_approved_tx, secret_rx) = tokio::sync::mpsc::channel::<Option<String>>(1);
+    let (_secret_approved_tx, secret_rx) =
+        tokio::sync::mpsc::channel::<Option<zeph_common::secret::Secret>>(1);
     AgentLoopArgs {
         provider,
         executor,


### PR DESCRIPTION
## Summary

- The sub-agent vault-secret request/approval flow only ever forwarded the requested key *name* back through the delivery channel and discarded whatever value it received; `PermissionGrants::is_active` was never called by any production code path, leaving `GrantKind::Secret` bookkeeping fully inert. The end-to-end "sub-agent requests secret → user approves → sub-agent uses it" capability was non-functional.
- `Agent::resolve_subagent_secret` now resolves the real value from the existing vault-backed custom-secrets map (the same one skills use for `requires_secrets`) at all three approval call sites before delivery.
- `SubAgentManager::deliver_secret` now carries the resolved `Secret` value and gates delivery on `PermissionGrants::is_active` for the exact requested key, making the grant check load-bearing for the first time.
- The sub-agent's `agent_loop.rs` no longer discards the delivered value — it attaches it to each subsequent tool call via a per-call `ExecutionContext` env override, deliberately not the shared `ToolExecutor::set_skill_env` slot (which would have leaked the secret into the parent agent's later, unrelated tool calls).

## Test plan

- [x] 11 new unit tests + 1 strengthened existing e2e test (grant-gate denial/positive-path, key normalization, `ExecutionContext` injection — see `.local/handoff/2026-07-11T00-56-16-testing.md` for the full list)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12641 passed, 0 failed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`) — clean
- [x] Testing playbook added: `.local/testing/playbooks/subagent-secret-delivery.md`; `coverage-status.md` row added
- [ ] Live verification (real vault secret, real sub-agent spawn, approve, confirm tool call sees the value) — pending, see playbook Scenarios 1-4

## Known scope cut (tracked separately)

Grant TTL is enforced only once at the delivery gate — a value already delivered to a running sub-agent remains usable for the rest of that sub-agent's turn even after its TTL would have elapsed (no live per-tool-call re-check). Follow-up issue to be filed.

Closes #5941
Closes #5942