### PR TITLE
fix(tools)!: remove permissive defaults on ToolExecutor/ErasedToolExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **BREAKING**: `ToolExecutor` and `ErasedToolExecutor` no longer provide permissive default
+  bodies for the six risk-bearing cross-cutting methods — `requires_confirmation`,
+  `execute_tool_call_confirmed`, the checkpoint trio (`checkpoint_undo`/`checkpoint_redo`/
+  `checkpoint_list`), and `is_tool_speculatable`, plus their `_erased` counterparts on the
+  object-safe trait (#6019). This recurring defect class — a wrapper forgetting to override one
+  of these and silently inheriting a default that disabled a security check, a checkpoint
+  capability, or a confirmation gate — required five prior one-off patches (#5930, #6011, #5998,
+  #6036, and the #5999/#6001/#6012 cluster). Every implementor of either trait must now supply
+  all six explicitly; the compiler rejects any omission at build time instead of the gap
+  surfacing only when a specific wrapper composition is exercised. Four new `macro_rules!`
+  helpers in `zeph-tools::executor_delegate` (`tool_executor_forward!`,
+  `tool_executor_no_inner_defaults!`, `erased_tool_executor_forward!`,
+  `erased_tool_executor_no_inner_defaults!`) keep the compiler-forced boilerplate to one line for
+  the common wrapper-forwards-to-inner and leaf-has-no-inner shapes; both `*_no_inner_defaults!`
+  macros carry a rustdoc warning against use on a type with a delegate field, since
+  `macro_rules!` cannot enforce that structurally. Closes three live gaps on the erased side
+  (previously dormant, gated on whether the wrapped executor supports checkpoints): the removed
+  `execute_tool_call_confirmed_erased` default already forwarded correctly
+  (`self.execute_tool_call_erased(call)`), so omitting it was not itself a live bug — the actual
+  gaps were the checkpoint trio and `is_tool_speculatable_erased`, whose removed defaults silently
+  reported "unsupported"/`false` regardless of the wrapped executor's real capability.
+  `FilteredToolExecutor` and `PlanModeExecutor` (`zeph-subagent::filter`) now forward the
+  checkpoint trio and `is_tool_speculatable_erased` to their inner executor; `PlanModeExecutor`
+  also now forwards `set_effective_trust`, which previously no-op'd silently, so a trust
+  cap set by an outer wrapper (e.g. `PolicyGateExecutor`) never reached the underlying tool while
+  a sub-agent was in plan mode. `PlanModeExecutor`'s checkpoint trio now intentionally forwards to
+  `inner` rather than staying "unsupported" — plan mode blocks new tool *execution* but checkpoint
+  undo/redo/list are metadata/administrative operations on already-executed side effects, not new
+  execution, so this is a deliberate scope decision, not an oversight.
+  `execute_tool_call_confirmed_erased` was nonetheless hand-written (not macro-forwarded) on all
+  three wrappers now that the trait requires it explicitly: `FilteredToolExecutor` and
+  `PlanModeExecutor` delegate to their own `execute_tool_call_erased` to preserve policy
+  enforcement / the execution block; `MemoryAwareExecutor` (`zeph-subagent::manager::spawn`)
+  replicates the `SandboxViolation` -> memory-tool fallback already present on its unconfirmed
+  path, since a blind forward to `inner` would have dropped that fallback specifically on the
+  confirmed path. `ShellExecutor` gained explicit
+  `requires_confirmation`/`execute_tool_call_confirmed`/`is_tool_speculatable` (previously
+  relying on the removed defaults despite implementing real checkpoints).
 - `fix(config)`: `Config::validate()` now calls 7 subsystem `validate()` functions that existed
   with real invariant checks but were unreachable from the production config-load path — only
   their own unit tests exercised them (#5932). `validate_pool()` was the most severe gap: two

--- a/crates/zeph-acp/src/fs.rs
+++ b/crates/zeph-acp/src/fs.rs
@@ -383,6 +383,8 @@ impl zeph_tools::ToolExecutor for AcpFileExecutor {
             _ => Ok(None),
         }
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 impl AcpFileExecutor {

--- a/crates/zeph-acp/src/terminal.rs
+++ b/crates/zeph-acp/src/terminal.rs
@@ -451,6 +451,8 @@ impl zeph_tools::ToolExecutor for AcpShellExecutor {
             claim_source: Some(zeph_tools::ClaimSource::Shell),
         }))
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 async fn forward_stdin_via_ext(

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
@@ -240,6 +240,8 @@ impl ToolExecutor for AirlineEnv {
             claim_source: None,
         }))
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
@@ -265,6 +265,8 @@ impl ToolExecutor for RetailEnv {
             claim_source: None,
         }))
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 // ─── Handlers ────────────────────────────────────────────────────────────────

--- a/crates/zeph-bench/src/runner.rs
+++ b/crates/zeph-bench/src/runner.rs
@@ -151,6 +151,8 @@ impl ToolExecutor for NoopExecutor {
     async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
         Ok(None)
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// Drives [`Agent<BenchmarkChannel>`] over a dataset and collects scored results.

--- a/crates/zeph-core/src/agent/speculative/mod.rs
+++ b/crates/zeph-core/src/agent/speculative/mod.rs
@@ -335,6 +335,26 @@ mod tests {
         fn is_tool_speculatable(&self, _: &str) -> bool {
             true
         }
+
+        fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> impl std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send
+        {
+            self.execute_tool_call(call)
+        }
+        fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+            zeph_tools::CheckpointListResult::default()
+        }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            false
+        }
     }
 
     #[tokio::test]

--- a/crates/zeph-core/src/agent/speculative/stream_drainer.rs
+++ b/crates/zeph-core/src/agent/speculative/stream_drainer.rs
@@ -203,6 +203,25 @@ mod tests {
             fn is_tool_speculatable(&self, _: &str) -> bool {
                 false
             }
+            fn execute_tool_call_confirmed(
+                &self,
+                call: &ToolCall,
+            ) -> impl std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send
+            {
+                self.execute_tool_call(call)
+            }
+            fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+                zeph_tools::CheckpointListResult::default()
+            }
+            fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+                false
+            }
         }
         let engine = Arc::new(super::super::SpeculationEngine::new(
             Arc::new(NullExec),
@@ -238,6 +257,25 @@ mod tests {
             fn is_tool_speculatable(&self, _: &str) -> bool {
                 self.count.fetch_add(1, Ordering::Relaxed);
                 true
+            }
+            fn execute_tool_call_confirmed(
+                &self,
+                call: &ToolCall,
+            ) -> impl std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send
+            {
+                self.execute_tool_call(call)
+            }
+            fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+                zeph_tools::CheckpointListResult::default()
+            }
+            fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+                false
             }
         }
 
@@ -308,6 +346,25 @@ mod tests {
             fn is_tool_speculatable(&self, _: &str) -> bool {
                 false
             }
+            fn execute_tool_call_confirmed(
+                &self,
+                call: &ToolCall,
+            ) -> impl std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send
+            {
+                self.execute_tool_call(call)
+            }
+            fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+                zeph_tools::CheckpointListResult::default()
+            }
+            fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+                false
+            }
         }
         let engine = Arc::new(super::super::SpeculationEngine::new(
             Arc::new(NullExec),
@@ -336,6 +393,25 @@ mod tests {
                 Ok(None)
             }
             fn is_tool_speculatable(&self, _: &str) -> bool {
+                false
+            }
+            fn execute_tool_call_confirmed(
+                &self,
+                call: &ToolCall,
+            ) -> impl std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send
+            {
+                self.execute_tool_call(call)
+            }
+            fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+                zeph_tools::CheckpointListResult::default()
+            }
+            fn requires_confirmation(&self, _call: &ToolCall) -> bool {
                 false
             }
         }
@@ -368,6 +444,25 @@ mod tests {
                 Ok(None)
             }
             fn is_tool_speculatable(&self, _: &str) -> bool {
+                false
+            }
+            fn execute_tool_call_confirmed(
+                &self,
+                call: &ToolCall,
+            ) -> impl std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send
+            {
+                self.execute_tool_call(call)
+            }
+            fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+                zeph_tools::CheckpointListResult::default()
+            }
+            fn requires_confirmation(&self, _call: &ToolCall) -> bool {
                 false
             }
         }
@@ -412,6 +507,25 @@ mod tests {
                 Ok(None)
             }
             fn is_tool_speculatable(&self, _: &str) -> bool {
+                false
+            }
+            fn execute_tool_call_confirmed(
+                &self,
+                call: &ToolCall,
+            ) -> impl std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send
+            {
+                self.execute_tool_call(call)
+            }
+            fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+                zeph_tools::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+                zeph_tools::CheckpointListResult::default()
+            }
+            fn requires_confirmation(&self, _call: &ToolCall) -> bool {
                 false
             }
         }

--- a/crates/zeph-core/src/agent/tests/agent_tests/common.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/common.rs
@@ -314,6 +314,7 @@ impl ToolExecutor for MockToolExecutor {
     fn tool_definitions(&self) -> Vec<zeph_tools::registry::ToolDef> {
         self.definitions.clone()
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 pub(crate) fn create_test_registry() -> SkillRegistry {

--- a/crates/zeph-core/src/agent/tests/confirmation_propagation_tests.rs
+++ b/crates/zeph-core/src/agent/tests/confirmation_propagation_tests.rs
@@ -93,6 +93,22 @@ impl ToolExecutor for DagAwareToolExecutor {
     ) -> Result<Option<ToolOutput>, ToolError> {
         Ok(Some(Self::make_output(call.tool_id.as_str(), "confirmed")))
     }
+
+    fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+        zeph_tools::CheckpointActionResult::unsupported()
+    }
+    fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+        zeph_tools::CheckpointActionResult::unsupported()
+    }
+    fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+        zeph_tools::CheckpointListResult::default()
+    }
+    fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+        false
+    }
+    fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+        false
+    }
 }
 
 fn dag_tool_use_response() -> ChatResponse {

--- a/crates/zeph-core/src/agent/tests/inline_tool_loop_tests.rs
+++ b/crates/zeph-core/src/agent/tests/inline_tool_loop_tests.rs
@@ -60,6 +60,8 @@ impl ToolExecutor for CallableToolExecutor {
             outputs.remove(0)
         }
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 fn tool_use_response(tool_id: &str, tool_name: &str) -> ChatResponse {
@@ -285,6 +287,8 @@ async fn elicitation_event_during_tool_execution_is_handled() {
                 claim_source: None,
             }))
         }
