### PR TITLE
fix(security): scan the full CI feature bundle in the cargo-deny advisories gate

### DIFF
--- a/.github/deny.toml
+++ b/.github/deny.toml
@@ -5,7 +5,14 @@ targets = [
     "aarch64-apple-darwin",
 ]
 all-features = false
-features = ["candle", "tui"]
+# Scan the "full" bundle rather than hand-picked leaf features: it is the most
+# feature-complete build shipped by CI (blocking `bundle-check` job) and release
+# artifacts, transitively covering pdf, candle (via classifiers), tui (via desktop),
+# acp, gateway, a2a, discord, slack, scheduler, profiling, sandbox, gonka, cocoon,
+# registry, and session. Keeping this as a single bundle reference (instead of an
+# enumerated feature list) avoids silent scan-scope drift whenever `full` gains a
+# new leaf feature (see #5994: `pdf` shipped in production but was invisible here).
+features = ["full"]
 
 [advisories]
 db-path = "~/.cargo/advisory-db"
@@ -15,7 +22,11 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # number_prefix unmaintained (via indicatif -> hf-hub, candle transitive dep)
 # proc-macro-error2 unmaintained (RUSTSEC-2026-0173, via aquamarine -> teloxide and i18n-embed-fl -> age)
 # Both are transitive; remove once teloxide/age update their proc-macro dependencies
-ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436", "RUSTSEC-2026-0173"]
+# ttf-parser unmaintained (RUSTSEC-2026-0192, via pdf-extract -> lopdf -> ttf-parser, pdf feature)
+# No patched version exists; advisory suggests migrating to `skrifa`. Transitive via
+# pdf-extract/lopdf, which do not offer a ttf-parser-free path yet; track migrating off
+# ttf-parser (or pdf-extract/lopdf entirely) once an upstream alternative lands
+ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436", "RUSTSEC-2026-0173", "RUSTSEC-2026-0192"]
 
 [licenses]
 confidence-threshold = 0.93

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `.github/deny.toml`: the `cargo-deny` advisories gate scanned only the `candle`
+  and `tui` features, excluding `pdf` and every other feature shipped by the
+  blocking `bundle-check` (`full`) CI job and release builds — any RUSTSEC
+  advisory affecting a `pdf`-only dependency (or any of `acp`, `gateway`, `a2a`,
+  `discord`, `slack`, `scheduler`, `profiling`, `sandbox`, `gonka`, `cocoon`,
+  `registry`, `session`) was invisible to the security gate despite shipping in
+  production (#5994). `[graph] features` now scans the `full` bundle itself
+  instead of an enumerated feature list, so the gate tracks whatever `full`
+  includes without manual upkeep. This surfaced `RUSTSEC-2026-0192` (`ttf-parser`
+  0.25.1 unmaintained, no patched version, via `pdf-extract` -> `lopdf` ->
+  `ttf-parser`), added to the advisories `ignore` list alongside the existing
+  unmaintained-dependency entries, with a comment noting the suggested
+  alternative (`skrifa`) for a future migration (#6085).
 - `zeph-gateway` and `zeph-a2a`: fixed a bearer-token brute-force bypass caused by
   middleware layer order (#6110, CWE-307). `auth_middleware` returns `401` directly
   without calling `next.run`, so with auth layered outside `rate_limit_middleware`,


### PR DESCRIPTION
## Summary
- `.github/deny.toml`'s `[graph] features` scanned only `["candle", "tui"]`, excluding `pdf` and other features that CI's blocking `full` bundle build actually ships, leaving any RUSTSEC advisory affecting a `pdf`-only dependency invisible to the advisories gate.
- Point the scan at the `full` feature bundle itself instead of an enumerated leaf-feature list, so it tracks CI's actual shipped surface and doesn't drift again as `full` gains new leaf features.
- Add an `ignore` entry for `RUSTSEC-2026-0192` (`ttf-parser` unmaintained, via `pdf-extract -> lopdf`, no patched version), which is now correctly surfaced by the widened scan.

Closes #5994
Closes #6085

## Test plan
- [x] `cargo deny check --config .github/deny.toml` (exact CI invocation, all axes) — clean: advisories/bans/licenses/sources all `ok`
- [x] `cargo audit` — confirms RUSTSEC-2026-0192, informational, feature-agnostic
- [x] Negative control: removing the new ignore entry causes `cargo deny check` to fail on `ttf-parser is unmaintained`, confirming the widened scope genuinely surfaces the advisory
- [x] `cargo tree --features full` confirms `ttf-parser`/`pdf-extract` are present under the new scope and absent under the old `candle,tui` scope
- [x] Confirmed `ml` (`candle` + `pdf`) is a strict subset of `full`'s features, so `ml`-only consumers remain covered
- [x] Full pre-commit suite clean: `cargo +nightly fmt --check`, clippy `--profile ci` with the full CI feature set, `cargo nextest run` (13125 passed / 0 failed), rustdoc gate
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `.local/testing/playbooks/security-deny-gate.md` added; `.local/testing/coverage-status.md` row updated in place