### PR TITLE
fix(skills): share one RoutingHead instance across ACP/serve sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-skills`/`src/acp.rs`/`src/serve/`: `SkillOrchestra`'s RL routing head lost learned
+  updates under concurrent ACP/`/sessions` agents (#5974). `#5921` wired `RoutingHead`
+  persistence into `spawn_acp_agent` and `build_agent_factory`, but each session independently
+  loaded its own in-memory copy from the `routing_head_weights` singleton row and persisted
+  back independently — concurrent sessions clobbered each other's REINFORCE weights
+  (last-write-wins). The head is now loaded/cold-started exactly once in
+  `crate::acp::build_shared_core` and cloned (a cheap `Arc` clone) into every session sharing
+  that core, so all sessions mutate the same `Arc<Mutex<RoutingHeadInner>>` and updates
+  serialize through that mutex instead of racing across independent copies. Also added
+  `RoutingHead::persist_snapshot()`, capturing `embed_dim`/weights/baseline/`update_count`
+  under one lock acquisition, closing a related TOCTOU where a concurrent `update()` could land
+  between the previously-separate locked reads used to build the persisted DB row. No config or
+  behavior change for `rl_routing_enabled = false` (still the default) or single-session
+  (`runner`/`daemon`) deployments.
 - `.github/deny.toml`: the `cargo-deny` advisories gate scanned only the `candle`
   and `tui` features, excluding `pdf` and every other feature shipped by the
   blocking `bundle-check` (`full`) CI job and release builds — any RUSTSEC

