### PR TITLE
fix(config,mcp,a2a): redact three more secret-bearing Debug/Serialize leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   path — both without any authentication. Both handlers now override `requires_auth()` to return
   `true`, matching the same defect class fixed for `/image` in #5967; the commands remain
   available from local CLI/TUI/ACP-stdio sessions.
+- `fix(config,mcp,a2a)`: three more secret-bearing config/runtime structs no longer leak
+  vault-resolved credentials through plain `Debug`/`Serialize` derives (#5968, #5965, #5964).
+  `MemoryConfig::database_url` (the resolved Postgres connection string, including embedded
+  username/password) is now wrapped in `zeph_common::secret::Secret` and skipped on
+  serialization, mirroring the existing `qdrant_api_key` field; `IbctKeyConfig::key_hex`
+  (`zeph-config`) and `IbctKey::key_bytes` (`zeph-a2a`) — the A2A HMAC signing key material —
+  now hand-write a redacting `Debug` impl that prints only `key_id`; and `McpTransport`'s
+  `Http.headers` and `Stdio.env` values (which commonly carry resolved MCP server bearer
+  tokens / API keys) are now redacted in `Debug` output while keeping header/env-var names
+  visible for diagnostics — `ServerEntry`'s derived `Debug` picks up the fix automatically via
+  per-field delegation. `Serialize` was intentionally left unchanged for all three (needed for
+  TOML config round-tripping); resolved secrets can still appear in a JSON serialization of
+  these structs, tracked as a follow-up (#6006).
 - `fix(commands)`: `/image` now requires a trusted (local) session, closing a remote arbitrary
   file read (#5967, CWE-284). `ImageCommand` previously left `requires_auth()` at its default
   `false`, so Telegram/Discord/Slack/gateway callers — none of which are trusted by

--- a/crates/zeph-a2a/src/ibct.rs
+++ b/crates/zeph-a2a/src/ibct.rs
@@ -86,13 +86,22 @@ pub enum IbctError {
 ///
 /// Multiple entries allow key rotation: old keys are kept until all in-flight tokens
 /// signed with them expire.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct IbctKey {
     /// Unique key identifier. Embedded in the token so the verifier can look it up.
     pub key_id: String,
     /// HMAC-SHA256 signing key (raw bytes, hex-encoded in config).
     #[serde(with = "hex_bytes")]
     pub key_bytes: Vec<u8>,
+}
+
+impl std::fmt::Debug for IbctKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IbctKey")
+            .field("key_id", &self.key_id)
+            .field("key_bytes", &"[REDACTED]")
+            .finish()
+    }
 }
 
 /// An Invocation-Bound Capability Token.
@@ -519,5 +528,15 @@ mod tests {
                 .verify(&[old_key, new_key], "https://agent.example.com", "task-1")
                 .is_ok()
         );
+    }
+
+    #[cfg(feature = "ibct")]
+    #[test]
+    fn ibct_key_debug_redacts_key_bytes() {
+        let key = test_key();
+        let debug = format!("{key:?}");
+        assert!(!debug.contains("super-secret-key-for-testing-only"));
+        assert!(debug.contains("k1"));
+        assert!(debug.contains("REDACTED"));
     }
 }

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -332,6 +332,18 @@ max_bot_chain_depth = 5
         assert_eq!(server.require_tls, client.require_tls);
         assert_eq!(server.ssrf_protection, client.ssrf_protection);
     }
