### PR TITLE
fix(durable): enforce encryption_gate INV-8 policy at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Security
 
+- `zeph-durable`/`zeph`: `zeph_durable::encryption_gate` (the documented INV-8 AEAD enforcement
+  policy) is now actually invoked at runtime — previously it was a unit-tested pure function that
+  no call site ever reached, so `src/commands/durable.rs::load_write_cipher` (the durable journal
+  write path) and `open_backend` (the `zeph durable` CLI read path, including `--reveal`) each
+  made their own cipher decision by checking only `[durable] encrypt_payload`, ignoring backend
+  and shared-database status entirely. A deployment with `encrypt_payload = false` on a durable
+  journal database reachable by more than one process/client (e.g. a shared volume, or a future
+  Postgres-backed deployment) would silently persist tool outputs and agent-turn state in
+  plaintext with zero warning and zero error (#5996). Both call sites now evaluate
+  `encryption_gate` before making the cipher decision: `encrypt_payload = false` combined with a
+  non-local backend or a shared database now fails closed with a hard error at startup / on the
+  CLI command, and the permitted single-user local override now emits the documented startup
+  `tracing::warn!`. Added a new `[durable] shared_db` config field (default `false`) so operators
+  can declare a shared-database deployment explicitly; a `postgres://`/`postgresql://` resolved
+  journal URL is also treated as shared automatically, as defense in depth. The TUI durable panel
+  poller (`durable_poll_task`, feature `tui`) now evaluates the same policy before opening the
+  journal — previously it bypassed the gate entirely, so the TUI panel could render a journal the
+  `zeph durable` CLI refused to open; a rejection now degrades gracefully to the panel's existing
+  "non-durable mode" state instead of erroring.
 - `zeph-commands`: 19 privileged slash-command handlers now override `requires_auth()` to
   return `true`, closing a trust-gate gap where they ran the default `false` and were therefore
   reachable from untrusted remote channels (Telegram/Discord/Slack) as well as trusted local

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -843,6 +843,7 @@ max_iterations = 1000                      # Max repetitions before loop auto-st
 enabled = false                            # Master opt-in (default: false — current behavior)
 backend = "local"                          # "local" (durable.db) or "restate" (server feature)
 encrypt_payload = true                     # AEAD-encrypt payloads (dev-only override; see security docs)
+shared_db = false                          # Declare the journal DB as multi-process/client (INV-8 gate)
 agent_turns = true                         # Wrap agent-loop steps when enabled
 orchestration = true                       # Journal /plan resume replan budget when enabled
 scheduler = true                           # Exactly-once scheduler job fire when enabled

--- a/book/src/reference/security/durable-encryption.md
+++ b/book/src/reference/security/durable-encryption.md
@@ -65,6 +65,13 @@ The rationale is the trust boundary: a single-user SQLite file inherits the
 operating-system file permissions, but a shared or networked database does not,
 so the journal must protect its own payloads there.
 
+"Shared database" is determined by `[durable].shared_db`: set it `true` whenever
+the journal database is reachable by more than one process or client (a
+network-shared volume, or any future Postgres-backed deployment). It defaults to
+`false` for an ordinary single-user local setup. A `postgres://`/`postgresql://`
+journal URL is also treated as shared automatically, even if `shared_db` was left
+unset, as defense in depth.
+
 ## Key rotation
 
 The `key_id` byte makes rotation possible without rewriting the journal:

--- a/config/default.toml
+++ b/config/default.toml
@@ -1677,6 +1677,11 @@ backend = "local"
 # Encrypt payloads with AEAD. Disabling is a dev-only override (forbidden for
 # non-local backends and shared databases).
 encrypt_payload = true
+# Declare the durable journal database as reachable by more than one process/client
+# (a network-shared volume, or any future Postgres-backed durable deployment). Set
+# true for such deployments — the INV-8 encryption_gate forbids encrypt_payload =
+# false whenever this is true. Leave false for an ordinary single-user local setup.
+shared_db = false
 # Per-adapter opt-in (only take effect when enabled = true).
 agent_turns = true
 orchestration = true

--- a/crates/zeph-config/src/durable.rs
+++ b/crates/zeph-config/src/durable.rs
@@ -57,6 +57,12 @@ pub struct DurableConfig {
     /// Encrypt payloads with AEAD. A `false` value is a development-only override (it emits a
     /// startup warning) and is forbidden for non-local backends (INV-8).
     pub encrypt_payload: bool,
+    /// Operator-declared flag: the durable journal database is reachable by more than one
+    /// process/client (a network-shared volume, or any future Postgres-backed durable
+    /// deployment). Required `true` for such deployments — enforced by `encryption_gate`
+    /// (INV-8), which forbids `encrypt_payload = false` when this is `true`. Default `false`
+    /// (an ordinary single-user local deployment).
+    pub shared_db: bool,
     /// P1 adapter: wrap agent-loop steps in durable steps.
     ///
     /// When `true` (with `enabled = true`), every ordinary agent turn's LLM call is journaled
@@ -99,6 +105,7 @@ impl Default for DurableConfig {
             enabled: false,
             backend: DurableBackend::Local,
             encrypt_payload: true,
+            shared_db: false,
             agent_turns: true,
             orchestration: true,
             scheduler: true,
@@ -167,6 +174,7 @@ mod tests {
         assert!(!cfg.enabled);
         assert_eq!(cfg.backend, DurableBackend::Local);
         assert!(cfg.encrypt_payload);
+        assert!(!cfg.shared_db);
         assert!(cfg.agent_turns);
         assert!(cfg.orchestration);
         assert!(cfg.scheduler);
@@ -214,5 +222,22 @@ mod tests {
         assert_eq!(cfg.journal_ack_timeout_ms, 5000);
         assert_eq!(cfg.retention.prune_batch_size, 999);
         assert_eq!(cfg.retention.ttl_completed_secs, 604_800);
+    }
+
+    /// Round-trips the INV-8 forbidden combination this issue's fix must reject at the
+    /// `encryption_gate` call site: `encrypt_payload = false` declared alongside `shared_db =
+    /// true`. This module only owns the pure data — the gate itself lives in `zeph-durable` — but
+    /// the config layer must still deserialize both fields correctly for the gate to see them.
+    #[test]
+    fn shared_db_and_disabled_encryption_round_trip_together() {
+        let cfg: DurableConfig = toml::from_str(
+            r"
+            encrypt_payload = false
+            shared_db = true
+            ",
+        )
+        .unwrap();
+        assert!(!cfg.encrypt_payload);
+        assert!(cfg.shared_db);
     }
 }

--- a/crates/zeph-config/src/migrate/infra.rs
+++ b/crates/zeph-config/src/migrate/infra.rs
@@ -596,6 +596,7 @@ pub fn migrate_durable_config(toml_src: &str) -> Result<MigrationResult, Migrate
          # enabled = false\n\
          # backend = \"local\"\n\
          # encrypt_payload = true\n\
+         # shared_db = false\n\
          # agent_turns = true\n\
          # orchestration = true\n\
          # scheduler = true\n\
@@ -619,6 +620,67 @@ pub fn migrate_durable_config(toml_src: &str) -> Result<MigrationResult, Migrate
         output,
         changed_count: 1,
         sections_changed: vec!["durable".to_owned()],
+    })
+}
+
+/// Adds a commented `# shared_db = false` advisory line to an existing active `[durable]` table
+/// that lacks the field: the operator-declared flag the INV-8 `encryption_gate` uses to forbid
+/// `encrypt_payload = false` on a multi-process/client journal database (#5996).
+///
+/// Purely additive with a safe default (`false`, matching current unflagged behavior) — no-op
+/// when `[durable]` is absent (covered by [`migrate_durable_config`] instead) or `shared_db`
+/// (active or commented) is already present.
+///
+/// # Errors
+///
+/// Returns [`MigrateError`] if the source is not valid TOML.
+pub fn migrate_durable_shared_db(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Anchored multiline pattern: matches `[durable]` with optional inline comment, followed by
+    // LF or CRLF. Does NOT match `[durable.retention]` so the replacement target stays aligned.
+    static DURABLE_HEADER_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+        Regex::new(r"(?m)^[ \t]*\[durable\][ \t]*(?:#[^\r\n]*)?\r?\n").expect("static pattern")
+    });
+
+    if !section_header_present(toml_src, "durable") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let already_present = toml_src.lines().any(|l| {
+        l.trim()
+            .trim_start_matches('#')
+            .trim()
+            .starts_with("shared_db")
+    });
+    if already_present || !DURABLE_HEADER_RE.is_match(toml_src) {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "# shared_db = false  # journal DB reachable by more than one process/client \
+        (INV-8 encryption_gate, #5996)\n";
+    let output = DURABLE_HEADER_RE
+        .replacen(toml_src, 1, |caps: &regex::Captures| {
+            format!("{}{comment}", &caps[0])
+        })
+        .into_owned();
+
+    let changed = output != toml_src;
+    let changed_count = usize::from(changed);
+    Ok(MigrationResult {
+        output,
+        changed_count,
+        sections_changed: if changed {
+            vec!["durable.shared_db".to_owned()]
+        } else {
+            Vec::new()
+        },
     })
 }
 

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -600,14 +600,14 @@ use steps::{
     MigrateAcpAuthClientsConfig, MigrateAcpSubagentsConfig, MigrateAgentBudgetHint,
     MigrateAgentRetryToToolsRetry, MigrateAutodreamConfig, MigrateCavemanConfig,
     MigrateCocoonProviderNotice, MigrateCocoonShowBalance, MigrateCompressionPredictorConfig,
-    MigrateDatabaseUrl, MigrateDeepLinkConfig, MigrateDurableConfig, MigrateEgressConfig,
-    MigrateEmbedProviderRename, MigrateEvalModelToProvider, MigrateFidelityTimeoutDefaults,
-    MigrateFiveSignalConfig, MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig,
-    MigrateGoalsConfig, MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig,
-    MigrateHooksTurnComplete, MigrateKnowledgeConfig, MigrateLlmStreamLimits,
-    MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
-    MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels, MigrateMemoryGraph,
-    MigrateMemoryGraphRecallIncludeImported, MigrateMemoryHebbian,
+    MigrateDatabaseUrl, MigrateDeepLinkConfig, MigrateDurableConfig, MigrateDurableSharedDb,
+    MigrateEgressConfig, MigrateEmbedProviderRename, MigrateEvalModelToProvider,
+    MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig, MigrateFocusAutoConsolidateMinWindow,
+    MigrateForgettingConfig, MigrateGoalsConfig, MigrateGonkagateToGonka,
+    MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete, MigrateKnowledgeConfig,
+    MigrateLlmStreamLimits, MigrateMagicDocsConfig, MigrateMcpElicitationConfig,
+    MigrateMcpMaxConnectAttempts, MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels,
+    MigrateMemoryGraph, MigrateMemoryGraphRecallIncludeImported, MigrateMemoryHebbian,
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateNliConfig,
@@ -765,6 +765,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateAcpAuthClientsConfig),
             // Step 78 — add [skills.registry] advisory block (spec-045, #5869)
             Box::new(MigrateSkillsRegistry),