+
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     let (elic_tx, elic_rx) = mpsc::channel::<ElicitationEvent>(4);

--- a/crates/zeph-core/src/agent/tests/pre_execution_audit_tests.rs
+++ b/crates/zeph-core/src/agent/tests/pre_execution_audit_tests.rs
@@ -35,6 +35,8 @@ impl ToolExecutor for NoOpExecutor {
     async fn execute_tool_call(&self, _call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         Ok(None)
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// When a pre-execution verifier blocks a tool call and an audit logger is wired,

--- a/crates/zeph-core/src/agent/tests/shutdown_summary_tests.rs
+++ b/crates/zeph-core/src/agent/tests/shutdown_summary_tests.rs
@@ -358,6 +358,8 @@ async fn filter_stats_metrics_increment_on_normal_native_tool_path() {
                 claim_source: None,
             }))
         }
+
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     let (mock, _counter) = MockProvider::default().with_tool_use(vec![
@@ -454,6 +456,8 @@ impl zeph_tools::executor::ToolExecutor for TwoToolExecutor {
             }))
         }
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 // Self-reflection remaining-tools path: when the first of two parallel tool calls returns

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -240,6 +240,7 @@ async fn infrastructure_error_does_not_trigger_self_reflection() {
                 "connection refused",
             ))))
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     // Provide a reflection response to detect if self-reflection fires.
@@ -776,6 +777,7 @@ impl ToolExecutor for FixedOutputExecutor {
             }
         }
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 // FirstFailsExecutor: fails on the first call (permanent error), succeeds thereafter.
@@ -819,6 +821,7 @@ impl ToolExecutor for FirstFailsExecutor {
             }
         }
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// Builds a minimal `ToolUseRequest` for test use.

--- a/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
@@ -693,6 +693,25 @@ impl ToolExecutor for AlwaysOkSpecExec {
     fn is_tool_speculatable(&self, _: &str) -> bool {
         true
     }
+
+    fn execute_tool_call_confirmed(
+        &self,
+        call: &ToolCall,
+    ) -> impl std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        self.execute_tool_call(call)
+    }
+    fn checkpoint_undo(&self, _n: usize) -> zeph_tools::executor::CheckpointActionResult {
+        zeph_tools::executor::CheckpointActionResult::unsupported()
+    }
+    fn checkpoint_redo(&self) -> zeph_tools::executor::CheckpointActionResult {
+        zeph_tools::executor::CheckpointActionResult::unsupported()
+    }
+    fn checkpoint_list(&self) -> zeph_tools::executor::CheckpointListResult {
+        zeph_tools::executor::CheckpointListResult::default()
+    }
+    fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+        false
+    }
 }
 
 struct AlwaysErrSpecExec;
@@ -709,6 +728,25 @@ impl ToolExecutor for AlwaysErrSpecExec {
 
     fn is_tool_speculatable(&self, _: &str) -> bool {
         true
+    }
+
+    fn execute_tool_call_confirmed(
+        &self,
+        call: &ToolCall,
+    ) -> impl std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        self.execute_tool_call(call)
+    }
+    fn checkpoint_undo(&self, _n: usize) -> zeph_tools::executor::CheckpointActionResult {
+        zeph_tools::executor::CheckpointActionResult::unsupported()
+    }
+    fn checkpoint_redo(&self) -> zeph_tools::executor::CheckpointActionResult {
+        zeph_tools::executor::CheckpointActionResult::unsupported()
+    }
+    fn checkpoint_list(&self) -> zeph_tools::executor::CheckpointListResult {
+        zeph_tools::executor::CheckpointListResult::default()
+    }
+    fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+        false
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
@@ -48,6 +48,7 @@ impl zeph_tools::executor::ToolExecutor for DelayExecutor {
             }))
         }
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 struct FailingNthExecutor {
@@ -93,6 +94,7 @@ impl zeph_tools::executor::ToolExecutor for FailingNthExecutor {
             }
         }
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 fn make_calls(n: usize) -> Vec<ToolCall> {

--- a/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
@@ -1056,6 +1056,7 @@ impl ToolExecutor for TransientThenOkExecutor {
     fn is_tool_retryable(&self, _tool_id: &str) -> bool {
         true
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// Always returns a `Transient` io error (to exhaust retries).
@@ -1088,6 +1089,7 @@ impl ToolExecutor for AlwaysTransientExecutor {
     fn is_tool_retryable(&self, _tool_id: &str) -> bool {
         true
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 #[tokio::test]

--- a/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
@@ -165,6 +165,7 @@ impl ToolExecutor for FixedOutputExecutor {
             }
         }
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// Returns success for the first `execute_tool_call` invocation and `[error]` output for all
@@ -211,6 +212,7 @@ impl ToolExecutor for FirstSuccessExecutor {
             }))
         }
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// Dispatches by `tool_id` to cover three outcomes in a single batch:
@@ -276,6 +278,7 @@ impl ToolExecutor for DispatchingExecutor {
     fn is_tool_retryable(&self, tool_id: &str) -> bool {
         tool_id == "tool-retryable"
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// Builds a minimal `ToolUseRequest` for test use.
@@ -447,6 +450,7 @@ async fn native_tool_network_error_records_tool_failure_not_success() {
                 "connection refused",
             ))))
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     let provider = mock_provider(vec![]);
@@ -1219,6 +1223,7 @@ async fn permanent_tool_error_pushes_tool_result() {
                 "HTTP 403 Forbidden",
             ))))
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     let executor = PermanentErrorExecutor;
@@ -1268,6 +1273,7 @@ async fn parallel_permanent_errors_both_push_tool_results() {
                 "HTTP 403 Forbidden",
             ))))
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     let executor = PermanentErrorExecutor2;
@@ -1477,6 +1483,7 @@ async fn transient_error_on_non_retryable_executor_is_not_retried() {
         fn is_tool_retryable(&self, _tool_id: &str) -> bool {
             false
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     let provider = mock_provider(vec![]);
@@ -2199,6 +2206,7 @@ impl ToolExecutor for RecordingExecutor {
             }))
         }
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 fn tafc_only_think_request(id: &str, name: &str) -> zeph_llm::provider::ToolUseRequest {

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -4395,6 +4395,7 @@ mod tests {
             fn is_tool_retryable(&self, _tool_id: &str) -> bool {
                 true
             }
+            zeph_tools::tool_executor_no_inner_defaults!();
         }
 
         fn tool_result_ids(agent: &Agent<MockChannel>, id: &str) -> Vec<&'static str> {

--- a/crates/zeph-core/src/memory_tools.rs
+++ b/crates/zeph-core/src/memory_tools.rs
@@ -250,6 +250,8 @@ impl ToolExecutor for MemoryToolExecutor {
             _ => Ok(None),
         }
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/overflow_tools.rs
+++ b/crates/zeph-core/src/overflow_tools.rs
@@ -102,6 +102,8 @@ impl ToolExecutor for OverflowToolExecutor {
             )))),
         }
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -139,6 +139,8 @@ impl ToolExecutor for SkillInvokeExecutor {
 
         Ok(Some(make_output(summary)))
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 fn make_output(summary: String) -> ToolOutput {

--- a/crates/zeph-core/src/skill_loader.rs
+++ b/crates/zeph-core/src/skill_loader.rs
@@ -127,6 +127,8 @@ impl ToolExecutor for SkillLoaderExecutor {
             claim_source: None,
         }))
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/testing.rs
+++ b/crates/zeph-core/src/testing.rs
@@ -193,6 +193,8 @@ impl zeph_tools::executor::ToolExecutor for MockToolExecutor {
     fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
         self.captured_env.lock().unwrap().push(env);
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/zeph-core/tests/turn_lifecycle.rs
+++ b/crates/zeph-core/tests/turn_lifecycle.rs
@@ -100,6 +100,7 @@ impl ToolExecutor for NoopExecutor {
     }
 
     fn set_skill_env(&self, _env: Option<std::collections::HashMap<String, String>>) {}
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// Tool executor that returns a single tool output then `Ok(None)` thereafter.
@@ -133,6 +134,7 @@ impl ToolExecutor for SingleToolExecutor {
     }
 
     fn set_skill_env(&self, _env: Option<std::collections::HashMap<String, String>>) {}
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// Build a minimal [`SkillRegistry`] backed by a temporary directory.

--- a/crates/zeph-index/src/mcp_server.rs
+++ b/crates/zeph-index/src/mcp_server.rs
@@ -471,6 +471,8 @@ impl ToolExecutor for IndexMcpServer {
             "symbol_definition" | "find_text_references" | "call_graph" | "module_summary"
         )
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 #[cfg(test)]

--- a/crates/zeph-mcp/src/executor.rs
+++ b/crates/zeph-mcp/src/executor.rs
@@ -203,6 +203,8 @@ impl ToolExecutor for McpToolExecutor {
             claim_source: Some(zeph_tools::ClaimSource::Mcp),
         }))
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/zeph-mcp/src/testing.rs
+++ b/crates/zeph-mcp/src/testing.rs
@@ -187,6 +187,8 @@ impl ToolExecutor for MockMcpServer {
             }),
         }
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 #[cfg(test)]

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -985,6 +985,33 @@ mod handle_tool_step_granted_secrets_tests {
         fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
             false
         }
