### PR TITLE
fix(tui): clear durable overlay and distinguish gate-rejection status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   journal URL is also treated as shared automatically, as defense in depth. The TUI durable panel
   poller (`durable_poll_task`, feature `tui`) now evaluates the same policy before opening the
   journal — previously it bypassed the gate entirely, so the TUI panel could render a journal the
-  `zeph durable` CLI refused to open; a rejection now degrades gracefully to the panel's existing
-  "non-durable mode" state instead of erroring.
+  `zeph durable` CLI refused to open; a rejection now degrades gracefully to a distinct
+  `GateRejected` panel status instead of erroring (see #6041 below for why it no longer reuses
+  the plain "non-durable mode" state).
 - `zeph-commands`: 19 privileged slash-command handlers now override `requires_auth()` to
   return `true`, closing a trust-gate gap where they ran the default `false` and were therefore
   reachable from untrusted remote channels (Telegram/Discord/Slack) as well as trusted local
@@ -88,6 +89,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `fix(tui)`: the durable executions overlay panel (`D` key) no longer bleeds stray glyphs from
+  whatever widget last drew into the same sidebar `Rect` earlier in the frame (e.g. a trailing
+  `e> t` fragment left over from the subagents/plan/security view rendered underneath) — `Clear`
+  was missing before the panel's own draw calls, unlike the other 8 overlay widgets in this
+  crate that already blank their area first (#6048). Also, `encryption_gate` (INV-8) rejecting
+  the deployment's configuration is now visually distinguishable from a plain "journal
+  unavailable" state: the panel previously collapsed both into the identical
+  `STATUS_UNAVAILABLE` message, so an operator had no way to tell a security-policy rejection
+  from durable execution simply being unconfigured; `DurableSnapshot.available: bool` is
+  replaced with a `DurableStatus` enum (`Unavailable` / `GateRejected` / `Available`) and gate
+  rejections now render the distinct `STATUS_GATE_REJECTED` message (#6041).
 - `fix(core,acp,tools)`: three more per-turn behavioral pipelines/executors that were
   constructed and wired into the `Agent` only in `src/runner.rs` (CLI/TUI) now reach ACP,
   daemon (A2A), and `serve-sessions` too — same "wire-X-into-ACP/daemon/serve" defect class as

--- a/crates/zeph-tui/src/widgets/durable.rs
+++ b/crates/zeph-tui/src/widgets/durable.rs
@@ -7,18 +7,24 @@
 //! never payload bytes. Data arrives as a [`DurableSnapshot`] via
 //! [`AgentEvent::DurableSnapshot`](crate::AgentEvent::DurableSnapshot), refreshed by the binary's
 //! durable poll task. When the journal is unreachable (durable execution disabled or the file is
-//! missing) the panel shows the [`STATUS_UNAVAILABLE`] message.
+//! missing) the panel shows the [`STATUS_UNAVAILABLE`] message; when `encryption_gate` (INV-8)
+//! rejects the deployment's configuration it shows [`STATUS_GATE_REJECTED`] instead, so the two
+//! distinct causes aren't conflated (see [`DurableStatus`]).
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+use ratatui::widgets::{Clear, List, ListItem, ListState, Paragraph};
 
 use crate::theme::Theme;
 
 /// Status message: the journal is unreachable, so the agent runs without durability (spec-011).
 pub const STATUS_UNAVAILABLE: &str = "Journal unavailable — non-durable mode";
+
+/// Status message: `encryption_gate` (INV-8) rejected this deployment's configuration.
+pub const STATUS_GATE_REJECTED: &str =
+    "Durable journal disabled by encryption policy (INV-8) — see logs";
 
 /// One durable execution, display-ready. Carries no payload bytes (INV-5 redaction).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,11 +41,24 @@ pub struct DurableRow {
     pub age_secs: u64,
 }
 
+/// Why the durable panel does or doesn't have live execution rows to show.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DurableStatus {
+    /// Durable execution disabled, or the journal file/backend could not be opened.
+    #[default]
+    Unavailable,
+    /// `encryption_gate` (INV-8) rejected this configuration (e.g. shared DB + `encrypt_payload=false`).
+    GateRejected,
+    /// Journal reachable; `executions` holds the live rows (possibly empty).
+    Available,
+}
+
 /// Snapshot of the durable journal for the panel, refreshed by the binary's poll task.
 #[derive(Debug, Clone, Default)]
 pub struct DurableSnapshot {
-    /// Whether the journal could be reached. `false` renders [`STATUS_UNAVAILABLE`].
-    pub available: bool,
+    /// Why the panel is or isn't showing live rows. Anything other than [`DurableStatus::Available`]
+    /// renders a status message instead of `executions`.
+    pub status: DurableStatus,
     /// Executions, newest first.
     pub executions: Vec<DurableRow>,
 }
