### PR TITLE
chore(build): disable sccache and enable incremental compilation locally

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,13 @@
 [build]
 warnings = "deny"
+
+# Local dev: disable sccache and use incremental compilation for fast rebuilds.
+# Safe for CI: every workflow already sets RUSTC_WRAPPER and CARGO_INCREMENTAL as
+# explicit job/step-level environment variables (see .github/workflows/*.yml), and
+# environment variables always take precedence over this config file. CI's own
+# `[profile.ci]` in Cargo.toml also pins `incremental = false` for `--profile ci`
+# builds, independent of this file. Do not add `rustflags` or `[profile.*.build-override]`
+# here — that combination previously leaked into CI and slowed it down (see commit
+# af1be7ba / reverted by cf75b63f). Applies to cargo build/test/nextest/clippy alike.
+rustc-wrapper = ""
+incremental = true


### PR DESCRIPTION
## Summary
- Local rebuilds were routed through a machine-wide sccache wrapper (`~/.cargo/config.toml`), which disables the benefit of incremental compilation for local `cargo build`/`test`/`nextest`/`clippy` runs.
- Adds `rustc-wrapper = ""` and `incremental = true` to the repo's tracked `.cargo/config.toml` to restore incremental compilation locally.
- CI is unaffected: every workflow already sets `RUSTC_WRAPPER` and `CARGO_INCREMENTAL` as explicit job/step env vars, which take precedence over this config file, and CI's `[profile.ci]` independently pins `incremental = false`.
- Deliberately excludes `rustflags` / `[profile.*.build-override]`, which a prior attempt (`af1be7ba`, reverted by `cf75b63f`) added and which slowed down CI with no env-var override available.

## Test plan
- [x] `sccache --show-stats` compile-request count unchanged across a forced local rebuild (sccache not invoked)
- [x] `cargo build -p zeph-common --verbose` shows a direct `rustc` invocation (no sccache prefix) with `-C incremental=...` present
- [x] `RUSTC_WRAPPER=sccache cargo build ... --verbose` reproduces the sccache wrapper on demand, confirming env-var precedence matches what CI relies on