### PR TITLE
fix(plugins): cap archive size in add_remote/download_archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `reqwest::get(url)` global client instead, following up to 10 redirects with no
   scheme-downgrade restriction (#6099). The anti-downgrade client construction is now a
   shared `https_safe_client()` helper used by all three archive-download call sites.
+- `zeph-plugins`: `PluginManager::add_remote` and `download_archive` called `response.bytes()`
+  unconditionally with no upper bound on body size, allowing a malicious or compromised host to
+  exhaust process memory (#6108). Unlike `download_and_extract`, which already rejected an
+  oversized `Content-Length` before reading the body, these two call sites had no such check —
+  and `download_archive` backs the unattended `check_auto_updates` path that runs on every
+  process startup for any plugin with `auto_update = true`. All three call sites now share a
+  single `fetch_archive_bytes` helper that rejects a declared `Content-Length` above
+  `MAX_ARCHIVE_BYTES` (52 MiB) before reading the body, removing the duplicated inline check
+  that previously lived only in `download_and_extract`.
 - `zeph-mcp`: `PinningOAuthHttpClient` (#6074) resolved, SSRF-validated, and DNS-pinned
   the target host of every OAuth HTTP request, but its underlying `reqwest::Client`
   only disabled auto-following redirects for `OAuthHttpRedirectPolicy::Stop` requests

--- a/crates/zeph-plugins/src/manager/registry.rs
+++ b/crates/zeph-plugins/src/manager/registry.rs
@@ -73,6 +73,61 @@ async fn get_https_safe(
         })
 }
 
+/// Maximum archive size accepted by `fetch_archive_bytes`: 50 MiB.
+///
+/// Checked against `Content-Length` before reading the body. Prevents memory exhaustion
+/// from oversized or gzip-bombed archives served by a malicious host.
+pub const MAX_ARCHIVE_BYTES: u64 = 52 * 1024 * 1024;
+
+/// Fetch the archive body at `url` through [`get_https_safe`], rejecting responses whose
+/// declared `Content-Length` exceeds [`MAX_ARCHIVE_BYTES`] before the body is read.
+///
+/// Shared by every archive-download call site ([`PluginManager::add_remote`],
+/// [`PluginManager::download_archive`], and [`download_and_extract`]) so there is exactly one
+/// place enforcing the size cap.
+///
+/// # Errors
+///
+/// - [`PluginError::InsecureUrl`] — a redirect tried to downgrade from `https://` to `http://`.
+/// - [`PluginError::DownloadFailed`] — HTTP request failed, returned a non-2xx status, the
+///   declared `Content-Length` exceeded [`MAX_ARCHIVE_BYTES`], or the download timed out.
+async fn fetch_archive_bytes(
+    url: &str,
+    timeout: std::time::Duration,
+) -> Result<Vec<u8>, PluginError> {
+    let response = get_https_safe(url, timeout).await?;
+
+    if !response.status().is_success() {
+        return Err(PluginError::DownloadFailed {
+            url: url.to_owned(),
+            reason: format!("HTTP {}", response.status()),
+        });
+    }
+
+    // Reject oversized archives before reading the body.
+    if let Some(content_length) = response.content_length()
+        && content_length > MAX_ARCHIVE_BYTES
+    {
+        return Err(PluginError::DownloadFailed {
+            url: url.to_owned(),
+            reason: format!("archive too large: {content_length} bytes (max {MAX_ARCHIVE_BYTES})"),
+        });
+    }
+
+    let bytes = tokio::time::timeout(timeout, response.bytes())
+        .await
+        .map_err(|_| PluginError::DownloadFailed {
+            url: url.to_owned(),
+            reason: format!("download timed out after {}s", timeout.as_secs()),
+        })?
+        .map_err(|e| PluginError::DownloadFailed {
+            url: url.to_owned(),
+            reason: format!("failed to read response body: {e}"),
+        })?;
+
+    Ok(bytes.to_vec())
+}
+
 impl PluginManager {
     /// Download and install a plugin from a remote URL with optional SHA-256 integrity pinning.
     ///
@@ -131,25 +186,7 @@ impl PluginManager {
 
         let timeout = std::time::Duration::from_secs(self.download_timeout_secs);
 
-        let response = get_https_safe(url, timeout).await?;
-
-        if !response.status().is_success() {
-            return Err(PluginError::DownloadFailed {
-                url: url.to_owned(),
-                reason: format!("HTTP {}", response.status()),
-            });
-        }
-
-        let bytes = tokio::time::timeout(timeout, response.bytes())
-            .await
-            .map_err(|_| PluginError::DownloadFailed {
-                url: url.to_owned(),
-                reason: format!("download timed out after {}s", self.download_timeout_secs),
-            })?
-            .map_err(|e| PluginError::DownloadFailed {
-                url: url.to_owned(),
-                reason: format!("failed to read response body: {e}"),
-            })?;
+        let bytes = fetch_archive_bytes(url, timeout).await?;
 
         // Verify SHA-256 before extracting anything.
         if let Some(expected) = expected_sha256 {
@@ -415,20 +452,9 @@ impl PluginManager {
         url: &str,
         timeout: std::time::Duration,
     ) -> Result<Vec<u8>, String> {
-        let response = get_https_safe(url, timeout)
+        fetch_archive_bytes(url, timeout)
             .await
-            .map_err(|e| e.to_string())?;
-
-        if !response.status().is_success() {
-            return Err(format!("HTTP {}", response.status()));
-        }
-
-        let raw = tokio::time::timeout(timeout, response.bytes())
-            .await
-            .map_err(|_| format!("body read timed out after {}s", timeout.as_secs()))?
-            .map_err(|e| format!("failed to read body: {e}"))?;
-
-        Ok(raw.to_vec())
+            .map_err(|e| e.to_string())
     }
 
     /// Download a plugin archive and load it as a session-scoped ephemeral plugin.
@@ -541,12 +567,6 @@ async fn read_plugin_source(path: &std::path::Path) -> Option<PluginSource> {
     }
 }
 
-/// Maximum archive size accepted by [`download_and_extract`]: 50 MiB.
-///
-/// Checked against `Content-Length` before reading the body. Prevents memory exhaustion
-/// from oversized or gzip-bombed archives served by a malicious host.
-pub const MAX_ARCHIVE_BYTES: u64 = 52 * 1024 * 1024;
-
 /// Download the archive at `url`, verify its SHA-256 digest (when provided), and extract it
 /// into `dest`.
 ///
@@ -574,36 +594,9 @@ pub async fn download_and_extract(
 ) -> Result<(), PluginError> {
     let timeout = std::time::Duration::from_secs(timeout_secs);
 
-    // Refuses to follow any redirect that downgrades from https (B1).
-    let response = get_https_safe(url, timeout).await?;
-
-    if !response.status().is_success() {
-        return Err(PluginError::DownloadFailed {
-            url: url.to_owned(),
-            reason: format!("HTTP {}", response.status()),
-        });
-    }
-
-    // Reject oversized archives before reading the body (B3).
-    if let Some(content_length) = response.content_length()
-        && content_length > MAX_ARCHIVE_BYTES
-    {
-        return Err(PluginError::DownloadFailed {
-            url: url.to_owned(),
-            reason: format!("archive too large: {content_length} bytes (max {MAX_ARCHIVE_BYTES})"),
-        });
-    }
-
-    let bytes = tokio::time::timeout(timeout, response.bytes())
-        .await
-        .map_err(|_| PluginError::DownloadFailed {
-            url: url.to_owned(),
-            reason: format!("download timed out after {timeout_secs}s"),
-        })?
-        .map_err(|e| PluginError::DownloadFailed {
-            url: url.to_owned(),
-            reason: format!("failed to read response body: {e}"),
-        })?;
+    // Refuses to follow any redirect that downgrades from https (B1), and rejects oversized
+    // archives before reading the body (B3).
+    let bytes = fetch_archive_bytes(url, timeout).await?;
 
     if let Some(expected) = sha256 {
         let actual = crate::integrity::sha256_hex(&bytes);

--- a/crates/zeph-plugins/src/manager/tests.rs
+++ b/crates/zeph-plugins/src/manager/tests.rs
@@ -998,6 +998,35 @@ async fn add_remote_wrong_hash_returns_integrity_error() {
     );
 }
 
+#[tokio::test]
+async fn add_remote_rejects_oversized_content_length() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    // The body is genuinely larger than MAX_ARCHIVE_BYTES so the server's real Content-Length
+    // header matches what it sends (a lying header causes hyper to reset the connection before
+    // the client ever sees a response) — the cap must still be enforced from the header alone,
+    // before the multi-megabyte body is ever read into memory.
+    let oversized_body = vec![0u8; usize::try_from(MAX_ARCHIVE_BYTES + 1).unwrap()];
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(oversized_body))
+        .mount(&mock_server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let plugins_dir = tmp.path().join("plugins");
+    let managed_dir = tmp.path().join("managed");
+    let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
+
+    let url = format!("{}/huge-plugin.tar.gz", mock_server.uri());
+    let err = mgr.add_remote(&url, None).await.unwrap_err();
+    assert!(
+        matches!(err, PluginError::DownloadFailed { ref reason, .. } if reason.contains("archive too large")),
+        "oversized Content-Length must be rejected with DownloadFailed, got {err:?}"
+    );
+}
+
 // --- auto_update and PluginSource tests ---
 
 #[tokio::test]
@@ -1327,6 +1356,64 @@ path = "skills/my-skill"
     );
 
     // Plugin must still be installed at the old version.
+    let installed = mgr.list_installed().unwrap();
+    assert_eq!(installed[0].version, "0.1.0");
+}
+
+#[tokio::test]
+async fn check_auto_updates_rejects_oversized_content_length() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let manifest = r#"[plugin]
+name = "huge-update"
+version = "0.1.0"
+description = "test"
+auto_update = true
+
+[[skills]]
+path = "skills/my-skill"
+"#;
+    write_plugin(&source, "huge-update", manifest, &[("my-skill", "body")]);
+    let archive = build_tar_gz(&source);
+    let hash = crate::integrity::sha256_hex(&archive);
+
+    let mock_server = MockServer::start().await;
+    // Install succeeds (declared Content-Length matches the real, small body).
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(archive)
+                .append_header("Content-Type", "application/octet-stream"),
+        )
+        .up_to_n_times(1)
+        .mount(&mock_server)
+        .await;
+    // Auto-update check serves a genuinely oversized body; the cap must be enforced from the
+    // real Content-Length header before the multi-megabyte body is read into memory.
+    let oversized_body = vec![0u8; usize::try_from(MAX_ARCHIVE_BYTES + 1).unwrap()];
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(oversized_body))
+        .mount(&mock_server)
+        .await;
+
+    let plugins_dir = tmp.path().join("plugins");
+    let managed_dir = tmp.path().join("managed");
+    let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
+    let url = format!("{}/huge-update.tar.gz", mock_server.uri());
+    mgr.add_remote(&url, Some(&hash)).await.unwrap();
+
+    let results = mgr.check_auto_updates().await;
+    assert_eq!(results.len(), 1);
+    assert!(
+        matches!(&results[0].status, AutoUpdateStatus::Failed(reason) if reason.contains("archive too large")),
+        "oversized Content-Length must yield Failed, got {:?}",
+        results[0].status
+    );
+
+    // Plugin must still be installed at the old version — the oversized download never applied.
     let installed = mgr.list_installed().unwrap();
     assert_eq!(installed[0].version, "0.1.0");
 }


