### PR TITLE
fix(session): correct session_dir() double-nesting and implement fork blob-copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   of `Completed`. Removed the reap driver's independent deadline entirely — it now
   drains until no tasks remain active, and `shutdown_all`'s own `sleep(timeout)` +
   force-abort is the sole deadline authority for the whole shutdown sequence.
+- `zeph-session`: `session_dir()` double-nested every on-disk session path as
+  `<data_dir>/sessions/<session_id>` instead of `<data_dir>/<session_id>` (#5981), since
+  `data_dir` (default `.zeph/sessions`) already names the sessions root. All callers
+  (`zeph-core`, `zeph-acp`, `src/runner.rs`, `src/commands/sessions.rs`, `src/acp.rs`,
+  `src/serve/agent_factory.rs`) resolve session paths exclusively through this function, so the
+  fix is a single-point change; the crate's own doc-test asserted the buggy double-nested path
+  and is corrected alongside it. A new `zeph_session::migrate_legacy_session_layout` runs once at
+  process startup (`src/runner.rs`, before any command dispatch), moving any session directory
+  still sitting at the old `<data_dir>/sessions/<session_id>` path up one level to
+  `<data_dir>/<session_id>`; a destination that already exists is left in place (skipped, with a
+  warning) rather than clobbered. Idempotent and a cheap no-op on installs with nothing to
+  migrate — without this, a pre-fix session would silently resume as a blank conversation
+  (`SessionEventLog::open` creates an empty log at the new, previously-unused path) with zero
+  error or warning.
+- `zeph-session`: `ForkEngine::fork` never implemented spec-068 §7.2 step 6 (#5982) — it copied
+  every raw event (including any `UserMessage.image_refs`) into the child's `events.jsonl` but
+  never copied the referenced files from the parent's `blobs/` directory into the child's.
+  Currently dormant (no production call site populates `image_refs` yet), but would have
+  silently dropped attachments once wired up. `ForkEngine::fork` now hard-links (falling back to
+  a copy on cross-device hard-link failure) each blob referenced in the copied event range into
+  the child's `blobs/` directory, creating it with `0o700` permissions (matching the sibling
+  session directory) only when needed; a blob missing on the parent's disk is logged and skipped
+  rather than failing the fork. Each `image_refs` hash is now validated as a non-empty, bare hex
+  string before being used in a `PathBuf::join` — an unvalidated entry containing a path
+  separator, `..`, or an absolute path would otherwise have let a fork read or write outside the
+  session's `blobs/` directory; the hash list is also deduped before copying so a hash referenced
+  twice in one fork range hard-links once instead of falling into the cross-device copy fallback
+  on the second occurrence.
 - `zeph-gateway` and `zeph-a2a`: fixed a bearer-token brute-force bypass caused by
   middleware layer order (#6110, CWE-307). `auth_middleware` returns `401` directly
   without calling `next.run`, so with auth layered outside `rate_limit_middleware`,

--- a/book/src/advanced/session-persistence.md
+++ b/book/src/advanced/session-persistence.md
@@ -20,7 +20,7 @@ session, in order, and can I replay it deterministically?*
 Each session writes to its own append-only JSONL file:
 
 ```text
-<data_dir>/sessions/<session_id>/events.jsonl
+<data_dir>/<session_id>/events.jsonl
 ```
 
 Every line is one `SessionEvent` — `SessionStarted`, `UserMessage`, `AssistantMessage`,

--- a/crates/zeph-config/src/session.rs
+++ b/crates/zeph-config/src/session.rs
@@ -36,7 +36,7 @@ pub struct SessionConfig {
     ///
     /// When `true`, every channel (CLI, TUI, Telegram, ACP) mints a
     /// [`zeph_common::SessionId`] on first turn and appends
-    /// `SessionEvent`s to `<data_dir>/sessions/<session_id>/events.jsonl`. When `false`, only the
+    /// `SessionEvent`s to `<data_dir>/<session_id>/events.jsonl`. When `false`, only the
     /// existing `messages` `SQLite` projection is written (pre-#5343 behavior).
     pub enabled: bool,
     /// Directory under which per-session event logs are stored (spec-068 §4.1).

--- a/crates/zeph-session/README.md
+++ b/crates/zeph-session/README.md
@@ -20,7 +20,7 @@ event log, deterministic replay, and fork engine, shared by every channel (CLI, 
 ## Overview
 
 Every conversation-session's history is appended as one line per event to
-`<data_dir>/sessions/<session_id>/events.jsonl` — the source of truth. The existing `acp_sessions`
+`<data_dir>/<session_id>/events.jsonl` — the source of truth. The existing `acp_sessions`
 table (promoted from ACP-only to channel-agnostic, per spec-068 Decision D1) tracks lightweight
 queryable metadata (`last_seq`, `status`, fork provenance) so `sessions list` and reconciliation on
 open don't require replaying every log.
@@ -58,7 +58,7 @@ The on-disk layout for one session is derived from the data directory and sessio
 use std::path::Path;
 
 let dir = zeph_session::session_dir(Path::new(".zeph/sessions"), "abc-123");
-assert_eq!(dir, Path::new(".zeph/sessions/sessions/abc-123"));
+assert_eq!(dir, Path::new(".zeph/sessions/abc-123"));
 ```
 
 ## Features

--- a/crates/zeph-session/src/error.rs
+++ b/crates/zeph-session/src/error.rs
@@ -40,4 +40,9 @@ pub enum SessionError {
     /// holding the session's advisory write lock.
     #[error("session event log at {0} is already locked by another process")]
     AlreadyLocked(String),
+
+    /// A `UserMessage.image_refs` entry was not a bare hex string, so it was rejected before
+    /// being joined into a filesystem path (#5982 follow-up, path-traversal guard).
+    #[error("invalid blob hash (must be a non-empty hex string): {0:?}")]
+    InvalidBlobHash(String),
 }

--- a/crates/zeph-session/src/fork.rs
+++ b/crates/zeph-session/src/fork.rs
@@ -9,11 +9,16 @@
 
 use std::path::Path;
 
+use tokio::fs;
+
 use crate::error::SessionError;
-use crate::event::SessionEvent;
+use crate::event::{SessionEvent, SessionEventEnvelope};
 use crate::log::SessionEventLog;
 use crate::replay::ReplayEngine;
 use crate::store::SessionStore;
+
+/// Name of the per-session directory holding content-hash-addressed blob files (spec §4.1).
+const BLOBS_DIR_NAME: &str = "blobs";
 
 /// The result of a successful fork.
 #[derive(Debug, Clone)]
@@ -114,6 +119,8 @@ impl ForkEngine {
                 .await?;
         }
 
+        copy_referenced_blobs(&src_dir, &child_dir, &to_copy).await?;
+
         store.record_fork(new_id, src_id, at_seq, owner).await?;
         store
             .update_seq(
@@ -139,6 +146,99 @@ impl ForkEngine {
             events_copied: to_copy.len(),
         })
     }
+}
+
+/// Copy the `blobs/` files referenced by `UserMessage.image_refs` in `events` from the parent's
+/// session directory into the child's (spec §7.2 step 6). Hard-links each blob (cheap, same
+/// filesystem — content-hash-addressed blobs are immutable so sharing the inode is safe); falls
+/// back to a full copy if the hard-link fails (e.g. `src_dir`/`child_dir` are on different
+/// filesystems/devices).
+///
+/// A referenced blob missing on disk is logged and skipped rather than treated as a hard
+/// error: the event-log copy (the fork's primary content) already succeeded by this point, and
+/// a missing blob only means the child loses one attachment rather than the whole conversation
+/// history — consistent with [`crate::log`]'s own torn-tail handling, which prefers a
+/// best-effort recovery over failing the whole read.
+///
+/// # Write-once contract
+///
+/// Hard-linking is only safe if blobs are content-addressed and never mutated in place after
+/// being written. No blob writer exists yet anywhere in this codebase to enforce that; when one
+/// lands, it MUST use append-by-new-hash semantics (never overwrite an existing hash's file) or
+/// this fork's hard-link would let a later parent-side mutation silently corrupt the child's
+/// copy through the shared inode.
+///
+/// # Errors
+///
+/// Returns [`SessionError::InvalidBlobHash`] if any `image_refs` entry is not a non-empty,
+/// bare hex string (rejected before use in [`Path::join`] to prevent path traversal), or
+/// [`SessionError::Io`] if directory creation, the hard-link, or the copy fallback fails.
+async fn copy_referenced_blobs(
+    src_dir: &Path,
+    child_dir: &Path,
+    events: &[SessionEventEnvelope],
+) -> Result<(), SessionError> {
+    let mut hashes: Vec<&str> = Vec::new();
+    for envelope in events {
+        let SessionEvent::UserMessage { image_refs, .. } = &envelope.kind else {
+            continue;
+        };
+        for hash in image_refs {
+            validate_blob_hash(hash)?;
+            hashes.push(hash.as_str());
+        }
+    }
+
+    if hashes.is_empty() {
+        return Ok(());
+    }
+
+    // Dedup: the same hash can legitimately appear twice (repeated attachment, or reused across
+    // messages) — without this, the second `hard_link` on an already-linked destination returns
+    // `AlreadyExists`, which would otherwise fall into the generic error arm below and trigger a
+    // wasteful (and, per that arm's own comment, misleading) copy fallback.
+    hashes.sort_unstable();
+    hashes.dedup();
+
+    let src_blobs = src_dir.join(BLOBS_DIR_NAME);
+    let child_blobs = child_dir.join(BLOBS_DIR_NAME);
+    fs::create_dir_all(&child_blobs).await?;
+    crate::log::set_permissions(&child_blobs, 0o700).await?;
+
+    for hash in hashes {
+        let src_blob = src_blobs.join(hash);
+        let child_blob = child_blobs.join(hash);
+
+        match fs::hard_link(&src_blob, &child_blob).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::warn!(
+                    blob = hash,
+                    path = %src_blob.display(),
+                    "fork: referenced blob missing on parent's disk, skipping"
+                );
+            }
+            Err(_) => {
+                // Hard-link failed for a reason other than a missing source (e.g. cross-device
+                // link, EXDEV) — fall back to a full copy.
+                fs::copy(&src_blob, &child_blob).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Rejects any `image_refs` hash that is not a non-empty, bare hex string, before it is used in
+/// a [`Path::join`] (#5982 follow-up). Content hashes elsewhere in this codebase are BLAKE3 hex
+/// (64 lowercase chars, `zeph_common::hash::blake3_hex`), but no length is enforced here since
+/// no blob writer exists yet to fix the format — a bare hexdigit charset already rules out `/`,
+/// `..`, and absolute paths, which is what makes `join` safe.
+fn validate_blob_hash(hash: &str) -> Result<(), SessionError> {
+    if hash.is_empty() || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(SessionError::InvalidBlobHash(hash.to_owned()));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -333,5 +433,252 @@ mod tests {
             .unwrap();
         // seed_parent appends 4 events total.
         assert_eq!(result.events_copied, 4);
+    }
+
+    /// Regression test for #5982 (spec §7.2 step 6): a blob referenced by a copied
+    /// `UserMessage.image_refs` must be hard-linked into the child's `blobs/` directory.
+    #[tokio::test]
+    async fn test_fork_copies_referenced_blobs() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        let parent_dir = crate::session_dir(data_dir.path(), "parent");
+        let parent_blobs = parent_dir.join("blobs");
+        tokio::fs::create_dir_all(&parent_blobs).await.unwrap();
+        tokio::fs::write(parent_blobs.join("a1b2c3"), b"image-bytes")
+            .await
+            .unwrap();
+
+        let parent_log = SessionEventLog::open(&parent_dir).await.unwrap();
+        parent_log
+            .append(
+                None,
+                None,
+                SessionEvent::UserMessage {
+                    text: "with image".to_owned(),
+                    image_refs: vec!["a1b2c3".to_owned()],
+                },
+            )
+            .await
+            .unwrap();
+        store.update_seq("parent", 4, 5).await.unwrap();
+
+        let result = ForkEngine::fork(data_dir.path(), "parent", "child", Some(5), &store, None)
+            .await
+            .unwrap();
+        assert_eq!(result.events_copied, 5);
+
+        let child_dir = crate::session_dir(data_dir.path(), "child");
+        let child_blob = child_dir.join("blobs").join("a1b2c3");
+        let copied = tokio::fs::read(&child_blob).await.unwrap();
+        assert_eq!(copied, b"image-bytes");
+    }
+
+    /// Regression test for #5982: a referenced blob missing on the parent's disk must not fail
+    /// the fork — it is logged and skipped, since the event-log copy (the fork's primary
+    /// content) already succeeded.
+    #[tokio::test]
+    async fn test_fork_skips_missing_blob_without_failing() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        let parent_dir = crate::session_dir(data_dir.path(), "parent");
+        let parent_log = SessionEventLog::open(&parent_dir).await.unwrap();
+        parent_log
+            .append(
+                None,
+                None,
+                SessionEvent::UserMessage {
+                    text: "with missing image".to_owned(),
+                    image_refs: vec!["deadbeef".to_owned()],
+                },
+            )
+            .await
+            .unwrap();
+        store.update_seq("parent", 4, 5).await.unwrap();
+
+        let result = ForkEngine::fork(data_dir.path(), "parent", "child", Some(5), &store, None)
+            .await
+            .unwrap();
+        assert_eq!(result.events_copied, 5);
+
+        let child_dir = crate::session_dir(data_dir.path(), "child");
+        assert!(!child_dir.join("blobs").join("deadbeef").exists());
+    }
+
+    /// Regression test for #5982: when no copied event references a blob, `fork` must not
+    /// create an empty `blobs/` directory in the child (keeps the eager-copy path a no-op for
+    /// the common, image-free case).
+    #[tokio::test]
+    async fn test_fork_without_image_refs_creates_no_blobs_dir() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        ForkEngine::fork(data_dir.path(), "parent", "child", Some(2), &store, None)
+            .await
+            .unwrap();
+
+        let child_dir = crate::session_dir(data_dir.path(), "child");
+        assert!(!child_dir.join("blobs").exists());
+    }
+
+    /// Regression test for the critic's S3 finding: a malicious `image_refs` entry containing a
+    /// path-traversal sequence must be rejected before it reaches `PathBuf::join`, not silently
+    /// joined (which would let the parent-side `hard_link` read an arbitrary file, or the
+    /// child-side path escape `blobs/`).
+    #[tokio::test]
+    async fn test_fork_rejects_path_traversal_in_image_refs() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        let parent_dir = crate::session_dir(data_dir.path(), "parent");
+        let parent_log = SessionEventLog::open(&parent_dir).await.unwrap();
+        parent_log
+            .append(
+                None,
+                None,
+                SessionEvent::UserMessage {
+                    text: "malicious ref".to_owned(),
+                    image_refs: vec!["../../../etc/passwd".to_owned()],
+                },
+            )
+            .await
+            .unwrap();
+        store.update_seq("parent", 4, 5).await.unwrap();
+
+        let err = ForkEngine::fork(data_dir.path(), "parent", "child", Some(5), &store, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SessionError::InvalidBlobHash(_)));
+
+        // No child directory content should have been created by the rejected fork attempt.
+        let child_dir = crate::session_dir(data_dir.path(), "child");
+        assert!(!child_dir.join("blobs").exists());
+    }
+
+    /// Regression test for the critic's S3 finding: an absolute-path `image_refs` entry must
+    /// also be rejected — `PathBuf::join` with an absolute path silently discards the base
+    /// directory entirely, which is the most severe form of this traversal.
+    #[tokio::test]
+    async fn test_fork_rejects_absolute_path_in_image_refs() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        let parent_dir = crate::session_dir(data_dir.path(), "parent");
+        let parent_log = SessionEventLog::open(&parent_dir).await.unwrap();
+        parent_log
+            .append(
+                None,
+                None,
+                SessionEvent::UserMessage {
+                    text: "malicious absolute ref".to_owned(),
+                    image_refs: vec!["/etc/passwd".to_owned()],
+                },
+            )
+            .await
+            .unwrap();
+        store.update_seq("parent", 4, 5).await.unwrap();
+
+        let err = ForkEngine::fork(data_dir.path(), "parent", "child", Some(5), &store, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SessionError::InvalidBlobHash(_)));
+    }
+
+    /// Regression test for the critic's M3 finding: the same hash referenced twice in the
+    /// copied range must not trigger the cross-device copy fallback on the second occurrence —
+    /// the hash list is deduped before any `hard_link` is attempted.
+    #[tokio::test]
+    async fn test_fork_dedups_duplicate_blob_hash() {
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        let parent_dir = crate::session_dir(data_dir.path(), "parent");
+        let parent_blobs = parent_dir.join("blobs");
+        tokio::fs::create_dir_all(&parent_blobs).await.unwrap();
+        tokio::fs::write(parent_blobs.join("cafe01"), b"shared-bytes")
+            .await
+            .unwrap();
+
+        let parent_log = SessionEventLog::open(&parent_dir).await.unwrap();
+        parent_log
+            .append(
+                None,
+                None,
+                SessionEvent::UserMessage {
+                    text: "first ref".to_owned(),
+                    image_refs: vec!["cafe01".to_owned()],
+                },
+            )
+            .await
+            .unwrap();
+        parent_log
+            .append(
+                None,
+                None,
+                SessionEvent::UserMessage {
+                    text: "second ref, same hash".to_owned(),
+                    image_refs: vec!["cafe01".to_owned()],
+                },
+            )
+            .await
+            .unwrap();
+        store.update_seq("parent", 4, 6).await.unwrap();
+
+        let result = ForkEngine::fork(data_dir.path(), "parent", "child", Some(6), &store, None)
+            .await
+            .unwrap();
+        assert_eq!(result.events_copied, 6);
+
+        let child_dir = crate::session_dir(data_dir.path(), "child");
+        let child_blob = child_dir.join("blobs").join("cafe01");
+        assert_eq!(tokio::fs::read(&child_blob).await.unwrap(), b"shared-bytes");
+    }
+
+    /// Regression test for the critic's M1 finding: the child's `blobs/` directory must get the
+    /// same `0o700` permission the crate already enforces on the sibling session directory.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_fork_sets_0700_on_child_blobs_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let store = SessionStore::new(make_pool().await);
+        let data_dir = tempfile::tempdir().unwrap();
+        seed_parent(data_dir.path(), &store, "parent").await;
+
+        let parent_dir = crate::session_dir(data_dir.path(), "parent");
+        let parent_blobs = parent_dir.join("blobs");
+        tokio::fs::create_dir_all(&parent_blobs).await.unwrap();
+        tokio::fs::write(parent_blobs.join("a1b2c3"), b"image-bytes")
+            .await
+            .unwrap();
+
+        let parent_log = SessionEventLog::open(&parent_dir).await.unwrap();
+        parent_log
+            .append(
+                None,
+                None,
+                SessionEvent::UserMessage {
+                    text: "with image".to_owned(),
+                    image_refs: vec!["a1b2c3".to_owned()],
+                },
+            )
+            .await
+            .unwrap();
+        store.update_seq("parent", 4, 5).await.unwrap();
+
+        ForkEngine::fork(data_dir.path(), "parent", "child", Some(5), &store, None)
+            .await
+            .unwrap();
+
+        let child_dir = crate::session_dir(data_dir.path(), "child");
+        let meta = tokio::fs::metadata(child_dir.join("blobs")).await.unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o700);
     }
 }

--- a/crates/zeph-session/src/lib.rs
+++ b/crates/zeph-session/src/lib.rs
@@ -58,7 +58,10 @@ pub use replay::{ReconstructedState, ReplayEngine};
 pub use store::{SessionFilter, SessionMetadata, SessionStatus, SessionStore};
 
 /// The on-disk directory for one session's event log and blobs, per spec §4.1:
-/// `<data_dir>/sessions/<session_id>/`.
+/// `<data_dir>/<session_id>/`.
+///
+/// `data_dir` (`[session] data_dir`, default `.zeph/sessions`) already names the sessions
+/// root — callers must not append an extra `sessions` segment (#5981).
 ///
 /// # Examples
 ///
@@ -66,9 +69,220 @@ pub use store::{SessionFilter, SessionMetadata, SessionStatus, SessionStore};
 /// use std::path::Path;
 ///
 /// let dir = zeph_session::session_dir(Path::new(".zeph/sessions"), "abc-123");
-/// assert_eq!(dir, Path::new(".zeph/sessions/sessions/abc-123"));
+/// assert_eq!(dir, Path::new(".zeph/sessions/abc-123"));
 /// ```
 #[must_use]
 pub fn session_dir(data_dir: &std::path::Path, session_id: &str) -> std::path::PathBuf {
-    data_dir.join("sessions").join(session_id)
+    data_dir.join(session_id)
+}
+
+/// The one-time startup migration report returned by [`migrate_legacy_session_layout`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MigrationReport {
+    /// Number of legacy session directories moved up one level to the fixed (#5981) layout.
+    pub migrated: usize,
+    /// Number of legacy session directories left in place because a directory already existed
+    /// at the destination (not clobbered — it may already have been recreated at the new path).
+    pub skipped: usize,
+}
+
+/// Moves any session directories still sitting at the pre-#5981 on-disk layout
+/// (`<data_dir>/sessions/<session_id>/`) up one level to the fixed layout
+/// (`<data_dir>/<session_id>/`), which is what [`session_dir`] now resolves to.
+///
+/// Before #5981, [`session_dir`] appended a redundant `sessions` segment, so any session created
+/// before the fix physically has its `events.jsonl`/`blobs/` one directory level deeper than
+/// where the crate now looks. Left unmigrated, [`log::SessionEventLog::open`] silently
+/// `create_dir_all`s and creates a blank log at the new (empty) path — the user's real history
+/// becomes unreachable with zero error or warning. This function is meant to be called once at
+/// process startup, before any session is opened, to make that transition transparent.
+///
+/// A destination that already exists is left untouched (skipped, with a `tracing::warn!`)
+/// rather than clobbered. Idempotent: once every legacy subdirectory has been moved (or
+/// skipped), a subsequent run finds an empty (or absent) `<data_dir>/sessions/` and returns
+/// cheaply; a missing `<data_dir>/sessions/` (a brand-new install, or one already migrated) is
+/// not an error.
+///
+/// # Errors
+///
+/// Returns [`SessionError::Io`] if `<data_dir>/sessions/` exists but cannot be listed, or if a
+/// rename or an existence check fails for a reason other than the destination not existing.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let dir = tempfile::tempdir().unwrap();
+/// // Brand-new install: no `sessions/` subdirectory yet — a cheap no-op, not an error.
+/// let report = zeph_session::migrate_legacy_session_layout(dir.path()).await.unwrap();
+/// assert_eq!(report, zeph_session::MigrationReport::default());
+/// # }
+/// ```
+pub async fn migrate_legacy_session_layout(
+    data_dir: &std::path::Path,
+) -> Result<MigrationReport, SessionError> {
+    let legacy_root = data_dir.join("sessions");
+
+    let mut entries = match tokio::fs::read_dir(&legacy_root).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(MigrationReport::default());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut report = MigrationReport::default();
+    while let Some(entry) = entries.next_entry().await? {
+        if !entry.file_type().await?.is_dir() {
+            continue;
+        }
+
+        let src = entry.path();
+        let dest = data_dir.join(entry.file_name());
+
+        if tokio::fs::try_exists(&dest).await? {
+            tracing::warn!(
+                src = %src.display(),
+                dest = %dest.display(),
+                "legacy session directory left in place: destination already exists (#5981)"
+            );
+            report.skipped += 1;
+            continue;
+        }
+
+        tokio::fs::rename(&src, &dest).await?;
+        report.migrated += 1;
+    }
+
+    if report.migrated > 0 || report.skipped > 0 {
+        tracing::info!(
+            migrated = report.migrated,
+            skipped = report.skipped,
+            "migrated legacy (#5981) session directory layout"
+        );
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{MigrationReport, migrate_legacy_session_layout, session_dir};
+
+    /// Regression test for #5981: `session_dir` must not append a redundant `sessions` segment
+    /// when `data_dir` (e.g. the configured default `.zeph/sessions`) already names the
+    /// sessions root, or every on-disk path double-nests as `sessions/sessions/<id>`.
+    #[test]
+    fn session_dir_does_not_double_nest() {
+        let dir = session_dir(Path::new(".zeph/sessions"), "abc-123");
+        assert_eq!(dir, Path::new(".zeph/sessions/abc-123"));
+    }
+
+    #[test]
+    fn session_dir_joins_arbitrary_data_dir() {
+        let dir = session_dir(Path::new("/var/lib/zeph/data"), "s1");
+        assert_eq!(dir, Path::new("/var/lib/zeph/data/s1"));
+    }
+
+    /// (a) Migrates an existing pre-#5981 session directory up one level, and — run a second
+    /// time — confirms idempotency (nothing left to move, cheap no-op).
+    #[tokio::test]
+    async fn migrate_moves_legacy_session_dir_up_one_level() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let legacy = data_dir.path().join("sessions").join("abc-123");
+        tokio::fs::create_dir_all(&legacy).await.unwrap();
+        tokio::fs::write(legacy.join("events.jsonl"), b"{}\n")
+            .await
+            .unwrap();
+
+        let report = migrate_legacy_session_layout(data_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(
+            report,
+            MigrationReport {
+                migrated: 1,
+                skipped: 0
+            }
+        );
+        assert!(
+            data_dir
+                .path()
+                .join("abc-123")
+                .join("events.jsonl")
+                .exists()
+        );
+        assert!(!legacy.exists());
+
+        // Idempotency: running again finds nothing left under `sessions/`.
+        let second = migrate_legacy_session_layout(data_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(second, MigrationReport::default());
+    }
+
+    /// (b) No-op when the legacy `sessions/` directory exists but is empty.
+    #[tokio::test]
+    async fn migrate_is_noop_when_legacy_dir_is_empty() {
+        let data_dir = tempfile::tempdir().unwrap();
+        tokio::fs::create_dir_all(data_dir.path().join("sessions"))
+            .await
+            .unwrap();
+
+        let report = migrate_legacy_session_layout(data_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(report, MigrationReport::default());
+    }
+
+    /// (c) Skips (with a warning, not an error) when a directory already exists at the
+    /// destination — must not clobber a session that may have already been recreated there.
+    #[tokio::test]
+    async fn migrate_skips_when_destination_already_exists() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let legacy = data_dir.path().join("sessions").join("abc-123");
+        tokio::fs::create_dir_all(&legacy).await.unwrap();
+        tokio::fs::write(legacy.join("events.jsonl"), b"old\n")
+            .await
+            .unwrap();
+
+        let dest = data_dir.path().join("abc-123");
+        tokio::fs::create_dir_all(&dest).await.unwrap();
+        tokio::fs::write(dest.join("events.jsonl"), b"new\n")
+            .await
+            .unwrap();
+
+        let report = migrate_legacy_session_layout(data_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(
+            report,
+            MigrationReport {
+                migrated: 0,
+                skipped: 1
+            }
+        );
+        assert_eq!(
+            tokio::fs::read(dest.join("events.jsonl")).await.unwrap(),
+            b"new\n",
+            "destination must not be clobbered"
+        );
+        assert!(legacy.exists(), "legacy directory must be left in place");
+    }
+
+    /// (d) No-op, not an error, when `<data_dir>/sessions/` doesn't exist at all (brand-new
+    /// install, or a `data_dir` already fully migrated).
+    #[tokio::test]
+    async fn migrate_is_noop_when_legacy_root_missing() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let report = migrate_legacy_session_layout(data_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(report, MigrationReport::default());
+    }
 }

--- a/crates/zeph-session/src/log.rs
+++ b/crates/zeph-session/src/log.rs
@@ -445,8 +445,11 @@ async fn read_events_chunked(
     Ok(())
 }
 
+/// Sets Unix permission bits on `path` (e.g. `0o700` for a directory, `0o600` for a file); a
+/// no-op on non-Unix targets. `pub(crate)` so other modules (e.g. [`crate::fork`]) can apply the
+/// same permission convention to directories/files they create outside this module.
 #[cfg(unix)]
-async fn set_permissions(path: &Path, mode: u32) -> Result<(), SessionError> {
+pub(crate) async fn set_permissions(path: &Path, mode: u32) -> Result<(), SessionError> {
     use std::os::unix::fs::PermissionsExt;
     fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).await?;
     Ok(())
@@ -502,7 +505,7 @@ impl AdvisoryLock {
 }
 
 #[cfg(not(unix))]
-async fn set_permissions(_path: &Path, _mode: u32) -> Result<(), SessionError> {
+pub(crate) async fn set_permissions(_path: &Path, _mode: u32) -> Result<(), SessionError> {
     Ok(())
 }
 

--- a/specs/068-session-persistence/spec.md
+++ b/specs/068-session-persistence/spec.md
@@ -65,7 +65,7 @@ Four distinct "session" concepts already exist in the codebase. The spec MUST NO
 ┌───────────────────────────────────────────────────────┐
 │  zeph-session  (new crate)                             │
 │                                                        │
-│  SessionEventLog  ──JSONL──▶  <data_dir>/sessions/    │
+│  SessionEventLog  ──JSONL──▶  <data_dir>/<session_id>/ │
 │  SessionStore     ──────────▶  acp_sessions (SQLite)   │
 │  ReplayEngine     (fold events → ReconstructedState)   │
 │  ForkEngine       (eager copy + new acp_sessions row)  │
@@ -99,8 +99,8 @@ Four distinct "session" concepts already exist in the codebase. The spec MUST NO
 ### 4.1 On-Disk Layout
 
 ```
-<data_dir>/sessions/<session_id>/events.jsonl   # append-only event log (source of truth)
-<data_dir>/sessions/<session_id>/blobs/<hash>   # referenced image/audio blobs (by content hash)
+<data_dir>/<session_id>/events.jsonl   # append-only event log (source of truth)
+<data_dir>/<session_id>/blobs/<hash>   # referenced image/audio blobs (by content hash)
 ```
 
 `<data_dir>` defaults to `.zeph/sessions/` (sibling of `memory.sqlite_path`'s parent directory). Configurable via `[session] data_dir`.
@@ -335,7 +335,7 @@ ForkEngine::fork(
 1. Validate `at_seq` ≤ `acp_sessions.last_seq` for `src_id` (cannot fork into the future).
 2. `ReplayEngine::replay(src_id, up_to = Some(at_seq))` to validate the cut point is internally consistent.
 3. Allocate `new_id` (UUID v4, matching ACP convention at `mod.rs:1747`).
-4. Create `<data_dir>/sessions/<new_id>/` directory with `0o700` permissions.
+4. Create `<data_dir>/<new_id>/` directory with `0o700` permissions.
 5. Copy JSONL lines `seq ∈ [0, at_seq)` from parent log into child's `events.jsonl`. Write a `SessionStarted{ forked_from: (src_id, at_seq) }` as the first line (seq = 0 in child log, or as a header event).
 6. Copy referenced blobs: for any `UserMessage.image_refs` in the copied range, hard-link (or copy) blobs into the child's `blobs/` directory.
 7. Insert new `acp_sessions` row via `SessionStore::record_fork(src_id, new_id, at_seq)`.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -804,6 +804,20 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         Some(std::sync::Arc::clone(&metrics_collector_arc)),
     );
 
+    // One-time startup migration for session directories still sitting at the pre-#5981 layout
+    // (`<data_dir>/sessions/<id>/`) — must run before any entry point below opens a session log,
+    // or a pre-fix session's real history becomes silently unreachable (critic finding S1).
+    // Best-effort: a migration failure is logged, not fatal, since the primary command dispatch
+    // (which may not even touch sessions, e.g. `zeph vault`) must not be blocked by it.
+    let session_data_dir = std::path::PathBuf::from(&base_config.session.data_dir);
+    if let Err(e) = zeph_session::migrate_legacy_session_layout(&session_data_dir).await {
+        tracing::warn!(
+            error = %e,
+            data_dir = %session_data_dir.display(),
+            "failed to migrate legacy (#5981) session directory layout; continuing startup"
+        );
+    }
+
     match cli.command {
         Some(Command::Init { output }) => return crate::init::run(output),
         Some(Command::Vault { command: vault_cmd }) => {


### PR DESCRIPTION
## Summary

- `session_dir()` appended a redundant `sessions` segment on top of the already-`sessions`-suffixed default `data_dir`, double-nesting every on-disk session path (`<data_dir>/sessions/<session_id>` instead of `<data_dir>/<session_id>`). A one-time startup migration (`migrate_legacy_session_layout`, wired into `src/runner.rs` before command dispatch) moves any session directory still at the old path up one level, so existing history stays reachable instead of silently resuming as a blank conversation.
- `ForkEngine::fork` never implemented spec-068 §7.2 step 6: referenced `image_refs` blobs were never copied into the child session's `blobs/` directory. It now hard-links (falling back to a copy on cross-device failure) each referenced blob into the child's `blobs/` directory, created with `0o700` permissions matching the sibling session directory.
- Each `image_refs` hash is validated as a bare hex string before use in a `PathBuf::join`, since an unvalidated entry could otherwise escape the `blobs/` directory via a path separator, `..`, or an absolute path. The hash list is also deduped before copying to avoid a redundant/misleading cross-device-copy fallback when the same hash appears twice in one fork range.
- Corrected the matching stale double-nested-path wording in `specs/068-session-persistence/spec.md`, `crates/zeph-config/src/session.rs`, `crates/zeph-session/README.md`, and `book/src/advanced/session-persistence.md`.

Closes #5981
Closes #5982

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13138 passed)
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Rustdoc gate: `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New unit tests: `session_dir()` regression, migration (happy path, no-op-empty, collision-skip, no-op-missing-root), fork blob-copy (happy path, missing-blob skip, no-`image_refs`-no-op, path-traversal rejection, duplicate-hash dedup), `0o700` permission assertion on the created child `blobs/` dir
- [x] `.local/testing/coverage-status.md` and `.local/testing/playbooks/session-persistence.md` updated with the new sub-features (marked `Partial` pending live-session verification)