--- a/crates/zeph-core/src/agent/learning/rl.rs
+++ b/crates/zeph-core/src/agent/learning/rl.rs
@@ -42,10 +42,14 @@ impl<C: Channel> Agent<C> {
             if (persist_interval == 0 || update_count % persist_interval == 0)
                 && let Some(mem) = memory
             {
-                let bytes = rl_head.to_bytes();
-                let embed_dim = i64::try_from(rl_head.embed_dim()).unwrap_or(i64::MAX);
-                let baseline = f64::from(rl_head.baseline());
-                let count = i64::from(update_count);
+                // #5974: snapshot embed_dim/bytes/baseline/update_count under one lock
+                // acquisition — this handle may be shared with concurrent sessions, and a
+                // second `update()` landing between separate locked reads would otherwise
+                // desync the persisted `update_count` column from the blob's own copy.
+                let (embed_dim, bytes, baseline, count) = rl_head.persist_snapshot();
+                let embed_dim = i64::try_from(embed_dim).unwrap_or(i64::MAX);
+                let baseline = f64::from(baseline);
+                let count = i64::from(count);
                 if let Err(e) = mem
                     .sqlite()
                     .save_routing_head_weights(embed_dim, &bytes, baseline, count)

--- a/crates/zeph-skills/src/rl_head.rs
+++ b/crates/zeph-skills/src/rl_head.rs
@@ -20,11 +20,21 @@
 //! Training: REINFORCE with running baseline. Weights are shared via
 //! `Arc<std::sync::Mutex<RoutingHeadInner>>` for safe concurrent access.
 //!
-//! # Single-instance limitation
+//! # Single-process sharing (#5974)
 //!
-//! SQLite weight persistence is singleton-row based. Two agent instances sharing
-//! the same DB will silently overwrite each other's weights (last writer wins).
-//! This is documented and accepted for MVP single-instance deployments.
+//! SQLite weight persistence is singleton-row based (`routing_head_weights WHERE id = 1`,
+//! upsert semantics). Callers that build multiple concurrent sessions/agents from one process
+//! (ACP, `zeph serve-sessions`) MUST load one [`RoutingHead`] and share it — via [`Clone`], which
+//! clones only the cheap `Arc` handle — across every session, rather than having each session
+//! independently load its own copy from the DB row. Independent copies would each evolve their
+//! own REINFORCE weights and clobber each other on persist (last writer wins); a single shared
+//! handle serializes updates through the inner `Mutex` instead, so no update is lost.
+//!
+//! # Cross-process limitation
+//!
+//! Two separate OS processes (e.g. two `zeph` daemons) pointed at the same `SQLite` DB still
+//! silently overwrite each other's persisted weights (last writer wins) — this is accepted for
+//! MVP single-instance deployments.
 
 use std::sync::{Arc, Mutex};
 
@@ -429,6 +439,30 @@ impl RoutingHead {
             .to_bytes()
     }
 
+    /// Atomic snapshot of everything needed to persist the routing head: `(embed_dim,
+    /// weights_bytes, baseline, update_count)`, all read under a single lock acquisition.
+    ///
+    /// When a [`RoutingHead`] handle is shared across concurrent sessions (#5974), calling
+    /// `update_count()`, `to_bytes()`, and `baseline()` as three separate locked calls lets a
+    /// concurrent `update()` land between them, producing a DB row whose `update_count` column
+    /// doesn't match the `update_count` encoded inside the serialized blob. This method closes
+    /// that gap the same way [`RerankOutcome`] closes the analogous `blended`/`update_count`
+    /// TOCTOU (see #5846).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mutex is poisoned.
+    #[must_use]
+    pub fn persist_snapshot(&self) -> (usize, Vec<u8>, f32, u32) {
+        let inner = self.inner.lock().expect("RoutingHead mutex poisoned");
+        (
+            inner.embed_dim,
+            inner.to_bytes(),
+            inner.baseline,
+            inner.update_count,
+        )
+    }
+
     /// Deserialize weights from bytes.
     #[must_use]
     pub fn from_bytes(data: &[u8]) -> Option<Self> {
@@ -605,6 +639,41 @@ mod tests {
         assert!(
             (s1 - s2).abs() < 1e-5,
             "score mismatch after round-trip: {s1} vs {s2}"
+        );
+    }
+
+    #[test]
+    fn persist_snapshot_matches_individual_getters() {
+        let head = make_head();
+        let q = dummy_embed(0.3, 4);
+        let s = dummy_embed(0.7, 4);
+        let _ = head.score(&q, &s, 0.6, 0.8, 10);
+        let _ = head.update(1.0, 0.01);
+
+        let (embed_dim, bytes, baseline, update_count) = head.persist_snapshot();
+        assert_eq!(embed_dim, head.embed_dim());
+        assert_eq!(bytes, head.to_bytes());
+        assert!((baseline - head.baseline()).abs() < 1e-6);
+        assert_eq!(update_count, head.update_count());
+    }
+
+    #[test]
+    fn persist_snapshot_reflects_shared_updates_from_cloned_handle() {
+        // Regression test for #5974: a RoutingHead handle shared (via Clone) across concurrent
+        // sessions must observe updates applied through any clone, since all clones point at
+        // the same Arc<Mutex<RoutingHeadInner>>.
+        let head = make_head();
+        let shared = head.clone();
+        let q = dummy_embed(0.1, 4);
+        let s = dummy_embed(0.2, 4);
+        let _ = shared.score(&q, &s, 0.8, 0.9, 5);
+        assert!(shared.update(1.0, 0.01));
+
+        let (_, _, _, update_count) = head.persist_snapshot();
+        assert_eq!(
+            update_count, 1,
+            "update applied via a cloned handle must be visible through the original handle's \
+             persist_snapshot"
         );
     }
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -164,12 +164,19 @@ pub(crate) struct SharedCore {
     pub(crate) matcher: Option<zeph_skills::matcher::SkillMatcherBackend>,
     pub(crate) memory: std::sync::Arc<zeph_memory::semantic::SemanticMemory>,
     pub(crate) budget_tokens: usize,
-    /// Resolved `SkillOrchestra` RL routing head embedding dimension (#5921), pre-computed
-    /// once here — mirrors `src/runner.rs`/`src/daemon.rs`'s `rl_embed_dim_resolved` — so
-    /// every session built from this core (ACP, `/sessions`, or the combined transport) can
-    /// load/cold-start an `RL` head without re-probing the embedding provider per session.
-    /// `None` when `config.skills.rl_routing_enabled` is `false`.
-    pub(crate) rl_embed_dim_resolved: Option<usize>,
+    /// `SkillOrchestra` RL routing head (#5921), loaded/cold-started exactly once here —
+    /// mirrors `src/runner.rs`/`src/daemon.rs`'s single-load pattern — and shared (via
+    /// [`Clone`], which only clones the cheap `Arc` handle) by every session built from this
+    /// core (ACP, `/sessions`, or the combined transport). `None` when
+    /// `config.skills.rl_routing_enabled` is `false`.
+    ///
+    /// Fixes #5974: previously each session independently loaded its own in-memory
+    /// `RoutingHead` copy from the `routing_head_weights` singleton row and persisted back
+    /// independently, so concurrent ACP/serve sessions clobbered each other's learned REINFORCE
+    /// weights (lost update). Loading once and sharing the same `Arc<Mutex<..>>` across every
+    /// session sharing this core means updates from any session apply to the one true
+    /// in-process state instead of a disposable copy.
+    pub(crate) rl_head: Option<zeph_skills::rl_head::RoutingHead>,
 }
 
 /// Build the resources common to `zeph serve-sessions` and standalone ACP session
@@ -221,6 +228,22 @@ pub(crate) async fn build_shared_core(
         None
     };
 
+    // #5974: load/cold-start the RL routing head exactly once here, so every session built
+    // from this core clones the same Arc<Mutex<..>> handle (see SharedCore::rl_head doc)
+    // instead of each session independently loading its own copy from the DB row.
+    let rl_head = if let Some(dim) = rl_embed_dim_resolved {
+        Some(
+            crate::runner::load_rl_head(&memory)
+                .await
+                .unwrap_or_else(|| {
+                    tracing::info!(dim, "rl_head: cold start, initializing fresh routing head");
+                    zeph_skills::rl_head::RoutingHead::new(dim)
+                }),
+        )
+    } else {
+        None
+    };
+
     Ok(SharedCore {
         provider,
         embedding_provider,
@@ -228,7 +251,7 @@ pub(crate) async fn build_shared_core(
         matcher,
         memory,
         budget_tokens,
-        rl_embed_dim_resolved,
+        rl_head,
     })
 }
 
@@ -293,16 +316,18 @@ pub(crate) struct SharedAgentDeps {
     /// for ACP sessions, silently ignoring the operator's configured trust levels).
     trust_config: zeph_core::config::TrustConfig,
     /// `config.skills.rl_routing_enabled`/`rl_learning_rate`/`rl_weight`/`rl_persist_interval`/
-    /// `rl_warmup_updates`, wired into `Agent::with_rl_routing` per session, plus the resolved
-    /// embed dim (`SharedCore::rl_embed_dim_resolved`) used to load/cold-start an `RL` head via
-    /// `Agent::with_rl_head` — mirrors `src/runner.rs` and `src/daemon.rs` (#5921: previously
-    /// never wired for ACP sessions).
+    /// `rl_warmup_updates`, wired into `Agent::with_rl_routing` per session, plus the shared
+    /// `RL` head (`SharedCore::rl_head`) wired into `Agent::with_rl_head` — mirrors
+    /// `src/runner.rs` and `src/daemon.rs` (#5921: previously never wired for ACP sessions).
+    /// `rl_head` is cloned (cheap `Arc` clone) from the *same* `SharedCore` instance into every
+    /// session, fixing #5974 (concurrent ACP sessions previously each loaded/persisted an
+    /// independent in-memory copy, clobbering each other's learned weights).
     rl_routing_enabled: bool,
     rl_learning_rate: f32,
     rl_weight: f32,
     rl_persist_interval: u32,
     rl_warmup_updates: u32,
-    rl_embed_dim_resolved: Option<usize>,
+    rl_head: Option<zeph_skills::rl_head::RoutingHead>,
     /// Base tool composite (file/shell/scrape/diagnostics + MCP + `search_code`), *not*
     /// wrapped in any gate. `spawn_acp_agent` composites this further with `skill_loader`/
     /// `memory`/`overflow`/ACP-native fs/shell per session, then wraps the FULL per-session
@@ -571,7 +596,7 @@ async fn build_acp_deps(
             matcher,
             memory,
             budget_tokens,
-            rl_embed_dim_resolved,
+            rl_head,
         },
         acp_mem_supervisor,
     ) = if let Some(p) = prebuilt_core {
@@ -1121,7 +1146,7 @@ async fn build_acp_deps(
         rl_weight: config.skills.rl_weight,
         rl_persist_interval: config.skills.rl_persist_interval,
         rl_warmup_updates: config.skills.rl_warmup_updates,
-        rl_embed_dim_resolved,
+        rl_head,
         tool_executor,
         permission_policy,
         policy_gate_pieces,
@@ -1883,22 +1908,14 @@ async fn spawn_acp_agent(
         .with_trajectory_config(d.trajectory_sentinel_config.clone())
         .0;
 
-    // SkillOrchestra: load persisted RL routing head weights, if enabled (#5921) — mirrors
-    // `src/runner.rs`/`src/daemon.rs`'s cold-start/load pattern. `d.rl_embed_dim_resolved` is
-    // pre-computed once in `build_shared_core`, shared across every session from this core.
-    // NOTE (S3, known limitation, not fixed here): `routing_head_weights` is a single global
-    // row (`WHERE id = 1`, last-write-wins upsert — crates/zeph-memory/src/store/skills.rs).
-    // Concurrent ACP sessions each load their own in-memory head from that row and persist back
-    // independently, so concurrent multi-session RL routing can clobber each other's learned
-    // weights. Bounded risk: `rl_routing_enabled` defaults to `false`. See #5974 for
-    // per-conversation persistence keying or write serialization.
-    if let Some(dim) = d.rl_embed_dim_resolved {
-        let head = crate::runner::load_rl_head(&d.memory)
-            .await
-            .unwrap_or_else(|| {
-                tracing::info!(dim, "rl_head: cold start, initializing fresh routing head");
-                zeph_skills::rl_head::RoutingHead::new(dim)
-            });
+    // SkillOrchestra: wire the RL routing head, if enabled (#5921). `d.rl_head` is loaded/
+    // cold-started exactly once in `build_shared_core` and cloned (cheap `Arc` clone) into every
+    // session sharing this core — fixes #5974, where each ACP session previously loaded its own
+    // independent in-memory copy from the `routing_head_weights` singleton row and persisted
+    // back independently, letting concurrent sessions clobber each other's learned REINFORCE
+    // weights. All sessions now mutate the SAME `Arc<Mutex<..>>`, so updates serialize through
+    // that mutex instead of racing across independent copies.
+    if let Some(head) = d.rl_head.clone() {
         agent = agent.with_rl_head(head);
     }
 
@@ -4346,7 +4363,7 @@ mod tests {
     /// `skill_support_similarity_threshold`/`skill_min_injection_score`/
     /// `skill_generation_provider`/`skill_disambiguate_provider`/`semantic_scan`/
     /// `semantic_scan_provider`/`trust_config`/`rl_routing_enabled`/`rl_learning_rate`/
-    /// `rl_weight`/`rl_persist_interval`/`rl_warmup_updates`/`rl_embed_dim_resolved` from
+    /// `rl_weight`/`rl_persist_interval`/`rl_warmup_updates`/`rl_head` from
     /// `config.skills.*` — previously these fields did not exist on either deps struct at all,
     /// so neither `spawn_acp_agent` nor `build_agent_factory` could call
     /// `Agent::with_skill_matching_config`/`with_skill_group_config`/
@@ -4489,12 +4506,15 @@ mod tests {
             serve_deps.rl_warmup_updates, 3,
             "config.skills.rl_warmup_updates must flow into ServeAgentDeps"
         );
+        let serve_rl_head = serve_deps
+            .rl_head
+            .clone()
+            .expect("rl_head must be Some when rl_routing_enabled and rl_embed_dim resolves");
         assert_eq!(
-            serve_deps.rl_embed_dim_resolved,
-            Some(8),
-            "the resolved RL embed dim (SharedCore::rl_embed_dim_resolved) must flow into \
-             ServeAgentDeps, proving build_shared_core's pre-computation reaches both deps \
-             structs from one shared value"
+            serve_rl_head.embed_dim(),
+            8,
+            "the resolved RL embed dim (config.skills.rl_embed_dim) must flow into the \
+             SharedCore::rl_head loaded for ServeAgentDeps"
         );
 
         assert!(
@@ -4558,12 +4578,32 @@ mod tests {
             acp_deps.rl_warmup_updates, 3,
             "config.skills.rl_warmup_updates must flow into SharedAgentDeps"
         );
+        let acp_rl_head = acp_deps
+            .rl_head
+            .clone()
+            .expect("rl_head must be Some when rl_routing_enabled and rl_embed_dim resolves");
         assert_eq!(
-            acp_deps.rl_embed_dim_resolved,
-            Some(8),
-            "the resolved RL embed dim (SharedCore::rl_embed_dim_resolved) must flow into \
-             SharedAgentDeps, proving build_shared_core's pre-computation reaches both deps \
-             structs from one shared value"
+            acp_rl_head.embed_dim(),
+            8,
+            "the resolved RL embed dim (config.skills.rl_embed_dim) must flow into the \
+             SharedCore::rl_head loaded for SharedAgentDeps"
+        );
+
+        // #5974 regression: acp_deps.rl_head and serve_deps.rl_head must be the SAME shared
+        // RoutingHead handle (same Arc<Mutex<..>>), not two independent copies each loaded from
+        // the DB row — otherwise concurrent ACP and `/sessions` agents built from one
+        // SharedCore would silently clobber each other's learned REINFORCE weights. Proven
+        // behaviorally through the public API: an update applied via one handle must be
+        // observable through the other.
+        let q = vec![0.0f32; 8];
+        let s = vec![0.0f32; 8];
+        let _ = acp_rl_head.score(&q, &s, 0.5, 0.5, 1);
+        assert!(acp_rl_head.update(1.0, 0.01));
+        assert_eq!(
+            serve_rl_head.update_count(),
+            1,
+            "acp_deps.rl_head and serve_deps.rl_head must share the same in-memory RoutingHead \
+             instance loaded once by build_shared_core (#5974)"
         );
     }
 

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -87,29 +87,15 @@ pub(crate) async fn build_agent_factory(
         (None, Vec::new())
     };
 
-    // SkillOrchestra: load persisted RL routing head weights, if enabled (#5921) — mirrors
-    // `src/runner.rs`/`src/daemon.rs`'s cold-start/load pattern. Must happen here, in the async
-    // prefix, since the returned closure is a plain synchronous `FnOnce` (see module docs) and
-    // cannot `.await`. `deps.rl_embed_dim_resolved` is pre-computed once in
-    // `crate::acp::build_shared_core`, shared across every session built from that core.
-    // NOTE (S3, known limitation, not fixed here): `routing_head_weights` is a single global
-    // row (`WHERE id = 1`, last-write-wins upsert — crates/zeph-memory/src/store/skills.rs).
-    // Concurrent `/sessions` agents each load their own in-memory head from that row and
-    // persist back independently, so concurrent multi-session RL routing can clobber each
-    // other's learned weights. Bounded risk: `rl_routing_enabled` defaults to `false`. See
-    // #5974 for per-conversation persistence keying or write serialization.
-    let rl_head = if let Some(dim) = deps.rl_embed_dim_resolved {
-        Some(
-            crate::runner::load_rl_head(&deps.memory)
-                .await
-                .unwrap_or_else(|| {
-                    tracing::info!(dim, "rl_head: cold start, initializing fresh routing head");
-                    zeph_skills::rl_head::RoutingHead::new(dim)
-                }),
-        )
-    } else {
-        None
-    };
+    // SkillOrchestra: wire the RL routing head, if enabled (#5921). `deps.rl_head` is loaded/
+    // cold-started exactly once in `crate::acp::build_shared_core` and cloned (cheap `Arc`
+    // clone) into every session built from that core — fixes #5974, where each `/sessions`
+    // agent previously loaded its own independent in-memory copy from the
+    // `routing_head_weights` singleton row and persisted back independently, letting
+    // concurrent sessions clobber each other's learned REINFORCE weights. All sessions now
+    // mutate the SAME `Arc<Mutex<..>>`, so updates serialize through that mutex instead of
+    // racing across independent copies.
+    let rl_head = deps.rl_head.clone();
 
     // #5958: shared trajectory risk slot — written by begin_turn(), read by PolicyGateExecutor —
     // and pending risk signal queue — executor layers push signal codes; begin_turn() drains.
@@ -840,7 +826,7 @@ mod tests {
             rl_weight: 0.0,
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
@@ -927,7 +913,7 @@ mod tests {
             rl_weight: 0.0,
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
@@ -1041,7 +1027,7 @@ mod tests {
             rl_weight: 0.0,
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
@@ -1140,7 +1126,7 @@ mod tests {
             rl_weight: 0.0,
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
@@ -1184,16 +1170,16 @@ mod tests {
 
     /// #5920/#5921 regression: `build_agent_factory` must call `Agent::with_trust_config` and
     /// `Agent::with_rl_routing`/`with_rl_head` so `ServeAgentDeps::trust_config`/
-    /// `rl_routing_enabled`/`rl_embed_dim_resolved` reach the built `Agent` — previously these
-    /// fields did not exist on `ServeAgentDeps` at all, so every `/sessions`-created agent
-    /// silently ran skill trust classification and `SkillOrchestra` RL routing on hardcoded
-    /// builder defaults regardless of config. Mirrors
-    /// `build_agent_factory_wires_skill_group_config` above for the same wire-X-into-
-    /// ACP/serve/daemon defect class, applied to trust config and RL routing this time. Asserts
-    /// the exact `/skills trust` `Display` output, not just "non-default", so a swapped
-    /// argument or a dropped `.with_trust_config(...)`/`.with_rl_routing(...)` call would also
-    /// be caught. `rl_embed_dim_resolved: Some(8)` also exercises the RL-head cold-start path
-    /// (`build_agent_factory`'s async prefix, since the returned closure cannot `.await`).
+    /// `rl_routing_enabled`/`rl_head` reach the built `Agent` — previously these fields did not
+    /// exist on `ServeAgentDeps` at all, so every `/sessions`-created agent silently ran skill
+    /// trust classification and `SkillOrchestra` RL routing on hardcoded builder defaults
+    /// regardless of config. Mirrors `build_agent_factory_wires_skill_group_config` above for
+    /// the same wire-X-into-ACP/serve/daemon defect class, applied to trust config and RL
+    /// routing this time. Asserts the exact `/skills trust` `Display` output, not just
+    /// "non-default", so a swapped argument or a dropped `.with_trust_config(...)`/
+    /// `.with_rl_routing(...)` call would also be caught. `rl_head: Some(..)` also exercises
+    /// the RL-head wiring path (`deps.rl_head.clone()`, see #5974: the head is now loaded once
+    /// in `crate::acp::build_shared_core` rather than per session here).
     #[tokio::test]
     async fn build_agent_factory_wires_trust_and_rl_config() {
         use zeph_commands::traits::agent::AgentAccess as _;
@@ -1238,7 +1224,7 @@ mod tests {
             rl_weight: 0.3,
             rl_persist_interval: 5,
             rl_warmup_updates: 3,
-            rl_embed_dim_resolved: Some(8),
+            rl_head: Some(zeph_skills::rl_head::RoutingHead::new(8)),
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
@@ -1275,9 +1261,8 @@ mod tests {
             "Skill trust config: default_level=Quarantined, local_level=Trusted, \
              bundled_level=Verified, hash_mismatch_level=Blocked | RL routing: enabled=true, \
              rl_head_loaded=true",
-            "ServeAgentDeps::trust_config/rl_routing_enabled/rl_embed_dim_resolved must reach \
-             the built Agent exactly via with_trust_config/with_rl_routing/with_rl_head; got: \
-             {output}"
+            "ServeAgentDeps::trust_config/rl_routing_enabled/rl_head must reach the built Agent \
+             exactly via with_trust_config/with_rl_routing/with_rl_head; got: {output}"
         );
     }
 
@@ -1334,7 +1319,7 @@ mod tests {
             rl_weight: 0.0,
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
@@ -1411,7 +1396,7 @@ mod tests {
             rl_weight: 0.0,
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default()

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -82,16 +82,19 @@ pub(crate) struct ServeAgentDeps {
     /// for `/sessions` agents, silently ignoring the operator's configured trust levels).
     pub(crate) trust_config: zeph_core::config::TrustConfig,
     /// `config.skills.rl_routing_enabled`/`rl_learning_rate`/`rl_weight`/`rl_persist_interval`/
-    /// `rl_warmup_updates`, wired into `Agent::with_rl_routing` per session, plus the resolved
-    /// embed dim (`crate::acp::SharedCore::rl_embed_dim_resolved`) used to load/cold-start an
-    /// `RL` head via `Agent::with_rl_head` — mirrors `src/runner.rs` and `src/daemon.rs`
-    /// (#5921: previously never wired for `/sessions` agents).
+    /// `rl_warmup_updates`, wired into `Agent::with_rl_routing` per session, plus the shared RL
+    /// head (`crate::acp::SharedCore::rl_head`) wired into `Agent::with_rl_head` — mirrors
+    /// `src/runner.rs` and `src/daemon.rs` (#5921: previously never wired for `/sessions`
+    /// agents). `rl_head` is cloned (cheap `Arc` clone) from the same `SharedCore` instance
+    /// shared with `SharedAgentDeps`, fixing #5974 (concurrent `/sessions` agents previously
+    /// each loaded/persisted an independent in-memory copy, clobbering each other's learned
+    /// weights).
     pub(crate) rl_routing_enabled: bool,
     pub(crate) rl_learning_rate: f32,
     pub(crate) rl_weight: f32,
     pub(crate) rl_persist_interval: u32,
     pub(crate) rl_warmup_updates: u32,
-    pub(crate) rl_embed_dim_resolved: Option<usize>,
+    pub(crate) rl_head: Option<zeph_skills::rl_head::RoutingHead>,
     /// Base tool composite (file/shell/scrape/cwd), *not* wrapped in any gate. Per SEC-H1
     /// (concurrent `/sessions` share this one `Arc`, but `TrustGateExecutor`/`PolicyGateExecutor`
     /// carry per-turn *mutable* trust state), `agent_factory::build_agent_factory` wraps a
@@ -439,7 +442,7 @@ pub(crate) async fn assemble_serve_deps(
         rl_weight: config.skills.rl_weight,
         rl_persist_interval: config.skills.rl_persist_interval,
         rl_warmup_updates: config.skills.rl_warmup_updates,
-        rl_embed_dim_resolved: core.rl_embed_dim_resolved,
+        rl_head: core.rl_head.clone(),
         tool_executor,
         capability_scopes_config,
         permission_policy,
@@ -749,7 +752,7 @@ mod tests {
             matcher: None,
             memory,
             budget_tokens: 4096,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
         };
         let cancel = tokio_util::sync::CancellationToken::new();
         let supervisor = zeph_common::task_supervisor::TaskSupervisor::new(cancel);
@@ -784,7 +787,7 @@ mod tests {
             matcher: None,
             memory,
             budget_tokens: 4096,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
         }
     }
 

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -525,7 +525,7 @@ mod tests {
             rl_weight: 0.0,
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -125,7 +125,7 @@ impl ServeTestHarness {
             rl_weight: 0.0,
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
-            rl_embed_dim_resolved: None,
+            rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),


### PR DESCRIPTION
## Summary

- Concurrent ACP/`serve-sessions` agents each independently loaded their own `RoutingHead` from the `routing_head_weights` singleton row and persisted back independently, silently clobbering each other's learned REINFORCE weights (last-write-wins).
- `crate::acp::build_shared_core` now loads/cold-starts the `RoutingHead` exactly once and every session clones the same `Arc<Mutex<RoutingHeadInner>>` handle, so updates from any session serialize through the shared mutex instead of racing across independent in-memory copies.
- Added `RoutingHead::persist_snapshot()` (single lock acquisition for `embed_dim`/weights/baseline/`update_count`), closing a related TOCTOU in `spawn_rl_head_update` where a concurrent `update()` could land between previously-separate locked reads, mirroring the existing `RerankOutcome`/#5846 precedent.
- No behavior change for `rl_routing_enabled = false` (still the default) or single-session (`runner.rs`/`daemon.rs`) deployments — both were confirmed never racy and are left untouched.

Closes #5974

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13136 passed, 0 failed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression test `build_combined_deps_wires_skill_matching_config_from_config` (`src/acp.rs`) behaviorally proves both `acp_deps.rl_head` and `serve_deps.rl_head` hold the same `Arc` from one `build_shared_core` call (update via one handle, `update_count()` via the other)
- [x] New unit tests `persist_snapshot_matches_individual_getters` / `persist_snapshot_reflects_shared_updates_from_cloned_handle` (`crates/zeph-skills/src/rl_head.rs`)
- [x] Coverage tracking updated in place: `.local/testing/coverage-status.md` (existing row for #5921, not a new row)