### PR TITLE
fix(llm): reduce Claude no-prefill bypass discoverability, add HTTP-level test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Testing
 
+- `zeph-llm`: reduced the discoverability of bypassing the Claude no-prefill funnel introduced
+  by #6154, and closed a real HTTP-level coverage gap (#6155, #6156). `split_messages`/
+  `split_messages_structured` in `crates/zeph-llm/src/claude/request.rs` are now
+  `pub(in crate::claude)` instead of `pub(super)`. In the current module nesting (`request` is
+  a direct child of `claude`, i.e. `mod.rs`) the two are functionally identical — Rust has no
+  way to grant a child module's item to its parent while excluding the parent's other children,
+  so this is a self-documenting anchor to the intended boundary, not a new compile-time barrier;
+  `claude::tests` remains exactly as reachable as before in raw visibility terms. A true
+  compile-error barrier is architecturally impossible while the no-prefill funnel
+  (`structured_history`/`plain_history`) lives in the parent module (`claude`/`mod.rs`) — a new
+  request-construction path added there calling the raw split functions directly would still
+  compile fine, so this remains a code-review catch rather than a compiler error. The actual
+  hardening is that the ~22 pure message-conversion tests (tool-use pairing, cache breakpoints,
+  image blocks, thinking/redacted-thinking blocks, compaction round-trip) that used to call
+  these functions directly moved from `claude/tests.rs` into a same-file `mod tests` inside
+  `request.rs`, so `claude::tests` no longer imports or calls them — removing the habit/
+  discoverability path a future author would reach for, not adding a compiler-enforced one. A
+  genuine compile-time guarantee (a newtype only constructible via `structured_history`/
+  `plain_history`, so a request body cannot accept an ungated history) is tracked as a
+  follow-up: #6158. Separately, `ClaudeProvider`'s Messages API
+  base URL is now an injectable field (`api_url`, defaulting to the real `API_URL` in
+  production) with a `#[cfg(test)]`-only `with_api_url` override, replacing a dead hand-rolled
+  TCP mock server in `claude/tests.rs` that had given up on HTTP-level assertions ("We can't
+  override API_URL from outside"). New `wiremock`-backed tests drive `chat_with_tools`,
+  `chat_with_tools_stream`, and `chat_typed` through a real (mocked) HTTP round-trip and assert
+  the no-prefill gate strips a trailing assistant message in the request actually sent over the
+  wire, closing the gap where prior coverage only exercised the identical body-construction
+  sequence via `debug_request_json` as a same-order proxy.
 - `zeph-worktree`: added a regression test confirming `WorktreeManager::remove()`'s single
   `git worktree remove --force` still refuses a `git worktree lock`-ed worktree (requires
   `-f -f`), the second safety layer alongside the `prunable`-gating from #6076 — previously

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -138,6 +138,9 @@ pub struct ClaudeProvider {
     /// tracking and provider selection can distinguish between multiple configured Claude
     /// instances (#5892).
     provider_name: String,
+    /// Messages API base URL. Always [`API_URL`] in production; overridable only under
+    /// `#[cfg(test)]` via `with_api_url` so tests can point requests at a mock HTTP server.
+    api_url: String,
 }
 
 impl fmt::Debug for ClaudeProvider {
@@ -176,6 +179,7 @@ impl fmt::Debug for ClaudeProvider {
                 &self.max_tool_description_bytes,
             )
             .field("provider_name", &self.provider_name)
+            .field("api_url", &self.api_url)
             .finish()
     }
 }
@@ -204,6 +208,7 @@ impl Clone for ClaudeProvider {
             max_tool_description_bytes: self.max_tool_description_bytes,
             stream_limits: self.stream_limits.clone(),
             provider_name: self.provider_name.clone(),
+            api_url: self.api_url.clone(),
         }
     }
 }
@@ -283,7 +288,18 @@ impl ClaudeProvider {
             prompt_cache_ttl: None,
             stream_limits: zeph_config::StreamLimits::default(),
             provider_name: "claude".to_owned(),
+            api_url: API_URL.to_owned(),
         }
+    }
+
+    /// Override the Messages API base URL. Test-only: points requests at a mock HTTP server
+    /// (e.g. `wiremock`) so tests can assert on the wire format Claude actually receives,
+    /// instead of only on the request body construction functions in isolation.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn with_api_url(mut self, url: impl Into<String>) -> Self {
+        self.api_url = url.into();
+        self
     }
 
     /// Set the name reported by [`LlmProvider::name`].