### PR DESCRIPTION
## Summary

`PluginManager::add_remote` and `download_archive` in `crates/zeph-plugins/src/manager/registry.rs` called `response.bytes()` unconditionally with no upper bound on body size, unlike `download_and_extract`, which already rejected an oversized `Content-Length` before reading the body. This allowed a malicious or compromised host to exhaust process memory (CWE-400):

- `add_remote` — manual permanent plugin install path.
- `download_archive` — backs the unattended `check_auto_updates`/`update_one_plugin` path, which runs on every process startup for any plugin with `auto_update = true`.

This closes the residual gap left by #6104, which consolidated the anti-downgrade HTTPS client across all three call sites but did not also consolidate the size check.

## Changes

- Added a shared `fetch_archive_bytes` helper (`crates/zeph-plugins/src/manager/registry.rs`) that bundles `get_https_safe` with a `Content-Length` pre-check against `MAX_ARCHIVE_BYTES` (52 MiB), rejecting oversized responses before the body is read.
- `add_remote`, `download_archive`, and `download_and_extract` all now call this single helper — there is exactly one place enforcing the cap instead of one (previously only `download_and_extract`).
- Added two regression tests exercising the cap via a real oversized response body (`add_remote_rejects_oversized_content_length`, `check_auto_updates_rejects_oversized_content_length`).

## Scope note

Matching `download_and_extract`'s existing behavior, the cap is `Content-Length`-based and enforced before the body read, not during a streamed read. A host that omits or lies about `Content-Length` (e.g. via chunked transfer-encoding) is not caught by this check — this is a pre-existing gap shared with `download_and_extract`'s original implementation, not a new one introduced here, and is out of scope for this issue. Documented as a known gap in `CHANGELOG.md` and `.local/testing/playbooks/plugins.md`; a streaming-enforced follow-up may be worth filing separately.

Closes #6108
Closes #6109

## Test plan

- [x] `cargo +nightly fmt --check` (workspace)
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12976 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links --deny rustdoc::private_intra_doc_links" cargo doc --no-deps --all-features -p zeph-plugins`
- [x] New `zeph-plugins` tests: 123/123 passed