+            // Step 79 — add shared_db = false advisory to an existing active [durable] table (#5996)
+            Box::new(MigrateDurableSharedDb),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -38,7 +38,9 @@
 //! step 75 adds a commented `qdrant_timeout_secs = 10` advisory under `[memory]`;
 //! step 76 adds a commented `high_gain_tools = []` advisory under `[tools.utility]` (#5659);
 //! step 77 adds a commented `[[acp.auth_clients]]` advisory block (#5868);
-//! step 78 adds a commented `[skills.registry]` advisory block (spec-045, #5869).
+//! step 78 adds a commented `[skills.registry]` advisory block (spec-045, #5869);
+//! step 79 adds a commented `shared_db = false` advisory to an existing active `[durable]`
+//! table (INV-8 `encryption_gate`, #5996).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -49,8 +51,8 @@ use super::{
     migrate_acp_subagents_config, migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry,
     migrate_autodream_config, migrate_caveman_config, migrate_cocoon_provider_notice,
     migrate_cocoon_show_balance, migrate_compression_predictor_config, migrate_database_url,
-    migrate_deep_link_config, migrate_durable_config, migrate_egress_config,
-    migrate_embed_provider_rename, migrate_eval_model_to_provider,
+    migrate_deep_link_config, migrate_durable_config, migrate_durable_shared_db,
+    migrate_egress_config, migrate_embed_provider_rename, migrate_eval_model_to_provider,
     migrate_fidelity_timeout_defaults, migrate_five_signal_config,
     migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
