### PR TITLE
fix(config,llm): redact secrets from Debug output on 7 config structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Security
+
+- `zeph-config` / `zeph-llm`: removed derived `Debug` from 7 secret-bearing config structs that
+  printed their plaintext secret verbatim in any `{:?}` output — logs, panics, error chains
+  (#5952, #5963). `GatewayConfig::auth_token`, `ProviderEntry::api_key`/`cocoon_access_hash`,
+  `ClassifiersConfig::hf_token`, `CandleConfig::hf_token`, `CandleInlineConfig::hf_token`,
+  `OpenAiConfig::api_key`, and `CompatibleConfig::api_key` are now redacted (`"[REDACTED]"` in
+  `zeph-config`, `"<redacted>"` in `zeph-llm`, matching each crate's existing manual-`Debug`
+  precedent) by a hand-written `impl Debug` that still lists every other field. `Option<String>`
+  secrets preserve the `None`-vs-`Some` distinction. `CandleInlineConfig` is embedded inside
+  `ProviderEntry`, so both were fixed together to avoid a transitive leak through nested `Debug`.
+
 ### Fixed
 
 - `fix(commands)`: `/image` now requires a trusted (local) session, closing a remote arbitrary

--- a/crates/zeph-config/src/classifiers.rs
+++ b/crates/zeph-config/src/classifiers.rs
@@ -78,7 +78,7 @@ pub enum InjectionEnforcementMode {
 ///
 /// When `enabled = false` (the default), all classifier code is bypassed and the existing
 /// regex-based detection runs unchanged.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
 pub struct ClassifiersConfig {
     /// Master switch. When `false`, classifiers are never loaded or invoked.
     #[serde(default)]
@@ -250,6 +250,32 @@ impl Default for ClassifiersConfig {
             pii_ner_allowlist: default_pii_ner_allowlist(),
             pii_ner_circuit_breaker: default_pii_ner_circuit_breaker(),
         }
+    }
+}
+
+impl std::fmt::Debug for ClassifiersConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClassifiersConfig")
+            .field("enabled", &self.enabled)
+            .field("timeout_ms", &self.timeout_ms)
+            .field("hf_token", &self.hf_token.as_ref().map(|_| "[REDACTED]"))
+            .field("scan_user_input", &self.scan_user_input)
+            .field("injection_model", &self.injection_model)
+            .field("enforcement_mode", &self.enforcement_mode)
+            .field("injection_threshold_soft", &self.injection_threshold_soft)
+            .field("injection_threshold", &self.injection_threshold)
+            .field("injection_model_sha256", &self.injection_model_sha256)
+            .field("three_class_model", &self.three_class_model)
+            .field("three_class_threshold", &self.three_class_threshold)
+            .field("three_class_model_sha256", &self.three_class_model_sha256)
+            .field("pii_enabled", &self.pii_enabled)
+            .field("pii_model", &self.pii_model)
+            .field("pii_threshold", &self.pii_threshold)
+            .field("pii_model_sha256", &self.pii_model_sha256)
+            .field("pii_ner_max_chars", &self.pii_ner_max_chars)
+            .field("pii_ner_allowlist", &self.pii_ner_allowlist)
+            .field("pii_ner_circuit_breaker", &self.pii_ner_circuit_breaker)
+            .finish()
     }
 }
 
@@ -511,5 +537,24 @@ mod tests {
     fn pii_ner_circuit_breaker_missing_uses_default() {
         let cfg: ClassifiersConfig = toml::from_str("").unwrap();
         assert_eq!(cfg.pii_ner_circuit_breaker, 2);
+    }
+
+    #[test]
+    fn classifiers_config_debug_redacts_hf_token() {
+        let cfg = ClassifiersConfig {
+            hf_token: Some("hf_SUPERSECRET".to_owned()),
+            ..ClassifiersConfig::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("hf_SUPERSECRET"));
+        assert!(dbg.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn classifiers_config_debug_none_hf_token() {
+        let cfg = ClassifiersConfig::default();
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("[REDACTED]"));
+        assert!(dbg.contains("hf_token: None"));
     }
 }

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -898,7 +898,7 @@ impl Default for CostConfig {
 /// max_body_size = 1048576
 /// webhook_send_timeout_secs = 5
 /// ```
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct GatewayConfig {
     /// Enable the HTTP gateway. Default: `false`.
     #[serde(default)]
@@ -952,6 +952,24 @@ impl Default for GatewayConfig {
             webhook_send_timeout_secs: default_gateway_webhook_send_timeout_secs(),
             trusted_proxy_cidrs: Vec::new(),
         }
+    }
+}
+
+impl std::fmt::Debug for GatewayConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GatewayConfig")
+            .field("enabled", &self.enabled)
+            .field("bind", &self.bind)
+            .field("port", &self.port)
+            .field(
+                "auth_token",
+                &self.auth_token.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("rate_limit", &self.rate_limit)
+            .field("max_body_size", &self.max_body_size)
+            .field("webhook_send_timeout_secs", &self.webhook_send_timeout_secs)
+            .field("trusted_proxy_cidrs", &self.trusted_proxy_cidrs)
+            .finish()
     }
 }
 
