### PR TITLE
fix(serve): wire per-session capability scopes, skill/memory tools, and policy fail-closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     (`TuiCommand::ViewLatency`, following the same pattern as `/cost`'s `view:cost`) prints
     the full avg/max turn-latency breakdown plus classifier p50/p95/call-count via
     `App::format_latency_stats`.
+- `serve-sessions`: closed three follow-up gaps in `/sessions*` HTTP+SSE session wiring
+  (#6045, #6046, #6008).
+  - `ScopedToolExecutor` (`[security.capability_scopes]`) is no longer built once, eagerly, and
+    shared across every concurrent `/sessions*` agent — it is now wrapped fresh per session in
+    `agent_factory::build_agent_factory`, mirroring `src/acp.rs`'s per-connection wrap, so each
+    session's `OutOfScope` capability-scope denials feed that session's own `TrajectorySentinel`
+    risk-escalation signal queue instead of being invisible to it. `assemble_serve_deps` still
+    validates the configured scope compiles against the tool registry at server startup (fatal
+    on a bad config, unchanged), it just no longer keeps the compiled instance — that startup
+    validation and the per-session wrap now share one `compose_session_tool_tree` helper so
+    both compile against the identical tool-id surface (including the `skill_loader`/
+    `invoke_skill`/`memory`/`overflow` tools below), fixing a false-positive startup abort for
+    any scope pattern that referenced one of those tools.
+  - `/sessions*` agents now get `skill_loader`/`invoke_skill`/`memory`/`overflow` tool executors,
+    matching CLI/TUI/ACP/daemon's tool surface — previously these were entirely absent from
+    serve's composite tool chain. MCP tools, the scheduler executor, and skill/config hot-reload
+    broadcast forwarding remain a separately-tracked known gap.
+  - A `[tools.policy]`/`[tools.authorization]` compile failure now aborts `serve-sessions`
+    startup instead of silently starting with declarative policy enforcement disabled — serve is
+    an HTTP-facing entrypoint with potentially remote/less-trusted callers, unlike CLI/TUI/ACP/
+    daemon (which stay intentionally fail-open on the same failure, unchanged).
 - `zeph-tui`: closed three independent dispatch/state gaps (#6061, #5984, #5983).
   - The task-registry overlay's supervisor-unavailable fallback (`render_subagents_slot`)
     drew its "supervisor not available" message directly into the shared subagents-slot

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -3638,6 +3638,7 @@ mod tests {
             adversarial_validator: None,
             adversarial_llm_client: None,
             adv_policy_info: None,
+            policy_configured: true,
         };
 
         let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1807,6 +1807,11 @@ pub(crate) struct PolicyGatePieces {
     /// currently reads this, to abort startup fail-closed on a real compile failure while
     /// staying fail-open when policy is legitimately absent. All other call sites (`runner.rs`,
     /// `acp.rs`, `daemon.rs`) ignore this field and keep their existing fail-open behavior.
+    ///
+    /// Only read from `src/serve/deps.rs`, which is gated behind `#[cfg(feature = "session")]`
+    /// (`src/main.rs`) — feature bundles that don't pull in `session` (e.g. `ide`, `chat`,
+    /// `bench`) never compile that reader, so this field is otherwise genuinely dead code there.
+    #[cfg_attr(not(feature = "session"), allow(dead_code))]
     pub(crate) policy_configured: bool,
 }
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1799,6 +1799,15 @@ pub(crate) struct PolicyGatePieces {
     /// populated unconditionally whenever the adversarial gate is enabled since it is plain
     /// data with no side effects, so entry points that ignore it are unaffected.
     pub(crate) adv_policy_info: Option<zeph_core::AdversarialPolicyInfo>,
+    /// `true` when `[tools.policy]`/`[tools.authorization]` was actually enabled by config
+    /// (the same `effective_policy.enabled` check `build_policy_gate_pieces` uses to decide
+    /// whether to attempt compilation at all) — regardless of whether that compile succeeded.
+    /// Lets a caller distinguish "`policy_enforcer` is None because compile failed" from
+    /// "`policy_enforcer` is None because no policy was configured" (#6008): only `serve/deps.rs`
+    /// currently reads this, to abort startup fail-closed on a real compile failure while
+    /// staying fail-open when policy is legitimately absent. All other call sites (`runner.rs`,
+    /// `acp.rs`, `daemon.rs`) ignore this field and keep their existing fail-open behavior.
+    pub(crate) policy_configured: bool,
 }
 
 /// Builds the adversarial-policy validator/LLM-client pair (and the `/adversarial-policy`
@@ -1944,6 +1953,7 @@ pub(crate) async fn build_policy_gate_pieces(
         } else {
             config.tools.policy.clone()
         };
+    let policy_configured = effective_policy.enabled;
     let policy_enforcer = if effective_policy.enabled {
         match zeph_tools::PolicyEnforcer::compile(&effective_policy) {
             Ok(enforcer) => Some(Arc::new(enforcer)),
@@ -1961,6 +1971,7 @@ pub(crate) async fn build_policy_gate_pieces(
         adversarial_validator,
         adversarial_llm_client,
         adv_policy_info,
+        policy_configured,
     }
 }
 
@@ -3390,6 +3401,7 @@ mod tests {
             adversarial_validator: None,
             adversarial_llm_client: None,
             adv_policy_info: None,
+            policy_configured: true,
         };
 
         let inner: Arc<dyn zeph_tools::ErasedToolExecutor> = Arc::new(NoopExec);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2227,6 +2227,7 @@ mod tests {
             adversarial_validator: None,
             adversarial_llm_client: None,
             adv_policy_info: None,
+            policy_configured: true,
         };
 
         let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -121,11 +121,31 @@ pub(crate) async fn build_agent_factory(
     let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
         Arc::new(parking_lot::Mutex::new(Vec::new()));
 
-    // SEC-H1 / R1: each session gets its own gate stack, wrapping the shared base composite —
-    // see `gate_serve_session_executor`'s doc comment for the full rationale and the INVARIANT
-    // that binds future serve tool-executor changes.
-    let gated_executor = gate_serve_session_executor(
+    // #6046: skill_loader/invoke_skill/memory/overflow — mirrors src/acp.rs's spawn_acp_agent
+    // and src/daemon.rs's run_daemon composition (skill_loader -> skill_invoke -> memory ->
+    // overflow -> base), closing the gap where `/sessions*` agents previously had none of these
+    // tools. Built here, in the async prefix (not the closure), since memory/overflow depend on
+    // this session's own `conversation_id` and skill_loader/skill_invoke need their own
+    // per-session `SkillTrustSnapshot` — mirrors ACP's per-connection build. Composed BEFORE the
+    // trust/policy/adversarial gate wrap below so these tools are covered by it too, instead of
+    // bypassing enforcement (#5977/#5611/#5748). `compose_session_tool_tree` is also called by
+    // `serve::deps::assemble_serve_deps`'s startup capability-scope validation (#6045/F1) — one
+    // source of truth for the tool-id surface a configured scope pattern may reference.
+    let memory_validation_config = deps.session_config.security.memory_validation.clone();
+    let (composed_base, trust_snapshot) = compose_session_tool_tree(
         deps.tool_executor,
+        &deps.registry,
+        &deps.memory,
+        conversation_id,
+        memory_validation_config,
+    );
+
+    // SEC-H1 / R1: each session gets its own gate stack, wrapping the composed per-session tree
+    // (base + skill_loader + skill_invoke + memory + overflow, #6046) — see
+    // `gate_serve_session_executor`'s doc comment for the full rationale and the INVARIANT that
+    // binds future serve tool-executor changes.
+    let gated_executor = gate_serve_session_executor(
+        composed_base,
         &deps.permission_policy,
         &deps.policy_gate_pieces,
         deps.audit_logger.as_ref(),
@@ -137,19 +157,28 @@ pub(crate) async fn build_agent_factory(
         // spawn_acp_agent's debug_config capture in src/acp.rs).
         let debug_config = deps.session_config.debug_config.clone();
 
-        // Spec 050 F2 (#5913): `capability_scopes` wrapping (when configured) already happened
-        // once in `serve::deps::assemble_serve_deps` — `deps.tool_executor` is shared/static
-        // across every `/sessions*` agent (unlike ACP's per-session composite), so the
-        // dead-glob outcome (FR-CG-005/NFR-CG-004) is knowable at startup and made fatal there
-        // (impl-critic F1), rather than degraded per-session here.
+        // #6045: wrap ScopedToolExecutor fresh per session (when
+        // `[security.capability_scopes]` is configured) around the already trust/policy/
+        // adversarial-gated tree — mirrors src/acp.rs/src/runner.rs's wiring order (Trust ->
+        // Policy/Adversarial -> Scope -> Shadow). `assemble_serve_deps` already validated
+        // `deps.capability_scopes_config` compiles against the tool registry at startup (fatal
+        // on error there, `serve::deps` module docs) — building the wrap fresh here, per
+        // session, lets `.with_signal_queue(...)` attach THIS session's own
+        // `trajectory_signal_queue` without leaking `OutOfScope` denials into other concurrent
+        // sessions sharing the same base composite (see `wrap_capability_scope`'s doc comment).
+        let scope_wrapped = wrap_capability_scope(
+            gated_executor.0,
+            &deps.capability_scopes_config,
+            &trajectory_signal_queue,
+        );
 
         // Spec 050 Phase 2 (#5913): wrap with ShadowProbeExecutor when
         // shadow_sentinel.enabled = true — mirrors src/runner.rs/src/acp.rs, where
         // ScopedToolExecutor/ShadowProbeExecutor wrap OUTSIDE/ABOVE the
         // Policy/Adversarial/Trust gate stack (not the raw base composite), so shadow-probing
-        // observes the same gated tree the agent actually dispatches through. Keyed by this
-        // session's own `conversation_id`, since `ServeAgentDeps.tool_executor` (unlike
-        // ACP's per-connection base chain) is shared across every `/sessions*` agent.
+        // observes the same gated (and now scoped) tree the agent actually dispatches through.
+        // Keyed by this session's own `conversation_id`, since `ServeAgentDeps.tool_executor`
+        // (unlike ACP's per-connection base chain) is shared across every `/sessions*` agent.
         let (final_tool_executor, shadow_sentinel_arc): (Arc<dyn ErasedToolExecutor>, _) =
             if deps.shadow_sentinel_config.enabled {
                 let sentinel_cfg = &deps.shadow_sentinel_config;
@@ -173,14 +202,14 @@ pub(crate) async fn build_agent_factory(
                         sentinel: Arc::clone(&sentinel),
                     });
                 let shadow_exec = zeph_tools::ShadowProbeExecutor::new(
-                    zeph_tools::DynExecutor(gated_executor.0.clone()),
+                    zeph_tools::DynExecutor(scope_wrapped),
                     probe_gate,
                     turn_number,
                     risk_level,
                 );
                 (Arc::new(shadow_exec), Some(sentinel))
             } else {
-                (gated_executor.0.clone(), None)
+                (scope_wrapped, None)
             };
 
         let mut agent = Agent::new_with_registry_arc(
@@ -209,6 +238,10 @@ pub(crate) async fn build_agent_factory(
         )
         .with_semantic_scan(deps.semantic_scan, deps.semantic_scan_provider)
         .with_trust_config(deps.trust_config)
+        // #6046: wire this session's SkillTrustSnapshot (from build_skill_executors above),
+        // matching src/acp.rs/src/daemon.rs — without this, SkillLoaderExecutor/
+        // SkillInvokeExecutor's trust bookkeeping would never reach the Agent that reads it.
+        .with_trust_snapshot(trust_snapshot)
         .with_rl_routing(
             deps.rl_routing_enabled,
             deps.rl_learning_rate,
@@ -273,20 +306,20 @@ pub(crate) async fn build_agent_factory(
 /// [`crate::agent_setup::apply_common_tool_gating`]'s doc comment and
 /// [`ServeAgentDeps::tool_executor`]'s doc comment for the full rationale.
 ///
-/// INVARIANT: `tool_executor` must already contain serve's ENTIRE tool surface (today: the base
-/// file/shell/scrape/cwd chain only — see `deps.rs::build_tool_executor`'s doc comment) — any
-/// tool executor added to `ServeAgentDeps` outside that base, or composed onto the result of
-/// this wrap, bypasses trust/policy/adversarial enforcement entirely. See #5977/#5611/#5748.
+/// INVARIANT: `tool_executor` must already contain serve's ENTIRE tool surface (the base
+/// file/shell/scrape/cwd chain plus `skill_loader`/`skill_invoke`/`memory`/`overflow`, #6046 — see
+/// `build_agent_factory`'s composition above this call and `deps.rs::build_tool_executor`'s doc
+/// comment for the base) — any tool executor added to `ServeAgentDeps` outside that composed
+/// tree, or composed onto the result of this wrap (other than the `ScopedToolExecutor`/
+/// `ShadowProbeExecutor` wraps `build_agent_factory` applies afterward, which wrap OUTSIDE the
+/// gate stack by design, matching `runner.rs`/`acp.rs`), bypasses trust/policy/adversarial
+/// enforcement entirely. See #5977/#5611/#5748.
 ///
 /// `trajectory`, when `Some`, wires `PolicyGateExecutor`'s trajectory-risk reporting (#5958) —
-/// see `apply_policy_gate_chain`'s doc comment. Note this does NOT cover `ScopedToolExecutor`
-/// (`[security.capability_scopes]`) `OutOfScope` denials feeding the same signal queue, unlike
-/// runner.rs/acp.rs/daemon.rs: serve wraps `ScopedToolExecutor` once, eagerly, in
-/// `deps.rs::assemble_serve_deps`, shared across every `/sessions*` agent (SEC-H1 rationale on
-/// `ServeAgentDeps::tool_executor`), before any per-session signal queue exists — attaching one
-/// session's queue there would leak its signals into every other session sharing the same
-/// executor. `PolicyGateExecutor`'s own declarative/adversarial-policy denials still reach
-/// `TrajectorySentinel` correctly since that gate IS per-session.
+/// see `apply_policy_gate_chain`'s doc comment. `ScopedToolExecutor`'s `OutOfScope` denials feed
+/// the same signal queue too, but that wrap happens separately, per session, in
+/// `wrap_capability_scope` (called by `build_agent_factory` after this function returns) — see
+/// its doc comment for why.
 fn gate_serve_session_executor(
     tool_executor: Arc<dyn zeph_tools::ErasedToolExecutor>,
     permission_policy: &zeph_tools::PermissionPolicy,
@@ -310,6 +343,128 @@ fn gate_serve_session_executor(
         audit_logger,
         trajectory,
     )
+}
+
+/// Wraps `tool_executor` (the already trust/policy/adversarial-gated tree from
+/// [`gate_serve_session_executor`]) in a fresh per-session `ScopedToolExecutor` when
+/// `[security.capability_scopes]` is configured (#6045) — mirrors `src/acp.rs`'s per-connection
+/// wrap and `src/runner.rs`'s wiring order (`ScopedToolExecutor` wraps OUTSIDE/ABOVE the
+/// Trust/Policy/Adversarial gate stack, not the raw base composite).
+///
+/// Built fresh per session, unlike `deps.rs::assemble_serve_deps`'s pre-#6045 eager wrap: a
+/// `ScopedToolExecutor` built once and shared across every `/sessions*` agent cannot receive a
+/// per-session `TrajectorySentinel` signal queue via `.with_signal_queue(...)` without leaking
+/// one session's `OutOfScope` denials into every other concurrent session sharing that instance
+/// — see [`ServeAgentDeps::capability_scopes_config`]'s doc comment. `assemble_serve_deps`
+/// already validated `scopes_cfg` compiles against the tool registry at server startup (fatal on
+/// error there, matching `runner.rs`/`daemon.rs`'s precedent for this process-global setting),
+/// so the `Err` branch below should be unreachable in practice — it is still handled fail-closed
+/// (deny all tool access for this session), not fail-open, matching how `src/acp.rs` handles the
+/// same theoretical race for its own per-connection wrap.
+fn wrap_capability_scope(
+    tool_executor: Arc<dyn zeph_tools::ErasedToolExecutor>,
+    scopes_cfg: &zeph_config::CapabilityScopesConfig,
+    trajectory_signal_queue: &zeph_tools::RiskSignalQueue,
+) -> Arc<dyn zeph_tools::ErasedToolExecutor> {
+    use zeph_tools::scope::build_scoped_executor;
+    if scopes_cfg.scopes.is_empty() {
+        return tool_executor;
+    }
+    let registry_ids: std::collections::HashSet<String> = tool_executor
+        .tool_definitions_erased()
+        .into_iter()
+        .map(|def| {
+            let id = def.id.to_string();
+            if id.contains(':') {
+                id
+            } else {
+                format!("builtin:{id}")
+            }
+        })
+        .collect();
+    // Retain a cheap Arc clone for the Err fallback below — `build_scoped_executor` takes
+    // `tool_executor` by value.
+    let fallback = Arc::clone(&tool_executor);
+    match build_scoped_executor(
+        zeph_tools::DynExecutor(tool_executor),
+        scopes_cfg,
+        &registry_ids,
+    ) {
+        Ok(scoped) => {
+            // #6045: OutOfScope denials feed the trajectory signal queue too, matching
+            // src/runner.rs/src/acp.rs/src/daemon.rs — otherwise capability-scope violations
+            // would be invisible to TrajectorySentinel's risk escalation.
+            let scoped = scoped.with_signal_queue(Arc::clone(trajectory_signal_queue));
+            Arc::new(scoped)
+        }
+        Err(e) => {
+            tracing::error!(
+                "capability_scopes: {e}, denying all tool access for this session (fail-closed)"
+            );
+            Arc::new(zeph_tools::scope::ScopedToolExecutor::new(
+                zeph_tools::DynExecutor(fallback),
+                zeph_tools::scope::ToolScope::empty(),
+            ))
+        }
+    }
+}
+
+/// Composes `skill_loader`/`skill_invoke`/`memory`/`overflow` (#6046) around `base`, mirroring
+/// `src/acp.rs`'s `spawn_acp_agent`/`src/daemon.rs`'s `run_daemon` composite order
+/// (`skill_loader -> skill_invoke -> memory -> overflow -> base`).
+///
+/// Two callers, one source of truth (#6045/F1): [`build_agent_factory`] uses this for the real
+/// per-session tool tree the agent dispatches through, and
+/// `serve::deps::assemble_serve_deps`'s startup `[security.capability_scopes]` validation uses
+/// it too — before this fix, that validation ran against `deps.rs::build_tool_executor`'s
+/// base-only registry (file/shell/scrape/cwd), which does NOT contain these four tools, so a
+/// scope pattern referencing e.g. `builtin:invoke_skill` compiled fine per-session but hit
+/// `ScopeError::DeadPattern` (a strict `builtin:`/`skill:` pattern matching zero registry ids)
+/// against the smaller startup registry, aborting `serve-sessions` startup even though the
+/// pattern was valid. Calling this same function at both sites keeps the two registries
+/// identical by construction — see [`ServeAgentDeps::capability_scopes_config`]'s doc comment.
+///
+/// `conversation_id`/`memory_validation_config` only affect `MemoryToolExecutor`'s *runtime*
+/// dispatch behavior (which conversation `memory_save`/`memory_search` read/write) — every
+/// executor's `tool_definitions()` is static regardless of these values, so a validation-only
+/// caller may pass placeholder values (e.g. `ConversationId(0)`,
+/// `MemoryWriteValidationConfig::default()`) safely; only the tool *ids* are used for
+/// registry-based scope validation, never the executors' dispatch behavior.
+#[allow(clippy::type_complexity)]
+pub(super) fn compose_session_tool_tree(
+    base: Arc<dyn ErasedToolExecutor>,
+    registry: &Arc<parking_lot::RwLock<zeph_skills::registry::SkillRegistry>>,
+    memory: &Arc<zeph_memory::semantic::SemanticMemory>,
+    conversation_id: zeph_memory::ConversationId,
+    memory_validation_config: zeph_config::MemoryWriteValidationConfig,
+) -> (
+    Arc<dyn ErasedToolExecutor>,
+    Arc<parking_lot::RwLock<std::collections::HashMap<String, zeph_core::SkillTrustSnapshot>>>,
+) {
+    let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::with_validator(
+        Arc::clone(memory),
+        conversation_id,
+        zeph_sanitizer::memory_validation::MemoryWriteValidator::new(memory_validation_config),
+    );
+    let overflow_executor =
+        zeph_core::overflow_tools::OverflowToolExecutor::new(Arc::new(memory.sqlite().clone()))
+            .with_conversation(conversation_id.0);
+    let (skill_loader_executor, skill_invoke_executor, trust_snapshot) =
+        crate::agent_setup::build_skill_executors(registry);
+    let composed: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::CompositeExecutor::new(
+        skill_loader_executor,
+        zeph_tools::CompositeExecutor::new(
+            skill_invoke_executor,
+            zeph_tools::CompositeExecutor::new(
+                memory_executor,
+                zeph_tools::CompositeExecutor::new(
+                    overflow_executor,
+                    zeph_tools::DynExecutor(base),
+                ),
+            ),
+        ),
+    ));
+    (composed, trust_snapshot)
 }
 
 /// Opens (and replays, per D-10) the durable event log for `session_id`, wraps it in a
@@ -687,6 +842,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_embed_dim_resolved: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
             policy_gate_pieces: crate::agent_setup::PolicyGatePieces::default(),
@@ -773,6 +929,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_embed_dim_resolved: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
             policy_gate_pieces: crate::agent_setup::PolicyGatePieces::default(),
@@ -886,6 +1043,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_embed_dim_resolved: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
             policy_gate_pieces: crate::agent_setup::PolicyGatePieces::default(),
@@ -984,6 +1142,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_embed_dim_resolved: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
             policy_gate_pieces: crate::agent_setup::PolicyGatePieces::default(),
@@ -1081,6 +1240,7 @@ mod tests {
             rl_warmup_updates: 3,
             rl_embed_dim_resolved: Some(8),
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
             policy_gate_pieces: crate::agent_setup::PolicyGatePieces::default(),
@@ -1176,6 +1336,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_embed_dim_resolved: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
             policy_gate_pieces: crate::agent_setup::PolicyGatePieces::default(),
@@ -1252,6 +1413,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_embed_dim_resolved: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default()
                 .with_autonomy(zeph_tools::AutonomyLevel::Full),
             audit_logger: None,
@@ -1377,6 +1539,7 @@ mod tests {
             adversarial_validator: None,
             adversarial_llm_client: None,
             adv_policy_info: None,
+            policy_configured: true,
         };
         let deps = make_gate_test_deps(
             memory,
@@ -1409,12 +1572,11 @@ mod tests {
     /// `gate_serve_session_executor` directly (same module) with a `[tools.policy]` deny rule
     /// and `Some((&trajectory_risk_slot, &trajectory_signal_queue))` exactly as
     /// `build_agent_factory` now does, and asserts the signal queue receives the `PolicyDeny`
-    /// code (`1`) after a denied call. Note this deliberately does NOT cover capability-scope
-    /// (`ScopedToolExecutor`) `OutOfScope` denials — per `gate_serve_session_executor`'s doc
-    /// comment, serve's `ScopedToolExecutor` is built once, eagerly, in
-    /// `deps.rs::assemble_serve_deps`, shared across every session, before any per-session
-    /// queue exists (SEC-H1); that gap is a documented, intentional deviation from ACP/daemon,
-    /// not something this PR closes.
+    /// code (`1`) after a denied call. The sibling capability-scope (`ScopedToolExecutor`)
+    /// `OutOfScope` signal source (#6045) is covered separately by
+    /// `wrap_capability_scope_wires_trajectory_signal_queue_on_out_of_scope_denial` below, since
+    /// that wrap now happens in a distinct function (`wrap_capability_scope`), called after
+    /// `gate_serve_session_executor` returns, not inside it.
     #[tokio::test]
     async fn gate_serve_session_executor_wires_trajectory_signal_queue_on_policy_denial() {
         let policy_config = zeph_tools::PolicyConfig {
@@ -1437,6 +1599,7 @@ mod tests {
             adversarial_validator: None,
             adversarial_llm_client: None,
             adv_policy_info: None,
+            policy_configured: true,
         };
 
         let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
@@ -1466,6 +1629,268 @@ mod tests {
              signal queue after a denied tool call, proving gate_serve_session_executor's \
              trajectory parameter is actually wired through to PolicyGateExecutor instead of \
              the old hardcoded None"
+        );
+    }
+
+    /// #6045 regression: `wrap_capability_scope`'s `ScopedToolExecutor` wrap must actually push
+    /// the `OutOfScope` signal code (`3`) into the trajectory signal queue it's given — before
+    /// this PR, serve's `ScopedToolExecutor` was built once, eagerly, in
+    /// `deps.rs::assemble_serve_deps`, shared across every `/sessions*` agent, before any
+    /// per-session queue existed, so it never received `.with_signal_queue(...)` at all and
+    /// capability-scope denials were invisible to `TrajectorySentinel`. Mirrors
+    /// `src/acp.rs`'s `trajectory_signal_queue_receives_scope_denial_in_acp_composite_chain`.
+    #[tokio::test]
+    async fn wrap_capability_scope_wires_trajectory_signal_queue_on_out_of_scope_denial() {
+        let scopes_cfg = zeph_config::CapabilityScopesConfig {
+            default_scope: "narrow".to_owned(),
+            scopes: std::collections::HashMap::from([(
+                "narrow".to_owned(),
+                zeph_config::ScopeConfig {
+                    patterns: vec!["builtin:read".to_owned()],
+                },
+            )]),
+            ..Default::default()
+        };
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+        // Base must register "read" (matching the "builtin:read" pattern above) so
+        // build_scoped_executor compiles successfully instead of hitting DeadPattern — a
+        // registry with zero matches for a strict `builtin:` pattern is a compile FAILURE
+        // (the fail-closed branch below, which intentionally does NOT get a signal queue,
+        // since it represents misconfiguration rather than a legitimate scope denial).
+        let wrapped = wrap_capability_scope(
+            Arc::new(zeph_tools::FileExecutor::new(vec![])),
+            &scopes_cfg,
+            &trajectory_signal_queue,
+        );
+
+        let denied = wrapped
+            .execute_tool_call_erased(&make_tool_call("bash"))
+            .await;
+        assert!(
+            matches!(denied, Err(zeph_tools::ToolError::OutOfScope { .. })),
+            "expected OutOfScope from ScopedToolExecutor for a tool outside the configured \
+             scope, got {denied:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![3u8],
+            "expected the OutOfScope signal code (3) to be pushed into the shared trajectory \
+             signal queue after a scope-denied tool call, proving wrap_capability_scope's \
+             .with_signal_queue(...) call is actually reachable"
+        );
+    }
+
+    /// #6045 end-to-end regression: a real agent built through `build_agent_factory` with
+    /// `[security.capability_scopes]` configured must admit an in-scope tool call while
+    /// rejecting an out-of-scope one — proving the per-session `wrap_capability_scope` call is
+    /// actually wired into the production closure (composed with #6046's `skill_loader`/
+    /// `skill_invoke`/`memory`/`overflow` tree), not just unit-tested in isolation above. Scopes on
+    /// `"builtin:set_working_directory"` (registered by `SetCwdExecutor`, present in
+    /// `make_gate_test_deps`'s base composite) specifically so `build_scoped_executor` compiles
+    /// a real scope instead of hitting `DeadPattern` (zero registry matches) and falling into
+    /// the fail-closed branch — which would also produce `OutOfScope` for every call and could
+    /// mask a broken scope wrap as a passing test.
+    #[tokio::test]
+    async fn build_agent_factory_wires_capability_scopes_per_session() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let session_id = zeph_common::SessionId::new("capability-scope-test-session");
+
+        let config = zeph_core::config::Config::default();
+        let session_config = zeph_core::AgentSessionConfig::from_config(&config, 4096);
+        let (condenser, token_counter) = make_test_condenser();
+        let mut deps = make_gate_test_deps(
+            memory,
+            session_config,
+            condenser,
+            token_counter,
+            crate::agent_setup::PolicyGatePieces::default(),
+        );
+        deps.capability_scopes_config = zeph_config::CapabilityScopesConfig {
+            default_scope: "narrow".to_owned(),
+            scopes: std::collections::HashMap::from([(
+                "narrow".to_owned(),
+                zeph_config::ScopeConfig {
+                    patterns: vec!["builtin:set_working_directory".to_owned()],
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let build_agent = build_agent_factory(deps, session_id, cid).await;
+        let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
+        let agent = build_agent(channel);
+        let executor = agent.tool_executor_arc();
+
+        // "invoke_skill" is registered (by #6046's skill_invoke_executor) but NOT admitted by
+        // the "narrow" scope above — must be rejected.
+        let denied = executor
+            .execute_tool_call_erased(&make_tool_call("invoke_skill"))
+            .await;
+        assert!(
+            matches!(denied, Err(zeph_tools::ToolError::OutOfScope { .. })),
+            "a [security.capability_scopes] scope that excludes \"invoke_skill\" must reject it \
+             through a /sessions-built agent's executor, proving build_agent_factory's \
+             per-session ScopedToolExecutor wrap is reachable, got {denied:?}"
+        );
+
+        // "set_working_directory" IS admitted — must reach past ScopedToolExecutor (proving the
+        // scope actually compiled, rather than the fail-closed empty-scope fallback denying
+        // everything indiscriminately).
+        let mut params = serde_json::Map::new();
+        params.insert("path".to_owned(), serde_json::Value::String(".".to_owned()));
+        let allowed = executor
+            .execute_tool_call_erased(&zeph_tools::ToolCall {
+                tool_id: "set_working_directory".into(),
+                params,
+                caller_id: None,
+                context: None,
+                tool_call_id: String::new(),
+                skill_name: None,
+            })
+            .await;
+        assert!(
+            !matches!(allowed, Err(zeph_tools::ToolError::OutOfScope { .. })),
+            "\"set_working_directory\" matches the active scope's pattern, so it must reach \
+             past ScopedToolExecutor instead of being rejected, got {allowed:?}"
+        );
+    }
+
+    /// #6045/F1 regression (critic finding): a `[security.capability_scopes]` scope that
+    /// admits a #6046 tool (`invoke_skill`, added by `compose_session_tool_tree`, not present
+    /// in `deps.rs::build_tool_executor`'s base file/shell/scrape/cwd chain) must actually admit
+    /// it through the per-session `ScopedToolExecutor` wrap, while still rejecting a tool
+    /// outside the scope. The sibling `build_agent_factory_wires_capability_scopes_per_session`
+    /// test above only scoped on a BASE tool and only asserted #6046-tool REJECTION — it would
+    /// not have caught F1 (the startup validation registry excluding #6046 tools entirely,
+    /// which manifests as `assemble_serve_deps` aborting startup, not as a per-session
+    /// admit/deny mismatch — see `assemble_serve_deps_succeeds_with_capability_scope_on_6046_tool`
+    /// in `serve/deps.rs` for that direct regression test). This test guards the per-session
+    /// admit path so a future regression narrowing `compose_session_tool_tree`'s output would
+    /// still be caught here even if the startup-validation registry stayed in sync.
+    #[tokio::test]
+    async fn build_agent_factory_admits_6046_tool_via_capability_scope() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let session_id = zeph_common::SessionId::new("capability-scope-6046-test-session");
+
+        let config = zeph_core::config::Config::default();
+        let session_config = zeph_core::AgentSessionConfig::from_config(&config, 4096);
+        let (condenser, token_counter) = make_test_condenser();
+        let mut deps = make_gate_test_deps(
+            memory,
+            session_config,
+            condenser,
+            token_counter,
+            crate::agent_setup::PolicyGatePieces::default(),
+        );
+        deps.capability_scopes_config = zeph_config::CapabilityScopesConfig {
+            default_scope: "skills-only".to_owned(),
+            scopes: std::collections::HashMap::from([(
+                "skills-only".to_owned(),
+                zeph_config::ScopeConfig {
+                    patterns: vec!["builtin:invoke_skill".to_owned()],
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let build_agent = build_agent_factory(deps, session_id, cid).await;
+        let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
+        let agent = build_agent(channel);
+        let executor = agent.tool_executor_arc();
+
+        // "invoke_skill" (a #6046 tool) IS admitted — must reach past ScopedToolExecutor.
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "skill_name".to_owned(),
+            serde_json::Value::String("nonexistent-skill".to_owned()),
+        );
+        let admitted = executor
+            .execute_tool_call_erased(&zeph_tools::ToolCall {
+                tool_id: "invoke_skill".into(),
+                params,
+                caller_id: None,
+                context: None,
+                tool_call_id: String::new(),
+                skill_name: None,
+            })
+            .await;
+        assert!(
+            !matches!(admitted, Err(zeph_tools::ToolError::OutOfScope { .. })),
+            "a [security.capability_scopes] scope on \"builtin:invoke_skill\" must admit it \
+             through a /sessions-built agent's executor — got {admitted:?}. If this fails, the \
+             startup validation registry (assemble_serve_deps) and the per-session scope \
+             registry (wrap_capability_scope) have diverged again (#6045/F1)."
+        );
+
+        // "set_working_directory" (a base tool, NOT in the scope) is still rejected.
+        let denied = executor
+            .execute_tool_call_erased(&make_tool_call("set_working_directory"))
+            .await;
+        assert!(
+            matches!(denied, Err(zeph_tools::ToolError::OutOfScope { .. })),
+            "a scope limited to \"builtin:invoke_skill\" must still reject \
+             \"set_working_directory\", got {denied:?}"
+        );
+    }
+
+    /// #6046 regression: `invoke_skill` must dispatch through `SkillInvokeExecutor` in a real
+    /// `/sessions`-built agent's composite — before this PR, `serve/deps.rs` never wired
+    /// `skill_loader`/`invoke_skill`/`memory`/`overflow` at all, so this call would have fallen
+    /// through to the base composite and failed with an unknown-tool error instead of
+    /// `SkillInvokeExecutor`'s own "skill not found" response. Mirrors `src/acp.rs`'s
+    /// `invoke_skill_reaches_skill_invoke_executor_in_full_acp_session_composite`.
+    #[tokio::test]
+    async fn build_agent_factory_wires_invoke_skill_executor() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let session_id = zeph_common::SessionId::new("invoke-skill-test-session");
+
+        let config = zeph_core::config::Config::default();
+        let session_config = zeph_core::AgentSessionConfig::from_config(&config, 4096);
+        let (condenser, token_counter) = make_test_condenser();
+        let deps = make_gate_test_deps(
+            memory,
+            session_config,
+            condenser,
+            token_counter,
+            crate::agent_setup::PolicyGatePieces::default(),
+        );
+
+        let build_agent = build_agent_factory(deps, session_id, cid).await;
+        let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
+        let agent = build_agent(channel);
+
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "skill_name".to_owned(),
+            serde_json::Value::String("nonexistent-skill".to_owned()),
+        );
+        let call = zeph_tools::ToolCall {
+            tool_id: "invoke_skill".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let result = agent
+            .tool_executor_arc()
+            .execute_tool_call_erased(&call)
+            .await;
+        let output = result
+            .expect("invoke_skill must dispatch successfully through SkillInvokeExecutor")
+            .expect("SkillInvokeExecutor must always return Some(ToolOutput) for invoke_skill");
+        assert!(
+            output
+                .summary
+                .contains("skill not found: nonexistent-skill"),
+            "expected the \"skill not found: ...\" summary that only SkillInvokeExecutor \
+             produces, proving invoke_skill actually reaches it in the /sessions-built agent's \
+             composite instead of falling through to an unknown-tool error, got: {output:?}"
         );
     }
 

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -9,7 +9,9 @@
 //! apply to a plain HTTP/SSE session, so it is not reused wholesale here. [`ServeAgentDeps`]
 //! covers the minimum needed for a working conversational session — provider, skills, memory,
 //! and a core tool set (shell/file/web/cwd, with sandbox and audit wired the same way
-//! `build_acp_deps` does for ACP sessions).
+//! `build_acp_deps` does for ACP sessions). `agent_factory::build_agent_factory` additionally
+//! composes `skill_loader`/`invoke_skill`/`memory`/`overflow` tool executors around this base
+//! per session (#6046), matching CLI/TUI/ACP/daemon's tool surface.
 //!
 //! **Known gap**: MCP tools, the scheduler executor, and skill/config hot-reload broadcast
 //! forwarding are not wired here — a session created via `/sessions` does not see MCP-provided
@@ -23,6 +25,13 @@
 //! SEC-H1). MCP is still absent from the gated tree (the gap above), so
 //! `agent_setup::register_mcp_tool_ids` is called with an empty slice for now — the seam a
 //! future MCP-wiring PR must populate.
+//!
+//! **`[tools.policy]` compile failure (#6008)**: unlike CLI/TUI/ACP/daemon, which stay
+//! fail-open (see `agent_setup::build_policy_gate_pieces`'s doc comment) since an operator
+//! running those locally sees the `tracing::error!` line themselves, [`assemble_serve_deps`]
+//! aborts `serve-sessions` startup on a real compile failure — an HTTP-facing entrypoint with
+//! potentially remote/less-trusted callers has no other way to learn policy enforcement is
+//! silently disabled.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -89,6 +98,21 @@ pub(crate) struct ServeAgentDeps {
     /// fresh trust/policy/adversarial gate stack around this shared base **per session** — see
     /// its doc comment. This field must never be dispatched to directly without that wrap.
     pub(crate) tool_executor: Arc<dyn ErasedToolExecutor>,
+    /// `[security.capability_scopes]` snapshot (#6045). `assemble_serve_deps` only *validates*
+    /// this compiles against the tool registry at startup (fatal on error, matching
+    /// `runner.rs`/`daemon.rs`'s precedent for this process-global config) — the actual
+    /// `ScopedToolExecutor` WRAP happens fresh per session in
+    /// `agent_factory::build_agent_factory`, mirroring `src/acp.rs`'s per-connection wrap, so
+    /// each session's `OutOfScope` denials can feed that session's own `TrajectorySentinel`
+    /// signal queue via `.with_signal_queue(...)` without leaking into other concurrent
+    /// sessions sharing this same config snapshot.
+    ///
+    /// The startup validation and the per-session wrap must compile patterns against the SAME
+    /// tool-id registry, or a pattern valid per-session can falsely abort startup (#6045/F1,
+    /// caught by adversarial review): both call sites use
+    /// `agent_factory::compose_session_tool_tree` to build that registry, so they can never
+    /// drift apart.
+    pub(crate) capability_scopes_config: zeph_config::CapabilityScopesConfig,
     /// Shared permission policy, threaded into each session's `TrustGateExecutor` wrap (via
     /// `agent_setup::apply_common_tool_gating`) in `agent_factory::build_agent_factory`.
     pub(crate) permission_policy: zeph_tools::PermissionPolicy,
@@ -201,6 +225,22 @@ pub(crate) async fn assemble_serve_deps(
     // session's trust level clobber another's).
     let policy_gate_pieces =
         crate::agent_setup::build_policy_gate_pieces(config, &core.provider).await;
+    // #6008: `PolicyEnforcer::compile` failure is intentionally fail-open at all four
+    // `Agent`-construction entry points (`build_policy_gate_pieces` leaves `policy_enforcer:
+    // None` and logs `tracing::error!`, per #5973/#5977/#5886) — CLI/TUI/ACP/daemon operators
+    // see that log line in their own terminal. `serve-sessions` is HTTP-facing with potentially
+    // remote/less-trusted callers who have no such visibility, so it diverges here: abort
+    // startup rather than silently accepting connections with declarative policy unenforced.
+    // `policy_configured` (true only when `[tools.policy]`/`[tools.authorization]` was actually
+    // enabled) distinguishes a real compile failure from policy being legitimately absent by
+    // config, which must stay fail-open (no rules configured is not a degraded state).
+    if policy_gate_pieces.policy_configured && policy_gate_pieces.policy_enforcer.is_none() {
+        anyhow::bail!(
+            "[tools.policy]/[tools.authorization] failed to compile (see the preceding error \
+             log for details) — refusing to start serve-sessions with policy enforcement \
+             silently disabled; fix the policy config or disable it explicitly to proceed"
+        );
+    }
     // R6: startup observability log, reflecting ACTUAL compiled/config state — emitted ONCE
     // here (not inside `build_policy_gate_pieces`, which would also change daemon/acp/runner
     // startup output). `policy=on` only distinguishes "compiled" from "off/failed"; the
@@ -214,45 +254,56 @@ pub(crate) async fn assemble_serve_deps(
         "serve-sessions: gate stack active (per-session trust/policy/adversarial wrap)"
     );
 
-    // Spec 050 F2 (#5913): wrap with ScopedToolExecutor when capability_scopes are configured —
-    // mirrors src/runner.rs/src/daemon.rs. `tool_executor` here is shared/static across every
-    // `/sessions*` agent (unlike ACP's per-session composite), so the dead-glob outcome
-    // (FR-CG-005/NFR-CG-004) is knowable at startup, before any live session exists — same as
-    // runner.rs's CLI process and daemon.rs's static agent, so this is a fatal startup error
-    // (`?`) rather than a per-session degradation (impl-critic F1: degrading to the unscoped
-    // executor would be fail-OPEN for a security control the operator explicitly enabled, and
-    // `capability_scopes` is process-global — a config typo would silently disable scoping for
-    // every `/sessions*` agent).
-    let tool_executor: Arc<dyn ErasedToolExecutor> = {
-        let scopes_cfg = config.security.capability_scopes.clone();
-        if scopes_cfg.scopes.is_empty() {
-            tool_executor
-        } else {
-            use zeph_tools::scope::build_scoped_executor;
-            let registry_ids: std::collections::HashSet<String> = tool_executor
-                .tool_definitions_erased()
-                .into_iter()
-                .map(|def| {
-                    let id = def.id.to_string();
-                    if id.contains(':') {
-                        id
-                    } else {
-                        format!("builtin:{id}")
-                    }
-                })
-                .collect();
-            match build_scoped_executor(
-                zeph_tools::DynExecutor(tool_executor),
-                &scopes_cfg,
-                &registry_ids,
-            ) {
-                Ok(scoped) => Arc::new(scoped),
-                Err(e) => {
-                    anyhow::bail!("capability_scopes: {e}");
+    // Spec 050 F2 (#5913): validate `capability_scopes` compiles against the tool registry —
+    // mirrors src/runner.rs/src/daemon.rs's fatal-startup-error precedent for this
+    // process-global config (a typo should not silently disable scoping for every
+    // `/sessions*` agent). The actual `ScopedToolExecutor` WRAP now happens fresh per session
+    // in `agent_factory::build_agent_factory` (#6045), mirroring `src/acp.rs`, so it can attach
+    // that session's own `TrajectorySentinel` signal queue — see
+    // `ServeAgentDeps::capability_scopes_config`'s doc comment. This is validation-only: the
+    // compiled `ScopedToolExecutor` built here is discarded, not stored, since `tool_executor`
+    // must stay the unscoped base for the per-session wrap to compose around.
+    //
+    // #6045/F1: the registry validated here MUST be the same tool-id surface the per-session
+    // wrap will scope, not just the shared base — otherwise a scope pattern referencing a
+    // #6046 tool (skill_loader/skill_invoke/memory/overflow, not present in the bare
+    // `build_tool_executor` base) compiles fine per-session but fatally aborts startup here as
+    // a `DeadPattern` (zero matches against the smaller base-only registry), even though the
+    // pattern is valid. `agent_factory::compose_session_tool_tree` is the one function both
+    // this validation and `build_agent_factory`'s real per-session tree call, so the two
+    // registries can never drift apart. `conversation_id`/`memory_validation_config` only
+    // affect runtime dispatch, not `tool_definitions()` — safe to use placeholder values here.
+    let capability_scopes_config = config.security.capability_scopes.clone();
+    if !capability_scopes_config.scopes.is_empty() {
+        use zeph_tools::scope::build_scoped_executor;
+        let (composed_for_validation, _trust_snapshot) =
+            crate::serve::agent_factory::compose_session_tool_tree(
+                Arc::clone(&tool_executor),
+                &core.registry,
+                &core.memory,
+                zeph_memory::ConversationId(0),
+                zeph_config::MemoryWriteValidationConfig::default(),
+            );
+        let registry_ids: std::collections::HashSet<String> = composed_for_validation
+            .tool_definitions_erased()
+            .into_iter()
+            .map(|def| {
+                let id = def.id.to_string();
+                if id.contains(':') {
+                    id
+                } else {
+                    format!("builtin:{id}")
                 }
-            }
+            })
+            .collect();
+        if let Err(e) = build_scoped_executor(
+            zeph_tools::DynExecutor(composed_for_validation),
+            &capability_scopes_config,
+            &registry_ids,
+        ) {
+            anyhow::bail!("capability_scopes: {e}");
         }
-    };
+    }
 
     // #5914: memory maintenance loops — mirrors src/runner.rs's CLI/TUI wiring so `/sessions*`
     // agents get the same ongoing eviction/tier-promotion/scene-consolidation/consolidation/
@@ -390,6 +441,7 @@ pub(crate) async fn assemble_serve_deps(
         rl_warmup_updates: config.skills.rl_warmup_updates,
         rl_embed_dim_resolved: core.rl_embed_dim_resolved,
         tool_executor,
+        capability_scopes_config,
         permission_policy,
         audit_logger,
         policy_gate_pieces,
@@ -580,10 +632,13 @@ pub(crate) async fn resolve_auth_token(app: &crate::bootstrap::AppBuilder) -> Op
 /// `agent_factory::build_agent_factory` (SEC-H1) — see [`ServeAgentDeps::tool_executor`]'s doc
 /// comment.
 ///
-/// INVARIANT: any tool executor added to serve's base composite MUST be composited in HERE,
-/// before this function returns — `agent_factory::build_agent_factory` gates exactly this
-/// returned tree (plus nothing else) per session; anything composed onto `ServeAgentDeps`
-/// downstream of that wrap would bypass trust/policy/adversarial enforcement entirely. See
+/// INVARIANT: any *shared, session-independent* tool executor MUST be composited in HERE,
+/// before this function returns, so it is part of the tree `agent_factory::build_agent_factory`
+/// gates. `skill_loader`/`invoke_skill`/`memory`/`overflow` (#6046) are the one exception —
+/// they depend on a per-session `conversation_id`, so `build_agent_factory` composes them
+/// itself, still *before* wrapping the trust/policy/adversarial gate stack around the combined
+/// tree — see its doc comment. Anything composed onto `ServeAgentDeps` downstream of that gate
+/// wrap (in either function) would bypass trust/policy/adversarial enforcement entirely. See
 /// #5977/#5611/#5748.
 async fn build_tool_executor(
     config: &zeph_core::config::Config,
@@ -720,15 +775,29 @@ mod tests {
         }
     }
 
-    /// Regression test confirming `ScopedToolExecutor` (Spec 050 F2, #5913) is reachable
-    /// through `assemble_serve_deps` itself — the real, shipped production function, not a
-    /// reconstruction — since `capability_scopes` wrapping now happens once here (fatal on a
-    /// bad config, mirroring `src/daemon.rs`) rather than per-session in
-    /// `agent_factory::build_agent_factory`. Configures a narrow `[security.capability_scopes]`
-    /// scope and asserts the resulting `ServeAgentDeps.tool_executor` rejects a tool outside
-    /// the scope while an in-scope tool still dispatches.
+    fn make_test_core(memory: Arc<SemanticMemory>) -> crate::acp::SharedCore {
+        let provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+        crate::acp::SharedCore {
+            provider: provider.clone(),
+            embedding_provider: provider,
+            registry: Arc::new(RwLock::new(zeph_skills::registry::SkillRegistry::empty())),
+            matcher: None,
+            memory,
+            budget_tokens: 4096,
+            rl_embed_dim_resolved: None,
+        }
+    }
+
+    /// #6045 regression: `assemble_serve_deps` must *validate* `[security.capability_scopes]`
+    /// at startup (fatal on a bad config, mirroring `src/runner.rs`/`src/daemon.rs`'s
+    /// precedent for this process-global setting) but must NOT bake a `ScopedToolExecutor`
+    /// wrap into `ServeAgentDeps.tool_executor` — that field must stay the unscoped base so
+    /// `agent_factory::build_agent_factory` can wrap it fresh per session (see
+    /// `ServeAgentDeps::capability_scopes_config`'s doc comment for why: a shared, eagerly
+    /// wrapped instance cannot receive a per-session `TrajectorySentinel` signal queue without
+    /// leaking one session's `OutOfScope` signals into every other concurrent session).
     #[tokio::test]
-    async fn assemble_serve_deps_wraps_tool_executor_with_capability_scopes() {
+    async fn assemble_serve_deps_validates_but_does_not_wrap_capability_scopes() {
         let mut config = zeph_core::config::Config::default();
         config.security.capability_scopes = zeph_config::CapabilityScopesConfig {
             default_scope: "narrow".to_owned(),
@@ -742,16 +811,7 @@ mod tests {
         };
         let app = crate::bootstrap::AppBuilder::for_test(config);
         let memory = make_memory().await;
-        let provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
-        let core = crate::acp::SharedCore {
-            provider: provider.clone(),
-            embedding_provider: provider,
-            registry: Arc::new(RwLock::new(zeph_skills::registry::SkillRegistry::empty())),
-            matcher: None,
-            memory,
-            budget_tokens: 4096,
-            rl_embed_dim_resolved: None,
-        };
+        let core = make_test_core(memory);
         let cancel = tokio_util::sync::CancellationToken::new();
         let supervisor = zeph_common::task_supervisor::TaskSupervisor::new(cancel);
 
@@ -759,7 +819,17 @@ mod tests {
             .await
             .expect("assemble_serve_deps must succeed with a valid single-pattern scope");
 
-        let denied = deps
+        assert_eq!(
+            deps.capability_scopes_config.scopes.len(),
+            1,
+            "the validated config must be carried forward on ServeAgentDeps for the \
+             per-session wrap"
+        );
+
+        // "bash" is outside the configured scope, but `deps.tool_executor` must still be the
+        // UNSCOPED base — `ScopedToolExecutor` no longer wraps it here — so this call must NOT
+        // be rejected with OutOfScope (it fails for an unrelated reason: no shell config).
+        let result = deps
             .tool_executor
             .execute_tool_call_erased(&zeph_tools::ToolCall {
                 tool_id: "bash".into(),
@@ -771,31 +841,133 @@ mod tests {
             })
             .await;
         assert!(
-            matches!(denied, Err(zeph_tools::ToolError::OutOfScope { .. })),
-            "expected OutOfScope from ScopedToolExecutor for a tool outside the configured \
-             scope, got {denied:?}"
+            !matches!(result, Err(zeph_tools::ToolError::OutOfScope { .. })),
+            "deps.tool_executor must stay unscoped after assemble_serve_deps — the scope wrap \
+             now happens per session in agent_factory::build_agent_factory, got {result:?}"
         );
+    }
 
-        // "read" matches the active scope's pattern, so it must reach the underlying
-        // `FileExecutor` instead of being rejected by `ScopedToolExecutor` — asserting on the
-        // absence of `OutOfScope` rather than a bare `is_ok()`, since an empty `params` map
-        // still fails `FileExecutor`'s own param validation (missing `path`), which is a
-        // separate, expected failure mode that proves the call *did* reach past the scope gate.
-        let allowed = deps
-            .tool_executor
-            .execute_tool_call_erased(&zeph_tools::ToolCall {
-                tool_id: "read".into(),
-                params: serde_json::Map::new(),
-                caller_id: None,
-                context: None,
-                tool_call_id: String::new(),
-                skill_name: None,
-            })
-            .await;
+    /// #6045/F1 regression (critic finding): before this fix, `assemble_serve_deps`'s startup
+    /// capability-scope validation compiled patterns against `build_tool_executor`'s base-only
+    /// registry (file/shell/scrape/cwd), which does NOT include the #6046 tools
+    /// (`skill_loader`/`invoke_skill`/`memory`/`overflow`). A scope pattern referencing a
+    /// #6046 tool — e.g. `builtin:invoke_skill`, a strict namespace under the default
+    /// `PatternStrictness::ProvisionalForDynamicNamespaces` — matched zero ids in that smaller
+    /// registry and hit `ScopeError::DeadPattern`, aborting `serve-sessions` startup entirely
+    /// even though the pattern is valid against the real per-session registry
+    /// `agent_factory::wrap_capability_scope` uses. `assemble_serve_deps` must now validate
+    /// against the SAME composed registry (`agent_factory::compose_session_tool_tree`) the
+    /// per-session wrap uses, so this must succeed, not abort.
+    #[tokio::test]
+    async fn assemble_serve_deps_succeeds_with_capability_scope_on_6046_tool() {
+        let mut config = zeph_core::config::Config::default();
+        config.security.capability_scopes = zeph_config::CapabilityScopesConfig {
+            default_scope: "skills-only".to_owned(),
+            scopes: std::collections::HashMap::from([(
+                "skills-only".to_owned(),
+                zeph_config::ScopeConfig {
+                    patterns: vec!["builtin:invoke_skill".to_owned()],
+                },
+            )]),
+            ..Default::default()
+        };
+        let app = crate::bootstrap::AppBuilder::for_test(config);
+        let memory = make_memory().await;
+        let core = make_test_core(memory);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let supervisor = zeph_common::task_supervisor::TaskSupervisor::new(cancel);
+
+        let result = assemble_serve_deps(&app, &core, &supervisor).await;
         assert!(
-            !matches!(allowed, Err(zeph_tools::ToolError::OutOfScope { .. })),
-            "expected read to reach past ScopedToolExecutor since it matches the active \
-             scope's pattern, got {allowed:?}"
+            result.is_ok(),
+            "a [security.capability_scopes] pattern targeting a #6046 tool (\"builtin:invoke_skill\") \
+             must NOT abort serve-sessions startup — it is valid against the real per-session \
+             registry, got err: {:?}",
+            result.err().map(|e| e.to_string())
         );
+    }
+
+    /// #6045: a `[security.capability_scopes]` pattern that fails to compile against the tool
+    /// registry must still abort `serve-sessions` startup — mirrors the pre-#6045 fatal-error
+    /// behavior, just moved to a validation-only build rather than the (now removed) eager wrap.
+    #[tokio::test]
+    async fn assemble_serve_deps_fails_startup_on_invalid_capability_scope_pattern() {
+        let mut config = zeph_core::config::Config::default();
+        config.security.capability_scopes = zeph_config::CapabilityScopesConfig {
+            default_scope: "broken".to_owned(),
+            scopes: std::collections::HashMap::from([(
+                "broken".to_owned(),
+                zeph_config::ScopeConfig {
+                    patterns: vec!["[".to_owned()],
+                },
+            )]),
+            ..Default::default()
+        };
+        let app = crate::bootstrap::AppBuilder::for_test(config);
+        let memory = make_memory().await;
+        let core = make_test_core(memory);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let supervisor = zeph_common::task_supervisor::TaskSupervisor::new(cancel);
+
+        let result = assemble_serve_deps(&app, &core, &supervisor).await;
+        assert!(
+            result.is_err(),
+            "an invalid capability_scopes glob pattern must abort serve-sessions startup"
+        );
+    }
+
+    /// #6008 regression: unlike CLI/TUI/ACP/daemon (which stay fail-open on a
+    /// `[tools.policy]` compile failure, per #5973/#5977/#5886), `assemble_serve_deps` must
+    /// abort `serve-sessions` startup instead of silently leaving `policy_enforcer: None` for
+    /// an HTTP-facing entrypoint. Uses an invalid `args_match` regex (`(` is unterminated) to
+    /// make `PolicyEnforcer::compile` fail without touching the filesystem.
+    #[tokio::test]
+    async fn assemble_serve_deps_fails_startup_on_policy_compile_failure() {
+        let mut config = zeph_core::config::Config::default();
+        config.tools.policy = zeph_tools::PolicyConfig {
+            enabled: true,
+            default_effect: zeph_tools::DefaultEffect::Allow,
+            rules: vec![zeph_tools::PolicyRuleConfig {
+                effect: zeph_tools::PolicyEffect::Deny,
+                tool: "shell".into(),
+                paths: vec![],
+                env: vec![],
+                trust_level: None,
+                args_match: Some("(".to_owned()),
+                capabilities: vec![],
+            }],
+            ..Default::default()
+        };
+        let app = crate::bootstrap::AppBuilder::for_test(config);
+        let memory = make_memory().await;
+        let core = make_test_core(memory);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let supervisor = zeph_common::task_supervisor::TaskSupervisor::new(cancel);
+
+        let result = assemble_serve_deps(&app, &core, &supervisor).await;
+        assert!(
+            result.is_err(),
+            "a [tools.policy] compile failure must abort serve-sessions startup (fail-closed), \
+             not silently disable policy enforcement"
+        );
+    }
+
+    /// Counterpart to the failure test above: `[tools.policy]` being absent/disabled entirely
+    /// is a legitimate, non-degraded state and must stay fail-open — `assemble_serve_deps` must
+    /// still succeed.
+    #[tokio::test]
+    async fn assemble_serve_deps_succeeds_when_policy_not_configured() {
+        let config = zeph_core::config::Config::default();
+        let app = crate::bootstrap::AppBuilder::for_test(config);
+        let memory = make_memory().await;
+        let core = make_test_core(memory);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let supervisor = zeph_common::task_supervisor::TaskSupervisor::new(cancel);
+
+        let deps = assemble_serve_deps(&app, &core, &supervisor).await.expect(
+            "[tools.policy] absent by config is legitimate and must stay fail-open, not \
+                 abort startup",
+        );
+        assert!(deps.policy_gate_pieces.policy_enforcer.is_none());
     }
 }

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -527,6 +527,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_embed_dim_resolved: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
             policy_gate_pieces: crate::agent_setup::PolicyGatePieces::default(),

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -127,6 +127,7 @@ impl ServeTestHarness {
             rl_warmup_updates: 0,
             rl_embed_dim_resolved: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
             policy_gate_pieces: crate::agent_setup::PolicyGatePieces::default(),


### PR DESCRIPTION
## Summary

Closes three follow-up gaps in Zeph's `src/serve/*` subsystem (`/sessions*` HTTP+SSE API), all identified during adversarial critic review of recent PRs (#5951/#5958/#5975, #5973/#5977/#5886):

- `ScopedToolExecutor` (`[security.capability_scopes]`) was built once, eagerly, and shared across every concurrent `/sessions*` agent, so it never received a per-session signal-queue wire-up — `OutOfScope` capability-scope denials never reached that session's `TrajectorySentinel` risk-escalation tracking, unlike ACP and daemon. It is now wrapped fresh per session, mirroring ACP's per-connection wiring order.
- `/sessions*` agents never had `skill_loader`, `invoke_skill` (`SkillInvokeExecutor`), `memory`, or `overflow` tool executors wired in at all, unlike CLI/TUI/ACP/daemon. These are now composed into serve's per-session tool chain, inside the existing trust/policy/adversarial gate stack.
- A `[tools.policy]`/`[tools.authorization]` compile failure silently fell back to disabled policy enforcement for serve too (the same fail-open CLI/ACP/daemon intentionally keep) — but serve is an HTTP-facing entrypoint with potentially remote/less-trusted callers who have no visibility into an operator-console-only `tracing::error!` line. Serve now aborts startup fail-closed on a real compile failure while staying fail-open when `[tools.policy]` is legitimately unconfigured.

A follow-up finding from the adversarial critic (startup capability-scope validation compiling against a different, narrower tool registry than the per-session wrap — a default-config-reachable false-positive startup abort) was fixed in the same PR by unifying both call sites through one `compose_session_tool_tree` helper, so the two registries can no longer drift apart.

Closes #6045
Closes #6046
Closes #6008

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13081/13081 passed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`) — clean
- [x] Adversarial critic review (2 rounds — found + fixed a registry-drift issue between startup validation and per-session scoping)
- [x] Code review — approved
- [x] `.local/testing/playbooks/serve.md` and `.local/testing/coverage-status.md` updated with live-testing scenarios for all three fixes