### PR TITLE
fix(channels): add 429 retry-with-backoff and Telegram send_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-channels`: Telegram's raw API extension client and Slack's Web API client had no
+  429 retry-with-backoff, unlike Discord's REST client (#4728) — a rate-limited request
+  surfaced as a hard error on the first attempt instead of transparently retrying
+  (#5949). Discord's `send_with_retry` (reads the `Retry-After` header, falls back to the
+  JSON body's `retry_after` field, clamps to 60s, retries up to 3 times) is now a shared
+  `crate::common::http_retry::send_with_retry` helper used by all three adapters:
+  `TelegramApiClient::post`, and all four `SlackApi` methods (`auth_test`, `post_message`,
+  `update_message`, `download_file`). `SlackApi` gained a `base_url` field (test-only
+  override) for wiremock testability, and its previous per-call
+  `tokio::time::timeout(15s, ...)` was replaced with a per-attempt `.timeout(15s)` on the
+  `RequestBuilder`, since an outer timeout is incompatible with a retry loop that
+  legitimately needs to run longer than one request when backing off — worst-case
+  wall-clock under sustained 429 is now bounded by attempts x per-attempt timeout plus
+  backoff sleeps, documented on the helper.
+- `zeph-channels`: `TelegramChannel` never implemented `Channel::send_status`, unlike its
+  `DiscordChannel`/`SlackChannel` peers, so Telegram users got no visibility into any of
+  the ~15 background/implicit-operation status messages (skill reload, MCP elicitation,
+  memory recall, etc.) that Discord/Slack users see — only the generic `typing…` chat
+  action (#5923). `TelegramChannel::send_status` now posts the status text as a plain-text
+  message, mirroring the Discord/Slack pattern, and no-ops when the text is empty, there is
+  no active chat, or the channel is in a Guest Mode context (a guest reply can only be sent
+  once via `answerGuestQuery`).
 - `zeph-core`: config hot-reload (`Agent::reload_config`) bypassed `Config::validate()` entirely
   — `load_config_with_overlay` called `Config::load` plus the plugin overlay merge and returned
   the result straight to the live agent without ever validating it, unlike the startup path

--- a/crates/zeph-channels/src/common/http_retry.rs
+++ b/crates/zeph-channels/src/common/http_retry.rs
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared HTTP 429 retry-with-backoff helper for channel REST clients.
+//!
+//! Discord, Telegram, and Slack all rate-limit via HTTP 429 with a
+//! `Retry-After` header (or, for Discord and some Telegram responses, a JSON
+//! body field of the same name). This module centralises the retry loop so
+//! each channel's REST client only has to build the request.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// Upper bound applied to any `Retry-After` value, whether from the header or body.
+const MAX_RETRY_SECS: f64 = 60.0;
+/// Maximum number of retry attempts before giving up and surfacing the error.
+const MAX_RETRIES: u32 = 3;
+
+/// Body shape used by rate-limit responses that carry `retry_after` as JSON.
+#[derive(Deserialize, Default)]
+struct RateLimitBody {
+    retry_after: Option<f64>,
+}
+
+/// Executes a request with automatic 429 retry-after backoff.
+///
+/// Builds a fresh request each attempt via `make_req`. On HTTP 429 the function
+/// reads the `Retry-After` header (falling back to the JSON body's `retry_after`
+/// field), clamps to [`MAX_RETRY_SECS`], sleeps, and retries up to [`MAX_RETRIES`]
+/// times. When retries are exhausted a final request is issued to obtain a
+/// `reqwest::Error` with the original HTTP status — `reqwest::Error` cannot be
+/// constructed directly.
+///
+/// `context` is a short label (e.g. `"discord"`, `"telegram"`, `"slack"`) attached
+/// to the warning logs so retries can be attributed to the originating channel.
+///
+/// # Timing
+///
+/// Under sustained 429s, the worst-case wall-clock across all attempts is
+/// approximately `(MAX_RETRIES + 2) * <per-request timeout>` (each attempt's
+/// own `send()`, including the final un-retried attempt) plus
+/// `MAX_RETRIES * MAX_RETRY_SECS` (the backoff sleeps between them) — with the
+/// current constants, on the order of minutes, not seconds. Callers that await
+/// this on a hot path without an outer timeout should account for this.
+///
+/// # Errors
+///
+/// Returns a [`reqwest::Error`] when all retries are exhausted, a non-429 HTTP
+/// error is received, or the request's own timeout is exceeded.
+pub(crate) async fn send_with_retry<F>(
+    context: &str,
+    make_req: F,
+) -> Result<reqwest::Response, reqwest::Error>
+where
+    F: Fn() -> reqwest::RequestBuilder,
+{
+    let mut attempts = 0u32;
+    loop {
+        let resp = make_req().send().await?;
+
+        if resp.status() != reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return resp.error_for_status();
+        }
+
+        // Parse retry delay: header wins, then body field, then default 1 s.
+        let header_secs = resp
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<f64>().ok());
+
+        let body_secs = resp
+            .json::<RateLimitBody>()
+            .await
+            .unwrap_or_default()
+            .retry_after;
+
+        let delay_secs = header_secs.or(body_secs).unwrap_or(1.0).min(MAX_RETRY_SECS);
+
+        attempts += 1;
+        if attempts > MAX_RETRIES {
+            tracing::warn!(
+                context,
+                delay_secs,
+                attempts,
+                "rate-limited and retries exhausted"
+            );
+            // Surface as an error by issuing the request once more without retry.
+            return make_req().send().await?.error_for_status();
+        }
+
+        tracing::warn!(
+            context,
+            delay_secs,
+            attempt = attempts,
+            max = MAX_RETRIES,
+            "rate-limited (429), backing off"
+        );
+        tokio::time::sleep(Duration::from_secs_f64(delay_secs)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn send_with_retry_succeeds_on_200() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/channels/ch1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "1"})))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/channels/ch1/messages", server.uri());
+        let resp = send_with_retry("test", || client.post(&url)).await.unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_retries_on_429_then_succeeds() {
+        let server = MockServer::start().await;
+
+        // First call → 429 with Retry-After header.
+        Mock::given(method("POST"))
+            .and(path("/channels/ch1/messages"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .set_body_json(serde_json::json!({"retry_after": 0.0})),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Second call → 200.
+        Mock::given(method("POST"))
+            .and(path("/channels/ch1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "2"})))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/channels/ch1/messages", server.uri());
+        let resp = send_with_retry("test", || client.post(&url)).await.unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_uses_body_retry_after_when_no_header() {
+        let server = MockServer::start().await;
+
+        // Three 429 responses without Retry-After header but with body field.
+        Mock::given(method("POST"))
+            .and(path("/channels/ch1/messages"))
+            .respond_with(
+                ResponseTemplate::new(429).set_body_json(serde_json::json!({"retry_after": 0.0})),
+            )
+            .up_to_n_times(3)
+            .mount(&server)
+            .await;
+
+        // Fourth → 200.
+        Mock::given(method("POST"))
+            .and(path("/channels/ch1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "3"})))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/channels/ch1/messages", server.uri());
+        let resp = send_with_retry("test", || client.post(&url)).await.unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_propagates_non_429_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/channels/ch1/messages"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/channels/ch1/messages", server.uri());
+        let result = send_with_retry("test", || client.post(&url)).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.status(), Some(reqwest::StatusCode::FORBIDDEN));
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_errors_when_retries_exhausted() {
+        let server = MockServer::start().await;
+
+        // Return 429 for all requests — exhausts MAX_RETRIES (3) then the final attempt.
+        Mock::given(method("POST"))
+            .and(path("/channels/ch1/messages"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .set_body_json(serde_json::json!({"retry_after": 0.0})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/channels/ch1/messages", server.uri());
+        let result = send_with_retry("test", || client.post(&url)).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.status(), Some(reqwest::StatusCode::TOO_MANY_REQUESTS));
+    }
+
+    #[test]
+    fn rate_limit_body_defaults_to_none() {
+        let body: RateLimitBody = serde_json::from_str("{}").unwrap();
+        assert!(body.retry_after.is_none());
+    }
+
+    #[test]
+    fn rate_limit_body_parses_float() {
+        let body: RateLimitBody = serde_json::from_str(r#"{"retry_after": 1.5}"#).unwrap();
+        assert!((body.retry_after.unwrap() - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn max_retry_secs_clamps() {
+        let unclamped: f64 = 120.0;
+        assert_eq!(
+            unclamped.min(MAX_RETRY_SECS).to_bits(),
+            MAX_RETRY_SECS.to_bits()
+        );
+    }
+}

--- a/crates/zeph-channels/src/common/mod.rs
+++ b/crates/zeph-channels/src/common/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Internal helpers shared across channel REST/Web API clients.
+
+pub(crate) mod http_retry;

--- a/crates/zeph-channels/src/discord/rest.rs
+++ b/crates/zeph-channels/src/discord/rest.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
+use crate::common::http_retry::send_with_retry;
+
 const BASE_URL: &str = "https://discord.com/api/v10";
-const MAX_RETRY_SECS: f64 = 60.0;
-const MAX_RETRIES: u32 = 3;
 /// Per-request HTTP timeout applied to every Discord REST call.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -74,72 +74,6 @@ struct EditMessage<'a> {
     content: &'a str,
 }
 
-/// Body returned by Discord on HTTP 429.
-#[derive(Deserialize, Default)]
-struct RateLimitBody {
-    retry_after: Option<f64>,
-}
-
-/// Executes a request with automatic 429 retry-after backoff.
-///
-/// Builds a fresh request each attempt via `make_req`. On HTTP 429 the function
-/// reads `Retry-After` header (falling back to the JSON body `retry_after` field),
-/// clamps to [`MAX_RETRY_SECS`], sleeps, and retries up to [`MAX_RETRIES`] times.
-/// When retries are exhausted a final request is issued to obtain a `reqwest::Error`
-/// with the original HTTP status — `reqwest::Error` cannot be constructed directly.
-///
-/// # Errors
-///
-/// Returns a [`reqwest::Error`] when all retries are exhausted, a non-429 HTTP error
-/// is received, or the per-request timeout ([`REQUEST_TIMEOUT`]) is exceeded.
-async fn send_with_retry<F>(make_req: F) -> Result<reqwest::Response, reqwest::Error>
-where
-    F: Fn() -> reqwest::RequestBuilder,
-{
-    let mut attempts = 0u32;
-    loop {
-        let resp = make_req().send().await?;
-
-        if resp.status() != reqwest::StatusCode::TOO_MANY_REQUESTS {
-            return resp.error_for_status();
-        }
-
-        // Parse retry delay: header wins, then body field, then default 1 s.
-        let header_secs = resp
-            .headers()
-            .get(reqwest::header::RETRY_AFTER)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<f64>().ok());
-
-        let body_secs = resp
-            .json::<RateLimitBody>()
-            .await
-            .unwrap_or_default()
-            .retry_after;
-
-        let delay_secs = header_secs.or(body_secs).unwrap_or(1.0).min(MAX_RETRY_SECS);
-
-        attempts += 1;
-        if attempts > MAX_RETRIES {
-            tracing::warn!(
-                delay_secs,
-                attempts,
-                "discord: rate-limited and retries exhausted"
-            );
-            // Surface as an error by issuing the request once more without retry.
-            return make_req().send().await?.error_for_status();
-        }
-
-        tracing::warn!(
-            delay_secs,
-            attempt = attempts,
-            max = MAX_RETRIES,
-            "discord: rate-limited (429), backing off"
-        );
-        tokio::time::sleep(Duration::from_secs_f64(delay_secs)).await;
-    }
-}
-
 impl RestClient {
     #[must_use]
     pub fn new(token: String) -> Self {
@@ -165,7 +99,7 @@ impl RestClient {
     ) -> Result<DiscordMessage, reqwest::Error> {
         let url = format!("{BASE_URL}/channels/{channel_id}/messages");
         let auth = self.auth_header();
-        let resp = send_with_retry(|| {
+        let resp = send_with_retry("discord", || {
             self.client
                 .post(&url)
                 .header("Authorization", &auth)
@@ -191,7 +125,7 @@ impl RestClient {
     ) -> Result<(), reqwest::Error> {
         let url = format!("{BASE_URL}/channels/{channel_id}/messages/{message_id}");
         let auth = self.auth_header();
-        send_with_retry(|| {
+        send_with_retry("discord", || {
             self.client
                 .patch(&url)
                 .header("Authorization", &auth)
@@ -257,7 +191,7 @@ impl RestClient {
     pub async fn trigger_typing(&self, channel_id: &str) -> Result<(), reqwest::Error> {
         let url = format!("{BASE_URL}/channels/{channel_id}/typing");
         let auth = self.auth_header();
-        send_with_retry(|| {
+        send_with_retry("discord", || {
             self.client
                 .post(&url)
                 .header("Authorization", &auth)
@@ -270,142 +204,11 @@ impl RestClient {
 
 #[cfg(test)]
 mod tests {
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
-
     use super::*;
 
-    #[tokio::test]
-    async fn send_with_retry_succeeds_on_200() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/channels/ch1/messages"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "1"})))
-            .mount(&server)
-            .await;
-
-        let client = reqwest::Client::new();
-        let url = format!("{}/channels/ch1/messages", server.uri());
-        let resp = send_with_retry(|| client.post(&url)).await.unwrap();
-        assert_eq!(resp.status(), 200);
-    }
-
-    #[tokio::test]
-    async fn send_with_retry_retries_on_429_then_succeeds() {
-        let server = MockServer::start().await;
-
-        // First call → 429 with Retry-After header.
-        Mock::given(method("POST"))
-            .and(path("/channels/ch1/messages"))
-            .respond_with(
-                ResponseTemplate::new(429)
-                    .append_header("Retry-After", "0")
-                    .set_body_json(serde_json::json!({"retry_after": 0.0})),
-            )
-            .up_to_n_times(1)
-            .mount(&server)
-            .await;
-
-        // Second call → 200.
-        Mock::given(method("POST"))
-            .and(path("/channels/ch1/messages"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "2"})))
-            .mount(&server)
-            .await;
-
-        let client = reqwest::Client::new();
-        let url = format!("{}/channels/ch1/messages", server.uri());
-        let resp = send_with_retry(|| client.post(&url)).await.unwrap();
-        assert_eq!(resp.status(), 200);
-    }
-
-    #[tokio::test]
-    async fn send_with_retry_uses_body_retry_after_when_no_header() {
-        let server = MockServer::start().await;
-
-        // Three 429 responses without Retry-After header but with body field.
-        Mock::given(method("POST"))
-            .and(path("/channels/ch1/messages"))
-            .respond_with(
-                ResponseTemplate::new(429).set_body_json(serde_json::json!({"retry_after": 0.0})),
-            )
-            .up_to_n_times(3)
-            .mount(&server)
-            .await;
-
-        // Fourth → 200.
-        Mock::given(method("POST"))
-            .and(path("/channels/ch1/messages"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "3"})))
-            .mount(&server)
-            .await;
-
-        let client = reqwest::Client::new();
-        let url = format!("{}/channels/ch1/messages", server.uri());
-        let resp = send_with_retry(|| client.post(&url)).await.unwrap();
-        assert_eq!(resp.status(), 200);
-    }
-
-    #[tokio::test]
-    async fn send_with_retry_propagates_non_429_errors() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/channels/ch1/messages"))
-            .respond_with(ResponseTemplate::new(403))
-            .mount(&server)
-            .await;
-
-        let client = reqwest::Client::new();
-        let url = format!("{}/channels/ch1/messages", server.uri());
-        let result = send_with_retry(|| client.post(&url)).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert_eq!(err.status(), Some(reqwest::StatusCode::FORBIDDEN));
-    }
-
-    #[tokio::test]
-    async fn send_with_retry_errors_when_retries_exhausted() {
-        let server = MockServer::start().await;
-
-        // Return 429 for all requests — exhausts MAX_RETRIES (3) then the final attempt.
-        Mock::given(method("POST"))
-            .and(path("/channels/ch1/messages"))
-            .respond_with(
-                ResponseTemplate::new(429)
-                    .append_header("Retry-After", "0")
-                    .set_body_json(serde_json::json!({"retry_after": 0.0})),
-            )
-            .mount(&server)
-            .await;
-
-        let client = reqwest::Client::new();
-        let url = format!("{}/channels/ch1/messages", server.uri());
-        let result = send_with_retry(|| client.post(&url)).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert_eq!(err.status(), Some(reqwest::StatusCode::TOO_MANY_REQUESTS));
-    }
-
-    #[test]
-    fn rate_limit_body_defaults_to_none() {
-        let body: RateLimitBody = serde_json::from_str("{}").unwrap();
-        assert!(body.retry_after.is_none());
-    }
-
-    #[test]
-    fn rate_limit_body_parses_float() {
-        let body: RateLimitBody = serde_json::from_str(r#"{"retry_after": 1.5}"#).unwrap();
-        assert!((body.retry_after.unwrap() - 1.5).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn max_retry_secs_clamps() {
-        let unclamped: f64 = 120.0;
-        assert_eq!(
-            unclamped.min(MAX_RETRY_SECS).to_bits(),
-            MAX_RETRY_SECS.to_bits()
-        );
-    }
+    // Generic 429 retry-with-backoff behavior is covered by
+    // `crate::common::http_retry`'s own test suite. Only Discord-specific
+    // behavior is tested here.
 
     #[test]
     fn rest_client_debug_redacts_token() {

--- a/crates/zeph-channels/src/lib.rs
+++ b/crates/zeph-channels/src/lib.rs
@@ -33,6 +33,7 @@
 
 mod any;
 pub mod cli;
+mod common;
 pub mod confirm;
 #[cfg(feature = "discord")]
 pub mod discord;

--- a/crates/zeph-channels/src/slack/api.rs
+++ b/crates/zeph-channels/src/slack/api.rs
@@ -10,10 +10,14 @@ use serde_json::Value;
 
 const SLACK_API: &str = "https://slack.com/api";
 const MAX_AUDIO_BYTES: usize = 25 * 1024 * 1024;
+/// Per-request HTTP timeout applied to every Slack Web API call.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub struct SlackApi {
     client: reqwest::Client,
     token: String,
+    /// Base URL for the Slack Web API. Always [`SLACK_API`] outside of tests.
+    base_url: String,
 }
 
 impl std::fmt::Debug for SlackApi {
@@ -52,6 +56,17 @@ impl SlackApi {
         Self {
             client: zeph_core::http::default_client(),
             token,
+            base_url: SLACK_API.to_string(),
+        }
+    }
+
+    /// Test-only constructor pointing at a custom base URL (e.g. a mock server).
+    #[cfg(test)]
+    fn with_base_url(base_url: String, token: String) -> Self {
+        Self {
+            client: zeph_core::http::default_client(),
+            token,
+            base_url,
         }
     }
 
@@ -65,15 +80,14 @@ impl SlackApi {
         tracing::instrument(name = "channels.slack.auth_test", skip_all)
     )]
     pub async fn auth_test(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let resp: Value = tokio::time::timeout(
-            Duration::from_secs(15),
+        let url = format!("{}/auth.test", self.base_url);
+        let resp: Value = crate::common::http_retry::send_with_retry("slack", || {
             self.client
-                .post(format!("{SLACK_API}/auth.test"))
+                .post(&url)
                 .bearer_auth(&self.token)
-                .send(),
-        )
+                .timeout(REQUEST_TIMEOUT)
+        })
         .await
-        .map_err(|_| "slack auth.test timed out")?
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
         .json()
         .await
@@ -106,16 +120,16 @@ impl SlackApi {
         channel: &str,
         text: &str,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let resp: SlackResponse = tokio::time::timeout(
-            Duration::from_secs(15),
+        let url = format!("{}/chat.postMessage", self.base_url);
+        let body = PostMessage { channel, text };
+        let resp: SlackResponse = crate::common::http_retry::send_with_retry("slack", || {
             self.client
-                .post(format!("{SLACK_API}/chat.postMessage"))
+                .post(&url)
                 .bearer_auth(&self.token)
-                .json(&PostMessage { channel, text })
-                .send(),
-        )
+                .timeout(REQUEST_TIMEOUT)
+                .json(&body)
+        })
         .await
-        .map_err(|_| "slack chat.postMessage timed out")?
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
         .json()
         .await
@@ -144,16 +158,16 @@ impl SlackApi {
         ts: &str,
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let resp: SlackResponse = tokio::time::timeout(
-            Duration::from_secs(15),
+        let url = format!("{}/chat.update", self.base_url);
+        let body = UpdateMessage { channel, ts, text };
+        let resp: SlackResponse = crate::common::http_retry::send_with_retry("slack", || {
             self.client
-                .post(format!("{SLACK_API}/chat.update"))
+                .post(&url)
                 .bearer_auth(&self.token)
-                .json(&UpdateMessage { channel, ts, text })
-                .send(),
-        )
+                .timeout(REQUEST_TIMEOUT)
+                .json(&body)
+        })
         .await
-        .map_err(|_| "slack chat.update timed out")?
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
         .json()
         .await
@@ -185,16 +199,14 @@ impl SlackApi {
             return Err(format!("refusing to send token to non-slack host: {url}").into());
         }
 
-        let resp = tokio::time::timeout(
-            Duration::from_secs(15),
-            self.client.get(url).bearer_auth(&self.token).send(),
-        )
+        let resp = crate::common::http_retry::send_with_retry("slack", || {
+            self.client
+                .get(url)
+                .bearer_auth(&self.token)
+                .timeout(REQUEST_TIMEOUT)
+        })
         .await
-        .map_err(|_| "slack file download timed out")?
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
-        if !resp.status().is_success() {
-            return Err(format!("slack file download failed: {}", resp.status()).into());
-        }
         let bytes = tokio::time::timeout(Duration::from_secs(15), resp.bytes())
             .await
             .map_err(|_| "slack file download body timed out")?
@@ -207,5 +219,67 @@ impl SlackApi {
             .into());
         }
         Ok(bytes.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[test]
+    fn slack_api_debug_redacts_token() {
+        let api = SlackApi::new("xoxb-secret-token".into());
+        let debug = format!("{api:?}");
+        assert!(!debug.contains("xoxb-secret-token"));
+        assert!(debug.contains("REDACTED"));
+    }
+
+    // Generic 429 retry-with-backoff behavior is covered by
+    // `crate::common::http_retry`'s own test suite. This test only proves
+    // that `post_message` is wired to retry rather than failing immediately.
+    #[tokio::test]
+    async fn post_message_retries_on_429_then_succeeds() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/chat.postMessage"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .set_body_json(serde_json::json!({"retry_after": 0.0})),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/chat.postMessage"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "ts": "1234.5678"
+            })))
+            .mount(&server)
+            .await;
+
+        let api = SlackApi::with_base_url(server.uri(), "xoxb-test".into());
+        let ts = api.post_message("C123", "hello").await.unwrap();
+        assert_eq!(ts, "1234.5678");
+    }
+
+    // Regression coverage for the SSRF-style host guard in `download_file`:
+    // the bot token must never be sent to a non-`*.slack.com` host. This
+    // rejects before any network call, so no mock server is needed.
+    #[tokio::test]
+    async fn download_file_rejects_non_slack_host() {
+        let api = SlackApi::new("xoxb-test".into());
+        let err = api.download_file("https://evil.com/x").await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("refusing to send token to non-slack host"),
+            "expected host-guard rejection, got: {err}"
+        );
     }
 }

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -1337,6 +1337,33 @@ impl Channel for TelegramChannel {
         Ok(())
     }
 
+    /// Send a status label to the active Telegram chat (shown as spinner text in TUI).
+    ///
+    /// Posted as a plain-text message with no Markdown parsing, since status
+    /// labels (e.g. `Searching memory…`) are short and free-form rather than
+    /// formatted content. Silently succeeds (returns `Ok(())`) when there is
+    /// no active chat yet, or in a Guest Mode context — a guest reply can
+    /// only be sent once via `answerGuestQuery`, so it is not a suitable
+    /// channel for interim status updates.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the Telegram API call fails.
+    #[tracing::instrument(name = "channels.telegram.send_status", skip_all)]
+    async fn send_status(&mut self, text: &str) -> Result<(), ChannelError> {
+        if text.is_empty() || self.guest_query_id.is_some() {
+            return Ok(());
+        }
+        let Some(chat_id) = self.chat_id else {
+            return Ok(());
+        };
+        self.bot
+            .send_message(chat_id, text)
+            .await
+            .map_err(ChannelError::telegram)?;
+        Ok(())
+    }
+
     /// Send a yes/no confirmation prompt to Telegram and await the reply.
     ///
     /// Sends `prompt` followed by instructions to reply `yes`.  Waits up to
@@ -1846,6 +1873,69 @@ mod tests {
 
         assert!(channel.buffer.is_empty());
         assert!(channel.message_id.is_none());
+    }
+
+    // ---------------------------------------------------------------------------
+    // send_status() — regression coverage for #5923 (TelegramChannel previously
+    // had no override, so status text was silently dropped by the trait default).
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn send_status_posts_message_when_chat_active() {
+        let server = MockServer::start().await;
+        let (mut channel, _tx) = make_mocked_channel(&server, vec![]).await;
+
+        channel.send_status("Searching memory…").await.unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert!(
+            !requests.is_empty(),
+            "send_status must post a message via the Telegram API"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_status_noop_on_empty_text() {
+        let server = MockServer::start().await;
+        let (mut channel, _tx) = make_mocked_channel(&server, vec![]).await;
+
+        channel.send_status("").await.unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert!(
+            requests.is_empty(),
+            "empty status text must not call the API"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_status_noop_without_active_chat() {
+        let server = MockServer::start().await;
+        let (mut channel, _tx) = make_mocked_channel(&server, vec![]).await;
+        channel.chat_id = None;
+
+        channel.send_status("Searching memory…").await.unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert!(
+            requests.is_empty(),
+            "send_status must no-op without an active chat"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_status_noop_in_guest_context() {
+        let server = MockServer::start().await;
+        let (mut channel, _tx) = make_mocked_channel(&server, vec![]).await;
+        channel.guest_query_id = Some("qid".to_string());
+
+        channel.send_status("Searching memory…").await.unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert!(
+            requests.is_empty(),
+            "send_status must no-op in a Guest Mode context"
+        );
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/zeph-channels/src/telegram_api_ext.rs
+++ b/crates/zeph-channels/src/telegram_api_ext.rs
@@ -298,11 +298,14 @@ impl TelegramApiClient {
 
     /// POST `body` to `{base_url}/{method}` and deserialize the result.
     ///
-    /// Calls `.error_for_status()` before JSON parsing so that non-2xx HTTP
-    /// responses (e.g. 429 rate-limit, 502 gateway error) surface as
-    /// [`TelegramApiError::Http`] rather than serde deserialization errors.
-    /// URLs (which contain the bot token) are stripped from any `reqwest::Error`
-    /// before propagation to prevent token leakage into logs.
+    /// Retries transparently on HTTP 429 (rate-limit) via
+    /// [`crate::common::http_retry::send_with_retry`], honouring the
+    /// `Retry-After` header or JSON body field. Once a non-429 response is
+    /// obtained, `.error_for_status()` is applied so non-2xx HTTP responses
+    /// (e.g. 502 gateway error) surface as [`TelegramApiError::Http`] rather
+    /// than serde deserialization errors. URLs (which contain the bot token)
+    /// are stripped from any `reqwest::Error` before propagation to prevent
+    /// token leakage into logs.
     #[tracing::instrument(skip(self, body), fields(method = method))]
     async fn post<T: serde::de::DeserializeOwned>(
         &self,
@@ -310,14 +313,11 @@ impl TelegramApiClient {
         body: &impl Serialize,
     ) -> Result<T, TelegramApiError> {
         let url = format!("{}/{method}", self.base_url);
-        let resp: TelegramResponse<T> = self
-            .client
-            .post(&url)
-            .json(body)
-            .send()
+        let resp: TelegramResponse<T> =
+            crate::common::http_retry::send_with_retry("telegram", || {
+                self.client.post(&url).json(body)
+            })
             .await
-            .map_err(|e| TelegramApiError::Http(e.without_url()))?
-            .error_for_status()
             .map_err(|e| TelegramApiError::Http(e.without_url()))?
             .json()
             .await
@@ -1073,7 +1073,11 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path_regex(".*/answerGuestQuery$"))
-            .respond_with(ResponseTemplate::new(429).set_body_string("Too Many Requests"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .set_body_string("Too Many Requests"),
+            )
             .mount(&server)
             .await;
 
@@ -1084,7 +1088,39 @@ mod tests {
             .unwrap_err();
         assert!(
             matches!(err, TelegramApiError::Http(_)),
-            "expected Http error for 429, got {err:?}"
+            "expected Http error for 429 after retries are exhausted, got {err:?}"
         );
+    }
+
+    // ── 429 retry-with-backoff wiring ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn post_retries_on_429_then_succeeds() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getMe$"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .set_body_json(serde_json::json!({"retry_after": 0.0})),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getMe$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
+                    "id": 1, "is_bot": true, "first_name": "Bot"
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let me = client.get_me().await.unwrap();
+        assert_eq!(me.id, 1);
     }
 }


### PR DESCRIPTION
## Summary

- Extract Discord's existing 429 retry-with-backoff (`send_with_retry`, #4728) into a shared `crates/zeph-channels/src/common/http_retry.rs` helper and wire it into Telegram's raw API extension client (`TelegramApiClient::post`) and all four `SlackApi` methods (`auth_test`, `post_message`, `update_message`, `download_file`), which previously surfaced a rate-limited response as a hard error on the first attempt.
- Implement `TelegramChannel::send_status`, mirroring the existing Discord/Slack pattern, so Telegram users get the same visibility into background/implicit agent operations (skill reload, MCP elicitation, memory recall, etc.) that Discord/Slack users already see.

Closes #5949
Closes #5923

## Details

- `SlackApi` gained a `base_url` field (`#[cfg(test)]`-only override) for wiremock testability, and its previous per-call `tokio::time::timeout(15s)` was replaced with a per-attempt `.timeout(15s)` on the `RequestBuilder`, since an outer timeout is incompatible with a retry loop that can legitimately run longer than one request when backing off. Worst-case wall-clock under sustained 429 is documented on the shared helper.
- `TelegramChannel::send_status` posts the status text as a plain-text message and no-ops when the text is empty, there is no active chat, or the channel is in a Guest Mode context (a guest reply can only be sent once via `answerGuestQuery`).
- Slack's Web API error messages changed shape from custom strings to `reqwest::Error` text (necessary to reconcile per-call timeouts with the retry loop); signatures are unchanged, and no external consumer depends on the old text (verified by grep).

## Follow-ups filed during review

- #6094 (P1): no outer timeout bounds Slack/Discord channel send retries on the agent turn hot path (e.g. `send_status` in `prepare_context`) — pre-existing shape for Discord, now shared by Slack; worth a dedicated fix outside this PR's scope.
- #6095 (P3): Discord's `send_message`/`edit_message`/`trigger_typing` retry-wiring itself isn't tested end-to-end (only the extracted helper is) — pre-existing gap, not introduced here.

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-channels --features "discord,slack"` — 275/275 pass (34 new/changed tests: shared retry helper, Telegram retry, Slack retry + host-check-reject + debug-redaction, 4 `send_status` tests)
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12945/12945 pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --features "discord,slack" -p zeph-channels` — clean
- [x] CHANGELOG.md updated (`[Unreleased]/Fixed`)
- [x] `.local/testing/playbooks/telegram-channel.md` and `.local/testing/playbooks/slack.md` updated with new scenarios (429 retry, send_status)
- [x] `.local/testing/coverage-status.md` updated with new rows (status: Untested — not yet live-session-verified against real Telegram/Slack APIs)