### PR TITLE
fix(core): offload trace-file writes and fix MetricsBridge clobbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     resolved a distinct judge via `build_eval_provider()`, but the scheduler path never did.
     `ExperimentTaskHandler` now resolves `eval_provider` the same way, falling back to the
     primary provider only when unset (#5947).
+- `zeph-core`: `TracingCollector::finish()` wrote `trace.json` via synchronous `std::fs`
+  I/O, reachable from the async agent turn loop (#6107). `write_trace_file` now offloads to
+  `tokio::task::spawn_blocking` when a Tokio runtime is active, falling back to an inline
+  synchronous write when none is present — `finish()` is also reachable from `Drop` (which
+  cannot `.await`) and from plain non-async unit tests, so a fallback was required rather than
+  making the offload unconditional. `finish()` now returns the write's `JoinHandle` so the
+  session-end call site (`agent/mod.rs`, where nothing else will write this session's trace)
+  can await it and guarantee the file lands before the process/runtime tears down, instead of
+  racing it fire-and-forget; the mid-session `/dump-format` switch site and `Drop` keep the
+  fire-and-forget behavior, mirroring `DebugDumper::write` from #6101, since a lost dump there
+  doesn't lose the only copy.
+- `zeph-core` (`profiling` feature): `MetricsBridge` derives per-phase turn timings from
+  tracing span durations, but `Agent::flush_turn_timings` unconditionally overwrote
+  `last_turn_timings` with the manually-timed (`Instant::now()`) value every turn, discarding
+  whatever the bridge had just written (#5946). The clobbering itself is now fixed:
+  `MetricsBridge` marks a bitmask (`MetricsSnapshot::bridge_timings_written`) for each field it
+  writes; `flush_turn_timings` reads that mask, reconciles it against the manual value, and
+  clears it, all inside a single `send_modify` closure so a concurrent `MetricsBridge::on_close`
+  write cannot land in the gap between reading and clearing the mask. Fields the bridge did not
+  mark this turn still fall back to the manual value. This is **not** the same as "`MetricsBridge`
+  is now fully functional" — three of the four span names in `WATCHED_SPANS`
+  (`agent.prepare_context`, `agent.tool_loop`, `agent.persist_message`) do not currently match
+  any real span in the codebase, so in practice the bridge only ever populates `llm_chat_ms`;
+  the other three fields continue to come from manual timing exactly as before this fix, just
+  no longer at risk of losing bridge data for fields the bridge was never actually producing.
+  Reconciling those span names, and `persist_message`'s multi-call-per-turn semantics (which
+  don't map 1:1 to the single-span-instance model `MetricsBridge` assumes), is tracked
+  separately in #6111.
 - `zeph-core`: removed two blocking-I/O sites from the async agent turn loop (#6020, #6029).
   - `rebuild_system_prompt` called `project::discover_project_configs`/`load_project_context`
     directly on every turn — a filesystem walk from cwd to the root plus a `read_to_string`

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -721,9 +721,16 @@ impl<C: Channel> Agent<C> {
         // AutoSkill A1: extract skill candidates from the completed session trace (spec 056).
         self.maybe_extract_skills_from_trace().await;
 
-        // Flush trace collector on normal exit (C-04: Drop handles error/panic paths).
-        if let Some(ref mut tc) = self.runtime.debug.trace_collector {
-            tc.finish();
+        // Flush trace collector on normal exit (C-04: Drop handles error/panic paths). This is
+        // the last write of the session's trace.json — nothing runs after it, so unlike the
+        // mid-session format-switch site (`state/mod.rs`) there's no latency benefit to firing
+        // it and forgetting; await the handle so the write is guaranteed to land instead of
+        // racing process/runtime teardown (#6107 critic finding S1).
+        if let Some(ref mut tc) = self.runtime.debug.trace_collector
+            && let Some(handle) = tc.finish()
+            && let Err(e) = handle.await
+        {
+            tracing::warn!(error = %e, "trace.json write task did not complete");
         }
 
         Ok(())

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -1083,7 +1083,10 @@ impl DebugState {
             && !now_trace
             && let Some(mut tc) = self.trace_collector.take()
         {
-            tc.finish();
+            // Fire-and-forget: this is a sync fn, and unlike the session-end call site
+            // (`agent/mod.rs`) a subsequent format switch or session activity follows, so
+            // there's a real concurrency benefit to not blocking on this write (#6107 critic S1).
+            let _ = tc.finish();
         }
 
         self.dump_format = new_format;

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -162,8 +162,15 @@ impl<C: Channel> Agent<C> {
     ///
     /// Call once per turn after all four phases have written to `pending_timings`.
     /// Resets `pending_timings` to default after flushing.
+    ///
+    /// When the `profiling` feature is compiled in, per-field values that `MetricsBridge`
+    /// marked as freshly written this turn (`MetricsSnapshot::bridge_timings_written`) take
+    /// precedence over the manual value computed here; unmarked fields keep the manual value.
+    /// This avoids unconditionally clobbering the bridge's span-derived timings every turn
+    /// (#5946) while still working correctly for fields the bridge does not (yet) populate.
     pub(super) fn flush_turn_timings(&mut self) {
-        let timings = std::mem::take(&mut self.runtime.metrics.pending_timings);
+        #[cfg_attr(not(feature = "profiling"), allow(unused_mut))]
+        let mut timings = std::mem::take(&mut self.runtime.metrics.pending_timings);
         tracing::debug!(
             prepare_context_ms = timings.prepare_context_ms,
             llm_chat_ms = timings.llm_chat_ms,
@@ -171,6 +178,30 @@ impl<C: Channel> Agent<C> {
             persist_message_ms = timings.persist_message_ms,
             "turn timings"
         );
+
+        // #5946 (critic finding S2): read the bridge's per-field "written this turn" mask,
+        // reconcile it into `timings`, AND clear the mask — all inside this one `send_modify`
+        // closure (via `update_metrics`), so the whole read-then-clear is atomic. A previous
+        // version read the mask via a separate `borrow()` and cleared it in a later, independent
+        // `update_metrics` call; a `MetricsBridge::on_close` write landing in the gap between
+        // those two steps would have had its bit and value silently discarded.
+        #[cfg(feature = "profiling")]
+        self.update_metrics(|m| {
+            let mask = m.bridge_timings_written;
+            if mask & crate::metrics_bridge::TimingField::PrepareContext.bridge_bit() != 0 {
+                timings.prepare_context_ms = m.last_turn_timings.prepare_context_ms;
+            }
+            if mask & crate::metrics_bridge::TimingField::LlmChat.bridge_bit() != 0 {
+                timings.llm_chat_ms = m.last_turn_timings.llm_chat_ms;
+            }
+            if mask & crate::metrics_bridge::TimingField::ToolExec.bridge_bit() != 0 {
+                timings.tool_exec_ms = m.last_turn_timings.tool_exec_ms;
+            }
+            if mask & crate::metrics_bridge::TimingField::PersistMessage.bridge_bit() != 0 {
+                timings.persist_message_ms = m.last_turn_timings.persist_message_ms;
+            }
+            m.bridge_timings_written = 0;
+        });
 
         if self.runtime.metrics.timing_window.len() >= 10 {
             self.runtime.metrics.timing_window.pop_front();
@@ -928,5 +959,37 @@ mod tests {
         assert_eq!(snap.max_turn_timings.llm_chat_ms, 120);
         // avg of 30,40,...,120 = (30+120)*10/2/10 = 75
         assert_eq!(snap.avg_turn_timings.llm_chat_ms, 75);
+    }
+
+    // #5946: fields MetricsBridge marked as written this turn keep the bridge's span-derived
+    // value instead of being clobbered by the manual `Instant::now()` value; unmarked fields
+    // still fall back to manual. The bitmask is cleared (taken) after the flush.
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn flush_turn_timings_prefers_bridge_value_for_marked_fields() {
+        let (mut agent, rx) = agent_with_metrics_watch();
+
+        if let Some(tx) = agent.runtime.metrics.metrics_tx.as_ref() {
+            tx.send_modify(|m| {
+                m.last_turn_timings.llm_chat_ms = 999;
+                m.bridge_timings_written = crate::metrics_bridge::TimingField::LlmChat.bridge_bit();
+            });
+        }
+
+        agent.runtime.metrics.pending_timings = make_timings(10, 200, 50, 5);
+        agent.flush_turn_timings();
+
+        let snap = rx.borrow();
+        assert_eq!(
+            snap.last_turn_timings.llm_chat_ms, 999,
+            "bridge-marked field must keep the bridge value, not the manual one"
+        );
+        assert_eq!(snap.last_turn_timings.prepare_context_ms, 10);
+        assert_eq!(snap.last_turn_timings.tool_exec_ms, 50);
+        assert_eq!(snap.last_turn_timings.persist_message_ms, 5);
+        assert_eq!(
+            snap.bridge_timings_written, 0,
+            "bitmask must be cleared after flush"
+        );
     }
 }

--- a/crates/zeph-core/src/debug_dump/trace.rs
+++ b/crates/zeph-core/src/debug_dump/trace.rs
@@ -460,11 +460,19 @@ impl TracingCollector {
 
     /// Finalize the session span and write `trace.json`.
     ///
-    /// Safe to call multiple times — subsequent calls after the first are no-ops.
-    /// Also sends spans over the `OTel` channel when the `otel` feature is enabled (C-05).
-    pub fn finish(&mut self) {
+    /// Safe to call multiple times — subsequent calls after the first are no-ops (returning
+    /// `None`). Also sends spans over the `OTel` channel when the `otel` feature is enabled
+    /// (C-05).
+    ///
+    /// Returns the `trace.json` write's `JoinHandle` when it was dispatched to the blocking
+    /// pool (a Tokio runtime was active), so a caller for whom this is the *only* remaining
+    /// write of the session — nothing runs after it — can `.await` it to guarantee the file
+    /// actually lands before the process/runtime tears down (#6107). Callers that don't need
+    /// that guarantee (a mid-session format switch, or `Drop`, which cannot `.await` anyway)
+    /// are free to drop the handle and keep the write fire-and-forget.
+    pub fn finish(&mut self) -> Option<tokio::task::JoinHandle<()>> {
         if self.flushed {
-            return;
+            return None;
         }
         self.flushed = true;
 
@@ -508,11 +516,7 @@ impl TracingCollector {
 
         let json = serialize_otlp_json(&all_spans, &self.service_name, &self.trace_metadata);
         let path = self.output_dir.join("trace.json");
-        if let Err(e) = write_trace_file(&path, json.as_bytes()) {
-            tracing::warn!(path = %path.display(), error = %e, "trace.json write failed");
-        } else {
-            tracing::info!(path = %path.display(), "OTel trace written");
-        }
+        let handle = write_trace_file(&path, json.as_bytes());
 
         // C-05: forward spans to OTLP exporter when the root crate has wired the channel.
         if let Some(ref tx) = self.trace_tx {
@@ -524,13 +528,18 @@ impl TracingCollector {
                 tracing::debug!("OTLP trace channel closed, skipping export");
             }
         }
+
+        handle
     }
 }
 
-// C-04: Drop flushes partial traces on error/panic/cancellation.
+// C-04: Drop flushes partial traces on error/panic/cancellation. Fire-and-forget: `Drop::drop`
+// cannot `.await` the returned handle, but this is a best-effort partial-trace capture (the
+// normal-exit path calls `finish()` explicitly and awaits it — see `agent/mod.rs`), not the
+// session's only copy of the trace.
 impl Drop for TracingCollector {
     fn drop(&mut self) {
-        self.finish();
+        let _ = self.finish();
     }
 }
 
@@ -630,24 +639,31 @@ pub fn serialize_otlp_json<S: std::hash::BuildHasher>(
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/// Write `data` to `path` with mode 0o600 on Unix (SEC-01).
-/// Falls back to `std::fs::write` on non-Unix platforms.
-fn write_trace_file(path: &Path, data: &[u8]) -> std::io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::io::Write as _;
-        use std::os::unix::fs::OpenOptionsExt as _;
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(path)?;
-        f.write_all(data)
-    }
-    #[cfg(not(unix))]
-    {
-        std::fs::write(path, data)
+/// Write `data` to `path` with mode 0o600 on Unix (SEC-01) via `zeph_common::fs_secure`.
+///
+/// Offloaded to the blocking thread pool when a Tokio runtime is available — `finish()` is
+/// reachable from the async agent hot path (#6107) and must never block it on synchronous
+/// file I/O — returning the `JoinHandle` so a caller for whom this write is session-critical
+/// (nothing else will write this session's trace) can await completion instead of racing
+/// process/runtime teardown. Callers that don't need that guarantee may drop the handle,
+/// mirroring the fire-and-forget `DebugDumper::write` pattern from #6101.
+///
+/// Falls back to an inline synchronous write (returning `None`) when no runtime is present,
+/// since `finish()` is also reachable from `Drop` (which cannot `.await`) and from plain
+/// non-async unit tests; this mirrors the runtime-detection idiom in
+/// `zeph_common::task_supervisor::TaskSupervisor::new`.
+fn write_trace_file(path: &Path, data: &[u8]) -> Option<tokio::task::JoinHandle<()>> {
+    let path = path.to_owned();
+    let data = data.to_vec();
+    let write_and_log = move || match zeph_common::fs_secure::write_private(&path, &data) {
+        Ok(()) => tracing::info!(path = %path.display(), "OTel trace written"),
+        Err(e) => tracing::warn!(path = %path.display(), error = %e, "trace.json write failed"),
+    };
+    if tokio::runtime::Handle::try_current().is_ok() {
+        Some(tokio::task::spawn_blocking(write_and_log))
+    } else {
+        write_and_log();
+        None
     }
 }
 
@@ -864,6 +880,36 @@ mod tests {
         c.finish();
         c.finish();
         assert!(tmp.path().join("trace.json").exists());
+    }
+
+    // #6107: every other test in this module runs as a plain `#[test]` (no Tokio runtime), so
+    // they only ever exercise `write_trace_file`'s synchronous fallback branch — the actual
+    // `spawn_blocking` dispatch added for #6107 was previously untested. This test runs inside
+    // a real runtime so `finish()` takes that branch (asserted via `Some`), then awaits the
+    // returned handle to confirm the write actually completes.
+    #[tokio::test]
+    async fn finish_dispatches_via_spawn_blocking_under_active_runtime() {
+        let tmp = tempdir().unwrap();
+        let mut c = make_collector(tmp.path());
+        c.begin_iteration(0, "hello");
+        c.end_iteration(0, SpanStatus::Ok);
+
+        let handle = c.finish();
+        assert!(
+            handle.is_some(),
+            "finish() must dispatch the write via spawn_blocking (Some) when a Tokio runtime \
+             is active, not silently take the synchronous fallback path (None)"
+        );
+        handle
+            .unwrap()
+            .await
+            .expect("spawn_blocking write task must not panic");
+
+        let path = tmp.path().join("trace.json");
+        assert!(
+            path.exists(),
+            "trace.json must exist once the spawn_blocking handle has been awaited"
+        );
     }
 
     #[test]

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -385,6 +385,16 @@ pub struct MetricsSnapshot {
     pub classifier: ClassifierMetricsSnapshot,
     /// Latency breakdown for the most recently completed agent turn.
     pub last_turn_timings: TurnTimings,
+    /// Bitmask of [`TurnTimings`] fields freshly written into `last_turn_timings` by
+    /// `MetricsBridge`'s span-derived timing since the last `flush_turn_timings` call
+    /// (bit `n` per `metrics_bridge::TimingField` ordinal: `prepare_context`=0, `llm_chat`=1,
+    /// `tool_exec`=2, `persist_message`=3).
+    ///
+    /// `flush_turn_timings` consults this per-field so it only falls back to the manual
+    /// `Instant::now()` timing for fields the bridge did not populate this turn, instead of
+    /// unconditionally clobbering every field (#5946). Cleared (taken) on every flush. Only
+    /// ever set when the `profiling` feature is compiled in.
+    pub bridge_timings_written: u8,
     /// Rolling average of per-phase latency over the last 10 turns.
     pub avg_turn_timings: TurnTimings,
     /// Maximum per-phase latency observed within the rolling window (tail-latency visibility).

--- a/crates/zeph-core/src/metrics_bridge.rs
+++ b/crates/zeph-core/src/metrics_bridge.rs
@@ -5,9 +5,16 @@
 //!
 //! [`MetricsBridge`] implements [`tracing_subscriber::Layer`] and observes
 //! the close event of a fixed set of known spans. When a watched span closes,
-//! the bridge computes the elapsed duration and writes it into the shared
-//! [`MetricsCollector`], replacing manual `Instant::now()` timing in the
-//! agent hot path.
+//! the bridge computes the elapsed duration, writes it into the shared
+//! [`MetricsCollector`], and marks the corresponding bit in
+//! [`crate::metrics::MetricsSnapshot::bridge_timings_written`].
+//!
+//! `Agent::flush_turn_timings` (`agent/utils.rs`) consults that bitmask once per turn: for
+//! each field the bridge marked as written, its span-derived value wins over the manual
+//! `Instant::now()` timing computed on the hot path; fields the bridge did not mark (either
+//! because no span with a matching name closed this turn, or a watched span name does not
+//! yet correspond to any real span) fall back to the manual value (#5946). This makes the
+//! two timing sources coexist per-field rather than one unconditionally clobbering the other.
 //!
 //! This module is compiled only when the `profiling` feature is enabled.
 
@@ -30,12 +37,31 @@ const WATCHED_SPANS: &[(&str, TimingField)] = &[
 ];
 
 /// Identifies which [`crate::metrics::TurnTimings`] field a watched span maps to.
+///
+/// `pub(crate)` so `Agent::flush_turn_timings` (`agent/utils.rs`) can look up
+/// [`Self::bridge_bit`] when deciding whether to keep the bridge's span-derived value or
+/// fall back to manual timing for a given field (#5946).
 #[derive(Clone, Copy)]
-enum TimingField {
+pub(crate) enum TimingField {
     PrepareContext,
     LlmChat,
     ToolExec,
     PersistMessage,
+}
+
+impl TimingField {
+    /// Bit set in [`crate::metrics::MetricsSnapshot::bridge_timings_written`] when this field
+    /// is written by [`MetricsBridge::on_close`]. Consumed by `Agent::flush_turn_timings`
+    /// (`agent/utils.rs`) to decide, per field, whether the bridge's span-derived value should
+    /// win over the manual `Instant::now()` timing for the current turn (#5946).
+    pub(crate) const fn bridge_bit(self) -> u8 {
+        match self {
+            Self::PrepareContext => 1 << 0,
+            Self::LlmChat => 1 << 1,
+            Self::ToolExec => 1 << 2,
+            Self::PersistMessage => 1 << 3,
+        }
+    }
 }
 
 /// Zero-size marker extension inserted in `on_new_span` for watched spans only.
@@ -150,19 +176,22 @@ where
                 let name = span.name();
                 if let Some((_, field)) = WATCHED_SPANS.iter().find(|(n, _)| *n == name) {
                     let field = *field;
-                    self.collector.update(|m| match field {
-                        TimingField::PrepareContext => {
-                            m.last_turn_timings.prepare_context_ms = duration_ms;
+                    self.collector.update(|m| {
+                        match field {
+                            TimingField::PrepareContext => {
+                                m.last_turn_timings.prepare_context_ms = duration_ms;
+                            }
+                            TimingField::LlmChat => {
+                                m.last_turn_timings.llm_chat_ms = duration_ms;
+                            }
+                            TimingField::ToolExec => {
+                                m.last_turn_timings.tool_exec_ms = duration_ms;
+                            }
+                            TimingField::PersistMessage => {
+                                m.last_turn_timings.persist_message_ms = duration_ms;
+                            }
                         }
-                        TimingField::LlmChat => {
-                            m.last_turn_timings.llm_chat_ms = duration_ms;
-                        }
-                        TimingField::ToolExec => {
-                            m.last_turn_timings.tool_exec_ms = duration_ms;
-                        }
-                        TimingField::PersistMessage => {
-                            m.last_turn_timings.persist_message_ms = duration_ms;
-                        }
+                        m.bridge_timings_written |= field.bridge_bit();
                     });
                 }
             }


### PR DESCRIPTION
## Summary

- `TracingCollector::finish()` wrote `trace.json` via synchronous `std::fs` I/O reachable from the async agent turn loop. `write_trace_file` now dispatches through `tokio::task::spawn_blocking` when a Tokio runtime is active, with a synchronous fallback for `Drop` and non-async unit tests (which cannot dispatch to a runtime that may not exist). The session-end call site awaits the returned `JoinHandle` so the file isn't lost on process/runtime teardown; the mid-session `/dump-format` switch site and `Drop` keep the fire-and-forget behavior, mirroring `DebugDumper::write` from #6101.
- `MetricsBridge` (`profiling` feature) derives per-phase turn timings from tracing span durations, but `Agent::flush_turn_timings` unconditionally overwrote `last_turn_timings` with the manually-timed value every turn, discarding whatever the bridge had just written. A per-field bitmask (`MetricsSnapshot::bridge_timings_written`) now tracks which fields the bridge populated this turn; `flush_turn_timings` reconciles bridge-vs-manual per field atomically inside a single `send_modify` closure, falling back to manual timing for unmarked fields. This is not the same as "`MetricsBridge` is now fully functional" — 3 of 4 `WATCHED_SPANS` names don't match any real span in the codebase, so in practice only `llm_chat_ms` is bridge-populated today; reconciling the span names is tracked separately in #6111.

Closes #6107
Closes #5946

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (12975/12975 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Targeted `zeph-core` nextest with and without `--features profiling`, including new tests `finish_dispatches_via_spawn_blocking_under_active_runtime` and `flush_turn_timings_prefers_bridge_value_for_marked_fields`
- [x] `.local/testing/coverage-status.md` and `.local/testing/playbooks/{hot-path-blocking-io,profiling}.md` updated per Development Rules 6-7
- [ ] Live-session verification of `trace.json` landing at real session-end and of the bridge/TUI round-trip under `--features profiling` — not yet run, tracked in the coverage-status rows as Untested/Partial