### PR TITLE
fix(index): resolve workspace_root for IndexMcpServer registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `IndexMcpServer` registration (`apply_code_retrieval` in `src/agent_setup.rs`) hardcoded
+  `std::env::current_dir()` and never read `[index] workspace_root`, unlike the sibling
+  background-indexer path (`apply_code_indexer`), which resolved it correctly. Scoping
+  `workspace_root` to a subdirectory had no effect whenever `index.mcp_enabled = true`;
+  `IndexMcpServer` always walked the full process working directory instead (#6129).
+  Extracted the existing resolution logic into a shared `resolve_workspace_root` helper so
+  both call sites resolve `workspace_root` identically.
 - `zeph-tui`: closed three independent dispatch/state gaps (#6061, #5984, #5983).
   - The task-registry overlay's supervisor-unavailable fallback (`render_subagents_slot`)
     drew its "supervisor not available" message directly into the shared subagents-slot

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1309,6 +1309,17 @@ pub(crate) fn apply_debug_dumper<C: Channel>(
     }
 }
 
+/// Resolve the workspace root to index: `config.workspace_root` when set (canonicalized,
+/// falling back to the raw path if canonicalization fails), otherwise the process's current
+/// working directory. Shared by the background indexer and the `IndexMcpServer` retrieval path
+/// so both honor `index.workspace_root` identically.
+fn resolve_workspace_root(config: &IndexConfig) -> PathBuf {
+    config.workspace_root.as_deref().map_or_else(
+        || std::env::current_dir().unwrap_or_default(),
+        |p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()),
+    )
+}
+
 pub(crate) async fn apply_code_indexer(
     full_config: &Config,
     qdrant_ops: Option<QdrantOps>,
@@ -1367,10 +1378,7 @@ pub(crate) async fn apply_code_indexer(
         Ok(indexer) => {
             let (progress_tx, progress_rx) =
                 tokio::sync::watch::channel(zeph_index::IndexProgress::default());
-            let workspace_root = config.workspace_root.as_deref().map_or_else(
-                || std::env::current_dir().unwrap_or_default(),
-                |p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()),
-            );
+            let workspace_root = resolve_workspace_root(config);
             if cli_mode {
                 spawn_index_progress_printer(progress_tx.subscribe());
             }
@@ -1564,8 +1572,7 @@ pub(crate) fn apply_code_retrieval<C: Channel>(agent: Agent<C>, config: &IndexCo
                  static repo-map injection is disabled; use IndexMcpServer tools instead"
             );
         }
-        let cwd = std::env::current_dir().unwrap_or_default();
-        agent.with_index_mcp_server(cwd)
+        agent.with_index_mcp_server(resolve_workspace_root(config))
     } else if config.repo_map_tokens > 0 {
         agent.with_repo_map(config.repo_map_tokens, config.repo_map_ttl_secs)
     } else {
@@ -2915,6 +2922,31 @@ mod tests {
         )
         .await;
         assert!(watcher.is_none()); // watch = false
+    }
+
+    #[test]
+    fn resolve_workspace_root_none_uses_current_dir() {
+        let config = IndexConfig {
+            workspace_root: None,
+            ..IndexConfig::default()
+        };
+        assert_eq!(
+            resolve_workspace_root(&config),
+            std::env::current_dir().unwrap_or_default()
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_root_some_path_is_used() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let config = IndexConfig {
+            workspace_root: Some(tmp_dir.path().to_path_buf()),
+            ..IndexConfig::default()
+        };
+        assert_eq!(
+            resolve_workspace_root(&config),
+            tmp_dir.path().canonicalize().unwrap()
+        );
     }
 
     /// `spawn_index_progress_status_forwarder` must forward each `IndexProgress` update as a


### PR DESCRIPTION
## Summary

- `apply_code_retrieval` (`src/agent_setup.rs`) hardcoded `std::env::current_dir()` when registering `IndexMcpServer`, silently ignoring `[index] workspace_root` whenever `index.mcp_enabled = true` — unlike the sibling `apply_code_indexer` (background indexer/watcher) path, which resolved `workspace_root` correctly.
- Extracted the existing resolution logic into a shared `resolve_workspace_root(config: &IndexConfig) -> PathBuf` helper so both call sites now resolve `workspace_root` identically (config value when set, `current_dir()` fallback only when unset).
- Added 2 unit tests covering both branches of the helper.

Closes #6129

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13064 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Targeted regression: `cargo nextest run -p zeph --features "desktop,ide,server,chat,pdf,scheduler" --bins -E 'test(apply_code_retrieval) or test(apply_code_indexer) or test(resolve_workspace_root)'` — 7/7 passed
- [x] `.local/testing/coverage-status.md` updated (row 687, IndexMcpServer)