### PR TITLE
fix(subagent): live TTL re-check for delivered secrets and per-task secret-request lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-subagent`: sub-agent vault secrets now re-validate their grant TTL live instead of
+  only gating once at delivery time, and a targeted secret-request lookup no longer drops a
+  concurrent sibling sub-agent's pending request (#5991, #5993).
+  - `SubAgentManager::deliver_secret` previously sent the bare resolved `Secret` value over
+    the sub-agent's channel; the running agent loop cached it for the rest of its
+    `run_agent_loop` invocation and kept injecting it into every subsequent tool call's
+    `ExecutionContext`, even after the originating grant's TTL had elapsed (#5991). Added
+    `grants::GrantedSecret` (value + absolute expiry, computed from the active grant via the
+    new `PermissionGrants::expires_at`) as the channel payload, and `handle_tool_step` now
+    evicts expired entries from `granted_secrets` before building the `ExecutionContext` for
+    every tool call, not just once at approval time.
+  - `handle_agent_approve`'s explicit `/agent approve <id>` path polled
+    `SubAgentManager::try_recv_secret_request` (which pops the first pending request across
+    *all* sub-agents) and filtered by task ID, silently discarding a different sub-agent's
+    pending request when it happened to pop first (#5993). Added
+    `SubAgentManager::try_recv_secret_request_for(task_id)`, which polls only that sub-agent's
+    own request channel, and switched the approve path to use it.
 - `zeph-channels`/`zeph-core`: hardened the channel send/retry/status path (#6094, #6106, #6095).
   - `Channel::send_status` was awaited inline on the agent turn hot path at ~45 call sites via
     `let _ = self.channel.send_status(...).await;`, with no outer timeout. Under sustained

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -300,10 +300,9 @@ impl<C: Channel> Agent<C> {
         };
         let req = {
             let mgr = self.services.orchestration.subagent_manager.as_mut()?;
-            mgr.try_recv_secret_request()
-                .filter(|(tid, _)| *tid == full_id)
+            mgr.try_recv_secret_request_for(&full_id)
         };
-        let Some((_, req)) = req else {
+        let Some(req) = req else {
             return Some(format!(
                 "No pending secret request for sub-agent '{full_id}'."
             ));

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -6,7 +6,6 @@ use std::time::Instant;
 
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
-use zeph_common::secret::Secret;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{
     ChatResponse, LlmProvider, Message, MessageMetadata, MessagePart, Role, ToolDefinition,
@@ -15,7 +14,7 @@ use zeph_sanitizer::{ContentSanitizer, ContentSource, ContentSourceKind};
 use zeph_tools::executor::{ErasedToolExecutor, ToolCall};
 
 use super::filter::FilteredToolExecutor;
-use super::grants::SecretRequest;
+use super::grants::{GrantedSecret, SecretRequest};
 use super::hooks::{HookDef, SubagentHooks, fire_hooks, make_base_hook_env, matching_hooks};
 use super::manager::SubAgentStatus;
 use super::state::SubAgentState;
@@ -59,7 +58,7 @@ pub(super) struct AgentLoopArgs {
     pub(super) status_tx: watch::Sender<SubAgentStatus>,
     pub(super) started_at: Instant,
     pub(super) secret_request_tx: mpsc::Sender<SecretRequest>,
-    pub(super) secret_rx: mpsc::Receiver<Option<Secret>>,
+    pub(super) secret_rx: mpsc::Receiver<Option<GrantedSecret>>,
     pub(super) background: bool,
     pub(super) hooks: SubagentHooks,
     pub(super) task_id: String,
@@ -194,9 +193,9 @@ async fn handle_secret_request(
     transcript_writer: Option<&TranscriptWriter>,
     seq: &mut u32,
     messages: &mut Vec<Message>,
-    granted_secrets: &mut HashMap<String, Secret>,
+    granted_secrets: &mut HashMap<String, GrantedSecret>,
     secret_request_tx: &mpsc::Sender<SecretRequest>,
-    secret_rx: &mut mpsc::Receiver<Option<Secret>>,
+    secret_rx: &mut mpsc::Receiver<Option<GrantedSecret>>,
     cancel: &CancellationToken,
     background: bool,
     is_text_response: bool,
@@ -253,13 +252,15 @@ async fn handle_secret_request(
             }
         };
         let reply = match outcome {
-            Some(Some(secret_value)) => {
+            Some(Some(granted)) => {
                 // Accumulated for the loop's lifetime and attached to every subsequent tool
                 // call's `ExecutionContext` (see `handle_tool_step`) — a per-call override,
                 // never written into the shared `ShellExecutor::skill_env` slot, because that
                 // slot is on the same executor instance the parent agent uses and would leak
                 // the secret into unrelated tool calls made outside this sub-agent's run.
-                granted_secrets.insert(key_name.clone(), secret_value);
+                // `handle_tool_step` re-checks `granted.is_expired()` before every tool call,
+                // so the cached value stops being usable once its grant's TTL elapses.
+                granted_secrets.insert(key_name.clone(), granted);
                 format!(
                     "[secret:{key_name}] approved — available as ${key_name} in the tool \
                      execution environment"
@@ -406,8 +407,8 @@ async fn run_turn(
     background: bool,
     started_at: Instant,
     secret_request_tx: &mpsc::Sender<SecretRequest>,
-    secret_rx: &mut mpsc::Receiver<Option<Secret>>,
-    granted_secrets: &mut HashMap<String, Secret>,
+    secret_rx: &mut mpsc::Receiver<Option<GrantedSecret>>,
+    granted_secrets: &mut HashMap<String, GrantedSecret>,
     sanitizer: &ContentSanitizer,
     llm_timeout: std::time::Duration,
 ) -> Result<TurnOutcome, super::error::SubAgentError> {
@@ -461,7 +462,7 @@ async fn run_turn(
         task_id,
         agent_name,
         sanitizer,
-        &*granted_secrets,
+        granted_secrets,
     )
     .await;
 
@@ -503,7 +504,7 @@ async fn handle_tool_step(
     task_id: &str,
     agent_name: &str,
     sanitizer: &ContentSanitizer,
-    granted_secrets: &HashMap<String, Secret>,
+    granted_secrets: &mut HashMap<String, GrantedSecret>,
 ) -> bool {
     match response {
         ChatResponse::Text(text) => {
@@ -553,6 +554,11 @@ async fn handle_tool_step(
                 // env override (highest-priority, call-scoped) rather than the executor's
                 // shared `skill_env` slot, which is aliased with the parent agent's own tool
                 // executor and would leak the secret beyond this sub-agent's run.
+                //
+                // Re-check the TTL live before every tool call rather than trusting the
+                // one-time gate at delivery time: a long-running turn loop can otherwise keep
+                // using a secret well after its grant expired (issue #5991).
+                granted_secrets.retain(|_, granted| !granted.is_expired());
                 let exec_ctx = if granted_secrets.is_empty() {
                     None
                 } else {
@@ -560,7 +566,7 @@ async fn handle_tool_step(
                         zeph_tools::ExecutionContext::new().with_envs(
                             granted_secrets
                                 .iter()
-                                .map(|(k, v)| (k.clone(), v.expose().to_owned())),
+                                .map(|(k, v)| (k.clone(), v.value.expose().to_owned())),
                         ),
                     )
                 };
@@ -744,8 +750,9 @@ pub(super) async fn run_agent_loop(
     let mut any_tool_called = false;
     // Accumulates resolved secret values across the loop's lifetime so a later approval
     // does not evict an earlier one from the tool executor's environment (see
-    // `handle_secret_request`).
-    let mut granted_secrets: HashMap<String, Secret> = HashMap::new();
+    // `handle_secret_request`). Entries whose grant TTL has elapsed are evicted live in
+    // `handle_tool_step`, not just gated once at delivery time.
+    let mut granted_secrets: HashMap<String, GrantedSecret> = HashMap::new();
 
     loop {
         if cancel.is_cancelled() {
@@ -912,7 +919,9 @@ mod make_hook_env_tests {
 mod handle_tool_step_granted_secrets_tests {
     use std::pin::Pin;
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
+    use zeph_common::secret::Secret;
     use zeph_llm::provider::ToolUseRequest;
     use zeph_tools::executor::{ErasedToolExecutor, ToolCall, ToolError, ToolOutput};
     use zeph_tools::registry::ToolDef;
@@ -1036,7 +1045,13 @@ mod handle_tool_step_granted_secrets_tests {
         let hooks = SubagentHooks::default();
         let mut messages = Vec::new();
         let mut granted_secrets = HashMap::new();
-        granted_secrets.insert("SOME_VAULT_KEY".to_owned(), Secret::new("the-secret-value"));
+        granted_secrets.insert(
+            "SOME_VAULT_KEY".to_owned(),
+            GrantedSecret {
+                value: Secret::new("the-secret-value"),
+                expires_at: Instant::now() + Duration::from_mins(5),
+            },
+        );
         let sanitizer = ContentSanitizer::new(&zeph_config::ContentIsolationConfig::default());
 
         let no_tool = handle_tool_step(
@@ -1047,7 +1062,7 @@ mod handle_tool_step_granted_secrets_tests {
             "task-1",
             "bot",
             &sanitizer,
-            &granted_secrets,
+            &mut granted_secrets,
         )
         .await;
         assert!(!no_tool, "a tool call was made");
@@ -1078,7 +1093,7 @@ mod handle_tool_step_granted_secrets_tests {
         );
         let hooks = SubagentHooks::default();
         let mut messages = Vec::new();
-        let granted_secrets: HashMap<String, Secret> = HashMap::new();
+        let mut granted_secrets: HashMap<String, GrantedSecret> = HashMap::new();
         let sanitizer = ContentSanitizer::new(&zeph_config::ContentIsolationConfig::default());
 
         let no_tool = handle_tool_step(
@@ -1089,7 +1104,7 @@ mod handle_tool_step_granted_secrets_tests {
             "task-1",
             "bot",
             &sanitizer,
-            &granted_secrets,
+            &mut granted_secrets,
         )
         .await;
         assert!(!no_tool);
@@ -1099,6 +1114,54 @@ mod handle_tool_step_granted_secrets_tests {
         assert!(
             calls[0].context.is_none(),
             "no granted secrets must leave context as None"
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_granted_secret_is_not_attached_and_is_evicted() {
+        // Regression guard for #5991: a secret whose grant TTL has already elapsed must
+        // not be re-injected into a tool call's ExecutionContext, and must be dropped
+        // from the loop's local cache rather than lingering for the rest of the run.
+        let recorder = Arc::new(RecordingExecutor::default());
+        let executor = FilteredToolExecutor::new(
+            Arc::clone(&recorder) as Arc<dyn ErasedToolExecutor>,
+            ToolPolicy::InheritAll,
+        );
+        let hooks = SubagentHooks::default();
+        let mut messages = Vec::new();
+        let mut granted_secrets = HashMap::new();
+        granted_secrets.insert(
+            "SOME_VAULT_KEY".to_owned(),
+            GrantedSecret {
+                value: Secret::new("the-secret-value"),
+                expires_at: Instant::now().checked_sub(Duration::from_secs(1)).unwrap(),
+            },
+        );
+
+        let sanitizer = ContentSanitizer::new(&zeph_config::ContentIsolationConfig::default());
+
+        let no_tool = handle_tool_step(
+            &executor,
+            tool_use_response(),
+            &mut messages,
+            &hooks,
+            "task-1",
+            "bot",
+            &sanitizer,
+            &mut granted_secrets,
+        )
+        .await;
+        assert!(!no_tool, "a tool call was made");
+
+        let calls = recorder.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(
+            calls[0].context.is_none(),
+            "an expired grant must not be attached to the tool call context"
+        );
+        assert!(
+            granted_secrets.is_empty(),
+            "an expired grant must be evicted from the local cache"
         );
     }
 }

--- a/crates/zeph-subagent/src/grants.rs
+++ b/crates/zeph-subagent/src/grants.rs
@@ -15,6 +15,7 @@
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
+use zeph_common::secret::Secret;
 
 /// Metadata sent by a sub-agent when it needs a secret from the vault.
 ///
@@ -197,6 +198,37 @@ impl PermissionGrants {
         self.grants.iter().any(|g| &g.kind == kind)
     }
 
+    /// Returns the absolute instant at which the active grant for `kind` expires.
+    ///
+    /// Automatically sweeps expired grants before checking, so a `None` result means
+    /// there is no active grant for `kind` (never granted, already expired, or revoked).
+    /// Used by [`SubAgentManager::deliver_secret`][crate::manager::SubAgentManager::deliver_secret]
+    /// to stamp the delivered value with its expiry so the sub-agent loop can re-validate the
+    /// TTL locally on every subsequent tool call, without needing further access to this
+    /// `PermissionGrants` instance (which stays on the manager side, not the spawned loop task).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use zeph_subagent::grants::{GrantKind, PermissionGrants};
+    ///
+    /// let mut grants = PermissionGrants::default();
+    /// let kind = GrantKind::Secret("api-key".to_owned());
+    /// assert!(grants.expires_at(&kind).is_none());
+    ///
+    /// grants.add(kind.clone(), Duration::from_mins(5));
+    /// assert!(grants.expires_at(&kind).is_some());
+    /// ```
+    #[must_use]
+    pub fn expires_at(&mut self, kind: &GrantKind) -> Option<Instant> {
+        self.sweep_expired();
+        self.grants
+            .iter()
+            .find(|g| &g.kind == kind)
+            .map(|g| g.granted_at + g.ttl)
+    }
+
     /// Grant access to a vault secret with the given TTL.
     ///
     /// Sweeps expired grants first. Logs an audit event at DEBUG (key is redacted
