### PR TITLE
fix(plugins): route add_remote/download_archive through anti-downgrade HTTPS client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- `zeph-plugins`: the HTTPS-downgrade-redirect protection in `registry.rs`
+  (a `reqwest::redirect::Policy::custom` that rejects any redirect leaving the `https`
+  scheme) previously guarded only `add_remote_ephemeral`'s session-scoped install path.
+  `PluginManager::add_remote` (permanent plugin install) and `download_archive` (used by
+  the unattended `check_auto_updates`/`update_one_plugin` auto-update path, which runs on
+  every process startup for any plugin with `auto_update = true`) both used the bare
+  `reqwest::get(url)` global client instead, following up to 10 redirects with no
+  scheme-downgrade restriction (#6099). The anti-downgrade client construction is now a
+  shared `https_safe_client()` helper used by all three archive-download call sites.
 - `zeph-mcp`: `PinningOAuthHttpClient` (#6074) resolved, SSRF-validated, and DNS-pinned
   the target host of every OAuth HTTP request, but its underlying `reqwest::Client`
   only disabled auto-following redirects for `OAuthHttpRedirectPolicy::Stop` requests

--- a/crates/zeph-plugins/src/manager/registry.rs
+++ b/crates/zeph-plugins/src/manager/registry.rs
@@ -12,6 +12,67 @@ use super::{
     validate_url_scheme, validate_url_scheme_ephemeral,
 };
 
+/// Build an HTTP client that refuses to follow any redirect leaving the `https` scheme.
+///
+/// Shared by every archive-download call site ([`PluginManager::add_remote`],
+/// [`PluginManager::download_archive`], and [`download_and_extract`]) so a malicious or
+/// compromised host cannot downgrade a redirect chain from `https://` to plaintext `http://`
+/// mid-download (an MITM-enabling protocol downgrade).
+fn https_safe_client() -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.url().scheme() == "https" {
+                attempt.follow()
+            } else {
+                let redirect_url = attempt.url().to_string();
+                attempt.error(format!(
+                    "redirect to non-HTTPS URL is not permitted: {redirect_url}"
+                ))
+            }
+        }))
+        .build()
+}
+
+/// Send a `GET` request to `url` through [`https_safe_client`], bounded by `timeout`.
+///
+/// reqwest surfaces the redirect policy's rejection as a generic transport error; this
+/// re-classifies it into [`PluginError::InsecureUrl`] so callers can distinguish a
+/// downgrade-redirect rejection from an ordinary connection failure.
+async fn get_https_safe(
+    url: &str,
+    timeout: std::time::Duration,
+) -> Result<reqwest::Response, PluginError> {
+    let client = https_safe_client().map_err(|e| PluginError::DownloadFailed {
+        url: url.to_owned(),
+        reason: format!("failed to build HTTP client: {e}"),
+    })?;
+
+    tokio::time::timeout(timeout, client.get(url).send())
+        .await
+        .map_err(|_| PluginError::DownloadFailed {
+            url: url.to_owned(),
+            reason: format!("download timed out after {}s", timeout.as_secs()),
+        })?
+        .map_err(|e| {
+            // reqwest's top-level Display omits the redirect policy's rejection text (it only
+            // says "error following redirect for url (...)") — the message lives in the
+            // deepest `source()` in the error chain, so walk to it before matching.
+            let mut cause: &dyn std::error::Error = &e;
+            while let Some(source) = cause.source() {
+                cause = source;
+            }
+            let cause_msg = cause.to_string();
+            if cause_msg.contains("redirect to non-HTTPS") {
+                PluginError::InsecureUrl(cause_msg)
+            } else {
+                PluginError::DownloadFailed {
+                    url: url.to_owned(),
+                    reason: e.to_string(),
+                }
+            }
+        })
+}
+
 impl PluginManager {
     /// Download and install a plugin from a remote URL with optional SHA-256 integrity pinning.
     ///
@@ -28,9 +89,14 @@ impl PluginManager {
     /// are encouraged to always supply the expected hash; unverified installs are permitted by
     /// default for backward compatibility but should be avoided in production.
     ///
+    /// The underlying HTTP client refuses to follow any redirect that leaves `https://`, so a
+    /// compromised or malicious host cannot downgrade the connection to plaintext `http://`
+    /// mid-download.
+    ///
     /// # Errors
     ///
     /// - [`PluginError::DownloadFailed`] — HTTP request failed or returned a non-2xx status.
+    /// - [`PluginError::InsecureUrl`] — a redirect tried to downgrade from `https://` to `http://`.
     /// - [`PluginError::IntegrityCheckFailed`] — SHA-256 digest mismatch.
     /// - [`PluginError::InvalidSource`] — archive cannot be extracted.
     /// - Any error that [`Self::add`] can return.
@@ -65,16 +131,7 @@ impl PluginManager {
 
         let timeout = std::time::Duration::from_secs(self.download_timeout_secs);
 
-        let response = tokio::time::timeout(timeout, reqwest::get(url))
-            .await
-            .map_err(|_| PluginError::DownloadFailed {
-                url: url.to_owned(),
-                reason: format!("download timed out after {}s", self.download_timeout_secs),
-            })?
-            .map_err(|e| PluginError::DownloadFailed {
-                url: url.to_owned(),
-                reason: e.to_string(),
-            })?;
+        let response = get_https_safe(url, timeout).await?;
 
         if !response.status().is_success() {
             return Err(PluginError::DownloadFailed {
@@ -358,9 +415,8 @@ impl PluginManager {
         url: &str,
         timeout: std::time::Duration,
     ) -> Result<Vec<u8>, String> {
-        let response = tokio::time::timeout(timeout, reqwest::get(url))
+        let response = get_https_safe(url, timeout)
             .await
-            .map_err(|_| format!("download timed out after {}s", timeout.as_secs()))?
             .map_err(|e| e.to_string())?;
 
         if !response.status().is_success() {
@@ -518,42 +574,8 @@ pub async fn download_and_extract(
 ) -> Result<(), PluginError> {
     let timeout = std::time::Duration::from_secs(timeout_secs);
 
-    // Build a client that refuses to follow any redirect that downgrades from https (B1).
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::custom(|attempt| {
-            if attempt.url().scheme() == "https" {
-                attempt.follow()
-            } else {
-                let redirect_url = attempt.url().to_string();
-                attempt.error(format!(
-                    "redirect to non-HTTPS URL is not permitted: {redirect_url}"
-                ))
-            }
-        }))
-        .build()
-        .map_err(|e| PluginError::DownloadFailed {
-            url: url.to_owned(),
-            reason: format!("failed to build HTTP client: {e}"),
-        })?;
-
-    let response = tokio::time::timeout(timeout, client.get(url).send())
-        .await
-        .map_err(|_| PluginError::DownloadFailed {
-            url: url.to_owned(),
-            reason: format!("download timed out after {timeout_secs}s"),
-        })?
-        .map_err(|e| {
-            // reqwest surfaces our custom redirect error as a generic error; re-classify it.
-            let msg = e.to_string();
-            if msg.contains("redirect to non-HTTPS") {
-                PluginError::InsecureUrl(msg)
-            } else {
-                PluginError::DownloadFailed {
-                    url: url.to_owned(),
-                    reason: msg,
-                }
-            }
-        })?;
+    // Refuses to follow any redirect that downgrades from https (B1).
+    let response = get_https_safe(url, timeout).await?;
 
     if !response.status().is_success() {
         return Err(PluginError::DownloadFailed {

--- a/crates/zeph-plugins/src/manager/tests.rs
+++ b/crates/zeph-plugins/src/manager/tests.rs
@@ -2270,3 +2270,101 @@ path = "../outside-skill"
         "dest must not be touched when the staged manifest fails validation"
     );
 }
+
+// --- regression: #6099 HTTPS downgrade redirect protection ---
+
+#[tokio::test]
+async fn add_remote_rejects_https_downgrade_redirect() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(302)
+                .insert_header("Location", "http://evil.example.com/payload.tar.gz"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let mgr = PluginManager::new(
+        tmp.path().join("plugins"),
+        tmp.path().join("managed"),
+        vec![],
+        vec![],
+    );
+    let url = format!("{}/redirect.tar.gz", mock_server.uri());
+    let err = mgr.add_remote(&url, None).await.unwrap_err();
+    assert!(
+        matches!(err, PluginError::InsecureUrl(ref reason) if reason.contains("non-HTTPS")),
+        "add_remote must reject a redirect leaving https, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn check_auto_updates_rejects_https_downgrade_redirect() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let manifest = r#"[plugin]
+name = "downgrade-update"
+version = "0.1.0"
+description = "test"
+auto_update = true
+
+[[skills]]
+path = "skills/my-skill"
+"#;
+    write_plugin(
+        &source,
+        "downgrade-update",
+        manifest,
+        &[("my-skill", "body")],
+    );
+    let archive = build_tar_gz(&source);
+    let hash = crate::integrity::sha256_hex(&archive);
+
+    let mock_server = MockServer::start().await;
+    // Install succeeds.
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(archive)
+                .append_header("Content-Type", "application/octet-stream"),
+        )
+        .up_to_n_times(1)
+        .mount(&mock_server)
+        .await;
+    // Auto-update check redirects to a non-HTTPS URL — must be rejected, not followed.
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(302)
+                .insert_header("Location", "http://evil.example.com/payload.tar.gz"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let plugins_dir = tmp.path().join("plugins");
+    let managed_dir = tmp.path().join("managed");
+    let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
+    let url = format!("{}/downgrade-update.tar.gz", mock_server.uri());
+    mgr.add_remote(&url, Some(&hash)).await.unwrap();
+
+    let results = mgr.check_auto_updates().await;
+    assert_eq!(results.len(), 1);
+    assert!(
+        matches!(
+            &results[0].status,
+            AutoUpdateStatus::Failed(reason) if reason.contains("non-HTTPS")
+        ),
+        "auto-update must reject a redirect leaving https, got {:?}",
+        results[0].status
+    );
+
+    // Plugin must still be installed at the old version — the downgraded update never applied.
+    let installed = mgr.list_installed().unwrap();
+    assert_eq!(installed[0].version, "0.1.0");
+}


### PR DESCRIPTION
## Summary
- `add_remote` (permanent plugin install) and `download_archive` (used by the unattended `check_auto_updates`/`update_one_plugin` auto-update path) used the bare `reqwest::get(url)` default client, which follows redirects across schemes with no protection.
- `download_and_extract` already rejected any redirect leaving `https` via a custom `reqwest::redirect::Policy`, but that protection was only reachable from the ephemeral install path.
- Extracted the anti-downgrade client construction into shared `https_safe_client()`/`get_https_safe()` helpers and routed all three archive-download call sites through them.
- Along the way, fixed a latent bug where a rejected downgrade redirect was misclassified as `DownloadFailed` instead of `InsecureUrl`, because reqwest's top-level `Display` for a redirect-policy error is generic and the real message only lives in the error's `source()` chain.

Closes #6099

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-plugins` (121/121 passed, including 2 new wiremock regression tests covering `add_remote` and the auto-update path)
- [x] `cargo test --doc -p zeph-plugins`
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)