### PR TITLE
fix(tui): wire live worktree state and turn-latency/classifier metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   per turn, not once, so bridging it would report the wrong (last) call's duration instead of
   the first user-message persist that `TurnTimings::persist_message_ms` is meant to measure;
   that field stays manually-timed only.
+- `zeph-tui`: closed two metrics/data wiring gaps left by PR #6131 (#6132, #6059).
+  - `TuiCommand::WorktreeList`/`WorktreeClean` were CLI-redirect stubs pointing users at
+    `zeph worktree list`/`clean` because no path existed from `zeph-tui` to the running
+    agent's live `WorktreeManager` (private inside `zeph-subagent::SubAgentManager`). Added a
+    real `/worktree list`/`/worktree clean [--force]` slash command
+    (`zeph-commands::handlers::worktree::WorktreeCommand`, wired through a new
+    `AgentAccess::list_worktrees`/`clean_worktrees` pair and
+    `Agent::handle_worktree_list_as_string`/`handle_worktree_clean_as_string` in
+    `zeph-core`), backed by `SubAgentManager::worktree_manager()` — a new public getter for
+    the same live manager instance `spawn` already uses. The TUI reducer now forwards
+    `TuiCommand::WorktreeList`/`WorktreeClean` as `Effect::SendUserInput("/worktree list" /
+    "/worktree clean")` instead of pushing a static message, so results reflect this
+    session's actual worktree state, consistent with how `/skill`, `/mcp`, and `/scheduler`
+    already work. `WorktreeManager` gained a `prune_branch_on_remove()` getter so
+    `/worktree clean` can read `WorktreeConfig::prune_branch_on_remove` directly from the
+    manager it already holds, without `SubAgentManager` needing to duplicate it or
+    `zeph-core` needing to depend on the full worktree config.
+  - `MetricsSnapshot::classifier` (p50/p95 latency per classifier task) and
+    `avg_turn_timings`/`max_turn_timings` (rolling-window turn latency) were populated every
+    turn but had zero consumers in `zeph-tui` — only `last_turn_timings.{prepare_context_ms,
+    llm_chat_ms}` ever reached a widget. The resources side panel's latency line now also
+    shows `tool_exec_ms`/`persist_message_ms`, and a new classifier-latency line (p50 only,
+    compact) appears once any classifier has recorded a call. A new `view:latency` command
+    (`TuiCommand::ViewLatency`, following the same pattern as `/cost`'s `view:cost`) prints
+    the full avg/max turn-latency breakdown plus classifier p50/p95/call-count via
+    `App::format_latency_stats`.
 - `zeph-tui`: closed three independent dispatch/state gaps (#6061, #5984, #5983).
   - The task-registry overlay's supervisor-unavailable fallback (`render_subagents_slot`)
     drew its "supervisor not available" message directly into the shared subagents-slot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10682,6 +10682,7 @@ dependencies = [
  "zeph-subagent",
  "zeph-tools",
  "zeph-vault",
+ "zeph-worktree",
  "zeroize",
 ]
 

--- a/book/src/advanced/tui.md
+++ b/book/src/advanced/tui.md
@@ -162,6 +162,9 @@ Available commands:
 | `view:tools` | List available tools | |
 | `view:config` | Show active configuration | |
 | `view:autonomy` | Show autonomy/trust level | |
+| `view:latency` | Show classifier and turn-latency breakdown (avg/max per phase, p50/p95 per classifier) | |
+| `worktree:list` | List active and stale git worktrees (`/worktree list`) | |
+| `worktree:clean` | Remove stale git worktrees (`/worktree clean`) | |
 | `session:new` | Start new conversation | |
 | `session:switch-next` | Switch to next conversation | |
 | `session:switch-prev` | Switch to previous conversation | |
@@ -490,7 +493,7 @@ The TUI dashboard displays real-time metrics collected from the agent loop via `
 |-------|---------|
 | **Skills** | Active/total skill count, matched skill names per query |
 | **Memory** | SQLite message count, conversation ID, Qdrant status, embeddings generated, summaries count, tool output prunes, embed backfill progress |
-| **Resources** | Prompt/completion/total tokens, API calls, last LLM latency (ms), provider and model name, prompt cache read/write tokens, filter stats |
+| **Resources** | Prompt/completion/total tokens, API calls, last LLM latency (ms), provider and model name, prompt cache read/write tokens, filter stats, per-phase turn-latency breakdown, classifier p50 latency |
 | **Compaction** | Compaction probe verdicts (Pass/SoftFail/HardFail/Error counts), last probe score, subgoal registry state (when orchestration active) |
 | **Security** | Sanitizer runs/flags/truncations, quarantine calls/failures, exfiltration blocks (images/URLs/memory), recent event log. Shown in place of sub-agents panel when events are recent (< 60s) |
 
@@ -548,6 +551,41 @@ Each filter reports how confident it is in the result. The `Confidence: F/1 P/0 
 **Example:** `Confidence: F/1 P/0 B/3` means 1 command was filtered with Full confidence (e.g. `cargo test` — 99% savings) and 3 commands fell through to Fallback (e.g. `cargo audit`, `cargo doc`, `cargo tree` — matched the filter pattern but output was passed through as-is).
 
 When multiple filters compose in a [pipeline](tools.md#output-filter-pipeline), the worst confidence across stages is propagated. A `Full` + `Partial` composition yields `Partial`.
+
+### Turn Latency and Classifier Metrics
+
+Once at least one turn has completed, the Resources panel shows a compact per-phase latency line for the most recent turn:
+
+```
+latency  ctx:12ms llm:340ms tool:58ms save:4ms
+```
+
+`ctx`/`llm`/`tool`/`save` are the context-assembly, LLM round-trip, tool-execution, and message-persistence phases of the turn, respectively.
+
+If [PII, prompt-injection, or feedback classifiers](../reference/security/untrusted-content-isolation.md) are enabled and at least one has run, a `classify` line appears below it with each classifier's p50 latency:
+
+```
+classify inj:7ms pii:3ms fb:-
+```
+
+A classifier that hasn't recorded a sample yet (e.g. `fb` above) shows `-` instead of a duration.
+
+For the full breakdown — rolling average and maximum per phase over the last 10 turns, plus each classifier's call count and p50/p95 latency — open the command palette and select `view:latency`:
+
+```
+Turn latency (rolling avg/max over last 10 turn(s)):
+  phase            avg       max
+  context         14ms      22ms
+  llm            355ms     520ms
+  tool            61ms     110ms
+  persist          4ms       9ms
+
+Classifier latency (p50/p95):
+  injection  calls:12    p50:   7ms p95:  15ms
+  pii        calls:12    p50:   3ms p95:   6ms
+```
+
+Both surfaces are silent until there is data to show: the resources-panel lines only appear once a turn has completed (or a classifier has run), and `view:latency` reports "No turn-timing samples recorded yet." until then.
 
 ## Security Indicators
 
@@ -713,6 +751,18 @@ To manually switch back before the sub-agent completes, press `Esc` in the trans
 Pressing `Enter` on a sub-agent entry loads its JSONL execution transcript into the chat panel. The transcript shows all messages exchanged by that sub-agent, including tool calls and intermediate reasoning, rendered with the same markdown and diff highlighting as the main conversation. Press `Esc` to return to the normal view.
 
 The SubAgents panel is replaced by the Security panel when recent security events exist (< 60 seconds). Press `a` explicitly to bring the SubAgents panel back when security events are active.
+
+### Worktree Commands
+
+When [worktree isolation](../guides/worktree.md) is enabled, `/worktree list` and `/worktree clean [--force]` work in TUI mode via the input line, same as any other slash command. The command palette (`Ctrl+P`) provides quick access without typing the full command:
+
+| Command | Palette entry | Description |
+|---------|---------------|-------------|
+| `/worktree list` | `worktree:list` | List active and stale worktrees tracked by this session's live worktree manager — the same instance sub-agent spawning uses, so results reflect the running agent's actual state |
+| `/worktree clean` | `worktree:clean` | Remove stale worktrees (skips entries git does not report as prunable, matching a plain `zeph worktree clean`) |
+| `/worktree clean --force` | — | Remove stale worktrees, including ones git does not report as prunable (matches `zeph worktree clean --force`) |
+
+Unlike the [CLI's `zeph worktree list`/`clean`](../guides/worktree.md#4-manage-worktrees), which construct a fresh manager from a disk scan on every invocation, the TUI's `/worktree` command reads the same live worktree manager the running agent uses to isolate sub-agents — so `list` reflects this session's actual state instead of a point-in-time snapshot from a separate process. If the worktree subsystem is disabled (`worktree.enabled = false`), both subcommands respond with a message saying so rather than an error.
 
 ## Deferred Model Warmup
 

--- a/crates/zeph-commands/src/handlers/mod.rs
+++ b/crates/zeph-commands/src/handlers/mod.rs
@@ -40,3 +40,4 @@ pub mod status;
 pub mod test_helpers;
 pub mod think_tokens;
 pub mod trajectory;
+pub mod worktree;

--- a/crates/zeph-commands/src/handlers/worktree.rs
+++ b/crates/zeph-commands/src/handlers/worktree.rs
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Worktree command handler: `/worktree`.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::context::CommandContext;
+use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
+
+/// List or clean the live session's git worktrees.
+///
+/// Subcommands: `list` (default) or `clean [--force]`. Reflects the running agent's actual
+/// worktree state rather than a fresh disk scan (contrast with the CLI's
+/// `zeph worktree list`/`clean`).
+pub struct WorktreeCommand;
+
+impl CommandHandler<CommandContext<'_>> for WorktreeCommand {
+    fn name(&self) -> &'static str {
+        "/worktree"
+    }
+
+    fn description(&self) -> &'static str {
+        "List or clean the live session's git worktrees"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "list | clean [--force]"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Advanced
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        use tracing::Instrument as _;
+        let span = tracing::info_span!("commands.worktree.handle");
+        Box::pin(
+            async move {
+                let words: Vec<&str> = args.split_whitespace().collect();
+                let result = match words.as_slice() {
+                    [] | ["list"] => ctx.agent.list_worktrees().await?,
+                    ["clean"] => ctx.agent.clean_worktrees(false).await?,
+                    ["clean", "--force"] => ctx.agent.clean_worktrees(true).await?,
+                    _ => {
+                        return Err(CommandError::new(
+                            "Unknown /worktree subcommand. Available: /worktree list, \
+                             /worktree clean [--force]",
+                        ));
+                    }
+                };
+                match result {
+                    Some(msg) => Ok(CommandOutput::Message(msg)),
+                    None => Ok(CommandOutput::Message(
+                        "Worktree subsystem is not enabled for this session.".to_owned(),
+                    )),
+                }
+            }
+            .instrument(span),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
+    use crate::sink::NullSink;
+
+    #[test]
+    fn worktree_name_and_description() {
+        assert_eq!(WorktreeCommand.name(), "/worktree");
+        assert!(!WorktreeCommand.description().is_empty());
+    }
+
+    #[tokio::test]
+    async fn worktree_none_returns_not_enabled_message() {
+        // NullAgent returns Ok(None), so the handler returns a "not enabled" message.
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+        let out = WorktreeCommand.handle(&mut ctx, "").await.unwrap();
+        let CommandOutput::Message(msg) = out else {
+            panic!("expected Message")
+        };
+        assert!(msg.contains("not enabled"));
+    }
+
+    #[tokio::test]
+    async fn worktree_list_subcommand_returns_not_enabled_message() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+        let out = WorktreeCommand.handle(&mut ctx, "list").await.unwrap();
+        let CommandOutput::Message(msg) = out else {
+            panic!("expected Message")
+        };
+        assert!(msg.contains("not enabled"));
+    }
+
+    #[tokio::test]
+    async fn worktree_clean_force_subcommand_returns_not_enabled_message() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+        let out = WorktreeCommand
+            .handle(&mut ctx, "clean --force")
+            .await
+            .unwrap();
+        let CommandOutput::Message(msg) = out else {
+            panic!("expected Message")
+        };
+        assert!(msg.contains("not enabled"));
+    }
+
+    #[tokio::test]
+    async fn worktree_clean_force_tolerates_irregular_whitespace() {
+        // Regression: exact-string matching on "clean --force" broke on double spaces or
+        // leading/trailing whitespace; split_whitespace tokenization must not.
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+        let out = WorktreeCommand
+            .handle(&mut ctx, "  clean   --force  ")
+            .await
+            .unwrap();
+        let CommandOutput::Message(msg) = out else {
+            panic!("expected Message")
+        };
+        assert!(msg.contains("not enabled"));
+    }
+
+    #[tokio::test]
+    async fn worktree_unknown_subcommand_returns_error() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+        let err = WorktreeCommand.handle(&mut ctx, "bogus").await.unwrap_err();
+        assert!(err.to_string().contains("Unknown"));
+    }
+}

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -609,6 +609,41 @@ pub trait AgentAccess: Send {
             Ok("Conversation-session persistence is not enabled in this context.".to_owned())
         })
     }
