### PR TITLE
fix(tui): clear fleet/task-registry overlays and fix Display padding in fleet panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   from durable execution simply being unconfigured; `DurableSnapshot.available: bool` is
   replaced with a `DurableStatus` enum (`Unavailable` / `GateRejected` / `Available`) and gate
   rejections now render the distinct `STATUS_GATE_REJECTED` message (#6041).
+- `fix(tui)`: the Fleet and Task Registry sidebar overlay panels (`f`/task-registry keys) had the
+  same missing-`Clear` stray-glyph bug as the durable panel above (#6048) — neither called
+  `Clear` before drawing into their shared sidebar `Rect`, so leftover glyphs from whatever
+  widget last rendered into that area could bleed through. Both now clear their `Rect` first,
+  matching the crate-wide overlay convention (#6054). Also, the Fleet panel's session table
+  rendered its KIND/STATUS/CH columns with no separating whitespace (e.g.
+  `interactiveactivetuigpt-4o-mini`) because `SessionKind`/`SessionStatus`/`SessionChannel`
+  implemented `Display` via `Formatter::write_str`, which silently ignores the width/fill/align
+  flags carried by `fleet.rs`'s `{:<N}` format specifiers; only `Formatter::pad` respects them.
+  All three `Display` impls now use `f.pad(self.as_str())`, so table columns align correctly
+  (#6015).
 - `fix(core,acp,tools)`: three more per-turn behavioral pipelines/executors that were
   constructed and wired into the `Agent` only in `src/runner.rs` (CLI/TUI) now reach ACP,
   daemon (A2A), and `serve-sessions` too — same "wire-X-into-ACP/daemon/serve" defect class as

--- a/crates/zeph-memory/src/store/agent_sessions.rs
+++ b/crates/zeph-memory/src/store/agent_sessions.rs
@@ -36,7 +36,7 @@ impl SessionKind {
 
 impl std::fmt::Display for SessionKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -84,7 +84,7 @@ impl SessionStatus {
 
 impl std::fmt::Display for SessionStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -131,7 +131,7 @@ impl SessionChannel {
 
 impl std::fmt::Display for SessionChannel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -531,6 +531,46 @@ mod tests {
         assert_eq!(
             SessionStatus::from_str("unknown").unwrap(),
             SessionStatus::Unknown
+        );
+    }
+
+    /// Locks in the `f.pad` fix (#6015): `f.write_str` ignores width/fill/align flags, so
+    /// `fleet.rs::build_session_item`'s `format!("{:<12}", row.kind)` used to render unpadded
+    /// text and break column alignment. `f.pad` must reproduce the same padding a plain `&str`
+    /// would get under an identical width specifier.
+    #[test]
+    fn session_kind_display_respects_width() {
+        assert_eq!(
+            format!("{:<12}", SessionKind::Interactive),
+            format!("{:<12}", "interactive")
+        );
+        assert_eq!(
+            format!("{:<12}", SessionKind::Acp),
+            format!("{:<12}", "acp")
+        );
+    }
+
+    #[test]
+    fn session_status_display_respects_width() {
+        assert_eq!(
+            format!("{:<11}", SessionStatus::Active),
+            format!("{:<11}", "active")
+        );
+        assert_eq!(
+            format!("{:<11}", SessionStatus::Cancelled),
+            format!("{:<11}", "cancelled")
+        );
+    }
+
+    #[test]
+    fn session_channel_display_respects_width() {
+        assert_eq!(
+            format!("{:<5}", SessionChannel::Cli),
+            format!("{:<5}", "cli")
+        );
+        assert_eq!(
+            format!("{:<5}", SessionChannel::Telegram),
+            format!("{:<5}", "telegram")
         );
     }
 }

--- a/crates/zeph-tui/src/widgets/fleet.rs
+++ b/crates/zeph-tui/src/widgets/fleet.rs
@@ -7,7 +7,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+use ratatui::widgets::{Clear, List, ListItem, ListState, Paragraph};
 use zeph_common::format_tokens;
 use zeph_memory::store::agent_sessions::{AgentSessionRow, SessionStatus};
 
@@ -78,6 +78,8 @@ pub fn render(
     list_state: &mut ListState,
     theme: &Theme,
 ) {
+    frame.render_widget(Clear, area);
+
     let header_text = format!(
         "fleet · {} session{}  [f]",
         snapshot.sessions.len(),
@@ -121,7 +123,11 @@ pub fn render(
 
 #[cfg(test)]
 mod tests {
-    use super::format_tokens;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use zeph_memory::store::agent_sessions::{SessionChannel, SessionKind};
+
+    use super::*;
 
     #[test]
     fn format_tokens_zero() {
@@ -146,5 +152,76 @@ mod tests {
     #[test]
     fn format_tokens_exactly_1m() {
         assert_eq!(format_tokens(1_000_000), "1.0M");
+    }
+
+    fn sample_row(id: &str) -> AgentSessionRow {
+        AgentSessionRow {
+            id: id.to_owned(),
+            kind: SessionKind::Interactive,
+            status: SessionStatus::Active,
+            channel: SessionChannel::Cli,
+            model: "claude-sonnet-5".to_owned(),
+            created_at: "2026-01-01T00:00:00".to_owned(),
+            last_active_at: "2026-01-01T00:00:00".to_owned(),
+            turns: 3,
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            reasoning_tokens: 0,
+            cost_cents: 1.2345,
+            goal_text: None,
+        }
+    }
+
+    /// Fills the whole area with a sentinel glyph before calling `render`, in the same frame —
+    /// mirroring the real bug shape (#6054): the fleet overlay shares its `Rect` with other
+    /// sidebar widgets (see `render_subagents_slot`) but, before the fix, never called `Clear`,
+    /// so stale glyphs from whatever rendered underneath survived in every cell the panel's own
+    /// content didn't touch.
+    fn render_over_sentinel(snapshot: &FleetSnapshot) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(80, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut list_state = ListState::default();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                for y in area.top()..area.bottom() {
+                    for x in area.left()..area.right() {
+                        frame.buffer_mut()[(x, y)].set_symbol("#");
+                    }
+                }
+                render(snapshot, frame, area, &mut list_state, &Theme::default());
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn render_clears_stale_glyphs_before_drawing_empty_state() {
+        let snapshot = FleetSnapshot {
+            sessions: Vec::new(),
+        };
+        let buf = render_over_sentinel(&snapshot);
+        for cell in &buf.content {
+            assert_ne!(
+                cell.symbol(),
+                "#",
+                "stray sentinel glyph survived render — Clear is missing or not applied to the whole area"
+            );
+        }
+    }
+
+    #[test]
+    fn render_clears_stale_glyphs_before_drawing_session_list() {
+        let snapshot = FleetSnapshot {
+            sessions: vec![sample_row("s1")],
+        };
+        let buf = render_over_sentinel(&snapshot);
+        for cell in &buf.content {
+            assert_ne!(
+                cell.symbol(),
+                "#",
+                "stray sentinel glyph survived render — Clear is missing or not applied to the whole area"
+            );
+        }
     }
 }

--- a/crates/zeph-tui/src/widgets/task_registry.rs
+++ b/crates/zeph-tui/src/widgets/task_registry.rs
@@ -22,7 +22,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{List, ListItem, Paragraph};
+use ratatui::widgets::{Clear, List, ListItem, Paragraph};
 use zeph_common::task_supervisor::{TaskSnapshot, TaskStatus};
 
 use crate::theme::Theme;
@@ -109,6 +109,8 @@ pub fn render(
     theme: &Theme,
     ascii: bool,
 ) {
+    frame.render_widget(Clear, area);
+
     let header_text = format!("tasks · {}", snapshots.len());
     let header = Line::from(Span::styled(
         header_text,
@@ -137,6 +139,8 @@ mod tests {
     use std::time::Instant;
 
     use insta::assert_snapshot;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
     use zeph_common::task_supervisor::{TaskSnapshot, TaskStatus};
 
     use crate::test_utils::render_to_string;
@@ -228,5 +232,52 @@ mod tests {
             super::render(&snapshots, 2, area, frame, &theme, false);
         });
         assert_snapshot!(output);
+    }
+
+    /// Fills the whole area with a sentinel glyph before calling `render`, in the same frame —
+    /// mirroring the real bug shape (#6054): the task registry overlay shares its `Rect` with
+    /// other sidebar widgets but, before the fix, never called `Clear`, so stale glyphs from
+    /// whatever rendered underneath survived in every cell the panel's own content didn't touch.
+    fn render_over_sentinel(snapshots: &[TaskSnapshot]) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(80, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                for y in area.top()..area.bottom() {
+                    for x in area.left()..area.right() {
+                        frame.buffer_mut()[(x, y)].set_symbol("#");
+                    }
+                }
+                let theme = crate::theme::Theme::default();
+                super::render(snapshots, 0, area, frame, &theme, false);
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn render_clears_stale_glyphs_before_drawing_empty_state() {
+        let buf = render_over_sentinel(&[]);
+        for cell in &buf.content {
+            assert_ne!(
+                cell.symbol(),
+                "#",
+                "stray sentinel glyph survived render — Clear is missing or not applied to the whole area"
+            );
+        }
+    }
+
+    #[test]
+    fn render_clears_stale_glyphs_before_drawing_task_list() {
+        let snapshots = [running_snapshot("config-watcher")];
+        let buf = render_over_sentinel(&snapshots);
+        for cell in &buf.content {
+            assert_ne!(
+                cell.symbol(),
+                "#",
+                "stray sentinel glyph survived render — Clear is missing or not applied to the whole area"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `fleet.rs` and `task_registry.rs` overlay widgets now call `ratatui::widgets::Clear` as the first statement of `render()`, matching the pattern already used by `durable.rs` (#6053) and 8 other overlay widgets in the crate — fixes stray glyphs bleeding through from whatever widget last drew into the shared sidebar `Rect`.
- `SessionKind`, `SessionStatus`, `SessionChannel` `Display` impls (`crates/zeph-memory/src/store/agent_sessions.rs`) switched from `Formatter::write_str` to `Formatter::pad`, so the width-specifier `format!("{:<N}", ...)` calls in `fleet.rs::build_session_item` actually pad columns instead of silently concatenating (`interactiveactivetuigpt-4o-mini` → `interactive  active     tui  gpt-4o-mini`).
- Added regression tests: 3 `Display`-width unit tests in `agent_sessions.rs`, plus sentinel-glyph tests in `fleet.rs`/`task_registry.rs` mirroring `durable.rs`'s existing `render_over_sentinel` pattern.

Scope was deliberately limited to the 3 confirmed call sites; 8 other instances of the same `f.write_str(self.as_str())` anti-pattern elsewhere in the codebase (noted in #6015) are left untouched as explicitly out of scope.

Closes #6054
Closes #6015

## Test plan

- [x] `cargo nextest -p zeph-memory` — 1639 passed, 0 failed
- [x] `cargo nextest -p zeph-tui` — 846 passed, 0 failed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12842 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [ ] Live TUI verification (tmux pty) — not run for this PR; automated regression tests cover both fixes. See `.local/testing/playbooks/fleet-dashboard.md` scenarios 8-9 for the live-verification steps a future CI cycle should run.