### PR TITLE
fix(security): consolidate duplicated sanitization and redaction logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     `apply_delta()` (atomic but decay-blind, unused in production) is removed — both
     properties now live in one method, eliminating the two-divergent-write-paths root
     cause.
+- `zeph-common`: consolidated three duplicated/diverging security-sanitization
+  implementations into single canonical sources, closing real defense-in-depth gaps
+  (#5925, #5915, #5917). `zeph_common::sanitize::strip_control_chars` and
+  `strip_control_chars_preserve_whitespace` previously stripped only ASCII controls plus
+  `BiDi` overrides — missing zero-width space/joiners, soft hyphen, BOM, Hangul/Khmer/
+  Mongolian fillers, and the Unicode Tags block that `zeph_common::patterns::
+  strip_format_chars` already covered. Both now share a single bypass-codepoint denylist
+  (`patterns::is_bypass_codepoint`), so `zeph-memory`'s graph-resolver `sanitize_fact`/
+  `sanitize_relation` (LLM-extracted entity/relation text stored in the graph and later
+  replayed into community-summarization prompts) transitively gain the stronger coverage
+  (#5925). `zeph-memory::graph::community`'s local `scrub_content` (only 4 filtered
+  categories) is removed; both call sites now use `strip_format_chars` directly (#5915).
+  `zeph-core::redact`'s `SECRET_PREFIXES`/`PATH_REGEX` and `zeph-memory::store::
+  compression_guidelines`'s `SECRET_RE`/`PATH_RE` duplicated the same prefix list
+  character-for-character while drifting apart — `zeph-memory` had gained `Authorization:
+  Bearer` header and standalone-JWT redaction that `zeph-core` lacked. A new
+  `zeph_common::secrets` module is now the single source of truth for
+  `SECRET_PREFIXES`/`PATH_PREFIXES`/`BEARER_TOKEN_PATTERN`/`JWT_PATTERN`; both crates build
+  their own `regex::Regex` from it (matching the existing `zeph_common::patterns`
+  raw-pattern convention), and `zeph-core::redact::redact_secrets`/`scrub_content` now also
+  redact Bearer headers and JWTs (#5917).
 - `zeph-mcp`: `sanitize_tools` walks `input_schema` and `output_schema` with the same
   recursive walker, which enforces `MAX_SCHEMA_DEPTH` (10) by returning without sanitizing
   the subtree at all once the cap is hit — no injection-pattern check, no truncation.

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -31,6 +31,7 @@ pub mod policy;
 pub mod quarantine;
 pub mod sanitize;
 pub mod secret;
+pub mod secrets;
 pub mod security_event;
 pub mod spawner;
 pub mod task_supervisor;

--- a/crates/zeph-common/src/patterns.rs
+++ b/crates/zeph-common/src/patterns.rs
@@ -141,6 +141,40 @@ pub const RAW_RESPONSE_PATTERNS: &[(&str, &str)] = &[
     ),
 ];
 
+/// Codepoints used as prompt-injection or secret-scrubbing bypass vectors: zero-width
+/// joiners, soft hyphen, BOM, directional overrides, Hangul/Khmer/Mongolian fillers, and
+/// the Unicode Tags block.
+///
+/// This is the single source of truth for the "invisible bypass character" denylist.
+/// Shared by [`strip_format_chars`] (preserves tab/newline) and
+/// [`crate::sanitize::strip_control_chars`] (strips all control characters, no
+/// whitespace exception) so both scrubbing paths cover the same codepoints and cannot
+/// silently drift apart — see #5925.
+#[must_use]
+pub(crate) fn is_bypass_codepoint(c: char) -> bool {
+    matches!(
+        c,
+        '\u{00AD}'  // Soft hyphen
+        | '\u{034F}'  // Combining grapheme joiner
+        | '\u{061C}'  // Arabic letter mark
+        | '\u{115F}'  // Hangul filler
+        | '\u{1160}'  // Hangul jungseong filler
+        | '\u{17B4}'  // Khmer vowel inherent aq
+        | '\u{17B5}'  // Khmer vowel inherent aa
+        | '\u{180B}'..='\u{180D}'  // Mongolian free variation selectors
+        | '\u{180F}'  // Mongolian free variation selector 4
+        | '\u{200B}'..='\u{200F}'  // Zero-width space/ZWNJ/ZWJ/LRM/RLM
+        | '\u{202A}'..='\u{202E}'  // Directional formatting
+        | '\u{2060}'..='\u{2064}'  // Word joiner / invisible separators
+        | '\u{2066}'..='\u{206F}'  // Bidi controls
+        | '\u{FEFF}'  // BOM / zero-width no-break space
+        | '\u{FFF9}'..='\u{FFFB}'  // Interlinear annotation
+        | '\u{1BCA0}'..='\u{1BCA3}'  // Shorthand format controls
+        | '\u{1D173}'..='\u{1D17A}'  // Musical symbol beam controls
+        | '\u{E0000}'..='\u{E007F}'  // Tags block
+    )
+}
+
 /// Strip Unicode format (Cf) characters, selected Lo-category fillers (U+115F, U+1160),
 /// and ASCII control characters (except tab/newline) from `text` before injection pattern
 /// matching.
@@ -148,6 +182,10 @@ pub const RAW_RESPONSE_PATTERNS: &[(&str, &str)] = &[
 /// These characters are invisible to humans but can break regex word boundaries,
 /// allowing attackers to smuggle injection keywords through zero-width joiners,
 /// soft hyphens, BOM, or Hangul filler codepoints.
+///
+/// Preserves tab and newline, unlike [`crate::sanitize::strip_control_chars`], which strips
+/// all control characters unconditionally — use that variant instead when the caller needs
+/// a single-line normalized value (e.g. an entity name or dedup key).
 ///
 /// # Examples
 ///
@@ -171,27 +209,7 @@ pub fn strip_format_chars(text: &str) -> String {
                 return false;
             }
             // Drop known Unicode Cf (format) codepoints that are used as bypass vectors
-            !matches!(
-                c,
-                '\u{00AD}'  // Soft hyphen
-                | '\u{034F}'  // Combining grapheme joiner
-                | '\u{061C}'  // Arabic letter mark
-                | '\u{115F}'  // Hangul filler
-                | '\u{1160}'  // Hangul jungseong filler
-                | '\u{17B4}'  // Khmer vowel inherent aq
-                | '\u{17B5}'  // Khmer vowel inherent aa
-                | '\u{180B}'..='\u{180D}'  // Mongolian free variation selectors
-                | '\u{180F}'  // Mongolian free variation selector 4
-                | '\u{200B}'..='\u{200F}'  // Zero-width space/ZWNJ/ZWJ/LRM/RLM
-                | '\u{202A}'..='\u{202E}'  // Directional formatting
-                | '\u{2060}'..='\u{2064}'  // Word joiner / invisible separators
-                | '\u{2066}'..='\u{206F}'  // Bidi controls
-                | '\u{FEFF}'  // BOM / zero-width no-break space
-                | '\u{FFF9}'..='\u{FFFB}'  // Interlinear annotation
-                | '\u{1BCA0}'..='\u{1BCA3}'  // Shorthand format controls
-                | '\u{1D173}'..='\u{1D17A}'  // Musical symbol beam controls
-                | '\u{E0000}'..='\u{E007F}'  // Tags block
-            )
+            !is_bypass_codepoint(c)
         })
         .collect()
 }

--- a/crates/zeph-common/src/sanitize.rs
+++ b/crates/zeph-common/src/sanitize.rs
@@ -27,28 +27,34 @@ impl OutputSanitizer for IdentitySanitizer {
     }
 }
 
-/// Strip ASCII control characters (U+0000–U+001F, U+007F) from `s`.
+/// Strip all Unicode control characters from `s`, plus the shared bypass-codepoint
+/// denylist (`BiDi` overrides, zero-width joiners, soft hyphen, BOM, Hangul/Khmer/Mongolian
+/// fillers, the Unicode Tags block — see [`crate::patterns::strip_format_chars`] for the
+/// full list).
 ///
-/// Also strips Unicode `BiDi` override codepoints (U+202A–U+202E, U+2066–U+2069)
-/// which can be used to visually obscure malicious content.
+/// Use [`strip_control_chars_preserve_whitespace`] instead when the input may contain
+/// intentional tabs or newlines that should be kept.
 #[must_use]
 pub fn strip_control_chars(s: &str) -> String {
     s.chars()
-        .filter(|c| !c.is_control() && !matches!(*c as u32, 0x202A..=0x202E | 0x2066..=0x2069))
+        .filter(|&c| !c.is_control() && !crate::patterns::is_bypass_codepoint(c))
         .collect()
 }
 
-/// Strip ASCII control characters while preserving common whitespace (`\t`, `\n`, `\r`).
+/// Strip ASCII control characters while preserving common whitespace (`\t`, `\n`, `\r`),
+/// plus the shared bypass-codepoint denylist (see [`strip_control_chars`] /
+/// [`crate::patterns::strip_format_chars`]).
 ///
-/// Also strips Unicode `BiDi` override codepoints (U+202A–U+202E, U+2066–U+2069).
 /// Use this variant when the input may contain intentional newlines or tabs that
-/// should be kept (e.g., multi-line tool output, webhook payloads).
+/// should be kept (e.g., multi-line tool output, webhook payloads). Note this preserves
+/// `\r` in addition to `\t`/`\n` (unlike [`crate::patterns::strip_format_chars`], which only
+/// preserves `\t`/`\n`) — callers that need CRLF line endings intact use this function.
 #[must_use]
 pub fn strip_control_chars_preserve_whitespace(s: &str) -> String {
     s.chars()
         .filter(|&c| {
             (!c.is_control() || c == '\t' || c == '\n' || c == '\r')
-                && !matches!(c as u32, 0x202A..=0x202E | 0x2066..=0x2069)
+                && !crate::patterns::is_bypass_codepoint(c)
         })
         .collect()
 }
@@ -90,5 +96,71 @@ mod tests {
     #[test]
     fn null_bytes_empty_string() {
         assert_eq!(strip_null_bytes(""), "");
+    }
+
+    // ── #5925: strip_control_chars now shares strip_format_chars's bypass-codepoint set ──
+
+    #[test]
+    fn strip_control_chars_removes_zero_width_space() {
+        let result = strip_control_chars("ig\u{200B}nore");
+        assert!(!result.contains('\u{200B}'));
+        assert_eq!(result, "ignore");
+    }
+
+    #[test]
+    fn strip_control_chars_removes_soft_hyphen() {
+        let result = strip_control_chars("nor\u{00AD}mal");
+        assert!(!result.contains('\u{00AD}'));
+        assert_eq!(result, "normal");
+    }
+
+    #[test]
+    fn strip_control_chars_removes_bom() {
+        let result = strip_control_chars("\u{FEFF}hello");
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn strip_control_chars_removes_hangul_khmer_mongolian_fillers() {
+        assert_eq!(strip_control_chars("a\u{115F}b"), "ab");
+        assert_eq!(strip_control_chars("a\u{1160}b"), "ab");
+        assert_eq!(strip_control_chars("a\u{17B4}b"), "ab");
+        assert_eq!(strip_control_chars("a\u{180B}b"), "ab");
+    }
+
+    #[test]
+    fn strip_control_chars_removes_tags_block() {
+        // U+E0041 TAG LATIN SMALL LETTER A — steganographic prompt-injection vector.
+        let result = strip_control_chars("safe\u{E0041}text");
+        assert!(!result.contains('\u{E0041}'));
+        assert_eq!(result, "safetext");
+    }
+
+    #[test]
+    fn preserve_whitespace_shares_bypass_codepoints_with_strip_format_chars() {
+        // Same bypass-codepoint filtering as strip_format_chars, but preserves `\r` too
+        // (strip_format_chars only preserves `\t`/`\n`) — see #5925.
+        let input = "ig\u{200B}nore\ninstructions\tnow";
+        assert_eq!(
+            strip_control_chars_preserve_whitespace(input),
+            crate::patterns::strip_format_chars(input)
+        );
+    }
+
+    #[test]
+    fn preserve_whitespace_keeps_carriage_return_unlike_strip_format_chars() {
+        let input = "line1\r\nline2";
+        assert_eq!(
+            strip_control_chars_preserve_whitespace(input),
+            "line1\r\nline2"
+        );
+        assert_eq!(crate::patterns::strip_format_chars(input), "line1\nline2");
+    }
+
+    #[test]
+    fn preserve_whitespace_removes_bypass_codepoints_keeps_newline_tab() {
+        let input = "a\u{00AD}b\nc\td\u{FEFF}e";
+        let result = strip_control_chars_preserve_whitespace(input);
+        assert_eq!(result, "ab\nc\tde");
     }
 }

--- a/crates/zeph-common/src/secrets.rs
+++ b/crates/zeph-common/src/secrets.rs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Canonical secret-token and path prefixes shared by redaction layers across crates.
+//!
+//! `zeph-core::redact` and `zeph-memory::store::compression_guidelines` both scrub
+//! secrets and filesystem paths before persisting or displaying untrusted text. Each
+//! crate previously carried its own hand-rolled copy of these lists, and the copies had
+//! already begun to drift from each other (see #5917). This module is the single source
+//! of truth for the raw prefixes/patterns; consumers compile their own `regex::Regex`
+//! instances from these constants — `zeph-common` does not depend on `regex` outside of
+//! tests, matching the pattern established by [`crate::patterns`].
+
+/// Prefixes of API keys, tokens, and other secret material recognized across Zeph.
+///
+/// Each entry is a literal prefix, not regex-escaped. Consumers building a regex
+/// alternation from this list must escape entries themselves (e.g. via `regex::escape`),
+/// since `ya29.` contains a literal `.` that must not be treated as "match any character".
+pub const SECRET_PREFIXES: &[&str] = &[
+    "sk-",
+    "sk_live_",
+    "sk_test_",
+    "AKIA",
+    "ghp_",
+    "gho_",
+    "-----BEGIN",
+    "xoxb-",
+    "xoxp-",
+    "AIza",
+    "ya29.",
+    "glpat-",
+    "hf_",
+    "npm_",
+    "dckr_pat_",
+];
+
+/// Absolute filesystem path prefixes redacted before persisting or displaying untrusted
+/// text, to avoid leaking local usernames or directory layout.
+pub const PATH_PREFIXES: &[&str] = &["/home/", "/Users/", "/root/", "/tmp/", "/var/"];
+
+/// Regex pattern matching `Authorization: Bearer <token>` headers.
+///
+/// Capture group 1 covers the header name up to and including the token's leading
+/// whitespace, so replacing with `"${1}[REDACTED]"` preserves the header name while
+/// redacting only the token value.
+pub const BEARER_TOKEN_PATTERN: &str = r"(?i)(Authorization:\s*Bearer\s+)\S+";
+
+/// Regex pattern matching standalone JWTs (three Base64url-encoded segments separated by
+/// dots).
+///
+/// The final segment uses `*` (not `+`) so it also matches `alg=none` JWTs, which carry an
+/// empty signature segment.
+pub const JWT_PATTERN: &str = r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*";
+
+#[cfg(test)]
+mod tests {
+    use regex::Regex;
+
+    use super::*;
+
+    #[test]
+    fn bearer_pattern_compiles_and_matches() {
+        let re = Regex::new(BEARER_TOKEN_PATTERN).unwrap();
+        assert!(re.is_match("Authorization: Bearer abc.def.ghi"));
+    }
+
+    #[test]
+    fn jwt_pattern_compiles_and_matches() {
+        let re = Regex::new(JWT_PATTERN).unwrap();
+        assert!(re.is_match("eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig"));
+    }
+
+    #[test]
+    fn jwt_pattern_matches_alg_none_empty_signature() {
+        let re = Regex::new(JWT_PATTERN).unwrap();
+        assert!(re.is_match("eyJhbGciOiJub25lIn0.eyJzdWIiOiJ1c2VyIn0."));
+    }
+
+    #[test]
+    fn secret_prefixes_build_valid_escaped_regex_alternation() {
+        let pattern = SECRET_PREFIXES
+            .iter()
+            .map(|p| regex::escape(p))
+            .collect::<Vec<_>>()
+            .join("|");
+        let full = format!("(?:{pattern})[^\\s]*");
+        let re = Regex::new(&full).expect("alternation built from SECRET_PREFIXES must compile");
+        assert!(re.is_match("sk-abc123"));
+        assert!(re.is_match("ya29.a0AfH6"));
+    }
+
+    #[test]
+    fn path_prefixes_build_valid_regex_alternation() {
+        let pattern = PATH_PREFIXES.join("|");
+        let full = format!("(?:{pattern})[^\\s]*");
+        let re = Regex::new(&full).expect("alternation built from PATH_PREFIXES must compile");
+        assert!(re.is_match("/home/user/file"));
+    }
+}

--- a/crates/zeph-core/src/redact.rs
+++ b/crates/zeph-core/src/redact.rs
@@ -4,66 +4,45 @@
 use std::borrow::Cow;
 use std::sync::LazyLock;
 
-/// Apply both secret redaction and path sanitization in a single pass.
+use regex::Regex;
+use zeph_common::secrets::{BEARER_TOKEN_PATTERN, JWT_PATTERN, PATH_PREFIXES, SECRET_PREFIXES};
+
+/// Apply URL-credential stripping, secret redaction (including Bearer headers and JWTs),
+/// and path sanitization in a single pass.
 ///
 /// Returns `Cow::Borrowed` when no changes are needed (zero-allocation fast path).
 #[must_use]
 pub fn scrub_content(text: &str) -> Cow<'_, str> {
     // Strip URL-embedded credentials first (https://user:pass@host → https://[REDACTED]@host).
-    let after_url = match URL_CREDS_REGEX.replace_all(text, "${scheme}[REDACTED]@") {
-        Cow::Borrowed(_) => Cow::Borrowed(text),
+    let after_url: Cow<'_, str> = URL_CREDS_REGEX.replace_all(text, "${scheme}[REDACTED]@");
+    let after_secrets: Cow<'_, str> = match redact_secrets(after_url.as_ref()) {
+        Cow::Borrowed(_) => after_url,
         Cow::Owned(s) => Cow::Owned(s),
     };
-    let after_url_str: &str = &after_url;
-
-    let after_secrets = match redact_secrets(after_url_str) {
-        Cow::Borrowed(_) => {
-            return match sanitize_paths(after_url_str) {
-                Cow::Owned(s) => Cow::Owned(s),
-                Cow::Borrowed(_) => after_url,
-            };
-        }
-        Cow::Owned(s) => s,
-    };
-
-    // Third pass: path sanitization on already-modified string
-    match sanitize_paths(&after_secrets) {
+    match sanitize_paths(after_secrets.as_ref()) {
+        Cow::Borrowed(_) => after_secrets,
         Cow::Owned(s) => Cow::Owned(s),
-        Cow::Borrowed(_) => Cow::Owned(after_secrets),
     }
 }
 
-use regex::Regex;
-
-const SECRET_PREFIXES: &[&str] = &[
-    "sk-",
-    "sk_live_",
-    "sk_test_",
-    "AKIA",
-    "ghp_",
-    "gho_",
-    "-----BEGIN",
-    "xoxb-",
-    "xoxp-",
-    "AIza",
-    "ya29\\.",
-    "glpat-",
-    "hf_",
-    "npm_",
-    "dckr_pat_",
-];
-
 // Matches any secret prefix followed by non-whitespace characters.
-// Using alternation so a single pass covers all prefixes.
+// Using alternation so a single pass covers all prefixes. Prefixes come from
+// zeph_common::secrets::SECRET_PREFIXES (the canonical, unescaped list — see #5917)
+// and are regex-escaped here since e.g. `ya29.` contains a literal dot.
 static SECRET_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    let pattern = SECRET_PREFIXES.join("|");
+    let pattern = SECRET_PREFIXES
+        .iter()
+        .map(|p| regex::escape(p))
+        .collect::<Vec<_>>()
+        .join("|");
     let full = format!("(?:{pattern})[^\\s\"'`,;{{}}\\[\\]]*");
     Regex::new(&full).expect("secret redaction regex is valid")
 });
 
 static PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?:/home/|/Users/|/root/|/tmp/|/var/)[^\s"'`,;{}\[\]]*"#)
-        .expect("path redaction regex is valid")
+    let alt = PATH_PREFIXES.join("|");
+    let full = format!(r#"(?:{alt})[^\s"'`,;{{}}\[\]]*"#);
+    Regex::new(&full).expect("path redaction regex is valid")
 });
 
 // Matches basic-auth credentials embedded in URLs: https://user:pass@host
