### PR TITLE
fix(acp): wire shutdown-summary, channel identity, help/model registry, and code-RAG into ACP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     (`dump_anchored_summary`, `dump_compaction_probe`, `dump_sidequest_eviction`, and the two
     test-only pruning dumps) keep the original synchronous write and are tracked as a
     follow-up.
+- `zeph-acp`: closed three ACP wiring gaps that only reached the CLI/TUI entry point (#5959,
+  #5986, #6022).
+  - Shutdown-summary config (`[memory] shutdown_summary*`) and channel-scoped provider
+    persistence (`[session] provider_persistence`/`persist_provider_overrides`) were wired only
+    in `src/runner.rs`; ACP sessions never produced a shutdown summary and never
+    persisted/restored a "last-used provider" preference (#5959). Fixing the latter uncovered a
+    critical collision: naively wiring channel-scoped persistence into ACP would have silently
+    overwritten a resumed session's own remembered provider (`AcpSessionConfigSnapshot`, #5373)
+    with another session's channel-wide preference. `Agent::restore_channel_provider` now skips
+    the channel-wide restore whenever a caller has already primed an explicit provider override,
+    so a session-specific choice always takes priority.
+  - ACP's native `/help` rendered a hardcoded 5-command string instead of the real 49-command
+    registry, and `/model refresh` errored instead of refreshing the model cache (#5986). `/help`
+    now renders from the same command registry the CLI/TUI use; `/model refresh` refreshes the
+    session's active provider's model cache instead of failing.
+  - Automatic code-RAG context retrieval and repo-map/`IndexMcpServer` injection
+    (`[index] enabled`) were wired only in `src/runner.rs`; ACP and the daemon (A2A server) never
+    received repo context regardless of configuration (#6022). Both entry points now wire it the
+    same way the CLI does.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10386,6 +10386,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "uuid",
+ "zeph-commands",
  "zeph-common",
  "zeph-config",
  "zeph-core",

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -68,6 +68,7 @@ tower = { workspace = true, features = ["util"], optional = true }
 tower-http = { workspace = true, features = ["cors", "limit"], optional = true }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
+zeph-commands.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-core.workspace = true

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -2490,14 +2490,11 @@ impl ZephAcpAgentState {
         let arg = parts.next().unwrap_or("").trim();
 
         let reply = match cmd {
-            "/help" => "Available commands:\n\
-                 /help — show this message\n\
-                 /model <id> — switch the active model\n\
-                 /mode <code|architect|ask> — switch session mode\n\
-                 /clear — clear session history\n\
-                 /review [path] — review recent changes (read-only)"
-                .to_owned(),
-            "/model" => self.handle_model_command(session_id, arg)?,
+            // #5986: render from the same `zeph_commands::COMMANDS` registry the CLI/TUI
+            // `CommandRegistry` uses, instead of a hand-rolled 5-command literal that drifted
+            // out of sync with the real command set (49 commands).
+            "/help" => zeph_commands::render_help_text(),
+            "/model" => self.handle_model_command(session_id, arg).await?,
             "/review" => {
                 return self.handle_review_command(session_id, arg);
             }
@@ -2663,7 +2660,35 @@ impl ZephAcpAgentState {
         }
     }
 
-    fn handle_model_command(
+    /// Refresh the remote model cache for the session's currently active provider, then update
+    /// the advertised `available_models` list.
+    ///
+    /// Mirrors `Agent::model_refresh_as_string` (`crates/zeph-core/src/agent/model_commands.rs`,
+    /// the CLI/TUI `/model refresh` handler), which likewise refreshes only the single active
+    /// provider, not every configured one. Reuses the shared [`warm_model_caches`] helper
+    /// (`src/acp.rs`'s ACP-startup cache warm-up) instead of a bespoke per-provider network loop
+    /// — a prior version of this method looped sequentially over every configured provider with
+    /// an independent 5-second timeout each, which could block this session's `do_prompt` handler
+    /// for up to 5s × N providers (#5986 critic finding M1).
+    async fn model_refresh_as_string(&self, session_id: &acp::schema::v1::SessionId) -> String {
+        let Some(ref factory) = self.provider_factory else {
+            return "model switching not configured".to_owned();
+        };
+        let current_model = {
+            let sessions = self.sessions.lock();
+            let Some(entry) = sessions.get(session_id) else {
+                return "session not found".to_owned();
+            };
+            entry.current_model.lock().clone()
+        };
+        let Some(provider) = factory(&current_model) else {
+            return format!("unknown model: {current_model}");
+        };
+        let fetched = warm_model_caches(provider, self.available_models.clone()).await;
+        format!("Fetched {fetched} models.")
+    }
+
+    async fn handle_model_command(
         &self,
         session_id: &acp::schema::v1::SessionId,
         arg: &str,
@@ -2672,6 +2697,12 @@ impl ZephAcpAgentState {
         if arg.is_empty() {
             let models = available_models.join(", ");
             return Ok(format!("Available models: {models}"));
+        }
+        // #5986: previously fell through to `resolve_model_fuzzy("refresh")`, which failed with
+        // an "no matching model found" error instead of refreshing the model list — unlike the
+        // CLI/TUI's documented `/model refresh` behavior.
+        if arg == "refresh" {
+            return Ok(self.model_refresh_as_string(session_id).await);
         }
         let Some(ref factory) = self.provider_factory else {
             return Err(acp::Error::internal_error().data("model switching not configured"));
@@ -3393,6 +3424,94 @@ fn is_acp_native_slash_command(trimmed_text: &str) -> bool {
         || trimmed_text.starts_with("/model ")
 }
 
+/// Populate model caches for a single provider, then expand every other unique provider slug
+/// present in `available_models` from its on-disk cache only (no extra network calls).
+///
+/// Used both at ACP startup (`src/acp.rs`, to warm every configured provider's cache before the
+/// server starts accepting connections — one call per provider there) and by `/model refresh`
+/// (`ZephAcpAgentState::model_refresh_as_string`, #5986) for the session's single currently
+/// active provider — mirroring `Agent::model_refresh_as_string`
+/// (`crates/zeph-core/src/agent/model_commands.rs`), which likewise refreshes only the active
+/// provider rather than looping over every configured one.
+///
+/// Uses a 5-second timeout so that a slow or unavailable provider does not block the caller.
+/// Returns the number of models fetched from the live network call (`0` on error or timeout);
+/// the on-disk cache expansion for other slugs always runs regardless of that outcome.
+pub async fn warm_model_caches(
+    provider: zeph_llm::any::AnyProvider,
+    available_models: SharedAvailableModels,
+) -> usize {
+    use zeph_llm::model_cache::ModelCache;
+
+    let provider_count = {
+        let models = available_models.read();
+        models
+            .iter()
+            .filter_map(|k| k.split_once(':').map(|(slug, _)| slug))
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+    };
+    tracing::info!(
+        providers = provider_count,
+        "warming model caches in background"
+    );
+
+    let fetch = async move {
+        match provider.list_models_remote().await {
+            Ok(models) => {
+                let count = models.len();
+                tracing::info!(models = count, "model cache fetch completed");
+                count
+            }
+            Err(e) => {
+                tracing::info!(error = %e, "model cache warm-up failed; keeping fallback list");
+                0
+            }
+        }
+    };
+
+    let Ok(fetched) = tokio::time::timeout(std::time::Duration::from_secs(5), fetch).await else {
+        tracing::info!("model cache warm-up timed out; keeping fallback list");
+        return 0;
+    };
+
+    // Collect unique provider slugs from the current available_models list.
+    let slugs: Vec<String> = {
+        let models = available_models.read();
+        models
+            .iter()
+            .filter_map(|k| k.split_once(':').map(|(s, _)| s.to_owned()))
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect()
+    };
+
+    for slug in slugs {
+        let cache = ModelCache::for_slug(&slug);
+        if cache.is_stale_async().await {
+            tracing::info!(provider = %slug, "model cache still stale after warm-up");
+            continue;
+        }
+        if let Ok(Some(entries)) = cache.load_async().await
+            && !entries.is_empty()
+        {
+            let new_keys: Vec<String> = entries
+                .into_iter()
+                .map(|m| format!("{slug}:{}", m.id))
+                .collect();
+            let count = new_keys.len();
+            let mut models = available_models.write();
+            models.retain(|k| !k.starts_with(&format!("{slug}:")));
+            models.extend(new_keys);
+            models.dedup();
+            tracing::info!(provider = %slug, models = count, "model cache ready");
+        }
+    }
+    let total_models = available_models.read().len();
+    tracing::info!(models = total_models, "model cache warming finished");
+    fetched
+}
+
 /// Map `(cancelled, stop_hint)` to the ACP `StopReason` wire value.
 fn compute_stop_reason(
     cancelled: bool,
@@ -3971,6 +4090,220 @@ mod session_event_replay_tests {
                 reason: "user_quit".to_owned(),
             })
             .is_empty()
+        );
+    }
+}
+
+/// Regression tests for #5986: ACP's `/help` and `/model refresh` slash commands.
+#[cfg(test)]
+mod slash_command_wiring_tests {
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use zeph_core::channel::LoopbackChannel;
+    use zeph_llm::any::AnyProvider;
+
+    use super::*;
+
+    /// Builds a bare agent (no registered session), optionally with a provider factory.
+    fn make_agent(
+        provider_factory: Option<ProviderFactory>,
+        available_models: Vec<String>,
+    ) -> (ZephAcpAgent, acp::schema::v1::SessionId) {
+        let spawner: AgentSpawner = Arc::new(|_ch, _ctx, _sc| Box::pin(async {}));
+        let mut agent = ZephAcpAgent::new(spawner, 4, 1800, None);
+        if let Some(factory) = provider_factory {
+            agent = agent.with_provider_factory(factory, Arc::new(RwLock::new(available_models)));
+        }
+        let session_id = acp::schema::v1::SessionId::new("slash-cmd-test".to_owned());
+        (agent, session_id)
+    }
+
+    /// Builds an agent with one registered session, returning a receiver that yields the next
+    /// `SessionNotification` `send_notification` pushes for that session — draining and acking
+    /// it immediately, mirroring `spawn_notify_drainer`'s ack contract without a real ACP
+    /// connection.
+    fn make_agent_with_captured_session(
+        provider_factory: Option<ProviderFactory>,
+        available_models: Vec<String>,
+    ) -> (
+        ZephAcpAgent,
+        acp::schema::v1::SessionId,
+        tokio::sync::oneshot::Receiver<acp::schema::v1::SessionNotification>,
+    ) {
+        let (agent, session_id) = make_agent(provider_factory, available_models);
+
+        let (_, handle) = LoopbackChannel::pair(4);
+        let provider_override = Arc::new(RwLock::new(None::<AnyProvider>));
+        let (notify_tx, notify_rx) = mpsc::channel(4);
+        let entry = ZephAcpAgent::make_session_entry(
+            handle,
+            "test-model".to_owned(),
+            std::path::PathBuf::from("."),
+            None,
+            provider_override,
+            SessionConfigSeed {
+                thinking_enabled: false,
+                auto_approve_level: "suggest".to_owned(),
+                temperature_preset: zeph_config::AcpTemperaturePreset::default(),
+            },
+            notify_tx,
+            notify_rx,
+        );
+        agent.sessions.lock().insert(session_id.clone(), entry);
+
+        let mut taken_rx = agent
+            .sessions
+            .lock()
+            .get(&session_id)
+            .expect("session was just inserted")
+            .notify_rx
+            .lock()
+            .take()
+            .expect("notify_rx must not yet be consumed");
+
+        let (captured_tx, captured_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            if let Some((notif, ack)) = taken_rx.recv().await {
+                ack.send(()).ok();
+                captured_tx.send(notif).ok();
+            }
+        });
+
+        (agent, session_id, captured_rx)
+    }
+
+    /// #5986: before this PR, ACP's `/help` returned a hand-rolled 5-command literal
+    /// (`/help`, `/model`, `/mode`, `/clear`, `/review`) that had drifted out of sync with the
+    /// real `zeph_commands::COMMANDS` registry the CLI/TUI `/help` renders from. Confirms
+    /// `handle_slash_command` now renders exactly what `zeph_commands::render_help_text()`
+    /// produces, and that commands absent from the old hardcoded list are present.
+    #[tokio::test]
+    async fn help_command_renders_full_command_registry_not_hardcoded_five() {
+        let (agent, session_id, captured_rx) = make_agent_with_captured_session(None, vec![]);
+
+        let response = agent
+            .handle_slash_command(&session_id, "/help")
+            .await
+            .expect("/help must succeed");
+        assert_eq!(response.stop_reason, acp::schema::v1::StopReason::EndTurn);
+
+        let notification = captured_rx
+            .await
+            .expect("handle_slash_command must push a notification carrying the /help reply");
+        let acp::schema::v1::SessionUpdate::AgentMessageChunk(chunk) = notification.update else {
+            panic!("expected AgentMessageChunk carrying the /help reply");
+        };
+        let acp::schema::v1::ContentBlock::Text(text) = chunk.content else {
+            panic!("expected ContentBlock::Text");
+        };
+
+        assert_eq!(
+            text.text,
+            zeph_commands::render_help_text(),
+            "ACP's /help reply must match zeph_commands::render_help_text() verbatim"
+        );
+        for cmd in ["/skills", "/memory", "/compact"] {
+            assert!(
+                text.text.contains(cmd),
+                "/help must list {cmd}, which is absent from the old hardcoded 5-command string"
+            );
+        }
+        assert!(
+            !text.text.contains("Available commands:"),
+            "/help must no longer render the old hardcoded heading"
+        );
+    }
+
+    /// #5986: `/model refresh` previously fell through to `resolve_model_fuzzy("refresh")`,
+    /// which failed with "no matching model found" since `"refresh"` never matches a real model
+    /// key. With no provider factory configured at all, the new refresh path must short-circuit
+    /// before touching session state or any network call and return an informational message,
+    /// not an error.
+    #[tokio::test]
+    async fn model_refresh_with_no_provider_factory_returns_ok_not_fuzzy_match_error() {
+        let (agent, session_id) = make_agent(None, vec![]);
+
+        let reply = agent
+            .handle_model_command(&session_id, "refresh")
+            .await
+            .expect("/model refresh must succeed, not error via resolve_model_fuzzy");
+        assert_eq!(reply, "model switching not configured");
+    }
+
+    /// #5986 M1 (critic finding): a prior implementation looped sequentially over every
+    /// configured provider slug with an independent 5s timeout each, which could block a
+    /// session's `do_prompt` handler for up to 5s * N providers. The fix refreshes only the
+    /// session's currently active provider — mirroring `Agent::model_refresh_as_string`'s
+    /// single-active-provider semantics — via the shared `warm_model_caches` helper. When the
+    /// session's active model key does not resolve through the provider factory, the reply must
+    /// still be `Ok`, naming the unresolved model, without ever reaching `list_models_remote`.
+    #[tokio::test]
+    async fn model_refresh_unresolvable_active_model_returns_ok_with_model_name() {
+        let factory: ProviderFactory = Arc::new(|_key: &str| None);
+        let (agent, session_id, _captured_rx) =
+            make_agent_with_captured_session(Some(factory), vec!["testslug:model-a".to_owned()]);
+
+        let reply = agent
+            .handle_model_command(&session_id, "refresh")
+            .await
+            .expect("/model refresh must succeed");
+        assert_eq!(reply, "unknown model: test-model");
+    }
+
+    /// #5986 M1 companion: an unregistered/stale session id must not panic or reach the
+    /// provider factory — `model_refresh_as_string` looks up the session before resolving any
+    /// provider.
+    #[tokio::test]
+    async fn model_refresh_missing_session_returns_ok_session_not_found() {
+        let factory: ProviderFactory = Arc::new(|_key: &str| None);
+        let (agent, session_id) = make_agent(Some(factory), vec![]);
+
+        let reply = agent
+            .handle_model_command(&session_id, "refresh")
+            .await
+            .expect("/model refresh must succeed");
+        assert_eq!(reply, "session not found");
+    }
+
+    /// #5986 success-path companion: when the session's active model *does* resolve through the
+    /// provider factory, `/model refresh` must reach `warm_model_caches` and report the live
+    /// fetch count. Uses `AnyProvider::Mock` (`zeph_llm::mock::MockProvider`) rather than a real
+    /// network-backed provider — `list_models_remote()` on the `Mock` variant returns
+    /// `Ok(p.models.clone())` synchronously (`zeph_llm::any`'s `AnyProvider::list_models_remote`
+    /// match arm), so this exercises the real success branch with zero network I/O, closing the
+    /// gap the developer's handoff flagged as needing a `wiremock`-backed provider.
+    #[tokio::test]
+    async fn model_refresh_active_provider_success_reports_fetched_count() {
+        let mock_provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::with_responses(vec![]).with_models(vec![
+                zeph_llm::model_cache::RemoteModelInfo {
+                    id: "model-a".to_owned(),
+                    display_name: "Model A".to_owned(),
+                    context_window: None,
+                    created_at: None,
+                },
+                zeph_llm::model_cache::RemoteModelInfo {
+                    id: "model-b".to_owned(),
+                    display_name: "Model B".to_owned(),
+                    context_window: None,
+                    created_at: None,
+                },
+            ]),
+        );
+        let factory: ProviderFactory = Arc::new(move |_key: &str| Some(mock_provider.clone()));
+        let (agent, session_id, _captured_rx) = make_agent_with_captured_session(
+            Some(factory),
+            vec!["acp-test-refresh-mock-slug:model-a".to_owned()],
+        );
+
+        let reply = agent
+            .handle_model_command(&session_id, "refresh")
+            .await
+            .expect("/model refresh must succeed");
+        assert_eq!(
+            reply, "Fetched 2 models.",
+            "must report the live list_models_remote() count from the resolved active provider"
         );
     }
 }

--- a/crates/zeph-acp/src/lib.rs
+++ b/crates/zeph-acp/src/lib.rs
@@ -84,6 +84,7 @@ pub mod transport;
 
 pub use agent::{
     AcpContext, AgentSpawner, ProviderFactory, SessionContext, SessionStatusNotifier, run_agent,
+    warm_model_caches,
 };
 pub use client::{
     AcpClientError, RunOutcome, SubagentConfig, SubagentHandle, run_session, spawn_subagent,

--- a/crates/zeph-commands/src/handlers/help.rs
+++ b/crates/zeph-commands/src/handlers/help.rs
@@ -10,6 +10,55 @@ use std::pin::Pin;
 use crate::context::CommandContext;
 use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
 
+/// Render the full `/help` listing: every entry in [`crate::COMMANDS`], grouped by
+/// [`SlashCategory`] in display order.
+///
+/// Extracted from [`HelpCommand::handle`] so callers without a [`CommandContext`] — notably
+/// the ACP session path (`zeph-acp`'s `is_acp_native_slash_command` shortcut, #5986) — can
+/// render the same command listing the CLI/TUI's `CommandRegistry` produces, instead of
+/// hand-rolling a separate, drift-prone copy.
+#[must_use]
+pub fn render_help_text() -> String {
+    let mut out = String::from("Slash commands:\n\n");
+
+    let categories = [
+        SlashCategory::Session,
+        SlashCategory::Configuration,
+        SlashCategory::Memory,
+        SlashCategory::Skills,
+        SlashCategory::Planning,
+        SlashCategory::Integration,
+        SlashCategory::Debugging,
+        SlashCategory::Advanced,
+    ];
+
+    for cat in &categories {
+        let entries: Vec<_> = crate::COMMANDS
+            .iter()
+            .filter(|c| &c.category == cat)
+            .collect();
+        if entries.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "{}:", cat.as_str());
+        for cmd in entries {
+            if cmd.args.is_empty() {
+                let _ = write!(out, "  {}", cmd.name);
+            } else {
+                let _ = write!(out, "  {} {}", cmd.name, cmd.args);
+            }
+            let _ = write!(out, "  — {}", cmd.description);
+            if let Some(feat) = cmd.feature_gate {
+                let _ = write!(out, " [requires: {feat}]");
+            }
+            let _ = writeln!(out);
+        }
+        let _ = writeln!(out);
+    }
+
+    out.trim_end().to_owned()
+}
+
 /// Display all available slash commands grouped by category.
 pub struct HelpCommand;
 
@@ -33,49 +82,7 @@ impl CommandHandler<CommandContext<'_>> for HelpCommand {
     ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
         use tracing::Instrument as _;
         let span = tracing::info_span!("commands.help.handle");
-        Box::pin(
-            async move {
-                let mut out = String::from("Slash commands:\n\n");
-
-                let categories = [
-                    SlashCategory::Session,
-                    SlashCategory::Configuration,
-                    SlashCategory::Memory,
-                    SlashCategory::Skills,
-                    SlashCategory::Planning,
-                    SlashCategory::Integration,
-                    SlashCategory::Debugging,
-                    SlashCategory::Advanced,
-                ];
-
-                for cat in &categories {
-                    let entries: Vec<_> = crate::COMMANDS
-                        .iter()
-                        .filter(|c| &c.category == cat)
-                        .collect();
-                    if entries.is_empty() {
-                        continue;
-                    }
-                    let _ = writeln!(out, "{}:", cat.as_str());
-                    for cmd in entries {
-                        if cmd.args.is_empty() {
-                            let _ = write!(out, "  {}", cmd.name);
-                        } else {
-                            let _ = write!(out, "  {} {}", cmd.name, cmd.args);
-                        }
-                        let _ = write!(out, "  — {}", cmd.description);
-                        if let Some(feat) = cmd.feature_gate {
-                            let _ = write!(out, " [requires: {feat}]");
-                        }
-                        let _ = writeln!(out);
-                    }
-                    let _ = writeln!(out);
-                }
-
-                Ok(CommandOutput::Message(out.trim_end().to_owned()))
-            }
-            .instrument(span),
-        )
+        Box::pin(async move { Ok(CommandOutput::Message(render_help_text())) }.instrument(span))
     }
 }
 

--- a/crates/zeph-commands/src/lib.rs
+++ b/crates/zeph-commands/src/lib.rs
@@ -31,6 +31,7 @@ pub mod sink;
 pub mod traits;
 
 pub use commands::{COMMANDS, is_recognized_command};
+pub use handlers::help::render_help_text;
 
 pub use context::CommandContext;
 pub use sink::{ChannelSink, NullSink};

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -732,7 +732,7 @@ fn default_mining_generation_timeout_ms() -> u64 {
 /// max_chunks = 12
 /// score_threshold = 0.25
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 pub struct IndexConfig {
     /// Enable code indexing. Default: `false`.

--- a/crates/zeph-core/src/agent/provider_cmd.rs
+++ b/crates/zeph-core/src/agent/provider_cmd.rs
@@ -29,6 +29,16 @@ impl<C: Channel> Agent<C> {
     /// When the provider name restore succeeds, provider overrides (e.g. `reasoning_effort`) are
     /// loaded from `pref_key = "provider_overrides"` and applied if the active provider supports
     /// them. Failures are logged as warnings and never block startup.
+    ///
+    /// Skips entirely when `provider_override` is already primed with a pending value (#5959
+    /// critic finding C1): a caller may have set that slot before `run()` was ever called — e.g.
+    /// ACP's per-session `AcpSessionConfigSnapshot` restore (#5373), which writes the session's
+    /// own remembered provider into the slot prior to spawning the `Agent`. `channel_type`/`""`
+    /// scoping here is channel-wide, not per-session, so restoring on top of an already-primed
+    /// override would silently overwrite that explicit, session-specific choice the next time
+    /// [`Agent::apply_provider_override`] runs (it would find the slot already cleared by this
+    /// function's own call to [`Agent::provider_switch_as_string`]). An explicit prior override
+    /// always wins over channel-level "last used" stickiness.
     #[tracing::instrument(name = "core.agent.restore_provider", skip_all)]
     pub(super) async fn restore_channel_provider(&mut self) {
         if !self.runtime.config.provider_persistence_enabled {
@@ -36,6 +46,19 @@ impl<C: Channel> Agent<C> {
         }
         let channel_type = self.runtime.config.channel_type.clone();
         if channel_type.is_empty() {
+            return;
+        }
+        if self
+            .runtime
+            .providers
+            .provider_override
+            .as_ref()
+            .is_some_and(|slot| slot.read().is_some())
+        {
+            tracing::debug!(
+                channel_type,
+                "skipping channel-preference provider restore: an explicit provider override is already primed"
+            );
             return;
         }
         let Some(memory) = self.services.memory.persistence.memory.as_ref() else {
@@ -1005,5 +1028,54 @@ mod tests {
         } else {
             panic!("inapplicable override should have been detected");
         }
+    }
+
+    /// #5959 critic finding C1 regression: `restore_channel_provider` must be a no-op when
+    /// `provider_override` is already primed (e.g. ACP's per-session `AcpSessionConfigSnapshot`
+    /// restore, #5373, which writes the session's own remembered provider into the slot before
+    /// `Agent::run` — and therefore this function — ever executes). Before the fix, this
+    /// function ran unconditionally and, given a stored channel-wide preference, would call
+    /// `provider_switch_as_string` which explicitly clears the override slot
+    /// (`*override_slot.write() = None;`), silently overwriting the session-specific choice with
+    /// a stale channel-wide "last used" preference shared across every session on that channel
+    /// (`channel_id` is hardcoded `""`, not scoped per session). No memory backend is configured
+    /// here at all — proving the check-before-clobber guard fires before the `SQLite` lookup is
+    /// even attempted, not just before a switch would occur.
+    #[tokio::test]
+    async fn restore_channel_provider_is_noop_when_override_already_primed() {
+        let mut qa = QuickTestAgent::minimal("ok");
+        qa.agent.runtime.config.channel_type = "acp".to_owned();
+        qa.agent.runtime.config.provider_persistence_enabled = true;
+
+        let primed_provider = mock_provider(vec!["primed".to_owned()]);
+        let override_slot = std::sync::Arc::new(parking_lot::RwLock::new(Some(primed_provider)));
+        qa.agent.runtime.providers.provider_override = Some(std::sync::Arc::clone(&override_slot));
+
+        qa.agent.restore_channel_provider().await;
+
+        assert!(
+            override_slot.read().is_some(),
+            "restore_channel_provider must not clear an already-primed provider_override slot"
+        );
+    }
+
+    /// Companion to the C1 regression above: when `provider_override` is primed but empty
+    /// (`Some(RwLock::new(None))` — the slot exists but nothing is pending, matching a fresh
+    /// `Agent::new()`/non-ACP channel that never primes it), `restore_channel_provider` must
+    /// still proceed past the guard (only `Some(Some(_))` short-circuits). With no memory
+    /// backend configured, it falls through to the very next guard and returns — verified only
+    /// via "does not panic", since there is no observable side effect to assert without a real
+    /// `SemanticMemory`.
+    #[tokio::test]
+    async fn restore_channel_provider_proceeds_when_override_slot_is_empty() {
+        let mut qa = QuickTestAgent::minimal("ok");
+        qa.agent.runtime.config.channel_type = "acp".to_owned();
+        qa.agent.runtime.config.provider_persistence_enabled = true;
+        qa.agent.runtime.providers.provider_override =
+            Some(std::sync::Arc::new(parking_lot::RwLock::new(None)));
+
+        // Must not panic: falls through the C1 guard (slot is Some(None), not Some(Some(_))),
+        // then returns at the next guard since no memory backend is configured.
+        qa.agent.restore_channel_provider().await;
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -352,6 +352,31 @@ pub(crate) struct SharedAgentDeps {
     history_limit: u32,
     recall_limit: usize,
     summarization_threshold: usize,
+    /// `config.memory.shutdown_summary*`, wired into `Agent::with_shutdown_summary_config`/
+    /// `with_shutdown_summary_provider` per session — mirrors `src/runner.rs` (#5959: previously
+    /// left on `MemoryCompactionState::default()` for ACP sessions, silently ignoring the
+    /// operator's configured shutdown-summary settings).
+    shutdown_summary: bool,
+    shutdown_summary_min_messages: usize,
+    shutdown_summary_max_messages: usize,
+    shutdown_summary_timeout_secs: u64,
+    shutdown_summary_provider: String,
+    /// `config.session.provider_persistence`/`persist_provider_overrides`, wired into
+    /// `Agent::with_channel_identity("acp", ...)` per session — mirrors `src/runner.rs`'s
+    /// active-channel wiring (#5959: previously never wired for ACP, so ACP sessions never
+    /// persisted/restored the last-used provider).
+    channel_provider_persistence: bool,
+    channel_persist_provider_overrides: bool,
+    /// `config.index`, wired into `agent_setup::apply_code_retrieval`/`apply_code_rag_retriever`
+    /// per session — mirrors `src/runner.rs` (#6022: previously never wired for ACP, so ACP
+    /// sessions got no static repo-map injection, `IndexMcpServer` registration, or automatic
+    /// code-RAG context retrieval).
+    index_config: zeph_core::config::IndexConfig,
+    /// Dedicated embedding provider for code retrieval, resolved once per connection via
+    /// `resolve_index_embed_provider` — passed to `apply_code_rag_retriever` per session.
+    code_index_provider: zeph_llm::any::AnyProvider,
+    /// Qdrant ops handle for code RAG retrieval; `None` when no vector backend is configured.
+    code_qdrant_ops: Option<zeph_memory::QdrantOps>,
     /// Broadcast sender for skill reload events. Each session subscribes independently.
     skill_reload_tx: tokio::sync::broadcast::Sender<zeph_skills::watcher::SkillEvent>,
     /// Broadcast sender for config reload events. Each session subscribes independently.
@@ -831,7 +856,7 @@ async fn build_acp_deps(
         if let Some(search_executor) = crate::agent_setup::build_search_code_executor(
             config,
             app.qdrant_ops().cloned(),
-            index_provider,
+            index_provider.clone(),
             memory.sqlite().pool().clone(),
             Some(std::sync::Arc::clone(&mcp_manager)),
         ) {
@@ -1105,6 +1130,16 @@ async fn build_acp_deps(
         history_limit: config.memory.history_limit,
         recall_limit: config.memory.semantic.recall_limit,
         summarization_threshold: config.memory.summarization_threshold,
+        shutdown_summary: config.memory.shutdown_summary,
+        shutdown_summary_min_messages: config.memory.shutdown_summary_min_messages,
+        shutdown_summary_max_messages: config.memory.shutdown_summary_max_messages,
+        shutdown_summary_timeout_secs: config.memory.shutdown_summary_timeout_secs,
+        shutdown_summary_provider: config.memory.shutdown_summary_provider.as_str().to_owned(),
+        channel_provider_persistence: config.session.provider_persistence,
+        channel_persist_provider_overrides: config.session.persist_provider_overrides,
+        index_config: config.index.clone(),
+        code_index_provider: index_provider,
+        code_qdrant_ops: app.qdrant_ops().cloned(),
         shutdown_rx,
         config_path: config_path_owned,
         mcp_tools,
@@ -1342,6 +1377,16 @@ async fn spawn_acp_agent(
     let history_limit = d.history_limit;
     let recall_limit = d.recall_limit;
     let summarization_threshold = d.summarization_threshold;
+    let shutdown_summary = d.shutdown_summary;
+    let shutdown_summary_min_messages = d.shutdown_summary_min_messages;
+    let shutdown_summary_max_messages = d.shutdown_summary_max_messages;
+    let shutdown_summary_timeout_secs = d.shutdown_summary_timeout_secs;
+    let shutdown_summary_provider = d.shutdown_summary_provider.clone();
+    let channel_provider_persistence = d.channel_provider_persistence;
+    let channel_persist_provider_overrides = d.channel_persist_provider_overrides;
+    let index_config = d.index_config.clone();
+    let code_index_provider = d.code_index_provider.clone();
+    let code_qdrant_ops = d.code_qdrant_ops.clone();
     let shutdown_rx = d.shutdown_rx.clone();
     let config_path = d.config_path.clone();
     let mcp_tools = d.mcp_tools.clone();
@@ -1790,11 +1835,35 @@ async fn spawn_acp_agent(
         .with_trajectory_and_category_config(d.trajectory_config.clone(), d.category_config.clone())
         .with_provider_pool(provider_pool, provider_config_snapshot)
         .with_embedding_provider(d.embedding_provider.clone())
+        .with_shutdown_summary_config(
+            shutdown_summary,
+            shutdown_summary_min_messages,
+            shutdown_summary_max_messages,
+            shutdown_summary_timeout_secs,
+        )
+        .with_shutdown_summary_provider(shutdown_summary_provider)
+        .with_channel_identity(
+            "acp",
+            channel_provider_persistence,
+            channel_persist_provider_overrides,
+        )
         .maybe_init_tool_schema_filter(tool_filter_config, provider.clone()),
     )
     .await;
 
     agent = agent.with_acp_session(true);
+
+    // #6022: wire code-RAG retrieval (static repo-map/IndexMcpServer injection plus automatic
+    // per-turn code-context retrieval) — mirrors src/runner.rs and src/daemon.rs. Previously ACP
+    // sessions got neither, since these calls only existed in the CLI/TUI bootstrap path.
+    agent = agent_setup::apply_code_retrieval(agent, &index_config);
+    agent = agent_setup::apply_code_rag_retriever(
+        agent,
+        &index_config,
+        code_qdrant_ops,
+        code_index_provider,
+        memory.sqlite().pool().clone(),
+    );
 
     // #5958: wire the trajectory risk slot/signal queue built above (spec 050 Invariant 2) plus
     // the TrajectorySentinel state machine itself into the agent, matching src/runner.rs and
@@ -2019,84 +2088,6 @@ async fn discover_models_from_config(config: &zeph_core::config::Config) -> Vec<
 
     models.dedup();
     models
-}
-
-/// Populate model caches for all providers before the ACP server starts.
-///
-/// Uses a 5-second timeout so that a slow or unavailable provider does not block startup.
-/// After a successful fetch, each unique provider slug present in `acp_available_models`
-/// is expanded from its on-disk cache, replacing the single config-time fallback entry.
-#[cfg(feature = "acp")]
-async fn warm_model_caches(
-    provider: zeph_llm::any::AnyProvider,
-    available_models: std::sync::Arc<RwLock<Vec<String>>>,
-) {
-    use zeph_llm::model_cache::ModelCache;
-
-    let provider_count = {
-        let models = available_models.read();
-        models
-            .iter()
-            .filter_map(|k| k.split_once(':').map(|(slug, _)| slug))
-            .collect::<std::collections::HashSet<_>>()
-            .len()
-    };
-    tracing::info!(
-        providers = provider_count,
-        "warming model caches in background"
-    );
-
-    let fetch = async move {
-        match provider.list_models_remote().await {
-            Ok(models) => tracing::info!(models = models.len(), "model cache fetch completed"),
-            Err(e) => {
-                tracing::info!(error = %e, "model cache warm-up failed; keeping fallback list");
-            }
-        }
-    };
-
-    if tokio::time::timeout(std::time::Duration::from_secs(5), fetch)
-        .await
-        .is_err()
-    {
-        tracing::info!("model cache warm-up timed out; keeping fallback list");
-        return;
-    }
-
-    // Collect unique provider slugs from the current available_models list.
-    let slugs: Vec<String> = {
-        let models = available_models.read();
-        models
-            .iter()
-            .filter_map(|k| k.split_once(':').map(|(s, _)| s.to_owned()))
-            .collect::<std::collections::HashSet<_>>()
-            .into_iter()
-            .collect()
-    };
-
-    for slug in slugs {
-        let cache = ModelCache::for_slug(&slug);
-        if cache.is_stale_async().await {
-            tracing::info!(provider = %slug, "model cache still stale after warm-up");
-            continue;
-        }
-        if let Ok(Some(entries)) = cache.load_async().await
-            && !entries.is_empty()
-        {
-            let new_keys: Vec<String> = entries
-                .into_iter()
-                .map(|m| format!("{slug}:{}", m.id))
-                .collect();
-            let count = new_keys.len();
-            let mut models = available_models.write();
-            models.retain(|k| !k.starts_with(&format!("{slug}:")));
-            models.extend(new_keys);
-            models.dedup();
-            tracing::info!(provider = %slug, models = count, "model cache ready");
-        }
-    }
-    let total_models = available_models.read().len();
-    tracing::info!(models = total_models, "model cache warming finished");
 }
 
 /// Build a `ProviderFactory` from the known named providers in config.
@@ -2367,7 +2358,7 @@ pub(crate) async fn run_acp_server(
     let (mut deps, _keepalive) = Box::pin(build_acp_deps(&app, None, None)).await?;
     let available_models = std::sync::Arc::clone(&deps.acp_available_models);
     let provider = deps.provider.clone();
-    warm_model_caches(provider, available_models).await;
+    zeph_acp::warm_model_caches(provider, available_models).await;
 
     // Apply CLI overrides to config-derived values.
     let effective_additional_dirs = if cli_additional_dirs.is_empty() {
@@ -2573,7 +2564,7 @@ pub(crate) async fn run_acp_http_server(
 
     let available_models = std::sync::Arc::clone(&deps.acp_available_models);
     let provider = deps.provider.clone();
-    warm_model_caches(provider, available_models).await;
+    zeph_acp::warm_model_caches(provider, available_models).await;
     *shared_deps.write().await = Some(Arc::new(deps));
     state.mark_ready();
     state.start_reaper();
@@ -2666,7 +2657,7 @@ pub(crate) async fn acp_http_ready_spawner(
 ) -> zeph_acp::SendAgentSpawner {
     let available_models = std::sync::Arc::clone(&deps.acp_available_models);
     let provider = deps.provider.clone();
-    warm_model_caches(provider, available_models).await;
+    zeph_acp::warm_model_caches(provider, available_models).await;
     std::sync::Arc::new(move |channel, acp_ctx, session_ctx| {
         let shared = std::sync::Arc::clone(&deps);
         Box::pin(spawn_acp_agent(shared, channel, acp_ctx, session_ctx))
@@ -4563,6 +4554,85 @@ mod tests {
             "the resolved RL embed dim (SharedCore::rl_embed_dim_resolved) must flow into \
              SharedAgentDeps, proving build_shared_core's pre-computation reaches both deps \
              structs from one shared value"
+        );
+    }
+
+    /// #5959/#6022 regression: before this PR, `SharedAgentDeps` had no
+    /// `shutdown_summary*`/`channel_provider_persistence`/`channel_persist_provider_overrides`/
+    /// `index_config` fields at all, so `spawn_acp_agent` had no way to call
+    /// `Agent::with_shutdown_summary_config`/`with_shutdown_summary_provider`/
+    /// `with_channel_identity("acp", ...)`/`agent_setup::apply_code_retrieval`/
+    /// `apply_code_rag_retriever` for ACP sessions — every ACP agent silently ran on builder
+    /// defaults (no shutdown summary, no provider-override persistence, no code-RAG retrieval)
+    /// regardless of what the operator configured in `config.memory.shutdown_summary*`,
+    /// `config.session.*`, and `config.index`. Drives the real `build_acp_deps` against a
+    /// mock-provider `AppBuilder::for_test` (same pattern as
+    /// `build_combined_deps_wires_skill_matching_config_from_config`) rather than hand-
+    /// constructing a `SharedAgentDeps` literal, so a regression in the config-to-deps mapping
+    /// is caught. Stops at the deps struct for the same reason documented on that sibling test:
+    /// `spawn_acp_agent`'s internal `Agent`-level wiring has no test seam yet (#5887).
+    #[cfg(feature = "acp")]
+    #[tokio::test]
+    async fn build_acp_deps_wires_shutdown_summary_channel_identity_and_index_config_from_config() {
+        let mut config =
+            zeph_core::config::Config::load(std::path::Path::new("/nonexistent")).unwrap();
+        config.llm.providers = vec![zeph_core::config::ProviderEntry {
+            provider_type: zeph_core::config::ProviderKind::Ollama,
+            base_url: Some("http://127.0.0.1:1".to_owned()),
+            model: Some("test-model".to_owned()),
+            ..Default::default()
+        }];
+        config.memory.sqlite_path = ":memory:".to_owned();
+        config.memory.shutdown_summary = true;
+        config.memory.shutdown_summary_min_messages = 7;
+        config.memory.shutdown_summary_max_messages = 42;
+        config.memory.shutdown_summary_timeout_secs = 9;
+        config.memory.shutdown_summary_provider = zeph_common::ProviderName::new("summary-test");
+        config.session.provider_persistence = true;
+        config.session.persist_provider_overrides = true;
+        config.index.enabled = true;
+        config.index.mcp_enabled = true;
+
+        let app = crate::bootstrap::AppBuilder::for_test(config);
+        let (deps, _keepalive) = Box::pin(build_acp_deps(&app, None, None))
+            .await
+            .expect("build_acp_deps must succeed against a mock-provider AppBuilder");
+
+        assert!(
+            deps.shutdown_summary,
+            "config.memory.shutdown_summary must flow into SharedAgentDeps"
+        );
+        assert_eq!(
+            deps.shutdown_summary_min_messages, 7,
+            "config.memory.shutdown_summary_min_messages must flow into SharedAgentDeps"
+        );
+        assert_eq!(
+            deps.shutdown_summary_max_messages, 42,
+            "config.memory.shutdown_summary_max_messages must flow into SharedAgentDeps"
+        );
+        assert_eq!(
+            deps.shutdown_summary_timeout_secs, 9,
+            "config.memory.shutdown_summary_timeout_secs must flow into SharedAgentDeps"
+        );
+        assert_eq!(
+            deps.shutdown_summary_provider, "summary-test",
+            "config.memory.shutdown_summary_provider must flow into SharedAgentDeps"
+        );
+        assert!(
+            deps.channel_provider_persistence,
+            "config.session.provider_persistence must flow into SharedAgentDeps"
+        );
+        assert!(
+            deps.channel_persist_provider_overrides,
+            "config.session.persist_provider_overrides must flow into SharedAgentDeps"
+        );
+        assert!(
+            deps.index_config.enabled,
+            "config.index.enabled must flow into SharedAgentDeps"
+        );
+        assert!(
+            deps.index_config.mcp_enabled,
+            "config.index.mcp_enabled must flow into SharedAgentDeps"
         );
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -766,16 +766,18 @@ pub(crate) async fn run_daemon(
     .with_conversation(conversation_id.0);
     let (skill_loader_executor, skill_invoke_executor, trust_snapshot) =
         agent_setup::build_skill_executors(&registry);
+    // Hoisted out of the composite-executor block below (rather than resolved twice) so it can
+    // also be passed to `apply_code_rag_retriever` once the agent exists (#6022: previously the
+    // daemon never wired code-RAG retrieval, only the on-demand `search_code` tool).
+    let index_provider = crate::bootstrap::resolve_index_embed_provider(config, provider.clone());
     let base_tool: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = {
         let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = std::sync::Arc::new(
             zeph_tools::CompositeExecutor::new(base_executor, mcp_executor),
         );
-        let index_provider =
-            crate::bootstrap::resolve_index_embed_provider(config, provider.clone());
         if let Some(search_executor) = agent_setup::build_search_code_executor(
             config,
             app.qdrant_ops().cloned(),
-            index_provider,
+            index_provider.clone(),
             memory.sqlite().pool().clone(),
             Some(std::sync::Arc::clone(&mcp_manager)),
         ) {
@@ -1039,6 +1041,18 @@ pub(crate) async fn run_daemon(
         trust_snapshot,
     };
     let agent = Box::pin(build_daemon_agent(deps, loopback_channel)).await;
+
+    // #6022: wire code-RAG retrieval (static repo-map/IndexMcpServer injection plus automatic
+    // per-turn code-context retrieval) — mirrors src/runner.rs. Previously the daemon only
+    // wired the on-demand `search_code` tool (above), never the automatic injection path.
+    let agent = agent_setup::apply_code_retrieval(agent, &config.index);
+    let agent = agent_setup::apply_code_rag_retriever(
+        agent,
+        &config.index,
+        app.qdrant_ops().cloned(),
+        index_provider,
+        memory.sqlite().pool().clone(),
+    );
 
     let agent = if let Some(logger) = daemon_audit_logger {
         agent.with_audit_logger(logger)


### PR DESCRIPTION
## Summary

Closes three ACP wiring gaps that only reached the CLI/TUI entry point:

- Shutdown-summary config (`[memory] shutdown_summary*`) and channel-scoped provider persistence (`[session] provider_persistence`/`persist_provider_overrides`) were wired only in `src/runner.rs` — ACP sessions never produced a customized shutdown summary and never persisted/restored a "last-used provider" preference.
- ACP's native `/help` rendered a hardcoded 5-command string instead of the real 49-command registry, and `/model refresh` errored instead of refreshing the model cache.
- Automatic code-RAG retrieval and repo-map/`IndexMcpServer` injection (`[index] enabled`) were wired only in `src/runner.rs` — ACP and the daemon (A2A server) never received repo context regardless of configuration. Serve inherits the fix transitively since it builds on the same ACP dependency chain.

Wiring channel-scoped provider persistence into ACP uncovered a critical collision with the existing per-session `AcpSessionConfigSnapshot` restore (#5373): the channel-wide "last used provider" restore ran unconditionally on every `Agent::run()` and could silently clobber a resumed session's own remembered provider with another session's channel-wide preference. `restore_channel_provider` now skips the channel-wide restore whenever an explicit provider override has already been primed, so a session-specific choice always takes priority — this is a core-agent fix, not ACP-only, but only ACP pre-primes the override slot today so no other channel's behavior changes.

`/model refresh` over ACP now resolves only the session's active provider and reuses the existing `warm_model_caches` helper (moved into `zeph-acp` so it can be shared), matching CLI/TUI's single-active-provider refresh semantics instead of looping over every configured provider.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12970 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression tests: ACP shutdown-summary/channel-identity/index-config wiring, `/help` full-registry rendering, `/model refresh` success/no-provider/session-lookup paths, `restore_channel_provider` no-op-when-override-primed (and companion negative case)
- [x] Testing playbook: `.local/testing/playbooks/wire-x-acp-daemon-serve-5959-5986-6022.md`
- [x] Coverage status updated: `.local/testing/coverage-status.md`

Closes #5959
Closes #5986
Closes #6022