### PR TITLE
fix(vault)!: default vault backend to age and reject unknown backend strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   hosts are all handled correctly. Also now recognizes two non-userinfo libpq credential forms and
   redacts the whole URL for them: query-param URIs (`?password=...`) and key-value DSNs
   (`host=... password=...`), neither of which the old regex covered at all.
+- **BREAKING**: `vault.backend` now defaults to `age` instead of `env` when a config omits the
+  `[vault]` section entirely (#5953). This aligns runtime behavior with the already-documented
+  default in `specs/010-security/spec.md` and `specs/038-vault/spec.md` — a fresh config with no
+  `[vault]` section previously resolved secrets from process environment variables silently;
+  it now requires an age vault identity (`~/.config/zeph/vault-key.txt` and `secrets.age`, or
+  `--vault-key`/`--vault-path`). Existing deployments that relied on the implicit `env` default
+  must either run `zeph vault init` to provision an age vault, or explicitly set
+  `vault.backend = "env"` in `config.toml` (understanding this stores secrets in plaintext
+  environment variables). `config/default.toml` and `crates/zeph-core/config/default.toml` were
+  updated to match; no config migration step was added because the previous `env` default was
+  never a persisted value — only a parse-time fallback applied to configs that omit the key.
+- `parse_backend_str` (the parser for the `--vault` CLI flag and `ZEPH_VAULT_BACKEND` env var)
+  now rejects unrecognized backend names with a hard error instead of silently falling back to
+  the weaker `env` backend with only a `tracing::warn!` log line (#5954). Combined with the
+  #5953 default change, a typo in `--vault`/`ZEPH_VAULT_BACKEND` (e.g. `--vault aeg`) previously
+  downgraded the effective secret-storage backend for the whole process without a startup
+  failure. `parse_vault_args` now returns `Result<VaultArgs, String>`; `AppBuilder::new` and the
+  `bench`/`doctor`/`gonka`/`cocoon` commands that call it propagate the error instead of
+  continuing with a silently-downgraded backend.
+
 - `zeph-config` / `zeph-llm`: removed derived `Debug` from 7 secret-bearing config structs that
   printed their plaintext secret verbatim in any `{:?}` output — logs, panics, error chains
   (#5952, #5963). `GatewayConfig::auth_token`, `ProviderEntry::api_key`/`cocoon_access_hash`,

--- a/book/src/guides/config-recipes.md
+++ b/book/src/guides/config-recipes.md
@@ -62,7 +62,7 @@ See [LLM Providers](../concepts/providers.md) for other Ollama-compatible models
 
 <details>
 <summary>Best response quality. Uses Anthropic's API for chat and context compaction.<br>
-<strong>Prerequisites:</strong> <code>ZEPH_CLAUDE_API_KEY</code> environment variable set.</summary>
+<strong>Prerequisites:</strong> Age vault configured (<code>zeph vault init</code>) with <code>ZEPH_CLAUDE_API_KEY</code> stored (<code>zeph vault set ZEPH_CLAUDE_API_KEY sk-ant-...</code>).</summary>
 
 ```toml
 [llm]
@@ -75,7 +75,7 @@ max_tokens = 8192
 # server_compaction = true  # let Claude API manage context instead of client-side compaction
 
 [vault]
-backend = "env"  # reads ZEPH_CLAUDE_API_KEY from environment
+backend = "age"  # reads ZEPH_CLAUDE_API_KEY from the age vault (default, recommended)
 
 [memory]
 history_limit = 50
@@ -94,7 +94,7 @@ See [Use a Cloud Provider](cloud-provider.md) and [Model Orchestrator](../advanc
 
 <details>
 <summary>Uses OpenAI for both chat and embeddings — no Ollama required.<br>
-<strong>Prerequisites:</strong> <code>ZEPH_OPENAI_API_KEY</code> environment variable set.</summary>
+<strong>Prerequisites:</strong> Age vault configured (<code>zeph vault init</code>) with <code>ZEPH_OPENAI_API_KEY</code> stored (<code>zeph vault set ZEPH_OPENAI_API_KEY sk-...</code>).</summary>
 
 ```toml
 [llm]
@@ -106,7 +106,7 @@ max_tokens = 4096
 embedding_model = "text-embedding-3-small"  # used for skill matching and semantic memory
 
 [vault]
-backend = "env"  # reads ZEPH_OPENAI_API_KEY from environment
+backend = "age"  # reads ZEPH_OPENAI_API_KEY from the age vault (default, recommended)
 
 [memory]
 history_limit = 50
@@ -123,7 +123,7 @@ history_limit = 50
 
 <details>
 <summary>Any OpenAI-compatible API: Groq, Together, Mistral, Fireworks, local vLLM, etc.<br>
-<strong>Prerequisites:</strong> Provider API key — set <code>ZEPH_COMPATIBLE_&lt;NAME&gt;_API_KEY</code> in your environment.</summary>
+<strong>Prerequisites:</strong> Provider API key stored in the age vault (<code>zeph vault init</code> then <code>zeph vault set ZEPH_COMPATIBLE_&lt;NAME&gt;_API_KEY ...</code>).</summary>
 
 ```toml
 [llm]
@@ -133,10 +133,10 @@ type = "compatible"
 base_url = "https://api.groq.com/openai/v1"
 model = "llama-3.3-70b-versatile"
 max_tokens = 4096
-# API key: set ZEPH_COMPATIBLE_GROQ_API_KEY in your environment
+# API key: zeph vault set ZEPH_COMPATIBLE_GROQ_API_KEY <your-key>
 
 [vault]
-backend = "env"
+backend = "age"  # default, recommended
 ```
 
 To switch providers, change `name`, `base_url`, and `model`. Common base URLs:
@@ -148,7 +148,7 @@ To switch providers, change `name`, `base_url`, and `model`. Common base URLs:
 | Fireworks | `https://api.fireworks.ai/inference/v1` |
 | Local vLLM | `http://localhost:8000/v1` |
 
-> **Note:** The env var name is `ZEPH_COMPATIBLE_<NAME>_API_KEY` where `<NAME>` is the `name`
+> **Note:** The vault key name is `ZEPH_COMPATIBLE_<NAME>_API_KEY` where `<NAME>` is the `name`
 > field uppercased. For the example above: `ZEPH_COMPATIBLE_GROQ_API_KEY`.
 
 </details>
@@ -159,7 +159,7 @@ To switch providers, change `name`, `base_url`, and `model`. Common base URLs:
 
 <details>
 <summary>Ollama runs locally for free; Claude handles requests when Ollama fails or is unavailable.<br>
-<strong>Prerequisites:</strong> Ollama running locally + <code>ZEPH_CLAUDE_API_KEY</code> set.</summary>
+<strong>Prerequisites:</strong> Ollama running locally + age vault configured with <code>ZEPH_CLAUDE_API_KEY</code> stored.</summary>
 
 ```toml
 [llm]
@@ -181,7 +181,7 @@ max_tokens = 4096
 default = true
 
 [vault]
-backend = "env"
+backend = "age"  # default, recommended
 ```
 
 > **Tip:** This setup keeps embeddings local (free, private) while giving you a cloud fallback
@@ -222,7 +222,7 @@ max_parallel = 2          # conservative for local inference
 confirm_before_execute = true
 
 [vault]
-backend = "env"
+backend = "env"  # dev-only: no secrets needed, both providers are local Ollama
 ```
 
 > **Note:** `[orchestration]` (lowercase) enables `/plan` CLI commands. `routing = "task"` was removed as unimplemented — see [Model Orchestrator](../advanced/orchestrator.md) for current multi-provider setup options.
@@ -248,7 +248,7 @@ model = "qwen3:8b"
 embedding_model = "qwen3-embedding"
 
 [vault]
-backend = "env"
+backend = "env"  # dev-only: no secrets needed for local Ollama
 
 # AST-based code indexing: builds a semantic map of the repository.
 # Uses SQLite vector backend by default; add recipe #10 for Qdrant.
@@ -284,7 +284,7 @@ See [LSP Code Intelligence](../guides/lsp.md) and [Code Indexing](../advanced/co
 
 <details>
 <summary>Persistent Telegram bot. Suitable for a server or always-on machine.<br>
-<strong>Prerequisites:</strong> Telegram bot token (from <a href="https://t.me/BotFather">@BotFather</a>) + <code>ZEPH_CLAUDE_API_KEY</code> set.</summary>
+<strong>Prerequisites:</strong> Telegram bot token (from <a href="https://t.me/BotFather">@BotFather</a>) + age vault configured with <code>ZEPH_CLAUDE_API_KEY</code> and <code>ZEPH_TELEGRAM_BOT_TOKEN</code> stored.</summary>
 
 ```toml
 [llm]
@@ -294,10 +294,10 @@ model = "claude-sonnet-5"
 max_tokens = 4096
 
 [vault]
-backend = "env"  # reads ZEPH_CLAUDE_API_KEY and ZEPH_TELEGRAM_BOT_TOKEN
+backend = "age"  # reads ZEPH_CLAUDE_API_KEY and ZEPH_TELEGRAM_BOT_TOKEN from the age vault
 
 [telegram]
-# token = "your-bot-token"  # or set ZEPH_TELEGRAM_BOT_TOKEN env var
+# token = "your-bot-token"  # or store via `zeph vault set ZEPH_TELEGRAM_BOT_TOKEN ...`
 allowed_users = ["yourusername"]  # restrict access — do not leave empty on a public server
 
 [memory]

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -663,7 +663,7 @@ embedding_seconds = 30      # Embedding generation timeout
 a2a_seconds = 30            # A2A remote call timeout
 
 [vault]
-backend = "env"  # "env" (default) or "age"; CLI --vault overrides this
+backend = "age"  # "age" (default, recommended) or "env"; CLI --vault overrides this
 
 [observability]
 exporter = "none"           # "none" or "otlp" (requires `otel` feature)

--- a/config/default.toml
+++ b/config/default.toml
@@ -615,8 +615,10 @@ max_daily_cents = 0
 
 
 [vault]
-# Secret retrieval backend: "env" reads from environment variables
-backend = "env"
+# Secret retrieval backend: "age" reads from an age-encrypted vault file (default,
+# recommended); "env" reads from environment variables (weaker, not recommended for
+# production — see specs/010-security/spec.md)
+backend = "age"
 
 [a2a]
 # Enable A2A server for agent-to-agent communication

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -107,7 +107,7 @@ fn default_repo_map_ttl_secs() -> u64 {
 }
 
 fn default_vault_backend() -> VaultBackend {
-    VaultBackend::Env
+    VaultBackend::Age
 }
 
 /// Selects the vault backend used to resolve secrets at startup.
@@ -115,10 +115,11 @@ fn default_vault_backend() -> VaultBackend {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum VaultBackend {
-    /// Resolve secrets from environment variables (default, zero-config).
-    #[default]
+    /// Resolve secrets from environment variables. Zero-config, but weaker than `age` —
+    /// not recommended for production use (see spec-010).
     Env,
-    /// Resolve secrets from an age-encrypted vault file.
+    /// Resolve secrets from an age-encrypted vault file (default, recommended).
+    #[default]
     Age,
     /// Resolve secrets from the OS keyring.
     Keyring,
@@ -836,7 +837,7 @@ impl Default for IndexConfig {
 /// ```
 #[derive(Debug, Deserialize, Serialize)]
 pub struct VaultConfig {
-    /// Which backend resolves secrets. Default: [`VaultBackend::Env`].
+    /// Which backend resolves secrets. Default: [`VaultBackend::Age`].
     #[serde(default = "default_vault_backend")]
     pub backend: VaultBackend,
 }

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -358,8 +358,10 @@ max_daily_cents = 500
 
 
 [vault]
-# Secret retrieval backend: "env" reads from environment variables
-backend = "env"
+# Secret retrieval backend: "age" reads from an age-encrypted vault file (default,
+# recommended); "env" reads from environment variables (weaker, not recommended for
+# production — see specs/010-security/spec.md)
+backend = "age"
 
 [a2a]
 # Enable A2A server for agent-to-agent communication

--- a/crates/zeph-vault/README.md
+++ b/crates/zeph-vault/README.md
@@ -60,10 +60,10 @@ zeph vault delete ZEPH_CLAUDE_API_KEY
 
 ```toml
 [vault]
-backend = "age"   # "env" or "age"; default is "env"
+backend = "age"   # "env" or "age"; default is "age"
 ```
 
-The `env` backend resolves `ZEPH_SECRET_`-prefixed secrets directly from environment variables — no file needed. Use `age` for production deployments where secrets must be stored on disk. The age backend keeps its identity and encrypted store under `~/.config/zeph/` (`vault-key.txt` and `secrets.age`).
+The `age` backend resolves secrets from an age-encrypted file on disk and is the default, recommended for all deployments. The `env` backend resolves `ZEPH_SECRET_`-prefixed secrets directly from environment variables — no file needed, but weaker (see `specs/010-security/spec.md`). The age backend keeps its identity and encrypted store under `~/.config/zeph/` (`vault-key.txt` and `secrets.age`).
 
 > [!IMPORTANT]
 > The age identity key file (`~/.config/zeph/vault-key.txt`) is created with Unix `0o600` permissions (owner read/write only). Vault writes are atomic — a temporary file is written and renamed, so a crash during write never corrupts `secrets.age`. Keep the key file secure: losing it makes the vault unrecoverable.

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -71,33 +71,42 @@ fn resolve_config_path_impl(
     xdg
 }
 
-fn parse_backend_str(s: &str) -> VaultBackend {
+/// Parse a vault backend string from a CLI flag or environment variable.
+///
+/// # Errors
+///
+/// Returns an error describing the invalid input when `s` is not one of the recognized
+/// backend names. Unlike the pre-#5954 behavior, an unrecognized value is never silently
+/// downgraded to [`VaultBackend::Env`] — that would defeat the purpose of an explicit
+/// `--vault`/`ZEPH_VAULT_BACKEND` override by falling back to the weakest backend.
+fn parse_backend_str(s: &str) -> Result<VaultBackend, String> {
     match s {
-        "age" => VaultBackend::Age,
-        "keyring" => VaultBackend::Keyring,
-        _ => {
-            tracing::warn!(
-                input = s,
-                "unknown vault backend '{}', falling back to env",
-                s
-            );
-            VaultBackend::Env
-        }
+        "env" => Ok(VaultBackend::Env),
+        "age" => Ok(VaultBackend::Age),
+        "keyring" => Ok(VaultBackend::Keyring),
+        other => Err(format!(
+            "unknown vault backend '{other}': expected one of \"env\", \"age\", \"keyring\""
+        )),
     }
 }
 
 /// Priority: CLI flag > `ZEPH_VAULT_*` env > config.vault.* > defaults
+///
+/// # Errors
+///
+/// Returns an error when `cli_backend` or the `ZEPH_VAULT_BACKEND` environment variable
+/// is set to an unrecognized backend name (see [`parse_backend_str`]).
 pub fn parse_vault_args(
     config: &Config,
     cli_backend: Option<&str>,
     cli_key_path: Option<&Path>,
     cli_vault_path: Option<&Path>,
-) -> VaultArgs {
+) -> Result<VaultArgs, String> {
     let env_backend = std::env::var("ZEPH_VAULT_BACKEND").ok();
-    let backend = cli_backend
-        .map(parse_backend_str)
-        .or_else(|| env_backend.as_deref().map(parse_backend_str))
-        .unwrap_or(config.vault.backend);
+    let backend = match cli_backend.or(env_backend.as_deref()) {
+        Some(s) => parse_backend_str(s)?,
+        None => config.vault.backend,
+    };
 
     let env_key = std::env::var("ZEPH_VAULT_KEY").ok();
     let default_dir = zeph_core::vault::default_vault_dir();
@@ -134,11 +143,11 @@ pub fn parse_vault_args(
             }
         });
 
-    VaultArgs {
+    Ok(VaultArgs {
         backend,
         key_path,
         vault_path,
-    }
+    })
 }
 
 #[cfg(test)]

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -139,10 +139,11 @@ pub struct AppBuilder {
 /// CLI-level vault arguments parsed from flags and config before the vault provider is constructed.
 ///
 /// Collects the three knobs an operator can override: which backend to use, the path to the
-/// age identity key, and the path to the age vault file. All three are optional because sensible
-/// defaults exist (env backend, no key/vault path required).
+/// age identity key, and the path to the age vault file. Falls back to `config.vault.backend`
+/// (default [`VaultBackend::Age`]) when no `--vault`/`ZEPH_VAULT_BACKEND` override is given.
+#[derive(Debug)]
 pub struct VaultArgs {
-    /// Which secret backend to instantiate. Defaults to [`VaultBackend::Env`].
+    /// Which secret backend to instantiate. Defaults to [`VaultBackend::Age`].
     pub backend: VaultBackend,
     /// Path to the age identity key file (`--vault-key`). Required when `backend = age`.
     pub key_path: Option<String>,
@@ -189,8 +190,8 @@ impl AppBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`BootstrapError`] if config loading, validation, vault construction,
-    /// secret resolution, or Qdrant URL parsing fails.
+    /// Returns [`BootstrapError`] if config loading, validation, vault backend parsing,
+    /// vault construction, secret resolution, or Qdrant URL parsing fails.
     pub async fn new(
         config_override: Option<&Path>,
         vault_override: Option<&str>,
@@ -207,7 +208,8 @@ impl AppBuilder {
             vault_override,
             vault_key_override,
             vault_path_override,
-        );
+        )
+        .map_err(BootstrapError::Provider)?;
         let (vault, age_vault): (
             Box<dyn VaultProvider>,
             Option<Arc<RwLock<AgeVaultProvider>>>,

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -34,30 +34,58 @@ fn remote_url_not_localhost() {
 
 #[test]
 fn vault_args_defaults_in_test_context() {
+    // #5953: an omitted `[vault] backend` must resolve to the age vault, not env.
     let config = Config::load(Path::new("/nonexistent")).unwrap();
-    let args = parse_vault_args(&config, None, None, None);
-    assert_eq!(args.backend, zeph_config::VaultBackend::Env);
-    assert!(args.key_path.is_none());
-    assert!(args.vault_path.is_none());
+    assert_eq!(config.vault.backend, zeph_config::VaultBackend::Age);
+    let args = parse_vault_args(&config, None, None, None).unwrap();
+    assert_eq!(args.backend, zeph_config::VaultBackend::Age);
+    assert!(args.key_path.is_some());
+    assert!(args.vault_path.is_some());
 }
 
 #[test]
 fn vault_args_uses_config_backend_as_fallback() {
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
-    config.vault.backend = zeph_config::VaultBackend::Age;
-    let args = parse_vault_args(&config, None, None, None);
-    assert_eq!(args.backend, zeph_config::VaultBackend::Age);
+    config.vault.backend = zeph_config::VaultBackend::Env;
+    let args = parse_vault_args(&config, None, None, None).unwrap();
+    assert_eq!(args.backend, zeph_config::VaultBackend::Env);
 }
 
 #[test]
 #[serial_test::serial]
 fn vault_args_env_overrides_config() {
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
-    config.vault.backend = zeph_config::VaultBackend::Age;
-    unsafe { std::env::set_var("ZEPH_VAULT_BACKEND", "env") };
-    let args = parse_vault_args(&config, None, None, None);
+    config.vault.backend = zeph_config::VaultBackend::Env;
+    unsafe { std::env::set_var("ZEPH_VAULT_BACKEND", "age") };
+    let args = parse_vault_args(&config, None, None, None).unwrap();
     unsafe { std::env::remove_var("ZEPH_VAULT_BACKEND") };
-    assert_eq!(args.backend, zeph_config::VaultBackend::Env);
+    assert_eq!(args.backend, zeph_config::VaultBackend::Age);
+}
+
+#[test]
+#[serial_test::serial]
+fn vault_args_unknown_cli_backend_errors() {
+    // #5954: an unrecognized `--vault` value must fail loudly, never fall back to `env`.
+    let config = Config::load(Path::new("/nonexistent")).unwrap();
+    let result = parse_vault_args(&config, Some("aeg"), None, None);
+    let err = result.expect_err("typo'd backend name must be rejected, not silently downgraded");
+    assert!(
+        err.contains("aeg"),
+        "error must name the invalid input: {err}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn vault_args_unknown_env_backend_errors() {
+    let config = Config::load(Path::new("/nonexistent")).unwrap();
+    unsafe { std::env::set_var("ZEPH_VAULT_BACKEND", "totally-bogus") };
+    let result = parse_vault_args(&config, None, None, None);
+    unsafe { std::env::remove_var("ZEPH_VAULT_BACKEND") };
+    assert!(
+        result.is_err(),
+        "unrecognized ZEPH_VAULT_BACKEND must be rejected, not silently downgraded to env"
+    );
 }
 
 #[test]
@@ -83,7 +111,8 @@ fn vault_args_cli_overrides_env_and_config() {
         Some("age"),
         Some(Path::new("/cli/key")),
         Some(Path::new("/cli/vault")),
-    );
+    )
+    .unwrap();
     unsafe { std::env::remove_var("ZEPH_VAULT_BACKEND") };
     assert_eq!(args.backend, zeph_config::VaultBackend::Age);
     assert_eq!(args.key_path.as_deref(), Some("/cli/key"));
@@ -96,7 +125,7 @@ fn vault_args_env_key_and_path_fallback() {
     let config = Config::load(Path::new("/nonexistent")).unwrap();
     unsafe { std::env::set_var("ZEPH_VAULT_KEY", "/env/key") };
     unsafe { std::env::set_var("ZEPH_VAULT_PATH", "/env/vault") };
-    let args = parse_vault_args(&config, None, None, None);
+    let args = parse_vault_args(&config, None, None, None).unwrap();
     unsafe { std::env::remove_var("ZEPH_VAULT_KEY") };
     unsafe { std::env::remove_var("ZEPH_VAULT_PATH") };
     assert_eq!(args.key_path.as_deref(), Some("/env/key"));

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -100,7 +100,8 @@ async fn handle_run_baseline(
     let path = resolve_config_path(config_path);
     let mut config = load_config_or_default(&path);
 
-    let vault_args = parse_vault_args(&config, None, None, None);
+    let vault_args = parse_vault_args(&config, None, None, None)
+        .map_err(|e| anyhow::anyhow!("invalid vault backend: {e}"))?;
     if let Some(vault) = crate::bootstrap::build_vault_provider(&vault_args)
         && let Err(e) = config.resolve_secrets(vault.as_ref()).await
     {
@@ -382,7 +383,8 @@ async fn handle_run(
     // Resolve vault secrets before building the provider.
     // The bench command is dispatched before AppBuilder runs, so we must
     // initialize the vault here to populate config.secrets.
-    let vault_args = parse_vault_args(&config, None, None, None);
+    let vault_args = parse_vault_args(&config, None, None, None)
+        .map_err(|e| anyhow::anyhow!("invalid vault backend: {e}"))?;
     if let Some(vault) = crate::bootstrap::build_vault_provider(&vault_args)
         && let Err(e) = config.resolve_secrets(vault.as_ref()).await
     {

--- a/src/commands/cocoon.rs
+++ b/src/commands/cocoon.rs
@@ -246,7 +246,13 @@ async fn check_vault_key(
     }
 
     let _span = tracing::info_span!("cli.cocoon.doctor.vault").entered();
-    let vault_args = crate::bootstrap::parse_vault_args(config, None, None, None);
+    let vault_args = match crate::bootstrap::parse_vault_args(config, None, None, None) {
+        Ok(args) => args,
+        Err(e) => {
+            results.push(CheckResult::fail("cocoon.vault", e, elapsed_ms(start)));
+            return;
+        }
+    };
 
     let vault: Box<dyn VaultProvider> = match vault_args.backend {
         VaultBackend::Age => {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -796,14 +796,21 @@ pub(crate) async fn run_doctor(
 
     // 2 + 3 + 4. Vault checks
     {
-        let vault_args = crate::bootstrap::parse_vault_args(&config, None, None, None);
-        if vault_args.backend == zeph_config::VaultBackend::Age {
-            if let Some(ref vault_path) = vault_args.vault_path {
-                results.push(check_vault_file_exists(vault_path));
-                results.push(check_vault_file_mode(vault_path, "vault.file_mode"));
+        let start = Instant::now();
+        match crate::bootstrap::parse_vault_args(&config, None, None, None) {
+            Ok(vault_args) => {
+                if vault_args.backend == zeph_config::VaultBackend::Age {
+                    if let Some(ref vault_path) = vault_args.vault_path {
+                        results.push(check_vault_file_exists(vault_path));
+                        results.push(check_vault_file_mode(vault_path, "vault.file_mode"));
+                    }
+                    if let Some(ref key_path) = vault_args.key_path {
+                        results.push(check_vault_key_mode(key_path));
+                    }
+                }
             }
-            if let Some(ref key_path) = vault_args.key_path {
-                results.push(check_vault_key_mode(key_path));
+            Err(e) => {
+                results.push(CheckResult::fail("vault.backend", e, elapsed_ms(start)));
             }
         }
     }

--- a/src/commands/gonka.rs
+++ b/src/commands/gonka.rs
@@ -46,7 +46,15 @@ async fn resolve_vault_secrets(
     config: &zeph_core::config::Config,
 ) -> (CheckResult, Option<String>, CheckResult, Option<String>) {
     let _span = tracing::info_span!("cli.gonka.doctor.vault").entered();
-    let vault_args = crate::bootstrap::parse_vault_args(config, None, None, None);
+    let vault_args = match crate::bootstrap::parse_vault_args(config, None, None, None) {
+        Ok(args) => args,
+        Err(e) => {
+            let start = Instant::now();
+            let r = CheckResult::fail("gonka.vault.private_key", e, elapsed_ms(start));
+            let addr_r = CheckResult::fail("gonka.vault.address", "skipped (vault unavailable)", 0);
+            return (r, None, addr_r, None);
+        }
+    };
 
     let vault: Box<dyn VaultProvider> = match vault_args.backend {
         VaultBackend::Age => {

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -733,7 +733,10 @@ fn step_deployment_mode(state: &mut WizardState) -> anyhow::Result<()> {
 fn step_vault(state: &mut WizardState) -> anyhow::Result<()> {
     println!("== Step 1/10: Secrets Backend ==\n");
 
-    let backends = ["env (environment variables)", "age (encrypted file)"];
+    let backends = [
+        "age (encrypted file, recommended)",
+        "env (environment variables)",
+    ];
     let selection = Select::new()
         .with_prompt("Select secrets backend")
         .items(backends)
@@ -741,8 +744,8 @@ fn step_vault(state: &mut WizardState) -> anyhow::Result<()> {
         .interact()?;
 
     state.vault_backend = match selection {
-        0 => "env".into(),
-        1 => "age".into(),
+        0 => "age".into(),
+        1 => "env".into(),
         _ => unreachable!(),
     };
 
@@ -1003,9 +1006,11 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
 
     config.vault = VaultConfig {
         backend: match state.vault_backend.as_str() {
-            "age" => VaultBackend::Age,
+            "env" => VaultBackend::Env,
             "keyring" => VaultBackend::Keyring,
-            _ => VaultBackend::Env,
+            // Defensive fallback (state.vault_backend is always "age" or "env" once
+            // step_vault runs): prefer the stronger, spec-010-recommended backend.
+            _ => VaultBackend::Age,
         },
     };
 

--- a/tests/daemon_boot.rs
+++ b/tests/daemon_boot.rs
@@ -55,6 +55,9 @@ fn daemon_boots_under_constrained_stack_ulimit() {
         .join("skills")
         .display()
         .to_string()]));
+    // This test needs zero secrets and isn't exercising vault behavior — pin to
+    // "env" so boot doesn't require a provisioned age identity/vault file.
+    doc["vault"]["backend"] = toml_edit::value("env");
     std::fs::write(&config_path, doc.to_string()).expect("write test config");
 
     let bin = zeph_bin_path();


### PR DESCRIPTION
## Summary
- `vault.backend` now defaults to `age` instead of `env` when `[vault] backend` is omitted from config, matching the security posture already documented in `specs/010-security/spec.md` and `specs/038-vault/spec.md`, and the project's hard rule against storing secrets in environment variables.
- `parse_backend_str`/`parse_vault_args` (the parser for `--vault`/`ZEPH_VAULT_BACKEND`) now returns a hard error on an unrecognized backend string instead of silently falling back to `env` with only a `tracing::warn!` log line. Propagated through `AppBuilder::new`, `bench`, `doctor`, `gonka`, and `cocoon` commands.
- Updated `config/default.toml`, `crates/zeph-core/config/default.toml`, `crates/zeph-vault/README.md`, `book/src/reference/configuration.md`, and the `--init` wizard prompt order to match the new default.
- Updated `book/src/guides/config-recipes.md`: the 5 recipes that store a real secret now use `backend = "age"` with corrected prerequisites (`zeph vault set ...`); the 4 local-only Ollama recipes keep `backend = "env"` with an explicit no-secrets-needed comment.

Closes #5953
Closes #5954

## Breaking change

Deployments relying on the implicit `env` default must either run `zeph vault init` to provision an age vault, or explicitly set `vault.backend = "env"` in `config.toml` to keep the previous (weaker) behavior. No config migration step was added since the old `env` default was never a persisted value, only a parse-time fallback for an omitted key — explicit `backend = "env"` configs are untouched.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo clippy --profile ci --workspace --all-targets --features bench -- -D warnings` (bench-gated code touched)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12701 passed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New/updated unit tests: default backend is `Age` when `[vault] backend` is omitted; unrecognized CLI/env backend strings return an error instead of falling back to `Env`