@@ -72,6 +91,8 @@ pub fn render(
     list_state: &mut ListState,
     theme: &Theme,
 ) {
+    frame.render_widget(Clear, area);
+
     let exec_count = snapshot.executions.len();
     let header_text = format!("durable · {exec_count}  [D]");
     let header = Line::from(Span::styled(
@@ -81,10 +102,18 @@ pub fn render(
     let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
     frame.render_widget(Paragraph::new(header), splits[0]);
 
-    if !snapshot.available {
-        let msg = Paragraph::new(STATUS_UNAVAILABLE).style(Style::default().fg(Color::Yellow));
-        frame.render_widget(msg, splits[1]);
-        return;
+    match snapshot.status {
+        DurableStatus::Unavailable => {
+            let msg = Paragraph::new(STATUS_UNAVAILABLE).style(Style::default().fg(Color::Yellow));
+            frame.render_widget(msg, splits[1]);
+            return;
+        }
+        DurableStatus::GateRejected => {
+            let msg = Paragraph::new(STATUS_GATE_REJECTED).style(Style::default().fg(Color::Red));
+            frame.render_widget(msg, splits[1]);
+            return;
+        }
+        DurableStatus::Available => {}
     }
 
     if snapshot.executions.is_empty() {
@@ -127,6 +156,9 @@ pub fn render(
 
 #[cfg(test)]
 mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
     use super::*;
 
     #[test]
@@ -142,5 +174,156 @@ mod tests {
         assert_eq!(status_color("running"), Color::Green);
         assert_eq!(status_color("failed"), Color::Red);
         assert_eq!(status_color("mystery"), Color::White);
+    }
+
+    /// Fills the whole area with a sentinel glyph before calling `render`, in the same frame —
+    /// mirroring the real bug shape (#6048): multiple widgets drawing into the identical `Rect`
+    /// within one `draw()` pass, where `Paragraph`/`List` only touch cells for their own content
+    /// and leave any earlier glyph in place. Without the `Clear` call in `render`, the sentinel
+    /// survives in every cell the status message doesn't cover; with it, none do.
+    fn render_over_sentinel(snapshot: &DurableSnapshot) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(80, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut list_state = ListState::default();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                for y in area.top()..area.bottom() {
+                    for x in area.left()..area.right() {
+                        frame.buffer_mut()[(x, y)].set_symbol("#");
+                    }
+                }
+                render(snapshot, frame, area, &mut list_state, &Theme::default());
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn render_clears_stale_glyphs_before_drawing_unavailable_status() {
+        let snapshot = DurableSnapshot {
+            status: DurableStatus::Unavailable,
+            executions: Vec::new(),
+        };
+        let buf = render_over_sentinel(&snapshot);
+        for cell in &buf.content {
+            assert_ne!(
+                cell.symbol(),
+                "#",
+                "stray sentinel glyph survived render — Clear is missing or not applied to the whole area"
+            );
+        }
+        let rendered: String = buf.content.iter().map(|c| c.symbol().to_owned()).collect();
+        assert!(
+            rendered.contains(STATUS_UNAVAILABLE),
+            "expected unavailable status text, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn render_clears_stale_glyphs_before_drawing_gate_rejected_status() {
+        let snapshot = DurableSnapshot {
+            status: DurableStatus::GateRejected,
+            executions: Vec::new(),
+        };
+        let buf = render_over_sentinel(&snapshot);
+        for cell in &buf.content {
+            assert_ne!(
+                cell.symbol(),
+                "#",
+                "stray sentinel glyph survived render — Clear is missing or not applied to the whole area"
+            );
+        }
+        let rendered: String = buf.content.iter().map(|c| c.symbol().to_owned()).collect();
+        assert!(
+            rendered.contains(STATUS_GATE_REJECTED),
+            "expected gate-rejected status text, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn render_clears_stale_glyphs_before_drawing_available_list() {
+        let snapshot = DurableSnapshot {
+            status: DurableStatus::Available,
+            executions: vec![DurableRow {
+                id_short: "abcd1234".into(),
+                kind: "agent_turn".into(),
+                status: "running".into(),
+                step_count: 3,
+                age_secs: 12,
+            }],
+        };
+        let buf = render_over_sentinel(&snapshot);
+        for cell in &buf.content {
+            assert_ne!(
+                cell.symbol(),
+                "#",
+                "stray sentinel glyph survived render — Clear is missing or not applied to the whole area"
+            );
+        }
+    }
+
+    #[test]
+    fn unavailable_and_gate_rejected_render_distinct_messages() {
+        assert_ne!(STATUS_UNAVAILABLE, STATUS_GATE_REJECTED);
+
+        let unavailable = render_over_sentinel(&DurableSnapshot {
+            status: DurableStatus::Unavailable,
+            executions: Vec::new(),
+        });
+        let rendered_unavailable: String = unavailable
+            .content
+            .iter()
+            .map(|c| c.symbol().to_owned())
+            .collect();
+        assert!(rendered_unavailable.contains(STATUS_UNAVAILABLE));
+        assert!(!rendered_unavailable.contains(STATUS_GATE_REJECTED));
+
+        let gate_rejected = render_over_sentinel(&DurableSnapshot {
+            status: DurableStatus::GateRejected,
+            executions: Vec::new(),
+        });
+        let rendered_gate_rejected: String = gate_rejected
+            .content
+            .iter()
+            .map(|c| c.symbol().to_owned())
+            .collect();
+        assert!(rendered_gate_rejected.contains(STATUS_GATE_REJECTED));
+        assert!(!rendered_gate_rejected.contains(STATUS_UNAVAILABLE));
+    }
+
+    #[test]
+    fn available_status_falls_through_to_executions_list() {
+        let snapshot = DurableSnapshot {
+            status: DurableStatus::Available,
+            executions: vec![DurableRow {
+                id_short: "deadbeef".into(),
+                kind: "dag_run".into(),
+                status: "completed".into(),
+                step_count: 7,
+                age_secs: 300,
+            }],
+        };
+        let buf = render_over_sentinel(&snapshot);
+        let rendered: String = buf.content.iter().map(|c| c.symbol().to_owned()).collect();
+        assert!(
+            rendered.contains("deadbeef"),
+            "expected execution row to render, got: {rendered:?}"
+        );
+        assert!(!rendered.contains(STATUS_UNAVAILABLE));
+        assert!(!rendered.contains(STATUS_GATE_REJECTED));
+    }
+
+    #[test]
+    fn available_status_with_empty_executions_renders_placeholder() {
+        let snapshot = DurableSnapshot {
+            status: DurableStatus::Available,
+            executions: Vec::new(),
+        };
+        let buf = render_over_sentinel(&snapshot);
+        let rendered: String = buf.content.iter().map(|c| c.symbol().to_owned()).collect();
+        assert!(rendered.contains("No durable executions recorded."));
+        assert!(!rendered.contains(STATUS_UNAVAILABLE));
+        assert!(!rendered.contains(STATUS_GATE_REJECTED));
     }
 }

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -709,6 +709,45 @@ mod tests {
             received[0]
         );
     }
+
+    /// Regression for #6041: an `encryption_gate` (INV-8) rejection must produce a
+    /// `DurableStatus::GateRejected` snapshot, not the same `Unavailable` status used for an
+    /// ordinary failed-to-open journal — the two failure modes must stay distinguishable in the
+    /// TUI. Uses a `postgres://`-scheme URL with `encrypt_payload = false` (default `true`) so
+    /// `enforce_encryption_gate` rejects deterministically without needing a real Postgres server;
+    /// the gate check runs before any backend connection is attempted.
+    #[tokio::test]
+    async fn durable_poll_task_sends_gate_rejected_on_encryption_gate_failure() {
+        use zeph_tui::widgets::durable::DurableStatus;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<zeph_tui::AgentEvent>(4);
+        let cfg = zeph_config::DurableConfig {
+            encrypt_payload: false,
+            ..zeph_config::DurableConfig::default()
+        };
+
+        durable_poll_task("postgres://user@host/db".to_owned(), cfg, tx).await;
+
+        let event = rx
+            .recv()
+            .await
+            .expect("expected a DurableSnapshot event on gate rejection");
+        match event {
+            zeph_tui::AgentEvent::DurableSnapshot(snapshot) => {
+                assert_eq!(
+                    snapshot.status,
+                    DurableStatus::GateRejected,
+                    "gate rejection must be distinguishable from a plain Unavailable snapshot"
+                );
+                assert!(snapshot.executions.is_empty());
+            }
+            other => panic!("expected DurableSnapshot event, got {other:?}"),
+        }
+        assert!(
+            rx.recv().await.is_none(),
+            "durable_poll_task must return immediately after a gate rejection, not loop"
+        );
+    }
 }
 
 #[cfg(feature = "tui")]
@@ -825,25 +864,26 @@ const DURABLE_REFRESH_SECS: u64 = 5;
 /// `encrypt_payload = false` must be rejected here too, or the TUI panel would happily render a
 /// journal the CLI refuses to open — a cross-mode divergence (#5996). Unlike the CLI, this is a
 /// best-effort background poller with no user waiting on an error message, so a gate rejection
-/// degrades gracefully to the same "non-durable mode" snapshot as a failed backend open, rather
-/// than panicking or looping forever.
+/// degrades gracefully to a `GateRejected` snapshot (distinct from a failed backend open, #6041)
+/// rather than panicking or looping forever.
 #[cfg(feature = "tui")]
 pub(crate) async fn durable_poll_task(
     db_url: String,
     cfg: zeph_config::DurableConfig,
     tx: tokio::sync::mpsc::Sender<zeph_tui::AgentEvent>,
 ) {
-    use zeph_tui::widgets::durable::{DurableRow, DurableSnapshot};
+    use zeph_tui::widgets::durable::{DurableRow, DurableSnapshot, DurableStatus};
 
     if let Err(e) = crate::commands::durable::enforce_encryption_gate(&cfg, &db_url) {
         tracing::warn!(
             error = %e,
-            "durable poll: encryption policy rejected this deployment; panel shows non-durable mode"
+            "durable poll: encryption policy rejected this deployment; panel shows gate-rejected status"
         );
         let _ = tx
-            .send(zeph_tui::AgentEvent::DurableSnapshot(
-                DurableSnapshot::default(),
-            ))
+            .send(zeph_tui::AgentEvent::DurableSnapshot(DurableSnapshot {
+                status: DurableStatus::GateRejected,
+                executions: Vec::new(),
+            }))
             .await;
         return;
     }
@@ -853,9 +893,10 @@ pub(crate) async fn durable_poll_task(
         Err(e) => {
             tracing::warn!(error = %e, "durable poll: failed to open journal; panel shows non-durable mode");
             let _ = tx
-                .send(zeph_tui::AgentEvent::DurableSnapshot(
-                    DurableSnapshot::default(),
-                ))
+                .send(zeph_tui::AgentEvent::DurableSnapshot(DurableSnapshot {
+                    status: DurableStatus::Unavailable,
+                    executions: Vec::new(),
+                }))
                 .await;
             return;
         }
@@ -910,7 +951,7 @@ pub(crate) async fn durable_poll_task(
             .collect();
 
         let snapshot = DurableSnapshot {
-            available: true,
+            status: DurableStatus::Available,
             executions,
         };
         if tx


### PR DESCRIPTION
## Summary

- `durable::render` never called `Clear` before drawing into its Rect, so leftover glyphs from whatever widget rendered into the same sidebar slot earlier in the same frame (subagents/plan_view/security) bled through as stray trailing characters after the status message.
- `DurableSnapshot`'s `available: bool` field could not distinguish an `encryption_gate` (INV-8) policy rejection from the ordinary "not configured"/"journal missing" case, so both rendered the identical "Journal unavailable — non-durable mode" text. Replaced with a 3-state `DurableStatus` enum (`Unavailable` / `GateRejected` / `Available`) and a distinct `STATUS_GATE_REJECTED` message.

Closes #6048
Closes #6041

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12824 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression tests added covering both fixes, including a Clear-before-render test verified to fail without the fix and pass with it, and tests for all three `DurableStatus` render paths
- [x] Manual TUI verification in a tmux pty with `[durable] shared_db = true, encrypt_payload = false` (triggers the encryption_gate rejection path): confirmed the durable sidebar shows the distinct `Durable journal disabled by encryption policy (INV-8)` message instead of the generic unavailable text, with no stray trailing characters across repeated `D` toggles, a switch to the Fleet panel and back, and a terminal resize