### PR TITLE
fix(security): rate-limit failed-auth requests in gateway and a2a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-gateway` and `zeph-a2a`: fixed a bearer-token brute-force bypass caused by
+  middleware layer order (#6110, CWE-307). `auth_middleware` returns `401` directly
+  without calling `next.run`, so with auth layered outside `rate_limit_middleware`,
+  failed-auth requests never reached the per-IP counter — an attacker could brute-force
+  the bearer token with zero rate limiting. Swapped the `.layer()` order in
+  `build_router` (`zeph-gateway/src/router.rs`) and `build_router_with_full_config`
+  (`zeph-a2a/src/server/router.rs`) so `rate_limit_middleware` wraps `auth_middleware`,
+  guaranteeing every request — including failed-auth ones — increments the counter
+  before the auth check runs.
 - `IndexMcpServer` registration (`apply_code_retrieval` in `src/agent_setup.rs`) hardcoded
   `std::env::current_dir()` and never read `[index] workspace_root`, unlike the sibling
   background-indexer path (`apply_code_indexer`), which resolved it correctly. Scoping

--- a/crates/zeph-a2a/src/server/router.rs
+++ b/crates/zeph-a2a/src/server/router.rs
@@ -46,11 +46,11 @@ pub fn build_router_with_full_config(
     let protected = Router::new()
         .route("/a2a", post(jsonrpc_handler))
         .route("/a2a/stream", post(stream_handler))
+        .layer(middleware::from_fn_with_state(auth_cfg, auth_middleware))
         .layer(middleware::from_fn_with_state(
             rate_state,
             rate_limit_middleware,
         ))
-        .layer(middleware::from_fn_with_state(auth_cfg, auth_middleware))
         .layer(RequestBodyLimitLayer::new(max_body_size));
 
     Router::new()
@@ -264,6 +264,41 @@ mod tests {
         // Third request should be rate-limited
         let resp = app.call(make_req()).await.unwrap();
         assert_eq!(resp.status(), 429, "request 3 should be rate-limited");
+    }
+
+    #[tokio::test]
+    async fn failed_auth_requests_are_rate_limited() {
+        use tower::Service;
+
+        // Regression test for #6110: repeated failed-auth requests from the same IP must
+        // still increment the rate-limit counter, so a bearer-token brute-force gets
+        // throttled with 429 instead of bypassing rate limiting via 401 short-circuits.
+        let mut app = build_router_with_config(test_state(), Some("secret-token"), 2);
+
+        let make_req = || {
+            let body = serde_json::json!({
+                "jsonrpc": "2.0", "id": "1",
+                "method": "tasks/get", "params": {"id": "x"}
+            });
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer wrong-token")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap()
+        };
+
+        let resp = app.call(make_req()).await.unwrap();
+        assert_eq!(resp.status(), 401);
+        let resp = app.call(make_req()).await.unwrap();
+        assert_eq!(resp.status(), 401);
+        let resp = app.call(make_req()).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            429,
+            "third failed-auth request from the same IP must be rate-limited"
+        );
     }
 
     fn ip_from_index(i: usize) -> IpAddr {

--- a/crates/zeph-common/src/http_middleware.rs
+++ b/crates/zeph-common/src/http_middleware.rs
@@ -269,6 +269,11 @@ impl RateLimitState {
 /// - No token, `require_auth = true` → 401 with a warning log
 /// - No token, `require_auth = false` → passes through, `AuthIdentity { authenticated: false }`
 ///
+/// On failure this returns `401` directly, without calling `next.run` — so this middleware
+/// must be layered *inside* [`rate_limit_middleware`] (i.e. `rate_limit_middleware` wraps
+/// it). Otherwise failed-auth requests would never reach the rate limiter, letting an
+/// attacker brute-force the bearer token with no per-IP throttling.
+///
 /// # Errors
 ///
 /// Returns `401 Unauthorized` on authentication failure.
@@ -335,6 +340,13 @@ pub async fn auth_middleware(
 /// receives `429 Too Many Requests`.
 ///
 /// Setting [`RateLimitState::limit`] to `0` disables rate limiting entirely.
+///
+/// This middleware must be layered *outside* [`auth_middleware`] (i.e. it wraps
+/// `auth_middleware`, not the other way around), so that its counter is incremented for
+/// every request — including ones that fail authentication — before `auth_middleware`
+/// gets a chance to short-circuit with `401`. Layering auth outermost would let a
+/// failed-auth request skip the counter entirely, allowing unthrottled bearer-token
+/// brute-forcing.
 ///
 /// # Errors
 ///

--- a/crates/zeph-gateway/src/router.rs
+++ b/crates/zeph-gateway/src/router.rs
@@ -21,8 +21,14 @@ use super::server::AppState;
 ///
 /// Middleware stack applied to `/webhook` (outermost → innermost):
 /// 1. [`RequestBodyLimitLayer`] — rejects bodies larger than `max_body_size`
-/// 2. [`auth_middleware`] — constant-time bearer-token check
-/// 3. [`rate_limit_middleware`] — per-IP fixed-window counter
+/// 2. [`rate_limit_middleware`] — per-IP fixed-window counter
+/// 3. [`auth_middleware`] — constant-time bearer-token check
+///
+/// Rate limiting must wrap auth, not the other way around: [`auth_middleware`] returns
+/// `401` without calling `next.run`, so if it were outer, failed-auth requests would never
+/// reach the counter and an attacker could brute-force the bearer token with no throttling.
+/// Placing [`rate_limit_middleware`] outermost of the pair guarantees every request —
+/// including failed-auth ones — increments the per-IP counter before the auth check runs.
 pub(crate) fn build_router(
     state: AppState,
     auth_token: Option<&str>,
@@ -35,11 +41,11 @@ pub(crate) fn build_router(
 
     let protected = Router::new()
         .route("/webhook", post(webhook_handler))
+        .layer(middleware::from_fn_with_state(auth_cfg, auth_middleware))
         .layer(middleware::from_fn_with_state(
             rate_state,
             rate_limit_middleware,
         ))
-        .layer(middleware::from_fn_with_state(auth_cfg, auth_middleware))
         .layer(RequestBodyLimitLayer::new(max_body_size));
 
     Router::new()
@@ -202,6 +208,35 @@ mod tests {
         assert_eq!(resp.status(), 200);
         let resp = app.call(make_req()).await.unwrap();
         assert_eq!(resp.status(), 429);
+    }
+
+    #[tokio::test]
+    async fn failed_auth_requests_are_rate_limited() {
+        // Regression test for #6110: repeated failed-auth requests from the same IP must
+        // still increment the rate-limit counter, so a bearer-token brute-force gets
+        // throttled with 429 instead of bypassing rate limiting via 401 short-circuits.
+        let (mut app, _rx) = make_router(Some("secret"), 2);
+        let make_req = || {
+            let body = serde_json::json!({"channel":"a","sender":"b","body":"c"});
+            Request::builder()
+                .method("POST")
+                .uri("/webhook")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer wrong")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap()
+        };
+
+        let resp = app.call(make_req()).await.unwrap();
+        assert_eq!(resp.status(), 401);
+        let resp = app.call(make_req()).await.unwrap();
+        assert_eq!(resp.status(), 401);
+        let resp = app.call(make_req()).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            429,
+            "third failed-auth request from the same IP must be rate-limited"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `auth_middleware` (`crates/zeph-common/src/http_middleware.rs`) returns `401` directly without calling `next.run`, so with it layered outside `rate_limit_middleware` in both `zeph-gateway` and `zeph-a2a`, failed-auth requests never reached the per-IP rate-limit counter — an attacker could brute-force the bearer token with zero throttling (CWE-307).
- Swapped the `.layer()` order in `build_router` (`zeph-gateway/src/router.rs`) and `build_router_with_full_config` (`zeph-a2a/src/server/router.rs`) so `rate_limit_middleware` wraps `auth_middleware`. Every request — including failed-auth ones — now increments the per-IP counter before the auth check can short-circuit.
- Corrected the doc comments in `http_middleware.rs` and both router files, which previously described the vulnerable ordering as intentional.
- Added a regression test per crate (`failed_auth_requests_are_rate_limited`) asserting repeated failed-auth requests from the same IP eventually return `429` instead of `401`.

Closes #6110

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13095 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] New regression tests verified to fail under the pre-fix layer ordering and pass under the fix, in both `zeph-gateway` and `zeph-a2a` (including under `--features server` for the a2a `server` module)