+
+        fn execute_tool_call_confirmed_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            self.execute_tool_call_erased(call)
+        }
+
+        fn checkpoint_undo_erased(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+            zeph_tools::CheckpointListResult::default()
+        }
+
+        fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
     }
 
     fn tool_use_response() -> ChatResponse {

--- a/crates/zeph-subagent/src/filter.rs
+++ b/crates/zeph-subagent/src/filter.rs
@@ -198,6 +198,18 @@ impl ErasedToolExecutor for FilteredToolExecutor {
         Box::pin(self.inner.execute_tool_call_erased(call))
     }
 
+    /// Same policy as `execute_tool_call_erased`: the confirmed path must go through the
+    /// same allow/deny check, not bypass it. Mirrors the removed trait default's behavior
+    /// (delegate to `execute_tool_call_erased`) while preserving the policy enforcement
+    /// already present there.
+    fn execute_tool_call_confirmed_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        self.execute_tool_call_erased(call)
+    }
+
     fn set_skill_env(&self, env: Option<HashMap<String, String>>) {
         self.inner.set_skill_env(env);
     }
@@ -213,6 +225,8 @@ impl ErasedToolExecutor for FilteredToolExecutor {
     fn requires_confirmation_erased(&self, call: &ToolCall) -> bool {
         self.inner.requires_confirmation_erased(call)
     }
+
+    zeph_tools::erased_tool_executor_forward!(inner);
 }
 
 // ── Plan mode executor ────────────────────────────────────────────────────────
@@ -274,8 +288,24 @@ impl ErasedToolExecutor for PlanModeExecutor {
         })))
     }
 
+    /// Plan mode blocks all execution, confirmed or not — reuse the same block as the
+    /// unconfirmed path rather than forwarding to `inner`.
+    fn execute_tool_call_confirmed_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        self.execute_tool_call_erased(call)
+    }
+
     fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
         self.inner.set_skill_env(env);
+    }
+
+    /// Read-only in plan mode: trust level is metadata, not an execution capability,
+    /// so it is safe (and necessary for parity with other read paths) to forward.
+    fn set_effective_trust(&self, level: zeph_tools::SkillTrustLevel) {
+        self.inner.set_effective_trust(level);
     }
 
     fn is_tool_retryable_erased(&self, _tool_id: &str) -> bool {
@@ -285,6 +315,13 @@ impl ErasedToolExecutor for PlanModeExecutor {
     fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
         false
     }
+
+    // Deliberate: this forwards the checkpoint trio to `inner` rather than reporting
+    // "unsupported" (the pre-#6019 behavior). Plan mode blocks new tool *execution*
+    // (`execute_tool_call_erased` above always returns `Blocked`); checkpoint undo/redo/list
+    // act on already-executed side effects and are administrative/read operations, not new
+    // execution, so exposing them while plan mode is active is in scope.
+    zeph_tools::erased_tool_executor_forward!(inner);
 }
 
 // ── Skill filtering ───────────────────────────────────────────────────────────
@@ -479,6 +516,33 @@ mod tests {
         fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
             false
         }
+
+        fn execute_tool_call_confirmed_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            self.execute_tool_call_erased(call)
+        }
+
+        fn checkpoint_undo_erased(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+            zeph_tools::CheckpointListResult::default()
+        }
+
+        fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
     }
 
     fn fenced_stub_box(tag: &'static str) -> Arc<dyn ErasedToolExecutor> {
@@ -552,6 +616,33 @@ mod tests {
         }
 
         fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
+            false
+        }
+
+        fn execute_tool_call_confirmed_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            self.execute_tool_call_erased(call)
+        }
+
+        fn checkpoint_undo_erased(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+            zeph_tools::CheckpointListResult::default()
+        }
+
+        fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
             false
         }
     }
@@ -957,6 +1048,220 @@ mod tests {
         assert_eq!(defs.len(), 2);
         assert!(defs.iter().any(|d| d.id == "shell"));
         assert!(defs.iter().any(|d| d.id == "web"));
+    }
+
+    // ── #6019: checkpoint/speculatable/trust forwarding regression ─────────
+
+    /// Inner executor whose checkpoint/speculatable/trust methods return distinguishable
+    /// non-default values, used to prove `FilteredToolExecutor` and `PlanModeExecutor`
+    /// forward to `inner` rather than falling through to the "unsupported"/`false`
+    /// defaults the removed trait defaults used to provide silently (#6019).
+    struct CheckpointingStub {
+        trust_recorded: std::sync::Mutex<Option<zeph_tools::SkillTrustLevel>>,
+    }
+
+    impl ErasedToolExecutor for CheckpointingStub {
+        fn execute_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn execute_confirmed_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn tool_definitions_erased(&self) -> Vec<ToolDef> {
+            vec![]
+        }
+
+        fn execute_tool_call_erased<'a>(
+            &'a self,
+            _call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn execute_tool_call_confirmed_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            self.execute_tool_call_erased(call)
+        }
+
+        fn is_tool_retryable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
+
+        fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
+            false
+        }
+
+        fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
+            true
+        }
+
+        fn set_effective_trust(&self, level: zeph_tools::SkillTrustLevel) {
+            *self.trust_recorded.lock().unwrap() = Some(level);
+        }
+
+        fn checkpoint_undo_erased(&self, n: usize) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult {
+                reverted_commands: n,
+                restored: 0,
+                deleted: 0,
+                supported: true,
+                message: "stub-undo".into(),
+            }
+        }
+
+        fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult {
+                reverted_commands: 0,
+                restored: 0,
+                deleted: 0,
+                supported: true,
+                message: "stub-redo".into(),
+            }
+        }
+
+        fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+            zeph_tools::CheckpointListResult {
+                entries: vec![],
+                redo_depth: 7,
+                supported: true,
+            }
+        }
+    }
+
+    fn checkpointing_stub() -> Arc<CheckpointingStub> {
+        Arc::new(CheckpointingStub {
+            trust_recorded: std::sync::Mutex::new(None),
+        })
+    }
+
+    #[test]
+    fn filtered_executor_forwards_checkpoint_trio_and_speculatable() {
+        let inner = checkpointing_stub();
+        let exec = FilteredToolExecutor::new(Arc::clone(&inner) as _, ToolPolicy::InheritAll);
+
+        let undo = exec.checkpoint_undo_erased(7);
+        assert!(
+            undo.supported,
+            "checkpoint_undo_erased must forward to inner"
+        );
+        assert_eq!(
+            undo.reverted_commands, 7,
+            "n must be forwarded, not hardcoded"
+        );
+        assert!(
+            exec.checkpoint_redo_erased().supported,
+            "checkpoint_redo_erased must forward to inner"
+        );
+        assert_eq!(
+            exec.checkpoint_list_erased().redo_depth,
+            7,
+            "checkpoint_list_erased must forward to inner"
+        );
+        assert!(
+            exec.is_tool_speculatable_erased("anything"),
+            "is_tool_speculatable_erased must forward to inner, not default to false"
+        );
+    }
+
+    #[tokio::test]
+    async fn filtered_executor_confirmed_erased_still_enforces_policy() {
+        // execute_tool_call_confirmed_erased must delegate through execute_tool_call_erased
+        // (preserving the policy check), not blind-forward straight to inner.
+        let inner = checkpointing_stub();
+        let exec = FilteredToolExecutor::with_disallowed(
+            Arc::clone(&inner) as _,
+            ToolPolicy::InheritAll,
+            vec!["blocked_tool".into()],
+        );
+        let call = ToolCall {
+            tool_id: "blocked_tool".into(),
+            params: serde_json::Map::default(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        // confirmed path must still enforce the denylist, not bypass it
+        let res = exec.execute_tool_call_confirmed_erased(&call).await;
+        assert_matches!(res, Err(ToolError::Blocked { .. }));
+    }
+
+    #[test]
+    fn plan_mode_forwards_checkpoint_trio_and_speculatable() {
+        let inner = checkpointing_stub();
+        let exec = PlanModeExecutor::new(Arc::clone(&inner) as _);
+
+        let undo = exec.checkpoint_undo_erased(3);
+        assert!(
+            undo.supported,
+            "checkpoint_undo_erased must forward to inner"
+        );
+        assert_eq!(undo.reverted_commands, 3);
+        assert!(exec.checkpoint_redo_erased().supported);
+        assert_eq!(exec.checkpoint_list_erased().redo_depth, 7);
+        assert!(
+            exec.is_tool_speculatable_erased("anything"),
+            "is_tool_speculatable_erased must forward to inner, not default to false"
+        );
+    }
+
+    #[test]
+    fn plan_mode_forwards_set_effective_trust() {
+        let inner = checkpointing_stub();
+        let exec = PlanModeExecutor::new(Arc::clone(&inner) as _);
+        exec.set_effective_trust(zeph_tools::SkillTrustLevel::Quarantined);
+        assert_eq!(
+            *inner.trust_recorded.lock().unwrap(),
+            Some(zeph_tools::SkillTrustLevel::Quarantined),
+            "set_effective_trust must forward to inner"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_mode_confirmed_erased_still_blocks_execution() {
+        let inner = checkpointing_stub();
+        let exec = PlanModeExecutor::new(Arc::clone(&inner) as _);
+        let call = ToolCall {
+            tool_id: "shell".into(),
+            params: serde_json::Map::default(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let res = exec.execute_tool_call_confirmed_erased(&call).await;
+        assert!(
+            res.is_err(),
+            "plan mode must block confirmed execution too, not just unconfirmed"
+        );
     }
 
     // ── normalize_tool_id tests ────────────────────────────────────────────

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -98,12 +98,30 @@ impl ErasedToolExecutor for MemoryAwareExecutor {
         })
     }
 
-    fn is_tool_retryable_erased(&self, tool_id: &str) -> bool {
-        self.inner.is_tool_retryable_erased(tool_id)
+    /// Mirrors `execute_tool_call_erased`'s `SandboxViolation` -> memory-executor fallback.
+    /// A blind forward to `inner` here would silently drop that fallback on the confirmed
+    /// path — a confirmed memory-tool call that sandbox-violates on `inner` would fail
+    /// instead of falling back, diverging from the unconfirmed path's behavior.
+    fn execute_tool_call_confirmed_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            match self.inner.execute_tool_call_confirmed_erased(call).await {
+                Err(ToolError::SandboxViolation { .. }) => {
+                    self.memory_executor
+                        .execute_tool_call_confirmed_erased(call)
+                        .await
+                }
+                other => other,
+            }
+        })
     }
 
-    fn is_tool_speculatable_erased(&self, tool_id: &str) -> bool {
-        self.inner.is_tool_speculatable_erased(tool_id)
+    fn is_tool_retryable_erased(&self, tool_id: &str) -> bool {
+        self.inner.is_tool_retryable_erased(tool_id)
     }
 
     fn requires_confirmation_erased(&self, call: &ToolCall) -> bool {
@@ -117,6 +135,8 @@ impl ErasedToolExecutor for MemoryAwareExecutor {
     fn set_effective_trust(&self, level: zeph_tools::SkillTrustLevel) {
         self.inner.set_effective_trust(level);
     }
+
+    zeph_tools::erased_tool_executor_forward!(inner);
 }
 
 pub(crate) fn build_filtered_executor(

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -86,6 +86,30 @@ impl ErasedToolExecutor for NoopExecutor {
     fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
         false
     }
+
+    fn execute_tool_call_confirmed_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        self.execute_tool_call_erased(call)
+    }
+
+    fn checkpoint_undo_erased(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+        zeph_tools::CheckpointActionResult::unsupported()
+    }
+
+    fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+        zeph_tools::CheckpointActionResult::unsupported()
+    }
+
+    fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+        zeph_tools::CheckpointListResult::default()
+    }
+
+    fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
+        false
+    }
 }
 
 fn mock_provider(responses: Vec<&str>) -> AnyProvider {
@@ -600,6 +624,33 @@ async fn tool_call_loop_two_turns() {
         }
 
         fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
+            false
+        }
+
+        fn execute_tool_call_confirmed_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            self.execute_tool_call_erased(call)
+        }
+
+        fn checkpoint_undo_erased(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+            zeph_tools::CheckpointListResult::default()
+        }
+
+        fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
             false
         }
     }
