### PR TITLE
fix(commands): require trusted session for /mcp and /plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(commands)`: `/mcp` and `/plugins` now require a trusted (local) session, closing an
+  unauthenticated remote code execution path (#5997, CWE-284). `McpCommand` and `PluginsCommand`
+  previously left `requires_auth()` at its default `false`, so Telegram/Discord/Slack/gateway
+  callers could invoke `/mcp add <id> <command> [args...]` to spawn an arbitrary local subprocess
+  (with the shipped default `mcp.allowed_commands = ["npx", "uvx", "node", "python", "python3"]`,
+  e.g. `python3 -c "..."`) or `/plugins add <path>` to install a plugin from an arbitrary local
+  path — both without any authentication. Both handlers now override `requires_auth()` to return
+  `true`, matching the same defect class fixed for `/image` in #5967; the commands remain
+  available from local CLI/TUI/ACP-stdio sessions.
 - `fix(commands)`: `/image` now requires a trusted (local) session, closing a remote arbitrary
   file read (#5967, CWE-284). `ImageCommand` previously left `requires_auth()` at its default
   `false`, so Telegram/Discord/Slack/gateway callers — none of which are trusted by

--- a/crates/zeph-commands/src/handlers/mcp.rs
+++ b/crates/zeph-commands/src/handlers/mcp.rs
@@ -41,6 +41,10 @@ impl CommandHandler<CommandContext<'_>> for McpCommand {
         SlashCategory::Integration
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -61,6 +65,7 @@ impl CommandHandler<CommandContext<'_>> for McpCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandRegistry;
     use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
     use crate::sink::NullSink;
     use std::assert_matches;
@@ -81,5 +86,40 @@ mod tests {
         let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
         let out = McpCommand.handle(&mut ctx, "list").await.unwrap();
         assert_matches!(out, CommandOutput::Message(_));
+    }
+
+    #[tokio::test]
+    async fn mcp_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(McpCommand);
+
+        let result = reg.dispatch(&mut ctx, "/mcp list", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn mcp_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(McpCommand);
+
+        let result = reg
+            .dispatch(&mut ctx, "/mcp add pwn python3 -c evil", false)
+            .await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }

--- a/crates/zeph-commands/src/handlers/plugins.rs
+++ b/crates/zeph-commands/src/handlers/plugins.rs
@@ -29,6 +29,10 @@ impl CommandHandler<CommandContext<'_>> for PluginsCommand {
         SlashCategory::Integration
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -49,6 +53,9 @@ impl CommandHandler<CommandContext<'_>> for PluginsCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandRegistry;
+    use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
+    use crate::sink::NullSink;
 
     #[test]
     fn name_matches_slash_plugins() {
@@ -68,5 +75,40 @@ mod tests {
     #[test]
     fn args_hint_is_non_empty() {
         assert!(!PluginsCommand.args_hint().is_empty());
+    }
+
+    #[tokio::test]
+    async fn plugins_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(PluginsCommand);
+
+        let result = reg.dispatch(&mut ctx, "/plugins list", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn plugins_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(PluginsCommand);
+
+        let result = reg
+            .dispatch(&mut ctx, "/plugins add /etc/passwd", false)
+            .await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }


### PR DESCRIPTION
## Summary
- `McpCommand` and `PluginsCommand` never overrode `CommandHandler::requires_auth()`, defaulting to `false`, so untrusted remote channels (Telegram/Discord/Slack/gateway) could dispatch `/mcp add` and `/plugins add` without authentication
- `/mcp add <id> <command> [args...]` spawns a local subprocess; with the shipped default `mcp.allowed_commands` allowlist (`npx`, `uvx`, `node`, `python`, `python3`), this is unauthenticated remote code execution
- `/plugins add <path>` installs a plugin from an arbitrary local path with no path-guard check
- Both handlers now override `requires_auth()` to return `true`, matching the same defect class already fixed for `/image` (#5967 / #5988)
- Added dispatch-level regression tests through a real `CommandRegistry`, asserting rejection when untrusted and success when trusted, mirroring the existing `/image` test pattern

Closes #5997

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-commands` (137 passed)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-commands`
- [x] New regression tests exercise the real `CommandRegistry::dispatch` gate, not just the trait method