### PR TITLE
fix(tools): forward requires_confirmation/is_tool_speculatable/execute_tool_call_confirmed through remaining ToolExecutor wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tools)`: `CompositeExecutor`, `AdversarialPolicyGateExecutor`, and `PolicyGateExecutor`
+  now forward `requires_confirmation`/`is_tool_speculatable`/`execute_tool_call_confirmed` to
+  their inner executors instead of silently falling through to the `ToolExecutor` trait's
+  no-op defaults (#5900, #5938, #5931). `CompositeExecutor::requires_confirmation` now
+  OR-forwards to both `first`/`second` leaves, mirroring the existing `is_tool_retryable`/
+  `is_tool_speculatable` pattern; `CompositeExecutor::execute_tool_call_confirmed` now
+  first-match-wins forwards, mirroring the existing `execute_confirmed` override — without it,
+  a confirmation-gating executor composed inside a `CompositeExecutor` would have its
+  confirm-bypass silently re-run the full (still-gating) `execute_tool_call` path after the
+  user approved. `AdversarialPolicyGateExecutor` and `PolicyGateExecutor` now plain-delegate
+  `requires_confirmation` (and `AdversarialPolicyGateExecutor` also `is_tool_speculatable`) to
+  `self.inner`. Same defect class as #5899/#5905/#5906 (fixed by #5930) — these three wrapper
+  layers were explicitly scoped out of that PR to keep it minimal.
 - `fix(commands)`: `/mcp` and `/plugins` now require a trusted (local) session, closing an
   unauthenticated remote code execution path (#5997, CWE-284). `McpCommand` and `PluginsCommand`
   previously left `requires_auth()` at its default `false`, so Telegram/Discord/Slack/gateway

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -244,6 +244,14 @@ impl<T: ToolExecutor> ToolExecutor for AdversarialPolicyGateExecutor<T> {
         self.inner.is_tool_retryable(tool_id)
     }
 
+    fn is_tool_speculatable(&self, tool_id: &str) -> bool {
+        self.inner.is_tool_speculatable(tool_id)
+    }
+
+    fn requires_confirmation(&self, call: &ToolCall) -> bool {
+        self.inner.requires_confirmation(call)
+    }
+
     fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
         self.inner.checkpoint_undo(n)
     }
@@ -535,6 +543,62 @@ mod tests {
         let gate = AdversarialPolicyGateExecutor::new(inner, make_validator(false), Arc::new(llm));
         let retryable = gate.is_tool_retryable("shell");
         assert!(!retryable, "MockInner returns false for is_tool_retryable");
+    }
+
+    /// Regression test for #5900: `is_tool_speculatable` must be forwarded to `self.inner`.
+    /// Before the fix it fell through to the base `ToolExecutor` default (`false`) regardless
+    /// of the inner executor's actual value.
+    #[derive(Debug)]
+    struct SpeculatableInner;
+    impl ToolExecutor for SpeculatableInner {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn delegation_is_tool_speculatable() {
+        let (_, llm) = MockLlm::new("ALLOW");
+        let gate = AdversarialPolicyGateExecutor::new(
+            SpeculatableInner,
+            make_validator(false),
+            Arc::new(llm),
+        );
+        assert!(
+            gate.is_tool_speculatable("fetch"),
+            "is_tool_speculatable must be forwarded to the inner executor's non-default value"
+        );
+    }
+
+    /// Regression test for #5931: `requires_confirmation` must be forwarded to `self.inner`.
+    /// Before the fix it fell through to the base `ToolExecutor` default (`false`) regardless
+    /// of the inner executor's actual policy.
+    #[derive(Debug)]
+    struct ConfirmationRequiredInner;
+    impl ToolExecutor for ConfirmationRequiredInner {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn delegation_requires_confirmation() {
+        let (_, llm) = MockLlm::new("ALLOW");
+        let gate = AdversarialPolicyGateExecutor::new(
+            ConfirmationRequiredInner,
+            make_validator(false),
+            Arc::new(llm),
+        );
+        assert!(
+            gate.requires_confirmation(&make_call("shell")),
+            "requires_confirmation must be forwarded to the inner executor's non-default value"
+        );
     }
 
     #[derive(Debug)]

--- a/crates/zeph-tools/src/composite.rs
+++ b/crates/zeph-tools/src/composite.rs
@@ -78,12 +78,32 @@ impl<A: ToolExecutor, B: ToolExecutor> ToolExecutor for CompositeExecutor<A, B> 
         self.second.execute_tool_call(call).await
     }
 
+    async fn execute_tool_call_confirmed(
+        &self,
+        call: &ToolCall,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        if let Some(output) = self.first.execute_tool_call_confirmed(call).await? {
+            return Ok(Some(output));
+        }
+        self.second.execute_tool_call_confirmed(call).await
+    }
+
     fn is_tool_retryable(&self, tool_id: &str) -> bool {
         self.first.is_tool_retryable(tool_id) || self.second.is_tool_retryable(tool_id)
     }
 
     fn is_tool_speculatable(&self, tool_id: &str) -> bool {
         self.first.is_tool_speculatable(tool_id) || self.second.is_tool_speculatable(tool_id)
+    }
+
+    /// Return `true` when either inner executor requires confirmation for `call`.
+    ///
+    /// Mirrors the OR-forwarding used by [`Self::is_tool_retryable`] and
+    /// [`Self::is_tool_speculatable`] — without this override the base
+    /// [`ToolExecutor::requires_confirmation`] default (`false`) silently bypasses
+    /// confirmation gating for any executor composed under `CompositeExecutor`. See #5900.
+    fn requires_confirmation(&self, call: &ToolCall) -> bool {
+        self.first.requires_confirmation(call) || self.second.requires_confirmation(call)
     }
 
     /// Forward the active skill's env injection to BOTH inner executors.
@@ -254,6 +274,105 @@ mod tests {
         assert!(debug.contains("CompositeExecutor"));
     }
 
+    /// Regression test for #5938: `execute_tool_call_confirmed` must reach the inner
+    /// executor's own `execute_tool_call_confirmed` override, not fall through to the
+    /// trait default (which re-dispatches via `execute_tool_call` and re-runs checks
+    /// the confirmed path is meant to bypass).
+    #[derive(Debug, Default)]
+    struct ConfirmedSpy {
+        confirmed_called: std::sync::Mutex<bool>,
+        unconfirmed_called: std::sync::Mutex<bool>,
+    }
+    impl ToolExecutor for ConfirmedSpy {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        async fn execute_tool_call(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            *self.unconfirmed_called.lock().unwrap() = true;
+            Ok(Some(ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "unconfirmed".to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            *self.confirmed_called.lock().unwrap() = true;
+            Ok(Some(ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "confirmed".to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_tool_call_confirmed_bypasses_unconfirmed_dispatch() {
+        let spy = ConfirmedSpy::default();
+        let composite = CompositeExecutor::new(spy, NoMatchExecutor);
+        let call = ToolCall {
+            tool_id: ToolName::new("read"),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = composite
+            .execute_tool_call_confirmed(&call)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.summary, "confirmed");
+        assert!(
+            *composite.first.confirmed_called.lock().unwrap(),
+            "execute_tool_call_confirmed must reach the inner executor's confirmed override"
+        );
+        assert!(
+            !*composite.first.unconfirmed_called.lock().unwrap(),
+            "execute_tool_call_confirmed must NOT re-dispatch through execute_tool_call"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_tool_call_confirmed_falls_through_to_second() {
+        let composite = CompositeExecutor::new(NoMatchExecutor, ConfirmedSpy::default());
+        let call = ToolCall {
+            tool_id: ToolName::new("read"),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = composite
+            .execute_tool_call_confirmed(&call)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.summary, "confirmed");
+        assert!(*composite.second.confirmed_called.lock().unwrap());
+    }
+
     #[derive(Debug)]
     struct FileToolExecutor;
     impl ToolExecutor for FileToolExecutor {
@@ -385,6 +504,64 @@ mod tests {
             fn set_effective_trust(&self, level: SkillTrustLevel) {
                 *self.last_trust.lock().unwrap() = Some(level);
             }
+        }
+
+        /// Regression test for #5900: `CompositeExecutor::requires_confirmation` must
+        /// OR-forward to both inner executors, mirroring `is_tool_retryable` and
+        /// `is_tool_speculatable`. Before the fix it fell through to the base
+        /// `ToolExecutor::requires_confirmation` default (`false`), silently dropping
+        /// any confirmation requirement declared by either leaf.
+        #[derive(Debug)]
+        struct FixedConfirmation(bool);
+        impl ToolExecutor for FixedConfirmation {
+            async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+                Ok(None)
+            }
+            fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+                self.0
+            }
+        }
+
+        fn confirmation_call() -> ToolCall {
+            ToolCall {
+                tool_id: ToolName::new("shell"),
+                params: serde_json::Map::new(),
+                caller_id: None,
+                context: None,
+                tool_call_id: String::new(),
+                skill_name: None,
+            }
+        }
+
+        #[test]
+        fn requires_confirmation_false_when_both_leaves_false() {
+            let composite =
+                CompositeExecutor::new(FixedConfirmation(false), FixedConfirmation(false));
+            assert!(!composite.requires_confirmation(&confirmation_call()));
+        }
+
+        #[test]
+        fn requires_confirmation_true_when_first_leaf_true() {
+            let composite =
+                CompositeExecutor::new(FixedConfirmation(true), FixedConfirmation(false));
+            assert!(composite.requires_confirmation(&confirmation_call()));
+        }
+
+        #[test]
+        fn requires_confirmation_true_when_second_leaf_true() {
+            let composite =
+                CompositeExecutor::new(FixedConfirmation(false), FixedConfirmation(true));
+            assert!(composite.requires_confirmation(&confirmation_call()));
+        }
+
+        #[test]
+        fn requires_confirmation_or_forwards_across_nested_composition() {
+            let nested = CompositeExecutor::new(FixedConfirmation(false), FixedConfirmation(true));
+            let outer = CompositeExecutor::new(nested, FixedConfirmation(false));
+            assert!(
+                outer.requires_confirmation(&confirmation_call()),
+                "a confirmation requirement on a nested leaf must reach the outer composite"
+            );
         }
 
         #[test]

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -381,6 +381,10 @@ impl<T: ToolExecutor> ToolExecutor for PolicyGateExecutor<T> {
         self.inner.is_tool_speculatable(tool_id)
     }
 
+    fn requires_confirmation(&self, call: &ToolCall) -> bool {
+        self.inner.requires_confirmation(call)
+    }
+
     fn checkpoint_undo(&self, n: usize) -> crate::executor::CheckpointActionResult {
         self.inner.checkpoint_undo(n)
     }
@@ -510,6 +514,45 @@ mod tests {
                 ..Default::default()
             }
         }
+    }
+
+    /// Regression test for #5931: `requires_confirmation` must be forwarded to `self.inner`.
+    /// Before the fix it fell through to the base `ToolExecutor` default (`false`) regardless
+    /// of the inner executor's actual policy.
+    #[derive(Debug)]
+    struct ConfirmationRequiredExecutor;
+
+    impl ToolExecutor for ConfirmationRequiredExecutor {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        async fn execute_tool_call(&self, _: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn requires_confirmation_delegated_to_inner() {
+        let config = PolicyConfig {
+            enabled: false,
+            default_effect: DefaultEffect::Allow,
+            rules: vec![],
+            policy_file: None,
+            policy_provider: ProviderName::default(),
+        };
+        let enforcer = Arc::new(PolicyEnforcer::compile(&config).unwrap());
+        let context = Arc::new(RwLock::new(PolicyContext {
+            trust_level: SkillTrustLevel::Trusted,
+            env: HashMap::new(),
+        }));
+        let gate = PolicyGateExecutor::new(ConfirmationRequiredExecutor, enforcer, context);
+        assert!(
+            gate.requires_confirmation(&make_call("shell")),
+            "requires_confirmation must be forwarded to the inner executor's non-default value"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `CompositeExecutor::requires_confirmation` now OR-forwards to both `first`/`second` inner executors, mirroring the existing `is_tool_retryable`/`is_tool_speculatable` pattern. Previously fell through to the trait default (`false`), silently discarding whatever the wrapped chain actually reported (#5900).
- `CompositeExecutor::execute_tool_call_confirmed` now first-match-wins forwards, mirroring the existing `execute_confirmed` override. Previously fell through to the trait default, which re-dispatched via `execute_tool_call` and re-ran the full (still-gating) confirmation check instead of bypassing it (#5938).
- `AdversarialPolicyGateExecutor::is_tool_speculatable` and `AdversarialPolicyGateExecutor`/`PolicyGateExecutor::requires_confirmation` now plain-delegate to `self.inner` (#5900, #5931).

Same defect class as #5899/#5905/#5906, fixed by #5930 — these three wrapper layers were explicitly scoped out of that PR to keep it minimal. Confirmed via direct code read that #5905/#5906 (open on GitHub only due to a comma-separated `Closes` auto-link limitation) and #5985 (`Arc<ShellExecutor>` checkpoint forwarding) are already fixed — no duplicate work in this PR.

An adversarial critique pass (verdict: minor, non-blocking) flagged that the same latent gap exists in three sibling wrappers not covered by these three issues: `CompressedExecutor` (missing `requires_confirmation`), `ToolFilter` (forwards none of the cross-cutting methods), and `Arc<ShellExecutor>`-style shadow-impls (partial). All are confirmed dormant — `TrustGateExecutor` is unconditionally the outermost confirmation authority in production wiring, so nothing is exploitable today. Kept out of scope for this PR; a follow-up issue will be filed separately.

## Test plan

- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12699/12699 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` clean
- [x] 9 new regression tests added (`composite.rs` x6, `adversarial_gate.rs` x2, `policy_gate.rs` x1), each using a spy/stub inner executor returning a distinguishable non-default value; the `execute_tool_call_confirmed` test additionally asserts the unconfirmed path was not touched

Closes #5900, #5938, #5931