@@ -1452,6 +1503,30 @@ impl ErasedToolExecutor for TrustTrackingExecutor {
     fn set_effective_trust(&self, level: zeph_tools::SkillTrustLevel) {
         *self.recorded.lock().unwrap() = Some(level);
     }
+
+    fn execute_tool_call_confirmed_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        self.execute_tool_call_erased(call)
+    }
+
+    fn checkpoint_undo_erased(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+        zeph_tools::CheckpointActionResult::unsupported()
+    }
+
+    fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+        zeph_tools::CheckpointActionResult::unsupported()
+    }
+
+    fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+        zeph_tools::CheckpointListResult::default()
+    }
+
+    fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
+        false
+    }
 }
 
 #[test]
@@ -2051,6 +2126,33 @@ async fn run_agent_loop_passes_tools_to_provider() {
         fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
             false
         }
+
+        fn execute_tool_call_confirmed_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            self.execute_tool_call_erased(call)
+        }
+
+        fn checkpoint_undo_erased(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+            zeph_tools::CheckpointListResult::default()
+        }
+
+        fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
     }
 
     // MockProvider with tool_use: records call count for chat_with_tools.
@@ -2135,6 +2237,33 @@ async fn run_agent_loop_executes_native_tool_call() {
         }
 
         fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
+            false
+        }
+
+        fn execute_tool_call_confirmed_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            self.execute_tool_call_erased(call)
+        }
+
+        fn checkpoint_undo_erased(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+            zeph_tools::CheckpointListResult::default()
+        }
+
+        fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
             false
         }
     }
@@ -2654,6 +2783,8 @@ impl ErasedToolExecutor for SandboxExecutor {
     fn is_tool_retryable_erased(&self, _tool_id: &str) -> bool {
         false
     }
+
+    zeph_tools::erased_tool_executor_no_inner_defaults!();
 }
 
 fn make_write_call(path: &str, content: &str) -> ToolCall {
@@ -2723,6 +2854,50 @@ async fn memory_aware_executor_blocks_path_traversal() {
     assert!(
         matches!(result, Err(ToolError::SandboxViolation { .. })),
         "path traversal should be blocked, got: {result:?}"
+    );
+}
+
+/// Regression for #6019: `execute_tool_call_confirmed_erased` must replicate the
+/// `SandboxViolation` -> memory-executor fallback that `execute_tool_call_erased` already
+/// has. Before the fix, the confirmed method was missing entirely (relying on the removed
+/// trait default, which delegates straight to `execute_tool_call_erased` on `inner` only —
+/// never reaching `memory_executor`), so a confirmed memory-tool write would fail instead
+/// of falling back.
+#[tokio::test]
+#[serial]
+async fn memory_aware_executor_confirmed_path_falls_back_to_memory_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let memory_dir = tmp.path().join("agent-memory");
+    std::fs::create_dir_all(&memory_dir).unwrap();
+
+    let memory_file = memory_dir.join("MEMORY.md");
+    let executor = MemoryAwareExecutor::new(Arc::new(SandboxExecutor), memory_dir.clone());
+
+    let call = make_write_call(memory_file.to_str().unwrap(), "# Memory\nconfirmed content");
+    let result = executor.execute_tool_call_confirmed_erased(&call).await;
+    assert!(
+        result.is_ok(),
+        "confirmed write to memory dir should succeed via fallback, got: {result:?}"
+    );
+}
+
+/// Companion to the fallback test above: the confirmed path must still enforce the
+/// sandbox for writes outside the memory dir, not blanket-allow everything.
+#[tokio::test]
+#[serial]
+async fn memory_aware_executor_confirmed_path_blocks_outside_memory_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let memory_dir = tmp.path().join("agent-memory");
+    std::fs::create_dir_all(&memory_dir).unwrap();
+
+    let outside_file = tmp.path().join("outside.txt");
+    let executor = MemoryAwareExecutor::new(Arc::new(SandboxExecutor), memory_dir);
+
+    let call = make_write_call(outside_file.to_str().unwrap(), "should be blocked");
+    let result = executor.execute_tool_call_confirmed_erased(&call).await;
+    assert!(
+        matches!(result, Err(ToolError::SandboxViolation { .. })),
+        "confirmed write outside memory dir should be blocked, got: {result:?}"
     );
 }
 

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -357,6 +357,8 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     fn make_call(tool_id: &str) -> ToolCall {
@@ -557,6 +559,25 @@ mod tests {
         fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
             true
         }
+
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+        fn checkpoint_undo(&self, _n: usize) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+            crate::executor::CheckpointListResult::default()
+        }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            false
+        }
     }
 
     #[tokio::test]
@@ -584,6 +605,25 @@ mod tests {
         }
         fn requires_confirmation(&self, _call: &ToolCall) -> bool {
             true
+        }
+
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+        fn checkpoint_undo(&self, _n: usize) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+            crate::executor::CheckpointListResult::default()
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
         }
     }
 
@@ -631,6 +671,19 @@ mod tests {
                 supported: true,
                 ..Default::default()
             }
+        }
+
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
+        }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            false
         }
     }
 
@@ -821,6 +874,8 @@ mod tests {
                     claim_source: Some(crate::executor::ClaimSource::Shell),
                 }))
             }
+
+            crate::tool_executor_no_inner_defaults!();
         }
 
         let dir = TempDir::new().unwrap();

--- a/crates/zeph-tools/src/composite.rs
+++ b/crates/zeph-tools/src/composite.rs
@@ -179,6 +179,8 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[derive(Debug)]
@@ -187,6 +189,8 @@ mod tests {
         async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
             Ok(None)
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[derive(Debug)]
@@ -197,6 +201,8 @@ mod tests {
                 command: "test".to_owned(),
             })
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[derive(Debug)]
@@ -216,6 +222,8 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[tokio::test]
@@ -323,6 +331,22 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        fn checkpoint_undo(&self, _n: usize) -> crate::CheckpointActionResult {
+            crate::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_redo(&self) -> crate::CheckpointActionResult {
+            crate::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_list(&self) -> crate::CheckpointListResult {
+            crate::CheckpointListResult::default()
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
+        }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            false
+        }
     }
 
     #[tokio::test]
@@ -400,6 +424,8 @@ mod tests {
                 Ok(None)
             }
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[derive(Debug)]
@@ -429,6 +455,8 @@ mod tests {
                 Ok(None)
             }
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[tokio::test]
@@ -504,6 +532,8 @@ mod tests {
             fn set_effective_trust(&self, level: SkillTrustLevel) {
                 *self.last_trust.lock().unwrap() = Some(level);
             }
+
+            crate::tool_executor_no_inner_defaults!();
         }
 
         /// Regression test for #5900: `CompositeExecutor::requires_confirmation` must
@@ -519,6 +549,25 @@ mod tests {
             }
             fn requires_confirmation(&self, _call: &ToolCall) -> bool {
                 self.0
+            }
+
+            async fn execute_tool_call_confirmed(
+                &self,
+                call: &ToolCall,
+            ) -> Result<Option<ToolOutput>, ToolError> {
+                self.execute_tool_call(call).await
+            }
+            fn checkpoint_undo(&self, _n: usize) -> crate::CheckpointActionResult {
+                crate::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_redo(&self) -> crate::CheckpointActionResult {
+                crate::CheckpointActionResult::unsupported()
+            }
+            fn checkpoint_list(&self) -> crate::CheckpointListResult {
+                crate::CheckpointListResult::default()
+            }
+            fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+                false
             }
         }
 

--- a/crates/zeph-tools/src/compression/decorator.rs
+++ b/crates/zeph-tools/src/compression/decorator.rs
@@ -254,6 +254,18 @@ mod tests {
         fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
             false
         }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            false
+        }
+        fn checkpoint_undo(&self, _n: usize) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+            crate::executor::CheckpointListResult::default()
+        }
     }
 
     /// Always replaces output with a fixed "compressed" string.