+
+    #[test]
+    fn ibct_key_config_debug_redacts_key_hex() {
+        let key = IbctKeyConfig {
+            key_id: "primary".into(),
+            key_hex: "deadbeefdeadbeefdeadbeefdeadbeef".into(),
+        };
+        let debug = format!("{key:?}");
+        assert!(!debug.contains("deadbeefdeadbeefdeadbeefdeadbeef"));
+        assert!(debug.contains("primary"));
+        assert!(debug.contains("REDACTED"));
+    }
 }
 
 fn default_slack_port() -> u16 {
@@ -547,12 +559,21 @@ impl std::fmt::Debug for SlackConfig {
 /// An IBCT signing key entry in the A2A server configuration.
 ///
 /// Multiple entries allow key rotation: keep old keys until all tokens signed with them expire.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct IbctKeyConfig {
     /// Unique key identifier. Must match the `key_id` field in issued IBCT tokens.
     pub key_id: String,
     /// Hex-encoded HMAC-SHA256 signing key.
     pub key_hex: String,
+}
+
+impl std::fmt::Debug for IbctKeyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IbctKeyConfig")
+            .field("key_id", &self.key_id)
+            .field("key_hex", &"[REDACTED]")
+            .finish()
+    }
 }
 
 fn default_ibct_ttl() -> u64 {

--- a/crates/zeph-config/src/memory/root.rs
+++ b/crates/zeph-config/src/memory/root.rs
@@ -318,8 +318,12 @@ pub struct MemoryConfig {
     /// Can be overridden by the vault key `ZEPH_DATABASE_URL`.
     /// Example: `postgres://user:pass@localhost:5432/zeph`
     /// Default: `None` (uses `sqlite_path` instead).
-    #[serde(default)]
-    pub database_url: Option<String>,
+    ///
+    /// The value is wrapped in [`Secret`] to prevent accidental logging — it commonly
+    /// embeds a username and password. `skip_serializing` prevents it from being written
+    /// back to TOML on config save, matching [`qdrant_api_key`](Self::qdrant_api_key).
+    #[serde(default, skip_serializing)]
+    pub database_url: Option<Secret>,
     /// Cost-sensitive store routing (#2444).
     ///
     /// When `store_routing.enabled = true`, query intent is classified and routed to

--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -218,7 +218,7 @@ impl SecretResolver for Config {
         }
         if let Some(val) = vault.get_secret("ZEPH_DATABASE_URL").await? {
             register_masked_secret(registry, "ZEPH_DATABASE_URL", &val);
-            self.memory.database_url = Some(val);
+            self.memory.database_url = Some(Secret::new(val));
         }
         if let Some(val) = vault.get_secret("ZEPH_QDRANT_API_KEY").await? {
             register_masked_secret(registry, "ZEPH_QDRANT_API_KEY", &val);

--- a/crates/zeph-mcp/src/manager/mod.rs
+++ b/crates/zeph-mcp/src/manager/mod.rs
@@ -45,7 +45,7 @@ const MAX_INJECTION_PENALTIES_PER_REGISTRATION: usize = 3;
 
 /// Transport type for MCP server connections.
 #[non_exhaustive]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub enum McpTransport {
     /// Stdio: spawn child process with command + args.
     Stdio {
@@ -67,6 +67,46 @@ pub enum McpTransport {
         callback_port: u16,
         client_name: String,
     },
+}
+
+impl std::fmt::Debug for McpTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Stdio { command, args, env } => {
+                // Env values commonly carry secrets (e.g. `GITHUB_PERSONAL_ACCESS_TOKEN`) —
+                // keep var names for diagnostics, redact values.
+                let redacted: HashMap<&str, &str> =
+                    env.keys().map(|k| (k.as_str(), "[REDACTED]")).collect();
+                f.debug_struct("Stdio")
+                    .field("command", command)
+                    .field("args", args)
+                    .field("env", &redacted)
+                    .finish()
+            }
+            Self::Http { url, headers } => {
+                // Header values may carry vault-resolved secrets (e.g. `Authorization`)
+                // resolved by `build_transport` — keep keys for diagnostics, redact values.
+                let redacted: HashMap<&str, &str> =
+                    headers.keys().map(|k| (k.as_str(), "[REDACTED]")).collect();
+                f.debug_struct("Http")
+                    .field("url", url)
+                    .field("headers", &redacted)
+                    .finish()
+            }
+            Self::OAuth {
+                url,
+                scopes,
+                callback_port,
+                client_name,
+            } => f
+                .debug_struct("OAuth")
+                .field("url", url)
+                .field("scopes", scopes)
+                .field("callback_port", callback_port)
+                .field("client_name", client_name)
+                .finish(),
+        }
+    }
 }
 
 /// Connection parameters for a single MCP server consumed by [`McpManager`].

