### PR TITLE
fix(worktree): harden clean/list test coverage and dedupe CLI/agent clean pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Testing
+
+- `zeph-worktree`: added a regression test confirming `WorktreeManager::remove()`'s single
+  `git worktree remove --force` still refuses a `git worktree lock`-ed worktree (requires
+  `-f -f`), the second safety layer alongside the `prunable`-gating from #6076 — previously
+  only confirmed manually against real git 2.50.1 (#6077).
+- `src/commands/worktree.rs`: added an end-to-end test calling the real `handle_worktree_command`
+  handler (not a reimplementation of its skip-gating logic) against a real git repo with a
+  mixed stale list (N>1 prunable + M>1 in-use entries in the same run) (#6077).
+- `zeph-worktree`: added `FakeGitRunner`-backed unit tests for the new shared
+  `WorktreeManager::clean`/`format_clean_summary` covering the mixed prunable/non-prunable
+  case, the `--force` bypass, a `remove()` failure being counted as `errored`, and — the
+  exact divergence caught in #6141's review — a final `prune()` failure recording a warning
+  without discarding an already-successful removal count (#6142).
+- `zeph-core`: added a live-`SubAgentManager` fixture test suite for `Agent::
+  handle_worktree_list_as_string`/`handle_worktree_clean_as_string` (`crates/zeph-core/src/
+  agent/worktree_commands.rs`) — a real `DefaultWorktreeManager` over a temp git repo wired
+  into a real `SubAgentManager` via `set_worktree_manager`, exercising the live-manager
+  `Some(wm)` branch end to end (0/1/N active worktrees, mixed prunable/in-use stale lists,
+  `--force` reaching `WorktreeManager` with correct semantics). Previously only the
+  disabled-subsystem `None` short-circuit had coverage, via `zeph-commands`'
+  `NullAgent`-backed tests (#6142).
+
 ### Changed
+
+- **DRY**: extracted the `zeph worktree clean` reconcile → remove → prune pipeline and its
+  removed/skipped/errored counting into a single `WorktreeManager::clean` method plus a
+  `format_clean_summary` free function (`zeph-worktree`), now shared by both the CLI
+  (`src/commands/worktree.rs`) and the agent-side `/worktree clean` slash command
+  (`crates/zeph-core/src/agent/worktree_commands.rs`) (#6142). These two call sites
+  previously duplicated the same loop independently, which already caused a real bug during
+  #6141's review (the agent-side path originally discarded the `prune()` failure instead of
+  reporting it, diverging from the CLI's warn-and-continue behavior). Only the `--force`
+  hint text in the skip warning still differs between the two surfaces (`force_hint`
+  parameter), since that's the one piece of legitimately surface-specific UX.
 
 - **BREAKING**: `zeph-db`'s `DbConfig` collapses `max_connections` and `pool_size` into a
   single `pool_size: u32` field, used as `sqlx`'s `.max_connections()` for both `SQLite` and
@@ -48,6 +82,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `claude-sonnet-4`, not `claude-sonnet-4-5` (#5902). Replaced with `claude-sonnet-5`,
   matching the dateless convention used for the current Sonnet release elsewhere in
   the book since #5901.
+- `zeph worktree clean`'s `Removed N, skipped M` summary omitted entries whose
+  `WorktreeManager::remove()` call itself failed (e.g. a locked worktree with `--force`),
+  silently undercounting the actual outcomes (#6077). Added an `errored` count, folded into a
+  new `format_clean_summary` helper so the total now always adds up to the number of stale
+  entries `reconcile()` discovered. Also fixed `WorktreeManager::reconcile()`'s doc comment,
+  which claimed it was "used at startup" — its only callers are the `zeph worktree list`/`clean`
+  CLI subcommands; there is no startup caller.
 - `zeph-gateway` and `zeph-a2a`: fixed a bearer-token brute-force bypass caused by
   middleware layer order (#6110, CWE-307). `auth_middleware` returns `401` directly
   without calling `next.run`, so with auth layered outside `rate_limit_middleware`,

--- a/crates/zeph-core/src/agent/worktree_commands.rs
+++ b/crates/zeph-core/src/agent/worktree_commands.rs
@@ -83,13 +83,17 @@ impl<C: Channel> Agent<C> {
     /// git does not report as prunable. Returns `Ok(None)` when the worktree subsystem is
     /// disabled for this session.
     ///
+    /// Delegates the actual reconcile/remove/prune pipeline and outcome counting to
+    /// [`WorktreeManager::clean`][zeph_worktree::WorktreeManager::clean], shared with the
+    /// CLI's `zeph worktree clean` (`src/commands/worktree.rs`), so the two surfaces cannot
+    /// silently diverge in behavior (#6142) — only the `--force` hint text differs.
+    ///
     /// # Errors
     ///
     /// Returns `Err` only when the initial git reconciliation fails (nothing has been
     /// removed yet, so there is no summary to lose). Per-worktree removal failures and a
     /// failure of the final registry-prune step are both reported inline in the summary
-    /// instead of aborting, matching the CLI's `zeph worktree clean` behavior — a prune
-    /// failure must not discard an otherwise-successful removal summary.
+    /// instead of aborting.
     pub(super) async fn handle_worktree_clean_as_string(
         &mut self,
         force: bool,
@@ -102,40 +106,269 @@ impl<C: Channel> Agent<C> {
         };
         let prune_branch_on_remove = wm.prune_branch_on_remove();
 
-        let stale = wm.reconcile().await?;
-        let mut removed = 0usize;
-        let mut skipped = 0usize;
-        let mut warnings = String::new();
-        for stale_wt in stale {
-            if !force && !stale_wt.is_safe_to_force_remove() {
-                let _ = writeln!(
-                    warnings,
-                    "warning: skipping {} — directory exists and git does not report it as \
-                     prunable; it may be in active use by another zeph session.",
-                    stale_wt.handle.path.display()
-                );
-                skipped += 1;
-                continue;
-            }
-            if let Err(e) = wm.remove(&stale_wt.handle, prune_branch_on_remove).await {
-                let _ = writeln!(
-                    warnings,
-                    "warning: failed to remove {}: {e}",
-                    stale_wt.handle.path.display()
-                );
-            } else {
-                removed += 1;
-            }
+        let outcome = wm
+            .clean(force, prune_branch_on_remove, "`/worktree clean --force`")
+            .await?;
+
+        let mut out = String::new();
+        for warning in &outcome.warnings {
+            let _ = writeln!(out, "{warning}");
         }
-        if let Err(e) = wm.prune().await {
-            let _ = writeln!(warnings, "warning: failed to prune worktree registry: {e}");
+        out.push_str(&zeph_worktree::format_clean_summary(&outcome));
+        Ok(Some(out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zeph_config::WorktreeConfig;
+    use zeph_worktree::{DefaultGitRunner, DefaultWorktreeManager};
+
+    use super::*;
+    use crate::testing::{MockChannel, MockToolExecutor, mock_provider};
+
+    fn git(args: &[&str], cwd: &std::path::Path) -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("git must be on PATH for this test")
+    }
+
+    fn init_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path();
+        assert!(git(&["init", "-q"], path).status.success());
+        git(&["config", "user.email", "test@example.com"], path);
+        git(&["config", "user.name", "Test"], path);
+        std::fs::write(path.join("README.md"), "test\n").expect("write README");
+        git(&["add", "."], path);
+        assert!(git(&["commit", "-q", "-m", "init"], path).status.success());
+        dir
+    }
+
+    fn worktree_config() -> WorktreeConfig {
+        WorktreeConfig {
+            enabled: true,
+            root: "worktrees".to_string(),
+            branch_prefix: "agent/".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn test_agent() -> Agent<MockChannel> {
+        Agent::new(
+            mock_provider(vec!["ignored".to_string()]),
+            MockChannel::new(Vec::<String>::new()),
+            zeph_skills::registry::SkillRegistry::load(&Vec::<std::path::PathBuf>::new()),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        )
+    }
+
+    /// Builds an `Agent` whose `SubAgentManager` is wired to a real, live
+    /// `DefaultWorktreeManager` over `repo_root` — mirroring how bootstrap wires the
+    /// two together in production (`src/agent_setup.rs`) — so
+    /// `handle_worktree_list_as_string`/`handle_worktree_clean_as_string` exercise the
+    /// actual `Some(wm)` branch instead of only the `None` (disabled-subsystem)
+    /// short-circuit that `zeph-commands`' `NullAgent`-backed tests already cover.
+    async fn agent_with_live_worktree_manager(repo_root: std::path::PathBuf) -> Agent<MockChannel> {
+        let wm = Arc::new(
+            DefaultWorktreeManager::new(repo_root, worktree_config(), DefaultGitRunner::new())
+                .await
+                .expect("construct live worktree manager"),
+        );
+        let mut sam = zeph_subagent::SubAgentManager::new(4);
+        sam.set_worktree_manager(wm);
+
+        let mut agent = test_agent();
+        agent.services.orchestration.subagent_manager = Some(sam);
+        agent
+    }
+
+    #[tokio::test]
+    async fn list_reports_no_worktrees_when_none_exist() {
+        let repo = init_repo();
+        let repo_root = repo.path().canonicalize().expect("canonicalize");
+        let mut agent = agent_with_live_worktree_manager(repo_root).await;
+
+        let out = agent.handle_worktree_list_as_string().await.unwrap();
+        assert_eq!(out.as_deref(), Some("No active worktrees."));
+    }
+
+    /// Covers the "active" (in-memory, non-stale) branch of `list` — a worktree created
+    /// through the *same* live manager instance the agent holds shows up via
+    /// `WorktreeManager::list()`, not `reconcile()`. This is genuinely new coverage: the
+    /// CLI's `zeph worktree list` always constructs a fresh manager per invocation, so its
+    /// own `list()` is trivially always empty and this branch is unreachable from there.
+    #[tokio::test]
+    async fn list_reports_active_worktrees_created_by_this_session() {
+        let repo = init_repo();
+        let repo_root = repo.path().canonicalize().expect("canonicalize");
+        let mut agent = agent_with_live_worktree_manager(repo_root).await;
+
+        {
+            let mgr = agent
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap();
+            let wm = mgr.worktree_manager().unwrap();
+            wm.create("agent-1").await.expect("create worktree");
+            wm.create("agent-2").await.expect("create worktree");
         }
 
-        let mut out = warnings;
-        let _ = write!(
-            out,
-            "Removed {removed} stale worktree(s), skipped {skipped} in-use candidate(s)."
+        let out = agent
+            .handle_worktree_list_as_string()
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(out.contains("AGENT ID"), "got: {out}");
+        assert!(out.contains("agent-1"), "got: {out}");
+        assert!(out.contains("agent-2"), "got: {out}");
+        assert!(!out.contains("Stale"), "got: {out}");
+    }
+
+    /// Covers the "stale" branch of `list` with both a prunable and a non-prunable entry
+    /// in the same result — using a *separate* creator manager (over the same repo) so
+    /// the agent's own live manager discovers them purely via `reconcile()`, exactly as a
+    /// worktree left behind by a crashed or concurrently running session would appear.
+    #[tokio::test]
+    async fn list_reports_stale_worktrees_with_prunable_and_in_use_reasons() {
+        let repo = init_repo();
+        let repo_root = repo.path().canonicalize().expect("canonicalize");
+
+        let creator = DefaultWorktreeManager::new(
+            repo_root.clone(),
+            worktree_config(),
+            DefaultGitRunner::new(),
+        )
+        .await
+        .expect("construct creator manager");
+        let prunable = creator.create("prunable-1").await.expect("create");
+        std::fs::remove_dir_all(&prunable.path).expect("remove prunable dir");
+        let in_use = creator.create("in-use-1").await.expect("create");
+
+        let mut agent = agent_with_live_worktree_manager(repo_root).await;
+        let out = agent
+            .handle_worktree_list_as_string()
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            out.contains("Stale (on disk but not tracked):"),
+            "got: {out}"
         );
-        Ok(Some(out))
+        assert!(
+            out.contains(&format!("{}  [prunable:", prunable.path.display())),
+            "got: {out}"
+        );
+        assert!(
+            out.contains(&format!(
+                "{}  [in use — not marked prunable by git; may belong to another session]",
+                in_use.path.display()
+            )),
+            "got: {out}"
+        );
+    }
+
+    /// End-to-end fixture test for #6142 part A: a mixed prunable/non-prunable stale
+    /// list through the real `handle_worktree_clean_as_string`, `force = false`. Confirms
+    /// the live-manager `Some(wm)` branch actually reaches `WorktreeManager::clean` with
+    /// the right semantics (prunable removed, non-prunable left alone) — not just the
+    /// `None`-manager short-circuit `zeph-commands`' existing tests cover.
+    #[tokio::test]
+    async fn clean_removes_prunable_and_skips_in_use_without_force() {
+        let repo = init_repo();
+        let repo_root = repo.path().canonicalize().expect("canonicalize");
+
+        let creator = DefaultWorktreeManager::new(
+            repo_root.clone(),
+            worktree_config(),
+            DefaultGitRunner::new(),
+        )
+        .await
+        .expect("construct creator manager");
+        let prunable = creator.create("prunable-1").await.expect("create");
+        std::fs::remove_dir_all(&prunable.path).expect("remove prunable dir");
+        let in_use = creator.create("in-use-1").await.expect("create");
+
+        let mut agent = agent_with_live_worktree_manager(repo_root.clone()).await;
+        let out = agent
+            .handle_worktree_clean_as_string(false)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            out.contains("Removed 1 stale worktree(s), skipped 1 in-use candidate(s), 0 error(s)."),
+            "got: {out}"
+        );
+        assert!(
+            in_use.path.exists(),
+            "in-use worktree must survive without --force"
+        );
+
+        let list = git(&["worktree", "list", "--porcelain"], &repo_root);
+        let list_str = String::from_utf8_lossy(&list.stdout);
+        assert!(
+            !list_str.contains(&*prunable.path.to_string_lossy()),
+            "prunable worktree must be gone from the registry: {list_str}"
+        );
+        assert!(
+            list_str.contains(&*in_use.path.to_string_lossy()),
+            "in-use worktree must remain in the registry: {list_str}"
+        );
+    }
+
+    /// `--force` variant reaching the live `WorktreeManager` with correct semantics: the
+    /// same non-prunable entry that survives without `force` is actually removed once
+    /// `force = true` is threaded through.
+    #[tokio::test]
+    async fn clean_with_force_removes_in_use_entry_too() {
+        let repo = init_repo();
+        let repo_root = repo.path().canonicalize().expect("canonicalize");
+
+        let creator = DefaultWorktreeManager::new(
+            repo_root.clone(),
+            worktree_config(),
+            DefaultGitRunner::new(),
+        )
+        .await
+        .expect("construct creator manager");
+        let in_use = creator.create("in-use-1").await.expect("create");
+
+        let mut agent = agent_with_live_worktree_manager(repo_root.clone()).await;
+        let out = agent
+            .handle_worktree_clean_as_string(true)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            out.contains("Removed 1 stale worktree(s), skipped 0 in-use candidate(s), 0 error(s)."),
+            "got: {out}"
+        );
+        assert!(
+            !in_use.path.exists(),
+            "in-use worktree must be removed once --force is passed"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_and_clean_return_none_when_worktree_subsystem_disabled() {
+        let mut agent = test_agent();
+        assert!(agent.services.orchestration.subagent_manager.is_none());
+
+        assert_eq!(agent.handle_worktree_list_as_string().await.unwrap(), None);
+        assert_eq!(
+            agent.handle_worktree_clean_as_string(false).await.unwrap(),
+            None
+        );
     }
 }

--- a/crates/zeph-worktree/src/lib.rs
+++ b/crates/zeph-worktree/src/lib.rs
@@ -53,7 +53,7 @@ pub mod sanitize;
 pub use error::WorktreeError;
 pub use git_runner::{DefaultGitRunner, GitRunner};
 pub use handle::{BARE_WORKTREE_SENTINEL, DETACHED_BRANCH_SENTINEL, StaleWorktree, WorktreeHandle};
-pub use manager::{WorktreeManager, probe_capabilities};
+pub use manager::{CleanOutcome, WorktreeManager, format_clean_summary, probe_capabilities};
 
 /// A [`WorktreeManager`] using the production [`DefaultGitRunner`].
 ///

--- a/crates/zeph-worktree/src/manager.rs
+++ b/crates/zeph-worktree/src/manager.rs
@@ -296,8 +296,11 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// worktrees that exist on disk but are not in the current session's
     /// in-memory list.
     ///
-    /// This is used at startup (and via `worktree clean`) to recover from a
-    /// previous crash that left stale worktrees behind. Each entry carries
+    /// This is called by the `zeph worktree list` and `zeph worktree clean`
+    /// CLI subcommands (`handle_worktree_command` in `src/commands/worktree.rs`)
+    /// to recover from a previous crash that left stale worktrees behind. There
+    /// is no startup caller — worktrees are only reconciled on-demand via these
+    /// subcommands. Each entry carries
     /// git's own `prunable` verdict (see [`StaleWorktree::is_safe_to_force_remove`])
     /// so callers can distinguish a worktree whose directory is already gone
     /// from one that is merely untracked by *this* process — the latter may
@@ -394,6 +397,105 @@ impl<R: GitRunner> WorktreeManager<R> {
         check_git_status(&out, "worktree prune")?;
         Ok(())
     }
+
+    /// Runs the full `worktree clean` pipeline: [`reconcile`][Self::reconcile], then
+    /// [`remove`][Self::remove] each stale entry that is either `prunable` or covered by
+    /// `force`, then [`prune`][Self::prune] the registry.
+    ///
+    /// Shared by the CLI (`zeph worktree clean`, `src/commands/worktree.rs`) and the
+    /// agent-side `/worktree clean` slash command (`crates/zeph-core/src/agent/
+    /// worktree_commands.rs`) so their removed/skipped/errored counts and per-entry
+    /// warnings cannot silently diverge — this exact divergence (a discarded `prune()`
+    /// failure on one call site) was caught in review during #6141 (#6142).
+    ///
+    /// `force_hint` is substituted into the skip-warning for a non-`force` run advising
+    /// the operator how to override it (e.g. `` `zeph worktree clean --force` `` for the
+    /// CLI, `` `/worktree clean --force` `` for the slash command) — the only piece of
+    /// UX text that legitimately differs between the two surfaces.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorktreeError::GitCommand`] only if the initial [`reconcile`][Self::reconcile] call
+    /// fails — nothing has been removed yet, so there is no partial outcome to lose.
+    /// Per-entry removal failures and a final prune failure are both recorded in the
+    /// returned [`CleanOutcome`] instead of aborting.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn example(mgr: &zeph_worktree::DefaultWorktreeManager) -> Result<(), zeph_worktree::WorktreeError> {
+    /// let outcome = mgr.clean(false, false, "`zeph worktree clean --force`").await?;
+    /// println!("{}", zeph_worktree::format_clean_summary(&outcome));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn clean(
+        &self,
+        force: bool,
+        prune_branch_on_remove: bool,
+        force_hint: &str,
+    ) -> Result<CleanOutcome, WorktreeError> {
+        let stale = self.reconcile().await?;
+        let mut outcome = CleanOutcome::default();
+        for stale_wt in stale {
+            if !force && !stale_wt.is_safe_to_force_remove() {
+                outcome.warnings.push(format!(
+                    "warning: skipping {} — directory exists and git does not report it as \
+                     prunable; it may be in active use by another zeph session. \
+                     Re-run with {force_hint} if you are certain it is abandoned.",
+                    stale_wt.handle.path.display()
+                ));
+                outcome.skipped += 1;
+                continue;
+            }
+            if let Err(e) = self.remove(&stale_wt.handle, prune_branch_on_remove).await {
+                outcome.warnings.push(format!(
+                    "warning: failed to remove {}: {e}",
+                    stale_wt.handle.path.display()
+                ));
+                outcome.errored += 1;
+            } else {
+                outcome.removed += 1;
+            }
+        }
+        // FR-CLEANUP-04: clear any remaining stale administrative entries
+        // (e.g. worktrees deleted outside Zeph) from the git registry.
+        if let Err(e) = self.prune().await {
+            outcome
+                .warnings
+                .push(format!("warning: failed to prune worktree registry: {e}"));
+        }
+        Ok(outcome)
+    }
+}
+
+/// Outcome of a [`WorktreeManager::clean`] pass.
+///
+/// Every stale entry `reconcile()` discovers is accounted for in exactly one of
+/// `removed`, `skipped`, or `errored` — the three always sum to the number of stale
+/// entries processed, so a caller can never silently undercount what happened.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CleanOutcome {
+    /// Number of stale entries successfully removed.
+    pub removed: usize,
+    /// Number of stale entries left in place because they were not `prunable` and
+    /// `force` was not passed.
+    pub skipped: usize,
+    /// Number of stale entries whose removal was attempted but the underlying
+    /// `git worktree remove` call itself failed (e.g. a locked worktree).
+    pub errored: usize,
+    /// One warning line per skipped, errored, or prune-failure event, in encounter order.
+    pub warnings: Vec<String>,
+}
+
+/// Formats a [`CleanOutcome`]'s counts into the standard one-line summary shared by
+/// both the CLI and agent-side `/worktree clean` output.
+#[must_use]
+pub fn format_clean_summary(outcome: &CleanOutcome) -> String {
+    format!(
+        "Removed {} stale worktree(s), skipped {} in-use candidate(s), {} error(s).",
+        outcome.removed, outcome.skipped, outcome.errored
+    )
 }
 
 /// Intermediate result of parsing one `git worktree list --porcelain` block,
@@ -1240,6 +1342,151 @@ mod tests {
         let mgr = make_manager(&dir, runner).await;
         let err = mgr.prune().await.unwrap_err();
         assert_matches!(err, WorktreeError::GitCommand { ref op, .. } if op == "worktree prune");
+    }
+
+    // --- clean (#6142: shared by CLI + agent-side /worktree clean) ---
+
+    /// Mixed prunable/non-prunable stale list, `force = false`: the prunable entry is
+    /// removed, the non-prunable one is skipped and left alone — the standard case
+    /// both the CLI and agent-side callers depend on.
+    #[tokio::test]
+    async fn clean_removes_prunable_and_skips_non_prunable_without_force() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
+             worktree {0}/worktrees/prunable-1\nHEAD def456\nbranch refs/heads/agent/prunable-1\n\
+             prunable gitdir file points to non-existent location\n\n\
+             worktree {0}/worktrees/in-use-1\nHEAD ghi789\nbranch refs/heads/agent/in-use-1\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes()); // reconcile: worktree list --porcelain
+        runner.push_ok(b"" as &[u8]); // remove prunable-1: worktree remove --force
+        runner.push_ok(b"" as &[u8]); // final: worktree prune
+
+        let mgr = make_manager(&dir, runner).await;
+        let outcome = mgr.clean(false, false, "`--force`").await.unwrap();
+
+        assert_eq!(outcome.removed, 1);
+        assert_eq!(outcome.skipped, 1);
+        assert_eq!(outcome.errored, 0);
+        assert_eq!(
+            outcome.warnings.len(),
+            1,
+            "only the skip warning: {:?}",
+            outcome.warnings
+        );
+        assert!(outcome.warnings[0].contains("in-use-1"));
+        assert!(outcome.warnings[0].contains("`--force`"));
+    }
+
+    /// `force = true` bypasses the non-prunable skip-gate: the same entry that would be
+    /// skipped without `--force` is now attempted and removed.
+    #[tokio::test]
+    async fn clean_with_force_removes_non_prunable_entries_too() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
+             worktree {0}/worktrees/in-use-1\nHEAD ghi789\nbranch refs/heads/agent/in-use-1\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+        runner.push_ok(b"" as &[u8]); // remove in-use-1 (force bypasses the skip-gate)
+        runner.push_ok(b"" as &[u8]); // final prune
+
+        let mgr = make_manager(&dir, runner).await;
+        let outcome = mgr.clean(true, false, "`--force`").await.unwrap();
+
+        assert_eq!(outcome.removed, 1);
+        assert_eq!(outcome.skipped, 0);
+        assert_eq!(outcome.errored, 0);
+    }
+
+    /// Regression test for #6077/#6142 (critic M2): a stale entry whose `remove()` call
+    /// itself fails (e.g. a locked worktree under `--force`) must be counted as
+    /// `errored`, not silently folded into `removed` or `skipped`.
+    #[tokio::test]
+    async fn clean_counts_errored_when_remove_fails() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
+             worktree {0}/worktrees/locked-1\nHEAD def456\nbranch refs/heads/agent/locked-1\n\
+             prunable gitdir file points to non-existent location\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+        runner.push_err(b"error: unable to remove worktree: it is locked\n" as &[u8]);
+        runner.push_ok(b"" as &[u8]); // final prune still runs
+
+        let mgr = make_manager(&dir, runner).await;
+        let outcome = mgr.clean(false, false, "`--force`").await.unwrap();
+
+        assert_eq!(outcome.removed, 0);
+        assert_eq!(outcome.skipped, 0);
+        assert_eq!(outcome.errored, 1);
+        assert_eq!(outcome.warnings.len(), 1);
+        assert!(outcome.warnings[0].contains("failed to remove"));
+    }
+
+    /// Regression test for the exact divergence caught in #6141's review: a failure of
+    /// the final `prune()` step must be recorded as a warning, not discard an
+    /// otherwise-successful removal count or turn the whole call into an `Err`.
+    #[tokio::test]
+    async fn clean_records_prune_failure_without_discarding_removed_count() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
+             worktree {0}/worktrees/prunable-1\nHEAD def456\nbranch refs/heads/agent/prunable-1\n\
+             prunable gitdir file points to non-existent location\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+        runner.push_ok(b"" as &[u8]); // remove succeeds
+        runner.push_err(b"fatal: not a working tree\n" as &[u8]); // prune fails
+
+        let mgr = make_manager(&dir, runner).await;
+        let outcome = mgr
+            .clean(false, false, "`--force`")
+            .await
+            .expect("a prune failure must not turn clean() into an Err");
+
+        assert_eq!(
+            outcome.removed, 1,
+            "the successful removal must not be discarded by a later prune failure"
+        );
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|w| w.contains("failed to prune worktree registry")),
+            "got: {:?}",
+            outcome.warnings
+        );
+    }
+
+    #[test]
+    fn format_clean_summary_all_zero() {
+        assert_eq!(
+            format_clean_summary(&CleanOutcome::default()),
+            "Removed 0 stale worktree(s), skipped 0 in-use candidate(s), 0 error(s)."
+        );
+    }
+
+    #[test]
+    fn format_clean_summary_includes_all_three_counts() {
+        let outcome = CleanOutcome {
+            removed: 2,
+            skipped: 1,
+            errored: 3,
+            warnings: Vec::new(),
+        };
+        let msg = format_clean_summary(&outcome);
+        assert!(msg.contains("Removed 2"), "got: {msg}");
+        assert!(msg.contains("skipped 1"), "got: {msg}");
+        assert!(msg.contains("3 error(s)"), "got: {msg}");
     }
 
     // --- parse_git_version ---

--- a/crates/zeph-worktree/tests/real_git_integration.rs
+++ b/crates/zeph-worktree/tests/real_git_integration.rs
@@ -13,7 +13,7 @@ use std::process::Command;
 use std::time::Duration;
 
 use zeph_config::WorktreeConfig;
-use zeph_worktree::{DETACHED_BRANCH_SENTINEL, DefaultGitRunner, WorktreeManager};
+use zeph_worktree::{DETACHED_BRANCH_SENTINEL, DefaultGitRunner, WorktreeError, WorktreeManager};
 
 fn git(args: &[&str], cwd: &Path) -> std::process::Output {
     Command::new("git")
@@ -220,6 +220,52 @@ fn detached_branch_sentinel_is_not_a_valid_git_ref_name() {
         "DETACHED_BRANCH_SENTINEL ({DETACHED_BRANCH_SENTINEL:?}) must be REJECTED by \
          `git check-ref-format --branch` — otherwise a real branch could be given this exact \
          name and collide with the sentinel (see #5936 review finding)"
+    );
+}
+
+/// Regression test for #6077 (tester gap A): `WorktreeManager::remove()`'s
+/// single `git worktree remove --force` is a *second* safety layer, alongside
+/// the `prunable`-gating callers perform before ever calling `remove` (#6055)
+/// — git itself refuses to remove a `git worktree lock`-ed worktree unless
+/// given a second `--force` (`remove -f -f`), which `remove()` deliberately
+/// never passes (see its doc comment). Before this test, that refusal was
+/// only confirmed manually against real git 2.50.1; if `remove()` were ever
+/// changed to pass `-f -f`, this protection would silently regress with
+/// nothing catching it.
+#[tokio::test]
+async fn remove_refuses_locked_worktree_with_single_force() {
+    let repo = init_repo();
+    let repo_root = repo.path().canonicalize().unwrap();
+
+    let mgr = WorktreeManager::new(repo_root.clone(), config(), DefaultGitRunner::new())
+        .await
+        .unwrap();
+    let handle = mgr.create("locked-agent").await.expect("create worktree");
+
+    let lock_out = git(
+        &["worktree", "lock", "--", &handle.path.to_string_lossy()],
+        &repo_root,
+    );
+    assert!(
+        lock_out.status.success(),
+        "git worktree lock must succeed: {lock_out:?}"
+    );
+
+    let err = mgr.remove(&handle, false).await.unwrap_err();
+    assert!(
+        matches!(err, WorktreeError::GitCommand { ref op, .. } if op == "worktree remove"),
+        "expected a `worktree remove` GitCommand failure, got: {err:?}"
+    );
+    assert!(
+        handle.path.exists(),
+        "a locked worktree's directory must survive `remove()`'s single --force"
+    );
+
+    // Unlock so the underlying tempdir can be cleaned up without a dangling
+    // lock file confusing later `git worktree` invocations against it.
+    git(
+        &["worktree", "unlock", "--", &handle.path.to_string_lossy()],
+        &repo_root,
     );
 }
 

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -72,38 +72,17 @@ pub(crate) async fn handle_worktree_command(
             }
         }
         WorktreeCommand::Clean { force } => {
-            let stale = wm.reconcile().await?;
-            let mut removed = 0usize;
-            let mut skipped = 0usize;
-            for stale_wt in stale {
-                if !force && !stale_wt.is_safe_to_force_remove() {
-                    eprintln!(
-                        "warning: skipping {} — directory exists and git does not report it as \
-                         prunable; it may be in active use by another zeph session. \
-                         Re-run with `zeph worktree clean --force` if you are certain it is abandoned.",
-                        stale_wt.handle.path.display()
-                    );
-                    skipped += 1;
-                    continue;
-                }
-                if let Err(e) = wm
-                    .remove(&stale_wt.handle, config.worktree.prune_branch_on_remove)
-                    .await
-                {
-                    eprintln!(
-                        "warning: failed to remove {}: {e}",
-                        stale_wt.handle.path.display()
-                    );
-                } else {
-                    removed += 1;
-                }
+            let outcome = wm
+                .clean(
+                    force,
+                    config.worktree.prune_branch_on_remove,
+                    "`zeph worktree clean --force`",
+                )
+                .await?;
+            for warning in &outcome.warnings {
+                eprintln!("{warning}");
             }
-            // FR-CLEANUP-04: clear any remaining stale administrative entries
-            // (e.g. worktrees deleted outside Zeph) from the git registry.
-            if let Err(e) = wm.prune().await {
-                eprintln!("warning: failed to prune worktree registry: {e}");
-            }
-            println!("Removed {removed} stale worktree(s), skipped {skipped} in-use candidate(s).");
+            println!("{}", zeph_worktree::format_clean_summary(&outcome));
         }
     }
 
@@ -115,8 +94,127 @@ mod tests {
     use std::io::Write as _;
 
     use clap::Parser as _;
+    use serial_test::serial;
 
     use crate::cli::{Cli, Command, WorktreeCommand};
+
+    fn git(args: &[&str], cwd: &std::path::Path) -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("git must be on PATH for this test")
+    }
+
+    fn init_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path();
+        assert!(git(&["init", "-q"], path).status.success());
+        git(&["config", "user.email", "test@example.com"], path);
+        git(&["config", "user.name", "Test"], path);
+        std::fs::write(path.join("README.md"), "test\n").expect("write README");
+        git(&["add", "."], path);
+        assert!(git(&["commit", "-q", "-m", "init"], path).status.success());
+        dir
+    }
+
+    /// Writes a full, valid config (not just a `[worktree]` snippet — most
+    /// `Config` fields have no section-level default) with worktrees enabled,
+    /// rooted at `worktrees` relative to the repo, and returns its path.
+    fn write_worktree_config(dir: &std::path::Path) -> std::path::PathBuf {
+        let mut cfg = zeph_core::config::Config::default();
+        cfg.worktree.enabled = true;
+        cfg.worktree.root = "worktrees".to_string();
+        cfg.worktree.branch_prefix = "agent/".to_string();
+        let toml_str = toml::to_string_pretty(&cfg).expect("serialize config");
+        let config_path = dir.join("zeph-test-config.toml");
+        std::fs::write(&config_path, toml_str).expect("write config");
+        config_path
+    }
+
+    /// End-to-end regression test for #6077 (tester gaps B + C): calls the
+    /// real production handler `handle_worktree_command(Clean)` directly
+    /// against a real git repo — rather than reimplementing its skip-gating
+    /// logic, as the previous integration test in
+    /// `crates/zeph-worktree/tests/real_git_integration.rs` did — over a
+    /// mixed stale list containing both prunable entries (directories deleted
+    /// externally, simulating a crash) and non-prunable ones (directories
+    /// left intact, simulating another concurrently running zeph session),
+    /// with N>1 removed and M>1 skipped in the same run.
+    ///
+    /// `#[serial]` because this mutates the process-global current directory
+    /// (`find_repo_root` resolves the repo from cwd); nextest — the sanctioned
+    /// runner for this project — gives every test its own process, but plain
+    /// `cargo test` would otherwise race this against other tests in this
+    /// binary that also touch cwd (see `src/acp.rs`, `src/url_scheme/register.rs`).
+    #[tokio::test]
+    #[serial]
+    async fn clean_handles_mixed_prunable_and_in_use_stale_list() {
+        let repo = init_repo();
+        let repo_root = repo.path().canonicalize().expect("canonicalize repo root");
+        let config_path = write_worktree_config(repo.path());
+
+        let creator = zeph_worktree::DefaultWorktreeManager::new(
+            repo_root.clone(),
+            zeph_config::WorktreeConfig {
+                enabled: true,
+                root: "worktrees".to_string(),
+                branch_prefix: "agent/".to_string(),
+                ..Default::default()
+            },
+            zeph_worktree::DefaultGitRunner::new(),
+        )
+        .await
+        .expect("construct fixture manager");
+
+        // Prunable: directories deleted externally (crash simulation).
+        let prunable_1 = creator.create("prunable-1").await.expect("create");
+        let prunable_2 = creator.create("prunable-2").await.expect("create");
+        std::fs::remove_dir_all(&prunable_1.path).expect("remove prunable-1 dir");
+        std::fs::remove_dir_all(&prunable_2.path).expect("remove prunable-2 dir");
+
+        // Non-prunable: directories left intact (another live session).
+        let in_use_1 = creator.create("in-use-1").await.expect("create");
+        let in_use_2 = creator.create("in-use-2").await.expect("create");
+
+        let orig_cwd = std::env::current_dir().expect("current_dir");
+        std::env::set_current_dir(&repo_root).expect("set_current_dir");
+        let result = super::handle_worktree_command(
+            WorktreeCommand::Clean { force: false },
+            Some(&config_path),
+        )
+        .await;
+        std::env::set_current_dir(orig_cwd).expect("restore current_dir");
+        result.expect("handle_worktree_command(Clean) must succeed");
+
+        let list = git(&["worktree", "list", "--porcelain"], &repo_root);
+        let list_str = String::from_utf8_lossy(&list.stdout);
+
+        assert!(
+            !list_str.contains(&*prunable_1.path.to_string_lossy()),
+            "prunable-1 must be removed from the git registry: {list_str}"
+        );
+        assert!(
+            !list_str.contains(&*prunable_2.path.to_string_lossy()),
+            "prunable-2 must be removed from the git registry: {list_str}"
+        );
+        assert!(
+            in_use_1.path.exists(),
+            "in-use-1 must survive a non-force clean"
+        );
+        assert!(
+            in_use_2.path.exists(),
+            "in-use-2 must survive a non-force clean"
+        );
+        assert!(
+            list_str.contains(&*in_use_1.path.to_string_lossy()),
+            "in-use-1 must remain in the git registry: {list_str}"
+        );
+        assert!(
+            list_str.contains(&*in_use_2.path.to_string_lossy()),
+            "in-use-2 must remain in the git registry: {list_str}"
+        );
+    }
 
     /// Regression test for #4701: `handle_worktree_command` must propagate a config parse
     /// error instead of silently falling back to `Config::default()`.


### PR DESCRIPTION
## Summary
- Add a regression test confirming `WorktreeManager::remove()`'s single `--force`
  still refuses a `git worktree lock`-ed worktree (previously only checked manually).
- Add an end-to-end test through the real `handle_worktree_command(Clean)` handler
  over a mixed prunable/in-use stale list (N>1/M>1), replacing an earlier
  reimplementation of the skip-gating logic.
- Fix `zeph worktree clean`'s summary to count entries whose `remove()` call itself
  failed (previously silently undercounted); fix `reconcile()`'s stale "used at
  startup" doc comment.
- Extract the CLI's and the `/worktree clean` slash command's independently
  duplicated reconcile/remove/prune loop into a single `WorktreeManager::clean` +
  `format_clean_summary` (`zeph-worktree`), closing the divergence class that
  caused a real bug during #6141's review (a discarded `prune()` failure).
- Add live-`SubAgentManager` fixture tests for `/worktree list`/`/worktree clean`
  exercising the real `Some(wm)` branch (previously only the disabled-subsystem
  short-circuit had coverage).

Closes #6142
Closes #6077

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13127 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `.local/testing/playbooks/worktree.md` (Scenarios 14/15) and `.local/testing/coverage-status.md` updated