@@ -401,6 +413,15 @@ mod tests {
                 redo_depth: 7,
                 supported: true,
             }
+        }
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
         }
     }
 

--- a/crates/zeph-tools/src/cwd.rs
+++ b/crates/zeph-tools/src/cwd.rs
@@ -89,6 +89,8 @@ impl ToolExecutor for SetCwdExecutor {
     async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
         Ok(None)
     }
+
+    crate::tool_executor_no_inner_defaults!();
 }
 
 #[cfg(test)]

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -198,6 +198,8 @@ impl ToolExecutor for DiagnosticsExecutor {
             server_id: None,
         }]
     }
+
+    crate::tool_executor_no_inner_defaults!();
 }
 
 /// Returns the path to the `cargo` binary, failing gracefully if not found.

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -650,6 +650,8 @@ pub fn deserialize_params<T: serde::de::DeserializeOwned>(
 ///             claim_source: None,
 ///         }))
 ///     }
+///
+///     zeph_tools::tool_executor_no_inner_defaults!();
 /// }
 /// ```
 /// # TODO (G3 — deferred: Tower-style tool middleware stack)
@@ -725,7 +727,13 @@ pub trait ToolExecutor: Send + Sync {
     /// Execute a structured tool call bypassing confirmation checks.
     ///
     /// Called after the user has explicitly approved the tool invocation.
-    /// Default implementation delegates to [`execute_tool_call`](ToolExecutor::execute_tool_call).
+    ///
+    /// Required (no default): a wrapper that forgets to override this silently falls back
+    /// to whatever an inherited default would do, which has repeatedly reintroduced #6019.
+    /// Executors with no confirmation-specific behavior should delegate to
+    /// [`execute_tool_call`](ToolExecutor::execute_tool_call); see
+    /// [`tool_executor_no_inner_defaults!`](crate::tool_executor_no_inner_defaults) for leaf
+    /// executors with no wrapped inner.
     ///
     /// # Errors
     ///
@@ -733,9 +741,7 @@ pub trait ToolExecutor: Send + Sync {
     fn execute_tool_call_confirmed(
         &self,
         call: &ToolCall,
-    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
-        self.execute_tool_call(call)
-    }
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send;
 
     /// Inject environment variables for the currently active skill. No-op by default.
     ///
@@ -759,26 +765,22 @@ pub trait ToolExecutor: Send + Sync {
 
     /// Undo the last `n` checkpointed write commands.
     ///
-    /// Returns [`CheckpointActionResult::unsupported`] by default. Executors that
-    /// implement checkpoints (i.e. [`ShellExecutor`](crate::ShellExecutor) with
-    /// `checkpoints_enabled = true`) override this.
-    fn checkpoint_undo(&self, _n: usize) -> CheckpointActionResult {
-        CheckpointActionResult::unsupported()
-    }
+    /// Required (no default). Executors that implement checkpoints (i.e.
+    /// [`ShellExecutor`](crate::ShellExecutor) with `checkpoints_enabled = true`) provide
+    /// real behavior here; all others should return [`CheckpointActionResult::unsupported`].
+    /// Wrappers must forward to their inner executor — see
+    /// [`tool_executor_forward!`](crate::tool_executor_forward).
+    fn checkpoint_undo(&self, n: usize) -> CheckpointActionResult;
 
     /// Redo the last undone checkpoint.
     ///
-    /// Returns [`CheckpointActionResult::unsupported`] by default.
-    fn checkpoint_redo(&self) -> CheckpointActionResult {
-        CheckpointActionResult::unsupported()
-    }
+    /// Required (no default). See [`checkpoint_undo`](ToolExecutor::checkpoint_undo).
+    fn checkpoint_redo(&self) -> CheckpointActionResult;
 
     /// List the current undo stack entries and redo depth.
     ///
-    /// Returns an empty [`CheckpointListResult`] with `supported = false` by default.
-    fn checkpoint_list(&self) -> CheckpointListResult {
-        CheckpointListResult::default()
-    }
+    /// Required (no default). See [`checkpoint_undo`](ToolExecutor::checkpoint_undo).
+    fn checkpoint_list(&self) -> CheckpointListResult;
 
     /// Whether a tool call can be safely dispatched speculatively (before the LLM finishes).
     ///
@@ -787,39 +789,54 @@ pub trait ToolExecutor: Send + Sync {
     /// 2. Side-effect-free or cheaply reversible.
     /// 3. Not subject to user confirmation (`needs_confirmation` must be false at call time).
     ///
-    /// Default: `false` (safe). Override to `true` only for tools that satisfy all three
-    /// properties. The engine additionally gates on trust level and confirmation status
-    /// regardless of this flag.
+    /// Required (no default). Return `false` (safe) unless the tool satisfies all three
+    /// properties above. The engine additionally gates on trust level and confirmation
+    /// status regardless of this flag.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use zeph_tools::ToolExecutor;
+    /// use zeph_tools::{ToolExecutor, ToolCall, ToolOutput, ToolError};
     ///
     /// struct ReadOnlyExecutor;
     /// impl ToolExecutor for ReadOnlyExecutor {
-    ///     async fn execute(&self, _: &str) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> {
+    ///     async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
     ///         Ok(None)
     ///     }
     ///     fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
     ///         true // read-only, idempotent
     ///     }
+    ///     fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+    ///         false
+    ///     }
+    ///     async fn execute_tool_call_confirmed(
+    ///         &self,
+    ///         call: &ToolCall,
+    ///     ) -> Result<Option<ToolOutput>, ToolError> {
+    ///         self.execute_tool_call(call).await
+    ///     }
+    ///     fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+    ///         zeph_tools::CheckpointActionResult::unsupported()
+    ///     }
+    ///     fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+    ///         zeph_tools::CheckpointActionResult::unsupported()
+    ///     }
+    ///     fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+    ///         zeph_tools::CheckpointListResult::default()
+    ///     }
     /// }
     /// ```
-    fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
-        false
-    }
+    fn is_tool_speculatable(&self, _tool_id: &str) -> bool;
 
     /// Return `true` when `call` would require user confirmation before execution.
     ///
     /// This is a pure metadata/policy query — implementations must **not** execute the tool.
     /// Used by the speculative engine to gate dispatch without causing double side-effects.
     ///
-    /// Default: `false`. Executors that enforce a confirmation policy (e.g. `TrustGateExecutor`)
-    /// must override this to reflect their actual policy without executing the tool.
-    fn requires_confirmation(&self, _call: &ToolCall) -> bool {
-        false
-    }
+    /// Required (no default). Executors with no confirmation policy of their own should
+    /// return `false`; executors that enforce one (e.g. `TrustGateExecutor`) must reflect
+    /// their actual policy without executing the tool.
+    fn requires_confirmation(&self, _call: &ToolCall) -> bool;
 }
 
 /// Object-safe erased version of [`ToolExecutor`] using boxed futures.
@@ -848,16 +865,19 @@ pub trait ErasedToolExecutor: Send + Sync {
         call: &'a ToolCall,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>;
 
+    /// Required (no default). TrustGateExecutor-style wrappers that override
+    /// [`ToolExecutor::execute_tool_call_confirmed`] reach it through the blanket impl below.
+    /// Other implementors should fall back to
+    /// [`execute_tool_call_erased`](ErasedToolExecutor::execute_tool_call_erased) (normal
+    /// enforcement path) unless they need to replicate confirmed-path-specific behavior
+    /// (e.g. a fallback that only applies on the unconfirmed path must be mirrored
+    /// explicitly, not assumed). See
+    /// [`erased_tool_executor_no_inner_defaults!`](crate::erased_tool_executor_no_inner_defaults)
+    /// for leaf executors with no wrapped inner.
     fn execute_tool_call_confirmed_erased<'a>(
         &'a self,
         call: &'a ToolCall,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
-    {
-        // TrustGateExecutor overrides ToolExecutor::execute_tool_call_confirmed; the blanket
-        // impl for T: ToolExecutor routes this call through it via execute_tool_call_confirmed_erased.
-        // Other implementors fall back to execute_tool_call_erased (normal enforcement path).
-        self.execute_tool_call_erased(call)
-    }
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>;
 
     /// Inject environment variables for the currently active skill. No-op by default.
     fn set_skill_env(&self, _env: Option<std::collections::HashMap<String, String>>) {}
@@ -865,42 +885,44 @@ pub trait ErasedToolExecutor: Send + Sync {
     /// Set the effective trust level for the currently active skill. No-op by default.
     fn set_effective_trust(&self, _level: crate::SkillTrustLevel) {}
 
-    /// Undo the last `n` checkpointed write commands. No-op (unsupported) by default.
-    fn checkpoint_undo_erased(&self, _n: usize) -> CheckpointActionResult {
-        CheckpointActionResult::unsupported()
-    }
+    /// Undo the last `n` checkpointed write commands.
+    ///
+    /// Required (no default). Wrappers must forward to their inner executor — see
+    /// [`erased_tool_executor_forward!`](crate::erased_tool_executor_forward). Leaf
+    /// executors with no checkpoint support should return
+    /// [`CheckpointActionResult::unsupported`].
+    fn checkpoint_undo_erased(&self, n: usize) -> CheckpointActionResult;
 
-    /// Redo the last undone checkpoint. No-op (unsupported) by default.
-    fn checkpoint_redo_erased(&self) -> CheckpointActionResult {
-        CheckpointActionResult::unsupported()
-    }
+    /// Redo the last undone checkpoint.
+    ///
+    /// Required (no default). See
+    /// [`checkpoint_undo_erased`](ErasedToolExecutor::checkpoint_undo_erased).
+    fn checkpoint_redo_erased(&self) -> CheckpointActionResult;
 
-    /// List the current undo stack entries and redo depth. Returns empty by default.
-    fn checkpoint_list_erased(&self) -> CheckpointListResult {
-        CheckpointListResult::default()
-    }
+    /// List the current undo stack entries and redo depth.
+    ///
+    /// Required (no default). See
+    /// [`checkpoint_undo_erased`](ErasedToolExecutor::checkpoint_undo_erased).
+    fn checkpoint_list_erased(&self) -> CheckpointListResult;
 
     /// Whether the executor can safely retry this tool call on a transient error.
     fn is_tool_retryable_erased(&self, tool_id: &str) -> bool;
 
     /// Whether a tool call can be safely dispatched speculatively.
     ///
-    /// Default: `false`. Override to `true` in read-only executors.
-    fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
-        false
-    }
+    /// Required (no default). Return `false` unless the executor is read-only and
+    /// idempotent for the given tool.
+    fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool;
 
     /// Return `true` when `call` would require user confirmation before execution.
     ///
     /// This is a pure metadata/policy query — implementations must **not** execute the tool.
     /// Used by the speculative engine to gate dispatch without causing double side-effects.
     ///
-    /// Default: `true` (confirmation required). Implementors that want to allow speculative
-    /// dispatch must explicitly return `false`. The blanket impl for `T: ToolExecutor`
+    /// Required (no default). Return `true` (confirmation required) unless the executor
+    /// explicitly wants to allow speculative dispatch. The blanket impl for `T: ToolExecutor`
     /// delegates to [`ToolExecutor::requires_confirmation`].
-    fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
-        true
-    }
+    fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool;
 }
 
 impl<T: ToolExecutor> ErasedToolExecutor for T {
@@ -1382,6 +1404,8 @@ mod tests {
         async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
             Ok(None)
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[tokio::test]
@@ -1490,6 +1514,8 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[tokio::test]
@@ -1568,6 +1594,8 @@ mod tests {
                 };
                 self.0.store(v, Ordering::Relaxed);
             }
+
+            crate::tool_executor_no_inner_defaults!();
         }
 
         let inner = std::sync::Arc::new(TrustCapture(AtomicU8::new(0)));
@@ -1859,6 +1887,8 @@ mod tests {
         async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
             Ok(None)
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     /// Stub that always signals confirmation is required via `ToolExecutor::requires_confirmation`.
@@ -1869,6 +1899,25 @@ mod tests {
         }
         fn requires_confirmation(&self, _call: &ToolCall) -> bool {
             true
+        }
+
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+        fn checkpoint_undo(&self, _n: usize) -> CheckpointActionResult {
+            CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_redo(&self) -> CheckpointActionResult {
+            CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_list(&self) -> CheckpointListResult {
+            CheckpointListResult::default()
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
         }
     }
 
@@ -1915,11 +1964,12 @@ mod tests {
     }
 
     #[test]
-    fn requires_confirmation_erased_default_on_erased_trait_is_true() {
-        // ErasedToolExecutor's own default (trait method body) returns true.
-        // We construct a DynExecutor wrapping ConfirmingExecutor and verify via the erased path.
-        // (We cannot instantiate ErasedToolExecutor directly without a concrete type.)
-        // Instead verify via a type that only implements ErasedToolExecutor manually:
+    fn requires_confirmation_erased_manual_impl_returns_true() {
+        // Prior to #6019, ErasedToolExecutor::requires_confirmation_erased had a
+        // trait-level default of `true`. That default was removed — every direct
+        // ErasedToolExecutor implementor must now provide it explicitly. This stub
+        // reproduces the old default's value by hand to document the historical
+        // behavior and confirm it still compiles as a deliberate choice.
         struct ManualErased;
         impl ErasedToolExecutor for ManualErased {
             fn execute_erased<'a>(
@@ -1952,12 +2002,13 @@ mod tests {
             fn is_tool_retryable_erased(&self, _tool_id: &str) -> bool {
                 false
             }
-            // requires_confirmation_erased NOT overridden → trait default returns true
+
+            crate::erased_tool_executor_no_inner_defaults!();
         }
         let exec = ManualErased;
         assert!(
             exec.requires_confirmation_erased(&dummy_call()),
-            "ErasedToolExecutor trait-level default for requires_confirmation_erased must be true"
+            "requires_confirmation_erased must be true (matches the removed trait default's value)"
         );
     }
 

--- a/crates/zeph-tools/src/executor_delegate.rs
+++ b/crates/zeph-tools/src/executor_delegate.rs
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Boilerplate-reduction macros for [`ToolExecutor`](crate::ToolExecutor) and
+//! [`ErasedToolExecutor`](crate::ErasedToolExecutor) implementors.
+//!
+//! Issue #6019: both traits used to give the six risk-bearing methods
+//! (`requires_confirmation`, `execute_tool_call_confirmed`, the checkpoint trio, and
+//! `is_tool_speculatable` — plus their `_erased` counterparts) permissive default bodies.
+//! Wrapper types that forgot to override one silently inherited a default that could
+//! disable a security check, a checkpoint capability, or a confirmation gate. This
+//! recurred five times across prior PRs. The traits no longer provide those defaults —
+//! every implementor must now supply all six, and the compiler enforces it.
+//!
+//! These four macros exist only to keep that compiler-forced boilerplate short. They do
+//! **not** themselves close the defect class — only the removal of the default bodies
+//! does that. A macro invoked on the wrong type (e.g. `tool_executor_no_inner_defaults!()`
+//! on a wrapper that owns an inner executor) silently reintroduces the exact bug this
+//! issue fixes, because `macro_rules!` cannot check "this type has no delegate field."
+//! Read each macro's own doc comment before using it.
+
+/// Forwards the four mechanical capability methods of
+/// [`ToolExecutor`](crate::ToolExecutor) — the checkpoint trio and `is_tool_speculatable`
+/// — to `self.$inner`.
+///
+/// Use inside `impl ToolExecutor for YourWrapper` where `$inner` is the **field name**
+/// (an identifier, not an expression — macro hygiene forbids capturing `self` at item
+/// position) of a field whose type implements [`ToolExecutor`](crate::ToolExecutor).
+///
+/// The two policy methods, `requires_confirmation` and `execute_tool_call_confirmed`, are
+/// intentionally **not** emitted by this macro — wrappers that gate on confirmation or
+/// checkpoint policy must implement those two explicitly, so the compiler forces every
+/// wrapper author to make a deliberate decision about them instead of inheriting one
+/// silently.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_tools::{ToolExecutor, ToolCall, ToolOutput, ToolError};
+///
+/// struct PassThrough<T> {
+///     inner: T,
+/// }
+///
+/// impl<T: ToolExecutor> ToolExecutor for PassThrough<T> {
+///     async fn execute(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+///         self.inner.execute(response).await
+///     }
+///
+///     fn requires_confirmation(&self, call: &ToolCall) -> bool {
+///         self.inner.requires_confirmation(call)
+///     }
+///
+///     async fn execute_tool_call_confirmed(
+///         &self,
+///         call: &ToolCall,
+///     ) -> Result<Option<ToolOutput>, ToolError> {
+///         self.inner.execute_tool_call_confirmed(call).await
+///     }
+///
+///     zeph_tools::tool_executor_forward!(inner);
+/// }
+/// ```
+#[macro_export]
+macro_rules! tool_executor_forward {
+    ($inner:ident) => {
+        fn checkpoint_undo(&self, n: usize) -> $crate::CheckpointActionResult {
+            $crate::ToolExecutor::checkpoint_undo(&self.$inner, n)
+        }
+
+        fn checkpoint_redo(&self) -> $crate::CheckpointActionResult {
+            $crate::ToolExecutor::checkpoint_redo(&self.$inner)
+        }
+
+        fn checkpoint_list(&self) -> $crate::CheckpointListResult {
+            $crate::ToolExecutor::checkpoint_list(&self.$inner)
+        }
+
+        fn is_tool_speculatable(&self, tool_id: &str) -> bool {
+            $crate::ToolExecutor::is_tool_speculatable(&self.$inner, tool_id)
+        }
+    };
+}
+
+/// Emits the six risk-bearing [`ToolExecutor`](crate::ToolExecutor) methods with the same
+/// trivial bodies the trait's removed defaults used to provide: no confirmation required,
+/// confirmed execution falls back to `execute_tool_call`, checkpoints unsupported, not
+/// speculatable.
+///
+/// # Use ONLY on leaf executors that own no wrapped executor
+///
+/// Invoking this macro on a type that wraps another [`ToolExecutor`](crate::ToolExecutor)
+/// (i.e. has an `inner`/delegate field) silently disables forwarding for all six methods
+/// and **reintroduces issue #6019**. Wrappers must use [`tool_executor_forward!`] for the
+/// mechanical four and hand-write `requires_confirmation` /
+/// `execute_tool_call_confirmed`. `macro_rules!` has no way to enforce this at compile
+/// time — review carefully.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_tools::{ToolExecutor, ToolOutput, ToolError};
+///
+/// struct EchoExecutor;
+///
+/// impl ToolExecutor for EchoExecutor {
+///     async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
+///         Ok(None)
+///     }
+///
+///     zeph_tools::tool_executor_no_inner_defaults!();
+/// }
+/// ```
+#[macro_export]
+macro_rules! tool_executor_no_inner_defaults {
+    () => {
+        fn requires_confirmation(&self, _call: &$crate::ToolCall) -> bool {
+            false
+        }
+
+        fn execute_tool_call_confirmed(
+            &self,
+            call: &$crate::ToolCall,
+        ) -> impl ::std::future::Future<
+            Output = ::std::result::Result<Option<$crate::ToolOutput>, $crate::ToolError>,
+        > + Send {
+            $crate::ToolExecutor::execute_tool_call(self, call)
+        }
+
+        fn checkpoint_undo(&self, _n: usize) -> $crate::CheckpointActionResult {
+            $crate::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_redo(&self) -> $crate::CheckpointActionResult {
+            $crate::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_list(&self) -> $crate::CheckpointListResult {
+            $crate::CheckpointListResult::default()
+        }
+
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
+        }
+    };
+}
+
+/// Erased-trait counterpart of [`tool_executor_forward!`]: forwards the checkpoint trio
+/// and `is_tool_speculatable_erased` to `self.$inner`.
+///
+/// Use inside `impl ErasedToolExecutor for YourWrapper` where `$inner` is the **field
+/// name** (an identifier, not an expression — see [`tool_executor_forward!`] for why) of
+/// a field whose type implements [`ErasedToolExecutor`](crate::ErasedToolExecutor). As
+/// with the static-side macro, the policy methods `requires_confirmation_erased` and
+/// `execute_tool_call_confirmed_erased` are not emitted and must be hand-written.
+#[macro_export]
+macro_rules! erased_tool_executor_forward {
+    ($inner:ident) => {
+        fn checkpoint_undo_erased(&self, n: usize) -> $crate::CheckpointActionResult {
+            $crate::ErasedToolExecutor::checkpoint_undo_erased(&*self.$inner, n)
+        }
+
+        fn checkpoint_redo_erased(&self) -> $crate::CheckpointActionResult {
+            $crate::ErasedToolExecutor::checkpoint_redo_erased(&*self.$inner)
+        }
+
+        fn checkpoint_list_erased(&self) -> $crate::CheckpointListResult {
+            $crate::ErasedToolExecutor::checkpoint_list_erased(&*self.$inner)
+        }
+
+        fn is_tool_speculatable_erased(&self, tool_id: &str) -> bool {
+            $crate::ErasedToolExecutor::is_tool_speculatable_erased(&*self.$inner, tool_id)
+        }
+    };
+}
+
+/// Erased-trait counterpart of [`tool_executor_no_inner_defaults!`]: emits the six
+/// risk-bearing [`ErasedToolExecutor`](crate::ErasedToolExecutor) methods with the same
+/// trivial bodies the trait's removed defaults used to provide.
+///
+/// # Use ONLY on leaf executors that own no wrapped executor
+///
+/// Invoking this macro on a type that wraps another
+/// [`ErasedToolExecutor`](crate::ErasedToolExecutor) silently disables forwarding for all
+/// six methods and **reintroduces issue #6019**. Wrappers must use
+/// [`erased_tool_executor_forward!`] for the mechanical four and hand-write
+/// `requires_confirmation_erased` / `execute_tool_call_confirmed_erased`.
+#[macro_export]
+macro_rules! erased_tool_executor_no_inner_defaults {
+    () => {
+        fn requires_confirmation_erased(&self, _call: &$crate::ToolCall) -> bool {
+            true
+        }
+
+        fn execute_tool_call_confirmed_erased<'a>(
+            &'a self,
+            call: &'a $crate::ToolCall,
+        ) -> ::std::pin::Pin<
+            Box<
+                dyn ::std::future::Future<
+                        Output = ::std::result::Result<
+                            Option<$crate::ToolOutput>,
+                            $crate::ToolError,
+                        >,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            $crate::ErasedToolExecutor::execute_tool_call_erased(self, call)
+        }
+
+        fn checkpoint_undo_erased(&self, _n: usize) -> $crate::CheckpointActionResult {
+            $crate::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_redo_erased(&self) -> $crate::CheckpointActionResult {
+            $crate::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_list_erased(&self) -> $crate::CheckpointListResult {
+            $crate::CheckpointListResult::default()
+        }
+
+        fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
+    };
+}

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -740,6 +740,8 @@ impl ToolExecutor for FileExecutor {
             },
         ]
     }
+
+    crate::tool_executor_no_inner_defaults!();
 }
 
 /// Lexically normalize a path by collapsing `.` and `..` components without

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -69,6 +69,7 @@ pub mod domain_match;
 pub mod error_taxonomy;
 pub mod execution_context;
 pub mod executor;
+pub mod executor_delegate;
 pub mod file;
 pub mod filter;
 pub mod moderation;

--- a/crates/zeph-tools/src/moderation.rs
+++ b/crates/zeph-tools/src/moderation.rs
@@ -300,6 +300,30 @@ impl<B: ReactionModerationBackend + std::fmt::Debug> ToolExecutor for Moderation
             "telegram_delete_reaction" | "telegram_delete_all_reactions"
         )
     }
+
+    async fn execute_tool_call_confirmed(
+        &self,
+        call: &ToolCall,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        self.execute_tool_call(call).await
+    }
+
+    fn checkpoint_undo(&self, _n: usize) -> crate::executor::CheckpointActionResult {
+        crate::executor::CheckpointActionResult::unsupported()
+    }
+
+    fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+        crate::executor::CheckpointActionResult::unsupported()
+    }
+
+    fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+        crate::executor::CheckpointListResult::default()
+    }
+
+    /// Reaction deletion is a one-shot, irreversible API call — never speculatable.
+    fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+        false
+    }
 }
 
 // ── Unit tests ─────────────────────────────────────────────────────────────

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -446,6 +446,8 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     fn make_gate(config: &PolicyConfig) -> PolicyGateExecutor<MockExecutor> {
@@ -514,6 +516,18 @@ mod tests {
                 ..Default::default()
             }
         }
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
+        }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            false
+        }
     }
 
     /// Regression test for #5931: `requires_confirmation` must be forwarded to `self.inner`.
