### PR TITLE
fix(db): redact_url no longer leaks part of password containing '@'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Security
 
+- `zeph-db`: `redact_url` no longer leaks the tail of a Postgres password containing `@` (#5969).
+  The previous regex (`://[^:]+:[^@]+@`) stopped at the first `@`, so
+  `postgres://user:p@ss@host/db` only redacted up to `p`, leaking `ss@host` verbatim into
+  `DbError::Connection` and CLI error output (`src/commands/db.rs`). Replaced with
+  `url::Url`-based userinfo parsing, which splits on the *last* `@` before the authority ends —
+  matching real client behavior — so passwords/usernames containing `@`, multiple `@`, and IPv6
+  hosts are all handled correctly. Also now recognizes two non-userinfo libpq credential forms and
+  redacts the whole URL for them: query-param URIs (`?password=...`) and key-value DSNs
+  (`host=... password=...`), neither of which the old regex covered at all.
 - `zeph-config` / `zeph-llm`: removed derived `Debug` from 7 secret-bearing config structs that
   printed their plaintext secret verbatim in any `{:?}` output — logs, panics, error chains
   (#5952, #5963). `GatewayConfig::auth_token`, `ProviderEntry::api_key`/`cocoon_access_hash`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10695,6 +10695,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
  "uuid",
  "zeph-common",
 ]

--- a/crates/zeph-db/Cargo.toml
+++ b/crates/zeph-db/Cargo.toml
@@ -23,7 +23,6 @@ postgres = ["sqlx/postgres"]
 test-utils = ["dep:testcontainers", "dep:testcontainers-modules", "postgres"]
 
 [dependencies]
-regex = { workspace = true }
 # "macros" required for sqlx::migrate! in driver implementations.
 sqlx = { workspace = true, features = ["macros", "migrate", "runtime-tokio", "tls-rustls"] }
 testcontainers = { workspace = true, features = ["watchdog"], optional = true }
@@ -31,10 +30,12 @@ testcontainers-modules = { workspace = true, features = ["postgres"], optional =
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
+url.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 zeph-common.workspace = true
 
 [dev-dependencies]
+regex = { workspace = true }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -167,22 +167,94 @@ impl DbConfig {
     }
 }
 
-/// Strip password from a database URL for safe logging.
+/// Strip credentials from a database URL for safe logging.
 ///
-/// Replaces `://user:password@` with `://[redacted]@`.
+/// Replaces the whole userinfo component (`user[:password]@`) with `[redacted]@`.
+/// Uses [`url::Url`] rather than a regex so the split between userinfo and host
+/// follows the same rule real clients use: the LAST unescaped `@` before the
+/// path/port delimits userinfo, so a password containing `@` (e.g.
+/// `postgres://user:p@ss@host/db`) is redacted in full instead of leaving its
+/// tail exposed.
 ///
-/// Returns `None` if the URL contains no embedded credentials (already safe).
-/// Returns `Some(redacted)` if credentials were found and replaced.
+/// Also recognizes two non-userinfo credential forms accepted by libpq and
+/// redacts the whole URL for them, rather than attempting a partial rewrite:
+/// - query-param URIs, e.g. `postgresql://host/db?password=secret`
+/// - key-value DSNs, e.g. `host=localhost dbname=zeph password=secret`
+///
+/// Returns `None` if the URL matches none of the recognized credential forms
+/// above (already safe). Returns `Some(redacted)` otherwise. This covers only
+/// the known common forms listed above — a URL carrying credentials in some
+/// other, unrecognized shape can still return `None`, so callers that fall
+/// back to the raw URL on `None` should not treat that as an absolute
+/// guarantee against leaking credentials.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_db::redact_url;
+///
+/// assert_eq!(
+///     redact_url("postgres://user:secret@host:5432/db").unwrap(),
+///     "postgres://[redacted]@host:5432/db"
+/// );
+/// assert_eq!(redact_url("sqlite:///data/zeph.db"), None);
+/// ```
 #[must_use]
 pub fn redact_url(url: &str) -> Option<String> {
-    use std::sync::LazyLock;
-    static RE: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r"://[^:]+:[^@]+@").expect("static regex"));
-    if RE.is_match(url) {
-        Some(RE.replace(url, "://[redacted]@").into_owned())
-    } else {
-        None
+    match url::Url::parse(url) {
+        Ok(mut parsed) => {
+            let has_userinfo = !parsed.username().is_empty() || parsed.password().is_some();
+            let has_password_param = parsed.query().is_some_and(contains_password_assignment);
+            if !has_userinfo && !has_password_param {
+                return None;
+            }
+            if has_password_param {
+                // Query-string credentials (libpq's `?password=...`) aren't safe
+                // to selectively strip without parsing every possible param
+                // dialect; redact the whole URL instead.
+                return Some("[redacted]".to_string());
+            }
+            // Clear userinfo entirely (an empty username + no password serializes
+            // with no "@" at all), then splice in the literal "[redacted]@" marker.
+            // Setting the username directly to "[redacted]" would percent-encode
+            // the brackets (`%5Bredacted%5D`), which is correct but not the
+            // human-readable marker this function promises callers.
+            if parsed.set_username("").is_err() || parsed.set_password(None).is_err() {
+                return Some("[redacted]".to_string());
+            }
+            let without_userinfo = parsed.as_str();
+            let host_start = without_userinfo.find("://")? + "://".len();
+            let mut redacted = String::with_capacity(without_userinfo.len() + 11);
+            redacted.push_str(&without_userinfo[..host_start]);
+            redacted.push_str("[redacted]@");
+            redacted.push_str(&without_userinfo[host_start..]);
+            Some(redacted)
+        }
+        Err(_) if url.contains('@') || contains_password_assignment(url) => {
+            Some("[redacted]".to_string())
+        }
+        Err(_) => None,
     }
+}
+
+/// Case-insensitive check for a `password=` key-value assignment, as used by
+/// libpq query-param URIs (`?password=...`) and key-value DSNs
+/// (`host=... password=...`). Whitespace between `password` and `=` is
+/// tolerated since libpq DSNs allow it (`password = secret`).
+fn contains_password_assignment(s: &str) -> bool {
+    let lower = s.to_ascii_lowercase();
+    let mut offset = 0;
+    while let Some(idx) = lower[offset..].find("password") {
+        let abs = offset + idx;
+        if lower[abs + "password".len()..]
+            .trim_start()
+            .starts_with('=')
+        {
+            return true;
+        }
+        offset = abs + 1;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -208,6 +280,73 @@ mod tests {
     fn redact_url_handles_sqlite_path() {
         let url = "sqlite:/path/to/db";
         assert!(redact_url(url).is_none());
+    }
+
+    #[test]
+    fn redact_url_fully_redacts_password_with_single_at() {
+        // Regression test for #5969: a password containing `@` used to leave
+        // its tail exposed because the old regex stopped at the first `@`.
+        let url = "postgres://user:p@ss@host:5432/db";
+        let redacted = redact_url(url).unwrap();
+        assert_eq!(redacted, "postgres://[redacted]@host:5432/db");
+        assert!(!redacted.contains("ss@host") && !redacted.contains("p@ss"));
+    }
+
+    #[test]
+    fn redact_url_fully_redacts_password_with_multiple_at() {
+        let url = "postgres://user:pa@ss@wo@rd@host:5432/db";
+        let redacted = redact_url(url).unwrap();
+        assert_eq!(redacted, "postgres://[redacted]@host:5432/db");
+        assert!(!redacted.contains("pa@ss@wo@rd"));
+    }
+
+    #[test]
+    fn redact_url_fully_redacts_username_with_at() {
+        let url = "postgres://us@er:pass@host:5432/db";
+        let redacted = redact_url(url).unwrap();
+        assert_eq!(redacted, "postgres://[redacted]@host:5432/db");
+        assert!(!redacted.contains("pass") && !redacted.contains("us@er"));
+    }
+
+    #[test]
+    fn redact_url_redacts_username_only_no_password() {
+        // No password separator — the bare username is still userinfo and is
+        // redacted too (a change from the old regex, which required a `:` and
+        // left a lone username exposed).
+        let url = "postgres://user@host:5432/db";
+        let redacted = redact_url(url).unwrap();
+        assert_eq!(redacted, "postgres://[redacted]@host:5432/db");
+    }
+
+    #[test]
+    fn redact_url_unparseable_with_at_is_conservatively_redacted() {
+        let url = "not a valid url but has user:pass@host in it";
+        let redacted = redact_url(url).unwrap();
+        assert_eq!(redacted, "[redacted]");
+    }
+
+    #[test]
+    fn redact_url_unparseable_without_at_returns_none() {
+        let url = "not a valid url at all";
+        assert!(redact_url(url).is_none());
+    }
+
+    #[test]
+    fn redact_url_redacts_libpq_query_param_password() {
+        // libpq accepts credentials as query params, not just userinfo.
+        let url = "postgresql://localhost/db?user=admin&password=s3cr3t";
+        let redacted = redact_url(url).unwrap();
+        assert_eq!(redacted, "[redacted]");
+        assert!(!redacted.contains("s3cr3t"));
+    }
+
+    #[test]
+    fn redact_url_redacts_libpq_key_value_dsn_password() {
+        // libpq key-value DSNs are not URLs at all and fail url::Url::parse.
+        let url = "host=localhost dbname=zeph password=s3cr3t";
+        let redacted = redact_url(url).unwrap();
+        assert_eq!(redacted, "[redacted]");
+        assert!(!redacted.contains("s3cr3t"));
     }
 
     #[cfg(all(unix, feature = "sqlite", not(feature = "postgres")))]


### PR DESCRIPTION
## Summary
- `redact_url` used a regex whose negated character class stopped at the first `@` in the password, so `postgres://user:p@ss@host/db` only redacted up to `p`, leaking `ss@host` verbatim into `DbError::Connection` and `zeph db migrate` CLI output
- Replaced with `url::Url`-based parsing, which splits userinfo from host on the *last* `@` before the authority ends, matching real client behavior (also correctly handles multiple `@`, `@` in username, IPv6 hosts)
- Also now recognizes two non-userinfo libpq credential forms the old regex never covered at all, redacting the whole URL for them: query-param URIs (`?password=...`) and key-value DSNs (`host=... password=...`)
- Added 9 regression tests covering all of the above; 3 pre-existing tests pass unchanged

## Test plan
- [x] `cargo nextest run -p zeph-db` — all `redact_url` tests pass (11 total)
- [x] `cargo test --doc -p zeph-db` — new `# Examples` doc-test passes
- [x] Full workspace check suite: `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12698 passed), rustdoc gate — all clean
- [x] Adversarial critique round (query-param/DSN leak gap found and closed) and code review round (CHANGELOG + doc-test gaps found and closed) both completed and approved

Closes #5969.