### PR TITLE
fix(db): fix Postgres LIMIT=0 crash and collapse DbConfig pool fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Changed
+
+- **BREAKING**: `zeph-db`'s `DbConfig` collapses `max_connections` and `pool_size` into a
+  single `pool_size: u32` field, used as `sqlx`'s `.max_connections()` for both `SQLite` and
+  `PostgreSQL` (#5970). Previously `pool_size` was documented "`SQLite` only" but was actually
+  what `connect_postgres` passed to `PgPoolOptions::max_connections()` (`max_connections` was
+  never read under Postgres), and `SQLite` combined the two fields as
+  `max_connections.max(pool_size)` — the larger value won, not a cap. Every call site already
+  set both fields to the same value by convention; this removes the redundant, contradictory
+  field. All in-tree `DbConfig` construction sites (`zeph-scheduler`, `zeph-memory`, `zeph-mcp`,
+  `zeph-durable`, `zeph-orchestration`, `zeph-index`, `src/bootstrap/mod.rs`,
+  `src/commands/db.rs`) are updated; `max_connections` was never exposed as a user-facing
+  `config.toml` key, so no config migration step is needed.
+
 ### Fixed
 
 - `zeph-channels`/`zeph-core`: hardened the channel send/retry/status path (#6094, #6106, #6095).
@@ -76,6 +90,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Reconciling those span names, and `persist_message`'s multi-call-per-turn semantics (which
   don't map 1:1 to the single-span-instance model `MetricsBridge` assumes), is tracked
   separately in #6111.
+- `zeph-db`/`zeph-session`/`zeph-memory`: `SessionStore::list`, `list_acp_sessions`,
+  `list_acp_sessions_for_owner`, and `list_agent_sessions` bound `LIMIT ?` with `-1` as their
+  `limit == 0` ("unlimited") sentinel — a `SQLite`-only convenience that `PostgreSQL` rejects at
+  execution time (`ERROR: LIMIT must not be negative`) (#5980). Any caller passing `limit = 0`
+  against a Postgres-backed deployment got a hard SQL error instead of "all rows". Added a
+  shared `zeph_db::limit_clause` helper that omits the `LIMIT` clause entirely when unlimited
+  (the only cross-backend-safe encoding — binding `NULL` in its place is separately rejected by
+  `SQLite`) and applied it at all four call sites. Also fixed a related, previously-uncovered
+  defect surfaced while adding Postgres test coverage: `SessionStore::get`/`list`/
+  `get_by_conversation_id` decoded `created_at`/`updated_at` straight into `String`, which fails
+  against Postgres's `TIMESTAMPTZ` columns regardless of `limit` — every `zeph-session` query
+  was broken on Postgres, caught only because the crate previously had no Postgres integration
+  test file at all. Added Postgres integration tests for `zeph-session` (new
+  `crates/zeph-session/tests/postgres_integration.rs`, `test-utils` feature) and extended
+  `crates/zeph-memory/tests/postgres_integration.rs` to cover the `limit = 0` path.
 - `zeph-core`: removed two blocking-I/O sites from the async agent turn loop (#6020, #6029).
   - `rebuild_system_prompt` called `project::discover_project_configs`/`load_project_context`
     directly on every turn — a filesystem walk from cwd to the root plus a `read_to_string`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11045,6 +11045,8 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
+ "testcontainers",
+ "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/zeph-db/README.md
+++ b/crates/zeph-db/README.md
@@ -77,7 +77,6 @@ use zeph_db::{DbConfig, DbPool};
 
 let config = DbConfig {
     url: "path/to/zeph.db".into(),
-    max_connections: 5,
     pool_size: 5,
 };
 

--- a/crates/zeph-db/src/instance_id.rs
+++ b/crates/zeph-db/src/instance_id.rs
@@ -52,7 +52,6 @@ mod tests {
     async fn setup_pool() -> DbPool {
         let pool = DbConfig {
             url: ":memory:".to_string(),
-            max_connections: 1,
             pool_size: 1,
         }
         .connect()

--- a/crates/zeph-db/src/lib.rs
+++ b/crates/zeph-db/src/lib.rs
@@ -217,9 +217,53 @@ pub fn placeholder_list(start: usize, count: usize) -> String {
         .join(", ")
 }
 
+/// Builds the `LIMIT` clause fragment (with leading space) and its bind value for the
+/// "`0` means unlimited" convention used across list-style queries (`SessionStore::list`,
+/// `list_acp_sessions`, `list_owned_sessions`, `list_agent_sessions`, ...).
+///
+/// `limit == 0` returns `("", None)`: the caller omits the `LIMIT` clause entirely.
+/// This is the only cross-backend-safe way to express "unlimited" — `LIMIT -1`, the
+/// `SQLite`-only convenience sentinel used before this helper existed, is rejected by
+/// `PostgreSQL` at execution time (`ERROR: LIMIT must not be negative`), and binding a
+/// `NULL` in its place is rejected by `SQLite` (`SQLITE_MISMATCH`), so neither backend
+/// accepts a single placeholder value that means "no limit".
+///
+/// Any other value returns `(" LIMIT ?", Some(limit))`; the caller appends the fragment
+/// to the query text and, only when the returned bind value is `Some`, adds a matching
+/// `.bind()` call.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_db::limit_clause;
+///
+/// assert_eq!(limit_clause(0), ("", None));
+/// assert_eq!(limit_clause(10), (" LIMIT ?", Some(10)));
+/// ```
+#[must_use]
+pub fn limit_clause(limit: u64) -> (&'static str, Option<i64>) {
+    if limit == 0 {
+        ("", None)
+    } else {
+        #[allow(clippy::cast_possible_wrap)]
+        (" LIMIT ?", Some(limit as i64))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn limit_clause_zero_is_unlimited() {
+        assert_eq!(limit_clause(0), ("", None));
+    }
+
+    #[test]
+    fn limit_clause_nonzero_binds_value() {
+        assert_eq!(limit_clause(1), (" LIMIT ?", Some(1)));
+        assert_eq!(limit_clause(42), (" LIMIT ?", Some(42)));
+    }
 
     #[test]
     fn rewrite_placeholders_basic() {

--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -8,12 +8,13 @@ use crate::error::DbError;
 pub struct DbConfig {
     /// Database URL. `SQLite`: file path or `:memory:`. `PostgreSQL`: connection URL.
     pub url: String,
-    /// Maximum number of connections in the pool.
-    pub max_connections: u32,
-    /// `SQLite` only: connection pool size. Default 5.
+    /// Maximum number of connections in the pool, passed to `sqlx`'s
+    /// `.max_connections()` builder call for both backends. Default 5.
     ///
-    /// `BEGIN IMMEDIATE` serializes concurrent writers at the `SQLite` level;
-    /// the pool size controls read concurrency only.
+    /// `SQLite`: `BEGIN IMMEDIATE` serializes concurrent writers at the `SQLite` level,
+    /// so this bound controls read concurrency only. In-memory databases are always
+    /// forced to a single connection regardless of this value, since each new
+    /// `:memory:` connection opens an isolated, unmigrated database.
     pub pool_size: u32,
 }
 
@@ -21,7 +22,6 @@ impl Default for DbConfig {
     fn default() -> Self {
         Self {
             url: String::new(),
-            max_connections: 5,
             pool_size: 5,
         }
     }
@@ -37,7 +37,7 @@ impl DbConfig {
     pub async fn connect(&self) -> Result<DbPool, DbError> {
         #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
         {
-            Self::connect_sqlite(&self.url, self.max_connections, self.pool_size).await
+            Self::connect_sqlite(&self.url, self.pool_size).await
         }
         #[cfg(feature = "postgres")]
         {
@@ -46,11 +46,7 @@ impl DbConfig {
     }
 
     #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
-    async fn connect_sqlite(
-        path: &str,
-        max_connections: u32,
-        pool_size: u32,
-    ) -> Result<DbPool, DbError> {
+    async fn connect_sqlite(path: &str, pool_size: u32) -> Result<DbPool, DbError> {
         use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
         use std::str::FromStr;
 
@@ -87,15 +83,11 @@ impl DbConfig {
             .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
             .synchronous(sqlx::sqlite::SqliteSynchronous::Normal);
 
-        // BEGIN IMMEDIATE serializes concurrent writers at the SQLite level.
-        // pool_size controls the connection count; max_connections is the upper bound.
-        // In-memory databases are connection-scoped: each new connection is a separate
-        // empty DB. Force a single connection so all queries share the migrated schema.
-        let effective_max = if path == ":memory:" {
-            1
-        } else {
-            max_connections.max(pool_size)
-        };
+        // BEGIN IMMEDIATE serializes concurrent writers at the SQLite level; pool_size
+        // controls read concurrency only. In-memory databases are connection-scoped:
+        // each new connection is a separate empty DB. Force a single connection so all
+        // queries share the migrated schema.
+        let effective_max = if path == ":memory:" { 1 } else { pool_size };
         let pool = SqlitePoolOptions::new()
             .max_connections(effective_max)
             .min_connections(1)
@@ -357,7 +349,6 @@ mod tests {
         let db_path = dir.path().join("test.db");
         let cfg = DbConfig {
             url: db_path.to_str().unwrap().to_owned(),
-            max_connections: 1,
             pool_size: 1,
         };
         cfg.connect().await.unwrap();

--- a/crates/zeph-db/tests/postgres_integration.rs
+++ b/crates/zeph-db/tests/postgres_integration.rs
@@ -27,11 +27,7 @@ mod pg {
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-        let config = DbConfig {
-            url,
-            max_connections: 5,
-            pool_size: 5,
-        };
+        let config = DbConfig { url, pool_size: 5 };
         let pool = config.connect().await.expect("failed to connect to PG");
         (pool, container)
     }

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -152,7 +152,6 @@ impl LocalBackend {
     pub async fn open(path: &str, max_payload_bytes: u64) -> Result<Self, DurableError> {
         let pool = zeph_db::DbConfig {
             url: path.to_string(),
-            max_connections: 5,
             pool_size: 5,
         }
         .connect()

--- a/crates/zeph-index/tests/postgres_integration.rs
+++ b/crates/zeph-index/tests/postgres_integration.rs
@@ -29,11 +29,7 @@ mod pg {
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-        let config = DbConfig {
-            url,
-            max_connections: 5,
-            pool_size: 5,
-        };
+        let config = DbConfig { url, pool_size: 5 };
         let pool = config.connect().await.expect("failed to connect to PG");
         (pool, container)
     }

--- a/crates/zeph-mcp/src/manager/tests.rs
+++ b/crates/zeph-mcp/src/manager/tests.rs
@@ -1270,7 +1270,6 @@ async fn validate_roots_preserves_name() {
 async fn make_trust_store() -> Arc<TrustScoreStore> {
     let pool = zeph_db::DbConfig {
         url: ":memory:".to_string(),
-        max_connections: 5,
         pool_size: 5,
     }
     .connect()

--- a/crates/zeph-mcp/src/trust_score.rs
+++ b/crates/zeph-mcp/src/trust_score.rs
@@ -356,7 +356,6 @@ mod tests {
     async fn test_pool() -> DbPool {
         zeph_db::DbConfig {
             url: ":memory:".to_string(),
-            max_connections: 5,
             pool_size: 5,
         }
         .connect()

--- a/crates/zeph-mcp/tests/postgres_integration.rs
+++ b/crates/zeph-mcp/tests/postgres_integration.rs
@@ -51,11 +51,7 @@ async fn start_pg() -> (zeph_db::DbPool, impl Drop) {
     let host = container.get_host().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-    let config = DbConfig {
-        url,
-        max_connections: 5,
-        pool_size: 5,
-    };
+    let config = DbConfig { url, pool_size: 5 };
     let pool = config.connect().await.expect("failed to connect to PG");
     (pool, container)
 }

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -2393,14 +2393,10 @@ mod tests {
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-        let pool = zeph_db::DbConfig {
-            url,
-            max_connections: 5,
-            pool_size: 5,
-        }
-        .connect()
-        .await
-        .expect("failed to connect to PG");
+        let pool = zeph_db::DbConfig { url, pool_size: 5 }
+            .connect()
+            .await
+            .expect("failed to connect to PG");
 
         let pg_store = crate::store::SqliteStore::from_pool(pool.clone())
             .await

--- a/crates/zeph-memory/src/store/acp_sessions.rs
+++ b/crates/zeph-memory/src/store/acp_sessions.rs
@@ -138,9 +138,6 @@ impl SqliteStore {
         &self,
         limit: usize,
     ) -> Result<Vec<AcpSessionInfo>, MemoryError> {
-        // LIMIT -1 in SQLite means no limit; cast limit=0 sentinel to -1.
-        #[allow(clippy::cast_possible_wrap)]
-        let sql_limit: i64 = if limit == 0 { -1 } else { limit as i64 };
         // spec-068 §12.3 / D-2: `acp_sessions.event_count` (migration 106, kept current by
         // `SessionStore::update_seq` on every turn flush per INV-SP-1) replaces the subquery
         // against `acp_session_events`, which the P1 write cutover leaves permanently empty for
@@ -152,20 +149,21 @@ impl SqliteStore {
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let updated_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let (limit_clause, limit_bind) = zeph_db::limit_clause(limit as u64);
         let raw = format!(
             "SELECT s.id, s.title, s.{created_at_sel}, s.{updated_at_sel}, \
              s.event_count AS message_count \
              FROM acp_sessions s \
-             ORDER BY s.updated_at DESC \
-             LIMIT ?"
+             ORDER BY s.updated_at DESC{limit_clause}"
         );
         let query_sql = zeph_db::rewrite_placeholders(&raw);
-        let rows = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
+        let mut query = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
             sqlx::AssertSqlSafe(query_sql),
-        )
-        .bind(sql_limit)
-        .fetch_all(&self.pool)
-        .await?;
+        );
+        if let Some(lim) = limit_bind {
+            query = query.bind(lim);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
         Ok(rows
             .into_iter()
@@ -382,28 +380,27 @@ impl SqliteStore {
         limit: usize,
         owner: &str,
     ) -> Result<Vec<AcpSessionInfo>, MemoryError> {
-        #[allow(clippy::cast_possible_wrap)]
-        let sql_limit: i64 = if limit == 0 { -1 } else { limit as i64 };
         let created_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
         let updated_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("updated_at");
+        let (limit_clause, limit_bind) = zeph_db::limit_clause(limit as u64);
         let raw = format!(
             "SELECT s.id, s.title, s.{created_at_sel}, s.{updated_at_sel}, \
              s.event_count AS message_count \
              FROM acp_sessions s \
              WHERE s.owner_key = ? \
-             ORDER BY s.updated_at DESC \
-             LIMIT ?"
+             ORDER BY s.updated_at DESC{limit_clause}"
         );
         let query_sql = zeph_db::rewrite_placeholders(&raw);
-        let rows = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
+        let mut query = zeph_db::query_as::<_, (String, Option<String>, String, String, i64)>(
             sqlx::AssertSqlSafe(query_sql),
         )
-        .bind(owner)
-        .bind(sql_limit)
-        .fetch_all(&self.pool)
-        .await?;
+        .bind(owner);
+        if let Some(lim) = limit_bind {
+            query = query.bind(lim);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
         Ok(rows
             .into_iter()

--- a/crates/zeph-memory/src/store/agent_sessions.rs
+++ b/crates/zeph-memory/src/store/agent_sessions.rs
@@ -311,8 +311,7 @@ impl SqliteStore {
         limit: u32,
         status_filter: Option<SessionStatus>,
     ) -> Result<Vec<AgentSessionRow>, MemoryError> {
-        #[allow(clippy::cast_possible_wrap)]
-        let sql_limit: i64 = if limit == 0 { -1 } else { i64::from(limit) };
+        let (limit_clause, limit_bind) = zeph_db::limit_clause(u64::from(limit));
 
         type SessionRow = (
             String,
@@ -344,26 +343,27 @@ impl SqliteStore {
                 "SELECT id, kind, status, channel, model, {created_at_sel}, {last_active_at_sel}, \
                  turns, prompt_tokens, completion_tokens, reasoning_tokens, cost_cents, goal_text \
                  FROM agent_sessions WHERE status = ? \
-                 ORDER BY last_active_at DESC LIMIT ?"
+                 ORDER BY last_active_at DESC{limit_clause}"
             );
             let query_sql = zeph_db::rewrite_placeholders(&raw);
-            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
-                .bind(sf.as_str())
-                .bind(sql_limit)
-                .fetch_all(&self.pool)
-                .await?
+            let mut query = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql)).bind(sf.as_str());
+            if let Some(lim) = limit_bind {
+                query = query.bind(lim);
+            }
+            query.fetch_all(&self.pool).await?
         } else {
             let raw = format!(
                 "SELECT id, kind, status, channel, model, {created_at_sel}, {last_active_at_sel}, \
                  turns, prompt_tokens, completion_tokens, reasoning_tokens, cost_cents, goal_text \
                  FROM agent_sessions \
-                 ORDER BY last_active_at DESC LIMIT ?"
+                 ORDER BY last_active_at DESC{limit_clause}"
             );
             let query_sql = zeph_db::rewrite_placeholders(&raw);
-            zeph_db::query_as(sqlx::AssertSqlSafe(query_sql))
-                .bind(sql_limit)
-                .fetch_all(&self.pool)
-                .await?
+            let mut query = zeph_db::query_as(sqlx::AssertSqlSafe(query_sql));
+            if let Some(lim) = limit_bind {
+                query = query.bind(lim);
+            }
+            query.fetch_all(&self.pool).await?
         };
 
         Ok(rows
@@ -513,6 +513,29 @@ mod tests {
         }
         let rows = store.list_agent_sessions(3, None).await.unwrap();
         assert_eq!(rows.len(), 3);
+    }
+
+    /// Regression test (#5980): `limit = 0` ("unlimited") used to bind `LIMIT ?` with `-1`, a
+    /// `SQLite`-only convenience `PostgreSQL` rejects at execution time. Exercises both the
+    /// filtered and unfiltered query branches on `SQLite`; Postgres coverage lives in
+    /// `tests/postgres_integration.rs::agent_sessions_upsert_and_list_postgres`.
+    #[tokio::test]
+    async fn list_unlimited_when_zero() {
+        let store = make_store().await;
+        for i in 0..5u8 {
+            store
+                .upsert_agent_session(&sample(&format!("s{i}")))
+                .await
+                .unwrap();
+        }
+        let rows = store.list_agent_sessions(0, None).await.unwrap();
+        assert_eq!(rows.len(), 5);
+
+        let filtered = store
+            .list_agent_sessions(0, Some(SessionStatus::Active))
+            .await
+            .unwrap();
+        assert_eq!(filtered.len(), 5);
     }
 
     #[tokio::test]

--- a/crates/zeph-memory/src/store/mod.rs
+++ b/crates/zeph-memory/src/store/mod.rs
@@ -104,7 +104,6 @@ impl SqliteStore {
     pub async fn with_pool_size(path: &str, pool_size: u32) -> Result<Self, MemoryError> {
         let pool = DbConfig {
             url: path.to_string(),
-            max_connections: pool_size,
             pool_size,
         }
         .connect()

--- a/crates/zeph-memory/tests/postgres_integration.rs
+++ b/crates/zeph-memory/tests/postgres_integration.rs
@@ -108,11 +108,7 @@ mod pg {
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-        let config = DbConfig {
-            url,
-            max_connections: 5,
-            pool_size: 5,
-        };
+        let config = DbConfig { url, pool_size: 5 };
         let pool = config.connect().await.expect("failed to connect to PG");
         (pool, container)
     }
@@ -1218,6 +1214,34 @@ mod pg {
         assert!(!info.updated_at.is_empty());
     }
 
+    // Regression coverage for issue #5980: `list_acp_sessions`/`list_acp_sessions_for_owner`
+    // bound `LIMIT ?` with `-1` as a `limit == 0` ("unlimited") sentinel. `LIMIT -1` is a
+    // `SQLite`-only convenience; `PostgreSQL` rejects a negative `LIMIT` at execution time
+    // (`ERROR: LIMIT must not be negative`), so `limit = 0` against Postgres previously errored
+    // instead of returning every row.
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn acp_sessions_list_unlimited_when_zero_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SqliteStore::from_pool(pool).await.unwrap();
+
+        for i in 0..5u8 {
+            store
+                .create_acp_session(&format!("sess-{i}"), Some("owner-a"))
+                .await
+                .unwrap();
+        }
+
+        let all = store.list_acp_sessions(0).await.unwrap();
+        assert_eq!(all.len(), 5);
+
+        let for_owner = store
+            .list_acp_sessions_for_owner(0, "owner-a")
+            .await
+            .unwrap();
+        assert_eq!(for_owner.len(), 5);
+    }
+
     // ── acp_sessions: session_config snapshot (#5373/#5384) ─────────────────────
     //
     // `thinking_enabled` is `INTEGER` on SQLite vs `BOOLEAN` on Postgres (migration
@@ -1795,6 +1819,17 @@ mod pg {
             .await
             .unwrap();
         assert!(none_active.is_empty());
+
+        // Regression coverage for issue #5980: `limit = 0` ("unlimited") previously bound
+        // `LIMIT -1`, which Postgres rejects (`ERROR: LIMIT must not be negative`), in both
+        // the filtered and unfiltered branches of this query.
+        let unlimited = store.list_agent_sessions(0, None).await.unwrap();
+        assert_eq!(unlimited.len(), 1);
+        let unlimited_filtered = store
+            .list_agent_sessions(0, Some(SessionStatus::Completed))
+            .await
+            .unwrap();
+        assert_eq!(unlimited_filtered.len(), 1);
     }
 
     // ── episodic_consolidation: full sweep (fetch_candidates → compute_cognitive_weight →

--- a/crates/zeph-orchestration/tests/postgres_integration.rs
+++ b/crates/zeph-orchestration/tests/postgres_integration.rs
@@ -38,11 +38,7 @@ async fn start_pg() -> (zeph_db::DbPool, impl Drop) {
     let host = container.get_host().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-    let config = DbConfig {
-        url,
-        max_connections: 5,
-        pool_size: 5,
-    };
+    let config = DbConfig { url, pool_size: 5 };
     let pool = config.connect().await.expect("failed to connect to PG");
     (pool, container)
 }

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -1017,7 +1017,6 @@ mod tests {
     async fn test_pool() -> DbPool {
         zeph_db::DbConfig {
             url: ":memory:".to_string(),
-            max_connections: 5,
             pool_size: 5,
         }
         .connect()

--- a/crates/zeph-scheduler/src/store.rs
+++ b/crates/zeph-scheduler/src/store.rs
@@ -120,7 +120,6 @@ impl JobStore {
     pub async fn open(path: &str) -> Result<Self, SchedulerError> {
         let pool = zeph_db::DbConfig {
             url: path.to_string(),
-            max_connections: 5,
             pool_size: 5,
         }
         .connect()
@@ -500,7 +499,6 @@ mod tests {
     async fn test_pool() -> DbPool {
         zeph_db::DbConfig {
             url: ":memory:".to_string(),
-            max_connections: 5,
             pool_size: 5,
         }
         .connect()

--- a/crates/zeph-session/Cargo.toml
+++ b/crates/zeph-session/Cargo.toml
@@ -16,12 +16,16 @@ readme = "README.md"
 default = ["sqlite"]
 sqlite = ["zeph-db/sqlite"]
 postgres = ["zeph-db/postgres"]
+# Enables test utilities and testcontainers for PostgreSQL integration tests.
+test-utils = ["dep:testcontainers", "dep:testcontainers-modules", "postgres"]
 
 [dependencies]
 rustix = { workspace = true, features = ["fs", "std"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sqlx = { workspace = true, features = ["macros"] }
+testcontainers = { workspace = true, features = ["watchdog"], optional = true }
+testcontainers-modules = { workspace = true, features = ["postgres"], optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt", "sync", "time"] }
 tracing.workspace = true

--- a/crates/zeph-session/src/store.rs
+++ b/crates/zeph-session/src/store.rs
@@ -197,14 +197,22 @@ impl SessionStore {
     /// Returns [`SessionError::Db`] if the query fails.
     #[tracing::instrument(name = "session.store.get", skip_all, level = "debug")]
     pub async fn get(&self, session_id: &str) -> Result<Option<SessionMetadata>, SessionError> {
-        let row = zeph_db::query_as::<_, SessionRow>(sql!(
-            "SELECT id, title, created_at, updated_at, conversation_id, last_seq, event_count, \
-             forked_from, forked_at_seq, status, last_condensed_seq \
+        // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite); project
+        // both through `Dialect::select_as_text` so they decode into `SessionRow`'s `String`
+        // fields, mirroring `zeph-memory`'s `list_acp_sessions`/`list_agent_sessions` fix for
+        // the same mismatch.
+        let created_at_sel = <ActiveDialect as Dialect>::select_as_text("created_at");
+        let updated_at_sel = <ActiveDialect as Dialect>::select_as_text("updated_at");
+        let raw = format!(
+            "SELECT id, title, {created_at_sel}, {updated_at_sel}, conversation_id, last_seq, \
+             event_count, forked_from, forked_at_seq, status, last_condensed_seq \
              FROM acp_sessions WHERE id = ?"
-        ))
-        .bind(session_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row = zeph_db::query_as::<_, SessionRow>(sqlx::AssertSqlSafe(query_sql))
+            .bind(session_id)
+            .fetch_optional(&self.pool)
+            .await?;
         row.map(TryInto::try_into).transpose()
     }
 
@@ -215,26 +223,27 @@ impl SessionStore {
     /// Returns [`SessionError::Db`] if the query fails.
     #[tracing::instrument(name = "session.store.list", skip_all, level = "debug")]
     pub async fn list(&self, filter: &SessionFilter) -> Result<Vec<SessionMetadata>, SessionError> {
-        #[allow(clippy::cast_possible_wrap)]
-        let sql_limit: i64 = if filter.limit == 0 {
-            -1
-        } else {
-            filter.limit as i64
-        };
         let status_filter = filter.status.map(SessionStatus::as_str);
+        let (limit_clause, limit_bind) = zeph_db::limit_clause(filter.limit as u64);
+        // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres — see `Self::get`.
+        let created_at_sel = <ActiveDialect as Dialect>::select_as_text("created_at");
+        let updated_at_sel = <ActiveDialect as Dialect>::select_as_text("updated_at");
 
-        let rows = zeph_db::query_as::<_, SessionRow>(sql!(
-            "SELECT id, title, created_at, updated_at, conversation_id, last_seq, event_count, \
-             forked_from, forked_at_seq, status, last_condensed_seq \
+        let raw = format!(
+            "SELECT id, title, {created_at_sel}, {updated_at_sel}, conversation_id, last_seq, \
+             event_count, forked_from, forked_at_seq, status, last_condensed_seq \
              FROM acp_sessions \
              WHERE (? IS NULL OR status = ?) \
-             ORDER BY updated_at DESC LIMIT ?"
-        ))
-        .bind(status_filter)
-        .bind(status_filter)
-        .bind(sql_limit)
-        .fetch_all(&self.pool)
-        .await?;
+             ORDER BY updated_at DESC{limit_clause}"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let mut query = zeph_db::query_as::<_, SessionRow>(sqlx::AssertSqlSafe(query_sql))
+            .bind(status_filter)
+            .bind(status_filter);
+        if let Some(lim) = limit_bind {
+            query = query.bind(lim);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
         rows.into_iter().map(TryInto::try_into).collect()
     }
@@ -281,14 +290,19 @@ impl SessionStore {
         &self,
         conversation_id: i64,
     ) -> Result<Option<SessionMetadata>, SessionError> {
-        let row = zeph_db::query_as::<_, SessionRow>(sql!(
-            "SELECT id, title, created_at, updated_at, conversation_id, last_seq, event_count, \
-             forked_from, forked_at_seq, status, last_condensed_seq \
+        // `created_at`/`updated_at` are `TIMESTAMPTZ` on Postgres — see `Self::get`.
+        let created_at_sel = <ActiveDialect as Dialect>::select_as_text("created_at");
+        let updated_at_sel = <ActiveDialect as Dialect>::select_as_text("updated_at");
+        let raw = format!(
+            "SELECT id, title, {created_at_sel}, {updated_at_sel}, conversation_id, last_seq, \
+             event_count, forked_from, forked_at_seq, status, last_condensed_seq \
              FROM acp_sessions WHERE conversation_id = ?"
-        ))
-        .bind(conversation_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        let row = zeph_db::query_as::<_, SessionRow>(sqlx::AssertSqlSafe(query_sql))
+            .bind(conversation_id)
+            .fetch_optional(&self.pool)
+            .await?;
         row.map(TryInto::try_into).transpose()
     }
 
@@ -523,6 +537,28 @@ mod tests {
 
         let all = store.list(&SessionFilter::default()).await.unwrap();
         assert_eq!(all.len(), 2);
+    }
+
+    /// Regression test (#5980): `SessionStore::list` used to bind `LIMIT ?` with `-1` for the
+    /// `limit == 0` ("unlimited") sentinel — a `SQLite`-only convenience that `PostgreSQL`
+    /// rejects at execution time. This exercises the non-zero limit branch on `SQLite`; the
+    /// Postgres-specific `limit == 0` regression is covered by
+    /// `tests/postgres_integration.rs::list_unlimited_when_zero_postgres`.
+    #[tokio::test]
+    async fn list_respects_nonzero_limit() {
+        let store = SessionStore::new(make_pool().await);
+        for i in 0..5u8 {
+            store.create(&format!("s{i}")).await.unwrap();
+        }
+
+        let limited = store
+            .list(&SessionFilter {
+                status: None,
+                limit: 3,
+            })
+            .await
+            .unwrap();
+        assert_eq!(limited.len(), 3);
     }
 
     #[tokio::test]

--- a/crates/zeph-session/tests/postgres_integration.rs
+++ b/crates/zeph-session/tests/postgres_integration.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `PostgreSQL` integration tests for `zeph-session`.
+//!
+//! These tests require Docker to be running. Run locally with:
+//! ```bash
+//! cargo nextest run -p zeph-session --features test-utils --test postgres_integration --run-ignored ignored-only
+//! ```
+//!
+//! Regression coverage for issue #5980: `SessionStore::list` bound `LIMIT ?` with `-1` as a
+//! `filter.limit == 0` ("unlimited") sentinel. `LIMIT -1` is a `SQLite`-only convenience;
+//! `PostgreSQL` rejects a negative `LIMIT` at execution time (`ERROR: LIMIT must not be
+//! negative`), so any caller passing `limit = 0` against Postgres got a hard SQL error instead
+//! of "all rows". The tests below exercise `SessionStore::list`'s `limit = 0` path against a
+//! real Postgres instance.
+
+#[cfg(feature = "test-utils")]
+mod pg {
+    use std::time::Duration;
+
+    use testcontainers::ImageExt as _;
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::postgres::Postgres;
+    use zeph_db::DbConfig;
+    use zeph_session::store::{SessionFilter, SessionStatus, SessionStore};
+
+    // Generous startup timeout: under concurrent CI load, the default 60s can elapse
+    // before Postgres is ready, and testcontainers-rs 0.27.3 leaks the container on a
+    // startup-timeout cancel (no Drop guard is ever created).
+    async fn start_pg() -> (zeph_db::DbPool, impl Drop) {
+        let image = Postgres::default().with_startup_timeout(Duration::from_mins(2));
+        let container = image.start().await.expect("docker must be available");
+        let host = container.get_host().await.unwrap();
+        let port = container.get_host_port_ipv4(5432).await.unwrap();
+        let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+        let config = DbConfig { url, pool_size: 5 };
+        let pool = config.connect().await.expect("failed to connect to PG");
+        (pool, container)
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn list_unlimited_when_zero_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SessionStore::new(pool);
+
+        for i in 0..5u8 {
+            store.create(&format!("sess-{i}")).await.unwrap();
+        }
+
+        // Regression for #5980: limit=0 must return every row, not error with
+        // "LIMIT must not be negative".
+        let all = store.list(&SessionFilter::default()).await.unwrap();
+        assert_eq!(all.len(), 5);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn list_respects_nonzero_limit_and_status_filter_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SessionStore::new(pool);
+
+        for i in 0..5u8 {
+            store.create(&format!("sess-{i}")).await.unwrap();
+        }
+        store
+            .set_status("sess-0", SessionStatus::Archived)
+            .await
+            .unwrap();
+
+        let limited = store
+            .list(&SessionFilter {
+                status: None,
+                limit: 3,
+            })
+            .await
+            .unwrap();
+        assert_eq!(limited.len(), 3);
+
+        let active = store
+            .list(&SessionFilter {
+                status: Some(SessionStatus::Active),
+                limit: 0,
+            })
+            .await
+            .unwrap();
+        assert_eq!(active.len(), 4);
+    }
+
+    // Regression coverage (review follow-up, #5980): `SessionStore::get` and
+    // `get_by_conversation_id` received the same `Dialect::select_as_text` `TIMESTAMPTZ` fix as
+    // `list()` (all three decode `created_at`/`updated_at` off the same `acp_sessions` columns),
+    // but only `list()` was exercised against real Postgres above. Without this test, a future
+    // regression isolated to `get`/`get_by_conversation_id` (e.g. a refactor that drops
+    // `select_as_text` from one of the three near-identical call sites) would pass the full
+    // suite on both backends, since SQLite never had this bug.
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn get_and_get_by_conversation_id_decode_timestamps_postgres() {
+        let (pool, _container) = start_pg().await;
+        let store = SessionStore::new(pool.clone());
+
+        store.create("sess-x").await.unwrap();
+
+        // `conversation_id` carries an FK to `conversations(id)` (migration 001); insert a row
+        // directly since creating conversations is zeph-memory's domain, out of scope here
+        // (mirrors the SQLite unit test `link_conversation_and_lookup_round_trips` in
+        // `src/store.rs`).
+        let (cid,): (i64,) = sqlx::query_as(zeph_db::sql!(
+            "INSERT INTO conversations DEFAULT VALUES RETURNING id"
+        ))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        store.link_conversation("sess-x", cid).await.unwrap();
+
+        let by_id = store
+            .get("sess-x")
+            .await
+            .unwrap()
+            .expect("session must exist");
+        assert_eq!(by_id.session_id, "sess-x");
+        assert!(
+            !by_id.created_at.is_empty(),
+            "created_at must decode as non-empty text"
+        );
+        assert!(
+            !by_id.updated_at.is_empty(),
+            "updated_at must decode as non-empty text"
+        );
+
+        let by_conv = store
+            .get_by_conversation_id(cid)
+            .await
+            .unwrap()
+            .expect("session must be found by conversation_id");
+        assert_eq!(by_conv.session_id, "sess-x");
+        assert!(!by_conv.created_at.is_empty());
+        assert!(!by_conv.updated_at.is_empty());
+    }
+}

--- a/specs/031-database-abstraction/spec.md
+++ b/specs/031-database-abstraction/spec.md
@@ -821,6 +821,28 @@ impl DbConfig {
         Ok(pool)
     }
 }
+```
+
+**Amendment 3 [2026-07-12]** (#5970): The `max_connections`/`write_pool_size` two-field design
+above was never actually implemented this way — the real `DbConfig` (see
+`crates/zeph-db/src/pool.rs`) shipped with `max_connections` and `pool_size` fields whose
+semantics contradicted both their names and this spec: `pool_size` (documented "SQLite only")
+was what `connect_postgres` actually passed to `.max_connections()`, and `SQLite` combined the
+two as `max_connections.max(pool_size)` — the larger value won, not a cap. `DbConfig` now has a
+single `pool_size: u32` field, applied as `.max_connections()` for both backends. `max_connections`
+is removed entirely (pre-v1.0.0, no deprecation shim). It was never a user-facing `config.toml`
+key, so this is an internal-API-only breaking change.
+
+```rust
+/// Configuration for database pool construction.
+pub struct DbConfig {
+    /// Database URL. SQLite: file path or `:memory:`. Postgres: connection URL.
+    pub url: String,
+    /// Maximum number of connections in the pool, applied uniformly to both backends'
+    /// `.max_connections()` builder call. Default 5.
+    pub pool_size: u32,
+}
+```
 
 /// Strip password from a database URL for safe logging.
 ///

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -583,7 +583,6 @@ impl AppBuilder {
         // (pool_size=5), causing pool.acquire() cancellation and semaphore drift in sqlx 0.8.
         let graph_pool = zeph_db::DbConfig {
             url: db_path.to_string(),
-            max_connections: self.config.memory.graph.pool_size,
             pool_size: self.config.memory.graph.pool_size,
         }
         .connect()

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -43,7 +43,6 @@ pub(crate) async fn handle_db_migrate(config_path: Option<&std::path::Path>) -> 
 
     let db_config = DbConfig {
         url: db_url.to_owned(),
-        max_connections: 1,
         pool_size: 1,
     };
 


### PR DESCRIPTION
## Summary
- `SessionStore::list` and 3 sibling `list_*` helpers bound `LIMIT ?` with `-1` as a `limit == 0` ("unlimited") sentinel — a SQLite-only convenience that PostgreSQL rejects at execution time. Added a shared `zeph_db::limit_clause()` helper that omits the `LIMIT` clause entirely when unlimited, applied consistently across all 5 affected call sites.
- Also fixes a related pre-existing bug surfaced by the new Postgres test coverage: `SessionStore::get`/`list`/`get_by_conversation_id` decoded `created_at`/`updated_at` as `String` against Postgres `TIMESTAMPTZ` columns, breaking every `SessionStore` query under the `postgres` feature.
- Collapsed `DbConfig::max_connections`/`pool_size` into a single `pool_size` field. The two fields had contradictory documentation and behavior (`pool_size` actually governed the Postgres pool despite being documented "SQLite only"; `max_connections` was dead under postgres and combined via `.max()` under sqlite), kept in sync only by caller convention across ~15 call sites. Pre-v1.0.0, so `max_connections` was removed outright rather than deprecated — confirmed via workspace-wide grep it was never a user-facing `config.toml` key, CLI flag, or `--init` wizard prompt, so no migration step is needed.

Closes #5980
Closes #5970

## Test plan
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12999/12999 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all pass
- [x] Per-crate rustdoc gate for touched published crates (zeph-db, zeph-session, zeph-memory, zeph-scheduler, zeph-orchestration, zeph-mcp, zeph-durable, zeph-index), with correct feature flags per crate (`postgres` for zeph-db; `daemon`/`llm-planning` where modules are feature-gated) — clean
- [x] Live-verified against real Postgres via testcontainers/Docker: `zeph-session` postgres_integration (3/3, including a new test covering `get`/`get_by_conversation_id`'s TIMESTAMPTZ decode path), `zeph-memory` postgres_integration (49/49, 0 regressions)
- [x] `.local/testing/playbooks/zeph-db-dual-backend.md` §14 and `.local/testing/coverage-status.md` updated with live-verification results
- [x] `CHANGELOG.md` updated under `[Unreleased]`