### PR TITLE
fix(llm): apply Claude no-prefill gate to all request-construction paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   between the previously-separate locked reads used to build the persisted DB row. No config or
   behavior change for `rl_routing_enabled = false` (still the default) or single-session
   (`runner`/`daemon`) deployments.
+- `zeph-llm` Claude provider: the no-prefill gate that strips a trailing assistant
+  message for models that reject assistant prefill (`ClaudeProvider::no_prefill`,
+  added by #5903 and extended to cover the unconditional `rejects_prefill` case by
+  #6145 — see that `[Unreleased]/Fixed` entry for exactly which models/
+  thinking-states the gate covers) was only applied in `build_request()`. The
+  other four request-construction paths on `ClaudeProvider` —
+  `chat_with_tools_stream` (the agent's primary tool-use loop), `chat_with_tools`,
+  `chat_typed`, and `debug_request_json` — built their request bodies
+  independently and never applied the gate, so a trailing-assistant-message
+  history routed through any of them could still trigger the same class of 400
+  for any model/thinking-state the gate is meant to cover (#6146). This is the
+  second time this bug class was filed, so the split step and the no-prefill
+  strip are now bundled into two funnel methods —
+  `ClaudeProvider::structured_history`/`plain_history` — that every
+  request-construction path calls to obtain its message history; the raw
+  `split_messages`/`split_messages_structured` functions are no longer imported
+  at the `claude` module's top level, so a future request path cannot easily
+  split a history without the strip being applied.
 - `.github/deny.toml`: the `cargo-deny` advisories gate scanned only the `candle`
   and `tui` features, excluding `pdf` and every other feature shipped by the
   blocking `bundle-check` (`full`) CI job and release builds — any RUSTSEC

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -62,9 +62,9 @@ use crate::retry::send_with_retry;
 use crate::sse::claude_sse_to_stream;
 
 use self::cache::{build_cache_control, log_cache_usage, split_system_into_blocks, tool_cache_key};
-use self::request::{parse_tool_response, split_messages, split_messages_structured};
+use self::request::parse_tool_response;
 use self::types::{
-    AnthropicContentBlock, AnthropicTool, ContextManagement, ContextManagementTrigger,
+    AnthropicContentBlock, AnthropicTool, ApiMessage, ContextManagement, ContextManagementTrigger,
     OutputConfig, RequestBody, StructuredApiMessage, SystemContentBlock, ToolApiResponse,
     ToolChoice, ToolRequestBody, TypedToolRequestBody, VisionRequestBody,
 };
@@ -904,6 +904,96 @@ impl ClaudeProvider {
         }
     }
 
+    /// Whether the conversation must end on a non-assistant turn for this request.
+    ///
+    /// Sonnet 4.6+ and the Opus 4.7+/Sonnet 5 generation reject assistant prefill
+    /// unconditionally (`rejects_prefill`). Opus 4.6 only rejects it while thinking is
+    /// enabled, which is why that case additionally checks `prefers_effort` alongside
+    /// `thinking_param`. Either way, the API returns 400 if the message history ends with
+    /// an assistant turn. Shared by every request-construction path (`build_request`,
+    /// `chat_with_tools`, `chat_with_tools_stream`, `chat_typed`, `debug_request_json`) so the
+    /// gate cannot drift out of sync between call sites again (#5903, #6145, #6146).
+    fn no_prefill(&self, thinking_param: Option<&types::ThinkingParam>) -> bool {
+        let cap = thinking_capability(&self.model);
+        cap.rejects_prefill || (cap.prefers_effort && thinking_param.is_some())
+    }
+
+    /// Strip trailing assistant messages from a structured chat history when [`Self::no_prefill`]
+    /// requires the request to end on a non-assistant turn.
+    fn strip_trailing_assistant_structured(
+        no_prefill: bool,
+        chat_messages: &mut Vec<StructuredApiMessage>,
+    ) {
+        if !no_prefill {
+            return;
+        }
+        while chat_messages.last().is_some_and(|m| m.role == "assistant") {
+            chat_messages.pop();
+        }
+    }
+
+    /// Strip trailing assistant messages from a plain (non-structured) chat history when
+    /// [`Self::no_prefill`] requires the request to end on a non-assistant turn.
+    fn strip_trailing_assistant_plain(no_prefill: bool, chat_messages: &mut Vec<ApiMessage<'_>>) {
+        if !no_prefill {
+            return;
+        }
+        while chat_messages.last().is_some_and(|m| m.role == "assistant") {
+            chat_messages.pop();
+        }
+    }
+
+    /// Split `messages` into a system prompt and a structured chat history, ready to send:
+    /// cache-control blocks are capped at Anthropic's budget and the no-prefill gate has
+    /// already been applied.
+    ///
+    /// This is the only sanctioned way to obtain a `Vec<StructuredApiMessage>` for a request
+    /// body. `split_messages_structured` itself is intentionally NOT imported at this module's
+    /// top level (see the local `use` inside this function) so it isn't one autocomplete away
+    /// from every call site — request-construction code must go through this funnel, which
+    /// bundles the split with the no-prefill strip so the two cannot be pulled apart again the
+    /// way they were before #6146 (this is the second filing of this bug class; #5903 fixed the
+    /// gate for `build_request` only).
+    fn structured_history(
+        &self,
+        messages: &[Message],
+        thinking_param: Option<&types::ThinkingParam>,
+        cache_tool_blocks: usize,
+    ) -> (Option<Vec<SystemContentBlock>>, Vec<StructuredApiMessage>) {
+        use self::request::split_messages_structured;
+
+        let (system, mut chat_messages) =
+            split_messages_structured(messages, self.cache_user_messages, self.prompt_cache_ttl);
+        let system_blocks =
+            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
+        Self::cap_block_cache_controls(
+            cache_tool_blocks,
+            system_blocks.as_deref(),
+            Some(&mut chat_messages),
+        );
+        Self::strip_trailing_assistant_structured(
+            self.no_prefill(thinking_param),
+            &mut chat_messages,
+        );
+        (system_blocks, chat_messages)
+    }
+
+    /// Split `messages` into a system prompt and a plain chat history, with the no-prefill gate
+    /// already applied. Same bypass-prevention rationale as [`Self::structured_history`].
+    fn plain_history<'m>(
+        &self,
+        messages: &'m [Message],
+        thinking_param: Option<&types::ThinkingParam>,
+    ) -> (Option<Vec<SystemContentBlock>>, Vec<ApiMessage<'m>>) {
+        use self::request::split_messages;
+
+        let (system, mut chat_messages) = split_messages(messages);
+        Self::strip_trailing_assistant_plain(self.no_prefill(thinking_param), &mut chat_messages);
+        let system_blocks =
+            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
+        (system_blocks, chat_messages)
+    }
+
     fn build_request(&self, messages: &[Message], stream: bool) -> reqwest::RequestBuilder {
         let (thinking_param, mut temperature, effort) = self.build_thinking_param();
         if thinking_param.is_none()
@@ -913,28 +1003,9 @@ impl ClaudeProvider {
         }
         let output_config = effort.map(|e| OutputConfig { effort: e }); // lgtm[rust/cleartext-logging]
 
-        let cap = thinking_capability(&self.model);
-        // Sonnet 4.6+ and the Opus 4.7+/Sonnet 5 generation reject assistant prefill
-        // unconditionally (`rejects_prefill`). Opus 4.6 only rejects it while thinking
-        // is enabled, which is why that case still checks `prefers_effort` alongside
-        // `thinking_param`. Either way, strip trailing assistant messages so the
-        // conversation always ends with a user turn.
-        let no_prefill = cap.rejects_prefill || (cap.prefers_effort && thinking_param.is_some());
-
         if Self::has_image_parts(messages) {
-            let (system, mut chat_messages) = split_messages_structured(
-                messages,
-                self.cache_user_messages,
-                self.prompt_cache_ttl,
-            );
-            let system_blocks =
-                system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
-            Self::cap_block_cache_controls(0, system_blocks.as_deref(), Some(&mut chat_messages));
-            if no_prefill {
-                while chat_messages.last().is_some_and(|m| m.role == "assistant") {
-                    chat_messages.pop();
-                }
-            }
+            let (system_blocks, chat_messages) =
+                self.structured_history(messages, thinking_param.as_ref(), 0);
             let beta = self.beta_header(false);
             let body = VisionRequestBody {
                 model: &self.model,
@@ -958,14 +1029,7 @@ impl ClaudeProvider {
             return req.header("content-type", "application/json").json(&body);
         }
 
-        let (system, mut chat_messages) = split_messages(messages);
-        if no_prefill {
-            while chat_messages.last().is_some_and(|m| m.role == "assistant") {
-                chat_messages.pop();
-            }
-        }
-        let system_blocks =
-            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
+        let (system_blocks, chat_messages) = self.plain_history(messages, thinking_param.as_ref());
         let beta = self.beta_header(false);
         let body = RequestBody {
             model: &self.model,
@@ -1062,8 +1126,6 @@ impl ClaudeProvider {
         messages: &[Message],
         tools: &[ToolDefinition],
     ) -> Result<crate::sse::ToolSseStream, LlmError> {
-        let (system, mut chat_messages) =
-            split_messages_structured(messages, self.cache_user_messages, self.prompt_cache_ttl);
         let api_tools = self.get_or_build_api_tools(tools);
 
         let (thinking_param, mut temperature, effort) = self.build_thinking_param();
@@ -1073,9 +1135,8 @@ impl ClaudeProvider {
             temperature = Some(t);
         }
         let output_config = effort.map(|e| OutputConfig { effort: e });
-        let system_blocks =
-            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
-        Self::cap_block_cache_controls(1, system_blocks.as_deref(), Some(&mut chat_messages));
+        let (system_blocks, chat_messages) =
+            self.structured_history(messages, thinking_param.as_ref(), 1);
         let has_tools = !tools.is_empty();
         let mut body = ToolRequestBody {
             model: &self.model,
@@ -1241,8 +1302,6 @@ impl LlmProvider for ClaudeProvider {
             parameters: schema_value,
             output_schema: None,
         };
-        let (system, mut chat_messages) =
-            split_messages_structured(messages, self.cache_user_messages, self.prompt_cache_ttl);
         let api_tool = AnthropicTool {
             name: tool.name.as_str(),
             description: &tool.description,
@@ -1255,9 +1314,8 @@ impl LlmProvider for ClaudeProvider {
             temperature = Some(t);
         }
         let output_config = effort.map(|e| OutputConfig { effort: e });
-        let system_blocks =
-            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
-        Self::cap_block_cache_controls(0, system_blocks.as_deref(), Some(&mut chat_messages));
+        let (system_blocks, chat_messages) =
+            self.structured_history(messages, thinking_param.as_ref(), 0);
         let tool_choice = ToolChoice {
             r#type: "tool",
             name: &tool_name,
@@ -1352,14 +1410,8 @@ impl LlmProvider for ClaudeProvider {
         let output_config = effort.map(|e| OutputConfig { effort: e });
 
         if !tools.is_empty() {
-            let (system, mut chat_messages) = split_messages_structured(
-                messages,
-                self.cache_user_messages,
-                self.prompt_cache_ttl,
-            );
-            let system_blocks =
-                system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
-            Self::cap_block_cache_controls(1, system_blocks.as_deref(), Some(&mut chat_messages));
+            let (system_blocks, chat_messages) =
+                self.structured_history(messages, thinking_param.as_ref(), 1);
             let api_tools = self.get_or_build_api_tools(tools);
             let body = ToolRequestBody {
                 model: &self.model,
@@ -1378,14 +1430,8 @@ impl LlmProvider for ClaudeProvider {
         }
 
         if Self::has_image_parts(messages) {
-            let (system, mut chat_messages) = split_messages_structured(
-                messages,
-                self.cache_user_messages,
-                self.prompt_cache_ttl,
-            );
-            let system_blocks =
-                system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
-            Self::cap_block_cache_controls(0, system_blocks.as_deref(), Some(&mut chat_messages));
+            let (system_blocks, chat_messages) =
+                self.structured_history(messages, thinking_param.as_ref(), 0);
             let body = VisionRequestBody {
                 model: &self.model,
                 max_tokens: self.max_tokens,
@@ -1401,9 +1447,7 @@ impl LlmProvider for ClaudeProvider {
                 .unwrap_or_else(|e| serde_json::json!({ "serialization_error": e.to_string() }));
         }
 
-        let (system, chat_messages) = split_messages(messages);
-        let system_blocks =
-            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
+        let (system_blocks, chat_messages) = self.plain_history(messages, thinking_param.as_ref());
         let body = RequestBody {
             model: &self.model,
             max_tokens: self.max_tokens,
@@ -1429,8 +1473,6 @@ impl LlmProvider for ClaudeProvider {
         messages: &[Message],
         tools: &[ToolDefinition],
     ) -> Result<ChatResponse, LlmError> {
-        let (system, mut chat_messages) =
-            split_messages_structured(messages, self.cache_user_messages, self.prompt_cache_ttl);
         let api_tools = self.get_or_build_api_tools(tools);
 
         let (thinking_param, mut temperature, effort) = self.build_thinking_param();
@@ -1440,9 +1482,8 @@ impl LlmProvider for ClaudeProvider {
             temperature = Some(t);
         }
         let output_config = effort.map(|e| OutputConfig { effort: e });
-        let system_blocks =
-            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
-        Self::cap_block_cache_controls(1, system_blocks.as_deref(), Some(&mut chat_messages));
+        let (system_blocks, chat_messages) =
+            self.structured_history(messages, thinking_param.as_ref(), 1);
         let has_tools = !tools.is_empty();
         let mut body = ToolRequestBody {
             model: &self.model,

--- a/crates/zeph-llm/src/claude/request.rs
+++ b/crates/zeph-llm/src/claude/request.rs
@@ -14,6 +14,12 @@ use super::types::{
 };
 use crate::CacheTtl;
 
+/// Raw message split, with no no-prefill gating applied.
+///
+/// Not re-exported at `claude` module top level and not meant to be called directly from a
+/// request-construction path — `ClaudeProvider::plain_history` is the funnel that applies the
+/// no-prefill strip after this split (see its doc comment for why). Called directly only by
+/// this crate's tests (to exercise the pure conversion logic) and by the funnel itself.
 pub(super) fn split_messages(messages: &[Message]) -> (Option<String>, Vec<ApiMessage<'_>>) {
     let mut system_parts = Vec::new();
     let mut chat = Vec::new();
@@ -47,6 +53,12 @@ pub(super) fn split_messages(messages: &[Message]) -> (Option<String>, Vec<ApiMe
     (system, chat)
 }
 
+/// Raw structured message split, with no no-prefill gating applied.
+///
+/// Not re-exported at `claude` module top level and not meant to be called directly from a
+/// request-construction path — `ClaudeProvider::structured_history` is the funnel that applies
+/// the no-prefill strip after this split (see its doc comment for why). Called directly only by
+/// this crate's tests (to exercise the pure conversion logic) and by the funnel itself.
 pub(super) fn split_messages_structured(
     messages: &[Message],
     cache_user_messages: bool,

--- a/crates/zeph-llm/src/claude/tests.rs
+++ b/crates/zeph-llm/src/claude/tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use super::cache::cache_min_tokens;
-use super::request::split_messages_structured;
+use super::request::{split_messages, split_messages_structured};
 use std::assert_matches;
 
 use super::types::{
@@ -2970,6 +2970,220 @@ fn build_request_opus_4_6_no_thinking_keeps_trailing_assistant() {
         msgs.last().and_then(|m| m["role"].as_str()),
         Some("assistant"),
         "Opus 4.6 keeps trailing assistant message when thinking is disabled"
+    );
+}
+
+// ── #6146: no-prefill gate must apply on every request-construction path,
+// not just build_request() ─────────────────────────────────────────────────
+
+#[test]
+fn no_prefill_true_for_opus_4_6_with_thinking() {
+    // Opus 4.6 is excluded from unconditional `rejects_prefill` (#6145) — it only rejects
+    // prefill while thinking is active, so this isolates the `prefers_effort` branch.
+    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-6".into(), 32_000)
+        .with_thinking(ThinkingConfig::Adaptive { effort: None })
+        .unwrap();
+    let (thinking_param, _, _) = provider.build_thinking_param();
+    assert!(provider.no_prefill(thinking_param.as_ref()));
+}
+
+#[test]
+fn no_prefill_false_for_opus_4_6_without_thinking() {
+    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-6".into(), 32_000);
+    let (thinking_param, _, _) = provider.build_thinking_param();
+    assert!(!provider.no_prefill(thinking_param.as_ref()));
+}
+
+#[test]
+fn no_prefill_true_for_sonnet_4_6_with_thinking() {
+    // Sonnet 4.6 rejects prefill unconditionally since #6145 (`rejects_prefill`), regardless
+    // of whether thinking is configured.
+    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 32_000)
+        .with_thinking(ThinkingConfig::Extended {
+            budget_tokens: 5_000,
+        })
+        .unwrap();
+    let (thinking_param, _, _) = provider.build_thinking_param();
+    assert!(provider.no_prefill(thinking_param.as_ref()));
+}
+
+#[test]
+fn no_prefill_true_for_sonnet_4_6_without_thinking() {
+    // Companion to the case above: `rejects_prefill` is unconditional, so this must also be
+    // true with no thinking configured at all — the case #6145 added and this branch's
+    // pre-rebase `no_prefill()` would have missed.
+    let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 32_000);
+    let (thinking_param, _, _) = provider.build_thinking_param();
+    assert!(provider.no_prefill(thinking_param.as_ref()));
+}
+
+#[test]
+fn strip_trailing_assistant_structured_removes_only_trailing_run() {
+    let mut messages = vec![
+        StructuredApiMessage {
+            role: "user".into(),
+            content: StructuredContent::Text("hi".into()),
+        },
+        StructuredApiMessage {
+            role: "assistant".into(),
+            content: StructuredContent::Text("mid".into()),
+        },
+        StructuredApiMessage {
+            role: "user".into(),
+            content: StructuredContent::Text("follow-up".into()),
+        },
+        StructuredApiMessage {
+            role: "assistant".into(),
+            content: StructuredContent::Text("trailing".into()),
+        },
+    ];
+    ClaudeProvider::strip_trailing_assistant_structured(true, &mut messages);
+    assert_eq!(
+        messages.len(),
+        3,
+        "only the trailing assistant run is stripped"
+    );
+    assert_eq!(messages.last().unwrap().role, "user");
+}
+
+#[test]
+fn strip_trailing_assistant_structured_noop_when_gate_false() {
+    let mut messages = vec![StructuredApiMessage {
+        role: "assistant".into(),
+        content: StructuredContent::Text("trailing".into()),
+    }];
+    ClaudeProvider::strip_trailing_assistant_structured(false, &mut messages);
+    assert_eq!(
+        messages.len(),
+        1,
+        "no_prefill=false must never strip messages"
+    );
+}
+
+#[test]
+fn strip_trailing_assistant_plain_removes_only_trailing_run() {
+    let mut messages = vec![
+        ApiMessage {
+            role: "user",
+            content: "hi",
+        },
+        ApiMessage {
+            role: "assistant",
+            content: "trailing",
+        },
+    ];
+    ClaudeProvider::strip_trailing_assistant_plain(true, &mut messages);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages.last().unwrap().role, "user");
+}
+
+#[test]
+fn debug_request_json_tools_branch_strips_trailing_assistant_for_opus_thinking() {
+    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-8".into(), 32_000)
+        .with_thinking(ThinkingConfig::Adaptive { effort: None })
+        .unwrap();
+    let messages = vec![
+        Message::from_legacy(Role::User, "hello"),
+        Message::from_legacy(Role::Assistant, "world"),
+    ];
+    let tools = vec![ToolDefinition {
+        name: "read_file".into(),
+        description: "Read a file".into(),
+        parameters: serde_json::json!({"type": "object", "properties": {}}),
+        output_schema: None,
+    }];
+
+    let body = provider.debug_request_json(&messages, &tools, false);
+    let msgs = body["messages"].as_array().unwrap();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "only the trailing assistant message should be stripped, not the whole history"
+    );
+    assert_eq!(
+        msgs[0]["role"].as_str(),
+        Some("user"),
+        "tool-use requests must strip trailing assistant messages for Opus with thinking"
+    );
+}
+
+#[test]
+fn debug_request_json_tools_branch_keeps_trailing_assistant_without_thinking() {
+    // Opus 4.6 is the only current model whose prefill rejection is thinking-gated
+    // (`prefers_effort`) rather than unconditional (`rejects_prefill`, #6145) — Opus 4.8
+    // would strip here regardless of thinking state.
+    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-6".into(), 32_000);
+    let messages = vec![
+        Message::from_legacy(Role::User, "hello"),
+        Message::from_legacy(Role::Assistant, "world"),
+    ];
+    let tools = vec![ToolDefinition {
+        name: "read_file".into(),
+        description: "Read a file".into(),
+        parameters: serde_json::json!({"type": "object", "properties": {}}),
+        output_schema: None,
+    }];
+
+    let body = provider.debug_request_json(&messages, &tools, false);
+    let msgs = body["messages"].as_array().unwrap();
+    assert_eq!(
+        msgs.last().and_then(|m| m["role"].as_str()),
+        Some("assistant"),
+        "trailing assistant message must be preserved when thinking is disabled"
+    );
+}
+
+#[test]
+fn debug_request_json_image_branch_strips_trailing_assistant_for_opus_thinking() {
+    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-8".into(), 32_000)
+        .with_thinking(ThinkingConfig::Adaptive { effort: None })
+        .unwrap();
+    let messages = vec![
+        Message::from_parts(
+            Role::User,
+            vec![MessagePart::Image(Box::new(ImageData {
+                data: vec![1, 2, 3],
+                mime_type: "image/png".into(),
+            }))],
+        ),
+        Message::from_legacy(Role::Assistant, "world"),
+    ];
+
+    let body = provider.debug_request_json(&messages, &[], false);
+    let msgs = body["messages"].as_array().unwrap();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "only the trailing assistant message should be stripped, not the whole history"
+    );
+    assert_eq!(
+        msgs[0]["role"].as_str(),
+        Some("user"),
+        "vision requests must strip trailing assistant messages for Opus with thinking"
+    );
+}
+
+#[test]
+fn debug_request_json_plain_branch_strips_trailing_assistant_for_opus_thinking() {
+    let provider = ClaudeProvider::new("key".into(), "claude-opus-4-8".into(), 32_000)
+        .with_thinking(ThinkingConfig::Adaptive { effort: None })
+        .unwrap();
+    let messages = vec![
+        Message::from_legacy(Role::User, "hello"),
+        Message::from_legacy(Role::Assistant, "world"),
+    ];
+
+    let body = provider.debug_request_json(&messages, &[], false);
+    let msgs = body["messages"].as_array().unwrap();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "only the trailing assistant message should be stripped, not the whole history"
+    );
+    assert_eq!(
+        msgs[0]["role"].as_str(),
+        Some("user"),
+        "plain (no tools, no image) requests must strip trailing assistant messages too"
     );
 }
 


### PR DESCRIPTION
## Summary

- The Claude no-prefill stripping gate (added by #5903, extended by #6145) was only applied in `build_request()`. `chat_with_tools_stream` (the agent's primary tool-use loop), `chat_with_tools`, `chat_typed`, and `debug_request_json` built their request bodies independently and never called the gate, so a trailing-assistant-message history routed through any of them could still trigger the same class of 400 that #5903/#6145 fixed for `build_request`.
- Bundles the message split and the no-prefill strip into two funnel methods, `ClaudeProvider::structured_history`/`plain_history`, that all six request-construction methods (8 body-construction sites total) now call exclusively to obtain their message history. The raw `split_messages`/`split_messages_structured` helpers are no longer imported at the `claude` module's top level, so a future request-construction path is less likely to split a history without the strip being applied — this is the second time this exact bug class has been filed, so the fix is structured to reduce (not fully compiler-close, see Known limitations below) the chance of a third recurrence.
- Picked up #6145 (merged mid-branch) via rebase and folded its `rejects_prefill` capability flag into the shared gate formula: `cap.rejects_prefill || (cap.prefers_effort && thinking_param.is_some())`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13158 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo doc`/`cargo test --doc` for `zeph-llm` specifically (candle+metal+cocoon+gonka+classifiers+testing, excluding the CUDA-only feature which isn't buildable on this machine — matches CI's own "all features except candle" convention for the workspace doc job)
- [x] 10 new/tightened regression tests added to `crates/zeph-llm/src/claude/tests.rs`, covering the shared helpers directly and all 3 branches of `debug_request_json`

**LLM Serialization Gate**: no live Claude API round-trip was performed — cloud test accounts (OpenAI + Anthropic) remain exhausted as of this session (same limitation noted in #6145). Coverage is unit/nextest only. `chat_with_tools_stream`/`chat_with_tools`/`chat_typed` are not independently exercised by an executing test because `API_URL` is a hardcoded const with no mock-server injection point (pre-existing limitation, not introduced by this PR) — their funnel wiring is verified by code inspection and by the identical construction-function sequence covered via `debug_request_json`'s tests instead.

## Known limitations (documented, non-blocking)

- The bypass-prevention barrier is a soft one: `split_messages`/`split_messages_structured` remain `pub(super)` (required by ~25 pre-existing tests that exercise the pure conversion logic directly) and are only removed from the top-level `use` in `mod.rs`. A determined future author could still write the fully-qualified path to bypass the funnel — this is reviewer/inspection-enforced, not compiler-enforced. A follow-up to relocate those tests into a `claude::request::tests` submodule and make the splitters fully private would close this gap; not done here to keep this PR's scope to the filed bug.
- `chat_with_tools_stream`/`chat_with_tools`/`chat_typed` lack an executing HTTP-level test (see LLM Serialization Gate note above) — worth a follow-up issue to make `API_URL` test-injectable.

Closes #6146