@@ -72,37 +51,40 @@ static URL_CREDS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         .expect("url credential redaction regex is valid")
 });
 
+// Matches `Authorization: Bearer <token>` headers, keeping the header name via capture group 1.
+static BEARER_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(BEARER_TOKEN_PATTERN).expect("bearer redaction regex is valid"));
+
+// Matches standalone JWTs (three Base64url-encoded segments separated by dots).
+static JWT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(JWT_PATTERN).expect("jwt redaction regex is valid"));
+
 /// Replace tokens containing known secret patterns with `[REDACTED]`.
 ///
-/// Detects secrets embedded in URLs, JSON values, and quoted strings.
-/// Returns `Cow::Borrowed` when no secrets found (zero-allocation fast path).
+/// Detects secrets embedded in URLs, JSON values, and quoted strings (via the
+/// [`zeph_common::secrets::SECRET_PREFIXES`] prefix list), `Authorization: Bearer` headers,
+/// and standalone JWTs. Returns `Cow::Borrowed` when nothing was redacted (zero-allocation
+/// fast path).
 #[must_use]
 pub fn redact_secrets(text: &str) -> Cow<'_, str> {
-    // Fast path: check for any prefix substring before running regex.
-    let raw_prefixes = &[
-        "sk-",
-        "sk_live_",
-        "sk_test_",
-        "AKIA",
-        "ghp_",
-        "gho_",
-        "-----BEGIN",
-        "xoxb-",
-        "xoxp-",
-        "AIza",
-        "ya29.",
-        "glpat-",
-        "hf_",
-        "npm_",
-        "dckr_pat_",
-    ];
-    if !raw_prefixes.iter().any(|p| text.contains(p)) {
-        return Cow::Borrowed(text);
-    }
+    // Fast path: check for any prefix substring before running the (more expensive)
+    // alternation regex. Bearer/JWT regexes below are cheap enough to run unconditionally —
+    // `Regex::replace_all` itself returns `Cow::Borrowed` when there is no match.
+    let has_prefix_match = SECRET_PREFIXES.iter().any(|p| text.contains(*p));
+    let after_prefixes: Cow<'_, str> = if has_prefix_match {
+        SECRET_REGEX.replace_all(text, "[REDACTED]")
+    } else {
+        Cow::Borrowed(text)
+    };
 
