### PR TITLE
fix(config): validate hot-reloaded config before applying to live agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`: config hot-reload (`Agent::reload_config`) bypassed `Config::validate()` entirely
+  — `load_config_with_overlay` called `Config::load` plus the plugin overlay merge and returned
+  the result straight to the live agent without ever validating it, unlike the startup path
+  (`src/bootstrap/mod.rs`, `src/tui_remote.rs`), which always calls `.validate()` immediately
+  after `Config::load()`. An invalid config edited into the running config file (empty/duplicate
+  LLM providers, inverted ACON/fidelity/trajectory thresholds, etc.) was silently applied to the
+  live runtime on the next reload instead of being rejected (#6063). `load_config_with_overlay`
+  now calls `config.validate()` on the fully-assembled config (after the plugin overlay merge, so
+  overlay-introduced invalid values are also caught) and returns `None` on failure, following the
+  same warn-and-keep-previous-state pattern already used for the `Config::load` and overlay-merge
+  error branches in the same function.
 - **BREAKING**: `ToolExecutor` and `ErasedToolExecutor` no longer provide permissive default
   bodies for the six risk-bearing cross-cutting methods — `requires_confirmation`,
   `execute_tool_call_confirmed`, the checkpoint trio (`checkpoint_undo`/`checkpoint_redo`/

--- a/crates/zeph-core/src/agent/config_reload.rs
+++ b/crates/zeph-core/src/agent/config_reload.rs
@@ -156,9 +156,10 @@ impl<C: Channel> Agent<C> {
 
         tracing::info!("config reloaded");
     }
-    /// Load config from disk, apply plugin overlays, and warn on shell divergence.
+    /// Load config from disk, apply plugin overlays, validate, and warn on shell divergence.
     ///
-    /// Returns `None` when loading or overlay merge fails (caller keeps prior runtime state).
+    /// Returns `None` when loading, overlay merge, or validation fails (caller keeps prior
+    /// runtime state).
     fn load_config_with_overlay(&mut self, path: &std::path::Path) -> Option<Config> {
         let mut config = match Config::load(path) {
             Ok(c) => c,
@@ -186,6 +187,15 @@ impl<C: Channel> Agent<C> {
                 }
             }
         };
+
+        // Validate the fully-assembled config (post-overlay) before it can reach the live
+        // agent — matches the startup path (Config::load + validate in bootstrap/mod.rs).
+        if let Err(e) = config.validate() {
+            tracing::warn!(
+                "config reload failed validation: {e:#}; keeping previous runtime state"
+            );
+            return None;
+        }
 
         // M4: detect shell-level divergence from the baked-in executor and warn loudly.
         // ShellExecutor is not rebuilt on hot-reload; only skill threshold is live.
@@ -245,5 +255,91 @@ impl<C: Channel> Agent<C> {
         }
 
         let _ = new_overlay;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::agent_tests::QuickTestAgent;
+    use super::*;
+
+    /// Writes `config` as TOML to a fresh file inside a per-test [`tempfile::TempDir`] and
+    /// returns both, so the directory outlives the returned path.
+    fn write_config(config: &Config) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, toml::to_string_pretty(config).unwrap()).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn load_config_with_overlay_returns_none_on_invalid_config() {
+        let mut config = Config::default();
+        // Inverted fidelity thresholds: full_threshold must be >= compressed_threshold.
+        config.memory.fidelity = Some(zeph_config::fidelity::FidelityConfig {
+            full_threshold: 0.2,
+            compressed_threshold: 0.5,
+            ..Default::default()
+        });
+        assert!(
+            config.validate().is_err(),
+            "fixture must actually fail validate()"
+        );
+        let (_dir, path) = write_config(&config);
+
+        let mut agent = QuickTestAgent::minimal("ok").agent;
+        agent.runtime.lifecycle.plugins_dir = std::path::PathBuf::new();
+
+        let result = agent.load_config_with_overlay(&path);
+        assert!(
+            result.is_none(),
+            "must return None when the reloaded config fails validate()"
+        );
+    }
+
+    #[test]
+    fn load_config_with_overlay_returns_some_on_valid_config() {
+        let config = Config::default();
+        assert!(config.validate().is_ok(), "fixture must be valid");
+        let (_dir, path) = write_config(&config);
+
+        let mut agent = QuickTestAgent::minimal("ok").agent;
+        agent.runtime.lifecycle.plugins_dir = std::path::PathBuf::new();
+
+        let result = agent.load_config_with_overlay(&path);
+        assert!(
+            result.is_some(),
+            "must return Some when the reloaded config passes validate()"
+        );
+    }
+
+    #[test]
+    fn reload_config_preserves_runtime_state_on_validation_failure() {
+        let mut config = Config::default();
+        config.memory.fidelity = Some(zeph_config::fidelity::FidelityConfig {
+            full_threshold: 0.2,
+            compressed_threshold: 0.5,
+            ..Default::default()
+        });
+        assert!(
+            config.validate().is_err(),
+            "fixture must actually fail validate()"
+        );
+        let (_dir, path) = write_config(&config);
+
+        let mut agent = QuickTestAgent::minimal("ok").agent;
+        agent.runtime.lifecycle.plugins_dir = std::path::PathBuf::new();
+        agent.runtime.lifecycle.config_path = Some(path);
+
+        // Sentinel: Config::default() sets max_active_skills to 5 (root.rs), so any
+        // value far from that proves the field was never touched by the aborted reload.
+        agent.services.skill.max_active_skills = 999;
+
+        agent.reload_config();
+
+        assert_eq!(
+            agent.services.skill.max_active_skills, 999,
+            "prior runtime state must be preserved when the reloaded config fails validate()"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `Agent::reload_config` never called `Config::validate()` on the reloaded config — unlike the startup path (`src/bootstrap/mod.rs`, `src/tui_remote.rs`), which always validates immediately after `Config::load()`. An invalid config edited into the running config file (empty/duplicate LLM providers, inverted ACON/fidelity/trajectory thresholds, etc.) was silently applied to the live agent runtime on the next hot-reload, bypassing all 7 invariant checks wired into `Config::validate()` by #6058.
- `load_config_with_overlay` now calls `config.validate()` on the fully-assembled config (after the plugin overlay merge, so overlay-introduced invalid values are also caught) and returns `None` on failure, following the same warn-and-keep-previous-state pattern already used for the `Config::load` and overlay-merge error branches in the same function.
- Added 3 regression tests (`crates/zeph-core/src/agent/config_reload.rs`): invalid config rejected, valid config still applies, and — the strongest guarantee — prior live runtime state is provably untouched after a rejected reload.

Closes #6063

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean, 0 warnings
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12882 passed, 0 failed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] New unit tests added and passing (`load_config_with_overlay_returns_none_on_invalid_config`, `load_config_with_overlay_returns_some_on_valid_config`, `reload_config_preserves_runtime_state_on_validation_failure`)
- [x] Testing playbook updated (`playbooks/config-validate-wiring.md`, Scenario 6) and `coverage-status.md` row added for live-session follow-up verification