### PR TITLE
fix(channels): bound send_status timeout and add Telegram 429 retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- `zeph-channels`/`zeph-core`: hardened the channel send/retry/status path (#6094, #6106, #6095).
+  - `Channel::send_status` was awaited inline on the agent turn hot path at ~45 call sites via
+    `let _ = self.channel.send_status(...).await;`, with no outer timeout. Under sustained
+    HTTP 429s, Slack/Discord's retry-with-backoff loop (`http_retry::send_with_retry`) could take
+    up to several minutes, stalling the turn for that long (#6094). Added
+    `Channel::send_status_best_effort` — a default trait method that wraps `send_status` in a
+    10s `tokio::time::timeout` and logs the outcome (`tracing::debug!` on success,
+    `tracing::warn!` on error or timeout) instead of returning a `Result`. All discard call
+    sites now use this method, which also closes #6106's "failures are silently discarded with
+    no logging" gap in one place rather than touching every call site individually.
+  - `TelegramChannel::send`/`send_status`/`send_or_edit` (backing `flush_chunks`) called
+    `self.bot.send_message`/`edit_message_text` directly via plain `teloxide::Bot`, bypassing the
+    429 retry-with-backoff resilience that Discord, Slack, and `TelegramApiClient` already have
+    (#6106). Added `common::teloxide_retry::send_teloxide_with_retry`, mirroring
+    `http_retry::send_with_retry`'s backoff semantics for `teloxide::RequestError::RetryAfter`,
+    and routed all three call sites through it.
+  - Discord's `RestClient` had no test-injectable base URL, unlike `SlackApi`/`TelegramApiClient`
+    (#6095). Added a `base_url` field defaulting to Discord's real API base plus a
+    `#[cfg(test)]` `with_base_url` constructor, and added wiremock tests confirming
+    `send_message`, `edit_message`, and `trigger_typing` each retry transparently on a 429.
 - `zeph-core`: removed two blocking-I/O sites from the async agent turn loop (#6020, #6029).
   - `rebuild_system_prompt` called `project::discover_project_configs`/`load_project_context`
     directly on every turn — a filesystem walk from cwd to the root plus a `read_to_string`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10656,6 +10656,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "tree-sitter",
  "uuid",
  "zeph-agent-context",

--- a/crates/zeph-channels/src/common/mod.rs
+++ b/crates/zeph-channels/src/common/mod.rs
@@ -4,3 +4,4 @@
 //! Internal helpers shared across channel REST/Web API clients.
 
 pub(crate) mod http_retry;
+pub(crate) mod teloxide_retry;

--- a/crates/zeph-channels/src/common/teloxide_retry.rs
+++ b/crates/zeph-channels/src/common/teloxide_retry.rs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared 429 retry-with-backoff helper for teloxide `Bot` requests.
+//!
+//! [`crate::common::http_retry`] provides this same resilience for the raw `reqwest`-based
+//! REST clients (Discord, Slack, [`crate::telegram_api_ext::TelegramApiClient`]). `TelegramChannel`'s
+//! primary send path instead goes through teloxide's typed `Bot` API (for `MarkdownV2` parsing,
+//! message-id tracking, etc.), which surfaces rate-limiting as
+//! [`teloxide::RequestError::RetryAfter`] rather than an HTTP 429 status — this module mirrors
+//! `http_retry`'s backoff semantics for that error shape instead.
+
+use std::time::Duration;
+
+use teloxide::requests::{Output, Request};
+
+/// Upper bound applied to any `RetryAfter` duration reported by Telegram.
+const MAX_RETRY_SECS: u64 = 60;
+/// Maximum number of retry attempts before giving up and surfacing the error.
+const MAX_RETRIES: u32 = 3;
+
+/// Sends a teloxide request, retrying with backoff on [`teloxide::RequestError::RetryAfter`].
+///
+/// Uses [`Request::send_ref`] so the same request value is resent on each attempt rather than
+/// rebuilding it. On any other error the failure is returned immediately.
+///
+/// `context` is a short label (e.g. `"telegram"`) attached to the warning logs.
+///
+/// # Timing
+///
+/// Under sustained rate-limiting, the worst-case wall-clock across all attempts is
+/// approximately `MAX_RETRIES * MAX_RETRY_SECS` (the backoff sleeps between attempts), on the
+/// order of minutes with the current constants — the same shape as
+/// [`crate::common::http_retry::send_with_retry`]'s documented worst case. This is deliberate for
+/// `TelegramChannel::send`/`flush_chunks` (the actual response content): a real reply is worth
+/// retrying to completion rather than dropping. The one caller that cannot tolerate this,
+/// `Channel::send_status` (an ephemeral status label with no value after a few seconds), is not
+/// bounded here — `zeph_core::channel::Channel::send_status_best_effort` wraps the whole
+/// `send_status` call (including any retry loop reached through this function) in its own much
+/// shorter, separately-configured timeout at the `Channel` trait level instead of this module
+/// applying one internally. Callers of `send`/`flush_chunks` (which do not go through
+/// `send_status_best_effort`) intentionally have no outer timeout and may legitimately block for
+/// the full worst case above.
+///
+/// # Errors
+///
+/// Returns the underlying [`teloxide::RequestError`] when a non-`RetryAfter` error occurs or
+/// when retries are exhausted.
+pub(crate) async fn send_teloxide_with_retry<R>(
+    context: &str,
+    req: &R,
+) -> Result<Output<R>, teloxide::RequestError>
+where
+    R: Request<Err = teloxide::RequestError>,
+{
+    let mut attempts = 0u32;
+    loop {
+        match req.send_ref().await {
+            Ok(value) => return Ok(value),
+            Err(teloxide::RequestError::RetryAfter(secs)) => {
+                let delay = secs.duration().min(Duration::from_secs(MAX_RETRY_SECS));
+                attempts += 1;
+                if attempts > MAX_RETRIES {
+                    tracing::warn!(
+                        context,
+                        delay_secs = delay.as_secs(),
+                        attempts,
+                        "telegram rate-limited and retries exhausted"
+                    );
+                    return req.send_ref().await;
+                }
+                tracing::warn!(
+                    context,
+                    delay_secs = delay.as_secs(),
+                    attempt = attempts,
+                    max = MAX_RETRIES,
+                    "telegram rate-limited (429), backing off"
+                );
+                tokio::time::sleep(delay).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}

--- a/crates/zeph-channels/src/discord/rest.rs
+++ b/crates/zeph-channels/src/discord/rest.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::http_retry::send_with_retry;
 
+/// Default base URL for the Discord REST API. Overridden only in tests via [`RestClient::with_base_url`].
 const BASE_URL: &str = "https://discord.com/api/v10";
 /// Per-request HTTP timeout applied to every Discord REST call.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -49,6 +50,8 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
 pub struct RestClient {
     client: reqwest::Client,
     token: String,
+    /// Base URL for the Discord REST API. Always [`BASE_URL`] outside of tests.
+    base_url: String,
 }
 
 impl std::fmt::Debug for RestClient {
@@ -78,7 +81,21 @@ impl RestClient {
     #[must_use]
     pub fn new(token: String) -> Self {
         let client = zeph_core::http::default_client();
-        Self { client, token }
+        Self {
+            client,
+            token,
+            base_url: BASE_URL.to_string(),
+        }
+    }
+
+    /// Test-only constructor pointing at a custom base URL (e.g. a mock server).
+    #[cfg(test)]
+    fn with_base_url(base_url: String, token: String) -> Self {
+        Self {
+            client: zeph_core::http::default_client(),
+            token,
+            base_url,
+        }
     }
 
     fn auth_header(&self) -> String {
@@ -97,7 +114,7 @@ impl RestClient {
         channel_id: &str,
         content: &str,
     ) -> Result<DiscordMessage, reqwest::Error> {
-        let url = format!("{BASE_URL}/channels/{channel_id}/messages");
+        let url = format!("{}/channels/{channel_id}/messages", self.base_url);
         let auth = self.auth_header();
         let resp = send_with_retry("discord", || {
             self.client
@@ -123,7 +140,10 @@ impl RestClient {
         message_id: &str,
         content: &str,
     ) -> Result<(), reqwest::Error> {
-        let url = format!("{BASE_URL}/channels/{channel_id}/messages/{message_id}");
+        let url = format!(
+            "{}/channels/{channel_id}/messages/{message_id}",
+            self.base_url
+        );
         let auth = self.auth_header();
         send_with_retry("discord", || {
             self.client
@@ -189,7 +209,7 @@ impl RestClient {
         tracing::instrument(name = "channels.discord.rest.trigger_typing", skip_all)
     )]
     pub async fn trigger_typing(&self, channel_id: &str) -> Result<(), reqwest::Error> {
-        let url = format!("{BASE_URL}/channels/{channel_id}/typing");
+        let url = format!("{}/channels/{channel_id}/typing", self.base_url);
         let auth = self.auth_header();
         send_with_retry("discord", || {
             self.client
@@ -204,6 +224,9 @@ impl RestClient {
 
 #[cfg(test)]
 mod tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
     use super::*;
 
     // Generic 429 retry-with-backoff behavior is covered by
@@ -215,9 +238,88 @@ mod tests {
         let rc = RestClient {
             client: reqwest::Client::new(),
             token: "secret-token".into(),
+            base_url: BASE_URL.to_string(),
         };
         let debug = format!("{rc:?}");
         assert!(!debug.contains("secret-token"));
         assert!(debug.contains("REDACTED"));
+    }
+
+    #[tokio::test]
+    async fn send_message_retries_on_429_then_succeeds() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/channels/123/messages"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .set_body_json(serde_json::json!({"retry_after": 0.0})),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/channels/123/messages"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "msg-1"})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = RestClient::with_base_url(server.uri(), "test-token".into());
+        let msg = client.send_message("123", "hello").await.unwrap();
+        assert_eq!(msg.id, "msg-1");
+    }
+
+    #[tokio::test]
+    async fn edit_message_retries_on_429_then_succeeds() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/channels/123/messages/456"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .set_body_json(serde_json::json!({"retry_after": 0.0})),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/channels/123/messages/456"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        let client = RestClient::with_base_url(server.uri(), "test-token".into());
+        client.edit_message("123", "456", "updated").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn trigger_typing_retries_on_429_then_succeeds() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/channels/123/typing"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .set_body_json(serde_json::json!({"retry_after": 0.0})),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/channels/123/typing"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        let client = RestClient::with_base_url(server.uri(), "test-token".into());
+        client.trigger_typing("123").await.unwrap();
     }
 }

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -487,6 +487,40 @@ impl TelegramChannel {
         }
     }
 
+    /// Sends `text` as a new message (retrying on Telegram rate-limiting) and records the
+    /// resulting message id in `self.message_id` so later chunks edit it in place.
+    async fn send_new_chunk(&mut self, chat_id: ChatId, text: &str) -> Result<(), ChannelError> {
+        let req = self
+            .bot
+            .send_message(chat_id, text)
+            .parse_mode(ParseMode::MarkdownV2);
+        let msg = crate::common::teloxide_retry::send_teloxide_with_retry("telegram", &req)
+            .await
+            .map_err(ChannelError::telegram)?;
+        self.message_id = Some(msg.id);
+        tracing::debug!("message sent with id: {:?}", msg.id);
+        Ok(())
+    }
+
+    /// Edits `msg_id` to `text`, retrying on Telegram rate-limiting.
+    ///
+    /// Returns the raw teloxide error rather than [`ChannelError`] so callers can inspect
+    /// specific failure strings (e.g. "message is not modified") before deciding how to react.
+    async fn edit_chunk(
+        &self,
+        chat_id: ChatId,
+        msg_id: MessageId,
+        text: &str,
+    ) -> Result<(), teloxide::RequestError> {
+        let req = self
+            .bot
+            .edit_message_text(chat_id, msg_id, text)
+            .parse_mode(ParseMode::MarkdownV2);
+        crate::common::teloxide_retry::send_teloxide_with_retry("telegram", &req)
+            .await
+            .map(|_| ())
+    }
+
     #[tracing::instrument(name = "channels.telegram.send_or_edit", skip_all)]
     async fn send_or_edit(&mut self) -> Result<(), ChannelError> {
         let Some(chat_id) = self.chat_id else {
@@ -515,14 +549,7 @@ impl TelegramChannel {
                 tracing::debug!("sending new message (length: {})", formatted_text.len());
                 let chunks = crate::markdown::utf8_chunks(&formatted_text, MAX_MESSAGE_LEN);
                 for chunk in chunks {
-                    let msg = self
-                        .bot
-                        .send_message(chat_id, chunk)
-                        .parse_mode(ParseMode::MarkdownV2)
-                        .await
-                        .map_err(ChannelError::telegram)?;
-                    self.message_id = Some(msg.id);
-                    tracing::debug!("new message sent with id: {:?}", msg.id);
+                    self.send_new_chunk(chat_id, chunk).await?;
                 }
             }
             Some(msg_id) => {
@@ -532,13 +559,7 @@ impl TelegramChannel {
                     formatted_text.len()
                 );
                 if formatted_text.len() <= MAX_MESSAGE_LEN {
-                    let edit_result = self
-                        .bot
-                        .edit_message_text(chat_id, msg_id, &formatted_text)
-                        .parse_mode(ParseMode::MarkdownV2)
-                        .await;
-
-                    if let Err(e) = edit_result {
+                    if let Err(e) = self.edit_chunk(chat_id, msg_id, &formatted_text).await {
                         let error_msg = e.to_string();
 
                         if error_msg.contains("message is not modified") {
@@ -550,14 +571,7 @@ impl TelegramChannel {
                                 "Telegram edit failed (message_id stale?): {e}, sending new message"
                             );
                             self.message_id = None;
-
-                            let msg = self
-                                .bot
-                                .send_message(chat_id, &formatted_text)
-                                .parse_mode(ParseMode::MarkdownV2)
-                                .await
-                                .map_err(ChannelError::telegram)?;
-                            self.message_id = Some(msg.id);
+                            self.send_new_chunk(chat_id, &formatted_text).await?;
                         } else {
                             return Err(ChannelError::telegram(e));
                         }
@@ -569,28 +583,17 @@ impl TelegramChannel {
                     // send remaining chunks as new messages.
                     let chunks = crate::markdown::utf8_chunks(&formatted_text, MAX_MESSAGE_LEN);
                     let mut iter = chunks.into_iter();
-                    if let Some(first) = iter.next() {
-                        let edit_result = self
-                            .bot
-                            .edit_message_text(chat_id, msg_id, first)
-                            .parse_mode(ParseMode::MarkdownV2)
-                            .await;
-                        if let Err(e) = edit_result {
-                            let error_msg = e.to_string();
-                            if !error_msg.contains("message is not modified") {
-                                tracing::warn!("Telegram edit failed during split: {e}");
-                            }
+                    if let Some(first) = iter.next()
+                        && let Err(e) = self.edit_chunk(chat_id, msg_id, first).await
+                    {
+                        let error_msg = e.to_string();
+                        if !error_msg.contains("message is not modified") {
+                            tracing::warn!("Telegram edit failed during split: {e}");
                         }
                     }
                     for chunk in iter {
-                        let msg = self
-                            .bot
-                            .send_message(chat_id, chunk)
-                            .parse_mode(ParseMode::MarkdownV2)
-                            .await
-                            .map_err(ChannelError::telegram)?;
-                        self.message_id = Some(msg.id);
-                        tracing::debug!("overflow chunk sent with id: {:?}", msg.id);
+                        self.send_new_chunk(chat_id, chunk).await?;
+                        tracing::debug!("overflow chunk sent");
                     }
                 }
             }
@@ -1204,17 +1207,21 @@ impl Channel for TelegramChannel {
         }
 
         if formatted_text.len() <= MAX_MESSAGE_LEN {
-            self.bot
+            let req = self
+                .bot
                 .send_message(chat_id, &formatted_text)
-                .parse_mode(ParseMode::MarkdownV2)
+                .parse_mode(ParseMode::MarkdownV2);
+            crate::common::teloxide_retry::send_teloxide_with_retry("telegram", &req)
                 .await
                 .map_err(ChannelError::telegram)?;
         } else {
             let chunks = crate::markdown::utf8_chunks(&formatted_text, MAX_MESSAGE_LEN);
             for chunk in chunks {
-                self.bot
+                let req = self
+                    .bot
                     .send_message(chat_id, chunk)
-                    .parse_mode(ParseMode::MarkdownV2)
+                    .parse_mode(ParseMode::MarkdownV2);
+                crate::common::teloxide_retry::send_teloxide_with_retry("telegram", &req)
                     .await
                     .map_err(ChannelError::telegram)?;
             }
@@ -1357,8 +1364,8 @@ impl Channel for TelegramChannel {
         let Some(chat_id) = self.chat_id else {
             return Ok(());
         };
-        self.bot
-            .send_message(chat_id, text)
+        let req = self.bot.send_message(chat_id, text);
+        crate::common::teloxide_retry::send_teloxide_with_retry("telegram", &req)
             .await
             .map_err(ChannelError::telegram)?;
         Ok(())
@@ -2097,6 +2104,57 @@ mod tests {
             requests.len() >= 2,
             "expected edit + at least 1 overflow send, got {}",
             requests.len()
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // send_teloxide_with_retry wiring — 429 (RetryAfter) retry-then-succeed,
+    // exercised through the real TelegramChannel send paths (issue #6106).
+    // ---------------------------------------------------------------------------
+
+    /// Regression test for #6106: `TelegramChannel::send` must retry (rather than
+    /// immediately fail) when the Bot API responds with `RetryAfter`, mirroring
+    /// `telegram_api_ext.rs`'s `post_retries_on_429_then_succeeds`. The scoped mock is
+    /// registered *before* `make_mocked_channel` mounts its catch-all `any()` 200 mock:
+    /// wiremock breaks priority ties (all mocks default to priority 5) by insertion
+    /// order, so this mock is tried first for the first `sendMessage` call, exhausts
+    /// after one match (`up_to_n_times(1)`), and the retried second call falls through
+    /// to the catch-all 200 response.
+    #[tokio::test]
+    async fn send_retries_on_telegram_429_then_succeeds() {
+        use wiremock::matchers::{method, path_regex};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            // teloxide sends the payload struct's type name ("SendMessage", PascalCase) as the
+            // method segment, not the Bot API docs' camelCase "sendMessage" — Telegram's method
+            // names are case-insensitive, so `(?i)` matches what the wire actually carries.
+            .and(path_regex("(?i).*/sendmessage$"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+                "ok": false,
+                "description": "Too Many Requests: retry after 0",
+                "parameters": {"retry_after": 0}
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let (mut channel, _tx) = make_mocked_channel(&server, vec![]).await;
+
+        channel
+            .send("hello")
+            .await
+            .expect("send must succeed after retrying past the 429");
+
+        let requests = server.received_requests().await.unwrap();
+        let send_message_calls = requests
+            .iter()
+            .filter(|r| r.url.path().to_lowercase().ends_with("/sendmessage"))
+            .count();
+        assert_eq!(
+            send_message_calls, 2,
+            "expected sendMessage to be called twice: 429 then success, got requests: {requests:?}"
         );
     }
 

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -107,6 +107,7 @@ sqlx.workspace = true
 sysinfo = { workspace = true, features = ["system"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+tracing-test.workspace = true
 tracing-subscriber = { workspace = true, features = ["parking_lot", "registry"] }
 zeph-llm = { workspace = true, features = ["testing"] }
 zeph-memory = { workspace = true, features = ["testing"] }

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -676,9 +676,11 @@ impl<C: Channel> Agent<C> {
             status_tx: self.services.session.status_tx.clone(),
             task_supervisor: Arc::clone(&self.runtime.lifecycle.task_supervisor),
         };
-        let _ = self.channel.send_status("recalling context...").await;
+        self.channel
+            .send_status_best_effort("recalling context...")
+            .await;
         let result = svc.prepare_context(query, &mut window, &mut view).await;
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
 
         let delta =
             result.map_err(|e| super::super::error::AgentError::ContextError(format!("{e:#}")))?;
@@ -1068,7 +1070,9 @@ impl<C: Channel> Agent<C> {
         {
             let provider = self.embedding_provider.clone();
             let embed_timeout_secs = self.runtime.config.timeouts.embedding_seconds;
-            let _ = self.channel.send_status("matching skills...").await;
+            self.channel
+                .send_status_best_effort("matching skills...")
+                .await;
             let match_result = matcher
                 .match_skills(
                     all_meta,
@@ -1349,7 +1353,7 @@ impl<C: Channel> Agent<C> {
                     (scored.iter().map(|s| s.index).collect(), false)
                 }
             };
-            let _ = self.channel.send_status("").await;
+            self.channel.send_status_best_effort("").await;
             (indices, fallback)
         } else {
             tracing::warn!(
@@ -1654,7 +1658,9 @@ impl<C: Channel> Agent<C> {
                             .discovery_provider
                             .clone()
                             .unwrap_or_else(|| self.embedding_provider.clone());
-                        let _ = self.channel.send_status("selecting tools...").await;
+                        self.channel
+                            .send_status_best_effort("selecting tools...")
+                            .await;
                         let embed_timeout = std::time::Duration::from_secs(
                             self.runtime.config.timeouts.embedding_seconds,
                         );
@@ -1696,7 +1702,7 @@ impl<C: Channel> Agent<C> {
                                 // MCP tools rather than silently degrading to the full unfiltered set.
                             }
                         }
-                        let _ = self.channel.send_status("").await;
+                        self.channel.send_status_best_effort("").await;
                     } else {
                         // Index not built (build failed at connect time).
                         tracing::warn!(
@@ -1767,7 +1773,9 @@ impl<C: Channel> Agent<C> {
                 .map(|d| (d.id.as_ref(), d.description.as_ref()))
                 .collect();
 
-            let _ = self.channel.send_status("filtering tools...").await;
+            self.channel
+                .send_status_best_effort("filtering tools...")
+                .await;
             let schema_embed_timeout =
                 std::time::Duration::from_secs(self.runtime.config.timeouts.embedding_seconds);
             match tokio::time::timeout(schema_embed_timeout, self.embedding_provider.embed(query))
@@ -1825,7 +1833,7 @@ impl<C: Channel> Agent<C> {
                     tracing::warn!("tool filter: query embed failed, using all tools: {e:#}");
                 }
             }
-            let _ = self.channel.send_status("").await;
+            self.channel.send_status_best_effort("").await;
         }
     }
 

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -44,7 +44,7 @@ impl<C: Channel> Agent<C> {
         // Forward collected statuses to the channel AND the TUI status sender.
         let collected = status.take();
         for msg in &collected {
-            let _ = self.channel.send_status(msg).await;
+            self.channel.send_status_best_effort(msg).await;
         }
         if let Some(ref tx) = self.services.session.status_tx {
             for msg in &collected {
@@ -150,9 +150,8 @@ impl<C: Channel> Agent<C> {
                 saved = tokens_before.saturating_sub(tokens_after),
                 "context compaction complete"
             );
-            let _ = self
-                .channel
-                .send_status(&format!(
+            self.channel
+                .send_status_best_effort(&format!(
                     "Compacting: {tokens_before}→{tokens_after} tokens"
                 ))
                 .await;

--- a/crates/zeph-core/src/agent/hooks_dispatch.rs
+++ b/crates/zeph-core/src/agent/hooks_dispatch.rs
@@ -60,9 +60,8 @@ impl<C: Channel> Agent<C> {
             "working directory changed"
         );
 
-        let _ = self
-            .channel
-            .send_status("Working directory changed\u{2026}")
+        self.channel
+            .send_status_best_effort("Working directory changed\u{2026}")
             .await;
 
         let hooks = self.services.session.hooks_config.cwd_changed.clone();
@@ -91,7 +90,7 @@ impl<C: Channel> Agent<C> {
             }
         }
 
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
     }
     /// Handle a `FileChangedEvent` from the file watcher.
     #[tracing::instrument(name = "core.agent.handle_file_changed", skip_all, level = "debug")]
@@ -101,9 +100,8 @@ impl<C: Channel> Agent<C> {
     ) {
         tracing::info!(path = %event.path.display(), "file changed");
 
-        let _ = self
-            .channel
-            .send_status("Running file-change hook\u{2026}")
+        self.channel
+            .send_status_best_effort("Running file-change hook\u{2026}")
             .await;
 
         let hooks = self
@@ -139,7 +137,7 @@ impl<C: Channel> Agent<C> {
             }
         }
 
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
     }
 }
 

--- a/crates/zeph-core/src/agent/learning/outcomes.rs
+++ b/crates/zeph-core/src/agent/learning/outcomes.rs
@@ -63,13 +63,13 @@ impl<C: Channel> Agent<C> {
         });
 
         let messages_before = self.msg.messages.len();
-        let _ = self.channel.send_status("reflecting...").await;
+        self.channel.send_status_best_effort("reflecting...").await;
         // Box::pin to break async recursion cycle (process_response -> attempt_self_reflection -> process_response)
         if let Err(e) = Box::pin(self.process_response()).await {
-            let _ = self.channel.send_status("").await;
+            self.channel.send_status_best_effort("").await;
             return Err(e);
         }
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
         let retry_succeeded = self.msg.messages.len() > messages_before;
 
         // D2Skill: record whether injected corrections led to success.

--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -553,9 +553,8 @@ impl<C: Channel> Agent<C> {
             }
         }
 
-        let _ = self
-            .channel
-            .send_status("MCP server requesting input…")
+        self.channel
+            .send_status_best_effort("MCP server requesting input…")
             .await;
         let response = match self.channel.elicit(channel_request).await {
             Ok(r) => r,
@@ -564,12 +563,12 @@ impl<C: Channel> Agent<C> {
                     server_id = event.server_id,
                     "elicitation channel error: {e:#}"
                 );
-                let _ = self.channel.send_status("").await;
+                self.channel.send_status_best_effort("").await;
                 let _ = event.response_tx.send(decline);
                 return;
             }
         };
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
 
         let result = match response {
             ElicitationResponse::Accepted(value) => {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1780,7 +1780,7 @@ impl<C: Channel> Agent<C> {
         // Cache-expiry warning (#2715): notify user when prompt cache has likely expired.
         if let Some(warning) = self.cache_expiry_warning() {
             tracing::info!(warning, "cache expiry warning");
-            let _ = self.channel.send_status(&warning).await;
+            self.channel.send_status_best_effort(&warning).await;
         }
 
         // Time-based microcompact (#2699): strip stale low-value tool outputs before compaction.

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -161,9 +161,8 @@ impl<C: crate::channel::Channel> Agent<C> {
         {
             Ok(handle_id) => {
                 *spawn_counter += 1;
-                let _ = self
-                    .channel
-                    .send_status(&format!(
+                self.channel
+                    .send_status_best_effort(&format!(
                         "Executing task {spawn_counter}/{task_count}: {task_title}..."
                     ))
                     .await;
@@ -199,9 +198,8 @@ impl<C: crate::channel::Channel> Agent<C> {
             .tasks
             .get(task_id.index())
             .map_or("unknown", |t| t.title.as_str());
-        let _ = self
-            .channel
-            .send_status(&format!(
+        self.channel
+            .send_status_best_effort(&format!(
                 "Executing task {spawn_counter}/{task_count} (inline): {task_title}..."
             ))
             .await;
@@ -532,7 +530,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                 } => {
                     if let Ok(Some(msg)) = result {
                         if msg.text.trim().eq_ignore_ascii_case("/plan cancel") {
-                            let _ = self.channel.send_status("Canceling plan...").await;
+                            self.channel.send_status_best_effort("Canceling plan...").await;
                             let cancel_actions = scheduler.cancel_all();
                             if let Some(s) = self.cancel_agents_from_actions(cancel_actions) {
                                 break 'tick s;

--- a/crates/zeph-core/src/agent/session_digest.rs
+++ b/crates/zeph-core/src/agent/session_digest.rs
@@ -288,9 +288,8 @@ impl<C: Channel> Agent<C> {
             &non_system[..]
         };
 
-        let _ = self
-            .channel
-            .send_status("Generating session digest...")
+        self.channel
+            .send_status_best_effort("Generating session digest...")
             .await;
 
         // PAAC secret masking (#5437) is structural at the provider boundary — `self.provider`
@@ -309,7 +308,7 @@ impl<C: Channel> Agent<C> {
         )
         .await;
 
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
 
         // Update the cached digest so it is available in the same session if re-used.
         if let Some((final_text, token_count)) = result {
@@ -467,13 +466,15 @@ impl<C: Channel> Agent<C> {
         let provider =
             self.resolve_background_provider(self.runtime.config.recap_config.provider.as_str());
 
-        let _ = self.channel.send_status("Generating recap...").await;
+        self.channel
+            .send_status_best_effort("Generating recap...")
+            .await;
 
         let timeout = Duration::from_secs(30);
         let recap_text = tokio::select! {
             () = tokio::time::sleep(timeout) => {
                 tracing::warn!("session recap: LLM call timed out after {timeout:?}");
-                let _ = self.channel.send_status("").await;
+                self.channel.send_status_best_effort("").await;
                 return Err(zeph_commands::CommandError("recap LLM timed out".into()));
             }
             result = provider.chat(&chat_messages) => {
@@ -481,7 +482,7 @@ impl<C: Channel> Agent<C> {
                     Ok(text) => text,
                     Err(e) => {
                         tracing::warn!("session recap: LLM call failed: {e:#}");
-                        let _ = self.channel.send_status("").await;
+                        self.channel.send_status_best_effort("").await;
                         return Err(zeph_commands::CommandError(
                             format!("recap LLM error: {e}"),
                         ));
@@ -490,7 +491,7 @@ impl<C: Channel> Agent<C> {
             }
         };
 
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
 
         let sanitized = sanitize_digest(&recap_text);
         let tc = &self.runtime.metrics.token_counter;

--- a/crates/zeph-core/src/agent/shutdown.rs
+++ b/crates/zeph-core/src/agent/shutdown.rs
@@ -199,27 +199,23 @@ impl<C: Channel> Agent<C> {
             .skip(1)
             .filter(|m| m.role == Role::User)
             .count();
-        if user_count
-            < self
-                .services
-                .memory
-                .compaction
-                .shutdown_summary_min_messages
-        {
+        let min_messages = self
+            .services
+            .memory
+            .compaction
+            .shutdown_summary_min_messages;
+        if user_count < min_messages {
             tracing::debug!(
                 user_count,
-                min = self
-                    .services
-                    .memory
-                    .compaction
-                    .shutdown_summary_min_messages,
+                min = min_messages,
                 "shutdown summary: too few user messages, skipping"
             );
             return;
         }
 
-        // TUI status — send errors silently ignored (TUI may already be gone at shutdown).
-        let _ = self.channel.send_status("Saving session summary...").await;
+        self.channel
+            .send_status_best_effort("Saving session summary...")
+            .await;
 
         // Collect last N messages (skip system prompt at index 0).
         let max = self
@@ -259,7 +255,7 @@ impl<C: Channel> Agent<C> {
         }];
 
         let Some(structured) = self.call_llm_for_session_summary(&chat_messages).await else {
-            let _ = self.channel.send_status("").await;
+            self.channel.send_status_best_effort("").await;
             return;
         };
 
@@ -275,8 +271,7 @@ impl<C: Channel> Agent<C> {
             );
         }
 
-        // Clear TUI status.
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
     }
     /// Gracefully shut down the agent and persist state.
     ///
@@ -295,7 +290,9 @@ impl<C: Channel> Agent<C> {
     /// Call this before dropping the agent to ensure no data loss.
     #[tracing::instrument(name = "core.agent.shutdown", skip_all, level = "debug")]
     pub async fn shutdown(&mut self) {
-        let _ = self.channel.send_status("Shutting down...").await;
+        self.channel
+            .send_status_best_effort("Shutting down...")
+            .await;
 
         // CRIT-1: persist Thompson state accumulated during this session.
         self.provider.save_router_state().await;

--- a/crates/zeph-core/src/agent/skill_reload.rs
+++ b/crates/zeph-core/src/agent/skill_reload.rs
@@ -138,7 +138,9 @@ impl<C: Channel> Agent<C> {
                 .await
                 .map(SkillMatcherBackend::InMemory);
         } else if let Some(ref mut backend) = self.services.skill.matcher {
-            let _ = self.channel.send_status("syncing skill index...").await;
+            self.channel
+                .send_status_best_effort("syncing skill index...")
+                .await;
             let on_progress: Option<Box<dyn Fn(usize, usize) + Send>> =
                 self.services.session.status_tx.clone().map(
                     |tx| -> Box<dyn Fn(usize, usize) + Send> {
@@ -163,7 +165,9 @@ impl<C: Channel> Agent<C> {
 
         if self.services.skill.hybrid_search {
             let descs: Vec<&str> = all_meta.iter().map(|m| m.description.as_str()).collect();
-            let _ = self.channel.send_status("rebuilding search index...").await;
+            self.channel
+                .send_status_best_effort("rebuilding search index...")
+                .await;
             self.services.skill.rebuild_bm25(&descs);
         }
     }
@@ -210,7 +214,9 @@ impl<C: Channel> Agent<C> {
         if self.services.skill.fingerprint() == old_fp {
             return;
         }
-        let _ = self.channel.send_status("reloading skills...").await;
+        self.channel
+            .send_status_best_effort("reloading skills...")
+            .await;
 
         let all_meta = self
             .services
@@ -257,7 +263,7 @@ impl<C: Channel> Agent<C> {
             msg.content = system_prompt;
         }
 
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
         tracing::info!(
             "reloaded {} skill(s)",
             self.services.skill.registry.read().all_meta().len()

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -201,9 +201,8 @@ impl<C: Channel> Agent<C> {
                     break (format!("{label} was cancelled."), false);
                 }
                 _ => {
-                    let _ = self
-                        .channel
-                        .send_status(&format!(
+                    self.channel
+                        .send_status_best_effort(&format!(
                             "{label}: turn {}/{}",
                             status.turns_used,
                             self.services

--- a/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
+++ b/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
@@ -32,12 +32,11 @@ impl<C: Channel> Agent<C> {
                         attempt,
                         "chat_with_tools context length exceeded, compacting and retrying"
                     );
-                    let _ = self
-                        .channel
-                        .send_status("context too long, compacting...")
+                    self.channel
+                        .send_status_best_effort("context too long, compacting...")
                         .await;
                     let _ = self.compact_context().await?;
-                    let _ = self.channel.send_status("").await;
+                    self.channel.send_status_best_effort("").await;
                 }
                 Err(e) if e.is_beta_header_rejected() && attempt + 1 < max_attempts => {
                     // SEC-COMPACT-03: the compact-2026-01-12 beta header was rejected by the API.
@@ -49,13 +48,12 @@ impl<C: Channel> Agent<C> {
                         falling back to client-side compaction and retrying"
                     );
                     self.runtime.providers.server_compaction_active = false;
-                    let _ = self
-                        .channel
-                        .send_status(
+                    self.channel
+                        .send_status_best_effort(
                             "server compaction unavailable, falling back to client-side...",
                         )
                         .await;
-                    let _ = self.channel.send_status("").await;
+                    self.channel.send_status_best_effort("").await;
                 }
                 Err(e) => return Err(e),
             }
@@ -538,12 +536,11 @@ impl<C: Channel> Agent<C> {
                         attempt,
                         "LLM context length exceeded, compacting and retrying"
                     );
-                    let _ = self
-                        .channel
-                        .send_status("context too long, compacting...")
+                    self.channel
+                        .send_status_best_effort("context too long, compacting...")
                         .await;
                     let _ = self.compact_context().await?;
-                    let _ = self.channel.send_status("").await;
+                    self.channel.send_status_best_effort("").await;
                 }
                 Err(e) => return Err(e),
             }

--- a/crates/zeph-core/src/agent/tool_execution/metrics_compact.rs
+++ b/crates/zeph-core/src/agent/tool_execution/metrics_compact.rs
@@ -91,9 +91,8 @@ impl<C: Channel> Agent<C> {
 
         // C2: server-side compaction — prune old messages and insert synthetic compaction message.
         if let Some(raw_summary) = self.provider.take_compaction_summary() {
-            let _ = self
-                .channel
-                .send_status("Compacting context (server-side)...")
+            self.channel
+                .send_status_best_effort("Compacting context (server-side)...")
                 .await;
             tracing::info!(
                 summary_len = raw_summary.len(),
@@ -126,7 +125,7 @@ impl<C: Channel> Agent<C> {
             });
             self.msg.messages.extend(tail);
             self.update_metrics(|m| m.server_compaction_events += 1);
-            let _ = self.channel.send_status("").await;
+            self.channel.send_status_best_effort("").await;
         }
 
         Ok(())

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -238,9 +238,8 @@ impl<C: Channel> Agent<C> {
                             tool = %tc.name, attempt, delay_ms, error = %e,
                             "transient tool error, retrying with backoff"
                         );
-                        let _ = self
-                            .channel
-                            .send_status(&format!("Retrying {}...", tc.name))
+                        self.channel
+                            .send_status_best_effort(&format!("Retrying {}...", tc.name))
                             .await;
                         // Interruptible backoff sleep: cancelled if agent shuts down.
                         tokio::select! {
@@ -254,7 +253,7 @@ impl<C: Channel> Agent<C> {
                                 return Ok(true);
                             }
                         }
-                        let _ = self.channel.send_status("").await;
+                        self.channel.send_status_best_effort("").await;
                         // NOTE: retry re-executions are NOT recorded in repeat-detection (CRIT-3).
                     }
                     result => break result,
@@ -314,14 +313,13 @@ impl<C: Channel> Agent<C> {
                 .map(std::string::ToString::to_string)
                 .unwrap_or_default();
 
-            let _ = self
-                .channel
-                .send_status(&format!("Reformatting parameters for {}...", tc.name))
+            self.channel
+                .send_status_best_effort(&format!("Reformatting parameters for {}...", tc.name))
                 .await;
             let new_result = self
                 .reformat_tool_call(&calls[idx], tc, &error_message, cancel)
                 .await;
-            let _ = self.channel.send_status("").await;
+            self.channel.send_status_best_effort("").await;
 
             if cancel.is_cancelled() {
                 self.cancel_tool_batch(tool_calls, "parameter reformat phase cancelled by user")
@@ -1244,9 +1242,8 @@ impl<C: Channel> Agent<C> {
             }
 
             if tier_count > 1 {
-                let _ = self
-                    .channel
-                    .send_status(&format!(
+                self.channel
+                    .send_status_best_effort(&format!(
                         "Executing tools (tier {}/{})\u{2026}",
                         tier_idx + 1,
                         tier_count
@@ -1328,7 +1325,7 @@ impl<C: Channel> Agent<C> {
             .await;
 
             if tier_count > 1 {
-                let _ = self.channel.send_status("").await;
+                self.channel.send_status_best_effort("").await;
             }
 
             // Check hook block cap after each tier (RF-1: counter is per-turn, not per-tier).
@@ -1531,9 +1528,8 @@ impl<C: Channel> Agent<C> {
         pending_system_hints: &mut Vec<String>,
     ) -> Result<Option<(usize, ToolExecFut)>, crate::agent::error::AgentError> {
         if self.tool_orchestrator.has_blocked_retrieval_this_turn() {
-            let _ = self
-                .channel
-                .send_status(&format!(
+            self.channel
+                .send_status_best_effort(&format!(
                     "Utility action: Retrieve skipped, context unavailable ({})",
                     tc.name
                 ))
@@ -1552,9 +1548,8 @@ impl<C: Channel> Agent<C> {
                 mandates = self.tool_orchestrator.retrieve_mandate_count,
                 "utility gate: Retrieve mandate limit reached this turn, proceeding directly"
             );
-            let _ = self
-                .channel
-                .send_status(&format!(
+            self.channel
+                .send_status_best_effort(&format!(
                     "Utility action: Retrieve loop detected, proceeding directly ({})",
                     tc.name
                 ))
@@ -1567,9 +1562,8 @@ impl<C: Channel> Agent<C> {
             ));
             return Ok(None);
         }
-        let _ = self
-            .channel
-            .send_status(&format!("Utility action: Retrieve ({})", tc.name))
+        self.channel
+            .send_status_best_effort(&format!("Utility action: Retrieve ({})", tc.name))
             .await;
         // Inject a system message directing the LLM to retrieve context first (#2620).
         pending_system_hints.push(format!(
@@ -1608,9 +1602,8 @@ impl<C: Channel> Agent<C> {
     ) -> Result<Option<(usize, ToolExecFut)>, crate::agent::error::AgentError> {
         match utility_actions[idx] {
             zeph_tools::UtilityAction::Respond => {
-                let _ = self
-                    .channel
-                    .send_status(&format!("Utility action: Respond ({})", tc.name))
+                self.channel
+                    .send_status_best_effort(&format!("Utility action: Respond ({})", tc.name))
                     .await;
                 Ok(Some(ready_fut(
                     idx,
@@ -1629,9 +1622,8 @@ impl<C: Channel> Agent<C> {
                     .await
             }
             zeph_tools::UtilityAction::Verify => {
-                let _ = self
-                    .channel
-                    .send_status(&format!("Utility action: Verify ({})", tc.name))
+                self.channel
+                    .send_status_best_effort(&format!("Utility action: Verify ({})", tc.name))
                     .await;
                 pending_system_hints.push(format!(
                     "[utility:verify] Before executing the '{}' tool again, verify \
@@ -1652,9 +1644,8 @@ impl<C: Channel> Agent<C> {
                 )))
             }
             zeph_tools::UtilityAction::Stop => {
-                let _ = self
-                    .channel
-                    .send_status(&format!("Utility action: Stop ({})", tc.name))
+                self.channel
+                    .send_status_best_effort(&format!("Utility action: Stop ({})", tc.name))
                     .await;
                 let threshold = self.tool_orchestrator.utility_scorer.threshold();
                 Ok(Some(ready_fut(
@@ -2516,7 +2507,9 @@ impl<C: Channel> Agent<C> {
         if self.services.session.lsp_hooks.is_some() {
             let tc_arc = std::sync::Arc::clone(&self.runtime.metrics.token_counter);
             let sanitizer = self.services.security.sanitizer.clone();
-            let _ = self.channel.send_status("Analyzing changes...").await;
+            self.channel
+                .send_status_best_effort("Analyzing changes...")
+                .await;
             // TODO: cooperative MCP cancellation — dropped futures here may leave
             // in-flight MCP JSON-RPC requests pending until the server-side timeout.
             let lsp_result = tokio::time::timeout(std::time::Duration::from_secs(30), async {
@@ -2535,7 +2528,7 @@ impl<C: Channel> Agent<C> {
                 }
             })
             .await;
-            let _ = self.channel.send_status("").await;
+            self.channel.send_status_best_effort("").await;
             if lsp_result.is_err() {
                 tracing::warn!("LSP after_tool batch timed out (30s)");
             }
@@ -3013,14 +3006,16 @@ impl<C: Channel> Agent<C> {
 
         // Show triage status indicator before inference when triage routing is active.
         if matches!(self.provider, zeph_llm::any::AnyProvider::Triage(_)) {
-            let _ = self.channel.send_status("Evaluating complexity...").await;
+            self.channel
+                .send_status_best_effort("Evaluating complexity...")
+                .await;
         } else {
-            let _ = self.channel.send_status("thinking...").await;
+            self.channel.send_status_best_effort("thinking...").await;
         }
 
         let chat_result = self.call_llm_durable(tool_defs, iteration).await?;
 
-        let _ = self.channel.send_status("").await;
+        self.channel.send_status_best_effort("").await;
 
         let Some(chat_result) = chat_result else {
             tracing::debug!("chat_with_tools returned None (timeout)");

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -205,6 +205,21 @@ pub struct ChannelMessage {
     pub is_from_bot: bool,
 }
 
+/// Upper bound on [`Channel::send_status_best_effort`]. Status sends are a UX nicety, not a
+/// value the agent turn depends on, so a slow or rate-limited channel (see issue #6094 — Discord
+/// and Slack's 429 retry loop can otherwise take minutes) must never stall the turn loop past
+/// this bound.
+///
+/// Deliberately much shorter than the full retry-loop worst case (~180-255s — see
+/// `common::http_retry`/`common::teloxide_retry`'s `# Timing` docs): a single status ping (e.g.
+/// "thinking...") is stale within seconds of being superseded by the next one, so there is no UX
+/// value in waiting anywhere near the full retry budget for it. 10s is long enough for one
+/// `Retry-After` backoff sleep to complete (typical values are 1-5s) but short enough that even a
+/// turn with several status transitions cannot accumulate more than a few tens of seconds of
+/// aggregate stall. `send`/`flush_chunks` (the actual response content) are NOT wrapped in this
+/// timeout — those are worth retrying to completion, unlike an ephemeral status label.
+const STATUS_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Bidirectional communication channel for the agent.
 ///
 /// # TODO (A3 — deferred: split monolithic Channel into focused sub-traits)
@@ -300,6 +315,28 @@ pub trait Channel: Send {
         _text: &str,
     ) -> impl Future<Output = Result<(), ChannelError>> + Send {
         async { Ok(()) }
+    }
+
+    /// Best-effort variant of [`send_status`](Channel::send_status) for the many call sites
+    /// where a status update is a UX nicety, not a value the turn depends on.
+    ///
+    /// Bounds the send to `STATUS_SEND_TIMEOUT` and logs the outcome (`tracing::debug!` on
+    /// success, `tracing::warn!` on error or timeout) instead of returning a `Result`. Callers
+    /// that used to write `let _ = channel.send_status(...).await;` should call this instead:
+    /// failures become visible in logs, and a slow/rate-limited channel (see #6094) can no
+    /// longer stall the agent turn loop.
+    fn send_status_best_effort(&mut self, text: &str) -> impl Future<Output = ()> + Send {
+        async move {
+            match tokio::time::timeout(STATUS_SEND_TIMEOUT, self.send_status(text)).await {
+                Ok(Ok(())) => tracing::debug!(text, "channel status sent"),
+                Ok(Err(error)) => tracing::warn!(%error, text, "channel status send failed"),
+                Err(_) => tracing::warn!(
+                    text,
+                    timeout_secs = STATUS_SEND_TIMEOUT.as_secs(),
+                    "channel status send timed out"
+                ),
+            }
+        }
     }
 
     /// Send a thinking/reasoning token chunk. No-op by default.
@@ -863,6 +900,134 @@ mod tests {
     async fn stub_channel_send_ok() {
         let mut ch = StubChannel;
         ch.send("hello").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_status_best_effort_succeeds_silently() {
+        let mut ch = StubChannel;
+        // Must not panic even though the return type carries no `Result`.
+        ch.send_status_best_effort("hello").await;
+    }
+
+    struct ErroringStatusChannel;
+
+    impl Channel for ErroringStatusChannel {
+        async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
+            Ok(None)
+        }
+
+        async fn send(&mut self, _text: &str) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn send_chunk(&mut self, _chunk: &str) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn send_status(&mut self, _text: &str) -> Result<(), ChannelError> {
+            Err(ChannelError::ChannelClosed)
+        }
+    }
+
+    #[tokio::test]
+    async fn send_status_best_effort_swallows_errors() {
+        let mut ch = ErroringStatusChannel;
+        // Must not propagate or panic — errors are logged, not surfaced.
+        ch.send_status_best_effort("hello").await;
+    }
+
+    // The two tests below use `tracing_test::traced_test` to assert on the actual log
+    // output of `send_status_best_effort`, not just its return type — closing the gap
+    // flagged in the #6106 handoff where only "doesn't panic" was verified.
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn send_status_best_effort_warns_on_error() {
+        let mut ch = ErroringStatusChannel;
+        ch.send_status_best_effort("hello").await;
+        assert!(
+            logs_contain("channel status send failed"),
+            "expected a tracing::warn! logging the send_status error"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn send_status_best_effort_debug_logs_on_success() {
+        let mut ch = StubChannel;
+        ch.send_status_best_effort("hello").await;
+        assert!(
+            logs_contain("channel status sent"),
+            "expected a tracing::debug! logging the successful send_status"
+        );
+    }
+
+    struct HangingStatusChannel;
+
+    impl Channel for HangingStatusChannel {
+        async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
+            Ok(None)
+        }
+
+        async fn send(&mut self, _text: &str) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn send_chunk(&mut self, _chunk: &str) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn send_status(&mut self, _text: &str) -> Result<(), ChannelError> {
+            std::future::pending().await
+        }
+    }
+
+    // Regression test for #6094: a channel whose `send_status` never resolves (e.g. stuck in
+    // a retry-with-backoff loop under sustained 429s) must not stall the caller past
+    // `STATUS_SEND_TIMEOUT`. Uses paused tokio time so the test itself completes instantly.
+    #[tokio::test(start_paused = true)]
+    async fn send_status_best_effort_times_out_instead_of_hanging() {
+        let mut ch = HangingStatusChannel;
+        let call = ch.send_status_best_effort("hello");
+        tokio::pin!(call);
+
+        // Not ready before the timeout elapses.
+        assert!(
+            futures::poll!(&mut call).is_pending(),
+            "expected send_status_best_effort to still be pending immediately"
+        );
+
+        tokio::time::advance(STATUS_SEND_TIMEOUT + std::time::Duration::from_secs(1)).await;
+
+        // Now the timeout has elapsed and the future must resolve (returns `()`, not stuck).
+        tokio::time::timeout(std::time::Duration::from_secs(1), call)
+            .await
+            .expect("send_status_best_effort must resolve once STATUS_SEND_TIMEOUT elapses");
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[tracing_test::traced_test]
+    async fn send_status_best_effort_warns_on_timeout() {
+        let mut ch = HangingStatusChannel;
+        let call = ch.send_status_best_effort("hello");
+        tokio::pin!(call);
+        let _ = futures::poll!(&mut call);
+
+        tokio::time::advance(STATUS_SEND_TIMEOUT + std::time::Duration::from_secs(1)).await;
+        call.await;
+
+        assert!(
+            logs_contain("channel status send timed out"),
+            "expected a tracing::warn! logging the send_status timeout"
+        );
     }
 
     #[test]

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1300,7 +1300,9 @@ async fn notify_lock_degraded(
     if let Some(notifier) = status_notifier {
         notifier.notify_status_nowait(SESSION_LOCK_DEGRADED_MESSAGE);
     } else {
-        let _ = channel.send_status(SESSION_LOCK_DEGRADED_MESSAGE).await;
+        channel
+            .send_status_best_effort(SESSION_LOCK_DEGRADED_MESSAGE)
+            .await;
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `Channel::send_status_best_effort`, a default trait method wrapping `send_status` in a 10s `tokio::time::timeout` with debug/warn logging, replacing ~45 silent `let _ = self.channel.send_status(...).await;` discard sites across the agent turn hot path. This bounds the previously-unbounded (~255s worst case) stall a rate-limited status send could cause, and gives every call site failure visibility for free.
- Add `crates/zeph-channels/src/common/teloxide_retry.rs::send_teloxide_with_retry`, a retry helper matching `teloxide::RequestError::RetryAfter`, so Telegram's `send`/`send_status`/`send_or_edit` get the same 429 backoff Slack/Discord already had via `http_retry::send_with_retry`.
- Add a test-injectable `base_url` + `#[cfg(test)] with_base_url` constructor to Discord's `RestClient`, mirroring the existing Slack/Telegram pattern, plus wiremock tests proving `send_message`/`edit_message`/`trigger_typing` retry transparently on a 429.

Closes #6094
Closes #6106
Closes #6095

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12986 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New tests: `send_status_best_effort` success/error/timeout (incl. tracing-output assertions via `tracing-test`), Telegram real-path 429 retry test, 3 Discord wiremock retry tests
- [x] `.local/testing/playbooks/channels.md` and `.local/testing/coverage-status.md` updated
- [x] `CHANGELOG.md` updated