--- a/crates/zeph-mcp/src/manager/tests.rs
+++ b/crates/zeph-mcp/src/manager/tests.rs
@@ -227,6 +227,24 @@ fn transport_stdio_debug() {
 }
 
 #[test]
+fn transport_stdio_debug_redacts_env_values() {
+    let mut env = HashMap::new();
+    env.insert(
+        "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+        "ghp_super_secret_token".to_string(),
+    );
+    let transport = McpTransport::Stdio {
+        command: "npx".into(),
+        args: vec![],
+        env,
+    };
+    let dbg = format!("{transport:?}");
+    assert!(!dbg.contains("ghp_super_secret_token"));
+    assert!(dbg.contains("GITHUB_PERSONAL_ACCESS_TOKEN"));
+    assert!(dbg.contains("REDACTED"));
+}
+
+#[test]
 fn transport_http_debug() {
     let transport = McpTransport::Http {
         url: "http://example.com".into(),
@@ -235,6 +253,60 @@ fn transport_http_debug() {
     let dbg = format!("{transport:?}");
     assert!(dbg.contains("Http"));
     assert!(dbg.contains("http://example.com"));
+}
+
+#[test]
+fn transport_http_debug_redacts_header_values() {
+    let mut headers = HashMap::new();
+    headers.insert(
+        "Authorization".to_string(),
+        "Bearer sk-super-secret-token".to_string(),
+    );
+    let transport = McpTransport::Http {
+        url: "http://example.com".into(),
+        headers,
+    };
+    let dbg = format!("{transport:?}");
+    assert!(!dbg.contains("sk-super-secret-token"));
+    assert!(dbg.contains("Authorization"));
+    assert!(dbg.contains("REDACTED"));
+}
+
+#[test]
+fn server_entry_debug_redacts_http_header_values() {
+    let mut entry = make_http_entry("secret-header-test");
+    let mut headers = HashMap::new();
+    headers.insert(
+        "Authorization".to_string(),
+        "Bearer sk-super-secret-token".to_string(),
+    );
+    entry.transport = McpTransport::Http {
+        url: "http://127.0.0.1:1/nonexistent".into(),
+        headers,
+    };
+    let dbg = format!("{entry:?}");
+    assert!(!dbg.contains("sk-super-secret-token"));
+    assert!(dbg.contains("Authorization"));
+    assert!(dbg.contains("REDACTED"));
+}
+
+#[test]
+fn server_entry_debug_redacts_stdio_env_values() {
+    let mut entry = make_entry("secret-env-test");
+    let mut env = HashMap::new();
+    env.insert(
+        "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+        "ghp_super_secret_token".to_string(),
+    );
+    entry.transport = McpTransport::Stdio {
+        command: "nonexistent-mcp-binary".into(),
+        args: Vec::new(),
+        env,
+    };
+    let dbg = format!("{entry:?}");
+    assert!(!dbg.contains("ghp_super_secret_token"));
+    assert!(dbg.contains("GITHUB_PERSONAL_ACCESS_TOKEN"));
+    assert!(dbg.contains("REDACTED"));
 }
 
 fn make_http_entry(id: &str) -> ServerEntry {

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -400,12 +400,10 @@ impl AppBuilder {
     ) -> Result<SemanticMemory, BootstrapError> {
         let embed_model = self.embedding_model();
         // Resolve the database path: prefer database_url (PostgreSQL) over sqlite_path.
-        let db_path: &str = self
-            .config
-            .memory
-            .database_url
-            .as_deref()
-            .unwrap_or(&self.config.memory.sqlite_path);
+        let db_path: &str = self.config.memory.database_url.as_ref().map_or(
+            self.config.memory.sqlite_path.as_str(),
+            zeph_common::secret::Secret::expose,
+        );
 
         if zeph_db::is_postgres_url(db_path) {
             return Err(BootstrapError::Memory(

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -339,11 +339,10 @@ fn check_fs_writable(name: &str, dir: &Path) -> CheckResult {
 }
 
 fn sqlite_parent_path(config: &zeph_core::config::Config) -> PathBuf {
-    let db_path = config
-        .memory
-        .database_url
-        .as_deref()
-        .unwrap_or(&config.memory.sqlite_path);
+    let db_path = config.memory.database_url.as_ref().map_or(
+        config.memory.sqlite_path.as_str(),
+        zeph_common::secret::Secret::expose,
+    );
     Path::new(db_path)
         .parent()
         .unwrap_or(Path::new("."))
@@ -352,11 +351,10 @@ fn sqlite_parent_path(config: &zeph_core::config::Config) -> PathBuf {
 
 async fn check_sqlite(config: &zeph_core::config::Config, timeout_secs: u64) -> CheckResult {
     let start = Instant::now();
-    let db_path = config
-        .memory
-        .database_url
-        .as_deref()
-        .unwrap_or(&config.memory.sqlite_path);
+    let db_path = config.memory.database_url.as_ref().map_or(
+        config.memory.sqlite_path.as_str(),
+        zeph_common::secret::Secret::expose,
+    );
 
     // Strip the sqlite:// or sqlite:/// prefix to get the raw file path.
     let file_path = db_path

--- a/src/db_url.rs
+++ b/src/db_url.rs
@@ -9,7 +9,8 @@ pub(crate) fn resolve_db_url(config: &zeph_core::config::Config) -> &str {
     config
         .memory
         .database_url
-        .as_deref()
+        .as_ref()
+        .map(zeph_common::secret::Secret::expose)
         .filter(|s| !s.is_empty())
         .unwrap_or(&config.memory.sqlite_path)
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -856,7 +856,10 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
             max_history: state.sessions_max_history,
             title_max_chars: state.sessions_title_max_chars,
         },
-        database_url: state.database_url.clone(),
+        database_url: state
+            .database_url
+            .clone()
+            .map(zeph_common::secret::Secret::new),
         // Never write the Qdrant API key to config — it lives in the vault only.
         // The vault key ZEPH_QDRANT_API_KEY is resolved at runtime by resolve_secrets().
         qdrant_api_key: None,
@@ -2938,7 +2941,11 @@ mod tests {
         };
         let config = build_config(&state);
         assert_eq!(
-            config.memory.database_url.as_deref(),
+            config
+                .memory
+                .database_url
+                .as_ref()
+                .map(zeph_common::secret::Secret::expose),
             Some("postgres://localhost:5432/zeph"),
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

Three more instances of a recurring defect class (secret-bearing config/runtime struct with a plain `#[derive(Debug)]`/`Serialize` that leaks a vault-resolved secret in plaintext via any `{:?}` print or JSON dump):

- `MemoryConfig::database_url` (#5968) — the resolved Postgres connection string, including embedded username/password, is now wrapped in `zeph_common::secret::Secret` and skipped on serialization, mirroring the existing `qdrant_api_key` field two lines below it. All 5 read call sites updated to `Secret::expose`.
- `IbctKeyConfig::key_hex` (zeph-config) and `IbctKey::key_bytes` (zeph-a2a) (#5965) — the A2A HMAC signing key used to sign/verify Invocation-Bound Capability Tokens. Both now hand-write a redacting `Debug` impl that prints only `key_id`, matching the `TelegramConfig`/`A2aServerConfig` precedent. `Serialize`/`Deserialize` left intact for TOML round-tripping.
- `McpTransport::Http.headers` / `Stdio.env` (#5964) — resolved MCP server bearer tokens/API keys. `McpTransport` gets a hand-written `Debug` impl that redacts header and env values while keeping keys/names visible for diagnostics. `ServerEntry`'s derived `Debug` picks up the fix automatically through per-field delegation (verified with a dedicated test), so no separate manual impl was needed there.

## Known follow-up (out of scope for this PR)

`Serialize` was intentionally left unchanged for all three structs — it's required for TOML config round-tripping (`--init`/`--migrate-config`/config load-save). This means a JSON serialization of `IbctKeyConfig`/`IbctKey` or `McpTransport`/`ServerEntry` can still expose the resolved secret, even though `Debug` is now safe. No live serialize-to-log/JSON call site was found during review, so this is a latent risk, not an active leak — tracked in #6006.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12665 passed, 0 failed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression tests assert `{:?}` output for each fixed struct does not contain the raw secret value, only redaction markers / non-secret identifiers

Closes #5968, #5965, #5964.