@@ -531,6 +545,25 @@ mod tests {
         }
         fn requires_confirmation(&self, _call: &ToolCall) -> bool {
             true
+        }
+
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+        fn checkpoint_undo(&self, _n: usize) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_redo(&self) -> crate::executor::CheckpointActionResult {
+            crate::executor::CheckpointActionResult::unsupported()
+        }
+        fn checkpoint_list(&self) -> crate::executor::CheckpointListResult {
+            crate::executor::CheckpointListResult::default()
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
         }
     }
 

--- a/crates/zeph-tools/src/scope.rs
+++ b/crates/zeph-tools/src/scope.rs
@@ -341,6 +341,7 @@ fn is_strict_pattern(pattern: &str, strictness: PatternStrictness) -> bool {
 /// struct MockExecutor;
 /// impl ToolExecutor for MockExecutor {
 ///     async fn execute(&self, _: &str) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> { Ok(None) }
+///     zeph_tools::tool_executor_no_inner_defaults!();
 /// }
 /// let executor = ScopedToolExecutor::new(MockExecutor, scope);
 /// ```
@@ -369,6 +370,7 @@ impl<E: ToolExecutor> ScopedToolExecutor<E> {
     /// struct Noop;
     /// impl zeph_tools::ToolExecutor for Noop {
     ///     async fn execute(&self, _: &str) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> { Ok(None) }
+    ///     zeph_tools::tool_executor_no_inner_defaults!();
     /// }
     /// let executor = ScopedToolExecutor::new(Noop, ToolScope::full());
     /// ```
@@ -430,6 +432,7 @@ impl<E: ToolExecutor> ScopedToolExecutor<E> {
     /// struct Noop;
     /// impl zeph_tools::ToolExecutor for Noop {
     ///     async fn execute(&self, _: &str) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> { Ok(None) }
+    ///     zeph_tools::tool_executor_no_inner_defaults!();
     /// }
     /// let mut executor = ScopedToolExecutor::new(Noop, ToolScope::full());
     /// // scope_for_task returns None for unregistered task types
@@ -677,6 +680,7 @@ impl<E: ToolExecutor> ToolExecutor for ScopedToolExecutor<E> {
 /// struct Noop;
 /// impl zeph_tools::ToolExecutor for Noop {
 ///     async fn execute(&self, _: &str) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> { Ok(None) }
+///     zeph_tools::tool_executor_no_inner_defaults!();
 /// }
 ///
 /// let cfg = CapabilityScopesConfig::default();
@@ -765,6 +769,8 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     struct CheckpointingExecutor;
@@ -796,6 +802,15 @@ mod tests {
         }
         fn requires_confirmation(&self, _call: &ToolCall) -> bool {
             true
+        }
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
         }
     }
 

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -391,6 +391,8 @@ impl ToolExecutor for WebScrapeExecutor {
     fn is_tool_retryable(&self, tool_id: &str) -> bool {
         matches!(tool_id, "web_scrape" | "fetch")
     }
+
+    crate::tool_executor_no_inner_defaults!();
 }
 
 fn tool_error_to_audit_result(e: &ToolError) -> AuditResult {

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -487,6 +487,8 @@ impl ToolExecutor for SearchCodeExecutor {
             server_id: None,
         }]
     }
+
+    crate::tool_executor_no_inner_defaults!();
 }
 
 /// Traverse `allowed_paths` collecting structural symbol hits synchronously.

