### PR TITLE
fix(worktree): gate force-removal on git prunable marker, add --force flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   zero-timeout runner where every `git` invocation failed instantly. Both call-site `.max(1)`
   duplications were removed now that the crate enforces the invariant internally; the
   `git_timeout_secs` doc comment on `WorktreeConfig` was corrected to say so.
+- `fix(worktree)`: `zeph worktree clean` no longer force-removes another, concurrently running
+  zeph session's worktree (#6055). `WorktreeManager::reconcile()` classified "stale" as simply
+  "not in this process's own in-memory `handles`", which is unconditionally empty for the
+  fresh, one-shot `WorktreeManager` that `zeph worktree clean` constructs per CLI invocation —
+  so every other git-registered worktree, including one with live uncommitted work belonging to
+  a separate session, was force-removed via `git worktree remove --force` with no dirty-tree
+  check. `reconcile()` now returns `Vec<StaleWorktree>` (**breaking**: was
+  `Vec<WorktreeHandle>`) — each entry carries git's own `prunable <reason>` porcelain-output
+  verdict, captured by a rewritten `parse_worktree_list_porcelain`, alongside the resolved
+  `WorktreeHandle`. `StaleWorktree::is_safe_to_force_remove()` is `true` only when git itself
+  reports the worktree's directory or `.git` gitdir-link as gone/broken — the one condition
+  under which force-removal cannot discard live work, regardless of which process created the
+  worktree. `zeph worktree clean` now skips (with a warning) any stale entry that is not
+  `prunable`, unless the new `--force` flag is passed; it prints a `Removed N, skipped M`
+  summary. `zeph worktree list` now surfaces each stale entry's prunable reason, or an
+  "in use — not marked prunable" note, so operators can decide before running `clean --force`.
+  `WorktreeManager::remove()` itself is unchanged — it still issues a single `--force`, which
+  correctly does not override an explicit `git worktree lock`.
+- `fix(worktree)`: `parse_worktree_list_porcelain` no longer mislabels a bare repository's main
+  worktree as detached-`HEAD` (#6052, found during #6051 review). `git worktree list --porcelain`
+  emits a `bare` line (no `HEAD`/`branch`/`detached` line at all) for these entries; they now get
+  the new, distinct `zeph_worktree::BARE_WORKTREE_SENTINEL` (`"(bare repository)"`) instead of
+  `DETACHED_BRANCH_SENTINEL`.
 - `fix(tools)`: `CompressedExecutor`, `ToolFilter`, and `Arc<ShellExecutor>` now forward the
   remaining cross-cutting `ToolExecutor` methods to their inner/wrapped executor instead of
   silently falling through to the trait's no-op defaults (#6012). `CompressedExecutor` now

--- a/crates/zeph-worktree/src/handle.rs
+++ b/crates/zeph-worktree/src/handle.rs
@@ -25,6 +25,19 @@ use std::{path::PathBuf, time::SystemTime};
 /// skip pruning it (#5936 review finding).
 pub const DETACHED_BRANCH_SENTINEL: &str = "(detached HEAD)";
 
+/// Sentinel used for [`WorktreeHandle::branch_name`] when a worktree discovered
+/// via [`WorktreeManager::reconcile`][crate::WorktreeManager::reconcile] is the
+/// main worktree of a bare repository (`git worktree list --porcelain` emits a
+/// `bare` line, with no `HEAD` or `branch`/`detached` line at all, for these
+/// entries).
+///
+/// Distinct from [`DETACHED_BRANCH_SENTINEL`] so operators and logs can tell
+/// "no branch because this is a bare repo" apart from "no branch because HEAD
+/// is detached" (#6052). Like [`DETACHED_BRANCH_SENTINEL`], the embedded space
+/// makes this an invalid git ref name, so it can never collide with a real
+/// branch.
+pub const BARE_WORKTREE_SENTINEL: &str = "(bare repository)";
+
 /// A live record of a git worktree that [`WorktreeManager`][crate::WorktreeManager]
 /// has created for a subagent.
 ///
@@ -50,4 +63,40 @@ pub struct WorktreeHandle {
     pub subagent_id: String,
     /// Wall-clock time when the worktree was created.
     pub created_at: SystemTime,
+}
+
+/// A worktree discovered by [`WorktreeManager::reconcile`][crate::WorktreeManager::reconcile]
+/// that is not present in the current process's own in-memory session state.
+///
+/// `prunable_reason` is git's own verdict from `git worktree list --porcelain`,
+/// which git derives by checking whether the worktree's directory and `.git`
+/// gitdir-link still exist and are valid — not by asking whether *this*
+/// process happens to recognise the path. This is the only staleness signal
+/// safe to force-remove on: a worktree created by a *different*, concurrently
+/// running zeph session updates the same on-disk git worktree registry that
+/// `reconcile` reads, so it is invisible to this process's `self.handles`
+/// (documented as session-local, in-RAM-only) yet fully intact on disk, and
+/// git will never mark it `prunable` while that's true.
+#[derive(Debug, Clone)]
+pub struct StaleWorktree {
+    /// The discovered worktree. `branch_name` is [`DETACHED_BRANCH_SENTINEL`]
+    /// for detached-HEAD worktrees and [`BARE_WORKTREE_SENTINEL`] for a bare
+    /// repository's main worktree, matching `reconcile`'s existing behavior.
+    pub handle: WorktreeHandle,
+    /// `Some(reason)` when git's own porcelain output includes a `prunable`
+    /// line for this worktree (directory or gitdir-link gone) — `None` means
+    /// the directory is intact and this worktree MUST NOT be force-removed
+    /// without an explicit operator override.
+    pub prunable_reason: Option<String>,
+}
+
+impl StaleWorktree {
+    /// True only when git itself has determined this worktree's directory or
+    /// `.git` link is gone/broken — the one condition under which
+    /// force-removal cannot discard live, uncommitted work, regardless of
+    /// which process created the worktree.
+    #[must_use]
+    pub fn is_safe_to_force_remove(&self) -> bool {
+        self.prunable_reason.is_some()
+    }
 }

--- a/crates/zeph-worktree/src/lib.rs
+++ b/crates/zeph-worktree/src/lib.rs
@@ -8,6 +8,8 @@
 //!
 //! - [`WorktreeManager`] — creates, removes, lists, and reconciles git worktrees
 //! - [`WorktreeHandle`] — a live record of one managed worktree
+//! - [`StaleWorktree`] — a worktree discovered by `reconcile` outside session state,
+//!   annotated with git's own `prunable` verdict
 //! - [`WorktreeError`] — all errors this crate can produce
 //! - [`GitRunner`] / [`DefaultGitRunner`]
 //!   — the git invocation abstraction and its production implementation
@@ -50,7 +52,7 @@ pub mod sanitize;
 
 pub use error::WorktreeError;
 pub use git_runner::{DefaultGitRunner, GitRunner};
-pub use handle::{DETACHED_BRANCH_SENTINEL, WorktreeHandle};
+pub use handle::{BARE_WORKTREE_SENTINEL, DETACHED_BRANCH_SENTINEL, StaleWorktree, WorktreeHandle};
 pub use manager::{WorktreeManager, probe_capabilities};
 
 /// A [`WorktreeManager`] using the production [`DefaultGitRunner`].

--- a/crates/zeph-worktree/src/manager.rs
+++ b/crates/zeph-worktree/src/manager.rs
@@ -13,7 +13,7 @@ use zeph_config::{WorktreeBaseRef, WorktreeConfig};
 use crate::{
     error::WorktreeError,
     git_runner::GitRunner,
-    handle::{DETACHED_BRANCH_SENTINEL, WorktreeHandle},
+    handle::{BARE_WORKTREE_SENTINEL, DETACHED_BRANCH_SENTINEL, StaleWorktree, WorktreeHandle},
     sanitize::{canonicalize_root, validate_branch_component},
 };
 
@@ -190,6 +190,16 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// path that no longer exists on disk, even if the branch prune step
     /// fails below.
     ///
+    /// This issues a single `git worktree remove --force`, which bypasses
+    /// git's "refuse to remove a dirty working tree" guard but — deliberately
+    /// — does *not* override an explicit `git worktree lock`; git demands a
+    /// second `-f` (`remove -f -f`) for that. Callers deciding *whether* to
+    /// call `remove` on a worktree not created by this session (e.g.
+    /// `zeph worktree clean`) MUST gate on
+    /// [`StaleWorktree::is_safe_to_force_remove`][crate::StaleWorktree::is_safe_to_force_remove]
+    /// or an explicit operator override first — `remove` itself performs no
+    /// such check (#6055).
+    ///
     /// # Errors
     ///
     /// Returns [`WorktreeError::GitCommand`] if either git command fails. If
@@ -272,11 +282,17 @@ impl<R: GitRunner> WorktreeManager<R> {
             .clone()
     }
 
-    /// Reads the git worktree registry and returns handles for worktrees that
-    /// exist on disk but are not in the current session's in-memory list.
+    /// Reads the git worktree registry and returns [`StaleWorktree`] entries for
+    /// worktrees that exist on disk but are not in the current session's
+    /// in-memory list.
     ///
     /// This is used at startup (and via `worktree clean`) to recover from a
-    /// previous crash that left stale worktrees behind.
+    /// previous crash that left stale worktrees behind. Each entry carries
+    /// git's own `prunable` verdict (see [`StaleWorktree::is_safe_to_force_remove`])
+    /// so callers can distinguish a worktree whose directory is already gone
+    /// from one that is merely untracked by *this* process — the latter may
+    /// belong to another, concurrently running session and MUST NOT be
+    /// force-removed without an explicit operator override (#6055).
     ///
     /// # Errors
     ///
@@ -287,14 +303,14 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// ```no_run
     /// # async fn example(mgr: &zeph_worktree::DefaultWorktreeManager) -> Result<(), zeph_worktree::WorktreeError> {
     /// let stale = mgr.reconcile().await?;
-    /// for h in &stale {
-    ///     println!("stale worktree: {:?}", h.path);
+    /// for s in &stale {
+    ///     println!("stale worktree: {:?} (safe to force-remove: {})", s.handle.path, s.is_safe_to_force_remove());
     /// }
     /// # Ok(())
     /// # }
     /// ```
     #[instrument(name = "worktree.reconcile", skip(self))]
-    pub async fn reconcile(&self) -> Result<Vec<WorktreeHandle>, WorktreeError> {
+    pub async fn reconcile(&self) -> Result<Vec<StaleWorktree>, WorktreeError> {
         let out = self
             .runner
             .run(&["worktree", "list", "--porcelain"], &self.repo_root)
@@ -302,7 +318,7 @@ impl<R: GitRunner> WorktreeManager<R> {
         check_git_status(&out, "worktree list")?;
 
         let output_str = String::from_utf8_lossy(&out.stdout);
-        let git_worktrees = parse_worktree_list_porcelain(&output_str);
+        let raw_entries = parse_worktree_list_porcelain(&output_str);
 
         let session_paths: std::collections::HashSet<PathBuf> = self
             .handles
@@ -312,11 +328,28 @@ impl<R: GitRunner> WorktreeManager<R> {
             .map(|h| h.path.clone())
             .collect();
 
-        let stale = git_worktrees
+        let stale = raw_entries
             .into_iter()
-            .filter(|h| !session_paths.contains(&h.path))
+            .filter(|e| !session_paths.contains(&e.path))
             // Skip the main worktree (repo_root itself).
-            .filter(|h| h.path != self.repo_root)
+            .filter(|e| e.path != self.repo_root)
+            .map(|e| {
+                let branch_name = match (e.branch, e.is_bare) {
+                    (Some(branch), _) => branch,
+                    (None, true) => BARE_WORKTREE_SENTINEL.to_string(),
+                    (None, false) => DETACHED_BRANCH_SENTINEL.to_string(),
+                };
+                StaleWorktree {
+                    handle: WorktreeHandle {
+                        path: e.path,
+                        branch_name,
+                        base_ref_resolved: String::new(),
+                        subagent_id: String::new(),
+                        created_at: SystemTime::UNIX_EPOCH,
+                    },
+                    prunable_reason: e.prunable_reason,
+                }
+            })
             .collect();
 
         Ok(stale)
@@ -353,60 +386,109 @@ impl<R: GitRunner> WorktreeManager<R> {
     }
 }
 
-/// Parses the output of `git worktree list --porcelain` into [`WorktreeHandle`]s.
+/// Intermediate result of parsing one `git worktree list --porcelain` block,
+/// before [`reconcile`][WorktreeManager::reconcile] resolves it into a
+/// [`StaleWorktree`].
 ///
-/// Each worktree block in the porcelain output looks like either:
+/// Kept private to this module: it exists only so the parser doesn't have to
+/// build a full [`WorktreeHandle`] (with placeholder `base_ref_resolved` /
+/// `subagent_id` / `created_at`) before the `branch_name` fallback (detached
+/// vs. bare vs. real branch) and the `prunable` verdict are both known.
+struct RawWorktreeEntry {
+    /// Absolute path from the `worktree <path>` line.
+    path: PathBuf,
+    /// `Some(name)` from a `branch refs/heads/<name>` line; `None` for a
+    /// `detached` or `bare` block.
+    branch: Option<String>,
+    /// `true` if this block's line was `bare` (the main worktree of a bare
+    /// repository) rather than `branch`/`detached`.
+    is_bare: bool,
+    /// `Some(reason)` from a `prunable <reason>` line — git's own signal that
+    /// this worktree's directory or `.git` gitdir-link is gone/broken.
+    prunable_reason: Option<String>,
+}
+
+/// Parses the output of `git worktree list --porcelain` into [`RawWorktreeEntry`]s.
+///
+/// Each worktree block in the porcelain output looks like one of:
 /// ```text
 /// worktree /path/to/worktree
 /// HEAD deadbeef...
 /// branch refs/heads/branch-name
 ///
 /// ```
-/// or, for a worktree on a detached `HEAD`:
+/// for a worktree on a detached `HEAD`:
 /// ```text
 /// worktree /path/to/worktree
 /// HEAD deadbeef...
 /// detached
 ///
 /// ```
+/// for the main worktree of a bare repository (#6052 — no `HEAD` line at all):
+/// ```text
+/// worktree /path/to/bare.git
+/// bare
+///
+/// ```
+/// or, when the directory/gitdir-link is gone or broken, with an extra line
+/// regardless of the block's other contents:
+/// ```text
+/// prunable gitdir file points to non-existent location
+/// ```
 /// A block is flushed as soon as its `worktree <path>` line is seen (i.e. when
 /// the *next* block starts, or at end of output) — regardless of whether a
-/// `branch` line was present. Detached-HEAD blocks get
-/// [`DETACHED_BRANCH_SENTINEL`] as their `branch_name` so they are not silently
-/// dropped (#5936).
-fn parse_worktree_list_porcelain(output: &str) -> Vec<WorktreeHandle> {
+/// `branch` line was present. Detached-HEAD and bare blocks are never silently
+/// dropped (#5936, #6052).
+fn parse_worktree_list_porcelain(output: &str) -> Vec<RawWorktreeEntry> {
     let mut result = Vec::new();
     let mut path: Option<PathBuf> = None;
     let mut branch: Option<String> = None;
+    let mut is_bare = false;
+    let mut prunable_reason: Option<String> = None;
 
     for line in output.lines() {
         if let Some(p) = line.strip_prefix("worktree ") {
-            if let Some(handle) = flush_worktree_block(path.take(), branch.take()) {
-                result.push(handle);
+            if let Some(entry) =
+                flush_worktree_block(path.take(), branch.take(), is_bare, prunable_reason.take())
+            {
+                result.push(entry);
             }
+            is_bare = false;
             path = Some(PathBuf::from(p));
         } else if let Some(b) = line.strip_prefix("branch refs/heads/") {
             branch = Some(b.to_string());
+        } else if let Some(reason) = line.strip_prefix("prunable ") {
+            prunable_reason = Some(reason.to_string());
+        } else if line == "bare" {
+            is_bare = true;
         }
+        // "locked ..." lines need no new handling here — a locked worktree is
+        // already protected by git's own single-`--force` refusal to remove
+        // it (see `WorktreeManager::remove`'s doc comment); "detached" lines
+        // need no explicit match either, since the `branch = None, is_bare =
+        // false` fallback already resolves to `DETACHED_BRANCH_SENTINEL`.
     }
 
-    if let Some(handle) = flush_worktree_block(path, branch) {
-        result.push(handle);
+    if let Some(entry) = flush_worktree_block(path, branch, is_bare, prunable_reason) {
+        result.push(entry);
     }
 
     result
 }
 
-/// Builds a [`WorktreeHandle`] from one parsed porcelain block, if a
-/// `worktree <path>` line was seen. `branch` is `None` for detached-`HEAD`
-/// worktrees and resolves to [`DETACHED_BRANCH_SENTINEL`].
-fn flush_worktree_block(path: Option<PathBuf>, branch: Option<String>) -> Option<WorktreeHandle> {
-    path.map(|wt_path| WorktreeHandle {
+/// Builds a [`RawWorktreeEntry`] from one parsed porcelain block, if a
+/// `worktree <path>` line was seen.
+fn flush_worktree_block(
+    path: Option<PathBuf>,
+    branch: Option<String>,
+    is_bare: bool,
+    prunable_reason: Option<String>,
+) -> Option<RawWorktreeEntry> {
+    path.map(|wt_path| RawWorktreeEntry {
         path: wt_path,
-        branch_name: branch.unwrap_or_else(|| DETACHED_BRANCH_SENTINEL.to_string()),
-        base_ref_resolved: String::new(),
-        subagent_id: String::new(),
-        created_at: SystemTime::UNIX_EPOCH,
+        branch,
+        is_bare,
+        prunable_reason,
     })
 }
 
@@ -916,7 +998,7 @@ mod tests {
         let stale = mgr.reconcile().await.unwrap();
         // The main worktree (repo_root) is filtered out; only agent worktrees remain.
         assert_eq!(stale.len(), 1);
-        assert_eq!(stale[0].branch_name, "agent/agent-1");
+        assert_eq!(stale[0].handle.branch_name, "agent/agent-1");
     }
 
     /// Regression test for #5936: a `detached` line (instead of `branch
@@ -934,8 +1016,11 @@ mod tests {
         let mgr = make_manager(&dir, runner).await;
         let stale = mgr.reconcile().await.unwrap();
         assert_eq!(stale.len(), 1);
-        assert_eq!(stale[0].branch_name, DETACHED_BRANCH_SENTINEL);
-        assert_eq!(stale[0].path, dir.path().join("worktrees/detached-1"));
+        assert_eq!(stale[0].handle.branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_eq!(
+            stale[0].handle.path,
+            dir.path().join("worktrees/detached-1")
+        );
     }
 
     /// A detached-HEAD block that is also the *last* block in the porcelain
@@ -947,7 +1032,8 @@ mod tests {
         let result = parse_worktree_list_porcelain(output);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].path, PathBuf::from("/repo"));
-        assert_eq!(result[0].branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_eq!(result[0].branch, None);
+        assert!(!result[0].is_bare);
     }
 
     /// Two secondary detached-HEAD worktrees back to back (no `branch` line
@@ -960,9 +1046,9 @@ mod tests {
         let result = parse_worktree_list_porcelain(output);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].path, PathBuf::from("/repo/wt-a"));
-        assert_eq!(result[0].branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_eq!(result[0].branch, None);
         assert_eq!(result[1].path, PathBuf::from("/repo/wt-b"));
-        assert_eq!(result[1].branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_eq!(result[1].branch, None);
     }
 
     /// Regression test for #5936: a repo where *every* worktree — including
@@ -984,11 +1070,14 @@ mod tests {
         let mgr = make_manager(&dir, runner).await;
         let stale = mgr.reconcile().await.unwrap();
         assert_eq!(stale.len(), 1, "main worktree filtered out by path only");
-        assert_eq!(stale[0].branch_name, DETACHED_BRANCH_SENTINEL);
-        assert_eq!(stale[0].path, dir.path().join("worktrees/detached-2"));
+        assert_eq!(stale[0].handle.branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_eq!(
+            stale[0].handle.path,
+            dir.path().join("worktrees/detached-2")
+        );
     }
 
-    /// **Finding for reviewer**: `git worktree list --porcelain` emits a
+    /// Regression test for #6052: `git worktree list --porcelain` emits a
     /// `bare` line (not `branch` or `detached`) for the main worktree of a
     /// bare repository:
     /// ```text
@@ -997,25 +1086,89 @@ mod tests {
     ///
     /// ```
     /// (confirmed against real `git worktree list --porcelain` output, git
-    /// 2.50.1 — no `HEAD` line is emitted for bare worktrees at all).
-    ///
-    /// Since #5936's fix flushes a block on *any* `worktree <path>` line
-    /// regardless of what follows, a `bare` block is now also flushed and
-    /// mislabeled with [`DETACHED_BRANCH_SENTINEL`] — even though a bare
-    /// worktree is semantically distinct from a detached-`HEAD` worktree.
-    /// This test documents *current* behavior; it is not a statement that
-    /// the behavior is correct. Neither `spec.md` nor `srs.md` for spec-063
-    /// mentions bare-repo worktrees at all, so this is an unspecified gap,
-    /// not a spec violation — but see the tester handoff for why it can
-    /// still cause a misleading `remove()` outcome downstream.
+    /// 2.50.1 — no `HEAD` line is emitted for bare worktrees at all). The
+    /// parser must capture this as `is_bare = true` rather than falling
+    /// through to the detached-HEAD fallback.
     #[test]
-    fn parse_worktree_list_porcelain_mislabels_bare_worktree_as_detached() {
+    fn parse_worktree_list_porcelain_marks_bare_worktree_as_bare() {
         let output = "worktree /path/to/bare.git\nbare\n\n";
         let result = parse_worktree_list_porcelain(output);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].path, PathBuf::from("/path/to/bare.git"));
-        // Documents the mislabeling: a bare worktree is reported as detached.
-        assert_eq!(result[0].branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_eq!(result[0].branch, None);
+        assert!(result[0].is_bare);
+    }
+
+    /// End-to-end regression test for #6052: `reconcile()` must label a bare
+    /// worktree with [`BARE_WORKTREE_SENTINEL`], not
+    /// [`DETACHED_BRANCH_SENTINEL`] — the two are semantically distinct and
+    /// must not collide.
+    #[tokio::test]
+    async fn reconcile_distinguishes_bare_from_detached_worktree() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\nworktree {0}/worktrees/bare-1\nbare\n\nworktree {0}/worktrees/detached-1\nHEAD def456\ndetached\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+
+        let mgr = make_manager(&dir, runner).await;
+        let stale = mgr.reconcile().await.unwrap();
+        assert_eq!(stale.len(), 2);
+        assert_eq!(stale[0].handle.branch_name, BARE_WORKTREE_SENTINEL);
+        assert_eq!(stale[1].handle.branch_name, DETACHED_BRANCH_SENTINEL);
+        assert_ne!(
+            BARE_WORKTREE_SENTINEL, DETACHED_BRANCH_SENTINEL,
+            "bare and detached sentinels must be distinct markers"
+        );
+    }
+
+    /// Regression test for #6055: a worktree whose directory is intact (no
+    /// `prunable` line in the porcelain output) must report
+    /// `prunable_reason == None` and `is_safe_to_force_remove() == false` —
+    /// this is the condition under which `clean` must skip-and-warn instead
+    /// of force-removing, since the worktree may belong to another,
+    /// concurrently running session.
+    #[tokio::test]
+    async fn reconcile_marks_directory_intact_worktree_as_not_prunable() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\nworktree {0}/worktrees/agent-1\nHEAD def456\nbranch refs/heads/agent/agent-1\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+
+        let mgr = make_manager(&dir, runner).await;
+        let stale = mgr.reconcile().await.unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].prunable_reason, None);
+        assert!(!stale[0].is_safe_to_force_remove());
+    }
+
+    /// Regression test for #6055: when git's porcelain output includes a
+    /// `prunable <reason>` line for a worktree, `reconcile()` must surface the
+    /// exact reason text and `is_safe_to_force_remove()` must be `true` — this
+    /// is the one condition under which `clean` may force-remove by default.
+    #[tokio::test]
+    async fn reconcile_captures_prunable_reason_text() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\nworktree {0}/worktrees/gone\nHEAD def456\nbranch refs/heads/agent/gone\nprunable gitdir file points to non-existent location\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+
+        let mgr = make_manager(&dir, runner).await;
+        let stale = mgr.reconcile().await.unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(
+            stale[0].prunable_reason,
+            Some("gitdir file points to non-existent location".to_string())
+        );
+        assert!(stale[0].is_safe_to_force_remove());
     }
 
     // --- prune ---

--- a/crates/zeph-worktree/tests/real_git_integration.rs
+++ b/crates/zeph-worktree/tests/real_git_integration.rs
@@ -102,7 +102,12 @@ async fn prune_clears_manually_deleted_worktree_administrative_entry() {
         1,
         "expected exactly the deleted worktree to be discovered as stale"
     );
-    assert_eq!(stale[0].path, handle.path);
+    assert_eq!(stale[0].handle.path, handle.path);
+    assert!(
+        stale[0].is_safe_to_force_remove(),
+        "a worktree whose directory was deleted directly must be reported as \
+         prunable by git, and therefore safe to force-remove"
+    );
 
     // Deliberately skip `remove()` — see doc comment above.
     cleaner.prune().await.expect("prune");
@@ -150,10 +155,14 @@ async fn clean_pipeline_end_to_end_clears_manually_deleted_worktree() {
         1,
         "expected exactly the deleted worktree to be discovered as stale"
     );
-    for h in &stale {
-        if let Err(e) = cleaner.remove(h, false).await {
+    for s in &stale {
+        assert!(
+            s.is_safe_to_force_remove(),
+            "deleted worktree must be prunable"
+        );
+        if let Err(e) = cleaner.remove(&s.handle, false).await {
             // Mirrors `handle_worktree_command`'s non-fatal per-entry handling.
-            eprintln!("warning: failed to remove {}: {e}", h.path.display());
+            eprintln!("warning: failed to remove {}: {e}", s.handle.path.display());
         }
     }
     cleaner.prune().await.expect("prune");
@@ -211,5 +220,81 @@ fn detached_branch_sentinel_is_not_a_valid_git_ref_name() {
         "DETACHED_BRANCH_SENTINEL ({DETACHED_BRANCH_SENTINEL:?}) must be REJECTED by \
          `git check-ref-format --branch` — otherwise a real branch could be given this exact \
          name and collide with the sentinel (see #5936 review finding)"
+    );
+}
+
+/// End-to-end regression test for #6055: `zeph worktree clean` must not
+/// force-remove a worktree whose directory is intact and not reported as
+/// `prunable` by git — such a worktree may belong to another, concurrently
+/// running zeph session. Mirrors the issue's own repro: one `WorktreeManager`
+/// creates a worktree and leaves it with uncommitted changes (simulating a
+/// live session); the `clean` gating logic then runs via a second, freshly
+/// constructed manager — matching the real cross-process `zeph worktree
+/// clean` invocation, whose in-memory `handles` always starts empty.
+#[tokio::test]
+async fn clean_without_force_preserves_intact_worktree_with_uncommitted_changes() {
+    let repo = init_repo();
+    let repo_root = repo.path().canonicalize().unwrap();
+
+    let live_session = WorktreeManager::new(repo_root.clone(), config(), DefaultGitRunner::new())
+        .await
+        .unwrap();
+    let handle = live_session
+        .create("live-session-agent")
+        .await
+        .expect("create worktree");
+
+    // Simulate uncommitted work belonging to the "other" live session.
+    let dirty_file = handle.path.join("dirty.txt");
+    std::fs::write(&dirty_file, "uncommitted work\n").unwrap();
+
+    let cleaner = WorktreeManager::new(repo_root.clone(), config(), DefaultGitRunner::new())
+        .await
+        .unwrap();
+
+    let stale = cleaner.reconcile().await.expect("reconcile");
+    assert_eq!(
+        stale.len(),
+        1,
+        "the live session's worktree is untracked by this process's handles"
+    );
+    assert!(
+        !stale[0].is_safe_to_force_remove(),
+        "an intact, non-prunable worktree must never be force-removable by default"
+    );
+
+    // Mirror `handle_worktree_command`'s `Clean` handler: skip unless the
+    // operator passed `--force` or git itself reports the entry as prunable.
+    let force = false;
+    for s in &stale {
+        if !force && !s.is_safe_to_force_remove() {
+            continue;
+        }
+        cleaner.remove(&s.handle, false).await.expect("remove");
+    }
+
+    assert!(
+        handle.path.exists(),
+        "worktree directory must survive a non-force clean"
+    );
+    assert!(
+        dirty_file.exists(),
+        "uncommitted work must survive a non-force clean"
+    );
+
+    // Re-run with the operator's explicit `--force` override.
+    let stale = cleaner.reconcile().await.expect("reconcile");
+    assert_eq!(stale.len(), 1);
+    let force = true;
+    for s in &stale {
+        if !force && !s.is_safe_to_force_remove() {
+            continue;
+        }
+        cleaner.remove(&s.handle, false).await.expect("remove");
+    }
+
+    assert!(
+        !handle.path.exists(),
+        "worktree directory must be removed once the operator passes --force"
     );
 }

--- a/specs/063-worktree-subsystem/spec.md
+++ b/specs/063-worktree-subsystem/spec.md
@@ -78,6 +78,18 @@ If worktree creation fails, the agent spawn MUST fail with a `SubAgentError` wra
 means the worktree is required. Best-effort fallback is forbidden because it would silently run the
 agent in the wrong repository tree.
 
+**INV-5 — `clean` MUST NOT force-remove a worktree whose directory is intact unless git's own
+`prunable` marker is present or the operator passes `--force`.**  
+`WorktreeManager::reconcile()`'s "stale" classification (git-registered but absent from *this*
+process's own in-memory `handles`) can never distinguish a genuinely orphaned worktree from one that
+belongs to a different, concurrently running zeph session — `handles` is documented as
+session-local, in-RAM-only (see `list()` above), so it is always empty for a freshly constructed
+`WorktreeManager` such as the one `zeph worktree clean` builds per one-shot CLI invocation. `git
+worktree list --porcelain`'s own `prunable <reason>` line is git's independent, filesystem-derived
+verdict (the worktree's directory or `.git` gitdir-link is gone/broken) and is the only signal safe
+to force-remove on by default. `zeph worktree clean` MUST skip and warn on any stale entry that is
+not `prunable`, unless the operator explicitly passes `--force` (#6055).
+
 ---
 
 ## NEVER
@@ -91,6 +103,7 @@ agent in the wrong repository tree.
 - **NEVER** add the `set_working_directory` tool to the allowed list for a worktree-opted agent, even if the caller explicitly requests it.
 - **NEVER** skip the capability probe when `worktree.enabled = true`; a missing `git` must be caught at bootstrap, not at first spawn.
 - **NEVER** allow `git_timeout_secs = 0`; the value is clamped to `max(1, configured_value)` in `DefaultGitRunner`.
+- **NEVER** force-remove a `reconcile()`-discovered worktree whose directory is intact and not reported `prunable` by git without an explicit operator `--force` (INV-5, #6055).
 
 ---
 
@@ -127,6 +140,7 @@ Dependency direction: `zeph-subagent → zeph-worktree → (zeph-config, tokio, 
 ```
 WorktreeManager          // owns base repo path + config; create/remove/list/reconcile
 WorktreeHandle           // path, branch_name, base_ref_resolved, subagent_id, created_at (UTC)
+StaleWorktree            // handle + git's own `prunable` verdict (#6055)
 WorktreeError            // thiserror enum — see variants below
 GitRunner (trait)        // abstraction for git invocations (testability seam)
 DefaultGitRunner         // impl: tokio::process::Command, timeout applied inside run()
@@ -140,7 +154,7 @@ impl WorktreeManager {
     pub async fn create(&self, subagent_id: &str) -> Result<WorktreeHandle, WorktreeError>;
     pub async fn remove(&self, handle: &WorktreeHandle, prune_branch: bool) -> Result<(), WorktreeError>;
     pub fn list(&self) -> &[WorktreeHandle];           // live-session in-RAM only
-    pub async fn reconcile(&self) -> Result<Vec<WorktreeHandle>, WorktreeError>; // reads git registry
+    pub async fn reconcile(&self) -> Result<Vec<StaleWorktree>, WorktreeError>; // reads git registry
 }
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -547,8 +547,15 @@ pub(crate) enum Command {
 pub(crate) enum WorktreeCommand {
     /// List active and stale worktrees for the current repository
     List,
-    /// Remove all stale worktrees that exist on disk but are not tracked in-session
-    Clean,
+    /// Remove stale worktrees that exist on disk but are not tracked in-session
+    Clean {
+        /// Also remove worktrees whose directory still exists and is not
+        /// marked `prunable` by git — i.e. worktrees that may belong to
+        /// another, currently running zeph session. Requires this explicit
+        /// flag; never applied automatically.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 /// Project-knowledge ingest subcommands (spec-067).

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -54,21 +54,48 @@ pub(crate) async fn handle_worktree_command(
                 }
                 if !stale.is_empty() {
                     println!("\nStale (on disk but not tracked):");
-                    for handle in &stale {
-                        println!("  {}", handle.path.display());
+                    for stale_wt in &stale {
+                        match &stale_wt.prunable_reason {
+                            Some(reason) => {
+                                println!(
+                                    "  {}  [prunable: {reason}]",
+                                    stale_wt.handle.path.display()
+                                );
+                            }
+                            None => println!(
+                                "  {}  [in use — not marked prunable by git; may belong to another session]",
+                                stale_wt.handle.path.display()
+                            ),
+                        }
                     }
                 }
             }
         }
-        WorktreeCommand::Clean => {
+        WorktreeCommand::Clean { force } => {
             let stale = wm.reconcile().await?;
-            let count = stale.len();
-            for handle in stale {
+            let mut removed = 0usize;
+            let mut skipped = 0usize;
+            for stale_wt in stale {
+                if !force && !stale_wt.is_safe_to_force_remove() {
+                    eprintln!(
+                        "warning: skipping {} — directory exists and git does not report it as \
+                         prunable; it may be in active use by another zeph session. \
+                         Re-run with `zeph worktree clean --force` if you are certain it is abandoned.",
+                        stale_wt.handle.path.display()
+                    );
+                    skipped += 1;
+                    continue;
+                }
                 if let Err(e) = wm
-                    .remove(&handle, config.worktree.prune_branch_on_remove)
+                    .remove(&stale_wt.handle, config.worktree.prune_branch_on_remove)
                     .await
                 {
-                    eprintln!("warning: failed to remove {}: {e}", handle.path.display());
+                    eprintln!(
+                        "warning: failed to remove {}: {e}",
+                        stale_wt.handle.path.display()
+                    );
+                } else {
+                    removed += 1;
                 }
             }
             // FR-CLEANUP-04: clear any remaining stale administrative entries
@@ -76,7 +103,7 @@ pub(crate) async fn handle_worktree_command(
             if let Err(e) = wm.prune().await {
                 eprintln!("warning: failed to prune worktree registry: {e}");
             }
-            println!("Removed {count} stale worktree(s).");
+            println!("Removed {removed} stale worktree(s), skipped {skipped} in-use candidate(s).");
         }
     }
 
@@ -86,6 +113,10 @@ pub(crate) async fn handle_worktree_command(
 #[cfg(test)]
 mod tests {
     use std::io::Write as _;
+
+    use clap::Parser as _;
+
+    use crate::cli::{Cli, Command, WorktreeCommand};
 
     /// Regression test for #4701: `handle_worktree_command` must propagate a config parse
     /// error instead of silently falling back to `Config::default()`.
@@ -106,6 +137,37 @@ mod tests {
         assert!(
             msg.contains("failed to load config"),
             "error must mention config load failure, got: {msg}"
+        );
+    }
+
+    /// Regression test for #6055: `zeph worktree clean --force` must parse
+    /// with `force == true`; plain `zeph worktree clean` must default to
+    /// `force == false` so `clean` never force-removes an in-use worktree
+    /// without an explicit operator opt-in.
+    #[test]
+    fn worktree_clean_force_flag_parses() {
+        let cli = Cli::try_parse_from(["zeph", "worktree", "clean", "--force"]).unwrap();
+        let Some(Command::Worktree {
+            command: WorktreeCommand::Clean { force },
+        }) = cli.command
+        else {
+            panic!("expected Worktree(Clean) command");
+        };
+        assert!(force, "--force must set force = true");
+    }
+
+    #[test]
+    fn worktree_clean_defaults_to_no_force() {
+        let cli = Cli::try_parse_from(["zeph", "worktree", "clean"]).unwrap();
+        let Some(Command::Worktree {
+            command: WorktreeCommand::Clean { force },
+        }) = cli.command
+        else {
+            panic!("expected Worktree(Clean) command");
+        };
+        assert!(
+            !force,
+            "clean without --force must default to force = false"
         );
     }
 }


### PR DESCRIPTION
## Summary

`zeph worktree clean` force-removed every git-registered worktree not tracked in the calling process's own in-memory state — including a worktree actively in use by a different, concurrently running zeph session — with no dirty-tree check and no confirmation, silently discarding uncommitted work via `git worktree remove --force`.

- `WorktreeManager::reconcile()` now returns `Vec<StaleWorktree>`, capturing git's own `prunable <reason>` porcelain line per worktree entry — the one signal that reliably indicates a worktree's directory or gitdir-link is actually gone, valid across process boundaries since it comes from git's own filesystem check rather than any process's in-memory state.
- `zeph worktree clean` only force-removes entries git itself reports as `prunable`; anything else (a worktree with an intact directory, dirty or clean, ours or another session's) is skipped with a warning unless the operator passes a new `--force` flag.
- `zeph worktree list` surfaces the prunable reason (or an "in use" note) per stale entry so operators can decide before running `clean --force`.
- Also fixes bare-repo worktrees being mislabeled as detached HEAD by the same porcelain parser (the parser only special-cased `branch`/absence-of-branch, so a bare-repo's `bare` porcelain line fell through to the detached-HEAD sentinel) — fixed in the same parser rewrite since both issues touch the identical code path.

This is a pre-1.0 breaking signature change (`reconcile()` return type), documented in CHANGELOG.md per project convention.

Closes #6055
Closes #6052

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (full workspace, 12863 passed)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-worktree` (47 passed, includes new cross-process integration test)
- [x] `cargo test --doc -p zeph-worktree`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New integration test reproduces the issue's exact repro: a worktree created by one `WorktreeManager` with an intact directory and uncommitted changes survives a `clean` run (no `--force`) by a second, freshly-constructed manager, and is only removed when `--force` is passed
- [x] Adversarial critique (verdict: minor, no blockers) and independent code review (verdict: approved) completed; non-blocking follow-up test-hardening items (locked-worktree regression test, mixed prunable/non-prunable list coverage) tracked for a fast-follow issue