@@ -1320,6 +1338,25 @@ mod tests {
             ..GatewayConfig::default()
         };
         assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn gateway_config_debug_redacts_auth_token() {
+        let cfg = GatewayConfig {
+            auth_token: Some("sk-SUPERSECRET".to_owned()),
+            ..GatewayConfig::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("sk-SUPERSECRET"));
+        assert!(dbg.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn gateway_config_debug_none_auth_token() {
+        let cfg = GatewayConfig::default();
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("[REDACTED]"));
+        assert!(dbg.contains("auth_token: None"));
     }
 
     #[test]

--- a/crates/zeph-config/src/providers/candle.rs
+++ b/crates/zeph-config/src/providers/candle.rs
@@ -75,7 +75,7 @@ pub enum CandleDevice {
 /// agent runs inference locally via `HuggingFace` Candle rather than a remote API.
 /// For inline provider definitions inside `[[llm.providers]]`, use
 /// [`CandleInlineConfig`] instead.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct CandleConfig {
     #[serde(default)]
     pub source: CandleSource,
@@ -110,6 +110,22 @@ pub struct CandleConfig {
 
 fn default_inference_timeout_secs() -> u64 {
     120
+}
+
+impl std::fmt::Debug for CandleConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CandleConfig")
+            .field("source", &self.source)
+            .field("local_path", &self.local_path)
+            .field("filename", &self.filename)
+            .field("chat_template", &self.chat_template)
+            .field("device", &self.device)
+            .field("embedding_repo", &self.embedding_repo)
+            .field("hf_token", &self.hf_token.as_ref().map(|_| "[REDACTED]"))
+            .field("generation", &self.generation)
+            .field("inference_timeout_secs", &self.inference_timeout_secs)
+            .finish()
+    }
 }
 
 /// Sampling / generation parameters for Candle local inference.
@@ -178,7 +194,7 @@ impl Default for GenerationParams {
 }
 /// Inline candle config for use inside `ProviderEntry`.
 /// Re-uses the generation params from `CandleConfig`.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct CandleInlineConfig {
     #[serde(default)]
     pub source: CandleSource,
@@ -231,5 +247,83 @@ impl Default for CandleInlineConfig {
             generation: GenerationParams::default(),
             inference_timeout_secs: default_inference_timeout_secs(),
         }
+    }
+}
+
+impl std::fmt::Debug for CandleInlineConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CandleInlineConfig")
+            .field("source", &self.source)
+            .field("local_path", &self.local_path)
+            .field("filename", &self.filename)
+            .field("chat_model_sha256", &self.chat_model_sha256)
+            .field("chat_template", &self.chat_template)
+            .field("device", &self.device)
+            .field("embedding_repo", &self.embedding_repo)
+            .field("embedding_model_sha256", &self.embedding_model_sha256)
+            .field("hf_token", &self.hf_token.as_ref().map(|_| "[REDACTED]"))
+            .field("generation", &self.generation)
+            .field("inference_timeout_secs", &self.inference_timeout_secs)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn candle_config_debug_redacts_hf_token() {
+        let cfg = CandleConfig {
+            source: CandleSource::default(),
+            local_path: String::new(),
+            filename: None,
+            chat_template: default_chat_template(),
+            device: CandleDevice::default(),
+            embedding_repo: None,
+            hf_token: Some("hf_SUPERSECRET".to_owned()),
+            generation: GenerationParams::default(),
+            inference_timeout_secs: default_inference_timeout_secs(),
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("hf_SUPERSECRET"));
+        assert!(dbg.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn candle_config_debug_none_hf_token() {
+        let cfg = CandleConfig {
+            source: CandleSource::default(),
+            local_path: String::new(),
+            filename: None,
+            chat_template: default_chat_template(),
+            device: CandleDevice::default(),
+            embedding_repo: None,
+            hf_token: None,
+            generation: GenerationParams::default(),
+            inference_timeout_secs: default_inference_timeout_secs(),
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("[REDACTED]"));
+        assert!(dbg.contains("hf_token: None"));
+    }
+
+    #[test]
+    fn candle_inline_config_debug_redacts_hf_token() {
+        let cfg = CandleInlineConfig {
+            hf_token: Some("hf_SUPERSECRET".to_owned()),
+            ..CandleInlineConfig::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("hf_SUPERSECRET"));
+        assert!(dbg.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn candle_inline_config_debug_none_hf_token() {
+        let cfg = CandleInlineConfig::default();
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("[REDACTED]"));
+        assert!(dbg.contains("hf_token: None"));
     }
 }

--- a/crates/zeph-config/src/providers/entry.rs
+++ b/crates/zeph-config/src/providers/entry.rs
@@ -56,7 +56,7 @@ pub struct CocoonPricing {
 ///
 /// Provider-specific fields use `#[serde(default)]` and are ignored by backends
 /// that do not use them (flat-union pattern).
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 pub struct ProviderEntry {
     /// Required: provider backend type.
@@ -231,6 +231,45 @@ impl Default for ProviderEntry {
             instruction_file: None,
             max_concurrent: None,
         }
+    }
+}
+
+impl std::fmt::Debug for ProviderEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderEntry")
+            .field("provider_type", &self.provider_type)
+            .field("name", &self.name)
+            .field("model", &self.model)
+            .field("base_url", &self.base_url)
+            .field("max_tokens", &self.max_tokens)
+            .field("embedding_model", &self.embedding_model)
+            .field("stt_model", &self.stt_model)
+            .field("stt_model_sha256", &self.stt_model_sha256)
+            .field("embed", &self.embed)
+            .field("default", &self.default)
+            .field("thinking", &self.thinking)
+            .field("server_compaction", &self.server_compaction)
+            .field("enable_extended_context", &self.enable_extended_context)
+            .field("prompt_cache_ttl", &self.prompt_cache_ttl)
+            .field("reasoning_effort", &self.reasoning_effort)
+            .field("thinking_level", &self.thinking_level)
+            .field("thinking_budget", &self.thinking_budget)
+            .field("include_thoughts", &self.include_thoughts)
+            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .field("candle", &self.candle)
+            .field("vision_model", &self.vision_model)
+            .field("gonka_nodes", &self.gonka_nodes)
+            .field("gonka_chain_prefix", &self.gonka_chain_prefix)
+            .field("cocoon_client_url", &self.cocoon_client_url)
+            .field(
+                "cocoon_access_hash",
+                &self.cocoon_access_hash.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("cocoon_health_check", &self.cocoon_health_check)
+            .field("cocoon_pricing", &self.cocoon_pricing)
+            .field("instruction_file", &self.instruction_file)
+            .field("max_concurrent", &self.max_concurrent)
+            .finish()
     }
 }
 
@@ -586,4 +625,44 @@ pub fn validate_pool(entries: &[ProviderEntry]) -> Result<(), crate::error::Conf
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ProviderKind;
+
+    #[test]
+    fn provider_entry_debug_redacts_api_key() {
+        let entry = ProviderEntry {
+            api_key: Some("sk-SUPERSECRET".to_owned()),
+            ..ProviderEntry::default()
+        };
+        let dbg = format!("{entry:?}");
+        assert!(!dbg.contains("sk-SUPERSECRET"));
+        assert!(dbg.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn provider_entry_debug_none_api_key() {
+        let entry = ProviderEntry::default();
+        let dbg = format!("{entry:?}");
+        assert!(!dbg.contains("[REDACTED]"));
+        assert!(dbg.contains("api_key: None"));
+    }
+
+    #[test]
+    fn provider_entry_debug_redacts_nested_candle_hf_token() {
+        let entry = ProviderEntry {
+            provider_type: ProviderKind::Candle,
+            candle: Some(super::super::CandleInlineConfig {
+                hf_token: Some("hf_SUPERSECRET".to_owned()),
+                ..super::super::CandleInlineConfig::default()
+            }),
+            ..ProviderEntry::default()
+        };
+        let dbg = format!("{entry:?}");
+        assert!(!dbg.contains("hf_SUPERSECRET"));
+        assert!(dbg.contains("[REDACTED]"));
+    }
 }

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -50,7 +50,7 @@ use crate::provider::{
 /// };
 /// let provider = CompatibleProvider::new(cfg);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CompatibleConfig {
     /// Human-readable provider name used in logs and [`LlmProvider::name`].
     pub provider_name: String,
@@ -70,6 +70,20 @@ pub struct CompatibleConfig {
     /// prefix table. Set explicitly for models the table does not recognise (e.g. fine-tuned
     /// reasoning models whose names do not start with `o` + digit).
     pub completion_tokens_param: Option<CompletionTokensParam>,
+}
+
+impl fmt::Debug for CompatibleConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CompatibleConfig")
+            .field("provider_name", &self.provider_name)
+            .field("api_key", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("max_tokens", &self.max_tokens)
+            .field("embedding_model", &self.embedding_model)
+            .field("completion_tokens_param", &self.completion_tokens_param)
+            .finish()
+    }
 }
 
 /// [`LlmProvider`] adapter for OpenAI-compatible REST endpoints.
@@ -498,5 +512,21 @@ mod tests {
     #[test]
     fn last_reasoning_tokens_initially_none() {
         assert!(test_provider().last_reasoning_tokens().is_none());
+    }
+
+    #[test]
+    fn compatible_config_debug_redacts_api_key() {
+        let cfg = CompatibleConfig {
+            provider_name: "together-ai".into(),
+            api_key: "sk-SUPERSECRET".into(),
+            base_url: "https://api.together.xyz/v1".into(),
+            model: "meta-llama/Llama-3.3-70B-Instruct-Turbo".into(),
+            max_tokens: 4096,
+            embedding_model: None,
+            completion_tokens_param: None,
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("sk-SUPERSECRET"));
+        assert!(dbg.contains("<redacted>"));
     }
 }

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -91,7 +91,7 @@ pub enum CompletionTokensParam {
 /// };
 /// let provider = OpenAiProvider::new(cfg);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct OpenAiConfig {
     /// Secret API key sent in the `Authorization: Bearer` header.
     pub api_key: String,
@@ -119,6 +119,21 @@ pub struct OpenAiConfig {
     /// prefix table. Set explicitly for models the table does not recognise (e.g. fine-tuned
     /// reasoning models whose names do not start with `o` + digit).
     pub completion_tokens_param: Option<CompletionTokensParam>,
+}
+
+impl fmt::Debug for OpenAiConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpenAiConfig")
+            .field("api_key", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("max_tokens", &self.max_tokens)
+            .field("embedding_model", &self.embedding_model)
+            .field("reasoning_effort", &self.reasoning_effort)
+            .field("context_window", &self.context_window)
+            .field("completion_tokens_param", &self.completion_tokens_param)
+            .finish()
+    }
 }
 
 use crate::provider::{

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -2287,3 +2287,20 @@ fn set_reasoning_effort_rejects_invalid_value() {
         "invalid value must be rejected and field must remain None"
     );
 }
+
+#[test]
+fn openai_config_debug_redacts_api_key() {
+    let cfg = OpenAiConfig {
+        api_key: "sk-SUPERSECRET".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 4096,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+    };
+    let dbg = format!("{cfg:?}");
+    assert!(!dbg.contains("sk-SUPERSECRET"));
+    assert!(dbg.contains("<redacted>"));
+}


### PR DESCRIPTION
## Summary

- `GatewayConfig`, `ProviderEntry`, `ClassifiersConfig`, `CandleConfig`, and `CandleInlineConfig` (zeph-config), plus `OpenAiConfig` and `CompatibleConfig` (zeph-llm), all derived plain `Debug` while holding a vault-resolved plaintext secret (`auth_token`/`api_key`/`hf_token`). Any `{:?}` formatting (logs, panics, error chains) leaked the secret in full.
- Replaced the derive with a hand-written `impl Debug` per struct that lists every field but redacts only the secret one, matching each crate's existing precedent (`TelegramConfig`/`DiscordConfig`/`SlackConfig`/`A2aServerConfig` in zeph-config using `"[REDACTED]"`; `OpenAiProvider`/`CompatibleProvider` in zeph-llm using `"<redacted>"`).
- `ProviderEntry` also redacts `cocoon_access_hash` as a defense-in-depth measure (always empty at rest in config; closes a naming-convention foot-gun).
- `CandleInlineConfig` is embedded in `ProviderEntry`; both were fixed together and a dedicated composition test confirms the nested `hf_token` does not leak transitively through `ProviderEntry`'s own `Debug`.
- 17 new unit tests assert the secret is absent and the redaction placeholder is present in `{:?}` output, including `None`-case coverage for `Option<String>` fields.
- Retyping to `zeph_common::secret::Secret` was considered and rejected: `Secret` derives only `Deserialize` (no `Serialize`/`Clone`), which would break TOML round-tripping via `--init`/`--migrate-config` for the structs that need it.

Closes #5952, closes #5963.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12672 passed, 35 skipped, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New unit tests per struct assert secret absence + placeholder presence in `{:?}` output
- [x] Composition test confirms `ProviderEntry` does not leak `CandleInlineConfig`'s nested `hf_token`