### PR TITLE
fix(skills): wire requires_trust_check setter and route CLI invoke through SkillTrustGate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   precedent) by a hand-written `impl Debug` that still lists every other field. `Option<String>`
   secrets preserve the `None`-vs-`Some` distinction. `CandleInlineConfig` is embedded inside
   `ProviderEntry`, so both were fixed together to avoid a transitive leak through nested `Debug`.
+- `zeph-memory`/`zeph-core`/`zeph`: `SqliteStore::set_requires_trust_check` (the setter for the
+  per-invocation blake3 integrity re-check gated by `SkillTrustSnapshot::requires_trust_check`,
+  `crates/zeph-core/src/skill_trust_gate.rs`) had zero production callers anywhere in the
+  codebase — the column defaulted to `0` for every skill in every deployment and could never be
+  set to `1` by any CLI flag, config knob, or in-session command, making the entire defense
+  unreachable in practice despite being fully implemented and unit-tested on the consumption side
+  since #4306/#6062 (#6080). `zeph skill trust <name> <level> --require-check` and the in-session
+  `/skill trust <name> <level> --require-check` now call the setter after updating the trust
+  level. Separately, the CLI's `zeph skill invoke <name>` preview command (`src/commands/skill.rs`)
+  was a hand-rolled reimplementation of the trust-gating pipeline that predated #6062's
+  consolidation onto the shared `SkillTrustGate`: it never checked `requires_trust_check` at all,
+  and echoed the raw unsanitized skill name into its not-found error instead of the sanitized form
+  every other trust-gated path uses (#6079). `SkillTrustGate` and `SkillBodyResolution` are now
+  `pub` at the `zeph-core` crate root, and `SkillCommand::Invoke` calls
+  `SkillTrustGate::resolve_body` directly — the same pipeline `load_skill`/`invoke_skill` use —
+  so the CLI preview can no longer drift from the agent-facing tools.
 
 ### Fixed
 

--- a/book/src/advanced/skill-trust.md
+++ b/book/src/advanced/skill-trust.md
@@ -55,6 +55,41 @@ When promoting a skill's trust level via `zeph skill trust <name> trusted` or `z
 
 Run `zeph skill verify <name>` to check integrity without changing trust level.
 
+## Per-Invocation Integrity Re-Check
+
+The promotion-time hash check above runs once, when you set a skill to `trusted`/`verified`. It
+does not protect against `SKILL.md` being modified on disk *after* promotion — a tampered file
+stays `trusted` until someone happens to run `zeph skill verify` again.
+
+Setting the `requires_trust_check` flag on a skill closes that gap: with the flag armed, the
+BLAKE3 hash is recomputed and compared against the stored hash on *every* dispatch (`load_skill`,
+`invoke_skill`, and `zeph skill invoke`), not just at promotion time. A mismatch aborts the
+invocation and demotes the skill to `quarantined` immediately, before its body is ever returned.
+
+Arm it with `--require-check` on the trust-setting commands:
+
+```bash
+# CLI
+zeph skill trust my-skill trusted --require-check
+```
+
+```text
+# In-session
+/skill trust my-skill trusted --require-check
+```
+
+`/skill trust <name>` (no level argument) shows the flag's current state as
+`requires_trust_check=true|false`. There is no command to clear it yet — the only way is to
+manually update the `requires_trust_check` column in the `skill_trust` SQLite table directly.
+This is a known usability gap, not a security one (the flag only ever makes enforcement
+stricter).
+
+> **Note:** `zeph skill invoke <name>` shares its trust pipeline with `load_skill`/`invoke_skill`.
+> A skill with no trust record at all resolves to `trusted` ("never classified", not "known
+> untrusted") across all three, not `quarantined` — this differs from the "newly discovered skill"
+> default in [Trust Tiers](#trust-tiers) above, which applies once a skill *has* been installed
+> and given a trust row.
+
 ## Managed Skills Directory
 
 External skills installed via `zeph skill install` are stored in `~/.config/zeph/skills/`. This directory is automatically appended to `skills.paths` at startup — no manual configuration required. Skills in this directory follow the same structure as local skills (`<name>/SKILL.md`).
@@ -65,7 +100,7 @@ External skills installed via `zeph skill install` are stored in `~/.config/zeph
 |---------|-------------|
 | `/skill trust` | List all skills with their trust level, source, and hash |
 | `/skill trust <name>` | Show trust details for a specific skill |
-| `/skill trust <name> <level>` | Set trust level (`trusted`, `verified`, `quarantined`, `blocked`) |
+| `/skill trust <name> <level>` | Set trust level (`trusted`, `verified`, `quarantined`, `blocked`); append `--require-check` to also arm the [per-invocation integrity re-check](#per-invocation-integrity-re-check) |
 | `/skill block <name>` | Block a skill (all tool access denied) |
 | `/skill unblock <name>` | Unblock a skill (reverts to `quarantined`) |
 | `/skill install <url\|path>` | Install an external skill (git URL or local path) with hot reload |

--- a/book/src/reference/cli.md
+++ b/book/src/reference/cli.md
@@ -91,7 +91,7 @@ Manage external skills. Installed skills are stored in `~/.config/zeph/skills/`.
 | `skill remove <name>` | Remove an installed skill by name |
 | `skill list` | List installed skills with trust level and source metadata |
 | `skill verify [name]` | Verify BLAKE3 integrity of one or all installed skills |
-| `skill trust <name> [level]` | Show or set trust level (`trusted`, `verified`, `quarantined`, `blocked`) |
+| `skill trust <name> [level]` | Show or set trust level (`trusted`, `verified`, `quarantined`, `blocked`); add `--require-check` when setting a level to also arm the per-invocation BLAKE3 integrity re-check (see [Skill Trust Levels](../advanced/skill-trust.md#per-invocation-integrity-re-check)) |
 | `skill block <name>` | Block a skill (deny all tool access) |
 | `skill unblock <name>` | Unblock a skill (revert to `quarantined`) |
 | `skill promote-heuristics [--skill <name>]` | Dry-run: show skills eligible for A6 heuristic → full promotion (requires `[skills.learning.heuristic_promotion_enabled = true]`) |
@@ -111,6 +111,9 @@ zeph skill list
 # Verify integrity and promote trust
 zeph skill verify my-skill
 zeph skill trust my-skill trusted
+
+# Promote and also arm the per-invocation integrity re-check
+zeph skill trust my-skill trusted --require-check
 
 # Remove a skill
 zeph skill remove my-skill

--- a/crates/zeph-core/src/agent/trust_commands.rs
+++ b/crates/zeph-core/src/agent/trust_commands.rs
@@ -49,17 +49,33 @@ impl<C: Channel> Agent<C> {
                         );
                     };
                     let updated = memory.sqlite().set_skill_trust_level(name, level).await?;
-                    if updated {
-                        Ok(format!("Trust level for \"{name}\" set to {level}."))
-                    } else {
-                        Ok(format!("Skill \"{name}\" not found in trust database."))
+                    if !updated {
+                        return Ok(format!("Skill \"{name}\" not found in trust database."));
                     }
+                    let mut output = format!("Trust level for \"{name}\" set to {level}.");
+                    // #6080: `--require-check` arms the per-invocation blake3 integrity
+                    // re-check (`SkillTrustGate::resolve_body`), previously unreachable from
+                    // any production entry point. Scan the whole remaining slice rather than
+                    // indexing a fixed position — a security toggle must not silently fail to
+                    // arm just because the flag isn't the 3rd token (review finding, #6080).
+                    if args[2..].contains(&"--require-check") {
+                        memory.sqlite().set_requires_trust_check(name, true).await?;
+                        let _ = write!(
+                            output,
+                            "\nPer-invocation integrity re-check enabled for \"{name}\"."
+                        );
+                    }
+                    Ok(output)
                 } else {
                     let row = memory.sqlite().load_skill_trust(name).await?;
                     match row {
                         Some(r) => Ok(format!(
-                            "{}: level={}, source={}, hash={}",
-                            r.skill_name, r.trust_level, r.source_kind, r.blake3_hash
+                            "{}: level={}, source={}, hash={}, requires_trust_check={}",
+                            r.skill_name,
+                            r.trust_level,
+                            r.source_kind,
+                            r.blake3_hash,
+                            r.requires_trust_check
                         )),
                         None => Ok(format!("No trust data for \"{name}\".")),
                     }
@@ -172,5 +188,186 @@ impl<C: Channel> Agent<C> {
                 )
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zeph_memory::semantic::SemanticMemory;
+    use zeph_memory::store::SourceKind;
+
+    use super::super::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use super::*;
+
+    async fn test_memory() -> Arc<SemanticMemory> {
+        let provider = zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+        Arc::new(
+            SemanticMemory::new(
+                ":memory:",
+                "http://127.0.0.1:1",
+                None,
+                provider,
+                "test-model",
+            )
+            .await
+            .unwrap(),
+        )
+    }
+
+    fn agent_with_memory(memory: Arc<SemanticMemory>) -> Agent<MockChannel> {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            memory,
+            zeph_memory::ConversationId(1),
+            50,
+            5,
+            50,
+        )
+    }
+
+    #[tokio::test]
+    async fn trust_require_check_flag_arms_per_invocation_check() {
+        let memory = test_memory().await;
+        memory
+            .sqlite()
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Quarantined,
+                SourceKind::Local,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+        let mut agent = agent_with_memory(memory.clone());
+
+        let out = agent
+            .handle_skill_trust_command_as_string(&["git", "trusted", "--require-check"])
+            .await
+            .unwrap();
+        assert!(out.contains("Trust level for \"git\" set to trusted"));
+        assert!(out.contains("Per-invocation integrity re-check enabled"));
+
+        let row = memory
+            .sqlite()
+            .load_skill_trust("git")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.trust_level, SkillTrustLevel::Trusted);
+        assert!(
+            row.requires_trust_check,
+            "--require-check must persist requires_trust_check=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn trust_require_check_flag_arms_even_when_not_the_third_token() {
+        // Regression test (review finding): the flag must be found by scanning the whole
+        // remaining slice, not by indexing a fixed position — otherwise a security toggle
+        // silently fails to arm on any extra/reordered trailing token while still reporting
+        // success.
+        let memory = test_memory().await;
+        memory
+            .sqlite()
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Quarantined,
+                SourceKind::Local,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+        let mut agent = agent_with_memory(memory.clone());
+
+        let out = agent
+            .handle_skill_trust_command_as_string(&["git", "trusted", "extra", "--require-check"])
+            .await
+            .unwrap();
+        assert!(out.contains("Trust level for \"git\" set to trusted"));
+        assert!(
+            out.contains("Per-invocation integrity re-check enabled"),
+            "flag must arm even when it isn't the 3rd token: {out}"
+        );
+
+        let row = memory
+            .sqlite()
+            .load_skill_trust("git")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(row.requires_trust_check);
+    }
+
+    #[tokio::test]
+    async fn trust_without_flag_leaves_requires_trust_check_false() {
+        let memory = test_memory().await;
+        memory
+            .sqlite()
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Quarantined,
+                SourceKind::Local,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+        let mut agent = agent_with_memory(memory.clone());
+
+        let out = agent
+            .handle_skill_trust_command_as_string(&["git", "trusted"])
+            .await
+            .unwrap();
+        assert!(out.contains("Trust level for \"git\" set to trusted"));
+        assert!(!out.contains("Per-invocation integrity re-check enabled"));
+
+        let row = memory
+            .sqlite()
+            .load_skill_trust("git")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!row.requires_trust_check);
+    }
+
+    #[tokio::test]
+    async fn trust_info_display_includes_requires_trust_check() {
+        let memory = test_memory().await;
+        memory
+            .sqlite()
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Trusted,
+                SourceKind::Local,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+        memory
+            .sqlite()
+            .set_requires_trust_check("git", true)
+            .await
+            .unwrap();
+        let mut agent = agent_with_memory(memory);
+
+        let out = agent
+            .handle_skill_trust_command_as_string(&["git"])
+            .await
+            .unwrap();
+        assert!(out.contains("requires_trust_check=true"));
     }
 }

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -126,6 +126,7 @@ pub use config::{Config, ConfigError};
 pub use runtime_context::RuntimeContext;
 pub use skill_invoker::{InvokeSkillParams, SkillInvokeExecutor, SkillTrustSnapshot};
 pub use skill_loader::SkillLoaderExecutor;
+pub use skill_trust_gate::{SkillBodyResolution, SkillTrustGate};
 pub use zeph_common::hash::blake3_hex as content_hash;
 pub use zeph_sanitizer::exfiltration::{
     ExfiltrationEvent, ExfiltrationGuard, ExfiltrationGuardConfig, extract_flagged_urls,

--- a/crates/zeph-core/src/skill_trust_gate.rs
+++ b/crates/zeph-core/src/skill_trust_gate.rs
@@ -11,6 +11,10 @@
 //! the *same* `trust_snapshot` `Arc` (see `agent_setup::build_skill_executors` in the binary
 //! crate), so the two tools cannot drift apart and observe identical trust state within a turn
 //! (#6049, #6050).
+//!
+//! [`SkillTrustGate`] and [`resolve_body`](SkillTrustGate::resolve_body) are also `pub` at the
+//! crate root so the binary crate's `zeph skill invoke` CLI preview command can route through
+//! the exact same pipeline instead of maintaining its own copy (#6079).
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -28,7 +32,8 @@ use crate::skill_invoker::SkillTrustSnapshot;
 ///
 /// Callers match on this to apply their own tool-specific output framing (e.g. `invoke_skill`
 /// appends an `<args>` block to `Body`) before truncating for the LLM.
-pub(crate) enum SkillBodyResolution {
+#[derive(Debug)]
+pub enum SkillBodyResolution {
     /// Refused by policy (blocked) or a failed integrity check — ready-to-return tool summary.
     Refused(String),
     /// `skill_name` has no entry in the registry — ready-to-return tool summary.
@@ -45,13 +50,33 @@ pub(crate) enum SkillBodyResolution {
 /// `trust_snapshot` `Arc` so `load_skill` and `invoke_skill` see identical trust state within a
 /// turn.
 #[derive(Clone, Debug)]
-pub(crate) struct SkillTrustGate {
+pub struct SkillTrustGate {
     registry: Arc<RwLock<SkillRegistry>>,
     trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustSnapshot>>>,
 }
 
 impl SkillTrustGate {
-    pub(crate) fn new(
+    /// Build a gate over `registry` and `trust_snapshot`.
+    ///
+    /// `trust_snapshot` should be the same `Arc` shared with any other trust-aware skill-body
+    /// consumer (see `agent_setup::build_skill_executors` in the binary crate) so they all
+    /// observe identical trust state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use std::sync::Arc;
+    ///
+    /// use parking_lot::RwLock;
+    /// use zeph_core::SkillTrustGate;
+    /// use zeph_skills::registry::SkillRegistry;
+    ///
+    /// let registry = Arc::new(RwLock::new(SkillRegistry::empty()));
+    /// let trust_snapshot = Arc::new(RwLock::new(HashMap::new()));
+    /// let _gate = SkillTrustGate::new(registry, trust_snapshot);
+    /// ```
+    pub fn new(
         registry: Arc<RwLock<SkillRegistry>>,
         trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustSnapshot>>>,
     ) -> Self {
@@ -145,10 +170,33 @@ impl SkillTrustGate {
     /// A missing trust-snapshot row resolves to `SkillTrustLevel::MISSING_ENTRY_FALLBACK`
     /// (Trusted) — "never classified", not "known untrusted". `skill_name` is sanitized before
     /// it appears in any returned message, including the not-found path.
-    pub(crate) async fn resolve_body(
-        &self,
-        skill_name: &str,
-    ) -> Result<SkillBodyResolution, ToolError> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only when the `requires_trust_check` integrity re-check's
+    /// `spawn_blocking` task panics or is cancelled — a hash mismatch, missing skill directory,
+    /// or unreadable `SKILL.md` are reported as `Ok(SkillBodyResolution::Refused(_))`, not `Err`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::HashMap;
+    /// # use std::sync::Arc;
+    /// # use parking_lot::RwLock;
+    /// # use zeph_core::{SkillBodyResolution, SkillTrustGate};
+    /// # use zeph_skills::registry::SkillRegistry;
+    /// # #[tokio::main] async fn main() {
+    /// let registry = Arc::new(RwLock::new(SkillRegistry::empty()));
+    /// let trust_snapshot = Arc::new(RwLock::new(HashMap::new()));
+    /// let gate = SkillTrustGate::new(registry, trust_snapshot);
+    ///
+    /// match gate.resolve_body("nonexistent").await.unwrap() {
+    ///     SkillBodyResolution::NotFound(message) => assert!(message.contains("nonexistent")),
+    ///     _ => panic!("expected NotFound for an empty registry"),
+    /// }
+    /// # }
+    /// ```
+    pub async fn resolve_body(&self, skill_name: &str) -> Result<SkillBodyResolution, ToolError> {
         let snapshot = self.resolve_snapshot(skill_name);
         let trust = snapshot
             .as_ref()
@@ -198,6 +246,151 @@ impl SkillTrustGate {
             Err(_) => Ok(SkillBodyResolution::NotFound(format!(
                 "skill not found: {skill_name_safe}"
             ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use zeph_skills::trust::compute_skill_hash;
+
+    use super::*;
+
+    fn make_registry_with_skill(dir: &Path, name: &str, body: &str) -> SkillRegistry {
+        let skill_dir = dir.join(name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: test skill\n---\n{body}"),
+        )
+        .unwrap();
+        SkillRegistry::load(&[dir.to_path_buf()])
+    }
+
+    fn make_gate(
+        registry: SkillRegistry,
+        snapshots: HashMap<String, SkillTrustSnapshot>,
+    ) -> SkillTrustGate {
+        SkillTrustGate::new(
+            Arc::new(RwLock::new(registry)),
+            Arc::new(RwLock::new(snapshots)),
+        )
+    }
+
+    // Exercises the gate directly (bypassing `SkillLoaderExecutor`/`SkillInvokeExecutor`) to
+    // guard the pipeline the CLI's `zeph skill invoke` now shares with the agent tools (#6079).
+
+    #[tokio::test]
+    async fn blocked_skill_refused_without_body_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "secret body that must not leak";
+        let registry = make_registry_with_skill(dir.path(), "blocked-skill", body);
+        let snapshots = HashMap::from([(
+            "blocked-skill".to_owned(),
+            SkillTrustSnapshot {
+                trust_level: SkillTrustLevel::Blocked,
+                requires_trust_check: false,
+                blake3_hash: String::new(),
+            },
+        )]);
+        let gate = make_gate(registry, snapshots);
+        match gate.resolve_body("blocked-skill").await.unwrap() {
+            SkillBodyResolution::Refused(message) => {
+                assert!(message.contains("blocked by policy"));
+                assert!(!message.contains("secret body"));
+            }
+            other => panic!("expected Refused, got a different variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn not_found_sanitizes_skill_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        let gate = make_gate(registry, HashMap::new());
+        match gate.resolve_body("<|im_start|>nonexistent").await.unwrap() {
+            SkillBodyResolution::NotFound(message) => {
+                assert!(message.contains("skill not found"));
+                assert!(message.contains("[BLOCKED:<|im_start|>]"));
+                assert!(
+                    !message
+                        .replace("[BLOCKED:<|im_start|>]", "")
+                        .contains("<|im_start|>")
+                );
+            }
+            other => panic!("expected NotFound, got a different variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn requires_trust_check_hash_match_returns_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "trusted content";
+        let registry = make_registry_with_skill(dir.path(), "checked-skill", body);
+        let hash = compute_skill_hash(&dir.path().join("checked-skill")).unwrap();
+        let snapshots = HashMap::from([(
+            "checked-skill".to_owned(),
+            SkillTrustSnapshot {
+                trust_level: SkillTrustLevel::Trusted,
+                requires_trust_check: true,
+                blake3_hash: hash,
+            },
+        )]);
+        let gate = make_gate(registry, snapshots);
+        match gate.resolve_body("checked-skill").await.unwrap() {
+            SkillBodyResolution::Body(returned) => assert!(returned.contains(body)),
+            other => panic!("expected Body, got a different variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn requires_trust_check_hash_mismatch_demotes_and_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "content that changed after install";
+        let registry = make_registry_with_skill(dir.path(), "tampered-skill", body);
+        let snapshots = HashMap::from([(
+            "tampered-skill".to_owned(),
+            SkillTrustSnapshot {
+                trust_level: SkillTrustLevel::Trusted,
+                requires_trust_check: true,
+                blake3_hash: "0".repeat(64),
+            },
+        )]);
+        let trust_snapshot = Arc::new(RwLock::new(snapshots));
+        let gate =
+            SkillTrustGate::new(Arc::new(RwLock::new(registry)), Arc::clone(&trust_snapshot));
+        match gate.resolve_body("tampered-skill").await.unwrap() {
+            SkillBodyResolution::Refused(message) => {
+                assert!(message.contains("demoted to Quarantined"));
+                assert!(!message.contains(body));
+            }
+            other => panic!("expected Refused, got a different variant: {other:?}"),
+        }
+        assert_eq!(
+            trust_snapshot
+                .read()
+                .get("tampered-skill")
+                .unwrap()
+                .trust_level,
+            SkillTrustLevel::Quarantined,
+            "in-memory snapshot must reflect the demotion for subsequent calls this turn"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_snapshot_defaults_to_trusted() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "unclassified skill body";
+        let registry = make_registry_with_skill(dir.path(), "unknown-skill", body);
+        let gate = make_gate(registry, HashMap::new());
+        match gate.resolve_body("unknown-skill").await.unwrap() {
+            SkillBodyResolution::Body(returned) => {
+                assert!(!returned.contains("QUARANTINED"));
+                assert!(returned.contains(body));
+            }
+            other => panic!("expected Body, got a different variant: {other:?}"),
         }
     }
 }

--- a/crates/zeph-memory/src/store/trust.rs
+++ b/crates/zeph-memory/src/store/trust.rs
@@ -474,6 +474,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_requires_trust_check_flag() {
+        let store = test_store().await;
+
+        store
+            .upsert_skill_trust(
+                "git",
+                SkillTrustLevel::Trusted,
+                SourceKind::Local,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+
+        let row = store.load_skill_trust("git").await.unwrap().unwrap();
+        assert!(
+            !row.requires_trust_check,
+            "requires_trust_check must default to false on insert"
+        );
+
+        let updated = store.set_requires_trust_check("git", true).await.unwrap();
+        assert!(updated);
+        let row = store.load_skill_trust("git").await.unwrap().unwrap();
+        assert!(row.requires_trust_check);
+
+        let updated = store.set_requires_trust_check("git", false).await.unwrap();
+        assert!(updated);
+        let row = store.load_skill_trust("git").await.unwrap().unwrap();
+        assert!(!row.requires_trust_check);
+    }
+
+    #[tokio::test]
+    async fn set_requires_trust_check_nonexistent() {
+        let store = test_store().await;
+        let updated = store.set_requires_trust_check("nope", true).await.unwrap();
+        assert!(!updated);
+    }
+
+    #[tokio::test]
     async fn update_hash() {
         let store = test_store().await;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -874,6 +874,10 @@ pub(crate) enum SkillCommand {
         name: String,
         /// Trust level: trusted, verified, quarantined, blocked
         level: String,
+        /// Enable per-invocation blake3 integrity re-check: re-hash SKILL.md before every
+        /// dispatch and demote to quarantined on mismatch (#4293, #6080)
+        #[arg(long)]
+        require_check: bool,
     },
     /// Block a skill
     Block {

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -199,7 +199,11 @@ pub(crate) async fn handle_skill_command(
             }
         }
 
-        SkillCommand::Trust { name, level } => {
+        SkillCommand::Trust {
+            name,
+            level,
+            require_check,
+        } => {
             let trust_level = level.parse::<zeph_common::SkillTrustLevel>().map_err(|_| {
                 anyhow::anyhow!(
                     "invalid trust level: {level}. Use: trusted, verified, quarantined, blocked"
@@ -207,7 +211,7 @@ pub(crate) async fn handle_skill_command(
             })?;
 
             // REV-003: re-verify hash before promoting to trusted/verified.
-            if matches!(
+            let store = if matches!(
                 trust_level,
                 zeph_common::SkillTrustLevel::Trusted | zeph_common::SkillTrustLevel::Verified
             ) {
@@ -234,29 +238,31 @@ pub(crate) async fn handle_skill_command(
                     }
                     Some(_) => {}
                 }
-
-                let updated = store
-                    .set_skill_trust_level(&name, trust_level)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
-                if updated {
-                    println!("Trust level for \"{name}\" set to {trust_level}.");
-                } else {
-                    anyhow::bail!("skill \"{name}\" not found in trust database");
-                }
+                store
             } else {
-                let store = zeph_memory::store::SqliteStore::new(&sqlite_path)
+                zeph_memory::store::SqliteStore::new(&sqlite_path)
                     .await
-                    .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
-                let updated = store
-                    .set_skill_trust_level(&name, trust_level)
+                    .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?
+            };
+
+            let updated = store
+                .set_skill_trust_level(&name, trust_level)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if !updated {
+                anyhow::bail!("skill \"{name}\" not found in trust database");
+            }
+            println!("Trust level for \"{name}\" set to {trust_level}.");
+
+            // #6080: expose the previously unreachable `requires_trust_check` setter so the
+            // per-invocation blake3 re-check (`SkillTrustGate::resolve_body`) can actually be
+            // armed for a skill.
+            if require_check {
+                store
+                    .set_requires_trust_check(&name, true)
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
-                if updated {
-                    println!("Trust level for \"{name}\" set to {trust_level}.");
-                } else {
-                    anyhow::bail!("skill \"{name}\" not found in trust database");
-                }
+                println!("Per-invocation integrity re-check enabled for \"{name}\".");
             }
         }
 
@@ -291,43 +297,52 @@ pub(crate) async fn handle_skill_command(
         }
 
         SkillCommand::Invoke { name, args } => {
-            use zeph_common::SkillTrustLevel;
-            use zeph_skills::prompt::{sanitize_skill_text, wrap_quarantined};
+            use std::collections::HashMap;
+            use std::sync::Arc;
 
-            let registry = zeph_skills::registry::SkillRegistry::load(&[managed_dir]);
+            use parking_lot::RwLock;
+            use zeph_core::{SkillBodyResolution, SkillTrustGate, SkillTrustSnapshot};
+            use zeph_skills::prompt::sanitize_skill_text;
 
-            // Resolve persisted trust from SQLite. No trust row → Quarantined (fail-closed,
-            // matches `SkillTrustLevel::default`).
-            let trust = {
+            let registry = Arc::new(RwLock::new(zeph_skills::registry::SkillRegistry::load(&[
+                managed_dir,
+            ])));
+
+            // Load the full trust map so the CLI preview observes the exact same trust state
+            // (including `requires_trust_check`) as the agent's `load_skill`/`invoke_skill`
+            // tools — see `SkillTrustGate` (#6079).
+            let trust_snapshot: HashMap<String, SkillTrustSnapshot> = {
                 let store = zeph_memory::store::SqliteStore::new(&sqlite_path)
                     .await
                     .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
                 store
-                    .load_skill_trust(&name)
+                    .load_all_skill_trust()
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?
-                    .map(|r| r.trust_level)
-                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|r| {
+                        (
+                            r.skill_name,
+                            SkillTrustSnapshot {
+                                trust_level: r.trust_level,
+                                requires_trust_check: r.requires_trust_check,
+                                blake3_hash: r.blake3_hash,
+                            },
+                        )
+                    })
+                    .collect()
             };
 
-            if trust == SkillTrustLevel::Blocked {
-                anyhow::bail!("skill is blocked by policy: {name}");
-            }
-
-            let raw = registry
-                .body(&name)
+            let gate = SkillTrustGate::new(registry, Arc::new(RwLock::new(trust_snapshot)));
+            let body = match gate
+                .resolve_body(&name)
+                .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?
-                .to_owned();
-
-            let sanitized = if trust == SkillTrustLevel::Trusted {
-                raw
-            } else {
-                sanitize_skill_text(&raw)
-            };
-            let body = if trust == SkillTrustLevel::Quarantined {
-                wrap_quarantined(&name, &sanitized)
-            } else {
-                sanitized
+            {
+                SkillBodyResolution::Refused(message) | SkillBodyResolution::NotFound(message) => {
+                    anyhow::bail!("{message}");
+                }
+                SkillBodyResolution::Body(body) => body,
             };
 
             match args {


### PR DESCRIPTION
## Summary

- `SqliteStore::set_requires_trust_check` (`crates/zeph-memory/src/store/trust.rs`) had zero production callers anywhere in the codebase. The per-invocation blake3 integrity re-check gated by `requires_trust_check` was fully implemented and unit-tested on the consumption side since #4306/#6062, but could never be armed on any real deployment. Adds `--require-check` to `zeph skill trust <name> <level>` (CLI, `src/cli.rs`/`src/commands/skill.rs`) and `/skill trust <name> <level> --require-check` (in-session, `crates/zeph-core/src/agent/trust_commands.rs`), both calling the previously-unreachable setter.
- `zeph skill invoke <name>` (`src/commands/skill.rs::SkillCommand::Invoke`) was a hand-rolled reimplementation of skill trust gating that predated #6062's consolidation onto the shared `SkillTrustGate`. It never checked `requires_trust_check` at all and echoed the raw unsanitized skill name into its not-found error. `SkillTrustGate`/`SkillBodyResolution` are now `pub` at the `zeph-core` crate root, and `SkillCommand::Invoke` calls `SkillTrustGate::resolve_body` directly, so the CLI preview can no longer drift from the agent-facing tools (`load_skill`/`invoke_skill`).

## Behavioral note

`skill invoke` on a skill with no trust row now resolves to `trusted` (`MISSING_ENTRY_FALLBACK`), matching `load_skill`/`invoke_skill`'s established design, instead of the CLI's previous `quarantined` fallback. This is a consistency fix, verified during review — both agent-facing tools already used this fallback; the CLI was the outlier.

## Review findings addressed

- Blocking: `trust_commands.rs`'s `--require-check` parsing checked only the exact 3rd argument position, silently no-op'ing (with a success-looking message) on any extra/reordered args. Fixed to scan the full remaining argument slice; added regression test `trust_require_check_flag_arms_even_when_not_the_third_token`.
- `resolve_body`'s new rustdoc doctest had an unnecessary `no_run`, so it only compiled without executing its assertion — removed.
- `book/src/reference/cli.md` and `book/src/advanced/skill-trust.md` updated to document `--require-check` and the per-invocation integrity re-check concept, per this project's docs-on-user-facing-change rule.

## Follow-up

`--require-check` is manual-only (no automatic trigger or config default), which satisfies #6080 as filed but doesn't fully deliver its "operator doesn't have to remember" security intent. Tracked separately: #6087.

Closes #6080
Closes #6079

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12898 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `mdbook build` clean for the two updated doc pages
- [x] 10 new unit tests + 2 new doctests covering the setter activation path, CLI invoke trust routing, and the misparse regression