### PR TITLE
fix(worktree): reconcile detached-HEAD worktrees, run prune on clean, clamp zero timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   classification) is now constructed and registered as a tool executor, with its trust-snapshot
   `Arc` also threaded onto the `Agent` via `with_trust_snapshot`, in ACP and daemon — previously
   `invoke_skill` was effectively CLI-only (#5975).
+- `fix(worktree)`: `WorktreeManager::reconcile()` no longer silently drops detached-`HEAD`
+  worktrees (#5936). `git worktree list --porcelain` emits a `detached` line instead of
+  `branch refs/heads/<name>` for these worktrees; the porcelain parser previously only flushed a
+  parsed block when both a `worktree <path>` line and a `branch` line were seen, so detached
+  entries were discarded and became permanently invisible to `zeph worktree list`/`zeph worktree
+  clean`. A block is now flushed whenever its `worktree <path>` line is seen, and detached
+  entries get the new `zeph_worktree::DETACHED_BRANCH_SENTINEL` (`"(detached HEAD)"` — the
+  embedded space makes it an invalid git ref name, so it can never collide with a real branch,
+  including one on a worktree foreign to zeph) as their `branch_name`; `WorktreeManager::remove`
+  skips the `git branch -D` step for this sentinel since there is no real branch to prune, while
+  the `git worktree remove --force` path is unaffected (it operates on `path`, not
+  `branch_name`).
+- `fix(worktree)`: `zeph worktree clean` now runs `git worktree prune` after removing stale
+  entries, per spec-063 FR-CLEANUP-04 (#5937). Previously it only issued `git worktree remove
+  --force` for entries discovered by `reconcile()`, leaving any stale administrative files (e.g.
+  from a worktree directory deleted outside Zeph) in the git registry. Added
+  `WorktreeManager::prune()`.
+- `fix(worktree)`: `DefaultGitRunner` now clamps `git_timeout_secs = 0` (and any sub-second
+  timeout) to a 1-second floor inside `new()`/`with_timeout()` itself, per spec-063's NEVER
+  invariant (#5939). Previously the clamp was duplicated ad hoc at two call sites
+  (`src/runner.rs`, `src/commands/worktree.rs`) and the crate's own `Default` impl bypassed both,
+  so `DefaultGitRunner::default()` (and any other future call site) could still construct a
+  zero-timeout runner where every `git` invocation failed instantly. Both call-site `.max(1)`
+  duplications were removed now that the crate enforces the invariant internally; the
+  `git_timeout_secs` doc comment on `WorktreeConfig` was corrected to say so.
 - `fix(tools)`: `CompressedExecutor`, `ToolFilter`, and `Arc<ShellExecutor>` now forward the
   remaining cross-cutting `ToolExecutor` methods to their inner/wrapped executor instead of
   silently falling through to the trait's no-op defaults (#6012). `CompressedExecutor` now

--- a/crates/zeph-config/src/worktree.rs
+++ b/crates/zeph-config/src/worktree.rs
@@ -79,7 +79,9 @@ pub struct WorktreeConfig {
     /// Applied to every `git` call issued by the worktree subsystem (e.g.
     /// `git worktree add`, `git fetch`, `git rev-parse`).  Increase this value
     /// on repositories that are slow to clone or when running over high-latency
-    /// network links.  A value of `0` is treated as `1` at the call site.
+    /// network links.  A value of `0` is clamped to `1` second by
+    /// [`DefaultGitRunner`](https://docs.rs/zeph-worktree/latest/zeph_worktree/git_runner/struct.DefaultGitRunner.html),
+    /// not by any call site.
     pub git_timeout_secs: u64,
 }
 

--- a/crates/zeph-worktree/src/git_runner.rs
+++ b/crates/zeph-worktree/src/git_runner.rs
@@ -52,24 +52,39 @@ pub trait GitRunner: Send + Sync {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct DefaultGitRunner {
     timeout: Duration,
 }
+
+/// Floor applied to every configured timeout so a `git_timeout_secs = 0`
+/// misconfiguration cannot produce an instantly-expiring command timeout
+/// (spec-063 NEVER: `git_timeout_secs = 0` is disallowed).
+const MIN_TIMEOUT: Duration = Duration::from_secs(1);
 
 impl DefaultGitRunner {
     /// Creates a runner with the default 30-second command timeout.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            timeout: Duration::from_secs(30),
-        }
+        Self::with_timeout(Duration::from_secs(30))
     }
 
     /// Creates a runner with a custom command timeout.
+    ///
+    /// `timeout` is clamped to a minimum of one second — a zero (or
+    /// sub-second) timeout would make every `git` invocation fail
+    /// immediately, which is never the caller's intent.
     #[must_use]
     pub fn with_timeout(timeout: Duration) -> Self {
-        Self { timeout }
+        Self {
+            timeout: timeout.max(MIN_TIMEOUT),
+        }
+    }
+}
+
+impl Default for DefaultGitRunner {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -221,5 +236,31 @@ impl GitRunner for FakeGitRunner {
             stdout: response.stdout,
             stderr: response.stderr,
         })
+    }
+}
+
+#[cfg(test)]
+mod runner_tests {
+    use super::*;
+
+    /// Regression test for #5939: `git_timeout_secs = 0` (surfaced as
+    /// `Duration::ZERO`) must not produce a runner whose every `git`
+    /// invocation times out instantly.
+    #[test]
+    fn with_timeout_clamps_zero_to_one_second() {
+        let runner = DefaultGitRunner::with_timeout(Duration::ZERO);
+        assert_eq!(runner.timeout, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn with_timeout_preserves_values_above_the_floor() {
+        let runner = DefaultGitRunner::with_timeout(Duration::from_mins(1));
+        assert_eq!(runner.timeout, Duration::from_mins(1));
+    }
+
+    #[test]
+    fn default_and_new_are_never_zero() {
+        assert_eq!(DefaultGitRunner::default().timeout, Duration::from_secs(30));
+        assert_eq!(DefaultGitRunner::new().timeout, Duration::from_secs(30));
     }
 }

--- a/crates/zeph-worktree/src/handle.rs
+++ b/crates/zeph-worktree/src/handle.rs
@@ -3,6 +3,28 @@
 
 use std::{path::PathBuf, time::SystemTime};
 
+/// Sentinel used for [`WorktreeHandle::branch_name`] when a worktree discovered
+/// via [`WorktreeManager::reconcile`][crate::WorktreeManager::reconcile] is on a
+/// detached `HEAD` rather than a branch (`git worktree list --porcelain` emits a
+/// `detached` line instead of `branch refs/heads/<name>` for these entries).
+///
+/// The embedded space makes this an invalid git ref name: `git
+/// check-ref-format` rejects any ref component containing a space (see
+/// `git help check-ref-format` — disallowed characters include space, `~`,
+/// `^`, `:`, `?`, `*`, `[`, `\`). `reconcile()` only ever populates
+/// `branch_name` from a `branch refs/heads/<name>` porcelain line, and git
+/// itself refuses to create a ref containing a space in the first place — so
+/// no real branch, including one on a worktree foreign to zeph (i.e. not
+/// created via [`WorktreeManager::create`][crate::WorktreeManager::create],
+/// which further restricts the subagent-id component to
+/// `^[A-Za-z0-9._-]+$`), can ever equal this sentinel. An earlier version of
+/// this constant, `"(detached)"`, lacked this property: parentheses are
+/// valid in git ref names, so a real branch literally named `(detached)`
+/// would have been indistinguishable from a detached-HEAD worktree, causing
+/// [`WorktreeManager::remove`][crate::WorktreeManager::remove] to silently
+/// skip pruning it (#5936 review finding).
+pub const DETACHED_BRANCH_SENTINEL: &str = "(detached HEAD)";
+
 /// A live record of a git worktree that [`WorktreeManager`][crate::WorktreeManager]
 /// has created for a subagent.
 ///
@@ -14,6 +36,10 @@ pub struct WorktreeHandle {
     /// Absolute path on disk where the worktree was checked out.
     pub path: PathBuf,
     /// The git branch name created for this worktree.
+    ///
+    /// For worktrees discovered by [`WorktreeManager::reconcile`][crate::WorktreeManager::reconcile]
+    /// that are on a detached `HEAD`, this is [`DETACHED_BRANCH_SENTINEL`] rather
+    /// than an actual branch name.
     pub branch_name: String,
     /// The resolved base ref used to create the branch.
     ///

--- a/crates/zeph-worktree/src/lib.rs
+++ b/crates/zeph-worktree/src/lib.rs
@@ -50,7 +50,7 @@ pub mod sanitize;
 
 pub use error::WorktreeError;
 pub use git_runner::{DefaultGitRunner, GitRunner};
-pub use handle::WorktreeHandle;
+pub use handle::{DETACHED_BRANCH_SENTINEL, WorktreeHandle};
 pub use manager::{WorktreeManager, probe_capabilities};
 
 /// A [`WorktreeManager`] using the production [`DefaultGitRunner`].

--- a/crates/zeph-worktree/src/manager.rs
+++ b/crates/zeph-worktree/src/manager.rs
@@ -13,7 +13,7 @@ use zeph_config::{WorktreeBaseRef, WorktreeConfig};
 use crate::{
     error::WorktreeError,
     git_runner::GitRunner,
-    handle::WorktreeHandle,
+    handle::{DETACHED_BRANCH_SENTINEL, WorktreeHandle},
     sanitize::{canonicalize_root, validate_branch_component},
 };
 
@@ -231,12 +231,21 @@ impl<R: GitRunner> WorktreeManager<R> {
             .retain(|h| h.path != handle.path);
 
         if prune_branch {
-            let branch = &handle.branch_name;
-            let out = self
-                .runner
-                .run(&["branch", "-D", "--", branch], &self.repo_root)
-                .await?;
-            check_git_status(&out, "branch -D")?;
+            if handle.branch_name == DETACHED_BRANCH_SENTINEL {
+                // A detached-HEAD worktree (see `reconcile`) has no branch to
+                // prune; `git branch -D` would just fail against the sentinel.
+                tracing::debug!(
+                    path = %handle.path.display(),
+                    "skipping branch prune for detached-HEAD worktree"
+                );
+            } else {
+                let branch = &handle.branch_name;
+                let out = self
+                    .runner
+                    .run(&["branch", "-D", "--", branch], &self.repo_root)
+                    .await?;
+                check_git_status(&out, "branch -D")?;
+            }
         }
 
         Ok(())
@@ -312,17 +321,59 @@ impl<R: GitRunner> WorktreeManager<R> {
 
         Ok(stale)
     }
+
+    /// Runs `git worktree prune` to clear stale administrative entries from
+    /// the git worktree registry (e.g. left behind when a worktree directory
+    /// was deleted directly instead of via [`remove`][Self::remove]).
+    ///
+    /// Per FR-CLEANUP-04, this SHALL be called by `zeph worktree clean` after
+    /// [`reconcile`][Self::reconcile]'s stale entries have been removed via
+    /// `git worktree remove --force`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorktreeError::GitCommand`] if `git worktree prune` fails.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn example(mgr: &zeph_worktree::DefaultWorktreeManager) -> Result<(), zeph_worktree::WorktreeError> {
+    /// mgr.prune().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[instrument(name = "worktree.prune", skip(self), err)]
+    pub async fn prune(&self) -> Result<(), WorktreeError> {
+        let out = self
+            .runner
+            .run(&["worktree", "prune"], &self.repo_root)
+            .await?;
+        check_git_status(&out, "worktree prune")?;
+        Ok(())
+    }
 }
 
 /// Parses the output of `git worktree list --porcelain` into [`WorktreeHandle`]s.
 ///
-/// Each worktree block in the porcelain output looks like:
+/// Each worktree block in the porcelain output looks like either:
 /// ```text
 /// worktree /path/to/worktree
 /// HEAD deadbeef...
 /// branch refs/heads/branch-name
 ///
 /// ```
+/// or, for a worktree on a detached `HEAD`:
+/// ```text
+/// worktree /path/to/worktree
+/// HEAD deadbeef...
+/// detached
+///
+/// ```
+/// A block is flushed as soon as its `worktree <path>` line is seen (i.e. when
+/// the *next* block starts, or at end of output) — regardless of whether a
+/// `branch` line was present. Detached-HEAD blocks get
+/// [`DETACHED_BRANCH_SENTINEL`] as their `branch_name` so they are not silently
+/// dropped (#5936).
 fn parse_worktree_list_porcelain(output: &str) -> Vec<WorktreeHandle> {
     let mut result = Vec::new();
     let mut path: Option<PathBuf> = None;
@@ -330,15 +381,8 @@ fn parse_worktree_list_porcelain(output: &str) -> Vec<WorktreeHandle> {
 
     for line in output.lines() {
         if let Some(p) = line.strip_prefix("worktree ") {
-            // Flush previous block if any.
-            if let (Some(wt_path), Some(br)) = (path.take(), branch.take()) {
-                result.push(WorktreeHandle {
-                    path: wt_path,
-                    branch_name: br,
-                    base_ref_resolved: String::new(),
-                    subagent_id: String::new(),
-                    created_at: SystemTime::UNIX_EPOCH,
-                });
+            if let Some(handle) = flush_worktree_block(path.take(), branch.take()) {
+                result.push(handle);
             }
             path = Some(PathBuf::from(p));
         } else if let Some(b) = line.strip_prefix("branch refs/heads/") {
@@ -346,18 +390,24 @@ fn parse_worktree_list_porcelain(output: &str) -> Vec<WorktreeHandle> {
         }
     }
 
-    // Flush the last block.
-    if let (Some(wt_path), Some(br)) = (path, branch) {
-        result.push(WorktreeHandle {
-            path: wt_path,
-            branch_name: br,
-            base_ref_resolved: String::new(),
-            subagent_id: String::new(),
-            created_at: SystemTime::UNIX_EPOCH,
-        });
+    if let Some(handle) = flush_worktree_block(path, branch) {
+        result.push(handle);
     }
 
     result
+}
+
+/// Builds a [`WorktreeHandle`] from one parsed porcelain block, if a
+/// `worktree <path>` line was seen. `branch` is `None` for detached-`HEAD`
+/// worktrees and resolves to [`DETACHED_BRANCH_SENTINEL`].
+fn flush_worktree_block(path: Option<PathBuf>, branch: Option<String>) -> Option<WorktreeHandle> {
+    path.map(|wt_path| WorktreeHandle {
+        path: wt_path,
+        branch_name: branch.unwrap_or_else(|| DETACHED_BRANCH_SENTINEL.to_string()),
+        base_ref_resolved: String::new(),
+        subagent_id: String::new(),
+        created_at: SystemTime::UNIX_EPOCH,
+    })
 }
 
 // --- Internal helpers -------------------------------------------------------
@@ -762,6 +812,30 @@ mod tests {
         mgr.remove(&handle, false).await.unwrap();
     }
 
+    /// Regression test for #5936: a detached-HEAD handle (`branch_name` ==
+    /// [`DETACHED_BRANCH_SENTINEL`]) has no real branch to prune. `remove` must
+    /// not issue a `git branch -D` call for it even when `prune_branch = true` —
+    /// only the single `worktree remove` response is queued, so an unwanted
+    /// second git call would panic the `FakeGitRunner` on an empty queue.
+    #[tokio::test]
+    async fn remove_skips_branch_prune_for_detached_head() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        // worktree remove → success (only response queued)
+        runner.push_ok(b"" as &[u8]);
+
+        let mgr = make_manager(&dir, runner).await;
+        let handle = WorktreeHandle {
+            path: dir.path().join("worktrees/detached-1"),
+            branch_name: DETACHED_BRANCH_SENTINEL.to_string(),
+            base_ref_resolved: String::new(),
+            subagent_id: String::new(),
+            created_at: SystemTime::now(),
+        };
+
+        mgr.remove(&handle, true).await.unwrap();
+    }
+
     #[tokio::test]
     async fn remove_with_branch_prune_issues_two_git_calls() {
         let dir = make_repo();
@@ -843,6 +917,142 @@ mod tests {
         // The main worktree (repo_root) is filtered out; only agent worktrees remain.
         assert_eq!(stale.len(), 1);
         assert_eq!(stale[0].branch_name, "agent/agent-1");
+    }
+
+    /// Regression test for #5936: a `detached` line (instead of `branch
+    /// refs/heads/<name>`) must not cause the block to be silently dropped.
+    #[tokio::test]
+    async fn reconcile_includes_detached_head_worktree() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\nworktree {0}/worktrees/detached-1\nHEAD def456\ndetached\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+
+        let mgr = make_manager(&dir, runner).await;
+        let stale = mgr.reconcile().await.unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_eq!(stale[0].path, dir.path().join("worktrees/detached-1"));
+    }
+
+    /// A detached-HEAD block that is also the *last* block in the porcelain
+    /// output (no trailing `worktree` line to trigger the flush) must still be
+    /// included — exercises the end-of-output flush path specifically.
+    #[test]
+    fn parse_worktree_list_porcelain_flushes_trailing_detached_block() {
+        let output = "worktree /repo\nHEAD abc123\ndetached\n";
+        let result = parse_worktree_list_porcelain(output);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, PathBuf::from("/repo"));
+        assert_eq!(result[0].branch_name, DETACHED_BRANCH_SENTINEL);
+    }
+
+    /// Two secondary detached-HEAD worktrees back to back (no `branch` line
+    /// anywhere between them) must both be flushed independently, not merged
+    /// into one block or have the first one dropped when the second
+    /// `worktree` line triggers its flush.
+    #[test]
+    fn parse_worktree_list_porcelain_flushes_consecutive_detached_blocks() {
+        let output = "worktree /repo/wt-a\nHEAD aaa111\ndetached\n\nworktree /repo/wt-b\nHEAD bbb222\ndetached\n\n";
+        let result = parse_worktree_list_porcelain(output);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].path, PathBuf::from("/repo/wt-a"));
+        assert_eq!(result[0].branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_eq!(result[1].path, PathBuf::from("/repo/wt-b"));
+        assert_eq!(result[1].branch_name, DETACHED_BRANCH_SENTINEL);
+    }
+
+    /// Regression test for #5936: a repo where *every* worktree — including
+    /// the main one — is on a detached `HEAD` (e.g. a shallow CI checkout)
+    /// has no `branch refs/heads/` line anywhere in the porcelain output.
+    /// `reconcile` must still parse without panicking; the main worktree is
+    /// filtered out by path (not by branch), so the only surviving entry is
+    /// the secondary detached worktree.
+    #[tokio::test]
+    async fn reconcile_repo_with_only_detached_head_worktrees() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\ndetached\n\nworktree {0}/worktrees/detached-2\nHEAD def456\ndetached\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+
+        let mgr = make_manager(&dir, runner).await;
+        let stale = mgr.reconcile().await.unwrap();
+        assert_eq!(stale.len(), 1, "main worktree filtered out by path only");
+        assert_eq!(stale[0].branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_eq!(stale[0].path, dir.path().join("worktrees/detached-2"));
+    }
+
+    /// **Finding for reviewer**: `git worktree list --porcelain` emits a
+    /// `bare` line (not `branch` or `detached`) for the main worktree of a
+    /// bare repository:
+    /// ```text
+    /// worktree /path/to/bare.git
+    /// bare
+    ///
+    /// ```
+    /// (confirmed against real `git worktree list --porcelain` output, git
+    /// 2.50.1 — no `HEAD` line is emitted for bare worktrees at all).
+    ///
+    /// Since #5936's fix flushes a block on *any* `worktree <path>` line
+    /// regardless of what follows, a `bare` block is now also flushed and
+    /// mislabeled with [`DETACHED_BRANCH_SENTINEL`] — even though a bare
+    /// worktree is semantically distinct from a detached-`HEAD` worktree.
+    /// This test documents *current* behavior; it is not a statement that
+    /// the behavior is correct. Neither `spec.md` nor `srs.md` for spec-063
+    /// mentions bare-repo worktrees at all, so this is an unspecified gap,
+    /// not a spec violation — but see the tester handoff for why it can
+    /// still cause a misleading `remove()` outcome downstream.
+    #[test]
+    fn parse_worktree_list_porcelain_mislabels_bare_worktree_as_detached() {
+        let output = "worktree /path/to/bare.git\nbare\n\n";
+        let result = parse_worktree_list_porcelain(output);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, PathBuf::from("/path/to/bare.git"));
+        // Documents the mislabeling: a bare worktree is reported as detached.
+        assert_eq!(result[0].branch_name, DETACHED_BRANCH_SENTINEL);
+    }
+
+    // --- prune ---
+
+    /// Regression test for #5937: `WorktreeManager::prune` must issue exactly
+    /// `git worktree prune` — the command `zeph worktree clean` is required to
+    /// run (FR-CLEANUP-04) after removing stale entries.
+    #[tokio::test]
+    async fn prune_issues_worktree_prune() {
+        let dir = make_repo();
+        let runner = Arc::new(FakeGitRunner::new());
+        runner.push_ok(b"" as &[u8]);
+
+        let mgr =
+            WorktreeManager::new(dir.path().to_path_buf(), test_config(), Arc::clone(&runner))
+                .await
+                .unwrap();
+
+        mgr.prune().await.unwrap();
+
+        let calls = runner.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].0,
+            vec!["worktree".to_string(), "prune".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_propagates_git_failure() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        runner.push_err(b"fatal: not a working tree\n" as &[u8]);
+
+        let mgr = make_manager(&dir, runner).await;
+        let err = mgr.prune().await.unwrap_err();
+        assert_matches!(err, WorktreeError::GitCommand { ref op, .. } if op == "worktree prune");
     }
 
     // --- parse_git_version ---

--- a/crates/zeph-worktree/tests/real_git_integration.rs
+++ b/crates/zeph-worktree/tests/real_git_integration.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MIT
+//! Real-`git` integration tests for [`WorktreeManager`].
+//!
+//! Unlike the unit tests in `src/manager.rs` (which use `FakeGitRunner`),
+//! these tests spawn the actual `git` binary against a temporary repository,
+//! exercising the full `reconcile` -> `remove` -> `prune` pipeline (#5936,
+//! #5937) and the `git_timeout_secs = 0` clamp (#5939) exactly as wired at
+//! the real construction call sites in `src/commands/worktree.rs` and
+//! `src/runner.rs`.
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use zeph_config::WorktreeConfig;
+use zeph_worktree::{DETACHED_BRANCH_SENTINEL, DefaultGitRunner, WorktreeManager};
+
+fn git(args: &[&str], cwd: &Path) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("git must be on PATH for this integration test")
+}
+
+fn init_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path();
+    assert!(git(&["init", "-q"], path).status.success());
+    git(&["config", "user.email", "test@example.com"], path);
+    git(&["config", "user.name", "Test"], path);
+    std::fs::write(path.join("README.md"), "test\n").unwrap();
+    git(&["add", "."], path);
+    assert!(git(&["commit", "-q", "-m", "init"], path).status.success());
+    dir
+}
+
+fn config() -> WorktreeConfig {
+    WorktreeConfig {
+        enabled: true,
+        root: "worktrees".to_string(),
+        branch_prefix: "agent/".to_string(),
+        ..WorktreeConfig::default()
+    }
+}
+
+/// End-to-end regression test for #5937 (FR-CLEANUP-04): when a worktree
+/// directory is deleted directly (`rm -rf`, simulating a crash or manual
+/// cleanup) instead of via `git worktree remove`, `git` leaves a "prunable"
+/// administrative entry behind. `WorktreeManager::prune()` — wired into
+/// `zeph worktree clean` after the `reconcile()`/`remove()` loop — must
+/// clear it.
+///
+/// This test isolates `prune()`'s own contribution by deliberately *not*
+/// calling `remove()` on the discovered stale handle: on the git version
+/// this suite runs against (2.50.1), `git worktree remove --force` on an
+/// already-missing directory happens to also clear the entry by itself, so
+/// a full-pipeline test alone would not prove `prune()` is load-bearing.
+/// Calling `reconcile()` + `prune()` only shows `prune()` independently
+/// clears the leftover entry, which is the FR-CLEANUP-04 guarantee.
+///
+/// The worktree is created by one `WorktreeManager` instance and discovered
+/// by a *second*, freshly-constructed one over the same repo — mirroring
+/// the real `zeph worktree clean` flow, which always runs in a brand-new
+/// process whose in-memory handle list starts empty. Using the same
+/// instance for both `create` and `reconcile` would make the handle
+/// self-tracked and therefore invisible to `reconcile` (which only reports
+/// worktrees *not* already in the current session's list).
+#[tokio::test]
+async fn prune_clears_manually_deleted_worktree_administrative_entry() {
+    let repo = init_repo();
+    let repo_root = repo.path().canonicalize().unwrap();
+
+    let creator = WorktreeManager::new(repo_root.clone(), config(), DefaultGitRunner::new())
+        .await
+        .unwrap();
+    let handle = creator
+        .create("clean-test-agent")
+        .await
+        .expect("create worktree");
+    assert!(handle.path.exists(), "worktree dir must exist after create");
+
+    // Simulate external deletion (crash, manual `rm -rf`) instead of `mgr.remove()`.
+    std::fs::remove_dir_all(&handle.path).unwrap();
+
+    let list_before = git(&["worktree", "list", "--porcelain"], &repo_root);
+    let before_str = String::from_utf8_lossy(&list_before.stdout);
+    assert!(
+        before_str.contains(handle.path.to_string_lossy().as_ref()),
+        "git registry should still reference the deleted worktree before cleanup: {before_str}"
+    );
+
+    // Fresh manager instance — empty in-memory handle list, as in a real
+    // `zeph worktree clean` invocation (new process per CLI call).
+    let cleaner = WorktreeManager::new(repo_root.clone(), config(), DefaultGitRunner::new())
+        .await
+        .unwrap();
+
+    let stale = cleaner.reconcile().await.expect("reconcile");
+    assert_eq!(
+        stale.len(),
+        1,
+        "expected exactly the deleted worktree to be discovered as stale"
+    );
+    assert_eq!(stale[0].path, handle.path);
+
+    // Deliberately skip `remove()` — see doc comment above.
+    cleaner.prune().await.expect("prune");
+
+    let list_after = git(&["worktree", "list", "--porcelain"], &repo_root);
+    let after_str = String::from_utf8_lossy(&list_after.stdout);
+    assert!(
+        !after_str.contains(handle.path.to_string_lossy().as_ref()),
+        "git registry must no longer reference the deleted worktree after prune: {after_str}"
+    );
+}
+
+/// End-to-end regression test for #5937 covering the exact sequence
+/// `WorktreeCommand::Clean` runs in `src/commands/worktree.rs`: `reconcile()`
+/// -> `remove()` each stale entry -> `prune()`. Confirms the full pipeline
+/// leaves `git worktree list` with no trace of the manually-deleted worktree.
+///
+/// As in `prune_clears_manually_deleted_worktree_administrative_entry`, the
+/// worktree is created by one manager instance and cleaned by a second,
+/// freshly-constructed one — matching the real `zeph worktree clean`
+/// process boundary — so `reconcile()`'s stale list is non-empty and the
+/// `remove()` step is actually exercised (not skipped as a no-op over an
+/// empty list).
+#[tokio::test]
+async fn clean_pipeline_end_to_end_clears_manually_deleted_worktree() {
+    let repo = init_repo();
+    let repo_root = repo.path().canonicalize().unwrap();
+
+    let creator = WorktreeManager::new(repo_root.clone(), config(), DefaultGitRunner::new())
+        .await
+        .unwrap();
+    let handle = creator
+        .create("clean-pipeline-agent")
+        .await
+        .expect("create worktree");
+    std::fs::remove_dir_all(&handle.path).unwrap();
+
+    let cleaner = WorktreeManager::new(repo_root.clone(), config(), DefaultGitRunner::new())
+        .await
+        .unwrap();
+
+    let stale = cleaner.reconcile().await.expect("reconcile");
+    assert_eq!(
+        stale.len(),
+        1,
+        "expected exactly the deleted worktree to be discovered as stale"
+    );
+    for h in &stale {
+        if let Err(e) = cleaner.remove(h, false).await {
+            // Mirrors `handle_worktree_command`'s non-fatal per-entry handling.
+            eprintln!("warning: failed to remove {}: {e}", h.path.display());
+        }
+    }
+    cleaner.prune().await.expect("prune");
+
+    let list_after = git(&["worktree", "list", "--porcelain"], &repo_root);
+    let after_str = String::from_utf8_lossy(&list_after.stdout);
+    assert!(
+        !after_str.contains(handle.path.to_string_lossy().as_ref()),
+        "git registry must no longer reference the deleted worktree after clean: {after_str}"
+    );
+}
+
+/// End-to-end regression test for #5939: `git_timeout_secs = 0` from config,
+/// constructed exactly as `handle_worktree_command`
+/// (`src/commands/worktree.rs`) and the bootstrap call site (`src/runner.rs`)
+/// build it — `DefaultGitRunner::with_timeout(Duration::from_secs(0))` — must
+/// still allow a real `git` invocation to complete rather than racing an
+/// instantly-expiring `tokio::time::timeout`.
+#[tokio::test]
+async fn zero_configured_timeout_still_allows_real_git_command_to_complete() {
+    let repo = init_repo();
+    let repo_root = repo.path().canonicalize().unwrap();
+
+    let git_timeout_secs: u64 = 0;
+    let runner = DefaultGitRunner::with_timeout(Duration::from_secs(git_timeout_secs));
+
+    let mgr = WorktreeManager::new(repo_root.clone(), config(), runner)
+        .await
+        .unwrap();
+
+    // Real process spawn racing the real `tokio::time::timeout`. Without the
+    // internal `.max(MIN_TIMEOUT)` clamp this times out immediately.
+    let result = mgr.reconcile().await;
+    assert!(
+        result.is_ok(),
+        "git_timeout_secs = 0 must not cause every git call to time out: {result:?}"
+    );
+}
+
+/// Regression test for the #5936 review finding: `DETACHED_BRANCH_SENTINEL`
+/// must be an invalid git ref name, otherwise a real branch on a worktree
+/// foreign to zeph could collide with it (see the constant's doc comment in
+/// `crates/zeph-worktree/src/handle.rs`). This shells out to the real `git
+/// check-ref-format` command — the authoritative ref-name validator — rather
+/// than re-implementing its rules, so the invariant cannot silently regress
+/// if someone changes the constant without re-checking this property.
+#[test]
+fn detached_branch_sentinel_is_not_a_valid_git_ref_name() {
+    let status = Command::new("git")
+        .args(["check-ref-format", "--branch", DETACHED_BRANCH_SENTINEL])
+        .status()
+        .expect("git must be on PATH for this integration test");
+    assert!(
+        !status.success(),
+        "DETACHED_BRANCH_SENTINEL ({DETACHED_BRANCH_SENTINEL:?}) must be REJECTED by \
+         `git check-ref-format --branch` — otherwise a real branch could be given this exact \
+         name and collide with the sentinel (see #5936 review finding)"
+    );
+}

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -33,8 +33,9 @@ pub(crate) async fn handle_worktree_command(
         anyhow::anyhow!("Not inside a git repository. Worktree commands require a git repo.")
     })?;
 
-    let timeout_secs = config.worktree.git_timeout_secs.max(1);
-    let runner = DefaultGitRunner::with_timeout(std::time::Duration::from_secs(timeout_secs));
+    let runner = DefaultGitRunner::with_timeout(std::time::Duration::from_secs(
+        config.worktree.git_timeout_secs,
+    ));
     probe_capabilities(&runner, &repo_root).await?;
     let wm = DefaultWorktreeManager::new(repo_root, config.worktree.clone(), runner).await?;
 
@@ -69,6 +70,11 @@ pub(crate) async fn handle_worktree_command(
                 {
                     eprintln!("warning: failed to remove {}: {e}", handle.path.display());
                 }
+            }
+            // FR-CLEANUP-04: clear any remaining stale administrative entries
+            // (e.g. worktrees deleted outside Zeph) from the git registry.
+            if let Err(e) = wm.prune().await {
+                eprintln!("warning: failed to prune worktree registry: {e}");
             }
             println!("Removed {count} stale worktree(s).");
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3220,9 +3220,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                      Set `worktree.enabled = false` to disable."
                 )
             })?;
