### PR TITLE
fix: thread --vault/--vault-key/--vault-path CLI flags into doctor/bench/gonka/cocoon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   handshake starts, mirroring the non-OAuth path (with matching cleanup on connection
   failure in `process_oauth_results`), and the `lock_tool_list`/`tool_list_locked`
   invariant now has test coverage for the first time.
+- `doctor`, `bench`, `gonka doctor`, and `cocoon doctor` all called
+  `parse_vault_args(&config, None, None, None)`, silently discarding the global
+  `--vault`/`--vault-key`/`--vault-path` CLI flags — only the real application startup path
+  (`AppBuilder::new`) threaded them through (#6037). `--vault <BACKEND>` and related flags
+  are now respected by all four commands, matching `AppBuilder::new`'s behavior; an
+  unrecognized `--vault` value is now rejected the same way on these paths as it already was
+  on the main startup path (#6025).
 - `IndexMcpServer` registration (`apply_code_retrieval` in `src/agent_setup.rs`) hardcoded
   `std::env::current_dir()` and never read `[index] workspace_root`, unlike the sibling
   background-indexer path (`apply_code_indexer`), which resolved it correctly. Scoping

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -17,9 +17,13 @@ use zeph_bench::{
 };
 use zeph_core::config::SecretResolver as _;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_bench_command(
     cmd: &BenchCommand,
     config_path: Option<&std::path::Path>,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     match cmd {
         BenchCommand::List => {
@@ -47,6 +51,9 @@ pub(crate) async fn handle_bench_command(
                     *resume,
                     *no_deterministic,
                     config_path,
+                    vault_override,
+                    vault_key_override,
+                    vault_path_override,
                 )
                 .await
             } else {
@@ -59,6 +66,9 @@ pub(crate) async fn handle_bench_command(
                     *resume,
                     *no_deterministic,
                     config_path,
+                    vault_override,
+                    vault_key_override,
+                    vault_path_override,
                 )
                 .await
             }
@@ -78,6 +88,9 @@ async fn handle_run_baseline(
     resume: bool,
     no_deterministic: bool,
     config_path: Option<&std::path::Path>,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     match dataset {
         "longmemeval" | "locomo" => {}
@@ -100,8 +113,13 @@ async fn handle_run_baseline(
     let path = resolve_config_path(config_path);
     let mut config = load_config_or_default(&path);
 
-    let vault_args = parse_vault_args(&config, None, None, None)
-        .map_err(|e| anyhow::anyhow!("invalid vault backend: {e}"))?;
+    let vault_args = parse_vault_args(
+        &config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    )
+    .map_err(|e| anyhow::anyhow!("invalid vault backend: {e}"))?;
     if let Some(vault) = crate::bootstrap::build_vault_provider(&vault_args)
         && let Err(e) = config.resolve_secrets(vault.as_ref()).await
     {
@@ -366,6 +384,9 @@ async fn handle_run(
     resume: bool,
     no_deterministic: bool,
     config_path: Option<&std::path::Path>,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     let reg = DatasetRegistry::new();
     if reg.get(dataset).is_none() {
@@ -383,8 +404,13 @@ async fn handle_run(
     // Resolve vault secrets before building the provider.
     // The bench command is dispatched before AppBuilder runs, so we must
     // initialize the vault here to populate config.secrets.
-    let vault_args = parse_vault_args(&config, None, None, None)
-        .map_err(|e| anyhow::anyhow!("invalid vault backend: {e}"))?;
+    let vault_args = parse_vault_args(
+        &config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    )
+    .map_err(|e| anyhow::anyhow!("invalid vault backend: {e}"))?;
     if let Some(vault) = crate::bootstrap::build_vault_provider(&vault_args)
         && let Err(e) = config.resolve_secrets(vault.as_ref()).await
     {
@@ -535,4 +561,75 @@ fn secs_to_ymdhms(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
     let mo = if mp < 10 { mp + 3 } else { mp - 9 };
     let y = if mo <= 2 { y + 1 } else { y };
     (y, mo, d, h, mi, s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression tests for #6037: `handle_bench_command`'s two `--baseline` /
+    // non-baseline call sites hardcoded `None, None, None` instead of
+    // forwarding the `--vault` CLI flag into `parse_vault_args`. Both
+    // functions validate the vault backend before touching the network, so
+    // this fails fast on the bogus override without requiring a live provider.
+
+    #[tokio::test]
+    async fn handle_run_baseline_rejects_invalid_vault_cli_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_file = dir.path().join("data.jsonl");
+        std::fs::write(&data_file, "").unwrap();
+        let config_path = dir.path().join("missing-config.toml");
+        let output = dir.path().join("out.json");
+
+        let err = handle_run_baseline(
+            "longmemeval",
+            &output,
+            Some(&data_file),
+            None,
+            None,
+            false,
+            false,
+            Some(config_path.as_path()),
+            Some("bogus_backend_name"),
+            None,
+            None,
+        )
+        .await
+        .expect_err("bogus --vault backend must be rejected");
+
+        assert!(
+            err.to_string().contains("unknown vault backend"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_run_rejects_invalid_vault_cli_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_file = dir.path().join("data.jsonl");
+        std::fs::write(&data_file, "").unwrap();
+        let config_path = dir.path().join("missing-config.toml");
+        let output = dir.path().join("out.json");
+
+        let err = handle_run(
+            "longmemeval",
+            &output,
+            Some(&data_file),
+            None,
+            None,
+            false,
+            false,
+            Some(config_path.as_path()),
+            Some("bogus_backend_name"),
+            None,
+            None,
+        )
+        .await
+        .expect_err("bogus --vault backend must be rejected");
+
+        assert!(
+            err.to_string().contains("unknown vault backend"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src/commands/cocoon.rs
+++ b/src/commands/cocoon.rs
@@ -233,6 +233,9 @@ async fn check_vault_key(
     config: &zeph_core::config::Config,
     entry: &zeph_config::ProviderEntry,
     results: &mut Vec<CheckResult>,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&Path>,
+    vault_path_override: Option<&Path>,
 ) {
     let start = Instant::now();
 
@@ -246,7 +249,12 @@ async fn check_vault_key(
     }
 
     let _span = tracing::info_span!("cli.cocoon.doctor.vault").entered();
-    let vault_args = match crate::bootstrap::parse_vault_args(config, None, None, None) {
+    let vault_args = match crate::bootstrap::parse_vault_args(
+        config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    ) {
         Ok(args) => args,
         Err(e) => {
             results.push(CheckResult::fail("cocoon.vault", e, elapsed_ms(start)));
@@ -323,10 +331,14 @@ async fn check_vault_key(
 /// # Errors
 ///
 /// Returns an error if I/O fails at the top level.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_cocoon_doctor(
     config_path: &Path,
     json: bool,
     timeout_secs: u64,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&Path>,
+    vault_path_override: Option<&Path>,
 ) -> anyhow::Result<i32> {
     let _span = tracing::info_span!("cli.cocoon.doctor").entered();
     let total_start = Instant::now();
@@ -361,7 +373,15 @@ pub(crate) async fn run_cocoon_doctor(
     check_model_listed(&client, &entry, health_opt.as_ref(), &mut results).await;
 
     // Check 6: Vault key (only when cocoon_access_hash is Some)
-    check_vault_key(&config, &entry, &mut results).await;
+    check_vault_key(
+        &config,
+        &entry,
+        &mut results,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    )
+    .await;
 
     let report = DoctorReport {
         results,
@@ -529,9 +549,38 @@ mod tests {
         };
         let config = zeph_core::config::Config::default();
         let mut results = Vec::new();
-        check_vault_key(&config, &entry, &mut results).await;
+        check_vault_key(&config, &entry, &mut results, None, None, None).await;
         assert_eq!(results[0].status, CheckStatus::Ok);
         assert!(results[0].detail.contains("skipped"));
+    }
+
+    #[tokio::test]
+    async fn cocoon_doctor_vault_rejects_invalid_cli_backend_override() {
+        // Regression test for #6037: the `--vault` CLI flag was silently
+        // discarded because `run_cocoon_doctor` hardcoded `None, None, None`
+        // instead of forwarding it to `check_vault_key`.
+        use zeph_config::ProviderEntry;
+        let entry = ProviderEntry {
+            cocoon_access_hash: Some("hash".into()),
+            ..ProviderEntry::default()
+        };
+        let config = zeph_core::config::Config::default();
+        let mut results = Vec::new();
+        check_vault_key(
+            &config,
+            &entry,
+            &mut results,
+            Some("bogus_backend_name"),
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(results[0].status, CheckStatus::Fail);
+        assert!(
+            results[0].detail.contains("unknown vault backend"),
+            "unexpected detail: {}",
+            results[0].detail
+        );
     }
 
     #[test]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -771,12 +771,15 @@ fn check_url_scheme() -> CheckResult {
 /// # Errors
 ///
 /// Returns an error if config resolution or I/O fails at the top level.
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub(crate) async fn run_doctor(
     config_path: &Path,
     json: bool,
     llm_timeout_secs: u64,
     mcp_timeout_secs: u64,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&Path>,
+    vault_path_override: Option<&Path>,
 ) -> anyhow::Result<i32> {
     let total_start = Instant::now();
     let mut results: Vec<CheckResult> = Vec::new();
@@ -797,7 +800,12 @@ pub(crate) async fn run_doctor(
     // 2 + 3 + 4. Vault checks
     {
         let start = Instant::now();
-        match crate::bootstrap::parse_vault_args(&config, None, None, None) {
+        match crate::bootstrap::parse_vault_args(
+            &config,
+            vault_override,
+            vault_key_override,
+            vault_path_override,
+        ) {
             Ok(vault_args) => {
                 if vault_args.backend == zeph_config::VaultBackend::Age {
                     if let Some(ref vault_path) = vault_args.vault_path {

--- a/src/commands/gonka.rs
+++ b/src/commands/gonka.rs
@@ -44,9 +44,17 @@ fn finish(report: &DoctorReport, json: bool) -> anyhow::Result<i32> {
 /// `address_opt` is the raw vault-stored bech32 address, used to verify against the derived one.
 async fn resolve_vault_secrets(
     config: &zeph_core::config::Config,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&Path>,
+    vault_path_override: Option<&Path>,
 ) -> (CheckResult, Option<String>, CheckResult, Option<String>) {
     let _span = tracing::info_span!("cli.gonka.doctor.vault").entered();
-    let vault_args = match crate::bootstrap::parse_vault_args(config, None, None, None) {
+    let vault_args = match crate::bootstrap::parse_vault_args(
+        config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    ) {
         Ok(args) => args,
         Err(e) => {
             let start = Instant::now();
@@ -370,11 +378,14 @@ async fn probe_all_nodes(
 /// # Errors
 ///
 /// Returns an error if config parsing or I/O fails at the top level.
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub(crate) async fn run_gonka_doctor(
     config_path: &Path,
     json: bool,
     timeout_secs: u64,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&Path>,
+    vault_path_override: Option<&Path>,
 ) -> anyhow::Result<i32> {
     let _span = tracing::info_span!("cli.gonka.doctor").entered();
     let total_start = Instant::now();
@@ -427,8 +438,13 @@ pub(crate) async fn run_gonka_doctor(
     }
 
     // 2 + 3. Vault: resolve private key and optional address
-    let (priv_key_result, priv_key_opt, addr_result, vault_addr_opt) =
-        resolve_vault_secrets(&config).await;
+    let (priv_key_result, priv_key_opt, addr_result, vault_addr_opt) = resolve_vault_secrets(
+        &config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    )
+    .await;
     let priv_key_failed = priv_key_result.status == CheckStatus::Fail;
     results.push(priv_key_result);
     results.push(addr_result);
@@ -580,5 +596,22 @@ mod tests {
     #[test]
     fn gonka_detect_clock_skew_returns_none_for_invalid_date() {
         assert!(detect_clock_skew("not a date").is_none());
+    }
+
+    #[tokio::test]
+    async fn gonka_doctor_vault_rejects_invalid_cli_backend_override() {
+        // Regression test for #6037: the `--vault` CLI flag was silently
+        // discarded because `run_gonka_doctor` hardcoded `None, None, None`
+        // instead of forwarding it to `resolve_vault_secrets`.
+        let config = zeph_core::config::Config::default();
+        let (priv_key_result, priv_key_opt, _addr_result, _addr_opt) =
+            resolve_vault_secrets(&config, Some("bogus_backend_name"), None, None).await;
+        assert_eq!(priv_key_result.status, CheckStatus::Fail);
+        assert!(
+            priv_key_result.detail.contains("unknown vault backend"),
+            "unexpected detail: {}",
+            priv_key_result.detail
+        );
+        assert!(priv_key_opt.is_none());
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -934,8 +934,14 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         }
         #[cfg(feature = "bench")]
         Some(Command::Bench { command: bench_cmd }) => {
-            return crate::commands::bench::handle_bench_command(&bench_cmd, cli.config.as_deref())
-                .await;
+            return crate::commands::bench::handle_bench_command(
+                &bench_cmd,
+                cli.config.as_deref(),
+                cli.vault.as_deref(),
+                cli.vault_key.as_deref(),
+                cli.vault_path.as_deref(),
+            )
+            .await;
         }
         #[cfg(all(unix, feature = "scheduler"))]
         Some(Command::Serve {
@@ -976,6 +982,9 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                 json,
                 llm_timeout_secs,
                 mcp_timeout_secs,
+                cli.vault.as_deref(),
+                cli.vault_key.as_deref(),
+                cli.vault_path.as_deref(),
             )
             .await?;
             std::process::exit(exit_code);
@@ -985,8 +994,15 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             command: crate::cli::GonkaCommand::Doctor { json, timeout_secs },
         }) => {
             let config_path = resolve_config_path(cli.config.as_deref());
-            let exit_code =
-                crate::commands::gonka::run_gonka_doctor(&config_path, json, timeout_secs).await?;
+            let exit_code = crate::commands::gonka::run_gonka_doctor(
+                &config_path,
+                json,
+                timeout_secs,
+                cli.vault.as_deref(),
+                cli.vault_key.as_deref(),
+                cli.vault_path.as_deref(),
+            )
+            .await?;
             std::process::exit(exit_code);
         }
         #[cfg(feature = "cocoon")]
@@ -994,9 +1010,15 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             command: crate::cli::CocoonCommand::Doctor { json, timeout_secs },
         }) => {
             let config_path = resolve_config_path(cli.config.as_deref());
-            let exit_code =
-                crate::commands::cocoon::run_cocoon_doctor(&config_path, json, timeout_secs)
-                    .await?;
+            let exit_code = crate::commands::cocoon::run_cocoon_doctor(
+                &config_path,
+                json,
+                timeout_secs,
+                cli.vault.as_deref(),
+                cli.vault_key.as_deref(),
+                cli.vault_path.as_deref(),
+            )
+            .await?;
             std::process::exit(exit_code);
         }
         Some(Command::Notify {


### PR DESCRIPTION
## Summary

- `parse_vault_args()` only received real `--vault`/`--vault-key`/`--vault-path` CLI override values on the main `AppBuilder::new` startup path. The `doctor`, `bench` (two call sites), `gonka doctor`, and `cocoon doctor` commands all hardcoded `None, None, None`, silently discarding whatever the user passed on the command line.
- Threaded `cli.vault`/`cli.vault_key`/`cli.vault_path` from `runner.rs::run(cli: Cli)` down through each command's call chain (`run_doctor`, `handle_bench_command`/`handle_run_baseline`/`handle_run`, `run_gonka_doctor`/`resolve_vault_secrets`, `run_cocoon_doctor`/`check_vault_key`), matching the existing pattern already used for `AppBuilder::new`.
- `parse_vault_args` itself is unchanged — its CLI-value validation (reject unrecognized backend) already worked correctly; the bug was purely that these 5 call sites never gave it the real values.
- Added regression tests proving an invalid `--vault` backend value is now rejected at the `cocoon doctor`, `gonka doctor`, and `bench` (`handle_run`/`handle_run_baseline`) call sites.

Closes #6037

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo clippy --profile ci --workspace --all-targets --features bench -- -D warnings` (second CI matrix entry, bench.rs touched)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler,bench,gonka,cocoon" --lib --bins` — full suite green
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — rustdoc gate clean
- [x] `cargo check --features "desktop,ide,server,chat,pdf,scheduler,bench,gonka,cocoon"` re-verified after rebase onto latest `main`