@@ -223,6 +255,58 @@ impl PermissionGrants {
         if count > 0 {
             tracing::debug!(count, "all permission grants revoked");
         }
+    }
+}
+
+/// A resolved secret value delivered to a sub-agent loop, paired with the absolute
+/// instant its originating grant expires.
+///
+/// Sent over the `secret_tx`/`secret_rx` channel
+/// (see [`SubAgentHandle::secret_tx`][crate::manager::SubAgentHandle::secret_tx]) instead of a
+/// bare [`Secret`] so the spawned agent loop task — which has no further access to the
+/// manager-side [`PermissionGrants`] once the value is delivered — can still re-validate the
+/// TTL locally before every tool call and evict the value once it expires.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::time::{Duration, Instant};
+/// use zeph_common::secret::Secret;
+/// use zeph_subagent::grants::GrantedSecret;
+///
+/// let granted = GrantedSecret {
+///     value: Secret::new("sekrit"),
+///     expires_at: Instant::now() + Duration::from_mins(5),
+/// };
+/// assert!(!granted.is_expired());
+/// ```
+#[derive(Debug)]
+pub struct GrantedSecret {
+    /// The resolved vault secret value.
+    pub value: Secret,
+    /// The absolute instant after which this value must no longer be used.
+    pub expires_at: Instant,
+}
+
+impl GrantedSecret {
+    /// Returns `true` if `expires_at` has already passed.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::time::{Duration, Instant};
+    /// use zeph_common::secret::Secret;
+    /// use zeph_subagent::grants::GrantedSecret;
+    ///
+    /// let expired = GrantedSecret {
+    ///     value: Secret::new("sekrit"),
+    ///     expires_at: Instant::now().checked_sub(Duration::from_secs(1)).unwrap(),
+    /// };
+    /// assert!(expired.is_expired());
+    /// ```
+    #[must_use]
+    pub fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
     }
 }
 

