### PR TITLE
fix(config): stop migrate-config from duplicating advisory blocks and false-reporting orchestration inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   matching the documented v1 scope boundary in `zeph-subagent/src/durable.rs`, and now logs a
   `tracing::warn!` at that fallback so the residual duplicate-spawn window is observable rather
   than silent (tracked as a known v1 limitation in #6010).
+- `fix(config)`: `--migrate-config --in-place` no longer duplicates advisory comment blocks or
+  falsely reports changes on repeated runs (#5945). `migrate_llm_stream_limits` (#4750) and the
+  two `[memory.hebbian]` splice steps (HL-F3/F4 #3345, HL-F5 #3346) guarded their idempotency by
+  checking for an *uncommented* field, but each step only ever writes a *commented* advisory
+  block — so the guard never matched the step's own prior output and re-appended the identical
+  block on every run. Guards now recognize the commented form they themselves write.
+  Separately, `migrate_orchestration_persistence` (#3107) and
+  `migrate_orchestration_asset_sensitivity` (spec-068, #3934) matched an exact
+  `"[orchestration]\n"` substring via `String::replacen` and unconditionally reported
+  `changed_count: 1` regardless of whether the replacement actually happened — `replacen`
+  silently no-ops when the pattern isn't found, so a header not immediately followed by a bare
+  newline caused a false "added" report on every run without ever writing anything. Both now
+  insert via the existing `insert_after_section` helper and only report a change when the output
+  actually differs from the input. Two same-defect-class siblings found during review are fixed
+  alongside these: `migrate_memory_hebbian_config` (HL-F1/F2, #3344) required an exact
+  `[memory.hebbian]` line match that fails against the header actually shipped in
+  `config/default.toml` (which carries a trailing inline comment), so it wrongly concluded the
+  section was absent and appended a duplicate block on the first run — this also blocked
+  `migrate_memory_hebbian_consolidation_config`/`migrate_memory_hebbian_spread_config` from ever
+  engaging against the real shipped config, since they shared the same exact-match precondition;
+  and `migrate_magic_docs_config` (#2702), which had the identical "guard checks for an
+  uncommented key the step never writes" defect as bug 1 above.
 - `fix(commands)`: `/mcp` and `/plugins` now require a trusted (local) session, closing an
   unauthenticated remote code execution path (#5997, CWE-284). `McpCommand` and `PluginsCommand`
   previously left `requires_auth()` at its default `false`, so Telegram/Discord/Slack/gateway

--- a/crates/zeph-config/src/migrate/features.rs
+++ b/crates/zeph-config/src/migrate/features.rs
@@ -9,7 +9,7 @@
 
 use regex::Regex;
 
-use super::{MigrateError, MigrationResult};
+use super::{MigrateError, MigrationResult, insert_after_section};
 
 /// Regex matching the `[tui]` section header line (used by step 67).
 static TUI_HEADER_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
@@ -298,6 +298,11 @@ pub fn migrate_autodream_config(toml_src: &str) -> Result<MigrationResult, Migra
 
 /// Add a commented-out `[magic_docs]` block if absent (#2702).
 ///
+/// Idempotent: skipped when an active `magic_docs` key is present, or when this step's own
+/// prior commented output (`# [magic_docs]`) is already present — `doc.contains_key` alone only
+/// recognizes an active key, so without the second check this step re-appended the block on
+/// every subsequent run (#5945).
+///
 /// # Errors
 ///
 /// Returns `MigrateError::Parse` if the TOML cannot be parsed.
@@ -306,7 +311,8 @@ pub fn migrate_magic_docs_config(toml_src: &str) -> Result<MigrationResult, Migr
 
     let mut doc = toml_src.parse::<toml_edit::DocumentMut>()?;
 
-    if doc.contains_key("magic_docs") {
+    let commented_present = toml_src.lines().any(|l| l.trim() == "# [magic_docs]");
+    if doc.contains_key("magic_docs") || commented_present {
         return Ok(MigrationResult {
             output: toml_src.to_owned(),
             changed_count: 0,
@@ -339,12 +345,20 @@ pub fn migrate_magic_docs_config(toml_src: &str) -> Result<MigrationResult, Migr
 /// Existing configs that omit this key pick up `true` via `#[serde(default)]`, so this
 /// migration is informational — it surfaces the new option without changing behaviour.
 ///
+/// Uses `insert_after_section` rather than an exact `"[orchestration]\n"` substring match, so
+/// insertion still succeeds when the header line carries trailing content (e.g. an inline
+/// comment from another step) instead of being followed immediately by a newline. The report
+/// only claims success when `output` actually differs from `toml_src` — `String::replacen`
+/// silently returns the input unchanged when its pattern isn't found, and blindly trusting it
+/// produced a false "added" report on every run without ever writing anything (#5945).
+///
 /// # Errors
 ///
 /// Returns [`MigrateError`] if the TOML document cannot be parsed.
 pub fn migrate_orchestration_persistence(toml_src: &str) -> Result<MigrationResult, MigrateError> {
-    // Skip if the key is already present (active or commented).
-    if toml_src.contains("persistence_enabled") || toml_src.contains("# persistence_enabled") {
+    // Skip if the key is already present — `contains` is a substring search, so this already
+    // matches both the active key and this step's own commented output (`# persistence_enabled`).
+    if toml_src.contains("persistence_enabled") {
         return Ok(MigrationResult {
             output: toml_src.to_owned(),
             changed_count: 0,
@@ -361,14 +375,21 @@ pub fn migrate_orchestration_persistence(toml_src: &str) -> Result<MigrationResu
         });
     }
 
-    // Insert the commented key right after the `[orchestration]` header line.
-    let comment = "# persistence_enabled = true  \
+    let comment = "\n# persistence_enabled = true  \
         # persist task graphs to SQLite after each tick; enables `/plan resume <id>` (#3107)\n";
-    let output = toml_src.replacen(
-        "[orchestration]\n",
-        &format!("[orchestration]\n{comment}"),
-        1,
-    );
+    let output = insert_after_section(toml_src, "orchestration", comment);
+    // Defensive: the guards above already guarantee `[orchestration]` is present and
+    // `insert_after_section` always inserts non-empty content when reached, so this is
+    // currently unreachable — kept so a future change to either guard can't silently
+    // regress into reporting a change that didn't happen (the original defect, #5945).
+    if output == toml_src {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
     Ok(MigrationResult {
         output,
         changed_count: 1,
@@ -729,15 +750,22 @@ pub fn migrate_tui_theme_config(toml_src: &str) -> Result<MigrationResult, Migra
 /// Advisory only: the migration is informational — it surfaces the new option without
 /// changing behaviour. Skipped when the key is already present or `[orchestration]` is absent.
 ///
+/// Uses `insert_after_section` rather than an exact `"[orchestration]\n"` substring match, so
+/// insertion still succeeds when the header line carries trailing content (e.g. an inline
+/// comment from another step) instead of being followed immediately by a newline. The report
+/// only claims success when `output` actually differs from `toml_src` — `String::replacen`
+/// silently returns the input unchanged when its pattern isn't found, and blindly trusting it
+/// produced a false "added" report on every run without ever writing anything (#5945).
+///
 /// # Errors
 ///
 /// Returns [`MigrateError`] if the TOML document cannot be parsed.
 pub fn migrate_orchestration_asset_sensitivity(
     toml_src: &str,
 ) -> Result<MigrationResult, MigrateError> {
-    if toml_src.contains("default_asset_sensitivity")
-        || toml_src.contains("# default_asset_sensitivity")
-    {
+    // `contains` is a substring search, so this already matches both the active key and this
+    // step's own commented output (`# default_asset_sensitivity`).
+    if toml_src.contains("default_asset_sensitivity") {
         return Ok(MigrationResult {
             output: toml_src.to_owned(),
             changed_count: 0,
@@ -753,13 +781,21 @@ pub fn migrate_orchestration_asset_sensitivity(
         });
     }
 
-    let comment = "# default_asset_sensitivity = \"public\"  \
+    let comment = "\n# default_asset_sensitivity = \"public\"  \
         # advisory asset sensitivity: public | internal | confidential (spec-068, #3934)\n";
-    let output = toml_src.replacen(
-        "[orchestration]\n",
-        &format!("[orchestration]\n{comment}"),
-        1,
-    );
+    let output = insert_after_section(toml_src, "orchestration", comment);
+    // Defensive: the guards above already guarantee `[orchestration]` is present and
+    // `insert_after_section` always inserts non-empty content when reached, so this is
+    // currently unreachable — kept so a future change to either guard can't silently
+    // regress into reporting a change that didn't happen (the original defect, #5945).
+    if output == toml_src {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
     Ok(MigrationResult {
         output,
         changed_count: 1,

--- a/crates/zeph-config/src/migrate/llm.rs
+++ b/crates/zeph-config/src/migrate/llm.rs
@@ -1147,12 +1147,23 @@ pub fn migrate_cocoon_show_balance(toml_src: &str) -> Result<MigrationResult, Mi
 /// All three fields carry compile-time defaults that reproduce pre-existing behavior, so
 /// existing deployments that skip the section are unaffected.
 ///
+/// Idempotent: `section_header_present` only recognizes an *active* header, so it never
+/// matches this step's own prior output (a commented `# [llm.stream_limits]` header) — an
+/// explicit line check for the commented form is required to avoid re-appending the block
+/// on every subsequent run (#5945).
+///
 /// # Errors
 ///
 /// This function is infallible in practice; the `Result` return type matches the
 /// migration function convention for use in chained pipelines.
 pub fn migrate_llm_stream_limits(toml_src: &str) -> Result<MigrationResult, MigrateError> {
-    if section_header_present(toml_src, "llm.stream_limits") || !toml_src.contains("[llm]") {
+    let commented_present = toml_src
+        .lines()
+        .any(|l| l.trim() == "# [llm.stream_limits]");
+    if section_header_present(toml_src, "llm.stream_limits")
+        || commented_present
+        || !toml_src.contains("[llm]")
+    {
         return Ok(MigrationResult {
             output: toml_src.to_owned(),
             changed_count: 0,

--- a/crates/zeph-config/src/migrate/memory.rs
+++ b/crates/zeph-config/src/migrate/memory.rs
@@ -7,7 +7,7 @@
 //! the [`Migration`](super::Migration) trait, and the [`MIGRATIONS`](super::MIGRATIONS)
 //! registry remain in the parent module.
 
-use super::{MigrateError, MigrationResult, insert_after_section};
+use super::{MigrateError, MigrationResult, insert_after_section, section_header_present};
 
 /// Add a commented-out `[memory.forgetting]` section if absent (#2397).
 ///
@@ -281,18 +281,19 @@ pub fn migrate_memory_reasoning_judge_config(
 
 /// Append a commented-out `[memory.hebbian]` block to `toml_src` when it is absent (HL-F1/F2, #3344).
 ///
-/// Idempotent: if a `[memory.hebbian]` or `# [memory.hebbian]` line already exists,
-/// the input is returned unchanged with `changed_count = 0`.
+/// Idempotent: skipped when an active `[memory.hebbian]` header is present — via
+/// `section_header_present`, which tolerates a trailing inline comment (the shipped
+/// `config/default.toml` header reads `[memory.hebbian]  # HL-F1/F2 (#3344) ...`, which an exact
+/// `l.trim() == "[memory.hebbian]"` line match fails to recognize, #5945) — or when this step's
+/// own prior commented output (`# [memory.hebbian]`) is already present.
 ///
 /// # Errors
 ///
 /// This function is infallible in practice; the `Result` return type matches the migration
 /// function convention for use in chained pipelines.
 pub fn migrate_memory_hebbian_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
-    if toml_src
-        .lines()
-        .any(|l| l.trim() == "[memory.hebbian]" || l.trim() == "# [memory.hebbian]")
-    {
+    let commented_present = toml_src.lines().any(|l| l.trim() == "# [memory.hebbian]");
+    if section_header_present(toml_src, "memory.hebbian") || commented_present {
         return Ok(MigrationResult {
             output: toml_src.to_owned(),
             changed_count: 0,
@@ -327,7 +328,11 @@ pub fn migrate_memory_hebbian_config(toml_src: &str) -> Result<MigrationResult, 
 pub fn migrate_memory_hebbian_consolidation_config(
     toml_src: &str,
 ) -> Result<MigrationResult, MigrateError> {
-    let has_section = toml_src.lines().any(|l| l.trim() == "[memory.hebbian]");
+    // `section_header_present` tolerates a trailing inline comment on the header line — an
+    // exact `l.trim() == "[memory.hebbian]"` match fails against the shipped
+    // `config/default.toml` header (`[memory.hebbian]  # HL-F1/F2 (#3344) ...`), which meant
+    // this step never engaged against the project's own real config (#5945).
+    let has_section = section_header_present(toml_src, "memory.hebbian");
 
     if !has_section {
         return Ok(MigrationResult {
@@ -337,16 +342,22 @@ pub fn migrate_memory_hebbian_consolidation_config(
         });
     }
 
-    // Check if all consolidation fields already present (active or commented).
-    let has_interval = toml_src
-        .lines()
-        .any(|l| l.trim().starts_with("consolidation_interval_secs"));
-    let has_threshold = toml_src
-        .lines()
-        .any(|l| l.trim().starts_with("consolidation_threshold"));
-    let has_provider = toml_src
-        .lines()
-        .any(|l| l.trim().starts_with("consolidate_provider"));
+    // Check if all consolidation fields already present (active or commented). The step's
+    // own prior output is always commented (`# consolidation_interval_secs = ...`), so the
+    // leading `#` must be stripped before the prefix check — otherwise this guard never
+    // matches its own output and the block duplicates on every subsequent run (#5945).
+    let has_field = |field: &str| {
+        toml_src.lines().any(|l| {
+            let trimmed = l.trim();
+            trimmed
+                .strip_prefix('#')
+                .map_or(trimmed, str::trim_start)
+                .starts_with(field)
+        })
+    };
+    let has_interval = has_field("consolidation_interval_secs");
+    let has_threshold = has_field("consolidation_threshold");
+    let has_provider = has_field("consolidate_provider");
 
     if has_interval && has_threshold && has_provider {
         return Ok(MigrationResult {
@@ -387,7 +398,11 @@ pub fn migrate_memory_hebbian_consolidation_config(
 pub fn migrate_memory_hebbian_spread_config(
     toml_src: &str,
 ) -> Result<MigrationResult, MigrateError> {
-    let has_section = toml_src.lines().any(|l| l.trim() == "[memory.hebbian]");
+    // `section_header_present` tolerates a trailing inline comment on the header line — an
+    // exact `l.trim() == "[memory.hebbian]"` match fails against the shipped
+    // `config/default.toml` header (`[memory.hebbian]  # HL-F1/F2 (#3344) ...`), which meant
+    // this step never engaged against the project's own real config (#5945).
+    let has_section = section_header_present(toml_src, "memory.hebbian");
 
     if !has_section {
         return Ok(MigrationResult {
@@ -397,19 +412,23 @@ pub fn migrate_memory_hebbian_spread_config(
         });
     }
 
-    // Check if all HL-F5 fields are already present (active or commented).
-    let has_spreading = toml_src
-        .lines()
-        .any(|l| l.trim().starts_with("spreading_activation"));
-    let has_depth = toml_src
-        .lines()
-        .any(|l| l.trim().starts_with("spread_depth"));
-    let has_budget = toml_src
-        .lines()
-        .any(|l| l.trim().starts_with("step_budget_ms"));
-    let has_embed_timeout = toml_src
-        .lines()
-        .any(|l| l.trim().starts_with("embed_timeout_secs"));
+    // Check if all HL-F5 fields are already present (active or commented). The step's own
+    // prior output is always commented (`# spreading_activation = ...`), so the leading `#`
+    // must be stripped before the prefix check — otherwise this guard never matches its own
+    // output and the block duplicates on every subsequent run (#5945).
+    let has_field = |field: &str| {
+        toml_src.lines().any(|l| {
+            let trimmed = l.trim();
+            trimmed
+                .strip_prefix('#')
+                .map_or(trimmed, str::trim_start)
+                .starts_with(field)
+        })
+    };
+    let has_spreading = has_field("spreading_activation");
+    let has_depth = has_field("spread_depth");
+    let has_budget = has_field("step_budget_ms");
+    let has_embed_timeout = has_field("embed_timeout_secs");
 
     if has_spreading && has_depth && has_budget && has_embed_timeout {
         return Ok(MigrationResult {

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -1695,19 +1695,18 @@ fn registry_names_are_unique_and_non_empty() {
 
 #[test]
 fn registry_is_idempotent_on_empty_input() {
-    // Migrations that append comment blocks cannot be idempotent by design:
-    // comment text is not parsed as TOML keys, so presence checks always fail.
-    const COMMENT_ONLY: &[&str] = &["migrate_magic_docs_config"];
-
+    // `migrate_magic_docs_config` used to be excluded here under the assumption that a step
+    // which only ever appends a commented block cannot be idempotent (comment text is not
+    // parsed as TOML keys, so a presence check against parsed keys always fails). That
+    // assumption was wrong: the fix is to additionally check for the step's own commented
+    // output as plain text, the same pattern `migrate_skills_registry` and the other steps
+    // fixed for #5945 use — no exclusion needed once that's in place.
     let mut toml = String::new();
     for m in MIGRATIONS.iter() {
         let result = m.apply(&toml).expect("registry migration must not fail");
         toml = result.output;
     }
     for m in MIGRATIONS.iter() {
-        if COMMENT_ONLY.contains(&m.name()) {
-            continue;
-        }
         let result = m
             .apply(&toml)
             .expect("registry migration must not fail on second pass");
@@ -3444,5 +3443,321 @@ fn step_74_idempotent_on_own_output() {
     assert_eq!(
         second.output, first.output,
         "output unchanged on second run"
+    );
+}
+
+// ── migrate_llm_stream_limits idempotency regression (#4750, #5945) ──
+//
+// The guard previously used `section_header_present`, which by design returns `false` for a
+// *commented* header — so the step never recognized its own prior output and re-appended the
+// block on every subsequent run.
+
+#[test]
+fn stream_limits_injects_commented_block_when_llm_section_present() {
+    let src = "[llm]\nprovider = \"ollama\"\n";
+    let result = migrate_llm_stream_limits(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("# [llm.stream_limits]"));
+    assert_eq!(result.sections_changed, vec!["llm.stream_limits"]);
+}
+
+#[test]
+fn stream_limits_noop_when_llm_section_absent() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_llm_stream_limits(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn stream_limits_idempotent_on_own_output() {
+    let src = "[llm]\nprovider = \"ollama\"\n";
+    let first = migrate_llm_stream_limits(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_llm_stream_limits(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
+    );
+    let third = migrate_llm_stream_limits(&second.output).expect("third migrate");
+    assert_eq!(third.changed_count, 0, "third run must also be a no-op");
+    assert_eq!(
+        third.output.matches("[llm.stream_limits]").count(),
+        1,
+        "block must not accumulate across repeated runs"
+    );
+}
+
+// ── migrate_memory_hebbian_consolidation_config idempotency regression (HL-F3/F4, #3345, #5945) ──
+//
+// The guard checked `l.trim().starts_with("consolidation_interval_secs")`, but the step's own
+// prior output is commented (`# consolidation_interval_secs = ...`), so the check never matched
+// and the block re-accumulated on every subsequent run.
+
+#[test]
+fn hebbian_consolidation_injects_fields_when_section_present() {
+    let src = "[memory.hebbian]\nenabled = true\n";
+    let result = migrate_memory_hebbian_consolidation_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("HL-F3/F4 consolidation fields"));
+}
+
+#[test]
+fn hebbian_consolidation_noop_when_section_absent() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_memory_hebbian_consolidation_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn hebbian_consolidation_idempotent_on_own_output() {
+    let src = "[memory.hebbian]\nenabled = true\n";
+    let first = migrate_memory_hebbian_consolidation_config(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second =
+        migrate_memory_hebbian_consolidation_config(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    let third = migrate_memory_hebbian_consolidation_config(&second.output).expect("third migrate");
+    assert_eq!(third.changed_count, 0, "third run must also be a no-op");
+    assert_eq!(
+        third
+            .output
+            .matches("HL-F3/F4 consolidation fields")
+            .count(),
+        1,
+        "block must not accumulate across repeated runs"
+    );
+}
+
+// ── migrate_memory_hebbian_spread_config idempotency regression (HL-F5, #3346, #5945) ──
+//
+// Same defect shape as the consolidation step above: the guard checked
+// `l.trim().starts_with("spreading_activation")`, which never matches the step's own commented
+// output.
+
+#[test]
+fn hebbian_spread_injects_fields_when_section_present() {
+    let src = "[memory.hebbian]\nenabled = true\n";
+    let result = migrate_memory_hebbian_spread_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("HL-F5 spreading-activation fields"));
+}
+
+#[test]
+fn hebbian_spread_noop_when_section_absent() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_memory_hebbian_spread_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn hebbian_spread_idempotent_on_own_output() {
+    let src = "[memory.hebbian]\nenabled = true\n";
+    let first = migrate_memory_hebbian_spread_config(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_memory_hebbian_spread_config(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    let third = migrate_memory_hebbian_spread_config(&second.output).expect("third migrate");
+    assert_eq!(third.changed_count, 0, "third run must also be a no-op");
+    assert_eq!(
+        third
+            .output
+            .matches("HL-F5 spreading-activation fields")
+            .count(),
+        1,
+        "block must not accumulate across repeated runs"
+    );
+}
+
+// ── migrate_orchestration_persistence idempotency regression (#3107, #5945) ──
+//
+// The step used `toml_src.replacen("[orchestration]\n", ..., 1)`, an exact-substring match that
+// silently no-ops when the header line is followed by anything other than a bare newline, while
+// `changed_count` was unconditionally reported as 1 regardless of whether the replacement
+// actually happened.
+
+#[test]
+fn orchestration_persistence_injects_key_when_section_present() {
+    let src = "[orchestration]\nenabled = true\n";
+    let result = migrate_orchestration_persistence(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("persistence_enabled"));
+    assert_eq!(
+        result.sections_changed,
+        vec!["orchestration.persistence_enabled"]
+    );
+}
+
+#[test]
+fn orchestration_persistence_noop_when_no_orchestration_section() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_orchestration_persistence(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn orchestration_persistence_noop_when_key_already_present() {
+    let src = "[orchestration]\npersistence_enabled = true\n";
+    let result = migrate_orchestration_persistence(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn orchestration_persistence_idempotent_on_own_output() {
+    let src = "[orchestration]\nenabled = true\n";
+    let first = migrate_orchestration_persistence(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_orchestration_persistence(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
+    );
+}
+
+#[test]
+fn orchestration_persistence_detects_and_skips_header_without_trailing_newline() {
+    // Simulates the header being immediately followed by other inserted content instead of a
+    // bare newline (e.g. another step's inline comment glued onto the header line). The old
+    // exact-match `replacen` would silently no-op here while still reporting `changed_count: 1`.
+    let src = "[orchestration]# some other advisory comment\nenabled = true\n";
+    let result = migrate_orchestration_persistence(src).expect("migrate");
+    assert_ne!(
+        result.output, src,
+        "output must actually change when changed_count is reported as 1"
+    );
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("persistence_enabled"));
+
+    // Running again over the actually-mutated output must be a true no-op.
+    let second = migrate_orchestration_persistence(&result.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0);
+    assert_eq!(second.output, result.output);
+}
+
+// ── migrate_orchestration_asset_sensitivity idempotency regression (spec-068, #3934, #5945) ──
+//
+// Same defect shape as `migrate_orchestration_persistence` above.
+
+#[test]
+fn orchestration_asset_sensitivity_detects_and_skips_header_without_trailing_newline() {
+    let src = "[orchestration]# some other advisory comment\nenabled = true\n";
+    let result = migrate_orchestration_asset_sensitivity(src).expect("migrate");
+    assert_ne!(
+        result.output, src,
+        "output must actually change when changed_count is reported as 1"
+    );
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("default_asset_sensitivity"));
+
+    // Running again over the actually-mutated output must be a true no-op.
+    let second = migrate_orchestration_asset_sensitivity(&result.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0);
+    assert_eq!(second.output, result.output);
+}
+
+// ── migrate_memory_hebbian_config idempotency regression (HL-F1/F2, #3344, #5945) ──
+//
+// The no-op guard required an exact `l.trim() == "[memory.hebbian]"` line match, but the header
+// in the shipped `config/default.toml` carries a trailing inline comment
+// (`[memory.hebbian]  # HL-F1/F2 (#3344) ...`), so the guard never recognized it as present and
+// appended a duplicate commented block on the first run. This also gated
+// `migrate_memory_hebbian_consolidation_config` / `migrate_memory_hebbian_spread_config`, whose
+// own `has_section` precondition used the identical exact-line match — both never engaged
+// against the real shipped config.
+
+#[test]
+fn hebbian_base_injects_block_when_section_absent() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_memory_hebbian_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("[memory.hebbian]"));
+    assert_eq!(result.sections_changed, vec!["memory.hebbian"]);
+}
+
+#[test]
+fn hebbian_base_noop_when_active_header_has_trailing_inline_comment() {
+    // Mirrors the real config/default.toml header shape.
+    let src = "[memory.hebbian]                       # HL-F1/F2 (#3344) Hebbian edge reinforcement\nenabled = true\n";
+    let result = migrate_memory_hebbian_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn hebbian_base_idempotent_on_own_output() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let first = migrate_memory_hebbian_config(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_memory_hebbian_config(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    let third = migrate_memory_hebbian_config(&second.output).expect("third migrate");
+    assert_eq!(third.changed_count, 0, "third run must also be a no-op");
+    assert_eq!(
+        third.output.matches("HL-F1/F2").count(),
+        1,
+        "block must not accumulate across repeated runs"
+    );
+}
+
+#[test]
+fn hebbian_consolidation_and_spread_engage_against_real_default_toml_header_shape() {
+    // Regression for the precondition bug: both steps used to require an exact
+    // `l.trim() == "[memory.hebbian]"` match, which fails against a header carrying a trailing
+    // inline comment — the shape actually shipped in config/default.toml.
+    let src = "[memory.hebbian]                       # HL-F1/F2 (#3344) Hebbian edge reinforcement\nenabled = true\n";
+    let consolidation = migrate_memory_hebbian_consolidation_config(src).expect("migrate");
+    assert_eq!(
+        consolidation.changed_count, 1,
+        "consolidation step must engage when the header carries a trailing inline comment"
+    );
+    let spread = migrate_memory_hebbian_spread_config(src).expect("migrate");
+    assert_eq!(
+        spread.changed_count, 1,
+        "spread step must engage when the header carries a trailing inline comment"
+    );
+}
+
+// ── migrate_magic_docs_config idempotency regression (#2702, #5945) ──
+//
+// The guard checked `doc.contains_key("magic_docs")` on the re-parsed document, but the step
+// only ever writes a *commented* `# [magic_docs]` block, which is never a parsed table key — so
+// the guard was always false on the next run and the block duplicated on every subsequent run.
+
+#[test]
+fn magic_docs_injects_block_when_absent() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_magic_docs_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("# [magic_docs]"));
+    assert_eq!(result.sections_changed, vec!["magic_docs"]);
+}
+
+#[test]
+fn magic_docs_noop_when_active_key_present() {
+    let src = "[magic_docs]\nenabled = true\n";
+    let result = migrate_magic_docs_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn magic_docs_idempotent_on_own_output() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let first = migrate_magic_docs_config(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_magic_docs_config(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    let third = migrate_magic_docs_config(&second.output).expect("third migrate");
+    assert_eq!(third.changed_count, 0, "third run must also be a no-op");
+    assert_eq!(
+        third.output.matches("# [magic_docs]").count(),
+        1,
+        "block must not accumulate across repeated runs"
     );
 }


### PR DESCRIPTION
## Summary

Fixes two idempotency bugs in `--migrate-config --in-place` surfaced during live testing (CI-1300), plus two same-defect-class siblings found and fixed during this PR's review cycle:

- `migrate_llm_stream_limits` and the `[memory.hebbian]` splice steps (HL-F3/F4, HL-F5) guarded idempotency by checking for an *uncommented* field, but each step only ever writes a *commented* advisory block — the guard never matched its own prior output, so the block was re-appended on every run. Guards now recognize the commented form they themselves write.
- `migrate_orchestration_persistence` and `migrate_orchestration_asset_sensitivity` matched an exact `"[orchestration]\n"` substring via `String::replacen`, which silently no-ops when an earlier step concatenated content onto the header with no newline, while unconditionally reporting `changed_count: 1`. Both now insert via the existing `insert_after_section` helper and only report a change when the output actually differs from the input.
- `migrate_memory_hebbian_config` (and its `_consolidation`/`_spread` siblings) required an exact `[memory.hebbian]` line match that fails against the header actually shipped in `config/default.toml` (which carries a trailing inline comment) — this also blocked the HL-F3/F4/HL-F5 fix above from ever being exercised against the real config during testing. Fixed to use the shared `section_header_present()` helper.
- `migrate_magic_docs_config` had the identical "guard checks for an uncommented key the step never writes" defect as the first bug — bundled in since it duplicates on the same command.

Closes #5945.

Explicitly out of scope (same defect class, confirmed live, deferred to a follow-up issue to keep this PR bounded): the `mcp`/`mcp.elicitation` migration step and `migrate_memory_retrieval_query_bias`.

## Verification

- `cargo nextest -p zeph-config`: 704/704 passed (22 new/changed tests).
- Full workspace `fmt --check`, `clippy --profile ci --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing"`, and the rustdoc gate: clean.
- Full workspace `nextest --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins`: 12712 passed, 0 failed (one pre-existing flaky test in an unrelated, untouched module, confirmed transient).
- Live repro against the real `config/default.toml`: run 1 applies all fixes (28 entries added), runs 2 and 3 are byte-identical no-ops — confirmed via full-file diff, not just per-section counts.

## Test plan

- [x] Unit tests: idempotency guards for all 7 fixed migration steps run twice, second pass asserts `changed_count == 0`
- [x] `registry_is_idempotent_on_empty_input` now passes with zero step exclusions (previously excluded `COMMENT_ONLY` steps as "can't be idempotent by design" — that assumption was wrong)
- [x] Live repro against real `config/default.toml`, 3 consecutive `--migrate-config --in-place` runs, byte-identical output after run 1
- [x] Full workspace check suite (fmt/clippy/nextest/rustdoc) green