### PR TITLE
fix(tui): close panel mutual-exclusion, status-label, and dispatch gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-tui`: closed three independent dispatch/state gaps (#6061, #5984, #5983).
+  - The task-registry overlay's supervisor-unavailable fallback (`render_subagents_slot`)
+    drew its "supervisor not available" message directly into the shared subagents-slot
+    `Rect` without a preceding `Clear`, unlike every other overlay in the crate, letting
+    stale glyphs from whatever rendered underneath bleed through. More significantly,
+    `active_panel` (Fleet/Durable/SubAgents/Tasks) and `show_task_panel` were tracked as
+    independent fields with no mutual-exclusion invariant, so the task panel could render
+    simultaneously with Fleet, Durable, or the interactive sub-agent sidebar — the latter
+    case left `j`/`k`/`Enter` still routed to a sidebar hidden behind the task panel.
+    Added `App::set_active_panel`, a single method all `active_panel`-mutating call sites
+    (`Action::SetActivePanel`, `Action::CyclePanelFocus`/Tab, `Action::ToggleTaskPanel`,
+    `TuiCommand::TaskPanel`/`FleetPanel`/`DurablePanel`) now go through, keeping
+    `show_task_panel` in sync so only one of the shared-Rect panels renders per frame.
+  - Loading a user theme file (`apply_theme`) and loading a sub-agent transcript
+    (`start_transcript_load`) both offload to `spawn_blocking` without ever setting
+    `status_label`, violating the "every background operation shows a status indicator"
+    convention every other async path in the TUI follows. Both now set `status_label`
+    before dispatch and clear it in their poll handlers on completion — and also on
+    cancellation, which the first pass missed: applying a built-in theme preset while a
+    user-file load is still in flight, or pressing Esc out of a sub-agent transcript view
+    before its load resolves, previously left the "loading..." label stuck indefinitely.
+  - `TuiCommand::SandboxStatus`/`TafcStatus` were parsed from the command palette but never
+    reached their already-implemented handlers in `forward_tui_commands`
+    (`src/tui_bridge.rs`) because `execute_command` never forwarded them through
+    `command_tx` — both are now wired into the existing `command_tx`-forwarding arm
+    alongside `ViewConfig`/`ViewAutonomy`. `TuiCommand::WorktreeList`/`WorktreeClean` were
+    silent no-ops with no backing implementation reachable from a running TUI session (the
+    live `WorktreeManager` instance is private to the agent's `SubAgentManager`, and the
+    CLI's `zeph worktree` subcommands construct their own, disconnected manager per
+    invocation); both now push a system message pointing to the equivalent CLI command
+    (`zeph worktree list` / `zeph worktree clean [--force]`) instead of doing nothing.
 - `zeph-subagent`: sub-agent vault secrets now re-validate their grant TTL live instead of
   only gating once at delivery time, and a targeted secret-request lookup no longer drops a
   concurrent sibling sub-agent's pending request (#5991, #5993).

--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -294,7 +294,7 @@ impl App {
         has_graph: bool,
     ) {
         use ratatui::text::{Line, Span};
-        use ratatui::widgets::Paragraph;
+        use ratatui::widgets::{Clear, Paragraph};
 
         // When SubAgents panel is focused (`a` key), always show the interactive sidebar.
         // Otherwise: auto-show plan when graph active, security events, or subagents list.
@@ -355,6 +355,7 @@ impl App {
                     Span::styled("≈ ", theme.highlight),
                     Span::styled("tasks  supervisor not available", theme.system_message),
                 ]);
+                frame.render_widget(Clear, area);
                 frame.render_widget(Paragraph::new(header), area);
             }
         }
@@ -426,5 +427,60 @@ fn shrink_top(area: ratatui::layout::Rect, n: u16) -> ratatui::layout::Rect {
         y: area.y + n,
         width: area.width,
         height: area.height - n,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use tokio::sync::mpsc;
+
+    use super::App;
+
+    fn make_app() -> App {
+        let (user_tx, _) = mpsc::channel(1);
+        let (_, agent_rx) = mpsc::channel(1);
+        App::new(user_tx, agent_rx)
+    }
+
+    /// Fills the whole area with a sentinel glyph before calling `render_subagents_slot`, in
+    /// the same frame — mirroring the real bug shape (#6061): the task-panel
+    /// supervisor-unavailable fallback shares its `Rect` with Fleet/Durable/task-registry
+    /// overlays but, before the fix, never called `Clear`, so stale glyphs from whatever
+    /// rendered underneath survived in every cell the fallback `Paragraph` didn't touch.
+    fn render_fallback_over_sentinel(app: &mut App) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(80, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                for y in area.top()..area.bottom() {
+                    for x in area.left()..area.right() {
+                        frame.buffer_mut()[(x, y)].set_symbol("#");
+                    }
+                }
+                app.render_subagents_slot(frame, area, 0, false, false, false);
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn task_panel_fallback_clears_stale_glyphs_when_supervisor_unavailable() {
+        let mut app = make_app();
+        app.show_task_panel = true;
+        assert!(app.task_supervisor.is_none());
+
+        let buf = render_fallback_over_sentinel(&mut app);
+
+        for cell in &buf.content {
+            assert_ne!(
+                cell.symbol(),
+                "#",
+                "stray sentinel glyph survived render — Clear is missing or not applied \
+                 to the whole area"
+            );
+        }
     }
 }

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -123,7 +123,10 @@ impl App {
     #[allow(clippy::too_many_lines)] // large match over all TuiCommand variants
     pub(super) fn execute_command(&mut self, cmd: TuiCommand) {
         match cmd {
-            TuiCommand::ViewConfig | TuiCommand::ViewAutonomy => {
+            TuiCommand::ViewConfig
+            | TuiCommand::ViewAutonomy
+            | TuiCommand::SandboxStatus
+            | TuiCommand::TafcStatus => {
                 if let Some(ref tx) = self.command_tx {
                     // try_send: capacity 16, user-triggered one at a time — overflow not possible in practice
                     let _ = tx.try_send(cmd);
@@ -1201,5 +1204,49 @@ mod tests {
             App::parse_session_slash("/theme "),
             Some(TuiCommand::ListThemes)
         );
+    }
+
+    // ── #5983 SandboxStatus/TafcStatus dispatch (was silently dropped) ──────────
+
+    #[test]
+    fn execute_command_forwards_sandbox_status_through_command_tx() {
+        let (mut app, _user_rx, _agent_tx) = make_app();
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
+        app.command_tx = Some(cmd_tx);
+
+        app.execute_command(TuiCommand::SandboxStatus);
+
+        let forwarded = cmd_rx.try_recv().expect("command must be forwarded");
+        assert_eq!(forwarded, TuiCommand::SandboxStatus);
+        assert!(
+            app.sessions.current().messages.is_empty(),
+            "must not fall back to a stub system message when command_tx is wired"
+        );
+    }
+
+    #[test]
+    fn execute_command_forwards_tafc_status_through_command_tx() {
+        let (mut app, _user_rx, _agent_tx) = make_app();
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
+        app.command_tx = Some(cmd_tx);
+
+        app.execute_command(TuiCommand::TafcStatus);
+
+        let forwarded = cmd_rx.try_recv().expect("command must be forwarded");
+        assert_eq!(forwarded, TuiCommand::TafcStatus);
+        assert!(app.sessions.current().messages.is_empty());
+    }
+
+    #[test]
+    fn execute_command_sandbox_status_falls_back_without_command_tx() {
+        // No command_tx wired (e.g. constructed without `with_command_tx`) — must report
+        // via a system message instead of silently dropping the command.
+        let (mut app, _user_rx, _agent_tx) = make_app();
+        assert!(app.command_tx.is_none());
+
+        app.execute_command(TuiCommand::SandboxStatus);
+
+        let msg = &app.sessions.current().messages.last().unwrap().content;
+        assert!(msg.contains("not available"));
     }
 }

--- a/crates/zeph-tui/src/app/reducer.rs
+++ b/crates/zeph-tui/src/app/reducer.rs
@@ -108,7 +108,7 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
             vec![]
         }
         Action::CyclePanelFocus => {
-            app.active_panel = match app.active_panel {
+            let next = match app.active_panel {
                 Panel::Chat => Panel::Skills,
                 Panel::Skills => Panel::Memory,
                 Panel::Memory => Panel::Resources,
@@ -117,10 +117,13 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
                 Panel::Fleet => Panel::Durable,
                 Panel::Durable => Panel::Chat,
             };
+            // Routed through set_active_panel so cycling into SubAgents/Fleet/Durable
+            // clears show_task_panel the same way every other entry point does (#6061).
+            app.set_active_panel(next);
             vec![]
         }
         Action::SetActivePanel(p) => {
-            app.active_panel = p;
+            app.set_active_panel(p);
             if p == Panel::SubAgents
                 && app.subagent_sidebar.selected().is_none()
                 && !app.metrics.sub_agents.is_empty()
@@ -134,7 +137,12 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
             vec![]
         }
         Action::ToggleTaskPanel => {
-            app.show_task_panel = !app.show_task_panel;
+            if app.show_task_panel {
+                app.show_task_panel = false;
+            } else {
+                // Claim active_panel so Fleet/Durable are displaced instead of stacking (#6061).
+                app.set_active_panel(Panel::Tasks);
+            }
             vec![]
         }
         Action::TogglePlanView => {
@@ -682,15 +690,21 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
                     return vec![];
                 }
                 TuiCommand::TaskPanel => {
-                    app.show_task_panel = !app.show_task_panel;
+                    if app.show_task_panel {
+                        app.show_task_panel = false;
+                    } else {
+                        // Claim active_panel so Fleet/Durable are displaced instead of
+                        // stacking on the task panel (#6061).
+                        app.set_active_panel(Panel::Tasks);
+                    }
                     return vec![];
                 }
                 TuiCommand::FleetPanel => {
-                    app.active_panel = Panel::Fleet;
+                    app.set_active_panel(Panel::Fleet);
                     return vec![];
                 }
                 TuiCommand::DurablePanel => {
-                    app.active_panel = Panel::Durable;
+                    app.set_active_panel(Panel::Durable);
                     return vec![];
                 }
                 TuiCommand::PlanToggleView => {
@@ -774,6 +788,23 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
                         "To ingest project artifacts: run \
                          `zeph knowledge ingest --source <specs|changelog|handoff|coverage|git-log>` \
                          from the CLI."
+                            .to_owned(),
+                    );
+                    return vec![];
+                }
+                TuiCommand::WorktreeList => {
+                    app.push_system_message_pub(
+                        "Worktree listing requires a fresh git scan and is not available \
+                         from a running TUI session.\n  Run from the CLI:\n  zeph worktree list"
+                            .to_owned(),
+                    );
+                    return vec![];
+                }
+                TuiCommand::WorktreeClean => {
+                    app.push_system_message_pub(
+                        "Worktree cleanup removes directories via git and is not available \
+                         from a running TUI session.\n  Run from the CLI:\n  zeph worktree clean \
+                         (add --force to remove entries git does not report as prunable)"
                             .to_owned(),
                     );
                     return vec![];
@@ -1067,6 +1098,56 @@ mod tests {
         assert_eq!(app.active_panel, Panel::Skills);
     }
 
+    // ── #6061 CyclePanelFocus (Tab key) must honor the mutual-exclusion invariant ──
+    //
+    // Flagged in the first coverage pass as untested: Tab-cycling into SubAgents/Fleet/
+    // Durable while the task panel is open used to leave both "active" simultaneously,
+    // since CyclePanelFocus assigned `active_panel` directly instead of going through
+    // set_active_panel like every other entry point. Now centralized — these confirm
+    // the fix closes that gap.
+
+    #[test]
+    fn cycle_panel_focus_into_subagents_clears_task_panel() {
+        let (mut app, _rx) = make_app();
+        app.active_panel = Panel::Resources;
+        app.show_task_panel = true;
+        reduce(&mut app, Action::CyclePanelFocus);
+        assert_eq!(app.active_panel, Panel::SubAgents);
+        assert!(!app.show_task_panel);
+    }
+
+    #[test]
+    fn cycle_panel_focus_into_fleet_clears_task_panel() {
+        let (mut app, _rx) = make_app();
+        app.active_panel = Panel::SubAgents;
+        app.show_task_panel = true;
+        reduce(&mut app, Action::CyclePanelFocus);
+        assert_eq!(app.active_panel, Panel::Fleet);
+        assert!(!app.show_task_panel);
+    }
+
+    #[test]
+    fn cycle_panel_focus_into_durable_clears_task_panel() {
+        let (mut app, _rx) = make_app();
+        app.active_panel = Panel::Fleet;
+        app.show_task_panel = true;
+        reduce(&mut app, Action::CyclePanelFocus);
+        assert_eq!(app.active_panel, Panel::Durable);
+        assert!(!app.show_task_panel);
+    }
+
+    #[test]
+    fn cycle_panel_focus_into_skills_does_not_clear_task_panel() {
+        // Negative case: cycling into a panel that does NOT share the subagents Rect
+        // must leave show_task_panel untouched.
+        let (mut app, _rx) = make_app();
+        app.active_panel = Panel::Chat;
+        app.show_task_panel = true;
+        reduce(&mut app, Action::CyclePanelFocus);
+        assert_eq!(app.active_panel, Panel::Skills);
+        assert!(app.show_task_panel);
+    }
+
     #[test]
     fn dispatch_toggle_mouse_flips_flag() {
         let (mut app, _rx) = make_app();
@@ -1129,6 +1210,137 @@ mod tests {
         let effects = reduce(&mut app, Action::Dispatch(TuiCommand::DurablePanel));
         assert!(effects.is_empty());
         assert_eq!(app.active_panel, Panel::Durable);
+    }
+
+    // ── #6061 active_panel / show_task_panel mutual exclusion ──────────────────
+
+    #[test]
+    fn dispatch_fleet_panel_clears_task_panel() {
+        let (mut app, _rx) = make_app();
+        app.show_task_panel = true;
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::FleetPanel));
+        assert!(effects.is_empty());
+        assert_eq!(app.active_panel, Panel::Fleet);
+        assert!(
+            !app.show_task_panel,
+            "activating Fleet must clear the task-panel overlay so it can't bleed \
+             through onto the shared Rect"
+        );
+    }
+
+    #[test]
+    fn dispatch_durable_panel_clears_task_panel() {
+        let (mut app, _rx) = make_app();
+        app.show_task_panel = true;
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::DurablePanel));
+        assert!(effects.is_empty());
+        assert_eq!(app.active_panel, Panel::Durable);
+        assert!(
+            !app.show_task_panel,
+            "activating Durable must clear the task-panel overlay so it can't bleed \
+             through onto the shared Rect"
+        );
+    }
+
+    #[test]
+    fn dispatch_task_panel_toggle_on_claims_active_panel() {
+        let (mut app, _rx) = make_app();
+        app.active_panel = Panel::Fleet;
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::TaskPanel));
+        assert!(effects.is_empty());
+        assert!(app.show_task_panel);
+        assert_eq!(
+            app.active_panel,
+            Panel::Tasks,
+            "toggling the task panel on must displace whatever panel (Fleet/Durable) \
+             previously owned the shared Rect"
+        );
+    }
+
+    #[test]
+    fn dispatch_task_panel_toggle_off_leaves_active_panel_untouched() {
+        let (mut app, _rx) = make_app();
+        app.show_task_panel = true;
+        app.active_panel = Panel::Tasks;
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::TaskPanel));
+        assert!(effects.is_empty());
+        assert!(!app.show_task_panel);
+        // Toggling off must not itself reassign active_panel — only the "on" transition claims it.
+        assert_eq!(app.active_panel, Panel::Tasks);
+    }
+
+    #[test]
+    fn action_set_active_panel_fleet_clears_task_panel() {
+        let (mut app, _rx) = make_app();
+        app.show_task_panel = true;
+        let effects = reduce(&mut app, Action::SetActivePanel(Panel::Fleet));
+        assert!(effects.is_empty());
+        assert_eq!(app.active_panel, Panel::Fleet);
+        assert!(
+            !app.show_task_panel,
+            "SetActivePanel(Fleet) must clear show_task_panel (covers the `f` keyboard \
+             shortcut path, distinct from the TuiCommand::FleetPanel command-palette path)"
+        );
+    }
+
+    #[test]
+    fn action_set_active_panel_durable_clears_task_panel() {
+        let (mut app, _rx) = make_app();
+        app.show_task_panel = true;
+        let effects = reduce(&mut app, Action::SetActivePanel(Panel::Durable));
+        assert!(effects.is_empty());
+        assert_eq!(app.active_panel, Panel::Durable);
+        assert!(
+            !app.show_task_panel,
+            "SetActivePanel(Durable) must clear show_task_panel (covers the `D` keyboard \
+             shortcut path)"
+        );
+    }
+
+    #[test]
+    fn action_set_active_panel_subagents_clears_task_panel() {
+        // S1: SubAgents renders as the interactive base layer of the same shared Rect as
+        // Fleet/Durable (not just an overlay), so it must also displace the task panel.
+        // Exercised through the full reduce() path (not just the App::set_active_panel
+        // unit test) since this arm has SubAgents-specific side effects (sidebar
+        // selection) that could theoretically interfere with the invariant.
+        let (mut app, _rx) = make_app();
+        app.show_task_panel = true;
+        let effects = reduce(&mut app, Action::SetActivePanel(Panel::SubAgents));
+        assert!(effects.is_empty());
+        assert_eq!(app.active_panel, Panel::SubAgents);
+        assert!(
+            !app.show_task_panel,
+            "SetActivePanel(SubAgents) must clear show_task_panel (covers the `a` keyboard \
+             shortcut path)"
+        );
+    }
+
+    #[test]
+    fn action_set_active_panel_chat_does_not_clear_task_panel() {
+        // Negative case: only Fleet/Durable share the subagents Rect with the task panel —
+        // switching to an unrelated panel must not incidentally clear show_task_panel.
+        let (mut app, _rx) = make_app();
+        app.show_task_panel = true;
+        let effects = reduce(&mut app, Action::SetActivePanel(Panel::Skills));
+        assert!(effects.is_empty());
+        assert_eq!(app.active_panel, Panel::Skills);
+        assert!(app.show_task_panel);
+    }
+
+    #[test]
+    fn action_toggle_task_panel_on_claims_active_panel() {
+        let (mut app, _rx) = make_app();
+        app.active_panel = Panel::Durable;
+        let effects = reduce(&mut app, Action::ToggleTaskPanel);
+        assert!(effects.is_empty());
+        assert!(app.show_task_panel);
+        assert_eq!(
+            app.active_panel,
+            Panel::Tasks,
+            "the `t` keyboard shortcut (Action::ToggleTaskPanel) must displace Fleet/Durable \
+             the same way TuiCommand::TaskPanel does"
+        );
     }
 
     #[test]
@@ -1225,6 +1437,26 @@ mod tests {
         );
         assert!(effects.is_empty());
         assert_eq!(app.sessions.current().messages.len(), 1);
+    }
+
+    // ── #5983 WorktreeList/WorktreeClean CLI-redirect (was silently dropped) ──
+
+    #[test]
+    fn dispatch_worktree_list_pushes_cli_redirect_message() {
+        let (mut app, _rx) = make_app();
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::WorktreeList));
+        assert!(effects.is_empty());
+        let msg = &app.sessions.current().messages.last().unwrap().content;
+        assert!(msg.contains("zeph worktree list"));
+    }
+
+    #[test]
+    fn dispatch_worktree_clean_pushes_cli_redirect_message() {
+        let (mut app, _rx) = make_app();
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::WorktreeClean));
+        assert!(effects.is_empty());
+        let msg = &app.sessions.current().messages.last().unwrap().content;
+        assert!(msg.contains("zeph worktree clean"));
     }
 
     // ── Group B tests ───────────────────────────────────────────────────────────

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -241,7 +241,14 @@ impl App {
         // Built-in presets are compile-time constants — no I/O, apply synchronously.
         if let Some(preset) = presets::Preset::from_name(name) {
             // Cancel any in-flight user-file load so it cannot revert this newer choice.
-            self.pending_theme = None;
+            if self.pending_theme.take().is_some() {
+                // Only clear if we actually had a load in flight — otherwise this could
+                // wipe an unrelated status_label (e.g. "indexing files..."). Its
+                // "loading theme..." label would otherwise never be cleared, since
+                // poll_pending_theme (the only other clearer) never runs once
+                // pending_theme is gone.
+                self.sessions.current_mut().status_label = None;
+            }
             self.pending_theme_name = None;
             let palette = preset.palette();
             let new_theme = Theme::from_palette_with_mode(&palette, self.effective_color_mode);
@@ -254,6 +261,7 @@ impl App {
 
         // User file: offload blocking I/O to a spawn_blocking thread.
         // The result is installed by `poll_pending_theme` on the next tick.
+        self.sessions.current_mut().status_label = Some("loading theme...".to_owned());
         let name_owned = name.to_owned();
         let (tx, rx) = tokio::sync::oneshot::channel();
         tokio::task::spawn_blocking(move || {
@@ -276,6 +284,7 @@ impl App {
         match rx.try_recv() {
             Ok(result) => {
                 self.pending_theme = None;
+                self.sessions.current_mut().status_label = None;
                 let name = self.pending_theme_name.take().unwrap_or_default();
                 match result {
                     Ok(palette) => {
@@ -299,6 +308,7 @@ impl App {
                 // Sender dropped without sending (spawn_blocking panicked).
                 self.pending_theme = None;
                 self.pending_theme_name = None;
+                self.sessions.current_mut().status_label = None;
                 tracing::warn!("pending theme load task dropped without result");
             }
         }
@@ -1041,6 +1051,30 @@ impl App {
         eff
     }
 
+    /// Sets `active_panel`, keeping `show_task_panel` in sync so at most one
+    /// panel/overlay ever claims `render_subagents_slot`'s shared `Rect` per frame (#6061).
+    ///
+    /// `SubAgents`, `Fleet`, and `Durable` all render into that Rect (`SubAgents` as the
+    /// interactive base layer with live key routing, `Fleet`/`Durable` as overlays on top of
+    /// it) — activating any of them clears `show_task_panel` so the task-panel overlay can't
+    /// silently cover live content or a hidden-but-still-key-routed sub-agent sidebar.
+    /// `Tasks` is the task panel's own marker value and sets `show_task_panel` back on.
+    /// `Chat`/`Skills`/`Memory`/`Resources` render in unrelated areas and are left alone —
+    /// the task panel may keep overlaying the (non-interactive) default baseline there.
+    ///
+    /// All call sites that change `active_panel` (`Action::SetActivePanel`,
+    /// `Action::CyclePanelFocus`, `TuiCommand::FleetPanel`/`DurablePanel`) must go through
+    /// this method rather than assigning the field directly, so the invariant holds
+    /// regardless of which input path triggered the change.
+    pub(crate) fn set_active_panel(&mut self, p: Panel) {
+        self.active_panel = p;
+        match p {
+            Panel::Tasks => self.show_task_panel = true,
+            Panel::SubAgents | Panel::Fleet | Panel::Durable => self.show_task_panel = false,
+            Panel::Chat | Panel::Skills | Panel::Memory | Panel::Resources => {}
+        }
+    }
+
     /// Configure the animation budget from config.
     ///
     /// # Examples
@@ -1414,7 +1448,7 @@ impl App {
 mod tests {
     use tokio::sync::mpsc;
 
-    use super::App;
+    use super::{App, Panel};
 
     fn make_app() -> App {
         let (user_tx, _) = mpsc::channel(1);
@@ -1509,5 +1543,210 @@ mod tests {
     fn remote_daemon_url_defaults_to_none() {
         let app = make_app();
         assert_eq!(app.remote_daemon_url(), None);
+    }
+
+    // ── #5984 status_label lifecycle around theme load ─────────────────────────
+
+    #[test]
+    fn apply_theme_preset_does_not_touch_status_label() {
+        // Built-in presets apply synchronously — there is no background load, so no
+        // "loading theme..." indicator should ever appear for this path.
+        let mut app = make_app();
+        app.apply_theme("zephyr-light").expect("valid preset");
+        assert_eq!(app.status_label(), None);
+    }
+
+    #[tokio::test]
+    async fn apply_theme_user_file_sets_status_label_before_dispatch() {
+        // A name that is not a built-in preset takes the user-file branch, which offloads
+        // to spawn_blocking (requires a Tokio runtime). status_label must be set
+        // synchronously, before the background task can possibly complete, so the
+        // spinner is visible immediately (#5984).
+        let mut app = make_app();
+        let result = app.apply_theme("my-custom-theme");
+        assert!(
+            matches!(result, Ok(false)),
+            "user-file branch defers via Ok(false)"
+        );
+        assert_eq!(
+            app.status_label(),
+            Some("loading theme..."),
+            "status_label must be set before the async dispatch, not after"
+        );
+    }
+
+    #[test]
+    fn poll_pending_theme_clears_status_label_on_success() {
+        let mut app = make_app();
+        app.sessions.current_mut().status_label = Some("loading theme...".to_owned());
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        app.pending_theme = Some(rx);
+        app.pending_theme_name = Some("custom".to_owned());
+        tx.send(Ok(crate::theme::presets::Preset::Zephyr.palette()))
+            .expect("receiver still open");
+
+        app.poll_pending_theme();
+
+        assert_eq!(app.status_label(), None);
+        assert!(app.pending_theme.is_none());
+    }
+
+    #[test]
+    fn poll_pending_theme_clears_status_label_on_load_error() {
+        // The Ok(result) branch covers both success and a load error inside the Result —
+        // status_label must be cleared in both sub-cases, not only on success.
+        let mut app = make_app();
+        app.sessions.current_mut().status_label = Some("loading theme...".to_owned());
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        app.pending_theme = Some(rx);
+        app.pending_theme_name = Some("custom".to_owned());
+        tx.send(Err(crate::theme::ThemeLoadError::UnsafeName(
+            "custom".to_owned(),
+        )))
+        .expect("receiver still open");
+
+        app.poll_pending_theme();
+
+        assert_eq!(app.status_label(), None);
+        assert!(app.pending_theme.is_none());
+    }
+
+    #[test]
+    fn poll_pending_theme_clears_status_label_when_task_panics() {
+        // Closed branch: the spawn_blocking task dropped its sender without sending
+        // (e.g. panicked) — status_label must not be left stuck on "loading theme...".
+        let mut app = make_app();
+        app.sessions.current_mut().status_label = Some("loading theme...".to_owned());
+        let (tx, rx) = tokio::sync::oneshot::channel::<
+            Result<crate::theme::SemanticPalette, crate::theme::ThemeLoadError>,
+        >();
+        app.pending_theme = Some(rx);
+        app.pending_theme_name = Some("custom".to_owned());
+        drop(tx);
+
+        app.poll_pending_theme();
+
+        assert_eq!(app.status_label(), None);
+        assert!(app.pending_theme.is_none());
+        assert!(app.pending_theme_name.is_none());
+    }
+
+    #[test]
+    fn poll_pending_theme_is_noop_while_still_pending() {
+        let mut app = make_app();
+        app.sessions.current_mut().status_label = Some("loading theme...".to_owned());
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        app.pending_theme = Some(rx);
+
+        app.poll_pending_theme();
+
+        // Not ready yet (TryRecvError::Empty) — status_label must remain set.
+        assert_eq!(app.status_label(), Some("loading theme..."));
+        assert!(app.pending_theme.is_some());
+    }
+
+    // ── #5984 apply_theme(preset) cancellation must not strand status_label ────
+
+    #[test]
+    fn apply_theme_preset_clears_status_label_when_cancelling_pending_user_load() {
+        // Reproduces the stuck-spinner bug: a user-file load is in flight (status_label =
+        // "loading theme..."), then the user picks a built-in preset before it resolves.
+        // The preset path cancels pending_theme, but poll_pending_theme (the only other
+        // clearer) will now never run again — apply_theme itself must clear the label.
+        let mut app = make_app();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        app.pending_theme = Some(rx);
+        app.pending_theme_name = Some("my-custom-theme".to_owned());
+        app.sessions.current_mut().status_label = Some("loading theme...".to_owned());
+
+        app.apply_theme("zephyr-light").expect("valid preset");
+
+        assert!(
+            app.pending_theme.is_none(),
+            "pending load must be cancelled"
+        );
+        assert_eq!(
+            app.status_label(),
+            None,
+            "cancelling the in-flight theme load must clear its status_label"
+        );
+    }
+
+    #[test]
+    fn apply_theme_preset_preserves_unrelated_status_label_when_nothing_pending() {
+        // Negative case for the same fix: if there is no pending_theme in flight, an
+        // unrelated status_label (e.g. from a concurrent file index) must survive a
+        // preset switch — the clear is conditioned on an actual cancellation happening.
+        let mut app = make_app();
+        assert!(app.pending_theme.is_none());
+        app.sessions.current_mut().status_label = Some("indexing files...".to_owned());
+
+        app.apply_theme("zephyr-light").expect("valid preset");
+
+        assert_eq!(
+            app.status_label(),
+            Some("indexing files..."),
+            "unrelated status_label must not be wiped by a preset switch with no \
+             in-flight theme load to cancel"
+        );
+    }
+
+    // ── #6061 set_active_panel is the single source of truth for the invariant ─
+
+    #[test]
+    fn set_active_panel_tasks_shows_task_panel() {
+        let mut app = make_app();
+        app.set_active_panel(Panel::Tasks);
+        assert_eq!(app.active_panel, Panel::Tasks);
+        assert!(app.show_task_panel);
+    }
+
+    #[test]
+    fn set_active_panel_subagents_hides_task_panel() {
+        // SubAgents renders as the interactive base layer of the shared Rect (not just an
+        // overlay like Fleet/Durable), so it must also displace the task panel.
+        let mut app = make_app();
+        app.show_task_panel = true;
+        app.set_active_panel(Panel::SubAgents);
+        assert_eq!(app.active_panel, Panel::SubAgents);
+        assert!(!app.show_task_panel);
+    }
+
+    #[test]
+    fn set_active_panel_fleet_hides_task_panel() {
+        let mut app = make_app();
+        app.show_task_panel = true;
+        app.set_active_panel(Panel::Fleet);
+        assert!(!app.show_task_panel);
+    }
+
+    #[test]
+    fn set_active_panel_durable_hides_task_panel() {
+        let mut app = make_app();
+        app.show_task_panel = true;
+        app.set_active_panel(Panel::Durable);
+        assert!(!app.show_task_panel);
+    }
+
+    #[test]
+    fn set_active_panel_unrelated_panels_leave_task_panel_untouched() {
+        // Chat/Skills/Memory/Resources render in unrelated areas — switching to them
+        // must not incidentally toggle show_task_panel in either direction.
+        let mut app = make_app();
+        for panel in [Panel::Chat, Panel::Skills, Panel::Memory, Panel::Resources] {
+            app.show_task_panel = true;
+            app.set_active_panel(panel);
+            assert!(
+                app.show_task_panel,
+                "{panel:?} must not clear show_task_panel"
+            );
+
+            app.show_task_panel = false;
+            app.set_active_panel(panel);
+            assert!(
+                !app.show_task_panel,
+                "{panel:?} must not set show_task_panel"
+            );
+        }
     }
 }

--- a/crates/zeph-tui/src/app/transcript.rs
+++ b/crates/zeph-tui/src/app/transcript.rs
@@ -22,7 +22,20 @@ impl App {
         self.sessions.current_mut().render_cache.clear();
         self.sessions.current_mut().scroll_offset = 0;
         self.sessions.current_mut().transcript_cache = None;
-        self.sessions.current_mut().pending_transcript = None;
+        if self
+            .sessions
+            .current_mut()
+            .pending_transcript
+            .take()
+            .is_some()
+        {
+            // Only clear if a load was actually in flight — otherwise this could wipe an
+            // unrelated status_label. Its "loading transcript..." label would otherwise
+            // never be cleared, since poll_pending_transcript (the only other clearer)
+            // never runs once pending_transcript is gone (e.g. Esc back to Main before
+            // the load resolves).
+            self.sessions.current_mut().status_label = None;
+        }
         // Kick off transcript load if switching to a subagent.
         if let AgentViewTarget::SubAgent { ref id, .. } = self.sessions.current().view_target {
             let id = id.clone();
@@ -47,6 +60,7 @@ impl App {
 
         let (tx, rx) = oneshot::channel();
         self.sessions.current_mut().pending_transcript = Some(rx);
+        self.sessions.current_mut().status_label = Some("loading transcript...".to_owned());
         // Determine if the agent is still active (for C2: skip warning on partial last line).
         let is_active = self
             .metrics
@@ -70,6 +84,7 @@ impl App {
         match rx.try_recv() {
             Ok((entries, total)) => {
                 self.sessions.current_mut().pending_transcript = None;
+                self.sessions.current_mut().status_label = None;
                 let turns_at_load = self
                     .sessions
                     .current()
@@ -92,6 +107,7 @@ impl App {
             Err(oneshot::error::TryRecvError::Empty) => {}
             Err(oneshot::error::TryRecvError::Closed) => {
                 self.sessions.current_mut().pending_transcript = None;
+                self.sessions.current_mut().status_label = None;
             }
         }
     }
@@ -168,5 +184,157 @@ impl App {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::{mpsc, oneshot};
+    use zeph_core::metrics::SubAgentMetrics;
+
+    use super::*;
+
+    fn make_app() -> App {
+        let (user_tx, _) = mpsc::channel(1);
+        let (_, agent_rx) = mpsc::channel(1);
+        App::new(user_tx, agent_rx)
+    }
+
+    fn sub_agent(id: &str, transcript_dir: Option<&str>) -> SubAgentMetrics {
+        SubAgentMetrics {
+            id: id.to_owned(),
+            name: "test-agent".to_owned(),
+            state: "completed".to_owned(),
+            transcript_dir: transcript_dir.map(str::to_owned),
+            ..Default::default()
+        }
+    }
+
+    // ── #5984 status_label lifecycle around transcript load ────────────────────
+
+    #[tokio::test]
+    async fn start_transcript_load_sets_status_label_before_dispatch() {
+        // start_transcript_load offloads to spawn_blocking, which requires a Tokio runtime.
+        let mut app = make_app();
+        app.metrics.sub_agents = vec![sub_agent("sa-1", Some("/tmp/zeph-test-nonexistent-dir"))];
+        app.start_transcript_load("sa-1");
+        assert_eq!(
+            app.status_label(),
+            Some("loading transcript..."),
+            "status_label must be set synchronously before the spawn_blocking dispatch"
+        );
+        assert!(app.sessions.current().pending_transcript.is_some());
+    }
+
+    #[test]
+    fn start_transcript_load_noop_when_no_transcript_dir() {
+        // No transcript_dir → transcript_path is None → early return, no dispatch at all.
+        let mut app = make_app();
+        app.metrics.sub_agents = vec![sub_agent("sa-1", None)];
+        app.start_transcript_load("sa-1");
+        assert_eq!(app.status_label(), None);
+        assert!(app.sessions.current().pending_transcript.is_none());
+    }
+
+    #[test]
+    fn poll_pending_transcript_clears_status_label_on_success() {
+        let mut app = make_app();
+        app.sessions.current_mut().status_label = Some("loading transcript...".to_owned());
+        app.sessions.current_mut().view_target = AgentViewTarget::SubAgent {
+            id: "sa-1".to_owned(),
+            name: "Planner".to_owned(),
+        };
+        let (tx, rx) = oneshot::channel();
+        app.sessions.current_mut().pending_transcript = Some(rx);
+        tx.send((Vec::new(), 0)).expect("receiver still open");
+
+        app.poll_pending_transcript();
+
+        assert_eq!(app.status_label(), None);
+        assert!(app.sessions.current().pending_transcript.is_none());
+    }
+
+    #[test]
+    fn poll_pending_transcript_clears_status_label_when_task_panics() {
+        // Closed branch: the spawn_blocking task dropped its sender without sending
+        // (e.g. panicked) — status_label must not be left stuck on "loading transcript...".
+        let mut app = make_app();
+        app.sessions.current_mut().status_label = Some("loading transcript...".to_owned());
+        let (tx, rx) = oneshot::channel::<(Vec<TuiTranscriptEntry>, usize)>();
+        app.sessions.current_mut().pending_transcript = Some(rx);
+        drop(tx);
+
+        app.poll_pending_transcript();
+
+        assert_eq!(app.status_label(), None);
+        assert!(app.sessions.current().pending_transcript.is_none());
+    }
+
+    #[test]
+    fn poll_pending_transcript_is_noop_while_still_pending() {
+        let mut app = make_app();
+        app.sessions.current_mut().status_label = Some("loading transcript...".to_owned());
+        let (_tx, rx) = oneshot::channel();
+        app.sessions.current_mut().pending_transcript = Some(rx);
+
+        app.poll_pending_transcript();
+
+        // Not ready yet (TryRecvError::Empty) — status_label must remain set.
+        assert_eq!(app.status_label(), Some("loading transcript..."));
+        assert!(app.sessions.current().pending_transcript.is_some());
+    }
+
+    // ── #5984 set_view_target cancellation must not strand status_label ────────
+
+    #[test]
+    fn set_view_target_cancels_pending_load_and_clears_status_label() {
+        // Reproduces the stuck-spinner bug: a transcript load is in flight
+        // (status_label = "loading transcript..."), then the user navigates away
+        // (e.g. Esc back to Main) before it resolves. The switch cancels
+        // pending_transcript, but poll_pending_transcript (the only other clearer)
+        // will now never run again — set_view_target itself must clear the label.
+        let mut app = make_app();
+        app.sessions.current_mut().view_target = AgentViewTarget::SubAgent {
+            id: "sa-1".to_owned(),
+            name: "Planner".to_owned(),
+        };
+        let (_tx, rx) = oneshot::channel();
+        app.sessions.current_mut().pending_transcript = Some(rx);
+        app.sessions.current_mut().status_label = Some("loading transcript...".to_owned());
+
+        app.set_view_target(AgentViewTarget::Main);
+
+        assert!(
+            app.sessions.current().pending_transcript.is_none(),
+            "pending load must be cancelled"
+        );
+        assert_eq!(
+            app.status_label(),
+            None,
+            "cancelling the in-flight transcript load must clear its status_label"
+        );
+    }
+
+    #[test]
+    fn set_view_target_preserves_unrelated_status_label_when_nothing_pending() {
+        // Negative case for the same fix: switching view targets with no pending_transcript
+        // in flight (e.g. no transcript_dir on record for the target agent, so
+        // start_transcript_load returns early) must not wipe an unrelated status_label.
+        let mut app = make_app();
+        assert!(app.metrics.sub_agents.is_empty());
+        app.sessions.current_mut().status_label = Some("indexing files...".to_owned());
+
+        app.set_view_target(AgentViewTarget::SubAgent {
+            id: "sa-1".to_owned(),
+            name: "Planner".to_owned(),
+        });
+
+        assert!(app.sessions.current().pending_transcript.is_none());
+        assert_eq!(
+            app.status_label(),
+            Some("indexing files..."),
+            "unrelated status_label must not be wiped when there was no in-flight \
+             transcript load to cancel"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes three independent zeph-tui bugs found this cycle, all sharing the same "silent gap" shape:

- **Task-panel overlay bleed-through**: `render_subagents_slot`'s supervisor-unavailable fallback drew directly into the shared subagents-slot `Rect` with no preceding `Clear`, unlike every other overlay in the crate. Root cause went deeper: `active_panel` (Fleet/Durable/SubAgents/Tasks) and `show_task_panel` were independent fields with no mutual-exclusion invariant, so the task panel could render simultaneously with Fleet, Durable, or the interactive sub-agent sidebar (the latter case left keyboard navigation routed to a hidden sidebar). All `active_panel`-mutating call sites (`Action::SetActivePanel`, `Action::CyclePanelFocus`/Tab, `Action::ToggleTaskPanel`, `TuiCommand::TaskPanel`/`FleetPanel`/`DurablePanel`) now go through a single `App::set_active_panel` helper that keeps `show_task_panel` in sync.
- **Missing status indicators**: `apply_theme`'s user-theme-file load and `start_transcript_load` both offload to `spawn_blocking` without ever setting `status_label`, breaking CLAUDE.md's "every background operation shows a status indicator" convention. Both now set/clear `status_label` on completion and on cancellation (applying a built-in preset while a user-file load is in flight, or pressing Esc out of a transcript view mid-load — previously left the "loading..." label stuck indefinitely).
- **Dispatch gaps**: `TuiCommand::SandboxStatus`/`TafcStatus` were parsed from the command palette but never forwarded through `command_tx`, even though their handlers already existed in `forward_tui_commands`. `TuiCommand::WorktreeList`/`WorktreeClean` have no backing data reachable from a running TUI session (the live `WorktreeManager` is private to the agent's `SubAgentManager`, and the CLI's `zeph worktree` subcommands construct their own disconnected instance per invocation) — both now redirect to the equivalent CLI command instead of silently no-oping. Full live-session integration is left as a follow-up (see below).

Closes #6061
Closes #5984
Closes #5983

## Follow-up

Filing a separate issue for live in-session `WorktreeList`/`WorktreeClean` integration (either an `active_worktrees` metrics field sourced from `SubAgentManager.worktree_manager`, or a new `/worktree` slash-command handler under `AgentAccess`) — out of scope for this bug-fix PR.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13054 passed, 0 failed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] 39 new tests added across `reducer.rs`/`draw.rs`/`state.rs`/`transcript.rs`/`keys.rs` covering both entry paths (keyboard `Action` and command-palette `TuiCommand`) for each fix, plus negative cases
- [x] Two internal review rounds (adversarial critic + independent test pass) found and closed 3 additional edge cases beyond the original issue reports (SetActivePanel(SubAgents), CyclePanelFocus/Tab, and status_label cancellation leaks)
- [x] Code review approved