--- a/crates/zeph-subagent/src/lib.rs
+++ b/crates/zeph-subagent/src/lib.rs
@@ -67,7 +67,7 @@ pub use durable::{
 pub use error::SubAgentError;
 pub use filter::{FilteredToolExecutor, PlanModeExecutor, filter_skills};
 pub use fleet::{FleetRegistry, FleetSessionInfo, FleetSessionStatus, SharedFleetRegistry};
-pub use grants::{Grant, GrantKind, PermissionGrants, SecretRequest};
+pub use grants::{Grant, GrantKind, GrantedSecret, PermissionGrants, SecretRequest};
 pub use hooks::{
     HookAction, HookDef, HookError, HookMatcher, HookOutput, HookRunResult, McpDispatch,
     PostToolUseHookInput, SubagentHooks, TOOL_ARGS_JSON_LIMIT, fire_hooks, hook_if_matches,

--- a/crates/zeph-subagent/src/manager/mod.rs
+++ b/crates/zeph-subagent/src/manager/mod.rs
@@ -16,7 +16,6 @@ use std::time::Instant;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use zeph_common::secret::Secret;
 use zeph_common::task_supervisor::BlockingHandle;
 use zeph_common::{SkillTrustLevel, TaskSupervisor};
 use zeph_config::{ContentIsolationConfig, McpServerConfig};
@@ -26,7 +25,7 @@ use crate::def::{PermissionMode, SubAgentDef};
 use crate::durable::DurableResolverSeat;
 use crate::error::SubAgentError;
 use crate::fleet::SharedFleetRegistry;
-use crate::grants::{PermissionGrants, SecretRequest};
+use crate::grants::{GrantedSecret, PermissionGrants, SecretRequest};
 use crate::state::SubAgentState;
 
 /// Parent-derived state propagated to a spawned sub-agent at spawn time.
@@ -184,8 +183,9 @@ pub struct SubAgentHandle {
     /// Receives secret requests from the sub-agent loop.
     pub pending_secret_rx: mpsc::Receiver<SecretRequest>,
     /// Delivers the approval outcome to the sub-agent loop: `None` = denied,
-    /// `Some(value)` = approved, carrying the resolved vault secret value.
-    pub secret_tx: mpsc::Sender<Option<Secret>>,
+    /// `Some(value)` = approved, carrying the resolved vault secret value and its
+    /// grant expiry so the loop can re-validate the TTL locally on every tool call.
+    pub secret_tx: mpsc::Sender<Option<GrantedSecret>>,
     /// ISO 8601 UTC timestamp recorded when the agent was spawned or resumed.
     pub started_at_str: String,
     /// Resolved transcript directory at spawn time; `None` if transcripts were disabled.

--- a/crates/zeph-subagent/src/manager/secrets.rs
+++ b/crates/zeph-subagent/src/manager/secrets.rs
@@ -8,7 +8,7 @@ use zeph_common::secret::Secret;
 
 use super::SubAgentManager;
 use crate::error::SubAgentError;
-use crate::grants::{GrantKind, SecretRequest};
+use crate::grants::{GrantKind, GrantedSecret, SecretRequest};
 
 /// Build the standard hook environment for a sub-agent lifecycle event.
 pub(crate) fn make_hook_env(
@@ -76,6 +76,10 @@ impl SubAgentManager {
     /// [`PermissionGrants::is_active`][crate::grants::PermissionGrants::is_active]
     /// load-bearing rather than unused bookkeeping.
     ///
+    /// The delivered value is stamped with the grant's expiry (see [`GrantedSecret`]) so the
+    /// sub-agent loop can keep re-validating the TTL locally on every subsequent tool call,
+    /// rather than trusting this one-time gate for the remainder of a long-running turn loop.
+    ///
     /// # Errors
     ///
     /// Returns [`SubAgentError::NotFound`] if the task ID is unknown, or
@@ -91,7 +95,7 @@ impl SubAgentManager {
             .get_mut(task_id)
             .ok_or_else(|| SubAgentError::NotFound(task_id.to_owned()))?;
 
-        if !handle.grants.is_active(&GrantKind::Secret(key.to_owned())) {
+        let Some(expires_at) = handle.grants.expires_at(&GrantKind::Secret(key.to_owned())) else {
             tracing::warn!(
                 task_id,
                 "secret delivery denied: no active grant (missing approval or TTL expired)"
@@ -99,11 +103,11 @@ impl SubAgentManager {
             return Err(SubAgentError::Invalid(
                 "no active grant for this secret".to_owned(),
             ));
-        }
+        };
 
         handle
             .secret_tx
-            .try_send(Some(value))
+            .try_send(Some(GrantedSecret { value, expires_at }))
             .map_err(|e| SubAgentError::Channel(e.to_string()))
     }
 
@@ -136,6 +140,25 @@ impl SubAgentManager {
             }
         }
         None
+    }
+
+    /// Try to receive a pending secret request from one specific sub-agent (non-blocking).
+    ///
+    /// Unlike [`try_recv_secret_request`](Self::try_recv_secret_request), this only polls
+    /// `task_id`'s own request channel, so it never pops and discards an unrelated sibling
+    /// sub-agent's pending request. Use this when the caller already knows which sub-agent
+    /// it wants to act on (e.g. an explicit `/agent approve <id>` command), instead of the
+    /// pop-then-filter pattern of polling [`try_recv_secret_request`](Self::try_recv_secret_request)
+    /// and discarding non-matching results — a discarded result is popped off the channel
+    /// and lost forever, silently starving the sub-agent that actually sent it.
+    ///
+    /// Returns `None` if `task_id` is unknown or has no pending request.
+    pub fn try_recv_secret_request_for(&mut self, task_id: &str) -> Option<SecretRequest> {
+        self.agents
+            .get_mut(task_id)?
+            .pending_secret_rx
+            .try_recv()
+            .ok()
     }
 }
 

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -8,7 +8,6 @@ use std::time::Instant;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
-use zeph_common::secret::Secret;
 use zeph_config::{BgIsolation, ContentIsolationConfig, SubAgentConfig};
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{Message, Role};
@@ -26,7 +25,7 @@ use crate::def::{MemoryScope, PermissionMode, SubAgentDef, ToolPolicy};
 use crate::error::SubAgentError;
 use crate::filter::{self, FilteredToolExecutor, PlanModeExecutor};
 use crate::fleet::{FleetSessionInfo, FleetSessionStatus};
-use crate::grants::{PermissionGrants, SecretRequest};
+use crate::grants::{GrantedSecret, PermissionGrants, SecretRequest};
 use crate::hooks::fire_hooks;
 use crate::manager::secrets::make_hook_env;
 use crate::memory::{ensure_memory_dir, escape_memory_content, load_memory_content};
@@ -672,7 +671,7 @@ impl SubAgentManager {
         }
 
         let (secret_request_tx, pending_secret_rx) = mpsc::channel::<SecretRequest>(4);
-        let (secret_tx, secret_rx) = mpsc::channel::<Option<Secret>>(4);
+        let (secret_tx, secret_rx) = mpsc::channel::<Option<GrantedSecret>>(4);
 
         let transcript_writer = self.create_transcript_writer(config, &task_id, &def.name, None);
 
@@ -1061,7 +1060,7 @@ impl SubAgentManager {
         }
 
         let (secret_request_tx, pending_secret_rx) = mpsc::channel::<SecretRequest>(4);
-        let (secret_tx, secret_rx) = mpsc::channel::<Option<Secret>>(4);
+        let (secret_tx, secret_rx) = mpsc::channel::<Option<GrantedSecret>>(4);
 
         let transcript_writer =
             self.create_transcript_writer(config, &new_task_id, &def.name, Some(&original_id));

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -312,7 +312,11 @@ async fn deliver_secret_after_approval_sends_value_over_channel() {
         .try_recv()
         .expect("value must be sent over the channel");
     let secret = received.expect("delivered value must be Some, not a denial");
-    assert_eq!(secret.expose(), "sekrit-value");
+    assert_eq!(secret.value.expose(), "sekrit-value");
+    assert!(
+        secret.expires_at > std::time::Instant::now(),
+        "delivered value must carry a future expiry"
+    );
 }
 
 #[test]
@@ -322,6 +326,76 @@ fn deliver_secret_unknown_task_id_returns_not_found() {
         .deliver_secret("unknown", "key", zeph_common::secret::Secret::new("sekrit"))
         .unwrap_err();
     assert_matches!(err, SubAgentError::NotFound(_));
+}
+
+// ── try_recv_secret_request_for concurrent-request tests (#5993) ───────────
+
+/// Insert a minimal active `SubAgentHandle` for `task_id` and return the sender half of
+/// its `pending_secret_rx` channel, so tests can push a `SecretRequest` onto it directly.
+fn insert_handle_with_pending_secret_channel(
+    mgr: &mut SubAgentManager,
+    task_id: &str,
+) -> tokio::sync::mpsc::Sender<SecretRequest> {
+    let (req_tx, pending_secret_rx) = tokio::sync::mpsc::channel(4);
+    let (secret_tx, _secret_rx) = tokio::sync::mpsc::channel(4);
+    let (status_tx, status_rx) = watch::channel(SubAgentStatus {
+        state: SubAgentState::Working,
+        last_message: None,
+        turns_used: 0,
+        started_at: std::time::Instant::now(),
+    });
+    drop(status_tx);
+    mgr.agents.insert(
+        task_id.to_owned(),
+        SubAgentHandle {
+            id: task_id.to_owned(),
+            def: sample_def(),
+            task_id: task_id.to_owned(),
+            state: SubAgentState::Working,
+            join_handle: None,
+            cancel: CancellationToken::new(),
+            status_rx,
+            grants: PermissionGrants::default(),
+            pending_secret_rx,
+            secret_tx,
+            started_at_str: String::new(),
+            transcript_dir: None,
+            mcp_tool_names: Vec::new(),
+        },
+    );
+    req_tx
+}
+
+#[tokio::test]
+async fn try_recv_secret_request_for_does_not_steal_sibling_request() {
+    // Regression guard for #5993: polling for one sub-agent's pending secret request must
+    // not pop-and-drop a different sub-agent's unrelated pending request.
+    let mut mgr = make_manager();
+    let _req_tx_a = insert_handle_with_pending_secret_channel(&mut mgr, "agent-a");
+    let req_tx_b = insert_handle_with_pending_secret_channel(&mut mgr, "agent-b");
+
+    // Only agent-b has a pending request; agent-a's channel is empty.
+    req_tx_b
+        .send(SecretRequest {
+            secret_key: "b-key".to_owned(),
+            reason: None,
+        })
+        .await
+        .unwrap();
+
+    // Polling specifically for agent-a must see nothing — and, critically, must not consume
+    // agent-b's request in the process.
+    assert!(mgr.try_recv_secret_request_for("agent-a").is_none());
+
+    // agent-b's request must still be retrievable afterward.
+    let req = mgr.try_recv_secret_request_for("agent-b");
+    assert_eq!(req.map(|r| r.secret_key), Some("b-key".to_owned()));
+}
+
+#[tokio::test]
+async fn try_recv_secret_request_for_unknown_task_id_returns_none() {
+    let mut mgr = make_manager();
+    assert!(mgr.try_recv_secret_request_for("unknown").is_none());
 }
 
 #[tokio::test]
@@ -2038,7 +2112,7 @@ fn make_agent_loop_args(
     });
     let (secret_request_tx, _secret_request_rx) = tokio::sync::mpsc::channel(1);
     let (_secret_approved_tx, secret_rx) =
-        tokio::sync::mpsc::channel::<Option<zeph_common::secret::Secret>>(1);
+        tokio::sync::mpsc::channel::<Option<crate::grants::GrantedSecret>>(1);
     AgentLoopArgs {
         provider,
         executor,


### PR DESCRIPTION
## Summary

- Deliver a grant's expiry alongside the secret value (`GrantedSecret { value, expires_at }`) and evict expired entries from `granted_secrets` before every tool call in the sub-agent turn loop, so a delivered secret can no longer keep working past its grant's TTL for the remainder of a long-running turn loop.
- Replace the pop-then-filter secret-request poll in `handle_agent_approve` with a per-task-id lookup (`SubAgentManager::try_recv_secret_request_for`), so approving one sub-agent's pending secret request can no longer pop and silently drop a concurrently-pending sibling sub-agent's request.

Both are follow-ups from PR #5990 (sub-agent vault-secret delivery, closing #5941/#5942), explicitly scoped out of that PR's fix and tracked as separate issues.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 12999/12999 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean, all crates passed
- [x] 3 new regression tests, independently confirmed to fail on reverted code: `expired_granted_secret_is_not_attached_and_is_evicted` (#5991), `try_recv_secret_request_for_does_not_steal_sibling_request` / `..._for_unknown_task_id_returns_none` (#5993)
- [x] Adversarial critique (verdict: minor, no redesign needed) and code review (approved) completed
- Live-session verification still pending — playbook updated with new scenarios (`.local/testing/playbooks/subagent-secret-delivery.md`, Scenarios 4-5)

Closes #5991
Closes #5993