### PR TITLE
fix(commands): close requires_auth() fail-open gap in 19 CommandHandler impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Security
 
+- `zeph-commands`: 19 privileged slash-command handlers now override `requires_auth()` to
+  return `true`, closing a trust-gate gap where they ran the default `false` and were therefore
+  reachable from untrusted remote channels (Telegram/Discord/Slack) as well as trusted local
+  sessions (#6003). Gated handlers: `UndoCommand`/`RedoCommand` (`/undo`, `/redo` — mutate the
+  on-disk working tree), `PlanCommand` (`/plan` — executes tools/shell via orchestration),
+  `SkillCommand` (`/skill` — installs/removes/trusts executable skills), `FeedbackCommand`
+  (`/feedback` — writes persistent self-learning input), `KnowledgeSlashCommand` (`/knowledge` —
+  unconfirmed destructive `rollback`), `AgentCommand`/`AgentsFleetCommand` (`/agent`, `/agents` —
+  spawn/mutate sub-agent definitions), `ConvCommand` (`/conv`, feature `session` — session
+  hijack/cross-session disclosure via `resume`/`fork`), `MemoryCommand`/`GraphCommand`
+  (`/memory`, `/graph` — mutate semantic memory / knowledge graph, LLM cost), `GoalCommand`
+  (`/goal` — mutates persisted goal FSM, can drive autonomous execution), `AcpCommand` (`/acp`,
+  feature `acp` — discloses ACP allowlist/auth/bind-address config), `CocoonCommand` (`/cocoon`,
+  feature `cocoon` — discloses sidecar state and TON balance), `CompactCommand`/
+  `NewConversationCommand` (`/compact`, `/new` — mutate conversation state, LLM cost/DoS), and
+  `ClearCommand`/`ResetCommand`/`ClearQueueCommand` (`/clear`, `/reset`, `/clear-queue` —
+  remote wipe of the operator's live session). `RecapCommand`, `SkillsCommand`,
+  `GuidelinesCommand`, `ExitCommand`, `QuitCommand`, and `HelpCommand` were audited and left at
+  the default (read-only, or already self-gated via `supports_exit()`). The
+  `CommandHandler::requires_auth()` default value itself is unchanged — revisiting the default
+  is deferred to a follow-up issue.
 - `zeph-db`: `redact_url` no longer leaks the tail of a Postgres password containing `@` (#5969).
   The previous regex (`://[^:]+:[^@]+@`) stopped at the first `@`, so
   `postgres://user:p@ss@host/db` only redacted up to `p`, leaking `ss@host` verbatim into

--- a/crates/zeph-commands/src/handlers/acp.rs
+++ b/crates/zeph-commands/src/handlers/acp.rs
@@ -33,6 +33,10 @@ impl CommandHandler<CommandContext<'_>> for AcpCommand {
         Some("acp")
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -70,5 +74,10 @@ mod tests {
     fn description_and_args_hint_non_empty() {
         assert!(!AcpCommand.description().is_empty());
         assert!(!AcpCommand.args_hint().is_empty());
+    }
+
+    #[test]
+    fn acp_requires_auth() {
+        assert!(AcpCommand.requires_auth());
     }
 }

--- a/crates/zeph-commands/src/handlers/agent_cmd.rs
+++ b/crates/zeph-commands/src/handlers/agent_cmd.rs
@@ -33,6 +33,10 @@ impl CommandHandler<CommandContext<'_>> for AgentCommand {
         SlashCategory::Integration
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -60,6 +64,7 @@ impl CommandHandler<CommandContext<'_>> for AgentCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandRegistry;
     use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
     use crate::sink::NullSink;
     use std::assert_matches;
@@ -93,5 +98,38 @@ mod tests {
         let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
         let out = AgentCommand.handle(&mut ctx, "list").await.unwrap();
         assert_matches!(out, CommandOutput::Silent);
+    }
+
+    #[tokio::test]
+    async fn agent_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(AgentCommand);
+
+        let result = reg.dispatch(&mut ctx, "/agent list", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn agent_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(AgentCommand);
+
+        let result = reg.dispatch(&mut ctx, "/agent list", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }

--- a/crates/zeph-commands/src/handlers/agents_fleet.rs
+++ b/crates/zeph-commands/src/handlers/agents_fleet.rs
@@ -138,6 +138,10 @@ impl CommandHandler<CommandContext<'_>> for AgentsFleetCommand {
         SlashCategory::Integration
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -267,6 +271,47 @@ mod tests {
     fn agents_fleet_command_name() {
         assert_eq!(AgentsFleetCommand.name(), "/agents");
         assert!(!AgentsFleetCommand.description().is_empty());
+    }
+
+    #[tokio::test]
+    async fn agents_fleet_dispatch_allowed_when_trusted() {
+        use crate::CommandRegistry;
+        use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
+        use crate::sink::NullSink;
+
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(AgentsFleetCommand);
+
+        let result = reg.dispatch(&mut ctx, "/agents list", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn agents_fleet_dispatch_rejected_when_untrusted() {
+        use crate::CommandRegistry;
+        use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
+        use crate::sink::NullSink;
+
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(AgentsFleetCommand);
+
+        let result = reg.dispatch(&mut ctx, "/agents list", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 
     // Test format_elapsed edge cases

--- a/crates/zeph-commands/src/handlers/checkpoint.rs
+++ b/crates/zeph-commands/src/handlers/checkpoint.rs
@@ -31,6 +31,10 @@ impl CommandHandler<CommandContext<'_>> for UndoCommand {
         SlashCategory::Session
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -70,6 +74,10 @@ impl CommandHandler<CommandContext<'_>> for RedoCommand {
         SlashCategory::Session
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -90,6 +98,7 @@ impl CommandHandler<CommandContext<'_>> for RedoCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandRegistry;
     use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
     use crate::sink::NullSink;
 
@@ -133,5 +142,71 @@ mod tests {
         if let Ok(CommandOutput::Message(msg)) = result {
             assert!(!msg.is_empty());
         }
+    }
+
+    #[tokio::test]
+    async fn undo_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(UndoCommand);
+
+        let result = reg.dispatch(&mut ctx, "/undo", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn undo_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(UndoCommand);
+
+        let result = reg.dispatch(&mut ctx, "/undo", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn redo_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(RedoCommand);
+
+        let result = reg.dispatch(&mut ctx, "/redo", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn redo_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(RedoCommand);
+
+        let result = reg.dispatch(&mut ctx, "/redo", true).await;
+        assert!(result.unwrap().is_ok());
     }
 }

--- a/crates/zeph-commands/src/handlers/cocoon.rs
+++ b/crates/zeph-commands/src/handlers/cocoon.rs
@@ -33,6 +33,10 @@ impl CommandHandler<CommandContext<'_>> for CocoonCommand {
         Some("cocoon")
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -70,5 +74,10 @@ mod tests {
     fn description_and_args_hint_non_empty() {
         assert!(!CocoonCommand.description().is_empty());
         assert!(!CocoonCommand.args_hint().is_empty());
+    }
+
+    #[test]
+    fn cocoon_requires_auth() {
+        assert!(CocoonCommand.requires_auth());
     }
 }

--- a/crates/zeph-commands/src/handlers/compaction.rs
+++ b/crates/zeph-commands/src/handlers/compaction.rs
@@ -32,6 +32,10 @@ impl CommandHandler<CommandContext<'_>> for CompactCommand {
         SlashCategory::Session
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -71,6 +75,10 @@ impl CommandHandler<CommandContext<'_>> for NewConversationCommand {
 
     fn category(&self) -> SlashCategory {
         SlashCategory::Session
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
     }
 
     fn handle<'a>(
@@ -141,7 +149,10 @@ fn parse_new_flags(args: &str) -> (bool, bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_new_flags;
+    use super::*;
+    use crate::CommandRegistry;
+    use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
+    use crate::sink::NullSink;
 
     #[test]
     fn no_flags_both_false() {
@@ -171,5 +182,71 @@ mod tests {
         assert_eq!(parse_new_flags("--keep"), (false, false));
         assert_eq!(parse_new_flags("--no"), (false, false));
         assert_eq!(parse_new_flags("keep-plan"), (false, false));
+    }
+
+    #[tokio::test]
+    async fn compact_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(CompactCommand);
+
+        let result = reg.dispatch(&mut ctx, "/compact", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn compact_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(CompactCommand);
+
+        let result = reg.dispatch(&mut ctx, "/compact", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn new_conversation_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(NewConversationCommand);
+
+        let result = reg.dispatch(&mut ctx, "/new", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn new_conversation_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(NewConversationCommand);
+
+        let result = reg.dispatch(&mut ctx, "/new", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }

--- a/crates/zeph-commands/src/handlers/conv.rs
+++ b/crates/zeph-commands/src/handlers/conv.rs
@@ -44,6 +44,10 @@ impl CommandHandler<CommandContext<'_>> for ConvCommand {
         Some("session")
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -64,6 +68,7 @@ impl CommandHandler<CommandContext<'_>> for ConvCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandRegistry;
     use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
     use crate::sink::NullSink;
 
@@ -86,5 +91,38 @@ mod tests {
         if let Ok(CommandOutput::Message(msg)) = result {
             assert!(!msg.is_empty());
         }
+    }
+
+    #[tokio::test]
+    async fn conv_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ConvCommand);
+
+        let result = reg.dispatch(&mut ctx, "/conv list", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn conv_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ConvCommand);
+
+        let result = reg.dispatch(&mut ctx, "/conv list", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }

--- a/crates/zeph-commands/src/handlers/goal.rs
+++ b/crates/zeph-commands/src/handlers/goal.rs
@@ -42,6 +42,10 @@ impl CommandHandler<CommandContext<'_>> for GoalCommand {
         SlashCategory::Session
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -62,6 +66,7 @@ impl CommandHandler<CommandContext<'_>> for GoalCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandRegistry;
     use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
     use crate::sink::NullSink;
 
@@ -94,5 +99,41 @@ mod tests {
         let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
         let result = GoalCommand.handle(&mut ctx, "").await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn goal_dispatch_allowed_when_trusted() {
+        // NullAgent::handle_goal errors, but the error must come from the handler,
+        // not from the trust gate rejecting the dispatch.
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(GoalCommand);
+
+        let result = reg.dispatch(&mut ctx, "/goal status", true).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(!err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn goal_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(GoalCommand);
+
+        let result = reg.dispatch(&mut ctx, "/goal status", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }

--- a/crates/zeph-commands/src/handlers/memory.rs
+++ b/crates/zeph-commands/src/handlers/memory.rs
@@ -31,6 +31,10 @@ impl CommandHandler<CommandContext<'_>> for MemoryCommand {
         SlashCategory::Memory
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -76,6 +80,10 @@ impl CommandHandler<CommandContext<'_>> for GraphCommand {
 
     fn category(&self) -> SlashCategory {
         SlashCategory::Memory
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
     }
 
     fn handle<'a>(
@@ -182,6 +190,10 @@ impl CommandHandler<CommandContext<'_>> for KnowledgeSlashCommand {
         SlashCategory::Memory
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -216,7 +228,10 @@ fn parse_backfill_limit(args: &str) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_backfill_limit;
+    use super::*;
+    use crate::CommandRegistry;
+    use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
+    use crate::sink::NullSink;
 
     #[test]
     fn backfill_limit_parsing() {
@@ -224,5 +239,104 @@ mod tests {
         assert_eq!(parse_backfill_limit("backfill"), None);
         assert_eq!(parse_backfill_limit("backfill --limit"), None);
         assert_eq!(parse_backfill_limit("backfill --limit 0"), Some(0));
+    }
+
+    #[tokio::test]
+    async fn memory_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(MemoryCommand);
+
+        let result = reg.dispatch(&mut ctx, "/memory tiers", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn memory_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(MemoryCommand);
+
+        let result = reg.dispatch(&mut ctx, "/memory tiers", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn graph_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(GraphCommand);
+
+        let result = reg.dispatch(&mut ctx, "/graph", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn graph_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(GraphCommand);
+
+        let result = reg.dispatch(&mut ctx, "/graph", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn knowledge_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(KnowledgeSlashCommand);
+
+        let result = reg.dispatch(&mut ctx, "/knowledge status", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn knowledge_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(KnowledgeSlashCommand);
+
+        let result = reg.dispatch(&mut ctx, "/knowledge status", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }

--- a/crates/zeph-commands/src/handlers/plan.rs
+++ b/crates/zeph-commands/src/handlers/plan.rs
@@ -33,6 +33,10 @@ impl CommandHandler<CommandContext<'_>> for PlanCommand {
         SlashCategory::Planning
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -59,6 +63,7 @@ impl CommandHandler<CommandContext<'_>> for PlanCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandRegistry;
     use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
     use crate::sink::NullSink;
     use std::assert_matches;
@@ -92,5 +97,38 @@ mod tests {
         let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
         let out = PlanCommand.handle(&mut ctx, "status").await.unwrap();
         assert_matches!(out, CommandOutput::Silent);
+    }
+
+    #[tokio::test]
+    async fn plan_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(PlanCommand);
+
+        let result = reg.dispatch(&mut ctx, "/plan status", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn plan_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(PlanCommand);
+
+        let result = reg.dispatch(&mut ctx, "/plan status", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }

--- a/crates/zeph-commands/src/handlers/session.rs
+++ b/crates/zeph-commands/src/handlers/session.rs
@@ -98,6 +98,10 @@ impl CommandHandler<CommandContext<'_>> for ClearCommand {
         SlashCategory::Session
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -129,6 +133,10 @@ impl CommandHandler<CommandContext<'_>> for ResetCommand {
 
     fn category(&self) -> SlashCategory {
         SlashCategory::Session
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
     }
 
     fn handle<'a>(
@@ -164,6 +172,10 @@ impl CommandHandler<CommandContext<'_>> for ClearQueueCommand {
 
     fn category(&self) -> SlashCategory {
         SlashCategory::Session
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
     }
 
     fn handle<'a>(
@@ -407,5 +419,134 @@ mod tests {
         assert!(reg.find_handler("/clear").is_some());
         assert!(reg.find_handler("/reset").is_some());
         assert!(reg.find_handler("/clear-queue").is_some());
+    }
+
+    #[tokio::test]
+    async fn clear_dispatch_allowed_when_trusted() {
+        let mut sink = MockSink { sent: vec![] };
+        let mut debug = MockDebug;
+        let mut messages = MockMessages {
+            cleared: false,
+            queue: 0,
+        };
+        let session = MockSession {
+            supports_exit: false,
+        };
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ClearCommand);
+
+        let result = reg.dispatch(&mut ctx, "/clear", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn clear_dispatch_rejected_when_untrusted() {
+        let mut sink = MockSink { sent: vec![] };
+        let mut debug = MockDebug;
+        let mut messages = MockMessages {
+            cleared: false,
+            queue: 0,
+        };
+        let session = MockSession {
+            supports_exit: false,
+        };
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ClearCommand);
+
+        let result = reg.dispatch(&mut ctx, "/clear", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn reset_dispatch_allowed_when_trusted() {
+        let mut sink = MockSink { sent: vec![] };
+        let mut debug = MockDebug;
+        let mut messages = MockMessages {
+            cleared: false,
+            queue: 0,
+        };
+        let session = MockSession {
+            supports_exit: false,
+        };
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ResetCommand);
+
+        let result = reg.dispatch(&mut ctx, "/reset", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn reset_dispatch_rejected_when_untrusted() {
+        let mut sink = MockSink { sent: vec![] };
+        let mut debug = MockDebug;
+        let mut messages = MockMessages {
+            cleared: false,
+            queue: 0,
+        };
+        let session = MockSession {
+            supports_exit: false,
+        };
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ResetCommand);
+
+        let result = reg.dispatch(&mut ctx, "/reset", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn clear_queue_dispatch_allowed_when_trusted() {
+        let mut sink = MockSink { sent: vec![] };
+        let mut debug = MockDebug;
+        let mut messages = MockMessages {
+            cleared: false,
+            queue: 0,
+        };
+        let session = MockSession {
+            supports_exit: false,
+        };
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ClearQueueCommand);
+
+        let result = reg.dispatch(&mut ctx, "/clear-queue", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn clear_queue_dispatch_rejected_when_untrusted() {
+        let mut sink = MockSink { sent: vec![] };
+        let mut debug = MockDebug;
+        let mut messages = MockMessages {
+            cleared: false,
+            queue: 0,
+        };
+        let session = MockSession {
+            supports_exit: false,
+        };
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(ClearQueueCommand);
+
+        let result = reg.dispatch(&mut ctx, "/clear-queue", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }

--- a/crates/zeph-commands/src/handlers/skill.rs
+++ b/crates/zeph-commands/src/handlers/skill.rs
@@ -36,6 +36,10 @@ impl CommandHandler<CommandContext<'_>> for SkillCommand {
         SlashCategory::Skills
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -108,6 +112,10 @@ impl CommandHandler<CommandContext<'_>> for FeedbackCommand {
         SlashCategory::Skills
     }
 
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -128,6 +136,7 @@ impl CommandHandler<CommandContext<'_>> for FeedbackCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CommandRegistry;
     use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
     use crate::sink::NullSink;
     use std::assert_matches;
@@ -187,5 +196,75 @@ mod tests {
             .await
             .unwrap();
         assert_matches!(out, CommandOutput::Message(_));
+    }
+
+    #[tokio::test]
+    async fn skill_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(SkillCommand);
+
+        let result = reg.dispatch(&mut ctx, "/skill stats", true).await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn skill_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(SkillCommand);
+
+        let result = reg.dispatch(&mut ctx, "/skill stats", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn feedback_dispatch_allowed_when_trusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(FeedbackCommand);
+
+        let result = reg
+            .dispatch(&mut ctx, "/feedback my-skill good job", true)
+            .await;
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn feedback_dispatch_rejected_when_untrusted() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+
+        let mut reg: CommandRegistry<CommandContext<'_>> = CommandRegistry::new();
+        reg.register(FeedbackCommand);
+
+        let result = reg
+            .dispatch(&mut ctx, "/feedback my-skill good job", false)
+            .await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
     }
 }


### PR DESCRIPTION
## Summary
- Third confirmed instance of the `CommandHandler::requires_auth()` fail-open-by-default defect class, after `/image` (#5967/#5988) and `/mcp`+`/plugins` (#5997/#6002).
- Audited all 50 `impl CommandHandler` blocks in `crates/zeph-commands/src/handlers/` and added `requires_auth() -> true` to the 19 that mutate local filesystem/process/config state, spawn processes, or disclose sensitive configuration: `UndoCommand`, `RedoCommand`, `PlanCommand`, `SkillCommand`, `KnowledgeSlashCommand`, `AgentCommand`, `AgentsFleetCommand`, `ConvCommand`, `MemoryCommand`, `GraphCommand`, `GoalCommand`, `AcpCommand`, `CompactCommand`, `FeedbackCommand`, `CocoonCommand`, `NewConversationCommand`, `ClearCommand`, `ResetCommand`, `ClearQueueCommand`.
- `RecapCommand`, `SkillsCommand`, `GuidelinesCommand`, `ExitCommand`, `QuitCommand`, `HelpCommand` audited and confirmed safe (read-only or self-gated via `supports_exit()`); left unchanged.
- The trait's fail-open default itself is unchanged — flipping it to fail-closed is a separate architectural decision, deferred to a follow-up issue.

## Test plan
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-commands --all-features` — 177/177 passed, including one dispatch-level allowed/rejected test pair per gated handler (or direct unit assert for `acp.rs`/`cocoon.rs`, matching each file's existing test convention).
- [x] `cargo +nightly fmt --check` — clean.
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean.
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-commands` and `cargo test --doc -p zeph-commands --all-features` — clean.
- [x] Independent adversarial critique (impl-critic): re-verified sweep completeness (all 50 handlers enumerated), trust-gate propagation across both dispatch paths, test-assertion quality (keys on the gate-exclusive error string, no false positives), scope-boundary correctness for the 6 ungated handlers, and feature-gate compile correctness under single-feature builds (`--features cocoon`). Verdict: approved, no blocking findings.
- [x] Independent code review: approved, no blocking findings.
- [ ] Live untrusted-channel rejection (Telegram/Discord/Slack) not exercised — same limitation as the two prior fixes in this class (requires live bot credentials, unavailable in CI). Tracked in `.local/testing/coverage-status.md`.