-            let timeout_secs = agents_config.worktree.git_timeout_secs.max(1);
             let runner = zeph_worktree::DefaultGitRunner::with_timeout(
-                std::time::Duration::from_secs(timeout_secs),
+                std::time::Duration::from_secs(agents_config.worktree.git_timeout_secs),
             );
             zeph_worktree::probe_capabilities(&runner, &repo_root)
                 .await


### PR DESCRIPTION
## Summary

Three related bug fixes in `crates/zeph-worktree`, spec-governed by `specs/063-worktree-subsystem/spec.md` and `srs.md`:

- `WorktreeManager::reconcile()` silently dropped detached-HEAD worktrees because the `git worktree list --porcelain` parser only flushed a block when both a `worktree <path>` line and a `branch` line were present. Detached worktrees emit `detached` instead of `branch`, so they became permanently invisible to `zeph worktree list`/`zeph worktree clean`. The parser now flushes whenever `worktree <path>` is seen, and assigns a new `DETACHED_BRANCH_SENTINEL` (`"(detached HEAD)"`) as `branch_name` when no branch line is present. The sentinel contains a space, which `git check-ref-format --branch` rejects, so it can never collide with a real branch name — including on a worktree foreign to zeph, since `reconcile()` enumerates all worktrees in the repo, not just zeph-managed ones.
- `zeph worktree clean` never called `git worktree prune` after removing stale entries, per spec-063 FR-CLEANUP-04. Added `WorktreeManager::prune()` and wired it into the clean command after the removal loop.
- `DefaultGitRunner` did not clamp `git_timeout_secs = 0` itself; the clamp was duplicated ad hoc at two call sites, and the crate's derived `Default` impl bypassed both (zero-initializing the `Duration` field). The clamp now lives in `DefaultGitRunner::new()`/`with_timeout()`, the ad hoc call-site clamps were removed, and `Default` is now a manual impl delegating to `new()`.

A P3 follow-up issue will be filed separately for `bare`-repo worktrees also falling through to the detached sentinel (mislabeling, not a spec violation — spec-063 doesn't cover bare worktrees) — that gap was found during review and intentionally deferred out of this PR's scope.

Closes #5936
Closes #5937
Closes #5939

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12828 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New real-git integration tests in `crates/zeph-worktree/tests/real_git_integration.rs` (uses the real `git` binary, not a fake runner): prune clears a manually-removed worktree's leftover admin entry, full clean pipeline (reconcile+remove+prune), zero-timeout clamp against a real git invocation, and the sentinel's ref-name invalidity via `git check-ref-format`
- [x] `.local/testing/playbooks/worktree.md` and `.local/testing/coverage-status.md` updated in the main repo