+
+    // ----- /worktree -----
+
+    /// Return a formatted list of active and stale git worktrees tracked by the live
+    /// session's worktree manager, or `None` when the worktree subsystem is disabled.
+    ///
+    /// Used by `/worktree` and `/worktree list`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when the underlying git reconciliation fails.
+    fn list_worktrees<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CommandError>> + Send + 'a>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    /// Remove stale worktrees tracked by the live session's worktree manager.
+    ///
+    /// `force` mirrors `zeph worktree clean --force`: also removes worktrees whose
+    /// directory git does not report as prunable. Returns `None` when the worktree
+    /// subsystem is disabled.
+    ///
+    /// Used by `/worktree clean`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when the underlying git reconciliation or registry pruning fails.
+    fn clean_worktrees<'a>(
+        &'a mut self,
+        force: bool,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CommandError>> + Send + 'a>> {
+        let _ = force;
+        Box::pin(async { Ok(None) })
+    }
 }
 
 /// A no-op [`AgentAccess`] implementation.
@@ -899,5 +934,39 @@ impl AgentAccess for NullAgent {
         _args: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
         Box::pin(async { Ok(String::new()) })
+    }
+
+    // ----- /worktree -----
+
+    /// Return a formatted list of active and stale git worktrees tracked by the live
+    /// session's worktree manager, or `None` when the worktree subsystem is disabled.
+    ///
+    /// Used by `/worktree` and `/worktree list`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when the underlying git reconciliation fails.
+    fn list_worktrees<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CommandError>> + Send + 'a>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    /// Remove stale worktrees tracked by the live session's worktree manager.
+    ///
+    /// `force` mirrors `zeph worktree clean --force`: also removes worktrees whose
+    /// directory git does not report as prunable. Returns `None` when the worktree
+    /// subsystem is disabled.
+    ///
+    /// Used by `/worktree clean`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when the underlying git reconciliation or registry pruning fails.
+    fn clean_worktrees<'a>(
+        &'a mut self,
+        _force: bool,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CommandError>> + Send + 'a>> {
+        Box::pin(async { Ok(None) })
     }
 }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -86,6 +86,7 @@ zeph-skills = { workspace = true, features = ["qdrant"] }
 zeph-subagent.workspace = true
 zeph-tools.workspace = true
 zeph-vault.workspace = true
