### PR TITLE
fix(subagent,core): replay journaled result on durable subagent resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `requires_confirmation` (and `AdversarialPolicyGateExecutor` also `is_tool_speculatable`) to
   `self.inner`. Same defect class as #5899/#5905/#5906 (fixed by #5930) — these three wrapper
   layers were explicitly scoped out of that PR to keep it minimal.
+- `fix(subagent,core)`: durable sub-agent resume now replays the journaled result instead of
+  unconditionally re-spawning the child (#5944, spec-064 §P4). With `[durable].subagent = true`,
+  restarting a crashed parent whose sub-agent had already finished (and resolved its durable
+  promise) previously discarded that promise and spawned a brand-new child from scratch,
+  duplicating LLM calls and any side-effecting tool calls (git operations, GitHub issue/PR
+  creation, file writes) the finished child had already performed. `maybe_make_durable_seat` is
+  replaced by `resolve_durable_spawn_gate`, which on a resumed run performs a non-blocking check
+  (`zeph_durable::DurableContext::take_resolved_promise`, exposed via the new
+  `zeph_subagent::try_replay_durable_subagent`) for whether the child already resolved its
+  promise before the crash; if so, `handle_agent_background` and `handle_agent_spawn_foreground`
+  skip `mgr.spawn(...)` entirely and feed the journaled `SubagentResult` through the normal
+  completion path instead. A still-pending resumed promise (child's fate unknown after a crash —
+  its resolver token is unrecoverable per INV-9) falls back to the pre-existing spawn behavior,
+  matching the documented v1 scope boundary in `zeph-subagent/src/durable.rs`, and now logs a
+  `tracing::warn!` at that fallback so the residual duplicate-spawn window is observable rather
+  than silent (tracked as a known v1 limitation in #6010).
 - `fix(commands)`: `/mcp` and `/plugins` now require a trusted (local) session, closing an
   unauthenticated remote code execution path (#5997, CWE-284). `McpCommand` and `PluginsCommand`
   previously left `requires_auth()` at its default `false`, so Telegram/Discord/Slack/gateway

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2214,7 +2214,7 @@ impl<C: Channel> Agent<C> {
     /// Mirror `config.durable.subagent` onto `services.session.durable_subagent` (#5452 FR-003).
     ///
     /// A direct, unconditional config copy — no I/O, no dependency on `agent_turns`. The P4
-    /// gate at the subagent-spawn call sites (`maybe_make_durable_seat`) separately requires
+    /// gate at the subagent-spawn call sites (`resolve_durable_spawn_gate`) separately requires
     /// `durable_ctx` to be `Some`, so setting this to `true` while `agent_turns = false` is a
     /// harmless no-op there (FR-008).
     #[must_use]

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -443,16 +443,31 @@ impl<C: Channel> Agent<C> {
         let skills = self.filtered_skills_for(name);
         let cfg = self.services.orchestration.subagent_config.clone();
         let mut spawn_ctx = self.build_spawn_context(&cfg);
-        // Background durable: seat wired so child can resolve; promise dropped (background
-        // results are collected via poll_subagents, not await_durable_subagent).
+        // Background durable: seat wired so child can resolve; on a fresh run the promise
+        // (await side) is dropped — background results are collected via poll_subagents. On a
+        // resumed run whose child already finished, replay short-circuits below instead.
         self.ensure_session_durable_ctx().await;
-        if let Some(seat) = maybe_make_durable_seat(
+        match resolve_durable_spawn_gate(
             self.services.session.durable_subagent,
             self.services.session.durable_ctx.as_deref(),
         )
         .await
         {
-            spawn_ctx.durable_resolver = Some(seat);
+            DurableSpawnGate::Fresh(seat) => spawn_ctx.durable_resolver = Some(seat),
+            DurableSpawnGate::Replayed(result) => {
+                let short = &result.task_id[..8.min(result.task_id.len())];
+                return Some(if result.output.is_empty() {
+                    format!(
+                        "[sub-agent {short}] completed (no output, replayed from durable journal)"
+                    )
+                } else {
+                    format!(
+                        "[sub-agent {short}] completed (replayed from durable journal):\n{}",
+                        result.output
+                    )
+                });
+            }
+            DurableSpawnGate::None => {}
         }
         let mgr = self.services.orchestration.subagent_manager.as_mut()?;
         match mgr
@@ -480,17 +495,39 @@ impl<C: Channel> Agent<C> {
         let skills = self.filtered_skills_for(name);
         let cfg = self.services.orchestration.subagent_config.clone();
         let mut spawn_ctx = self.build_spawn_context(&cfg);
-        // Wire the durable resolver seat so the child can resolve its promise on exit.
-        // The promise (await side) is dropped here; foreground result is collected via
-        // poll_subagent_until_done which reads the join-handle output directly.
+        // Wire the durable resolver seat so the child can resolve its promise on exit. On a
+        // fresh run the promise (await side) is dropped here; foreground result is collected
+        // via poll_subagent_until_done which reads the join-handle output directly. On a
+        // resumed run whose child already finished, replay short-circuits below instead.
         self.ensure_session_durable_ctx().await;
-        if let Some(seat) = maybe_make_durable_seat(
+        match resolve_durable_spawn_gate(
             self.services.session.durable_subagent,
             self.services.session.durable_ctx.as_deref(),
         )
         .await
         {
-            spawn_ctx.durable_resolver = Some(seat);
+            DurableSpawnGate::Fresh(seat) => spawn_ctx.durable_resolver = Some(seat),
+            DurableSpawnGate::Replayed(result) => {
+                let success = result.state == zeph_subagent::SubAgentState::Completed;
+                let text = if success {
+                    result.output
+                } else {
+                    result.error.unwrap_or_else(|| "unknown error".to_owned())
+                };
+                let _ = self
+                    .channel
+                    .send(&format!(
+                        "Sub-agent '{name}' replayed from durable journal (already finished \
+                         before the parent restarted)."
+                    ))
+                    .await;
+                let _ = self
+                    .channel
+                    .notify_foreground_subagent_completed(&result.task_id, name, success)
+                    .await;
+                return Some(text);
+            }
+            DurableSpawnGate::None => {}
         }
         let mgr = self.services.orchestration.subagent_manager.as_mut()?;
         let task_id = match mgr
@@ -749,25 +786,57 @@ impl<C: Channel> Agent<C> {
     }
 }
 
-/// Create a durable resolver seat for the next sub-agent spawn when the gate is open.
+/// Outcome of checking the durable-execution gate before a sub-agent spawn (spec-064 §P4).
+enum DurableSpawnGate {
+    /// Fresh run: wire this seat into `SpawnContext::durable_resolver` so the child resolves
+    /// the promise on exit (INV-9 channel rule).
+    Fresh(zeph_subagent::DurableResolverSeat),
+    /// Resumed run whose child already resolved its promise before the parent crashed. The
+    /// caller must skip `spawn` entirely and replay this result instead — spawning here would
+    /// duplicate the LLM calls and any side-effecting tool calls the finished child already
+    /// performed (#5944).
+    Replayed(zeph_subagent::SubagentResult),
+    /// Gate closed: durable subagent support disabled, a resumed run whose child promise is
+    /// still pending (out of v1 scope — see `durable.rs` module docs "Scope boundary"), or an
+    /// error (logged at `warn`). The caller degrades to a plain spawn with no durable wiring.
+    None,
+}
+
+/// Check the durable-execution gate for the next sub-agent spawn.
 ///
-/// Returns `Some(seat)` when `enabled` is `true` and `ctx` is `Some` and the promise row
-/// was freshly created (first run). The seat goes into `SpawnContext::durable_resolver` for
-/// the child's background task (INV-9 channel rule).
-///
-/// Returns `None` when the gate is closed, on a resumed parent (token unrecoverable, INV-9),
-/// or on error (logged at `warn`) — the caller degrades to the plain spawn path.
-async fn maybe_make_durable_seat(
+/// See [`DurableSpawnGate`] for the three possible outcomes.
+async fn resolve_durable_spawn_gate(
     enabled: bool,
     ctx: Option<&zeph_durable::DurableContext>,
-) -> Option<zeph_subagent::DurableResolverSeat> {
-    let ctx = ctx.filter(|_| enabled)?;
-    match zeph_subagent::make_durable_promise(ctx).await {
-        Ok((_promise, Some(seat))) => Some(seat),
-        Ok((_promise, None)) => None, // Resumed: token unrecoverable (INV-9).
+) -> DurableSpawnGate {
+    let Some(ctx) = ctx.filter(|_| enabled) else {
+        return DurableSpawnGate::None;
+    };
+    let (promise, seat) = match zeph_subagent::make_durable_promise(ctx).await {
+        Ok(pair) => pair,
         Err(e) => {
             tracing::warn!(error = %e, "durable: make_durable_promise failed — degrading to non-durable spawn");
-            None
+            return DurableSpawnGate::None;
+        }
+    };
+    if let Some(seat) = seat {
+        return DurableSpawnGate::Fresh(seat);
+    }
+    // Resumed: token unrecoverable (INV-9). Check without blocking whether the child already
+    // resolved the promise before the crash — replay it instead of re-spawning a duplicate.
+    match zeph_subagent::try_replay_durable_subagent(ctx, &promise).await {
+        Ok(Some(result)) => DurableSpawnGate::Replayed(result),
+        Ok(None) => {
+            tracing::warn!(
+                "durable: resumed sub-agent promise still pending after restart — original \
+                 child did not resolve before the crash; re-spawning may duplicate side effects \
+                 (#5944 residual v1 gap)"
+            );
+            DurableSpawnGate::None
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "durable: replay check failed on resumed sub-agent promise — degrading to non-durable spawn");
+            DurableSpawnGate::None
         }
     }
 }
@@ -1084,7 +1153,7 @@ mod tests {
     /// Agent with `durable_ctx` populated via the real `ensure_session_durable_ctx` bootstrap
     /// path (mirrors `durable_bootstrap::tests::agent_with_conversation`), with
     /// `durable_subagent` set per `subagent_enabled` — used to test the FR-003/US-002 seat
-    /// wiring gate at `maybe_make_durable_seat`, not just the config-to-builder plumbing.
+    /// wiring gate at `resolve_durable_spawn_gate`, not just the config-to-builder plumbing.
     async fn agent_with_durable_ctx_ready(subagent_enabled: bool) -> Agent<MockChannel> {
         let provider = mock_provider(vec!["ok".into()]);
         let channel = MockChannel::new(vec![]);
@@ -1112,14 +1181,14 @@ mod tests {
     async fn seat_wired_when_subagent_enabled_and_durable_ctx_populated() {
         let agent = Box::pin(agent_with_durable_ctx_ready(true)).await;
 
-        let seat = maybe_make_durable_seat(
+        let gate = resolve_durable_spawn_gate(
             agent.services.session.durable_subagent,
             agent.services.session.durable_ctx.as_deref(),
         )
         .await;
 
         assert!(
-            seat.is_some(),
+            matches!(gate, DurableSpawnGate::Fresh(_)),
             "US-002: [durable] subagent=true with a populated durable_ctx must yield a seat, \
              not just wire the config-to-builder plumbing"
         );
@@ -1129,16 +1198,235 @@ mod tests {
     async fn seat_absent_when_subagent_disabled() {
         let agent = Box::pin(agent_with_durable_ctx_ready(false)).await;
 
-        let seat = maybe_make_durable_seat(
+        let gate = resolve_durable_spawn_gate(
             agent.services.session.durable_subagent,
             agent.services.session.durable_ctx.as_deref(),
         )
         .await;
 
         assert!(
-            seat.is_none(),
+            matches!(gate, DurableSpawnGate::None),
             "FR-008: durable_subagent=false must keep the seat gate closed even when \
              durable_ctx is populated"
+        );
+    }
+
+    // ── #5944 end-to-end replay regression tests ────────────────────────────
+    //
+    // These simulate a real parent-process restart: two *separate* `Agent` instances
+    // pointed at the same on-disk sqlite durable journal and the same `conversation_id`,
+    // so the second instance's `DurableContext` genuinely re-derives the first's
+    // `ExecutionId`/`PromiseId` (mirrors `try_replay_durable_subagent_sees_already_resolved_promise_on_resume`
+    // in `zeph-subagent/src/durable.rs`, but at the `handle_agent_background`/
+    // `handle_agent_spawn_foreground` call-site level rather than the adapter level).
+
+    fn subagent_def(name: &str) -> zeph_subagent::SubAgentDef {
+        use zeph_subagent::def::{SkillFilter, SubAgentPermissions, ToolPolicy};
+        use zeph_subagent::hooks::SubagentHooks;
+
+        zeph_subagent::SubAgentDef {
+            name: name.to_owned(),
+            description: "A helper bot".into(),
+            model: None,
+            tools: ToolPolicy::InheritAll,
+            disallowed_tools: vec![],
+            permissions: SubAgentPermissions::default(),
+            skills: SkillFilter::default(),
+            system_prompt: "You are helpful.".into(),
+            hooks: SubagentHooks::default(),
+            memory: None,
+            source: None,
+            file_path: None,
+        }
+    }
+
+    /// Builds an `Agent` wired for durable sub-agent spawns against a real sqlite file at
+    /// `db_url`, with a `SubAgentManager` carrying a single "helper" definition so
+    /// `handle_agent_background`/`handle_agent_spawn_foreground` can run past the gate check.
+    async fn agent_with_durable_and_manager(
+        db_url: &str,
+        conversation_id: i64,
+    ) -> Agent<MockChannel> {
+        let provider = mock_provider(vec!["ok".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.memory.persistence.conversation_id =
+            Some(zeph_memory::ConversationId(conversation_id));
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(db_url.to_owned());
+        agent.services.session.durable_subagent = true;
+
+        let mut mgr = zeph_subagent::SubAgentManager::new(4);
+        mgr.definitions_mut().push(subagent_def("helper"));
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        agent.ensure_session_durable_ctx().await;
+        assert!(
+            agent.services.session.durable_ctx.is_some(),
+            "test setup: durable_ctx must be populated before exercising the handler"
+        );
+        agent
+    }
+
+    #[tokio::test]
+    async fn handle_agent_background_replays_finished_child_without_respawning() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+
+        // "Run 1": the child finishes and resolves its promise before the parent crashes.
+        let agent1 = Box::pin(agent_with_durable_and_manager(&db_url, 100)).await;
+        let ctx1 = agent1.services.session.durable_ctx.clone().unwrap();
+        let (_promise1, seat) = zeph_subagent::make_durable_promise(&ctx1).await.unwrap();
+        let seat = seat.expect("test setup: run 1 must be fresh and yield a resolver seat");
+        let loop_result: Result<String, zeph_subagent::SubAgentError> =
+            Ok("child finished before crash".to_owned());
+        zeph_subagent::resolve_durable_promise(seat, "task-e2e-01", &loop_result).await;
+        agent1
+            .services
+            .session
+            .durable_writer
+            .as_ref()
+            .unwrap()
+            .flush()
+            .await
+            .unwrap();
+
+        // "Run 2": a brand-new `Agent` (simulating the restarted parent) with the same
+        // conversation_id and db file re-derives the same promise and must see it resolved.
+        let mut agent2 = Box::pin(agent_with_durable_and_manager(&db_url, 100)).await;
+
+        let resp = agent2
+            .handle_agent_background("helper", "do work")
+            .await
+            .unwrap();
+        assert!(
+            resp.contains("replayed from durable journal"),
+            "expected a replay notice, got: {resp}"
+        );
+        assert!(
+            resp.contains("child finished before crash"),
+            "expected the journaled output to be surfaced, got: {resp}"
+        );
+        assert!(
+            agent2
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap()
+                .statuses()
+                .is_empty(),
+            "mgr.spawn must not be called when the child result is replayed"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_agent_spawn_foreground_replays_finished_child_without_respawning() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+
+        // "Run 1": the child finishes and resolves its promise before the parent crashes.
+        let agent1 = Box::pin(agent_with_durable_and_manager(&db_url, 200)).await;
+        let ctx1 = agent1.services.session.durable_ctx.clone().unwrap();
+        let (_promise1, seat) = zeph_subagent::make_durable_promise(&ctx1).await.unwrap();
+        let seat = seat.expect("test setup: run 1 must be fresh and yield a resolver seat");
+        let loop_result: Result<String, zeph_subagent::SubAgentError> =
+            Ok("foreground child output".to_owned());
+        zeph_subagent::resolve_durable_promise(seat, "task-e2e-02", &loop_result).await;
+        agent1
+            .services
+            .session
+            .durable_writer
+            .as_ref()
+            .unwrap()
+            .flush()
+            .await
+            .unwrap();
+
+        // "Run 2": a brand-new `Agent` re-derives the same promise and must see it resolved,
+        // returning the journaled output directly instead of spawning and polling a new child.
+        let mut agent2 = Box::pin(agent_with_durable_and_manager(&db_url, 200)).await;
+
+        let resp = agent2
+            .handle_agent_spawn_foreground("helper", "do work")
+            .await
+            .unwrap();
+        assert_eq!(resp, "foreground child output");
+        assert!(
+            agent2
+                .channel
+                .sent_messages()
+                .iter()
+                .any(|m| m.contains("replayed from durable journal")),
+            "expected the replay notice to be sent to the channel"
+        );
+        assert!(
+            agent2
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap()
+                .statuses()
+                .is_empty(),
+            "mgr.spawn must not be called when the child result is replayed"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_agent_background_resumed_still_pending_falls_back_to_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+
+        // "Run 1": the promise is created (child spawned) but never resolved — simulates a
+        // child that was still genuinely running (or lost) when the parent crashed.
+        let agent1 = Box::pin(agent_with_durable_and_manager(&db_url, 300)).await;
+        let ctx1 = agent1.services.session.durable_ctx.clone().unwrap();
+        let (_promise1, seat) = zeph_subagent::make_durable_promise(&ctx1).await.unwrap();
+        assert!(
+            seat.is_some(),
+            "test setup: run 1 must be fresh and yield a resolver seat"
+        );
+        agent1
+            .services
+            .session
+            .durable_writer
+            .as_ref()
+            .unwrap()
+            .flush()
+            .await
+            .unwrap();
+
+        // "Run 2": resumed execution observes the same promise still pending — per the
+        // documented v1 scope boundary (INV-9: no way to recover an orphaned resolver token)
+        // the gate must degrade to a plain spawn rather than replay or block indefinitely.
+        let mut agent2 = Box::pin(agent_with_durable_and_manager(&db_url, 300)).await;
+
+        let resp = agent2
+            .handle_agent_background("helper", "do work")
+            .await
+            .unwrap();
+        assert!(
+            resp.contains("started in background"),
+            "still-pending resumed promise must fall back to a normal spawn, got: {resp}"
+        );
+        assert_eq!(
+            agent2
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap()
+                .statuses()
+                .len(),
+            1,
+            "exactly one real spawn must occur on the still-pending fallback path"
         );
     }
 }

--- a/crates/zeph-durable/src/handle.rs
+++ b/crates/zeph-durable/src/handle.rs
@@ -302,9 +302,22 @@ impl DurableContext {
         .await
     }
 
-    /// Read a promise's state and, if resolved, open and decode its value.
+    /// Read a promise's state and, if resolved, open and decode its value — without parking.
+    ///
+    /// Unlike [`await_promise`](Self::await_promise), this performs a single backend read and
+    /// returns immediately regardless of resolution state: `Ok(None)` means the promise row
+    /// exists but has not been resolved yet. Callers on an interactive path (e.g. a resumed
+    /// parent deciding whether to replay a journaled subagent result or spawn a fresh one) use
+    /// this to avoid an unbounded park on a promise that may never resolve (INV-9: a resumed
+    /// promise's resolver token is unrecoverable, so nothing can ever resolve it if the
+    /// original resolver is gone).
+    ///
+    /// # Errors
+    ///
+    /// - [`DurableError::UnknownPromise`] if the promise row is missing (e.g. pruned).
+    /// - A decode/integrity error if the resolved payload cannot be opened into `T`.
     #[tracing::instrument(name = "durable.context.take_resolved_promise", skip_all, fields(promise_id = %id.as_uuid()))]
-    async fn take_resolved_promise<T: DeserializeOwned>(
+    pub async fn take_resolved_promise<T: DeserializeOwned>(
         &self,
         id: PromiseId,
     ) -> Result<Option<T>, DurableError> {

--- a/crates/zeph-subagent/src/durable.rs
+++ b/crates/zeph-subagent/src/durable.rs
@@ -10,9 +10,9 @@
 //! # Scope boundary
 //!
 //! This adapter covers the **finished-child replay** case only: when a parent resumes after a
-//! crash and the child already resolved its promise, `await_durable_subagent` returns the
-//! journaled `SubagentResult` immediately without re-spawning the child (spec §1038, acceptance
-//! test item 4).
+//! crash and the child already resolved its promise, [`try_replay_durable_subagent`] returns the
+//! journaled `SubagentResult` immediately so the call site can skip re-spawning the child (spec
+//! §1038, acceptance test item 4).
 //!
 //! The still-running-child-on-parent-crash case is intentionally out of scope. Only the BLAKE3
 //! hash of the resolver token is persisted (INV-9); the raw 32-byte token is `Zeroizing` and
@@ -33,11 +33,18 @@
 //! `DurableContext` are available). When `durable.enabled && durable.subagent`, the call site:
 //!
 //! 1. Calls [`make_durable_promise`] to create the promise and optionally a resolver seat.
-//! 2. Places the seat in [`crate::manager::SpawnContext::durable_resolver`] before spawning.
-//! 3. Calls [`await_durable_subagent`] instead of [`crate::SubAgentManager::collect`].
+//! 2. On a **fresh** run (`seat` is `Some`) it places the seat in
+//!    [`crate::manager::SpawnContext::durable_resolver`] before spawning, so the child resolves
+//!    the promise on exit via [`resolve_durable_promise`].
+//! 3. On a **resumed** run (`seat` is `None`) it calls [`try_replay_durable_subagent`] against
+//!    the re-derived promise. If the child already resolved, the call site replays the journaled
+//!    `SubagentResult` and skips `spawn` entirely — the fix this module exists for. If the
+//!    promise is still pending, the call site falls back to a plain spawn (documented "Scope
+//!    boundary" gap above: a genuinely in-flight child cannot be re-attached to after a crash).
 //!
-//! When either flag is `false`, `SpawnContext::durable_resolver` is `None` and the plain
-//! `spawn`/`collect` path runs byte-identically to today (opt-in, zero overhead when disabled).
+//! When `durable.enabled && durable.subagent` is `false`, `SpawnContext::durable_resolver` stays
+//! `None` and the plain `spawn`/`collect` path runs byte-identically to today (opt-in, zero
+//! overhead when disabled).
 
 use std::sync::Arc;
 
@@ -170,6 +177,28 @@ pub async fn await_durable_subagent(
     }
     .instrument(span)
     .await
+}
+
+/// Non-blocking check for a resumed subagent promise's journaled result (spec §1038).
+///
+/// Unlike [`await_durable_subagent`], this never parks: it performs a single backend read and
+/// returns `Ok(None)` immediately if the child has not resolved yet. Call sites that decide
+/// between replaying a journaled result and spawning a fresh child (see module docs, "Gate
+/// pattern") use this on a resumed promise (`promise.is_resumed()`) to avoid blocking the
+/// interactive path on a promise that may never resolve — its resolver token is unrecoverable
+/// (INV-9), so nothing can resolve it if the original child is gone.
+///
+/// # Errors
+///
+/// Propagates [`DurableError`] if the promise row is missing (pruned) or the payload cannot
+/// be decoded.
+pub async fn try_replay_durable_subagent(
+    ctx: &DurableContext,
+    promise: &DurablePromise<SubagentResult>,
+) -> Result<Option<SubagentResult>, SubAgentError> {
+    ctx.take_resolved_promise(promise.id())
+        .await
+        .map_err(|e| SubAgentError::Durable(e.to_string()))
 }
 
 /// Called from the child's background task after the agent loop terminates.
@@ -320,5 +349,136 @@ mod tests {
         assert!(result.error.is_none());
         assert_eq!(result.state, crate::state::SubAgentState::Completed);
         let _ = promise_id;
+    }
+
+    /// #5944 regression: a resumed context (simulating a parent restart — a fresh
+    /// `DurableContext` over the same execution/backend, step counter reset to 0) whose child
+    /// already resolved the promise before the crash must see the journaled result via
+    /// `try_replay_durable_subagent` without parking.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn try_replay_durable_subagent_sees_already_resolved_promise_on_resume() {
+        use std::sync::Arc;
+        use zeph_durable::{
+            DurableBackendEnum, DurableConfig, DurableContext, ExecutionId, ExecutionKind,
+            JournalWriter, LocalBackend,
+        };
+
+        let exec_id = ExecutionId::new();
+        let config = DurableConfig {
+            journal_flush_interval_ms: 5,
+            journal_ack_timeout_ms: 2000,
+            ..DurableConfig::default()
+        };
+
+        let local = Arc::new(LocalBackend::open(":memory:", 1_048_576).await.unwrap());
+        local.init().await.unwrap();
+        local
+            .open_execution(exec_id, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+
+        let (writer, handle) = JournalWriter::new(local.clone(), &config);
+        let _writer_task = tokio::spawn(writer.run());
+        let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
+
+        // "Run 1": fresh promise created and resolved by the child before the parent crashes.
+        let ctx1 = DurableContext::new(
+            exec_id,
+            ExecutionKind::AgentTurn,
+            false,
+            backend.clone(),
+            handle.clone(),
+            &config,
+        );
+        let (_promise1, seat_opt) = make_durable_promise(&ctx1).await.unwrap();
+        let seat = seat_opt.expect("fresh execution must yield a resolver seat");
+        let loop_result: Result<String, crate::error::SubAgentError> =
+            Ok("finished before crash".to_owned());
+        resolve_durable_promise(seat, "task-resumed-01", &loop_result).await;
+
+        // "Run 2": simulates the restarted parent re-deriving the same promise position.
+        let ctx2 = DurableContext::new(
+            exec_id,
+            ExecutionKind::AgentTurn,
+            true,
+            backend,
+            handle,
+            &config,
+        );
+        let (promise2, seat_opt2) = make_durable_promise(&ctx2).await.unwrap();
+        assert!(
+            promise2.is_resumed(),
+            "test setup: run 2 must observe a resumed promise, not a fresh one"
+        );
+        assert!(seat_opt2.is_none());
+
+        let replayed = try_replay_durable_subagent(&ctx2, &promise2).await.unwrap();
+        let result =
+            replayed.expect("child already resolved before the crash — must replay, not spawn");
+        assert_eq!(result.task_id, "task-resumed-01");
+        assert_eq!(result.output, "finished before crash");
+        assert_eq!(result.state, crate::state::SubAgentState::Completed);
+    }
+
+    /// #5944: the still-pending resumed case must return `None` immediately rather than
+    /// parking — the caller falls back to a plain spawn (documented v1 scope gap).
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn try_replay_durable_subagent_returns_none_when_still_pending() {
+        use std::sync::Arc;
+        use zeph_durable::{
+            DurableBackendEnum, DurableConfig, DurableContext, ExecutionId, ExecutionKind,
+            JournalWriter, LocalBackend,
+        };
+
+        let exec_id = ExecutionId::new();
+        let config = DurableConfig {
+            journal_flush_interval_ms: 5,
+            journal_ack_timeout_ms: 2000,
+            ..DurableConfig::default()
+        };
+
+        let local = Arc::new(LocalBackend::open(":memory:", 1_048_576).await.unwrap());
+        local.init().await.unwrap();
+        local
+            .open_execution(exec_id, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+
+        let (writer, handle) = JournalWriter::new(local.clone(), &config);
+        let _writer_task = tokio::spawn(writer.run());
+        let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
+
+        // "Run 1": fresh promise created; the child never resolves it (still running/lost).
+        let ctx1 = DurableContext::new(
+            exec_id,
+            ExecutionKind::AgentTurn,
+            false,
+            backend.clone(),
+            handle.clone(),
+            &config,
+        );
+        let (_promise1, seat_opt) = make_durable_promise(&ctx1).await.unwrap();
+        assert!(seat_opt.is_some());
+
+        // "Run 2": resumed context re-derives the same pending promise.
+        let ctx2 = DurableContext::new(
+            exec_id,
+            ExecutionKind::AgentTurn,
+            true,
+            backend,
+            handle,
+            &config,
+        );
+        let (promise2, seat_opt2) = make_durable_promise(&ctx2).await.unwrap();
+        assert!(promise2.is_resumed());
+        assert!(seat_opt2.is_none());
+
+        let replayed = try_replay_durable_subagent(&ctx2, &promise2).await.unwrap();
+        assert!(
+            replayed.is_none(),
+            "still-pending resumed promise must return None without parking"
+        );
     }
 }

--- a/crates/zeph-subagent/src/lib.rs
+++ b/crates/zeph-subagent/src/lib.rs
@@ -62,7 +62,7 @@ pub use def::{
 };
 pub use durable::{
     DurableResolverSeat, SubagentResult, await_durable_subagent, make_durable_promise,
-    resolve_durable_promise,
+    resolve_durable_promise, try_replay_durable_subagent,
 };
 pub use error::SubAgentError;
 pub use filter::{FilteredToolExecutor, PlanModeExecutor, filter_skills};

--- a/specs/064-durable-execution/spec.md
+++ b/specs/064-durable-execution/spec.md
@@ -884,8 +884,15 @@ Respects the invariant "fire via `message_queue` injection, never direct agent c
 ### P4 — Subagent Durable Promise (`zeph-subagent`)
 
 Parent opens a `DurablePromise<SubagentResult>` at spawn time; the subagent resolves it on
-completion via the `DurableHandle` resolver. On parent crash: restarted execution's `await_promise`
-replays to the journaled resolution if the child finished, or re-parks if still running.
+completion via the `DurableHandle` resolver. On parent crash: restarted execution replays to the
+journaled resolution if the child finished (via a non-blocking check,
+`try_replay_durable_subagent` in `zeph-subagent`, wrapping `DurableContext::take_resolved_promise`)
+before spawning a fresh child. If the promise is still pending, the general re-park behavior
+described above applies to distributed backends; the v1 `LocalBackend`-only integration
+(`resolve_durable_spawn_gate` in `zeph-core`, #5944) falls back to a plain spawn instead of
+parking — subagents run as in-process tokio tasks, so a still-pending promise after a real
+process crash always means the child died with the parent (never "genuinely still running"),
+and INV-9 makes its resolver token unrecoverable either way, so parking would hang forever.
 
 The JSONL transcript remains the human-readable record; the durable journal carries resumable
 control state. Reconciles with spec-063 (worktree teardown) and spec-044 (MCP re-inherit on


### PR DESCRIPTION
## Summary

- `zeph-subagent`'s durable-promise adapter (`durable.rs`) implemented the "finished-child replay" case documented since #4954, but the only production call site in `zeph-core` discarded the resumed promise unconditionally and always re-spawned the sub-agent, duplicating LLM calls and any side-effecting tool calls (git operations, GitHub issue/PR creation, file writes) a finished child had already performed.
- `maybe_make_durable_seat` is replaced by `resolve_durable_spawn_gate` (`DurableSpawnGate::{Fresh, Replayed, None}`). On a resumed run it performs a non-blocking check via the new `zeph_subagent::try_replay_durable_subagent` (wrapping `DurableContext::take_resolved_promise`, now `pub`) for whether the child already resolved before the crash.
- `handle_agent_background` / `handle_agent_spawn_foreground` skip `mgr.spawn(...)` entirely when the promise already resolved, feeding the journaled `SubagentResult` through the normal completion-notification path instead.
- A still-pending resumed promise (child's fate unknown after a crash — resolver token unrecoverable per INV-9) falls back to the pre-existing spawn behavior, matching the documented v1 scope boundary, and now emits a `tracing::warn!` so the residual duplicate-spawn window is observable rather than silent. Tracked as a known v1 limitation in #6010.
- `specs/064-durable-execution/spec.md` §888 updated to record that the v1 `LocalBackend` integration falls back to spawn rather than re-parking, and why.

Closes #5944.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12695/12695 passing, includes 3 new end-to-end regression tests exercising `handle_agent_background`/`handle_agent_spawn_foreground` through the replay branch and the still-pending fallback, using two independently-constructed `Agent` instances over a shared on-disk sqlite journal to simulate a real parent-process restart)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-subagent -p zeph-durable -p zeph-core`
- [x] Adversarial critique (rust-critic): verdict significant → 1 gap (silent duplicate-spawn fallback path) fixed with a warning log + follow-up issue #6010; core replay/fallback design explicitly approved
- [x] Code review (rust-code-reviewer): verdict approved, all check-suite gates independently re-verified