### PR TITLE
fix(acp,daemon,serve): wire SelfCheckPipeline, TrajectorySentinel, and SkillInvokeExecutor into all entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(core,acp,tools)`: three more per-turn behavioral pipelines/executors that were
+  constructed and wired into the `Agent` only in `src/runner.rs` (CLI/TUI) now reach ACP,
+  daemon (A2A), and `serve-sessions` too — same "wire-X-into-ACP/daemon/serve" defect class as
+  #5913/#5914/#5978. `zeph_core::quality::SelfCheckPipeline` (Proposer -> Checker MARCH
+  response-quality verification, `config.quality.self_check`) is now built and attached via
+  `Agent::with_quality_pipeline` in all four entry points, extracted into a shared
+  `agent_setup::build_quality_pipeline` helper so the four call sites cannot diverge (#5951).
+  `TrajectorySentinel` (spec-050 risk-escalation state machine, `[security.trajectory]`) is now
+  wired via `Agent::with_trajectory_config`/`with_trajectory_risk_slot`/`with_signal_queue` in
+  ACP (per session), daemon, and serve (per session); the paired
+  `PolicyGateExecutor::with_trajectory_risk`/`with_signal_queue` and
+  `ScopedToolExecutor::with_signal_queue` plumbing (already threaded through
+  `agent_setup::apply_policy_gate_chain`'s `trajectory` parameter, added by #5978's PR in
+  anticipation of this fix) is now populated in all three entry points — serve's globally-shared
+  `ScopedToolExecutor` (built once in `assemble_serve_deps`, before any per-session queue
+  exists) is a documented exception: its `OutOfScope` denials do not feed the trajectory signal
+  queue, since doing so would leak one session's signals into every other session sharing that
+  executor (#5958). `SkillInvokeExecutor` (the `invoke_skill` tool — per-invocation trust check
+  including a blake3 integrity re-check and fail-closed refusal on `Blocked`/quarantine-denied
+  classification) is now constructed and registered as a tool executor, with its trust-snapshot
+  `Arc` also threaded onto the `Agent` via `with_trust_snapshot`, in ACP and daemon — previously
+  `invoke_skill` was effectively CLI-only (#5975).
 - `fix(tools)`: `CompressedExecutor`, `ToolFilter`, and `Arc<ShellExecutor>` now forward the
   remaining cross-cutting `ToolExecutor` methods to their inner/wrapped executor instead of
   silently falling through to the trait's no-op defaults (#6012). `CompressedExecutor` now

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -334,6 +334,15 @@ pub(crate) struct SharedAgentDeps {
     /// (named-provider resolution + secret masking are static config work) — mirrors the
     /// `adversarial_policy_validator`/`adversarial_policy_llm_client` resolution above.
     shadow_sentinel_probe_provider: zeph_llm::any::AnyProvider,
+    /// Spec 050 (#5958): `[security.trajectory]` snapshot. `spawn_acp_agent` builds a fresh
+    /// per-session `TrajectorySentinel` risk slot/signal queue from this when wiring
+    /// `Agent::with_trajectory_config`, mirroring `src/runner.rs`/`src/daemon.rs`.
+    trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig,
+    /// #5951: pre-built `SelfCheckPipeline` (`config.quality.self_check`), shared across every
+    /// session from this connection — provider masking is static config work, so it does not
+    /// need to be rebuilt per session. `spawn_acp_agent` attaches it via
+    /// `Agent::with_quality_pipeline`, mirroring `src/runner.rs`.
+    quality_pipeline: Option<std::sync::Arc<zeph_core::quality::SelfCheckPipeline>>,
     skill_paths: Vec<PathBuf>,
     /// `pub(crate)` (unlike its sibling fields) solely so the `build_combined_deps` test harness
     /// (`crate::serve::test_support::build_shared_pair`, #5420 N5) can assert `Arc::ptr_eq`
@@ -883,6 +892,17 @@ async fn build_acp_deps(
         }
     };
 
+    // Spec 050 (#5958): `[security.trajectory]` snapshot — `spawn_acp_agent` builds the
+    // per-session risk slot/signal queue from this, mirroring `src/runner.rs`/`src/daemon.rs`.
+    let trajectory_sentinel_config = config.security.trajectory.clone();
+    // #5951: built once per connection — provider masking is static config work, mirrors
+    // `shadow_sentinel_probe_provider` above.
+    let quality_pipeline = crate::agent_setup::build_quality_pipeline(
+        config,
+        &provider,
+        app.secret_registry().as_ref(),
+    );
+
     let mcp_registry = create_mcp_registry(
         config,
         &provider,
@@ -1076,6 +1096,8 @@ async fn build_acp_deps(
         capability_scopes_config,
         shadow_sentinel_config,
         shadow_sentinel_probe_provider,
+        trajectory_sentinel_config,
+        quality_pipeline,
         skill_paths,
         skill_reload_tx,
         config_reload_tx,
@@ -1411,6 +1433,17 @@ async fn spawn_acp_agent(
         ex
     };
     let skill_loader_executor = zeph_core::SkillLoaderExecutor::new(Arc::clone(&registry));
+    // #5975: pre-allocate trust snapshot Arc shared between the agent's SkillState and
+    // SkillInvokeExecutor — written once per turn by prepare_context, read by the executor.
+    // Mirrors src/runner.rs; previously ACP never constructed SkillInvokeExecutor at all, so
+    // `invoke_skill` was effectively CLI-only.
+    let trust_snapshot: Arc<
+        parking_lot::RwLock<
+            std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>,
+        >,
+    > = Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
+    let skill_invoke_executor =
+        zeph_core::SkillInvokeExecutor::new(Arc::clone(&registry), Arc::clone(&trust_snapshot));
     let (base_composite, cancel_signal, provider_override, parent_tool_use_id): (
         Arc<dyn ErasedToolExecutor>,
         _,
@@ -1448,10 +1481,13 @@ async fn spawn_acp_agent(
         base = Arc::new(zeph_tools::CompositeExecutor::new(
             skill_loader_executor,
             zeph_tools::CompositeExecutor::new(
-                memory_executor,
+                skill_invoke_executor,
                 zeph_tools::CompositeExecutor::new(
-                    overflow_executor,
-                    zeph_tools::DynExecutor(base),
+                    memory_executor,
+                    zeph_tools::CompositeExecutor::new(
+                        overflow_executor,
+                        zeph_tools::DynExecutor(base),
+                    ),
                 ),
             ),
         ));
@@ -1468,10 +1504,13 @@ async fn spawn_acp_agent(
         let base: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::CompositeExecutor::new(
             skill_loader_executor,
             zeph_tools::CompositeExecutor::new(
-                memory_executor,
+                skill_invoke_executor,
                 zeph_tools::CompositeExecutor::new(
-                    overflow_executor,
-                    zeph_tools::DynExecutor(Arc::clone(&tool_executor) as Arc<_>),
+                    memory_executor,
+                    zeph_tools::CompositeExecutor::new(
+                        overflow_executor,
+                        zeph_tools::DynExecutor(Arc::clone(&tool_executor) as Arc<_>),
+                    ),
                 ),
             ),
         ));
@@ -1488,6 +1527,15 @@ async fn spawn_acp_agent(
     );
     crate::agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &mcp_tools);
 
+    // #5958: shared trajectory risk slot — written by begin_turn(), read by PolicyGateExecutor —
+    // and pending risk signal queue — executor layers push signal codes; begin_turn() drains.
+    // Built fresh per session (like ShadowSentinel below), mirroring src/runner.rs; previously
+    // ACP never created these, so TrajectorySentinel was never wired into any ACP session.
+    let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
+        Arc::new(parking_lot::RwLock::new(0u8));
+    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+        Arc::new(parking_lot::Mutex::new(Vec::new()));
+
     // Wire AdversarialPolicyGateExecutor / PolicyGateExecutor around the trust-gated
     // per-session composite, using the pieces pre-built once per connection in
     // `build_acp_deps` — previously these gates wrapped only the connection-scoped
@@ -1498,7 +1546,7 @@ async fn spawn_acp_agent(
         trust_gated,
         &d.policy_gate_pieces,
         d.audit_logger.as_ref(),
-        None,
+        Some((&trajectory_risk_slot, &trajectory_signal_queue)),
     );
 
     // Spec 050 F2 (#5913): wrap with ScopedToolExecutor when capability_scopes are configured —
@@ -1529,7 +1577,13 @@ async fn spawn_acp_agent(
             // takes `tool_executor` by value.
             let fallback = zeph_tools::DynExecutor(Arc::clone(&tool_executor.0));
             match build_scoped_executor(tool_executor, scopes_cfg, &registry_ids) {
-                Ok(scoped) => zeph_tools::DynExecutor(Arc::new(scoped)),
+                Ok(scoped) => {
+                    // #5958: OutOfScope denials feed the trajectory signal queue too, matching
+                    // src/runner.rs/src/daemon.rs — otherwise capability-scope violations would
+                    // be invisible to TrajectorySentinel's risk escalation.
+                    let scoped = scoped.with_signal_queue(Arc::clone(&trajectory_signal_queue));
+                    zeph_tools::DynExecutor(Arc::new(scoped))
+                }
                 Err(e) => {
                     // Misconfiguration (FR-CG-005) is fatal for the single-process CLI run
                     // (runner.rs aborts startup); ACP serves many concurrent IDE clients on one
@@ -1715,6 +1769,8 @@ async fn spawn_acp_agent(
         .with_skill_provider_names(skill_generation_provider, skill_disambiguate_provider)
         .with_semantic_scan(semantic_scan, semantic_scan_provider)
         .with_trust_config(d.trust_config.clone())
+        .with_trust_snapshot(Arc::clone(&trust_snapshot))
+        .with_quality_pipeline(d.quality_pipeline.clone())
         .with_rl_routing(
             d.rl_routing_enabled,
             d.rl_learning_rate,
@@ -1749,6 +1805,15 @@ async fn spawn_acp_agent(
     .await;
 
     agent = agent.with_acp_session(true);
+
+    // #5958: wire the trajectory risk slot/signal queue built above (spec 050 Invariant 2) plus
+    // the TrajectorySentinel state machine itself into the agent, matching src/runner.rs and
+    // src/daemon.rs.
+    agent = agent
+        .with_trajectory_risk_slot(trajectory_risk_slot)
+        .with_signal_queue(trajectory_signal_queue)
+        .with_trajectory_config(d.trajectory_sentinel_config.clone())
+        .0;
 
     // SkillOrchestra: load persisted RL routing head weights, if enabled (#5921) — mirrors
     // `src/runner.rs`/`src/daemon.rs`'s cold-start/load pattern. `d.rl_embed_dim_resolved` is
@@ -3532,6 +3597,204 @@ mod tests {
         );
     }
 
+    /// Regression test confirming `PolicyGateExecutor`'s trajectory-risk signal queue (#5958,
+    /// spec 050) is wired through `agent_setup::apply_policy_gate_chain` when called from ACP:
+    /// `spawn_acp_agent` previously passed `None` for the `trajectory` parameter, so a
+    /// declarative-policy denial never reached `TrajectorySentinel` for ACP-dispatched calls.
+    /// Reconstructs the same trust-gated base chain the sibling `policy_gate_denies_tool_in_acp_composite_chain`
+    /// test uses, wraps it via `apply_policy_gate_chain` with a deny rule and
+    /// `Some((&trajectory_risk_slot, &trajectory_signal_queue))` exactly as `spawn_acp_agent`
+    /// now does, and asserts the signal queue receives the `PolicyDeny` code (`1`) after a
+    /// denied call. This is the observable wiring surface reachable from this crate — the
+    /// downstream `trajectory_risk_slot` mutation happens inside `Agent::begin_turn` (private to
+    /// `zeph-core`, already covered by that crate's own `agent/trajectory.rs` unit tests).
+    #[tokio::test]
+    async fn trajectory_signal_queue_receives_policy_denial_in_acp_composite_chain() {
+        let config = zeph_core::config::Config::default();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = crate::agent_setup::build_diagnostics_executor(&config);
+        let base_executor = crate::agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+        );
+        let (trust_gated, _mcp_ids_handle) = crate::agent_setup::apply_common_tool_gating(
+            zeph_tools::DynExecutor(Arc::new(base_executor)),
+            &zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full),
+        );
+
+        let policy_config = zeph_tools::PolicyConfig {
+            enabled: true,
+            default_effect: zeph_tools::DefaultEffect::Allow,
+            rules: vec![zeph_tools::PolicyRuleConfig {
+                effect: zeph_tools::PolicyEffect::Deny,
+                tool: "overflow_flush".into(),
+                paths: vec![],
+                env: vec![],
+                trust_level: None,
+                args_match: None,
+                capabilities: vec![],
+            }],
+            ..Default::default()
+        };
+        let enforcer = zeph_tools::PolicyEnforcer::compile(&policy_config).unwrap();
+        let pieces = crate::agent_setup::PolicyGatePieces {
+            policy_enforcer: Some(Arc::new(enforcer)),
+            adversarial_validator: None,
+            adversarial_llm_client: None,
+            adv_policy_info: None,
+        };
+
+        let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
+            Arc::new(parking_lot::RwLock::new(0u8));
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+        let gated = crate::agent_setup::apply_policy_gate_chain(
+            trust_gated,
+            &pieces,
+            None,
+            Some((&trajectory_risk_slot, &trajectory_signal_queue)),
+        );
+
+        let denied = gated
+            .execute_tool_call(&acp_test_call("overflow_flush"))
+            .await;
+        assert!(
+            matches!(denied, Err(zeph_tools::ToolError::Blocked { .. })),
+            "expected Blocked from PolicyGateExecutor's deny rule, got {denied:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![1u8],
+            "expected the PolicyDeny signal code (1) to be pushed into the shared trajectory \
+             signal queue after a denied tool call, proving apply_policy_gate_chain's ACP call \
+             site actually wires PolicyGateExecutor::with_signal_queue instead of passing None"
+        );
+    }
+
+    /// Companion to `trajectory_signal_queue_receives_policy_denial_in_acp_composite_chain`
+    /// covering the other #5958 signal source `spawn_acp_agent` wires: `ScopedToolExecutor`
+    /// (`[security.capability_scopes]`) `OutOfScope` denials. Before this PR, ACP's
+    /// `ScopedToolExecutor` was never given a signal queue at all, so capability-scope
+    /// violations were invisible to `TrajectorySentinel`'s risk escalation. Reconstructs the
+    /// same scope wrap the sibling `capability_scopes_denies_tool_outside_scope_in_acp_composite_chain`
+    /// test uses, adding `.with_signal_queue(...)` exactly as `spawn_acp_agent` now does, and
+    /// asserts the queue receives the `OutOfScope` signal code (`3`).
+    #[tokio::test]
+    async fn trajectory_signal_queue_receives_scope_denial_in_acp_composite_chain() {
+        use std::collections::HashSet;
+        use zeph_tools::scope::build_scoped_executor;
+
+        let config = zeph_core::config::Config::default();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = crate::agent_setup::build_diagnostics_executor(&config);
+        let base_executor = crate::agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+        );
+        let policy =
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
+        let base_executor = zeph_tools::TrustGateExecutor::new(base_executor, policy);
+
+        let registry_ids: HashSet<String> = base_executor
+            .tool_definitions()
+            .into_iter()
+            .map(|def| {
+                let id = def.id.to_string();
+                if id.contains(':') {
+                    id
+                } else {
+                    format!("builtin:{id}")
+                }
+            })
+            .collect();
+
+        let scopes_cfg = zeph_config::CapabilityScopesConfig {
+            default_scope: "narrow".to_owned(),
+            scopes: std::collections::HashMap::from([(
+                "narrow".to_owned(),
+                zeph_config::ScopeConfig {
+                    patterns: vec!["builtin:read".to_owned()],
+                },
+            )]),
+            ..Default::default()
+        };
+        let scoped = build_scoped_executor(base_executor, &scopes_cfg, &registry_ids)
+            .expect("build_scoped_executor must compile a valid single-pattern scope");
+
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let scoped = scoped.with_signal_queue(Arc::clone(&trajectory_signal_queue));
+
+        let denied = scoped
+            .execute_tool_call(&acp_test_call("diagnostics"))
+            .await;
+        assert!(
+            matches!(denied, Err(zeph_tools::ToolError::OutOfScope { .. })),
+            "expected OutOfScope from ScopedToolExecutor for a tool outside the configured \
+             scope, got {denied:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![3u8],
+            "expected the OutOfScope signal code (3) to be pushed into the shared trajectory \
+             signal queue after a scope-denied tool call, proving spawn_acp_agent's new \
+             `.with_signal_queue(...)` call on the ScopedToolExecutor branch is reachable"
+        );
+    }
+
+    /// Regression test confirming `SkillInvokeExecutor` (#5975) is reachable through ACP's full
+    /// per-session composite: before this PR, `spawn_acp_agent` never constructed
+    /// `SkillInvokeExecutor` at all, so `invoke_skill` tool calls fell through to
+    /// `memory`/`overflow`/`base` (none of which handle that tool id) and would have surfaced
+    /// as `ToolError::NotFound` instead of a skill body/summary. Reuses
+    /// `build_full_acp_session_composite_with_native_fs_shell`, now updated to insert
+    /// `skill_invoke` between `skill_loader` and `memory` matching `spawn_acp_agent`'s current
+    /// nesting order, and calls `invoke_skill` for a name absent from the (empty) registry —
+    /// only `SkillInvokeExecutor` produces the `"skill not found: {name}"` summary text; the
+    /// default (missing trust-snapshot entry) trust level resolves to
+    /// `SkillTrustLevel::MISSING_ENTRY_FALLBACK` (`Trusted`), which is not `Blocked`, so the
+    /// call reaches the body lookup instead of being short-circuited.
+    #[tokio::test]
+    async fn invoke_skill_reaches_skill_invoke_executor_in_full_acp_session_composite() {
+        let (session_composite, _trust_snapshot) =
+            build_full_acp_session_composite_with_native_fs_shell().await;
+
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "skill_name".to_owned(),
+            serde_json::Value::String("nonexistent-skill".to_owned()),
+        );
+        let call = zeph_tools::ToolCall {
+            tool_id: "invoke_skill".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = session_composite.execute_tool_call_erased(&call).await;
+        let output = result
+            .expect("invoke_skill must dispatch successfully through SkillInvokeExecutor")
+            .expect("SkillInvokeExecutor must always return Some(ToolOutput) for invoke_skill");
+        assert!(
+            output
+                .summary
+                .contains("skill not found: nonexistent-skill"),
+            "expected the \"skill not found: ...\" summary that only SkillInvokeExecutor \
+             produces, proving invoke_skill actually reaches it in the full ACP session \
+             composite instead of falling through to memory/overflow/base, got: {output:?}"
+        );
+    }
+
     /// Regression test confirming the five #5914 memory-maintenance loops (eviction,
     /// tier-promotion, scene-consolidation, consolidation, forgetting) are actually
     /// registered on the ACP connection's own `TaskSupervisor`: `build_acp_deps` previously
@@ -3737,12 +4000,23 @@ mod tests {
     /// Builds the full per-session composite `spawn_acp_agent` assembles when the IDE supplies
     /// an `AcpContext` (the primary ACP embedding case) — `ToolFilter`-wrapped base composed
     /// with `AcpNativeStandIn` fs/shell stand-ins (occupying the same slot as
-    /// `AcpFileExecutor`/`AcpShellExecutor`), then `skill_loader`/`memory`/`overflow` layered
-    /// outside, matching `spawn_acp_agent`'s exact nesting order.
-    async fn build_full_acp_session_composite_with_native_fs_shell() -> Arc<dyn ErasedToolExecutor>
-    {
+    /// `AcpFileExecutor`/`AcpShellExecutor`), then `skill_loader`/`skill_invoke`/`memory`/
+    /// `overflow` layered outside, matching `spawn_acp_agent`'s exact nesting order (#5975 added
+    /// `skill_invoke` between `skill_loader` and `memory`). Returns the `trust_snapshot` Arc
+    /// alongside the composite so callers can pre-populate trust rows for `invoke_skill` tests.
+    async fn build_full_acp_session_composite_with_native_fs_shell() -> (
+        Arc<dyn ErasedToolExecutor>,
+        Arc<
+            RwLock<std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>>,
+        >,
+    ) {
         let registry = Arc::new(RwLock::new(zeph_skills::registry::SkillRegistry::empty()));
         let skill_loader_executor = zeph_core::SkillLoaderExecutor::new(Arc::clone(&registry));
+        let trust_snapshot: Arc<
+            RwLock<std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>>,
+        > = Arc::new(RwLock::new(std::collections::HashMap::new()));
+        let skill_invoke_executor =
+            zeph_core::SkillInvokeExecutor::new(Arc::clone(&registry), Arc::clone(&trust_snapshot));
 
         let mock_provider =
             zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
@@ -3772,7 +4046,7 @@ mod tests {
 
         // Mirrors spawn_acp_agent's `Some(ctx)` branch: base -> ToolFilter (suppress
         // read/write/glob) -> composite with the fs stand-in -> composite with the shell
-        // stand-in -> skill_loader/memory/overflow layered outside.
+        // stand-in -> skill_loader/skill_invoke/memory/overflow layered outside.
         let mut base: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::FileExecutor::new(vec![]));
         let filtered =
             zeph_tools::ToolFilter::new(zeph_tools::DynExecutor(base), &["read", "write", "glob"]);
@@ -3789,14 +4063,17 @@ mod tests {
         base = Arc::new(zeph_tools::CompositeExecutor::new(
             skill_loader_executor,
             zeph_tools::CompositeExecutor::new(
-                memory_executor,
+                skill_invoke_executor,
                 zeph_tools::CompositeExecutor::new(
-                    overflow_executor,
-                    zeph_tools::DynExecutor(base),
+                    memory_executor,
+                    zeph_tools::CompositeExecutor::new(
+                        overflow_executor,
+                        zeph_tools::DynExecutor(base),
+                    ),
                 ),
             ),
         ));
-        base
+        (base, trust_snapshot)
     }
 
     /// Regression test closing the gap found in review: the sibling `policy_gate_denies_tool_in_acp_composite_chain`
@@ -3813,7 +4090,8 @@ mod tests {
     /// not just calls into the `base` chain.
     #[tokio::test]
     async fn policy_gate_denies_skill_and_memory_tools_in_full_acp_session_composite() {
-        let session_composite = build_full_acp_session_composite_with_native_fs_shell().await;
+        let (session_composite, _trust_snapshot) =
+            build_full_acp_session_composite_with_native_fs_shell().await;
 
         let policy_config = zeph_tools::PolicyConfig {
             enabled: true,
@@ -3880,7 +4158,8 @@ mod tests {
             }
         }
 
-        let session_composite = build_full_acp_session_composite_with_native_fs_shell().await;
+        let (session_composite, _trust_snapshot) =
+            build_full_acp_session_composite_with_native_fs_shell().await;
 
         let validator = Arc::new(zeph_tools::PolicyValidator::new(
             vec!["never allow load_skill, memory_search, write_file, or bash".to_owned()],

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1218,6 +1218,43 @@ pub(crate) fn apply_secret_masking<C: Channel>(
     }
 }
 
+/// Builds a `SelfCheckPipeline` from `config.quality.self_check` (#5951), shared by every agent
+/// entry point (CLI's `runner.rs`, `acp.rs`'s `spawn_acp_agent`, `daemon.rs`'s `run_daemon`,
+/// `serve/agent_factory.rs`) so the Proposer -> Checker MARCH quality-verification pass runs
+/// uniformly regardless of transport instead of being CLI-only.
+///
+/// `SelfCheckPipeline` clones `provider` for its own Proposer/Checker roles rather than reading
+/// it off the (already-masked) `Agent`, so it is not covered by `Agent::with_secret_registry`'s
+/// retroactive wrap (#5437 round-3) and needs this explicit mask here.
+///
+/// Returns `None` when `self_check` is disabled or pipeline construction fails (logged as a
+/// warning — a construction failure degrades to "no self-check" rather than aborting startup).
+pub(crate) fn build_quality_pipeline(
+    config: &Config,
+    provider: &zeph_llm::any::AnyProvider,
+    secret_registry: Option<&Arc<zeph_sanitizer::secret_mask::SecretMaskRegistry>>,
+) -> Option<Arc<zeph_core::quality::SelfCheckPipeline>> {
+    if !config.quality.self_check {
+        return None;
+    }
+    let quality_provider = match secret_registry {
+        Some(registry) => provider
+            .clone()
+            .masked(Arc::clone(registry) as Arc<dyn zeph_llm::masking::OutboundMasker>),
+        None => provider.clone(),
+    };
+    match zeph_core::quality::SelfCheckPipeline::build(
+        &zeph_core::quality::QualityConfig::from(&config.quality),
+        &quality_provider,
+    ) {
+        Ok(pipeline) => Some(pipeline),
+        Err(e) => {
+            tracing::warn!(error = %e, "self-check pipeline init failed");
+            None
+        }
+    }
+}
+
 /// Wires a [`zeph_core::debug_dump::DebugDumper`] into `agent` for `dir`/`format`, shared by
 /// every agent entry point that honors `[debug] enabled = true` (CLI, ACP, daemon, serve-sessions).
 ///
@@ -2380,6 +2417,35 @@ mod tests {
             config.skills.max_active_skills.get(),
             NoopExec,
         )
+    }
+
+    /// #5951 regression: `build_quality_pipeline` is the single shared helper every entry point
+    /// (`runner.rs`, `acp.rs`, `daemon.rs`, `serve/agent_factory.rs`) now calls to construct the
+    /// `SelfCheckPipeline` before wiring it via `Agent::with_quality_pipeline` — asserts the two
+    /// branches those call sites depend on: disabled config returns `None` (no pipeline built,
+    /// no cost) and enabled config with a valid provider returns `Some`.
+    #[test]
+    fn build_quality_pipeline_disabled_returns_none() {
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.quality.self_check = false;
+        let pipeline = build_quality_pipeline(&config, &offline_provider(), None);
+        assert!(
+            pipeline.is_none(),
+            "expected None when config.quality.self_check is false"
+        );
+    }
+
+    #[test]
+    fn build_quality_pipeline_enabled_returns_some() {
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.quality.self_check = true;
+        let pipeline = build_quality_pipeline(&config, &offline_provider(), None);
+        assert!(
+            pipeline.is_some(),
+            "expected Some(pipeline) when config.quality.self_check is true and \
+             QualityConfig::validate() passes with the default per_call_timeout_ms/ \
+             latency_budget_ms/min_evidence values"
+        );
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -296,6 +296,12 @@ where
     mcp_manager: std::sync::Arc<zeph_mcp::McpManager>,
     mcp_shared_tools: std::sync::Arc<RwLock<Vec<zeph_mcp::McpTool>>>,
     provider_config_snapshot: zeph_core::ProviderConfigSnapshot,
+    /// #5975: shared with `SkillInvokeExecutor` — see `run_daemon`'s construction site.
+    trust_snapshot: std::sync::Arc<
+        parking_lot::RwLock<
+            std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>,
+        >,
+    >,
 }
 
 /// Build the `Agent` from the `AgentBuilder` construction chain used by the daemon (A2A)
@@ -344,6 +350,7 @@ where
     .with_plugin_dirs_supplier(deps.plugin_dirs_supplier)
     .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())
     .with_trust_config(config.skills.trust.clone())
+    .with_trust_snapshot(deps.trust_snapshot)
     .with_memory(
         deps.memory,
         deps.conversation_id,
@@ -759,6 +766,19 @@ pub(crate) async fn run_daemon(
     .with_conversation(conversation_id.0);
     let skill_loader_executor =
         zeph_core::SkillLoaderExecutor::new(std::sync::Arc::clone(&registry));
+    // #5975: pre-allocate trust snapshot Arc shared between the agent's SkillState and
+    // SkillInvokeExecutor — written once per turn by prepare_context, read by the executor.
+    // Mirrors src/runner.rs; previously the daemon never constructed SkillInvokeExecutor at all,
+    // so `invoke_skill` was effectively CLI-only.
+    let trust_snapshot: std::sync::Arc<
+        parking_lot::RwLock<
+            std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>,
+        >,
+    > = std::sync::Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
+    let skill_invoke_executor = zeph_core::SkillInvokeExecutor::new(
+        std::sync::Arc::clone(&registry),
+        std::sync::Arc::clone(&trust_snapshot),
+    );
     let base_tool: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = {
         let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = std::sync::Arc::new(
             zeph_tools::CompositeExecutor::new(base_executor, mcp_executor),
@@ -784,20 +804,31 @@ pub(crate) async fn run_daemon(
         zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::CompositeExecutor::new(
             skill_loader_executor,
             zeph_tools::CompositeExecutor::new(
-                memory_executor,
+                skill_invoke_executor,
                 zeph_tools::CompositeExecutor::new(
-                    overflow_executor,
-                    zeph_tools::DynExecutor(base_tool),
+                    memory_executor,
+                    zeph_tools::CompositeExecutor::new(
+                        overflow_executor,
+                        zeph_tools::DynExecutor(base_tool),
+                    ),
                 ),
             ),
         )));
-    // Gate the FULLY composed tree (base chain + mcp + search + skill loader + memory +
-    // overflow) behind one outermost TrustGateExecutor, matching runner.rs and ACP
+    // Gate the FULLY composed tree (base chain + mcp + search + skill loader + skill invoke +
+    // memory + overflow) behind one outermost TrustGateExecutor, matching runner.rs and ACP
     // (`src/acp.rs`). Previously only the base chain was gated here, so a Quarantined skill
     // could still reach `memory_save` and any MCP-sourced tool.
     let (trust_gated, mcp_ids_handle) =
         agent_setup::apply_common_tool_gating(inner_executor, &permission_policy);
     agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &mcp_tools);
+    // #5958: shared trajectory risk slot — written by begin_turn(), read by PolicyGateExecutor —
+    // and pending risk signal queue — executor layers push signal codes; begin_turn() drains.
+    // Mirrors src/runner.rs; previously the daemon never created these, so TrajectorySentinel
+    // was never wired into the daemon's tool-gate chain or the Agent itself (see below).
+    let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
+        std::sync::Arc::new(parking_lot::RwLock::new(0u8));
+    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+        std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
     // Wire the same PolicyGateExecutor / AdversarialPolicyGateExecutor stack the CLI
     // path (src/runner.rs) applies around its full tool composite, so declarative
     // (`[tools.policy]`/`[tools.authorization]`) and LLM-based (`[tools.adversarial_policy]`)
@@ -810,7 +841,7 @@ pub(crate) async fn run_daemon(
         trust_gated,
         &policy_gate_pieces,
         daemon_audit_logger.as_ref(),
-        None,
+        Some((&trajectory_risk_slot, &trajectory_signal_queue)),
     );
 
     // Spec 050 F2 (#5913): wrap with ScopedToolExecutor when capability_scopes are configured —
@@ -842,7 +873,14 @@ pub(crate) async fn run_daemon(
                 })
                 .collect();
             match build_scoped_executor(tool_executor, &scopes_cfg, &registry_ids) {
-                Ok(scoped) => zeph_tools::DynExecutor(std::sync::Arc::new(scoped)),
+                Ok(scoped) => {
+                    // #5958: OutOfScope denials feed the trajectory signal queue too, matching
+                    // src/runner.rs — otherwise capability-scope violations would be invisible
+                    // to TrajectorySentinel's risk escalation.
+                    let scoped =
+                        scoped.with_signal_queue(std::sync::Arc::clone(&trajectory_signal_queue));
+                    zeph_tools::DynExecutor(std::sync::Arc::new(scoped))
+                }
                 Err(e) => {
                     return Err(anyhow::anyhow!("capability_scopes: {e}"));
                 }
@@ -1011,6 +1049,7 @@ pub(crate) async fn run_daemon(
         mcp_manager,
         mcp_shared_tools,
         provider_config_snapshot,
+        trust_snapshot,
     };
     let agent = Box::pin(build_daemon_agent(deps, loopback_channel)).await;
 
@@ -1150,6 +1189,21 @@ pub(crate) async fn run_daemon(
     if let Some(sentinel) = shadow_sentinel_arc {
         agent = agent.with_shadow_sentinel(sentinel);
     }
+
+    // #5958: wire the trajectory risk slot/signal queue built above (spec 050 Invariant 2) plus
+    // the TrajectorySentinel state machine itself into the agent, matching src/runner.rs.
+    agent = agent
+        .with_trajectory_risk_slot(trajectory_risk_slot)
+        .with_signal_queue(trajectory_signal_queue)
+        .with_trajectory_config(config.security.trajectory.clone())
+        .0;
+
+    // #5951: wire the self-check quality pipeline, matching src/runner.rs.
+    agent = agent.with_quality_pipeline(agent_setup::build_quality_pipeline(
+        config,
+        &provider,
+        app.secret_registry().as_ref(),
+    ));
 
     // #5566: daemon mode (the process that actually serves `[gateway]` long-lived, since
     // `spawn_gateway_server` only forwards webhooks into an already-built agent) never wired
@@ -1392,6 +1446,9 @@ mod tests {
             mcp_manager,
             mcp_shared_tools: std::sync::Arc::new(RwLock::new(Vec::new())),
             provider_config_snapshot,
+            trust_snapshot: std::sync::Arc::new(parking_lot::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
         };
 
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
@@ -1478,6 +1535,9 @@ mod tests {
             mcp_manager,
             mcp_shared_tools: std::sync::Arc::new(RwLock::new(Vec::new())),
             provider_config_snapshot,
+            trust_snapshot: std::sync::Arc::new(parking_lot::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
         };
 
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
@@ -1553,6 +1613,9 @@ mod tests {
             mcp_manager,
             mcp_shared_tools: std::sync::Arc::new(RwLock::new(Vec::new())),
             provider_config_snapshot,
+            trust_snapshot: std::sync::Arc::new(parking_lot::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
         };
 
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
@@ -2107,6 +2170,227 @@ mod tests {
             !matches!(allowed, Err(zeph_tools::ToolError::OutOfScope { .. })),
             "expected read to reach past ScopedToolExecutor since it matches the active \
              scope's pattern, got {allowed:?}"
+        );
+    }
+
+    /// Regression test confirming `PolicyGateExecutor`'s trajectory-risk signal queue (#5958,
+    /// spec 050) is wired through `agent_setup::apply_policy_gate_chain` when called from
+    /// `run_daemon`: previously `None` was passed for the `trajectory` parameter, so a
+    /// declarative-policy denial never reached `TrajectorySentinel` for daemon-dispatched
+    /// calls. Reconstructs the same trust-gated base chain the sibling
+    /// `policy_gate_denies_tool_in_daemon_composite_chain` test uses, wraps it via
+    /// `apply_policy_gate_chain` with a deny rule and
+    /// `Some((&trajectory_risk_slot, &trajectory_signal_queue))` exactly as `run_daemon` now
+    /// does, and asserts the signal queue receives the `PolicyDeny` code (`1`) after a denied
+    /// call. This is the observable wiring surface reachable from this crate — the downstream
+    /// `trajectory_risk_slot` mutation happens inside `Agent::begin_turn` (private to
+    /// `zeph-core`, already covered by that crate's own `agent/trajectory.rs` unit tests).
+    #[tokio::test]
+    async fn trajectory_signal_queue_receives_policy_denial_in_daemon_composite_chain() {
+        use zeph_tools::executor::ToolExecutor;
+
+        let config = Config::default();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = agent_setup::build_diagnostics_executor(&config);
+        let base_executor = agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+        );
+        let (trust_gated, _mcp_ids_handle) = agent_setup::apply_common_tool_gating(
+            zeph_tools::DynExecutor(std::sync::Arc::new(base_executor)),
+            &zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full),
+        );
+
+        let policy_config = zeph_tools::PolicyConfig {
+            enabled: true,
+            default_effect: zeph_tools::DefaultEffect::Allow,
+            rules: vec![zeph_tools::PolicyRuleConfig {
+                effect: zeph_tools::PolicyEffect::Deny,
+                tool: "diagnostics".into(),
+                paths: vec![],
+                env: vec![],
+                trust_level: None,
+                args_match: None,
+                capabilities: vec![],
+            }],
+            ..Default::default()
+        };
+        let enforcer = zeph_tools::PolicyEnforcer::compile(&policy_config).unwrap();
+        let pieces = agent_setup::PolicyGatePieces {
+            policy_enforcer: Some(std::sync::Arc::new(enforcer)),
+            adversarial_validator: None,
+            adversarial_llm_client: None,
+            adv_policy_info: None,
+        };
+
+        let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
+            std::sync::Arc::new(parking_lot::RwLock::new(0u8));
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+        let gated = agent_setup::apply_policy_gate_chain(
+            trust_gated,
+            &pieces,
+            None,
+            Some((&trajectory_risk_slot, &trajectory_signal_queue)),
+        );
+
+        let denied = gated
+            .execute_tool_call(&daemon_test_call("diagnostics"))
+            .await;
+        assert!(
+            matches!(denied, Err(zeph_tools::ToolError::Blocked { .. })),
+            "expected Blocked from PolicyGateExecutor's deny rule, got {denied:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![1u8],
+            "expected the PolicyDeny signal code (1) to be pushed into the shared trajectory \
+             signal queue after a denied tool call, proving apply_policy_gate_chain's daemon \
+             call site actually wires PolicyGateExecutor::with_signal_queue instead of passing \
+             None"
+        );
+    }
+
+    /// Companion to `trajectory_signal_queue_receives_policy_denial_in_daemon_composite_chain`
+    /// covering the other #5958 signal source `run_daemon` wires: `ScopedToolExecutor`
+    /// (`[security.capability_scopes]`) `OutOfScope` denials. Before this PR, the daemon's
+    /// `ScopedToolExecutor` was never given a signal queue, so capability-scope violations
+    /// were invisible to `TrajectorySentinel`'s risk escalation. Reconstructs the same scope
+    /// wrap the sibling `capability_scopes_denies_tool_outside_scope_in_daemon_composite_chain`
+    /// test uses, adding `.with_signal_queue(...)` exactly as `run_daemon` now does, and
+    /// asserts the queue receives the `OutOfScope` signal code (`3`).
+    #[tokio::test]
+    async fn trajectory_signal_queue_receives_scope_denial_in_daemon_composite_chain() {
+        use std::collections::HashSet;
+        use zeph_tools::executor::ToolExecutor;
+        use zeph_tools::scope::build_scoped_executor;
+
+        let config = Config::default();
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = agent_setup::build_diagnostics_executor(&config);
+        let base_executor = agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+        );
+        let policy =
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
+        let base_executor = zeph_tools::TrustGateExecutor::new(base_executor, policy);
+
+        let registry_ids: HashSet<String> = base_executor
+            .tool_definitions()
+            .into_iter()
+            .map(|def| {
+                let id = def.id.to_string();
+                if id.contains(':') {
+                    id
+                } else {
+                    format!("builtin:{id}")
+                }
+            })
+            .collect();
+
+        let scopes_cfg = zeph_config::CapabilityScopesConfig {
+            default_scope: "narrow".to_owned(),
+            scopes: std::collections::HashMap::from([(
+                "narrow".to_owned(),
+                zeph_config::ScopeConfig {
+                    patterns: vec!["builtin:read".to_owned()],
+                },
+            )]),
+            ..Default::default()
+        };
+        let scoped = build_scoped_executor(base_executor, &scopes_cfg, &registry_ids)
+            .expect("build_scoped_executor must compile a valid single-pattern scope");
+
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let scoped = scoped.with_signal_queue(std::sync::Arc::clone(&trajectory_signal_queue));
+
+        let denied = scoped
+            .execute_tool_call(&daemon_test_call("diagnostics"))
+            .await;
+        assert!(
+            matches!(denied, Err(zeph_tools::ToolError::OutOfScope { .. })),
+            "expected OutOfScope from ScopedToolExecutor for a tool outside the configured \
+             scope, got {denied:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![3u8],
+            "expected the OutOfScope signal code (3) to be pushed into the shared trajectory \
+             signal queue after a scope-denied tool call, proving run_daemon's new \
+             `.with_signal_queue(...)` call on the ScopedToolExecutor branch is reachable"
+        );
+    }
+
+    /// Regression test confirming `SkillInvokeExecutor` (#5975) is reachable through the
+    /// daemon composite chain: before this PR, `run_daemon` never constructed
+    /// `SkillInvokeExecutor` at all, so `invoke_skill` calls fell through to
+    /// memory/overflow/base (none of which handle that tool id) and would have surfaced as
+    /// `ToolError::NotFound` instead of a skill body/summary. Reconstructs `run_daemon`'s
+    /// `skill_loader -> skill_invoke -> ...` nesting order with the real production executor
+    /// types (a lightweight `DaemonTaggedMock` stands in for memory, since only ordering and
+    /// `SkillInvokeExecutor`'s own reachability are under test) and calls `invoke_skill` for a
+    /// name absent from the (empty) registry — only `SkillInvokeExecutor` produces the
+    /// `"skill not found: {name}"` summary text.
+    #[tokio::test]
+    async fn skill_invoke_executor_reachable_in_daemon_composite_chain() {
+        use zeph_tools::executor::ToolExecutor;
+
+        let registry =
+            std::sync::Arc::new(RwLock::new(zeph_skills::registry::SkillRegistry::empty()));
+        let skill_loader_executor =
+            zeph_core::SkillLoaderExecutor::new(std::sync::Arc::clone(&registry));
+        let trust_snapshot: std::sync::Arc<
+            RwLock<std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>>,
+        > = std::sync::Arc::new(RwLock::new(std::collections::HashMap::new()));
+        let skill_invoke_executor = zeph_core::SkillInvokeExecutor::new(
+            std::sync::Arc::clone(&registry),
+            std::sync::Arc::clone(&trust_snapshot),
+        );
+
+        let composite = zeph_tools::CompositeExecutor::new(
+            skill_loader_executor,
+            zeph_tools::CompositeExecutor::new(
+                skill_invoke_executor,
+                DaemonTaggedMock("memory_save"),
+            ),
+        );
+
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "skill_name".to_owned(),
+            serde_json::Value::String("nonexistent-skill".to_owned()),
+        );
+        let call = zeph_tools::ToolCall {
+            tool_id: "invoke_skill".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let output = composite
+            .execute_tool_call(&call)
+            .await
+            .expect("invoke_skill must dispatch successfully through SkillInvokeExecutor")
+            .expect("SkillInvokeExecutor must always return Some(ToolOutput) for invoke_skill");
+        assert!(
+            output
+                .summary
+                .contains("skill not found: nonexistent-skill"),
+            "expected the \"skill not found: ...\" summary that only SkillInvokeExecutor \
+             produces, proving invoke_skill reaches it in the daemon composite chain instead \
+             of falling through to memory/overflow/base, got: {output:?}"
         );
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3607,26 +3607,11 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     };
 
     let agent = {
-        // #5437 round-3: SelfCheckPipeline clones `provider` for its own Proposer/Checker
-        // roles rather than reading it off the (already-masked) Agent, so it needs its own
-        // explicit wrap here — it is not covered by `with_secret_registry`'s retroactive
-        // wrap of the Agent's own provider fields.
-        let quality_provider = match app.secret_registry() {
-            Some(registry) => provider
-                .clone()
-                .masked(registry as std::sync::Arc<dyn zeph_llm::masking::OutboundMasker>),
-            None => provider.clone(),
-        };
-        let pipeline = if config.quality.self_check {
-            zeph_core::quality::SelfCheckPipeline::build(
-                &zeph_core::quality::QualityConfig::from(&config.quality),
-                &quality_provider,
-            )
-            .map_err(|e| anyhow::anyhow!("self-check pipeline init failed: {e}"))
-            .ok()
-        } else {
-            None
-        };
+        let pipeline = crate::agent_setup::build_quality_pipeline(
+            config,
+            &provider,
+            app.secret_registry().as_ref(),
+        );
         agent.with_quality_pipeline(pipeline)
     };
 

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -111,6 +111,16 @@ pub(crate) async fn build_agent_factory(
         None
     };
 
+    // #5958: shared trajectory risk slot — written by begin_turn(), read by PolicyGateExecutor —
+    // and pending risk signal queue — executor layers push signal codes; begin_turn() drains.
+    // Built fresh per session (like the ShadowSentinel below), mirroring src/runner.rs/
+    // src/acp.rs/src/daemon.rs; previously serve-sessions never created these, so
+    // TrajectorySentinel was never wired into any `/sessions*` agent.
+    let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
+        Arc::new(parking_lot::RwLock::new(0u8));
+    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+        Arc::new(parking_lot::Mutex::new(Vec::new()));
+
     // SEC-H1 / R1: each session gets its own gate stack, wrapping the shared base composite —
     // see `gate_serve_session_executor`'s doc comment for the full rationale and the INVARIANT
     // that binds future serve tool-executor changes.
@@ -119,6 +129,7 @@ pub(crate) async fn build_agent_factory(
         &deps.permission_policy,
         &deps.policy_gate_pieces,
         deps.audit_logger.as_ref(),
+        Some((&trajectory_risk_slot, &trajectory_signal_queue)),
     );
 
     move |channel| {
@@ -214,7 +225,10 @@ pub(crate) async fn build_agent_factory(
         )
         .with_session_sink(session_sink)
         .with_session_persistence_config(Some(deps.session_persistence_config))
-        .with_provider_pool(deps.provider_pool, deps.provider_config_snapshot);
+        .with_provider_pool(deps.provider_pool, deps.provider_config_snapshot)
+        // #5951: wire the self-check quality pipeline, matching src/runner.rs/src/acp.rs/
+        // src/daemon.rs.
+        .with_quality_pipeline(deps.quality_pipeline);
         if !preloaded_messages.is_empty() {
             agent = agent.with_preloaded_messages(preloaded_messages);
         }
@@ -223,6 +237,14 @@ pub(crate) async fn build_agent_factory(
         if let Some(sentinel) = shadow_sentinel_arc {
             agent = agent.with_shadow_sentinel(sentinel);
         }
+        // #5958: wire the trajectory risk slot/signal queue built above (spec 050 Invariant 2)
+        // plus the TrajectorySentinel state machine itself into the agent, matching
+        // src/runner.rs/src/acp.rs/src/daemon.rs.
+        agent = agent
+            .with_trajectory_risk_slot(trajectory_risk_slot)
+            .with_signal_queue(trajectory_signal_queue)
+            .with_trajectory_config(deps.trajectory_sentinel_config)
+            .0;
         if let Some(head) = rl_head {
             agent = agent.with_rl_head(head);
         }
@@ -255,11 +277,25 @@ pub(crate) async fn build_agent_factory(
 /// file/shell/scrape/cwd chain only — see `deps.rs::build_tool_executor`'s doc comment) — any
 /// tool executor added to `ServeAgentDeps` outside that base, or composed onto the result of
 /// this wrap, bypasses trust/policy/adversarial enforcement entirely. See #5977/#5611/#5748.
+///
+/// `trajectory`, when `Some`, wires `PolicyGateExecutor`'s trajectory-risk reporting (#5958) —
+/// see `apply_policy_gate_chain`'s doc comment. Note this does NOT cover `ScopedToolExecutor`
+/// (`[security.capability_scopes]`) `OutOfScope` denials feeding the same signal queue, unlike
+/// runner.rs/acp.rs/daemon.rs: serve wraps `ScopedToolExecutor` once, eagerly, in
+/// `deps.rs::assemble_serve_deps`, shared across every `/sessions*` agent (SEC-H1 rationale on
+/// `ServeAgentDeps::tool_executor`), before any per-session signal queue exists — attaching one
+/// session's queue there would leak its signals into every other session sharing the same
+/// executor. `PolicyGateExecutor`'s own declarative/adversarial-policy denials still reach
+/// `TrajectorySentinel` correctly since that gate IS per-session.
 fn gate_serve_session_executor(
     tool_executor: Arc<dyn zeph_tools::ErasedToolExecutor>,
     permission_policy: &zeph_tools::PermissionPolicy,
     policy_gate_pieces: &crate::agent_setup::PolicyGatePieces,
     audit_logger: Option<&Arc<zeph_tools::AuditLogger>>,
+    trajectory: Option<(
+        &zeph_tools::TrajectoryRiskSlot,
+        &zeph_tools::RiskSignalQueue,
+    )>,
 ) -> zeph_tools::DynExecutor {
     let (trust_gated, mcp_ids_handle) = crate::agent_setup::apply_common_tool_gating(
         zeph_tools::DynExecutor(tool_executor),
@@ -272,7 +308,7 @@ fn gate_serve_session_executor(
         trust_gated,
         policy_gate_pieces,
         audit_logger,
-        None, // R8: serve has no TrajectorySentinel wiring yet; #5958 seam, mirrors daemon/acp.
+        trajectory,
     )
 }
 
@@ -668,6 +704,8 @@ mod tests {
             shadow_sentinel_probe_provider: AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
         };
 
         let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
@@ -756,6 +794,8 @@ mod tests {
             shadow_sentinel_probe_provider: AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
         };
 
         let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
@@ -863,6 +903,8 @@ mod tests {
             shadow_sentinel_probe_provider: AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
         };
 
         let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
@@ -959,6 +1001,8 @@ mod tests {
             shadow_sentinel_probe_provider: AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
         };
 
         let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
@@ -1054,6 +1098,8 @@ mod tests {
             shadow_sentinel_probe_provider: AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
         };
 
         let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
@@ -1147,6 +1193,8 @@ mod tests {
             shadow_sentinel_probe_provider: AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
         };
 
         let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
@@ -1222,6 +1270,8 @@ mod tests {
             shadow_sentinel_probe_provider: AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
         }
     }
 
@@ -1348,6 +1398,74 @@ mod tests {
             matches!(result, Err(zeph_tools::ToolError::Blocked { .. })),
             "a [tools.policy] deny rule for \"shell\" must block the call through a \
              /sessions-built agent's executor, got {result:?}"
+        );
+    }
+
+    /// #5958 regression: `gate_serve_session_executor`'s `trajectory` parameter must actually
+    /// reach `PolicyGateExecutor::with_signal_queue` when `Some` — before this PR,
+    /// `build_agent_factory` always passed `None` here (the `R8` seam comment this test's
+    /// doc-referenced production code used to carry), so a declarative-policy denial never
+    /// reached `TrajectorySentinel` for any `/sessions*`-dispatched call. Calls the private
+    /// `gate_serve_session_executor` directly (same module) with a `[tools.policy]` deny rule
+    /// and `Some((&trajectory_risk_slot, &trajectory_signal_queue))` exactly as
+    /// `build_agent_factory` now does, and asserts the signal queue receives the `PolicyDeny`
+    /// code (`1`) after a denied call. Note this deliberately does NOT cover capability-scope
+    /// (`ScopedToolExecutor`) `OutOfScope` denials — per `gate_serve_session_executor`'s doc
+    /// comment, serve's `ScopedToolExecutor` is built once, eagerly, in
+    /// `deps.rs::assemble_serve_deps`, shared across every session, before any per-session
+    /// queue exists (SEC-H1); that gap is a documented, intentional deviation from ACP/daemon,
+    /// not something this PR closes.
+    #[tokio::test]
+    async fn gate_serve_session_executor_wires_trajectory_signal_queue_on_policy_denial() {
+        let policy_config = zeph_tools::PolicyConfig {
+            enabled: true,
+            default_effect: zeph_tools::DefaultEffect::Allow,
+            rules: vec![zeph_tools::PolicyRuleConfig {
+                effect: zeph_tools::PolicyEffect::Deny,
+                tool: "shell".into(),
+                paths: vec![],
+                env: vec![],
+                trust_level: None,
+                args_match: None,
+                capabilities: vec![],
+            }],
+            ..Default::default()
+        };
+        let enforcer = Arc::new(zeph_tools::PolicyEnforcer::compile(&policy_config).unwrap());
+        let policy_gate_pieces = crate::agent_setup::PolicyGatePieces {
+            policy_enforcer: Some(enforcer),
+            adversarial_validator: None,
+            adversarial_llm_client: None,
+            adv_policy_info: None,
+        };
+
+        let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
+            Arc::new(parking_lot::RwLock::new(0u8));
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+        let gated = gate_serve_session_executor(
+            Arc::new(zeph_tools::SetCwdExecutor),
+            &zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full),
+            &policy_gate_pieces,
+            None,
+            Some((&trajectory_risk_slot, &trajectory_signal_queue)),
+        );
+
+        let denied = gated
+            .execute_tool_call_erased(&make_tool_call("shell"))
+            .await;
+        assert!(
+            matches!(denied, Err(zeph_tools::ToolError::Blocked { .. })),
+            "expected Blocked from PolicyGateExecutor's deny rule, got {denied:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![1u8],
+            "expected the PolicyDeny signal code (1) to be pushed into the shared trajectory \
+             signal queue after a denied tool call, proving gate_serve_session_executor's \
+             trajectory parameter is actually wired through to PolicyGateExecutor instead of \
+             the old hardcoded None"
         );
     }
 

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -129,6 +129,16 @@ pub(crate) struct ServeAgentDeps {
     /// (named-provider resolution + secret masking are static config work) — mirrors
     /// `src/acp.rs`'s `SharedAgentDeps::shadow_sentinel_probe_provider`.
     pub(crate) shadow_sentinel_probe_provider: AnyProvider,
+    /// Spec 050 (#5958): `[security.trajectory]` snapshot. `agent_factory::build_agent_factory`
+    /// builds a fresh per-session `TrajectorySentinel` risk slot/signal queue from this when
+    /// wiring `Agent::with_trajectory_config`, mirroring `src/runner.rs`/`src/daemon.rs`/
+    /// `src/acp.rs`.
+    pub(crate) trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig,
+    /// #5951: pre-built `SelfCheckPipeline` (`config.quality.self_check`), shared across every
+    /// `/sessions*` agent built from this `ServeAgentDeps` — provider masking is static config
+    /// work, so it does not need to be rebuilt per session. `agent_factory::build_agent_factory`
+    /// attaches it via `Agent::with_quality_pipeline`, mirroring `src/runner.rs`.
+    pub(crate) quality_pipeline: Option<Arc<zeph_core::quality::SelfCheckPipeline>>,
 }
 
 /// Assemble [`ServeAgentDeps`] once at `zeph serve-sessions` startup, plus the resolved bearer
@@ -344,6 +354,18 @@ pub(crate) async fn assemble_serve_deps(
         }
     };
 
+    // Spec 050 (#5958): `[security.trajectory]` snapshot — `build_agent_factory` builds the
+    // per-session risk slot/signal queue from this, mirroring `src/runner.rs`/`src/daemon.rs`/
+    // `src/acp.rs`.
+    let trajectory_sentinel_config = config.security.trajectory.clone();
+    // #5951: built once here — provider masking is static config work, mirrors
+    // `shadow_sentinel_probe_provider` above.
+    let quality_pipeline = crate::agent_setup::build_quality_pipeline(
+        config,
+        &core.provider,
+        app.secret_registry().as_ref(),
+    );
+
     Ok(ServeAgentDeps {
         provider: core.provider.clone(),
         embedding_provider: core.embedding_provider.clone(),
@@ -383,6 +405,8 @@ pub(crate) async fn assemble_serve_deps(
         provider_config_snapshot,
         shadow_sentinel_config,
         shadow_sentinel_probe_provider,
+        trajectory_sentinel_config,
+        quality_pipeline,
     })
 }
 

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -547,6 +547,8 @@ mod tests {
             shadow_sentinel_probe_provider: AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
         };
         AppState {
             registry: Arc::new(LiveSessionRegistry::new()),

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -147,6 +147,8 @@ impl ServeTestHarness {
             shadow_sentinel_probe_provider: AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
         };
 
         let state = AppState {


### PR DESCRIPTION
## Summary

- `SelfCheckPipeline` (`config.quality.self_check`), `TrajectorySentinel` (`config.security.trajectory`, spec-050), and `SkillInvokeExecutor` (`invoke_skill` tool) were each constructed and wired into the `Agent` only in `src/runner.rs` (CLI/TUI entrypoint) — another instance of the recurring "wire-X-into-ACP/daemon/serve" defect class (18+ prior confirmed instances in this codebase).
- Extracted `agent_setup::build_quality_pipeline` as a shared helper used by all four entry points (`runner.rs`, `acp.rs`, `daemon.rs`, `serve`), closing a future-divergence risk.
- Wired `TrajectorySentinel` config plus the paired `PolicyGateExecutor`/`ScopedToolExecutor` signal-queue plumbing into `acp.rs` (per-session), `daemon.rs` (process-wide), and `serve/agent_factory.rs` (per-session).
- Constructed and registered `SkillInvokeExecutor` in the ACP and daemon composite tool chains, sharing a `trust_snapshot` Arc with the `Agent`. Serve does not wire `skill_loader`/`memory`/`overflow` at all (separate pre-existing gap, tracked in #6046) and is correctly out of scope for this fix.
- Added 9 regression tests covering reachability of each fix through the real production composite chains in `acp.rs`, `daemon.rs`, and `serve/agent_factory.rs`.

## Known limitation (not fixed here)

Serve's `ScopedToolExecutor` (`[security.capability_scopes]` wrap) is built once, eagerly, and shared across every concurrent `/sessions*` agent — before any per-session trajectory signal queue exists. Attaching a per-session queue there would leak one session's `OutOfScope` signals into every other session sharing that executor. This is documented in code (`gate_serve_session_executor`'s doc comment) and tracked as a follow-up in #6045. It is a bounded defense-in-depth gap, not a control bypass or a regression from baseline (serve had zero trajectory wiring before this PR).

## Follow-up issues filed

- #6045 — serve `ScopedToolExecutor` capability-scope denials never reach `TrajectorySentinel` signal queue (tracks the known limitation above)
- #6046 — serve `/sessions*` never wires `skill_loader`, `memory`, or `overflow` tools at all (confirmed pre-existing gap, broader than just `invoke_skill`)

Closes #5951
Closes #5975
Refs #5958

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12817 passed, 0 failed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] 9 new regression tests added (reachability through real production composite chains, not shallow/tautological)
- [x] Adversarial critic review — no critical/blocking findings
- [x] Code review — approved
- [x] `.local/testing/playbooks/` and `coverage-status.md` updated (main repo path)