@@ -947,13 +963,16 @@ impl ClaudeProvider {
     /// cache-control blocks are capped at Anthropic's budget and the no-prefill gate has
     /// already been applied.
     ///
-    /// This is the only sanctioned way to obtain a `Vec<StructuredApiMessage>` for a request
-    /// body. `split_messages_structured` itself is intentionally NOT imported at this module's
-    /// top level (see the local `use` inside this function) so it isn't one autocomplete away
-    /// from every call site — request-construction code must go through this funnel, which
-    /// bundles the split with the no-prefill strip so the two cannot be pulled apart again the
-    /// way they were before #6146 (this is the second filing of this bug class; #5903 fixed the
-    /// gate for `build_request` only).
+    /// This is the *sanctioned* way to obtain a `Vec<StructuredApiMessage>` for a request body,
+    /// not a compiler-enforced one. `split_messages_structured` itself is intentionally NOT
+    /// imported at this module's top level (see the local `use` inside this function) so it
+    /// isn't one autocomplete away from every call site, which raises the friction of pulling
+    /// the split and the no-prefill strip apart again the way they were before #6146 (this is
+    /// the second filing of this bug class; #5903 fixed the gate for `build_request` only). A
+    /// true compile-time barrier is not achievable while this funnel lives in `claude` (this
+    /// module) and `split_messages_structured` must remain visible to it — see the doc comment
+    /// on `split_messages_structured` in `request.rs` and follow-up #6158 for a design that
+    /// would make bypassing this funnel a compile error instead of a code-review catch.
     fn structured_history(
         &self,
         messages: &[Message],
@@ -979,7 +998,8 @@ impl ClaudeProvider {
     }
 
     /// Split `messages` into a system prompt and a plain chat history, with the no-prefill gate
-    /// already applied. Same bypass-prevention rationale as [`Self::structured_history`].
+    /// already applied. Same friction-raising rationale (not a compile-time guarantee) as
+    /// [`Self::structured_history`].
     fn plain_history<'m>(
         &self,
         messages: &'m [Message],
@@ -1020,7 +1040,7 @@ impl ClaudeProvider {
             };
             let mut req = self
                 .client
-                .post(API_URL)
+                .post(&self.api_url)
                 .header("x-api-key", &self.api_key)
                 .header("anthropic-version", ANTHROPIC_VERSION);
             if let Some(b) = beta {
@@ -1045,7 +1065,7 @@ impl ClaudeProvider {
 
         let mut req = self
             .client
-            .post(API_URL)
+            .post(&self.api_url)
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", ANTHROPIC_VERSION);
         if let Some(b) = beta {
@@ -1158,7 +1178,7 @@ impl ClaudeProvider {
             let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
                 let mut req = self
                     .client
-                    .post(API_URL)
+                    .post(&self.api_url)
                     .header("x-api-key", &self.api_key)
                     .header("anthropic-version", ANTHROPIC_VERSION);
                 if let Some(ref b) = beta {
@@ -1339,7 +1359,7 @@ impl LlmProvider for ClaudeProvider {
             let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
                 let mut req = self
                     .client
-                    .post(API_URL)
+                    .post(&self.api_url)
                     .header("x-api-key", &self.api_key)
                     .header("anthropic-version", ANTHROPIC_VERSION);
                 if let Some(ref b) = beta {
@@ -1505,7 +1525,7 @@ impl LlmProvider for ClaudeProvider {
             let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
                 let mut req = self
                     .client
-                    .post(API_URL)
+                    .post(&self.api_url)
                     .header("x-api-key", &self.api_key)
                     .header("anthropic-version", ANTHROPIC_VERSION);
                 if let Some(ref b) = beta {

--- a/crates/zeph-llm/src/claude/request.rs
+++ b/crates/zeph-llm/src/claude/request.rs
@@ -18,9 +18,27 @@ use crate::CacheTtl;
 ///
 /// Not re-exported at `claude` module top level and not meant to be called directly from a
 /// request-construction path — `ClaudeProvider::plain_history` is the funnel that applies the
-/// no-prefill strip after this split (see its doc comment for why). Called directly only by
-/// this crate's tests (to exercise the pure conversion logic) and by the funnel itself.
-pub(super) fn split_messages(messages: &[Message]) -> (Option<String>, Vec<ApiMessage<'_>>) {
+/// no-prefill strip after this split (see its doc comment for why).
+///
+/// Visibility is `pub(in crate::claude)` rather than plain `pub(super)`, but in the current
+/// module nesting (`request` is a direct child of `claude`, and `mod.rs` *is* the `claude`
+/// module) the two are functionally identical — this is a self-documenting anchor to the
+/// intended boundary, NOT a new compile-time bypass barrier. Rust has no way to grant a child
+/// module's item to its parent while excluding the parent's other children, so `claude::tests`
+/// remains exactly as reachable as before in raw visibility terms. A true compile-error barrier
+/// is architecturally impossible while `structured_history`/`plain_history` live in the parent
+/// module (`claude`/`mod.rs`) and therefore need at least this visibility to call these
+/// functions — a new request-construction path added directly in `mod.rs` that calls
+/// `split_messages`/`split_messages_structured` instead of the funnel would still compile fine;
+/// it remains a code-review catch, not a compiler error. The actual hardening this change
+/// delivers is moving the tests that used to call this directly out of `claude::tests` and into
+/// this file's own `mod tests` below — reduced discoverability/habit, not a compiler-enforced
+/// guarantee. A genuine compile-time guarantee (e.g. a newtype only constructible by
+/// `structured_history`/`plain_history`, so a request body cannot accept an ungated history) is
+/// tracked as a follow-up: #6158.
+pub(in crate::claude) fn split_messages(
+    messages: &[Message],
+) -> (Option<String>, Vec<ApiMessage<'_>>) {
     let mut system_parts = Vec::new();
     let mut chat = Vec::new();
 
@@ -57,9 +75,10 @@ pub(super) fn split_messages(messages: &[Message]) -> (Option<String>, Vec<ApiMe
 ///
 /// Not re-exported at `claude` module top level and not meant to be called directly from a
 /// request-construction path — `ClaudeProvider::structured_history` is the funnel that applies
-/// the no-prefill strip after this split (see its doc comment for why). Called directly only by
-/// this crate's tests (to exercise the pure conversion logic) and by the funnel itself.
-pub(super) fn split_messages_structured(
+/// the no-prefill strip after this split (see its doc comment for why). See [`split_messages`]
+/// for why the `pub(in crate::claude)` visibility here is a documentation anchor rather than a
+/// new compile-time barrier, and for the compile-time-enforcement follow-up (#6158).
+pub(in crate::claude) fn split_messages_structured(
     messages: &[Message],
     cache_user_messages: bool,
     ttl: Option<CacheTtl>,
@@ -453,4 +472,758 @@ pub(super) fn compute_matched_tool_ids<'m>(
             })
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{ImageData, MessageMetadata};
+
+    #[test]
+    fn split_messages_extracts_system() {
+        let messages = vec![
+            Message {
+                role: Role::System,
+                content: "You are helpful.".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::User,
+                content: "Hi".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+        ];
+
+        let (system, chat) = split_messages(&messages);
+        assert_eq!(system.unwrap(), "You are helpful.");
+        assert_eq!(chat.len(), 1);
+        assert_eq!(chat[0].role, "user");
+    }
+
+    #[test]
+    fn split_messages_no_system() {
+        let messages = vec![Message {
+            role: Role::User,
+            content: "Hi".into(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+
+        let (system, chat) = split_messages(&messages);
+        assert!(system.is_none());
+        assert_eq!(chat.len(), 1);
+    }
+
+    #[test]
+    fn split_messages_multiple_system() {
+        let messages = vec![
+            Message {
+                role: Role::System,
+                content: "Part 1".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::System,
+                content: "Part 2".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::User,
+                content: "Hi".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+        ];
+
+        let (system, _) = split_messages(&messages);
+        assert_eq!(system.unwrap(), "Part 1\n\nPart 2");
+    }
+
+    #[test]
+    fn split_messages_all_roles() {
+        let messages = vec![
+            Message {
+                role: Role::System,
+                content: "system prompt".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::User,
+                content: "user msg".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::Assistant,
+                content: "assistant reply".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::User,
+                content: "followup".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+        ];
+        let (system, chat) = split_messages(&messages);
+        assert_eq!(system.unwrap(), "system prompt");
+        assert_eq!(chat.len(), 3);
+        assert_eq!(chat[0].role, "user");
+        assert_eq!(chat[0].content, "user msg");
+        assert_eq!(chat[1].role, "assistant");
+        assert_eq!(chat[1].content, "assistant reply");
+        assert_eq!(chat[2].role, "user");
+        assert_eq!(chat[2].content, "followup");
+    }
+
+    #[test]
+    fn split_messages_empty() {
+        let (system, chat) = split_messages(&[]);
+        assert!(system.is_none());
+        assert!(chat.is_empty());
+    }
+
+    #[test]
+    fn split_messages_only_system() {
+        let messages = vec![Message {
+            role: Role::System,
+            content: "instruction".into(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+        let (system, chat) = split_messages(&messages);
+        assert_eq!(system.unwrap(), "instruction");
+        assert!(chat.is_empty());
+    }
+
+    #[test]
+    fn split_messages_only_assistant() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: "reply".into(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+        let (system, chat) = split_messages(&messages);
+        assert!(system.is_none());
+        assert_eq!(chat.len(), 1);
+        assert_eq!(chat[0].role, "assistant");
+    }
+
+    #[test]
+    fn split_messages_interleaved_system() {
+        let messages = vec![
+            Message {
+                role: Role::System,
+                content: "first".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::User,
+                content: "question".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::System,
+                content: "second".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+        ];
+        let (system, chat) = split_messages(&messages);
+        assert_eq!(system.unwrap(), "first\n\nsecond");
+        assert_eq!(chat.len(), 1);
+    }
+
+    #[test]
+    fn split_messages_structured_with_tool_parts() {
+        let messages = vec![
+            Message::from_parts(
+                Role::Assistant,
+                vec![
+                    MessagePart::Text {
+                        text: "I'll run that".into(),
+                    },
+                    MessagePart::ToolUse {
+                        id: "t1".into(),
+                        name: "bash".into(),
+                        input: serde_json::json!({"command": "ls"}),
+                    },
+                ],
+            ),
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::ToolResult {
+                    tool_use_id: "t1".into(),
+                    content: "file1.rs".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+        let (system, chat) = split_messages_structured(&messages, true, None);
+        assert!(system.is_none());
+        assert_eq!(chat.len(), 2);
+
+        let assistant_json = serde_json::to_string(&chat[0]).unwrap();
+        assert!(assistant_json.contains("tool_use"));
+        assert!(assistant_json.contains("\"id\":\"t1\""));
+
+        let user_json = serde_json::to_string(&chat[1]).unwrap();
+        assert!(user_json.contains("tool_result"));
+        assert!(user_json.contains("\"tool_use_id\":\"t1\""));
+    }
+
+    /// FIX2 regression: an assistant message with a `ToolUse` part that has NO matching
+    /// `ToolResult` in the next user message must emit a text block instead of a `tool_use`
+    /// block, preventing Claude API 400 errors caused by unmatched `tool_use/tool_result` pairs.
+    #[test]
+    fn split_messages_structured_downgrades_unmatched_tool_use_to_text() {
+        // Orphaned assistant[ToolUse] — no following user[ToolResult].
+        let messages = vec![
+            Message::from_parts(
+                Role::Assistant,
+                vec![
+                    MessagePart::Text {
+                        text: "Let me run this.".into(),
+                    },
+                    MessagePart::ToolUse {
+                        id: "orphan_id".into(),
+                        name: "shell".into(),
+                        input: serde_json::json!({"command": "ls"}),
+                    },
+                ],
+            ),
+            // Next message is NOT a ToolResult response — simulates compaction-split orphan.
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::Text {
+                    text: "Thanks, what did you find?".into(),
+                }],
+            ),
+        ];
+
+        let (_, chat) = split_messages_structured(&messages, false, None);
+        assert_eq!(chat.len(), 2);
+
+        // The assistant block must NOT contain a tool_use block for the unmatched ID.
+        let assistant_json = serde_json::to_string(&chat[0]).unwrap();
+        assert!(
+            !assistant_json.contains("\"type\":\"tool_use\""),
+            "unmatched tool_use must be downgraded: {assistant_json}"
+        );
+        // The orphaned ID must appear in a text fallback instead.
+        assert!(
+            assistant_json.contains("orphan_id") || assistant_json.contains("shell"),
+            "downgraded tool_use must appear as text fallback: {assistant_json}"
+        );
+    }
+
+    /// FIX2 regression: a matched `tool_use/tool_result` pair must still emit a real
+    /// `tool_use` block. The defensive check must not break valid exchanges.
+    #[test]
+    fn split_messages_structured_preserves_matched_tool_use_block() {
+        let messages = vec![
+            Message::from_parts(
+                Role::Assistant,
+                vec![MessagePart::ToolUse {
+                    id: "matched_id".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({"command": "echo hi"}),
+                }],
+            ),
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::ToolResult {
+                    tool_use_id: "matched_id".into(),
+                    content: "hi".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+
+        let (_, chat) = split_messages_structured(&messages, false, None);
+        assert_eq!(chat.len(), 2);
+
+        let assistant_json = serde_json::to_string(&chat[0]).unwrap();
+        assert!(
+            assistant_json.contains("\"type\":\"tool_use\""),
+            "matched tool_use must be emitted as tool_use block: {assistant_json}"
+        );
+        assert!(assistant_json.contains("\"id\":\"matched_id\""));
+    }
+
+    /// RC1 regression: when a `ToolUse` was downgraded to text (because the next user message had
+    /// no matching `ToolResult`), the corresponding `ToolResult` in the user message must ALSO be
+    /// downgraded to text instead of being emitted as a native `ToolResult` block.
+    /// Previously only the `ToolUse` was downgraded, leaving an orphaned `ToolResult` that caused
+    /// Claude API 400 errors on session restore.
+    #[test]
+    fn split_structured_downgrades_orphaned_tool_result() {
+        // Scenario: assistant emits tool_use "t_orphan", but the following user message has a
+        // ToolResult for a DIFFERENT id — so "t_orphan" is downgraded. The ToolResult for
+        // "t_orphan" (which does appear in the user message) must also be downgraded.
+        let messages = vec![
+            Message::from_parts(
+                Role::Assistant,
+                vec![MessagePart::ToolUse {
+                    id: "t_orphan".into(),
+                    name: "memory_save".into(),
+                    input: serde_json::json!({"content": "x"}),
+                }],
+            ),
+            // User message references t_orphan but the assistant ToolUse was not matched
+            // (there is no ToolResult for t_orphan in the NEXT user message from assistant's
+            // perspective — the assistant sees this user message has t_orphan, but the
+            // matched_tool_ids logic checks whether the ToolResult id matches).
+            // To trigger the orphan path: provide a user message whose ToolResult id does NOT
+            // match the ToolUse id — so matched_tool_ids for "t_orphan" is empty.
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::ToolResult {
+                    tool_use_id: "t_orphan".into(),
+                    content: "saved".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+
+        // Verify the full round-trip: the assistant ToolUse is matched (t_orphan has a
+        // corresponding ToolResult), so this tests the happy path.
+        let (_, chat) = split_messages_structured(&messages, false, None);
+        assert_eq!(chat.len(), 2);
+
+        // The assistant message must emit t_orphan as a real tool_use (matched pair).
+        let assistant_json = serde_json::to_string(&chat[0]).unwrap();
+        assert!(
+            assistant_json.contains("\"type\":\"tool_use\""),
+            "matched tool_use must be emitted as native block: {assistant_json}"
+        );
+
+        // The user message must emit t_orphan as a real tool_result (matched pair).
+        let user_json = serde_json::to_string(&chat[1]).unwrap();
+        assert!(
+            user_json.contains("\"type\":\"tool_result\""),
+            "matched tool_result must be emitted as native block: {user_json}"
+        );
+
+        // Now test the actual RC1 scenario: assistant emits TWO tool_use IDs but the user
+        // message only has a ToolResult for ONE of them. The unmatched tool_use is downgraded,
+        // and the ToolResult for the unmatched id must NOT appear in the user message output.
+        let messages_partial = vec![
+            Message::from_parts(
+                Role::Assistant,
+                vec![
+                    MessagePart::ToolUse {
+                        id: "t_matched".into(),
+                        name: "shell".into(),
+                        input: serde_json::json!({"command": "ls"}),
+                    },
+                    MessagePart::ToolUse {
+                        id: "t_missing_result".into(),
+                        name: "shell".into(),
+                        input: serde_json::json!({"command": "pwd"}),
+                    },
+                ],
+            ),
+            // User only provides result for t_matched; t_missing_result has no ToolResult.
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::ToolResult {
+                    tool_use_id: "t_matched".into(),
+                    content: "output".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+
+        let (_, chat2) = split_messages_structured(&messages_partial, false, None);
+        assert_eq!(chat2.len(), 2);
+
+        // t_missing_result must be downgraded to text in the assistant message: if its ID
+        // appears at all it must not be inside a native tool_use block.
+        let assistant_json2 = serde_json::to_string(&chat2[0]).unwrap();
+        let has_native_missing = assistant_json2.contains("\"type\":\"tool_use\"")
+            && assistant_json2.contains("\"id\":\"t_missing_result\"");
+        assert!(
+            !has_native_missing,
+            "t_missing_result must not appear as a native tool_use block: {assistant_json2}"
+        );
+
+        // t_matched must still be emitted as a real tool_use.
+        assert!(
+            assistant_json2.contains("\"id\":\"t_matched\""),
+            "t_matched must be emitted as native tool_use: {assistant_json2}"
+        );
+
+        // The user message must only have t_matched as a real tool_result.
+        let user_json2 = serde_json::to_string(&chat2[1]).unwrap();
+        assert!(
+            user_json2.contains("\"type\":\"tool_result\""),
+            "matched tool_result must be emitted as native block: {user_json2}"
+        );
+        assert!(
+            user_json2.contains("\"tool_use_id\":\"t_matched\""),
+            "t_matched tool_result must be present: {user_json2}"
+        );
+    }
+
+    /// RC4 regression: system messages interleaved in the message list must NOT appear in the
+    /// `visible` index array used by `split_messages_structured`. If they did, the +1 peek used
+    /// to check whether a `ToolUse` has a matching `ToolResult` would land on a system message
+    /// instead of the actual next user message, causing false-positive downgrades.
+    #[test]
+    fn split_structured_system_not_in_visible() {
+        // System message appears between the assistant ToolUse and the user ToolResult.
+        // With the RC4 fix the system message is filtered out of `visible`, so idx+1 correctly
+        // lands on the user message and the ToolUse is NOT downgraded.
+        let messages = vec![
+            Message {
+                role: Role::System,
+                content: "You are a helpful assistant.".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message::from_parts(
+                Role::Assistant,
+                vec![MessagePart::ToolUse {
+                    id: "t_sys_test".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({"command": "echo hi"}),
+                }],
+            ),
+            // Interleaved system message — must not disrupt the +1 peek.
+            Message {
+                role: Role::System,
+                content: "Additional context injected mid-conversation.".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::ToolResult {
+                    tool_use_id: "t_sys_test".into(),
+                    content: "hi".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+
+        let (system_text, chat) = split_messages_structured(&messages, false, None);
+
+        // Both system messages must be extracted to the system string.
+        let system = system_text.unwrap_or_default();
+        assert!(
+            system.contains("You are a helpful assistant."),
+            "first system message must be in system text: {system}"
+        );
+        assert!(
+            system.contains("Additional context"),
+            "interleaved system message must be in system text: {system}"
+        );
+
+        // chat must contain only user and assistant messages (no system).
+        assert_eq!(
+            chat.len(),
+            2,
+            "chat must contain exactly assistant + user messages (no system), got {}",
+            chat.len()
+        );
+        assert_eq!(chat[0].role, "assistant");
+        assert_eq!(chat[1].role, "user");
+
+        // The ToolUse must NOT be downgraded — system messages must not break the +1 peek.
+        let assistant_json = serde_json::to_string(&chat[0]).unwrap();
+        assert!(
+            assistant_json.contains("\"type\":\"tool_use\""),
+            "ToolUse must be emitted as native block when system messages are filtered: {assistant_json}"
+        );
+        assert!(
+            assistant_json.contains("\"id\":\"t_sys_test\""),
+            "correct tool_use id must be present: {assistant_json}"
+        );
+
+        // The ToolResult must be emitted as a native block (not downgraded).
+        let user_json = serde_json::to_string(&chat[1]).unwrap();
+        assert!(
+            user_json.contains("\"type\":\"tool_result\""),
+            "ToolResult must be emitted as native block: {user_json}"
+        );
+    }
+
+    #[test]
+    fn split_messages_structured_produces_image_block() {
+        let data = vec![0xFFu8, 0xD8, 0xFF];
+        let msg = Message::from_parts(
+            Role::User,
+            vec![
+                MessagePart::Text {
+                    text: "look at this".into(),
+                },
+                MessagePart::Image(Box::new(ImageData {
+                    data: data.clone(),
+                    mime_type: "image/jpeg".into(),
+                })),
+            ],
+        );
+        let (system, chat) = split_messages_structured(&[msg], true, None);
+        assert!(system.is_none());
+        assert_eq!(chat.len(), 1);
+        assert_eq!(chat[0].role, "user");
+        match &chat[0].content {
+            StructuredContent::Blocks(blocks) => {
+                assert_eq!(blocks.len(), 2);
+                match &blocks[0] {
+                    AnthropicContentBlock::Text { text, .. } => assert_eq!(text, "look at this"),
+                    _ => panic!("expected Text block first"),
+                }
+                match &blocks[1] {
+                    AnthropicContentBlock::Image { source } => {
+                        assert_eq!(source.source_type, "base64");
+                        assert_eq!(source.media_type, "image/jpeg");
+                        assert_eq!(source.data, STANDARD.encode(&data));
+                    }
+                    _ => panic!("expected Image block second"),
+                }
+            }
+            StructuredContent::Text(_) => panic!("expected Blocks content"),
+        }
+    }
+
+    #[test]
+    fn thinking_block_serializes_in_structured_message() {
+        let msg = Message::from_parts(
+            Role::Assistant,
+            vec![
+                MessagePart::ThinkingBlock {
+                    thinking: "my reasoning".into(),
+                    signature: "abc".into(),
+                },
+                MessagePart::Text {
+                    text: "answer".into(),
+                },
+            ],
+        );
+        let (_, chat) = split_messages_structured(&[msg], true, None);
+        assert_eq!(chat.len(), 1);
+        let json = serde_json::to_value(&chat[0]).unwrap();
+        let blocks = json["content"].as_array().unwrap();
+        assert_eq!(blocks[0]["type"], "thinking");
+        assert_eq!(blocks[0]["thinking"], "my reasoning");
+        assert_eq!(blocks[0]["signature"], "abc");
+        assert_eq!(blocks[1]["type"], "text");
+    }
+
+    #[test]
+    fn redacted_thinking_block_serializes_in_structured_message() {
+        let msg = Message::from_parts(
+            Role::Assistant,
+            vec![MessagePart::RedactedThinkingBlock {
+                data: "secret".into(),
+            }],
+        );
+        let (_, chat) = split_messages_structured(&[msg], true, None);
+        let json = serde_json::to_value(&chat[0]).unwrap();
+        let blocks = json["content"].as_array().unwrap();
+        assert_eq!(blocks[0]["type"], "redacted_thinking");
+        assert_eq!(blocks[0]["data"], "secret");
+    }
+
+    #[test]
+    fn split_messages_structured_single_message_no_cache_breakpoint() {
+        let messages = vec![Message {
+            role: Role::User,
+            content: "only message".into(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+        let (_, chat) = split_messages_structured(&messages, true, None);
+        assert_eq!(chat.len(), 1);
+        // With only 1 message, no breakpoint is placed
+        let json = serde_json::to_value(&chat[0]).unwrap();
+        let has_cache = json.to_string().contains("cache_control");
+        assert!(
+            !has_cache,
+            "single message must not have cache_control breakpoint"
+        );
+    }
+
+    #[test]
+    fn split_messages_structured_two_messages_places_breakpoint_on_user() {
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: "first user".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::Assistant,
+                content: "assistant reply".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+        ];
+        let (_, chat) = split_messages_structured(&messages, true, None);
+        assert_eq!(chat.len(), 2);
+        // Breakpoint must be on the user message at index 0 (only user in range)
+        let user_json = serde_json::to_value(&chat[0]).unwrap();
+        assert!(
+            user_json.to_string().contains("cache_control"),
+            "user message must carry cache_control breakpoint"
+        );
+        let assistant_json = serde_json::to_value(&chat[1]).unwrap();
+        assert!(
+            !assistant_json.to_string().contains("cache_control"),
+            "assistant message must not have cache_control"
+        );
+    }
+
+    #[test]
+    fn split_messages_structured_breakpoint_targets_last_minus_20_position() {
+        // Build 25 messages: user/assistant alternating, user first
+        let mut messages = Vec::new();
+        for i in 0..25u32 {
+            let role = if i % 2 == 0 {
+                Role::User
+            } else {
+                Role::Assistant
+            };
+            let content = format!("message {i}");
+            messages.push(Message {
+                role,
+                content,
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            });
+        }
+        let (_, chat) = split_messages_structured(&messages, true, None);
+        assert_eq!(chat.len(), 25);
+        // target = 25 - 20 = 5; first user at or after index 5 is index 6 (even indices are user)
+        // Actually index 5 is assistant (odd), so search finds index 6 (user)
+        let mut breakpoint_idx = None;
+        for (i, msg) in chat.iter().enumerate() {
+            let json = serde_json::to_value(msg).unwrap();
+            if json.to_string().contains("cache_control") {
+                breakpoint_idx = Some(i);
+                break;
+            }
+        }
+        let idx = breakpoint_idx.expect("must have a breakpoint somewhere");
+        assert_eq!(
+            chat[idx].role, "user",
+            "breakpoint must be on a user message"
+        );
+        // Breakpoint index must be >= max(0, total-20) = 5
+        assert!(idx >= 5, "breakpoint must be at or after position total-20");
+    }
+
+    #[test]
+    fn split_messages_structured_cache_enabled_adds_cache_control() {
+        let messages = vec![
+            Message::from_legacy(Role::User, "first"),
+            Message::from_legacy(Role::Assistant, "answer"),
+            Message::from_legacy(Role::User, "second"),
+        ];
+        let (_, chat) = split_messages_structured(&messages, true, None);
+        assert_eq!(chat.len(), 3);
+        // Breakpoint targets the user message at max(0, total-20) = 0, which is chat[0].
+        let has_cache = chat.iter().any(|m| {
+            m.role == "user"
+                && match &m.content {
+                    StructuredContent::Blocks(blocks) => blocks.iter().any(|b| {
+                        matches!(
+                            b,
+                            AnthropicContentBlock::Text {
+                                cache_control: Some(_),
+                                ..
+                            }
+                        )
+                    }),
+                    StructuredContent::Text(_) => false,
+                }
+        });
+        assert!(
+            has_cache,
+            "at least one user message must have cache_control when enabled"
+        );
+    }
+
+    #[test]
+    fn split_messages_structured_cache_disabled_no_cache_control() {
+        let messages = vec![
+            Message::from_legacy(Role::User, "first"),
+            Message::from_legacy(Role::Assistant, "answer"),
+            Message::from_legacy(Role::User, "second"),
+        ];
+        let (_, chat) = split_messages_structured(&messages, false, None);
+        assert_eq!(chat.len(), 3);
+        // With cache disabled, last user message stays as plain Text.
+        assert!(
+            matches!(&chat[2].content, StructuredContent::Text(_)),
+            "last user message must remain Text when cache disabled"
+        );
+    }
+
+    #[test]
+    fn split_messages_structured_compaction_round_trip() {
+        // Compaction in an assistant message must be emitted verbatim as an
+        // AnthropicContentBlock::Compaction so the API can prune history correctly.
+        // A Compaction in a user message must be silently dropped.
+        let messages = vec![
+            Message::from_parts(
+                Role::Assistant,
+                vec![
+                    MessagePart::Text {
+                        text: "Before compaction.".into(),
+                    },
+                    MessagePart::Compaction {
+                        summary: "History was compacted here.".into(),
+                    },
+                ],
+            ),
+            Message::from_parts(
+                Role::User,
+                vec![
+                    MessagePart::Text {
+                        text: "Continue.".into(),
+                    },
+                    MessagePart::Compaction {
+                        summary: "should be dropped".into(),
+                    },
+                ],
+            ),
+        ];
+        let (system, chat) = split_messages_structured(&messages, false, None);
+        assert!(system.is_none());
+        assert_eq!(chat.len(), 2);
+
+        // Assistant message: must contain a Compaction block with the original summary.
+        if let StructuredContent::Blocks(blocks) = &chat[0].content {
+            let has_compaction = blocks.iter().any(|b| {
+                matches!(b, AnthropicContentBlock::Compaction { summary }
+                    if summary == "History was compacted here.")
+            });
+            assert!(
+                has_compaction,
+                "assistant Compaction block must be preserved"
+            );
+        } else {
+            panic!("expected Blocks for assistant message");
+        }
+
+        // User message: Compaction must be silently dropped.
+        let user_json = serde_json::to_string(&chat[1]).unwrap();
+        assert!(
+            !user_json.contains("compaction"),
+            "Compaction in user message must be dropped"
+        );
+    }
 }

--- a/crates/zeph-llm/src/claude/tests.rs
+++ b/crates/zeph-llm/src/claude/tests.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use super::cache::cache_min_tokens;
-use super::request::{split_messages, split_messages_structured};
 use std::assert_matches;
 
 use super::types::{
@@ -93,70 +92,6 @@ fn with_provider_name_overrides_name() {
     let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-5-20250929".into(), 1024)
         .with_provider_name("quality-claude");
     assert_eq!(provider.name(), "quality-claude");
-}
-
-#[test]
-fn split_messages_extracts_system() {
-    let messages = vec![
-        Message {
-            role: Role::System,
-            content: "You are helpful.".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::User,
-            content: "Hi".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-    ];
-
-    let (system, chat) = split_messages(&messages);
-    assert_eq!(system.unwrap(), "You are helpful.");
-    assert_eq!(chat.len(), 1);
-    assert_eq!(chat[0].role, "user");
-}
-
-#[test]
-fn split_messages_no_system() {
-    let messages = vec![Message {
-        role: Role::User,
-        content: "Hi".into(),
-        parts: vec![],
-        metadata: MessageMetadata::default(),
-    }];
-
-    let (system, chat) = split_messages(&messages);
-    assert!(system.is_none());
-    assert_eq!(chat.len(), 1);
-}
-
-#[test]
-fn split_messages_multiple_system() {
-    let messages = vec![
-        Message {
-            role: Role::System,
-            content: "Part 1".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::System,
-            content: "Part 2".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::User,
-            content: "Hi".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-    ];
-
-    let (system, _) = split_messages(&messages);
-    assert_eq!(system.unwrap(), "Part 1\n\nPart 2");
 }
 
 #[test]
@@ -302,52 +237,6 @@ fn request_body_serializes_stream_true() {
 }
 
 #[test]
-fn split_messages_all_roles() {
-    let messages = vec![
-        Message {
-            role: Role::System,
-            content: "system prompt".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::User,
-            content: "user msg".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::Assistant,
-            content: "assistant reply".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::User,
-            content: "followup".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-    ];
-    let (system, chat) = split_messages(&messages);
-    assert_eq!(system.unwrap(), "system prompt");
-    assert_eq!(chat.len(), 3);
-    assert_eq!(chat[0].role, "user");
-    assert_eq!(chat[0].content, "user msg");
-    assert_eq!(chat[1].role, "assistant");
-    assert_eq!(chat[1].content, "assistant reply");
-    assert_eq!(chat[2].role, "user");
-    assert_eq!(chat[2].content, "followup");
-}
-
-#[test]
-fn split_messages_empty() {
-    let (system, chat) = split_messages(&[]);
-    assert!(system.is_none());
-    assert!(chat.is_empty());
-}
-
-#[test]
 fn api_message_serializes() {
     let msg = ApiMessage {
         role: "user",
@@ -398,60 +287,6 @@ async fn chat_stream_with_unreachable_endpoint_errors() {
     }];
     let result = provider.chat_stream(&messages).await;
     assert!(result.is_err());
-}
-
-#[test]
-fn split_messages_only_system() {
-    let messages = vec![Message {
-        role: Role::System,
-        content: "instruction".into(),
-        parts: vec![],
-        metadata: MessageMetadata::default(),
-    }];
-    let (system, chat) = split_messages(&messages);
-    assert_eq!(system.unwrap(), "instruction");
-    assert!(chat.is_empty());
-}
-
-#[test]
-fn split_messages_only_assistant() {
-    let messages = vec![Message {
-        role: Role::Assistant,
-        content: "reply".into(),
-        parts: vec![],
-        metadata: MessageMetadata::default(),
-    }];
-    let (system, chat) = split_messages(&messages);
-    assert!(system.is_none());
-    assert_eq!(chat.len(), 1);
-    assert_eq!(chat[0].role, "assistant");
-}
-
-#[test]
-fn split_messages_interleaved_system() {
-    let messages = vec![
-        Message {
-            role: Role::System,
-            content: "first".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::User,
-            content: "question".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::System,
-            content: "second".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-    ];
-    let (system, chat) = split_messages(&messages);
-    assert_eq!(system.unwrap(), "first\n\nsecond");
-    assert_eq!(chat.len(), 1);
 }
 
 #[test]
@@ -792,321 +627,6 @@ fn parse_tool_response_with_compaction() {
 }
 
 #[test]
-fn split_messages_structured_with_tool_parts() {
-    let messages = vec![
-        Message::from_parts(
-            Role::Assistant,
-            vec![
-                MessagePart::Text {
-                    text: "I'll run that".into(),
-                },
-                MessagePart::ToolUse {
-                    id: "t1".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({"command": "ls"}),
-                },
-            ],
-        ),
-        Message::from_parts(
-            Role::User,
-            vec![MessagePart::ToolResult {
-                tool_use_id: "t1".into(),
-                content: "file1.rs".into(),
-                is_error: false,
-            }],
-        ),
-    ];
-    let (system, chat) = split_messages_structured(&messages, true, None);
-    assert!(system.is_none());
-    assert_eq!(chat.len(), 2);
-
-    let assistant_json = serde_json::to_string(&chat[0]).unwrap();
-    assert!(assistant_json.contains("tool_use"));
-    assert!(assistant_json.contains("\"id\":\"t1\""));
-
-    let user_json = serde_json::to_string(&chat[1]).unwrap();
-    assert!(user_json.contains("tool_result"));
-    assert!(user_json.contains("\"tool_use_id\":\"t1\""));
-}
-
-/// FIX2 regression: an assistant message with a `ToolUse` part that has NO matching
-/// `ToolResult` in the next user message must emit a text block instead of a `tool_use`
-/// block, preventing Claude API 400 errors caused by unmatched `tool_use/tool_result` pairs.
-#[test]
-fn split_messages_structured_downgrades_unmatched_tool_use_to_text() {
-    // Orphaned assistant[ToolUse] — no following user[ToolResult].
-    let messages = vec![
-        Message::from_parts(
-            Role::Assistant,
-            vec![
-                MessagePart::Text {
-                    text: "Let me run this.".into(),
-                },
-                MessagePart::ToolUse {
-                    id: "orphan_id".into(),
-                    name: "shell".into(),
-                    input: serde_json::json!({"command": "ls"}),
-                },
-            ],
-        ),
-        // Next message is NOT a ToolResult response — simulates compaction-split orphan.
-        Message::from_parts(
-            Role::User,
-            vec![MessagePart::Text {
-                text: "Thanks, what did you find?".into(),
-            }],
-        ),
-    ];
-
-    let (_, chat) = split_messages_structured(&messages, false, None);
-    assert_eq!(chat.len(), 2);
-
-    // The assistant block must NOT contain a tool_use block for the unmatched ID.
-    let assistant_json = serde_json::to_string(&chat[0]).unwrap();
-    assert!(
-        !assistant_json.contains("\"type\":\"tool_use\""),
-        "unmatched tool_use must be downgraded: {assistant_json}"
-    );
-    // The orphaned ID must appear in a text fallback instead.
-    assert!(
-        assistant_json.contains("orphan_id") || assistant_json.contains("shell"),
-        "downgraded tool_use must appear as text fallback: {assistant_json}"
-    );
-}
-
-/// FIX2 regression: a matched `tool_use/tool_result` pair must still emit a real
-/// `tool_use` block. The defensive check must not break valid exchanges.
-#[test]
-fn split_messages_structured_preserves_matched_tool_use_block() {
-    let messages = vec![
-        Message::from_parts(
-            Role::Assistant,
-            vec![MessagePart::ToolUse {
-                id: "matched_id".into(),
-                name: "bash".into(),
-                input: serde_json::json!({"command": "echo hi"}),
-            }],
-        ),
-        Message::from_parts(
-            Role::User,
-            vec![MessagePart::ToolResult {
-                tool_use_id: "matched_id".into(),
-                content: "hi".into(),
-                is_error: false,
-            }],
-        ),
-    ];
-
-    let (_, chat) = split_messages_structured(&messages, false, None);
-    assert_eq!(chat.len(), 2);
-
-    let assistant_json = serde_json::to_string(&chat[0]).unwrap();
-    assert!(
-        assistant_json.contains("\"type\":\"tool_use\""),
-        "matched tool_use must be emitted as tool_use block: {assistant_json}"
-    );
-    assert!(assistant_json.contains("\"id\":\"matched_id\""));
-}
-
-/// RC1 regression: when a `ToolUse` was downgraded to text (because the next user message had
-/// no matching `ToolResult`), the corresponding `ToolResult` in the user message must ALSO be
-/// downgraded to text instead of being emitted as a native `ToolResult` block.
-/// Previously only the `ToolUse` was downgraded, leaving an orphaned `ToolResult` that caused
-/// Claude API 400 errors on session restore.
-#[test]
-fn split_structured_downgrades_orphaned_tool_result() {
-    // Scenario: assistant emits tool_use "t_orphan", but the following user message has a
-    // ToolResult for a DIFFERENT id — so "t_orphan" is downgraded. The ToolResult for
-    // "t_orphan" (which does appear in the user message) must also be downgraded.
-    let messages = vec![
-        Message::from_parts(
-            Role::Assistant,
-            vec![MessagePart::ToolUse {
-                id: "t_orphan".into(),
-                name: "memory_save".into(),
-                input: serde_json::json!({"content": "x"}),
-            }],
-        ),
-        // User message references t_orphan but the assistant ToolUse was not matched
-        // (there is no ToolResult for t_orphan in the NEXT user message from assistant's
-        // perspective — the assistant sees this user message has t_orphan, but the
-        // matched_tool_ids logic checks whether the ToolResult id matches).
-        // To trigger the orphan path: provide a user message whose ToolResult id does NOT
-        // match the ToolUse id — so matched_tool_ids for "t_orphan" is empty.
-        Message::from_parts(
-            Role::User,
-            vec![MessagePart::ToolResult {
-                tool_use_id: "t_orphan".into(),
-                content: "saved".into(),
-                is_error: false,
-            }],
-        ),
-    ];
-
-    // Verify the full round-trip: the assistant ToolUse is matched (t_orphan has a
-    // corresponding ToolResult), so this tests the happy path.
-    let (_, chat) = split_messages_structured(&messages, false, None);
-    assert_eq!(chat.len(), 2);
-
-    // The assistant message must emit t_orphan as a real tool_use (matched pair).
-    let assistant_json = serde_json::to_string(&chat[0]).unwrap();
-    assert!(
-        assistant_json.contains("\"type\":\"tool_use\""),
-        "matched tool_use must be emitted as native block: {assistant_json}"
-    );
-
-    // The user message must emit t_orphan as a real tool_result (matched pair).
-    let user_json = serde_json::to_string(&chat[1]).unwrap();
-    assert!(
-        user_json.contains("\"type\":\"tool_result\""),
-        "matched tool_result must be emitted as native block: {user_json}"
-    );
-
-    // Now test the actual RC1 scenario: assistant emits TWO tool_use IDs but the user
-    // message only has a ToolResult for ONE of them. The unmatched tool_use is downgraded,
-    // and the ToolResult for the unmatched id must NOT appear in the user message output.
-    let messages_partial = vec![
-        Message::from_parts(
-            Role::Assistant,
-            vec![
-                MessagePart::ToolUse {
-                    id: "t_matched".into(),
-                    name: "shell".into(),
-                    input: serde_json::json!({"command": "ls"}),
-                },
-                MessagePart::ToolUse {
-                    id: "t_missing_result".into(),
-                    name: "shell".into(),
-                    input: serde_json::json!({"command": "pwd"}),
-                },
-            ],
-        ),
-        // User only provides result for t_matched; t_missing_result has no ToolResult.
-        Message::from_parts(
-            Role::User,
-            vec![MessagePart::ToolResult {
-                tool_use_id: "t_matched".into(),
-                content: "output".into(),
-                is_error: false,
-            }],
-        ),
-    ];
-
-    let (_, chat2) = split_messages_structured(&messages_partial, false, None);
-    assert_eq!(chat2.len(), 2);
-
-    // t_missing_result must be downgraded to text in the assistant message: if its ID
-    // appears at all it must not be inside a native tool_use block.
-    let assistant_json2 = serde_json::to_string(&chat2[0]).unwrap();
-    let has_native_missing = assistant_json2.contains("\"type\":\"tool_use\"")
-        && assistant_json2.contains("\"id\":\"t_missing_result\"");
-    assert!(
-        !has_native_missing,
-        "t_missing_result must not appear as a native tool_use block: {assistant_json2}"
-    );
-
-    // t_matched must still be emitted as a real tool_use.
-    assert!(
-        assistant_json2.contains("\"id\":\"t_matched\""),
-        "t_matched must be emitted as native tool_use: {assistant_json2}"
-    );
-
-    // The user message must only have t_matched as a real tool_result.
-    let user_json2 = serde_json::to_string(&chat2[1]).unwrap();
-    assert!(
-        user_json2.contains("\"type\":\"tool_result\""),
-        "matched tool_result must be emitted as native block: {user_json2}"
-    );
-    assert!(
-        user_json2.contains("\"tool_use_id\":\"t_matched\""),
-        "t_matched tool_result must be present: {user_json2}"
-    );
-}
-
-/// RC4 regression: system messages interleaved in the message list must NOT appear in the
-/// `visible` index array used by `split_messages_structured`. If they did, the +1 peek used
-/// to check whether a `ToolUse` has a matching `ToolResult` would land on a system message
-/// instead of the actual next user message, causing false-positive downgrades.
-#[test]
-fn split_structured_system_not_in_visible() {
-    // System message appears between the assistant ToolUse and the user ToolResult.
-    // With the RC4 fix the system message is filtered out of `visible`, so idx+1 correctly
-    // lands on the user message and the ToolUse is NOT downgraded.
-    let messages = vec![
-        Message {
-            role: Role::System,
-            content: "You are a helpful assistant.".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message::from_parts(
-            Role::Assistant,
-            vec![MessagePart::ToolUse {
-                id: "t_sys_test".into(),
-                name: "bash".into(),
-                input: serde_json::json!({"command": "echo hi"}),
-            }],
-        ),
-        // Interleaved system message — must not disrupt the +1 peek.
-        Message {
-            role: Role::System,
-            content: "Additional context injected mid-conversation.".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message::from_parts(
-            Role::User,
-            vec![MessagePart::ToolResult {
-                tool_use_id: "t_sys_test".into(),
-                content: "hi".into(),
-                is_error: false,
-            }],
-        ),
-    ];
-
-    let (system_text, chat) = split_messages_structured(&messages, false, None);
-
-    // Both system messages must be extracted to the system string.
-    let system = system_text.unwrap_or_default();
-    assert!(
-        system.contains("You are a helpful assistant."),
-        "first system message must be in system text: {system}"
-    );
-    assert!(
-        system.contains("Additional context"),
-        "interleaved system message must be in system text: {system}"
-    );
-
-    // chat must contain only user and assistant messages (no system).
-    assert_eq!(
-        chat.len(),
-        2,
-        "chat must contain exactly assistant + user messages (no system), got {}",
-        chat.len()
-    );
-    assert_eq!(chat[0].role, "assistant");
-    assert_eq!(chat[1].role, "user");
-
-    // The ToolUse must NOT be downgraded — system messages must not break the +1 peek.
-    let assistant_json = serde_json::to_string(&chat[0]).unwrap();
-    assert!(
-        assistant_json.contains("\"type\":\"tool_use\""),
-        "ToolUse must be emitted as native block when system messages are filtered: {assistant_json}"
-    );
-    assert!(
-        assistant_json.contains("\"id\":\"t_sys_test\""),
-        "correct tool_use id must be present: {assistant_json}"
-    );
-
-    // The ToolResult must be emitted as a native block (not downgraded).
-    let user_json = serde_json::to_string(&chat[1]).unwrap();
-    assert!(
-        user_json.contains("\"type\":\"tool_result\""),
-        "ToolResult must be emitted as native block: {user_json}"
-    );
-}
-
-#[test]
 fn supports_tool_use_returns_true() {
     let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-5-20250929".into(), 1024);
     assert!(provider.supports_tool_use());
@@ -1126,47 +646,6 @@ fn anthropic_content_block_image_serializes_correctly() {
     assert_eq!(json["source"]["type"], "base64");
     assert_eq!(json["source"]["media_type"], "image/jpeg");
     assert_eq!(json["source"]["data"], "abc123");
-}
-
-#[test]
-fn split_messages_structured_produces_image_block() {
-    use base64::{Engine, engine::general_purpose::STANDARD};
-
-    let data = vec![0xFFu8, 0xD8, 0xFF];
-    let msg = Message::from_parts(
-        Role::User,
-        vec![
-            MessagePart::Text {
-                text: "look at this".into(),
-            },
-            MessagePart::Image(Box::new(ImageData {
-                data: data.clone(),
-                mime_type: "image/jpeg".into(),
-            })),
-        ],
-    );
-    let (system, chat) = split_messages_structured(&[msg], true, None);
-    assert!(system.is_none());
-    assert_eq!(chat.len(), 1);
-    assert_eq!(chat[0].role, "user");
-    match &chat[0].content {
-        StructuredContent::Blocks(blocks) => {
-            assert_eq!(blocks.len(), 2);
-            match &blocks[0] {
-                AnthropicContentBlock::Text { text, .. } => assert_eq!(text, "look at this"),
-                _ => panic!("expected Text block first"),
-            }
-            match &blocks[1] {
-                AnthropicContentBlock::Image { source } => {
-                    assert_eq!(source.source_type, "base64");
-                    assert_eq!(source.media_type, "image/jpeg");
-                    assert_eq!(source.data, STANDARD.encode(&data));
-                }
-                _ => panic!("expected Image block second"),
-            }
-        }
-        StructuredContent::Text(_) => panic!("expected Blocks content"),
-    }
 }
 
 #[test]
@@ -1229,84 +708,28 @@ fn tool_cache_serialized_shape_snapshot() {
     insta::assert_snapshot!(pretty);
 }
 
-/// Spawn a minimal HTTP server that captures request bodies and returns fixed JSON responses.
-/// Returns `(port, captured_bodies_receiver, join_handle)`.
-async fn spawn_capture_server(
-    responses: Vec<String>,
-) -> (
-    u16,
-    tokio::sync::mpsc::Receiver<String>,
-    tokio::task::JoinHandle<()>,
-) {
-    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
-    use tokio::net::TcpListener;
-
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    let (tx, rx) = tokio::sync::mpsc::channel(16);
-
-    let handle = tokio::spawn(async move {
-        for resp in responses {
-            let Ok((mut stream, _)) = listener.accept().await else {
-                break;
-            };
-            let tx = tx.clone();
-            tokio::spawn(async move {
-                let (reader, mut writer) = stream.split();
-                let mut buf_reader = BufReader::new(reader);
-
-                // Read headers to find Content-Length
-                let mut content_length: usize = 0;
-                loop {
-                    let mut line = String::new();
-                    buf_reader.read_line(&mut line).await.unwrap_or(0);
-                    if line == "\r\n" || line == "\n" || line.is_empty() {
-                        break;
-                    }
-                    if line.to_lowercase().starts_with("content-length:") {
-                        content_length = line
-                            .split(':')
-                            .nth(1)
-                            .and_then(|v| v.trim().parse().ok())
-                            .unwrap_or(0);
-                    }
-                }
-
-                // Read body
-                let mut body = vec![0u8; content_length];
-                buf_reader.read_exact(&mut body).await.ok();
-                let body_str = String::from_utf8_lossy(&body).into_owned();
-                tx.send(body_str).await.ok();
-
-                let resp_bytes = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                    resp.len(),
-                    resp
-                );
-                writer.write_all(resp_bytes.as_bytes()).await.ok();
-            });
-        }
-    });
-
-    (port, rx, handle)
-}
-
-fn tool_api_response_json() -> String {
-    r#"{"content":[{"type":"text","text":"done"}],"usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}"#.into()
-}
-
 #[tokio::test]
 async fn chat_with_tools_sends_correct_tool_fields() {
     use crate::provider::ToolDefinition;
+    use crate::testing::claude_tool_use_response;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer};
 
-    let response = tool_api_response_json();
-    let (port, mut rx, handle) = spawn_capture_server(vec![response]).await;
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(claude_tool_use_response(
+            "read_file",
+            "toolu_1",
+            &serde_json::json!({"path": "/tmp/f"}),
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
 
-    let client = reqwest::Client::new();
-    let provider =
-        ClaudeProvider::new("test-key".into(), "claude-test".into(), 256).with_client(client);
+    let provider = ClaudeProvider::new("test-key".into(), "claude-test".into(), 256)
+        .with_api_url(format!("{}/v1/messages", server.uri()));
 
-    // Override API_URL via a custom client pointed at our mock
     let tools = vec![ToolDefinition {
         name: "read_file".into(),
         description: "Read a file from disk".into(),
@@ -1315,18 +738,163 @@ async fn chat_with_tools_sends_correct_tool_fields() {
     }];
     let messages = vec![Message::from_legacy(Role::User, "read /tmp/f")];
 
-    // We can't override API_URL from outside, so test via get_or_build_api_tools directly
-    // and verify the serialized body shape via snapshot.
-    let _ = (port, &mut rx);
+    let result = provider.chat_with_tools(&messages, &tools).await;
+    assert!(result.is_ok(), "request must succeed: {result:?}");
 
-    let api_tools = provider.get_or_build_api_tools(&tools);
-    assert_eq!(api_tools.len(), 1);
-    assert_eq!(api_tools[0]["name"], "read_file");
-    assert_eq!(api_tools[0]["description"], "Read a file from disk");
-    assert!(api_tools[0]["input_schema"].is_object());
-    assert_eq!(api_tools[0]["input_schema"]["type"], "object");
-    let _ = messages;
-    handle.abort();
+    let reqs = server.received_requests().await.unwrap();
+    assert_eq!(reqs.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+    let sent_tools = body["tools"].as_array().expect("tools array present");
+    assert_eq!(sent_tools.len(), 1);
+    assert_eq!(sent_tools[0]["name"], "read_file");
+    assert_eq!(sent_tools[0]["description"], "Read a file from disk");
+    assert!(sent_tools[0]["input_schema"].is_object());
+    assert_eq!(sent_tools[0]["input_schema"]["type"], "object");
+}
+
+// ── #6156: HTTP-level regression coverage — drive chat_with_tools_stream,
+// chat_with_tools, and chat_typed through a mock server and assert the no-prefill
+// gate strips a trailing assistant message in the request actually sent over the
+// wire, not just in the body-construction functions exercised via debug_request_json ──
+
+#[tokio::test]
+async fn chat_with_tools_no_prefill_strips_trailing_assistant_over_wire() {
+    use crate::provider::ToolDefinition;
+    use crate::testing::claude_tool_use_response;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(claude_tool_use_response(
+            "read_file",
+            "toolu_1",
+            &serde_json::json!({"path": "a.rs"}),
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // claude-sonnet-5 unconditionally rejects assistant prefill (rejects_prefill).
+    let provider = ClaudeProvider::new("test-key".into(), TEST_CLAUDE_MODEL.into(), 1024)
+        .with_api_url(format!("{}/v1/messages", server.uri()));
+
+    let tools = vec![ToolDefinition {
+        name: "read_file".into(),
+        description: "Read a file".into(),
+        parameters: serde_json::json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+        output_schema: None,
+    }];
+    let messages = vec![
+        Message::from_legacy(Role::User, "hello"),
+        Message::from_legacy(Role::Assistant, "trailing"),
+    ];
+
+    let result = provider.chat_with_tools(&messages, &tools).await;
+    assert!(result.is_ok(), "request must succeed: {result:?}");
+
+    let reqs = server.received_requests().await.unwrap();
+    assert_eq!(reqs.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+    let msgs = body["messages"].as_array().unwrap();
+    assert_eq!(
+        msgs.last().and_then(|m| m["role"].as_str()),
+        Some("user"),
+        "no-prefill gate must strip the trailing assistant message from the wire request: {body}"
+    );
+}
+
+#[tokio::test]
+async fn chat_with_tools_stream_no_prefill_strips_trailing_assistant_over_wire() {
+    use crate::provider::ToolDefinition;
+    use crate::testing::claude_tool_use_sse_response;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(claude_tool_use_sse_response(
+            "toolu_1",
+            "read_file",
+            r#"{"path":"a.rs"}"#,
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = ClaudeProvider::new("test-key".into(), TEST_CLAUDE_MODEL.into(), 1024)
+        .with_api_url(format!("{}/v1/messages", server.uri()));
+
+    let tools = vec![ToolDefinition {
+        name: "read_file".into(),
+        description: "Read a file".into(),
+        parameters: serde_json::json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+        output_schema: None,
+    }];
+    let messages = vec![
+        Message::from_legacy(Role::User, "hello"),
+        Message::from_legacy(Role::Assistant, "trailing"),
+    ];
+
+    let result = provider.chat_with_tools_stream(&messages, &tools).await;
+    assert!(result.is_ok(), "request must succeed: {:?}", result.err());
+
+    let reqs = server.received_requests().await.unwrap();
+    assert_eq!(reqs.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+    let msgs = body["messages"].as_array().unwrap();
+    assert_eq!(
+        msgs.last().and_then(|m| m["role"].as_str()),
+        Some("user"),
+        "no-prefill gate must strip the trailing assistant message from the wire request: {body}"
+    );
+}
+
+#[tokio::test]
+async fn chat_typed_no_prefill_strips_trailing_assistant_over_wire() {
+    use crate::testing::claude_tool_use_response;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer};
+
+    #[derive(Debug, serde::Deserialize, schemars::JsonSchema, PartialEq)]
+    struct TypedOut {
+        value: String,
+    }
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(claude_tool_use_response(
+            "submit_TypedOut",
+            "toolu_1",
+            &serde_json::json!({"value": "ok"}),
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = ClaudeProvider::new("test-key".into(), TEST_CLAUDE_MODEL.into(), 1024)
+        .with_api_url(format!("{}/v1/messages", server.uri()));
+
+    let messages = vec![
+        Message::from_legacy(Role::User, "hello"),
+        Message::from_legacy(Role::Assistant, "trailing"),
+    ];
+
+    let result: Result<TypedOut, _> = provider.chat_typed(&messages).await;
+    assert!(result.is_ok(), "request must succeed: {result:?}");
+
+    let reqs = server.received_requests().await.unwrap();
+    assert_eq!(reqs.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+    let msgs = body["messages"].as_array().unwrap();
+    assert_eq!(
+        msgs.last().and_then(|m| m["role"].as_str()),
+        Some("user"),
+        "no-prefill gate must strip the trailing assistant message from the wire request: {body}"
+    );
 }
 
 #[tokio::test]
@@ -2162,45 +1730,6 @@ fn parse_tool_response_with_redacted_thinking() {
 }
 
 #[test]
-fn thinking_block_serializes_in_structured_message() {
-    let msg = Message::from_parts(
-        Role::Assistant,
-        vec![
-            MessagePart::ThinkingBlock {
-                thinking: "my reasoning".into(),
-                signature: "abc".into(),
-            },
-            MessagePart::Text {
-                text: "answer".into(),
-            },
-        ],
-    );
-    let (_, chat) = split_messages_structured(&[msg], true, None);
-    assert_eq!(chat.len(), 1);
-    let json = serde_json::to_value(&chat[0]).unwrap();
-    let blocks = json["content"].as_array().unwrap();
-    assert_eq!(blocks[0]["type"], "thinking");
-    assert_eq!(blocks[0]["thinking"], "my reasoning");
-    assert_eq!(blocks[0]["signature"], "abc");
-    assert_eq!(blocks[1]["type"], "text");
-}
-
-#[test]
-fn redacted_thinking_block_serializes_in_structured_message() {
-    let msg = Message::from_parts(
-        Role::Assistant,
-        vec![MessagePart::RedactedThinkingBlock {
-            data: "secret".into(),
-        }],
-    );
-    let (_, chat) = split_messages_structured(&[msg], true, None);
-    let json = serde_json::to_value(&chat[0]).unwrap();
-    let blocks = json["content"].as_array().unwrap();
-    assert_eq!(blocks[0]["type"], "redacted_thinking");
-    assert_eq!(blocks[0]["data"], "secret");
-}
-
-#[test]
 fn thinking_content_block_roundtrip() {
     let block = AnthropicContentBlock::Thinking {
         thinking: "internal reasoning".into(),
@@ -2430,95 +1959,6 @@ fn build_request_multi_turn_no_top_level_cache_control() {
 
 // ── #1087: message-level breakpoint at position max(0, total-20) ──────────
 
-#[test]
-fn split_messages_structured_single_message_no_cache_breakpoint() {
-    let messages = vec![Message {
-        role: Role::User,
-        content: "only message".into(),
-        parts: vec![],
-        metadata: MessageMetadata::default(),
-    }];
-    let (_, chat) = split_messages_structured(&messages, true, None);
-    assert_eq!(chat.len(), 1);
-    // With only 1 message, no breakpoint is placed
-    let json = serde_json::to_value(&chat[0]).unwrap();
-    let has_cache = json.to_string().contains("cache_control");
-    assert!(
-        !has_cache,
-        "single message must not have cache_control breakpoint"
-    );
-}
-
-#[test]
-fn split_messages_structured_two_messages_places_breakpoint_on_user() {
-    let messages = vec![
-        Message {
-            role: Role::User,
-            content: "first user".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-        Message {
-            role: Role::Assistant,
-            content: "assistant reply".into(),
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        },
-    ];
-    let (_, chat) = split_messages_structured(&messages, true, None);
-    assert_eq!(chat.len(), 2);
-    // Breakpoint must be on the user message at index 0 (only user in range)
-    let user_json = serde_json::to_value(&chat[0]).unwrap();
-    assert!(
-        user_json.to_string().contains("cache_control"),
-        "user message must carry cache_control breakpoint"
-    );
-    let assistant_json = serde_json::to_value(&chat[1]).unwrap();
-    assert!(
-        !assistant_json.to_string().contains("cache_control"),
-        "assistant message must not have cache_control"
-    );
-}
-
-#[test]
-fn split_messages_structured_breakpoint_targets_last_minus_20_position() {
-    // Build 25 messages: user/assistant alternating, user first
-    let mut messages = Vec::new();
-    for i in 0..25u32 {
-        let role = if i % 2 == 0 {
-            Role::User
-        } else {
-            Role::Assistant
-        };
-        let content = format!("message {i}");
-        messages.push(Message {
-            role,
-            content,
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        });
-    }
-    let (_, chat) = split_messages_structured(&messages, true, None);
-    assert_eq!(chat.len(), 25);
-    // target = 25 - 20 = 5; first user at or after index 5 is index 6 (even indices are user)
-    // Actually index 5 is assistant (odd), so search finds index 6 (user)
-    let mut breakpoint_idx = None;
-    for (i, msg) in chat.iter().enumerate() {
-        let json = serde_json::to_value(msg).unwrap();
-        if json.to_string().contains("cache_control") {
-            breakpoint_idx = Some(i);
-            break;
-        }
-    }
-    let idx = breakpoint_idx.expect("must have a breakpoint somewhere");
-    assert_eq!(
-        chat[idx].role, "user",
-        "breakpoint must be on a user message"
-    );
-    // Breakpoint index must be >= max(0, total-20) = 5
-    assert!(idx >= 5, "breakpoint must be at or after position total-20");
-}
-
 fn count_cache_control_occurrences(value: &serde_json::Value) -> usize {
     match value {
         serde_json::Value::Object(map) => {
@@ -2706,53 +2146,6 @@ fn tool_cache_hits_on_same_tools() {
 }
 
 // --- #1093: cache_user_messages toggle ---
-
-#[test]
-fn split_messages_structured_cache_enabled_adds_cache_control() {
-    let messages = vec![
-        Message::from_legacy(Role::User, "first"),
-        Message::from_legacy(Role::Assistant, "answer"),
-        Message::from_legacy(Role::User, "second"),
-    ];
-    let (_, chat) = split_messages_structured(&messages, true, None);
-    assert_eq!(chat.len(), 3);
-    // Breakpoint targets the user message at max(0, total-20) = 0, which is chat[0].
-    let has_cache = chat.iter().any(|m| {
-        m.role == "user"
-            && match &m.content {
-                StructuredContent::Blocks(blocks) => blocks.iter().any(|b| {
-                    matches!(
-                        b,
-                        AnthropicContentBlock::Text {
-                            cache_control: Some(_),
-                            ..
-                        }
-                    )
-                }),
-                StructuredContent::Text(_) => false,
-            }
-    });
-    assert!(
-        has_cache,
-        "at least one user message must have cache_control when enabled"
-    );
-}
-
-#[test]
-fn split_messages_structured_cache_disabled_no_cache_control() {
-    let messages = vec![
-        Message::from_legacy(Role::User, "first"),
-        Message::from_legacy(Role::Assistant, "answer"),
-        Message::from_legacy(Role::User, "second"),
-    ];
-    let (_, chat) = split_messages_structured(&messages, false, None);
-    assert_eq!(chat.len(), 3);
-    // With cache disabled, last user message stays as plain Text.
-    assert!(
-        matches!(&chat[2].content, StructuredContent::Text(_)),
-        "last user message must remain Text when cache disabled"
-    );
-}
 
 #[test]
 fn with_cache_user_messages_builder() {
@@ -3512,61 +2905,6 @@ fn handle_compact_beta_rejection_returns_false_for_non_rejection_error() {
     );
     assert!(!retried);
     assert!(!provider.is_server_compaction_rejected());
-}
-
-#[test]
-fn split_messages_structured_compaction_round_trip() {
-    // Compaction in an assistant message must be emitted verbatim as an
-    // AnthropicContentBlock::Compaction so the API can prune history correctly.
-    // A Compaction in a user message must be silently dropped.
-    let messages = vec![
-        Message::from_parts(
-            Role::Assistant,
-            vec![
-                MessagePart::Text {
-                    text: "Before compaction.".into(),
-                },
-                MessagePart::Compaction {
-                    summary: "History was compacted here.".into(),
-                },
-            ],
-        ),
-        Message::from_parts(
-            Role::User,
-            vec![
-                MessagePart::Text {
-                    text: "Continue.".into(),
-                },
-                MessagePart::Compaction {
-                    summary: "should be dropped".into(),
-                },
-            ],
-        ),
-    ];
-    let (system, chat) = split_messages_structured(&messages, false, None);
-    assert!(system.is_none());
-    assert_eq!(chat.len(), 2);
-
-    // Assistant message: must contain a Compaction block with the original summary.
-    if let StructuredContent::Blocks(blocks) = &chat[0].content {
-        let has_compaction = blocks.iter().any(|b| {
-            matches!(b, AnthropicContentBlock::Compaction { summary }
-                if summary == "History was compacted here.")
-        });
-        assert!(
-            has_compaction,
-            "assistant Compaction block must be preserved"
-        );
-    } else {
-        panic!("expected Blocks for assistant message");
-    }
-
-    // User message: Compaction must be silently dropped.
-    let user_json = serde_json::to_string(&chat[1]).unwrap();
-    assert!(
-        !user_json.contains("compaction"),
-        "Compaction in user message must be dropped"
-    );
 }
 
 #[test]

--- a/crates/zeph-llm/src/testing.rs
+++ b/crates/zeph-llm/src/testing.rs
@@ -138,6 +138,38 @@ pub fn claude_messages_response(content: &str) -> ResponseTemplate {
     ResponseTemplate::new(200).set_body_json(body)
 }
 
+/// Non-streaming Anthropic Messages API response containing a single `tool_use` block.
+///
+/// Compatible with `ClaudeProvider::chat_with_tools`, `chat_with_tools_stream` (non-streaming
+/// send path), and `chat_typed`.
+#[must_use]
+pub fn claude_tool_use_response(
+    tool_name: &str,
+    tool_id: &str,
+    input: &serde_json::Value,
+) -> ResponseTemplate {
+    let body = serde_json::json!({
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "model": TEST_CLAUDE_MODEL,
+        "content": [{
+            "type": "tool_use",
+            "id": tool_id,
+            "name": tool_name,
+            "input": input
+        }],
+        "stop_reason": "tool_use",
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0
+        }
+    });
+    ResponseTemplate::new(200).set_body_json(body)
+}
+
 /// Claude 429 rate-limit / 529 overload response.
 #[must_use]
 pub fn claude_overload_response(status: u16) -> ResponseTemplate {
@@ -178,6 +210,43 @@ pub fn claude_sse_stream_response(chunks: &[&str]) -> ResponseTemplate {
     );
     body.push_str(
         "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":5}}\n\n",
+    );
+    body.push_str("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n");
+
+    ResponseTemplate::new(200)
+        .insert_header("content-type", "text/event-stream")
+        .set_body_string(body)
+}
+
+/// Claude streaming SSE response containing a single `tool_use` block.
+///
+/// Encodes `input_json` (already-serialized JSON) as one `input_json_delta` event.
+/// Compatible with `ClaudeProvider::chat_with_tools_stream`.
+#[must_use]
+pub fn claude_tool_use_sse_response(
+    tool_id: &str,
+    tool_name: &str,
+    input_json: &str,
+) -> ResponseTemplate {
+    let mut body = String::new();
+
+    body.push_str(
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-5\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n",
+    );
+    let _ = write!(
+        body,
+        "event: content_block_start\ndata: {{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{{\"type\":\"tool_use\",\"id\":\"{tool_id}\",\"name\":\"{tool_name}\",\"input\":{{}}}}}}\n\n"
+    );
+    let escaped = input_json.replace('\\', "\\\\").replace('"', "\\\"");
+    let _ = write!(
+        body,
+        "event: content_block_delta\ndata: {{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{{\"type\":\"input_json_delta\",\"partial_json\":\"{escaped}\"}}}}\n\n"
+    );
+    body.push_str(
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    );
+    body.push_str(
+        "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":5}}\n\n",
     );
     body.push_str("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n");
 


### PR DESCRIPTION
## Summary

Follow-up hardening from PR #6154 (closed #6146), which added the `structured_history`/`plain_history` funnel methods to apply the Claude no-prefill gate across all request-construction paths.

- `split_messages`/`split_messages_structured` (`crates/zeph-llm/src/claude/request.rs`) narrowed from `pub(super)` to `pub(in crate::claude)`, and the ~22 pure-conversion tests that called them directly relocated from `claude/tests.rs` into a new `request.rs::tests` submodule. This removes the sibling-module glob-import reachability a future call site would otherwise find by autocomplete. Note: this raises bypass *friction*, not a compiler-enforced barrier — Rust cannot grant a child module's item to its parent while excluding the parent's other children, so a call site added elsewhere inside `crate::claude` could still reach the raw split functions directly. Doc comments on the splitters and on the funnel methods state this honestly. A design that would make bypassing the funnel a genuine compile error is tracked in #6158.
- Claude's Messages API base URL is now carried on an injectable `api_url` field on `ClaudeProvider` (defaulting to the existing `API_URL` constant) with a `#[cfg(test)]`-only builder, replacing a dead hand-rolled TCP mock that had given up on HTTP-level assertions. Three new `wiremock`-backed tests drive `chat_with_tools`, `chat_with_tools_stream`, and `chat_typed` through a mocked HTTP round-trip and assert the no-prefill gate strips a trailing assistant message in the request actually sent over the wire — closing the gap where prior coverage only exercised the identical body-construction sequence via `debug_request_json` as a same-order proxy.

Zero production behavior change: the split functions are byte-identical aside from the visibility keyword, and `api_url` has exactly one construction path (`ClaudeProvider::new`) defaulting to the real endpoint.

Closes #6155
Closes #6156

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci -p zeph-llm --all-targets --features testing -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm --lib --bins` — 1046 passed, 10 skipped, 0 failed
- [x] `cargo test --doc -p zeph-llm --features testing` — 29 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-llm --features testing`
- [x] Negative control: temporarily disabled the no-prefill strip in `structured_history`, confirmed all 3 new HTTP-level tests fail with a clear assertion, then restored and re-verified a clean diff
- [x] Verified all 22 relocated tests match name-for-name against the pre-relocation set, no silent content drop
- [x] `cargo check --workspace --features "desktop,ide,server,chat,pdf,scheduler" --locked` — confirmed no other crate constructs `ClaudeProvider` via struct-literal syntax, so the new field doesn't break anything
- [x] Live API session test judged not required (see review notes): zero production behavior diff, and the underlying no-prefill gate itself was already live-tested when #6154 shipped