--- a/crates/zeph-tools/src/shadow_probe.rs
+++ b/crates/zeph-tools/src/shadow_probe.rs
@@ -543,6 +543,8 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     /// Inner executor that always returns `ConfirmationRequired`, simulating
@@ -561,6 +563,8 @@ mod tests {
                 command: call.tool_id.to_string(),
             })
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     fn make_call(tool: &str) -> ToolCall {
@@ -821,6 +825,18 @@ mod tests {
                 supported: true,
                 ..Default::default()
             }
+        }
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
+        }
+        fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+            false
         }
     }
 

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -1870,6 +1870,21 @@ impl ToolExecutor for ShellExecutor {
             supported: true,
         }
     }
+
+    fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+        false
+    }
+
+    async fn execute_tool_call_confirmed(
+        &self,
+        call: &ToolCall,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        self.execute_tool_call(call).await
+    }
+
+    fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+        false
+    }
 }
 
 impl ShellExecutor {

--- a/crates/zeph-tools/src/tool_filter.rs
+++ b/crates/zeph-tools/src/tool_filter.rs
@@ -145,6 +145,8 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[test]

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -362,6 +362,8 @@ mod tests {
                 claim_source: None,
             }))
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     fn make_call(tool_id: &str) -> ToolCall {
@@ -731,6 +733,8 @@ mod tests {
         fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
             *self.captured.lock().unwrap() = env;
         }
+
+        crate::tool_executor_no_inner_defaults!();
     }
 
     #[test]
