### PR TITLE
fix(durable): wire control-entry HMAC to a production key with read-side verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     pending request when it happened to pop first (#5993). Added
     `SubAgentManager::try_recv_secret_request_for(task_id)`, which polls only that sub-agent's
     own request channel, and switched the approve path to use it.
+- `zeph-durable`/`zeph-core`/`zeph`: the INV-8 control-entry row HMAC — documented in
+  `specs/064-durable-execution/spec.md` as closing the `EffectIntent`-forgery attack vector
+  (security HIGH-2b) for shared-DB/Restate deployments — was never wired to a production key or
+  verified on read (#6043, #6044). `LocalBackend::with_hmac_key` had no production caller, so
+  `hmac_key` was always `None`, every control entry's `hmac` column was always written `NULL`
+  regardless of deployment, and no code path recomputed or compared it on read. Added
+  `zeph_core::durable::derive_control_hmac_key_b64`, which derives the HMAC key as a BLAKE3
+  `derive_key` subkey of the same vault-resolved `ZEPH_DURABLE_KEY` used for the AEAD payload
+  cipher (domain-separated, so the two keys are cryptographically independent despite sharing one
+  vault secret — no new vault entry required). The key is now resolved and attached at every
+  production choke point that opens a `LocalBackend` — the P1/P2 agent-loop adapters
+  (`crates/zeph-core/src/agent/durable_bootstrap.rs`, `plan.rs`), the `zeph durable` CLI write and
+  read paths (`load_write_hmac_key`, `open_backend` in `src/commands/durable.rs`), and the
+  scheduler daemon (`src/commands/scheduler_daemon.rs`) — gated by the same
+  `shared_db`/`postgres://`-detection policy as the AEAD `encryption_gate`: a single-user local,
+  non-shared database never resolves the key (matching the documented stance that its control
+  entries carry no HMAC), and a declared/detected shared database fails closed if
+  `ZEPH_DURABLE_KEY` cannot be resolved. `LocalBackend` now also verifies every `EffectIntent` it
+  reads: `verify_control_hmac` recomputes the HMAC and constant-time-compares it (`blake3::Hash`
+  equality, mirroring the existing promise resolver-token check) against the stored value, and
+  fails closed with the new `DurableError::ControlIntegrity` variant on a mismatch or a missing
+  HMAC on a keyed backend — closing the actual forgery vector the spec claimed was already closed.
 - `zeph-channels`/`zeph-core`: hardened the channel send/retry/status path (#6094, #6106, #6095).
   - `Channel::send_status` was awaited inline on the agent turn hot path at ~45 call sites via
     `let _ = self.channel.send_status(...).await;`, with no outer timeout. Under sustained

--- a/book/src/reference/security/durable-encryption.md
+++ b/book/src/reference/security/durable-encryption.md
@@ -72,6 +72,35 @@ network-shared volume, or any future Postgres-backed deployment). It defaults to
 journal URL is also treated as shared automatically, even if `shared_db` was left
 unset, as defense in depth.
 
+## Control-entry HMAC (`EffectIntent` forgery protection)
+
+Some journal entries carry no payload at all — an `EffectIntent` records the
+*intent* to run an exactly-once-guarded effect before it fires, so there is
+nothing to encrypt. On a shared database these "control" rows still need
+tamper-evidence: an attacker who can insert rows directly should not be able to
+forge or relocate an `EffectIntent` and trick a resumed execution into skipping
+or re-running a guarded effect.
+
+For a declared/detected shared database, every `EffectIntent` row is stamped
+with a row-level HMAC over its identity — `(execution_id, step_id, entry_kind,
+idempotency_key)` — keyed with a BLAKE3 subkey derived from `ZEPH_DURABLE_KEY`
+(domain-separated from the AEAD payload key, so the two keys are
+cryptographically independent even though they share one vault secret). Every
+read of an `EffectIntent` recomputes and constant-time-verifies this HMAC; a
+mismatch — including a row missing its HMAC on a keyed backend — is rejected
+fail-closed.
+
+This uses the same `shared_db`/`postgres://`-detection gate described above: a
+single-user local, non-shared database never computes or verifies this HMAC
+(the row's `hmac` column stays `NULL`), matching the accepted stance that the
+DB-file trust boundary already covers that deployment.
+
+This forgery guarantee depends on `shared_db`/`postgres://` being declared
+consistently across the writer and every reader of a given journal file; a
+reader that disagrees (e.g. runs unkeyed against a keyed writer's file) now
+fails closed as soon as it encounters any row carrying a stamped HMAC, rather
+than silently trusting it as an ordinary unverified field.
+
 ## Key rotation
 
 The `key_id` byte makes rotation possible without rewriting the journal:

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2169,17 +2169,21 @@ impl<C: Channel> Agent<C> {
     }
 
     /// `db_url` is the `sqlite://…/durable.db` connection string (a sibling of the main DB).
-    /// The `cipher` is `None` when `config.encrypt_payload = false` (development mode only).
+    /// The `cipher` is `None` when `config.encrypt_payload = false` (development mode only). The
+    /// `hmac_key` is `None` for a single-user local, non-shared database (INV-8) — see
+    /// `crate::durable::derive_control_hmac_key_b64`.
     #[must_use]
     pub fn with_durable_orchestration(
         mut self,
         config: zeph_config::DurableConfig,
         db_url: String,
         cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
+        hmac_key: Option<[u8; 32]>,
     ) -> Self {
         self.services.orchestration.durable_config = Some(config);
         self.services.orchestration.durable_db_url = Some(db_url);
         self.services.orchestration.durable_cipher = cipher;
+        self.services.orchestration.durable_hmac_key = hmac_key;
         self
     }
 
@@ -2205,11 +2209,13 @@ impl<C: Channel> Agent<C> {
         db_url: String,
         sqlite_path: String,
         cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
+        hmac_key: Option<[u8; 32]>,
     ) -> Self {
         self.services.session.durable_agent_turns_config = Some(config);
         self.services.session.durable_agent_turns_db_url = Some(db_url);
         self.services.session.durable_agent_turns_sqlite_path = Some(sqlite_path);
         self.services.session.durable_agent_turns_cipher = cipher;
+        self.services.session.durable_agent_turns_hmac_key = hmac_key;
         self
     }
 

--- a/crates/zeph-core/src/agent/durable_bootstrap.rs
+++ b/crates/zeph-core/src/agent/durable_bootstrap.rs
@@ -18,8 +18,12 @@ use zeph_durable::{DurableBackendEnum, JournalWriterHandle, LocalBackend, Payloa
 use crate::agent::Agent;
 use crate::channel::Channel;
 
-/// Open a [`LocalBackend`] at `db_url`, initialise its schema, attach `cipher` if present, and
-/// spawn its [`JournalWriter`](zeph_durable::JournalWriter) actor via `task_supervisor`.
+/// Open a [`LocalBackend`] at `db_url`, initialise its schema, attach `cipher` and `hmac_key` if
+/// present, and spawn its [`JournalWriter`](zeph_durable::JournalWriter) actor via
+/// `task_supervisor`.
+///
+/// `hmac_key` is `None` for a single-user local, non-shared database (INV-8) — the documented
+/// stance where control entries carry no HMAC.
 ///
 /// Returns `None` (after logging a `tracing::warn!`) on any I/O failure so callers degrade to
 /// non-durable mode rather than fail session bootstrap (#5452 FR-004).
@@ -29,6 +33,7 @@ pub(crate) async fn open_durable_backend(
     cfg: &zeph_config::DurableConfig,
     db_url: &str,
     cipher: Option<Arc<dyn PayloadCipher>>,
+    hmac_key: Option<[u8; 32]>,
 ) -> Option<(
     Arc<DurableBackendEnum>,
     JournalWriterHandle,
@@ -47,6 +52,11 @@ pub(crate) async fn open_durable_backend(
     }
     let local = if let Some(c) = cipher {
         local.with_cipher(c)
+    } else {
+        local
+    };
+    let local = if let Some(k) = hmac_key {
+        local.with_hmac_key(k)
     } else {
         local
     };
@@ -100,6 +110,7 @@ impl<C: Channel> Agent<C> {
             return;
         };
         let cipher = self.services.session.durable_agent_turns_cipher.clone();
+        let hmac_key = self.services.session.durable_agent_turns_hmac_key;
 
         tracing::debug!("durable agent_turns: opening backend start");
         let backend_result = open_durable_backend(
@@ -108,6 +119,7 @@ impl<C: Channel> Agent<C> {
             &cfg,
             &db_url,
             cipher,
+            hmac_key,
         )
         .await;
         tracing::debug!("durable agent_turns: opening backend done");

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -286,6 +286,7 @@ impl<C: crate::channel::Channel> Agent<C> {
             }
             let db_url = self.services.orchestration.durable_db_url.clone()?;
             let cipher = self.services.orchestration.durable_cipher.clone();
+            let hmac_key = self.services.orchestration.durable_hmac_key;
             let (backend, handle, task_handle) =
                 crate::agent::durable_bootstrap::open_durable_backend(
                     &self.runtime.lifecycle.task_supervisor,
@@ -293,6 +294,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                     &cfg,
                     &db_url,
                     cipher,
+                    hmac_key,
                 )
                 .await?;
             self.services.orchestration.durable_backend = Some(backend);

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -724,6 +724,9 @@ pub(crate) struct OrchestrationState {
     pub(crate) durable_writer_task: Option<zeph_common::task_supervisor::BlockingHandle<()>>,
     /// Cipher for encrypting P2 budget snapshots. `None` when `encrypt_payload = false`.
     pub(crate) durable_cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
+    /// Control-entry row HMAC key (INV-8) for the P2 durable backend. `None` for a single-user
+    /// local, non-shared database — the documented stance where control entries carry no HMAC.
+    pub(crate) durable_hmac_key: Option<[u8; 32]>,
 }
 
 /// Groups instruction hot-reload state.
@@ -883,6 +886,10 @@ pub(crate) struct SessionState {
     /// Sibling companion to [`Self::durable_agent_turns_config`]: the AEAD cipher to attach to
     /// the backend, `None` when `encrypt_payload = false` (development mode only).
     pub(crate) durable_agent_turns_cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
+    /// Sibling companion to [`Self::durable_agent_turns_config`]: the control-entry row HMAC key
+    /// (INV-8) to attach to the backend. `None` for a single-user local, non-shared database —
+    /// the documented stance where control entries carry no HMAC.
+    pub(crate) durable_agent_turns_hmac_key: Option<[u8; 32]>,
     /// Set to `true` the first time `ensure_session_durable_ctx` runs (success or failure) so a
     /// failed backend construction (missing vault key, disk error) is not retried on every turn.
     /// Reset to `false` by `reset_durable_ctx_for_conversation_switch` (`/new`, `/conv resume`,
@@ -1296,6 +1303,7 @@ impl SessionState {
             durable_agent_turns_db_url: None,
             durable_agent_turns_sqlite_path: None,
             durable_agent_turns_cipher: None,
+            durable_agent_turns_hmac_key: None,
             durable_ctx_init_attempted: false,
             durable_writer: None,
             durable_writer_task: None,

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -79,6 +79,7 @@ fn make_session_state() -> SessionState {
         durable_agent_turns_db_url: None,
         durable_agent_turns_sqlite_path: None,
         durable_agent_turns_cipher: None,
+        durable_agent_turns_hmac_key: None,
         durable_ctx_init_attempted: false,
         durable_writer: None,
         durable_writer_task: None,

--- a/crates/zeph-core/src/durable.rs
+++ b/crates/zeph-core/src/durable.rs
@@ -189,6 +189,46 @@ impl XChaCha20Poly1305Cipher {
     }
 }
 
+/// Domain-separation context for deriving the control-entry HMAC key (INV-8) from
+/// `ZEPH_DURABLE_KEY` via BLAKE3 `derive_key`.
+const CONTROL_HMAC_CONTEXT: &str = "zeph-durable v1 control-entry HMAC key 2026";
+
+/// Derive the row-level control-entry HMAC key (INV-8) from the base64-encoded `ZEPH_DURABLE_KEY`
+/// vault value.
+///
+/// The HMAC key is not a separate vault secret: it is a BLAKE3 `derive_key` subkey of the same
+/// `ZEPH_DURABLE_KEY` used for the AEAD payload cipher, domain-separated by a fixed context string
+/// so the two keys are cryptographically independent even though they share one root secret —
+/// the same pattern used for the promise resolver-token hash in `zeph-durable`'s `promise.rs`.
+///
+/// # Errors
+///
+/// Returns [`CipherKeyError::MalformedEncoding`] when `b64_key` is not valid base64, or
+/// [`CipherKeyError::InvalidKeyLength`] when the decoded key is not exactly 32 bytes.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_core::durable::{derive_control_hmac_key_b64, generate_durable_key_b64};
+///
+/// let key = generate_durable_key_b64();
+/// assert!(derive_control_hmac_key_b64(&key).is_ok());
+/// assert!(derive_control_hmac_key_b64("not base64!").is_err());
+/// ```
+pub fn derive_control_hmac_key_b64(b64_key: &str) -> Result<[u8; KEY_LEN], CipherKeyError> {
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64_key.trim())
+        .map_err(|_| CipherKeyError::MalformedEncoding)?;
+    if bytes.len() != KEY_LEN {
+        return Err(CipherKeyError::InvalidKeyLength {
+            expected: KEY_LEN,
+            actual: bytes.len(),
+        });
+    }
+    Ok(blake3::derive_key(CONTROL_HMAC_CONTEXT, &bytes))
+}
+
 /// Generate a fresh random 32-byte durable payload key, base64-encoded for vault storage.
 ///
 /// Stored under `ZEPH_DURABLE_KEY` (never inline in TOML); decode it back with
@@ -407,6 +447,42 @@ mod tests {
             Err(CipherKeyError::InvalidKeyLength {
                 expected: 32,
                 actual: 5
+            })
+        ));
+    }
+
+    #[test]
+    fn control_hmac_key_derives_deterministically_and_independently_of_the_aead_key() {
+        use base64::Engine as _;
+
+        let vault_key = generate_durable_key_b64();
+        let hmac_key = derive_control_hmac_key_b64(&vault_key).unwrap();
+
+        // Deterministic: the same vault value always derives the same subkey.
+        assert_eq!(derive_control_hmac_key_b64(&vault_key).unwrap(), hmac_key);
+
+        // Cryptographically independent of the raw AEAD key material (domain separation via a
+        // fixed `derive_key` context distinct from the AEAD cipher's own use of the raw bytes).
+        let raw_aead_key = base64::engine::general_purpose::STANDARD
+            .decode(vault_key.trim())
+            .unwrap();
+        assert_ne!(hmac_key.as_slice(), raw_aead_key.as_slice());
+    }
+
+    #[test]
+    fn control_hmac_key_rejects_malformed_or_mislength_input() {
+        use base64::Engine as _;
+
+        assert!(matches!(
+            derive_control_hmac_key_b64("not base64!"),
+            Err(CipherKeyError::MalformedEncoding)
+        ));
+        let short = base64::engine::general_purpose::STANDARD.encode(b"too short");
+        assert!(matches!(
+            derive_control_hmac_key_b64(&short),
+            Err(CipherKeyError::InvalidKeyLength {
+                expected: 32,
+                actual: 9
             })
         ));
     }

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -15,8 +15,10 @@
 //! injected [`PayloadCipher`] before they touch the database, with the entry's location bound as
 //! associated data so a sealed blob cannot be relocated to another step or execution. Control
 //! entries (currently [`EntryKind::EffectIntent`]) carry no payload; when an HMAC key is configured
-//! the backend stamps a keyed BLAKE3 row HMAC over their identity for shared-database deployments.
-//! When no cipher is injected the payload is stored verbatim — a development-only posture gated by
+//! the backend stamps a keyed BLAKE3 row HMAC over their identity for shared-database deployments,
+//! and every read recomputes and constant-time-verifies that HMAC, failing closed with
+//! [`DurableError::ControlIntegrity`] on a forged or relocated row. When no cipher is injected the
+//! payload is stored verbatim — a development-only posture gated by
 //! [`encryption_gate`](crate::encryption_gate) at startup.
 //!
 //! # Scope
@@ -168,7 +170,7 @@ impl LocalBackend {
     }
 
     /// Configure the keyed-BLAKE3 HMAC key stamped over control entries on shared-database
-    /// deployments.
+    /// deployments, and used to verify them again on every read (INV-8).
     #[must_use]
     pub fn with_hmac_key(mut self, key: [u8; 32]) -> Self {
         self.hmac_key = Some(key);
@@ -1021,15 +1023,73 @@ impl LocalBackend {
         entry: &JournalEntry,
         idem_key: Option<&IdempotencyKey>,
     ) -> Option<Vec<u8>> {
+        self.compute_control_hmac(
+            entry.execution_id,
+            entry.step_id,
+            entry.entry.tag(),
+            idem_key,
+        )
+        .map(|h| h.to_vec())
+    }
+
+    /// Core keyed-BLAKE3 computation shared by [`control_hmac`](Self::control_hmac) (write path,
+    /// takes a full [`JournalEntry`]) and [`verify_control_hmac`](Self::verify_control_hmac) (read
+    /// path, which has the row's identity fields but not yet a reconstructed entry). Returns `None`
+    /// when no HMAC key is configured (single-user local).
+    fn compute_control_hmac(
+        &self,
+        execution_id: ExecutionId,
+        step_id: StepId,
+        tag: &'static str,
+        idem_key: Option<&IdempotencyKey>,
+    ) -> Option<[u8; 32]> {
         let key = self.hmac_key.as_ref()?;
         let mut input = Vec::with_capacity(16 + 4 + 16 + 32);
-        input.extend_from_slice(entry.execution_id.as_bytes());
-        input.extend_from_slice(&entry.step_id.value().to_le_bytes());
-        input.extend_from_slice(entry.entry.tag().as_bytes());
+        input.extend_from_slice(execution_id.as_bytes());
+        input.extend_from_slice(&step_id.value().to_le_bytes());
+        input.extend_from_slice(tag.as_bytes());
         if let Some(k) = idem_key {
             input.extend_from_slice(k.as_bytes());
         }
-        Some(blake3::keyed_hash(key, &input).as_bytes().to_vec())
+        Some(*blake3::keyed_hash(key, &input).as_bytes())
+    }
+
+    /// Recompute and constant-time-verify a control entry's row HMAC read back from storage
+    /// (INV-8).
+    ///
+    /// A no-op only when no HMAC key is configured **and** the row carries no stored HMAC — the
+    /// documented single-user local stance where control entries carry no HMAC and none is
+    /// enforced. If this backend is unkeyed but the row *does* carry a stamped HMAC, that is
+    /// config drift between the writer and this reader (e.g. `shared_db` toggled, or a reader
+    /// whose config disagrees with the writer's over the same physical file) and is rejected
+    /// fail-closed rather than silently trusted, since an `EffectIntent`'s fields are plaintext
+    /// and an unkeyed reader has no way to tell a genuine stamped row from a forged one. When a
+    /// key *is* configured, every control row this backend reads must carry a matching HMAC: a
+    /// missing HMAC or a mismatch both indicate the row was forged, relocated, or written without
+    /// the configured key, and both fail closed with [`DurableError::ControlIntegrity`].
+    ///
+    /// The comparison uses [`blake3::Hash`] equality, which compares in constant time (the same
+    /// idiom used for the promise resolver-token check in `promise.rs`), so a forged HMAC reveals
+    /// no timing signal.
+    fn verify_control_hmac(
+        &self,
+        execution_id: ExecutionId,
+        step_id: StepId,
+        tag: &'static str,
+        idem_key: Option<&IdempotencyKey>,
+        stored: Option<[u8; 32]>,
+    ) -> Result<(), DurableError> {
+        let Some(expected) = self.compute_control_hmac(execution_id, step_id, tag, idem_key) else {
+            return if stored.is_some() {
+                Err(DurableError::ControlIntegrity)
+            } else {
+                Ok(())
+            };
+        };
+        match stored {
+            Some(stored) if blake3::Hash::from(expected) == blake3::Hash::from(stored) => Ok(()),
+            _ => Err(DurableError::ControlIntegrity),
+        }
     }
 
     /// Derive the persisted column values for an entry, sealing payloads and stamping HMACs.
@@ -1189,6 +1249,13 @@ impl LocalBackend {
                 let hmac = hmac
                     .map(|bytes| slice_to_array32(&bytes, "effect_intent hmac"))
                     .transpose()?;
+                self.verify_control_hmac(
+                    id,
+                    step_id,
+                    EntryKindTag::EffectIntent.as_str(),
+                    Some(&idem_key),
+                    hmac,
+                )?;
                 EntryKind::EffectIntent {
                     idempotency_key: idem_key,
                     effect,
@@ -1766,6 +1833,82 @@ mod tests {
             }
             other => panic!("unexpected entry kind: {other:?}"),
         }
+    }
+
+    /// Regression for #6043/#6044: a control entry written under one HMAC key must fail closed
+    /// with [`DurableError::ControlIntegrity`] when read back under a *different* key — the
+    /// forged/relocated-row rejection the row HMAC exists to provide. Both backends share the
+    /// same underlying pool (a second `LocalBackend` handle over the same connection), so this
+    /// exercises the read path's recompute-and-compare, not just a difference in whether a key is
+    /// configured at all.
+    #[tokio::test]
+    async fn read_execution_rejects_control_hmac_under_wrong_key() {
+        let writer = mem_backend(1_048_576).await.with_hmac_key([1u8; 32]);
+        let exec = ExecutionId::new();
+        writer
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        writer.append(effect_intent(exec, 0)).await.unwrap();
+
+        let wrong_key_reader =
+            LocalBackend::new(writer.pool().clone(), 1_048_576).with_hmac_key([2u8; 32]);
+        assert_matches!(
+            wrong_key_reader.read_execution(exec).await,
+            Err(DurableError::ControlIntegrity)
+        );
+
+        // Reading under the correct key still succeeds.
+        let right_key_reader =
+            LocalBackend::new(writer.pool().clone(), 1_048_576).with_hmac_key([1u8; 32]);
+        assert!(right_key_reader.read_execution(exec).await.is_ok());
+    }
+
+    /// Regression for #6043/#6044: a control entry written by an *unkeyed* backend (`hmac =
+    /// NULL`) must fail closed when later read by a keyed backend — a keyed backend enforces that
+    /// every control row it reads carries a matching HMAC, so a missing HMAC is treated the same
+    /// as a mismatched one rather than silently passing through unverified.
+    #[tokio::test]
+    async fn read_execution_rejects_missing_hmac_on_keyed_backend() {
+        let writer = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        writer
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        writer.append(effect_intent(exec, 0)).await.unwrap();
+
+        let keyed_reader =
+            LocalBackend::new(writer.pool().clone(), 1_048_576).with_hmac_key([3u8; 32]);
+        assert_matches!(
+            keyed_reader.read_execution(exec).await,
+            Err(DurableError::ControlIntegrity)
+        );
+    }
+
+    /// Regression for #6043/#6044 (review S1): a control entry written by a *keyed* backend must
+    /// fail closed when later read by an *unkeyed* backend, rather than silently trusting the
+    /// stamped HMAC as an ordinary (unverified) plaintext field. Before this fix,
+    /// `verify_control_hmac` returned `Ok(())` unconditionally whenever the reader had no HMAC
+    /// key, regardless of whether the stored row carried one — so config drift between a keyed
+    /// writer and an unkeyed reader over the same physical file (e.g. `shared_db` toggled, or a
+    /// reader whose config disagrees with the writer's) let a stamped row through unverified,
+    /// which is exactly the forgery-acceptance gap #6043 says the row HMAC closes.
+    #[tokio::test]
+    async fn read_execution_rejects_stamped_hmac_on_unkeyed_backend() {
+        let writer = mem_backend(1_048_576).await.with_hmac_key([4u8; 32]);
+        let exec = ExecutionId::new();
+        writer
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        writer.append(effect_intent(exec, 0)).await.unwrap();
+
+        let unkeyed_reader = LocalBackend::new(writer.pool().clone(), 1_048_576);
+        assert_matches!(
+            unkeyed_reader.read_execution(exec).await,
+            Err(DurableError::ControlIntegrity)
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-durable/src/error.rs
+++ b/crates/zeph-durable/src/error.rs
@@ -62,6 +62,13 @@ pub enum DurableError {
     #[error("replay integrity check failed: sealed payload did not authenticate")]
     ReplayIntegrity,
 
+    /// A control entry's row-level HMAC (INV-8) did not verify against a recomputed value: the row
+    /// was forged, relocated to a different step/execution, or is missing its HMAC even though the
+    /// backend is keyed. Fails closed like [`ReplayIntegrity`](Self::ReplayIntegrity), but for
+    /// HMAC-authenticated control entries (`EffectIntent`) rather than AEAD-sealed payloads.
+    #[error("control-entry integrity check failed: row HMAC did not authenticate")]
+    ControlIntegrity,
+
     /// An execution exceeded the hard per-execution step cap and was aborted rather than allowed to
     /// grow unboundedly.
     #[error("execution exceeded the step cap of {cap} steps")]

--- a/specs/064-durable-execution/spec.md
+++ b/specs/064-durable-execution/spec.md
@@ -387,6 +387,27 @@ over `(execution_id, step_id, entry_kind, idem_key|promise_id|due_at)`. This clo
 `EffectIntent`-forgery attack vector (security HIGH-2b). For single-user SQLite the HMAC field is
 `None` (DB-file trust boundary is the documented, accepted stance).
 
+The HMAC key is not a second vault secret: it is a BLAKE3 `derive_key` subkey of the same
+`ZEPH_DURABLE_KEY` used for the AEAD payload cipher, domain-separated by a fixed context string so
+the two keys are cryptographically independent
+(`zeph_core::durable::derive_control_hmac_key_b64`). It is resolved and attached
+(`LocalBackend::with_hmac_key`) at the same production choke points and gated by the same
+`shared_db`/`postgres://`-detection policy as the AEAD `encryption_gate` (INV-8): a single-user
+local, non-shared database never resolves the key, and a declared/detected shared database fails
+closed if `ZEPH_DURABLE_KEY` cannot be resolved from the vault. Every read of an `EffectIntent`
+control entry recomputes the HMAC and compares it in constant time
+(`blake3::Hash` equality, mirroring the promise resolver-token check); a mismatch — including a
+missing HMAC on a keyed backend, or a *stamped* HMAC read by an unkeyed backend — fails closed with
+`DurableError::ControlIntegrity`. `PromiseCreated` and `TimerArmed` carry the same `hmac` field on
+the wire type but are not yet journaled by `LocalBackend` (promise/timer persistence lives in a
+separate layer, see `promise.rs`), so HMAC computation and verification currently applies only to
+`EffectIntent`.
+
+This forgery guarantee depends on `shared_db`/`postgres://` being declared consistently across the
+writer and every reader of a given journal file; a reader that disagrees (e.g. runs unkeyed against
+a keyed writer's file) now fails closed as soon as it encounters any row carrying a stamped HMAC,
+rather than silently trusting it as an ordinary unverified field.
+
 ### DurableContext (handle.rs) — `&self` API
 
 ```rust

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -128,6 +128,48 @@ fn load_durable_cipher() -> anyhow::Result<XChaCha20Poly1305Cipher> {
         .map_err(|e| anyhow::anyhow!("invalid ZEPH_DURABLE_KEY: {e}"))
 }
 
+/// Resolve the control-entry row HMAC key (INV-8) for the durable journal at `url`, deriving it
+/// from the vault-stored `ZEPH_DURABLE_KEY` when this deployment is a declared/detected shared
+/// database ([`is_shared_db`]).
+///
+/// Returns `Ok(None)` for a single-user local, non-shared database — the documented stance where
+/// control entries carry no HMAC and none is enforced (INV-8). Fails closed (`Err`) when the
+/// deployment is shared but `ZEPH_DURABLE_KEY` cannot be resolved or decoded: a shared database
+/// must never silently run without the row-HMAC forgery defense.
+fn load_control_hmac_key(
+    config: &zeph_core::config::DurableConfig,
+    url: &str,
+) -> anyhow::Result<Option<[u8; 32]>> {
+    if !is_shared_db(config, url) {
+        return Ok(None);
+    }
+    let dir = zeph_core::vault::default_vault_dir();
+    let provider = AgeVaultProvider::load(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
+        .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
+    let key = provider.get("ZEPH_DURABLE_KEY").ok_or_else(|| {
+        anyhow::anyhow!(
+            "ZEPH_DURABLE_KEY not found in vault; required to compute the control-entry row HMAC \
+             on a shared database (INV-8)"
+        )
+    })?;
+    let hmac_key = zeph_core::durable::derive_control_hmac_key_b64(key).map_err(|e| {
+        anyhow::anyhow!("invalid ZEPH_DURABLE_KEY for control-entry HMAC derivation: {e}")
+    })?;
+    Ok(Some(hmac_key))
+}
+
+/// Resolve the control-entry HMAC key to attach on a durable *write* path (INV-8), mirroring
+/// [`load_write_cipher`]'s `config` → `url` resolution.
+///
+/// # Errors
+///
+/// Returns an error when this deployment is a shared database and `ZEPH_DURABLE_KEY` cannot be
+/// resolved from the vault.
+pub(crate) fn load_write_hmac_key(config: &Config) -> anyhow::Result<Option<[u8; 32]>> {
+    let url = resolve_durable_db_url(config);
+    load_control_hmac_key(&config.durable, &url)
+}
+
 /// Resolve the AEAD payload cipher to attach on a durable *write* path when
 /// `config.durable.encrypt_payload` is enabled (INV-5).
 ///
@@ -164,11 +206,17 @@ pub(crate) fn load_write_cipher(
 /// gate exists to reject, regardless of whether the read is via a write path or `--reveal`
 /// (#5996). The permitted single-user local override still emits a startup `WARN` and proceeds.
 ///
+/// Also attaches the control-entry HMAC key ([`load_control_hmac_key`]) whenever this deployment
+/// is a declared/detected shared database, unconditionally of `reveal` — HMAC verification guards
+/// every read of a control entry (`list`/`show`/`inspect`/`prune`/`resume`/`--reveal` alike), not
+/// just the decrypted view (#6043/#6044).
+///
 /// Returns `Ok(None)` when no journal file exists yet (a friendly signal that durable execution has
 /// not run on this deployment), so the caller can print guidance instead of creating an empty file.
 async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<LocalBackend>> {
     let url = resolve_durable_db_url(config);
     enforce_encryption_gate(&config.durable, &url)?;
+    let hmac_key = load_control_hmac_key(&config.durable, &url)?;
     if url != ":memory:" && !Path::new(&url).exists() {
         println!(
             "No durable journal at {url}.\n\
@@ -183,6 +231,11 @@ async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<Lo
         .init()
         .await
         .map_err(|e| anyhow::anyhow!("failed to initialize durable schema: {e}"))?;
+    let backend = if let Some(key) = hmac_key {
+        backend.with_hmac_key(key)
+    } else {
+        backend
+    };
     if reveal && config.durable.encrypt_payload {
         let cipher = load_durable_cipher()?;
         Ok(Some(backend.with_cipher(Arc::new(cipher))))
@@ -819,6 +872,95 @@ mod tests {
         assert!(
             load_write_cipher(&config).is_err(),
             "a postgres:// resolved URL must be treated as shared even without shared_db=true"
+        );
+    }
+
+    /// Regression for #6043/#6044: a single-user local, non-shared database must never resolve a
+    /// control-entry HMAC key — the documented INV-8 stance where such deployments' control
+    /// entries carry no HMAC. No vault access should even be attempted.
+    #[tokio::test]
+    async fn load_write_hmac_key_returns_none_for_single_user_local() {
+        let config = Config::default();
+        assert!(!config.durable.shared_db);
+        assert!(
+            load_write_hmac_key(&config).unwrap().is_none(),
+            "single-user local, non-shared database must not resolve an HMAC key"
+        );
+    }
+
+    /// Regression for #6043/#6044: a declared shared database must fail closed when
+    /// `ZEPH_DURABLE_KEY` cannot be resolved from the vault, mirroring
+    /// `open_backend_reveal_requires_key_when_encrypt_payload_enabled`'s pattern for the AEAD key.
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial]
+    async fn load_write_hmac_key_fails_closed_when_shared_db_declared_and_key_missing() {
+        let mut config = Config::default();
+        config.durable.shared_db = true;
+
+        let vault_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", vault_dir.path());
+        }
+
+        let result = load_write_hmac_key(&config);
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            result.is_err(),
+            "a declared shared database must fail closed without ZEPH_DURABLE_KEY (INV-8)"
+        );
+    }
+
+    /// Regression for #6043/#6044: a declared shared database resolves a real 32-byte HMAC key
+    /// from a seeded vault, mirroring
+    /// `write_path_attaches_cipher_and_seals_payload_when_encrypt_payload_enabled`'s pattern for
+    /// the AEAD cipher — this exercises the exact glue `runner.rs` and `scheduler_daemon.rs` call.
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial]
+    async fn load_write_hmac_key_resolves_real_key_when_shared_db_declared() {
+        let mut config = Config::default();
+        config.durable.shared_db = true;
+
+        let vault_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", vault_dir.path());
+        }
+
+        let vault_root = zeph_core::vault::default_vault_dir();
+        zeph_core::vault::AgeVaultProvider::init_vault(&vault_root).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
+        provider.set_secret_mut(
+            "ZEPH_DURABLE_KEY".to_owned(),
+            zeph_core::durable::generate_durable_key_b64(),
+        );
+        provider.save().unwrap();
+
+        let result = load_write_hmac_key(&config);
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            result.unwrap().is_some(),
+            "a declared shared database with a real vault key must resolve an HMAC key"
         );
     }
 }

--- a/src/commands/scheduler_daemon.rs
+++ b/src/commands/scheduler_daemon.rs
@@ -173,7 +173,9 @@ async fn run_foreground(
 }
 
 /// Open the scheduler's durable backend, attach the write-path AEAD cipher when
-/// `[durable] encrypt_payload = true`, and spawn its journal-writer task under `sched_supervisor`.
+/// `[durable] encrypt_payload = true` and the control-entry HMAC key when this deployment is a
+/// declared/detected shared database (INV-8), then spawn its journal-writer task under
+/// `sched_supervisor`.
 ///
 /// Returns `Ok(None)` when durable execution is disabled for the scheduler
 /// (`[durable] enabled = false` or `[durable] scheduler = false`), so the caller runs without
@@ -181,9 +183,10 @@ async fn run_foreground(
 ///
 /// # Errors
 ///
-/// Returns an error if the durable backend cannot be opened or initialized, or if the AEAD
-/// cipher cannot be resolved when `encrypt_payload = true` — this fails closed instead of
-/// silently falling back to plaintext.
+/// Returns an error if the durable backend cannot be opened or initialized, if the AEAD cipher
+/// cannot be resolved when `encrypt_payload = true`, or if the control-entry HMAC key cannot be
+/// resolved for a shared database — every case fails closed instead of silently running with a
+/// weaker security posture.
 async fn build_durable_adapter(
     config: &zeph_core::config::Config,
     sched_supervisor: &zeph_common::TaskSupervisor,
@@ -191,10 +194,11 @@ async fn build_durable_adapter(
     if !(config.durable.enabled && config.durable.scheduler) {
         return Ok(None);
     }
-    // Resolve the write-path cipher (which evaluates the INV-8 encryption_gate, #5996) before
-    // opening the backend, so a forbidden config fails closed without creating a stray empty
-    // journal file on disk first.
+    // Resolve the write-path cipher (which evaluates the INV-8 encryption_gate, #5996) and the
+    // control-entry HMAC key (#6043/#6044) before opening the backend, so a forbidden config
+    // fails closed without creating a stray empty journal file on disk first.
     let cipher = crate::commands::durable::load_write_cipher(config)?;
+    let hmac_key = crate::commands::durable::load_write_hmac_key(config)?;
     let durable_url = crate::commands::durable::resolve_durable_db_url(config);
     let local = zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
         .await
@@ -205,6 +209,11 @@ async fn build_durable_adapter(
         .context("failed to init scheduler durable schema")?;
     let local = if let Some(cipher) = cipher {
         local.with_cipher(cipher)
+    } else {
+        local
+    };
+    let local = if let Some(key) = hmac_key {
+        local.with_hmac_key(key)
     } else {
         local
     };

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3239,7 +3239,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         let agent = if config.durable.enabled && config.durable.orchestration {
             let durable_url = crate::commands::durable::resolve_durable_db_url(config);
             let cipher = crate::commands::durable::load_write_cipher(config)?;
-            agent.with_durable_orchestration(config.durable.clone(), durable_url, cipher)
+            let hmac_key = crate::commands::durable::load_write_hmac_key(config)?;
+            agent.with_durable_orchestration(config.durable.clone(), durable_url, cipher, hmac_key)
         } else {
             agent
         };
@@ -3248,11 +3249,13 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         let agent = if config.durable.enabled && config.durable.agent_turns {
             let durable_url = crate::commands::durable::resolve_durable_db_url(config);
             let cipher = crate::commands::durable::load_write_cipher(config)?;
+            let hmac_key = crate::commands::durable::load_write_hmac_key(config)?;
             agent.with_durable_agent_turns(
                 config.durable.clone(),
                 durable_url,
                 config.memory.sqlite_path.clone(),
                 cipher,
+                hmac_key,
             )
         } else {
             agent


### PR DESCRIPTION
## Summary

`LocalBackend::with_hmac_key` (the row-level control-entry HMAC documented at INV-8 for shared-DB deployments) had no production caller, so the `hmac` field on `EffectIntent` control rows was always stamped `None`, and no code path ever recomputed or verified it on read — the spec's claim that this closes the `EffectIntent`-forgery attack vector (security HIGH-2b) was false in code.

- Derive the control-entry HMAC key as a BLAKE3 `derive_key` subkey of the same vault-resolved `ZEPH_DURABLE_KEY` used for the AEAD payload cipher (distinct domain-separation context, no new vault secret).
- Wire the key at the same runtime choke points PR #6040 used for the AEAD cipher: the shared P1/P2 durable bootstrap path, the scheduler daemon adapter, and the CLI read path (`zeph durable list/show/inspect/prune/resume`).
- Gate key resolution on the existing `shared_db`/`postgres://` detection policy — no new config surface, so no `--init`/`--migrate-config` changes were needed.
- Add read-side verification in `LocalBackend::row_to_entry`: every `EffectIntent` row is recomputed and constant-time-compared against its stored HMAC, failing closed with a new `DurableError::ControlIntegrity` variant on mismatch.
- Close a review-caught residual: an *unkeyed* reader that encounters a row still carrying a stamped HMAC now fails closed too, instead of silently trusting the row as unverified plaintext (reachable via `shared_db` config drift between a writer and a reader over the same physical file).

Single-user local SQLite is unaffected — `hmac` stays `None` and unverified, matching the documented INV-8 stance.

Closes #6043
Closes #6044

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13008 passed, 0 failed
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all doc-tests pass
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New unit tests: HMAC verified successfully under the correct key; rejected under a wrong key; rejected when missing on a keyed backend; rejected when present but the reader is unkeyed (the review-caught residual); key-derivation determinism and domain separation from the AEAD key; fail-closed/resolves-correctly key loading for single-user vs. declared-shared-DB configs