### PR TITLE
fix(scheduler): harden provenance trust boundary and push recent-runs query into SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   a private address — it can still be attacker-controlled, so credentials must not
   follow it cross-origin), and `Content-Length`/`Content-Type`/`Content-Encoding` are
   dropped whenever the body is emptied by a method downgrade.
+- `zeph-scheduler`: `Scheduler::init()`'s DB-hydration loop read `TaskProvenance` verbatim from
+  the writer-controllable `scheduled_jobs.provenance` column, so a direct-SQL / out-of-process
+  writer could self-label a row `"static"` or `"user_added"` to dodge the RTW-A re-entry defenses
+  (#6114). This is latent hardening, not an active bypass fix — hydration only ever loads
+  periodic rows with `Value::Null` config, and the provenance-gated injection check only fires
+  for oneshot+`Custom` tasks, so no hydrated row reaches it today. `init()` now forces
+  `TaskProvenance::External` on every hydrated row regardless of the stored label, latching the
+  invariant that a row not written by this process's trusted in-session path is untrusted.
 - `zeph-mcp`: closed three gaps in the MCP tool trust pipeline (#6071, #6072, #6073).
   - `sanitize_tools`'s depth-cap drop path (see #6068 below) dropped unsanitizable
     `input_schema`/`output_schema` content beyond `MAX_SCHEMA_DEPTH` but never incremented
@@ -1077,6 +1085,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `refactor(session)`: extracted a shared `finish_torn_tail` helper in
   `crates/zeph-session/src/log.rs` for the identical torn-tail warn+repair epilogue duplicated
   between `read_events` and `read_events_chunked` (#5852).
+- `perf(scheduler)`: `daemon_status()`'s `recent_runs` fetched every active job via
+  `list_jobs_full()` and sorted/truncated in Rust rather than pushing the ordering and limit
+  into SQL (#6115). Added `JobStore::list_recent_runs`/`count_active_jobs`; ordering uses
+  `ORDER BY last_run IS NULL, last_run DESC LIMIT ?`, which evaluates to a sortable `0`/`1`
+  (`SQLite`) or `false`/`true` (`PostgreSQL`) value on both backends without relying on
+  `PostgreSQL`-only `NULLS LAST` syntax.
+- `chore(scheduler)`: removed the unused `blake3` and `uuid` dependencies from
+  `crates/zeph-scheduler/Cargo.toml` — neither was referenced anywhere in the crate's source
+  (#6098).
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11015,7 +11015,6 @@ dependencies = [
 name = "zeph-scheduler"
 version = "0.22.0"
 dependencies = [
- "blake3",
  "chrono",
  "cron",
  "reqwest 0.13.4",
@@ -11028,7 +11027,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "uuid",
  "wiremock",
  "zeph-common",
  "zeph-config",

--- a/crates/zeph-scheduler/Cargo.toml
+++ b/crates/zeph-scheduler/Cargo.toml
@@ -24,7 +24,6 @@ postgres = ["zeph-db/postgres", "zeph-durable/postgres"]
 default = ["sqlite"]
 
 [dependencies]
-blake3.workspace = true
 chrono = { workspace = true, features = ["std", "clock"] }
 cron.workspace = true
 reqwest = { workspace = true, features = ["json", "rustls"] }
@@ -35,7 +34,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "sync", "time"] }
 tracing.workspace = true
-uuid.workspace = true
 zeph-common = { workspace = true, optional = true }
 zeph-config.workspace = true
 zeph-db.workspace = true

--- a/crates/zeph-scheduler/src/daemon.rs
+++ b/crates/zeph-scheduler/src/daemon.rs
@@ -270,22 +270,21 @@ pub async fn daemon_status(
     let store = crate::store::JobStore::open(store_url).await?;
     store.init().await?;
 
-    let mut jobs = store.list_jobs_full().await?;
-    let task_count = jobs.len();
+    let task_count = store.count_active_jobs().await?;
 
-    // Sort by last_run descending (never-run jobs sort last) so `recent_runs` actually
-    // reflects recency rather than the alphabetical order returned by list_jobs_full.
-    jobs.sort_by(|a, b| b.last_run.cmp(&a.last_run));
-
-    let recent_runs: Vec<TaskRunSummary> = jobs
+    // Ordering and truncation are pushed into SQL (`list_recent_runs`) rather than fetching
+    // every active job and sorting in Rust — see `JobStore::list_recent_runs` for the
+    // dual-backend-safe `ORDER BY ... LIMIT` approach.
+    let recent_runs: Vec<TaskRunSummary> = store
+        .list_recent_runs(recent_n)
+        .await?
         .into_iter()
-        .take(recent_n)
-        .map(|j| TaskRunSummary {
-            name: j.name,
-            mode: j.task_mode,
-            last_run: j.last_run.unwrap_or_default(),
-            next_run: j.next_run,
-            status: j.status,
+        .map(|r| TaskRunSummary {
+            name: r.name,
+            mode: r.task_mode,
+            last_run: r.last_run.unwrap_or_default(),
+            next_run: r.next_run,
+            status: r.status,
         })
         .collect();
 

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -334,7 +334,16 @@ impl Scheduler {
                 }
                 continue;
             };
-            let hydrated_provenance = TaskProvenance::from_provenance_str(&job.provenance);
+            // #6114: rows reaching this loop are, by construction, not from this process's
+            // trusted in-session path (static `add_task` upserts are skipped via `static_names`
+            // above; control-channel adds live in `self.tasks` for their whole session and are
+            // never hydrated in the same session that created them). The `provenance` column is
+            // writer-controllable (direct SQL / out-of-process CLI), so it cannot be trusted as
+            // read — force the most restrictive tier regardless of the stored label. This hardens
+            // a latent trust-model gap (defense-in-depth); it does not patch an active bypass,
+            // since hydration only ever loads periodic rows with `Value::Null` config, which
+            // never reach a provenance-gated decision point today.
+            let hydrated_provenance = TaskProvenance::External;
             match ScheduledTask::periodic_with_provenance(
                 job.name.clone(),
                 cron_expr.as_ref(),
@@ -939,11 +948,12 @@ impl Scheduler {
         // stricter handling than `TaskProvenance::UserAdded`, matching the tier's documented
         // contract (see `TaskProvenance::is_external`), without weakening the existing baseline.
         //
-        // Caveat: `provenance` is trusted as read from the DB (`from_provenance_str`, task.rs) —
-        // a direct-SQL writer can self-label a row `"static"` or `"user_added"` to dodge this
-        // check entirely. Not a regression (pre-fix was equally bypassable, and the default
-        // `injection_pattern_check = true` closes the practical gap for `UserAdded` too); tracked
-        // as a follow-up to force `External` on all DB-hydrated rows regardless of stored label.
+        // Note: DB-hydrated rows (`init()` in scheduler.rs) are always forced to
+        // `TaskProvenance::External` regardless of the stored `provenance` column (#6114) — a
+        // direct-SQL writer cannot self-label a row to dodge this check. That said, this path is
+        // reached only by `OneShot` + `TaskKind::Custom` tasks, and hydration only ever loads
+        // periodic rows, so a hydrated row can never reach `inject_custom_task` in the first
+        // place; the forced-External hardening matters for future code paths, not this one.
         let apply_injection_check = self.reentry_defense_enabled
             && task.provenance != TaskProvenance::Static
             && (self.injection_pattern_check || task.provenance.is_external());
@@ -1431,6 +1441,72 @@ mod tests {
         );
     }
 
+    /// `init()` forces `TaskProvenance::External` on every DB-hydrated row, ignoring the
+    /// stored `provenance` column label entirely.
+    ///
+    /// Regression test for #6114: a direct-SQL / out-of-process writer could self-label a row
+    /// `"static"` or `"user_added"` to dodge the RTW-A re-entry defenses at hydration. This test
+    /// writes rows stamped `"static"` and `"user_added"` directly to the store — as a writer
+    /// bypassing the trusted in-session path would — and asserts both hydrate as `External`.
+    #[tokio::test]
+    async fn init_forces_external_provenance_on_hydrated_rows_regardless_of_stored_label() {
+        let pool = test_pool().await;
+        let store = JobStore::new(pool.clone());
+        store.init().await.unwrap();
+
+        store
+            .upsert_job_with_provenance(
+                "spoofed-static",
+                "0 * * * * *",
+                "health_check",
+                "periodic",
+                None,
+                "",
+                "static",
+            )
+            .await
+            .unwrap();
+        store
+            .upsert_job_with_provenance(
+                "spoofed-user-added",
+                "0 * * * * *",
+                "health_check",
+                "periodic",
+                None,
+                "",
+                "user_added",
+            )
+            .await
+            .unwrap();
+
+        let store2 = JobStore::new(pool.clone());
+        let (_tx, rx) = watch::channel(false);
+        let (mut scheduler, _msg_tx) = Scheduler::new(store2, rx);
+        scheduler.init().await.unwrap();
+
+        let spoofed_static = scheduler
+            .tasks
+            .iter()
+            .find(|t| t.name == "spoofed-static")
+            .expect("spoofed-static must be hydrated");
+        assert_eq!(
+            spoofed_static.provenance,
+            TaskProvenance::External,
+            "stored 'static' label must not be trusted — hydrated rows are always External"
+        );
+
+        let spoofed_user_added = scheduler
+            .tasks
+            .iter()
+            .find(|t| t.name == "spoofed-user-added")
+            .expect("spoofed-user-added must be hydrated");
+        assert_eq!(
+            spoofed_user_added.provenance,
+            TaskProvenance::External,
+            "stored 'user_added' label must not be trusted — hydrated rows are always External"
+        );
+    }
+
     /// `init()` does NOT re-add jobs that are already present in `self.tasks` — avoids
     /// duplicates when both `add_task()` and a DB record exist for the same name.
     #[tokio::test]
@@ -1818,15 +1894,17 @@ mod tests {
         );
     }
 
-    /// RTW-A Mechanism 2: tasks hydrated from DB during `init()` get External provenance
-    /// when the DB row has no provenance column value.
+    /// RTW-A Mechanism 2: tasks hydrated from DB during `init()` always get External
+    /// provenance, regardless of the stored `provenance` column value (#6114).
     #[tokio::test]
     async fn reentry_mech2_hydrated_jobs_get_external_provenance() {
         let pool = test_pool().await;
         let store = JobStore::new(pool.clone());
         store.init().await.unwrap();
 
-        // Insert a DB row without explicit provenance (defaults to 'external').
+        // upsert_job_with_mode writes 'static' provenance (the trusted-path default) — this
+        // deliberately exercises the case where the stored label is NOT External, to confirm
+        // the hydration loop ignores it and forces External regardless (#6114).
         store
             .upsert_job_with_mode(
                 "hydrated-job",
@@ -1850,16 +1928,10 @@ mod tests {
             .find(|t| t.name == "hydrated-job")
             .expect("hydrated job must appear in tasks after init()");
 
-        // upsert_job_with_mode writes 'static' provenance by default (trusted path).
-        // The DB row was written with the trusted upsert path, so it will carry 'static'.
-        // This verifies the provenance field round-trips through the store.
-        assert!(
-            matches!(
-                task.provenance,
-                crate::task::TaskProvenance::Static | crate::task::TaskProvenance::External
-            ),
-            "hydrated job must have a valid provenance (got {:?})",
-            task.provenance
+        assert_eq!(
+            task.provenance,
+            crate::task::TaskProvenance::External,
+            "DB-hydrated jobs must always be External, even when the stored label is 'static'"
         );
     }
 

--- a/crates/zeph-scheduler/src/store.rs
+++ b/crates/zeph-scheduler/src/store.rs
@@ -72,6 +72,21 @@ pub struct ScheduledTaskInfo {
     pub last_run: Option<String>,
 }
 
+/// A single row returned by [`JobStore::list_recent_runs`], ordered by recency.
+#[derive(Debug, Clone)]
+pub struct RecentRunRecord {
+    /// Unique task name.
+    pub name: String,
+    /// Execution mode: `"periodic"` or `"oneshot"`.
+    pub task_mode: String,
+    /// Last recorded run time (RFC 3339), or `None` if the task has never run.
+    pub last_run: Option<String>,
+    /// Next scheduled run time as an ISO 8601 / RFC 3339 string, or empty if unknown.
+    pub next_run: String,
+    /// Current job status: `"pending"`, `"completed"`, `"done"`, or `"error"`.
+    pub status: String,
+}
+
 /// Persistent storage layer for scheduled jobs.
 ///
 /// All job definitions and run history are stored in a `SQLite` database managed by
@@ -480,6 +495,58 @@ impl JobStore {
             .collect())
     }
 
+    /// Count active (non-done) jobs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the SQL query fails.
+    #[tracing::instrument(name = "sched.store.count_active_jobs", skip_all, err)]
+    pub async fn count_active_jobs(&self) -> Result<usize, SchedulerError> {
+        let (count,): (i64,) = zeph_db::query_as(sql!(
+            "SELECT COUNT(*) FROM scheduled_jobs WHERE status != 'done'"
+        ))
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(usize::try_from(count).unwrap_or(0))
+    }
+
+    /// List the `n` most recently run (non-done) jobs, ordered by `last_run` descending.
+    ///
+    /// Never-run jobs (`last_run IS NULL`) sort last. Ordering and truncation are pushed into
+    /// SQL via `ORDER BY last_run IS NULL, last_run DESC LIMIT ?` rather than fetched-then-sorted
+    /// in Rust: `last_run IS NULL` evaluates to a sortable `0`/`1` (`SQLite`) or `false`/`true`
+    /// (`PostgreSQL`) value, giving "`NULLS LAST`" semantics on both backends without relying on
+    /// `PostgreSQL`-only `NULLS LAST` syntax, which `SQLite` does not support.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the SQL query fails.
+    #[tracing::instrument(name = "sched.store.list_recent_runs", skip_all, err)]
+    pub async fn list_recent_runs(&self, n: usize) -> Result<Vec<RecentRunRecord>, SchedulerError> {
+        #[allow(clippy::type_complexity)]
+        let rows: Vec<(String, String, Option<String>, Option<String>, String)> =
+            zeph_db::query_as(sql!(
+                "SELECT name, task_mode, last_run, COALESCE(next_run, run_at), status \
+                 FROM scheduled_jobs WHERE status != 'done' \
+                 ORDER BY last_run IS NULL, last_run DESC LIMIT ?"
+            ))
+            .bind(i64::try_from(n).unwrap_or(i64::MAX))
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(
+                |(name, task_mode, last_run, next_run, status)| RecentRunRecord {
+                    name,
+                    task_mode,
+                    last_run,
+                    next_run: next_run.unwrap_or_default(),
+                    status,
+                },
+            )
+            .collect())
+    }
+
     /// Returns a reference to the underlying connection pool.
     ///
     /// Primarily used in tests that need to execute raw SQL against the same database.
@@ -806,6 +873,60 @@ mod tests {
             matches!(result, Err(SchedulerError::DuplicateJob(ref n)) if n == "dup_job"),
             "expected DuplicateJob, got {result:?}"
         );
+    }
+
+    /// `list_recent_runs` orders by `last_run` descending with never-run jobs sorted last, and
+    /// respects the `n` limit — verifies the SQL `ORDER BY last_run IS NULL, last_run DESC LIMIT ?`
+    /// approach (#6115) matches the previous fetch-then-sort-in-Rust behavior.
+    #[tokio::test]
+    async fn list_recent_runs_orders_by_recency_with_nulls_last_and_respects_limit() {
+        let pool = test_pool().await;
+        let store = JobStore::new(pool);
+        store.init().await.unwrap();
+
+        let now = chrono::Utc::now();
+        let older_ts = (now - chrono::Duration::days(200)).to_rfc3339();
+        let newer_ts = (now - chrono::Duration::days(10)).to_rfc3339();
+
+        store
+            .upsert_job("older", "0 * * * * *", "health_check")
+            .await
+            .unwrap();
+        store
+            .record_run("older", &older_ts, "2026-01-02T00:00:00Z")
+            .await
+            .unwrap();
+
+        store
+            .upsert_job("newer", "0 * * * * *", "health_check")
+            .await
+            .unwrap();
+        store
+            .record_run("newer", &newer_ts, "2026-06-02T00:00:00Z")
+            .await
+            .unwrap();
+
+        store
+            .upsert_job("never_run", "0 * * * * *", "health_check")
+            .await
+            .unwrap();
+
+        assert_eq!(store.count_active_jobs().await.unwrap(), 3);
+
+        let recent = store.list_recent_runs(10).await.unwrap();
+        let names: Vec<&str> = recent.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["newer", "older", "never_run"],
+            "list_recent_runs must order by last_run descending, never-run last"
+        );
+        assert_eq!(recent[0].last_run.as_deref(), Some(newer_ts.as_str()));
+        assert_eq!(recent[1].last_run.as_deref(), Some(older_ts.as_str()));
+        assert_eq!(recent[2].last_run, None);
+
+        let limited = store.list_recent_runs(1).await.unwrap();
+        assert_eq!(limited.len(), 1, "limit must be applied in SQL");
+        assert_eq!(limited[0].name, "newer");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Force `TaskProvenance::External` on all DB-hydrated jobs at `Scheduler::init()` instead of trusting the writer-controllable `provenance` column verbatim. Closes a latent (currently unreachable) trust-model gap where a direct-SQL actor could self-label a row as `UserAdded`/`Static` to dodge the RTW-A re-entry defenses. Hardening / defense-in-depth, not a fix for an active exploit.
- Push `daemon_status`'s recent-runs ordering and limit into SQL via new `JobStore::list_recent_runs`/`count_active_jobs` methods, replacing the fetch-all-then-sort-in-Rust approach, using a dual-backend-safe `ORDER BY last_run IS NULL, last_run DESC LIMIT ?` in place of Postgres-only `NULLS LAST` syntax.
- Remove unused `blake3` and `uuid` dependencies from `zeph-scheduler`.

Closes #6114
Closes #6115
Closes #6098

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins -E 'package(zeph-scheduler)'` — 116/116 passed, including two new regression tests
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-scheduler --features daemon`
- [x] Rebased onto latest `origin/main` (three unrelated upstream commits), clean rebase, full check suite re-run post-rebase