@@ -750,6 +754,8 @@ mod tests {
             fn is_tool_retryable(&self, tool_id: &str) -> bool {
                 tool_id == "fetch"
             }
+
+            crate::tool_executor_no_inner_defaults!();
         }
         let gate = TrustGateExecutor::new(RetryableExecutor, PermissionPolicy::default());
         assert!(gate.is_tool_retryable("fetch"));
@@ -790,6 +796,18 @@ mod tests {
                     supported: true,
                     ..Default::default()
                 }
+            }
+            async fn execute_tool_call_confirmed(
+                &self,
+                call: &ToolCall,
+            ) -> Result<Option<ToolOutput>, ToolError> {
+                self.execute_tool_call(call).await
+            }
+            fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+                false
+            }
+            fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+                false
             }
         }
         let gate = TrustGateExecutor::new(CheckpointingExecutor, PermissionPolicy::default());

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -3095,6 +3095,7 @@ mod tests {
                 claim_source: None,
             }))
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     fn acp_test_call(tool_id: &str) -> zeph_tools::ToolCall {
@@ -3538,6 +3539,7 @@ mod tests {
                     claim_source: None,
                 }))
             }
+            zeph_tools::tool_executor_no_inner_defaults!();
         }
 
         let pool = zeph_db::DbConfig {
@@ -3985,6 +3987,7 @@ mod tests {
                 self.tool_id
             );
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     /// Builds the full per-session composite `spawn_acp_agent` assembles when the IDE supplies

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -2405,6 +2405,7 @@ mod tests {
         async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
             Ok(None)
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     fn offline_provider() -> AnyProvider {
@@ -3166,6 +3167,7 @@ mod tests {
                 claim_source: None,
             }))
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     fn make_tool_call(tool_id: &str) -> zeph_tools::ToolCall {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1753,6 +1753,7 @@ mod tests {
                 claim_source: None,
             }))
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     fn daemon_test_call(tool_id: &str) -> zeph_tools::ToolCall {
@@ -2426,6 +2427,7 @@ mod tests {
                     claim_source: None,
                 }))
             }
+            zeph_tools::tool_executor_no_inner_defaults!();
         }
 
         let pool = zeph_db::DbConfig {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5325,6 +5325,7 @@ mod tests {
                     claim_source: None,
                 }))
             }
+            zeph_tools::tool_executor_no_inner_defaults!();
         }
 
         let sentinel = std::sync::Arc::new(ShadowSentinel::new(

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -559,6 +559,7 @@ mod tests {
             ) -> Result<Option<ToolOutput>, ToolError> {
                 Ok(None)
             }
+            zeph_tools::tool_executor_no_inner_defaults!();
         }
 
         let (channel, _handle) = LoopbackChannel::pair(16);

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -512,6 +512,8 @@ impl ToolExecutor for SchedulerExecutor {
             _ => Ok(None),
         }
     }
+
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 /// `Arc`-wrapper so `SchedulerExecutor` can be shared across ACP sessions without `Clone`.
@@ -530,6 +532,33 @@ impl ToolExecutor for DynSchedulerExecutor {
 
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         self.0.execute_tool_call(call).await
+    }
+
+    fn requires_confirmation(&self, call: &ToolCall) -> bool {
+        self.0.requires_confirmation(call)
+    }
+
+    async fn execute_tool_call_confirmed(
+        &self,
+        call: &ToolCall,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        self.0.execute_tool_call_confirmed(call).await
+    }
+
+    fn checkpoint_undo(&self, n: usize) -> zeph_tools::CheckpointActionResult {
+        self.0.checkpoint_undo(n)
+    }
+
+    fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+        self.0.checkpoint_redo()
+    }
+
+    fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+        self.0.checkpoint_list()
+    }
+
+    fn is_tool_speculatable(&self, tool_id: &str) -> bool {
+        self.0.is_tool_speculatable(tool_id)
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -178,6 +178,7 @@ impl ToolExecutor for MockToolExecutor {
     async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
         Ok(None)
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 struct OutputToolExecutor {
@@ -214,6 +215,7 @@ impl ToolExecutor for OutputToolExecutor {
             claim_source: None,
         }))
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 struct EmptyOutputToolExecutor;
@@ -248,6 +250,7 @@ impl ToolExecutor for EmptyOutputToolExecutor {
             claim_source: None,
         }))
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 struct ErrorOutputToolExecutor;
@@ -282,6 +285,7 @@ impl ToolExecutor for ErrorOutputToolExecutor {
             claim_source: None,
         }))
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 struct BlockedToolExecutor;
@@ -298,6 +302,7 @@ impl ToolExecutor for BlockedToolExecutor {
             command: "rm -rf /".into(),
         })
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 struct ConfirmToolExecutor;
@@ -347,6 +352,22 @@ impl ToolExecutor for ConfirmToolExecutor {
             claim_source: None,
         }))
     }
+
+    fn checkpoint_undo(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+        zeph_tools::CheckpointActionResult::unsupported()
+    }
+    fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
+        zeph_tools::CheckpointActionResult::unsupported()
+    }
+    fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
+        zeph_tools::CheckpointListResult::default()
+    }
+    fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+        false
+    }
+    fn requires_confirmation(&self, _call: &ToolCall) -> bool {
+        true
+    }
 }
 
 struct SandboxToolExecutor;
@@ -363,6 +384,7 @@ impl ToolExecutor for SandboxToolExecutor {
             path: "/etc/passwd".into(),
         })
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 struct IoErrorToolExecutor;
@@ -381,6 +403,7 @@ impl ToolExecutor for IoErrorToolExecutor {
             "command not found",
         )))
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 struct ExitCodeToolExecutor;
@@ -415,6 +438,7 @@ impl ToolExecutor for ExitCodeToolExecutor {
             claim_source: None,
         }))
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 // -- Config tests --
@@ -2557,6 +2581,7 @@ mod self_learning {
         async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
             Ok(None)
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     struct ErrorToolExecutor;
@@ -2594,6 +2619,7 @@ mod self_learning {
                 claim_source: None,
             }))
         }
+        zeph_tools::tool_executor_no_inner_defaults!();
     }
 
     async fn make_memory(provider: &AnyProvider) -> (SemanticMemory, ConversationId) {

--- a/tests/performance_agent_integration.rs
+++ b/tests/performance_agent_integration.rs
@@ -145,6 +145,7 @@ impl ToolExecutor for InstrumentedMockExecutor {
             claim_source: None,
         }))
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 #[derive(Clone)]
@@ -160,6 +161,7 @@ impl ToolExecutor for BlockingMockExecutor {
             command: call.tool_id.to_string(),
         })
     }
+    zeph_tools::tool_executor_no_inner_defaults!();
 }
 
 // ==========================


### PR DESCRIPTION
## Summary

Closes the recurring `ToolExecutor`/`ErasedToolExecutor` wrapper-forwarding defect class: a decorator's own `impl` block silently omits an override for a cross-cutting method and falls back to the trait's permissive default instead of forwarding to `self.inner`. This has recurred five times in roughly two months (#5899/#5905/#5906, #5900/#5938/#5931, #5985, #6012, and a 5th recurrence inside the very commit that closed #6012), each fixed with a one-off manual patch that did not prevent the next occurrence.

**Mechanism (Option B + macro assist, architecturally reviewed and approved across two rounds):**
- Removed the permissive default bodies for `requires_confirmation`, `execute_tool_call_confirmed`, `checkpoint_undo`/`checkpoint_redo`/`checkpoint_list`, and `is_tool_speculatable` on **both** `ToolExecutor` and `ErasedToolExecutor` (`crates/zeph-tools/src/executor.rs`). This makes them required, so the compiler forces an explicit choice at every impl site instead of allowing a silent fallback.
- Added four `macro_rules!` helpers in the new `crates/zeph-tools/src/executor_delegate.rs` to absorb the resulting boilerplate: a forward macro and a no-inner-defaults macro for each trait.
- Fixed three production `ErasedToolExecutor` wrappers on the subagent tool-dispatch path with live forwarding gaps, discovered during architecture review:
  - `FilteredToolExecutor` / `PlanModeExecutor` (`crates/zeph-subagent/src/filter.rs`) — now forward the checkpoint trio and `is_tool_speculatable_erased`; `PlanModeExecutor` also now forwards `set_effective_trust`, which was previously silently dropped.
  - `MemoryAwareExecutor` (`crates/zeph-subagent/src/manager/spawn.rs`) — its confirmed-call path now replicates the existing sandbox-violation-to-memory-executor fallback instead of bypassing it.
- Real impl-site count ended up at 167 (150 static + 17 erased) — significantly more than the initial ~107 estimate, since the compiler also surfaced test-only mocks across `src/`, root `tests/`, and scattered `#[cfg(test)]` modules that a manual `crates/`-only enumeration missed. This is the intended behavior of the compile-time-guarantee approach.
- Rejected the `ambassador` delegation-macro crate (RPITIT-incompatible with this trait's native-async-fn methods, and all-or-nothing per trait while most wrappers specialize `execute`) and pure macro-only forwarding (still relies on remembering to invoke the macro — same review-dependent gap).

## Process

Two architecture review rounds: the first plan only covered `ToolExecutor`, and the critic caught that `ErasedToolExecutor` — the actual substrate the subagent system dispatches through — was left out with 13 direct impl sites including 3 production wrappers with live gaps. The revised plan folded both traits in and was approved. Implementation was independently validated by four parallel reviewers (tests, performance, security, adversarial critique) with no blocking findings, then went through one code-review round (a documentation-only correction: an invented method name `set_effective_trust_erased` in the CHANGELOG/playbook that doesn't exist on either trait) before approval.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo clippy --profile ci --workspace --all-targets --features bench -- -D warnings` (zeph-bench files touched)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12815 passed, 0 failed, 35 skipped (reproduced independently three times across the review chain)
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all 34 crate doctest binaries, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression tests for the 3 fixed production erased wrappers (checkpoint forwarding, trust-cap propagation, confirmed-path sandbox fallback)
- [x] Live-testing playbook and coverage-status.md row added

Closes #6019