### PR TITLE
fix(tools): forward checkpoint methods through Arc<ShellExecutor>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   working directory that the process could access. `ImageCommand` now overrides `requires_auth()`
   to return `true`, matching the existing `/cache-stats` and `/notify-test` handlers in the same
   module; the command remains available from local CLI/TUI/ACP-stdio sessions.
+- `fix(tools)`: `checkpoint_undo`/`checkpoint_redo`/`checkpoint_list` are now forwarded by
+  `impl ToolExecutor for std::sync::Arc<ShellExecutor>` (#5985). This impl block predates the
+  checkpoint feature and only overrode `execute`/`tool_definitions`/`execute_tool_call`/
+  `set_skill_env`, so the three checkpoint methods fell through to the trait's no-op default —
+  `/undo`, `/redo`, and `/undo list` always reported "Checkpoints are not enabled" in the plain
+  default production wiring (no `capability_scopes`/`shadow_sentinel` gating required to
+  reproduce), because `agent_setup.rs` wraps the shell executor in an `Arc` before building the
+  executor chain, so every checkpoint call resolved against the incomplete `Arc<ShellExecutor>`
+  impl rather than `ShellExecutor`'s own correct one. This is the same defect class as
+  #5899/#5905/#5906 but at the leaf type's own smart-pointer shadow-impl rather than a decorator
+  wrapper.
 - `fix(mcp)`: Qdrant-backed MCP tool registry now rehydrates real `input_schema` (plus
   `output_schema`/`security_meta`) for semantically-matched tools instead of surfacing them to
   the LLM with an empty `{}` schema (#5935). `Agent::match_mcp_tools()` no longer trusts

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -1745,6 +1745,18 @@ impl ToolExecutor for std::sync::Arc<ShellExecutor> {
     fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
         self.as_ref().set_skill_env(env);
     }
+
+    fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
+        self.as_ref().checkpoint_undo(n)
+    }
+
+    fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+        self.as_ref().checkpoint_redo()
+    }
+
+    fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+        self.as_ref().checkpoint_list()
+    }
 }
 
 impl ToolExecutor for ShellExecutor {

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -3397,3 +3397,49 @@ async fn supervised_background_run_limit_still_enforced() {
 
     cancel.cancel();
 }
+
+// --- Arc<ShellExecutor> checkpoint forwarding (regression for #5985) ---
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn arc_wrapped_executor_forwards_checkpoint_methods() {
+    let dir = tempfile::tempdir().unwrap();
+    // Canonicalize so path comparisons don't trip on macOS's /var -> /private/var symlink.
+    let dir_path = dir.path().canonicalize().unwrap();
+    let file_path = dir_path.join("checkpoint_target.txt");
+
+    let config = ShellConfig {
+        checkpoints_enabled: true,
+        allowed_paths: vec![dir_path.to_string_lossy().into_owned()],
+        ..default_config()
+    };
+    // Wrapped exactly as agent_setup.rs wires the shell slot in the executor chain.
+    let executor: Arc<ShellExecutor> = Arc::new(ShellExecutor::new(&config));
+
+    let command = format!("echo hello > {}", file_path.display());
+    let response = format!("```bash\n{command}\n```");
+    executor.execute(&response).await.unwrap();
+
+    let list = executor.checkpoint_list();
+    assert!(
+        list.supported,
+        "Arc<ShellExecutor>::checkpoint_list must forward to the real impl, not the trait default"
+    );
+    assert_eq!(list.entries.len(), 1);
+    assert!(file_path.exists());
+
+    let undo = executor.checkpoint_undo(1);
+    assert!(
+        undo.supported,
+        "Arc<ShellExecutor>::checkpoint_undo must forward to the real impl, not the trait default"
+    );
+    assert_eq!(undo.deleted, 1);
+    assert!(!file_path.exists());
+
+    let redo = executor.checkpoint_redo();
+    assert!(
+        redo.supported,
+        "Arc<ShellExecutor>::checkpoint_redo must forward to the real impl, not the trait default"
+    );
+    assert!(file_path.exists());
+}


### PR DESCRIPTION
## Summary
- `impl ToolExecutor for std::sync::Arc<ShellExecutor>` in `crates/zeph-tools/src/shell/mod.rs` predates the checkpoint feature and only overrode `execute`/`tool_definitions`/`execute_tool_call`/`set_skill_env`, so `checkpoint_undo`/`checkpoint_redo`/`checkpoint_list` silently fell through to the trait's unsupported default.
- Because `agent_setup.rs` wraps the shell executor in an `Arc` before building the executor chain, every checkpoint call resolved against this incomplete impl instead of `ShellExecutor`'s own correct one, so `/undo`, `/redo`, and `/undo list` always reported "Checkpoints are not enabled" in the plain default production wiring — no `capability_scopes`/`shadow_sentinel` gating required to reproduce.
- Added the three forwarding overrides (`self.as_ref().checkpoint_X(...)`), mirroring the existing `execute_tool_call` forwarding pattern in the same impl block.
- Same defect class as #5899/#5905/#5906, but at the leaf type's own smart-pointer shadow-impl rather than a decorator/wrapper type. Workspace-wide grep confirms `Arc<ShellExecutor>` was the only *active* instance of this pattern (a structurally similar but currently harmless case exists in `DynSchedulerExecutor`, noted below).

Closes #5985

## Test plan
- [x] Added `arc_wrapped_executor_forwards_checkpoint_methods` regression test in `crates/zeph-tools/src/shell/tests.rs`, constructing a real `Arc<ShellExecutor>` and calling checkpoint methods through the `Arc` handle as a `dyn ToolExecutor` — independently verified by two reviewers to fail pre-fix and pass post-fix (not a false-positive test).
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12646 passed, 0 failed
- [x] `cargo nextest run -p zeph-tools` (full crate) — 1355 passed, 0 failed

## Follow-ups (not in scope for this PR, to be filed separately)
- `DynSchedulerExecutor` (`src/scheduler_executor.rs:519`) is a structurally similar shadow-wrapper pattern — parity-correct today but the same footgun shape.
- Latent P2: `capture_snapshot_for` silently drops checkpoints for newly-created files under symlinked `allowed_paths` prefixes on macOS (`canonicalize()`/`absolute()` don't resolve `/tmp` → `/private/tmp`), only a `tracing::warn!`, no user-visible error.
- P3 test gap: no existing test covers `checkpoint_redo`-with-no-prior-undo, `checkpoint_list` ordering with 2+ entries, or multi-checkpoint undo-stack depth (pre-existing gap, not introduced by this fix).