@@ -951,5 +953,18 @@ impl Migration for MigrateAcpAuthClientsConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_acp_auth_clients_config(toml_src)
+    }
+}
+
+/// Step 79 — adds a commented `shared_db = false` advisory to an existing active `[durable]`
+/// table (INV-8 `encryption_gate`, #5996).
+pub(super) struct MigrateDurableSharedDb;
+impl Migration for MigrateDurableSharedDb {
+    fn name(&self) -> &'static str {
+        "migrate_durable_shared_db"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_durable_shared_db(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        78,
-        "MIGRATIONS registry must contain all 78 sequential steps"
+        79,
+        "MIGRATIONS registry must contain all 79 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1678,7 +1678,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 78);
+    assert_eq!(MIGRATIONS.len(), 79);
 }
 
 #[test]
@@ -1716,7 +1716,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–78).
+    // Names must follow the documented step order (steps 1–79).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1796,6 +1796,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_utility_high_gain_tools",
         "migrate_acp_auth_clients_config",
         "migrate_skills_registry",
+        "migrate_durable_shared_db",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -3759,5 +3760,77 @@ fn magic_docs_idempotent_on_own_output() {
         third.output.matches("# [magic_docs]").count(),
         1,
         "block must not accumulate across repeated runs"
+    );
+}
+
+// ── migrate_durable_shared_db tests (step 79, #5996) ─────────────────────
+
+#[test]
+fn step_79_adds_commented_advisory_when_durable_active_and_missing_field() {
+    let src = "[durable]\nenabled = true\nencrypt_payload = true\n";
+    let result = migrate_durable_shared_db(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("# shared_db = false"));
+    assert!(!result.output.contains("\nshared_db ="));
+    assert!(result.output.contains("enabled = true"));
+    assert!(result.output.contains("encrypt_payload = true"));
+    assert_eq!(
+        result.sections_changed,
+        vec!["durable.shared_db".to_owned()]
+    );
+}
+
+#[test]
+fn step_79_noop_when_shared_db_already_present() {
+    let src = "[durable]\nenabled = true\nshared_db = true\n";
+    let result = migrate_durable_shared_db(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_79_noop_when_shared_db_comment_already_present() {
+    let src = "[durable]\nenabled = true\n# shared_db = false\n";
+    let result = migrate_durable_shared_db(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_79_noop_when_durable_section_absent() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_durable_shared_db(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_79_noop_when_durable_only_commented_advisory() {
+    let src = "# [durable]\n# enabled = false\n";
+    let result = migrate_durable_shared_db(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_79_does_not_match_durable_retention_subtable() {
+    let src = "[durable.retention]\nttl_completed_secs = 604800\n";
+    let result = migrate_durable_shared_db(src).expect("migrate");
+    assert_eq!(
+        result.changed_count, 0,
+        "[durable.retention] alone must not count as an active [durable] table"
+    );
+}
+
+#[test]
+fn step_79_idempotent_on_own_output() {
+    let src = "[durable]\nenabled = true\n";
+    let first = migrate_durable_shared_db(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_durable_shared_db(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
     );
 }

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -73,6 +73,49 @@ fn fmt_ts(ms: i64) -> String {
     )
 }
 
+/// Whether the durable journal at `url` must be treated as a shared, multi-client database for
+/// the INV-8 AEAD gate (`zeph_durable::encryption_gate`).
+///
+/// Trusts the operator-declared `config.durable.shared_db` flag, but also recognizes a
+/// `postgres://`/`postgresql://` URL scheme as shared-by-construction — defense in depth so a
+/// future Postgres-backed `resolve_durable_db_url` is caught by the gate even before the flag is
+/// set for that deployment.
+fn is_shared_db(config: &zeph_core::config::DurableConfig, url: &str) -> bool {
+    config.shared_db || url.starts_with("postgres://") || url.starts_with("postgresql://")
+}
+
+/// Evaluate the INV-8 AEAD enforcement policy for the resolved durable journal `url` and emit the
+/// documented startup warning for the permitted `encrypt_payload = false` override.
+///
+/// Shared by every durable-journal entry point that opens a `LocalBackend` — the CLI write path
+/// ([`load_write_cipher`]), the CLI read path ([`open_backend`]), and the TUI durable panel poller
+/// (`durable_poll_task` in `tui_bridge.rs`) — so a misconfigured shared-DB deployment is rejected
+/// consistently regardless of which surface touches the journal first (#5996).
+///
+/// # Errors
+///
+/// Returns an error when [`zeph_durable::encryption_gate`] rejects the configuration (a
+/// non-local backend or a declared/detected shared database combined with `encrypt_payload =
+/// false`).
+pub(crate) fn enforce_encryption_gate(
+    config: &zeph_core::config::DurableConfig,
+    url: &str,
+) -> anyhow::Result<()> {
+    let shared_db = is_shared_db(config, url);
+    match zeph_durable::encryption_gate(config, shared_db) {
+        Ok(zeph_durable::EncryptionGate::Enabled) => Ok(()),
+        Ok(zeph_durable::EncryptionGate::DisabledLocalWarn) => {
+            tracing::warn!(
+                "durable: AEAD payload encryption is disabled (encrypt_payload = false); \
+                 journal payloads are stored in plaintext. This is a development-only override, \
+                 permitted only for a single-user local, non-shared database (INV-8)."
+            );
+            Ok(())
+        }
+        Err(e) => Err(anyhow::Error::new(e).context("durable execution security policy")),
+    }
+}
+
 /// Load the AEAD cipher from the vault-stored `ZEPH_DURABLE_KEY` for `--reveal`.
 fn load_durable_cipher() -> anyhow::Result<XChaCha20Poly1305Cipher> {
     let dir = zeph_core::vault::default_vault_dir();
@@ -88,6 +131,10 @@ fn load_durable_cipher() -> anyhow::Result<XChaCha20Poly1305Cipher> {
 /// Resolve the AEAD payload cipher to attach on a durable *write* path when
 /// `config.durable.encrypt_payload` is enabled (INV-5).
 ///
+/// First evaluates the INV-8 `encryption_gate` security policy: `encrypt_payload = false` is
+/// rejected outright on a non-local backend or a declared/detected shared database (#5996), and
+/// emits a startup `WARN` for the permitted single-user local override.
+///
 /// Returns `Ok(None)` when encryption is disabled — the documented dev-only override where
 /// payloads are stored as plaintext, so no cipher is attached and writes stay unchanged.
 /// Returns `Ok(Some(cipher))` when encryption is enabled and `ZEPH_DURABLE_KEY` resolves from
@@ -96,6 +143,9 @@ fn load_durable_cipher() -> anyhow::Result<XChaCha20Poly1305Cipher> {
 pub(crate) fn load_write_cipher(
     config: &Config,
 ) -> anyhow::Result<Option<Arc<dyn zeph_durable::PayloadCipher>>> {
+    let url = resolve_durable_db_url(config);
+    enforce_encryption_gate(&config.durable, &url)?;
+
     if !config.durable.encrypt_payload {
         return Ok(None);
     }
@@ -108,10 +158,17 @@ pub(crate) fn load_write_cipher(
 /// documented dev-only override), stored payloads are already plaintext, so `--reveal` must not
 /// require `ZEPH_DURABLE_KEY` to be present in the vault.
 ///
+/// First evaluates the INV-8 `encryption_gate` security policy (see [`enforce_encryption_gate`]):
+/// a declared/detected shared database with `encrypt_payload = false` is rejected on this read
+/// path too — reading a plaintext journal on a shared database is still the forbidden state the
+/// gate exists to reject, regardless of whether the read is via a write path or `--reveal`
+/// (#5996). The permitted single-user local override still emits a startup `WARN` and proceeds.
+///
 /// Returns `Ok(None)` when no journal file exists yet (a friendly signal that durable execution has
 /// not run on this deployment), so the caller can print guidance instead of creating an empty file.
 async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<LocalBackend>> {
     let url = resolve_durable_db_url(config);
+    enforce_encryption_gate(&config.durable, &url)?;
     if url != ":memory:" && !Path::new(&url).exists() {
         println!(
             "No durable journal at {url}.\n\
@@ -534,6 +591,37 @@ mod tests {
         assert!(backend.is_some());
     }
 
+    /// Regression for #5996 (critic finding S2): `open_backend` — the `zeph durable`
+    /// CLI read path shared by `list`/`show`/`inspect`/`prune`/`resume`/`--reveal` — must reject
+    /// `encrypt_payload = false` combined with a declared `shared_db = true`, the same INV-8
+    /// forbidden combination `load_write_cipher` rejects on the write path. Without this test the
+    /// `enforce_encryption_gate(&config.durable, &url)?` line in `open_backend` could be silently
+    /// deleted with the rest of the suite still green.
+    #[tokio::test]
+    async fn open_backend_rejects_disabled_encryption_when_shared_db_declared() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.encrypt_payload = false;
+        config.durable.shared_db = true;
+
+        let url = resolve_durable_db_url(&config);
+        std::fs::write(&url, []).unwrap();
+
+        let result = open_backend(&config, false).await;
+        assert!(
+            result.is_err(),
+            "open_backend must fail closed for encrypt_payload=false on a declared shared_db (INV-8)"
+        );
+
+        // Also rejected on the --reveal path, before any decryption is even attempted.
+        let reveal_result = open_backend(&config, true).await;
+        assert!(
+            reveal_result.is_err(),
+            "open_backend --reveal must fail closed for the same forbidden combination"
+        );
+    }
+
     /// Regression for #5404: `--reveal` must still require `ZEPH_DURABLE_KEY` when
     /// `encrypt_payload = true` (the default, encrypted-at-rest posture).
     #[allow(unsafe_code)]
@@ -680,5 +768,57 @@ mod tests {
             EntryKind::StepResult { payload, .. } => assert_eq!(payload.as_ref(), plaintext),
             other => panic!("unexpected entry kind: {other:?}"),
         }
+    }
+
+    /// Regression for #5996: `encrypt_payload = false` combined with a declared `shared_db =
+    /// true` must fail closed via the INV-8 `encryption_gate`, instead of silently persisting
+    /// plaintext journal payloads to a multi-client database.
+    #[tokio::test]
+    async fn load_write_cipher_rejects_disabled_encryption_when_shared_db_declared() {
+        let mut config = Config::default();
+        config.durable.encrypt_payload = false;
+        config.durable.shared_db = true;
+        assert!(
+            load_write_cipher(&config).is_err(),
+            "encrypt_payload=false on a declared shared_db must fail closed (INV-8)"
+        );
+    }
+
+    /// Regression for #5996: the documented dev-only override (`encrypt_payload = false` on an
+    /// ordinary single-user local, non-shared database) must still succeed — the gate only warns.
+    #[tokio::test]
+    async fn load_write_cipher_warns_but_succeeds_for_undeclared_local_override() {
+        let mut config = Config::default();
+        config.durable.encrypt_payload = false;
+        // shared_db left at its default (false) - the permitted dev-only override.
+        assert!(load_write_cipher(&config).unwrap().is_none());
+    }
+
+    /// Regression for #5996: `is_shared_db` recognizes a `postgres://`/`postgresql://` URL scheme
+    /// as shared-by-construction even when the operator has not (yet) set `shared_db = true` —
+    /// defense in depth for a future Postgres-backed `resolve_durable_db_url`.
+    #[test]
+    fn is_shared_db_detects_postgres_url_scheme_even_when_flag_unset() {
+        let config = zeph_core::config::DurableConfig::default();
+        assert!(!config.shared_db);
+        assert!(is_shared_db(&config, "postgres://user@host/db"));
+        assert!(is_shared_db(&config, "postgresql://user@host/db"));
+        assert!(!is_shared_db(&config, "/local/path/durable.db"));
+    }
+
+    /// Regression for #5996: a `postgres://`-scheme URL combined with `encrypt_payload = false`
+    /// must fail closed via `load_write_cipher` even though `shared_db` was never explicitly set
+    /// — the URL-scheme detection in [`is_shared_db`] is defense in depth, not the primary signal.
+    #[tokio::test]
+    async fn load_write_cipher_rejects_disabled_encryption_for_postgres_url_scheme() {
+        let mut config = Config::default();
+        config.durable.encrypt_payload = false;
+        // memory.sqlite_path drives resolve_durable_db_url; a `postgres://`-looking value
+        // exercises the URL-scheme branch of `is_shared_db` without needing a real Postgres build.
+        config.memory.sqlite_path = "postgres://user@host/db".to_owned();
+        assert!(
+            load_write_cipher(&config).is_err(),
+            "a postgres:// resolved URL must be treated as shared even without shared_db=true"
+        );
     }
 }

--- a/src/commands/scheduler_daemon.rs
+++ b/src/commands/scheduler_daemon.rs
@@ -191,6 +191,10 @@ async fn build_durable_adapter(
     if !(config.durable.enabled && config.durable.scheduler) {
         return Ok(None);
     }
+    // Resolve the write-path cipher (which evaluates the INV-8 encryption_gate, #5996) before
+    // opening the backend, so a forbidden config fails closed without creating a stray empty
+    // journal file on disk first.
+    let cipher = crate::commands::durable::load_write_cipher(config)?;
     let durable_url = crate::commands::durable::resolve_durable_db_url(config);
     let local = zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
         .await
@@ -199,7 +203,6 @@ async fn build_durable_adapter(
         .init()
         .await
         .context("failed to init scheduler durable schema")?;
-    let cipher = crate::commands::durable::load_write_cipher(config)?;
     let local = if let Some(cipher) = cipher {
         local.with_cipher(cipher)
     } else {

--- a/src/init/durable.rs
+++ b/src/init/durable.rs
@@ -57,6 +57,16 @@ pub(super) fn step_durable(state: &mut WizardState) -> anyhow::Result<()> {
         DurableBackend::Local
     };
 
+    // INV-8 (encryption_gate, #5996): the gate forbids encrypt_payload = false whenever this
+    // deployment's journal database is reachable by more than one process/client.
+    state.durable.shared_db = Confirm::new()
+        .with_prompt(
+            "Is this durable journal database shared across multiple processes/containers \
+             (e.g. a network-shared volume, or a shared Postgres server)?",
+        )
+        .default(false)
+        .interact()?;
+
     let customize = Confirm::new()
         .with_prompt("Customize retention (TTL and size caps)?")
         .default(false)

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -819,6 +819,14 @@ const DURABLE_REFRESH_SECS: u64 = 5;
 /// Read-only: it never mutates the journal. Runs until the `tx` channel closes (agent exited). Spawned
 /// only when `[durable] enabled = true`; otherwise the panel keeps its default state and renders the
 /// "non-durable mode" message.
+///
+/// First evaluates the INV-8 `encryption_gate` security policy (same as the `zeph durable` CLI's
+/// `open_backend`, `src/commands/durable.rs`): a declared/detected shared database combined with
+/// `encrypt_payload = false` must be rejected here too, or the TUI panel would happily render a
+/// journal the CLI refuses to open — a cross-mode divergence (#5996). Unlike the CLI, this is a
+/// best-effort background poller with no user waiting on an error message, so a gate rejection
+/// degrades gracefully to the same "non-durable mode" snapshot as a failed backend open, rather
+/// than panicking or looping forever.
 #[cfg(feature = "tui")]
 pub(crate) async fn durable_poll_task(
     db_url: String,
@@ -826,6 +834,19 @@ pub(crate) async fn durable_poll_task(
     tx: tokio::sync::mpsc::Sender<zeph_tui::AgentEvent>,
 ) {
     use zeph_tui::widgets::durable::{DurableRow, DurableSnapshot};
+
+    if let Err(e) = crate::commands::durable::enforce_encryption_gate(&cfg, &db_url) {
+        tracing::warn!(
+            error = %e,
+            "durable poll: encryption policy rejected this deployment; panel shows non-durable mode"
+        );
+        let _ = tx
+            .send(zeph_tui::AgentEvent::DurableSnapshot(
+                DurableSnapshot::default(),
+            ))
+            .await;
+        return;
+    }
 
     let backend = match zeph_durable::LocalBackend::open(&db_url, cfg.max_payload_bytes).await {
         Ok(b) => b,


### PR DESCRIPTION
## Summary
- `zeph_durable::encryption_gate` (the documented INV-8 AEAD enforcement policy) was a unit-tested pure function that no production call site ever reached. `load_write_cipher`/`open_backend` in `src/commands/durable.rs` each made their own cipher decision from `encrypt_payload` alone, ignoring backend and shared-database status, so a misconfigured shared-DB deployment silently persisted durable journal payloads (tool outputs, agent-turn state) in plaintext with zero warning and zero error.
- Both call sites now evaluate `encryption_gate` before deciding on a cipher: a forbidden combination (`encrypt_payload = false` on a non-local or shared-DB backend) fails closed with a hard error, and the permitted single-user local override emits the documented startup `tracing::warn!`.
- Added a new `[durable] shared_db` config field (default `false`) so operators can declare a shared-database deployment explicitly; a `postgres://`/`postgresql://` resolved journal URL is also treated as shared automatically, as defense in depth.
- The TUI durable panel poller (`durable_poll_task`, feature `tui`) had the same gap and bypassed the gate entirely — it now evaluates the same policy and degrades gracefully to the panel's existing "non-durable mode" state on rejection, instead of rendering a journal the CLI would refuse to open.
- Also fixed a related ordering issue in `scheduler_daemon.rs::build_durable_adapter`: the gate check now runs before the backend is opened, avoiding a stray empty journal file being created on a forbidden config.
- Includes the mandatory integration points: `config.toml` documentation, a config-migration step (step 79), an `--init` wizard prompt, mdBook docs, and a testing playbook scenario + coverage-status.md row.

Closes #5996

## Test plan
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12808 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] New regression tests cover both the write path (`load_write_cipher`) and the read path (`open_backend`) rejecting the forbidden `encrypt_payload=false` + shared-DB combination, plus the permitted local-only override and postgres:// URL-scheme detection
- [x] Adversarially reviewed: traced every durable cipher/backend-construction site workspace-wide (runner.rs orchestration + agent-turn adapters, scheduler_daemon, subagent durable-context path, TUI poller) to confirm no bypass remains