### PR TITLE
fix(skills): gate load_skill through the same trust pipeline as invoke_skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Security
 
+- `zeph-core`: `load_skill` (`SkillLoaderExecutor`) had no trust check at all — it read the raw
+  `SKILL.md` body straight from `SkillRegistry::body` and returned it verbatim, bypassing the
+  entire skill-trust defense-in-depth pipeline that `invoke_skill` already enforced: `Blocked`
+  skills were never refused, `Quarantined`/non-Trusted bodies were never sanitized or wrapped,
+  and the LLM-supplied `skill_name` was echoed unsanitized into the not-found error. The turn-
+  level `TrustGateExecutor` gate does not close this gap — it only denies `load_skill` when the
+  turn's folded `effective_trust` is Quarantined, and never inspects the `skill_name` argument
+  itself, so a `load_skill` call naming a Blocked/Quarantined skill sailed through on any turn
+  where the active skill set wasn't already Quarantined (#6050). `SkillLoaderExecutor` now shares
+  the exact same trust pipeline as `SkillInvokeExecutor` via a new `SkillTrustGate` (extracted
+  into `crates/zeph-core/src/skill_trust_gate.rs`, #6049): Blocked is refused before any body
+  read, non-Trusted bodies are sanitized, Quarantined bodies are additionally wrapped, the
+  per-invocation blake3 integrity re-check now also applies to `load_skill`, and `skill_name` is
+  sanitized on every output path (found, blocked, and not-found). `SkillLoaderExecutor::new` now
+  takes the same `trust_snapshot` `Arc` as `SkillInvokeExecutor`; a new
+  `agent_setup::build_skill_executors` helper constructs both executors around one shared `Arc`
+  so `load_skill` and `invoke_skill` can no longer observe divergent trust state or be wired up
+  independently, replacing five duplicated inline construction sites across `src/runner.rs`,
+  `src/acp.rs`, and `src/daemon.rs` (prod and test).
 - `zeph-durable`/`zeph`: `zeph_durable::encryption_gate` (the documented INV-8 AEAD enforcement
   policy) is now actually invoked at runtime — previously it was a unit-tested pure function that
   no call site ever reached, so `src/commands/durable.rs::load_write_cipher` (the durable journal

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -105,6 +105,7 @@ pub mod runtime_context;
 pub mod runtime_layer;
 pub mod skill_invoker;
 pub mod skill_loader;
+mod skill_trust_gate;
 pub use zeph_common::text;
 
 #[cfg(test)]

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -8,9 +8,11 @@
 //! intent-neutral preview), `invoke_skill` carries intent-to-apply semantics: the next turn
 //! is expected to follow the returned skill body.
 //!
-//! The executor applies the same defense-in-depth pipeline as `format_skills_prompt`:
+//! The shared `SkillTrustGate` (crate-private) applies the same defense-in-depth
+//! pipeline as `format_skills_prompt` (and as `load_skill`'s
+//! [`SkillLoaderExecutor`](crate::skill_loader::SkillLoaderExecutor)):
 //! - Non-Trusted bodies pass through [`sanitize_skill_text`].
-//! - Quarantined bodies are additionally wrapped with [`wrap_quarantined`].
+//! - Quarantined bodies are additionally wrapped with [`wrap_quarantined`](zeph_skills::prompt::wrap_quarantined).
 //! - Blocked skills are refused before any body read.
 //! - `args` are always sanitized regardless of trust level (LLM-chosen text).
 //!
@@ -24,13 +26,14 @@ use parking_lot::RwLock;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use zeph_common::SkillTrustLevel;
-use zeph_skills::prompt::{sanitize_skill_text, wrap_quarantined};
+use zeph_skills::prompt::sanitize_skill_text;
 use zeph_skills::registry::SkillRegistry;
-use zeph_skills::trust::compute_skill_hash;
 use zeph_tools::executor::{
     ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params, truncate_tool_output,
 };
 use zeph_tools::registry::{InvocationHint, ToolDef};
+
+use crate::skill_trust_gate::{SkillBodyResolution, SkillTrustGate};
 
 /// Per-invocation trust metadata snapshot for a single skill.
 ///
@@ -61,106 +64,26 @@ pub struct InvokeSkillParams {
 
 /// Tool executor that returns a skill body by name with trust-aware sanitization.
 ///
-/// Holds a shared reference to the skill registry and a per-turn trust snapshot
-/// refreshed by the agent loop. Both are cheap `Arc` clones — no allocation on hot path.
+/// Delegates trust resolution, integrity checking, sanitization, and quarantine wrapping to a
+/// shared `SkillTrustGate` (crate-private) — the same pipeline `load_skill`
+/// ([`crate::skill_loader::SkillLoaderExecutor`]) uses, so the two tools cannot drift apart.
 #[derive(Clone, Debug)]
 pub struct SkillInvokeExecutor {
-    registry: Arc<RwLock<SkillRegistry>>,
-    /// Per-skill trust snapshot refreshed once per turn by the agent.
-    /// Absence of an entry means no trust row exists — treat as Quarantined
-    /// (see `SkillTrustLevel::default`).
-    trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustSnapshot>>>,
+    gate: SkillTrustGate,
 }
 
 impl SkillInvokeExecutor {
     /// Create a new executor with shared registry and trust snapshot.
     ///
-    /// Both `Arc`s must be the same instances held by the agent so updates are
-    /// visible without re-constructing the executor.
+    /// Both `Arc`s must be the same instances held by the agent — and shared with
+    /// `SkillLoaderExecutor` — so updates are visible without re-constructing the executor.
     #[must_use]
     pub fn new(
         registry: Arc<RwLock<SkillRegistry>>,
         trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustSnapshot>>>,
     ) -> Self {
         Self {
-            registry,
-            trust_snapshot,
-        }
-    }
-
-    /// Resolve the trust snapshot entry for a skill.
-    ///
-    /// Returns `None` when no row exists — callers treat absence as Quarantined (fail-closed).
-    fn resolve_snapshot(&self, skill_name: &str) -> Option<SkillTrustSnapshot> {
-        self.trust_snapshot.read().get(skill_name).cloned()
-    }
-
-    /// Run the per-invocation blake3 integrity check.
-    ///
-    /// Returns `Some(output)` when the invocation must be aborted (hash mismatch, empty stored
-    /// hash, missing skill dir, or IO error). Returns `None` when the check passes and dispatch
-    /// should proceed.
-    async fn check_integrity(
-        &self,
-        skill_name: &str,
-        skill_name_safe: &str,
-        entry: &SkillTrustSnapshot,
-    ) -> Result<Option<ToolOutput>, ToolError> {
-        if entry.blake3_hash.is_empty() {
-            tracing::warn!(
-                skill = %skill_name,
-                "requires_trust_check is set but no stored hash found, aborting invocation"
-            );
-            return Ok(Some(make_output(format!(
-                "skill integrity check failed: {skill_name_safe} \
-                 — requires_trust_check is set but no stored hash found"
-            ))));
-        }
-        let stored_hash = entry.blake3_hash.clone();
-        let skill_dir = {
-            let guard = self.registry.read();
-            guard.skill_dir(skill_name)
-        };
-        let Some(dir) = skill_dir else {
-            tracing::warn!(
-                skill = %skill_name,
-                "requires_trust_check: skill_dir not found, aborting invocation"
-            );
-            return Ok(Some(make_output(format!(
-                "skill integrity check failed: {skill_name_safe} — skill directory not found"
-            ))));
-        };
-        let current_hash = tokio::task::spawn_blocking(move || compute_skill_hash(&dir))
-            .await
-            .map_err(|e| ToolError::InvalidParams {
-                message: format!("spawn_blocking join error: {e}"),
-            })?;
-        match current_hash {
-            Ok(hash) if hash != stored_hash => {
-                tracing::warn!(
-                    skill = %skill_name,
-                    "hash mismatch on per-invocation check, demoting to Quarantined"
-                );
-                self.trust_snapshot
-                    .write()
-                    .entry(skill_name.to_owned())
-                    .and_modify(|e| e.trust_level = SkillTrustLevel::Quarantined);
-                // TODO: persist demotion to trust store (#4293 follow-up)
-                Ok(Some(make_output(format!(
-                    "skill integrity check failed: {skill_name_safe} — demoted to Quarantined"
-                ))))
-            }
-            Err(e) => {
-                tracing::warn!(
-                    skill = %skill_name,
-                    err = %e,
-                    "failed to re-hash skill, aborting invocation"
-                );
-                Ok(Some(make_output(format!(
-                    "skill integrity check failed: {skill_name_safe} — cannot read SKILL.md"
-                ))))
-            }
-            Ok(_) => Ok(None), // hash matches, proceed
+            gate: SkillTrustGate::new(registry, trust_snapshot),
         }
     }
 }
@@ -197,51 +120,11 @@ impl ToolExecutor for SkillInvokeExecutor {
 
         tracing::Span::current().record("skill", skill_name.as_str());
 
-        let snapshot = self.resolve_snapshot(&skill_name);
-        let trust = snapshot
-            .as_ref()
-            .map_or(SkillTrustLevel::MISSING_ENTRY_FALLBACK, |s| s.trust_level);
-        // Sanitize skill_name before it appears in any tool output: it originates from the LLM
-        // and could carry injection markers (e.g. `<|im_start|>`).
-        let skill_name_safe = sanitize_skill_text(&skill_name);
-
-        // Blocked skills are refused before any body read — executor defense layer.
-        if trust == SkillTrustLevel::Blocked {
-            return Ok(Some(make_output(format!(
-                "skill is blocked by policy: {skill_name_safe}"
-            ))));
-        }
-
-        // Per-invocation integrity check: re-hash SKILL.md when requires_trust_check is set.
-        if let Some(entry) = snapshot.as_ref().filter(|s| s.requires_trust_check) {
-            let abort = self
-                .check_integrity(&skill_name, &skill_name_safe, entry)
-                .await?;
-            if let Some(output) = abort {
-                return Ok(Some(output));
+        let summary = match self.gate.resolve_body(&skill_name).await? {
+            SkillBodyResolution::Refused(message) | SkillBodyResolution::NotFound(message) => {
+                message
             }
-        }
-
-        // Clone body out of the read guard before any .await — never hold lock across await.
-        let body = {
-            let guard = self.registry.read();
-            guard.body(&skill_name).map(str::to_owned)
-        };
-
-        let summary = match body {
-            Ok(raw_body) => {
-                // Apply the same pipeline as `format_skills_prompt:194-204`:
-                // sanitize for non-Trusted, additionally wrap for Quarantined.
-                let sanitized = if trust == SkillTrustLevel::Trusted {
-                    raw_body
-                } else {
-                    sanitize_skill_text(&raw_body)
-                };
-                let wrapped = if trust == SkillTrustLevel::Quarantined {
-                    wrap_quarantined(&skill_name_safe, &sanitized)
-                } else {
-                    sanitized
-                };
+            SkillBodyResolution::Body(wrapped) => {
                 let full = if params.args.trim().is_empty() {
                     wrapped
                 } else {
@@ -252,7 +135,6 @@ impl ToolExecutor for SkillInvokeExecutor {
                 };
                 truncate_tool_output(&full)
             }
-            Err(_) => format!("skill not found: {skill_name_safe}"),
         };
 
         Ok(Some(make_output(summary)))

--- a/crates/zeph-core/src/skill_loader.rs
+++ b/crates/zeph-core/src/skill_loader.rs
@@ -1,6 +1,23 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Tool executor that loads a full skill body by name, gated by the same trust-aware pipeline
+//! as `invoke_skill`.
+//!
+//! [`SkillLoaderExecutor`] implements `load_skill` — a native tool the LLM can call to preview a
+//! skill's full body without committing to follow it (unlike `invoke_skill`, which carries
+//! intent-to-apply semantics). Both tools share a
+//! `SkillTrustGate` (crate-private) built from the same
+//! `trust_snapshot` `Arc`, so they observe identical trust state within a turn:
+//! - Non-Trusted bodies pass through [`sanitize_skill_text`](zeph_skills::prompt::sanitize_skill_text).
+//! - Quarantined bodies are additionally wrapped with [`wrap_quarantined`](zeph_skills::prompt::wrap_quarantined).
+//! - Blocked skills are refused before any body read.
+//! - `skill_name` is sanitized before it appears in any output path (found, blocked, not-found).
+//!
+//! `load_skill` and `invoke_skill` are both listed in `QUARANTINE_DENIED`, so when a Quarantined
+//! skill is active the trust gate refuses both before this executor is reached.
+
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -13,6 +30,9 @@ use zeph_tools::executor::{
 };
 use zeph_tools::registry::{InvocationHint, ToolDef};
 
+use crate::skill_invoker::SkillTrustSnapshot;
+use crate::skill_trust_gate::{SkillBodyResolution, SkillTrustGate};
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LoadSkillParams {
     /// Name of the skill to load (from `<other_skills>` catalog).
@@ -20,15 +40,44 @@ pub struct LoadSkillParams {
 }
 
 /// Tool executor that loads a full skill body by name from the shared registry.
+///
+/// Delegates trust resolution, integrity checking, sanitization, and quarantine wrapping to a
+/// shared `SkillTrustGate` (crate-private) — the same pipeline `invoke_skill`
+/// ([`crate::skill_invoker::SkillInvokeExecutor`]) uses, so the two tools cannot drift apart.
 #[derive(Clone, Debug)]
 pub struct SkillLoaderExecutor {
-    registry: Arc<RwLock<SkillRegistry>>,
+    gate: SkillTrustGate,
 }
 
 impl SkillLoaderExecutor {
+    /// Create a new executor with shared registry and trust snapshot.
+    ///
+    /// `trust_snapshot` must be the same `Arc` shared with `SkillInvokeExecutor` (see
+    /// `agent_setup::build_skill_executors` in the binary crate) so `load_skill` and
+    /// `invoke_skill` see identical trust state within a turn.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use std::sync::Arc;
+    ///
+    /// use parking_lot::RwLock;
+    /// use zeph_core::SkillLoaderExecutor;
+    /// use zeph_skills::registry::SkillRegistry;
+    ///
+    /// let registry = Arc::new(RwLock::new(SkillRegistry::empty()));
+    /// let trust_snapshot = Arc::new(RwLock::new(HashMap::new()));
+    /// let _executor = SkillLoaderExecutor::new(registry, trust_snapshot);
+    /// ```
     #[must_use]
-    pub fn new(registry: Arc<RwLock<SkillRegistry>>) -> Self {
-        Self { registry }
+    pub fn new(
+        registry: Arc<RwLock<SkillRegistry>>,
+        trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustSnapshot>>>,
+    ) -> Self {
+        Self {
+            gate: SkillTrustGate::new(registry, trust_snapshot),
+        }
     }
 }
 
@@ -48,20 +97,21 @@ impl ToolExecutor for SkillLoaderExecutor {
         }]
     }
 
+    #[tracing::instrument(name = "core.skill_loader.execute", skip_all, fields(skill = tracing::field::Empty))]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         if call.tool_id != "load_skill" {
             return Ok(None);
         }
         let params: LoadSkillParams = deserialize_params(&call.params)?;
         let skill_name: String = params.skill_name.chars().take(128).collect();
-        let body = {
-            let guard = self.registry.read();
-            guard.body(&skill_name).map(str::to_owned)
-        };
 
-        let summary = match body {
-            Ok(b) => truncate_tool_output(&b),
-            Err(_) => format!("skill not found: {skill_name}"),
+        tracing::Span::current().record("skill", skill_name.as_str());
+
+        let summary = match self.gate.resolve_body(&skill_name).await? {
+            SkillBodyResolution::Refused(message) | SkillBodyResolution::NotFound(message) => {
+                message
+            }
+            SkillBodyResolution::Body(wrapped) => truncate_tool_output(&wrapped),
         };
 
         Ok(Some(ToolOutput {
@@ -83,6 +133,8 @@ impl ToolExecutor for SkillLoaderExecutor {
 mod tests {
     use std::path::Path;
 
+    use zeph_common::SkillTrustLevel;
+
     use super::*;
 
     fn make_registry_with_skill(dir: &Path, name: &str, body: &str) -> SkillRegistry {
@@ -96,15 +148,33 @@ mod tests {
         SkillRegistry::load(&[dir.to_path_buf()])
     }
 
-    #[tokio::test]
-    async fn load_existing_skill_returns_body() {
-        let dir = tempfile::tempdir().unwrap();
-        let registry =
-            make_registry_with_skill(dir.path(), "git-commit", "## Instructions\nDo git stuff");
-        let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
-        let call = ToolCall {
+    fn make_snapshot(level: SkillTrustLevel) -> SkillTrustSnapshot {
+        SkillTrustSnapshot {
+            trust_level: level,
+            requires_trust_check: false,
+            blake3_hash: String::new(),
+        }
+    }
+
+    /// `trust_map` is `None` to exercise the missing-row-defaults-to-Trusted path.
+    fn make_executor(
+        registry: SkillRegistry,
+        trust_map: HashMap<String, SkillTrustLevel>,
+    ) -> SkillLoaderExecutor {
+        let snapshot_map: HashMap<String, SkillTrustSnapshot> = trust_map
+            .into_iter()
+            .map(|(k, v)| (k, make_snapshot(v)))
+            .collect();
+        SkillLoaderExecutor::new(
+            Arc::new(RwLock::new(registry)),
+            Arc::new(RwLock::new(snapshot_map)),
+        )
+    }
+
+    fn make_call(skill_name: &str) -> ToolCall {
+        ToolCall {
             tool_id: zeph_common::ToolName::new("load_skill"),
-            params: serde_json::json!({"skill_name": "git-commit"})
+            params: serde_json::json!({"skill_name": skill_name})
                 .as_object()
                 .unwrap()
                 .clone(),
@@ -113,8 +183,20 @@ mod tests {
 
             tool_call_id: String::new(),
             skill_name: None,
-        };
-        let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn load_existing_skill_returns_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry =
+            make_registry_with_skill(dir.path(), "git-commit", "## Instructions\nDo git stuff");
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor
+            .execute_tool_call(&make_call("git-commit"))
+            .await
+            .unwrap()
+            .unwrap();
         assert!(result.summary.contains("## Instructions"));
         assert!(result.summary.contains("Do git stuff"));
     }
@@ -123,20 +205,12 @@ mod tests {
     async fn load_nonexistent_skill_returns_error_message() {
         let dir = tempfile::tempdir().unwrap();
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
-        let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
-        let call = ToolCall {
-            tool_id: zeph_common::ToolName::new("load_skill"),
-            params: serde_json::json!({"skill_name": "nonexistent"})
-                .as_object()
-                .unwrap()
-                .clone(),
-            caller_id: None,
-            context: None,
-
-            tool_call_id: String::new(),
-            skill_name: None,
-        };
-        let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor
+            .execute_tool_call(&make_call("nonexistent"))
+            .await
+            .unwrap()
+            .unwrap();
         assert!(result.summary.contains("skill not found"));
         assert!(result.summary.contains("nonexistent"));
     }
@@ -145,7 +219,7 @@ mod tests {
     fn tool_definitions_returns_load_skill() {
         let dir = tempfile::tempdir().unwrap();
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
-        let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
+        let executor = make_executor(registry, HashMap::new());
         let defs = executor.tool_definitions();
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].id.as_ref(), "load_skill");
@@ -155,7 +229,7 @@ mod tests {
     async fn execute_returns_none_for_wrong_tool_id() {
         let dir = tempfile::tempdir().unwrap();
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
-        let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
+        let executor = make_executor(registry, HashMap::new());
         let call = ToolCall {
             tool_id: zeph_common::ToolName::new("bash"),
             params: serde_json::Map::new(),
@@ -175,20 +249,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let long_body = "x".repeat(MAX_TOOL_OUTPUT_CHARS + 1000);
         let registry = make_registry_with_skill(dir.path(), "big-skill", &long_body);
-        let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
-        let call = ToolCall {
-            tool_id: zeph_common::ToolName::new("load_skill"),
-            params: serde_json::json!({"skill_name": "big-skill"})
-                .as_object()
-                .unwrap()
-                .clone(),
-            caller_id: None,
-            context: None,
-
-            tool_call_id: String::new(),
-            skill_name: None,
-        };
-        let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor
+            .execute_tool_call(&make_call("big-skill"))
+            .await
+            .unwrap()
+            .unwrap();
         assert!(result.summary.contains("truncated"));
         assert!(result.summary.len() < long_body.len() + 200);
     }
@@ -197,20 +263,12 @@ mod tests {
     async fn empty_registry_returns_error_message() {
         let dir = tempfile::tempdir().unwrap();
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
-        let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
-        let call = ToolCall {
-            tool_id: zeph_common::ToolName::new("load_skill"),
-            params: serde_json::json!({"skill_name": "any"})
-                .as_object()
-                .unwrap()
-                .clone(),
-            caller_id: None,
-            context: None,
-
-            tool_call_id: String::new(),
-            skill_name: None,
-        };
-        let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor
+            .execute_tool_call(&make_call("any"))
+            .await
+            .unwrap()
+            .unwrap();
         assert!(result.summary.contains("skill not found"));
     }
 
@@ -219,7 +277,7 @@ mod tests {
     async fn execute_always_returns_none() {
         let dir = tempfile::tempdir().unwrap();
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
-        let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
+        let executor = make_executor(registry, HashMap::new());
         let result = executor.execute("any response text").await.unwrap();
         assert!(result.is_none());
     }
@@ -230,26 +288,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let registry =
             make_registry_with_skill(dir.path(), "shared-skill", "## Concurrent test body");
-        let executor = Arc::new(SkillLoaderExecutor::new(Arc::new(RwLock::new(registry))));
+        let executor = Arc::new(make_executor(registry, HashMap::new()));
 
         let handles: Vec<_> = (0..8)
             .map(|_| {
                 let ex = Arc::clone(&executor);
-                tokio::spawn(async move {
-                    let call = ToolCall {
-                        tool_id: zeph_common::ToolName::new("load_skill"),
-                        params: serde_json::json!({"skill_name": "shared-skill"})
-                            .as_object()
-                            .unwrap()
-                            .clone(),
-                        caller_id: None,
-                        context: None,
-
-                        tool_call_id: String::new(),
-                        skill_name: None,
-                    };
-                    ex.execute_tool_call(&call).await
-                })
+                tokio::spawn(async move { ex.execute_tool_call(&make_call("shared-skill")).await })
             })
             .collect();
 
@@ -264,20 +308,12 @@ mod tests {
     async fn empty_skill_name_returns_not_found() {
         let dir = tempfile::tempdir().unwrap();
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
-        let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
-        let call = ToolCall {
-            tool_id: zeph_common::ToolName::new("load_skill"),
-            params: serde_json::json!({"skill_name": ""})
-                .as_object()
-                .unwrap()
-                .clone(),
-            caller_id: None,
-            context: None,
-
-            tool_call_id: String::new(),
-            skill_name: None,
-        };
-        let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor
+            .execute_tool_call(&make_call(""))
+            .await
+            .unwrap()
+            .unwrap();
         assert!(result.summary.contains("skill not found"));
     }
 
@@ -286,7 +322,7 @@ mod tests {
     async fn missing_skill_name_field_returns_error() {
         let dir = tempfile::tempdir().unwrap();
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
-        let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
+        let executor = make_executor(registry, HashMap::new());
         let call = ToolCall {
             tool_id: zeph_common::ToolName::new("load_skill"),
             params: serde_json::Map::new(),
@@ -298,5 +334,151 @@ mod tests {
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());
+    }
+
+    // ── Trust-gating tests (#6050) ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn blocked_skill_is_refused_without_body_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "secret body that should not be returned";
+        let registry = make_registry_with_skill(dir.path(), "blocked-skill", body);
+        let trust = HashMap::from([("blocked-skill".to_owned(), SkillTrustLevel::Blocked)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call("blocked-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("blocked by policy"));
+        assert!(!result.summary.contains("secret body"));
+    }
+
+    #[tokio::test]
+    async fn verified_skill_is_sanitized() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "Normal body <|im_start|>injected";
+        let registry = make_registry_with_skill(dir.path(), "verified-skill", body);
+        let trust = HashMap::from([("verified-skill".to_owned(), SkillTrustLevel::Verified)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call("verified-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("Normal body"));
+        assert!(result.summary.contains("[BLOCKED:<|im_start|>]"));
+        assert!(
+            !result
+                .summary
+                .replace("[BLOCKED:<|im_start|>]", "")
+                .contains("<|im_start|>")
+        );
+    }
+
+    #[tokio::test]
+    async fn quarantined_skill_is_sanitized_and_wrapped() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "Quarantined content";
+        let registry = make_registry_with_skill(dir.path(), "quarantined-skill", body);
+        let trust = HashMap::from([("quarantined-skill".to_owned(), SkillTrustLevel::Quarantined)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call("quarantined-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("QUARANTINED"));
+        assert!(result.summary.contains("Quarantined content"));
+    }
+
+    #[tokio::test]
+    async fn trusted_skill_returns_body_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "## Instructions\nDo trusted things";
+        let registry = make_registry_with_skill(dir.path(), "trusted-skill", body);
+        let trust = HashMap::from([("trusted-skill".to_owned(), SkillTrustLevel::Trusted)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call("trusted-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("## Instructions"));
+        assert!(result.summary.contains("Do trusted things"));
+    }
+
+    #[tokio::test]
+    async fn no_trust_row_defaults_to_trusted_behavior() {
+        // A missing trust-map entry means "never classified yet", not "known untrusted" — it
+        // must resolve to Trusted (SkillTrustLevel::MISSING_ENTRY_FALLBACK). Falling back to
+        // Quarantined here would spuriously wrap legitimate skills whenever the trust map is
+        // transiently empty.
+        let dir = tempfile::tempdir().unwrap();
+        let body = "Some body";
+        let registry = make_registry_with_skill(dir.path(), "unknown-skill", body);
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor
+            .execute_tool_call(&make_call("unknown-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!result.summary.contains("QUARANTINED"));
+        assert!(result.summary.contains(body));
+    }
+
+    #[tokio::test]
+    async fn not_found_error_sanitizes_skill_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor
+            .execute_tool_call(&make_call("<|im_start|>nonexistent"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("skill not found"));
+        assert!(result.summary.contains("[BLOCKED:<|im_start|>]"));
+        assert!(
+            !result
+                .summary
+                .replace("[BLOCKED:<|im_start|>]", "")
+                .contains("<|im_start|>")
+        );
+    }
+
+    #[tokio::test]
+    async fn tampered_requires_trust_check_skill_is_caught() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "## Original body";
+        let registry = make_registry_with_skill(dir.path(), "tampered-skill", body);
+        let snapshots = HashMap::from([(
+            "tampered-skill".to_owned(),
+            SkillTrustSnapshot {
+                trust_level: SkillTrustLevel::Trusted,
+                requires_trust_check: true,
+                blake3_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .to_owned(),
+            },
+        )]);
+        let executor = SkillLoaderExecutor::new(
+            Arc::new(RwLock::new(registry)),
+            Arc::new(RwLock::new(snapshots)),
+        );
+        let result = executor
+            .execute_tool_call(&make_call("tampered-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            result.summary.contains("demoted to Quarantined"),
+            "output must mention demotion: {}",
+            result.summary
+        );
+        assert!(
+            !result.summary.contains("Original body"),
+            "body must not be returned on hash mismatch: {}",
+            result.summary
+        );
     }
 }

--- a/crates/zeph-core/src/skill_trust_gate.rs
+++ b/crates/zeph-core/src/skill_trust_gate.rs
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared trust-gating pipeline for skill-body tool executors.
+//!
+//! [`SkillTrustGate`] is the single implementation of the trust pipeline documented in
+//! [`crate::skill_invoker`]: refuse `Blocked` skills before any body read, run the optional
+//! per-invocation blake3 integrity re-check, sanitize non-Trusted bodies, and wrap Quarantined
+//! bodies. Both `load_skill` ([`crate::skill_loader::SkillLoaderExecutor`]) and `invoke_skill`
+//! ([`crate::skill_invoker::SkillInvokeExecutor`]) hold their own `SkillTrustGate` built from
+//! the *same* `trust_snapshot` `Arc` (see `agent_setup::build_skill_executors` in the binary
+//! crate), so the two tools cannot drift apart and observe identical trust state within a turn
+//! (#6049, #6050).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use zeph_common::SkillTrustLevel;
+use zeph_skills::prompt::{sanitize_skill_text, wrap_quarantined};
+use zeph_skills::registry::SkillRegistry;
+use zeph_skills::trust::compute_skill_hash;
+use zeph_tools::executor::ToolError;
+
+use crate::skill_invoker::SkillTrustSnapshot;
+
+/// Outcome of resolving a skill body through [`SkillTrustGate::resolve_body`].
+///
+/// Callers match on this to apply their own tool-specific output framing (e.g. `invoke_skill`
+/// appends an `<args>` block to `Body`) before truncating for the LLM.
+pub(crate) enum SkillBodyResolution {
+    /// Refused by policy (blocked) or a failed integrity check — ready-to-return tool summary.
+    Refused(String),
+    /// `skill_name` has no entry in the registry — ready-to-return tool summary.
+    NotFound(String),
+    /// Body resolved and gated (sanitized for non-Trusted, wrapped for Quarantined). Not yet
+    /// truncated — callers append any additional framing first, then call
+    /// [`truncate_tool_output`](zeph_tools::executor::truncate_tool_output).
+    Body(String),
+}
+
+/// Shared registry + trust-snapshot pair backing both skill-body tool executors.
+///
+/// Cloning is cheap — both fields are `Arc`s. Construct one instance per executor from the same
+/// `trust_snapshot` `Arc` so `load_skill` and `invoke_skill` see identical trust state within a
+/// turn.
+#[derive(Clone, Debug)]
+pub(crate) struct SkillTrustGate {
+    registry: Arc<RwLock<SkillRegistry>>,
+    trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustSnapshot>>>,
+}
+
+impl SkillTrustGate {
+    pub(crate) fn new(
+        registry: Arc<RwLock<SkillRegistry>>,
+        trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustSnapshot>>>,
+    ) -> Self {
+        Self {
+            registry,
+            trust_snapshot,
+        }
+    }
+
+    /// Resolve the trust snapshot entry for a skill.
+    ///
+    /// Returns `None` when no row exists — [`resolve_body`](Self::resolve_body) treats absence
+    /// as `SkillTrustLevel::MISSING_ENTRY_FALLBACK` (Trusted), not Quarantined.
+    fn resolve_snapshot(&self, skill_name: &str) -> Option<SkillTrustSnapshot> {
+        self.trust_snapshot.read().get(skill_name).cloned()
+    }
+
+    /// Run the per-invocation blake3 integrity check.
+    ///
+    /// Returns `Some(message)` when the invocation must be aborted (hash mismatch, empty stored
+    /// hash, missing skill dir, or IO error). Returns `None` when the check passes and dispatch
+    /// should proceed.
+    async fn check_integrity(
+        &self,
+        skill_name: &str,
+        skill_name_safe: &str,
+        entry: &SkillTrustSnapshot,
+    ) -> Result<Option<String>, ToolError> {
+        if entry.blake3_hash.is_empty() {
+            tracing::warn!(
+                skill = %skill_name,
+                "requires_trust_check is set but no stored hash found, aborting invocation"
+            );
+            return Ok(Some(format!(
+                "skill integrity check failed: {skill_name_safe} \
+                 — requires_trust_check is set but no stored hash found"
+            )));
+        }
+        let stored_hash = entry.blake3_hash.clone();
+        let skill_dir = {
+            let guard = self.registry.read();
+            guard.skill_dir(skill_name)
+        };
+        let Some(dir) = skill_dir else {
+            tracing::warn!(
+                skill = %skill_name,
+                "requires_trust_check: skill_dir not found, aborting invocation"
+            );
+            return Ok(Some(format!(
+                "skill integrity check failed: {skill_name_safe} — skill directory not found"
+            )));
+        };
+        let current_hash = tokio::task::spawn_blocking(move || compute_skill_hash(&dir))
+            .await
+            .map_err(|e| ToolError::InvalidParams {
+                message: format!("spawn_blocking join error: {e}"),
+            })?;
+        match current_hash {
+            Ok(hash) if hash != stored_hash => {
+                tracing::warn!(
+                    skill = %skill_name,
+                    "hash mismatch on per-invocation check, demoting to Quarantined"
+                );
+                self.trust_snapshot
+                    .write()
+                    .entry(skill_name.to_owned())
+                    .and_modify(|e| e.trust_level = SkillTrustLevel::Quarantined);
+                // TODO: persist demotion to trust store (#4293 follow-up)
+                Ok(Some(format!(
+                    "skill integrity check failed: {skill_name_safe} — demoted to Quarantined"
+                )))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    skill = %skill_name,
+                    err = %e,
+                    "failed to re-hash skill, aborting invocation"
+                );
+                Ok(Some(format!(
+                    "skill integrity check failed: {skill_name_safe} — cannot read SKILL.md"
+                )))
+            }
+            Ok(_) => Ok(None), // hash matches, proceed
+        }
+    }
+
+    /// Resolve `skill_name` through the trust pipeline shared by `load_skill` and
+    /// `invoke_skill`: refuse `Blocked` before any body read, re-check integrity when
+    /// `requires_trust_check` is set, then sanitize/wrap the body per trust level.
+    ///
+    /// A missing trust-snapshot row resolves to `SkillTrustLevel::MISSING_ENTRY_FALLBACK`
+    /// (Trusted) — "never classified", not "known untrusted". `skill_name` is sanitized before
+    /// it appears in any returned message, including the not-found path.
+    pub(crate) async fn resolve_body(
+        &self,
+        skill_name: &str,
+    ) -> Result<SkillBodyResolution, ToolError> {
+        let snapshot = self.resolve_snapshot(skill_name);
+        let trust = snapshot
+            .as_ref()
+            .map_or(SkillTrustLevel::MISSING_ENTRY_FALLBACK, |s| s.trust_level);
+        // Sanitize skill_name before it appears in any tool output: it originates from the LLM
+        // and could carry injection markers (e.g. `<|im_start|>`).
+        let skill_name_safe = sanitize_skill_text(skill_name);
+
+        // Blocked skills are refused before any body read — executor defense layer.
+        if trust == SkillTrustLevel::Blocked {
+            return Ok(SkillBodyResolution::Refused(format!(
+                "skill is blocked by policy: {skill_name_safe}"
+            )));
+        }
+
+        // Per-invocation integrity check: re-hash SKILL.md when requires_trust_check is set.
+        if let Some(entry) = snapshot.as_ref().filter(|s| s.requires_trust_check)
+            && let Some(message) = self
+                .check_integrity(skill_name, &skill_name_safe, entry)
+                .await?
+        {
+            return Ok(SkillBodyResolution::Refused(message));
+        }
+
+        // Clone body out of the read guard before any further await — never hold lock across await.
+        let body = {
+            let guard = self.registry.read();
+            guard.body(skill_name).map(str::to_owned)
+        };
+
+        match body {
+            Ok(raw_body) => {
+                // Apply the same pipeline as `format_skills_prompt`: sanitize for non-Trusted,
+                // additionally wrap for Quarantined.
+                let sanitized = if trust == SkillTrustLevel::Trusted {
+                    raw_body
+                } else {
+                    sanitize_skill_text(&raw_body)
+                };
+                let wrapped = if trust == SkillTrustLevel::Quarantined {
+                    wrap_quarantined(&skill_name_safe, &sanitized)
+                } else {
+                    sanitized
+                };
+                Ok(SkillBodyResolution::Body(wrapped))
+            }
+            Err(_) => Ok(SkillBodyResolution::NotFound(format!(
+                "skill not found: {skill_name_safe}"
+            ))),
+        }
+    }
+}

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1432,18 +1432,8 @@ async fn spawn_acp_agent(
         }
         ex
     };
-    let skill_loader_executor = zeph_core::SkillLoaderExecutor::new(Arc::clone(&registry));
-    // #5975: pre-allocate trust snapshot Arc shared between the agent's SkillState and
-    // SkillInvokeExecutor — written once per turn by prepare_context, read by the executor.
-    // Mirrors src/runner.rs; previously ACP never constructed SkillInvokeExecutor at all, so
-    // `invoke_skill` was effectively CLI-only.
-    let trust_snapshot: Arc<
-        parking_lot::RwLock<
-            std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>,
-        >,
-    > = Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
-    let skill_invoke_executor =
-        zeph_core::SkillInvokeExecutor::new(Arc::clone(&registry), Arc::clone(&trust_snapshot));
+    let (skill_loader_executor, skill_invoke_executor, trust_snapshot) =
+        agent_setup::build_skill_executors(&registry);
     let (base_composite, cancel_signal, provider_override, parent_tool_use_id): (
         Arc<dyn ErasedToolExecutor>,
         _,
@@ -4011,12 +4001,8 @@ mod tests {
         >,
     ) {
         let registry = Arc::new(RwLock::new(zeph_skills::registry::SkillRegistry::empty()));
-        let skill_loader_executor = zeph_core::SkillLoaderExecutor::new(Arc::clone(&registry));
-        let trust_snapshot: Arc<
-            RwLock<std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>>,
-        > = Arc::new(RwLock::new(std::collections::HashMap::new()));
-        let skill_invoke_executor =
-            zeph_core::SkillInvokeExecutor::new(Arc::clone(&registry), Arc::clone(&trust_snapshot));
+        let (skill_loader_executor, skill_invoke_executor, trust_snapshot) =
+            agent_setup::build_skill_executors(&registry);
 
         let mock_provider =
             zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default());

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1255,6 +1255,35 @@ pub(crate) fn build_quality_pipeline(
     }
 }
 
+/// Builds `load_skill`'s [`SkillLoaderExecutor`](zeph_core::SkillLoaderExecutor) and
+/// `invoke_skill`'s [`SkillInvokeExecutor`](zeph_core::SkillInvokeExecutor) sharing one
+/// `trust_snapshot` `Arc`, shared by every agent entry point (CLI's `runner.rs`, `acp.rs`'s
+/// `spawn_acp_agent`, `daemon.rs`'s `run_daemon`) so the two skill-body tools cannot construct
+/// independent trust state and drift apart (#6049).
+///
+/// Closes #6050 by construction: prior to this helper, `SkillLoaderExecutor` could be (and was)
+/// built without a `trust_snapshot` at all, bypassing the trust gate entirely for `load_skill`.
+/// The returned `Arc` is the single per-turn snapshot written once by
+/// `apply_skill_trust_and_gating` and read lock-free by both executors — callers must also
+/// thread it into `.with_trust_snapshot(...)` on the agent builder (the `SkillState` writer) so
+/// all three holders share the same instance.
+pub(crate) fn build_skill_executors(
+    registry: &Arc<RwLock<zeph_skills::registry::SkillRegistry>>,
+) -> (
+    zeph_core::SkillLoaderExecutor,
+    zeph_core::SkillInvokeExecutor,
+    Arc<RwLock<std::collections::HashMap<String, zeph_core::SkillTrustSnapshot>>>,
+) {
+    let trust_snapshot: Arc<
+        RwLock<std::collections::HashMap<String, zeph_core::SkillTrustSnapshot>>,
+    > = Arc::new(RwLock::new(std::collections::HashMap::new()));
+    let loader =
+        zeph_core::SkillLoaderExecutor::new(Arc::clone(registry), Arc::clone(&trust_snapshot));
+    let invoker =
+        zeph_core::SkillInvokeExecutor::new(Arc::clone(registry), Arc::clone(&trust_snapshot));
+    (loader, invoker, trust_snapshot)
+}
+
 /// Wires a [`zeph_core::debug_dump::DebugDumper`] into `agent` for `dir`/`format`, shared by
 /// every agent entry point that honors `[debug] enabled = true` (CLI, ACP, daemon, serve-sessions).
 ///

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -764,21 +764,8 @@ pub(crate) async fn run_daemon(
         std::sync::Arc::new(memory.sqlite().clone()),
     )
     .with_conversation(conversation_id.0);
-    let skill_loader_executor =
-        zeph_core::SkillLoaderExecutor::new(std::sync::Arc::clone(&registry));
-    // #5975: pre-allocate trust snapshot Arc shared between the agent's SkillState and
-    // SkillInvokeExecutor — written once per turn by prepare_context, read by the executor.
-    // Mirrors src/runner.rs; previously the daemon never constructed SkillInvokeExecutor at all,
-    // so `invoke_skill` was effectively CLI-only.
-    let trust_snapshot: std::sync::Arc<
-        parking_lot::RwLock<
-            std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>,
-        >,
-    > = std::sync::Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
-    let skill_invoke_executor = zeph_core::SkillInvokeExecutor::new(
-        std::sync::Arc::clone(&registry),
-        std::sync::Arc::clone(&trust_snapshot),
-    );
+    let (skill_loader_executor, skill_invoke_executor, trust_snapshot) =
+        agent_setup::build_skill_executors(&registry);
     let base_tool: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = {
         let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = std::sync::Arc::new(
             zeph_tools::CompositeExecutor::new(base_executor, mcp_executor),
@@ -2348,15 +2335,8 @@ mod tests {
 
         let registry =
             std::sync::Arc::new(RwLock::new(zeph_skills::registry::SkillRegistry::empty()));
-        let skill_loader_executor =
-            zeph_core::SkillLoaderExecutor::new(std::sync::Arc::clone(&registry));
-        let trust_snapshot: std::sync::Arc<
-            RwLock<std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>>,
-        > = std::sync::Arc::new(RwLock::new(std::collections::HashMap::new()));
-        let skill_invoke_executor = zeph_core::SkillInvokeExecutor::new(
-            std::sync::Arc::clone(&registry),
-            std::sync::Arc::clone(&trust_snapshot),
-        );
+        let (skill_loader_executor, skill_invoke_executor, _trust_snapshot) =
+            agent_setup::build_skill_executors(&registry);
 
         let composite = zeph_tools::CompositeExecutor::new(
             skill_loader_executor,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2373,19 +2373,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         std::sync::Arc::new(memory.sqlite().clone()),
     )
     .with_conversation(conversation_id.0);
-    let skill_loader_executor =
-        zeph_core::SkillLoaderExecutor::new(std::sync::Arc::clone(&registry));
-    // Pre-allocate trust snapshot Arc shared between the agent's SkillState and
-    // SkillInvokeExecutor — written once per turn by prepare_context, read by the executor.
-    let trust_snapshot: std::sync::Arc<
-        parking_lot::RwLock<
-            std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>,
-        >,
-    > = std::sync::Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
-    let skill_invoke_executor = zeph_core::SkillInvokeExecutor::new(
-        std::sync::Arc::clone(&registry),
-        std::sync::Arc::clone(&trust_snapshot),
-    );
+    let (skill_loader_executor, skill_invoke_executor, trust_snapshot) =
+        agent_setup::build_skill_executors(&registry);
     let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> =
         std::sync::Arc::new(tool_setup.executor);
     let inner_executor =


### PR DESCRIPTION
## Summary

- `SkillLoaderExecutor` (the `load_skill` tool) returned raw `SKILL.md` bodies for any registered skill, including ones classified `Blocked` or `Quarantined`, with no refusal or sanitization. The turn-level `TrustGateExecutor` gate does not close this gap: it only denies `load_skill` when the turn's folded `effective_trust` is `Quarantined`, and never inspects the `skill_name` argument itself — so a `load_skill` call naming a `Blocked`/`Quarantined` skill bypassed the entire trust defense-in-depth pipeline that `invoke_skill` already enforced.
- Extracted the shared trust-gating pipeline (Blocked refusal before any body read, sanitize non-Trusted bodies, wrap Quarantined bodies, blake3 integrity re-check, `skill_name` sanitization on every output path) into a new `SkillTrustGate`, used by both `SkillLoaderExecutor` and `SkillInvokeExecutor` so the two tools cannot drift apart in the future.
- Added an `agent_setup::build_skill_executors` helper that constructs both executors around one shared `trust_snapshot` `Arc`, replacing five duplicated inline construction sites across `src/runner.rs`, `src/acp.rs`, and `src/daemon.rs` (production and test helpers).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12835 passed, 35 skipped, 0 failed)
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New unit test suite in `skill_loader.rs` mirroring `skill_invoker.rs`'s trust tests: blocked-refused-without-body-read, non-trusted-sanitized, quarantined-wrapped, trusted-verbatim, missing-row-defaults-to-Trusted, not-found sanitizes `skill_name`, tampered `requires_trust_check` skill caught by integrity re-check
- [x] `.local/testing/playbooks/skill-trust-cli.md` and `.local/testing/coverage-status.md` updated

Closes #6050
Closes #6049