+zeph-worktree.workspace = true
 zeroize.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1851,6 +1851,29 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
             ))
         })
     }
+
+    // ----- /worktree -----
+
+    fn list_worktrees<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CommandError>> + Send + 'a>> {
+        Box::pin(async move {
+            self.handle_worktree_list_as_string()
+                .await
+                .map_err(|e| CommandError::new(e.to_string()))
+        })
+    }
+
+    fn clean_worktrees<'a>(
+        &'a mut self,
+        force: bool,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CommandError>> + Send + 'a>> {
+        Box::pin(async move {
+            self.handle_worktree_clean_as_string(force)
+                .await
+                .map_err(|e| CommandError::new(e.to_string()))
+        })
+    }
 }
 
 impl<C: Channel> Agent<C> {

--- a/crates/zeph-core/src/agent/error.rs
+++ b/crates/zeph-core/src/agent/error.rs
@@ -121,6 +121,11 @@ pub enum AgentError {
     /// or `SessionStore` metadata read/write.
     #[error(transparent)]
     Session(#[from] zeph_session::SessionError),
+
+    /// A `/worktree list`/`/worktree clean` operation failed (git reconciliation, removal, or
+    /// registry pruning).
+    #[error(transparent)]
+    Worktree(#[from] zeph_worktree::WorktreeError),
 }
 
 impl AgentError {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -67,6 +67,7 @@ mod trust_commands;
 pub mod turn;
 mod utils;
 pub(crate) mod vigil;
+mod worktree_commands;
 
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Write as _;
@@ -616,6 +617,7 @@ impl<C: Channel> Agent<C> {
                     status::{FocusCommand, GuardrailCommand, SideQuestCommand, StatusCommand},
                     think_tokens::ThinkTokensCommand,
                     trajectory::{ScopeCommand, TrajectoryCommand},
+                    worktree::WorktreeCommand,
                 };
 
                 let mut agent_reg = CommandRegistry::new();
@@ -663,6 +665,7 @@ impl<C: Channel> Agent<C> {
                 agent_reg.register(UndoCommand);
                 agent_reg.register(RedoCommand);
                 agent_reg.register(ConvCommand);
+                agent_reg.register(WorktreeCommand);
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut agent_null_sink,

--- a/crates/zeph-core/src/agent/worktree_commands.rs
+++ b/crates/zeph-core/src/agent/worktree_commands.rs
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Channel-free `/worktree` command implementation for use via
+//! [`zeph_commands::traits::agent::AgentAccess`].
+//!
+//! Operates on the same live [`zeph_worktree::DefaultWorktreeManager`] instance the running
+//! agent's [`zeph_subagent::SubAgentManager`] uses to create per-subagent worktrees, so
+//! `/worktree list` and `/worktree clean` reflect this session's actual state. Contrast with
+//! the CLI's `zeph worktree list`/`clean` (`src/commands/worktree.rs`), which constructs a
+//! fresh manager from a disk scan on every invocation.
+
+use std::fmt::Write as _;
+
+use super::{Agent, error::AgentError};
+use crate::channel::Channel;
+
+impl<C: Channel> Agent<C> {
+    /// Channel-free `/worktree list` — formats active and stale worktrees tracked by the
+    /// live session's worktree manager.
+    ///
+    /// Returns `Ok(None)` when the worktree subsystem is disabled for this session.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when git reconciliation fails.
+    pub(super) async fn handle_worktree_list_as_string(
+        &mut self,
+    ) -> Result<Option<String>, AgentError> {
+        let Some(mgr) = &self.services.orchestration.subagent_manager else {
+            return Ok(None);
+        };
+        let Some(wm) = mgr.worktree_manager() else {
+            return Ok(None);
+        };
+
+        let stale = wm.reconcile().await?;
+        let active = wm.list();
+
+        if active.is_empty() && stale.is_empty() {
+            return Ok(Some("No active worktrees.".to_owned()));
+        }
+
+        let mut out = String::new();
+        if !active.is_empty() {
+            let _ = writeln!(out, "{:<36}  PATH", "AGENT ID");
+            for handle in &active {
+                let _ = writeln!(out, "{:<36}  {}", handle.subagent_id, handle.path.display());
+            }
+        }
+        if !stale.is_empty() {
+            if !active.is_empty() {
+                out.push('\n');
+            }
+            out.push_str("Stale (on disk but not tracked):\n");
+            for stale_wt in &stale {
+                match &stale_wt.prunable_reason {
+                    Some(reason) => {
+                        let _ = writeln!(
+                            out,
+                            "  {}  [prunable: {reason}]",
+                            stale_wt.handle.path.display()
+                        );
+                    }
+                    None => {
+                        let _ = writeln!(
+                            out,
+                            "  {}  [in use — not marked prunable by git; may belong to \
+                             another session]",
+                            stale_wt.handle.path.display()
+                        );
+                    }
+                }
+            }
+        }
+        Ok(Some(out.trim_end().to_owned()))
+    }
+
+    /// Channel-free `/worktree clean [--force]` — removes stale worktrees tracked by the
+    /// live session's worktree manager.
+    ///
+    /// `force` mirrors `zeph worktree clean --force`: also removes worktrees whose directory
+    /// git does not report as prunable. Returns `Ok(None)` when the worktree subsystem is
+    /// disabled for this session.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` only when the initial git reconciliation fails (nothing has been
+    /// removed yet, so there is no summary to lose). Per-worktree removal failures and a
+    /// failure of the final registry-prune step are both reported inline in the summary
+    /// instead of aborting, matching the CLI's `zeph worktree clean` behavior — a prune
+    /// failure must not discard an otherwise-successful removal summary.
+    pub(super) async fn handle_worktree_clean_as_string(
+        &mut self,
+        force: bool,
+    ) -> Result<Option<String>, AgentError> {
+        let Some(mgr) = &self.services.orchestration.subagent_manager else {
+            return Ok(None);
+        };
+        let Some(wm) = mgr.worktree_manager() else {
+            return Ok(None);
+        };
+        let prune_branch_on_remove = wm.prune_branch_on_remove();
+
+        let stale = wm.reconcile().await?;
+        let mut removed = 0usize;
+        let mut skipped = 0usize;
+        let mut warnings = String::new();
+        for stale_wt in stale {
+            if !force && !stale_wt.is_safe_to_force_remove() {
+                let _ = writeln!(
+                    warnings,
+                    "warning: skipping {} — directory exists and git does not report it as \
+                     prunable; it may be in active use by another zeph session.",
+                    stale_wt.handle.path.display()
+                );
+                skipped += 1;
+                continue;
+            }
+            if let Err(e) = wm.remove(&stale_wt.handle, prune_branch_on_remove).await {
+                let _ = writeln!(
+                    warnings,
+                    "warning: failed to remove {}: {e}",
+                    stale_wt.handle.path.display()
+                );
+            } else {
+                removed += 1;
+            }
+        }
+        if let Err(e) = wm.prune().await {
+            let _ = writeln!(warnings, "warning: failed to prune worktree registry: {e}");
+        }
+
+        let mut out = warnings;
+        let _ = write!(
+            out,
+            "Removed {removed} stale worktree(s), skipped {skipped} in-use candidate(s)."
+        );
+        Ok(Some(out))
+    }
+}

--- a/crates/zeph-subagent/src/manager/mod.rs
+++ b/crates/zeph-subagent/src/manager/mod.rs
@@ -316,6 +316,11 @@ pub struct SubAgentManager {
     /// its full run so that plain agents cannot observe a stale cwd mutated by a worktree
     /// agent (INV-1). Only agents with `permissions.worktree = true` and a non-`None`
     /// `bg_isolation` actually get a dedicated worktree.
+    ///
+    /// This is the single live instance shared by the running agent's `/worktree`
+    /// slash command (see [`worktree_manager`][Self::worktree_manager]) — distinct from
+    /// the CLI's `zeph worktree list`/`clean`, which constructs its own fresh manager
+    /// per invocation (`src/commands/worktree.rs`).
     worktree_manager: Option<Arc<zeph_worktree::DefaultWorktreeManager>>,
     /// Process-level serialisation mutex for working-directory mutations (INV-1).
     ///
@@ -388,6 +393,19 @@ impl SubAgentManager {
     /// `permissions.worktree = true` receive a dedicated git worktree.
     pub fn set_worktree_manager(&mut self, wm: Arc<zeph_worktree::DefaultWorktreeManager>) {
         self.worktree_manager = Some(wm);
+    }
+
+    /// Returns the live worktree manager, if the worktree subsystem is enabled for this
+    /// session.
+    ///
+    /// This is the same instance [`spawn`][Self::spawn] uses to create per-subagent
+    /// worktrees, so callers (e.g. the `/worktree` slash command) observe this session's
+    /// actual live state rather than a fresh disk scan. Its own
+    /// `prune_branch_on_remove()` reflects `WorktreeConfig::prune_branch_on_remove` — no
+    /// need to retain a separate copy on `SubAgentManager`.
+    #[must_use]
+    pub fn worktree_manager(&self) -> Option<&Arc<zeph_worktree::DefaultWorktreeManager>> {
+        self.worktree_manager.as_ref()
     }
 
     /// Drain completed hook tasks and spawn a new one if below the limit.

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -561,6 +561,57 @@ impl App {
         out
     }
 
+    pub(crate) fn format_latency_stats(&self) -> String {
+        use std::fmt::Write as _;
+
+        if self.metrics.timing_sample_count == 0 {
+            return "No turn-timing samples recorded yet.".to_owned();
+        }
+        let avg = &self.metrics.avg_turn_timings;
+        let max = &self.metrics.max_turn_timings;
+        let mut out = format!(
+            "Turn latency (rolling avg/max over last {} turn(s)):\n  {:<10} {:>9} {:>9}",
+            self.metrics.timing_sample_count, "phase", "avg", "max"
+        );
+        for (label, avg_ms, max_ms) in [
+            ("context", avg.prepare_context_ms, max.prepare_context_ms),
+            ("llm", avg.llm_chat_ms, max.llm_chat_ms),
+            ("tool", avg.tool_exec_ms, max.tool_exec_ms),
+            ("persist", avg.persist_message_ms, max.persist_message_ms),
+        ] {
+            let _ = write!(out, "\n  {label:<10} {avg_ms:>7}ms {max_ms:>7}ms");
+        }
+
+        let c = &self.metrics.classifier;
+        let tasks = [
+            ("injection", &c.injection),
+            ("pii", &c.pii),
+            ("feedback", &c.feedback),
+        ];
+        if tasks.iter().any(|(_, t)| t.call_count > 0) {
+            let _ = write!(out, "\n\nClassifier latency (p50/p95):");
+            for (label, task) in tasks {
+                if task.call_count == 0 {
+                    continue;
+                }
+                let p50 = task
+                    .p50_ms
+                    .map_or_else(|| "-".to_owned(), |v| format!("{v}ms"));
+                let p95 = task
+                    .p95_ms
+                    .map_or_else(|| "-".to_owned(), |v| format!("{v}ms"));
+                let _ = write!(
+                    out,
+                    "\n  {label:<10} calls:{:<5} p50:{p50:>6} p95:{p95:>6}",
+                    task.call_count
+                );
+            }
+        } else {
+            out.push_str("\n\nClassifier latency: no samples recorded yet.");
+        }
+        out
+    }
+
     pub(crate) fn format_tool_list(&self) -> String {
         if self.metrics.active_mcp_tools.is_empty() {
             return "No tools available.".to_owned();

--- a/crates/zeph-tui/src/app/reducer.rs
+++ b/crates/zeph-tui/src/app/reducer.rs
@@ -792,24 +792,6 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
                     );
                     return vec![];
                 }
-                TuiCommand::WorktreeList => {
-                    app.push_system_message_pub(
-                        "Worktree listing requires a fresh git scan and is not available \
-                         from a running TUI session.\n  Run from the CLI:\n  zeph worktree list"
-                            .to_owned(),
-                    );
-                    return vec![];
-                }
-                TuiCommand::WorktreeClean => {
-                    app.push_system_message_pub(
-                        "Worktree cleanup removes directories via git and is not available \
-                         from a running TUI session.\n  Run from the CLI:\n  zeph worktree clean \
-                         (add --force to remove entries git does not report as prunable)"
-                            .to_owned(),
-                    );
-                    return vec![];
-                }
-
                 // ── Group B — pure formatter reads ──────────────────────────────
                 TuiCommand::SkillList => {
                     let msg = app.format_skill_list();
@@ -833,6 +815,11 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
                 }
                 TuiCommand::ViewTools => {
                     let msg = app.format_tool_list();
+                    app.push_system_message_pub(msg);
+                    return vec![];
+                }
+                TuiCommand::ViewLatency => {
+                    let msg = app.format_latency_stats();
                     app.push_system_message_pub(msg);
                     return vec![];
                 }
@@ -888,6 +875,12 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
                 }
                 TuiCommand::TrajectoryStats => {
                     return vec![Effect::SendUserInput("/memory trajectory".to_owned())];
+                }
+                TuiCommand::WorktreeList => {
+                    return vec![Effect::SendUserInput("/worktree list".to_owned())];
+                }
+                TuiCommand::WorktreeClean => {
+                    return vec![Effect::SendUserInput("/worktree clean".to_owned())];
                 }
                 TuiCommand::MemoryTreeStats => {
                     return vec![Effect::SendUserInput("/memory tree".to_owned())];
@@ -1439,26 +1432,6 @@ mod tests {
         assert_eq!(app.sessions.current().messages.len(), 1);
     }
 
-    // ── #5983 WorktreeList/WorktreeClean CLI-redirect (was silently dropped) ──
-
-    #[test]
-    fn dispatch_worktree_list_pushes_cli_redirect_message() {
-        let (mut app, _rx) = make_app();
-        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::WorktreeList));
-        assert!(effects.is_empty());
-        let msg = &app.sessions.current().messages.last().unwrap().content;
-        assert!(msg.contains("zeph worktree list"));
-    }
-
-    #[test]
-    fn dispatch_worktree_clean_pushes_cli_redirect_message() {
-        let (mut app, _rx) = make_app();
-        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::WorktreeClean));
-        assert!(effects.is_empty());
-        let msg = &app.sessions.current().messages.last().unwrap().content;
-        assert!(msg.contains("zeph worktree clean"));
-    }
-
     // ── Group B tests ───────────────────────────────────────────────────────────
 
     #[test]
@@ -1497,6 +1470,14 @@ mod tests {
     fn dispatch_view_tools_pushes_system_message() {
         let (mut app, _rx) = make_app();
         let effects = reduce(&mut app, Action::Dispatch(TuiCommand::ViewTools));
+        assert!(effects.is_empty());
+        assert_eq!(app.sessions.current().messages.len(), 1);
+    }
+
+    #[test]
+    fn dispatch_view_latency_pushes_system_message() {
+        let (mut app, _rx) = make_app();
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::ViewLatency));
         assert!(effects.is_empty());
         assert_eq!(app.sessions.current().messages.len(), 1);
     }
@@ -1696,6 +1677,29 @@ mod tests {
         assert_eq!(
             effects,
             vec![Effect::SendUserInput("/memory trajectory".to_owned())]
+        );
+    }
+
+    // ── #6132 WorktreeList/WorktreeClean now forward to the real /worktree
+    //    slash command instead of the static CLI-redirect message from #6131 ──
+
+    #[test]
+    fn dispatch_worktree_list_sends_slash_command() {
+        let (mut app, _rx) = make_app();
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::WorktreeList));
+        assert_eq!(
+            effects,
+            vec![Effect::SendUserInput("/worktree list".to_owned())]
+        );
+    }
+
+    #[test]
+    fn dispatch_worktree_clean_sends_slash_command() {
+        let (mut app, _rx) = make_app();
+        let effects = reduce(&mut app, Action::Dispatch(TuiCommand::WorktreeClean));
+        assert_eq!(
+            effects,
+            vec![Effect::SendUserInput("/worktree clean".to_owned())]
         );
     }
 

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -26,6 +26,7 @@ pub enum TuiCommand {
     ViewTools,
     ViewConfig,
     ViewAutonomy,
+    ViewLatency,
     // New action commands
     Quit,
     Help,
@@ -263,6 +264,13 @@ fn build_view_commands() -> Vec<CommandEntry> {
             category: "view",
             shortcut: None,
             command: TuiCommand::ViewAutonomy,
+        },
+        CommandEntry {
+            id: "view:latency",
+            label: "Show classifier and turn-latency breakdown",
+            category: "view",
+            shortcut: None,
+            command: TuiCommand::ViewLatency,
         },
         CommandEntry {
             id: "tasks",
@@ -1013,7 +1021,8 @@ mod tests {
 
     #[test]
     fn registry_has_correct_count() {
-        assert_eq!(command_registry().len(), 27);
+        // +1 view:latency (#6059)
+        assert_eq!(command_registry().len(), 28);
     }
 
     #[test]

--- a/crates/zeph-tui/src/widgets/resources.rs
+++ b/crates/zeph-tui/src/widgets/resources.rs
@@ -5,8 +5,8 @@
 //!
 //! Shows a compact summary of LLM routing, session token usage, and API calls:
 //! `tokens`, `api`, `route` — matching design spec §4. Extra lines (cache,
-//! MCP, latency, background shell, classifiers) appear only when they carry
-//! non-zero data, so the panel stays quiet during idle sessions.
+//! MCP, background shell, turn latency, classifiers) appear only when they
+//! carry non-zero data, so the panel stays quiet during idle sessions.
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -23,7 +23,8 @@ use crate::theme::Theme;
 /// Render the resources panel into `area`.
 ///
 /// Layout (spec §4): section title · tokens · api · route, with optional
-/// cache, MCP, background-shell, and turn-latency lines when non-zero.
+/// cache, MCP, background-shell, turn-latency, and classifier-latency lines
+/// when non-zero.
 pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &Theme) {
     let mut lines: Vec<Line<'_>> = vec![Line::from(Span::styled(
         "resources",
@@ -37,6 +38,7 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect, theme: &
     append_mcp_line(&mut lines, metrics, theme);
     append_shell_background_section(&mut lines, metrics);
     append_turn_latency_section(&mut lines, metrics);
+    append_classifier_latency_line(&mut lines, metrics);
 
     let resources = Paragraph::new(lines).block(Block::default().borders(Borders::NONE));
     frame.render_widget(resources, area);
@@ -151,9 +153,35 @@ fn append_turn_latency_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnaps
     }
     let last = &metrics.last_turn_timings;
     lines.push(Line::from(format!(
-        "  latency  ctx:{}ms llm:{}ms",
-        last.prepare_context_ms, last.llm_chat_ms,
+        "  latency  ctx:{}ms llm:{}ms tool:{}ms save:{}ms",
+        last.prepare_context_ms, last.llm_chat_ms, last.tool_exec_ms, last.persist_message_ms,
     )));
+}
+
+/// Classifier p50 latency (injection/PII/feedback) — only when at least one
+/// classifier has recorded a call. Full p50/p95/call-count breakdown is
+/// available via the `view:latency` command (see `App::format_latency_stats`).
+fn append_classifier_latency_line(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
+    let c = &metrics.classifier;
+    if c.injection.call_count == 0 && c.pii.call_count == 0 && c.feedback.call_count == 0 {
+        return;
+    }
+    let mut detail = String::new();
+    for (label, task) in [("inj", &c.injection), ("pii", &c.pii), ("fb", &c.feedback)] {
+        if task.call_count == 0 {
+            continue;
+        }
+        if !detail.is_empty() {
+            detail.push(' ');
+        }
+        // "-" for a missing sample matches the placeholder used by the detailed
+        // `view:latency` breakdown (`App::format_latency_stats`).
+        let p50 = task
+            .p50_ms
+            .map_or_else(|| "-".to_owned(), |v| format!("{v}ms"));
+        let _ = write!(detail, "{label}:{p50}");
+    }
+    lines.push(Line::from(format!("  classify {detail}")));
 }
 
 #[cfg(test)]
@@ -299,6 +327,94 @@ mod tests {
         assert!(
             output.contains("01:15"),
             "must show elapsed mm:ss; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn resources_shows_turn_latency_breakdown_when_samples_exist() {
+        use zeph_core::metrics::TurnTimings;
+
+        let metrics = MetricsSnapshot {
+            timing_sample_count: 3,
+            last_turn_timings: TurnTimings {
+                prepare_context_ms: 12,
+                llm_chat_ms: 340,
+                tool_exec_ms: 58,
+                persist_message_ms: 4,
+            },
+            ..MetricsSnapshot::default()
+        };
+        let output = render_to_string(50, 10, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
+        });
+        assert!(
+            output.contains("latency"),
+            "must show latency header; got: {output:?}"
+        );
+        assert!(
+            output.contains("ctx:12ms"),
+            "must show context latency; got: {output:?}"
+        );
+        assert!(
+            output.contains("tool:58ms"),
+            "must show tool exec latency; got: {output:?}"
+        );
+        assert!(
+            output.contains("save:4ms"),
+            "must show persist latency; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn resources_omits_turn_latency_when_no_samples() {
+        let metrics = MetricsSnapshot::default();
+        let output = render_to_string(50, 10, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
+        });
+        assert!(
+            !output.contains("latency"),
+            "must not show latency when no samples; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn resources_shows_classifier_latency_when_calls_recorded() {
+        use zeph_core::metrics::{ClassifierMetricsSnapshot, TaskMetricsSnapshot};
+
+        let metrics = MetricsSnapshot {
+            classifier: ClassifierMetricsSnapshot {
+                injection: TaskMetricsSnapshot {
+                    call_count: 4,
+                    p50_ms: Some(7),
+                    p95_ms: Some(15),
+                },
+                pii: TaskMetricsSnapshot::default(),
+                feedback: TaskMetricsSnapshot::default(),
+            },
+            ..MetricsSnapshot::default()
+        };
+        let output = render_to_string(50, 10, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
+        });
+        assert!(
+            output.contains("classify"),
+            "must show classify header; got: {output:?}"
+        );
+        assert!(
+            output.contains("inj:7ms"),
+            "must show injection p50; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn resources_omits_classifier_latency_when_no_calls() {
+        let metrics = MetricsSnapshot::default();
+        let output = render_to_string(50, 10, |frame, area| {
+            super::render(&metrics, frame, area, &theme());
+        });
+        assert!(
+            !output.contains("classify"),
+            "must not show classify when no calls; got: {output:?}"
         );
     }
 

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__command_palette__tests__command_palette_rounded_border_snapshot.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__command_palette__tests__command_palette_rounded_border_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/zeph-tui/src/widgets/command_palette.rs
+assertion_line: 272
 expression: output
 ---
                                                                                 
@@ -14,6 +15,7 @@ expression: output
                 │view:tools            List available tools    │                
                 │view:config           Show active configuratio│                
                 │view:autonomy         Show autonomy/trust leve│                
+                │view:latency          Show classifier and turn│                
                 │tasks                 Toggle task registry pan│                
                 │fleet                 Fleet: show agent sessio│                
                 │durable               Durable: show durable ex│                
@@ -22,5 +24,4 @@ expression: output
                 │session:next          Switch to next session (│                
                 │session:prev          Switch to previous sessi│                
                 │session:close         Close current session (/│                
-                │session:undo          Undo last shell checkpoi│                
                 ╰──────────────────────────────────────────────╯

--- a/crates/zeph-worktree/src/manager.rs
+++ b/crates/zeph-worktree/src/manager.rs
@@ -104,6 +104,16 @@ impl<R: GitRunner> WorktreeManager<R> {
         &self.repo_root
     }
 
+    /// Whether [`remove`][Self::remove] should also delete the branch, per the
+    /// `WorktreeConfig::prune_branch_on_remove` this manager was constructed with.
+    ///
+    /// Exposed so callers that only hold the manager (not the original config, e.g.
+    /// `/worktree clean` in `zeph-core`) don't need to thread the config separately.
+    #[must_use]
+    pub fn prune_branch_on_remove(&self) -> bool {
+        self.config.prune_branch_on_remove
+    }
+
     /// Creates a new worktree for `subagent_id` according to the configured
     /// `base_ref` strategy.
     ///
@@ -743,6 +753,30 @@ mod tests {
         runner.push_err(b"not a git repo\n" as &[u8]);
         let err = probe_capabilities(&runner, dir.path()).await.unwrap_err();
         assert_matches!(err, WorktreeError::NotAGitRepo);
+    }
+
+    // --- config accessors ---
+
+    #[tokio::test]
+    async fn prune_branch_on_remove_reflects_constructor_config() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let config = WorktreeConfig {
+            prune_branch_on_remove: true,
+            ..test_config()
+        };
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
+        assert!(mgr.prune_branch_on_remove());
+    }
+
+    #[tokio::test]
+    async fn prune_branch_on_remove_defaults_to_false() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let mgr = make_manager(&dir, runner).await;
+        assert!(!mgr.prune_branch_on_remove());
     }
 
     // --- create (Head mode) ---


### PR DESCRIPTION
## Summary

- `/worktree list` and `/worktree clean [--force]` are now real, live slash commands instead of the CLI-redirect stub PR #6131 left in place — they read the same live `Arc<DefaultWorktreeManager>` instance sub-agent spawning already uses, so results reflect this session's actual state rather than a fresh disk scan.
- The TUI resources side panel and a new `view:latency` command now surface `MetricsSnapshot`'s classifier p50/p95 latency and rolling avg/max turn-timing breakdown, which were computed every turn but never had a consumer in `zeph-tui`.
- `book/src/advanced/tui.md` documents both additions, including a note on the live-instance-vs-fresh-scan distinction between the TUI's `/worktree` command and the CLI's `zeph worktree list/clean`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13075 passed, 0 failed, 35 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `mdbook build` clean
- [x] `.local/testing/playbooks/tui.md` updated with new scenarios (S14-S17); not yet exercised in a live TUI session — pending next CI cycle
- [x] `.local/testing/coverage-status.md` rows updated in place

Closes #6132
Closes #6059