-    let result = SECRET_REGEX.replace_all(text, "[REDACTED]");
-    match result {
-        Cow::Borrowed(_) => Cow::Borrowed(text),
+    let after_bearer: Cow<'_, str> =
+        match BEARER_REGEX.replace_all(after_prefixes.as_ref(), "${1}[REDACTED]") {
+            Cow::Borrowed(_) => after_prefixes,
+            Cow::Owned(s) => Cow::Owned(s),
+        };
+
+    match JWT_REGEX.replace_all(after_bearer.as_ref(), "[REDACTED_JWT]") {
+        Cow::Borrowed(_) => after_bearer,
         Cow::Owned(s) => Cow::Owned(s),
     }
 }
@@ -110,9 +92,7 @@ pub fn redact_secrets(text: &str) -> Cow<'_, str> {
 /// Replace absolute filesystem paths with `[PATH]` to prevent information disclosure.
 #[must_use]
 pub fn sanitize_paths(text: &str) -> Cow<'_, str> {
-    const PATH_PREFIXES: &[&str] = &["/home/", "/Users/", "/root/", "/tmp/", "/var/"];
-
-    if !PATH_PREFIXES.iter().any(|p| text.contains(p)) {
+    if !PATH_PREFIXES.iter().any(|p| text.contains(*p)) {
         return Cow::Borrowed(text);
     }
 
@@ -244,23 +224,7 @@ mod tests {
 
     #[test]
     fn all_secret_prefixes_tested() {
-        for prefix in &[
-            "sk-",
-            "sk_live_",
-            "sk_test_",
-            "AKIA",
-            "ghp_",
-            "gho_",
-            "-----BEGIN",
-            "xoxb-",
-            "xoxp-",
-            "AIza",
-            "ya29.",
-            "glpat-",
-            "hf_",
-            "npm_",
-            "dckr_pat_",
-        ] {
+        for prefix in SECRET_PREFIXES {
             let text = format!("token: {prefix}abc123");
             let result = redact_secrets(&text);
             assert!(result.contains("[REDACTED]"), "Failed for prefix: {prefix}");
@@ -433,6 +397,70 @@ mod tests {
         }
     }
 
+    // ── #5917: Bearer/JWT coverage added to redact_secrets/scrub_content ──────────────
+
+    #[test]
+    fn redacts_bearer_token() {
+        let result = redact_secrets("Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.signature");
+        assert!(
+            result.contains("[REDACTED]"),
+            "Bearer token must be redacted: {result}"
+        );
+        assert!(
+            !result.contains("eyJhbGciOiJSUzI1NiJ9"),
+            "raw JWT header must not appear: {result}"
+        );
+        assert!(
+            result.contains("Authorization:"),
+            "header name must be preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn redacts_bearer_token_case_insensitive() {
+        let result = redact_secrets("authorization: bearer eyJhbGciOiJSUzI1NiJ9.payload.signature");
+        assert!(
+            result.contains("[REDACTED]"),
+            "Bearer header match must be case-insensitive: {result}"
+        );
+    }
+
+    #[test]
+    fn redacts_standalone_jwt() {
+        let jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.SflKxwRJSMeKKF2";
+        let input = format!("token value: {jwt} was found in logs");
+        let result = redact_secrets(&input);
+        assert!(
+            result.contains("[REDACTED_JWT]"),
+            "standalone JWT must be replaced with [REDACTED_JWT]: {result}"
+        );
+        assert!(
+            !result.contains("eyJhbGci"),
+            "raw JWT must not appear: {result}"
+        );
+    }
+
+    #[test]
+    fn redacts_alg_none_jwt_with_empty_signature() {
+        let input = "token: eyJhbGciOiJub25lIn0.eyJzdWIiOiJ1c2VyIn0. was submitted";
+        let result = redact_secrets(input);
+        assert!(
+            result.contains("[REDACTED_JWT]"),
+            "alg=none JWT with empty signature must be redacted: {result}"
+        );
+    }
+
+    #[test]
+    fn scrub_content_redacts_secret_path_bearer_and_jwt_together() {
+        let text =
+            "key sk-abc123 at /home/user/f with Authorization: Bearer eyJhbG.pay.sig and eyJx.b.c";
+        let result = scrub_content(text);
+        assert!(result.contains("[REDACTED]"), "API key must be redacted");
+        assert!(result.contains("[PATH]"), "path must be redacted");
+        assert!(!result.contains("sk-abc123"), "raw API key must not appear");
+        assert!(!result.contains("eyJhbG"), "raw JWT must not appear");
+    }
+
     proptest! {
         #[test]
         fn redact_secrets_never_panics(s in ".*") {
@@ -446,13 +474,12 @@ mod tests {
 
         #[test]
         fn redact_preserves_non_secret_text(s in "[a-zA-Z0-9 .,!?]{1,200}") {
-            // Only test strings that genuinely contain no secret prefixes.
-            let secret_prefixes = [
-                "sk-", "sk_live_", "sk_test_", "AKIA", "ghp_", "gho_",
-                "-----BEGIN", "xoxb-", "xoxp-", "AIza", "ya29.", "glpat-",
-                "hf_", "npm_", "dckr_pat_",
-            ];
-            if !secret_prefixes.iter().any(|p| s.contains(p)) {
+            // Only test strings that genuinely contain nothing redact_secrets will touch:
+            // no known secret prefix, no "eyJ" (JWT marker), no case-insensitive "bearer".
+            let has_secret_prefix = SECRET_PREFIXES.iter().any(|p| s.contains(*p));
+            let has_jwt_marker = s.contains("eyJ");
+            let has_bearer_marker = s.to_lowercase().contains("bearer");
+            if !has_secret_prefix && !has_jwt_marker && !has_bearer_marker {
                 let result = redact_secrets(&s);
                 assert_eq!(result.as_ref(), s.as_str());
             }
@@ -466,13 +493,9 @@ mod tests {
         #[test]
         fn scrub_content_result_never_contains_raw_secret(s in ".*") {
             let result = scrub_content(&s);
-            let secret_prefixes = [
-                "sk-", "sk_live_", "sk_test_", "AKIA", "ghp_", "gho_",
-                "xoxb-", "xoxp-", "AIza", "glpat-", "dckr_pat_",
-            ];
-            for prefix in secret_prefixes {
+            for prefix in SECRET_PREFIXES {
                 assert!(
-                    !result.contains(prefix),
+                    !result.contains(*prefix),
                     "scrub_content must redact prefix: {prefix}"
                 );
             }

--- a/crates/zeph-memory/src/graph/community.rs
+++ b/crates/zeph-memory/src/graph/community.rs
@@ -12,6 +12,7 @@ use petgraph::Graph;
 use petgraph::graph::NodeIndex;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
+use zeph_common::patterns::strip_format_chars;
 use zeph_llm::LlmProvider as _;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{Message, Role};
@@ -22,25 +23,6 @@ use super::store::GraphStore;
 use super::types::{Edge, Entity};
 
 const MAX_LABEL_PROPAGATION_ITERATIONS: usize = 50;
-
-/// Strip control characters, Unicode bidi overrides, and zero-width characters from `s`
-/// to prevent prompt injection via entity names or edge facts sourced from untrusted text.
-///
-/// Filtered categories:
-/// - All Unicode control characters (`Cc` category, covers ASCII controls and more)
-/// - Bidi control characters: U+202A–U+202E, U+2066–U+2069
-/// - Zero-width and invisible characters: U+200B–U+200F (includes U+200C, U+200D)
-/// - Byte-order mark: U+FEFF
-fn scrub_content(s: &str) -> String {
-    s.chars()
-        .filter(|c| {
-            !c.is_control()
-                && !matches!(*c as u32,
-                    0x200B..=0x200F | 0x202A..=0x202E | 0x2066..=0x2069 | 0xFEFF
-                )
-        })
-        .collect()
-}
 
 /// Stats returned from graph eviction.
 #[derive(Debug, Default)]
@@ -251,7 +233,7 @@ fn classify_communities(
         let mut intra_edge_ids: Vec<i64> = Vec::new();
         for (&(src, tgt), facts) in edge_facts_map {
             if member_set.contains(&src) && member_set.contains(&tgt) {
-                intra_facts.extend(facts.iter().map(|f| scrub_content(f)));
+                intra_facts.extend(facts.iter().map(|f| strip_format_chars(f)));
                 if let Some(ids) = edge_id_map.get(&(src, tgt)) {
                     intra_edge_ids.extend_from_slice(ids);
                 }
@@ -268,7 +250,7 @@ fn classify_communities(
 
         let entity_names: Vec<String> = entity_ids
             .iter()
-            .filter_map(|id| entity_name_map.get(id).map(|&s| scrub_content(s)))
+            .filter_map(|id| entity_name_map.get(id).map(|&s| strip_format_chars(s)))
             .collect();
 
         // Append label_index to prevent ON CONFLICT(name) collisions when two communities
@@ -937,40 +919,106 @@ mod tests {
         assert_eq!(store2.extraction_count().await.unwrap(), 5);
     }
 
+    // ── #5915: community.rs's local scrub_content removed — migrated call sites now use
+    // zeph_common::patterns::strip_format_chars directly. These tests exercise both
+    // migrated call sites (entity_names and intra_facts) via classify_communities to prove
+    // codepoints the old local scrub_content missed (soft hyphen, Hangul/Khmer/Mongolian
+    // fillers, Unicode Tags block) are now stripped end-to-end, not just unit-tested on the
+    // shared helper in isolation. ──────────────────────────────────────────────────────
+
     #[test]
-    fn test_scrub_content_ascii_control() {
-        // Newline, carriage return, null byte, tab (all ASCII control chars) must be stripped.
-        let input = "hello\nworld\r\x00\x01\x09end";
-        assert_eq!(scrub_content(input), "helloworldend");
+    fn test_classify_communities_strips_bypass_codepoints_from_facts_and_names() {
+        let mut edge_facts_map: HashMap<(i64, i64), Vec<String>> = HashMap::new();
+        edge_facts_map.insert(
+            (1, 2),
+            vec!["fact\u{00AD}with\u{200B}soft\u{FEFF}hyphen".to_owned()],
+        );
+        let mut edge_id_map: HashMap<(i64, i64), Vec<i64>> = HashMap::new();
+        edge_id_map.insert((1, 2), vec![1]);
+
+        let mut communities: HashMap<usize, Vec<i64>> = HashMap::new();
+        communities.insert(0, vec![1, 2]);
+
+        let mut entity_name_map: HashMap<i64, &str> = HashMap::new();
+        entity_name_map.insert(1, "Entity\u{115F}One");
+        entity_name_map.insert(2, "Entity\u{1160}Two\u{17B4}");
+
+        let stored_fingerprints: HashMap<String, i64> = HashMap::new();
+        let sorted_labels = vec![0usize];
+
+        let result = classify_communities(
+            &communities,
+            &edge_facts_map,
+            &edge_id_map,
+            &entity_name_map,
+            &stored_fingerprints,
+            &sorted_labels,
+        );
+
+        assert_eq!(result.to_summarize.len(), 1);
+        let data = &result.to_summarize[0];
+
+        for fact in &data.intra_facts {
+            assert!(
+                !fact.contains('\u{00AD}'),
+                "soft hyphen must be stripped: {fact:?}"
+            );
+            assert!(
+                !fact.contains('\u{200B}'),
+                "zero-width space must be stripped: {fact:?}"
+            );
+            assert!(!fact.contains('\u{FEFF}'), "BOM must be stripped: {fact:?}");
+            assert!(fact.contains("factwithsofthyphen"));
+        }
+
+        for name in &data.entity_names {
+            assert!(
+                !name.contains('\u{115F}'),
+                "Hangul filler must be stripped: {name:?}"
+            );
+            assert!(
+                !name.contains('\u{1160}'),
+                "Hangul jungseong filler must be stripped: {name:?}"
+            );
+            assert!(
+                !name.contains('\u{17B4}'),
+                "Khmer filler must be stripped: {name:?}"
+            );
+        }
+        assert!(data.entity_names.contains(&"EntityOne".to_owned()));
+        assert!(data.entity_names.contains(&"EntityTwo".to_owned()));
     }
 
     #[test]
-    fn test_scrub_content_bidi_overrides() {
-        // U+202A LEFT-TO-RIGHT EMBEDDING, U+202E RIGHT-TO-LEFT OVERRIDE,
-        // U+2066 LEFT-TO-RIGHT ISOLATE, U+2069 POP DIRECTIONAL ISOLATE.
-        let input = "safe\u{202A}inject\u{202E}end\u{2066}iso\u{2069}done".to_string();
-        assert_eq!(scrub_content(&input), "safeinjectendisodone");
-    }
+    fn test_classify_communities_strips_tags_block_from_facts() {
+        // U+E0041 TAG LATIN SMALL LETTER A — steganographic prompt-injection vector.
+        let mut edge_facts_map: HashMap<(i64, i64), Vec<String>> = HashMap::new();
+        edge_facts_map.insert((1, 2), vec!["safe\u{E0041}fact".to_owned()]);
+        let mut edge_id_map: HashMap<(i64, i64), Vec<i64>> = HashMap::new();
+        edge_id_map.insert((1, 2), vec![1]);
 
-    #[test]
-    fn test_scrub_content_zero_width() {
-        // U+200B ZERO WIDTH SPACE, U+200C ZERO WIDTH NON-JOINER, U+200D ZERO WIDTH JOINER,
-        // U+200F RIGHT-TO-LEFT MARK.
-        let input = "a\u{200B}b\u{200C}c\u{200D}d\u{200F}e".to_string();
-        assert_eq!(scrub_content(&input), "abcde");
-    }
+        let mut communities: HashMap<usize, Vec<i64>> = HashMap::new();
+        communities.insert(0, vec![1, 2]);
 
-    #[test]
-    fn test_scrub_content_bom() {
-        // U+FEFF BYTE ORDER MARK must be stripped.
-        let input = "\u{FEFF}hello".to_string();
-        assert_eq!(scrub_content(&input), "hello");
-    }
+        let mut entity_name_map: HashMap<i64, &str> = HashMap::new();
+        entity_name_map.insert(1, "A");
+        entity_name_map.insert(2, "B");
 
-    #[test]
-    fn test_scrub_content_clean_string_unchanged() {
-        let input = "Hello, World! 123 — normal text.";
-        assert_eq!(scrub_content(input), input);
+        let stored_fingerprints: HashMap<String, i64> = HashMap::new();
+        let sorted_labels = vec![0usize];
+
+        let result = classify_communities(
+            &communities,
+            &edge_facts_map,
+            &edge_id_map,
+            &entity_name_map,
+            &stored_fingerprints,
+            &sorted_labels,
+        );
+
+        let data = &result.to_summarize[0];
+        assert!(data.intra_facts.iter().all(|f| !f.contains('\u{E0041}')));
+        assert!(data.intra_facts.iter().any(|f| f == "safefact"));
     }
 
     #[test]

--- a/crates/zeph-memory/src/graph/resolver/tests.rs
+++ b/crates/zeph-memory/src/graph/resolver/tests.rs
@@ -83,6 +83,43 @@ fn sanitize_fact_truncates_oversized_input() {
     assert_eq!(result.len(), MAX_FACT_BYTES);
 }
 
+// ── #5925: sanitize_relation/sanitize_fact call strip_control_chars, which now shares
+// strip_format_chars's bypass-codepoint set — verify the extra coverage flows through. ──
+
+#[test]
+fn sanitize_relation_strips_zero_width_space() {
+    assert_eq!(sanitize_relation("us\u{200B}es"), "uses");
+}
+
+#[test]
+fn sanitize_relation_strips_soft_hyphen() {
+    assert_eq!(sanitize_relation("us\u{00AD}es"), "uses");
+}
+
+#[test]
+fn sanitize_relation_strips_hangul_filler() {
+    assert_eq!(sanitize_relation("us\u{115F}es"), "uses");
+}
+
+#[test]
+fn sanitize_fact_strips_bom_and_zero_width() {
+    let dirty = "\u{FEFF}Alice us\u{200B}es Rust";
+    assert_eq!(sanitize_fact(dirty), "Alice uses Rust");
+}
+
+#[test]
+fn sanitize_fact_strips_mongolian_and_khmer_fillers() {
+    let dirty = "Alice\u{180B} uses\u{17B4} Rust";
+    assert_eq!(sanitize_fact(dirty), "Alice uses Rust");
+}
+
+#[test]
+fn sanitize_fact_strips_tags_block() {
+    // U+E0041 TAG LATIN SMALL LETTER A — steganographic prompt-injection vector.
+    let dirty = "Alice uses\u{E0041} Rust";
+    assert_eq!(sanitize_fact(dirty), "Alice uses Rust");
+}
+
 // ── Existing tests (resolve() with no embedding store — exact match only) ──
 
 #[tokio::test]
@@ -483,6 +520,20 @@ fn strip_control_chars_removes_bidi() {
 fn strip_control_chars_preserves_normal_unicode() {
     assert_eq!(strip_control_chars("привет мир"), "привет мир");
     assert_eq!(strip_control_chars("日本語"), "日本語");
+}
+
+#[test]
+fn strip_control_chars_removes_soft_hyphen_and_bom() {
+    assert_eq!(strip_control_chars("nor\u{00AD}mal"), "normal");
+    assert_eq!(strip_control_chars("\u{FEFF}hello"), "hello");
+}
+
+#[test]
+fn strip_control_chars_removes_hangul_khmer_mongolian_fillers() {
+    assert_eq!(
+        strip_control_chars("a\u{115F}b\u{1160}c\u{17B4}d\u{180B}e"),
+        "abcde"
+    );
 }
 
 #[test]

--- a/crates/zeph-memory/src/store/compression_guidelines.rs
+++ b/crates/zeph-memory/src/store/compression_guidelines.rs
@@ -9,32 +9,37 @@ use std::sync::LazyLock;
 use zeph_db::sql;
 
 use regex::Regex;
+use zeph_common::secrets::{BEARER_TOKEN_PATTERN, JWT_PATTERN, PATH_PREFIXES, SECRET_PREFIXES};
 use zeph_common::text::truncate_to_bytes_ref;
 
 use crate::error::MemoryError;
 use crate::store::SqliteStore;
 use crate::types::ConversationId;
 
+// Prefixes come from zeph_common::secrets::SECRET_PREFIXES (the canonical, unescaped
+// list shared with zeph-core::redact — see #5917) and are regex-escaped here since e.g.
+// `ya29.` contains a literal dot.
 static SECRET_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"(?:sk-|sk_live_|sk_test_|AKIA|ghp_|gho_|-----BEGIN|xoxb-|xoxp-|AIza|ya29\.|glpat-|hf_|npm_|dckr_pat_)[^\s"'`,;\{\}\[\]]*"#,
-    )
-    .expect("secret regex")
+    let alt = SECRET_PREFIXES
+        .iter()
+        .map(|p| regex::escape(p))
+        .collect::<Vec<_>>()
+        .join("|");
+    Regex::new(&format!(r#"(?:{alt})[^\s"'`,;\{{\}}\[\]]*"#)).expect("secret regex")
 });
 
 static PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?:/home/|/Users/|/root/|/tmp/|/var/)[^\s"'`,;\{\}\[\]]*"#).expect("path regex")
+    let alt = PATH_PREFIXES.join("|");
+    Regex::new(&format!(r#"(?:{alt})[^\s"'`,;\{{\}}\[\]]*"#)).expect("path regex")
 });
 
 /// Matches `Authorization: Bearer <token>` headers; captures the token value for redaction.
 static BEARER_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)(Authorization:\s*Bearer\s+)\S+").expect("bearer regex"));
+    LazyLock::new(|| Regex::new(BEARER_TOKEN_PATTERN).expect("bearer regex"));
 
 /// Matches standalone JWT tokens (three Base64url-encoded parts separated by dots).
 /// The signature segment uses `*` to handle `alg=none` JWTs with an empty signature.
-static JWT_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*").expect("jwt regex")
-});
+static JWT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(JWT_PATTERN).expect("jwt regex"));
 
 /// Redact secrets and filesystem paths from text before persistent storage.
 ///


### PR DESCRIPTION
## Summary

Three issues shared the same defect class: duplicated/weaker security-sanitization logic across `zeph-common`/`zeph-core`/`zeph-memory`.

- **#5925** — `zeph_common::sanitize::strip_control_chars` and `strip_control_chars_preserve_whitespace` stripped only ASCII controls plus a narrow BiDi range, while `zeph_common::patterns::strip_format_chars` already covered 19+ Cf/Lo bypass categories (zero-width space/joiners, soft hyphen, BOM, Hangul/Khmer/Mongolian fillers, Unicode Tags block). Neither doc comment cross-referenced the other, and `zeph-memory`'s graph resolver (`sanitize_fact`/`sanitize_relation`) called the weaker function on LLM-extracted graph text later replayed into community-summarization prompts. Both strippers now share a single `patterns::is_bypass_codepoint` denylist; `strip_control_chars_preserve_whitespace` keeps its own `\r`-preserving filter (documented divergence from `strip_format_chars`, which only preserves `\t`/`\n`) to avoid regressing existing tab/newline/CR-preservation behavior.
- **#5915** — `zeph-memory::graph::community`'s private `scrub_content` (4 filtered categories) is removed; both call sites now call `zeph_common::patterns::strip_format_chars` directly, closing a real gap where entity names/edge facts could carry Tags-block steganography or soft-hyphen-obscured injection strings straight into an LLM summarization prompt.
- **#5917** — `zeph-core::redact`'s `SECRET_PREFIXES`/`PATH_REGEX` and `zeph-memory::store::compression_guidelines`'s `SECRET_RE`/`PATH_RE` duplicated the same 15-prefix list character-for-character while already drifting apart (`zeph-memory` had gained Bearer/JWT redaction that `zeph-core` lacked). A new `zeph_common::secrets` module (`SECRET_PREFIXES`, `PATH_PREFIXES`, `BEARER_TOKEN_PATTERN`, `JWT_PATTERN`) is the single source of truth; both crates build their own `regex::Regex` from it, and `zeph-core::redact` gains the Bearer/JWT coverage it previously lacked.

## Notes for reviewers

- `strip_control_chars_preserve_whitespace`'s strengthening affects several untrusted-input paths beyond the three issue titles: gateway webhook ingestion, tiered retrieval, optical forgetting, and zeph-sanitizer — all intentional, strict security strengthening.
- `zeph-core::scrub_content` now also redacts standalone JWT-shaped strings (`eyJ...`) on tool args/outputs — verified via proptest (4096 cases) that this doesn't false-positive on the previously-excluded secret prefixes; live-testing playbook scenario added to spot-check legitimate base64-JSON tool output.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12937 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc` on touched crates
- [x] New unit/integration tests proving previously-missed codepoints (zero-width space, soft hyphen, BOM, Hangul/Khmer/Mongolian fillers, Unicode Tags block) are stripped at every migrated call site, and that Bearer/JWT patterns survive the `SECRET_PREFIXES` consolidation
- [x] `.local/testing/playbooks/security-sanitization.md` and `.local/testing/coverage-status.md` updated

Closes #5925
Closes #5915
Closes #5917